### PR TITLE
chore: bump opencode fallback to 1.1.36

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Download OpenCode sidecar
         shell: bash
         env:
-          OPENCODE_VERSION: 1.1.25
+          OPENCODE_VERSION: 1.1.36
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install OpenCode CLI
         shell: bash
         env:
-          OPENCODE_VERSION: 1.1.25
+          OPENCODE_VERSION: 1.1.36
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Download OpenCode sidecar
         shell: bash
         env:
-          OPENCODE_VERSION: 1.1.25
+          OPENCODE_VERSION: 1.1.36
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -250,7 +250,7 @@ jobs:
       - name: Download OpenCode sidecar
         shell: bash
         env:
-          OPENCODE_VERSION: 1.1.25
+          OPENCODE_VERSION: 1.1.36
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- update the CI fallback OpenCode version to 1.1.36 across build workflows