### PR TITLE
fix(macos): add entitlements for bundled opencode

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@different-ai/openwork",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwork"
-version = "0.2.8"
+version = "0.2.9"
 description = "OpenWork"
 authors = ["Different AI"]
 edition = "2021"

--- a/packages/desktop/src-tauri/entitlements.plist
+++ b/packages/desktop/src-tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-executable-page-protection</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenWork",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "identifier": "com.differentai.openwork",
   "build": {
     "beforeDevCommand": "pnpm dev:web",
@@ -24,6 +24,9 @@
   },
   "bundle": {
     "createUpdaterArtifacts": true,
+    "macOS": {
+      "entitlements": "./entitlements.plist"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Why
On signed/notarized macOS builds, the bundled `opencode` sidecar can fail to start with:

`Ran out of executable memory while allocating ...`

That’s a hardened runtime / JIT entitlement issue.

## What
- Add `packages/desktop/src-tauri/entitlements.plist` with the JIT/executable-memory entitlements required by the bundled OpenCode sidecar.
- Wire it into Tauri config via `bundle.macOS.entitlements`.
- Bump patch version to `0.2.9` so we can ship this as a release.

## Verification
- `cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm build:web`