### PR TITLE
fix: build updater artifacts in release workflow

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -29,9 +29,9 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            args: "--target aarch64-apple-darwin --bundles dmg"
+            args: "--target aarch64-apple-darwin --bundles dmg,updater"
           - target: x86_64-apple-darwin
-            args: "--target x86_64-apple-darwin --bundles dmg"
+            args: "--target x86_64-apple-darwin --bundles dmg,updater"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Release job was failing in the  step because we were only building , so no updater  artifacts existed.

This updates the matrix args to build both DMG and updater bundles: .