### PR TITLE
fix(owpenbot): repair settings and devtools wiring

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -123,7 +123,9 @@ import {
   readOpencodeConfig,
   writeOpencodeConfig,
   openworkServerInfo,
+  owpenbotInfo,
   type OpenworkServerInfo,
+  type OwpenbotInfo,
 } from "./lib/tauri";
 import {
   createOpenworkServerClient,
@@ -229,6 +231,7 @@ export default function App() {
   const [openworkServerCheckedAt, setOpenworkServerCheckedAt] = createSignal<number | null>(null);
   const [openworkServerWorkspaceId, setOpenworkServerWorkspaceId] = createSignal<string | null>(null);
   const [openworkServerHostInfo, setOpenworkServerHostInfo] = createSignal<OpenworkServerInfo | null>(null);
+  const [owpenbotInfoState, setOwpenbotInfoState] = createSignal<OwpenbotInfo | null>(null);
   const [openworkAuditEntries, setOpenworkAuditEntries] = createSignal<OpenworkAuditEntry[]>([]);
   const [openworkAuditStatus, setOpenworkAuditStatus] = createSignal<"idle" | "loading" | "error">("idle");
   const [openworkAuditError, setOpenworkAuditError] = createSignal<string | null>(null);
@@ -406,6 +409,32 @@ export default function App() {
         if (active) setOpenworkServerHostInfo(info);
       } catch {
         if (active) setOpenworkServerHostInfo(null);
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 10_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
+  createEffect(() => {
+    if (!isTauriRuntime()) return;
+    if (!developerMode()) {
+      setOwpenbotInfoState(null);
+      return;
+    }
+
+    let active = true;
+
+    const run = async () => {
+      try {
+        const info = await owpenbotInfo();
+        if (active) setOwpenbotInfoState(info);
+      } catch {
+        if (active) setOwpenbotInfoState(null);
       }
     };
 
@@ -3375,6 +3404,7 @@ export default function App() {
     openworkAuditStatus: openworkAuditStatus(),
     openworkAuditError: openworkAuditError(),
     engineInfo: workspaceStore.engine(),
+    owpenbotInfo: owpenbotInfoState(),
     updateOpenworkServerSettings,
     resetOpenworkServerSettings,
     testOpenworkServerConnection,

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -11,7 +11,7 @@ import type {
 import type { McpDirectoryInfo } from "../constants";
 import { formatRelativeTime, normalizeDirectoryPath } from "../utils";
 import type { OpenworkAuditEntry, OpenworkServerCapabilities, OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
-import type { EngineInfo, OpenworkServerInfo, WorkspaceInfo } from "../lib/tauri";
+import type { EngineInfo, OpenworkServerInfo, OwpenbotInfo, WorkspaceInfo } from "../lib/tauri";
 
 import Button from "../components/button";
 import OpenWorkLogo from "../components/openwork-logo";
@@ -57,6 +57,7 @@ export type DashboardViewProps = {
   openworkAuditStatus: "idle" | "loading" | "error";
   openworkAuditError: string | null;
   engineInfo: EngineInfo | null;
+  owpenbotInfo: OwpenbotInfo | null;
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
   resetOpenworkServerSettings: () => void;
   testOpenworkServerConnection: (next: OpenworkServerSettings) => Promise<boolean>;
@@ -875,6 +876,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   openworkAuditStatus={props.openworkAuditStatus}
                   openworkAuditError={props.openworkAuditError}
                   engineInfo={props.engineInfo}
+                  owpenbotInfo={props.owpenbotInfo}
                   updateOpenworkServerSettings={props.updateOpenworkServerSettings}
                   resetOpenworkServerSettings={props.resetOpenworkServerSettings}
                   testOpenworkServerConnection={props.testOpenworkServerConnection}

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -337,6 +337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,7 +1672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1775,6 +1781,19 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.0",
 ]
 
 [[package]]
@@ -2220,6 +2239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,7 +2263,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2609,10 +2638,13 @@ dependencies = [
 name = "openwork"
 version = "0.6.2"
 dependencies = [
+ "base64 0.22.1",
  "gethostname",
+ "image",
  "json5",
  "local-ip-address",
  "notify",
+ "qrcode",
  "serde",
  "serde_json",
  "tauri",
@@ -2990,6 +3022,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,6 +3144,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+dependencies = [
+ "image",
 ]
 
 [[package]]
@@ -4212,7 +4275,7 @@ dependencies = [
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -4830,7 +4893,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -13,6 +13,9 @@ json5 = "0.4"
 notify = "6.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"
+image = { version = "0.25", default-features = false, features = ["png"] }
+qrcode = { version = "0.14", default-features = false, features = ["image"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2.5.3"

--- a/packages/desktop/src-tauri/src/owpenbot/mod.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/mod.rs
@@ -1,5 +1,2 @@
 pub mod manager;
 pub mod spawn;
-
-pub use manager::*;
-pub use spawn::*;

--- a/packages/desktop/src-tauri/src/owpenbot/spawn.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/spawn.rs
@@ -9,7 +9,7 @@ pub fn build_owpenbot_args(
     workspace_path: &str,
     opencode_url: Option<&str>,
 ) -> Vec<String> {
-    let mut args = vec!["start".to_string(), workspace_path.to_string()];
+    let args = vec!["start".to_string(), workspace_path.to_string()];
 
     if let Some(url) = opencode_url {
         if !url.trim().is_empty() {


### PR DESCRIPTION
## Summary
- align owpenbot settings with CLI config keys, pairing output, and status reads
- render QR codes as PNGs in Tauri so the settings preview works
- add an Owpenbot sidecar card to the Developer devtools panel with status + logs

## Testing
- cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml
- pnpm install
- pnpm typecheck