### PR TITLE
feat: auto-start OpenWork server sidecar

### DIFF
--- a/packages/app/pr/openwork-server.md
+++ b/packages/app/pr/openwork-server.md
@@ -31,6 +31,8 @@ Remote clients cannot read or write workspace config because critical state live
 - Functional: expose workspace config read/write APIs for `.opencode` and `opencode.json`
 - Functional: list installed skills, plugins, MCPs for a workspace without direct FS access
 - Functional: allow saving new skills, plugins, and MCP entries from a remote client
+- Functional: host mode auto-starts the OpenWork server alongside the OpenCode engine
+- UX: surface pairing URL + tokens in Settings for host mode
 - UX: show remote-config origin, last updated time, and change attribution
 
 ---
@@ -167,6 +169,16 @@ This section captures the exact OpenCode semantics the OpenWork server must resp
 - Basic auth can be enabled via `OPENCODE_SERVER_PASSWORD` (username defaults to `opencode`).
 - The OpenWork server should not bypass OpenCode auth; if OpenCode is password-protected, the host UI must collect credentials and pass them to the client.
 - OpenCode publishes its OpenAPI spec at `/doc`; the OpenWork server should track upstream changes and avoid duplicating stable APIs.
+
+---
+## Host auto-start + pairing UX
+- When OpenWork runs in Host mode, it starts the OpenWork server automatically after the OpenCode engine comes online.
+- The host UI exposes a pairing card in Settings with:
+  - OpenWork Server URL (prefers `.local` hostname, falls back to LAN IP)
+  - Client token (for remote devices)
+  - Host token (for approvals)
+- Tokens are generated per run unless supplied by host config.
+- Pairing info should be copyable (tap-to-copy) and masked by default.
 
 ---
 ## Endpoint examples (requests and responses)

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -54,7 +54,7 @@ export type OpenworkMcpItem = {
   disabledByTools?: boolean;
 };
 
-export const DEFAULT_OPENWORK_SERVER_PORT = 4097;
+export const DEFAULT_OPENWORK_SERVER_PORT = 8787;
 
 const STORAGE_URL_OVERRIDE = "openwork.server.urlOverride";
 const STORAGE_PORT_OVERRIDE = "openwork.server.port";

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -12,6 +12,21 @@ export type EngineInfo = {
   lastStderr: string | null;
 };
 
+export type OpenworkServerInfo = {
+  running: boolean;
+  host: string | null;
+  port: number | null;
+  baseUrl: string | null;
+  connectUrl: string | null;
+  mdnsUrl: string | null;
+  lanUrl: string | null;
+  clientToken: string | null;
+  hostToken: string | null;
+  pid: number | null;
+  lastStdout: string | null;
+  lastStderr: string | null;
+};
+
 export type EngineDoctorResult = {
   found: boolean;
   inPath: boolean;
@@ -211,6 +226,22 @@ export async function opencodeCommandDelete(input: {
 
 export async function engineStop(): Promise<EngineInfo> {
   return invoke<EngineInfo>("engine_stop");
+}
+
+export async function openworkServerStart(input: {
+  workspacePath: string;
+}): Promise<OpenworkServerInfo> {
+  return invoke<OpenworkServerInfo>("openwork_server_start", {
+    workspacePath: input.workspacePath,
+  });
+}
+
+export async function openworkServerStop(): Promise<OpenworkServerInfo> {
+  return invoke<OpenworkServerInfo>("openwork_server_stop");
+}
+
+export async function openworkServerInfo(): Promise<OpenworkServerInfo> {
+  return invoke<OpenworkServerInfo>("openwork_server_info");
 }
 
 export async function engineInfo(): Promise<EngineInfo> {

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -228,18 +228,6 @@ export async function engineStop(): Promise<EngineInfo> {
   return invoke<EngineInfo>("engine_stop");
 }
 
-export async function openworkServerStart(input: {
-  workspacePath: string;
-}): Promise<OpenworkServerInfo> {
-  return invoke<OpenworkServerInfo>("openwork_server_start", {
-    workspacePath: input.workspacePath,
-  });
-}
-
-export async function openworkServerStop(): Promise<OpenworkServerInfo> {
-  return invoke<OpenworkServerInfo>("openwork_server_stop");
-}
-
 export async function openworkServerInfo(): Promise<OpenworkServerInfo> {
   return invoke<OpenworkServerInfo>("openwork_server_info");
 }

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -11,6 +11,7 @@ import type {
 import type { McpDirectoryInfo } from "../constants";
 import { formatRelativeTime, normalizeDirectoryPath } from "../utils";
 import type { OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
+import type { OpenworkServerInfo } from "../lib/tauri";
 
 import Button from "../components/button";
 import OpenWorkLogo from "../components/openwork-logo";
@@ -49,6 +50,7 @@ export type DashboardViewProps = {
   openworkServerStatus: OpenworkServerStatus;
   openworkServerUrl: string;
   openworkServerSettings: OpenworkServerSettings;
+  openworkServerHostInfo: OpenworkServerInfo | null;
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
   resetOpenworkServerSettings: () => void;
   testOpenworkServerConnection: (next: OpenworkServerSettings) => Promise<boolean>;
@@ -941,6 +943,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   openworkServerStatus={props.openworkServerStatus}
                   openworkServerUrl={props.openworkServerUrl}
                   openworkServerSettings={props.openworkServerSettings}
+                  openworkServerHostInfo={props.openworkServerHostInfo}
                   updateOpenworkServerSettings={props.updateOpenworkServerSettings}
                   resetOpenworkServerSettings={props.resetOpenworkServerSettings}
                   testOpenworkServerConnection={props.testOpenworkServerConnection}

--- a/packages/desktop/scripts/prepare-sidecar.mjs
+++ b/packages/desktop/scripts/prepare-sidecar.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "child_process";
-import { existsSync, mkdirSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
 import { fileURLToPath } from "url";
@@ -8,42 +8,106 @@ const TARGET_TRIPLE = "x86_64-pc-windows-msvc";
 const DOWNLOAD_URL =
   "https://github.com/anomalyco/opencode/releases/latest/download/opencode-windows-x64.zip";
 
-if (process.platform !== "win32") {
-  console.log("Skipping Windows sidecar download (non-Windows host).");
-  process.exit(0);
-}
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sidecarDir = join(__dirname, "..", "src-tauri", "sidecars");
-const targetSidecarPath = join(sidecarDir, `opencode-${TARGET_TRIPLE}.exe`);
-const devSidecarPath = join(sidecarDir, "opencode.exe");
+const repoRoot = join(__dirname, "..", "..");
+const serverDir = join(repoRoot, "server");
+const serverCli = join(serverDir, "dist", "cli.js");
+const bunTypesPath = join(serverDir, "node_modules", "bun-types", "package.json");
 
-if (existsSync(targetSidecarPath)) {
-  console.log(`OpenCode sidecar already present: ${targetSidecarPath}`);
-  process.exit(0);
-}
+const resolveTargetTriple = () => {
+  const envTarget =
+    process.env.TAURI_ENV_TARGET_TRIPLE ||
+    process.env.CARGO_CFG_TARGET_TRIPLE ||
+    process.env.TARGET;
+  if (envTarget) return envTarget;
 
-mkdirSync(sidecarDir, { recursive: true });
+  if (process.platform === "darwin") {
+    return process.arch === "arm64" ? "aarch64-apple-darwin" : "x86_64-apple-darwin";
+  }
+  if (process.platform === "linux") {
+    return process.arch === "arm64" ? "aarch64-unknown-linux-gnu" : "x86_64-unknown-linux-gnu";
+  }
+  if (process.platform === "win32") {
+    return TARGET_TRIPLE;
+  }
+  return null;
+};
 
-const stamp = Date.now();
-const zipPath = join(tmpdir(), `opencode-windows-x64-${stamp}.zip`);
-const extractDir = join(tmpdir(), `opencode-windows-x64-${stamp}`);
-const extractedExe = join(extractDir, "opencode.exe");
+const ensureOpenworkServerSidecar = () => {
+  if (process.platform === "win32") {
+    console.log("OpenWork server sidecar prep is not automated on Windows.");
+    return;
+  }
 
-const psQuote = (value) => `'${value.replace(/'/g, "''")}'`;
-const psScript = [
-  "$ErrorActionPreference = 'Stop'",
-  `Invoke-WebRequest -Uri ${psQuote(DOWNLOAD_URL)} -OutFile ${psQuote(zipPath)}`,
-  `Expand-Archive -Path ${psQuote(zipPath)} -DestinationPath ${psQuote(extractDir)} -Force`,
-  `if (!(Test-Path ${psQuote(extractedExe)})) { throw 'opencode.exe missing in archive' }`,
-  `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(targetSidecarPath)} -Force`,
-  `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(devSidecarPath)} -Force`,
-].join("; ");
+  if (!existsSync(bunTypesPath)) {
+    const install = spawnSync("pnpm", ["-C", serverDir, "install"], { stdio: "inherit" });
+    if (install.status !== 0) {
+      process.exit(install.status ?? 1);
+    }
+  }
 
-const result = spawnSync("powershell", ["-NoProfile", "-Command", psScript], {
-  stdio: "inherit",
-});
+  const build = spawnSync("pnpm", ["-C", serverDir, "build"], { stdio: "inherit" });
+  if (build.status !== 0) {
+    process.exit(build.status ?? 1);
+  }
 
-if (result.status !== 0) {
-  process.exit(result.status ?? 1);
-}
+  mkdirSync(sidecarDir, { recursive: true });
+  const nodePath = process.execPath.replace(/"/g, "\\\"");
+  const cliPath = serverCli.replace(/"/g, "\\\"");
+  const launcher = `#!/usr/bin/env bash\n"${nodePath}" "${cliPath}" "$@"\n`;
+  const target = resolveTargetTriple();
+  const devSidecarPath = join(sidecarDir, "openwork-server");
+  const targetSidecarPath = target ? join(sidecarDir, `openwork-server-${target}`) : null;
+
+  writeFileSync(devSidecarPath, launcher, "utf8");
+  chmodSync(devSidecarPath, 0o755);
+
+  if (targetSidecarPath) {
+    writeFileSync(targetSidecarPath, launcher, "utf8");
+    chmodSync(targetSidecarPath, 0o755);
+  }
+};
+
+const ensureOpencodeWindowsSidecar = () => {
+  if (process.platform !== "win32") {
+    console.log("Skipping Windows sidecar download (non-Windows host).\n");
+    return;
+  }
+
+  const targetSidecarPath = join(sidecarDir, `opencode-${TARGET_TRIPLE}.exe`);
+  const devSidecarPath = join(sidecarDir, "opencode.exe");
+
+  if (existsSync(targetSidecarPath)) {
+    console.log(`OpenCode sidecar already present: ${targetSidecarPath}`);
+    return;
+  }
+
+  mkdirSync(sidecarDir, { recursive: true });
+
+  const stamp = Date.now();
+  const zipPath = join(tmpdir(), `opencode-windows-x64-${stamp}.zip`);
+  const extractDir = join(tmpdir(), `opencode-windows-x64-${stamp}`);
+  const extractedExe = join(extractDir, "opencode.exe");
+
+  const psQuote = (value) => `'${value.replace(/'/g, "''")}'`;
+  const psScript = [
+    "$ErrorActionPreference = 'Stop'",
+    `Invoke-WebRequest -Uri ${psQuote(DOWNLOAD_URL)} -OutFile ${psQuote(zipPath)}`,
+    `Expand-Archive -Path ${psQuote(zipPath)} -DestinationPath ${psQuote(extractDir)} -Force`,
+    `if (!(Test-Path ${psQuote(extractedExe)})) { throw 'opencode.exe missing in archive' }`,
+    `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(targetSidecarPath)} -Force`,
+    `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(devSidecarPath)} -Force`,
+  ].join("; ");
+
+  const result = spawnSync("powershell", ["-NoProfile", "-Command", psScript], {
+    stdio: "inherit",
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+};
+
+ensureOpenworkServerSidecar();
+ensureOpencodeWindowsSidecar();

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -856,6 +856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1279,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2074,6 +2090,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "local-ip-address"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612ed4ea9ce5acfb5d26339302528a5e1e59dfed95e9e11af3c083236ff1d15d"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror 1.0.69",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,6 +2268,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2556,7 +2609,9 @@ dependencies = [
 name = "openwork"
 version = "0.4.2"
 dependencies = [
+ "gethostname",
  "json5",
+ "local-ip-address",
  "notify",
  "serde",
  "serde_json",
@@ -2567,6 +2622,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "uuid",
  "walkdir",
  "zip 0.6.6",
 ]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -17,6 +17,9 @@ tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2.5.3"
 tauri-plugin-shell = "2"
+uuid = { version = "1", features = ["v4"] }
+gethostname = "0.4"
+local-ip-address = "0.5"
 walkdir = "2.5"
 zip = "0.6"
 

--- a/packages/desktop/src-tauri/src/commands/mod.rs
+++ b/packages/desktop/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod command_files;
 pub mod config;
 pub mod engine;
 pub mod misc;
+pub mod openwork_server;
 pub mod opkg;
 pub mod skills;
 pub mod updater;

--- a/packages/desktop/src-tauri/src/commands/openwork_server.rs
+++ b/packages/desktop/src-tauri/src/commands/openwork_server.rs
@@ -1,0 +1,26 @@
+use tauri::{AppHandle, State};
+
+use crate::openwork_server::{manager::OpenworkServerManager, start_openwork_server};
+use crate::types::OpenworkServerInfo;
+
+#[tauri::command]
+pub fn openwork_server_info(manager: State<OpenworkServerManager>) -> OpenworkServerInfo {
+    let mut state = manager.inner.lock().expect("openwork server mutex poisoned");
+    OpenworkServerManager::snapshot_locked(&mut state)
+}
+
+#[tauri::command]
+pub fn openwork_server_stop(manager: State<OpenworkServerManager>) -> OpenworkServerInfo {
+    let mut state = manager.inner.lock().expect("openwork server mutex poisoned");
+    OpenworkServerManager::stop_locked(&mut state);
+    OpenworkServerManager::snapshot_locked(&mut state)
+}
+
+#[tauri::command]
+pub fn openwork_server_start(
+    app: AppHandle,
+    manager: State<OpenworkServerManager>,
+    workspace_path: String,
+) -> Result<OpenworkServerInfo, String> {
+    start_openwork_server(&app, &manager, &workspace_path)
+}

--- a/packages/desktop/src-tauri/src/commands/openwork_server.rs
+++ b/packages/desktop/src-tauri/src/commands/openwork_server.rs
@@ -1,6 +1,6 @@
-use tauri::{AppHandle, State};
+use tauri::State;
 
-use crate::openwork_server::{manager::OpenworkServerManager, start_openwork_server};
+use crate::openwork_server::manager::OpenworkServerManager;
 use crate::types::OpenworkServerInfo;
 
 #[tauri::command]
@@ -9,18 +9,4 @@ pub fn openwork_server_info(manager: State<OpenworkServerManager>) -> OpenworkSe
     OpenworkServerManager::snapshot_locked(&mut state)
 }
 
-#[tauri::command]
-pub fn openwork_server_stop(manager: State<OpenworkServerManager>) -> OpenworkServerInfo {
-    let mut state = manager.inner.lock().expect("openwork server mutex poisoned");
-    OpenworkServerManager::stop_locked(&mut state);
-    OpenworkServerManager::snapshot_locked(&mut state)
-}
-
-#[tauri::command]
-pub fn openwork_server_start(
-    app: AppHandle,
-    manager: State<OpenworkServerManager>,
-    workspace_path: String,
-) -> Result<OpenworkServerInfo, String> {
-    start_openwork_server(&app, &manager, &workspace_path)
-}
+// start/stop are handled by engine lifecycle

--- a/packages/desktop/src-tauri/src/engine/manager.rs
+++ b/packages/desktop/src-tauri/src/engine/manager.rs
@@ -45,7 +45,7 @@ impl EngineManager {
     }
 
     pub fn stop_locked(state: &mut EngineState) {
-        if let Some(mut child) = state.child.take() {
+        if let Some(child) = state.child.take() {
             let _ = child.kill();
         }
         state.child_exited = true;

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use commands::command_files::{
 use commands::config::{read_opencode_config, write_opencode_config};
 use commands::engine::{engine_doctor, engine_info, engine_install, engine_start, engine_stop};
 use commands::misc::{opencode_mcp_auth, reset_opencode_cache, reset_openwork_state};
-use commands::openwork_server::{openwork_server_info, openwork_server_start, openwork_server_stop};
+use commands::openwork_server::openwork_server_info;
 use commands::opkg::{import_skill, opkg_install};
 use commands::skills::{install_skill_template, list_local_skills, uninstall_skill};
 use commands::updater::updater_environment;
@@ -53,8 +53,6 @@ pub fn run() {
             engine_info,
             engine_doctor,
             engine_install,
-            openwork_server_start,
-            openwork_server_stop,
             openwork_server_info,
             workspace_bootstrap,
             workspace_set_active,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod engine;
 mod fs;
 mod opkg;
+mod openwork_server;
 mod paths;
 mod platform;
 mod types;
@@ -18,6 +19,7 @@ use commands::command_files::{
 use commands::config::{read_opencode_config, write_opencode_config};
 use commands::engine::{engine_doctor, engine_info, engine_install, engine_start, engine_stop};
 use commands::misc::{opencode_mcp_auth, reset_opencode_cache, reset_openwork_state};
+use commands::openwork_server::{openwork_server_info, openwork_server_start, openwork_server_stop};
 use commands::opkg::{import_skill, opkg_install};
 use commands::skills::{install_skill_template, list_local_skills, uninstall_skill};
 use commands::updater::updater_environment;
@@ -27,6 +29,7 @@ use commands::workspace::{
     workspace_openwork_write, workspace_set_active, workspace_update_remote,
 };
 use engine::manager::EngineManager;
+use openwork_server::manager::OpenworkServerManager;
 use workspace::watch::WorkspaceWatchState;
 
 pub fn run() {
@@ -42,6 +45,7 @@ pub fn run() {
 
     builder
         .manage(EngineManager::default())
+        .manage(OpenworkServerManager::default())
         .manage(WorkspaceWatchState::default())
         .invoke_handler(tauri::generate_handler![
             engine_start,
@@ -49,6 +53,9 @@ pub fn run() {
             engine_info,
             engine_doctor,
             engine_install,
+            openwork_server_start,
+            openwork_server_stop,
+            openwork_server_info,
             workspace_bootstrap,
             workspace_set_active,
             workspace_create,

--- a/packages/desktop/src-tauri/src/openwork_server/manager.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/manager.rs
@@ -1,0 +1,71 @@
+use std::sync::{Arc, Mutex};
+
+use tauri_plugin_shell::process::CommandChild;
+
+use crate::types::OpenworkServerInfo;
+
+#[derive(Default)]
+pub struct OpenworkServerManager {
+    pub inner: Arc<Mutex<OpenworkServerState>>,
+}
+
+#[derive(Default)]
+pub struct OpenworkServerState {
+    pub child: Option<CommandChild>,
+    pub child_exited: bool,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub base_url: Option<String>,
+    pub connect_url: Option<String>,
+    pub mdns_url: Option<String>,
+    pub lan_url: Option<String>,
+    pub client_token: Option<String>,
+    pub host_token: Option<String>,
+    pub last_stdout: Option<String>,
+    pub last_stderr: Option<String>,
+}
+
+impl OpenworkServerManager {
+    pub fn snapshot_locked(state: &mut OpenworkServerState) -> OpenworkServerInfo {
+        let (running, pid) = match state.child.as_ref() {
+            None => (false, None),
+            Some(child) if state.child_exited => {
+                state.child = None;
+                (false, None)
+            }
+            Some(child) => (true, Some(child.pid())),
+        };
+
+        OpenworkServerInfo {
+            running,
+            host: state.host.clone(),
+            port: state.port,
+            base_url: state.base_url.clone(),
+            connect_url: state.connect_url.clone(),
+            mdns_url: state.mdns_url.clone(),
+            lan_url: state.lan_url.clone(),
+            client_token: state.client_token.clone(),
+            host_token: state.host_token.clone(),
+            pid,
+            last_stdout: state.last_stdout.clone(),
+            last_stderr: state.last_stderr.clone(),
+        }
+    }
+
+    pub fn stop_locked(state: &mut OpenworkServerState) {
+        if let Some(child) = state.child.take() {
+            let _ = child.kill();
+        }
+        state.child_exited = true;
+        state.host = None;
+        state.port = None;
+        state.base_url = None;
+        state.connect_url = None;
+        state.mdns_url = None;
+        state.lan_url = None;
+        state.client_token = None;
+        state.host_token = None;
+        state.last_stdout = None;
+        state.last_stderr = None;
+    }
+}

--- a/packages/desktop/src-tauri/src/openwork_server/mod.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/mod.rs
@@ -1,0 +1,131 @@
+use std::sync::{Arc, Mutex};
+
+use gethostname::gethostname;
+use local_ip_address::local_ip;
+use tauri::AppHandle;
+use tauri_plugin_shell::process::CommandEvent;
+use uuid::Uuid;
+
+use crate::types::OpenworkServerInfo;
+use crate::utils::truncate_output;
+
+pub mod manager;
+pub mod spawn;
+
+use manager::OpenworkServerManager;
+use spawn::{resolve_openwork_port, spawn_openwork_server};
+
+#[derive(Default)]
+struct OutputState {
+    stdout: String,
+    stderr: String,
+    exited: bool,
+    exit_code: Option<i32>,
+}
+
+fn generate_token() -> String {
+    Uuid::new_v4().to_string()
+}
+
+fn build_urls(port: u16) -> (Option<String>, Option<String>, Option<String>) {
+    let hostname = gethostname().to_string_lossy().trim().to_string();
+    let mdns_url = if hostname.is_empty() {
+        None
+    } else {
+        let trimmed = hostname.trim_end_matches(".local");
+        Some(format!("http://{trimmed}.local:{port}"))
+    };
+
+    let lan_url = local_ip()
+        .ok()
+        .map(|ip| format!("http://{ip}:{port}"));
+
+    let connect_url = mdns_url.clone().or(lan_url.clone());
+
+    (connect_url, mdns_url, lan_url)
+}
+
+pub fn start_openwork_server(
+    app: &AppHandle,
+    manager: &OpenworkServerManager,
+    workspace_path: &str,
+) -> Result<OpenworkServerInfo, String> {
+    let mut state = manager.inner.lock().map_err(|_| "openwork server mutex poisoned".to_string())?;
+    OpenworkServerManager::stop_locked(&mut state);
+
+    let host = "0.0.0.0".to_string();
+    let port = resolve_openwork_port()?;
+    let client_token = generate_token();
+    let host_token = generate_token();
+
+    let (mut rx, child) = spawn_openwork_server(app, &host, port, workspace_path, &client_token, &host_token)?;
+
+    state.child = Some(child);
+    state.child_exited = false;
+    state.host = Some(host.clone());
+    state.port = Some(port);
+    state.base_url = Some(format!("http://127.0.0.1:{port}"));
+    let (connect_url, mdns_url, lan_url) = build_urls(port);
+    state.connect_url = connect_url;
+    state.mdns_url = mdns_url;
+    state.lan_url = lan_url;
+    state.client_token = Some(client_token);
+    state.host_token = Some(host_token);
+    state.last_stdout = None;
+    state.last_stderr = None;
+
+    let output_state = Arc::new(Mutex::new(OutputState::default()));
+    let output_state_handle = output_state.clone();
+    let state_handle = manager.inner.clone();
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(line_bytes) => {
+                    let line = String::from_utf8_lossy(&line_bytes).to_string();
+                    if let Ok(mut output) = output_state_handle.lock() {
+                        output.stdout.push_str(&line);
+                    }
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        let next = state.last_stdout.as_deref().unwrap_or_default().to_string() + &line;
+                        state.last_stdout = Some(truncate_output(&next, 8000));
+                    }
+                }
+                CommandEvent::Stderr(line_bytes) => {
+                    let line = String::from_utf8_lossy(&line_bytes).to_string();
+                    if let Ok(mut output) = output_state_handle.lock() {
+                        output.stderr.push_str(&line);
+                    }
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        let next = state.last_stderr.as_deref().unwrap_or_default().to_string() + &line;
+                        state.last_stderr = Some(truncate_output(&next, 8000));
+                    }
+                }
+                CommandEvent::Terminated(payload) => {
+                    if let Ok(mut output) = output_state_handle.lock() {
+                        output.exited = true;
+                        output.exit_code = payload.code;
+                    }
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        state.child_exited = true;
+                    }
+                }
+                CommandEvent::Error(message) => {
+                    if let Ok(mut output) = output_state_handle.lock() {
+                        output.exited = true;
+                        output.exit_code = Some(-1);
+                        output.stderr.push_str(&message);
+                    }
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        state.child_exited = true;
+                        let next = state.last_stderr.as_deref().unwrap_or_default().to_string() + &message;
+                        state.last_stderr = Some(truncate_output(&next, 8000));
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+
+    Ok(OpenworkServerManager::snapshot_locked(&mut state))
+}

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -18,7 +18,7 @@ pub fn resolve_openwork_port() -> Result<u16, String> {
 }
 
 pub fn build_openwork_args(host: &str, port: u16, workspace_path: &str, token: &str, host_token: &str) -> Vec<String> {
-    vec![
+    let mut args = vec![
         "--host".to_string(),
         host.to_string(),
         "--port".to_string(),
@@ -35,7 +35,14 @@ pub fn build_openwork_args(host: &str, port: u16, workspace_path: &str, token: &
         "tauri://localhost".to_string(),
         "--cors".to_string(),
         "http://tauri.localhost".to_string(),
-    ]
+    ];
+
+    if cfg!(debug_assertions) {
+        args.push("--cors".to_string());
+        args.push("*".to_string());
+    }
+
+    args
 }
 
 pub fn spawn_openwork_server(

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -27,8 +27,6 @@ pub fn build_openwork_args(host: &str, port: u16, workspace_path: &str, token: &
         token.to_string(),
         "--host-token".to_string(),
         host_token.to_string(),
-        "--approval".to_string(),
-        "auto".to_string(),
         "--workspace".to_string(),
         workspace_path.to_string(),
         "--cors".to_string(),

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -1,0 +1,62 @@
+use std::net::TcpListener;
+use std::path::Path;
+
+use tauri::AppHandle;
+use tauri::async_runtime::Receiver;
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+
+const DEFAULT_OPENWORK_PORT: u16 = 8787;
+
+pub fn resolve_openwork_port() -> Result<u16, String> {
+    if TcpListener::bind(("0.0.0.0", DEFAULT_OPENWORK_PORT)).is_ok() {
+        return Ok(DEFAULT_OPENWORK_PORT);
+    }
+    let listener = TcpListener::bind(("0.0.0.0", 0)).map_err(|e| e.to_string())?;
+    let port = listener.local_addr().map_err(|e| e.to_string())?.port();
+    Ok(port)
+}
+
+pub fn build_openwork_args(host: &str, port: u16, workspace_path: &str, token: &str, host_token: &str) -> Vec<String> {
+    vec![
+        "--host".to_string(),
+        host.to_string(),
+        "--port".to_string(),
+        port.to_string(),
+        "--token".to_string(),
+        token.to_string(),
+        "--host-token".to_string(),
+        host_token.to_string(),
+        "--approval".to_string(),
+        "auto".to_string(),
+        "--workspace".to_string(),
+        workspace_path.to_string(),
+        "--cors".to_string(),
+        "http://localhost:5173".to_string(),
+        "--cors".to_string(),
+        "tauri://localhost".to_string(),
+        "--cors".to_string(),
+        "http://tauri.localhost".to_string(),
+    ]
+}
+
+pub fn spawn_openwork_server(
+    app: &AppHandle,
+    host: &str,
+    port: u16,
+    workspace_path: &str,
+    token: &str,
+    host_token: &str,
+) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
+    let command = match app.shell().sidecar("openwork-server") {
+        Ok(command) => command,
+        Err(_) => app.shell().command("openwork-server"),
+    };
+
+    let args = build_openwork_args(host, port, workspace_path, token, host_token);
+    command
+        .args(args)
+        .current_dir(Path::new(workspace_path))
+        .spawn()
+        .map_err(|e| format!("Failed to start OpenWork server: {e}"))
+}

--- a/packages/desktop/src-tauri/src/types.rs
+++ b/packages/desktop/src-tauri/src/types.rs
@@ -65,6 +65,23 @@ pub struct EngineInfo {
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct OpenworkServerInfo {
+    pub running: bool,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub base_url: Option<String>,
+    pub connect_url: Option<String>,
+    pub mdns_url: Option<String>,
+    pub lan_url: Option<String>,
+    pub client_token: Option<String>,
+    pub host_token: Option<String>,
+    pub pid: Option<u32>,
+    pub last_stdout: Option<String>,
+    pub last_stderr: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct EngineDoctorResult {
     pub found: bool,
     pub in_path: bool,

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -35,7 +35,8 @@
       "icons/icon.ico"
     ],
     "externalBin": [
-      "sidecars/opencode"
+      "sidecars/opencode",
+      "sidecars/openwork-server"
     ]
   },
   "plugins": {

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -10,7 +10,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "types": ["bun", "node"]
+    "types": ["bun-types", "node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- auto-start the OpenWork server sidecar alongside the OpenCode engine and expose status via Tauri commands
- add host pairing UI in Settings with URL + tokens and update client default port to 8787
- document host auto-start + pairing flow in the OpenWork server PRD