### PR TITLE
ci: harden opencode installer

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -34,9 +34,25 @@ jobs:
 
       - name: Install OpenCode CLI
         shell: bash
+        env:
+          OPENCODE_VERSION: 1.1.25
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          curl -fsSL https://opencode.ai/install | bash
+          version="${OPENCODE_VERSION}"
+
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            latest=$(curl -fsSL \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/anomalyco/opencode/releases/latest \
+              | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+            if [ -n "$latest" ]; then
+              version="$latest"
+            fi
+          fi
+
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$version"
           echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - name: Verify OpenCode


### PR DESCRIPTION
## Summary
- pin the opencode installer to a known version and use authenticated GitHub API to resolve latest
- avoid unauthenticated rate limits that caused version lookup failures in CI