### PR TITLE
docs: folder-scoped workspaces PRD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ OpenWork exists to bring OpenCode's agentic power to non-technical people throug
 
 - **Purpose-first UI**: prioritize clarity, safety, and approachability for non-technical users.
 - **Parity with OpenCode**: anything the UI can do must map cleanly to OpenCode tools.
+- **Prefer OpenCode primitives**: represent concepts using OpenCode’s native surfaces first (folders/projects, `.opencode`, `opencode.json`, skills, plugins) before introducing new abstractions.
 - **Self-referential**: maintain a gitignored mirror of OpenCode at `vendor/opencode` for inspection.
 - **Self-building**: prefer prompts, skills, and composable primitives over bespoke logic.
 - **Open source**: keep the repo portable; no secrets committed.


### PR DESCRIPTION
## Summary
- Clarifies a guiding principle to prefer OpenCode primitives (folders, `.opencode`, `opencode.json`).
- Reframes the workspace PRD around folder-scoped workspaces and adds a Starter Workspace + workspace templates concept.

Docs only (no behavior changes).