### PR TITLE
Fix updater JSON action input

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -281,4 +281,4 @@ jobs:
           tauriScript: pnpm exec tauri -vvv
           args: ${{ matrix.args }}
           retryAttempts: 3
-          uploadUpdaterJson: true
+          includeUpdaterJson: true


### PR DESCRIPTION
## Summary
- switch tauri-action input to `includeUpdaterJson`, matching the supported key list