### PR TITLE
feat: prompt for OpenCode workspace path

### DIFF
--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owpenwork",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "WhatsApp bridge for a running OpenCode server",
   "private": false,
   "type": "module",

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -32,7 +32,7 @@ import { createClient } from "./opencode.js";
 import { truncateText } from "./text.js";
 import { loginWhatsApp, unpairWhatsApp } from "./whatsapp.js";
 
-const VERSION = "0.1.14";
+const VERSION = "0.1.15";
 
 type SetupStep = "config" | "whatsapp" | "telegram" | "start";
 
@@ -229,6 +229,25 @@ async function runSetupWizard(
       if (dmPolicy === "open") {
         allowFrom = allowFrom.length ? allowFrom : ["*"];
       }
+    }
+
+    const currentWorkspace = config.configFile.opencodeDirectory ?? config.opencodeDirectory;
+    const keepDefault = unwrap(
+      await confirm({
+        message: `Use this OpenCode workspace? (${currentWorkspace})`,
+        initialValue: true,
+      }),
+    ) as boolean;
+
+    if (!keepDefault) {
+      const workspace = unwrap(
+        await text({
+          message: "OpenCode workspace path",
+          placeholder: "/path/to/workspace",
+          validate: (value: string) => (String(value ?? "").trim() ? undefined : "Path required"),
+        }),
+      ) as string;
+      next.opencodeDirectory = workspace.trim();
     }
 
     next.channels = next.channels ?? {};

--- a/packages/owpenbot/src/config.ts
+++ b/packages/owpenbot/src/config.ts
@@ -16,6 +16,8 @@ export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
 
 export type OwpenbotConfigFile = {
   version: number;
+  opencodeUrl?: string;
+  opencodeDirectory?: string;
   channels?: {
     whatsapp?: {
       dmPolicy?: DmPolicy;
@@ -181,17 +183,17 @@ export function loadConfig(
   options: { requireOpencode?: boolean } = {},
 ): Config {
   const requireOpencode = options.requireOpencode ?? false;
-  const opencodeDirectory = env.OPENCODE_DIRECTORY?.trim() ?? "";
-  if (!opencodeDirectory && requireOpencode) {
-    throw new Error("OPENCODE_DIRECTORY is required");
-  }
-  const resolvedDirectory = opencodeDirectory || process.cwd();
 
   const dataDir = expandHome(env.OWPENBOT_DATA_DIR ?? "~/.owpenbot");
   const dbPath = expandHome(env.OWPENBOT_DB_PATH ?? path.join(dataDir, "owpenbot.db"));
   const logFile = expandHome(env.OWPENBOT_LOG_FILE ?? path.join(dataDir, "logs", "owpenbot.log"));
   const configPath = resolveConfigPath(dataDir, env);
   const { config: configFile } = readConfigFile(configPath);
+  const opencodeDirectory = env.OPENCODE_DIRECTORY?.trim() || configFile.opencodeDirectory || "";
+  if (!opencodeDirectory && requireOpencode) {
+    throw new Error("OPENCODE_DIRECTORY is required");
+  }
+  const resolvedDirectory = opencodeDirectory || process.cwd();
   const whatsappFile = configFile.channels?.whatsapp ?? {};
   const whatsappAccountId = env.WHATSAPP_ACCOUNT_ID?.trim() || "default";
   const accountAuthDir = whatsappFile.accounts?.[whatsappAccountId]?.authDir;
@@ -219,7 +221,7 @@ export function loadConfig(
   return {
     configPath,
     configFile,
-    opencodeUrl: env.OPENCODE_URL?.trim() ?? "http://127.0.0.1:4096",
+    opencodeUrl: env.OPENCODE_URL?.trim() || configFile.opencodeUrl || "http://127.0.0.1:4096",
     opencodeDirectory: resolvedDirectory,
     opencodeUsername: env.OPENCODE_SERVER_USERNAME?.trim() || undefined,
     opencodePassword: env.OPENCODE_SERVER_PASSWORD?.trim() || undefined,


### PR DESCRIPTION
## Summary
- allow owpenwork setup to persist a custom OpenCode workspace path
- read opencode URL/directory from config when env overrides are absent
- keep default OpenCode URL at http://127.0.0.1:4096