### PR TITLE
fix: provide updater key password and rotate pubkey

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -93,6 +93,7 @@ jobs:
 
           # Tauri updater signing
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
           # macOS signing (maps from existing repo secrets)
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmluaWduIHB1YmxpYyBrZXk6IDQ0OTZCOTU4MzI2OEQ0MEIKUldRTDFHZ3lXTG1XUkNPazcxdGpTcTQ4OGJrOFB3TGVKdXNCSHRicXd5bVdsZUh5djhxd2tIMW0K",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUwNDdCNTAwMTcxNUUxQTQKUldTazRSVVhBTFZIVUpNRi9OQnNRaElZY1NUWUQxS1ZJOTFUeUdPd2d6ZnFmMW5QV2xJQ1hXTTkK",
       "endpoints": ["https://github.com/different-ai/openwork/releases/latest/download/latest.json"]
     }
   }


### PR DESCRIPTION
Release builds were failing to sign updater bundles because the updater private key is encrypted and the workflow did not provide .

This:
- Adds  env to the release workflow.
- Rotates the embedded updater  in  to match the updated signing key material.

Operational: repo secrets updated:  + .