### PR TITLE
Fix artifact open action

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@opencode-ai/sdk": "^1.1.19",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "~2.5.0",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-process": "~2.3.1",
     "@tauri-apps/plugin-updater": "~2.9.0",
     "jsonc-parser": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ~2.5.0
         version: 2.5.0
+      '@tauri-apps/plugin-opener':
+        specifier: ^2.5.3
+        version: 2.5.3
       '@tauri-apps/plugin-process':
         specifier: ~2.3.1
         version: 2.3.1
@@ -530,6 +533,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.5.0':
     resolution: {integrity: sha512-I0R0ygwRd9AN8Wj5GnzCogOlqu2+OWAtBd0zEC4+kQCI32fRowIyuhPCBoUv4h/lQt2bM39kHlxPHD5vDcFjiA==}
+
+  '@tauri-apps/plugin-opener@2.5.3':
+    resolution: {integrity: sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==}
 
   '@tauri-apps/plugin-process@2.3.1':
     resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
@@ -1387,6 +1393,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
 
   '@tauri-apps/plugin-dialog@2.5.0':
+    dependencies:
+      '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-opener@2.5.3':
     dependencies:
       '@tauri-apps/api': 2.9.1
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
+tauri-plugin-opener = "2.5.3"
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,8 @@
     "core:default",
     "dialog:allow-open",
     "updater:default",
-    "process:default"
+    "process:default",
+    "opener:allow-reveal-item-in-dir",
+    "opener:allow-open-path"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,7 +30,9 @@ use commands::workspace::{
 use engine::manager::EngineManager;
 
 pub fn run() {
-  let builder = tauri::Builder::default().plugin(tauri_plugin_dialog::init());
+  let builder = tauri::Builder::default()
+    .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_opener::init());
 
   #[cfg(desktop)]
   let builder = builder

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -400,6 +400,7 @@ export function deriveArtifacts(list: MessageWithParts[]): ArtifactItem[] {
         results.push({
           id,
           name,
+          path: match,
           kind: "file",
           size: state.size ? String(state.size) : undefined,
         });

--- a/src/views/SessionView.tsx
+++ b/src/views/SessionView.tsx
@@ -29,6 +29,7 @@ import Button from "../components/Button";
 import PartView from "../components/PartView";
 import ThinkingBlock, { type ThinkingStep } from "../components/ThinkingBlock";
 import WorkspaceChip from "../components/WorkspaceChip";
+import { isTauriRuntime, isWindowsPlatform } from "../app/utils";
 
 export type SessionViewProps = {
   selectedSessionId: string | null;
@@ -131,6 +132,51 @@ export default function SessionView(props: SessionViewProps) {
 
   const toggleSidebar = (key: "progress" | "artifacts" | "context") => {
     props.setExpandedSidebarSections((current) => ({ ...current, [key]: !current[key] }));
+  };
+
+  const artifactActionLabel = () => (isWindowsPlatform() ? "Open" : "Reveal");
+
+  const artifactActionToast = () => (isWindowsPlatform() ? "Opened in default app." : "Revealed in file manager.");
+
+  const resolveArtifactPath = (artifact: ArtifactItem) => {
+    const rawPath = artifact.path?.trim();
+    if (!rawPath) return null;
+    if (/^(?:[a-zA-Z]:[\\/]|~[\\/]|\//.test(rawPath)) {
+      return rawPath;
+    }
+
+    const root = props.activeWorkspaceDisplay.path?.trim();
+    if (!root) return rawPath;
+
+    const separator = root.includes("\\") ? "\\" : "/";
+    const trimmedRoot = root.replace(/[\\/]+$/, "");
+    const trimmedPath = rawPath.replace(/^[\\/]+/, "");
+    return `${trimmedRoot}${separator}${trimmedPath}`;
+  };
+
+  const handleOpenArtifact = async (artifact: ArtifactItem) => {
+    const resolvedPath = resolveArtifactPath(artifact);
+    if (!resolvedPath) {
+      setArtifactToast("Artifact path missing.");
+      return;
+    }
+
+    if (!isTauriRuntime()) {
+      setArtifactToast("Open is only available in the desktop app.");
+      return;
+    }
+
+    try {
+      const { openPath, revealItemInDir } = await import("@tauri-apps/plugin-opener");
+      if (isWindowsPlatform()) {
+        await openPath(resolvedPath);
+      } else {
+        await revealItemInDir(resolvedPath);
+      }
+      setArtifactToast(artifactActionToast());
+    } catch (error) {
+      setArtifactToast(error instanceof Error ? error.message : "Could not open artifact.");
+    }
   };
 
   return (
@@ -368,12 +414,8 @@ export default function SessionView(props: SessionViewProps) {
                         <div class="text-xs text-zinc-500">Document</div>
                       </div>
                     </div>
-                    <Button
-                      variant="outline"
-                      class="text-xs"
-                      onClick={() => setArtifactToast("Open isn't wired yet — I can hook this to reveal in Finder next.")}
-                    >
-                      Open
+                    <Button variant="outline" class="text-xs" onClick={() => handleOpenArtifact(artifact)}>
+                      {artifactActionLabel()}
                     </Button>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- wire artifact cards to reveal/open the generated file using the Tauri opener plugin
- persist artifact paths from tool output and resolve them against the active workspace
- enable opener permissions in the Tauri capability config

## Testing
- not run (UI change)