### PR TITLE
feat: host mode prefers OpenWork server for skills/plugins management

### DIFF
--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -185,10 +185,17 @@ export class OpenworkServerError extends Error {
   }
 }
 
-function buildHeaders(token?: string, extra?: Record<string, string>) {
+function buildHeaders(
+  token?: string,
+  hostToken?: string,
+  extra?: Record<string, string>,
+) {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (token) {
     headers.Authorization = `Bearer ${token}`;
+  }
+  if (hostToken) {
+    headers["X-OpenWork-Host-Token"] = hostToken;
   }
   if (extra) {
     Object.assign(headers, extra);
@@ -199,12 +206,12 @@ function buildHeaders(token?: string, extra?: Record<string, string>) {
 async function requestJson<T>(
   baseUrl: string,
   path: string,
-  options: { method?: string; token?: string; body?: unknown } = {},
+  options: { method?: string; token?: string; hostToken?: string; body?: unknown } = {},
 ): Promise<T> {
   const url = `${baseUrl}${path}`;
   const response = await fetch(url, {
     method: options.method ?? "GET",
-    headers: buildHeaders(options.token),
+    headers: buildHeaders(options.token, options.hostToken),
     body: options.body ? JSON.stringify(options.body) : undefined,
   });
 
@@ -220,76 +227,91 @@ async function requestJson<T>(
   return json as T;
 }
 
-export function createOpenworkServerClient(options: { baseUrl: string; token?: string }) {
+export function createOpenworkServerClient(options: { baseUrl: string; token?: string; hostToken?: string }) {
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
   const token = options.token;
+  const hostToken = options.hostToken;
 
   return {
     baseUrl,
     token,
     health: () => requestJson<{ ok: boolean; version: string; uptimeMs: number }>(baseUrl, "/health"),
-    capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token }),
-    listWorkspaces: () => requestJson<{ items: OpenworkWorkspaceInfo[] }>(baseUrl, "/workspaces", { token }),
+    capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken }),
+    listWorkspaces: () => requestJson<{ items: OpenworkWorkspaceInfo[] }>(baseUrl, "/workspaces", { token, hostToken }),
     getConfig: (workspaceId: string) =>
       requestJson<{ opencode: Record<string, unknown>; openwork: Record<string, unknown>; updatedAt?: number | null }>(
         baseUrl,
         `/workspace/${workspaceId}/config`,
-        { token },
+        { token, hostToken },
       ),
     patchConfig: (workspaceId: string, payload: { opencode?: Record<string, unknown>; openwork?: Record<string, unknown> }) =>
       requestJson<{ updatedAt?: number | null }>(baseUrl, `/workspace/${workspaceId}/config`, {
         token,
+        hostToken,
         method: "PATCH",
         body: payload,
       }),
-    listPlugins: (workspaceId: string) =>
-      requestJson<{ items: OpenworkPluginItem[]; loadOrder: string[] }>(baseUrl, `/workspace/${workspaceId}/plugins`, {
-        token,
-      }),
+    listPlugins: (workspaceId: string, options?: { includeGlobal?: boolean }) => {
+      const query = options?.includeGlobal ? "?includeGlobal=true" : "";
+      return requestJson<{ items: OpenworkPluginItem[]; loadOrder: string[] }>(
+        baseUrl,
+        `/workspace/${workspaceId}/plugins${query}`,
+        { token, hostToken },
+      );
+    },
     addPlugin: (workspaceId: string, spec: string) =>
       requestJson<{ items: OpenworkPluginItem[]; loadOrder: string[] }>(
         baseUrl,
         `/workspace/${workspaceId}/plugins`,
-        { token, method: "POST", body: { spec } },
+        { token, hostToken, method: "POST", body: { spec } },
       ),
     removePlugin: (workspaceId: string, name: string) =>
       requestJson<{ items: OpenworkPluginItem[]; loadOrder: string[] }>(
         baseUrl,
         `/workspace/${workspaceId}/plugins/${encodeURIComponent(name)}`,
-        { token, method: "DELETE" },
+        { token, hostToken, method: "DELETE" },
       ),
-    listSkills: (workspaceId: string) =>
-      requestJson<{ items: OpenworkSkillItem[] }>(baseUrl, `/workspace/${workspaceId}/skills`, { token }),
+    listSkills: (workspaceId: string, options?: { includeGlobal?: boolean }) => {
+      const query = options?.includeGlobal ? "?includeGlobal=true" : "";
+      return requestJson<{ items: OpenworkSkillItem[] }>(
+        baseUrl,
+        `/workspace/${workspaceId}/skills${query}`,
+        { token, hostToken },
+      );
+    },
     upsertSkill: (workspaceId: string, payload: { name: string; content: string; description?: string }) =>
       requestJson<OpenworkSkillItem>(baseUrl, `/workspace/${workspaceId}/skills`, {
         token,
+        hostToken,
         method: "POST",
         body: payload,
       }),
     listMcp: (workspaceId: string) =>
-      requestJson<{ items: OpenworkMcpItem[] }>(baseUrl, `/workspace/${workspaceId}/mcp`, { token }),
+      requestJson<{ items: OpenworkMcpItem[] }>(baseUrl, `/workspace/${workspaceId}/mcp`, { token, hostToken }),
     addMcp: (workspaceId: string, payload: { name: string; config: Record<string, unknown> }) =>
       requestJson<{ items: OpenworkMcpItem[] }>(baseUrl, `/workspace/${workspaceId}/mcp`, {
         token,
+        hostToken,
         method: "POST",
         body: payload,
       }),
     removeMcp: (workspaceId: string, name: string) =>
       requestJson<{ items: OpenworkMcpItem[] }>(baseUrl, `/workspace/${workspaceId}/mcp/${encodeURIComponent(name)}`, {
         token,
+        hostToken,
         method: "DELETE",
       }),
     listCommands: (workspaceId: string, scope: "workspace" | "global" = "workspace") =>
       requestJson<{ items: OpenworkCommandItem[] }>(
         baseUrl,
         `/workspace/${workspaceId}/commands?scope=${scope}`,
-        { token },
+        { token, hostToken },
       ),
     listAudit: (workspaceId: string, limit = 50) =>
       requestJson<{ items: OpenworkAuditEntry[] }>(
         baseUrl,
         `/workspace/${workspaceId}/audit?limit=${limit}`,
-        { token },
+        { token, hostToken },
       ),
     upsertCommand: (
       workspaceId: string,
@@ -297,12 +319,14 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     ) =>
       requestJson<{ items: OpenworkCommandItem[] }>(baseUrl, `/workspace/${workspaceId}/commands`, {
         token,
+        hostToken,
         method: "POST",
         body: payload,
       }),
     deleteCommand: (workspaceId: string, name: string) =>
       requestJson<{ ok: boolean }>(baseUrl, `/workspace/${workspaceId}/commands/${encodeURIComponent(name)}`, {
         token,
+        hostToken,
         method: "DELETE",
       }),
   };

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -11,7 +11,7 @@ import type {
 import type { McpDirectoryInfo } from "../constants";
 import { formatRelativeTime, normalizeDirectoryPath } from "../utils";
 import type { OpenworkAuditEntry, OpenworkServerCapabilities, OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
-import type { EngineInfo, OpenworkServerInfo } from "../lib/tauri";
+import type { EngineInfo, OpenworkServerInfo, WorkspaceInfo } from "../lib/tauri";
 
 import Button from "../components/button";
 import OpenWorkLogo from "../components/openwork-logo";

--- a/packages/desktop/scripts/prepare-sidecar.mjs
+++ b/packages/desktop/scripts/prepare-sidecar.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from "child_process";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
+import { existsSync, mkdirSync } from "fs";
+import { dirname, join, resolve } from "path";
 import { tmpdir } from "os";
 import { fileURLToPath } from "url";
 
@@ -10,169 +10,57 @@ const DOWNLOAD_URL =
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sidecarDir = join(__dirname, "..", "src-tauri", "sidecars");
-const repoRoot = join(__dirname, "..", "..");
-const serverDir = join(repoRoot, "server");
-const serverCli = join(serverDir, "dist", "cli.js");
-const bunTypesPath = join(serverDir, "node_modules", "bun-types", "package.json");
+const openworkServerName = process.platform === "win32" ? "openwork-server.exe" : "openwork-server";
+const openworkServerPath = join(sidecarDir, openworkServerName);
 
-const resolveBun = () => {
-  if (process.env.BUN_PATH) return process.env.BUN_PATH;
-  const result = spawnSync("bun", ["--version"], { stdio: "ignore" });
-  if (result.status === 0) return "bun";
-  const which = spawnSync("bash", ["-lc", "command -v bun"], { encoding: "utf8" });
-  const bunPath = which.stdout?.trim();
-  return bunPath ? bunPath : null;
-};
+const openworkServerDir = resolve(__dirname, "..", "..", "server");
+const targetSidecarPath = join(sidecarDir, `opencode-${TARGET_TRIPLE}.exe`);
+const devSidecarPath = join(sidecarDir, "opencode.exe");
 
-const resolveBunTarget = (target) => {
-  if (!target) return null;
-  if (target === "x86_64-pc-windows-msvc") return "bun-windows-x64";
-  return null;
-};
-
-const resolveTargetTriple = () => {
-  const envTarget =
-    process.env.TAURI_ENV_TARGET_TRIPLE ||
-    process.env.CARGO_CFG_TARGET_TRIPLE ||
-    process.env.TARGET;
-  if (envTarget) return envTarget;
-
-  if (process.platform === "darwin") {
-    return process.arch === "arm64" ? "aarch64-apple-darwin" : "x86_64-apple-darwin";
-  }
-  if (process.platform === "linux") {
-    return process.arch === "arm64" ? "aarch64-unknown-linux-gnu" : "x86_64-unknown-linux-gnu";
-  }
-  if (process.platform === "win32") {
-    return TARGET_TRIPLE;
-  }
-  return null;
-};
-
-const ensureOpenworkServerSidecar = () => {
-  const target = resolveTargetTriple();
-  const isWindows = process.platform === "win32";
-  const devSidecarPath = join(sidecarDir, isWindows ? "openwork-server.exe" : "openwork-server");
-  const targetSidecarPath = target
-    ? join(sidecarDir, `openwork-server-${target}${isWindows ? ".exe" : ""}`)
-    : null;
-
-  if (targetSidecarPath && existsSync(targetSidecarPath) && existsSync(devSidecarPath)) {
-    console.log(`OpenWork server sidecar already present: ${targetSidecarPath}`);
-    return;
-  }
-
-  if (isWindows) {
-    const bunPath = resolveBun();
-    if (!bunPath) {
-      console.error("Bun is required to compile the OpenWork server sidecar on Windows.");
-      console.error("Install Bun or set BUN_PATH, then re-run the build.");
-      process.exit(1);
-    }
-
-    if (!existsSync(bunTypesPath)) {
-      const install = spawnSync("pnpm", ["-C", serverDir, "install"], { stdio: "inherit" });
-      if (install.status !== 0) {
-        process.exit(install.status ?? 1);
-      }
-    }
-
-    const bunTarget = resolveBunTarget(target) ?? "bun-windows-x64";
-    const entrypoint = join(serverDir, "src", "cli.ts");
-    const outputPath = targetSidecarPath ?? devSidecarPath;
-
-    mkdirSync(sidecarDir, { recursive: true });
-
-    const build = spawnSync(
-      bunPath,
-      ["build", entrypoint, "--compile", `--target=${bunTarget}`, "--outfile", outputPath],
-      { stdio: "inherit", cwd: serverDir }
-    );
-    if (build.status !== 0) {
-      process.exit(build.status ?? 1);
-    }
-
-    if (!existsSync(outputPath)) {
-      console.error(`OpenWork server sidecar was not created at ${outputPath}`);
-      process.exit(1);
-    }
-
-    if (outputPath !== devSidecarPath) {
-      copyFileSync(outputPath, devSidecarPath);
-    }
-
-    return;
-  }
-
-  if (!existsSync(bunTypesPath)) {
-    const install = spawnSync("pnpm", ["-C", serverDir, "install"], { stdio: "inherit" });
-    if (install.status !== 0) {
-      process.exit(install.status ?? 1);
-    }
-  }
-
-  const build = spawnSync("pnpm", ["-C", serverDir, "build"], { stdio: "inherit" });
-  if (build.status !== 0) {
-    process.exit(build.status ?? 1);
-  }
-
+if (!existsSync(openworkServerPath)) {
   mkdirSync(sidecarDir, { recursive: true });
-  const bunPath = resolveBun();
-  const cliPath = serverCli.replace(/"/g, "\\\"");
-  const launcher = bunPath
-    ? `#!/usr/bin/env bash\n"${bunPath.replace(/"/g, "\\\"")}" "${cliPath}" "$@"\n`
-    : "#!/usr/bin/env bash\n" +
-      "echo 'Bun is required to run the OpenWork server. Install bun.sh and re-run pnpm dev.'\n" +
-      "exit 1\n";
+  const buildResult = spawnSync(
+    "bun",
+    ["./script/build.ts", "--outdir", sidecarDir, "--filename", "openwork-server"],
+    { cwd: openworkServerDir, stdio: "inherit" }
+  );
 
-  writeFileSync(devSidecarPath, launcher, "utf8");
-  chmodSync(devSidecarPath, 0o755);
-
-  if (targetSidecarPath) {
-    writeFileSync(targetSidecarPath, launcher, "utf8");
-    chmodSync(targetSidecarPath, 0o755);
+  if (buildResult.status !== 0) {
+    process.exit(buildResult.status ?? 1);
   }
-};
+}
 
-const ensureOpencodeWindowsSidecar = () => {
-  if (process.platform !== "win32") {
-    console.log("Skipping Windows sidecar download (non-Windows host).\n");
-    return;
-  }
+if (process.platform !== "win32") {
+  console.log("Skipping Windows sidecar download (non-Windows host).");
+  process.exit(0);
+}
 
-  const targetSidecarPath = join(sidecarDir, `opencode-${TARGET_TRIPLE}.exe`);
-  const devSidecarPath = join(sidecarDir, "opencode.exe");
+if (existsSync(targetSidecarPath)) {
+  console.log(`OpenCode sidecar already present: ${targetSidecarPath}`);
+  process.exit(0);
+}
 
-  if (existsSync(targetSidecarPath)) {
-    console.log(`OpenCode sidecar already present: ${targetSidecarPath}`);
-    return;
-  }
+mkdirSync(sidecarDir, { recursive: true });
 
-  mkdirSync(sidecarDir, { recursive: true });
+const stamp = Date.now();
+const zipPath = join(tmpdir(), `opencode-windows-x64-${stamp}.zip`);
+const extractDir = join(tmpdir(), `opencode-windows-x64-${stamp}`);
+const extractedExe = join(extractDir, "opencode.exe");
 
-  const stamp = Date.now();
-  const zipPath = join(tmpdir(), `opencode-windows-x64-${stamp}.zip`);
-  const extractDir = join(tmpdir(), `opencode-windows-x64-${stamp}`);
-  const extractedExe = join(extractDir, "opencode.exe");
+const psQuote = (value) => `'${value.replace(/'/g, "''")}'`;
+const psScript = [
+  "$ErrorActionPreference = 'Stop'",
+  `Invoke-WebRequest -Uri ${psQuote(DOWNLOAD_URL)} -OutFile ${psQuote(zipPath)}`,
+  `Expand-Archive -Path ${psQuote(zipPath)} -DestinationPath ${psQuote(extractDir)} -Force`,
+  `if (!(Test-Path ${psQuote(extractedExe)})) { throw 'opencode.exe missing in archive' }`,
+  `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(targetSidecarPath)} -Force`,
+  `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(devSidecarPath)} -Force`,
+].join("; ");
 
-  const psQuote = (value) => `'${value.replace(/'/g, "''")}'`;
-  const psScript = [
-    "$ErrorActionPreference = 'Stop'",
-    `Invoke-WebRequest -Uri ${psQuote(DOWNLOAD_URL)} -OutFile ${psQuote(zipPath)}`,
-    `Expand-Archive -Path ${psQuote(zipPath)} -DestinationPath ${psQuote(extractDir)} -Force`,
-    `if (!(Test-Path ${psQuote(extractedExe)})) { throw 'opencode.exe missing in archive' }`,
-    `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(targetSidecarPath)} -Force`,
-    `Copy-Item -Path ${psQuote(extractedExe)} -Destination ${psQuote(devSidecarPath)} -Force`,
-  ].join("; ");
+const result = spawnSync("powershell", ["-NoProfile", "-Command", psScript], {
+  stdio: "inherit",
+});
 
-  const result = spawnSync("powershell", ["-NoProfile", "-Command", psScript], {
-    stdio: "inherit",
-  });
-
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
-};
-
-ensureOpenworkServerSidecar();
-ensureOpencodeWindowsSidecar();
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
+    "build:bin": "bun ./script/build.ts --outdir dist/bin",
+    "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-windows-x64",
     "start": "bun dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/server/script/build.ts
+++ b/packages/server/script/build.ts
@@ -1,0 +1,120 @@
+import * as fs from "node:fs";
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const bunRuntime = (globalThis as typeof globalThis & {
+  Bun?: {
+    build?: (...args: any[]) => Promise<any>;
+    argv?: string[];
+  };
+}).Bun;
+
+if (!bunRuntime?.build || !bunRuntime.argv) {
+  console.error("This script must be run with Bun.");
+  process.exit(1);
+}
+
+const bun = bunRuntime as { build: (...args: any[]) => Promise<any>; argv: string[] };
+
+type BuildOptions = {
+  targets: string[];
+  outdir: string;
+  filename: string;
+};
+
+function readArgs(argv: string[]): BuildOptions {
+  const options: BuildOptions = {
+    targets: [],
+    outdir: resolve("dist", "bin"),
+    filename: "openwork-server",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (!value) continue;
+
+    if (value === "--target") {
+      const next = argv[index + 1];
+      if (next) {
+        options.targets.push(next);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (value.startsWith("--target=")) {
+      const next = value.slice("--target=".length).trim();
+      if (next) options.targets.push(next);
+      continue;
+    }
+
+    if (value === "--outdir") {
+      const next = argv[index + 1];
+      if (next) {
+        options.outdir = resolve(next);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (value.startsWith("--outdir=")) {
+      const next = value.slice("--outdir=".length).trim();
+      if (next) options.outdir = resolve(next);
+      continue;
+    }
+
+    if (value === "--filename") {
+      const next = argv[index + 1];
+      if (next) {
+        options.filename = next;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (value.startsWith("--filename=")) {
+      const next = value.slice("--filename=".length).trim();
+      if (next) options.filename = next;
+    }
+  }
+
+  return options;
+}
+
+function outputName(filename: string, target?: string) {
+  const needsExe = target ? target.includes("windows") : process.platform === "win32";
+  const suffix = target ? `-${target}` : "";
+  const ext = needsExe ? ".exe" : "";
+  return `${filename}${suffix}${ext}`;
+}
+
+async function buildOnce(entrypoint: string, outdir: string, filename: string, target?: string) {
+  fs.mkdirSync(outdir, { recursive: true });
+  const outfile = join(outdir, outputName(filename, target));
+
+  const result = await bun.build({
+    entrypoints: [entrypoint],
+    outfile,
+    target,
+    minify: true,
+    sourcemap: "none",
+    compile: true,
+  });
+
+  if (!result.success) {
+    for (const log of result.logs) {
+      console.error(log.message);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Built ${outfile}`);
+}
+
+const options = readArgs(bun.argv.slice(2));
+const entrypoint = resolve("src", "cli.ts");
+const targets = options.targets.length ? options.targets : [undefined];
+
+for (const target of targets) {
+  await buildOnce(entrypoint, options.outdir, options.filename, target);
+}

--- a/packages/server/src/workspace-files.ts
+++ b/packages/server/src/workspace-files.ts
@@ -1,7 +1,12 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 export function opencodeConfigPath(workspaceRoot: string): string {
-  return join(workspaceRoot, "opencode.json");
+  const jsoncPath = join(workspaceRoot, "opencode.jsonc");
+  const jsonPath = join(workspaceRoot, "opencode.json");
+  if (existsSync(jsoncPath)) return jsoncPath;
+  if (existsSync(jsonPath)) return jsonPath;
+  return jsoncPath;
 }
 
 export function openworkConfigPath(workspaceRoot: string): string {


### PR DESCRIPTION
## Summary

This PR makes host mode use the OpenWork server for config-backed operations (skills/plugins/commands/MCP/default model), adds the server binary build script, and fixes the sidecar build so Bun is not required at runtime.

## Changes

### OpenWork Server Client (`openwork-server.ts`)
- Added `hostToken` parameter to `createOpenworkServerClient`
- All API calls now send `X-OpenWork-Host-Token` header when hostToken is provided
- Added `includeGlobal` query param support to `listSkills` and `listPlugins`

### Extensions Store (`extensions.ts`)
- `refreshSkills`: Host mode now uses OpenWork server first (with `includeGlobal: true` for global skills), falls back to local filesystem
- `refreshPlugins`: Host mode uses OpenWork server for project scope plugins when available
- `addPlugin`: Host mode uses OpenWork server for project scope when available
- `installSkillCreator`: Host mode or remote workspace uses OpenWork server when available

### Commands + MCP + Default Model (`command-state.ts`, `app.tsx`)
- `saveCommand` / `deleteCommand` / `loadCommands`: use OpenWork server for workspace-scope commands in host mode when available
- `connectNotion`, `connectMcp`, `refreshMcpServers`: use OpenWork server when connected in host mode
- Default model read/write uses OpenWork server in host mode (falls back to local FS)
- Host mode resolves workspace id via OpenWork server and fetches host capabilities
- Host mode client uses host token for write approvals

### Server Binary Build (`packages/server/script/build.ts`)
- Added Bun build script for compiling standalone server binary
- Added `build:bin` and `build:bin:all` scripts to package.json
- Supports cross-compilation targets (darwin-arm64, darwin-x64, linux-x64, windows-x64)

### Sidecar Build Fix (`prepare-sidecar.mjs`)
- Compile OpenWork server into a standalone binary on all platforms
- Removes shell launcher that required Bun at runtime

### Config Path Preference (`workspace-files.ts`)
- `opencodeConfigPath` now prefers `opencode.jsonc` over `opencode.json`
- Falls back to `opencode.json` if `.jsonc` doesn't exist

### Dashboard
- Fixed missing `WorkspaceInfo` import

## Testing
- [x] `pnpm typecheck` passes
- [x] `pnpm build:web` passes

## Task Checklist
- [x] OpenWork server binary build script
- [x] Update prepare-sidecar.mjs to compile openwork-server
- [x] Add openwork-server to Tauri externalBin sidecars (already in origin/dev)
- [x] Config path prefers `opencode.jsonc`
- [x] OpenWork server client supports host token header
- [x] Host-mode extensions use server-first (skills, plugins)
- [x] Host-mode commands use server for workspace scope
- [x] Host-mode MCP, Notion, default model use server