### PR TITLE
fix(engine): resolve sidecar via current binary dir

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -93,5 +93,8 @@ jobs:
           cp "$bin_path" "packages/desktop/src-tauri/sidecars/${target_name}"
           chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
 
+      - name: Run Rust tests (engine + sidecar resolution)
+        run: cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml --locked
+
       - name: Build desktop app
         run: pnpm --filter @different-ai/openwork exec tauri build --config src-tauri/tauri.conf.ci.json --target x86_64-unknown-linux-gnu --bundles deb

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/desktop/src-tauri/src/commands/misc.rs
+++ b/packages/desktop/src-tauri/src/commands/misc.rs
@@ -133,7 +133,11 @@ pub fn opencode_mcp_auth(
   }
 
   let resource_dir = app.path().resource_dir().ok();
-  let (program, _in_path, notes) = resolve_engine_path(true, resource_dir.as_deref());
+  let current_bin_dir = tauri::process::current_binary(&app.env())
+    .ok()
+    .and_then(|path| path.parent().map(|parent| parent.to_path_buf()));
+  let (program, _in_path, notes) =
+    resolve_engine_path(true, resource_dir.as_deref(), current_bin_dir.as_deref());
   let Some(program) = program else {
     let notes_text = notes.join("\n");
     return Err(format!(

--- a/packages/desktop/src-tauri/src/engine/doctor.rs
+++ b/packages/desktop/src-tauri/src/engine/doctor.rs
@@ -48,6 +48,7 @@ pub fn opencode_serve_help(program: &OsStr) -> (bool, Option<i32>, Option<String
 pub fn resolve_sidecar_candidate(
   prefer_sidecar: bool,
   resource_dir: Option<&Path>,
+  current_bin_dir: Option<&Path>,
 ) -> (Option<std::path::PathBuf>, Vec<String>) {
   if !prefer_sidecar {
     return (None, Vec::new());
@@ -58,6 +59,10 @@ pub fn resolve_sidecar_candidate(
   #[cfg(not(windows))]
   {
     let mut candidates = Vec::new();
+
+    if let Some(current_bin_dir) = current_bin_dir {
+      candidates.push(current_bin_dir.join(crate::engine::paths::opencode_executable_name()));
+    }
 
     if let Some(resource_dir) = resource_dir {
       candidates.push(
@@ -95,8 +100,10 @@ pub fn resolve_sidecar_candidate(
 pub fn resolve_engine_path(
   prefer_sidecar: bool,
   resource_dir: Option<&Path>,
+  current_bin_dir: Option<&Path>,
 ) -> (Option<std::path::PathBuf>, bool, Vec<String>) {
-  let (sidecar, mut notes) = resolve_sidecar_candidate(prefer_sidecar, resource_dir);
+  let (sidecar, mut notes) =
+    resolve_sidecar_candidate(prefer_sidecar, resource_dir, current_bin_dir);
   let (resolved, in_path, more_notes) = match sidecar {
     Some(path) => (Some(path), false, Vec::new()),
     None => resolve_opencode_executable(),
@@ -104,4 +111,57 @@ pub fn resolve_engine_path(
 
   notes.extend(more_notes);
   (resolved, in_path, notes)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[cfg(not(windows))]
+  fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nanos = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .map(|d| d.as_nanos())
+      .unwrap_or(0);
+
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("openwork-{name}-{}-{}", std::process::id(), nanos));
+    dir
+  }
+
+  #[test]
+  #[cfg(not(windows))]
+  fn resolves_sidecar_from_current_binary_dir() {
+    let dir = unique_temp_dir("sidecar-test");
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+
+    let sidecar_path = dir.join(crate::engine::paths::opencode_executable_name());
+    std::fs::write(&sidecar_path, b"").expect("create fake sidecar");
+
+    let (resolved, notes) = resolve_sidecar_candidate(true, None, Some(dir.as_path()));
+    assert_eq!(resolved.as_ref(), Some(&sidecar_path));
+    assert!(notes
+      .iter()
+      .any(|note| note.contains("Using bundled sidecar")), "missing success note: {:?}", notes);
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
+
+  #[test]
+  #[cfg(not(windows))]
+  fn resolve_engine_path_prefers_sidecar() {
+    let dir = unique_temp_dir("engine-path-test");
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+
+    let sidecar_path = dir.join(crate::engine::paths::opencode_executable_name());
+    std::fs::write(&sidecar_path, b"").expect("create fake sidecar");
+
+    let (resolved, in_path, _notes) = resolve_engine_path(true, None, Some(dir.as_path()));
+    assert_eq!(resolved.as_ref(), Some(&sidecar_path));
+    assert!(!in_path);
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
 }


### PR DESCRIPTION
## What
- Resolve bundled OpenCode sidecar by checking the directory next to the running app binary (matches OpenCode Desktop behavior).
- Keep existing `resource_dir` + dev fallbacks for safety.

## Why
On machines without an OpenCode CLI install, OpenWork defaults to sidecar mode. The bundled sidecar is placed next to the app executable (e.g. macOS `Contents/MacOS/opencode`), but OpenWork only searched `Contents/Resources`, causing "OpenCode CLI not found" errors.

## Test
- Added Rust unit tests for sidecar resolution (`cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml`).
- Updated PR workflow to run those tests in CI (`.github/workflows/build-desktop.yml`).