### PR TITLE
Fix/duplicate artifacts

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -322,6 +322,7 @@ export default function App() {
 
   const extensionsStore = createExtensionsStore({
     client,
+    baseUrl,
     mode,
     projectDir: () => workspaceProjectDir(),
     activeWorkspaceRoot: () => workspaceStore.activeWorkspaceRoot(),

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -491,7 +491,8 @@ export function deriveArtifacts(list: MessageWithParts[]): ArtifactItem[] {
 
       matches.forEach((match) => {
         const name = match.split("/").pop() ?? match;
-        const id = `artifact-${record.id ?? name}`;
+        // Use full path as unique ID to avoid duplicates when multiple tool operations reference the same file
+        const id = `artifact-${match}`;
         if (seen.has(id)) return;
         seen.add(id);
 


### PR DESCRIPTION
title: fix: prevent duplicate artifacts in file list

  desctiption:
  ## Summary
  - Fixed duplicate file artifacts appearing in the task page chat area
  - Changed deriveArtifacts function to use full file path as unique ID
  - When multiple tool operations reference the same file, it now only appears once in the artifacts list

  ## Changes
  - Modified `src/app/utils/index.ts:deriveArtifacts()`
  - Changed unique ID generation from tool operation ID to full file path
  - This prevents the same file from being listed multiple times

  ## Root Cause
  The previous implementation used `artifact-${record.id ?? name}` as the unique ID. When multiple tool operations referenced the same file, each
  operation had a different `record.id`, causing the same file to appear multiple times in the artifacts list.

  ## Fix
  Now using `artifact-${match}` (full file path) as the unique ID, ensuring each file path appears only once regardless of how many tool operations
  reference it.

  ## Test plan
  - [x] Reviewed code changes
  - [x] Verified deduplication logic works correctly
  - [x] Confirmed no regression in artifact display