### PR TITLE
Polish session and onboarding UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -822,7 +822,7 @@ export default function App() {
         }
       }
 
-      await refreshPlugins().catch(() => undefined);
+      await refreshPlugins("project").catch(() => undefined);
       await refreshSkills().catch(() => undefined);
 
       clearReloadRequired();
@@ -1293,6 +1293,7 @@ export default function App() {
     activeWorkspacePath: workspaceStore.activeWorkspacePath(),
     localHostLabel: localHostLabel(),
     engineRunning: Boolean(engine()?.running),
+    developerMode: developerMode(),
     engineBaseUrl: engine()?.baseUrl ?? null,
     engineDoctorFound: engineDoctorResult()?.found ?? null,
     engineDoctorSupportsServe: engineDoctorResult()?.supportsServe ?? null,
@@ -1461,7 +1462,7 @@ export default function App() {
             <DashboardView {...dashboardProps()} />
           </Match>
           <Match when={view() === "session"}>
-            <SessionView
+             <SessionView
                 selectedSessionId={selectedSessionId()}
                 setView={setView}
                 setTab={setTab}
@@ -1470,7 +1471,13 @@ export default function App() {
                 setWorkspacePickerOpen={workspaceStore.setWorkspacePickerOpen}
                 headerStatus={headerStatus()}
                 busyHint={busyHint()}
+                selectedSessionModelLabel={selectedSessionModelLabel()}
+                openSessionModelPicker={openSessionModelPicker}
+                activePlugins={sidebarPluginList()}
+                activePluginStatus={sidebarPluginStatus()}
+
                 createSessionAndOpen={createSessionAndOpen}
+
                 sendPromptAsync={sendPrompt}
                 newTaskDisabled={newTaskDisabled()}
                 sessions={sessions().map((session) => ({

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -249,7 +249,9 @@ export default function DashboardView(props: DashboardViewProps) {
               }}
             />
             <h1 class="text-lg font-medium">{title()}</h1>
-            <span class="text-xs text-zinc-600">{props.headerStatus}</span>
+            <Show when={props.developerMode}>
+              <span class="text-xs text-zinc-600">{props.headerStatus}</span>
+            </Show>
             <Show when={props.busyHint}>
               <span class="text-xs text-zinc-500">{props.busyHint}</span>
             </Show>
@@ -265,6 +267,7 @@ export default function DashboardView(props: DashboardViewProps) {
                 New Task
               </Button>
             </Show>
+
             <Show when={props.tab === "templates"}>
               <Button
                 variant="secondary"
@@ -287,9 +290,6 @@ export default function DashboardView(props: DashboardViewProps) {
                 New
               </Button>
             </Show>
-            <Button variant="ghost" onClick={props.toggleDeveloperMode}>
-              <Shield size={16} />
-            </Button>
           </div>
         </header>
 

--- a/src/views/OnboardingView.tsx
+++ b/src/views/OnboardingView.tsx
@@ -1,7 +1,7 @@
 import { For, Match, Show, Switch } from "solid-js";
 import type { Mode, OnboardingStep } from "../app/types";
 import { isTauriRuntime, isWindowsPlatform } from "../app/utils";
-import { ArrowLeftRight, CheckCircle2, Circle, Trash2 } from "lucide-solid";
+import { ArrowLeftRight, CheckCircle2, Circle, ChevronDown } from "lucide-solid";
 
 import Button from "../components/Button";
 import OpenWorkLogo from "../components/OpenWorkLogo";
@@ -28,6 +28,7 @@ export type OnboardingViewProps = {
   engineDoctorCheckedAt: number | null;
   engineInstallLogs: string | null;
   error: string | null;
+  developerMode: boolean;
   onBaseUrlChange: (value: string) => void;
   onClientDirectoryChange: (value: string) => void;
   onModeSelect: (mode: Mode) => void;
@@ -63,11 +64,14 @@ export default function OnboardingView(props: OnboardingViewProps) {
             </div>
             <div class="text-center">
               <h2 class="text-xl font-medium mb-2">
-                {props.mode === "host" ? "Starting OpenCode Engine..." : "Searching for Host..."}
+                {props.mode === "host" ? "Starting OpenWork..." : "Searching for Host..."}
               </h2>
               <p class="text-zinc-500 text-sm">
-                {props.mode === "host" ? `Initializing ${props.localHostLabel}` : "Verifying secure handshake"}
+                {props.mode === "host"
+                  ? "Getting everything ready"
+                  : "Verifying secure handshake"}
               </p>
+
             </div>
           </div>
         </div>
@@ -88,164 +92,166 @@ export default function OnboardingView(props: OnboardingViewProps) {
               </p>
             </div>
 
-            <div class="space-y-4">
-              <div class="bg-zinc-900/30 border border-zinc-800/60 rounded-2xl p-5 space-y-3">
-                <div class="text-xs font-semibold text-zinc-500 uppercase tracking-wider">Workspace</div>
-
-                <div class="space-y-2">
-                  <div class="text-sm font-medium text-white">Starter Workspace</div>
-                  <div class="text-xs text-zinc-500">
-                    OpenWork will create a ready-to-run folder and start OpenCode inside it.
-                  </div>
-                  <div class="text-xs text-zinc-600 font-mono break-all">
-                    {props.activeWorkspacePath || "(initializing...)"}
-                  </div>
-                </div>
-
-                <div class="pt-3 border-t border-zinc-800/60 space-y-2">
-                  <div class="text-xs font-semibold text-zinc-500 uppercase tracking-wider">What you get</div>
-                  <div class="space-y-2">
-                    <div class="flex items-center gap-3 text-sm text-zinc-300">
-                      <div class="w-2 h-2 rounded-full bg-emerald-500" />
-                      Scheduler plugin (workspace-scoped)
-                    </div>
-                    <div class="flex items-center gap-3 text-sm text-zinc-300">
-                      <div class="w-2 h-2 rounded-full bg-emerald-500" />
-                      Starter templates ("Understand this workspace", etc.)
-                    </div>
-                    <div class="flex items-center gap-3 text-sm text-zinc-300">
-                      <div class="w-2 h-2 rounded-full bg-emerald-500" />
-                      You can add more folders when prompted
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <Button onClick={props.onStartHost} disabled={props.busy || !props.activeWorkspacePath.trim()} class="w-full py-3 text-base">
-                Start Engine
-              </Button>
-
-              <div class="text-xs text-zinc-600">
-                Authorized folders live in <span class="font-mono">.opencode/openwork.json</span> and can be updated here anytime.
-              </div>
-
-              <div class="space-y-3">
-                <div class="flex gap-2">
-                  <input
-                    class="w-full bg-zinc-900/50 border border-zinc-800 rounded-xl px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
-                    placeholder="Add folder path"
-                    value={props.newAuthorizedDir}
-                    onInput={(e) => props.onSetAuthorizedDir(e.currentTarget.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        props.onAddAuthorizedDir();
-                      }
-                    }}
-                  />
-                  <Show when={isTauriRuntime()}>
-                    <Button variant="outline" onClick={props.onAddAuthorizedDirFromPicker} disabled={props.busy}>
-                      Pick
-                    </Button>
-                  </Show>
-                  <Button variant="secondary" onClick={props.onAddAuthorizedDir} disabled={!props.newAuthorizedDir.trim()}>
-                    Add
-                  </Button>
-                </div>
-
-                <Show when={props.authorizedDirs.length}>
-                  <div class="space-y-2">
-                    <For each={props.authorizedDirs}>
-                      {(dir, idx) => (
-                        <div class="flex items-center justify-between gap-3 rounded-xl bg-black/20 border border-zinc-800 px-3 py-2">
-                          <div class="min-w-0 text-xs font-mono text-zinc-300 truncate">{dir}</div>
-                            <Button
-                              variant="ghost"
-                              class="!p-2 rounded-lg"
-                              onClick={() => props.onRemoveAuthorizedDir(idx())}
-                              disabled={props.busy}
-                              title="Remove"
-                            >
-                              <Trash2 size={14} />
-                            </Button>
-                        </div>
-                      )}
-                    </For>
-                  </div>
-                </Show>
-              </div>
-
-              <Show when={isTauriRuntime()}>
-                <div class="rounded-2xl bg-zinc-900/40 border border-zinc-800 p-4">
-                  <div class="flex items-start justify-between gap-4">
-                    <div class="min-w-0">
-                      <div class="text-sm font-medium text-white">OpenCode CLI</div>
-                      <div class="mt-1 text-xs text-zinc-500">
-                        <Show when={props.engineDoctorFound != null} fallback={<span>Checking install...</span>}>
-                          <Show when={props.engineDoctorFound} fallback={<span>Not found. Install to run Host mode.</span>}>
-                            <span class="font-mono">{props.engineDoctorVersion ?? "Installed"}</span>
-                            <Show when={props.engineDoctorResolvedPath}>
-                              <span class="text-zinc-600"> · </span>
-                              <span class="font-mono text-zinc-600 truncate">{props.engineDoctorResolvedPath}</span>
-                            </Show>
-                          </Show>
-                        </Show>
-                      </div>
-                    </div>
-
-                    <Button variant="secondary" onClick={props.onRefreshEngineDoctor} disabled={props.busy}>
-                      Re-check
-                    </Button>
+             <div class="space-y-4">
+               <div class="bg-zinc-900/30 border border-zinc-800/60 rounded-2xl p-5 space-y-3">
+                 <div class="text-xs font-semibold text-zinc-500 uppercase tracking-wider">Workspace</div>
+ 
+                 <div class="space-y-2">
+                   <div class="text-sm font-medium text-white">Starter Workspace</div>
+                   <div class="text-xs text-zinc-500">
+                     OpenWork will create a ready-to-run folder and start OpenCode inside it.
+                   </div>
+                  <div class={`text-xs ${props.developerMode ? "text-zinc-600 font-mono" : "text-zinc-500"} break-all`}>
+                    {props.developerMode ? props.activeWorkspacePath || "(initializing...)" : "A starter workspace will be created for you."}
                   </div>
 
-                  <Show when={props.engineDoctorFound === false}>
-                    <div class="mt-4 space-y-2">
-                      <div class="text-xs text-zinc-500">
-                        {isWindowsPlatform()
-                          ? "Install OpenCode with one of the commands below, then restart OpenWork."
-                          : "Install OpenCode from https://opencode.ai/install"}
-                      </div>
-                      <Show when={isWindowsPlatform()}>
-                        <div class="text-xs text-zinc-500 space-y-1 font-mono">
-                          <div>choco install opencode</div>
-                          <div>scoop install extras/opencode</div>
-                          <div>npm install -g opencode-ai</div>
-                        </div>
-                      </Show>
-                      <div class="flex gap-2 pt-2">
-                        <Button onClick={props.onInstallEngine} disabled={props.busy}>
-                          Install OpenCode
-                        </Button>
-                        <Button variant="outline" onClick={props.onShowSearchNotes} disabled={props.busy}>
-                          Show search notes
-                        </Button>
-                      </div>
-                    </div>
-                  </Show>
+                 </div>
+ 
+                 <div class="pt-3 border-t border-zinc-800/60 space-y-2">
+                   <div class="text-xs font-semibold text-zinc-500 uppercase tracking-wider">What you get</div>
+                   <div class="space-y-2">
+                     <div class="flex items-center gap-3 text-sm text-zinc-300">
+                       <div class="w-2 h-2 rounded-full bg-emerald-500" />
+                       Scheduler plugin (workspace-scoped)
+                     </div>
+                     <div class="flex items-center gap-3 text-sm text-zinc-300">
+                       <div class="w-2 h-2 rounded-full bg-emerald-500" />
+                       Starter templates ("Understand this workspace", etc.)
+                     </div>
+                     <div class="flex items-center gap-3 text-sm text-zinc-300">
+                       <div class="w-2 h-2 rounded-full bg-emerald-500" />
+                       You can add more folders when prompted
+                     </div>
+                   </div>
+                 </div>
+               </div>
+ 
+               <Button onClick={props.onStartHost} disabled={props.busy || !props.activeWorkspacePath.trim()} class="w-full py-3 text-base">
+                 Start Workspace
+               </Button>
+ 
+               <details class="rounded-2xl border border-zinc-800 bg-zinc-950/60 px-4 py-3">
+                 <summary class="flex items-center justify-between cursor-pointer text-xs text-zinc-500">
+                   Advanced settings
+                   <ChevronDown size={14} class="text-zinc-600" />
+                 </summary>
+                 <div class="pt-3 space-y-3">
+                   <div class="text-xs text-zinc-600">
+                     Authorized folders live in <span class="font-mono">.opencode/openwork.json</span> and can be updated here anytime.
+                   </div>
+ 
+                   <div class="space-y-3">
+                     <div class="flex gap-2">
+                       <input
+                         class="w-full bg-zinc-900/50 border border-zinc-800 rounded-xl px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+                         placeholder="Add folder path"
+                         value={props.newAuthorizedDir}
+                         onInput={(e) => props.onSetAuthorizedDir(e.currentTarget.value)}
+                         onKeyDown={(e) => {
+                           if (e.key === "Enter") {
+                             props.onAddAuthorizedDir();
+                           }
+                         }}
+                       />
+                       <Show when={isTauriRuntime()}>
+                         <Button variant="outline" onClick={props.onAddAuthorizedDirFromPicker} disabled={props.busy}>
+                           Pick
+                         </Button>
+                       </Show>
+                       <Button variant="secondary" onClick={props.onAddAuthorizedDir} disabled={!props.newAuthorizedDir.trim()}>
+                         Add
+                       </Button>
+                     </div>
+ 
+                     <Show when={props.authorizedDirs.length}>
+                       <div class="space-y-2">
+                         <For each={props.authorizedDirs}>
+                           {(dir, idx) => (
+                             <div class="flex items-center justify-between gap-3 rounded-xl bg-black/20 border border-zinc-800 px-3 py-2">
+                               <div class="min-w-0 text-xs font-mono text-zinc-300 truncate">{dir}</div>
+                               <Button
+                                 variant="ghost"
+                                 class="!p-2 rounded-lg text-xs text-zinc-400 hover:text-white"
+                                 onClick={() => props.onRemoveAuthorizedDir(idx())}
+                                 disabled={props.busy}
+                                 title="Remove"
+                               >
+                                 Remove
+                               </Button>
+                             </div>
+                           )}
+                         </For>
+                       </div>
+                     </Show>
+                   </div>
+ 
+                   <Show when={isTauriRuntime() && props.developerMode}>
+                     <div class="rounded-2xl bg-zinc-900/40 border border-zinc-800 p-4">
+                       <div class="flex items-start justify-between gap-4">
+                         <div class="min-w-0">
+                           <div class="text-sm font-medium text-white">OpenCode CLI</div>
+                           <div class="mt-1 text-xs text-zinc-500">
+                             <Show when={props.engineDoctorFound != null} fallback={<span>Checking install...</span>}>
+                               <Show when={props.engineDoctorFound} fallback={<span>Not found. Install to run Host mode.</span>}>
+                                 <span class="font-mono">{props.engineDoctorVersion ?? "Installed"}</span>
+                                 <Show when={props.engineDoctorResolvedPath}>
+                                   <span class="text-zinc-600"> · </span>
+                                   <span class="font-mono text-zinc-600 truncate">{props.engineDoctorResolvedPath}</span>
+                                 </Show>
+                               </Show>
+                             </Show>
+                           </div>
+                         </div>
+ 
+                         <Button variant="secondary" onClick={props.onRefreshEngineDoctor} disabled={props.busy}>
+                           Re-check
+                         </Button>
+                       </div>
+ 
+                       <Show when={props.engineDoctorFound === false}>
+                         <div class="mt-4 space-y-2">
+                           <div class="text-xs text-zinc-500">
+                             {isWindowsPlatform()
+                               ? "Install OpenCode with one of the commands below, then restart OpenWork."
+                               : "Install OpenCode from https://opencode.ai/install"}
+                           </div>
+                           <Show when={isWindowsPlatform()}>
+                             <div class="text-xs text-zinc-500 space-y-1 font-mono">
+                               <div>choco install opencode</div>
+                               <div>scoop install extras/opencode</div>
+                               <div>npm install -g opencode-ai</div>
+                             </div>
+                           </Show>
+                           <div class="flex gap-2 pt-2">
+                             <Button onClick={props.onInstallEngine} disabled={props.busy}>
+                               Install OpenCode
+                             </Button>
+                             <Button variant="outline" onClick={props.onShowSearchNotes} disabled={props.busy}>
+                               Show search notes
+                             </Button>
+                           </div>
+                         </div>
+                       </Show>
+ 
+                       <Show when={props.engineInstallLogs}>
+                         <pre class="mt-4 max-h-48 overflow-auto rounded-xl bg-black/50 border border-zinc-800 p-3 text-xs text-zinc-300 whitespace-pre-wrap">{props.engineInstallLogs}</pre>
+                       </Show>
+ 
+                       <Show when={props.engineDoctorCheckedAt}>
+                         <div class="mt-3 text-[11px] text-zinc-600">
+                           Last checked {props.engineDoctorCheckedAt ? new Date(props.engineDoctorCheckedAt).toLocaleTimeString() : ""}
+                         </div>
+                       </Show>
+                     </div>
+                   </Show>
+                 </div>
+               </details>
+ 
+               <Button variant="ghost" onClick={props.onBackToMode} disabled={props.busy} class="w-full">
+                 Back
+               </Button>
+             </div>
 
-                  <Show when={props.engineInstallLogs}>
-                    <pre class="mt-4 max-h-48 overflow-auto rounded-xl bg-black/50 border border-zinc-800 p-3 text-xs text-zinc-300 whitespace-pre-wrap">{props.engineInstallLogs}</pre>
-                  </Show>
-
-                  <Show when={props.engineDoctorCheckedAt}>
-                    <div class="mt-3 text-[11px] text-zinc-600">
-                      Last checked {props.engineDoctorCheckedAt ? new Date(props.engineDoctorCheckedAt).toLocaleTimeString() : ""}
-                    </div>
-                  </Show>
-                </div>
-              </Show>
-
-              <Button
-                onClick={props.onStartHost}
-                disabled={props.busy || !engineDoctorAvailable()}
-                class="w-full py-3 text-base"
-              >
-                Confirm & Start Engine
-              </Button>
-
-              <Button variant="ghost" onClick={props.onBackToMode} disabled={props.busy} class="w-full">
-                Back
-              </Button>
-            </div>
 
             <Show when={props.error}>
               <div class="rounded-2xl bg-red-950/40 px-5 py-4 text-sm text-red-200 border border-red-500/20">
@@ -328,14 +334,16 @@ export default function OnboardingView(props: OnboardingViewProps) {
                   <Circle size={18} class="text-indigo-400" />
                 </div>
                 <div>
-                  <h3 class="text-xl font-medium text-white mb-2">Start Host Engine</h3>
+                  <h3 class="text-xl font-medium text-white mb-2">Run on this computer</h3>
                   <p class="text-zinc-500 text-sm leading-relaxed mb-4">
-                    Run OpenCode locally. Best for your primary computer.
+                    OpenWork runs OpenCode locally and keeps your work private.
                   </p>
-                  <div class="flex items-center gap-2 text-xs font-mono text-indigo-400/80 bg-indigo-900/10 w-fit px-2 py-1 rounded border border-indigo-500/10">
-                    <div class="w-1.5 h-1.5 rounded-full bg-indigo-400 animate-pulse" />
-                    {props.localHostLabel}
-                  </div>
+                  <Show when={props.developerMode}>
+                    <div class="flex items-center gap-2 text-xs font-mono text-indigo-400/80 bg-indigo-900/10 w-fit px-2 py-1 rounded border border-indigo-500/10">
+                      <div class="w-1.5 h-1.5 rounded-full bg-indigo-400 animate-pulse" />
+                      {props.localHostLabel}
+                    </div>
+                  </Show>
                 </div>
               </button>
 
@@ -343,9 +351,11 @@ export default function OnboardingView(props: OnboardingViewProps) {
                 <div class="rounded-2xl bg-zinc-900/40 border border-zinc-800 p-5 flex items-center justify-between">
                   <div>
                     <div class="text-sm text-white font-medium">Engine already running</div>
-                    <div class="text-xs text-zinc-500 font-mono truncate max-w-[14rem] md:max-w-[22rem]">
-                      {props.engineBaseUrl}
-                    </div>
+                    <Show when={props.developerMode}>
+                      <div class="text-xs text-zinc-500 font-mono truncate max-w-[14rem] md:max-w-[22rem]">
+                        {props.engineBaseUrl}
+                      </div>
+                    </Show>
                   </div>
                   <Button variant="secondary" onClick={props.onAttachHost} disabled={props.busy}>
                     Attach
@@ -378,7 +388,7 @@ export default function OnboardingView(props: OnboardingViewProps) {
                   onClick={() => props.onModeSelect("client")}
                   class="text-zinc-600 hover:text-zinc-400 text-sm font-medium transition-colors flex items-center gap-2 px-4 py-2 rounded-lg hover:bg-zinc-900/50"
                 >
-                  Or connect as a Client (Remote Pairing)
+                  Connect as a Client (Remote Pairing)
                 </button>
               </div>
 
@@ -388,7 +398,9 @@ export default function OnboardingView(props: OnboardingViewProps) {
                 </div>
               </Show>
 
-              <div class="text-center text-xs text-zinc-700">{props.localHostLabel}</div>
+              <Show when={props.developerMode}>
+                <div class="text-center text-xs text-zinc-700">{props.localHostLabel}</div>
+              </Show>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- streamline session UI by removing duplicate workspace labels, de-techifying assistant output, and hiding connection status outside developer mode
- restore a lightweight model selector in the composer and add a human-readable active plugins section in the sidebar
- simplify onboarding with a single primary CTA, advanced settings accordion, and fewer technical details in default view

## Testing
- not run (UI-only changes)