### PR TITLE
Open welcome session after onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -721,6 +721,8 @@ export default function App() {
     loadWorkspaceTemplates,
     loadSessions,
     refreshPendingPermissions,
+    selectedSessionId,
+    selectSession,
     setSelectedSessionId,
     setMessages,
     setTodos,


### PR DESCRIPTION
## Summary
- open the newly created welcome session after first-time onboarding
- keep the dashboard fallback when no welcome session is created
- soften the welcome prompt to avoid CLI/path language