### PR TITLE
Improve OpenCode engine onboarding diagnostics

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -7,6 +7,7 @@ use crate::engine::doctor::resolve_engine_path;
 use crate::paths::home_dir;
 use crate::platform::command_for_program;
 use crate::types::ExecResult;
+use tauri::{AppHandle, Manager};
 
 #[derive(serde::Serialize)]
 pub struct CacheResetResult {
@@ -118,7 +119,11 @@ pub fn reset_openwork_state(app: tauri::AppHandle, mode: String) -> Result<(), S
 /// Run `opencode mcp auth <server_name>` in the given project directory.
 /// This spawns the process detached so the OAuth flow can open a browser.
 #[tauri::command]
-pub fn opencode_mcp_auth(project_dir: String, server_name: String) -> Result<ExecResult, String> {
+pub fn opencode_mcp_auth(
+  app: AppHandle,
+  project_dir: String,
+  server_name: String,
+) -> Result<ExecResult, String> {
   let project_dir = project_dir.trim();
   let server_name = server_name.trim();
 
@@ -129,7 +134,8 @@ pub fn opencode_mcp_auth(project_dir: String, server_name: String) -> Result<Exe
     return Err("server_name is required".to_string());
   }
 
-  let (program, _in_path, notes) = resolve_engine_path(false);
+  let resource_dir = app.path().resource_dir().ok();
+  let (program, _in_path, notes) = resolve_engine_path(true, resource_dir.as_deref());
   let Some(program) = program else {
     let notes_text = notes.join("\n");
     return Err(format!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,6 +30,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
+    ],
+    "externalBin": [
+      "sidecars/opencode"
     ]
   },
   "plugins": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,7 @@ export default function App() {
   const [tab, setTab] = createSignal<DashboardTab>("home");
 
   const [engineSource, setEngineSource] = createSignal<"path" | "sidecar">(
-    "path"
+    isTauriRuntime() ? "sidecar" : "path"
   );
 
   const [baseUrl, setBaseUrl] = createSignal("http://127.0.0.1:4096");
@@ -1570,9 +1570,12 @@ export default function App() {
     engineDoctorVersion: engineDoctorResult()?.version ?? null,
     engineDoctorResolvedPath: engineDoctorResult()?.resolvedPath ?? null,
     engineDoctorNotes: engineDoctorResult()?.notes ?? [],
+    engineDoctorServeHelpStdout: engineDoctorResult()?.serveHelpStdout ?? null,
+    engineDoctorServeHelpStderr: engineDoctorResult()?.serveHelpStderr ?? null,
     engineDoctorCheckedAt: engineDoctorCheckedAt(),
     engineInstallLogs: engineInstallLogs(),
     error: error(),
+    isWindows: isWindowsPlatform(),
     onBaseUrlChange: setBaseUrl,
     onClientDirectoryChange: setClientDirectory,
     onModeSelect: (nextMode: Mode) => {

--- a/src/app/workspace.ts
+++ b/src/app/workspace.ts
@@ -142,7 +142,7 @@ export function createWorkspaceStore(options: {
     if (!isTauriRuntime()) return;
 
     try {
-      const result = await engineDoctor();
+      const result = await engineDoctor({ preferSidecar: options.engineSource() === "sidecar" });
       setEngineDoctorResult(result);
       setEngineDoctorCheckedAt(Date.now());
     } catch (e) {
@@ -341,7 +341,7 @@ export function createWorkspaceStore(options: {
     }
 
     try {
-      const result = await engineDoctor();
+      const result = await engineDoctor({ preferSidecar: options.engineSource() === "sidecar" });
       setEngineDoctorResult(result);
       setEngineDoctorCheckedAt(Date.now());
 
@@ -355,7 +355,13 @@ export function createWorkspaceStore(options: {
       }
 
       if (!result.supportsServe) {
-        options.setError("OpenCode CLI is installed, but `opencode serve` is unavailable. Update OpenCode and retry.");
+        const serveDetails = [result.serveHelpStdout, result.serveHelpStderr]
+          .filter((value) => value && value.trim())
+          .join("\n\n");
+        const suffix = serveDetails ? `\n\nServe output:\n${serveDetails}` : "";
+        options.setError(
+          `OpenCode CLI is installed, but \`opencode serve\` is unavailable. Update OpenCode and retry.${suffix}`
+        );
         return false;
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- prefer bundled OpenCode sidecar paths and include external bin in the Tauri bundle
- surface OpenCode install/diagnostic details in onboarding, including serve output
- extend engine warmup and capture stdout/stderr on early exit

## Testing
- pnpm typecheck
- pnpm build:web