### PR TITLE
Fix onboarding workspace guide skill

### DIFF
--- a/.opencode/skill/opencode-primitives/SKILL.md
+++ b/.opencode/skill/opencode-primitives/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: opencode-primitives
+description: Reference OpenCode docs when implementing skills, plugins, MCPs, or config-driven behavior.
+---
+
+## Purpose
+Use this skill whenever OpenWork behavior is implemented directly on top of OpenCode primitives (skills, plugins, MCP servers, opencode.json config, tools/permissions). It anchors decisions to the official OpenCode documentation and keeps terminology consistent in the UI.
+
+## Doc Sources (Always cite when relevant)
+- Skills: https://opencode.ai/docs/skills
+- Plugins: https://opencode.ai/docs/plugins/
+- MCP servers: https://opencode.ai/docs/mcp-servers/
+- Config (opencode.json, locations, precedence): https://opencode.ai/docs/config/
+
+## Key Facts To Apply
+### Skills
+- Skill files live in `.opencode/skills/<name>/SKILL.md` or global `~/.config/opencode/skills/<name>/SKILL.md`.
+- Skills are discovered by walking up to the git worktree and loading any matching `skills/*/SKILL.md` in `.opencode/` or `.claude/skills/`.
+- `SKILL.md` requires YAML frontmatter: `name` + `description`.
+- Name rules: lowercase alphanumeric with single hyphens (`^[a-z0-9]+(-[a-z0-9]+)*$`), length 1-64, must match directory name.
+- Description length: 1-1024 characters.
+- Access is governed by `opencode.json` permissions (`permission.skill` allow/deny/ask).
+
+### Plugins
+- Local plugins live in `.opencode/plugins/` (project) or `~/.config/opencode/plugins/` (global).
+- npm plugins are listed in `opencode.json` under `plugin` and installed with Bun at startup.
+- Load order: global config, project config, global plugins dir, project plugins dir.
+
+### MCP Servers
+- MCP servers are defined in `opencode.json` under `mcp` with unique names.
+- Local servers use `type: "local"` + `command` array; remote servers use `type: "remote"` + `url`.
+- Servers can be enabled/disabled via `enabled`.
+- MCP tools are managed via `tools` in config, including glob patterns.
+- OAuth is handled automatically for remote servers; can be pre-registered or disabled.
+
+### Config (opencode.json)
+- Supports JSON and JSONC.
+- Precedence order: remote `.well-known/opencode` -> global `~/.config/opencode/opencode.json` -> custom path -> project `opencode.json` -> `.opencode/` directories -> inline env overrides.
+- `.opencode` subdirectories are plural by default (`agents/`, `commands/`, `plugins/`, `skills/`, `tools/`, `themes/`), with singular names supported for compatibility.
+
+## When to Invoke
+- Adding or adjusting OpenWork flows that reference skills, plugins, MCP servers, or OpenCode config.
+- Designing onboarding guidance that mentions skill/plugin installation, config locations, or permission prompts.
+- Implementing UIs that surface OpenCode primitives (skills tab, plugin manager, MCP toggles).
+
+## Usage
+Call `skill({ name: "opencode-primitives" })` before implementing or documenting any OpenWork behavior that maps to OpenCode primitives.

--- a/src-tauri/src/workspace/files.rs
+++ b/src-tauri/src/workspace/files.rs
@@ -35,7 +35,7 @@ pub fn sanitize_template_id(raw: &str) -> Option<String> {
 }
 
 fn seed_workspace_guide(skill_root: &PathBuf) -> Result<(), String> {
-  let guide_dir = skill_root.join("workspace_guide");
+  let guide_dir = skill_root.join("workspace-guide");
   if guide_dir.exists() {
     return Ok(());
   }
@@ -43,24 +43,53 @@ fn seed_workspace_guide(skill_root: &PathBuf) -> Result<(), String> {
   fs::create_dir_all(&guide_dir)
     .map_err(|e| format!("Failed to create {}: {e}", guide_dir.display()))?;
 
-  let doc = r#"# Workspace Guide
+  let doc = r#"---
+name: workspace-guide
+description: Workspace guide to introduce OpenWork and onboard new users.
+---
 
-This workspace is a real folder with local configuration.
+# Welcome to OpenWork
 
-## What lives where
+Hi, I\'m Ben and this is OpenWork. It\'s an open-source alternative to Claude\'s cowork. It helps you work on your files with AI and automate the mundane tasks so you don\'t have to.
 
-- Workspace plugins: `opencode.json`
-- Workspace skills: `.opencode/skill/*`
-- Workspace templates: `.openwork/templates/*.json`
-- OpenWork workspace metadata: `.opencode/openwork.json`
+Before we start, use the question tool to ask:
+"Are you more technical or non-technical? I\'ll tailor the explanation."
 
-## What to try
+## If the person is non-technical
+OpenWork feels like a chat app, but it can safely work with the files you allow. Put files in this workspace and I can summarize them, create new ones, or help organize them.
 
-- Run the template **Understand this workspace**
-- Install a skill from the Skills tab
-- Add a plugin in the Plugins tab
+Try:
+- "Summarize the files in this workspace."
+- "Create a checklist for my week."
+- "Draft a short summary from this document."
 
-Be concise and practical."#;
+## Skills and plugins (simple)
+Skills add new capabilities. Plugins add advanced features like scheduling or browser automation. We can add them later when you\'re ready.
+
+## If the person is technical
+OpenWork is a GUI for OpenCode. Everything that works in OpenCode works here.
+
+Most reliable setup today:
+1) Install OpenCode from opencode.ai
+2) Configure providers there (models and API keys)
+3) Come back to OpenWork and start a session
+
+Skills:
+- Install from the Skills tab, or add them to this workspace.
+- Docs: https://opencode.ai/docs/skills
+
+Plugins:
+- Configure in opencode.json or use the Plugins tab.
+- Docs: https://opencode.ai/docs/plugins/
+
+MCP servers:
+- Add external tools via opencode.json.
+- Docs: https://opencode.ai/docs/mcp-servers/
+
+Config reference:
+- Docs: https://opencode.ai/docs/config/
+
+End with two friendly next actions to try in OpenWork."#;
 
   fs::write(guide_dir.join("SKILL.md"), doc)
     .map_err(|e| format!("Failed to write SKILL.md: {e}"))?;

--- a/src/app/extensions.ts
+++ b/src/app/extensions.ts
@@ -39,7 +39,7 @@ export function createExtensionsStore(options: {
   const [packageSearch, setPackageSearch] = createSignal("");
 
   const skillDocFallbacks: Record<string, string> = {
-    workspace_guide: "Starter workspace guide. Explains what lives in this workspace and what to try next.",
+    "workspace-guide": "Workspace guide that introduces OpenWork and suggests first steps.",
   };
   const failedSkillDocs = new Set<string>();
   const skillDocKey = (root: string, name: string) => `${root}::${name}`;

--- a/src/app/workspace.ts
+++ b/src/app/workspace.ts
@@ -263,7 +263,7 @@ export function createWorkspaceStore(options: {
                 {
                   type: "text",
                   text:
-                    "Load the `workspace_guide` skill from this workspace and give a short, welcoming overview of what lives here (skills, plugins, templates) versus what's global. Avoid CLI language or raw file paths. Then suggest two friendly next actions to try inside OpenWork.",
+                    "Give a short, welcoming overview of this workspace and how to use OpenWork. If a workspace guide skill is available, use it. Avoid CLI language or raw file paths. End with two friendly next actions to try inside OpenWork.",
                 },
               ],
             });


### PR DESCRIPTION
## Summary
- seed a valid workspace guide skill with onboarding copy and doc links
- avoid hard-coded skill name in the welcome prompt
- update skill fallback copy for the new workspace guide name
