### PR TITLE
feat: add devtools audit visibility

### DIFF
--- a/.opencode/skills/openwork-debug/SKILL.md
+++ b/.opencode/skills/openwork-debug/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: openwork-debug
+description: Debug OpenWork sidecars, config, and audit trail
+---
+
+## Credential check
+
+Set these before running the HTTP checks:
+
+- `OPENWORK_SERVER_URL`
+- `OPENWORK_SERVER_TOKEN`
+- `OPENWORK_WORKSPACE_ID` (optional; use `/workspaces` to discover)
+
+## Quick usage (read-only)
+
+```bash
+curl -s "$OPENWORK_SERVER_URL/health"
+curl -s "$OPENWORK_SERVER_URL/capabilities" \
+  -H "Authorization: Bearer $OPENWORK_SERVER_TOKEN"
+
+curl -s "$OPENWORK_SERVER_URL/workspaces" \
+  -H "Authorization: Bearer $OPENWORK_SERVER_TOKEN"
+```
+
+## Workspace config snapshot
+
+```bash
+curl -s "$OPENWORK_SERVER_URL/workspace/$OPENWORK_WORKSPACE_ID/config" \
+  -H "Authorization: Bearer $OPENWORK_SERVER_TOKEN"
+```
+
+## Audit log (recent)
+
+```bash
+curl -s "$OPENWORK_SERVER_URL/workspace/$OPENWORK_WORKSPACE_ID/audit?limit=25" \
+  -H "Authorization: Bearer $OPENWORK_SERVER_TOKEN"
+```
+
+## OpenCode engine checks
+
+```bash
+opencode -p "ping" -f json -q
+opencode mcp list
+opencode mcp debug <name>
+```
+
+## DB fallback (read-only)
+
+When the engine API is unavailable, you can inspect the SQLite db:
+
+```bash
+sqlite3 ~/.opencode/opencode.db "select id, title, status from sessions order by updated_at desc limit 5;"
+sqlite3 ~/.opencode/opencode.db "select role, content from messages order by created_at desc limit 10;"
+```
+
+## Notes
+
+- Audit logs are stored at `.opencode/openwork/audit.jsonl` in the workspace root.
+- OpenWork server writes only within approved workspace roots.

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -58,6 +58,22 @@ export type OpenworkMcpItem = {
   disabledByTools?: boolean;
 };
 
+export type OpenworkActor = {
+  type: "remote" | "host";
+  clientId?: string;
+  tokenHash?: string;
+};
+
+export type OpenworkAuditEntry = {
+  id: string;
+  workspaceId: string;
+  actor: OpenworkActor;
+  action: string;
+  target: string;
+  summary: string;
+  timestamp: number;
+};
+
 export const DEFAULT_OPENWORK_SERVER_PORT = 8787;
 
 const STORAGE_URL_OVERRIDE = "openwork.server.urlOverride";
@@ -267,6 +283,12 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       requestJson<{ items: OpenworkCommandItem[] }>(
         baseUrl,
         `/workspace/${workspaceId}/commands?scope=${scope}`,
+        { token },
+      ),
+    listAudit: (workspaceId: string, limit = 50) =>
+      requestJson<{ items: OpenworkAuditEntry[] }>(
+        baseUrl,
+        `/workspace/${workspaceId}/audit?limit=${limit}`,
         { token },
       ),
     upsertCommand: (

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -10,8 +10,8 @@ import type {
 } from "../types";
 import type { McpDirectoryInfo } from "../constants";
 import { formatRelativeTime, normalizeDirectoryPath } from "../utils";
-import type { OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
-import type { OpenworkServerInfo } from "../lib/tauri";
+import type { OpenworkAuditEntry, OpenworkServerCapabilities, OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
+import type { EngineInfo, OpenworkServerInfo } from "../lib/tauri";
 
 import Button from "../components/button";
 import OpenWorkLogo from "../components/openwork-logo";
@@ -51,6 +51,12 @@ export type DashboardViewProps = {
   openworkServerUrl: string;
   openworkServerSettings: OpenworkServerSettings;
   openworkServerHostInfo: OpenworkServerInfo | null;
+  openworkServerCapabilities: OpenworkServerCapabilities | null;
+  openworkServerWorkspaceId: string | null;
+  openworkAuditEntries: OpenworkAuditEntry[];
+  openworkAuditStatus: "idle" | "loading" | "error";
+  openworkAuditError: string | null;
+  engineInfo: EngineInfo | null;
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
   resetOpenworkServerSettings: () => void;
   testOpenworkServerConnection: (next: OpenworkServerSettings) => Promise<boolean>;
@@ -863,6 +869,12 @@ export default function DashboardView(props: DashboardViewProps) {
                   openworkServerUrl={props.openworkServerUrl}
                   openworkServerSettings={props.openworkServerSettings}
                   openworkServerHostInfo={props.openworkServerHostInfo}
+                  openworkServerCapabilities={props.openworkServerCapabilities}
+                  openworkServerWorkspaceId={props.openworkServerWorkspaceId}
+                  openworkAuditEntries={props.openworkAuditEntries}
+                  openworkAuditStatus={props.openworkAuditStatus}
+                  openworkAuditError={props.openworkAuditError}
+                  engineInfo={props.engineInfo}
                   updateOpenworkServerSettings={props.updateOpenworkServerSettings}
                   resetOpenworkServerSettings={props.resetOpenworkServerSettings}
                   testOpenworkServerConnection={props.testOpenworkServerConnection}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -893,7 +893,7 @@ export default function SettingsView(props: SettingsViewProps) {
                   </div>
                   <div class="space-y-1">
                     <div class="text-[11px] text-gray-7 font-mono truncate">
-                      {props.openworkServerHostInfo?.baseUrl ?? props.openworkServerUrl || "Base URL unavailable"}
+                      {(props.openworkServerHostInfo?.baseUrl ?? props.openworkServerUrl) || "Base URL unavailable"}
                     </div>
                     <div class="text-[11px] text-gray-7 font-mono truncate">PID: {props.openworkServerHostInfo?.pid ?? "—"}</div>
                   </div>

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -57,6 +57,7 @@ Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CON
 - `GET /workspace/:id/commands`
 - `POST /workspace/:id/commands`
 - `DELETE /workspace/:id/commands/:name`
+- `GET /workspace/:id/audit`
 - `GET /workspace/:id/export`
 - `POST /workspace/:id/import`
 

--- a/packages/server/src/audit.ts
+++ b/packages/server/src/audit.ts
@@ -26,3 +26,21 @@ export async function readLastAudit(workspaceRoot: string): Promise<AuditEntry |
     return null;
   }
 }
+
+export async function readAuditEntries(workspaceRoot: string, limit = 50): Promise<AuditEntry[]> {
+  const path = auditLogPath(workspaceRoot);
+  if (!(await exists(path))) return [];
+  const content = await readFile(path, "utf8");
+  const rawLines = content.trim().split("\n").filter(Boolean);
+  if (!rawLines.length) return [];
+  const slice = rawLines.slice(-Math.max(1, limit));
+  const entries: AuditEntry[] = [];
+  for (let i = slice.length - 1; i >= 0; i -= 1) {
+    try {
+      entries.push(JSON.parse(slice[i]) as AuditEntry);
+    } catch {
+      // ignore malformed entry
+    }
+  }
+  return entries;
+}


### PR DESCRIPTION
## Summary
- add a Devtools section in Settings for sidecar health, logs, capabilities, and audit trail
- expose an audit log endpoint in the OpenWork server with client support
- document debug CLI flows in the new openwork-debug skill

## Testing
- Not run (not requested)