### PR TITLE
feat(ui): expand tool steps by default in session view

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -96,14 +96,18 @@ export default function MessageList(props: MessageListProps) {
     return "";
   };
 
+  // Note: expandedStepIds now tracks COLLAPSED steps (inverted logic for default-expanded behavior)
   const toggleSteps = (id: string, relatedIds: string[] = []) => {
     props.setExpandedStepIds((current) => {
       const next = new Set(current);
-      const expanded = next.has(id) || relatedIds.some((relatedId) => next.has(relatedId));
-      if (expanded) {
+      // Inverted: if in set = collapsed, so check if collapsed to expand (remove from set)
+      const isCollapsed = next.has(id) || relatedIds.some((relatedId) => next.has(relatedId));
+      if (isCollapsed) {
+        // Currently collapsed -> expand by removing from set
         next.delete(id);
         relatedIds.forEach((relatedId) => next.delete(relatedId));
       } else {
+        // Currently expanded -> collapse by adding to set
         next.add(id);
         relatedIds.forEach((relatedId) => next.delete(relatedId));
       }
@@ -111,9 +115,10 @@ export default function MessageList(props: MessageListProps) {
     });
   };
 
+  // Inverted: steps are expanded by default (when NOT in the set)
   const isStepsExpanded = (id: string, relatedIds: string[] = []) =>
-    props.expandedStepIds.has(id) ||
-    relatedIds.some((relatedId) => props.expandedStepIds.has(relatedId));
+    !props.expandedStepIds.has(id) &&
+    !relatedIds.some((relatedId) => props.expandedStepIds.has(relatedId));
 
   const renderablePartsForMessage = (message: MessageWithParts) =>
     message.parts.filter((part) => {
@@ -246,7 +251,7 @@ export default function MessageList(props: MessageListProps) {
                     </button>
                     <Show when={expanded()}>
                       <div
-                        class={`mt-3 rounded-xl border p-3 ${
+                        class={`mt-3 rounded-xl border p-3 max-h-96 overflow-auto ${
                           block.isUser
                             ? "border-gray-6 bg-gray-1/60"
                             : "border-gray-6/70 bg-gray-2/40"
@@ -347,7 +352,7 @@ export default function MessageList(props: MessageListProps) {
                               </button>
                               <Show when={expanded()}>
                                 <div
-                                  class={`mt-3 rounded-xl border p-3 ${
+                                  class={`mt-3 rounded-xl border p-3 max-h-96 overflow-auto ${
                                     block.isUser
                                       ? "border-gray-6 bg-gray-1/60"
                                       : "border-gray-6/70 bg-gray-2/40"


### PR DESCRIPTION
## Summary
- Inverted expandedStepIds logic to track collapsed steps instead of expanded
- Steps now show expanded by default, users can collapse if desired
- Added max-h-96 overflow-auto to step containers to prevent overwhelming the view with very long outputs

## Changes
- Modified `packages/app/src/app/components/session/message-list.tsx`:
  - `toggleSteps()` now adds IDs to set when collapsing, removes when expanding
  - `isStepsExpanded()` returns true when ID is NOT in the set
  - Added `max-h-96 overflow-auto` class to both step container divs

## Testing
- `pnpm typecheck` passes