### PR TITLE
fix: remove unnecessary escape characters in skill.md template

### DIFF
--- a/packages/desktop/src-tauri/src/workspace/files.rs
+++ b/packages/desktop/src-tauri/src/workspace/files.rs
@@ -51,10 +51,10 @@ description: Workspace guide to introduce OpenWork and onboard new users.
 
 # Welcome to OpenWork
 
-Hi, I\'m Ben and this is OpenWork. It\'s an open-source alternative to Claude\'s cowork. It helps you work on your files with AI and automate the mundane tasks so you don\'t have to.
+Hi, I'm Ben and this is OpenWork. It's an open-source alternative to Claude's cowork. It helps you work on your files with AI and automate the mundane tasks so you don't have to.
 
 Before we start, use the question tool to ask:
-"Are you more technical or non-technical? I\'ll tailor the explanation."
+"Are you more technical or non-technical? I'll tailor the explanation."
 
 ## If the person is non-technical
 OpenWork feels like a chat app, but it can safely work with the files you allow. Put files in this workspace and I can summarize them, create new ones, or help organize them.
@@ -65,7 +65,7 @@ Try:
 - "Draft a short summary from this document."
 
 ## Skills and plugins (simple)
-Skills add new capabilities. Plugins add advanced features like scheduling or browser automation. We can add them later when you\'re ready.
+Skills add new capabilities. Plugins add advanced features like scheduling or browser automation. We can add them later when you're ready.
 
 ## If the person is technical
 OpenWork is a GUI for OpenCode. Everything that works in OpenCode works here.


### PR DESCRIPTION
- Workspace guide template rendered with extra backslashes (e.g., `I\'m` instead of `I'm`).
- Delete existing `SKILL.md` or create a brand new workspace when testing, as old files still contain backslashes.

Screenshot:

![Xnip2026-01-24_22-20-48](https://github.com/user-attachments/assets/0f127f7e-2925-4efb-a088-06a8a63090b9)
