### PR TITLE
feat(owpenbot): add send command and sidecar integration

### DIFF
--- a/packages/desktop/src-tauri/src/commands/mod.rs
+++ b/packages/desktop/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod engine;
 pub mod misc;
 pub mod openwork_server;
 pub mod opkg;
+pub mod owpenbot;
 pub mod skills;
 pub mod updater;
 pub mod workspace;

--- a/packages/desktop/src-tauri/src/commands/owpenbot.rs
+++ b/packages/desktop/src-tauri/src/commands/owpenbot.rs
@@ -1,0 +1,147 @@
+use tauri::{AppHandle, State};
+use tauri_plugin_shell::process::CommandEvent;
+
+use crate::owpenbot::manager::OwpenbotManager;
+use crate::owpenbot::spawn::spawn_owpenbot;
+use crate::types::OwpenbotInfo;
+use crate::utils::truncate_output;
+
+#[tauri::command]
+pub fn owpenbot_info(manager: State<OwpenbotManager>) -> OwpenbotInfo {
+    let mut state = manager.inner.lock().expect("owpenbot mutex poisoned");
+    OwpenbotManager::snapshot_locked(&mut state)
+}
+
+#[tauri::command]
+pub fn owpenbot_start(
+    app: AppHandle,
+    manager: State<OwpenbotManager>,
+    workspace_path: String,
+    opencode_url: Option<String>,
+) -> Result<OwpenbotInfo, String> {
+    let mut state = manager
+        .inner
+        .lock()
+        .map_err(|_| "owpenbot mutex poisoned".to_string())?;
+    OwpenbotManager::stop_locked(&mut state);
+
+    let (mut rx, child) = spawn_owpenbot(&app, &workspace_path, opencode_url.as_deref())?;
+
+    state.child = Some(child);
+    state.child_exited = false;
+    state.workspace_path = Some(workspace_path);
+    state.opencode_url = opencode_url;
+    state.last_stdout = None;
+    state.last_stderr = None;
+
+    let state_handle = manager.inner.clone();
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(line_bytes) => {
+                    let line = String::from_utf8_lossy(&line_bytes).to_string();
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        let next = state
+                            .last_stdout
+                            .as_deref()
+                            .unwrap_or_default()
+                            .to_string()
+                            + &line;
+                        state.last_stdout = Some(truncate_output(&next, 8000));
+
+                        // Check for WhatsApp linked status in output
+                        if line.contains("WhatsApp linked") {
+                            state.whatsapp_linked = true;
+                        }
+                    }
+                }
+                CommandEvent::Stderr(line_bytes) => {
+                    let line = String::from_utf8_lossy(&line_bytes).to_string();
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        let next = state
+                            .last_stderr
+                            .as_deref()
+                            .unwrap_or_default()
+                            .to_string()
+                            + &line;
+                        state.last_stderr = Some(truncate_output(&next, 8000));
+                    }
+                }
+                CommandEvent::Terminated(payload) => {
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        state.child_exited = true;
+                        if let Some(code) = payload.code {
+                            let next = format!("Owpenbot exited (code {code}).");
+                            state.last_stderr = Some(truncate_output(&next, 8000));
+                        }
+                    }
+                }
+                CommandEvent::Error(message) => {
+                    if let Ok(mut state) = state_handle.try_lock() {
+                        state.child_exited = true;
+                        let next = state
+                            .last_stderr
+                            .as_deref()
+                            .unwrap_or_default()
+                            .to_string()
+                            + &message;
+                        state.last_stderr = Some(truncate_output(&next, 8000));
+                    }
+                }
+                _ => {}
+            }
+        }
+    });
+
+    Ok(OwpenbotManager::snapshot_locked(&mut state))
+}
+
+#[tauri::command]
+pub fn owpenbot_stop(manager: State<OwpenbotManager>) -> Result<OwpenbotInfo, String> {
+    let mut state = manager
+        .inner
+        .lock()
+        .map_err(|_| "owpenbot mutex poisoned".to_string())?;
+    OwpenbotManager::stop_locked(&mut state);
+    Ok(OwpenbotManager::snapshot_locked(&mut state))
+}
+
+#[tauri::command]
+pub async fn owpenbot_qr(app: AppHandle) -> Result<String, String> {
+    use tauri_plugin_shell::ShellExt;
+
+    let command = match app.shell().sidecar("owpenbot") {
+        Ok(command) => command,
+        Err(_) => app.shell().command("owpenbot"),
+    };
+
+    let output = command
+        .args(["whatsapp", "qr", "--format", "base64", "--json"])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to get QR code: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Failed to get QR code: {stderr}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Parse JSON response
+    #[derive(serde::Deserialize)]
+    struct QrResponse {
+        qr: Option<String>,
+        error: Option<String>,
+    }
+
+    let response: QrResponse =
+        serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse QR response: {e}"))?;
+
+    if let Some(error) = response.error {
+        return Err(error);
+    }
+
+    response.qr.ok_or_else(|| "No QR code returned".to_string())
+}

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod engine;
 mod fs;
 mod opkg;
 mod openwork_server;
+mod owpenbot;
 mod paths;
 mod platform;
 mod types;
@@ -21,6 +22,7 @@ use commands::engine::{engine_doctor, engine_info, engine_install, engine_start,
 use commands::misc::{opencode_mcp_auth, reset_opencode_cache, reset_openwork_state};
 use commands::openwork_server::openwork_server_info;
 use commands::opkg::{import_skill, opkg_install};
+use commands::owpenbot::{owpenbot_info, owpenbot_qr, owpenbot_start, owpenbot_stop};
 use commands::skills::{install_skill_template, list_local_skills, uninstall_skill};
 use commands::updater::updater_environment;
 use commands::workspace::{
@@ -30,6 +32,7 @@ use commands::workspace::{
 };
 use engine::manager::EngineManager;
 use openwork_server::manager::OpenworkServerManager;
+use owpenbot::manager::OwpenbotManager;
 use workspace::watch::WorkspaceWatchState;
 
 pub fn run() {
@@ -46,6 +49,7 @@ pub fn run() {
     builder
         .manage(EngineManager::default())
         .manage(OpenworkServerManager::default())
+        .manage(OwpenbotManager::default())
         .manage(WorkspaceWatchState::default())
         .invoke_handler(tauri::generate_handler![
             engine_start,
@@ -54,6 +58,10 @@ pub fn run() {
             engine_doctor,
             engine_install,
             openwork_server_info,
+            owpenbot_info,
+            owpenbot_start,
+            owpenbot_stop,
+            owpenbot_qr,
             workspace_bootstrap,
             workspace_set_active,
             workspace_create,

--- a/packages/desktop/src-tauri/src/owpenbot/manager.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/manager.rs
@@ -1,0 +1,62 @@
+use std::sync::{Arc, Mutex};
+
+use tauri_plugin_shell::process::CommandChild;
+
+use crate::types::OwpenbotInfo;
+
+#[derive(Default)]
+pub struct OwpenbotManager {
+    pub inner: Arc<Mutex<OwpenbotState>>,
+}
+
+#[derive(Default)]
+pub struct OwpenbotState {
+    pub child: Option<CommandChild>,
+    pub child_exited: bool,
+    pub workspace_path: Option<String>,
+    pub opencode_url: Option<String>,
+    pub qr_data: Option<String>,
+    pub whatsapp_linked: bool,
+    pub telegram_configured: bool,
+    pub last_stdout: Option<String>,
+    pub last_stderr: Option<String>,
+}
+
+impl OwpenbotManager {
+    pub fn snapshot_locked(state: &mut OwpenbotState) -> OwpenbotInfo {
+        let (running, pid) = match state.child.as_ref() {
+            None => (false, None),
+            Some(_child) if state.child_exited => {
+                state.child = None;
+                (false, None)
+            }
+            Some(child) => (true, Some(child.pid())),
+        };
+
+        OwpenbotInfo {
+            running,
+            workspace_path: state.workspace_path.clone(),
+            opencode_url: state.opencode_url.clone(),
+            qr_data: state.qr_data.clone(),
+            whatsapp_linked: state.whatsapp_linked,
+            telegram_configured: state.telegram_configured,
+            pid,
+            last_stdout: state.last_stdout.clone(),
+            last_stderr: state.last_stderr.clone(),
+        }
+    }
+
+    pub fn stop_locked(state: &mut OwpenbotState) {
+        if let Some(child) = state.child.take() {
+            let _ = child.kill();
+        }
+        state.child_exited = true;
+        state.workspace_path = None;
+        state.opencode_url = None;
+        state.qr_data = None;
+        state.whatsapp_linked = false;
+        state.telegram_configured = false;
+        state.last_stdout = None;
+        state.last_stderr = None;
+    }
+}

--- a/packages/desktop/src-tauri/src/owpenbot/mod.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/mod.rs
@@ -1,0 +1,5 @@
+pub mod manager;
+pub mod spawn;
+
+pub use manager::*;
+pub use spawn::*;

--- a/packages/desktop/src-tauri/src/owpenbot/spawn.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/spawn.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use tauri::AppHandle;
+use tauri::async_runtime::Receiver;
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+
+pub fn build_owpenbot_args(
+    workspace_path: &str,
+    opencode_url: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec!["start".to_string(), workspace_path.to_string()];
+
+    if let Some(url) = opencode_url {
+        if !url.trim().is_empty() {
+            // Set via environment variable instead since CLI doesn't have --opencode-url flag
+            // The bridge will use OPENCODE_URL env var
+        }
+    }
+
+    args
+}
+
+pub fn spawn_owpenbot(
+    app: &AppHandle,
+    workspace_path: &str,
+    opencode_url: Option<&str>,
+) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
+    let command = match app.shell().sidecar("owpenbot") {
+        Ok(command) => command,
+        Err(_) => app.shell().command("owpenbot"),
+    };
+
+    let args = build_owpenbot_args(workspace_path, opencode_url);
+    
+    let mut cmd = command.args(args);
+    
+    // Pass opencode URL via environment if provided
+    if let Some(url) = opencode_url {
+        if !url.trim().is_empty() {
+            cmd = cmd.env("OPENCODE_URL", url);
+        }
+    }
+    
+    // Set the opencode directory
+    cmd = cmd.env("OPENCODE_DIRECTORY", workspace_path);
+    
+    cmd.current_dir(Path::new(workspace_path))
+        .spawn()
+        .map_err(|e| format!("Failed to start owpenbot: {e}"))
+}

--- a/packages/desktop/src-tauri/src/types.rs
+++ b/packages/desktop/src-tauri/src/types.rs
@@ -82,6 +82,20 @@ pub struct OpenworkServerInfo {
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct OwpenbotInfo {
+    pub running: bool,
+    pub workspace_path: Option<String>,
+    pub opencode_url: Option<String>,
+    pub qr_data: Option<String>,
+    pub whatsapp_linked: bool,
+    pub telegram_configured: bool,
+    pub pid: Option<u32>,
+    pub last_stdout: Option<String>,
+    pub last_stderr: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct EngineDoctorResult {
     pub found: bool,
     pub in_path: bool,

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -36,7 +36,8 @@
     ],
     "externalBin": [
       "sidecars/opencode",
-      "sidecars/openwork-server"
+      "sidecars/openwork-server",
+      "sidecars/owpenbot"
     ]
   },
   "plugins": {

--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "dev": "tsx src/cli.ts",
     "build": "tsc -p tsconfig.json",
+    "build:binary": "bun run script/build.ts",
     "start": "node dist/cli.js start",
     "whatsapp:login": "node dist/cli.js whatsapp login",
     "pairing-code": "node dist/cli.js pairing-code",

--- a/packages/owpenbot/script/build.ts
+++ b/packages/owpenbot/script/build.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const bunRuntime = (globalThis as typeof globalThis & {
+  Bun?: {
+    build?: (...args: any[]) => Promise<any>;
+    argv?: string[];
+  };
+}).Bun;
+
+if (!bunRuntime?.build || !bunRuntime.argv) {
+  console.error("This script must be run with Bun.");
+  process.exit(1);
+}
+
+const bun = bunRuntime as { build: (...args: any[]) => Promise<any>; argv: string[] };
+
+type BuildOptions = {
+  targets: string[];
+  outdir: string;
+  filename: string;
+};
+
+function readArgs(argv: string[]): BuildOptions {
+  const options: BuildOptions = {
+    targets: [],
+    outdir: resolve("dist", "bin"),
+    filename: "owpenbot",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (!value) continue;
+
+    if (value === "--target") {
+      const next = argv[index + 1];
+      if (next) {
+        options.targets.push(next);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (value.startsWith("--target=")) {
+      const next = value.slice("--target=".length).trim();
+      if (next) options.targets.push(next);
+      continue;
+    }
+
+    if (value === "--outdir") {
+      const next = argv[index + 1];
+      if (next) {
+        options.outdir = resolve(next);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (value.startsWith("--outdir=")) {
+      const next = value.slice("--outdir=".length).trim();
+      if (next) options.outdir = resolve(next);
+      continue;
+    }
+
+    if (value === "--filename") {
+      const next = argv[index + 1];
+      if (next) {
+        options.filename = next;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (value.startsWith("--filename=")) {
+      const next = value.slice("--filename=".length).trim();
+      if (next) options.filename = next;
+    }
+  }
+
+  return options;
+}
+
+function outputName(filename: string, target?: string) {
+  const needsExe = target ? target.includes("windows") : process.platform === "win32";
+  const suffix = target ? `-${target}` : "";
+  const ext = needsExe ? ".exe" : "";
+  return `${filename}${suffix}${ext}`;
+}
+
+async function buildOnce(entrypoint: string, outdir: string, filename: string, target?: string) {
+  mkdirSync(outdir, { recursive: true });
+  const outfile = join(outdir, outputName(filename, target));
+
+  const args = ["build", entrypoint, "--compile", "--outfile", outfile];
+  if (target) {
+    args.push("--target", target);
+  }
+
+  const result = spawnSync("bun", args, { stdio: "inherit" });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const options = readArgs(bun.argv.slice(2));
+const entrypoint = resolve("src", "cli.ts");
+const targets = options.targets.length ? options.targets : [undefined];
+
+for (const target of targets) {
+  await buildOnce(entrypoint, options.outdir, options.filename, target);
+}


### PR DESCRIPTION
## Summary

- Add `send` command for testing message delivery to WhatsApp/Telegram
- Create sidecar build infrastructure for owpenbot binary
- Integrate owpenbot with Tauri desktop app

## Changes

### Part 1: `send` Command
Added `send` command to CLI for testing message delivery:
```bash
owpenbot send --channel whatsapp --to "+1234567890" --message "Hello"
owpenbot send --channel telegram --to "12345678" --message "Hello"
```

### Part 2: Sidecar Build Script
- Created `packages/owpenbot/script/build.ts` following the pattern from server
- Added `build:binary` script to package.json

### Part 3: Desktop Sidecar Preparation
- Updated `prepare-sidecar.mjs` to compile owpenbot alongside openwork-server
- Copies to `sidecars/owpenbot-{target-triple}`

### Part 4: Tauri Config
- Added owpenbot to `externalBin` in tauri.conf.json

### Part 5: Tauri Owpenbot Module
- Created `src/owpenbot/` module with manager.rs, spawn.rs, mod.rs
- Added Tauri commands: `owpenbot_start`, `owpenbot_stop`, `owpenbot_info`, `owpenbot_qr`
- Registered OwpenbotManager and commands in lib.rs