### PR TITLE
refactor: enhance markdown rendering (fixes #171)

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -36,6 +36,7 @@
     "@tauri-apps/plugin-updater": "~2.9.0",
     "jsonc-parser": "^3.2.1",
     "lucide-solid": "^0.562.0",
+    "marked": "^17.0.1",
     "solid-js": "^1.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #171

Changes:
- Replace regex-based parsing with `marked` library
- Add support for full Markdown syntax (headings, lists, tables, blockquotes)
- Improve type safety with proper type guards
- Add empty string optimization
- Reuse `safeStringify` from utils instead of duplicating code

![image](https://github.com/user-attachments/assets/6da1f8ae-9f77-4be7-8502-6f3ebd2ddcde)
