### PR TITLE
feat(settings): add reset onboarding actions

### DIFF
--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -220,3 +220,7 @@ export async function writeOpencodeConfig(
 ): Promise<ExecResult> {
   return invoke<ExecResult>("write_opencode_config", { scope, projectDir, content });
 }
+
+export async function resetOpenworkState(mode: "onboarding" | "all"): Promise<void> {
+  return invoke<void>("reset_openwork_state", { mode });
+}


### PR DESCRIPTION
## Summary
- Add Settings -> Advanced actions to reset onboarding or all local OpenWork state (requires typing RESET).
- Add Tauri command `reset_openwork_state` to clear app cache and optionally app data, then relaunch.

## Why
Retesting onboarding currently requires manually deleting macOS app data/WebView storage. This makes it a one-click, safe, scoped reset flow for devs (and power users) while blocking resets during active runs.

## How to Test
1) Run OpenWork desktop (`pnpm dev`).
2) Navigate to Settings -> Advanced.
3) Click "Reset onboarding"; type `RESET`; confirm.
4) App relaunches and onboarding should appear fresh.
5) Repeat with "Reset app data" for a more aggressive reset.