### PR TITLE
fix: auto-focus primary inputs when menus/modals open

### DIFF
--- a/packages/app/src/app/components/command-run-modal.tsx
+++ b/packages/app/src/app/components/command-run-modal.tsx
@@ -1,5 +1,4 @@
-import { Show } from "solid-js";
-
+import { Show, createEffect } from "solid-js";
 import { X } from "lucide-solid";
 import type { WorkspaceCommand } from "../types";
 import { t, currentLocale } from "../../i18n";
@@ -17,9 +16,23 @@ export type CommandRunModalProps = {
 };
 
 export default function CommandRunModal(props: CommandRunModalProps) {
+  let inputRef: HTMLInputElement | undefined;
   const translate = (key: string) => t(key, currentLocale());
   const name = () => props.command?.name ?? "";
   const description = () => props.command?.description ?? "";
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      props.onRun();
+    }
+  };
+
+  createEffect(() => {
+    if (props.open && props.command) {
+      requestAnimationFrame(() => inputRef?.focus());
+    }
+  });
 
   return (
     <Show when={props.open && props.command}>
@@ -46,9 +59,11 @@ export default function CommandRunModal(props: CommandRunModalProps) {
               </div>
 
               <TextInput
+                ref={inputRef}
                 label={translate("commands.details_label")}
                 value={props.details}
                 onInput={(event) => props.onDetailsChange(event.currentTarget.value)}
+                onKeyDown={handleKeyDown}
                 placeholder={translate("commands.details_placeholder")}
                 hint={translate("commands.details_hint")}
               />

--- a/packages/app/src/app/components/create-remote-workspace-modal.tsx
+++ b/packages/app/src/app/components/create-remote-workspace-modal.tsx
@@ -17,6 +17,7 @@ export default function CreateRemoteWorkspaceModal(props: {
   subtitle?: string;
   confirmLabel?: string;
 }) {
+  let inputRef: HTMLInputElement | undefined;
   const translate = (key: string) => t(key, currentLocale());
 
   const [baseUrl, setBaseUrl] = createSignal("");
@@ -31,6 +32,12 @@ export default function CreateRemoteWorkspaceModal(props: {
   const submitting = () => props.submitting ?? false;
 
   const canSubmit = createMemo(() => baseUrl().trim().length > 0 && !submitting());
+
+  createEffect(() => {
+    if (props.open) {
+      requestAnimationFrame(() => inputRef?.focus());
+    }
+  });
 
   createEffect(() => {
     if (!props.open) return;
@@ -70,6 +77,7 @@ export default function CreateRemoteWorkspaceModal(props: {
 
         <div class="space-y-4">
           <TextInput
+            ref={inputRef}
             label={translate("dashboard.remote_base_url_label")}
             placeholder={translate("dashboard.remote_base_url_placeholder")}
             value={baseUrl()}

--- a/packages/app/src/app/components/create-workspace-modal.tsx
+++ b/packages/app/src/app/components/create-workspace-modal.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createSignal } from "solid-js";
+import { For, Show, createEffect, createSignal } from "solid-js";
 
 import { CheckCircle2, FolderPlus, Loader2, X } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
@@ -17,11 +17,18 @@ export default function CreateWorkspaceModal(props: {
   subtitle?: string;
   confirmLabel?: string;
 }) {
+  let pickFolderRef: HTMLButtonElement | undefined;
   const translate = (key: string) => t(key, currentLocale());
 
   const [preset, setPreset] = createSignal<"starter" | "automation" | "minimal">("starter");
   const [selectedFolder, setSelectedFolder] = createSignal<string | null>(null);
   const [pickingFolder, setPickingFolder] = createSignal(false);
+
+  createEffect(() => {
+    if (props.open) {
+      requestAnimationFrame(() => pickFolderRef?.focus());
+    }
+  });
 
   const options = () => [
     {
@@ -99,6 +106,7 @@ export default function CreateWorkspaceModal(props: {
               <div class="ml-9">
                 <button
                   type="button"
+                  ref={pickFolderRef}
                   onClick={handlePickFolder}
                   disabled={pickingFolder() || submitting()}
                   class={`w-full border border-dashed border-gray-7 bg-gray-2/50 rounded-xl p-4 text-left transition ${

--- a/packages/app/src/app/components/rename-session-modal.tsx
+++ b/packages/app/src/app/components/rename-session-modal.tsx
@@ -1,4 +1,4 @@
-import { Show } from "solid-js";
+import { Show, createEffect } from "solid-js";
 import { X } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
 
@@ -16,7 +16,19 @@ export type RenameSessionModalProps = {
 };
 
 export default function RenameSessionModal(props: RenameSessionModalProps) {
+  let inputRef: HTMLInputElement | undefined;
   const translate = (key: string) => t(key, currentLocale());
+
+  createEffect(() => {
+    if (props.open) {
+      requestAnimationFrame(() => {
+        inputRef?.focus();
+        if (inputRef) {
+          inputRef.select();
+        }
+      });
+    }
+  });
 
   return (
     <Show when={props.open}>
@@ -35,6 +47,7 @@ export default function RenameSessionModal(props: RenameSessionModalProps) {
 
             <div class="mt-6">
               <TextInput
+                ref={inputRef}
                 label={translate("session.rename_label")}
                 value={props.title}
                 onInput={(e) => props.onTitleChange(e.currentTarget.value)}

--- a/packages/app/src/app/components/text-input.tsx
+++ b/packages/app/src/app/components/text-input.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from "solid-js";
+import { splitProps, JSX } from "solid-js";
 
 type TextInputProps = JSX.InputHTMLAttributes<HTMLInputElement> & {
   label?: string;
@@ -6,20 +6,21 @@ type TextInputProps = JSX.InputHTMLAttributes<HTMLInputElement> & {
 };
 
 export default function TextInput(props: TextInputProps) {
-  const { label, hint, class: className, ...rest } = props;
+  const [local, rest] = splitProps(props, ["label", "hint", "class", "ref"]);
 
   return (
     <label class="block">
-      {label ? (
-        <div class="mb-1 text-xs font-medium text-gray-11">{label}</div>
+      {local.label ? (
+        <div class="mb-1 text-xs font-medium text-gray-11">{local.label}</div>
       ) : null}
       <input
         {...rest}
+        ref={local.ref}
         class={`w-full rounded-xl bg-gray-2/60 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-10 shadow-[0_0_0_1px_rgba(255,255,255,0.08)] focus:outline-none focus:ring-2 focus:ring-gray-6/20 ${
-          className ?? ""
+          local.class ?? ""
         }`.trim()}
       />
-      {hint ? <div class="mt-1 text-xs text-gray-10">{hint}</div> : null}
+      {local.hint ? <div class="mt-1 text-xs text-gray-10">{local.hint}</div> : null}
     </label>
   );
 }

--- a/packages/app/src/app/components/workspace-picker.tsx
+++ b/packages/app/src/app/components/workspace-picker.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo } from "solid-js";
+import { For, Show, createEffect, createMemo } from "solid-js";
 
 import { Check, Globe, Loader2, Plus, Search, Trash2, Upload } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
@@ -33,6 +33,13 @@ export default function WorkspacePicker(props: {
   });
 
   const totalCount = createMemo(() => props.workspaces.length);
+  let searchInputRef: HTMLInputElement | undefined;
+
+  createEffect(() => {
+    if (props.open) {
+      requestAnimationFrame(() => searchInputRef?.focus());
+    }
+  });
 
   return (
     <Show when={props.open}>
@@ -48,6 +55,7 @@ export default function WorkspacePicker(props: {
             <div class="relative">
               <Search size={14} class="absolute left-3 top-2.5 text-gray-10" />
               <input
+                ref={(el) => (searchInputRef = el)}
                 type="text"
                 placeholder={translate("dashboard.find_workspace")}
                 value={props.search}


### PR DESCRIPTION
Fixes keyboard focus issues in modals and composer.

Closes #271

**Changes:**
- composer.tsx: Auto-focus on mount
- command-run-modal.tsx: Focus input + Enter support
- create-remote-workspace-modal.tsx: Focus URL input and rest
- rename-session-modal.tsx: Focus + prev select text
- workspace-picker.tsx: Focus search input
- text-input.tsx: Fix ref forwarding