### PR TITLE
feat: improve chat run feedback

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -1,4 +1,5 @@
 import { For, Show, createMemo, createSignal, onCleanup } from "solid-js";
+import type { JSX } from "solid-js";
 import type { Part } from "@opencode-ai/sdk/v2/client";
 import { Check, ChevronDown, Circle, Copy, File, FileText } from "lucide-solid";
 
@@ -15,6 +16,7 @@ export type MessageListProps = {
   expandedStepIds: Set<string>;
   setExpandedStepIds: (updater: (current: Set<string>) => Set<string>) => void;
   onOpenArtifact: (artifact: ArtifactItem) => void;
+  footer?: JSX.Element;
 };
 
 export default function MessageList(props: MessageListProps) {
@@ -249,6 +251,7 @@ export default function MessageList(props: MessageListProps) {
           );
         }}
       </For>
+      <Show when={props.footer}>{props.footer}</Show>
     </div>
   );
 }

--- a/packages/app/src/app/index.css
+++ b/packages/app/src/app/index.css
@@ -43,6 +43,7 @@ body {
   animation: soft-pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
+
 :root {
   color-scheme: light;
 }


### PR DESCRIPTION
## Summary
- add a lightweight, terminal-style run status line with elapsed time in the session chat
- track run phases from send → thinking → responding using session status + streaming detection
- allow MessageList to render a footer element for run status UI