### PR TITLE
Pick workspace folder first

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1908,7 +1908,8 @@ export default function App() {
       <CreateWorkspaceModal
         open={workspaceStore.createWorkspaceOpen()}
         onClose={() => workspaceStore.setCreateWorkspaceOpen(false)}
-        onConfirm={(preset) => workspaceStore.createWorkspaceFlow(preset)}
+        onPickFolder={workspaceStore.pickWorkspaceFolder}
+        onConfirm={(preset, folder) => workspaceStore.createWorkspaceFlow(preset, folder)}
       />
     </>
   );

--- a/src/components/CreateWorkspaceModal.tsx
+++ b/src/components/CreateWorkspaceModal.tsx
@@ -7,9 +7,11 @@ import Button from "./Button";
 export default function CreateWorkspaceModal(props: {
   open: boolean;
   onClose: () => void;
-  onConfirm: (preset: "starter" | "automation" | "minimal") => void;
+  onConfirm: (preset: "starter" | "automation" | "minimal", folder: string | null) => void;
+  onPickFolder: () => Promise<string | null>;
 }) {
   const [preset, setPreset] = createSignal<"starter" | "automation" | "minimal">("starter");
+  const [selectedFolder, setSelectedFolder] = createSignal<string | null>(null);
 
   const options = () => [
     {
@@ -28,6 +30,26 @@ export default function CreateWorkspaceModal(props: {
       desc: "Empty project. Adds only core config.",
     },
   ];
+
+  const folderLabel = () => {
+    const folder = selectedFolder();
+    if (!folder) return "Choose a folder";
+    const parts = folder.replace(/\\/g, "/").split("/").filter(Boolean);
+    return parts[parts.length - 1] ?? folder;
+  };
+
+  const folderSubLabel = () => {
+    const folder = selectedFolder();
+    if (!folder) return "You will choose a directory next.";
+    return folder;
+  };
+
+  const handlePickFolder = async () => {
+    const next = await props.onPickFolder();
+    if (next) {
+      setSelectedFolder(next);
+    }
+  };
 
   return (
     <Show when={props.open}>
@@ -52,12 +74,20 @@ export default function CreateWorkspaceModal(props: {
                 Select Folder
               </div>
               <div class="ml-9">
-                <div class="w-full border border-dashed border-zinc-700 bg-zinc-900/50 rounded-xl p-4 text-left">
-                  <div class="flex items-center gap-3 text-zinc-400">
-                    <FolderPlus size={20} />
-                    <span class="text-sm">You will choose a directory next.</span>
+                <button
+                  type="button"
+                  onClick={handlePickFolder}
+                  class="w-full border border-dashed border-zinc-700 bg-zinc-900/50 rounded-xl p-4 text-left transition hover:border-zinc-500"
+                >
+                  <div class="flex items-center gap-3 text-zinc-200">
+                    <FolderPlus size={20} class="text-zinc-400" />
+                    <div class="flex-1 min-w-0">
+                      <div class="text-sm font-medium text-zinc-100 truncate">{folderLabel()}</div>
+                      <div class="text-xs text-zinc-500 font-mono truncate mt-1">{folderSubLabel()}</div>
+                    </div>
+                    <span class="text-xs text-zinc-500">Change</span>
                   </div>
-                </div>
+                </button>
               </div>
             </div>
 
@@ -68,16 +98,19 @@ export default function CreateWorkspaceModal(props: {
                 </div>
                 Choose Preset
               </div>
-              <div class="ml-9 grid gap-3">
+              <div class={`ml-9 grid gap-3 ${!selectedFolder() ? "opacity-50" : ""}`.trim()}>
                 <For each={options()}>
                   {(opt) => (
                     <div
-                      onClick={() => setPreset(opt.id)}
+                      onClick={() => {
+                        if (!selectedFolder()) return;
+                        setPreset(opt.id);
+                      }}
                       class={`p-4 rounded-xl border cursor-pointer transition-all ${
                         preset() === opt.id
                           ? "bg-indigo-500/10 border-indigo-500/50"
                           : "bg-zinc-900 border-zinc-800 hover:border-zinc-700"
-                      }`}
+                      } ${!selectedFolder() ? "pointer-events-none" : ""}`.trim()}
                     >
                       <div class="flex justify-between items-start">
                         <div>
@@ -105,7 +138,13 @@ export default function CreateWorkspaceModal(props: {
             <Button variant="ghost" onClick={props.onClose}>
               Cancel
             </Button>
-            <Button onClick={() => props.onConfirm(preset())}>Create Workspace</Button>
+            <Button
+              onClick={() => props.onConfirm(preset(), selectedFolder())}
+              disabled={!selectedFolder()}
+              title={!selectedFolder() ? "Choose a folder to continue." : undefined}
+            >
+              Create Workspace
+            </Button>
           </div>
         </div>
       </div>

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -37,7 +37,8 @@ export type DashboardViewProps = {
   activateWorkspace: (id: string) => void;
   createWorkspaceOpen: boolean;
   setCreateWorkspaceOpen: (open: boolean) => void;
-  createWorkspaceFlow: (preset: "starter" | "automation" | "minimal") => void;
+  createWorkspaceFlow: (preset: "starter" | "automation" | "minimal", folder: string | null) => void;
+  pickWorkspaceFolder: () => Promise<string | null>;
   sessions: Array<{ id: string; slug?: string | null; title: string; time: { updated: number }; directory?: string | null }>;
   sessionStatusById: Record<string, string>;
   activeWorkspaceRoot: string;


### PR DESCRIPTION
## Summary
- let users pick a folder at step 1 in the workspace modal
- require a selected folder before preset selection and creation
- separate folder picking from workspace creation flow
