### PR TITLE
fix: add rpm to release-macos-aarch64.yml

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -39,6 +39,7 @@ jobs:
             libsoup-3.0-dev \
             libwebkit2gtk-4.1-dev \
             libssl-dev \
+            rpm \
             libdbus-1-dev \
             librsvg2-dev
 

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -140,8 +140,8 @@ jobs:
             args: "--target x86_64-apple-darwin --bundles dmg,app"
           - platform: ubuntu-22.04
             os_type: linux
-            target: aarch64-unknown-linux-gnu
-            args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
+            target: x86_64-unknown-linux-gnu
+            args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
           - platform: windows-2022
             os_type: windows
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -141,7 +141,7 @@ jobs:
           - platform: ubuntu-22.04
             os_type: linux
             target: x86_64-unknown-linux-gnu
-            args: "--target x86_64-unknown-linux-gnu --bundles deb"
+            args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
           - platform: windows-2022
             os_type: windows
             target: x86_64-pc-windows-msvc
@@ -231,6 +231,7 @@ jobs:
             libsoup-3.0-dev \
             libwebkit2gtk-4.1-dev \
             libssl-dev \
+            rpm \
             libdbus-1-dev \
             librsvg2-dev
 

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -140,8 +140,8 @@ jobs:
             args: "--target x86_64-apple-darwin --bundles dmg,app"
           - platform: ubuntu-22.04
             os_type: linux
-            target: x86_64-unknown-linux-gnu
-            args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
+            target: aarch64-unknown-linux-gnu
+            args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
           - platform: windows-2022
             os_type: windows
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
I realised I also didn't add it to this file, apologies for the mistake.