### PR TITLE
fix: improve Windows OpenCode discovery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1013,7 +1013,7 @@ export default function App() {
       if (!result.found) {
         setError(
           isWindowsPlatform()
-            ? "OpenCode CLI not found. Install OpenCode for Windows, then restart OpenWork. If it is installed, ensure `opencode.exe` is on PATH (try `opencode --version` in PowerShell)."
+            ? "OpenCode CLI not found. Install with one of these, then restart OpenWork: choco install opencode, scoop install extras/opencode, or npm install -g opencode-ai. If it is installed, ensure `opencode.exe` or `opencode.cmd` is on PATH (try `opencode --version` in PowerShell)."
             : "OpenCode CLI not found. Install with `brew install anomalyco/tap/opencode` or `curl -fsSL https://opencode.ai/install | bash`, then retry.",
         );
         return false;

--- a/src/views/OnboardingView.tsx
+++ b/src/views/OnboardingView.tsx
@@ -1,6 +1,6 @@
 import { For, Match, Show, Switch } from "solid-js";
 import type { Mode, OnboardingStep } from "../app/types";
-import { isTauriRuntime } from "../app/utils";
+import { isTauriRuntime, isWindowsPlatform } from "../app/utils";
 import { ArrowLeftRight, CheckCircle2, Circle, Trash2 } from "lucide-solid";
 
 import Button from "../components/Button";
@@ -199,7 +199,18 @@ export default function OnboardingView(props: OnboardingViewProps) {
 
                   <Show when={props.engineDoctorFound === false}>
                     <div class="mt-4 space-y-2">
-                      <div class="text-xs text-zinc-500">Install OpenCode from https://opencode.ai/install</div>
+                      <div class="text-xs text-zinc-500">
+                        {isWindowsPlatform()
+                          ? "Install OpenCode with one of the commands below, then restart OpenWork."
+                          : "Install OpenCode from https://opencode.ai/install"}
+                      </div>
+                      <Show when={isWindowsPlatform()}>
+                        <div class="text-xs text-zinc-500 space-y-1 font-mono">
+                          <div>choco install opencode</div>
+                          <div>scoop install extras/opencode</div>
+                          <div>npm install -g opencode-ai</div>
+                        </div>
+                      </Show>
                       <div class="flex gap-2 pt-2">
                         <Button onClick={props.onInstallEngine} disabled={props.busy}>
                           Install OpenCode


### PR DESCRIPTION
## Summary
- expand Windows CLI discovery paths and handle .cmd shims
- detect early engine failures and capture stderr
- add Windows install guidance copy in onboarding and error messaging