### PR TITLE
feat: support opencode.jsonc configs

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1819,6 +1819,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonptr"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,8 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
+ "json5",
  "serde",
  "serde_json",
  "tauri",
@@ -2477,6 +2489,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -4466,6 +4521,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+json5 = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }

--- a/packages/desktop/src-tauri/src/engine/spawn.rs
+++ b/packages/desktop/src-tauri/src/engine/spawn.rs
@@ -38,11 +38,20 @@ pub fn build_engine_command(program: &Path, hostname: &str, port: u16, project_d
     command.env("XDG_DATA_HOME", xdg_data_home);
   }
 
-  if let Some(xdg_config_home) = maybe_infer_xdg_home(
+  let xdg_config_home = maybe_infer_xdg_home(
     "XDG_CONFIG_HOME",
     candidate_xdg_config_dirs(),
-    Path::new("opencode/opencode.json"),
-  ) {
+    Path::new("opencode/opencode.jsonc"),
+  )
+  .or_else(|| {
+    maybe_infer_xdg_home(
+      "XDG_CONFIG_HOME",
+      candidate_xdg_config_dirs(),
+      Path::new("opencode/opencode.json"),
+    )
+  });
+
+  if let Some(xdg_config_home) = xdg_config_home {
     command.env("XDG_CONFIG_HOME", xdg_config_home);
   }
 


### PR DESCRIPTION
## Summary
- prefer opencode.jsonc (fall back to opencode.json) for project/global config resolution
- default new workspace config to opencode.jsonc and parse JSONC when seeding
- update config discovery for engine startup and add json5 dependency

## Testing
- cargo check
- pnpm typecheck (fails: tsc missing in demo-state.ts; pre-existing)