### PR TITLE
fix: unblock permission prompt actions

### DIFF
--- a/.opencode/skill/solidjs-patterns/SKILL.md
+++ b/.opencode/skill/solidjs-patterns/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: solidjs-patterns
+description: SolidJS reactivity + UI state patterns for OpenWork
+---
+
+## Why this skill exists
+
+OpenWork’s UI is SolidJS: it updates via **signals**, not React-style rerenders.
+Most “UI stuck” bugs are actually **state coupling** bugs (e.g. one global `busy()` disabling an unrelated action), not rerender issues.
+
+This skill captures the patterns we want to consistently use in OpenWork.
+
+## Core rules
+
+- Prefer **fine-grained signals** over shared global flags.
+- Keep async actions **scoped** (each action gets its own `pending` state).
+- Derive UI state via `createMemo()` instead of duplicating booleans.
+- Avoid mutating arrays/objects stored in signals; always create new values.
+
+## Scoped async actions (recommended)
+
+When an operation can overlap with others (permissions, installs, background refresh), don’t reuse a global `busy()`.
+
+Use a dedicated signal per action:
+
+```ts
+const [replying, setReplying] = createSignal(false);
+
+async function respond() {
+  if (replying()) return;
+  setReplying(true);
+  try {
+    await doTheThing();
+  } finally {
+    setReplying(false);
+  }
+}
+```
+
+### Why
+
+A single `busy()` boolean creates deadlocks:
+
+- Long-running task sets `busy(true)`
+- A permission prompt appears and its buttons are disabled by `busy()`
+- The task can’t continue until permission is answered
+- The user can’t answer because buttons are disabled
+
+Fix: permission UI must be disabled only by a **permission-specific** pending state.
+
+## Signal snapshots in async handlers
+
+If you read signals inside an async function and you need stable values, snapshot early:
+
+```ts
+const request = activePermission();
+if (!request) return;
+const requestID = request.id;
+
+await respondPermission(requestID, "always");
+```
+
+## Derived UI state
+
+Prefer `createMemo()` for computed disabled states:
+
+```ts
+const canSend = createMemo(() => prompt().trim().length > 0 && !busy());
+```
+
+## Lists
+
+- Use setter callbacks for derived updates:
+
+```ts
+setItems((current) => current.filter((x) => x.id !== id));
+```
+
+- Don’t mutate `current` in-place.
+
+## Practical checklist (SolidJS UI changes)
+
+- Does any button depend on a global flag that could be true during long-running work?
+- Could two async actions overlap and fight over one boolean?
+- Is any UI state duplicated (can be derived instead)?
+- Do event handlers read signals after an `await` where values might have changed?
+
+## References
+
+- SolidJS: https://www.solidjs.com/docs/latest
+- SolidJS signals: https://www.solidjs.com/docs/latest/api#createsignal
+- SolidJS memos: https://www.solidjs.com/docs/latest/api#creatememo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,14 @@ Key primitives to expose:
 | Interaction latency | <100ms |
 | Bundle size (JS) | <200KB gzipped |
 
+## Skill: SolidJS Patterns
+
+When editing SolidJS UI (`src/**/*.tsx`), consult:
+
+- `.opencode/skill/solidjs-patterns/SKILL.md`
+
+This captures OpenWork’s preferred reactivity + UI state patterns (avoid global `busy()` deadlocks; use scoped async state).
+
 ## Skill: Trigger a Release
 
 OpenWork releases are built by GitHub Actions (`Release App`) and publish signed + notarized macOS DMGs to the GitHub Release for a tag.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -544,6 +544,7 @@ export default function App() {
     Array<{ id: string; content: string; status: string; priority: string }>
   >([]);
   const [pendingPermissions, setPendingPermissions] = createSignal<PendingPermission[]>([]);
+  const [permissionReplyBusy, setPermissionReplyBusy] = createSignal(false);
 
   const [prompt, setPrompt] = createSignal("");
   const [lastPromptSent, setLastPromptSent] = createSignal("");
@@ -1361,9 +1362,9 @@ export default function App() {
 
   async function respondPermission(requestID: string, reply: "once" | "always" | "reject") {
     const c = client();
-    if (!c) return;
+    if (!c || permissionReplyBusy()) return;
 
-    setBusy(true);
+    setPermissionReplyBusy(true);
     setError(null);
 
     try {
@@ -1372,7 +1373,7 @@ export default function App() {
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unknown error");
     } finally {
-      setBusy(false);
+      setPermissionReplyBusy(false);
     }
   }
 
@@ -3453,7 +3454,7 @@ export default function App() {
                       variant="outline"
                       class="w-full border-red-500/20 text-red-400 hover:bg-red-950/30"
                       onClick={() => respondPermission(activePermission()!.id, "reject")}
-                      disabled={busy()}
+                      disabled={permissionReplyBusy()}
                     >
                       Deny
                     </Button>
@@ -3462,7 +3463,7 @@ export default function App() {
                         variant="secondary"
                         class="text-xs"
                         onClick={() => respondPermission(activePermission()!.id, "once")}
-                        disabled={busy()}
+                        disabled={permissionReplyBusy()}
                       >
                         Once
                       </Button>
@@ -3470,7 +3471,7 @@ export default function App() {
                         variant="primary"
                         class="text-xs font-bold bg-amber-500 hover:bg-amber-400 text-black border-none shadow-amber-500/20"
                         onClick={() => respondPermission(activePermission()!.id, "always")}
-                        disabled={busy()}
+                        disabled={permissionReplyBusy()}
                       >
                         Allow
                       </Button>


### PR DESCRIPTION
## Summary
- Fixes a deadlock where permission prompt buttons were disabled while `busy()` (e.g. during long-running `session.prompt()`), preventing users from replying and leaving runs stuck.
- Uses a permission-scoped pending signal (`permissionReplyBusy`) so only the permission buttons disable while the reply is in-flight.
- Adds a `solidjs-patterns` skill and wires it into `AGENTS.md` to document preferred SolidJS UI state patterns (avoid global busy coupling).

## Testing
- `pnpm typecheck`