### PR TITLE
test: add owpenwork cli checks

### DIFF
--- a/packages/owpenbot/README.md
+++ b/packages/owpenbot/README.md
@@ -119,4 +119,6 @@ owpenwork status
 ```bash
 pnpm -C packages/owpenbot test:unit
 pnpm -C packages/owpenbot test:smoke
+pnpm -C packages/owpenbot test:cli
+pnpm -C packages/owpenbot test:npx
 ```

--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -35,7 +35,9 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "setup": "node scripts/setup.mjs",
     "test:unit": "pnpm build && node --test test/*.test.js",
-    "test:smoke": "node scripts/smoke.mjs"
+    "test:smoke": "node scripts/smoke.mjs",
+    "test:cli": "pnpm build && node scripts/test-cli.mjs",
+    "test:npx": "node scripts/test-npx.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.1.19",

--- a/packages/owpenbot/scripts/test-cli.mjs
+++ b/packages/owpenbot/scripts/test-cli.mjs
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const cliPath = path.resolve("dist", "cli.js");
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      ...options,
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+      if (options.expectTimeout) {
+        resolve({ code: null, stdout, stderr, timedOut: true });
+        return;
+      }
+      reject(new Error(`Timeout running ${cmd} ${args.join(" ")}`));
+    }, options.timeoutMs ?? 5000);
+
+    child.on("close", (code) => {
+      if (timedOut) return;
+      clearTimeout(timeout);
+      resolve({ code, stdout, stderr, timedOut: false });
+    });
+
+    if (options.input) {
+      child.stdin.write(options.input);
+      child.stdin.end();
+    }
+  });
+}
+
+async function runHelp() {
+  const result = await run("node", [cliPath, "--help"], { timeoutMs: 3000 });
+  if (result.code !== 0) {
+    throw new Error(`Help failed: ${result.stderr}`);
+  }
+  if (!result.stdout.includes("OpenCode WhatsApp")) {
+    throw new Error("Help output missing expected header");
+  }
+}
+
+async function runSetupNonInteractive() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "owpenbot-"));
+  const env = {
+    ...process.env,
+    OWPENBOT_DATA_DIR: tempDir,
+    OWPENBOT_DB_PATH: path.join(tempDir, "owpenbot.db"),
+    OWPENBOT_CONFIG_PATH: path.join(tempDir, "owpenbot.json"),
+    OPENCODE_DIRECTORY: tempDir,
+  };
+  const result = await run("node", [cliPath, "setup", "--non-interactive"], {
+    env,
+    timeoutMs: 5000,
+  });
+  if (result.code !== 0) {
+    throw new Error(`Setup failed: ${result.stderr}`);
+  }
+  const cfg = await fs.readFile(path.join(tempDir, "owpenbot.json"), "utf-8");
+  if (!cfg.includes("whatsapp")) {
+    throw new Error("Config missing whatsapp section");
+  }
+}
+
+async function runSetupInteractive() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "owpenbot-"));
+  const env = {
+    ...process.env,
+    OWPENBOT_DATA_DIR: tempDir,
+    OWPENBOT_DB_PATH: path.join(tempDir, "owpenbot.db"),
+    OWPENBOT_CONFIG_PATH: path.join(tempDir, "owpenbot.json"),
+    OPENCODE_DIRECTORY: tempDir,
+  };
+  const input = "1\n+15551234567\n";
+  const result = await run("node", ["--no-warnings", cliPath, "setup"], {
+    env,
+    timeoutMs: 1500,
+    expectTimeout: true,
+  });
+  const output = `${result.stdout}${result.stderr}`;
+  if (!output.includes("WhatsApp setup")) {
+    throw new Error("Interactive setup prompt not detected");
+  }
+}
+
+await runHelp();
+await runSetupNonInteractive();
+await runSetupInteractive();
+console.log("CLI smoke tests passed");

--- a/packages/owpenbot/scripts/test-npx.mjs
+++ b/packages/owpenbot/scripts/test-npx.mjs
@@ -1,0 +1,54 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      ...options,
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Timeout running ${cmd} ${args.join(" ")}`));
+    }, options.timeoutMs ?? 60000);
+
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+const tempCache = await fs.mkdtemp(path.join(os.tmpdir(), "owpenbot-npx-"));
+const env = {
+  ...process.env,
+  npm_config_yes: "true",
+  NPM_CONFIG_CACHE: tempCache,
+};
+
+const result = await run("npx", ["--yes", "owpenwork", "--help"], {
+  env,
+  timeoutMs: 60000,
+});
+
+if (result.code !== 0) {
+  throw new Error(result.stderr || "npx owpenwork failed");
+}
+
+if (!result.stdout.includes("OpenCode WhatsApp")) {
+  throw new Error("npx output missing expected header");
+}
+
+console.log("npx owpenwork ok");


### PR DESCRIPTION
## Summary
- add CLI smoke tests that exercise help output, non-interactive setup, and prompt detection
- add an npx-based sanity check to validate the published package entrypoint
- document the new test commands in the owpenbot README

## Testing
- pnpm -C packages/owpenbot test:unit
- pnpm -C packages/owpenbot test:cli
- pnpm -C packages/owpenbot test:npx