### PR TITLE
feat: add local state provider scaffold

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@opencode-ai/sdk": "^1.1.19",
     "@radix-ui/colors": "^3.0.0",
+    "@solid-primitives/storage": "^4.3.3",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "~2.6.0",
     "@tauri-apps/plugin-opener": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@opencode-ai/sdk": "^1.1.19",
     "@radix-ui/colors": "^3.0.0",
+    "@solid-primitives/event-bus": "^1.1.2",
     "@solid-primitives/storage": "^4.3.3",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "~2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/colors':
         specifier: ^3.0.0
         version: 3.0.0
+      '@solid-primitives/storage':
+        specifier: ^4.3.3
+        version: 4.3.3(solid-js@1.9.10)
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.9.1
@@ -443,6 +446,23 @@ packages:
     resolution: {integrity: sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==}
     cpu: [x64]
     os: [win32]
+
+  '@solid-primitives/storage@4.3.3':
+    resolution: {integrity: sha512-ACbNwMZ1s8VAvld6EUXkDkX/US3IhtlPLxg6+B2s9MwNUugwdd51I98LPEaHrdLpqPmyzqgoJe0TxEFlf3Dqrw==}
+    peerDependencies:
+      '@tauri-apps/plugin-store': '*'
+      solid-js: ^1.6.12
+      solid-start: '*'
+    peerDependenciesMeta:
+      '@tauri-apps/plugin-store':
+        optional: true
+      solid-start:
+        optional: true
+
+  '@solid-primitives/utils@6.3.2':
+    resolution: {integrity: sha512-hZ/M/qr25QOCcwDPOHtGjxTD8w2mNyVAYvcfgwzBHq2RwNqHNdDNsMZYap20+ruRwW4A3Cdkczyoz0TSxLCAPQ==}
+    peerDependencies:
+      solid-js: ^1.6.12
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -1260,6 +1280,15 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.55.1':
     optional: true
+
+  '@solid-primitives/storage@4.3.3(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
+
+  '@solid-primitives/utils@6.3.2(solid-js@1.9.10)':
+    dependencies:
+      solid-js: 1.9.10
 
   '@tailwindcss/node@4.1.18':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/colors':
         specifier: ^3.0.0
         version: 3.0.0
+      '@solid-primitives/event-bus':
+        specifier: ^1.1.2
+        version: 1.1.2(solid-js@1.9.10)
       '@solid-primitives/storage':
         specifier: ^4.3.3
         version: 4.3.3(solid-js@1.9.10)
@@ -446,6 +449,11 @@ packages:
     resolution: {integrity: sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==}
     cpu: [x64]
     os: [win32]
+
+  '@solid-primitives/event-bus@1.1.2':
+    resolution: {integrity: sha512-l+n10/51neGcMaP3ypYt21bXfoeWh8IaC8k7fYuY3ww2a8S1Zv2N2a7FF5Qn+waTu86l0V8/nRHjkyqVIZBYwA==}
+    peerDependencies:
+      solid-js: ^1.6.12
 
   '@solid-primitives/storage@4.3.3':
     resolution: {integrity: sha512-ACbNwMZ1s8VAvld6EUXkDkX/US3IhtlPLxg6+B2s9MwNUugwdd51I98LPEaHrdLpqPmyzqgoJe0TxEFlf3Dqrw==}
@@ -1280,6 +1288,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.55.1':
     optional: true
+
+  '@solid-primitives/event-bus@1.1.2(solid-js@1.9.10)':
+    dependencies:
+      '@solid-primitives/utils': 6.3.2(solid-js@1.9.10)
+      solid-js: 1.9.10
 
   '@solid-primitives/storage@4.3.3(solid-js@1.9.10)':
     dependencies:

--- a/src/app/context/global-sdk.tsx
+++ b/src/app/context/global-sdk.tsx
@@ -1,0 +1,131 @@
+import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2/client";
+import { createGlobalEmitter } from "@solid-primitives/event-bus";
+import { batch, createContext, onCleanup, useContext, type ParentProps } from "solid-js";
+
+import { usePlatform } from "./platform";
+import { useServer } from "./server";
+
+type GlobalSDKContextValue = {
+  url: string;
+  client: ReturnType<typeof createOpencodeClient>;
+  event: ReturnType<typeof createGlobalEmitter<{ [key: string]: Event }>>;
+};
+
+const GlobalSDKContext = createContext<GlobalSDKContextValue | undefined>(undefined);
+
+export function GlobalSDKProvider(props: ParentProps) {
+  const server = useServer();
+  const platform = usePlatform();
+  const abort = new AbortController();
+
+  const eventClient = createOpencodeClient({
+    baseUrl: server.url,
+    signal: abort.signal,
+    fetch: platform.fetch,
+  });
+
+  const emitter = createGlobalEmitter<{ [key: string]: Event }>();
+
+  type Queued = { directory: string; payload: Event };
+
+  let queue: Array<Queued | undefined> = [];
+  const coalesced = new Map<string, number>();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let last = 0;
+
+  const keyForEvent = (directory: string, payload: Event) => {
+    if (payload.type === "session.status") return `session.status:${directory}:${payload.properties.sessionID}`;
+    if (payload.type === "lsp.updated") return `lsp.updated:${directory}`;
+    if (payload.type === "todo.updated") return `todo.updated:${directory}:${payload.properties.sessionID}`;
+    if (payload.type === "mcp.tools.changed") return `mcp.tools.changed:${directory}:${payload.properties.server}`;
+    if (payload.type === "message.part.updated") {
+      const part = payload.properties.part;
+      return `message.part.updated:${directory}:${part.messageID}:${part.id}`;
+    }
+  };
+
+  const flush = () => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+
+    const events = queue;
+    queue = [];
+    coalesced.clear();
+    if (events.length === 0) return;
+
+    last = Date.now();
+    batch(() => {
+      for (const entry of events) {
+        if (!entry) continue;
+        emitter.emit(entry.directory, entry.payload);
+      }
+    });
+  };
+
+  const schedule = () => {
+    if (timer) return;
+    const elapsed = Date.now() - last;
+    timer = setTimeout(flush, Math.max(0, 16 - elapsed));
+  };
+
+  const stop = () => {
+    flush();
+  };
+
+  void (async () => {
+    const subscription = await eventClient.event.subscribe(undefined, { signal: abort.signal });
+    let yielded = Date.now();
+
+    for await (const event of subscription.stream as AsyncIterable<unknown>) {
+      const record = event as Event & { directory?: string; payload?: Event };
+      const payload = record.payload ?? record;
+      if (!payload?.type) continue;
+
+      const directory = typeof record.directory === "string" ? record.directory : "global";
+      const key = keyForEvent(directory, payload);
+      if (key) {
+        const index = coalesced.get(key);
+        if (index !== undefined) {
+          queue[index] = undefined;
+        }
+        coalesced.set(key, queue.length);
+      }
+
+      queue.push({ directory, payload });
+      schedule();
+
+      if (Date.now() - yielded < 8) continue;
+      yielded = Date.now();
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+  })()
+    .finally(stop)
+    .catch(() => undefined);
+
+  onCleanup(() => {
+    abort.abort();
+    stop();
+  });
+
+  const client = createOpencodeClient({
+    baseUrl: server.url,
+    fetch: platform.fetch,
+    throwOnError: true,
+  });
+
+  const value: GlobalSDKContextValue = {
+    url: server.url,
+    client,
+    event: emitter,
+  };
+
+  return <GlobalSDKContext.Provider value={value}>{props.children}</GlobalSDKContext.Provider>;
+}
+
+export function useGlobalSDK() {
+  const context = useContext(GlobalSDKContext);
+  if (!context) {
+    throw new Error("Global SDK context is missing");
+  }
+  return context;
+}

--- a/src/app/context/global-sync.tsx
+++ b/src/app/context/global-sync.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+import { createStore, type SetStoreFunction, type Store } from "solid-js/store";
+
+import type { Message, Part, Session } from "@opencode-ai/sdk/v2/client";
+
+import type { TodoItem } from "../types";
+
+export type WorkspaceState = {
+  status: "idle" | "loading" | "partial" | "ready";
+  session: Session[];
+  session_status: Record<string, string>;
+  message: Record<string, Message[]>;
+  part: Record<string, Part[]>;
+  todo: Record<string, TodoItem[]>;
+};
+
+type WorkspaceStore = [Store<WorkspaceState>, SetStoreFunction<WorkspaceState>];
+
+type GlobalSyncContextValue = {
+  data: Store<{ ready: boolean; error?: string }>;
+  child: (directory: string) => WorkspaceStore;
+};
+
+const GlobalSyncContext = createContext<GlobalSyncContextValue | undefined>(undefined);
+
+const createWorkspaceState = (): WorkspaceState => ({
+  status: "idle",
+  session: [],
+  session_status: {},
+  message: {},
+  part: {},
+  todo: {},
+});
+
+export function GlobalSyncProvider(props: ParentProps) {
+  const [globalStore] = createStore({ ready: true, error: undefined as string | undefined });
+  const children = new Map<string, WorkspaceStore>();
+
+  const child = (directory: string): WorkspaceStore => {
+    const key = directory || "global";
+    const existing = children.get(key);
+    if (existing) return existing;
+    const store = createStore<WorkspaceState>(createWorkspaceState());
+    children.set(key, store);
+    return store;
+  };
+
+  const value: GlobalSyncContextValue = {
+    data: globalStore,
+    child,
+  };
+
+  return <GlobalSyncContext.Provider value={value}>{props.children}</GlobalSyncContext.Provider>;
+}
+
+export function useGlobalSync() {
+  const context = useContext(GlobalSyncContext);
+  if (!context) {
+    throw new Error("Global sync context is missing");
+  }
+  return context;
+}

--- a/src/app/context/local.tsx
+++ b/src/app/context/local.tsx
@@ -1,0 +1,69 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+import { createStore, type SetStoreFunction, type Store } from "solid-js/store";
+
+import type { DashboardTab, DemoSequence, ModelRef, View } from "../types";
+import { Persist, persisted } from "../utils/persist";
+
+type LocalUIState = {
+  view: View;
+  tab: DashboardTab;
+  demoMode: boolean;
+  demoSequence: DemoSequence;
+};
+
+type LocalPreferences = {
+  showThinking: boolean;
+  modelVariant: string | null;
+  defaultModel: ModelRef | null;
+};
+
+type LocalContextValue = {
+  ui: Store<LocalUIState>;
+  setUi: SetStoreFunction<LocalUIState>;
+  prefs: Store<LocalPreferences>;
+  setPrefs: SetStoreFunction<LocalPreferences>;
+  ready: () => boolean;
+};
+
+const LocalContext = createContext<LocalContextValue | undefined>(undefined);
+
+export function LocalProvider(props: ParentProps) {
+  const [ui, setUi, , uiReady] = persisted(
+    Persist.global("local.ui", ["openwork.ui"]),
+    createStore<LocalUIState>({
+      view: "onboarding",
+      tab: "home",
+      demoMode: false,
+      demoSequence: "cold-open",
+    }),
+  );
+
+  const [prefs, setPrefs, , prefsReady] = persisted(
+    Persist.global("local.preferences", ["openwork.preferences"]),
+    createStore<LocalPreferences>({
+      showThinking: false,
+      modelVariant: null,
+      defaultModel: null,
+    }),
+  );
+
+  const ready = () => uiReady() && prefsReady();
+
+  const value: LocalContextValue = {
+    ui,
+    setUi,
+    prefs,
+    setPrefs,
+    ready,
+  };
+
+  return <LocalContext.Provider value={value}>{props.children}</LocalContext.Provider>;
+}
+
+export function useLocal() {
+  const context = useContext(LocalContext);
+  if (!context) {
+    throw new Error("Local context is missing");
+  }
+  return context;
+}

--- a/src/app/context/platform.tsx
+++ b/src/app/context/platform.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+
+export type SyncStorage = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+export type AsyncStorage = {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+};
+
+export type Platform = {
+  platform: "web" | "desktop";
+  os?: "macos" | "windows" | "linux";
+  version?: string;
+  openLink(url: string): void;
+  restart(): Promise<void>;
+  notify(title: string, description?: string, href?: string): Promise<void>;
+  storage?: (name?: string) => SyncStorage | AsyncStorage;
+  checkUpdate?: () => Promise<{ updateAvailable: boolean; version?: string }>;
+  update?: () => Promise<void>;
+  fetch?: typeof fetch;
+  getDefaultServerUrl?: () => Promise<string | null>;
+  setDefaultServerUrl?: (url: string | null) => Promise<void>;
+};
+
+const PlatformContext = createContext<Platform | undefined>(undefined);
+
+export function PlatformProvider(props: ParentProps & { value: Platform }) {
+  return (
+    <PlatformContext.Provider value={props.value}>
+      {props.children}
+    </PlatformContext.Provider>
+  );
+}
+
+export function usePlatform() {
+  const context = useContext(PlatformContext);
+  if (!context) {
+    throw new Error("Platform context is missing");
+  }
+  return context;
+}

--- a/src/app/context/server.tsx
+++ b/src/app/context/server.tsx
@@ -1,0 +1,180 @@
+import { createContext, createEffect, createMemo, createSignal, onCleanup, useContext, type ParentProps } from "solid-js";
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+
+export function normalizeServerUrl(input: string) {
+  const trimmed = input.trim();
+  if (!trimmed) return;
+  const withProtocol = /^https?:\/\//.test(trimmed) ? trimmed : `http://${trimmed}`;
+  return withProtocol.replace(/\/+$/, "");
+}
+
+export function serverDisplayName(url: string) {
+  if (!url) return "";
+  return url.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+}
+
+type ServerContextValue = {
+  url: string;
+  name: string;
+  list: string[];
+  healthy: () => boolean | undefined;
+  setActive: (url: string) => void;
+  add: (url: string) => void;
+  remove: (url: string) => void;
+};
+
+const ServerContext = createContext<ServerContextValue | undefined>(undefined);
+
+export function ServerProvider(props: ParentProps & { defaultUrl: string }) {
+  const [list, setList] = createSignal<string[]>([]);
+  const [active, setActiveRaw] = createSignal("");
+  const [healthy, setHealthy] = createSignal<boolean | undefined>(undefined);
+  const [ready, setReady] = createSignal(false);
+
+  const readStoredList = () => {
+    try {
+      const raw = window.localStorage.getItem("openwork.server.list");
+      const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+      return Array.isArray(parsed) ? parsed.filter((item) => typeof item === "string") : [];
+    } catch {
+      return [];
+    }
+  };
+
+  const readStoredActive = () => {
+    try {
+      const stored = window.localStorage.getItem("openwork.server.active");
+      return typeof stored === "string" ? stored : "";
+    } catch {
+      return "";
+    }
+  };
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    if (ready()) return;
+
+    const storedList = readStoredList();
+    const fallback = normalizeServerUrl(props.defaultUrl) ?? "";
+    const storedActive = normalizeServerUrl(readStoredActive());
+
+    const initialList = storedList.length ? storedList : fallback ? [fallback] : [];
+    const initialActive = storedActive || initialList[0] || fallback || "";
+
+    setList(initialList);
+    setActiveRaw(initialActive);
+    setReady(true);
+  });
+
+  createEffect(() => {
+    if (!ready()) return;
+    if (typeof window === "undefined") return;
+
+    try {
+      window.localStorage.setItem("openwork.server.list", JSON.stringify(list()));
+      window.localStorage.setItem("openwork.server.active", active());
+    } catch {
+      // ignore
+    }
+  });
+
+  const activeUrl = createMemo(() => active());
+
+  const checkHealth = async (url: string) => {
+    if (!url) return false;
+    const client = createOpencodeClient({
+      baseUrl: url,
+      signal: AbortSignal.timeout(3000),
+    });
+    return client.global
+      .health()
+      .then((result) => result.data?.healthy === true)
+      .catch(() => false);
+  };
+
+  createEffect(() => {
+    const url = activeUrl();
+    if (!url) return;
+
+    setHealthy(undefined);
+
+    let activeRun = true;
+    let busy = false;
+
+    const run = () => {
+      if (busy) return;
+      busy = true;
+      void checkHealth(url)
+        .then((next) => {
+          if (!activeRun) return;
+          setHealthy(next);
+        })
+        .finally(() => {
+          busy = false;
+        });
+    };
+
+    run();
+    const interval = window.setInterval(run, 10_000);
+
+    onCleanup(() => {
+      activeRun = false;
+      window.clearInterval(interval);
+    });
+  });
+
+  const setActive = (input: string) => {
+    const next = normalizeServerUrl(input);
+    if (!next) return;
+    setActiveRaw(next);
+  };
+
+  const add = (input: string) => {
+    const next = normalizeServerUrl(input);
+    if (!next) return;
+
+    setList((current) => {
+      if (current.includes(next)) return current;
+      return [...current, next];
+    });
+    setActiveRaw(next);
+  };
+
+  const remove = (input: string) => {
+    const next = normalizeServerUrl(input);
+    if (!next) return;
+
+    setList((current) => current.filter((item) => item !== next));
+    setActiveRaw((current) => {
+      if (current !== next) return current;
+      const remaining = list().filter((item) => item !== next);
+      return remaining[0] ?? "";
+    });
+  };
+
+  const value: ServerContextValue = {
+    get url() {
+      return activeUrl();
+    },
+    get name() {
+      return serverDisplayName(activeUrl());
+    },
+    get list() {
+      return list();
+    },
+    healthy,
+    setActive,
+    add,
+    remove,
+  };
+
+  return <ServerContext.Provider value={value}>{props.children}</ServerContext.Provider>;
+}
+
+export function useServer() {
+  const context = useContext(ServerContext);
+  if (!context) {
+    throw new Error("Server context is missing");
+  }
+  return context;
+}

--- a/src/app/context/sync.tsx
+++ b/src/app/context/sync.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+import type { SetStoreFunction, Store } from "solid-js/store";
+
+import { useGlobalSync, type WorkspaceState } from "./global-sync";
+
+type SyncContextValue = {
+  directory: string;
+  data: Store<WorkspaceState>;
+  set: SetStoreFunction<WorkspaceState>;
+};
+
+const SyncContext = createContext<SyncContextValue | undefined>(undefined);
+
+export function SyncProvider(props: ParentProps & { directory: string }) {
+  const globalSync = useGlobalSync();
+  const [store, setStore] = globalSync.child(props.directory);
+
+  const value: SyncContextValue = {
+    directory: props.directory,
+    data: store,
+    set: setStore,
+  };
+
+  return <SyncContext.Provider value={value}>{props.children}</SyncContext.Provider>;
+}
+
+export function useSync() {
+  const context = useContext(SyncContext);
+  if (!context) {
+    throw new Error("Sync context is missing");
+  }
+  return context;
+}

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
-@config "../tailwind.config.ts";
+@config "../../tailwind.config.ts";
 
-@import "./styles/colors.css";
+@import "../styles/colors.css";
 
 :root {
   color-scheme: light;

--- a/src/app/pages/mcp.tsx
+++ b/src/app/pages/mcp.tsx
@@ -24,16 +24,6 @@ export type McpViewProps = {
   connectMcp: (entry: McpDirectoryInfo) => void;
   showMcpReloadBanner: boolean;
   reloadMcpEngine: () => void;
-  advancedName: string;
-  setAdvancedName: (value: string) => void;
-  advancedUrl: string;
-  setAdvancedUrl: (value: string) => void;
-  advancedOAuth: boolean;
-  setAdvancedOAuth: (value: boolean) => void;
-  advancedEnabled: boolean;
-  setAdvancedEnabled: (value: boolean) => void;
-  addAdvancedMcp: () => void;
-  testAdvancedMcp: () => void;
 };
 
 const statusBadge = (status: "connected" | "needs_auth" | "needs_client_registration" | "failed" | "disabled" | "disconnected") => {

--- a/src/app/utils/persist.ts
+++ b/src/app/utils/persist.ts
@@ -1,0 +1,253 @@
+import { makePersisted } from "@solid-primitives/storage";
+import { createResource, type Accessor } from "solid-js";
+import type { SetStoreFunction, Store } from "solid-js/store";
+
+import { usePlatform, type AsyncStorage, type SyncStorage } from "../context/platform";
+
+type InitType = Promise<string> | string | null;
+type PersistedWithReady<T> = [Store<T>, SetStoreFunction<T>, InitType, Accessor<boolean>];
+
+type PersistTarget = {
+  storage?: string;
+  key: string;
+  legacy?: string[];
+  migrate?: (value: unknown) => unknown;
+};
+
+const LEGACY_STORAGE = "default.dat";
+const GLOBAL_STORAGE = "openwork.global.dat";
+
+function snapshot(value: unknown) {
+  return JSON.parse(JSON.stringify(value)) as unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function merge(defaults: unknown, value: unknown): unknown {
+  if (value === undefined) return defaults;
+  if (value === null) return value;
+
+  if (Array.isArray(defaults)) {
+    if (Array.isArray(value)) return value;
+    return defaults;
+  }
+
+  if (isRecord(defaults)) {
+    if (!isRecord(value)) return defaults;
+
+    const result: Record<string, unknown> = { ...defaults };
+    for (const key of Object.keys(value)) {
+      if (key in defaults) {
+        result[key] = merge((defaults as Record<string, unknown>)[key], (value as Record<string, unknown>)[key]);
+      } else {
+        result[key] = (value as Record<string, unknown>)[key];
+      }
+    }
+    return result;
+  }
+
+  return value;
+}
+
+function parse(value: string) {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function checksum(input: string) {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+function workspaceStorage(dir: string) {
+  const head = dir.slice(0, 12) || "workspace";
+  const sum = checksum(dir);
+  return `openwork.workspace.${head}.${sum}.dat`;
+}
+
+function localStorageWithPrefix(prefix: string): SyncStorage {
+  const base = `${prefix}:`;
+  return {
+    getItem: (key) => localStorage.getItem(base + key),
+    setItem: (key, value) => localStorage.setItem(base + key, value),
+    removeItem: (key) => localStorage.removeItem(base + key),
+  };
+}
+
+export const Persist = {
+  global(key: string, legacy?: string[]): PersistTarget {
+    return { storage: GLOBAL_STORAGE, key, legacy };
+  },
+  workspace(dir: string, key: string, legacy?: string[]): PersistTarget {
+    return { storage: workspaceStorage(dir), key: `workspace:${key}`, legacy };
+  },
+  session(dir: string, session: string, key: string, legacy?: string[]): PersistTarget {
+    return { storage: workspaceStorage(dir), key: `session:${session}:${key}`, legacy };
+  },
+  scoped(dir: string, session: string | undefined, key: string, legacy?: string[]): PersistTarget {
+    if (session) return Persist.session(dir, session, key, legacy);
+    return Persist.workspace(dir, key, legacy);
+  },
+};
+
+export function removePersisted(target: { storage?: string; key: string }) {
+  const platform = usePlatform();
+  const isDesktop = platform.platform === "desktop" && !!platform.storage;
+
+  if (isDesktop) {
+    return platform.storage?.(target.storage)?.removeItem(target.key);
+  }
+
+  if (!target.storage) {
+    localStorage.removeItem(target.key);
+    return;
+  }
+
+  localStorageWithPrefix(target.storage).removeItem(target.key);
+}
+
+export function persisted<T>(
+  target: string | PersistTarget,
+  store: [Store<T>, SetStoreFunction<T>],
+): PersistedWithReady<T> {
+  const platform = usePlatform();
+  const config: PersistTarget = typeof target === "string" ? { key: target } : target;
+
+  const defaults = snapshot(store[0]);
+  const legacy = config.legacy ?? [];
+
+  const isDesktop = platform.platform === "desktop" && !!platform.storage;
+
+  const currentStorage = (() => {
+    if (isDesktop) return platform.storage?.(config.storage);
+    if (!config.storage) return localStorage;
+    return localStorageWithPrefix(config.storage);
+  })();
+
+  const legacyStorage = (() => {
+    if (!isDesktop) return localStorage;
+    if (!config.storage) return platform.storage?.();
+    return platform.storage?.(LEGACY_STORAGE);
+  })();
+
+  const storage = (() => {
+    if (!isDesktop) {
+      const current = currentStorage as SyncStorage;
+      const legacyStore = legacyStorage as SyncStorage;
+
+      const api: SyncStorage = {
+        getItem: (key) => {
+          const raw = current.getItem(key);
+          if (raw !== null) {
+            const parsed = parse(raw);
+            if (parsed === undefined) return raw;
+
+            const migrated = config.migrate ? config.migrate(parsed) : parsed;
+            const merged = merge(defaults, migrated);
+            const next = JSON.stringify(merged);
+            if (raw !== next) current.setItem(key, next);
+            return next;
+          }
+
+          for (const legacyKey of legacy) {
+            const legacyRaw = legacyStore.getItem(legacyKey);
+            if (legacyRaw === null) continue;
+
+            current.setItem(key, legacyRaw);
+            legacyStore.removeItem(legacyKey);
+
+            const parsed = parse(legacyRaw);
+            if (parsed === undefined) return legacyRaw;
+
+            const migrated = config.migrate ? config.migrate(parsed) : parsed;
+            const merged = merge(defaults, migrated);
+            const next = JSON.stringify(merged);
+            if (legacyRaw !== next) current.setItem(key, next);
+            return next;
+          }
+
+          return null;
+        },
+        setItem: (key, value) => {
+          current.setItem(key, value);
+        },
+        removeItem: (key) => {
+          current.removeItem(key);
+        },
+      };
+
+      return api;
+    }
+
+    const current = currentStorage as AsyncStorage;
+    const legacyStore = legacyStorage as AsyncStorage | undefined;
+
+    const api: AsyncStorage = {
+      getItem: async (key) => {
+        const raw = await current.getItem(key);
+        if (raw !== null) {
+          const parsed = parse(raw);
+          if (parsed === undefined) return raw;
+
+          const migrated = config.migrate ? config.migrate(parsed) : parsed;
+          const merged = merge(defaults, migrated);
+          const next = JSON.stringify(merged);
+          if (raw !== next) await current.setItem(key, next);
+          return next;
+        }
+
+        if (!legacyStore) return null;
+
+        for (const legacyKey of legacy) {
+          const legacyRaw = await legacyStore.getItem(legacyKey);
+          if (legacyRaw === null) continue;
+
+          await current.setItem(key, legacyRaw);
+          await legacyStore.removeItem(legacyKey);
+
+          const parsed = parse(legacyRaw);
+          if (parsed === undefined) return legacyRaw;
+
+          const migrated = config.migrate ? config.migrate(parsed) : parsed;
+          const merged = merge(defaults, migrated);
+          const next = JSON.stringify(merged);
+          if (legacyRaw !== next) await current.setItem(key, next);
+          return next;
+        }
+
+        return null;
+      },
+      setItem: async (key, value) => {
+        await current.setItem(key, value);
+      },
+      removeItem: async (key) => {
+        await current.removeItem(key);
+      },
+    };
+
+    return api;
+  })();
+
+  const [state, setState, init] = makePersisted(store, { name: config.key, storage });
+
+  const isAsync = init instanceof Promise;
+  const [ready] = createResource(
+    () => init,
+    async (initValue) => {
+      if (initValue instanceof Promise) await initValue;
+      return true;
+    },
+    { initialValue: !isAsync },
+  );
+
+  return [state, setState, init, () => ready() === true];
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,10 @@
 import { render } from "solid-js/web";
 
 import { bootstrapTheme } from "./app/theme";
-import "./styles.css";
+import "./app/index.css";
 import App from "./app/app";
+import { PlatformProvider, type Platform } from "./app/context/platform";
+import { isTauriRuntime } from "./app/utils";
 
 bootstrapTheme();
 
@@ -13,4 +15,72 @@ if (!root) {
   throw new Error("Root element not found");
 }
 
-render(() => <App />, root);
+const platform: Platform = {
+  platform: isTauriRuntime() ? "desktop" : "web",
+  openLink(url: string) {
+    if (isTauriRuntime()) {
+      void import("@tauri-apps/plugin-opener")
+        .then(({ openUrl }) => openUrl(url))
+        .catch(() => undefined);
+      return;
+    }
+
+    window.open(url, "_blank");
+  },
+  restart: async () => {
+    if (isTauriRuntime()) {
+      const { relaunch } = await import("@tauri-apps/plugin-process");
+      await relaunch();
+      return;
+    }
+
+    window.location.reload();
+  },
+  notify: async (title, description, href) => {
+    if (!("Notification" in window)) return;
+
+    const permission =
+      Notification.permission === "default"
+        ? await Notification.requestPermission().catch(() => "denied")
+        : Notification.permission;
+
+    if (permission !== "granted") return;
+
+    const inView = document.visibilityState === "visible" && document.hasFocus();
+    if (inView) return;
+
+    await Promise.resolve()
+      .then(() => {
+        const notification = new Notification(title, {
+          body: description ?? "",
+        });
+        notification.onclick = () => {
+          window.focus();
+          if (href) {
+            window.history.pushState(null, "", href);
+            window.dispatchEvent(new PopStateEvent("popstate"));
+          }
+          notification.close();
+        };
+      })
+      .catch(() => undefined);
+  },
+  storage: (name) => {
+    const prefix = name ? `${name}:` : "";
+    return {
+      getItem: (key) => window.localStorage.getItem(prefix + key),
+      setItem: (key, value) => window.localStorage.setItem(prefix + key, value),
+      removeItem: (key) => window.localStorage.removeItem(prefix + key),
+    };
+  },
+  fetch,
+};
+
+render(
+  () => (
+    <PlatformProvider value={platform}>
+      <App />
+    </PlatformProvider>
+  ),
+  root,
+);


### PR DESCRIPTION
## Summary
- add a `LocalProvider` with persisted UI + preference stores
- define stable local state shape for view/tab/demo + model prefs
- stack on #143 for sync scaffolding

## Testing
- pnpm -C /Users/benjaminshafii/digital-empire/worktrees/sub-openwork-state-arch-local typecheck
- pnpm -C /Users/benjaminshafii/digital-empire/worktrees/sub-openwork-state-arch-local build:web