### PR TITLE
feat: show MCP status and reload actions

### DIFF
--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -144,6 +144,15 @@ export type McpServerEntry = {
   config: McpServerConfig;
 };
 
+export type McpStatus =
+  | { status: "connected" }
+  | { status: "disabled" }
+  | { status: "failed"; error: string }
+  | { status: "needs_auth" }
+  | { status: "needs_client_registration"; error: string };
+
+export type McpStatusMap = Record<string, McpStatus>;
+
 export type ReloadReason = "plugins" | "skills" | "mcp";
 
 export type PendingPermission = ApiPermissionRequest & {

--- a/src/views/DashboardView.tsx
+++ b/src/views/DashboardView.tsx
@@ -3,6 +3,7 @@ import type {
   CuratedPackage,
   DashboardTab,
   McpServerEntry,
+  McpStatusMap,
   PluginScope,
   SkillCard,
   WorkspaceTemplate,
@@ -123,6 +124,8 @@ export type DashboardViewProps = {
   mcpServers: McpServerEntry[];
   mcpStatus: string | null;
   mcpLastUpdatedAt: number | null;
+  mcpStatuses: McpStatusMap;
+  mcpConnectingName: string | null;
   selectedMcp: string | null;
   setSelectedMcp: (value: string | null) => void;
   quickConnect: McpDirectoryInfo[];
@@ -139,6 +142,8 @@ export type DashboardViewProps = {
   setAdvancedEnabled: (value: boolean) => void;
   advancedCommand: string;
   advancedAuthCommand: string;
+  showMcpReloadBanner: boolean;
+  reloadMcpEngine: () => void;
   createSessionAndOpen: () => void;
   selectSession: (sessionId: string) => Promise<void> | void;
   defaultModelLabel: string;
@@ -698,6 +703,8 @@ export default function DashboardView(props: DashboardViewProps) {
                 mcpServers={props.mcpServers}
                 mcpStatus={props.mcpStatus}
                 mcpLastUpdatedAt={props.mcpLastUpdatedAt}
+                mcpStatuses={props.mcpStatuses}
+                mcpConnectingName={props.mcpConnectingName}
                 selectedMcp={props.selectedMcp}
                 setSelectedMcp={props.setSelectedMcp}
                 quickConnect={props.quickConnect}
@@ -714,6 +721,8 @@ export default function DashboardView(props: DashboardViewProps) {
                 setAdvancedEnabled={props.setAdvancedEnabled}
                 advancedCommand={props.advancedCommand}
                 advancedAuthCommand={props.advancedAuthCommand}
+                showMcpReloadBanner={props.showMcpReloadBanner}
+                reloadMcpEngine={props.reloadMcpEngine}
               />
             </Match>
 


### PR DESCRIPTION
## Summary
- fetch MCP status via `/mcp` and surface connected/disconnected states
- add connecting indicator + reload banner for MCP changes
- use MCP API add for quick connect and advanced add to avoid config duplication