### PR TITLE
feat: guide owpenwork setup flow

### DIFF
--- a/packages/owpenbot/README.md
+++ b/packages/owpenbot/README.md
@@ -19,12 +19,10 @@ npm install -g owpenwork
 Quick run without install:
 
 ```bash
-npx owpenwork setup
-npx owpenwork whatsapp login
-npx owpenwork start
+npx owpenwork
 ```
 
-Then follow the printed next steps (run `owpenbot setup`, link WhatsApp, start the bridge).
+Then follow the prompts (setup, QR login, start).
 
 1) One-command setup (installs deps, builds, creates `.env` if missing):
 
@@ -43,25 +41,13 @@ Recommended:
 - `OPENCODE_SERVER_USERNAME`
 - `OPENCODE_SERVER_PASSWORD`
 
-3) Run setup (writes `~/.owpenbot/owpenbot.json`):
+3) Run owpenwork and follow the guided setup:
 
 ```bash
-owpenwork setup
+owpenwork
 ```
 
-4) Link WhatsApp (QR):
-
-```bash
-owpenwork whatsapp login
-```
-
-5) Start the bridge:
-
-```bash
-owpenwork start
-```
-
-Owpenbot keeps the WhatsApp session alive once connected.
+Owpenwork keeps the WhatsApp session alive once connected.
 
 6) Pair a user with the bot (only if DM policy is pairing):
 
@@ -75,8 +61,8 @@ Owpenbot keeps the WhatsApp session alive once connected.
 
 Use your own WhatsApp account as the bot and test from a second number you control.
 
-1) Run `owpenwork setup` and choose “personal number.”
-2) Run `owpenwork whatsapp login` to scan the QR.
+1) Run `owpenwork` and choose “personal number.”
+2) Scan the QR when prompted.
 3) Message yourself or from a second number; your number is already allowlisted.
 
 Note: WhatsApp’s “message yourself” thread is not reliable for bot testing.
@@ -86,8 +72,8 @@ Note: WhatsApp’s “message yourself” thread is not reliable for bot testing
 Use a separate WhatsApp number as the bot account so it stays independent from your personal chat history.
 
 1) Create a new WhatsApp account for the dedicated number.
-2) Run `owpenwork setup` and choose “dedicated number.”
-3) Run `owpenwork whatsapp login` to scan the QR.
+2) Run `owpenwork` and choose “dedicated number.”
+3) Scan the QR when prompted.
 4) If DM policy is pairing, approve codes with `owpenwork pairing approve <code>`.
 
 ## Telegram (Untested)
@@ -99,9 +85,8 @@ Telegram support is wired but not E2E tested yet. To try it:
 ## Commands
 
 ```bash
-owpenwork setup
-owpenwork whatsapp login
-owpenwork start
+owpenwork
+owpenwork --non-interactive
 owpenwork pairing list
 owpenwork pairing approve <code>
 owpenwork status
@@ -110,7 +95,7 @@ owpenwork status
 ## Defaults
 
 - SQLite at `~/.owpenbot/owpenbot.db` unless overridden.
-- Config stored at `~/.owpenbot/owpenbot.json` (created by `owpenbot setup`).
+- Config stored at `~/.owpenbot/owpenbot.json` (created by `owpenwork` or `owpenwork setup`).
 - DM policy defaults to `pairing` unless changed in setup.
 - Group chats are disabled unless `GROUPS_ENABLED=true`.
 

--- a/packages/owpenbot/install.sh
+++ b/packages/owpenbot/install.sh
@@ -140,9 +140,8 @@ cat <<EOF
 Owpenbot installed.
 
 Next steps:
-1) Run setup: owpenwork setup
-2) Link WhatsApp: owpenwork whatsapp login
-3) Start bridge: owpenwork start
+1) Run owpenwork: owpenwork
+2) Follow the guided setup + QR login
 
 Owpenbot will print a QR code during login and keep the session alive.
 EOF

--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owpenwork",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "WhatsApp bridge for a running OpenCode server",
   "private": false,
   "type": "module",

--- a/packages/owpenbot/scripts/test-cli.mjs
+++ b/packages/owpenbot/scripts/test-cli.mjs
@@ -64,7 +64,7 @@ async function runSetupNonInteractive() {
     OWPENBOT_CONFIG_PATH: path.join(tempDir, "owpenbot.json"),
     OPENCODE_DIRECTORY: tempDir,
   };
-  const result = await run("node", [cliPath, "setup", "--non-interactive"], {
+  const result = await run("node", [cliPath, "--non-interactive"], {
     env,
     timeoutMs: 5000,
   });
@@ -87,7 +87,7 @@ async function runSetupInteractive() {
     OPENCODE_DIRECTORY: tempDir,
   };
   const input = "1\n+15551234567\n";
-  const result = await run("node", ["--no-warnings", cliPath, "setup"], {
+  const result = await run("node", ["--no-warnings", cliPath], {
     env,
     timeoutMs: 1500,
     expectTimeout: true,


### PR DESCRIPTION
## Summary
- run a guided flow when invoking `owpenwork` with no subcommands (setup, login, start)
- add non-interactive and check flags for scripted installs
- align docs and installer messaging with the single-command experience

## Testing
- pnpm -C packages/owpenbot test:unit
- pnpm -C packages/owpenbot test:cli
- pnpm -C packages/owpenbot test:npx