### PR TITLE
fix: prevent auto-scroll when toggling view steps

### DIFF
--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, on, onCleanup, onMount } from "solid-js";
 import type { Agent, Part, Provider } from "@opencode-ai/sdk/v2/client";
 import type {
   ArtifactItem,
@@ -361,11 +361,23 @@ export default function SessionView(props: SessionViewProps) {
     }
   });
 
-  createEffect(() => {
-    props.messages.length;
-    props.todos.length;
-    messagesEndEl?.scrollIntoView({ behavior: "smooth" });
-  });
+  createEffect(
+    on(
+      () => [
+        props.messages.length,
+        props.todos.length,
+        props.messages.reduce((acc, m) => acc + m.parts.length, 0),
+      ],
+      (current, previous) => {
+        if (!previous) return;
+        const [mLen, tLen, pCount] = current;
+        const [prevM, prevT, prevP] = previous;
+        if (mLen > prevM || tLen > prevT || pCount > prevP) {
+          messagesEndEl?.scrollIntoView({ behavior: "smooth" });
+        }
+      },
+    ),
+  );
 
   const triggerFlyout = (
     sourceEl: Element | null,


### PR DESCRIPTION
## 🐛 Problem
Clicking "View steps" causes the page to unexpectedly jump to the bottom.

## 🔧 Changes
- Modified `createEffect` to use `on()` with explicit dependency tracking
- Added comparison between previous and current counts
- Only triggers scroll when counts increase (new content added)