### PR TITLE
Skip onboarding and start in chat

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -473,8 +473,7 @@ export default function App() {
       return;
     }
 
-    if (currentView() !== "session") return;
-    void createSessionAndOpen();
+    return;
   });
 
   const [prompt, setPrompt] = createSignal("");
@@ -541,8 +540,13 @@ export default function App() {
     if (!content && !resolvedDraft.attachments.length) return;
 
     const c = client();
-    const sessionID = selectedSessionId();
-    if (!c || !sessionID) return;
+    if (!c) return;
+    let sessionID = selectedSessionId();
+    if (!sessionID) {
+      await createSessionAndOpen();
+      sessionID = selectedSessionId();
+    }
+    if (!sessionID) return;
 
     setBusy(true);
     setBusyLabel("status.running");

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -589,7 +589,7 @@ export function createWorkspaceStore(options: {
       options.refreshPlugins().catch(() => undefined);
       if (!options.selectedSessionId()) {
         options.setTab("home");
-        options.setView("dashboard");
+        options.setView("session");
       }
 
       // If the user successfully connected, treat onboarding as complete so we
@@ -1056,16 +1056,7 @@ export function createWorkspaceStore(options: {
       options.setMode(null);
       options.setOnboardingStep("mode");
 
-      const showOnboarding = (() => {
-        if (typeof window === "undefined") return true;
-        try {
-          return window.localStorage.getItem("openwork.onboardingComplete") !== "1";
-        } catch {
-          return true;
-        }
-      })();
-
-      options.setView(showOnboarding ? "onboarding" : "dashboard");
+      options.setView("session");
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
       options.setError(addOpencodeCacheHint(message));
@@ -1350,7 +1341,7 @@ export function createWorkspaceStore(options: {
       return;
     }
 
-    if (!modePref && onboardingComplete && activeWorkspacePath().trim()) {
+    if (!modePref && activeWorkspacePath().trim()) {
       options.setMode("host");
 
       if (info?.running && info.baseUrl) {
@@ -1359,7 +1350,9 @@ export function createWorkspaceStore(options: {
         if (!ok) {
           options.setMode(null);
           options.setOnboardingStep("mode");
+          return;
         }
+        markOnboardingComplete();
         return;
       }
 
@@ -1367,7 +1360,9 @@ export function createWorkspaceStore(options: {
       const ok = await startHost({ workspacePath: activeWorkspacePath().trim() });
       if (!ok) {
         options.setOnboardingStep("host");
+        return;
       }
+      markOnboardingComplete();
       return;
     }
 

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -398,11 +398,11 @@ export default function DashboardView(props: DashboardViewProps) {
           <Show when={!props.clientConnected}>
             <Button
               variant="secondary"
-              onClick={() => props.setView("onboarding")}
+              onClick={() => props.setWorkspacePickerOpen(true)}
               disabled={props.busy}
               class="w-full"
             >
-              Connect
+              Connect folder
             </Button>
           </Show>
         </div>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -491,7 +491,7 @@ export default function SessionView(props: SessionViewProps) {
   });
 
   const handleCreateSkill = () => {
-    props.setPrompt("@skill-creator ");
+    props.setPrompt("/skill create ");
     window.dispatchEvent(new CustomEvent("openwork:focusPrompt"));
   };
 

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -490,6 +490,54 @@ export default function SessionView(props: SessionViewProps) {
     return props.sessions.find((session) => session.id === id)?.title ?? "";
   });
 
+  const starterSkillOrder = [
+    "get-started",
+    "skill-creator",
+    "command-creator",
+    "agent-creator",
+    "plugin-creator",
+    "custom-cal-com-creator",
+  ];
+
+  const starterSkills = createMemo(() => {
+    const skills = props.skills ?? [];
+    const picked: SkillCard[] = [];
+    const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+    for (const name of starterSkillOrder) {
+      const skill = byName.get(name);
+      if (skill) {
+        picked.push(skill);
+        byName.delete(name);
+      }
+    }
+
+    for (const skill of skills) {
+      if (picked.length >= 6) break;
+      if (skill.name.endsWith("-creator") && !picked.some((item) => item.name === skill.name)) {
+        picked.push(skill);
+      }
+    }
+
+    return picked.slice(0, 6);
+  });
+
+  const starterSkillPrompt = (skill: SkillCard) => {
+    if (skill.name === "get-started") return "get started";
+    return `@${skill.name} `;
+  };
+
+  const formatSkillLabel = (name: string) =>
+    name
+      .split("-")
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+
+  const handleStarterSkill = (skill: SkillCard) => {
+    props.setPrompt(starterSkillPrompt(skill));
+  };
+
   const renameCanSave = createMemo(() => {
     if (renameBusy()) return false;
     const next = renameTitle().trim();
@@ -1040,14 +1088,66 @@ export default function SessionView(props: SessionViewProps) {
             ref={(el) => (chatContainerEl = el)}
           >
             <Show when={props.messages.length === 0}>
-              <div class="text-center py-20 space-y-4">
+              <div class="text-center py-16 px-6 space-y-6">
                 <div class="w-16 h-16 bg-gray-2 rounded-3xl mx-auto flex items-center justify-center border border-gray-6">
                   <Zap class="text-gray-7" />
                 </div>
-                <h3 class="text-xl font-medium">Ready to work</h3>
-                <p class="text-gray-10 text-sm max-w-xs mx-auto">
-                  Describe a task. I'll show progress and ask for permissions when needed.
-                </p>
+                <div class="space-y-2">
+                  <h3 class="text-xl font-medium">Ready when you are</h3>
+                  <p class="text-gray-10 text-sm max-w-sm mx-auto">
+                    Describe a task. I&apos;ll show progress and ask for permissions when needed.
+                  </p>
+                </div>
+                <Show when={starterSkills().length}>
+                  <div class="mx-auto w-full max-w-2xl text-left space-y-4">
+                    <div class="text-xs uppercase tracking-wide text-gray-9">Starter skills</div>
+                    <div class="grid gap-3 sm:grid-cols-2">
+                      <For each={starterSkills()}>
+                        {(skill) => (
+                          <button
+                            type="button"
+                            class="w-full rounded-xl border border-gray-6 bg-gray-2/40 p-4 text-left transition hover:border-gray-7 hover:bg-gray-2/70"
+                            onClick={() => handleStarterSkill(skill)}
+                          >
+                            <div class="space-y-2">
+                              <div class="flex items-center justify-between gap-3">
+                                <div class="text-sm font-medium text-gray-12">
+                                  {formatSkillLabel(skill.name)}
+                                </div>
+                                <span class="text-[11px] text-gray-9 font-mono">@{skill.name}</span>
+                              </div>
+                              <div class="text-xs text-gray-10">
+                                {skill.description ?? "Run this skill to get started."}
+                              </div>
+                            </div>
+                          </button>
+                        )}
+                      </For>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2">
+                      <Button
+                        variant="outline"
+                        class="text-xs h-8 px-3"
+                        onClick={() => props.setWorkspacePickerOpen(true)}
+                      >
+                        Connect folder
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        class="text-xs h-8 px-2"
+                        onClick={() => {
+                          props.setTab("skills");
+                          props.setView("dashboard");
+                        }}
+                      >
+                        View all skills
+                      </Button>
+                    </div>
+                    <div class="text-xs text-gray-9">
+                      Connect a folder when you&apos;re ready to work with files.
+                    </div>
+                  </div>
+                </Show>
               </div>
             </Show>
 

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -490,52 +490,9 @@ export default function SessionView(props: SessionViewProps) {
     return props.sessions.find((session) => session.id === id)?.title ?? "";
   });
 
-  const starterSkillOrder = [
-    "get-started",
-    "skill-creator",
-    "command-creator",
-    "agent-creator",
-    "plugin-creator",
-    "custom-cal-com-creator",
-  ];
-
-  const starterSkills = createMemo(() => {
-    const skills = props.skills ?? [];
-    const picked: SkillCard[] = [];
-    const byName = new Map(skills.map((skill) => [skill.name, skill]));
-
-    for (const name of starterSkillOrder) {
-      const skill = byName.get(name);
-      if (skill) {
-        picked.push(skill);
-        byName.delete(name);
-      }
-    }
-
-    for (const skill of skills) {
-      if (picked.length >= 6) break;
-      if (skill.name.endsWith("-creator") && !picked.some((item) => item.name === skill.name)) {
-        picked.push(skill);
-      }
-    }
-
-    return picked.slice(0, 6);
-  });
-
-  const starterSkillPrompt = (skill: SkillCard) => {
-    if (skill.name === "get-started") return "get started";
-    return `@${skill.name} `;
-  };
-
-  const formatSkillLabel = (name: string) =>
-    name
-      .split("-")
-      .filter(Boolean)
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(" ");
-
-  const handleStarterSkill = (skill: SkillCard) => {
-    props.setPrompt(starterSkillPrompt(skill));
+  const handleCreateSkill = () => {
+    props.setPrompt("@skill-creator ");
+    window.dispatchEvent(new CustomEvent("openwork:focusPrompt"));
   };
 
   const renameCanSave = createMemo(() => {
@@ -1006,25 +963,7 @@ export default function SessionView(props: SessionViewProps) {
   };
 
   return (
-    <Show
-      when={props.selectedSessionId}
-      fallback={
-        <div class="min-h-screen flex items-center justify-center bg-gray-1 text-gray-12 p-6">
-          <div class="text-center space-y-4">
-            <div class="text-lg font-medium">No session selected</div>
-            <Button
-              onClick={() => {
-                props.setTab("sessions");
-                props.setView("dashboard");
-              }}
-            >
-              Back to dashboard
-            </Button>
-          </div>
-        </div>
-      }
-    >
-      <div class="h-screen flex flex-col bg-gray-1 text-gray-12 relative">
+    <div class="h-screen flex flex-col bg-gray-1 text-gray-12 relative">
         <header class="h-16 border-b border-gray-6 flex items-center justify-between px-6 bg-gray-1/80 backdrop-blur-md z-10 sticky top-0">
           <div class="flex items-center gap-3">
             <Button
@@ -1093,61 +1032,16 @@ export default function SessionView(props: SessionViewProps) {
                   <Zap class="text-gray-7" />
                 </div>
                 <div class="space-y-2">
-                  <h3 class="text-xl font-medium">Ready when you are</h3>
+                  <h3 class="text-xl font-medium">Start with a skill</h3>
                   <p class="text-gray-10 text-sm max-w-sm mx-auto">
-                    Describe a task. I&apos;ll show progress and ask for permissions when needed.
+                    Tell OpenWork what you want to reuse. We&apos;ll shape it into a skill you can run anytime.
                   </p>
                 </div>
-                <Show when={starterSkills().length}>
-                  <div class="mx-auto w-full max-w-2xl text-left space-y-4">
-                    <div class="text-xs uppercase tracking-wide text-gray-9">Starter skills</div>
-                    <div class="grid gap-3 sm:grid-cols-2">
-                      <For each={starterSkills()}>
-                        {(skill) => (
-                          <button
-                            type="button"
-                            class="w-full rounded-xl border border-gray-6 bg-gray-2/40 p-4 text-left transition hover:border-gray-7 hover:bg-gray-2/70"
-                            onClick={() => handleStarterSkill(skill)}
-                          >
-                            <div class="space-y-2">
-                              <div class="flex items-center justify-between gap-3">
-                                <div class="text-sm font-medium text-gray-12">
-                                  {formatSkillLabel(skill.name)}
-                                </div>
-                                <span class="text-[11px] text-gray-9 font-mono">@{skill.name}</span>
-                              </div>
-                              <div class="text-xs text-gray-10">
-                                {skill.description ?? "Run this skill to get started."}
-                              </div>
-                            </div>
-                          </button>
-                        )}
-                      </For>
-                    </div>
-                    <div class="flex flex-wrap items-center gap-2">
-                      <Button
-                        variant="outline"
-                        class="text-xs h-8 px-3"
-                        onClick={() => props.setWorkspacePickerOpen(true)}
-                      >
-                        Connect folder
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        class="text-xs h-8 px-2"
-                        onClick={() => {
-                          props.setTab("skills");
-                          props.setView("dashboard");
-                        }}
-                      >
-                        View all skills
-                      </Button>
-                    </div>
-                    <div class="text-xs text-gray-9">
-                      Connect a folder when you&apos;re ready to work with files.
-                    </div>
-                  </div>
-                </Show>
+                <div class="flex justify-center">
+                  <Button variant="primary" class="h-11 px-5" onClick={handleCreateSkill}>
+                    Create your first skill
+                  </Button>
+                </div>
               </div>
             </Show>
 
@@ -1374,7 +1268,6 @@ export default function SessionView(props: SessionViewProps) {
         <For each={flyouts()}>
           {(item) => <FlyoutItem item={item} />}
         </For>
-      </div>
-    </Show>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- default the app route to /session and auto-select or create a session after sessions load
- replace onboarding entry points with the workspace picker and session view
- add a starter skills shelf in the empty chat state

## Testing
- not run (not requested)