### PR TITLE
chore: ignore Tauri sidecars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 
 # Tauri/Rust
 src-tauri/target/
+src-tauri/sidecars/
 
 # Env
 .env


### PR DESCRIPTION
## Summary
- Ignores `src-tauri/sidecars/` so local downloaded/bundled binaries don’t dirty the git working tree.

## Why
- Sidecars are build/download artifacts and are platform-specific + large.