### PR TITLE
Fix workspace modal stays open after creating workspace

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import { getVersion } from "@tauri-apps/api/app";
 import ModelPickerModal from "./components/ModelPickerModal";
 import ResetModal from "./components/ResetModal";
 import TemplateModal from "./components/TemplateModal";
+import WorkspacePicker from "./components/WorkspacePicker";
+import CreateWorkspaceModal from "./components/CreateWorkspaceModal";
 import OnboardingView from "./views/OnboardingView";
 import DashboardView from "./views/DashboardView";
 import SessionView from "./views/SessionView";
@@ -1890,6 +1892,23 @@ export default function App() {
         onDescriptionChange={setTemplateDraftDescription}
         onPromptChange={setTemplateDraftPrompt}
         onScopeChange={setTemplateDraftScope}
+      />
+
+      <WorkspacePicker
+        open={workspaceStore.workspacePickerOpen()}
+        workspaces={workspaceStore.filteredWorkspaces()}
+        activeWorkspaceId={workspaceStore.activeWorkspaceId()}
+        search={workspaceStore.workspaceSearch()}
+        onSearch={workspaceStore.setWorkspaceSearch}
+        onClose={() => workspaceStore.setWorkspacePickerOpen(false)}
+        onSelect={workspaceStore.activateWorkspace}
+        onCreateNew={() => workspaceStore.setCreateWorkspaceOpen(true)}
+      />
+
+      <CreateWorkspaceModal
+        open={workspaceStore.createWorkspaceOpen()}
+        onClose={() => workspaceStore.setCreateWorkspaceOpen(false)}
+        onConfirm={(preset) => workspaceStore.createWorkspaceFlow(preset)}
       />
     </>
   );

--- a/src/app/workspace.ts
+++ b/src/app/workspace.ts
@@ -315,11 +315,15 @@ export function createWorkspaceStore(options: {
       return;
     }
 
+    // Close the modal immediately when confirming - folder picker will appear
+    setCreateWorkspaceOpen(false);
+
     try {
       const selection = await pickDirectory({ title: "Choose workspace folder" });
       const folder =
         typeof selection === "string" ? selection : Array.isArray(selection) ? selection[0] : null;
 
+      // User cancelled folder selection
       if (!folder) return;
 
       options.setBusy(true);
@@ -340,7 +344,6 @@ export function createWorkspaceStore(options: {
       }
 
       setWorkspacePickerOpen(false);
-      setCreateWorkspaceOpen(false);
       options.setView("dashboard");
       options.setTab("home");
     } catch (e) {

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -4,10 +4,8 @@ import type { WorkspaceInfo } from "../lib/tauri";
 import { formatRelativeTime } from "../app/utils";
 
 import Button from "../components/Button";
-import CreateWorkspaceModal from "../components/CreateWorkspaceModal";
 import OpenWorkLogo from "../components/OpenWorkLogo";
 import WorkspaceChip from "../components/WorkspaceChip";
-import WorkspacePicker from "../components/WorkspacePicker";
 import PluginsView from "./PluginsView";
 import SettingsView from "./SettingsView";
 import SkillsView from "./SkillsView";
@@ -562,23 +560,6 @@ export default function DashboardView(props: DashboardViewProps) {
             </div>
           </div>
         </Show>
-
-        <WorkspacePicker
-          open={props.workspacePickerOpen}
-          workspaces={props.filteredWorkspaces}
-          activeWorkspaceId={props.activeWorkspaceId}
-          search={props.workspaceSearch}
-          onSearch={props.setWorkspaceSearch}
-          onClose={() => props.setWorkspacePickerOpen(false)}
-          onSelect={props.activateWorkspace}
-          onCreateNew={() => props.setCreateWorkspaceOpen(true)}
-        />
-
-        <CreateWorkspaceModal
-          open={props.createWorkspaceOpen}
-          onClose={() => props.setCreateWorkspaceOpen(false)}
-          onConfirm={(preset) => props.createWorkspaceFlow(preset)}
-        />
 
         <nav class="md:hidden fixed bottom-0 left-0 right-0 border-t border-zinc-800 bg-zinc-950/90 backdrop-blur-md">
           <div class="mx-auto max-w-5xl px-4 py-3 grid grid-cols-6 gap-2">


### PR DESCRIPTION
## Summary

Fixes #76 - The Create Workspace modal now closes immediately when the user clicks "Create Workspace", before the folder picker appears.

## Changes

- **Move modals to app level**: WorkspacePicker and CreateWorkspaceModal are now rendered at the App.tsx level instead of inside DashboardView
- **Close modal on confirm**: The CreateWorkspaceModal closes immediately when user clicks Create, so the folder picker isn't blocked by the overlay
- **Enable workspace switching from session view**: Since modals are now at the app level, clicking the workspace chip in SessionView now properly opens the workspace picker

## Testing

1. Click "New Workspace" from the workspace picker
2. Select a preset and click "Create Workspace"
3. The modal should close immediately and the folder picker should appear
4. After selecting a folder, the workspace should be created
5. The workspace picker should also work when opened from within a session