### PR TITLE
fix: prevent reload toast on startup and refine trigger logic

### DIFF
--- a/packages/app/src/app/components/reload-workspace-toast.tsx
+++ b/packages/app/src/app/components/reload-workspace-toast.tsx
@@ -51,10 +51,12 @@ export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
               </Show>
             </div>
             
-            <Show when={props.description}>
+            <Show when={props.description || props.error}>
               <div class="text-xs text-gray-10 truncate leading-none mt-0.5">
                 {props.hasActiveRuns 
                   ? <span class="text-amber-11 font-medium">Reloading will stop active tasks.</span>
+                  : props.error 
+                  ? <span class="text-red-9 font-medium">{props.error}</span>
                   : props.description
                 }
               </div>

--- a/packages/app/src/app/system-state.ts
+++ b/packages/app/src/app/system-state.ts
@@ -40,6 +40,7 @@ export function createSystemState(options: {
   const [reloadRequired, setReloadRequired] = createSignal(false);
   const [reloadReasons, setReloadReasons] = createSignal<ReloadReason[]>([]);
   const [reloadLastTriggeredAt, setReloadLastTriggeredAt] = createSignal<number | null>(null);
+  const [reloadLastFinishedAt, setReloadLastFinishedAt] = createSignal<number | null>(null);
   const [reloadBusy, setReloadBusy] = createSignal(false);
   const [reloadError, setReloadError] = createSignal<string | null>(null);
 
@@ -285,6 +286,7 @@ export function createSystemState(options: {
       setReloadError(e instanceof Error ? e.message : safeStringify(e));
     } finally {
       setReloadBusy(false);
+      setReloadLastFinishedAt(Date.now());
     }
   }
 
@@ -453,6 +455,8 @@ export function createSystemState(options: {
     reloadRequired,
     reloadReasons,
     reloadLastTriggeredAt,
+    reloadLastFinishedAt,
+    setReloadLastFinishedAt,
     reloadBusy,
     reloadError,
     reloadCopy,


### PR DESCRIPTION
Closes #272

## Summary
Fix reload toast appearing on every startup and reduce false triggers from Finder operations.

## Changes

**Frontend**
- Remove duplicate `workspaceBootstrap()` call
- Add 3s startup silence + 2s post-reload cooldown
- Block reload signals during transitions
- Clear toast on workspace switch
- Show error message when reload fails

**Backend (watch.rs)**
- **Reduce sensitivity:** Previously, in `Reveal in Finder`, just browsing folders in Finder would trigger the reload toast. Now only actual file content changes trigger it.
- Filter system files (`.DS_Store`, `desktop.ini`, `.localized`)
- Ignore metadata-only changes

## Tests
- [x] Edit `opencode.jsonc`, skills md files, or plugins → toast appears
- [x] Reveal in Finder / browse folders → no toast
- [x] App startup → no spurious toast
- [x] Switch workspace with pending toast → clears