### PR TITLE
feat: add owpenwork tui setup

### DIFF
--- a/packages/owpenbot/README.md
+++ b/packages/owpenbot/README.md
@@ -22,7 +22,7 @@ Quick run without install:
 npx owpenwork
 ```
 
-Then follow the prompts (setup, QR login, start).
+Then follow the guided setup (choose what to configure, link WhatsApp, start).
 
 1) One-command setup (installs deps, builds, creates `.env` if missing):
 
@@ -79,17 +79,20 @@ Use a separate WhatsApp number as the bot account so it stays independent from y
 ## Telegram (Untested)
 
 Telegram support is wired but not E2E tested yet. To try it:
-- Set `TELEGRAM_BOT_TOKEN`.
-- Optionally set `TELEGRAM_ENABLED=true`.
+- Run `owpenwork login telegram --token <token>`.
+- Or set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ENABLED=true`.
 
 ## Commands
 
 ```bash
 owpenwork
 owpenwork --non-interactive
+owpenwork login whatsapp
+owpenwork login telegram --token <token>
 owpenwork pairing list
 owpenwork pairing approve <code>
 owpenwork status
+owpenwork doctor --reset
 ```
 
 ## Defaults

--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owpenwork",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "WhatsApp bridge for a running OpenCode server",
   "private": false,
   "type": "module",
@@ -40,6 +40,7 @@
     "test:npx": "node scripts/test-npx.mjs"
   },
   "dependencies": {
+    "@clack/prompts": "^0.11.0",
     "@opencode-ai/sdk": "^1.1.19",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "better-sqlite3": "^11.7.0",

--- a/packages/owpenbot/scripts/test-cli.mjs
+++ b/packages/owpenbot/scripts/test-cli.mjs
@@ -85,16 +85,21 @@ async function runSetupInteractive() {
     OWPENBOT_DB_PATH: path.join(tempDir, "owpenbot.db"),
     OWPENBOT_CONFIG_PATH: path.join(tempDir, "owpenbot.json"),
     OPENCODE_DIRECTORY: tempDir,
+    OWPENWORK_TEST_SELECTIONS: "config",
+    OWPENWORK_TEST_SETUP: "personal",
+    OWPENWORK_FORCE_TUI: "1",
   };
-  const input = "1\n+15551234567\n";
   const result = await run("node", ["--no-warnings", cliPath], {
     env,
-    timeoutMs: 1500,
-    expectTimeout: true,
+    timeoutMs: 5000,
   });
   const output = `${result.stdout}${result.stderr}`;
-  if (!output.includes("WhatsApp setup")) {
+  if (!output.includes("Owpenwork Setup")) {
     throw new Error("Interactive setup prompt not detected");
+  }
+  const cfg = await fs.readFile(path.join(tempDir, "owpenbot.json"), "utf-8");
+  if (!cfg.includes("+15551234567")) {
+    throw new Error("Interactive config missing allowlist number");
   }
 }
 

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { createInterface } from "node:readline/promises";
 
+import {
+  cancel,
+  confirm,
+  intro,
+  isCancel,
+  log,
+  multiselect,
+  outro,
+  select,
+  spinner,
+  text,
+} from "@clack/prompts";
 import { Command } from "commander";
 
 import { startBridge } from "./bridge.js";
@@ -18,18 +29,216 @@ import { BridgeStore } from "./db.js";
 import { createLogger } from "./logger.js";
 import { loginWhatsApp, unpairWhatsApp } from "./whatsapp.js";
 
-const program = new Command();
+const VERSION = "0.1.8";
 
+type SetupStep = "config" | "whatsapp" | "telegram" | "start";
 
-program
-  .name("owpenbot")
-  .version("0.1.7")
-  .description("OpenCode WhatsApp + Telegram bridge")
-  .argument("[path]")
-  .option("--non-interactive", "Run setup defaults and exit", false)
-  .option("--check", "Validate config/auth and exit", false);
+const STEP_OPTIONS: Array<{ value: SetupStep; label: string; hint?: string }> = [
+  {
+    value: "config",
+    label: "Setup configuration",
+    hint: "DM policy + allowlist",
+  },
+  {
+    value: "whatsapp",
+    label: "Link WhatsApp",
+    hint: "Scan QR",
+  },
+  {
+    value: "telegram",
+    label: "Link Telegram",
+    hint: "Optional",
+  },
+  {
+    value: "start",
+    label: "Start bridge",
+    hint: "Listen for messages",
+  },
+];
 
-const runStart = async (pathOverride?: string) => {
+const STEP_SET = new Set<SetupStep>(["config", "whatsapp", "telegram", "start"]);
+
+function isInteractive() {
+  return Boolean(process.stdin.isTTY || process.env.OWPENWORK_FORCE_TUI === "1");
+}
+
+function unwrap<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel("Setup cancelled");
+    process.exit(0);
+  }
+  return value as T;
+}
+
+function parseSelections(raw?: string): SetupStep[] | null {
+  if (!raw) return null;
+  const selections = raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .filter((item): item is SetupStep => STEP_SET.has(item as SetupStep));
+  return selections.length ? selections : [];
+}
+
+function defaultSelections(configExists: boolean, whatsappLinked: boolean): SetupStep[] {
+  const selections: SetupStep[] = [];
+  if (!configExists) selections.push("config");
+  if (!whatsappLinked) selections.push("whatsapp");
+  selections.push("start");
+  return selections;
+}
+
+function updateConfig(configPath: string, updater: (cfg: OwpenbotConfigFile) => OwpenbotConfigFile) {
+  const { config } = readConfigFile(configPath);
+  const base = config ?? { version: 1 };
+  const next = updater(base);
+  next.version = next.version ?? 1;
+  writeConfigFile(configPath, next);
+  return next;
+}
+
+async function runSetupWizard(
+  config: ReturnType<typeof loadConfig>,
+  options: { nonInteractive: boolean; useTui: boolean },
+) {
+  const testMode = process.env.OWPENWORK_TEST_SETUP;
+  const next = updateConfig(config.configPath, (cfg) => ({ ...cfg }));
+
+  if (options.nonInteractive || testMode) {
+    next.channels = next.channels ?? {};
+    const mode = testMode === "dedicated" ? "dedicated" : "personal";
+    const allowFrom = mode === "personal" ? ["+15551234567"] : [];
+    next.channels.whatsapp = {
+      dmPolicy: mode === "personal" ? "allowlist" : "pairing",
+      allowFrom,
+      selfChatMode: mode === "personal",
+      accounts: {
+        [config.whatsappAccountId]: {
+          authDir: config.whatsappAuthDir,
+        },
+      },
+    };
+    writeConfigFile(config.configPath, next);
+    log.success(`Wrote ${config.configPath}`);
+    return;
+  }
+
+  if (options.useTui) {
+    const mode = unwrap(
+      await select({
+        message: "WhatsApp number",
+        options: [
+          {
+            value: "personal",
+            label: "Personal number (no pairing)",
+            hint: "Allowlist your own number",
+          },
+          {
+            value: "dedicated",
+            label: "Dedicated number",
+            hint: "Pairing or allowlist",
+          },
+        ],
+        initialValue: "personal",
+      }),
+    ) as "personal" | "dedicated";
+
+    let dmPolicy: DmPolicy = "pairing";
+    let allowFrom: string[] = [];
+    let selfChatMode = false;
+
+    if (mode === "personal") {
+      const number = unwrap(
+        await text({
+          message: "Your WhatsApp number (E.164)",
+          placeholder: "+15551234567",
+          validate: (value: string) => {
+            const normalized = normalizeWhatsAppId(String(value ?? ""));
+            return /^\+\d+$/.test(normalized) ? undefined : "Use E.164 format (+123...)";
+          },
+        }),
+      ) as string;
+      allowFrom = [normalizeWhatsAppId(number)];
+      dmPolicy = "allowlist";
+      selfChatMode = true;
+    } else {
+      dmPolicy = unwrap(
+        await select({
+          message: "Direct messages",
+          options: [
+            { value: "pairing", label: "Pairing (recommended)" },
+            { value: "allowlist", label: "Allowlist only" },
+            { value: "open", label: "Open (public)" },
+            { value: "disabled", label: "Disabled" },
+          ],
+          initialValue: "pairing",
+        }),
+      ) as DmPolicy;
+
+      const listInput = unwrap(
+        await text({
+          message: "Allowlist numbers (comma-separated, optional)",
+          placeholder: "+15551234567, +15551234568",
+        }),
+      ) as string;
+      if (listInput.trim()) {
+        allowFrom = listInput
+          .split(",")
+          .map((item) => normalizeWhatsAppId(item))
+          .filter(Boolean);
+      }
+      if (dmPolicy === "open") {
+        allowFrom = allowFrom.length ? allowFrom : ["*"];
+      }
+    }
+
+    next.channels = next.channels ?? {};
+    next.channels.whatsapp = {
+      dmPolicy,
+      allowFrom,
+      selfChatMode,
+      accounts: {
+        [config.whatsappAccountId]: {
+          authDir: config.whatsappAuthDir,
+        },
+      },
+    };
+    writeConfigFile(config.configPath, next);
+    log.success(`Wrote ${config.configPath}`);
+    return;
+  }
+}
+
+async function runTelegramSetup(config: ReturnType<typeof loadConfig>, tokenOverride?: string) {
+  const tokenFromEnv = tokenOverride ?? process.env.OWPENWORK_TEST_TELEGRAM_TOKEN;
+  let token = tokenFromEnv || config.telegramToken;
+  if (!token) {
+    if (!isInteractive()) {
+      log.warn("Telegram token missing. Provide TELEGRAM_BOT_TOKEN or use login command.");
+      return;
+    }
+    token = unwrap(
+      await text({
+        message: "Telegram bot token",
+        placeholder: "123456:ABCDEF...",
+        validate: (value: string) => (String(value ?? "").trim() ? undefined : "Token required"),
+      }),
+    ) as string;
+  }
+
+  updateConfig(config.configPath, (cfg) => {
+    const next = { ...cfg } as OwpenbotConfigFile;
+    next.channels = next.channels ?? {};
+    next.channels.telegram = {
+      token,
+      enabled: true,
+    };
+    return next;
+  });
+  log.success("Telegram token saved.");
+}
+
+async function runStart(pathOverride?: string) {
   if (pathOverride?.trim()) {
     process.env.OPENCODE_DIRECTORY = pathOverride.trim();
   }
@@ -49,94 +258,6 @@ const runStart = async (pathOverride?: string) => {
 
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
-};
-
-async function runSetupWizard(config: ReturnType<typeof loadConfig>, nonInteractive: boolean) {
-  const { config: existing } = readConfigFile(config.configPath);
-  const next: OwpenbotConfigFile = existing ?? { version: 1 };
-
-  if (nonInteractive) {
-    next.version = 1;
-    next.channels = next.channels ?? {};
-    next.channels.whatsapp = {
-      dmPolicy: "pairing",
-      allowFrom: [],
-      selfChatMode: false,
-      accounts: {
-        [config.whatsappAccountId]: {
-          authDir: config.whatsappAuthDir,
-        },
-      },
-    };
-    writeConfigFile(config.configPath, next);
-    console.log(`Wrote ${config.configPath}`);
-    return;
-  }
-
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const phoneMode = await rl.question(
-    "WhatsApp setup: (1) Personal number (2) Dedicated number [1]: ",
-  );
-  const mode = phoneMode.trim() === "2" ? "dedicated" : "personal";
-
-  let dmPolicy: DmPolicy = "pairing";
-  let allowFrom: string[] = [];
-  let selfChatMode = false;
-
-  if (mode === "personal") {
-    let normalized = "";
-    while (!normalized) {
-      const number = await rl.question("Your WhatsApp number (E.164, e.g. +15551234567): ");
-      const candidate = normalizeWhatsAppId(number);
-      if (!/^\+\d+$/.test(candidate)) {
-        console.log("Invalid number. Try again.");
-        continue;
-      }
-      normalized = candidate;
-    }
-    allowFrom = [normalized];
-    dmPolicy = "allowlist";
-    selfChatMode = true;
-  } else {
-    const policyInput = await rl.question(
-      "DM policy: (1) Pairing (2) Allowlist (3) Open (4) Disabled [1]: ",
-    );
-    const policyChoice = policyInput.trim();
-    if (policyChoice === "2") dmPolicy = "allowlist";
-    else if (policyChoice === "3") dmPolicy = "open";
-    else if (policyChoice === "4") dmPolicy = "disabled";
-    else dmPolicy = "pairing";
-
-    const listInput = await rl.question(
-      "Allowlist numbers (comma-separated, optional): ",
-    );
-    if (listInput.trim()) {
-      allowFrom = listInput
-        .split(",")
-        .map((item) => normalizeWhatsAppId(item))
-        .filter(Boolean);
-    }
-    if (dmPolicy === "open") {
-      allowFrom = allowFrom.length ? allowFrom : ["*"];
-    }
-  }
-
-  rl.close();
-
-  next.version = 1;
-  next.channels = next.channels ?? {};
-  next.channels.whatsapp = {
-    dmPolicy,
-    allowFrom,
-    selfChatMode,
-    accounts: {
-      [config.whatsappAccountId]: {
-        authDir: config.whatsappAuthDir,
-      },
-    },
-  };
-  writeConfigFile(config.configPath, next);
-  console.log(`Wrote ${config.configPath}`);
 }
 
 async function runGuidedFlow(pathArg: string | undefined, opts: { nonInteractive: boolean; check: boolean }) {
@@ -148,34 +269,112 @@ async function runGuidedFlow(pathArg: string | undefined, opts: { nonInteractive
     process.env.OPENCODE_DIRECTORY = config.opencodeDirectory;
   }
 
+  const authPath = path.join(config.whatsappAuthDir, "creds.json");
+  const whatsappLinked = fs.existsSync(authPath);
+  const configExists = fs.existsSync(config.configPath);
+
   if (opts.check) {
-    const authPath = path.join(config.whatsappAuthDir, "creds.json");
-    const linked = fs.existsSync(authPath);
-    const cfgExists = fs.existsSync(config.configPath);
-    console.log(`Config: ${cfgExists ? "yes" : "no"}`);
-    console.log(`WhatsApp linked: ${linked ? "yes" : "no"}`);
-    process.exit(linked && cfgExists ? 0 : 1);
+    console.log(`Config: ${configExists ? "yes" : "no"}`);
+    console.log(`WhatsApp linked: ${whatsappLinked ? "yes" : "no"}`);
+    console.log(`Telegram configured: ${config.telegramToken ? "yes" : "no"}`);
+    process.exit(configExists && whatsappLinked ? 0 : 1);
   }
 
-  const cfgExists = fs.existsSync(config.configPath);
-  const cfgHasWhatsApp = config.configFile.channels?.whatsapp;
-  if (!cfgExists || !cfgHasWhatsApp) {
-    await runSetupWizard(config, opts.nonInteractive);
-    if (opts.nonInteractive) {
-      console.log("Next: owpenwork whatsapp login");
-      return;
+  if (opts.nonInteractive) {
+    await runSetupWizard(config, { nonInteractive: true, useTui: false });
+    console.log("Next: owpenwork whatsapp login");
+    return;
+  }
+
+  if (!isInteractive()) {
+    console.log("Non-interactive shell. Run `owpenwork start` or `owpenwork --non-interactive`.");
+    return;
+  }
+
+  intro("Owpenwork Setup");
+  const selectedFromEnv = parseSelections(process.env.OWPENWORK_TEST_SELECTIONS);
+  const selections = selectedFromEnv ??
+    unwrap(
+      await multiselect({
+        message: "Select what to set up",
+        options: STEP_OPTIONS,
+        initialValues: defaultSelections(configExists, whatsappLinked),
+        required: false,
+      }),
+    );
+
+  const selectedSteps = Array.isArray(selections) ? selections : [];
+  if (!selectedSteps.length) {
+    cancel("No steps selected");
+    process.exit(0);
+  }
+
+  const total = selectedSteps.length;
+  let index = 1;
+
+  const runStep = async (label: string, task: () => Promise<void>) => {
+    const spin = spinner();
+    spin.start(`Step ${index}/${total}: ${label}`);
+    await task();
+    spin.stop(`Step ${index}/${total}: ${label} done`);
+    index += 1;
+  };
+
+  for (const step of selectedSteps) {
+    if (step === "config") {
+      await runStep("Setup configuration", async () => {
+        await runSetupWizard(config, { nonInteractive: false, useTui: true });
+        config = loadConfig(process.env, { requireOpencode: false });
+      });
+      continue;
+    }
+
+    if (step === "whatsapp") {
+      await runStep("Link WhatsApp", async () => {
+        const alreadyLinked = fs.existsSync(authPath);
+        if (alreadyLinked) {
+          const relink = unwrap(
+            await confirm({
+              message: "WhatsApp already linked. Relink?",
+              initialValue: false,
+            }),
+          ) as boolean;
+          if (!relink) return;
+        }
+        await loginWhatsApp(config, createLogger(config.logLevel));
+      });
+      continue;
+    }
+
+    if (step === "telegram") {
+      await runStep("Link Telegram", async () => {
+        await runTelegramSetup(config);
+        config = loadConfig(process.env, { requireOpencode: false });
+      });
+      continue;
+    }
+
+    if (step === "start") {
+      log.info("Starting bridge...");
+      outro("Owpenwork is running.");
+      await runStart(pathArg);
     }
   }
 
-  config = loadConfig(process.env, { requireOpencode: false });
-
-  const authPath = path.join(config.whatsappAuthDir, "creds.json");
-  if (!fs.existsSync(authPath)) {
-    await loginWhatsApp(config, createLogger(config.logLevel));
+  if (!selectedSteps.includes("start")) {
+    outro("Setup complete.");
   }
-
-  await runStart(pathArg);
 }
+
+const program = new Command();
+
+program
+  .name("owpenbot")
+  .version(VERSION)
+  .description("OpenCode WhatsApp + Telegram bridge")
+  .argument("[path]")
+  .option("--non-interactive", "Run setup defaults and exit", false)
+  .option("--check", "Validate config/auth and exit", false);
 
 program
   .command("start")
@@ -197,7 +396,32 @@ program
   .option("--non-interactive", "Write defaults without prompts", false)
   .action(async (opts) => {
     const config = loadConfig(process.env, { requireOpencode: false });
-    await runSetupWizard(config, Boolean(opts.nonInteractive));
+    if (!isInteractive() && !opts.nonInteractive) {
+      console.log("Non-interactive shell. Use --non-interactive.");
+      return;
+    }
+    intro("Owpenwork Setup");
+    await runSetupWizard(config, { nonInteractive: Boolean(opts.nonInteractive), useTui: true });
+    outro("Setup complete.");
+  });
+
+const login = program.command("login").description("Link channels");
+
+login
+  .command("whatsapp")
+  .description("Login to WhatsApp via QR code")
+  .action(async () => {
+    const config = loadConfig(process.env, { requireOpencode: false });
+    await loginWhatsApp(config, createLogger(config.logLevel));
+  });
+
+login
+  .command("telegram")
+  .option("--token <token>", "Telegram bot token")
+  .description("Save Telegram bot token")
+  .action(async (opts) => {
+    const config = loadConfig(process.env, { requireOpencode: false });
+    await runTelegramSetup(config, opts.token as string | undefined);
   });
 
 program
@@ -225,8 +449,7 @@ whatsapp
   .description("Login to WhatsApp via QR code")
   .action(async () => {
     const config = loadConfig(process.env, { requireOpencode: false });
-    const logger = createLogger(config.logLevel);
-    await loginWhatsApp(config, logger);
+    await loginWhatsApp(config, createLogger(config.logLevel));
   });
 
 whatsapp
@@ -234,8 +457,7 @@ whatsapp
   .description("Logout of WhatsApp and clear auth state")
   .action(() => {
     const config = loadConfig(process.env, { requireOpencode: false });
-    const logger = createLogger(config.logLevel);
-    unpairWhatsApp(config, logger);
+    unpairWhatsApp(config, createLogger(config.logLevel));
   });
 
 program
@@ -243,8 +465,7 @@ program
   .description("Print a WhatsApp QR code to pair")
   .action(async () => {
     const config = loadConfig(process.env, { requireOpencode: false });
-    const logger = createLogger(config.logLevel);
-    await loginWhatsApp(config, logger);
+    await loginWhatsApp(config, createLogger(config.logLevel));
   });
 
 program
@@ -252,8 +473,7 @@ program
   .description("Clear WhatsApp pairing data")
   .action(() => {
     const config = loadConfig(process.env, { requireOpencode: false });
-    const logger = createLogger(config.logLevel);
-    unpairWhatsApp(config, logger);
+    unpairWhatsApp(config, createLogger(config.logLevel));
   });
 
 const pairing = program.command("pairing").description("Pairing requests");
@@ -315,6 +535,7 @@ program
     const linked = fs.existsSync(authPath);
     console.log(`Config: ${config.configPath}`);
     console.log(`WhatsApp linked: ${linked ? "yes" : "no"}`);
+    console.log(`Telegram configured: ${config.telegramToken ? "yes" : "no"}`);
     console.log(`Auth dir: ${config.whatsappAuthDir}`);
     console.log(`OpenCode URL: ${config.opencodeUrl}`);
   });
@@ -339,10 +560,12 @@ program
 
     let confirmed = resetRequested;
     if (!resetRequested) {
-      const rl = createInterface({ input: process.stdin, output: process.stdout });
-      const answer = await rl.question("Reset owpenbot state (y/N)? ");
-      rl.close();
-      confirmed = answer.trim().toLowerCase() === "y";
+      const answer = await confirm({ message: "Reset owpenbot state?", initialValue: false });
+      if (isCancel(answer)) {
+        cancel("Reset cancelled");
+        return;
+      }
+      confirmed = Boolean(answer);
     }
 
     if (!confirmed) return;
@@ -353,7 +576,7 @@ program
         fs.rmSync(target, { recursive: true, force: true });
       }
     }
-    console.log("Reset complete. Run: owpenwork setup");
+    console.log("Reset complete. Run: owpenwork");
   });
 
 program.parseAsync(process.argv).catch((error) => {

--- a/packages/owpenbot/src/config.ts
+++ b/packages/owpenbot/src/config.ts
@@ -29,6 +29,10 @@ export type OwpenbotConfigFile = {
         }
       >;
     };
+    telegram?: {
+      token?: string;
+      enabled?: boolean;
+    };
   };
 };
 
@@ -208,6 +212,8 @@ export function loadConfig(
   const toolOutputLimit = parseInteger(env.TOOL_OUTPUT_LIMIT) ?? 1200;
   const permissionMode = env.PERMISSION_MODE?.toLowerCase() === "deny" ? "deny" : "allow";
 
+  const telegramToken = env.TELEGRAM_BOT_TOKEN?.trim() || configFile.channels?.telegram?.token || undefined;
+
   return {
     configPath,
     configFile,
@@ -215,8 +221,11 @@ export function loadConfig(
     opencodeDirectory: resolvedDirectory,
     opencodeUsername: env.OPENCODE_SERVER_USERNAME?.trim() || undefined,
     opencodePassword: env.OPENCODE_SERVER_PASSWORD?.trim() || undefined,
-    telegramToken: env.TELEGRAM_BOT_TOKEN?.trim() || undefined,
-    telegramEnabled: parseBoolean(env.TELEGRAM_ENABLED, Boolean(env.TELEGRAM_BOT_TOKEN?.trim())),
+    telegramToken,
+    telegramEnabled: parseBoolean(
+      env.TELEGRAM_ENABLED,
+      configFile.channels?.telegram?.enabled ?? Boolean(telegramToken),
+    ),
     whatsappAuthDir,
     whatsappAccountId,
     whatsappDmPolicy: dmPolicy,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
 
   packages/owpenbot:
     dependencies:
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
       '@opencode-ai/sdk':
         specifier: ^1.1.19
         version: 1.1.20
@@ -210,6 +213,12 @@ packages:
 
   '@cacheable/utils@2.3.3':
     resolution: {integrity: sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -1612,6 +1621,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   solid-js@1.9.10:
     resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
 
@@ -1919,6 +1931,17 @@ snapshots:
     dependencies:
       hashery: 1.4.0
       keyv: 5.6.0
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -3095,6 +3118,8 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  sisteransi@1.0.5: {}
 
   solid-js@1.9.10:
     dependencies:


### PR DESCRIPTION
## Summary
- add a TUI-style guided flow for `owpenwork` with multi-select setup steps
- add optional Telegram token setup in the guided flow and config loading
- update CLI tests and docs to match the new guided experience

## Testing
- pnpm -C packages/owpenbot test:unit
- pnpm -C packages/owpenbot test:cli
- pnpm -C packages/owpenbot test:npx