### PR TITLE
feat: streaming, thinking controls, engine source

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2014,7 +2014,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openwork"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/components/PartView.tsx
+++ b/src/components/PartView.tsx
@@ -5,6 +5,7 @@ import type { Part } from "@opencode-ai/sdk/v2/client";
 type Props = {
   part: Part;
   developerMode?: boolean;
+  showThinking?: boolean;
   tone?: "light" | "dark";
 };
 
@@ -55,6 +56,7 @@ export default function PartView(props: Props) {
   const p = () => props.part;
   const developerMode = () => props.developerMode ?? false;
   const tone = () => props.tone ?? "light";
+  const showThinking = () => props.showThinking ?? true;
 
   const textClass = () => (tone() === "dark" ? "text-black" : "text-neutral-100");
   const subtleTextClass = () => (tone() === "dark" ? "text-black/70" : "text-neutral-400");
@@ -67,9 +69,16 @@ export default function PartView(props: Props) {
       </Match>
 
       <Match when={p().type === "reasoning"}>
-        <Show when={developerMode() && typeof (p() as any).text === "string" && (p() as any).text.trim()}>
+        <Show
+          when={
+            showThinking() &&
+            developerMode() &&
+            typeof (p() as any).text === "string" &&
+            (p() as any).text.trim()
+          }
+        >
           <details class={`rounded-lg ${panelBgClass()} p-2`.trim()}>
-            <summary class={`cursor-pointer text-xs ${subtleTextClass()}`.trim()}>Reasoning</summary>
+            <summary class={`cursor-pointer text-xs ${subtleTextClass()}`.trim()}>Thinking</summary>
             <pre
               class={`mt-2 whitespace-pre-wrap break-words text-xs ${
                 tone() === "dark" ? "text-black" : "text-neutral-200"

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -18,8 +18,14 @@ export type EngineDoctorResult = {
   notes: string[];
 };
 
-export async function engineStart(projectDir: string): Promise<EngineInfo> {
-  return invoke<EngineInfo>("engine_start", { projectDir });
+export async function engineStart(
+  projectDir: string,
+  options?: { preferSidecar?: boolean },
+): Promise<EngineInfo> {
+  return invoke<EngineInfo>("engine_start", {
+    projectDir,
+    preferSidecar: options?.preferSidecar ?? false,
+  });
 }
 
 export async function engineStop(): Promise<EngineInfo> {


### PR DESCRIPTION
## Summary
- Switch prompt sending to `session.promptAsync()` so the UI is driven by SSE `message.part.updated` events (fixes the "answer pops in" UX).
- Add streaming-safe placeholder messages so part updates render immediately.
- Replace hardcoded Zen-only model list with dynamic `config.providers()` model picker so existing local providers/models show up.
- Add settings for Thinking visibility (dev-only), model variant, and engine source selection (PATH vs Sidecar).

## Notes
- Sidecar mode is a foundation only: it prefers a bundled binary if present and otherwise falls back to PATH.
- Engine resolution now supports `OPENCODE_BIN_PATH` override.

## Test Plan
- `pnpm -C apps/openwork typecheck`
- `pnpm -C apps/openwork test:events`
- Manual: run OpenWork, send a prompt, watch the assistant bubble stream.