### PR TITLE
feat: seamless workspaces and multi-project sessions

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1125,9 +1125,13 @@ export default function App() {
       return;
     }
     if (workspaceStore.activeWorkspaceId() !== workspaceId) {
+      const workspace = workspaceStore.workspaces().find((item) => item.id === workspaceId);
+      const targetBaseUrl = normalizeServerUrl(workspace?.baseUrl ?? "");
+      const currentBaseUrl = normalizeServerUrl(server.url) ?? "";
+      const sameServer = Boolean(targetBaseUrl && currentBaseUrl && targetBaseUrl === currentBaseUrl);
       const ok = await workspaceStore.activateWorkspace(workspaceId, {
-        silent: true,
-        preferExistingConnection: true,
+        silent: !workspace || workspace.workspaceType !== "remote" || sameServer,
+        preferExistingConnection: sameServer,
         skipHostRestart: true,
       });
       if (!ok) return;
@@ -1137,9 +1141,13 @@ export default function App() {
 
   const createSessionForWorkspace = async (workspaceId: string) => {
     if (workspaceStore.activeWorkspaceId() !== workspaceId) {
+      const workspace = workspaceStore.workspaces().find((item) => item.id === workspaceId);
+      const targetBaseUrl = normalizeServerUrl(workspace?.baseUrl ?? "");
+      const currentBaseUrl = normalizeServerUrl(server.url) ?? "";
+      const sameServer = Boolean(targetBaseUrl && currentBaseUrl && targetBaseUrl === currentBaseUrl);
       const ok = await workspaceStore.activateWorkspace(workspaceId, {
-        silent: true,
-        preferExistingConnection: true,
+        silent: !workspace || workspace.workspaceType !== "remote" || sameServer,
+        preferExistingConnection: sameServer,
         skipHostRestart: true,
       });
       if (!ok) return;

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1177,10 +1177,11 @@ export default function App() {
       const targetBaseUrl = normalizeServerUrl(workspace?.baseUrl ?? "");
       const currentBaseUrl = normalizeServerUrl(server.url) ?? "";
       const sameServer = Boolean(targetBaseUrl && currentBaseUrl && targetBaseUrl === currentBaseUrl);
+      const isRemoteWorkspace = workspace?.workspaceType === "remote";
       const ok = await workspaceStore.activateWorkspace(workspaceId, {
-        silent: !workspace || workspace.workspaceType !== "remote" || sameServer,
-        preferExistingConnection: sameServer,
-        skipHostRestart: true,
+        silent: Boolean(isRemoteWorkspace && sameServer),
+        preferExistingConnection: Boolean(isRemoteWorkspace && sameServer),
+        skipHostRestart: Boolean(isRemoteWorkspace),
       });
       if (!ok) return;
     }
@@ -1193,10 +1194,11 @@ export default function App() {
       const targetBaseUrl = normalizeServerUrl(workspace?.baseUrl ?? "");
       const currentBaseUrl = normalizeServerUrl(server.url) ?? "";
       const sameServer = Boolean(targetBaseUrl && currentBaseUrl && targetBaseUrl === currentBaseUrl);
+      const isRemoteWorkspace = workspace?.workspaceType === "remote";
       const ok = await workspaceStore.activateWorkspace(workspaceId, {
-        silent: !workspace || workspace.workspaceType !== "remote" || sameServer,
-        preferExistingConnection: sameServer,
-        skipHostRestart: true,
+        silent: Boolean(isRemoteWorkspace && sameServer),
+        preferExistingConnection: Boolean(isRemoteWorkspace && sameServer),
+        skipHostRestart: Boolean(isRemoteWorkspace),
       });
       if (!ok) return;
     }

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -366,9 +366,7 @@ export default function App() {
         return copy;
       });
 
-      await loadSessions(workspaceStore.activeWorkspaceRoot().trim()).catch(
-        () => undefined
-      );
+      // Session lists refresh via project aggregation.
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
       setError(addOpencodeCacheHint(message));
@@ -1127,7 +1125,11 @@ export default function App() {
       return;
     }
     if (workspaceStore.activeWorkspaceId() !== workspaceId) {
-      const ok = await workspaceStore.activateWorkspace(workspaceId);
+      const ok = await workspaceStore.activateWorkspace(workspaceId, {
+        silent: true,
+        preferExistingConnection: true,
+        skipHostRestart: true,
+      });
       if (!ok) return;
     }
     await selectSession(sessionId);
@@ -1135,7 +1137,11 @@ export default function App() {
 
   const createSessionForWorkspace = async (workspaceId: string) => {
     if (workspaceStore.activeWorkspaceId() !== workspaceId) {
-      const ok = await workspaceStore.activateWorkspace(workspaceId);
+      const ok = await workspaceStore.activateWorkspace(workspaceId, {
+        silent: true,
+        preferExistingConnection: true,
+        skipHostRestart: true,
+      });
       if (!ok) return;
     }
     await createSessionAndOpen();
@@ -1911,12 +1917,7 @@ export default function App() {
       mark("session unwrapped");
       // Set selectedSessionId BEFORE switching view to avoid "No session selected" flash
       setBusyLabel("status.loading_session");
-      await withTimeout(
-        loadSessions(workspaceStore.activeWorkspaceRoot().trim()),
-        12_000,
-        "session.list"
-      );
-      mark("sessions loaded");
+      mark("sessions refresh skipped");
       await selectSession(session.id);
       mark("session selected");
       // Now switch view AFTER session is selected

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -39,6 +39,7 @@ import {
   MCP_QUICK_CONNECT,
   MODEL_PREF_KEY,
   SESSION_MODEL_PREF_KEY,
+  SESSION_LIST_LIMIT,
   SUGGESTED_PLUGINS,
   THINKING_PREF_KEY,
   VARIANT_PREF_KEY,
@@ -816,6 +817,12 @@ export default function App() {
     return mode() === "host";
   };
 
+  const sessionListQuery = (directory: string) => ({
+    directory,
+    roots: true,
+    limit: SESSION_LIST_LIMIT,
+  });
+
   const loadProjectSessions = async (workspace: WorkspaceInfo) => {
     const key = workspace.id;
     const directory = workspaceDirectory(workspace);
@@ -851,7 +858,7 @@ export default function App() {
 
     try {
       const client = createClient(baseUrl, directory);
-      const list = unwrap(await client.session.list());
+      const list = unwrap(await client.session.list(sessionListQuery(directory)));
       setProjectSessions(key, list);
       setSessionCache(key, list);
       setProjectSessionMeta(key, {

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -2472,7 +2472,7 @@ export default function App() {
     projectGroups: projectGroups(),
     allSessions: allSessions(),
     openProjectSession: openSessionFromProject,
-    createSessionInWorkspace,
+    createSessionInWorkspace: createSessionForWorkspace,
     activeWorkspaceRoot: isDemoMode()
       ? demoActiveWorkspaceDisplay().path
       : workspaceStore.activeWorkspaceRoot().trim(),

--- a/packages/app/src/app/components/server-manager-modal.tsx
+++ b/packages/app/src/app/components/server-manager-modal.tsx
@@ -20,6 +20,7 @@ export type ServerManagerModalProps = {
   onSetActive: (url: string) => void;
   onReconnect: () => void;
   onRestart?: () => void;
+  onDiscoverProjects?: () => void;
 };
 
 export default function ServerManagerModal(props: ServerManagerModalProps) {
@@ -55,6 +56,7 @@ export default function ServerManagerModal(props: ServerManagerModalProps) {
 
   const showReconnect = createMemo(() => props.mode === "client" && props.healthy === false);
   const showRestart = createMemo(() => props.mode === "host" && props.healthy === false && props.onRestart);
+  const showDiscover = createMemo(() => Boolean(props.mode) && props.onDiscoverProjects);
 
   return (
     <Show when={props.open}>
@@ -99,6 +101,16 @@ export default function ServerManagerModal(props: ServerManagerModalProps) {
                   >
                     <RefreshCcw size={12} />
                     Restart
+                  </Button>
+                </Show>
+                <Show when={showDiscover()}>
+                  <Button
+                    variant="outline"
+                    class="text-xs h-7 px-2"
+                    onClick={() => props.onDiscoverProjects?.()}
+                    disabled={props.busy || !props.activeUrl}
+                  >
+                    Discover projects
                   </Button>
                 </Show>
               </div>

--- a/packages/app/src/app/components/server-manager-modal.tsx
+++ b/packages/app/src/app/components/server-manager-modal.tsx
@@ -19,6 +19,7 @@ export type ServerManagerModalProps = {
   onRemove: (url: string) => void;
   onSetActive: (url: string) => void;
   onReconnect: () => void;
+  onRestart?: () => void;
 };
 
 export default function ServerManagerModal(props: ServerManagerModalProps) {
@@ -52,6 +53,9 @@ export default function ServerManagerModal(props: ServerManagerModalProps) {
     setNewUrl("");
   };
 
+  const showReconnect = createMemo(() => props.mode === "client" && props.healthy === false);
+  const showRestart = createMemo(() => props.mode === "host" && props.healthy === false && props.onRestart);
+
   return (
     <Show when={props.open}>
       <div class="fixed inset-0 z-50 bg-gray-1/60 backdrop-blur-sm flex items-center justify-center p-4">
@@ -75,7 +79,7 @@ export default function ServerManagerModal(props: ServerManagerModalProps) {
                 <Show when={props.version}>
                   <span class="text-xs text-gray-10 font-mono">v{props.version}</span>
                 </Show>
-                <Show when={props.mode === "client"}>
+                <Show when={showReconnect()}>
                   <Button
                     variant="outline"
                     class="text-xs h-7 px-2"
@@ -84,6 +88,17 @@ export default function ServerManagerModal(props: ServerManagerModalProps) {
                   >
                     <RefreshCcw size={12} />
                     Reconnect
+                  </Button>
+                </Show>
+                <Show when={showRestart()}>
+                  <Button
+                    variant="outline"
+                    class="text-xs h-7 px-2"
+                    onClick={() => props.onRestart?.()}
+                    disabled={props.busy || !props.activeUrl}
+                  >
+                    <RefreshCcw size={12} />
+                    Restart
                   </Button>
                 </Show>
               </div>

--- a/packages/app/src/app/components/server-manager-modal.tsx
+++ b/packages/app/src/app/components/server-manager-modal.tsx
@@ -61,19 +61,19 @@ export default function ServerManagerModal(props: ServerManagerModalProps) {
   return (
     <Show when={props.open}>
       <div class="fixed inset-0 z-50 bg-gray-1/60 backdrop-blur-sm flex items-center justify-center p-4">
-        <div class="bg-gray-2 border border-gray-6/70 w-full max-w-xl rounded-2xl shadow-2xl overflow-hidden">
-          <div class="p-6">
-            <div class="flex items-start justify-between gap-4">
-              <div>
-                <h3 class="text-lg font-semibold text-gray-12">Servers</h3>
-                <p class="text-sm text-gray-11 mt-1">Manage OpenCode server connections.</p>
-              </div>
-              <Button variant="ghost" class="!p-2 rounded-full" onClick={props.onClose}>
-                <X size={16} />
-              </Button>
+        <div class="bg-gray-2 border border-gray-6/70 w-full max-w-xl rounded-2xl shadow-2xl overflow-hidden max-h-[85vh] flex flex-col">
+          <div class="p-6 border-b border-gray-6/70 flex items-start justify-between gap-4">
+            <div>
+              <h3 class="text-lg font-semibold text-gray-12">Servers</h3>
+              <p class="text-sm text-gray-11 mt-1">Manage OpenCode server connections.</p>
             </div>
+            <Button variant="ghost" class="!p-2 rounded-full" onClick={props.onClose}>
+              <X size={16} />
+            </Button>
+          </div>
 
-            <div class="mt-6 space-y-4">
+          <div class="p-6 overflow-y-auto flex-1">
+            <div class="space-y-4">
               <div class="flex flex-wrap items-center gap-2">
                 <span class={`inline-flex items-center gap-2 text-xs px-2.5 py-1 rounded-full border ${activeStatusStyle()}`}>
                   {activeStatusLabel()}
@@ -180,12 +180,11 @@ export default function ServerManagerModal(props: ServerManagerModalProps) {
                   }}
                 </For>
               </div>
-            </div>
-
-            <div class="mt-6 flex justify-end">
-              <Button variant="outline" onClick={props.onClose}>
-                Close
-              </Button>
+              <div class="mt-6 flex justify-end">
+                <Button variant="outline" onClick={props.onClose}>
+                  Close
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/app/src/app/components/server-manager-modal.tsx
+++ b/packages/app/src/app/components/server-manager-modal.tsx
@@ -1,0 +1,168 @@
+import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
+
+import { Check, Plus, RefreshCcw, Trash2, X } from "lucide-solid";
+
+import Button from "./button";
+import TextInput from "./text-input";
+import { serverDisplayName } from "../context/server";
+
+export type ServerManagerModalProps = {
+  open: boolean;
+  servers: string[];
+  activeUrl: string;
+  healthy: boolean | undefined;
+  version: string | null;
+  busy: boolean;
+  mode: "host" | "client" | null;
+  onClose: () => void;
+  onAdd: (url: string) => void;
+  onRemove: (url: string) => void;
+  onSetActive: (url: string) => void;
+  onReconnect: () => void;
+};
+
+export default function ServerManagerModal(props: ServerManagerModalProps) {
+  const [newUrl, setNewUrl] = createSignal("");
+
+  createEffect(() => {
+    if (!props.open) {
+      setNewUrl("");
+    }
+  });
+
+  const activeStatusLabel = createMemo(() => {
+    if (!props.activeUrl) return "No active server";
+    if (props.healthy === undefined) return "Checking health";
+    return props.healthy ? "Healthy" : "Unreachable";
+  });
+
+  const activeStatusStyle = createMemo(() => {
+    if (!props.activeUrl || props.healthy === undefined) {
+      return "bg-gray-4/50 text-gray-11 border-gray-7/50";
+    }
+    return props.healthy
+      ? "bg-green-7/10 text-green-11 border-green-7/20"
+      : "bg-red-7/10 text-red-11 border-red-7/20";
+  });
+
+  const addServer = () => {
+    const value = newUrl().trim();
+    if (!value) return;
+    props.onAdd(value);
+    setNewUrl("");
+  };
+
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 bg-gray-1/60 backdrop-blur-sm flex items-center justify-center p-4">
+        <div class="bg-gray-2 border border-gray-6/70 w-full max-w-xl rounded-2xl shadow-2xl overflow-hidden">
+          <div class="p-6">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h3 class="text-lg font-semibold text-gray-12">Servers</h3>
+                <p class="text-sm text-gray-11 mt-1">Manage OpenCode server connections.</p>
+              </div>
+              <Button variant="ghost" class="!p-2 rounded-full" onClick={props.onClose}>
+                <X size={16} />
+              </Button>
+            </div>
+
+            <div class="mt-6 space-y-4">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class={`inline-flex items-center gap-2 text-xs px-2.5 py-1 rounded-full border ${activeStatusStyle()}`}>
+                  {activeStatusLabel()}
+                </span>
+                <Show when={props.version}>
+                  <span class="text-xs text-gray-10 font-mono">v{props.version}</span>
+                </Show>
+                <Show when={props.mode === "client"}>
+                  <Button
+                    variant="outline"
+                    class="text-xs h-7 px-2"
+                    onClick={props.onReconnect}
+                    disabled={props.busy || !props.activeUrl}
+                  >
+                    <RefreshCcw size={12} />
+                    Reconnect
+                  </Button>
+                </Show>
+              </div>
+
+              <div class="bg-gray-1/60 border border-gray-6 rounded-xl p-4 space-y-3">
+                <TextInput
+                  label="Add server"
+                  value={newUrl()}
+                  onInput={(event) => setNewUrl(event.currentTarget.value)}
+                  placeholder="http://localhost:4096"
+                  hint="Use full URL or host:port"
+                />
+                <div class="flex justify-end">
+                  <Button variant="outline" onClick={addServer} disabled={!newUrl().trim()}>
+                    <Plus size={14} />
+                    Add server
+                  </Button>
+                </div>
+              </div>
+
+              <div class="space-y-2">
+                <For each={props.servers}>
+                  {(serverUrl) => {
+                    const isActive = () => serverUrl === props.activeUrl;
+                    return (
+                      <div
+                        class={`flex items-center justify-between gap-3 rounded-xl border p-3 ${
+                          isActive()
+                            ? "border-gray-6 bg-gray-1/80"
+                            : "border-gray-6/40 bg-gray-1/40"
+                        }`}
+                      >
+                        <div class="min-w-0">
+                          <div class="text-sm text-gray-12 truncate">
+                            {serverDisplayName(serverUrl)}
+                          </div>
+                          <div class="text-xs text-gray-7 font-mono truncate">{serverUrl}</div>
+                        </div>
+                        <div class="flex items-center gap-2">
+                          <Show when={isActive()}>
+                            <span class="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-gray-5/60 text-gray-12">
+                              <Check size={12} />
+                              Active
+                            </span>
+                          </Show>
+                          <Show when={!isActive()}>
+                            <Button
+                              variant="outline"
+                              class="text-xs h-8 px-3"
+                              onClick={() => props.onSetActive(serverUrl)}
+                              disabled={props.mode === "host"}
+                            >
+                              Use
+                            </Button>
+                          </Show>
+                          <Button
+                            variant="ghost"
+                            class="text-xs h-8 px-2"
+                            onClick={() => props.onRemove(serverUrl)}
+                            disabled={props.servers.length <= 1}
+                          >
+                            <Trash2 size={14} />
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  }}
+                </For>
+              </div>
+            </div>
+
+            <div class="mt-6 flex justify-end">
+              <Button variant="outline" onClick={props.onClose}>
+                Close
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -10,6 +10,8 @@ export type ComposerProps = {
   prompt: string;
   setPrompt: (value: string) => void;
   busy: boolean;
+  sessionReady: boolean;
+  queuedPrompt: boolean;
   onSend: () => void;
   commandMatches: CommandItem[];
   onRunCommand: (commandId: string) => void;
@@ -25,7 +27,7 @@ export default function Composer(props: ComposerProps) {
   const [commandIndex, setCommandIndex] = createSignal(0);
 
   const commandMenuOpen = createMemo(() => {
-    return props.prompt.startsWith("/") && !props.busy;
+    return props.prompt.startsWith("/") && !props.busy && props.sessionReady;
   });
 
   const syncHeight = () => {
@@ -192,7 +194,7 @@ export default function Composer(props: ComposerProps) {
                 />
 
                 <button
-                  disabled={!props.prompt.trim() || props.busy}
+                  disabled={!props.prompt.trim() || props.busy || !props.sessionReady}
                   onClick={props.onSend}
                   class="p-2 bg-gray-12 text-gray-1 rounded-xl hover:scale-105 active:scale-95 transition-all disabled:opacity-0 disabled:scale-75 shadow-lg shrink-0 flex items-center justify-center"
                   title="Run"
@@ -200,6 +202,11 @@ export default function Composer(props: ComposerProps) {
                   <ArrowRight size={18} />
                 </button>
               </div>
+              <Show when={!props.sessionReady || props.queuedPrompt}>
+                <div class="mt-2 text-[11px] text-gray-9">
+                  {props.queuedPrompt ? "Queued to send when ready" : "Loading session..."}
+                </div>
+              </Show>
             </div>
           </div>
         </div>

--- a/packages/app/src/app/components/session/sidebar.tsx
+++ b/packages/app/src/app/components/session/sidebar.tsx
@@ -13,9 +13,17 @@ export type SidebarProps = {
   todos: TodoItem[];
   expandedSections: SidebarSectionState;
   onToggleSection: (section: keyof SidebarSectionState) => void;
-  sessions: Array<{ id: string; title: string; slug?: string | null }>;
+  sessionEntries: Array<{
+    id: string;
+    title: string;
+    slug?: string | null;
+    workspaceId: string;
+    workspaceName: string;
+    updatedAt: number;
+  }>;
+  activeWorkspaceId: string;
   selectedSessionId: string | null;
-  onSelectSession: (id: string) => void;
+  onSelectSession: (workspaceId: string, sessionId: string) => void;
   sessionStatusById: Record<string, string>;
   onCreateSession: () => void;
   newTaskDisabled: boolean;
@@ -49,7 +57,7 @@ export default function SessionSidebar(props: SidebarProps) {
         <div>
           <div class="text-[10px] text-gray-9 uppercase tracking-widest font-semibold mb-3 px-2">Recents</div>
           <div class="space-y-1">
-            <For each={props.sessions.slice(0, 8)}>
+            <For each={props.sessionEntries.slice(0, 12)}>
               {(session) => (
                 <button
                   class={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
@@ -57,10 +65,15 @@ export default function SessionSidebar(props: SidebarProps) {
                       ? "bg-gray-3 text-gray-12 font-medium"
                       : "text-gray-11 hover:text-gray-12 hover:bg-gray-2"
                   }`}
-                  onClick={() => props.onSelectSession(session.id)}
+                  onClick={() => props.onSelectSession(session.workspaceId, session.id)}
                 >
                   <div class="flex items-center justify-between gap-2 w-full overflow-hidden">
-                    <span class="truncate">{session.title}</span>
+                    <div class="min-w-0 flex-1">
+                      <div class="truncate">{session.title}</div>
+                      <Show when={session.workspaceId !== props.activeWorkspaceId}>
+                        <div class="text-[10px] text-gray-8 mt-1 truncate">{session.workspaceName}</div>
+                      </Show>
+                    </div>
                     <Show
                       when={
                         props.sessionStatusById[session.id] &&

--- a/packages/app/src/app/components/session/sidebar.tsx
+++ b/packages/app/src/app/components/session/sidebar.tsx
@@ -1,5 +1,5 @@
 import { For, Show, createMemo } from "solid-js";
-import { Check, ChevronDown, Plus } from "lucide-solid";
+import { Check, ChevronDown, Loader2, Plus } from "lucide-solid";
 
 import type { TodoItem } from "../../types";
 
@@ -25,6 +25,7 @@ export type SidebarProps = {
   selectedSessionId: string | null;
   onSelectSession: (workspaceId: string, sessionId: string) => void;
   sessionStatusById: Record<string, string>;
+  sessionLoadState: Record<string, "idle" | "loading" | "ready" | "error">;
   onCreateSession: () => void;
   newTaskDisabled: boolean;
 };
@@ -95,6 +96,9 @@ export default function SessionSidebar(props: SidebarProps) {
                           }`}
                         />
                       </span>
+                    </Show>
+                    <Show when={props.sessionLoadState[session.id] === "loading"}>
+                      <Loader2 class="h-3 w-3 text-gray-8 animate-spin" />
                     </Show>
                   </div>
                 </button>

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -7,6 +7,7 @@ export const VARIANT_PREF_KEY = "openwork.modelVariant";
 export const DEMO_MODE_PREF_KEY = "openwork.demoMode";
 export const DEMO_SEQUENCE_PREF_KEY = "openwork.demoSequence";
 export const LANGUAGE_PREF_KEY = "openwork.language";
+export const SESSION_LIST_LIMIT = 100;
 
 export const DEFAULT_MODEL: ModelRef = {
   providerID: "opencode",

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -223,16 +223,15 @@ export function createSessionStore(options: {
   async function loadSessions(scopeRoot?: string) {
     const c = options.client();
     if (!c) return;
-    const root = scopeRoot?.trim();
+    const normalizedRoot = normalizeDirectoryPath(scopeRoot);
     const query: { directory?: string; roots: boolean; limit: number } = {
       roots: true,
       limit: SESSION_LIST_LIMIT,
     };
-    if (root) {
-      query.directory = root;
+    if (normalizedRoot) {
+      query.directory = normalizedRoot;
     }
     const list = unwrap(await c.session.list(query));
-    const normalizedRoot = normalizeDirectoryPath(root);
     const filtered = normalizedRoot
       ? list.filter((session) => normalizeDirectoryPath(session.directory) === normalizedRoot)
       : list;

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -217,6 +217,9 @@ export function createWorkspaceStore(options: {
           syncActiveWorkspaceId(id);
           setProjectDir(directory);
           options.setClientDirectory(directory);
+          options.setBaseUrl(baseUrl);
+          options.setSseConnected(false);
+          options.setClient(createClient(baseUrl, directory || undefined));
           setWorkspaceConfig(null);
           setWorkspaceConfigLoaded(true);
           setAuthorizedDirs([]);

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -204,7 +204,7 @@ export function createWorkspaceStore(options: {
       currentBase &&
       currentBase === nextBase;
 
-    if (!optionsOverride?.silent || !canReuseConnection) {
+    if (!optionsOverride?.silent) {
       setConnectingWorkspaceId(id);
     }
 

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -44,6 +44,7 @@ export type DashboardViewProps = {
   newTaskDisabled: boolean;
   headerStatus: string;
   error: string | null;
+  openServerManager: () => void;
   activeWorkspaceDisplay: WorkspaceInfo;
   workspaceSearch: string;
   setWorkspaceSearch: (value: string) => void;
@@ -767,6 +768,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   busy={props.busy}
                   developerMode={props.developerMode}
                   toggleDeveloperMode={props.toggleDeveloperMode}
+                  openServerManager={props.openServerManager}
                   stopHost={props.stopHost}
                   engineSource={props.engineSource}
                   setEngineSource={props.setEngineSource}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -40,6 +40,10 @@ export type SessionViewProps = {
   setWorkspaceSearch: (value: string) => void;
   setWorkspacePickerOpen: (open: boolean) => void;
   headerStatus: string;
+  serverName: string;
+  serverHealthy: boolean | undefined;
+  serverVersion: string | null;
+  openServerManager: () => void;
   busyHint: string | null;
   createSessionAndOpen: () => void;
   sendPromptAsync: () => Promise<void>;
@@ -740,6 +744,24 @@ export default function SessionView(props: SessionViewProps) {
                  props.setWorkspacePickerOpen(true);
                }}
              />
+             <Button
+               variant="ghost"
+               class="!px-2 !py-1 rounded-full flex items-center gap-2"
+               onClick={props.openServerManager}
+             >
+               <span
+                 classList={{
+                   "size-2 rounded-full": true,
+                   "bg-green-9": props.serverHealthy === true,
+                   "bg-red-9": props.serverHealthy === false,
+                   "bg-gray-7": props.serverHealthy === undefined,
+                 }}
+               />
+               <span class="text-xs text-gray-11">{props.serverName || "Server"}</span>
+               <Show when={props.serverVersion}>
+                 <span class="text-[10px] text-gray-8 font-mono">v{props.serverVersion}</span>
+               </Show>
+             </Button>
              <Show when={props.developerMode}>
                <span class="text-xs text-gray-7">{props.headerStatus}</span>
              </Show>

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -12,6 +12,7 @@ export type SettingsViewProps = {
   busy: boolean;
   developerMode: boolean;
   toggleDeveloperMode: () => void;
+  openServerManager: () => void;
   stopHost: () => void;
   engineSource: "path" | "sidecar";
   setEngineSource: (value: "path" | "sidecar") => void;
@@ -107,6 +108,9 @@ export default function SettingsView(props: SettingsViewProps) {
         <div class="text-xs text-gray-10">{props.headerStatus}</div>
         <div class="text-xs text-gray-7 font-mono">{props.baseUrl}</div>
         <div class="pt-2 flex flex-wrap gap-2">
+          <Button variant="outline" onClick={props.openServerManager}>
+            Manage servers
+          </Button>
           <Button variant="secondary" onClick={props.toggleDeveloperMode}>
             <Shield size={16} />
             {props.developerMode ? "Disable Developer Mode" : "Enable Developer Mode"}


### PR DESCRIPTION
## Summary
- add server manager modal with health/version indicators, reconnect/restart, and project discovery
- aggregate per-project sessions with caching and workspace-aware routing
- update dashboard/session surfaces for multi-project workflows and remove session-level workspace switching

## Testing
- Not run (not requested)