### PR TITLE
fix(ui): remove developer shield icon

### DIFF
--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -12,7 +12,7 @@ import PluginsView from "./PluginsView";
 import SettingsView from "./SettingsView";
 import SkillsView from "./SkillsView";
 import TemplatesView from "./TemplatesView";
-import { Command, Cpu, FileText, Package, Play, Plus, Shield, Smartphone } from "lucide-solid";
+import { Command, Cpu, FileText, Package, Play, Plus, Settings, Smartphone } from "lucide-solid";
 
 export type DashboardViewProps = {
   tab: DashboardTab;
@@ -203,7 +203,7 @@ export default function DashboardView(props: DashboardViewProps) {
             {navItem("templates", "Templates", <FileText size={18} />)}
             {navItem("skills", "Skills", <Package size={18} />)}
             {navItem("plugins", "Plugins", <Cpu size={18} />)}
-            {navItem("settings", "Settings", <Shield size={18} />)}
+            {navItem("settings", "Settings", <Settings size={18} />)}
           </nav>
         </div>
 
@@ -633,7 +633,7 @@ export default function DashboardView(props: DashboardViewProps) {
               }`}
               onClick={() => props.setTab("settings")}
             >
-              <Shield size={18} />
+              <Settings size={18} />
               Settings
             </button>
           </div>


### PR DESCRIPTION
## Summary
- replace the developer shield icon in the dashboard settings nav with the neutral settings icon
- keep developer mode access in Settings without exposing a dev-specific header affordance

## Testing
- not run (UI-only icon update)