### PR TITLE
fix(ci): build OpenWork server sidecar on Windows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -120,6 +120,12 @@ jobs:
         with:
           version: 10.27.0
 
+      - name: Setup Bun
+        if: matrix.os_type == 'windows'
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.1.29"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -218,6 +218,12 @@ jobs:
         with:
           version: 10.27.0
 
+      - name: Setup Bun
+        if: matrix.os_type == 'windows'
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.1.29"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- compile the OpenWork server sidecar on Windows using Bun in sidecar prep
- install Bun in prerelease and release Windows workflows to support compilation
- keep non-Windows sidecar preparation unchanged

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @different-ai/openwork run prepare:sidecar