### PR TITLE
fix: display saved command immediately without app restart

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -796,6 +796,8 @@ export default function App() {
     openRunModal,
     confirmRunModal,
     closeRunModal,
+    justSavedCommand,
+    clearJustSavedCommand,
   } = commandState;
 
   const commandRegistry = createCommandRegistry();
@@ -2499,6 +2501,8 @@ export default function App() {
     openCommandModal,
     runCommand: openRunModal,
     deleteCommand,
+    justSavedCommand: justSavedCommand(),
+    clearJustSavedCommand,
     refreshSkills: (options?: { force?: boolean }) => refreshSkills(options).catch(() => undefined),
     refreshPlugins: (scopeOverride?: PluginScope) =>
       refreshPlugins(scopeOverride).catch(() => undefined),

--- a/packages/app/src/app/command-state.ts
+++ b/packages/app/src/app/command-state.ts
@@ -55,6 +55,9 @@ export function createCommandState(options: {
   const [runModalCommand, setRunModalCommand] = createSignal<WorkspaceCommand | null>(null);
   const [runModalDetails, setRunModalDetails] = createSignal("");
 
+  // Track the just-saved command for scroll-to and highlight animation
+  const [justSavedCommand, setJustSavedCommand] = createSignal<{ name: string; scope: string } | null>(null);
+
   const workspaceCommands = createMemo(() => commands().filter((c) => c.scope === "workspace"));
   const globalCommands = createMemo(() => commands().filter((c) => c.scope === "global"));
   const otherCommands = createMemo(() => commands().filter((c) => c.scope === "unknown"));
@@ -127,7 +130,37 @@ export function createCommandState(options: {
           template: draft.template,
         },
       });
-      await loadCommands({ workspaceRoot, quiet: true });
+
+      // Directly add/update the command in local state since the SDK's
+      // command list won't reflect the new file until app restart
+      const newCommand: WorkspaceCommand = {
+        name: safeName,
+        description: draft.description || undefined,
+        template: draft.template,
+        scope: draft.scope,
+      };
+
+      setCommands((current) => {
+        // Check if command already exists (update case)
+        const existingIndex = current.findIndex(
+          (c) => c.name === safeName && c.scope === draft.scope
+        );
+
+        let updated: WorkspaceCommand[];
+        if (existingIndex >= 0) {
+          // Update existing command
+          updated = [...current];
+          updated[existingIndex] = newCommand;
+        } else {
+          // Add new command
+          updated = [...current, newCommand];
+        }
+
+        // Keep sorted alphabetically
+        return updated.sort((a, b) => a.name.localeCompare(b.name));
+      });
+
+      setJustSavedCommand({ name: safeName, scope: draft.scope });
       setCommandModalOpen(false);
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
@@ -310,6 +343,10 @@ export function createCommandState(options: {
     setRunModalCommand(null);
   }
 
+  function clearJustSavedCommand() {
+    setJustSavedCommand(null);
+  }
+
   return {
     commands,
     setCommands,
@@ -340,5 +377,7 @@ export function createCommandState(options: {
     openRunModal,
     confirmRunModal,
     closeRunModal,
+    justSavedCommand,
+    clearJustSavedCommand,
   };
 }

--- a/packages/app/src/app/index.css
+++ b/packages/app/src/app/index.css
@@ -43,6 +43,27 @@ body {
   animation: soft-pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
+/* Highlight animation for just-saved command */
+@keyframes command-highlight {
+  0% {
+    box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.6);
+    border-color: rgba(99, 102, 241, 0.8);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(99, 102, 241, 0);
+    border-color: rgba(99, 102, 241, 0.4);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(99, 102, 241, 0);
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.command-just-saved {
+  animation: command-highlight 2s ease-out;
+  border-color: rgba(99, 102, 241, 0.8);
+}
+
 
 :root {
   color-scheme: light;

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -86,6 +86,8 @@ export type DashboardViewProps = {
   resetCommandDraft?: (scope?: "workspace" | "global") => void;
   runCommand: (command: WorkspaceCommand) => void;
   deleteCommand: (command: WorkspaceCommand) => void;
+  justSavedCommand?: { name: string; scope: string } | null;
+  clearJustSavedCommand?: () => void;
   refreshSkills: (options?: { force?: boolean }) => void;
   refreshPlugins: (scopeOverride?: PluginScope) => void;
   refreshMcpServers: () => void;
@@ -707,6 +709,8 @@ export default function DashboardView(props: DashboardViewProps) {
                 resetCommandDraft={props.resetCommandDraft}
                 runCommand={props.runCommand}
                 deleteCommand={props.deleteCommand}
+                justSavedCommand={props.justSavedCommand}
+                clearJustSavedCommand={props.clearJustSavedCommand}
               />
             </Match>
 


### PR DESCRIPTION
## Summary

- Fix command not appearing in list after save until app restart
- Add scroll-to-center and highlight animation for better UX

## Test plan

- [ ] Save a new command and verify it appears in the list immediately (without restart)
- [ ] Verify the page scrolls to show the saved command
- [ ] Verify the highlight animation plays for ~2 seconds
- [ ] Verify saving a command with the same name updates the existing entry
- [ ] Verify commands remain sorted alphabetically after save
