### PR TITLE
feat(owpenbot): refactor CLI to non-interactive with JSON output

### DIFF
--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -40,7 +40,6 @@
     "test:npx": "node scripts/test-npx.mjs"
   },
   "dependencies": {
-    "@clack/prompts": "^0.11.0",
     "@opencode-ai/sdk": "^1.1.31",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "better-sqlite3": "^11.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,9 +82,6 @@ importers:
 
   packages/owpenbot:
     dependencies:
-      '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
       '@opencode-ai/sdk':
         specifier: ^1.1.31
         version: 1.1.39
@@ -246,12 +243,6 @@ packages:
 
   '@cacheable/utils@2.3.3':
     resolution: {integrity: sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==}
-
-  '@clack/core@0.5.0':
-    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
-
-  '@clack/prompts@0.11.0':
-    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -1677,9 +1668,6 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
-  sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
   solid-js@1.9.10:
     resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
 
@@ -1992,17 +1980,6 @@ snapshots:
     dependencies:
       hashery: 1.4.0
       keyv: 5.6.0
-
-  '@clack/core@0.5.0':
-    dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@0.11.0':
-    dependencies:
-      '@clack/core': 0.5.0
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -3199,8 +3176,6 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-
-  sisteransi@1.0.5: {}
 
   solid-js@1.9.10:
     dependencies:


### PR DESCRIPTION
## Summary

- Remove `@clack/prompts` dependency and all interactive wizard/TUI code
- Add global `--json` flag for machine-parseable output on all commands
- Implement `config get/set` subcommands for programmatic config management

## Changes

### Removed
- All `@clack/prompts` imports and usage (cancel, confirm, intro, isCancel, log, multiselect, outro, select, spinner, text)
- `runSetupWizard()` interactive function
- `runGuidedFlow()` interactive function  
- `runTelegramSetup()` interactive parts
- `isInteractive()` checks
- `unwrap()` helper
- All TUI spinners and progress indicators
- `setup` and `doctor` interactive commands

### Added
- Global `--json` flag for JSON output
- `config get [key]` - Get config value(s), supports dot notation (e.g., `channels.whatsapp.dmPolicy`)
- `config set <key> <value>` - Set config value (auto-parses JSON for arrays/objects)
- `health` - Check bridge health, exit 0 if healthy, 1 if not
- `status --json` - Show WhatsApp/Telegram/OpenCode status as JSON
- `whatsapp status --json` - WhatsApp status as JSON
- `whatsapp qr [--format ascii|base64]` - Get QR code non-interactively
- `telegram status --json` - Telegram status as JSON
- `telegram set-token <token>` - Set Telegram bot token
- `pairing list --json` - List pending pairing requests as JSON

### Kept (working as before)
- `start` - Runs the bridge
- `pairing approve/deny` - Manage pairing requests
- `whatsapp login/logout` - WhatsApp auth management
- Legacy aliases (`qr`, `unpair`, `login whatsapp/telegram`, `pairing-code`)

## JSON Output Examples

```json
// owpenbot --json health
{"healthy": true, "opencodeUrl": "http://127.0.0.1:4096", "channels": {"whatsapp": "linked", "telegram": "configured"}}

// owpenbot --json status
{"config": "~/.owpenbot/owpenbot.json", "whatsapp": {"linked": true, "dmPolicy": "pairing"}, "telegram": {"configured": true}, "opencode": {"url": "http://127.0.0.1:4096"}}

// owpenbot --json config get
{"version": 1, "channels": {...}}

// owpenbot --json pairing list
[{"code": "123456", "peerId": "+1234567890", "channel": "whatsapp", "expiresAt": "..."}]
```

## Testing

- `pnpm typecheck` passes
- `pnpm build` passes
- All commands tested with and without `--json` flag
- Commands work without TTY (for sidecar/scheduled job use)