### PR TITLE
Add session commands, auth picker, and completion

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -195,6 +195,7 @@ export default function App() {
     loadSessions,
     refreshPendingPermissions,
     selectSession,
+    renameSession,
     respondPermission,
     setSessions,
     setSessionStatusById,
@@ -227,6 +228,7 @@ export default function App() {
     activeArtifacts,
     activeWorkingFiles,
     selectDemoSession,
+    renameDemoSession,
   } = demoState;
 
   const [prompt, setPrompt] = createSignal("");
@@ -287,6 +289,20 @@ export default function App() {
       setBusyLabel(null);
       setBusyStartedAt(null);
     }
+  }
+
+  async function renameSessionTitle(sessionID: string, title: string) {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      throw new Error("Session name is required");
+    }
+
+    if (isDemoMode()) {
+      renameDemoSession(sessionID, trimmed);
+      return;
+    }
+
+    await renameSession(sessionID, trimmed);
   }
 
 
@@ -1790,6 +1806,7 @@ export default function App() {
                 }
               }}
               sessionStatus={selectedSessionStatus()}
+              renameSession={renameSessionTitle}
             error={error()}
           />
         </Match>

--- a/packages/app/src/app/components/model-picker-modal.tsx
+++ b/packages/app/src/app/components/model-picker-modal.tsx
@@ -67,9 +67,8 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
   });
 
   createEffect(() => {
-    if (!props.open) return;
-
     const onKeyDown = (event: KeyboardEvent) => {
+      if (!props.open) return;
       if (event.key === "Escape") {
         event.preventDefault();
         event.stopPropagation();

--- a/packages/app/src/app/components/provider-auth-modal.tsx
+++ b/packages/app/src/app/components/provider-auth-modal.tsx
@@ -1,0 +1,147 @@
+import { CheckCircle2, X } from "lucide-solid";
+import type { Provider } from "@opencode-ai/sdk/v2/client";
+import { createMemo, For, Show } from "solid-js";
+
+import Button from "./button";
+
+type ProviderAuthMethod = { type: "oauth" | "api"; label: string };
+type ProviderAuthEntry = {
+  id: string;
+  name: string;
+  methods: ProviderAuthMethod[];
+  connected: boolean;
+};
+
+export type ProviderAuthModalProps = {
+  open: boolean;
+  loading: boolean;
+  submitting: boolean;
+  error: string | null;
+  providers: Provider[];
+  connectedProviderIds: string[];
+  authMethods: Record<string, ProviderAuthMethod[]>;
+  onSelect: (providerId: string) => void;
+  onClose: () => void;
+};
+
+export default function ProviderAuthModal(props: ProviderAuthModalProps) {
+  const entries = createMemo<ProviderAuthEntry[]>(() => {
+    const methods = props.authMethods ?? {};
+    const connected = new Set(props.connectedProviderIds ?? []);
+    const providers = props.providers ?? [];
+
+    return Object.keys(methods)
+      .map((id): ProviderAuthEntry => {
+        const provider = providers.find((item) => item.id === id);
+        return {
+          id,
+          name: provider?.name ?? id,
+          methods: methods[id] ?? [],
+          connected: connected.has(id),
+        };
+      })
+      .sort((a, b) => {
+        const aIsOpencode = a.id === "opencode";
+        const bIsOpencode = b.id === "opencode";
+        if (aIsOpencode !== bIsOpencode) return aIsOpencode ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+  });
+
+  const methodLabel = (method: ProviderAuthMethod) =>
+    method.label || (method.type === "oauth" ? "OAuth" : "API key");
+
+  const actionDisabled = () => props.loading || props.submitting;
+
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 bg-gray-1/60 backdrop-blur-sm flex items-start justify-center p-4 overflow-y-auto">
+        <div class="bg-gray-2 border border-gray-6/70 w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden max-h-[calc(100vh-2rem)] flex flex-col">
+          <div class="p-6 flex flex-col min-h-0">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h3 class="text-lg font-semibold text-gray-12">Connect provider</h3>
+                <p class="text-sm text-gray-11 mt-1">Choose a provider to authenticate.</p>
+              </div>
+              <Button variant="ghost" class="!p-2 rounded-full" onClick={props.onClose}>
+                <X size={16} />
+              </Button>
+            </div>
+
+            <Show when={props.error}>
+              <div class="mt-4 rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
+                {props.error}
+              </div>
+            </Show>
+
+            <Show when={props.loading}>
+              <div class="mt-6 rounded-xl border border-gray-6 bg-gray-1/60 px-4 py-3 text-sm text-gray-10 animate-pulse">
+                Loading providers...
+              </div>
+            </Show>
+
+            <Show when={!props.loading}>
+              <div class="mt-5 space-y-2 overflow-y-auto pr-1 -mr-1 min-h-0">
+                <Show
+                  when={entries().length}
+                  fallback={<div class="text-sm text-gray-10">No providers available.</div>}
+                >
+                  <For each={entries()}>
+                    {(entry) => (
+                      <button
+                        type="button"
+                        class="w-full rounded-xl border border-gray-6 bg-gray-1/40 px-4 py-3 text-left transition-colors hover:bg-gray-1/70 disabled:opacity-60 disabled:cursor-not-allowed"
+                        disabled={actionDisabled()}
+                        onClick={() => props.onSelect(entry.id)}
+                      >
+                        <div class="flex items-center justify-between gap-3">
+                          <div class="min-w-0">
+                            <div class="text-sm font-medium text-gray-12 truncate">{entry.name}</div>
+                            <div class="text-[11px] text-gray-8 font-mono truncate">{entry.id}</div>
+                          </div>
+                          <Show when={entry.connected}>
+                            <div class="flex items-center gap-1 text-[11px] text-green-11 bg-green-7/10 border border-green-7/20 px-2 py-1 rounded-full">
+                              <CheckCircle2 size={12} />
+                              Connected
+                            </div>
+                          </Show>
+                        </div>
+                        <div class="mt-2 flex flex-wrap gap-2">
+                          <For each={entry.methods}>
+                            {(method) => (
+                              <span
+                                class={`text-[10px] uppercase tracking-[0.2em] px-2 py-1 rounded-full border ${
+                                  method.type === "oauth"
+                                    ? "bg-indigo-7/15 text-indigo-11 border-indigo-7/30"
+                                    : "bg-gray-3 text-gray-11 border-gray-6"
+                                }`}
+                              >
+                                {methodLabel(method)}
+                              </span>
+                            )}
+                          </For>
+                        </div>
+                      </button>
+                    )}
+                  </For>
+                </Show>
+              </div>
+            </Show>
+
+            <Show when={props.submitting}>
+              <div class="mt-4 text-xs text-gray-10">Opening authentication...</div>
+            </Show>
+
+            <div class="mt-4 text-xs text-gray-9">
+              OAuth providers open in your browser. API key providers require editing your `opencode.json`.
+            </div>
+
+            <Button variant="ghost" class="mt-4" onClick={props.onClose} disabled={actionDisabled()}>
+              Close
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -422,7 +422,7 @@ export default function SessionView(props: SessionViewProps) {
         try {
           const providerId = extractCommandArgs(props.prompt);
           if (providerId) {
-            const message = await props.startProviderAuth(providerId || undefined);
+            const message = await props.startProviderAuth(providerId);
             setCommandToast(message || "Auth flow started");
             clearPrompt();
             return;
@@ -457,6 +457,7 @@ export default function SessionView(props: SessionViewProps) {
           const agents = await props.listAgents();
           if (!agents.length) {
             setCommandToast("No agents available");
+            clearPrompt();
             return;
           }
 
@@ -472,6 +473,7 @@ export default function SessionView(props: SessionViewProps) {
 
           if (!candidate) {
             setCommandToast("Agent name is required");
+            clearPrompt();
             return;
           }
 
@@ -480,6 +482,7 @@ export default function SessionView(props: SessionViewProps) {
           );
           if (!match) {
             setCommandToast(`Unknown agent. Available: ${formatListHint(agentNames)}`);
+            clearPrompt();
             return;
           }
 
@@ -530,6 +533,7 @@ export default function SessionView(props: SessionViewProps) {
 
         if (!nextTitle) {
           setCommandToast("Session name is required");
+          clearPrompt();
           return;
         }
 
@@ -664,12 +668,8 @@ export default function SessionView(props: SessionViewProps) {
       }
       if (event.key === "Enter") {
         event.preventDefault();
-        const active = matches[commandIndex()];
-        if (active) {
-          applyCommandCompletion(active.id);
-          runCommand(active.id);
-          return;
-        }
+        handlePrimaryAction();
+        return;
       }
     }
 

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -310,6 +310,13 @@ export default function SessionView(props: SessionViewProps) {
     return body.slice(spaceIndex + 1).trim();
   };
 
+  const activeSessionTitle = createMemo(() => {
+    const selectedId = props.selectedSessionId;
+    if (!selectedId) return "";
+    const entry = props.sessions.find((session) => session.id === selectedId);
+    return entry?.title ?? "";
+  });
+
   const commandList = createMemo(() => [
     {
       id: "models",
@@ -331,9 +338,18 @@ export default function SessionView(props: SessionViewProps) {
           return;
         }
 
-        const nextTitle = extractCommandArgs(props.prompt);
+        let nextTitle = extractCommandArgs(props.prompt);
         if (!nextTitle) {
-          setCommandToast("Usage: /rename <title>");
+          const fallback = activeSessionTitle();
+          const prompted = window.prompt("Rename session", fallback);
+          if (prompted == null) {
+            return;
+          }
+          nextTitle = prompted.trim();
+        }
+
+        if (!nextTitle) {
+          setCommandToast("Session name is required");
           return;
         }
 


### PR DESCRIPTION
## Summary
- Add `/model`, `/connect`, `/auth`, `/agent`, `/save`, and `/rename` command support in the session prompt.
- Provide a provider auth picker modal to avoid guessing provider IDs.
- Add command autocomplete with arrow/Tab navigation and Enter-to-run.
- Sort sessions by activity and support session renaming.

## Testing
- `pnpm --filter @different-ai/openwork typecheck`
- `pnpm --filter @different-ai/openwork test:e2e`