### PR TITLE
fix: engine diagnostics + onboarding recovery

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -73,6 +73,8 @@ struct EngineState {
   hostname: Option<String>,
   port: Option<u16>,
   base_url: Option<String>,
+  last_stdout: Option<String>,
+  last_stderr: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -84,6 +86,8 @@ pub struct EngineInfo {
   pub hostname: Option<String>,
   pub port: Option<u16>,
   pub pid: Option<u32>,
+  pub last_stdout: Option<String>,
+  pub last_stderr: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -95,6 +99,9 @@ pub struct EngineDoctorResult {
   pub version: Option<String>,
   pub supports_serve: bool,
   pub notes: Vec<String>,
+  pub serve_help_status: Option<i32>,
+  pub serve_help_stdout: Option<String>,
+  pub serve_help_stderr: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -204,15 +211,38 @@ fn opencode_version(program: &OsStr) -> Option<String> {
   None
 }
 
-fn opencode_supports_serve(program: &OsStr) -> bool {
-  Command::new(program)
-    .arg("serve")
-    .arg("--help")
-    .stdout(Stdio::null())
-    .stderr(Stdio::null())
-    .status()
-    .map(|s| s.success())
-    .unwrap_or(false)
+fn truncate_output(input: &str, max_chars: usize) -> String {
+  if input.len() <= max_chars {
+    return input.to_string();
+  }
+
+  // Keep tail to preserve error context.
+  input.chars().skip(input.chars().count() - max_chars).collect()
+}
+
+fn opencode_serve_help(program: &OsStr) -> (bool, Option<i32>, Option<String>, Option<String>) {
+  match Command::new(program).arg("serve").arg("--help").output() {
+    Ok(output) => {
+      let status = output.status.code();
+      let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+      let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+      let ok = output.status.success();
+
+      let stdout = if stdout.is_empty() {
+        None
+      } else {
+        Some(truncate_output(&stdout, 4000))
+      };
+      let stderr = if stderr.is_empty() {
+        None
+      } else {
+        Some(truncate_output(&stderr, 4000))
+      };
+
+      (ok, status, stdout, stderr)
+    }
+    Err(_) => (false, None, None, None),
+  }
 }
 
 fn resolve_opencode_executable() -> (Option<PathBuf>, bool, Vec<String>) {
@@ -394,6 +424,8 @@ impl EngineManager {
       hostname: state.hostname.clone(),
       port: state.port,
       pid,
+      last_stdout: state.last_stdout.clone(),
+      last_stderr: state.last_stderr.clone(),
     }
   }
 
@@ -406,6 +438,8 @@ impl EngineManager {
     state.project_dir = None;
     state.hostname = None;
     state.port = None;
+    state.last_stdout = None;
+    state.last_stderr = None;
   }
 }
 
@@ -422,17 +456,60 @@ fn engine_stop(manager: State<EngineManager>) -> EngineInfo {
   EngineManager::snapshot_locked(&mut state)
 }
 
-#[tauri::command]
-fn engine_doctor() -> EngineDoctorResult {
-  let (resolved, in_path, notes) = resolve_opencode_executable();
+fn resolve_sidecar_candidate(prefer_sidecar: bool) -> (Option<PathBuf>, Vec<String>) {
+  if !prefer_sidecar {
+    return (None, Vec::new());
+  }
 
-  let (version, supports_serve) = match resolved.as_ref() {
-    Some(path) => (
-      opencode_version(path.as_os_str()),
-      opencode_supports_serve(path.as_os_str()),
-    ),
-    None => (None, false),
+  let mut notes = Vec::new();
+
+  #[cfg(not(windows))]
+  {
+    // Best-effort: if we eventually bundle a binary, it will likely live here (dev) or be
+    // injected during bundling.
+    let candidate = PathBuf::from("src-tauri/sidecars").join(OPENCODE_EXECUTABLE);
+    if candidate.is_file() {
+      notes.push(format!("Using bundled sidecar: {}", candidate.display()));
+      return (Some(candidate), notes);
+    }
+
+    notes.push(format!("Sidecar requested but missing: {}", candidate.display()));
+    return (None, notes);
+  }
+
+  #[cfg(windows)]
+  {
+    notes.push("Sidecar requested but unsupported on Windows".to_string());
+    (None, notes)
+  }
+}
+
+#[tauri::command]
+fn engine_doctor(prefer_sidecar: Option<bool>) -> EngineDoctorResult {
+  let prefer_sidecar = prefer_sidecar.unwrap_or(false);
+
+  let (sidecar, mut notes) = resolve_sidecar_candidate(prefer_sidecar);
+  let (resolved, in_path, more_notes) = match sidecar {
+    Some(path) => (Some(path), false, Vec::new()),
+    None => resolve_opencode_executable(),
   };
+
+  notes.extend(more_notes);
+
+  let (version, supports_serve, serve_help_status, serve_help_stdout, serve_help_stderr) =
+    match resolved.as_ref() {
+      Some(path) => {
+        let (ok, status, stdout, stderr) = opencode_serve_help(path.as_os_str());
+        (
+          opencode_version(path.as_os_str()),
+          ok,
+          status,
+          stdout,
+          stderr,
+        )
+      }
+      None => (None, false, None, None, None),
+    };
 
   EngineDoctorResult {
     found: resolved.is_some(),
@@ -441,6 +518,9 @@ fn engine_doctor() -> EngineDoctorResult {
     version,
     supports_serve,
     notes,
+    serve_help_status,
+    serve_help_stdout,
+    serve_help_stderr,
   }
 }
 
@@ -501,30 +581,10 @@ fn engine_start(
 
   let mut notes = Vec::new();
 
-  let resolved_sidecar = if prefer_sidecar.unwrap_or(false) {
-    #[cfg(not(windows))]
-    {
-      // Best-effort: if we eventually bundle a binary, it will likely live here.
-      let candidate = PathBuf::from("src-tauri/sidecars").join(OPENCODE_EXECUTABLE);
-      if candidate.is_file() {
-        notes.push(format!("Using bundled sidecar: {}", candidate.display()));
-        Some(candidate)
-      } else {
-        notes.push(format!(
-          "Sidecar requested but missing: {}",
-          candidate.display()
-        ));
-        None
-      }
-    }
-    #[cfg(windows)]
-    {
-      notes.push("Sidecar requested but unsupported on Windows".to_string());
-      None
-    }
-  } else {
-    None
-  };
+  let (resolved_sidecar, mut sidecar_notes) =
+    resolve_sidecar_candidate(prefer_sidecar.unwrap_or(false));
+
+  notes.append(&mut sidecar_notes);
 
   let (program, _in_path, more_notes) = match resolved_sidecar {
     Some(path) => (Some(path), false, Vec::new()),
@@ -555,8 +615,8 @@ fn engine_start(
     .arg("http://tauri.localhost")
     .current_dir(&project_dir)
     .stdin(Stdio::null())
-    .stdout(Stdio::null())
-    .stderr(Stdio::null());
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped());
 
   // Best-effort: restore env parity with terminal installs.
   // If the GUI process doesn't have XDG_* vars but the user's OpenCode auth/config lives under
@@ -581,9 +641,16 @@ fn engine_start(
   // Tag requests and logs to make debugging easier.
   command.env("OPENCODE_CLIENT", "openwork");
 
+  // Inherit the current environment (Command already does) but also pass through an explicit
+  // marker for UI-driven launches so we can key off it in engine logs.
+  command.env("OPENWORK", "1");
+
   let child = command
     .spawn()
     .map_err(|e| format!("Failed to start opencode: {e}"))?;
+
+  state.last_stdout = None;
+  state.last_stderr = None;
 
   state.child = Some(child);
   state.project_dir = Some(project_dir);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -7,6 +7,8 @@ export type EngineInfo = {
   hostname: string | null;
   port: number | null;
   pid: number | null;
+  lastStdout: string | null;
+  lastStderr: string | null;
 };
 
 export type EngineDoctorResult = {
@@ -16,6 +18,9 @@ export type EngineDoctorResult = {
   version: string | null;
   supportsServe: boolean;
   notes: string[];
+  serveHelpStatus: number | null;
+  serveHelpStdout: string | null;
+  serveHelpStderr: string | null;
 };
 
 export async function engineStart(
@@ -36,8 +41,12 @@ export async function engineInfo(): Promise<EngineInfo> {
   return invoke<EngineInfo>("engine_info");
 }
 
-export async function engineDoctor(): Promise<EngineDoctorResult> {
-  return invoke<EngineDoctorResult>("engine_doctor");
+export async function engineDoctor(options?: {
+  preferSidecar?: boolean;
+}): Promise<EngineDoctorResult> {
+  return invoke<EngineDoctorResult>("engine_doctor", {
+    preferSidecar: options?.preferSidecar ?? false,
+  });
 }
 
 export async function pickDirectory(options?: {


### PR DESCRIPTION
## What
- Adds richer engine diagnostics in Host onboarding (sidecar-aware `engine_doctor`, captures `serve --help` status/stdout/stderr).
- Lets users proceed even when `supportsServe` is false (attempt start; show debug details when it fails).
- Enables a discreet Developer Mode unlock during onboarding (7 taps on the Host title) and exposes engine source + diagnostics there.

## Why
Users can get stuck in onboarding with the generic error `opencode serve unavailable` and have no way to inspect which binary was resolved or why. This makes Host-mode setup fragile, especially when GUI PATH differs from terminal PATH.

## Notes
- `engine_doctor` now accepts `preferSidecar` so it checks the same binary `engine_start` will use.
- The onboarding "Confirm & Start Engine" button is now only hard-disabled when the CLI is missing (not when serve support is uncertain).