### PR TITLE
Add router-based navigation and refresh workspace switch overlay

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "chrome-devtools": {
+      "type": "local",
+      "command": ["npx", "-y", "chrome-devtools-mcp@latest"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
       "better-sqlite3",
       "esbuild",
       "protobufjs"
-    ]
+    ],
+    "patchedDependencies": {
+      "@solidjs/router@0.15.4": "patches/@solidjs__router@0.15.4.patch"
+    }
   },
   "packageManager": "pnpm@10.27.0"
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/colors": "^3.0.0",
     "@solid-primitives/event-bus": "^1.1.2",
     "@solid-primitives/storage": "^4.3.3",
+    "@solidjs/router": "^0.15.4",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "~2.6.0",
     "@tauri-apps/plugin-opener": "^2.5.3",

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -10,7 +10,6 @@ import {
 import {
   Navigate,
   Route,
-  Routes,
   useLocation,
   useNavigate,
   useParams,
@@ -2397,13 +2396,11 @@ export default function App() {
 
   return (
     <>
-      <Routes>
-        <Route path="/" component={RootRoute} />
-        <Route path="/onboarding" component={OnboardingRoute} />
-        <Route path="/dashboard/:tab?" component={DashboardRoute} />
-        <Route path="/session/:sessionId?" component={SessionRoute} />
-        <Route path="*all" component={FallbackRoute} />
-      </Routes>
+      <Route path="/" component={RootRoute} />
+      <Route path="/onboarding" component={OnboardingRoute} />
+      <Route path="/dashboard/:tab?" component={DashboardRoute} />
+      <Route path="/session/:sessionId?" component={SessionRoute} />
+      <Route path="*" component={FallbackRoute} />
 
       <WorkspaceSwitchOverlay
         open={workspaceSwitchOpen()}

--- a/packages/app/src/app/components/workspace-switch-overlay.tsx
+++ b/packages/app/src/app/components/workspace-switch-overlay.tsx
@@ -1,18 +1,8 @@
 import { Show, createMemo } from "solid-js";
-import { Dynamic } from "solid-js/web";
-
-import { Folder, Globe, Zap } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
+import OpenWorkLogo from "./openwork-logo";
 
 import type { WorkspaceInfo } from "../lib/tauri";
-
-function iconForWorkspace(preset: string, workspaceType: string) {
-  if (workspaceType === "remote") return Globe;
-  if (preset === "starter") return Zap;
-  if (preset === "automation") return Folder;
-  if (preset === "minimal") return Globe;
-  return Folder;
-}
 
 export default function WorkspaceSwitchOverlay(props: {
   open: boolean;
@@ -58,10 +48,6 @@ export default function WorkspaceSwitchOverlay(props: {
     return props.workspace.directory?.trim() ?? "";
   });
 
-  const Icon = createMemo(() =>
-    iconForWorkspace(props.workspace?.preset ?? "starter", props.workspace?.workspaceType ?? "local")
-  );
-
   return (
     <Show when={props.open}>
       <div class="fixed inset-0 z-[60] overflow-hidden bg-gray-1 text-gray-12 motion-safe:animate-in motion-safe:fade-in motion-safe:duration-300">
@@ -99,8 +85,8 @@ export default function WorkspaceSwitchOverlay(props: {
                 class="absolute -inset-1 rounded-full border border-gray-6/30 motion-safe:animate-spin motion-reduce:opacity-60"
                 style={{ "animation-duration": "9s", "animation-direction": "reverse" }}
               />
-              <div class="relative h-24 w-24 rounded-3xl bg-gray-2/80 border border-gray-6/70 shadow-2xl flex items-center justify-center text-gray-12">
-                <Dynamic component={Icon()} size={26} />
+              <div class="relative h-24 w-24 rounded-3xl bg-gray-1/90 border border-gray-5/60 shadow-2xl flex items-center justify-center">
+                <OpenWorkLogo size={44} class="drop-shadow-sm" />
               </div>
             </div>
 

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -484,11 +484,6 @@ export function createWorkspaceStore(options: {
     directory?: string | null;
     displayName?: string | null;
   }) {
-    if (!isTauriRuntime()) {
-      options.setError(t("app.error.tauri_required", currentLocale()));
-      return false;
-    }
-
     const baseUrl = input.baseUrl.trim();
     if (!baseUrl) {
       options.setError(t("app.error.remote_base_url_required", currentLocale()));
@@ -518,14 +513,37 @@ export function createWorkspaceStore(options: {
     options.setBusyLabel("status.creating_workspace");
     options.setBusyStartedAt(Date.now());
 
+    const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+    const displayName = input.displayName?.trim() || null;
+    const workspaceId = `remote:${normalizedBaseUrl}:${resolvedDirectory}`;
+
     try {
-      const ws = await workspaceCreateRemote({
-        baseUrl,
-        directory: resolvedDirectory ? resolvedDirectory : null,
-        displayName: input.displayName?.trim() ? input.displayName.trim() : null,
-      });
-      setWorkspaces(ws.workspaces);
-      syncActiveWorkspaceId(ws.activeId);
+      if (isTauriRuntime()) {
+        const ws = await workspaceCreateRemote({
+          baseUrl: normalizedBaseUrl,
+          directory: resolvedDirectory ? resolvedDirectory : null,
+          displayName,
+        });
+        setWorkspaces(ws.workspaces);
+        syncActiveWorkspaceId(ws.activeId);
+      } else {
+        const nextWorkspace: WorkspaceInfo = {
+          id: workspaceId,
+          name: displayName ?? normalizedBaseUrl,
+          path: "",
+          preset: "remote",
+          workspaceType: "remote",
+          baseUrl: normalizedBaseUrl,
+          directory: resolvedDirectory || null,
+          displayName,
+        };
+
+        setWorkspaces((prev) => {
+          const withoutMatch = prev.filter((workspace) => workspace.id !== workspaceId);
+          return [...withoutMatch, nextWorkspace];
+        });
+        syncActiveWorkspaceId(workspaceId);
+      }
 
       setProjectDir(resolvedDirectory);
       setWorkspaceConfig(null);

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -408,8 +408,8 @@ export function createWorkspaceStore(options: {
 
       options.refreshSkills({ force: true }).catch(() => undefined);
       if (!options.selectedSessionId()) {
-        options.setView("dashboard");
         options.setTab("home");
+        options.setView("dashboard");
       }
 
       // If the user successfully connected, treat onboarding as complete so we
@@ -466,8 +466,8 @@ export function createWorkspaceStore(options: {
 
       setWorkspacePickerOpen(false);
       setCreateWorkspaceOpen(false);
-      options.setView("dashboard");
       options.setTab("home");
+      options.setView("dashboard");
       markOnboardingComplete();
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -34,7 +34,7 @@ export type DashboardViewProps = {
   tab: DashboardTab;
   setTab: (tab: DashboardTab) => void;
   view: "dashboard" | "session" | "onboarding";
-  setView: (view: "dashboard" | "session" | "onboarding") => void;
+  setView: (view: "dashboard" | "session" | "onboarding", sessionId?: string) => void;
   mode: "host" | "client" | null;
   baseUrl: string;
   clientConnected: boolean;
@@ -211,9 +211,9 @@ export default function DashboardView(props: DashboardViewProps) {
   const openSessionFromList = (sessionId: string) => {
     // Defer view switch to avoid click-through on the same event frame.
     window.setTimeout(() => {
-      props.setView("session");
-      props.setTab("sessions");
       void props.selectSession(sessionId);
+      props.setTab("sessions");
+      props.setView("session", sessionId);
     }, 0);
   };
 

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -33,7 +33,7 @@ import FlyoutItem from "../components/flyout-item";
 
 export type SessionViewProps = {
   selectedSessionId: string | null;
-  setView: (view: View) => void;
+  setView: (view: View, sessionId?: string) => void;
   setTab: (tab: DashboardTab) => void;
   activeWorkspaceDisplay: WorkspaceDisplay;
   setWorkspaceSearch: (value: string) => void;
@@ -655,8 +655,8 @@ export default function SessionView(props: SessionViewProps) {
             <div class="text-lg font-medium">No session selected</div>
             <Button
               onClick={() => {
-                props.setView("dashboard");
                 props.setTab("sessions");
+                props.setView("dashboard");
               }}
             >
               Back to dashboard
@@ -672,8 +672,8 @@ export default function SessionView(props: SessionViewProps) {
               variant="ghost"
               class="!p-2 rounded-full"
               onClick={() => {
-                props.setView("dashboard");
                 props.setTab("sessions");
+                props.setView("dashboard");
               }}
             >
               <ArrowRight class="rotate-180 w-5 h-5" />
@@ -713,11 +713,11 @@ export default function SessionView(props: SessionViewProps) {
                }}
                sessions={props.sessions}
                selectedSessionId={props.selectedSessionId}
-               onSelectSession={async (id) => {
-                 await props.selectSession(id);
-                 props.setView("session");
-                 props.setTab("sessions");
-               }}
+                onSelectSession={async (id) => {
+                  await props.selectSession(id);
+                  props.setView("session", id);
+                  props.setTab("sessions");
+                }}
                sessionStatusById={props.sessionStatusById}
                onCreateSession={props.createSessionAndOpen}
                newTaskDisabled={props.newTaskDisabled}

--- a/packages/app/src/app/template-state.ts
+++ b/packages/app/src/app/template-state.ts
@@ -17,7 +17,7 @@ export function createTemplateState(options: {
   setSessionModelById: (value: Record<string, ModelRef> | ((current: Record<string, ModelRef>) => Record<string, ModelRef>)) => void;
   defaultModel: Accessor<ModelRef>;
   modelVariant: Accessor<string | null>;
-  setView: (view: "onboarding" | "dashboard" | "session") => void;
+  setView: (view: "onboarding" | "dashboard" | "session", sessionId?: string) => void;
   isDemoMode: Accessor<boolean>;
   activeWorkspaceRoot: Accessor<string>;
   setBusy: (value: boolean) => void;

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,5 +1,6 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
+import { HashRouter, Router } from "@solidjs/router";
 
 import { bootstrapTheme } from "./app/theme";
 import "./app/index.css";
@@ -14,6 +15,8 @@ const root = document.getElementById("root");
 if (!root) {
   throw new Error("Root element not found");
 }
+
+const RouterComponent = isTauriRuntime() ? HashRouter : Router;
 
 const platform: Platform = {
   platform: isTauriRuntime() ? "desktop" : "web",
@@ -79,7 +82,9 @@ const platform: Platform = {
 render(
   () => (
     <PlatformProvider value={platform}>
-      <AppEntry />
+      <RouterComponent>
+        <AppEntry />
+      </RouterComponent>
     </PlatformProvider>
   ),
   root,

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,6 +1,6 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
-import { HashRouter, Router } from "@solidjs/router";
+import { HashRouter, Route, Router } from "@solidjs/router";
 
 import { bootstrapTheme } from "./app/theme";
 import "./app/index.css";
@@ -83,7 +83,7 @@ render(
   () => (
     <PlatformProvider value={platform}>
       <RouterComponent>
-        <AppEntry />
+        <Route path="/*all" component={AppEntry} />
       </RouterComponent>
     </PlatformProvider>
   ),

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,6 +1,6 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
-import { HashRouter, Route, Router } from "@solidjs/router";
+import { HashRouter, Router } from "@solidjs/router";
 
 import { bootstrapTheme } from "./app/theme";
 import "./app/index.css";
@@ -83,7 +83,7 @@ render(
   () => (
     <PlatformProvider value={platform}>
       <RouterComponent>
-        <Route path="/*all" component={AppEntry} />
+        <AppEntry />
       </RouterComponent>
     </PlatformProvider>
   ),

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,6 +1,6 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
-import { HashRouter, Router } from "@solidjs/router";
+import { HashRouter, Route, Router } from "@solidjs/router";
 
 import { bootstrapTheme } from "./app/theme";
 import "./app/index.css";
@@ -82,8 +82,8 @@ const platform: Platform = {
 render(
   () => (
     <PlatformProvider value={platform}>
-      <RouterComponent>
-        <AppEntry />
+      <RouterComponent root={AppEntry}>
+        <Route path="*all" component={() => null} />
       </RouterComponent>
     </PlatformProvider>
   ),

--- a/patches/@solidjs__router@0.15.4.patch
+++ b/patches/@solidjs__router@0.15.4.patch
@@ -1,0 +1,20 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 2acf9f2213ac91f71bf844c53bf63be28ce7d79d..49eac35140e3e004963ad5f9b2ffe315a740339f 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,4 +1,5 @@
+ export * from "./routers/index.js";
++export * from "./routers/index.js";
+ export * from "./components.jsx";
+ export * from "./lifecycle.js";
+ export { useHref, useIsRouting, useLocation, useMatch, useCurrentMatches, useNavigate, useParams, useResolvedPath, useSearchParams, useBeforeLeave, usePreloadRoute } from "./routing.js";
+diff --git a/dist/index.jsx b/dist/index.jsx
+index c9079ba9cf5244de3c4a3fe938d33c67ab13fc00..305f052987ae0b2aec0edb163fec6d0dcf663581 100644
+--- a/dist/index.jsx
++++ b/dist/index.jsx
+@@ -1,4 +1,5 @@
+ export * from "./routers/index.js";
++export * from "./routers/index.js";
+ export * from "./components.jsx";
+ export * from "./lifecycle.js";
+ export { useHref, useIsRouting, useLocation, useMatch, useCurrentMatches, useNavigate, useParams, useResolvedPath, useSearchParams, useBeforeLeave, usePreloadRoute } from "./routing.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@solidjs/router@0.15.4':
+    hash: 1db11a7c28fe4da76187d42efaffc6b9a70ad370462fffb794ff90e67744d770
+    path: patches/@solidjs__router@0.15.4.patch
+
 importers:
 
   .: {}
@@ -24,7 +29,7 @@ importers:
         version: 4.3.3(solid-js@1.9.10)
       '@solidjs/router':
         specifier: ^0.15.4
-        version: 0.15.4(solid-js@1.9.10)
+        version: 0.15.4(patch_hash=1db11a7c28fe4da76187d42efaffc6b9a70ad370462fffb794ff90e67744d770)(solid-js@1.9.10)
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.9.1
@@ -2361,7 +2366,7 @@ snapshots:
     dependencies:
       solid-js: 1.9.10
 
-  '@solidjs/router@0.15.4(solid-js@1.9.10)':
+  '@solidjs/router@0.15.4(patch_hash=1db11a7c28fe4da76187d42efaffc6b9a70ad370462fffb794ff90e67744d770)(solid-js@1.9.10)':
     dependencies:
       solid-js: 1.9.10
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@solid-primitives/storage':
         specifier: ^4.3.3
         version: 4.3.3(solid-js@1.9.10)
+      '@solidjs/router':
+        specifier: ^0.15.4
+        version: 0.15.4(solid-js@1.9.10)
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.9.1
@@ -891,6 +894,11 @@ packages:
     resolution: {integrity: sha512-hZ/M/qr25QOCcwDPOHtGjxTD8w2mNyVAYvcfgwzBHq2RwNqHNdDNsMZYap20+ruRwW4A3Cdkczyoz0TSxLCAPQ==}
     peerDependencies:
       solid-js: ^1.6.12
+
+  '@solidjs/router@0.15.4':
+    resolution: {integrity: sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ==}
+    peerDependencies:
+      solid-js: ^1.8.6
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -2350,6 +2358,10 @@ snapshots:
       solid-js: 1.9.10
 
   '@solid-primitives/utils@6.3.2(solid-js@1.9.10)':
+    dependencies:
+      solid-js: 1.9.10
+
+  '@solidjs/router@0.15.4(solid-js@1.9.10)':
     dependencies:
       solid-js: 1.9.10
 


### PR DESCRIPTION
## Summary
- add Solid Router with hash routing on desktop to sync view/tab from URLs
- route session navigation by session ID while keeping dashboard tab state aligned
- restore the OpenWork logo in the workspace switch overlay and add router dependency

## Testing
- not run (not requested)