### PR TITLE
Enable MCP connect for remote workspaces

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -323,7 +323,7 @@ export default function MessageList(props: MessageListProps) {
                         />
                       </Show>
                       <Show when={group.kind === "steps"}>
-                        {() => {
+                        {(() => {
                           const stepGroup = group as { kind: "steps"; id: string; parts: Part[] };
                           const expanded = () => isStepsExpanded(stepGroup.id);
                           return (
@@ -355,7 +355,7 @@ export default function MessageList(props: MessageListProps) {
                               </Show>
                             </div>
                           );
-                        }}
+                        })()}
                       </Show>
                     </div>
                   )}

--- a/packages/app/src/app/mcp.ts
+++ b/packages/app/src/app/mcp.ts
@@ -17,29 +17,31 @@ export function validateMcpServerName(name: string): string {
   return trimmed;
 }
 
+export function parseMcpServersFromConfig(mcp: McpConfigValue): McpServerEntry[] {
+  if (!mcp || typeof mcp !== "object") {
+    return [];
+  }
+
+  return Object.entries(mcp).flatMap(([name, value]) => {
+    if (!value || typeof value !== "object") {
+      return [];
+    }
+
+    const config = value as McpServerConfig;
+    if (config.type !== "remote" && config.type !== "local") {
+      return [];
+    }
+
+    return [{ name, config }];
+  });
+}
+
 export function parseMcpServersFromContent(content: string): McpServerEntry[] {
   if (!content.trim()) return [];
 
   try {
     const parsed = parse(content) as Record<string, unknown> | undefined;
-    const mcp = parsed?.mcp as McpConfigValue;
-
-    if (!mcp || typeof mcp !== "object") {
-      return [];
-    }
-
-    return Object.entries(mcp).flatMap(([name, value]) => {
-      if (!value || typeof value !== "object") {
-        return [];
-      }
-
-      const config = value as McpServerConfig;
-      if (config.type !== "remote" && config.type !== "local") {
-        return [];
-      }
-
-      return [{ name, config }];
-    });
+    return parseMcpServersFromConfig(parsed?.mcp as McpConfigValue);
   } catch {
     return [];
   }

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -127,6 +127,7 @@ export type DashboardViewProps = {
   connectMcp: (entry: McpDirectoryInfo) => void;
   showMcpReloadBanner: boolean;
   mcpReloadBlocked: boolean;
+  isRemoteWorkspace: boolean;
   reloadMcpEngine: () => void;
   createSessionAndOpen: () => void;
   setPrompt: (value: string) => void;
@@ -753,6 +754,7 @@ export default function DashboardView(props: DashboardViewProps) {
                 connectMcp={props.connectMcp}
                 showMcpReloadBanner={props.showMcpReloadBanner}
                 reloadBlocked={props.mcpReloadBlocked}
+                isRemoteWorkspace={props.isRemoteWorkspace}
                 reloadMcpEngine={props.reloadMcpEngine}
               />
             </Match>

--- a/packages/app/src/app/pages/mcp.tsx
+++ b/packages/app/src/app/pages/mcp.tsx
@@ -38,6 +38,7 @@ export type McpViewProps = {
   connectMcp: (entry: McpDirectoryInfo) => void;
   showMcpReloadBanner: boolean;
   reloadBlocked: boolean;
+  isRemoteWorkspace: boolean;
   reloadMcpEngine: () => void;
 };
 
@@ -180,8 +181,13 @@ export default function McpView(props: McpViewProps) {
     return status?.status === "connected";
   };
 
-  const canConnect = (entry: McpDirectoryInfo) =>
-    props.mode === "host" && isTauriRuntime() && !props.busy && !!props.activeWorkspaceRoot.trim();
+  const canConnect = (entry: McpDirectoryInfo) => {
+    if (props.busy || !props.activeWorkspaceRoot.trim()) return false;
+    if (props.isRemoteWorkspace) {
+      return props.mode === "client";
+    }
+    return props.mode === "host" && isTauriRuntime();
+  };
 
   return (
     <section class="space-y-6">


### PR DESCRIPTION
## Summary
- load and update MCP config via SDK for remote/client workspaces
- relax MCP connect gating to allow remote workspace clients
- fix Solid Show usage to satisfy typecheck

## Testing
- pnpm -C packages/app typecheck