### PR TITLE
refactor: extract app helpers and modals

### DIFF
--- a/src/app/plugins.ts
+++ b/src/app/plugins.ts
@@ -1,0 +1,93 @@
+import { parse } from "jsonc-parser";
+
+import type { OpencodeConfigFile } from "../lib/tauri";
+
+type PluginListValue = string | string[] | null | undefined;
+
+type PluginConfig = {
+  content: string | null;
+} | null;
+
+export function normalizePluginList(value: PluginListValue) {
+  if (!value) return [] as string[];
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter((entry) => entry.length > 0);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  return [] as string[];
+}
+
+export function stripPluginVersion(spec: string) {
+  const trimmed = spec.trim();
+  if (!trimmed) return "";
+
+  const looksLikeVersion = (suffix: string) =>
+    /^(latest|next|beta|alpha|canary|rc|stable|\d)/i.test(suffix);
+
+  if (trimmed.startsWith("@")) {
+    const slashIndex = trimmed.indexOf("/");
+    if (slashIndex === -1) return trimmed;
+
+    const atIndex = trimmed.indexOf("@", slashIndex + 1);
+    if (atIndex === -1) return trimmed;
+
+    const suffix = trimmed.slice(atIndex + 1);
+    return looksLikeVersion(suffix) ? trimmed.slice(0, atIndex) : trimmed;
+  }
+
+  const atIndex = trimmed.indexOf("@");
+  if (atIndex === -1) return trimmed;
+
+  const suffix = trimmed.slice(atIndex + 1);
+  return looksLikeVersion(suffix) ? trimmed.slice(0, atIndex) : trimmed;
+}
+
+export function isPluginInstalled(pluginList: string[], pluginName: string, aliases: string[] = []) {
+  const normalized = pluginList.flatMap((entry) => {
+    const raw = entry.toLowerCase();
+    const stripped = stripPluginVersion(entry).toLowerCase();
+    return stripped && stripped !== raw ? [raw, stripped] : [raw];
+  });
+
+  const list = new Set(normalized);
+  return [pluginName, ...aliases].some((entry) => list.has(entry.toLowerCase()));
+}
+
+export function loadPluginsFromConfig(
+  config: PluginConfig,
+  onList: (next: string[]) => void,
+  onError: (message: string) => void,
+) {
+  if (!config?.content) {
+    onList([]);
+    return;
+  }
+
+  try {
+    const parsed = parse(config.content) as Record<string, unknown> | undefined;
+    const next = normalizePluginList(parsed?.plugin as PluginListValue);
+    onList(next);
+  } catch (e) {
+    onList([]);
+    onError(e instanceof Error ? e.message : "Failed to parse opencode.json");
+  }
+}
+
+export function parsePluginsFromConfig(config: OpencodeConfigFile | null) {
+  if (!config?.content) return [] as string[];
+  return parsePluginListFromContent(config.content);
+}
+
+export function parsePluginListFromContent(content: string) {
+  try {
+    const parsed = parse(content) as Record<string, unknown> | undefined;
+    return normalizePluginList(parsed?.plugin as PluginListValue);
+  } catch {
+    return [] as string[];
+  }
+}

--- a/src/app/templates.ts
+++ b/src/app/templates.ts
@@ -1,0 +1,46 @@
+import type { WorkspaceTemplate } from "./types";
+
+type TemplateDraft = {
+  title: string;
+  description: string;
+  prompt: string;
+  scope: "workspace" | "global";
+};
+
+type TemplateDraftSetters = {
+  setTitle: (value: string) => void;
+  setDescription: (value: string) => void;
+  setPrompt: (value: string) => void;
+  setScope: (value: "workspace" | "global") => void;
+};
+
+export function resetTemplateDraft(setters: TemplateDraftSetters, scope: "workspace" | "global" = "workspace") {
+  setters.setTitle("");
+  setters.setDescription("");
+  setters.setPrompt("");
+  setters.setScope(scope);
+}
+
+export function buildTemplateDraft(params: {
+  seedTitle?: string;
+  seedPrompt?: string;
+  scope?: "workspace" | "global";
+}): TemplateDraft {
+  return {
+    title: params.seedTitle ?? "",
+    description: "",
+    prompt: params.seedPrompt ?? "",
+    scope: params.scope ?? "workspace",
+  };
+}
+
+export function createTemplateRecord(draft: TemplateDraft): WorkspaceTemplate {
+  return {
+    id: `tmpl_${Date.now()}`,
+    title: draft.title,
+    description: draft.description,
+    prompt: draft.prompt,
+    createdAt: Date.now(),
+    scope: draft.scope,
+  };
+}

--- a/src/app/updater.ts
+++ b/src/app/updater.ts
@@ -1,0 +1,39 @@
+import { createSignal } from "solid-js";
+
+import type { UpdateHandle } from "./types";
+import type { UpdaterEnvironment } from "../lib/tauri";
+
+export type UpdateStatus =
+  | { state: "idle"; lastCheckedAt: number | null }
+  | { state: "checking"; startedAt: number }
+  | { state: "available"; lastCheckedAt: number; version: string; date?: string; notes?: string }
+  | {
+      state: "downloading";
+      lastCheckedAt: number;
+      version: string;
+      totalBytes: number | null;
+      downloadedBytes: number;
+      notes?: string;
+    }
+  | { state: "ready"; lastCheckedAt: number; version: string; notes?: string }
+  | { state: "error"; lastCheckedAt: number | null; message: string };
+
+export type PendingUpdate = { update: UpdateHandle; version: string; notes?: string } | null;
+
+export function createUpdaterState() {
+  const [updateAutoCheck, setUpdateAutoCheck] = createSignal(true);
+  const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>({ state: "idle", lastCheckedAt: null });
+  const [pendingUpdate, setPendingUpdate] = createSignal<PendingUpdate>(null);
+  const [updateEnv, setUpdateEnv] = createSignal<UpdaterEnvironment | null>(null);
+
+  return {
+    updateAutoCheck,
+    setUpdateAutoCheck,
+    updateStatus,
+    setUpdateStatus,
+    pendingUpdate,
+    setPendingUpdate,
+    updateEnv,
+    setUpdateEnv,
+  } as const;
+}

--- a/src/components/ModelPickerModal.tsx
+++ b/src/components/ModelPickerModal.tsx
@@ -1,0 +1,122 @@
+import { For, Show } from "solid-js";
+
+import { CheckCircle2, Circle, Search, X } from "lucide-solid";
+
+import Button from "./Button";
+import { modelEquals } from "../app/utils";
+import type { ModelOption, ModelRef } from "../app/types";
+
+export type ModelPickerModalProps = {
+  open: boolean;
+  options: ModelOption[];
+  filteredOptions: ModelOption[];
+  query: string;
+  setQuery: (value: string) => void;
+  target: "default" | "session";
+  current: ModelRef;
+  onSelect: (model: ModelRef) => void;
+  onClose: () => void;
+};
+
+export default function ModelPickerModal(props: ModelPickerModalProps) {
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-start justify-center p-4 overflow-y-auto">
+        <div class="bg-zinc-900 border border-zinc-800/70 w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden max-h-[calc(100vh-2rem)] flex flex-col">
+          <div class="p-6 flex flex-col min-h-0">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h3 class="text-lg font-semibold text-white">
+                  {props.target === "default" ? "Default model" : "Model"}
+                </h3>
+                <p class="text-sm text-zinc-400 mt-1">
+                  Choose from your configured providers. This selection {props.target === "default"
+                    ? "will be used for new sessions"
+                    : "applies to your next message"}.
+                </p>
+              </div>
+              <Button variant="ghost" class="!p-2 rounded-full" onClick={props.onClose}>
+                <X size={16} />
+              </Button>
+            </div>
+
+            <div class="mt-5">
+              <div class="relative">
+                <Search size={16} class="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500" />
+                <input
+                  type="text"
+                  value={props.query}
+                  onInput={(e) => props.setQuery(e.currentTarget.value)}
+                  placeholder="Search models…"
+                  class="w-full bg-zinc-950/40 border border-zinc-800 rounded-xl py-2.5 pl-9 pr-3 text-sm text-zinc-100 placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600"
+                />
+              </div>
+              <Show when={props.query.trim()}>
+                <div class="mt-2 text-xs text-zinc-500">
+                  Showing {props.filteredOptions.length} of {props.options.length}
+                </div>
+              </Show>
+            </div>
+
+            <div class="mt-4 space-y-2 overflow-y-auto pr-1 -mr-1 min-h-0">
+              <For each={props.filteredOptions}>
+                {(opt) => {
+                  const active = () =>
+                    modelEquals(props.current, {
+                      providerID: opt.providerID,
+                      modelID: opt.modelID,
+                    });
+
+                  return (
+                    <button
+                      class={`w-full text-left rounded-2xl border px-4 py-3 transition-colors ${
+                        active()
+                          ? "border-white/20 bg-white/5"
+                          : "border-zinc-800/70 bg-zinc-950/40 hover:bg-zinc-950/60"
+                      }`}
+                      onClick={() =>
+                        props.onSelect({
+                          providerID: opt.providerID,
+                          modelID: opt.modelID,
+                        })
+                      }
+                    >
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                          <div class="text-sm font-medium text-zinc-100 flex items-center gap-2">
+                            <span class="truncate">{opt.title}</span>
+                          </div>
+                          <Show when={opt.description}>
+                            <div class="text-xs text-zinc-500 mt-1 truncate">{opt.description}</div>
+                          </Show>
+                          <Show when={opt.footer}>
+                            <div class="text-[11px] text-zinc-600 mt-2">{opt.footer}</div>
+                          </Show>
+                          <div class="text-[11px] text-zinc-600 font-mono mt-2">
+                            {opt.providerID}/{opt.modelID}
+                          </div>
+                        </div>
+
+                        <div class="pt-0.5 text-zinc-500">
+                          <Show when={active()} fallback={<Circle size={14} />}>
+                            <CheckCircle2 size={14} class="text-emerald-400" />
+                          </Show>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                }}
+              </For>
+            </div>
+
+            <div class="mt-5 flex justify-end shrink-0">
+              <Button variant="outline" onClick={props.onClose}>
+                Done
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/src/components/ResetModal.tsx
+++ b/src/components/ResetModal.tsx
@@ -1,0 +1,84 @@
+import { Match, Show, Switch } from "solid-js";
+
+import { X } from "lucide-solid";
+
+import Button from "./Button";
+import TextInput from "./TextInput";
+
+export type ResetModalProps = {
+  open: boolean;
+  mode: "onboarding" | "all";
+  text: string;
+  busy: boolean;
+  canReset: boolean;
+  hasActiveRuns: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  onTextChange: (value: string) => void;
+};
+
+export default function ResetModal(props: ResetModalProps) {
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4">
+        <div class="bg-zinc-900 border border-zinc-800/70 w-full max-w-xl rounded-2xl shadow-2xl overflow-hidden">
+          <div class="p-6">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h3 class="text-lg font-semibold text-white">
+                  <Switch>
+                    <Match when={props.mode === "onboarding"}>Reset onboarding</Match>
+                    <Match when={true}>Reset app data</Match>
+                  </Switch>
+                </h3>
+                <p class="text-sm text-zinc-400 mt-1">
+                  Type <span class="font-mono">RESET</span> to confirm. OpenWork will restart.
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                class="!p-2 rounded-full"
+                onClick={props.onClose}
+                disabled={props.busy}
+              >
+                <X size={16} />
+              </Button>
+            </div>
+
+            <div class="mt-6 space-y-4">
+              <div class="rounded-xl bg-black/20 border border-zinc-800 p-3 text-xs text-zinc-400">
+                <Switch>
+                  <Match when={props.mode === "onboarding"}>
+                    Clears OpenWork local preferences and workspace onboarding markers.
+                  </Match>
+                  <Match when={true}>Clears OpenWork cache and app data on this device.</Match>
+                </Switch>
+              </div>
+
+              <Show when={props.hasActiveRuns}>
+                <div class="text-xs text-red-300">Stop active runs before resetting.</div>
+              </Show>
+
+              <TextInput
+                label="Confirmation"
+                placeholder="Type RESET"
+                value={props.text}
+                onInput={(e) => props.onTextChange(e.currentTarget.value)}
+                disabled={props.busy}
+              />
+            </div>
+
+            <div class="mt-6 flex justify-end gap-2">
+              <Button variant="outline" onClick={props.onClose} disabled={props.busy}>
+                Cancel
+              </Button>
+              <Button variant="danger" onClick={props.onConfirm} disabled={!props.canReset}>
+                Reset & Restart
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/src/components/TemplateModal.tsx
+++ b/src/components/TemplateModal.tsx
@@ -1,0 +1,101 @@
+import { Show } from "solid-js";
+
+import { X } from "lucide-solid";
+
+import Button from "./Button";
+import TextInput from "./TextInput";
+
+export type TemplateModalProps = {
+  open: boolean;
+  title: string;
+  description: string;
+  prompt: string;
+  scope: "workspace" | "global";
+  onClose: () => void;
+  onSave: () => void;
+  onTitleChange: (value: string) => void;
+  onDescriptionChange: (value: string) => void;
+  onPromptChange: (value: string) => void;
+  onScopeChange: (value: "workspace" | "global") => void;
+};
+
+export default function TemplateModal(props: TemplateModalProps) {
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4">
+        <div class="bg-zinc-900 border border-zinc-800/70 w-full max-w-xl rounded-2xl shadow-2xl overflow-hidden">
+          <div class="p-6">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h3 class="text-lg font-semibold text-white">Save Template</h3>
+                <p class="text-sm text-zinc-400 mt-1">Reuse a workflow with one tap.</p>
+              </div>
+              <Button variant="ghost" class="!p-2 rounded-full" onClick={props.onClose}>
+                <X size={16} />
+              </Button>
+            </div>
+
+            <div class="mt-6 space-y-4">
+              <TextInput
+                label="Title"
+                value={props.title}
+                onInput={(e) => props.onTitleChange(e.currentTarget.value)}
+                placeholder="e.g. Daily standup summary"
+              />
+
+              <TextInput
+                label="Description (optional)"
+                value={props.description}
+                onInput={(e) => props.onDescriptionChange(e.currentTarget.value)}
+                placeholder="What does this template do?"
+              />
+
+              <div class="grid grid-cols-2 gap-2">
+                <button
+                  class={`px-3 py-2 rounded-xl border text-sm transition-colors ${
+                    props.scope === "workspace"
+                      ? "bg-white/10 text-white border-white/20"
+                      : "text-zinc-400 border-zinc-800 hover:text-white"
+                  }`}
+                  onClick={() => props.onScopeChange("workspace")}
+                  type="button"
+                >
+                  Workspace
+                </button>
+                <button
+                  class={`px-3 py-2 rounded-xl border text-sm transition-colors ${
+                    props.scope === "global"
+                      ? "bg-white/10 text-white border-white/20"
+                      : "text-zinc-400 border-zinc-800 hover:text-white"
+                  }`}
+                  onClick={() => props.onScopeChange("global")}
+                  type="button"
+                >
+                  Global
+                </button>
+              </div>
+
+              <label class="block">
+                <div class="mb-1 text-xs font-medium text-neutral-300">Prompt</div>
+                <textarea
+                  class="w-full min-h-40 rounded-xl bg-neutral-900/60 px-3 py-2 text-sm text-neutral-100 placeholder:text-neutral-500 shadow-[0_0_0_1px_rgba(255,255,255,0.08)] focus:outline-none focus:ring-2 focus:ring-white/20"
+                  value={props.prompt}
+                  onInput={(e) => props.onPromptChange(e.currentTarget.value)}
+                  placeholder="Write the instructions you want to reuse…"
+                />
+                <div class="mt-1 text-xs text-neutral-500">This becomes the first user message.</div>
+              </label>
+            </div>
+
+            <div class="mt-6 flex justify-end gap-2">
+              <Button variant="outline" onClick={props.onClose}>
+                Cancel
+              </Button>
+              <Button onClick={props.onSave}>Save</Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -60,6 +60,7 @@ export type DashboardViewProps = {
   setTemplateDraftPrompt: (value: string) => void;
   setTemplateDraftScope: (value: "workspace" | "global") => void;
   openTemplateModal: () => void;
+  resetTemplateDraft?: (scope?: "workspace" | "global") => void;
   runTemplate: (template: WorkspaceTemplate) => void;
   deleteTemplate: (templateId: string) => void;
   refreshSkills: () => void;
@@ -287,10 +288,17 @@ export default function DashboardView(props: DashboardViewProps) {
               <Button
                 variant="secondary"
                 onClick={() => {
-                  props.setTemplateDraftTitle("");
-                  props.setTemplateDraftDescription("");
-                  props.setTemplateDraftPrompt("");
-                  props.openTemplateModal();
+                    const reset = props.resetTemplateDraft;
+                    if (reset) {
+                      reset("workspace");
+                    } else {
+                      props.setTemplateDraftTitle("");
+                      props.setTemplateDraftDescription("");
+                      props.setTemplateDraftPrompt("");
+                      props.setTemplateDraftScope("workspace");
+                    }
+                    props.openTemplateModal();
+
                 }}
                 disabled={props.busy}
               >
@@ -472,10 +480,15 @@ export default function DashboardView(props: DashboardViewProps) {
                   <Button
                     variant="secondary"
                     onClick={() => {
-                      props.setTemplateDraftTitle("");
-                      props.setTemplateDraftDescription("");
-                      props.setTemplateDraftPrompt("");
-                      props.setTemplateDraftScope("workspace");
+                      const reset = props.resetTemplateDraft;
+                      if (reset) {
+                        reset("workspace");
+                      } else {
+                        props.setTemplateDraftTitle("");
+                        props.setTemplateDraftDescription("");
+                        props.setTemplateDraftPrompt("");
+                        props.setTemplateDraftScope("workspace");
+                      }
                       props.openTemplateModal();
                     }}
                     disabled={props.busy}


### PR DESCRIPTION
## Summary
- extract plugin/template/updater helpers into app modules and wire App state to use them
- move model picker, reset, and template modals into dedicated components
- reuse template draft reset helper for dashboard entry points

## Testing
- not run (not requested)