### PR TITLE
chore: bump owpenwork to 0.1.13

### DIFF
--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owpenwork",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "WhatsApp bridge for a running OpenCode server",
   "private": false,
   "type": "module",

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -32,7 +32,7 @@ import { createClient } from "./opencode.js";
 import { truncateText } from "./text.js";
 import { loginWhatsApp, unpairWhatsApp } from "./whatsapp.js";
 
-const VERSION = "0.1.12";
+const VERSION = "0.1.13";
 
 type SetupStep = "config" | "whatsapp" | "telegram" | "start";
 


### PR DESCRIPTION
## Summary
- bump owpenwork version to 0.1.13 for the latest WhatsApp fixes