### PR TITLE
feat(templates): add auto-run toggle for templates

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -649,7 +649,7 @@ export default function App() {
     openTemplateModal,
     saveTemplate,
     deleteTemplate,
-    runTemplate,
+    applyTemplate,
     loadWorkspaceTemplates,
   } = templateState;
 
@@ -1853,7 +1853,7 @@ export default function App() {
       setTemplateDraftScope(scope);
     },
     openTemplateModal,
-    runTemplate,
+    applyTemplate,
     deleteTemplate,
     refreshSkills: (options?: { force?: boolean }) => refreshSkills(options).catch(() => undefined),
     refreshPlugins: (scopeOverride?: PluginScope) =>

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -642,6 +642,8 @@ export default function App() {
     setTemplateDraftPrompt,
     templateDraftScope,
     setTemplateDraftScope,
+    templateDraftAutoRun,
+    setTemplateDraftAutoRun,
     workspaceTemplates,
     globalTemplates,
     openTemplateModal,
@@ -1352,8 +1354,15 @@ export default function App() {
       applyThemeMode(isDark ? "dark" : "light");
     });
 
+    // Listen for setPrompt events from template system (when autoRun is disabled)
+    const handleSetPrompt = (e: CustomEvent<string>) => {
+      setPrompt(e.detail);
+    };
+    window.addEventListener("openwork:setPrompt", handleSetPrompt as EventListener);
+
     onCleanup(() => {
       unsubscribeTheme();
+      window.removeEventListener("openwork:setPrompt", handleSetPrompt as EventListener);
     });
 
     createEffect(() => {
@@ -2083,12 +2092,14 @@ export default function App() {
         description={templateDraftDescription()}
         prompt={templateDraftPrompt()}
         scope={templateDraftScope()}
+        autoRun={templateDraftAutoRun()}
         onClose={() => setTemplateModalOpen(false)}
         onSave={saveTemplate}
         onTitleChange={setTemplateDraftTitle}
         onDescriptionChange={setTemplateDraftDescription}
         onPromptChange={setTemplateDraftPrompt}
         onScopeChange={setTemplateDraftScope}
+        onAutoRunChange={setTemplateDraftAutoRun}
       />
 
       <WorkspacePicker

--- a/packages/app/src/app/components/template-modal.tsx
+++ b/packages/app/src/app/components/template-modal.tsx
@@ -12,12 +12,14 @@ export type TemplateModalProps = {
   description: string;
   prompt: string;
   scope: "workspace" | "global";
+  autoRun: boolean;
   onClose: () => void;
   onSave: () => void;
   onTitleChange: (value: string) => void;
   onDescriptionChange: (value: string) => void;
   onPromptChange: (value: string) => void;
   onScopeChange: (value: "workspace" | "global") => void;
+  onAutoRunChange: (value: boolean) => void;
 };
 
 export default function TemplateModal(props: TemplateModalProps) {
@@ -88,6 +90,25 @@ export default function TemplateModal(props: TemplateModalProps) {
                 />
                 <div class="mt-1 text-xs text-gray-10">{translate("templates.prompt_hint")}</div>
               </label>
+
+              {/* Auto-run Toggle */}
+              <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                <div class="min-w-0">
+                  <div class="text-sm text-gray-12">{translate("templates.auto_run_label")}</div>
+                  <div class="text-xs text-gray-7">{translate("templates.auto_run_hint")}</div>
+                </div>
+                <button
+                  type="button"
+                  class={`px-3 py-1 rounded-full text-xs font-medium border transition-colors shrink-0 ${
+                    props.autoRun
+                      ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
+                      : "text-gray-10 border-gray-6 hover:text-gray-12"
+                  }`}
+                  onClick={() => props.onAutoRunChange(!props.autoRun)}
+                >
+                  {props.autoRun ? "On" : "Off"}
+                </button>
+              </div>
             </div>
 
             <div class="mt-6 flex justify-end gap-2">

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -78,7 +78,7 @@ export type DashboardViewProps = {
   setTemplateDraftScope: (value: "workspace" | "global") => void;
   openTemplateModal: () => void;
   resetTemplateDraft?: (scope?: "workspace" | "global") => void;
-  runTemplate: (template: WorkspaceTemplate) => void;
+  applyTemplate: (template: WorkspaceTemplate) => void;
   deleteTemplate: (templateId: string) => void;
   refreshSkills: (options?: { force?: boolean }) => void;
   refreshPlugins: (scopeOverride?: PluginScope) => void;
@@ -536,7 +536,7 @@ export default function DashboardView(props: DashboardViewProps) {
                     <For each={quickTemplates()}>
                       {(t) => (
                         <button
-                          onClick={() => props.runTemplate(t)}
+                          onClick={() => props.applyTemplate(t)}
                           class="group p-5 rounded-2xl bg-gray-2/30 border border-gray-6/50 hover:bg-gray-2 hover:border-gray-7 transition-all text-left"
                         >
                           <div class="w-10 h-10 rounded-full bg-gray-4 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
@@ -544,7 +544,7 @@ export default function DashboardView(props: DashboardViewProps) {
                           </div>
                           <h4 class="font-medium text-gray-12 mb-1">{t.title}</h4>
                           <p class="text-sm text-gray-10">
-                            {t.description || "Run a saved workflow"}
+                            {t.description || "Apply a saved workflow"}
                           </p>
                         </button>
                       )}
@@ -697,7 +697,7 @@ export default function DashboardView(props: DashboardViewProps) {
                 setTemplateDraftScope={props.setTemplateDraftScope}
                 openTemplateModal={props.openTemplateModal}
                 resetTemplateDraft={props.resetTemplateDraft}
-                runTemplate={props.runTemplate}
+                applyTemplate={props.applyTemplate}
                 deleteTemplate={props.deleteTemplate}
               />
             </Match>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -9,7 +9,6 @@ import type {
   TodoItem,
   View,
   WorkspaceDisplay,
-  WorkspaceTemplate,
 } from "../types";
 
 import {
@@ -17,8 +16,6 @@ import {
   HardDrive,
   Shield,
   Zap,
-  Bug,
-  X,
 } from "lucide-solid";
 
 import Button from "../components/button";
@@ -108,25 +105,6 @@ export default function SessionView(props: SessionViewProps) {
   const [renameTitle, setRenameTitle] = createSignal("");
   const [renameBusy, setRenameBusy] = createSignal(false);
 
-  // DEBUG: Track last used template from window global
-  const [debugPanelOpen, setDebugPanelOpen] = createSignal(false);
-  const [debugLastTemplate, setDebugLastTemplate] = createSignal<WorkspaceTemplate | null>(null);
-
-  // Poll for debug template changes
-  createEffect(() => {
-    if (debugPanelOpen()) {
-      const checkTemplate = () => {
-        const template = (window as any).__DEBUG_LAST_TEMPLATE__ as WorkspaceTemplate | undefined;
-        if (template) {
-          setDebugLastTemplate(template);
-        }
-      };
-      checkTemplate();
-      const interval = setInterval(checkTemplate, 500);
-      return () => clearInterval(interval);
-    }
-  });
-
   type Flyout = {
     id: string;
     rect: { top: number; left: number; width: number; height: number };
@@ -139,7 +117,7 @@ export default function SessionView(props: SessionViewProps) {
   const [prevArtifactCount, setPrevArtifactCount] = createSignal(0);
   const [prevFileCount, setPrevFileCount] = createSignal(0);
   const [isInitialLoad, setIsInitialLoad] = createSignal(true);
-  
+
   const pendingArtifactRafIds = new Set<number>();
 
   onMount(() => {
@@ -217,7 +195,7 @@ export default function SessionView(props: SessionViewProps) {
     }
     setPrevArtifactCount(count);
   });
-  
+
   createEffect(() => {
      const files = props.workingFiles;
      const count = files.length;
@@ -611,7 +589,7 @@ export default function SessionView(props: SessionViewProps) {
                 }
               `}
             </style>
-            
+
             <Show when={props.messages.length === 0}>
               <div class="text-center py-20 space-y-4">
                 <div class="w-16 h-16 bg-gray-2 rounded-3xl mx-auto flex items-center justify-center border border-gray-6">
@@ -624,7 +602,7 @@ export default function SessionView(props: SessionViewProps) {
               </div>
             </Show>
 
-            <MessageList 
+            <MessageList
               messages={props.messages}
               artifacts={props.artifacts}
               developerMode={props.developerMode}
@@ -636,7 +614,7 @@ export default function SessionView(props: SessionViewProps) {
 
             <div ref={(el) => (messagesEndEl = el)} />
           </div>
-          
+
           <Minimap containerRef={() => chatContainerEl} messages={props.messages} />
 
           <Show when={artifactToast()}>
@@ -646,7 +624,7 @@ export default function SessionView(props: SessionViewProps) {
           </Show>
         </div>
 
-        <Composer 
+        <Composer
            prompt={props.prompt}
            setPrompt={props.setPrompt}
            busy={props.busy}
@@ -758,93 +736,6 @@ export default function SessionView(props: SessionViewProps) {
         <For each={flyouts()}>
           {(item) => <FlyoutItem item={item} />}
         </For>
-
-        {/* DEBUG: Template Debug Panel Toggle Button */}
-        <button
-          onClick={() => {
-            setDebugPanelOpen(!debugPanelOpen());
-            // Log current state
-            const template = (window as any).__DEBUG_LAST_TEMPLATE__;
-            console.log("[DEBUG Session] Last used template from window:", template);
-          }}
-          class="fixed bottom-4 left-4 z-50 bg-purple-600 hover:bg-purple-500 text-white p-2 rounded-full shadow-lg"
-          title="Toggle Template Debug Panel (Session)"
-        >
-          <Bug size={20} />
-        </button>
-
-        {/* DEBUG: Floating Template Debug Panel */}
-        <Show when={debugPanelOpen()}>
-          <div class="fixed bottom-16 left-4 z-50 w-96 max-h-[60vh] bg-gray-1 border border-purple-600 rounded-xl shadow-2xl overflow-hidden">
-            <div class="bg-purple-600 text-white px-4 py-2 flex items-center justify-between">
-              <span class="font-semibold text-sm">🐛 Session Template Debug</span>
-              <button onClick={() => setDebugPanelOpen(false)} class="hover:bg-purple-500 p-1 rounded">
-                <X size={16} />
-              </button>
-            </div>
-            <div class="p-4 overflow-y-auto max-h-[calc(60vh-3rem)] text-xs font-mono">
-              <Show
-                when={debugLastTemplate()}
-                fallback={
-                  <div class="text-gray-10">
-                    <p>No template has been used yet in this session.</p>
-                    <p class="mt-2 text-gray-7">Run a template from the Templates page to see its data here.</p>
-                  </div>
-                }
-              >
-                <div class="space-y-3">
-                  <div class="text-purple-400 font-bold">Last Used Template</div>
-
-                  <div class="p-3 bg-gray-2 rounded border border-gray-6">
-                    <div class="text-gray-12 font-semibold text-sm">{debugLastTemplate()?.title}</div>
-                    <div class="text-gray-10 mt-2">ID: {debugLastTemplate()?.id}</div>
-                    <div class="text-gray-10 mt-1">Scope: {debugLastTemplate()?.scope}</div>
-
-                    <div class="mt-3 p-2 bg-gray-1 rounded border border-gray-6">
-                      <div class="text-gray-11 font-semibold mb-1">autoRun Analysis:</div>
-                      <div class="space-y-1">
-                        <div>
-                          <span class="text-gray-10">Value: </span>
-                          <span class={debugLastTemplate()?.autoRun === false ? "text-red-400 font-bold" : "text-green-400 font-bold"}>
-                            {String(debugLastTemplate()?.autoRun)}
-                          </span>
-                        </div>
-                        <div>
-                          <span class="text-gray-10">typeof: </span>
-                          <span class="text-blue-400">{typeof debugLastTemplate()?.autoRun}</span>
-                        </div>
-                        <div>
-                          <span class="text-gray-10">autoRun === false: </span>
-                          <span class={debugLastTemplate()?.autoRun === false ? "text-red-400" : "text-green-400"}>
-                            {String(debugLastTemplate()?.autoRun === false)}
-                          </span>
-                        </div>
-                        <div>
-                          <span class="text-gray-10">autoRun !== false (shouldAutoRun): </span>
-                          <span class={debugLastTemplate()?.autoRun !== false ? "text-green-400" : "text-red-400"}>
-                            {String(debugLastTemplate()?.autoRun !== false)}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div class="mt-3">
-                      <div class="text-gray-10">Prompt (truncated):</div>
-                      <div class="text-gray-7 mt-1 p-2 bg-gray-1 rounded border border-gray-6 max-h-24 overflow-y-auto">
-                        {debugLastTemplate()?.prompt?.slice(0, 200)}
-                        {(debugLastTemplate()?.prompt?.length ?? 0) > 200 ? "..." : ""}
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="text-gray-7 text-xs mt-2">
-                    Check browser console for detailed logs (search for "[DEBUG")
-                  </div>
-                </div>
-              </Show>
-            </div>
-          </div>
-        </Show>
       </div>
     </Show>
   );

--- a/packages/app/src/app/pages/templates.tsx
+++ b/packages/app/src/app/pages/templates.tsx
@@ -1,10 +1,10 @@
-import { For, Show } from "solid-js";
+import { For, Show, createSignal } from "solid-js";
 
 import type { WorkspaceTemplate } from "../types";
 import { formatRelativeTime } from "../utils";
 
 import Button from "../components/button";
-import { FileText, Play, Plus, Trash2 } from "lucide-solid";
+import { FileText, Play, Plus, Trash2, Bug, X } from "lucide-solid";
 
 export type TemplatesViewProps = {
   busy: boolean;
@@ -21,6 +21,8 @@ export type TemplatesViewProps = {
 };
 
 export default function TemplatesView(props: TemplatesViewProps) {
+  const [debugOpen, setDebugOpen] = createSignal(false);
+
   const openNewTemplate = () => {
     const reset = props.resetTemplateDraft;
     if (reset) {
@@ -33,6 +35,25 @@ export default function TemplatesView(props: TemplatesViewProps) {
     }
     props.openTemplateModal();
   };
+
+  // Debug: Log template data when component mounts or templates change
+  const logTemplates = () => {
+    console.log("[DEBUG Templates] Workspace Templates:", props.workspaceTemplates);
+    console.log("[DEBUG Templates] Global Templates:", props.globalTemplates);
+    props.workspaceTemplates.forEach((t, i) => {
+      console.log(`[DEBUG] Workspace Template ${i}:`, {
+        id: t.id,
+        title: t.title,
+        autoRun: t.autoRun,
+        autoRunType: typeof t.autoRun,
+        autoRunStrictEqual: t.autoRun === false,
+        autoRunLooseEqual: t.autoRun == false,
+      });
+    });
+  };
+
+  // Log on mount
+  logTemplates();
 
   return (
     <section class="space-y-4">
@@ -110,6 +131,81 @@ export default function TemplatesView(props: TemplatesViewProps) {
               </For>
             </div>
           </Show>
+        </div>
+      </Show>
+
+      {/* Debug Panel Toggle Button */}
+      <button
+        onClick={() => {
+          setDebugOpen(!debugOpen());
+          logTemplates();
+        }}
+        class="fixed bottom-4 right-4 z-50 bg-amber-600 hover:bg-amber-500 text-white p-2 rounded-full shadow-lg"
+        title="Toggle Template Debug Panel"
+      >
+        <Bug size={20} />
+      </button>
+
+      {/* Floating Debug Panel */}
+      <Show when={debugOpen()}>
+        <div class="fixed bottom-16 right-4 z-50 w-96 max-h-[70vh] bg-gray-1 border border-amber-600 rounded-xl shadow-2xl overflow-hidden">
+          <div class="bg-amber-600 text-white px-4 py-2 flex items-center justify-between">
+            <span class="font-semibold text-sm">🐛 Templates Debug Panel</span>
+            <button onClick={() => setDebugOpen(false)} class="hover:bg-amber-500 p-1 rounded">
+              <X size={16} />
+            </button>
+          </div>
+          <div class="p-4 overflow-y-auto max-h-[calc(70vh-3rem)] text-xs font-mono">
+            <div class="mb-4">
+              <div class="text-amber-400 font-bold mb-2">Workspace Templates ({props.workspaceTemplates.length})</div>
+              <For each={props.workspaceTemplates} fallback={<div class="text-gray-10">No workspace templates</div>}>
+                {(t) => (
+                  <div class="mb-3 p-2 bg-gray-2 rounded border border-gray-6">
+                    <div class="text-gray-12 font-semibold">{t.title}</div>
+                    <div class="text-gray-10 mt-1">ID: {t.id}</div>
+                    <div class="mt-1">
+                      <span class="text-gray-10">autoRun: </span>
+                      <span class={t.autoRun === false ? "text-red-400 font-bold" : "text-green-400 font-bold"}>
+                        {String(t.autoRun)}
+                      </span>
+                      <span class="text-gray-7"> (type: {typeof t.autoRun})</span>
+                    </div>
+                    <div class="text-gray-10 mt-1">
+                      autoRun !== false: {String(t.autoRun !== false)}
+                    </div>
+                    <div class="text-gray-7 mt-1 truncate" title={t.prompt}>
+                      Prompt: {t.prompt.slice(0, 50)}...
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+
+            <div>
+              <div class="text-green-400 font-bold mb-2">Global Templates ({props.globalTemplates.length})</div>
+              <For each={props.globalTemplates} fallback={<div class="text-gray-10">No global templates</div>}>
+                {(t) => (
+                  <div class="mb-3 p-2 bg-gray-2 rounded border border-gray-6">
+                    <div class="text-gray-12 font-semibold">{t.title}</div>
+                    <div class="text-gray-10 mt-1">ID: {t.id}</div>
+                    <div class="mt-1">
+                      <span class="text-gray-10">autoRun: </span>
+                      <span class={t.autoRun === false ? "text-red-400 font-bold" : "text-green-400 font-bold"}>
+                        {String(t.autoRun)}
+                      </span>
+                      <span class="text-gray-7"> (type: {typeof t.autoRun})</span>
+                    </div>
+                    <div class="text-gray-10 mt-1">
+                      autoRun !== false: {String(t.autoRun !== false)}
+                    </div>
+                    <div class="text-gray-7 mt-1 truncate" title={t.prompt}>
+                      Prompt: {t.prompt.slice(0, 50)}...
+                    </div>
+                  </div>
+                )}
+              </For>
+            </div>
+          </div>
         </div>
       </Show>
     </section>

--- a/packages/app/src/app/pages/templates.tsx
+++ b/packages/app/src/app/pages/templates.tsx
@@ -16,7 +16,7 @@ export type TemplatesViewProps = {
   setTemplateDraftScope: (value: "workspace" | "global") => void;
   openTemplateModal: () => void;
   resetTemplateDraft?: (scope?: "workspace" | "global") => void;
-  runTemplate: (template: WorkspaceTemplate) => void;
+  applyTemplate: (template: WorkspaceTemplate) => void;
   deleteTemplate: (templateId: string) => void;
 };
 
@@ -68,9 +68,9 @@ export default function TemplatesView(props: TemplatesViewProps) {
                       <div class="mt-2 text-xs text-gray-7 font-mono">{formatRelativeTime(t.createdAt)}</div>
                     </div>
                     <div class="shrink-0 flex gap-2">
-                      <Button variant="secondary" onClick={() => props.runTemplate(t)} disabled={props.busy}>
+                      <Button variant="secondary" onClick={() => props.applyTemplate(t)} disabled={props.busy}>
                         <Play size={16} />
-                        Run
+                        Apply
                       </Button>
                       <Button variant="danger" onClick={() => props.deleteTemplate(t.id)} disabled={props.busy}>
                         <Trash2 size={16} />
@@ -97,9 +97,9 @@ export default function TemplatesView(props: TemplatesViewProps) {
                       <div class="mt-2 text-xs text-gray-7 font-mono">{formatRelativeTime(t.createdAt)}</div>
                     </div>
                     <div class="shrink-0 flex gap-2">
-                      <Button variant="secondary" onClick={() => props.runTemplate(t)} disabled={props.busy}>
+                      <Button variant="secondary" onClick={() => props.applyTemplate(t)} disabled={props.busy}>
                         <Play size={16} />
-                        Run
+                        Apply
                       </Button>
                       <Button variant="danger" onClick={() => props.deleteTemplate(t.id)} disabled={props.busy}>
                         <Trash2 size={16} />

--- a/packages/app/src/app/pages/templates.tsx
+++ b/packages/app/src/app/pages/templates.tsx
@@ -1,10 +1,10 @@
-import { For, Show, createSignal } from "solid-js";
+import { For, Show } from "solid-js";
 
 import type { WorkspaceTemplate } from "../types";
 import { formatRelativeTime } from "../utils";
 
 import Button from "../components/button";
-import { FileText, Play, Plus, Trash2, Bug, X } from "lucide-solid";
+import { FileText, Play, Plus, Trash2 } from "lucide-solid";
 
 export type TemplatesViewProps = {
   busy: boolean;
@@ -21,8 +21,6 @@ export type TemplatesViewProps = {
 };
 
 export default function TemplatesView(props: TemplatesViewProps) {
-  const [debugOpen, setDebugOpen] = createSignal(false);
-
   const openNewTemplate = () => {
     const reset = props.resetTemplateDraft;
     if (reset) {
@@ -35,25 +33,6 @@ export default function TemplatesView(props: TemplatesViewProps) {
     }
     props.openTemplateModal();
   };
-
-  // Debug: Log template data when component mounts or templates change
-  const logTemplates = () => {
-    console.log("[DEBUG Templates] Workspace Templates:", props.workspaceTemplates);
-    console.log("[DEBUG Templates] Global Templates:", props.globalTemplates);
-    props.workspaceTemplates.forEach((t, i) => {
-      console.log(`[DEBUG] Workspace Template ${i}:`, {
-        id: t.id,
-        title: t.title,
-        autoRun: t.autoRun,
-        autoRunType: typeof t.autoRun,
-        autoRunStrictEqual: t.autoRun === false,
-        autoRunLooseEqual: t.autoRun == false,
-      });
-    });
-  };
-
-  // Log on mount
-  logTemplates();
 
   return (
     <section class="space-y-4">
@@ -131,81 +110,6 @@ export default function TemplatesView(props: TemplatesViewProps) {
               </For>
             </div>
           </Show>
-        </div>
-      </Show>
-
-      {/* Debug Panel Toggle Button */}
-      <button
-        onClick={() => {
-          setDebugOpen(!debugOpen());
-          logTemplates();
-        }}
-        class="fixed bottom-4 right-4 z-50 bg-amber-600 hover:bg-amber-500 text-white p-2 rounded-full shadow-lg"
-        title="Toggle Template Debug Panel"
-      >
-        <Bug size={20} />
-      </button>
-
-      {/* Floating Debug Panel */}
-      <Show when={debugOpen()}>
-        <div class="fixed bottom-16 right-4 z-50 w-96 max-h-[70vh] bg-gray-1 border border-amber-600 rounded-xl shadow-2xl overflow-hidden">
-          <div class="bg-amber-600 text-white px-4 py-2 flex items-center justify-between">
-            <span class="font-semibold text-sm">🐛 Templates Debug Panel</span>
-            <button onClick={() => setDebugOpen(false)} class="hover:bg-amber-500 p-1 rounded">
-              <X size={16} />
-            </button>
-          </div>
-          <div class="p-4 overflow-y-auto max-h-[calc(70vh-3rem)] text-xs font-mono">
-            <div class="mb-4">
-              <div class="text-amber-400 font-bold mb-2">Workspace Templates ({props.workspaceTemplates.length})</div>
-              <For each={props.workspaceTemplates} fallback={<div class="text-gray-10">No workspace templates</div>}>
-                {(t) => (
-                  <div class="mb-3 p-2 bg-gray-2 rounded border border-gray-6">
-                    <div class="text-gray-12 font-semibold">{t.title}</div>
-                    <div class="text-gray-10 mt-1">ID: {t.id}</div>
-                    <div class="mt-1">
-                      <span class="text-gray-10">autoRun: </span>
-                      <span class={t.autoRun === false ? "text-red-400 font-bold" : "text-green-400 font-bold"}>
-                        {String(t.autoRun)}
-                      </span>
-                      <span class="text-gray-7"> (type: {typeof t.autoRun})</span>
-                    </div>
-                    <div class="text-gray-10 mt-1">
-                      autoRun !== false: {String(t.autoRun !== false)}
-                    </div>
-                    <div class="text-gray-7 mt-1 truncate" title={t.prompt}>
-                      Prompt: {t.prompt.slice(0, 50)}...
-                    </div>
-                  </div>
-                )}
-              </For>
-            </div>
-
-            <div>
-              <div class="text-green-400 font-bold mb-2">Global Templates ({props.globalTemplates.length})</div>
-              <For each={props.globalTemplates} fallback={<div class="text-gray-10">No global templates</div>}>
-                {(t) => (
-                  <div class="mb-3 p-2 bg-gray-2 rounded border border-gray-6">
-                    <div class="text-gray-12 font-semibold">{t.title}</div>
-                    <div class="text-gray-10 mt-1">ID: {t.id}</div>
-                    <div class="mt-1">
-                      <span class="text-gray-10">autoRun: </span>
-                      <span class={t.autoRun === false ? "text-red-400 font-bold" : "text-green-400 font-bold"}>
-                        {String(t.autoRun)}
-                      </span>
-                      <span class="text-gray-7"> (type: {typeof t.autoRun})</span>
-                    </div>
-                    <div class="text-gray-10 mt-1">
-                      autoRun !== false: {String(t.autoRun !== false)}
-                    </div>
-                    <div class="text-gray-7 mt-1 truncate" title={t.prompt}>
-                      Prompt: {t.prompt.slice(0, 50)}...
-                    </div>
-                  </div>
-                )}
-              </For>
-            </div>
-          </div>
         </div>
       </Show>
     </section>

--- a/packages/app/src/app/template-state.ts
+++ b/packages/app/src/app/template-state.ts
@@ -143,7 +143,8 @@ export function createTemplateState(options: {
     setGlobalTemplatesLoaded(true);
   }
 
-  async function runTemplate(template: WorkspaceTemplate) {
+  // Apply a template to create a new session
+  async function applyTemplate(template: WorkspaceTemplate) {
     if (options.isDemoMode()) {
       options.setView("session");
       return;
@@ -154,6 +155,9 @@ export function createTemplateState(options: {
 
     // Check autoRun setting (default to true for backwards compatibility)
     const shouldAutoRun = template.autoRun !== false;
+
+    // Trim the prompt before using
+    const trimmedPrompt = template.prompt.trim();
 
     options.setBusy(true);
     options.setError(null);
@@ -173,7 +177,7 @@ export function createTemplateState(options: {
           sessionID: session.id,
           model,
           variant: options.modelVariant() ?? undefined,
-          parts: [{ type: "text", text: template.prompt }],
+          parts: [{ type: "text", text: trimmedPrompt }],
         });
 
         options.setSessionModelById((current) => ({
@@ -182,7 +186,7 @@ export function createTemplateState(options: {
         }));
       } else {
         // Don't auto-run: populate the prompt input and let user send manually
-        window.dispatchEvent(new CustomEvent("openwork:setPrompt", { detail: template.prompt }));
+        window.dispatchEvent(new CustomEvent("openwork:setPrompt", { detail: trimmedPrompt }));
       }
     } catch (e) {
       const message = e instanceof Error ? e.message : t("app.unknown_error", currentLocale());
@@ -350,7 +354,7 @@ export function createTemplateState(options: {
     openTemplateModal,
     saveTemplate,
     deleteTemplate,
-    runTemplate,
+    applyTemplate,
     loadWorkspaceTemplates,
   };
 }

--- a/packages/app/src/app/template-state.ts
+++ b/packages/app/src/app/template-state.ts
@@ -29,9 +29,6 @@ export function createTemplateState(options: {
   const [workspaceTemplatesLoaded, setWorkspaceTemplatesLoaded] = createSignal(false);
   const [globalTemplatesLoaded, setGlobalTemplatesLoaded] = createSignal(false);
 
-  // DEBUG: Track the last template used for debugging purposes
-  const [lastUsedTemplate, setLastUsedTemplate] = createSignal<WorkspaceTemplate | null>(null);
-
   const [templateModalOpen, setTemplateModalOpen] = createSignal(false);
   const [templateDraftTitle, setTemplateDraftTitle] = createSignal("");
   const [templateDraftDescription, setTemplateDraftDescription] = createSignal("");
@@ -147,25 +144,6 @@ export function createTemplateState(options: {
   }
 
   async function runTemplate(template: WorkspaceTemplate) {
-    // DEBUG: Log template data when running
-    console.log("[DEBUG runTemplate] Template being run:", {
-      id: template.id,
-      title: template.title,
-      autoRun: template.autoRun,
-      autoRunType: typeof template.autoRun,
-      autoRunStrictEqualFalse: template.autoRun === false,
-      autoRunLooseEqualFalse: template.autoRun == false,
-      fullTemplate: template,
-    });
-
-    // DEBUG: Store the template being used for debugging
-    setLastUsedTemplate(template);
-
-    // Also expose to window for debugging
-    if (typeof window !== "undefined") {
-      (window as any).__DEBUG_LAST_TEMPLATE__ = template;
-    }
-
     if (options.isDemoMode()) {
       options.setView("session");
       return;
@@ -176,7 +154,6 @@ export function createTemplateState(options: {
 
     // Check autoRun setting (default to true for backwards compatibility)
     const shouldAutoRun = template.autoRun !== false;
-    console.log("[DEBUG runTemplate] shouldAutoRun calculated as:", shouldAutoRun);
 
     options.setBusy(true);
     options.setError(null);
@@ -190,7 +167,6 @@ export function createTemplateState(options: {
       options.setView("session");
 
       if (shouldAutoRun) {
-        console.log("[DEBUG runTemplate] AUTO-RUNNING template - sending prompt automatically");
         const model = options.defaultModel();
 
         await c.session.promptAsync({
@@ -206,7 +182,6 @@ export function createTemplateState(options: {
         }));
       } else {
         // Don't auto-run: populate the prompt input and let user send manually
-        console.log("[DEBUG runTemplate] NOT AUTO-RUNNING - just populating prompt input");
         window.dispatchEvent(new CustomEvent("openwork:setPrompt", { detail: template.prompt }));
       }
     } catch (e) {
@@ -243,23 +218,13 @@ export function createTemplateState(options: {
         if (parsedFrontmatter) {
           const meta = parsedFrontmatter.data;
 
-          // DEBUG: Log raw frontmatter data
-          console.log("[DEBUG parseTemplateContent] Raw frontmatter meta:", meta);
-          console.log("[DEBUG parseTemplateContent] meta.autoRun:", {
-            value: meta.autoRun,
-            type: typeof meta.autoRun,
-            isBoolean: typeof meta.autoRun === "boolean",
-            isStringFalse: meta.autoRun === "false",
-            isStringTrue: meta.autoRun === "true",
-          });
-
           const title = typeof meta.title === "string" ? meta.title : t("common.untitled", currentLocale());
           const promptText = parsedFrontmatter.body ?? "";
           if (!promptText.trim()) return false;
 
           const createdAtValue = Number(meta.createdAt);
 
-          // DEBUG: Convert string "true"/"false" to actual booleans
+          // Convert string "true"/"false" to actual booleans (frontmatter parser returns strings)
           let autoRunValue: boolean;
           if (typeof meta.autoRun === "boolean") {
             autoRunValue = meta.autoRun;
@@ -270,8 +235,6 @@ export function createTemplateState(options: {
           } else {
             autoRunValue = true; // default
           }
-
-          console.log("[DEBUG parseTemplateContent] Final autoRunValue:", autoRunValue);
 
           pushTemplate({
             id: typeof meta.id === "string" ? meta.id : fallbackId,
@@ -288,14 +251,6 @@ export function createTemplateState(options: {
         const parsed = safeParseJson<Partial<WorkspaceTemplate> & Record<string, unknown>>(raw);
         if (!parsed) return false;
 
-        // DEBUG: Log JSON parsed data
-        console.log("[DEBUG parseTemplateContent JSON] Parsed JSON:", parsed);
-        console.log("[DEBUG parseTemplateContent JSON] parsed.autoRun:", {
-          value: parsed.autoRun,
-          type: typeof parsed.autoRun,
-          isBoolean: typeof parsed.autoRun === "boolean",
-        });
-
         const title = typeof parsed.title === "string" ? parsed.title : t("common.untitled", currentLocale());
         const promptText = typeof parsed.prompt === "string" ? parsed.prompt : "";
         if (!promptText.trim()) return false;
@@ -309,8 +264,6 @@ export function createTemplateState(options: {
         } else {
           jsonAutoRunValue = true; // default
         }
-
-        console.log("[DEBUG parseTemplateContent JSON] Final jsonAutoRunValue:", jsonAutoRunValue);
 
         pushTemplate({
           id: typeof parsed.id === "string" ? parsed.id : fallbackId,
@@ -329,11 +282,6 @@ export function createTemplateState(options: {
         try {
           const content = unwrap(await c.file.read({ directory: root, path }));
           if (content.type !== "text") return false;
-
-          // DEBUG: Log raw file content
-          console.log("[DEBUG readTemplatePath] Raw file content for", path, ":");
-          console.log(content.content);
-
           return parseTemplateContent(content.content, fallbackId);
         } catch {
           return false;
@@ -404,7 +352,5 @@ export function createTemplateState(options: {
     deleteTemplate,
     runTemplate,
     loadWorkspaceTemplates,
-    // DEBUG: Expose last used template for debugging
-    lastUsedTemplate,
   };
 }

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -92,6 +92,7 @@ export type Template = {
   description: string;
   prompt: string;
   createdAt: number;
+  autoRun?: boolean;
 };
 
 export type SkillCard = {

--- a/packages/app/src/app/utils/templates.ts
+++ b/packages/app/src/app/utils/templates.ts
@@ -5,6 +5,7 @@ type TemplateDraft = {
   description: string;
   prompt: string;
   scope: "workspace" | "global";
+  autoRun: boolean;
 };
 
 type TemplateDraftSetters = {
@@ -12,6 +13,7 @@ type TemplateDraftSetters = {
   setDescription: (value: string) => void;
   setPrompt: (value: string) => void;
   setScope: (value: "workspace" | "global") => void;
+  setAutoRun: (value: boolean) => void;
 };
 
 export function resetTemplateDraft(setters: TemplateDraftSetters, scope: "workspace" | "global" = "workspace") {
@@ -19,18 +21,21 @@ export function resetTemplateDraft(setters: TemplateDraftSetters, scope: "worksp
   setters.setDescription("");
   setters.setPrompt("");
   setters.setScope(scope);
+  setters.setAutoRun(true);
 }
 
 export function buildTemplateDraft(params: {
   seedTitle?: string;
   seedPrompt?: string;
   scope?: "workspace" | "global";
+  autoRun?: boolean;
 }): TemplateDraft {
   return {
     title: params.seedTitle ?? "",
     description: "",
     prompt: params.seedPrompt ?? "",
     scope: params.scope ?? "workspace",
+    autoRun: params.autoRun ?? true,
   };
 }
 
@@ -42,5 +47,6 @@ export function createTemplateRecord(draft: TemplateDraft): WorkspaceTemplate {
     prompt: draft.prompt,
     createdAt: Date.now(),
     scope: draft.scope,
+    autoRun: draft.autoRun,
   };
 }

--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -152,7 +152,7 @@ export default {
   "templates.empty_state": "Starter templates will appear here. Create one or save from a session.",
   "templates.workspace": "Workspace",
   "templates.global": "Global",
-  "templates.run": "Run",
+  "templates.apply": "Apply",
   "templates.modal_title": "Save Template",
   "templates.modal_description": "Reuse a workflow with one tap.",
   "templates.title_label": "Title",

--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -162,6 +162,8 @@ export default {
   "templates.prompt_label": "Prompt",
   "templates.prompt_placeholder": "Write the instructions you want to reuse…",
   "templates.prompt_hint": "This becomes the first user message.",
+  "templates.auto_run_label": "Auto-run",
+  "templates.auto_run_hint": "Automatically start the session when this template is used.",
 
   // ==================== Skills ====================
   "skills.title": "Skills",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -163,6 +163,8 @@ export default {
   "templates.prompt_label": "提示词",
   "templates.prompt_placeholder": "编写您想重用的指令…",
   "templates.prompt_hint": "这将成为第一条用户消息。",
+  "templates.auto_run_label": "自动运行",
+  "templates.auto_run_hint": "使用此模板时自动开始会话。",
 
   // ==================== Skills ====================
   "skills.title": "Skills",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -153,7 +153,7 @@ export default {
   "templates.empty_state": "初始模板将显示在这里。创建一个或从会话保存。",
   "templates.workspace": "工作区",
   "templates.global": "全局",
-  "templates.run": "运行",
+  "templates.apply": "应用",
   "templates.modal_title": "保存模板",
   "templates.modal_description": "一键重用工作流程。",
   "templates.title_label": "标题",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "json5",
  "serde",

--- a/packages/desktop/src-tauri/src/types.rs
+++ b/packages/desktop/src-tauri/src/types.rs
@@ -149,6 +149,12 @@ pub struct WorkspaceTemplate {
     pub prompt: String,
     #[serde(default)]
     pub created_at: u64,
+    #[serde(default = "default_auto_run")]
+    pub auto_run: Option<bool>,
+}
+
+fn default_auto_run() -> Option<bool> {
+    Some(true)
 }
 
 fn default_workspace_state_version() -> u8 {

--- a/packages/desktop/src-tauri/src/workspace/files.rs
+++ b/packages/desktop/src-tauri/src/workspace/files.rs
@@ -114,6 +114,7 @@ fn seed_templates(templates_dir: &PathBuf) -> Result<(), String> {
       description: "Safe, practical file workflows".to_string(),
       prompt: "Show me how to interact with files in this workspace. Include safe examples for reading, summarizing, and editing.".to_string(),
       created_at: now_ms(),
+      auto_run: Some(true),
     },
     WorkspaceTemplate {
       id: "tmpl_learn_skills".to_string(),
@@ -121,6 +122,7 @@ fn seed_templates(templates_dir: &PathBuf) -> Result<(), String> {
       description: "How skills work and how to create your own".to_string(),
       prompt: "Explain what skills are, how to use them, and how to create a new skill for this workspace.".to_string(),
       created_at: now_ms(),
+      auto_run: Some(true),
     },
     WorkspaceTemplate {
       id: "tmpl_learn_plugins".to_string(),
@@ -128,6 +130,7 @@ fn seed_templates(templates_dir: &PathBuf) -> Result<(), String> {
       description: "What plugins are and how to install them".to_string(),
       prompt: "Explain what plugins are and how to install them in this workspace.".to_string(),
       created_at: now_ms(),
+      auto_run: Some(true),
     },
   ];
 

--- a/packages/desktop/src-tauri/src/workspace/templates.rs
+++ b/packages/desktop/src-tauri/src/workspace/templates.rs
@@ -31,6 +31,7 @@ pub fn serialize_template_frontmatter(template: &WorkspaceTemplate) -> Result<St
   out.push_str(&escape_yaml_scalar(&template.description));
   out.push_str("\n");
   out.push_str(&format!("createdAt: {}\n", template.created_at));
+  out.push_str(&format!("autoRun: {}\n", template.auto_run.unwrap_or(true)));
   out.push_str("---\n\n");
   out.push_str(template.prompt.trim_end());
   out.push('\n');
@@ -55,6 +56,7 @@ pub fn write_template(workspace_path: &str, template: WorkspaceTemplate) -> Resu
     description: template.description,
     prompt: template.prompt,
     created_at: default_template_created_at(template.created_at),
+    auto_run: template.auto_run,
   };
 
   let template_dir = templates_dir.join(&template_id);


### PR DESCRIPTION
## Summary
- Add autoRun toggle to template modal allowing users to control whether templates auto-execute
- When autoRun is disabled, template creates session but populates prompt input for user review
- Persist autoRun setting to workspace template YAML files

## Changes

### Frontend (TypeScript/SolidJS)
- `types.ts` - Add `autoRun?: boolean` to Template type
- `utils/templates.ts` - Add autoRun to draft types and functions
- `template-state.ts` - Add signal, parsing from YAML/JSON, respect flag in runTemplate
- `template-modal.tsx` - Add On/Off toggle button UI
- `app.tsx` - Wire up props + setPrompt event listener
- `en.ts` / `zh.ts` - Add i18n translations

### Backend (Rust/Tauri)
- `types.rs` - Add `auto_run: Option<bool>` with serde default
- `templates.rs` - Serialize autoRun to YAML, pass through in write_template

## Test Plan
- [ ] Create template with auto-run ON, verify it auto-executes
- [ ] Create template with auto-run OFF, verify prompt populates but doesn't send
- [ ] Close and reopen app, verify autoRun setting persists