### PR TITLE
chore: release v0.2.8

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@different-ai/openwork",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.2.8",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.2.6"
+version = "0.2.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwork"
-version = "0.2.6"
+version = "0.2.8"
 description = "OpenWork"
 authors = ["Different AI"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenWork",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "identifier": "com.differentai.openwork",
   "build": {
     "beforeDevCommand": "pnpm dev:web",


### PR DESCRIPTION
## Release v0.2.8

This release includes the sidecar resolution fix merged in #165.

## Included changes
- Fix: OpenWork resolves the bundled OpenCode sidecar from the app binary directory (so host mode works on machines without OpenCode installed).
- CI: add Rust unit tests for sidecar resolution and run them in the PR build workflow.

## Verification
- `cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm build:web`