### PR TITLE
feat: hydrate global sync data

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -97,6 +97,7 @@ import { createSystemState } from "./system-state";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { createSessionStore } from "./context/session";
 import { createExtensionsStore } from "./context/extensions";
+import { useGlobalSync } from "./context/global-sync";
 import { createWorkspaceStore } from "./context/workspace";
 import {
   updaterEnvironment,
@@ -593,13 +594,19 @@ export default function App() {
     abortRefreshes,
   } = extensionsStore;
 
-  const [providers, setProviders] = createSignal<Provider[]>([]);
-  const [providerDefaults, setProviderDefaults] = createSignal<
-    Record<string, string>
-  >({});
-  const [providerConnectedIds, setProviderConnectedIds] = createSignal<
-    string[]
-  >([]);
+  const globalSync = useGlobalSync();
+  const providers = createMemo(() => globalSync.data.provider.all ?? []);
+  const providerDefaults = createMemo(() => globalSync.data.provider.default ?? {});
+  const providerConnectedIds = createMemo(() => globalSync.data.provider.connected ?? []);
+  const setProviders = (value: Provider[]) => {
+    globalSync.set("provider", "all", value);
+  };
+  const setProviderDefaults = (value: Record<string, string>) => {
+    globalSync.set("provider", "default", value);
+  };
+  const setProviderConnectedIds = (value: string[]) => {
+    globalSync.set("provider", "connected", value);
+  };
 
   const [defaultModel, setDefaultModel] = createSignal<ModelRef>(DEFAULT_MODEL);
   const sessionModelOverridesKey = (workspaceId: string) =>

--- a/packages/app/src/app/context/global-sdk.tsx
+++ b/packages/app/src/app/context/global-sdk.tsx
@@ -1,13 +1,21 @@
 import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2/client";
 import { createGlobalEmitter } from "@solid-primitives/event-bus";
-import { batch, createContext, onCleanup, useContext, type ParentProps } from "solid-js";
+import {
+  batch,
+  createContext,
+  createEffect,
+  createSignal,
+  onCleanup,
+  useContext,
+  type ParentProps,
+} from "solid-js";
 
 import { usePlatform } from "./platform";
 import { useServer } from "./server";
 
 type GlobalSDKContextValue = {
-  url: string;
-  client: ReturnType<typeof createOpencodeClient>;
+  url: () => string;
+  client: () => ReturnType<typeof createOpencodeClient>;
   event: ReturnType<typeof createGlobalEmitter<{ [key: string]: Event }>>;
 };
 
@@ -16,105 +24,119 @@ const GlobalSDKContext = createContext<GlobalSDKContextValue | undefined>(undefi
 export function GlobalSDKProvider(props: ParentProps) {
   const server = useServer();
   const platform = usePlatform();
-  const abort = new AbortController();
-
-  const eventClient = createOpencodeClient({
-    baseUrl: server.url,
-    signal: abort.signal,
-    fetch: platform.fetch,
-  });
-
   const emitter = createGlobalEmitter<{ [key: string]: Event }>();
+  const [client, setClient] = createSignal(
+    createOpencodeClient({
+      baseUrl: server.url,
+      fetch: platform.fetch,
+      throwOnError: true,
+    }),
+  );
+  const [url, setUrl] = createSignal(server.url);
 
-  type Queued = { directory: string; payload: Event };
+  createEffect(() => {
+    const baseUrl = server.url;
+    setUrl(baseUrl);
 
-  let queue: Array<Queued | undefined> = [];
-  const coalesced = new Map<string, number>();
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let last = 0;
-
-  const keyForEvent = (directory: string, payload: Event) => {
-    if (payload.type === "session.status") return `session.status:${directory}:${payload.properties.sessionID}`;
-    if (payload.type === "lsp.updated") return `lsp.updated:${directory}`;
-    if (payload.type === "todo.updated") return `todo.updated:${directory}:${payload.properties.sessionID}`;
-    if (payload.type === "mcp.tools.changed") return `mcp.tools.changed:${directory}:${payload.properties.server}`;
-    if (payload.type === "message.part.updated") {
-      const part = payload.properties.part;
-      return `message.part.updated:${directory}:${part.messageID}:${part.id}`;
-    }
-  };
-
-  const flush = () => {
-    if (timer) clearTimeout(timer);
-    timer = undefined;
-
-    const events = queue;
-    queue = [];
-    coalesced.clear();
-    if (events.length === 0) return;
-
-    last = Date.now();
-    batch(() => {
-      for (const entry of events) {
-        if (!entry) continue;
-        emitter.emit(entry.directory, entry.payload);
-      }
+    const abort = new AbortController();
+    const eventClient = createOpencodeClient({
+      baseUrl,
+      signal: abort.signal,
+      fetch: platform.fetch,
     });
-  };
 
-  const schedule = () => {
-    if (timer) return;
-    const elapsed = Date.now() - last;
-    timer = setTimeout(flush, Math.max(0, 16 - elapsed));
-  };
+    setClient(
+      createOpencodeClient({
+        baseUrl,
+        fetch: platform.fetch,
+        throwOnError: true,
+      }),
+    );
 
-  const stop = () => {
-    flush();
-  };
+    type Queued = { directory: string; payload: Event };
 
-  void (async () => {
-    const subscription = await eventClient.event.subscribe(undefined, { signal: abort.signal });
-    let yielded = Date.now();
+    let queue: Array<Queued | undefined> = [];
+    const coalesced = new Map<string, number>();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let last = 0;
 
-    for await (const event of subscription.stream as AsyncIterable<unknown>) {
-      const record = event as Event & { directory?: string; payload?: Event };
-      const payload = record.payload ?? record;
-      if (!payload?.type) continue;
-
-      const directory = typeof record.directory === "string" ? record.directory : "global";
-      const key = keyForEvent(directory, payload);
-      if (key) {
-        const index = coalesced.get(key);
-        if (index !== undefined) {
-          queue[index] = undefined;
-        }
-        coalesced.set(key, queue.length);
+    const keyForEvent = (directory: string, payload: Event) => {
+      if (payload.type === "session.status") return `session.status:${directory}:${payload.properties.sessionID}`;
+      if (payload.type === "lsp.updated") return `lsp.updated:${directory}`;
+      if (payload.type === "todo.updated") return `todo.updated:${directory}:${payload.properties.sessionID}`;
+      if (payload.type === "mcp.tools.changed") return `mcp.tools.changed:${directory}:${payload.properties.server}`;
+      if (payload.type === "message.part.updated") {
+        const part = payload.properties.part;
+        return `message.part.updated:${directory}:${part.messageID}:${part.id}`;
       }
+    };
 
-      queue.push({ directory, payload });
-      schedule();
+    const flush = () => {
+      if (timer) clearTimeout(timer);
+      timer = undefined;
 
-      if (Date.now() - yielded < 8) continue;
-      yielded = Date.now();
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    }
-  })()
-    .finally(stop)
-    .catch(() => undefined);
+      const events = queue;
+      queue = [];
+      coalesced.clear();
+      if (events.length === 0) return;
 
-  onCleanup(() => {
-    abort.abort();
-    stop();
-  });
+      last = Date.now();
+      batch(() => {
+        for (const entry of events) {
+          if (!entry) continue;
+          emitter.emit(entry.directory, entry.payload);
+        }
+      });
+    };
 
-  const client = createOpencodeClient({
-    baseUrl: server.url,
-    fetch: platform.fetch,
-    throwOnError: true,
+    const schedule = () => {
+      if (timer) return;
+      const elapsed = Date.now() - last;
+      timer = setTimeout(flush, Math.max(0, 16 - elapsed));
+    };
+
+    const stop = () => {
+      flush();
+    };
+
+    void (async () => {
+      const subscription = await eventClient.event.subscribe(undefined, { signal: abort.signal });
+      let yielded = Date.now();
+
+      for await (const event of subscription.stream as AsyncIterable<unknown>) {
+        const record = event as Event & { directory?: string; payload?: Event };
+        const payload = record.payload ?? record;
+        if (!payload?.type) continue;
+
+        const directory = typeof record.directory === "string" ? record.directory : "global";
+        const key = keyForEvent(directory, payload);
+        if (key) {
+          const index = coalesced.get(key);
+          if (index !== undefined) {
+            queue[index] = undefined;
+          }
+          coalesced.set(key, queue.length);
+        }
+
+        queue.push({ directory, payload });
+        schedule();
+
+        if (Date.now() - yielded < 8) continue;
+        yielded = Date.now();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+    })()
+      .finally(stop)
+      .catch(() => undefined);
+
+    onCleanup(() => {
+      abort.abort();
+      stop();
+    });
   });
 
   const value: GlobalSDKContextValue = {
-    url: server.url,
+    url,
     client,
     event: emitter,
   };

--- a/packages/app/src/app/context/global-sync.tsx
+++ b/packages/app/src/app/context/global-sync.tsx
@@ -1,9 +1,26 @@
-import { createContext, useContext, type ParentProps } from "solid-js";
+import { createContext, createEffect, useContext, type ParentProps } from "solid-js";
 import { createStore, type SetStoreFunction, type Store } from "solid-js/store";
 
-import type { Message, Part, Session } from "@opencode-ai/sdk/v2/client";
+import type {
+  Command,
+  Config,
+  ConfigProvidersResponse,
+  Event,
+  GlobalHealthResponse,
+  LspStatus,
+  Project,
+  ProviderListResponse,
+  ProviderAuthResponse,
+  Message,
+  Part,
+  Session,
+  VcsInfo,
+} from "@opencode-ai/sdk/v2/client";
 
-import type { TodoItem } from "../types";
+import type { McpStatusMap, TodoItem } from "../types";
+import { unwrap } from "../lib/opencode";
+import { safeStringify } from "../utils";
+import { useGlobalSDK } from "./global-sdk";
 
 export type WorkspaceState = {
   status: "idle" | "loading" | "partial" | "ready";
@@ -16,9 +33,33 @@ export type WorkspaceState = {
 
 type WorkspaceStore = [Store<WorkspaceState>, SetStoreFunction<WorkspaceState>];
 
+type ProjectMeta = {
+  name?: string;
+  icon?: Project["icon"];
+  commands?: Project["commands"];
+};
+
+type GlobalState = {
+  ready: boolean;
+  error?: string;
+  serverVersion?: string;
+  config: Config;
+  provider: ProviderListResponse;
+  providerAuth: ProviderAuthResponse;
+  command: Record<string, Command[]>;
+  mcp: Record<string, McpStatusMap>;
+  lsp: Record<string, LspStatus[]>;
+  project: Project[];
+  projectMeta: Record<string, ProjectMeta>;
+  vcs: Record<string, VcsInfo | null>;
+};
+
 type GlobalSyncContextValue = {
-  data: Store<{ ready: boolean; error?: string }>;
+  data: Store<GlobalState>;
+  set: SetStoreFunction<GlobalState>;
   child: (directory: string) => WorkspaceStore;
+  refresh: () => Promise<void>;
+  refreshDirectory: (directory: string) => Promise<void>;
 };
 
 const GlobalSyncContext = createContext<GlobalSyncContextValue | undefined>(undefined);
@@ -33,22 +74,210 @@ const createWorkspaceState = (): WorkspaceState => ({
 });
 
 export function GlobalSyncProvider(props: ParentProps) {
-  const [globalStore] = createStore({ ready: true, error: undefined as string | undefined });
+  const globalSDK = useGlobalSDK();
+  const defaultProvider: ProviderListResponse = { all: [], connected: [], default: {} };
+  const [globalStore, setGlobalStore] = createStore<GlobalState>({
+    ready: false,
+    error: undefined,
+    serverVersion: undefined,
+    config: {},
+    provider: defaultProvider,
+    providerAuth: {},
+    command: {},
+    mcp: {},
+    lsp: {},
+    project: [],
+    projectMeta: {},
+    vcs: {},
+  });
   const children = new Map<string, WorkspaceStore>();
+  const subscriptions = new Map<string, () => void>();
+
+  const keyFor = (directory: string) => directory || "global";
+
+  const setError = (error: unknown) => {
+    const message = error instanceof Error ? error.message : safeStringify(error);
+    setGlobalStore("error", message || "Unknown error");
+  };
+
+  const setProjectMeta = (projects: Project[]) => {
+    const next: Record<string, ProjectMeta> = {};
+    for (const project of projects) {
+      if (!project?.worktree) continue;
+      next[project.worktree] = {
+        name: project.name,
+        icon: project.icon,
+        commands: project.commands,
+      };
+    }
+    setGlobalStore("projectMeta", next);
+  };
+
+  const refreshConfig = async () => {
+    const result = unwrap(await globalSDK.client().config.get());
+    setGlobalStore("config", result);
+  };
+
+  const refreshProviders = async () => {
+    try {
+      const result = unwrap(await globalSDK.client().provider.list());
+      setGlobalStore("provider", result);
+    } catch {
+      const fallback = unwrap(await globalSDK.client().config.providers()) as ConfigProvidersResponse;
+      setGlobalStore("provider", {
+        all: fallback.providers as ProviderListResponse["all"],
+        connected: [],
+        default: fallback.default,
+      });
+    }
+  };
+
+  const refreshProviderAuth = async () => {
+    try {
+      const result = await globalSDK.client().provider.auth();
+      setGlobalStore("providerAuth", result.data ?? {});
+    } catch {
+      setGlobalStore("providerAuth", {});
+    }
+  };
+
+  const refreshCommands = async (directory?: string) => {
+    const result = unwrap(await globalSDK.client().command.list({ directory })) as Command[];
+    setGlobalStore("command", keyFor(directory ?? ""), result);
+  };
+
+  const refreshMcp = async (directory?: string) => {
+    const result = unwrap(await globalSDK.client().mcp.status({ directory })) as McpStatusMap;
+    setGlobalStore("mcp", keyFor(directory ?? ""), result as McpStatusMap);
+  };
+
+  const refreshLsp = async (directory?: string) => {
+    const result = unwrap(await globalSDK.client().lsp.status({ directory })) as LspStatus[];
+    setGlobalStore("lsp", keyFor(directory ?? ""), result as LspStatus[]);
+  };
+
+  const refreshVcs = async (directory: string) => {
+    try {
+      const result = unwrap(await globalSDK.client().vcs.get({ directory })) as VcsInfo;
+      setGlobalStore("vcs", keyFor(directory), result ?? null);
+    } catch {
+      setGlobalStore("vcs", keyFor(directory), null);
+    }
+  };
+
+  const refreshProjects = async () => {
+    const projects = unwrap(await globalSDK.client().project.list()) as Project[];
+    setGlobalStore("project", projects);
+    setProjectMeta(projects);
+    await Promise.allSettled(
+      projects
+        .map((project) => project.worktree)
+        .filter((worktree): worktree is string => typeof worktree === "string" && worktree.length > 0)
+        .map((worktree) => refreshVcs(worktree)),
+    );
+  };
+
+  const refreshDirectory = async (directory: string) => {
+    if (!directory) return;
+    await Promise.allSettled([
+      refreshCommands(directory),
+      refreshMcp(directory),
+      refreshLsp(directory),
+      refreshVcs(directory),
+    ]);
+  };
+
+  const refresh = async () => {
+    setGlobalStore("ready", false);
+    setGlobalStore("error", undefined);
+
+    try {
+      const health = unwrap(await globalSDK.client().global.health()) as GlobalHealthResponse;
+      if (!health?.healthy) {
+        setGlobalStore("error", "Server reported unhealthy status.");
+        return;
+      }
+
+      if (globalStore.serverVersion && health.version !== globalStore.serverVersion) {
+        setGlobalStore("command", {});
+        setGlobalStore("mcp", {});
+        setGlobalStore("lsp", {});
+        setGlobalStore("project", []);
+        setGlobalStore("projectMeta", {});
+        setGlobalStore("vcs", {});
+      }
+      setGlobalStore("serverVersion", health.version);
+    } catch (error) {
+      setError(error);
+      return;
+    }
+
+    const results = await Promise.allSettled([
+      refreshConfig(),
+      refreshProviders(),
+      refreshProviderAuth(),
+      refreshCommands(),
+      refreshMcp(),
+      refreshLsp(),
+      refreshProjects(),
+    ]);
+
+    for (const result of results) {
+      if (result.status === "rejected") {
+        setError(result.reason);
+      }
+    }
+
+    setGlobalStore("ready", true);
+  };
 
   const child = (directory: string): WorkspaceStore => {
-    const key = directory || "global";
+    const key = keyFor(directory);
     const existing = children.get(key);
     if (existing) return existing;
     const store = createStore<WorkspaceState>(createWorkspaceState());
     children.set(key, store);
+    void refreshDirectory(directory);
+    if (!subscriptions.has(key)) {
+      const unsubscribe = globalSDK.event.listen(key, (event: Event) => {
+        if (event.type === "lsp.updated") {
+          void refreshLsp(directory);
+        }
+        if (event.type === "mcp.tools.changed") {
+          void refreshMcp(directory);
+        }
+      });
+      subscriptions.set(key, unsubscribe);
+    }
     return store;
   };
 
   const value: GlobalSyncContextValue = {
     data: globalStore,
+    set: setGlobalStore,
     child,
+    refresh,
+    refreshDirectory,
   };
+
+  createEffect(() => {
+    const url = globalSDK.url();
+    if (!url) return;
+    void refresh();
+  });
+
+  const globalKey = keyFor("");
+  if (!subscriptions.has(globalKey)) {
+    const unsubscribe = globalSDK.event.listen(globalKey, (event: Event) => {
+      if (event.type === "lsp.updated") {
+        void refreshLsp();
+      }
+      if (event.type === "mcp.tools.changed") {
+        void refreshMcp();
+      }
+    });
+    subscriptions.set(globalKey, unsubscribe);
+  }
 
   return <GlobalSyncContext.Provider value={value}>{props.children}</GlobalSyncContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- hydrate global sync with config/provider/command/MCP/LSP/project/VCS data and refresh on server changes
- rebind global SDK client/event stream when server URL changes
- source provider lists from global sync for a single UI truth