### PR TITLE
feat: add Notion MCP onboarding flow

### DIFF
--- a/prd/mcp-skill-onboarding.md
+++ b/prd/mcp-skill-onboarding.md
@@ -101,3 +101,41 @@ without having to understand MCP tools or write prompts from scratch.
 - What is the minimal Notion OAuth scope for the CRM demo?
 - Should MCP reload be automatic or user-initiated?
 - Where should curated Notion skill live (OpenPackage vs local curated list)?
+
+## What Needs To Be Built
+- MCP surface placement: a single “Connect Notion” card in Settings (or a small MCPs section in Settings) so the flow is discoverable without adding a new top-level tab.
+- Connection state UI: status row with three states (Not connected, Connecting…, Connected) plus a one-line value statement (“Connect Notion to power your CRM workflow”).
+- OAuth completion affordance: confirmation row after OAuth returning to OpenWork that shows the active workspace and the chosen scope summary.
+- Config write confirmation: a quiet inline success message that `opencode.json` was updated, without surfacing raw JSON.
+- Reload path: reuse the existing reload banner and add MCP as a reload reason so the banner appears after MCP connect and skill install.
+- Skill discovery CTA: a featured “Manage CRM in Notion” tile pinned in Skills with a short outcome line and a single install button.
+- First-run prompt helper: a “Try it now” CTA that inserts “setup my crm” into the prompt input after the final reload.
+- Failure recovery UX: inline retry actions for OAuth, config write, skill install, and reload, keeping users in the flow without modal walls.
+
+## Required Technical Implementation
+### UI Surface Mapping (OpenWork)
+- Settings view: add a Notion MCP card or “MCPs” section inside `src/views/SettingsView.tsx` with connection status and a “Connect” action.
+- Skills view: add a curated “Manage CRM in Notion” entry in `src/app/constants.ts` (curated list) and render it through `src/views/SkillsView.tsx` like other curated packages.
+- Prompt CTA: implement the “Try it now” button near the chat input in `src/views/DashboardView.tsx` or the session prompt surface, reusing the existing input setter.
+- Status + error copy: reuse the standard `setError` and `setBusyLabel` surfaces from `src/App.tsx` and `src/app/extensions.ts`.
+
+### OpenCode SDK + OpenWork Primitives
+- Config read/write: use existing Tauri helpers `read_opencode_config` / `write_opencode_config` from `src/lib/tauri.ts` to update the project `opencode.json`.
+- MCP config schema: add a Notion entry under `mcp` in `opencode.json` with `type` and connection details (remote server URL or local command) matching OpenCode MCP spec.
+- Skills discovery: rely on `client.file.list()` and `client.file.read()` from `src/app/extensions.ts` for `.opencode/skill/*` discovery; no new indexing logic.
+- Skill install: reuse `opkg_install` and `import_skill` in `src/lib/tauri.ts` to land the curated skill into `.opencode/skill/manage-crm-notion/`.
+- Event stream: continue using `client.event.subscribe()` (already active) so MCP-auth and tool usage appear in the run timeline as normal.
+
+### Reload Behavior (End-to-End)
+- Mark reload required: extend `ReloadReason` in `src/app/types.ts` to include `"mcp"`, then call `markReloadRequired("mcp")` after MCP config writes.
+- Banner copy: update the reload copy in `src/App.tsx` to include an MCP-specific message (e.g., “Reload to activate MCP tools”).
+- Host-only guardrails: keep the existing host-only and no-active-runs checks in `reloadEngineInstance` to prevent unsafe reloads.
+- Engine refresh: rely on `client.instance.dispose()` and `waitForHealthy()` in `src/App.tsx` to restart the OpenCode process, then re-fetch providers, plugins, and skills.
+- Post-reload refresh: call `refreshPlugins("project")` and `refreshSkills()` after reload to ensure the Notion MCP + skill appear immediately in UI.
+- Retry surface: if reload fails, reuse `reloadError` state to show a retry CTA on the same banner.
+
+### Behavior + Data
+- OAuth state: store transient connection state locally (signal/store) with timestamps for “Connecting…” and “Connected” display.
+- Audit log: append a lightweight OpenWork audit entry for OAuth success/failure, config write, and reload (mirrors existing activity log behavior).
+- Workspace scope: ensure all MCP config writes and skill installs target the active workspace root (`projectDir`).
+- Safety: do not auto-run the CRM prompt; insert text into the input so the user explicitly confirms execution.

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -41,6 +41,13 @@ export const CURATED_PACKAGES: CuratedPackage[] = [
     installable: true,
   },
   {
+    name: "Notion CRM Skill",
+    source: "github:different-ai/openwork-skills#subdirectory=manage-crm-notion",
+    description: "Set up a Notion CRM with pipelines, contacts, and follow-ups.",
+    tags: ["notion", "crm", "demo"],
+    installable: true,
+  },
+  {
     name: "Awesome Claude Skills",
     source: "https://github.com/ComposioHQ/awesome-claude-skills",
     description: "Curated list of Claude skills and prompts (not an OpenPackage yet).",

--- a/src/app/extensions.ts
+++ b/src/app/extensions.ts
@@ -32,6 +32,7 @@ export function createExtensionsStore(options: {
   setBusyStartedAt: (value: number | null) => void;
   setError: (value: string | null) => void;
   markReloadRequired: (reason: ReloadReason) => void;
+  onNotionSkillInstalled?: () => void;
 }) {
   const [skills, setSkills] = createSignal<SkillCard[]>([]);
   const [skillsStatus, setSkillsStatus] = createSignal<string | null>(null);
@@ -40,6 +41,7 @@ export function createExtensionsStore(options: {
 
   const skillDocFallbacks: Record<string, string> = {
     "workspace-guide": "Workspace guide that introduces OpenWork and suggests first steps.",
+    "manage-crm-notion": "Set up a Notion CRM with pipelines, contacts, and follow-ups.",
   };
   const failedSkillDocs = new Set<string>();
   const skillDocKey = (root: string, name: string) => `${root}::${name}`;
@@ -254,6 +256,7 @@ export function createExtensionsStore(options: {
 
     const targetDir = options.projectDir().trim();
     const pkg = (sourceOverride ?? openPackageSource()).trim();
+    const isNotionSkillInstall = pkg.toLowerCase().includes("manage-crm-notion");
 
     if (!targetDir) {
       options.setError("Pick a project folder first.");
@@ -277,6 +280,9 @@ export function createExtensionsStore(options: {
       } else {
         setSkillsStatus(result.stdout || "Installed.");
         options.markReloadRequired("skills");
+        if (isNotionSkillInstall) {
+          options.onNotionSkillInstalled?.();
+        }
       }
 
       await refreshSkills();

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -128,7 +128,7 @@ export type SuggestedPlugin = {
 
 export type PluginScope = "project" | "global";
 
-export type ReloadReason = "plugins" | "skills";
+export type ReloadReason = "plugins" | "skills" | "mcp";
 
 export type PendingPermission = ApiPermissionRequest & {
   receivedAt: number;

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -132,8 +132,14 @@ export type DashboardViewProps = {
    safeStringify: (value: unknown) => string;
    repairOpencodeCache: () => void;
    cacheRepairBusy: boolean;
-   cacheRepairResult: string | null;
-   demoMode: boolean;
+  cacheRepairResult: string | null;
+  notionStatus: "disconnected" | "connecting" | "connected" | "error";
+  notionStatusDetail: string | null;
+  notionError: string | null;
+  notionBusy: boolean;
+  connectNotion: () => void;
+  demoMode: boolean;
+
    toggleDemoMode: () => void;
    demoSequence: "cold-open" | "scheduler" | "summaries" | "groceries";
    setDemoSequence: (value: "cold-open" | "scheduler" | "summaries" | "groceries") => void;
@@ -516,47 +522,53 @@ export default function DashboardView(props: DashboardViewProps) {
             </Match>
 
             <Match when={props.tab === "settings"}>
-              <SettingsView
-                mode={props.mode}
-                baseUrl={props.baseUrl}
-                headerStatus={props.headerStatus}
-                busy={props.busy}
-                developerMode={props.developerMode}
-                toggleDeveloperMode={props.toggleDeveloperMode}
-                stopHost={props.stopHost}
-                engineSource={props.engineSource}
-                setEngineSource={props.setEngineSource}
-                isWindows={props.isWindows}
-                defaultModelLabel={props.defaultModelLabel}
-                defaultModelRef={props.defaultModelRef}
-                openDefaultModelPicker={props.openDefaultModelPicker}
-                showThinking={props.showThinking}
-                toggleShowThinking={props.toggleShowThinking}
-                modelVariantLabel={props.modelVariantLabel}
-                editModelVariant={props.editModelVariant}
-                updateAutoCheck={props.updateAutoCheck}
-                toggleUpdateAutoCheck={props.toggleUpdateAutoCheck}
-                updateStatus={props.updateStatus}
-                updateEnv={props.updateEnv}
-                appVersion={props.appVersion}
-                checkForUpdates={props.checkForUpdates}
-                downloadUpdate={props.downloadUpdate}
-                installUpdateAndRestart={props.installUpdateAndRestart}
-                anyActiveRuns={props.anyActiveRuns}
-                onResetStartupPreference={props.onResetStartupPreference}
-                openResetModal={props.openResetModal}
-                resetModalBusy={props.resetModalBusy}
-                pendingPermissions={props.pendingPermissions}
-                events={props.events}
-                safeStringify={props.safeStringify}
-                repairOpencodeCache={props.repairOpencodeCache}
-                cacheRepairBusy={props.cacheRepairBusy}
-                cacheRepairResult={props.cacheRepairResult}
-                demoMode={props.demoMode}
-                toggleDemoMode={props.toggleDemoMode}
-                demoSequence={props.demoSequence}
-                setDemoSequence={props.setDemoSequence}
-              />
+                <SettingsView
+                  mode={props.mode}
+                  baseUrl={props.baseUrl}
+                  headerStatus={props.headerStatus}
+                  busy={props.busy}
+                  developerMode={props.developerMode}
+                  toggleDeveloperMode={props.toggleDeveloperMode}
+                  stopHost={props.stopHost}
+                  engineSource={props.engineSource}
+                  setEngineSource={props.setEngineSource}
+                  isWindows={props.isWindows}
+                  defaultModelLabel={props.defaultModelLabel}
+                  defaultModelRef={props.defaultModelRef}
+                  openDefaultModelPicker={props.openDefaultModelPicker}
+                  showThinking={props.showThinking}
+                  toggleShowThinking={props.toggleShowThinking}
+                  modelVariantLabel={props.modelVariantLabel}
+                  editModelVariant={props.editModelVariant}
+                  updateAutoCheck={props.updateAutoCheck}
+                  toggleUpdateAutoCheck={props.toggleUpdateAutoCheck}
+                  updateStatus={props.updateStatus}
+                  updateEnv={props.updateEnv}
+                  appVersion={props.appVersion}
+                  checkForUpdates={props.checkForUpdates}
+                  downloadUpdate={props.downloadUpdate}
+                  installUpdateAndRestart={props.installUpdateAndRestart}
+                  anyActiveRuns={props.anyActiveRuns}
+                  onResetStartupPreference={props.onResetStartupPreference}
+                  openResetModal={props.openResetModal}
+                  resetModalBusy={props.resetModalBusy}
+                  pendingPermissions={props.pendingPermissions}
+                  events={props.events}
+                  safeStringify={props.safeStringify}
+                  repairOpencodeCache={props.repairOpencodeCache}
+                  cacheRepairBusy={props.cacheRepairBusy}
+                  cacheRepairResult={props.cacheRepairResult}
+                  notionStatus={props.notionStatus}
+                  notionStatusDetail={props.notionStatusDetail}
+                  notionError={props.notionError}
+                  notionBusy={props.notionBusy}
+                  connectNotion={props.connectNotion}
+                  demoMode={props.demoMode}
+                  toggleDemoMode={props.toggleDemoMode}
+                  demoSequence={props.demoSequence}
+                  setDemoSequence={props.setDemoSequence}
+                />
+
             </Match>
           </Switch>
         </div>

--- a/src/views/SessionView.tsx
+++ b/src/views/SessionView.tsx
@@ -73,6 +73,8 @@ export type SessionViewProps = {
   selectedSessionModelLabel: string;
   openSessionModelPicker: () => void;
   activePermission: PendingPermission | null;
+  showTryNotionPrompt: boolean;
+  onTryNotionPrompt: () => void;
   permissionReplyBusy: boolean;
   respondPermission: (requestID: string, reply: "once" | "always" | "reject") => void;
   respondPermissionAndRemember: (requestID: string, reply: "once" | "always" | "reject") => void;
@@ -668,28 +670,40 @@ export default function SessionView(props: SessionViewProps) {
                 <ChevronDown size={16} class="text-zinc-600" />
               </div>
             </button>
-            <div class="relative">
-              <input
-                type="text"
-                disabled={props.busy}
-                value={props.prompt}
-                onInput={(e) => props.setPrompt(e.currentTarget.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    props.sendPromptAsync().catch(() => undefined);
-                  }
-                }}
-                placeholder={props.busy ? "Working..." : "Ask OpenWork to do something..."}
-                class="w-full bg-zinc-900 border border-zinc-800 rounded-2xl py-4 pl-5 pr-14 text-white placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all disabled:opacity-50"
-              />
-              <button
-                disabled={!props.prompt.trim() || props.busy}
-                onClick={() => props.sendPromptAsync().catch(() => undefined)}
-                class="absolute right-2 top-2 p-2 bg-white text-black rounded-xl hover:scale-105 active:scale-95 transition-all disabled:opacity-0 disabled:scale-75"
-                title="Run"
-              >
-                <ArrowRight size={20} />
-              </button>
+            <div class="space-y-2">
+              <Show when={props.showTryNotionPrompt}>
+                <button
+                  type="button"
+                  class="w-full flex items-center justify-between gap-3 rounded-2xl border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-left text-sm text-emerald-100 transition-colors hover:bg-emerald-500/15"
+                  onClick={() => props.onTryNotionPrompt()}
+                >
+                  <span>Try it now: set up my CRM in Notion</span>
+                  <span class="text-xs text-emerald-200">Insert prompt</span>
+                </button>
+              </Show>
+              <div class="relative">
+                <input
+                  type="text"
+                  disabled={props.busy}
+                  value={props.prompt}
+                  onInput={(e) => props.setPrompt(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      props.sendPromptAsync().catch(() => undefined);
+                    }
+                  }}
+                  placeholder={props.busy ? "Working..." : "Ask OpenWork to do something..."}
+                  class="w-full bg-zinc-900 border border-zinc-800 rounded-2xl py-4 pl-5 pr-14 text-white placeholder-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all disabled:opacity-50"
+                />
+                <button
+                  disabled={!props.prompt.trim() || props.busy}
+                  onClick={() => props.sendPromptAsync().catch(() => undefined)}
+                  class="absolute right-2 top-2 p-2 bg-white text-black rounded-xl hover:scale-105 active:scale-95 transition-all disabled:opacity-0 disabled:scale-75"
+                  title="Run"
+                >
+                  <ArrowRight size={20} />
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -54,6 +54,11 @@ export type SettingsViewProps = {
   repairOpencodeCache: () => void;
   cacheRepairBusy: boolean;
   cacheRepairResult: string | null;
+  notionStatus: "disconnected" | "connecting" | "connected" | "error";
+  notionStatusDetail: string | null;
+  notionError: string | null;
+  notionBusy: boolean;
+  connectNotion: () => void;
 };
 
 export default function SettingsView(props: SettingsViewProps) {
@@ -65,6 +70,33 @@ export default function SettingsView(props: SettingsViewProps) {
   const updateDownloadedBytes = () => props.updateStatus?.downloadedBytes ?? null;
   const updateTotalBytes = () => props.updateStatus?.totalBytes ?? null;
   const updateErrorMessage = () => props.updateStatus?.message ?? null;
+
+  const notionStatusLabel = () => {
+    switch (props.notionStatus) {
+      case "connected":
+        return "Connected";
+      case "connecting":
+        return "Reload required";
+      case "error":
+        return "Connection failed";
+      default:
+        return "Not connected";
+    }
+  };
+
+  const notionStatusStyle = () => {
+    if (props.notionStatus === "connected") {
+      return "bg-emerald-500/10 text-emerald-300 border-emerald-500/20";
+    }
+    if (props.notionStatus === "error") {
+      return "bg-red-500/10 text-red-300 border-red-500/20";
+    }
+    if (props.notionStatus === "connecting") {
+      return "bg-amber-500/10 text-amber-300 border-amber-500/20";
+    }
+    return "bg-zinc-800/60 text-zinc-400 border-zinc-700/50";
+  };
+
 
   return (
     <section class="space-y-6">
@@ -116,6 +148,37 @@ export default function SettingsView(props: SettingsViewProps) {
               </Show>
             </div>
           </div>
+        </Show>
+      </div>
+
+      <div class="bg-zinc-900/30 border border-zinc-800/50 rounded-2xl p-5 space-y-4">
+        <div class="flex items-start justify-between gap-4">
+          <div class="space-y-2">
+            <div class="text-sm font-medium text-white">Notion</div>
+            <div class="text-xs text-zinc-500">Connect your workspace to power CRM workflows.</div>
+            <div class={`inline-flex items-center gap-2 text-[11px] px-2 py-1 rounded-full border ${notionStatusStyle()}`}>
+              <span>{notionStatusLabel()}</span>
+              <Show when={props.notionStatusDetail}>
+                <span class="text-zinc-400">• {props.notionStatusDetail}</span>
+              </Show>
+            </div>
+          </div>
+          <Button
+            variant={props.notionStatus === "connected" ? "outline" : "secondary"}
+            onClick={props.connectNotion}
+            disabled={props.notionBusy || props.notionStatus === "connecting" || props.mode !== "host" || !isTauriRuntime()}
+          >
+            {props.notionBusy ? "Connecting..." : props.notionStatus === "connected" ? "Manage" : "Connect Notion"}
+          </Button>
+        </div>
+        <div class="text-xs text-zinc-600">
+          OpenWork only accesses what you approve. You can disconnect anytime.
+        </div>
+        <Show when={props.notionStatus === "connecting"}>
+          <div class="text-xs text-zinc-500">Reload the engine to activate the connection.</div>
+        </Show>
+        <Show when={props.notionError}>
+          <div class="text-xs text-red-300">{props.notionError}</div>
         </Show>
       </div>
 

--- a/src/views/SkillsView.tsx
+++ b/src/views/SkillsView.tsx
@@ -84,6 +84,28 @@ export default function SkillsView(props: SkillsViewProps) {
           <div class="text-xs text-zinc-500">{props.filteredPackages.length}</div>
         </div>
 
+        <div class="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <div class="text-sm font-medium text-emerald-100">Manage CRM in Notion</div>
+              <div class="text-xs text-emerald-200/80 mt-1">Set up pipelines, contacts, and follow-ups in minutes.</div>
+            </div>
+            <Button
+              variant="secondary"
+              onClick={() => props.useCuratedPackage({
+                name: "Notion CRM Skill",
+                source: "github:different-ai/openwork-skills#subdirectory=manage-crm-notion",
+                description: "Set up a Notion CRM with pipelines, contacts, and follow-ups.",
+                tags: ["notion", "crm", "demo"],
+                installable: true,
+              })}
+              disabled={props.busy || props.mode !== "host" || !isTauriRuntime()}
+            >
+              Install
+            </Button>
+          </div>
+        </div>
+
         <input
           class="w-full bg-zinc-900/50 border border-zinc-800 rounded-xl px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
           placeholder="Search packages or lists (e.g. claude, registry, community)"


### PR DESCRIPTION
## Summary
- add Notion MCP connect card and reload flow in Settings
- add curated Notion CRM skill tile and Try it now prompt CTA
- document full implementation plan in the MCP onboarding PRD

## Testing
- pnpm typecheck
- pnpm build:web