### PR TITLE
test: expand e2e coverage and cache repair

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,49 @@
+name: OpenWork Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  openwork-tests:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-14]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Install OpenCode CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://opencode.ai/install | bash
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
+      - name: Verify OpenCode
+        run: opencode --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run e2e tests
+        run: pnpm test:e2e

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:events": "node scripts/events.mjs",
     "test:todos": "node scripts/todos.mjs",
     "test:permissions": "node scripts/permissions.mjs",
-    "test:e2e": "node scripts/e2e.mjs"
+    "test:session-switch": "node scripts/session-switch.mjs",
+    "test:fs-engine": "node scripts/fs-engine.mjs",
+    "test:e2e": "node scripts/e2e.mjs && node scripts/session-switch.mjs && node scripts/fs-engine.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.1.19",

--- a/scripts/_util.mjs
+++ b/scripts/_util.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import net from "node:net";
-import { realpathSync } from "node:fs";
+import { realpathSync, statSync } from "node:fs";
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
@@ -152,4 +152,13 @@ export function parseArgs(argv) {
     args.set(key, value);
   }
   return args;
+}
+
+export function canWriteWorkspace(directory) {
+  try {
+    const stat = statSync(directory);
+    return stat && stat.isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/scripts/fs-engine.mjs
+++ b/scripts/fs-engine.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  findFreePort,
+  makeClient,
+  parseArgs,
+  spawnOpencodeServe,
+  waitForHealthy,
+} from "./_util.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const directory = args.get("dir") ?? process.cwd();
+
+const port = await findFreePort();
+const server = await spawnOpencodeServe({ directory, port });
+
+try {
+  const client = makeClient({ baseUrl: server.baseUrl, directory: server.cwd });
+  await waitForHealthy(client);
+
+  const root = ".openwork/test-engine";
+  const nestedDir = path.join(root, "nested");
+  const filePath = path.join(root, "hello.txt");
+
+  await mkdir(path.join(directory, nestedDir), { recursive: true });
+  await writeFile(path.join(directory, filePath), "openwork engine test\n", "utf8");
+
+  const entries = await client.file.list({ directory, path: root });
+  assert.ok(entries.some((entry) => entry.name === "nested" && entry.type === "directory"));
+  assert.ok(entries.some((entry) => entry.name === "hello.txt" && entry.type === "file"));
+
+  const read = await client.file.read({ directory, path: filePath });
+  assert.equal(read.type, "text");
+  assert.ok(read.content.includes("openwork engine test"));
+
+  await rm(path.join(directory, root), { recursive: true, force: true });
+
+  console.log(
+    JSON.stringify({
+      ok: true,
+      baseUrl: server.baseUrl,
+      directory: server.cwd,
+      root,
+    }),
+  );
+} catch (e) {
+  const message = e instanceof Error ? e.message : String(e);
+  console.error(JSON.stringify({ ok: false, error: message, stderr: server.getStderr() }));
+  process.exitCode = 1;
+} finally {
+  await server.close();
+}

--- a/scripts/session-switch.mjs
+++ b/scripts/session-switch.mjs
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+
+import {
+  findFreePort,
+  makeClient,
+  parseArgs,
+  spawnOpencodeServe,
+  waitForHealthy,
+} from "./_util.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const directory = args.get("dir") ?? process.cwd();
+
+const port = await findFreePort();
+const server = await spawnOpencodeServe({ directory, port });
+
+const results = {
+  ok: true,
+  baseUrl: server.baseUrl,
+  directory: server.cwd,
+  steps: [],
+};
+
+function step(name, fn) {
+  results.steps.push({ name, status: "running" });
+  const idx = results.steps.length - 1;
+
+  return Promise.resolve()
+    .then(fn)
+    .then((data) => {
+      results.steps[idx] = { name, status: "ok", data };
+    })
+    .catch((e) => {
+      results.ok = false;
+      results.steps[idx] = {
+        name,
+        status: "error",
+        error: e instanceof Error ? e.message : String(e),
+      };
+      throw e;
+    });
+}
+
+function getMessageSessionId(message) {
+  if (message && typeof message.sessionID === "string") return message.sessionID;
+  if (message && message.info && typeof message.info.sessionID === "string") return message.info.sessionID;
+  return null;
+}
+
+function extractLastText(messages) {
+  const list = Array.isArray(messages) ? messages.slice() : [];
+  for (let i = list.length - 1; i >= 0; i -= 1) {
+    const msg = list[i];
+    const parts = Array.isArray(msg?.parts) ? msg.parts : [];
+    for (let p = parts.length - 1; p >= 0; p -= 1) {
+      const part = parts[p];
+      if (part && part.type === "text" && typeof part.text === "string") {
+        return part.text;
+      }
+    }
+  }
+  return null;
+}
+
+try {
+  const client = makeClient({ baseUrl: server.baseUrl, directory: server.cwd });
+  await waitForHealthy(client);
+
+  let sessionA;
+  let sessionB;
+
+  await step("session.create A", async () => {
+    sessionA = await client.session.create({ title: "OpenWork session A" });
+    assert.ok(sessionA?.id);
+    return { id: sessionA.id };
+  });
+
+  await step("session.create B", async () => {
+    sessionB = await client.session.create({ title: "OpenWork session B" });
+    assert.ok(sessionB?.id);
+    return { id: sessionB.id };
+  });
+
+  await step("session.prompt A", async () => {
+    await client.session.prompt({
+      sessionID: sessionA.id,
+      noReply: true,
+      parts: [{ type: "text", text: "Hello from session A" }],
+    });
+    return { sessionID: sessionA.id };
+  });
+
+  await step("session.prompt B", async () => {
+    await client.session.prompt({
+      sessionID: sessionB.id,
+      noReply: true,
+      parts: [{ type: "text", text: "Hello from session B" }],
+    });
+    return { sessionID: sessionB.id };
+  });
+
+  await step("session.messages A", async () => {
+    const messages = await client.session.messages({ sessionID: sessionA.id, limit: 50 });
+    assert.ok(Array.isArray(messages));
+    for (const msg of messages) {
+      const msgSessionId = getMessageSessionId(msg);
+      assert.equal(msgSessionId, sessionA.id);
+    }
+    const text = extractLastText(messages);
+    assert.ok(text && text.includes("session A"));
+    return { count: messages.length };
+  });
+
+  await step("session.messages B", async () => {
+    const messages = await client.session.messages({ sessionID: sessionB.id, limit: 50 });
+    assert.ok(Array.isArray(messages));
+    for (const msg of messages) {
+      const msgSessionId = getMessageSessionId(msg);
+      assert.equal(msgSessionId, sessionB.id);
+    }
+    const text = extractLastText(messages);
+    assert.ok(text && text.includes("session B"));
+    return { count: messages.length };
+  });
+
+  await step("session.messages switch", async () => {
+    const [messagesA, messagesB] = await Promise.all([
+      client.session.messages({ sessionID: sessionA.id, limit: 50 }),
+      client.session.messages({ sessionID: sessionB.id, limit: 50 }),
+    ]);
+
+    const textA = extractLastText(messagesA);
+    const textB = extractLastText(messagesB);
+
+    assert.ok(textA && textA.includes("session A"));
+    assert.ok(textB && textB.includes("session B"));
+
+    return { aCount: messagesA.length, bCount: messagesB.length };
+  });
+
+  console.log(JSON.stringify(results, null, 2));
+} catch (e) {
+  const message = e instanceof Error ? e.message : String(e);
+  results.ok = false;
+  results.error = message;
+  results.stderr = server.getStderr();
+  console.error(JSON.stringify(results, null, 2));
+  process.exitCode = 1;
+} finally {
+  await server.close();
+}

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1,5 +1,85 @@
 use tauri::Manager;
 
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use crate::paths::home_dir;
+
+#[derive(serde::Serialize)]
+pub struct CacheResetResult {
+  pub removed: Vec<String>,
+  pub missing: Vec<String>,
+  pub errors: Vec<String>,
+}
+
+fn opencode_cache_candidates() -> Vec<PathBuf> {
+  let mut candidates: Vec<PathBuf> = Vec::new();
+
+  if let Ok(value) = std::env::var("XDG_CACHE_HOME") {
+    let trimmed = value.trim();
+    if !trimmed.is_empty() {
+      candidates.push(PathBuf::from(trimmed).join("opencode"));
+    }
+  }
+
+  if let Some(home) = home_dir() {
+    candidates.push(home.join(".cache").join("opencode"));
+
+    #[cfg(target_os = "macos")]
+    {
+      candidates.push(home.join("Library").join("Caches").join("opencode"));
+    }
+  }
+
+  #[cfg(windows)]
+  {
+    if let Ok(value) = std::env::var("LOCALAPPDATA") {
+      let trimmed = value.trim();
+      if !trimmed.is_empty() {
+        candidates.push(PathBuf::from(trimmed).join("opencode"));
+      }
+    }
+    if let Ok(value) = std::env::var("APPDATA") {
+      let trimmed = value.trim();
+      if !trimmed.is_empty() {
+        candidates.push(PathBuf::from(trimmed).join("opencode"));
+      }
+    }
+  }
+
+  let mut seen = HashSet::new();
+  candidates
+    .into_iter()
+    .filter(|path| seen.insert(path.to_string_lossy().to_string()))
+    .collect()
+}
+
+#[tauri::command]
+pub fn reset_opencode_cache() -> Result<CacheResetResult, String> {
+  let candidates = opencode_cache_candidates();
+  let mut removed = Vec::new();
+  let mut missing = Vec::new();
+  let mut errors = Vec::new();
+
+  for path in candidates {
+    if path.exists() {
+      if let Err(err) = std::fs::remove_dir_all(&path) {
+        errors.push(format!("Failed to remove {}: {err}", path.display()));
+      } else {
+        removed.push(path.to_string_lossy().to_string());
+      }
+    } else {
+      missing.push(path.to_string_lossy().to_string());
+    }
+  }
+
+  Ok(CacheResetResult {
+    removed,
+    missing,
+    errors,
+  })
+}
+
 #[tauri::command]
 pub fn reset_openwork_state(app: tauri::AppHandle, mode: String) -> Result<(), String> {
   let mode = mode.trim();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ pub use types::*;
 
 use commands::config::{read_opencode_config, write_opencode_config};
 use commands::engine::{engine_doctor, engine_info, engine_install, engine_start, engine_stop};
-use commands::misc::reset_openwork_state;
+use commands::misc::{reset_opencode_cache, reset_openwork_state};
 use commands::opkg::{import_skill, opkg_install};
 use commands::updater::updater_environment;
 use commands::workspace::{
@@ -60,7 +60,8 @@ pub fn run() {
       read_opencode_config,
       write_opencode_config,
       updater_environment,
-      reset_openwork_state
+      reset_openwork_state,
+      reset_opencode_cache
     ])
     .run(tauri::generate_context!())
     .expect("error while running OpenWork");

--- a/src/app/extensions.ts
+++ b/src/app/extensions.ts
@@ -3,7 +3,7 @@ import { createSignal } from "solid-js";
 import { applyEdits, modify } from "jsonc-parser";
 
 import type { Client, CuratedPackage, Mode, PluginScope, ReloadReason, SkillCard } from "./types";
-import { isTauriRuntime } from "./utils";
+import { addOpencodeCacheHint, isTauriRuntime } from "./utils";
 import {
   isPluginInstalled,
   loadPluginsFromConfig as loadPluginsFromConfigHelpers,
@@ -281,7 +281,8 @@ export function createExtensionsStore(options: {
 
       await refreshSkills();
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : String(e));
+      const message = e instanceof Error ? e.message : String(e);
+      options.setError(addOpencodeCacheHint(message));
     } finally {
       options.setBusy(false);
     }
@@ -333,7 +334,8 @@ export function createExtensionsStore(options: {
 
       await refreshSkills();
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : "Unknown error");
+      const message = e instanceof Error ? e.message : "Unknown error";
+      options.setError(addOpencodeCacheHint(message));
     } finally {
       options.setBusy(false);
     }

--- a/src/app/session.ts
+++ b/src/app/session.ts
@@ -11,6 +11,7 @@ import type {
   TodoItem,
 } from "./types";
 import {
+  addOpencodeCacheHint,
   modelFromUserMessage,
   normalizeEvent,
   normalizeSessionStatus,
@@ -46,6 +47,12 @@ export function createSessionStore(options: {
   const [pendingPermissions, setPendingPermissions] = createSignal<PendingPermission[]>([]);
   const [permissionReplyBusy, setPermissionReplyBusy] = createSignal(false);
   const [events, setEvents] = createSignal<OpencodeEvent[]>([]);
+
+  const addError = (error: unknown, fallback = "Unknown error") => {
+    const message = error instanceof Error ? error.message : fallback;
+    if (!message) return;
+    options.setError(addOpencodeCacheHint(message));
+  };
 
   const selectedSession = createMemo(() => {
     const id = options.selectedSessionId();
@@ -128,7 +135,7 @@ export function createSessionStore(options: {
       unwrap(await c.permission.reply({ requestID, reply }));
       await refreshPendingPermissions();
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : "Unknown error");
+      addError(e);
     } finally {
       setPermissionReplyBusy(false);
     }

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -233,6 +233,23 @@ export function safeParseJson<T>(raw: string): T | null {
   }
 }
 
+export function addOpencodeCacheHint(message: string) {
+  const lower = message.toLowerCase();
+  const cacheSignals = [
+    ".cache/opencode",
+    "library/caches/opencode",
+    "appdata/local/opencode",
+    "fetch_jwks.js",
+    "opencode cache",
+  ];
+
+  if (cacheSignals.some((signal) => lower.includes(signal)) && lower.includes("enoent")) {
+    return `${message}\n\nOpenCode cache looks corrupted. Use Repair cache in Settings to rebuild it.`;
+  }
+
+  return message;
+}
+
 export function parseTemplateFrontmatter(raw: string) {
   const trimmed = raw.trimStart();
   if (!trimmed.startsWith("---")) return null;

--- a/src/app/workspace.ts
+++ b/src/app/workspace.ts
@@ -8,7 +8,7 @@ import type {
   WorkspaceOpenworkConfig,
   WorkspacePreset,
 } from "./types";
-import { isTauriRuntime, safeStringify, writeModePreference } from "./utils";
+import { addOpencodeCacheHint, isTauriRuntime, safeStringify, writeModePreference } from "./utils";
 import { unwrap } from "../lib/opencode";
 import {
   engineDoctor,
@@ -300,7 +300,8 @@ export function createWorkspaceStore(options: {
     } catch (e) {
       options.setClient(null);
       options.setConnectedVersion(null);
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
       return false;
     } finally {
       options.setBusy(false);
@@ -344,7 +345,8 @@ export function createWorkspaceStore(options: {
       options.setView("dashboard");
       options.setTab("home");
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
     } finally {
       options.setBusy(false);
       options.setBusyLabel(null);
@@ -365,7 +367,8 @@ export function createWorkspaceStore(options: {
 
       return folder ?? null;
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
       return null;
     }
   }
@@ -430,7 +433,8 @@ export function createWorkspaceStore(options: {
 
       return true;
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
       return false;
     } finally {
       options.setBusy(false);
@@ -464,7 +468,8 @@ export function createWorkspaceStore(options: {
       options.setOnboardingStep("mode");
       options.setView("onboarding");
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
     } finally {
       options.setBusy(false);
       options.setBusyLabel(null);
@@ -490,7 +495,8 @@ export function createWorkspaceStore(options: {
 
       await refreshEngineDoctor();
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
     } finally {
       options.setBusy(false);
       options.setBusyLabel(null);
@@ -535,7 +541,8 @@ export function createWorkspaceStore(options: {
     try {
       await persistAuthorizedRoots(roots);
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
     }
   }
 
@@ -555,7 +562,8 @@ export function createWorkspaceStore(options: {
         await persistAuthorizedRoots(roots);
       }
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
     }
   }
 
@@ -566,7 +574,8 @@ export function createWorkspaceStore(options: {
     try {
       await persistAuthorizedRoots(roots);
     } catch (e) {
-      options.setError(e instanceof Error ? e.message : safeStringify(e));
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
     }
   }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -224,3 +224,13 @@ export async function writeOpencodeConfig(
 export async function resetOpenworkState(mode: "onboarding" | "all"): Promise<void> {
   return invoke<void>("reset_openwork_state", { mode });
 }
+
+export type CacheResetResult = {
+  removed: string[];
+  missing: string[];
+  errors: string[];
+};
+
+export async function resetOpencodeCache(): Promise<CacheResetResult> {
+  return invoke<CacheResetResult>("reset_opencode_cache");
+}

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -117,24 +117,28 @@ export type DashboardViewProps = {
   checkForUpdates: () => void;
   downloadUpdate: () => void;
   installUpdateAndRestart: () => void;
-  anyActiveRuns: boolean;
-  engineSource: "path" | "sidecar";
-  setEngineSource: (value: "path" | "sidecar") => void;
-  isWindows: boolean;
-  toggleDeveloperMode: () => void;
-  developerMode: boolean;
-  stopHost: () => void;
-  openResetModal: (mode: "onboarding" | "all") => void;
-  resetModalBusy: boolean;
-  onResetStartupPreference: () => void;
-  pendingPermissions: unknown;
-  events: unknown;
-  safeStringify: (value: unknown) => string;
-  demoMode: boolean;
-  toggleDemoMode: () => void;
-  demoSequence: "cold-open" | "scheduler" | "summaries" | "groceries";
-  setDemoSequence: (value: "cold-open" | "scheduler" | "summaries" | "groceries") => void;
-};
+   anyActiveRuns: boolean;
+   engineSource: "path" | "sidecar";
+   setEngineSource: (value: "path" | "sidecar") => void;
+   isWindows: boolean;
+   toggleDeveloperMode: () => void;
+   developerMode: boolean;
+   stopHost: () => void;
+   openResetModal: (mode: "onboarding" | "all") => void;
+   resetModalBusy: boolean;
+   onResetStartupPreference: () => void;
+   pendingPermissions: unknown;
+   events: unknown;
+   safeStringify: (value: unknown) => string;
+   repairOpencodeCache: () => void;
+   cacheRepairBusy: boolean;
+   cacheRepairResult: string | null;
+   demoMode: boolean;
+   toggleDemoMode: () => void;
+   demoSequence: "cold-open" | "scheduler" | "summaries" | "groceries";
+   setDemoSequence: (value: "cold-open" | "scheduler" | "summaries" | "groceries") => void;
+ };
+
 
 export default function DashboardView(props: DashboardViewProps) {
   const title = createMemo(() => {
@@ -545,6 +549,9 @@ export default function DashboardView(props: DashboardViewProps) {
                 pendingPermissions={props.pendingPermissions}
                 events={props.events}
                 safeStringify={props.safeStringify}
+                repairOpencodeCache={props.repairOpencodeCache}
+                cacheRepairBusy={props.cacheRepairBusy}
+                cacheRepairResult={props.cacheRepairResult}
                 demoMode={props.demoMode}
                 toggleDemoMode={props.toggleDemoMode}
                 demoSequence={props.demoSequence}
@@ -556,8 +563,31 @@ export default function DashboardView(props: DashboardViewProps) {
 
         <Show when={props.error}>
           <div class="mx-auto max-w-5xl px-6 md:px-10 pb-24 md:pb-10">
-            <div class="rounded-2xl bg-red-950/40 px-5 py-4 text-sm text-red-200 border border-red-500/20">
-              {props.error}
+            <div class="rounded-2xl bg-red-950/40 px-5 py-4 text-sm text-red-200 border border-red-500/20 space-y-3">
+              <div>{props.error}</div>
+              <Show when={props.developerMode}>
+                <div class="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="secondary"
+                    class="text-xs h-8 py-0 px-3"
+                    onClick={props.repairOpencodeCache}
+                    disabled={props.cacheRepairBusy || !props.developerMode}
+                  >
+                    {props.cacheRepairBusy ? "Repairing cache" : "Repair cache"}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    class="text-xs h-8 py-0 px-3"
+                    onClick={props.stopHost}
+                    disabled={props.busy}
+                  >
+                    Retry
+                  </Button>
+                  <Show when={props.cacheRepairResult}>
+                    <span class="text-xs text-red-200/80">{props.cacheRepairResult}</span>
+                  </Show>
+                </div>
+              </Show>
             </div>
           </div>
         </Show>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -51,6 +51,9 @@ export type SettingsViewProps = {
   pendingPermissions: unknown;
   events: unknown;
   safeStringify: (value: unknown) => string;
+  repairOpencodeCache: () => void;
+  cacheRepairBusy: boolean;
+  cacheRepairResult: string | null;
 };
 
 export default function SettingsView(props: SettingsViewProps) {
@@ -428,18 +431,41 @@ export default function SettingsView(props: SettingsViewProps) {
         <section>
           <h3 class="text-sm font-medium text-zinc-400 uppercase tracking-wider mb-4">Developer</h3>
 
-          <div class="grid md:grid-cols-2 gap-4">
-            <div class="bg-zinc-900/30 border border-zinc-800/50 rounded-2xl p-4">
-              <div class="text-xs text-zinc-500 mb-2">Pending permissions</div>
-              <pre class="text-xs text-zinc-200 whitespace-pre-wrap break-words max-h-64 overflow-auto">
-                {props.safeStringify(props.pendingPermissions)}
-              </pre>
+          <div class="space-y-4">
+            <div class="bg-zinc-900/30 border border-zinc-800/50 rounded-2xl p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div class="min-w-0">
+                <div class="text-sm text-zinc-200">OpenCode cache</div>
+                <div class="text-xs text-zinc-600">
+                  Repairs cached data used to start the engine. Safe to run.
+                </div>
+                <Show when={props.cacheRepairResult}>
+                  <div class="text-xs text-zinc-400 mt-2">{props.cacheRepairResult}</div>
+                </Show>
+              </div>
+              <Button
+                variant="secondary"
+                class="text-xs h-8 py-0 px-3 shrink-0"
+                onClick={props.repairOpencodeCache}
+                disabled={props.cacheRepairBusy || !isTauriRuntime()}
+                title={isTauriRuntime() ? "" : "Cache repair requires the desktop app"}
+              >
+                {props.cacheRepairBusy ? "Repairing cache" : "Repair cache"}
+              </Button>
             </div>
-            <div class="bg-zinc-900/30 border border-zinc-800/50 rounded-2xl p-4">
-              <div class="text-xs text-zinc-500 mb-2">Recent events</div>
-              <pre class="text-xs text-zinc-200 whitespace-pre-wrap break-words max-h-64 overflow-auto">
-                {props.safeStringify(props.events)}
-              </pre>
+
+            <div class="grid md:grid-cols-2 gap-4">
+              <div class="bg-zinc-900/30 border border-zinc-800/50 rounded-2xl p-4">
+                <div class="text-xs text-zinc-500 mb-2">Pending permissions</div>
+                <pre class="text-xs text-zinc-200 whitespace-pre-wrap break-words max-h-64 overflow-auto">
+                  {props.safeStringify(props.pendingPermissions)}
+                </pre>
+              </div>
+              <div class="bg-zinc-900/30 border border-zinc-800/50 rounded-2xl p-4">
+                <div class="text-xs text-zinc-500 mb-2">Recent events</div>
+                <pre class="text-xs text-zinc-200 whitespace-pre-wrap break-words max-h-64 overflow-auto">
+                  {props.safeStringify(props.events)}
+                </pre>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add OpenCode cache repair command + UI affordance with error hinting
- expand e2e coverage with session switching and file system engine checks
- run tests in CI on macOS and Linux with OpenCode install