### PR TITLE
feat: inline artifacts in chat

### DIFF
--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -50,6 +50,7 @@ export type ArtifactItem = {
   path?: string;
   kind: "file" | "text";
   size?: string;
+  messageId?: string;
 };
 
 export type OpencodeEvent = {

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -469,6 +469,7 @@ export function deriveArtifacts(list: MessageWithParts[]): ArtifactItem[] {
   const filePattern = /([\w./\-]+\.(?:pdf|docx|doc|txt|md|csv|json|js|ts|tsx|xlsx|pptx|png|jpg|jpeg))/gi;
 
   list.forEach((message) => {
+    const messageId = String((message.info as any).id ?? "");
     message.parts.forEach((part) => {
       if (part.type !== "tool") return;
       const record = part as any;
@@ -491,7 +492,8 @@ export function deriveArtifacts(list: MessageWithParts[]): ArtifactItem[] {
 
       matches.forEach((match) => {
         const name = match.split("/").pop() ?? match;
-        const id = `artifact-${record.id ?? name}`;
+        const idBase = record.id ?? name;
+        const id = messageId ? `artifact-${messageId}-${idBase}` : `artifact-${idBase}`;
         if (seen.has(id)) return;
         seen.add(id);
 
@@ -501,6 +503,7 @@ export function deriveArtifacts(list: MessageWithParts[]): ArtifactItem[] {
           path: match,
           kind: "file",
           size: state.size ? String(state.size) : undefined,
+          messageId: messageId || undefined,
         });
       });
     });


### PR DESCRIPTION
## Summary
- attach message IDs to derived artifacts for inline placement
- render artifact cards directly under their triggering message
- fall back to an end-of-chat list when no message ID exists

## Testing
- pnpm typecheck
- pnpm build:web