### PR TITLE
fix: reload workspace when OpenCode config changes

### DIFF
--- a/packages/app/src/app/components/reload-workspace-toast.tsx
+++ b/packages/app/src/app/components/reload-workspace-toast.tsx
@@ -1,0 +1,71 @@
+import { Show } from "solid-js";
+import { AlertTriangle, RefreshCcw } from "lucide-solid";
+
+import Button from "./button";
+
+export type ReloadWorkspaceToastProps = {
+  open: boolean;
+  title: string;
+  description: string;
+  warning: string;
+  blockedReason?: string | null;
+  error?: string | null;
+  reloadLabel: string;
+  dismissLabel: string;
+  busy?: boolean;
+  canReload: boolean;
+  onReload: () => void;
+  onDismiss: () => void;
+};
+
+export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
+  return (
+    <Show when={props.open}>
+      <div class="fixed top-6 right-6 z-50 w-[min(420px,calc(100vw-2rem))]">
+        <div class="rounded-2xl border border-gray-6/70 bg-gray-1/95 p-4 shadow-xl backdrop-blur animate-in fade-in slide-in-from-top-11 duration-200">
+          <div class="flex items-start gap-3">
+            <div class="mt-0.5 flex h-9 w-9 items-center justify-center rounded-full border border-amber-7/30 bg-amber-7/10 text-amber-11">
+              <RefreshCcw size={16} />
+            </div>
+            <div class="flex-1 space-y-2">
+              <div>
+                <div class="text-sm font-semibold text-gray-12">{props.title}</div>
+                <div class="text-xs text-gray-10">{props.description}</div>
+              </div>
+              <div class="text-xs text-gray-10">{props.warning}</div>
+              <Show when={props.blockedReason}>
+                <div class="flex items-start gap-2 rounded-lg border border-amber-7/30 bg-amber-7/10 px-3 py-2 text-xs text-amber-11">
+                  <AlertTriangle size={14} class="mt-0.5 shrink-0" />
+                  <span>{props.blockedReason}</span>
+                </div>
+              </Show>
+              <Show when={props.error}>
+                <div class="rounded-lg border border-red-7/30 bg-red-7/10 px-3 py-2 text-xs text-red-11">
+                  {props.error}
+                </div>
+              </Show>
+            </div>
+          </div>
+          <div class="mt-3 flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              class="h-8 px-3 text-xs"
+              onClick={() => props.onDismiss()}
+              disabled={props.busy}
+            >
+              {props.dismissLabel}
+            </Button>
+            <Button
+              variant="secondary"
+              class="h-8 px-3 text-xs"
+              onClick={() => props.onReload()}
+              disabled={!props.canReload}
+            >
+              {props.reloadLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -146,7 +146,7 @@ export type McpStatus =
 
 export type McpStatusMap = Record<string, McpStatus>;
 
-export type ReloadReason = "plugins" | "skills" | "mcp";
+export type ReloadReason = "plugins" | "skills" | "mcp" | "config";
 
 export type PendingPermission = ApiPermissionRequest & {
   receivedAt: number;

--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -553,6 +553,18 @@ export default {
   "settings.updates_not_supported": "Updates are not supported in this environment.",
   "settings.updates_desktop_only": "Updates are only available in the desktop app.",
 
+  // ==================== Reload ====================
+  "reload.toast_title": "Reload required",
+  "reload.toast_description": "You need to reload your workspace for these changes to take effect.",
+  "reload.toast_warning": "Reloading may interrupt active sessions or workflows.",
+  "reload.toast_warning_active": "Active runs detected. Reloading now would interrupt them.",
+  "reload.toast_reload": "Reload",
+  "reload.toast_reloading": "Reloading...",
+  "reload.toast_dismiss": "Dismiss",
+  "reload.toast_blocked_host": "Reloading is only available in Host mode.",
+  "reload.toast_blocked_connect": "Connect to this workspace to reload.",
+  "reload.toast_blocked_runs": "Waiting for active tasks to complete before reloading.",
+
   // ==================== Onboarding ====================
   "onboarding.starting_host": "Starting OpenWork...",
   "onboarding.searching_host": "Searching for Host...",
@@ -664,6 +676,7 @@ export default {
   "status.loading_session": "Loading session",
   "status.creating_task": "Creating new task",
   "status.starting_engine": "Starting engine",
+  "status.reloading_engine": "Reloading engine",
   "status.restarting_engine": "Restarting engine",
   "status.installing_opencode": "Installing OpenCode",
   "status.disconnecting": "Disconnecting",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -547,6 +547,18 @@ export default {
   "settings.updates_not_supported": "此环境不支持更新。",
   "settings.updates_desktop_only": "更新仅在桌面应用中可用。",
 
+  // ==================== Reload ====================
+  "reload.toast_title": "需要重新加载",
+  "reload.toast_description": "你需要重新加载工作区才能使这些更改生效。",
+  "reload.toast_warning": "重新加载可能会中断正在进行的会话或流程。",
+  "reload.toast_warning_active": "检测到活动运行，立即重新加载将会中断它们。",
+  "reload.toast_reload": "重新加载",
+  "reload.toast_reloading": "正在重新加载...",
+  "reload.toast_dismiss": "忽略",
+  "reload.toast_blocked_host": "仅主机模式可重新加载。",
+  "reload.toast_blocked_connect": "连接到此工作区后才能重新加载。",
+  "reload.toast_blocked_runs": "请先停止活动运行再重新加载。",
+
   // ==================== Onboarding ====================
   "onboarding.starting_host": "正在启动 OpenWork...",
   "onboarding.searching_host": "正在搜索主机...",
@@ -658,6 +670,7 @@ export default {
   "status.loading_session": "正在加载会话",
   "status.creating_task": "正在创建新任务",
   "status.starting_engine": "正在启动引擎",
+  "status.reloading_engine": "正在重新加载引擎",
   "status.restarting_engine": "正在重启引擎",
   "status.installing_opencode": "正在安装 OpenCode",
   "status.disconnecting": "正在断开连接",


### PR DESCRIPTION
## Summary
- add reload-required toast with reload action and active-run warnings
- detect OpenCode config/skill changes from chat tool output and flag reload
- reload engine by stopping/starting OpenCode and reconnecting to workspace