### PR TITLE
fix: load workspace templates on initial connect

### DIFF
--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -396,7 +396,8 @@ export function createWorkspaceStore(options: {
       options.setPendingPermissions([]);
       options.setSessionStatusById({});
 
-      if (context?.workspaceType === "remote" && targetRoot) {
+      // Load workspace templates for all workspace types (local and remote)
+      if (targetRoot) {
         await options
           .loadWorkspaceTemplates({ workspaceRoot: targetRoot, quiet: true })
           .catch(() => undefined);


### PR DESCRIPTION
## Summary
- Fix workspace templates not loading on initial connect for local workspaces

## Problem
Workspace templates were only loaded during `connect()` when `workspaceType === "remote"`. This caused templates in local workspaces to not appear until a new template was created (which triggered a reload via `saveTemplate()`).

## Solution
Removed the `workspaceType === "remote"` restriction so templates load for all workspace types.

## Test plan
- [ ] Open a local workspace with existing templates in `.openwork/templates/`
- [ ] Verify templates appear immediately after connecting
- [ ] Verify remote workspace template loading still works