### PR TITLE
feat(owpenbot): Add file attachment support via FILE: protocol in WhatsApp

### DIFF
--- a/packages/owpenbot/src/whatsapp.ts
+++ b/packages/owpenbot/src/whatsapp.ts
@@ -254,9 +254,14 @@ export function createWhatsAppAdapter(
         recordSentMessage(sent?.key?.id);
       } catch (err: unknown) {
         log.error({ error: err, filePath }, "failed to send file");
+        let errorMessage: string;
+        if (err instanceof Error) {
+          errorMessage = err.message || "Unknown error";
+        } else {
+          errorMessage = err != null ? String(err) : "Unknown error";
+        }
         const sent = await socket.sendMessage(peerId, {
-            // @ts-ignore - TS doesn't know about error.message on unknown
-          text: `⚠️ Error sending file: ${err?.message || "Unknown error"}`,
+          text: `⚠️ Error sending file: ${errorMessage}`,
         });
         recordSentMessage(sent?.key?.id);
       }

--- a/packages/owpenbot/src/whatsapp.ts
+++ b/packages/owpenbot/src/whatsapp.ts
@@ -229,7 +229,7 @@ export function createWhatsAppAdapter(
       try {
         if (!fs.existsSync(filePath)) {
           const sent = await socket.sendMessage(peerId, {
-            text: `⚠️ Error: File not found at ${filePath}`,
+            text: "⚠️ Error: File not found.",
           });
           recordSentMessage(sent?.key?.id);
           return;

--- a/packages/owpenbot/src/whatsapp.ts
+++ b/packages/owpenbot/src/whatsapp.ts
@@ -228,9 +228,10 @@ export function createWhatsAppAdapter(
 
       try {
         if (!fs.existsSync(filePath)) {
-          await socket.sendMessage(peerId, {
+          const sent = await socket.sendMessage(peerId, {
             text: `⚠️ Error: File not found at ${filePath}`,
           });
+          recordSentMessage(sent?.key?.id);
           return;
         }
 
@@ -253,10 +254,11 @@ export function createWhatsAppAdapter(
         recordSentMessage(sent?.key?.id);
       } catch (err: unknown) {
         log.error({ error: err, filePath }, "failed to send file");
-        await socket.sendMessage(peerId, {
+        const sent = await socket.sendMessage(peerId, {
             // @ts-ignore - TS doesn't know about error.message on unknown
           text: `⚠️ Error sending file: ${err?.message || "Unknown error"}`,
         });
+        recordSentMessage(sent?.key?.id);
       }
     },
     async sendTyping(peerId: string) {

--- a/packages/owpenbot/src/whatsapp.ts
+++ b/packages/owpenbot/src/whatsapp.ts
@@ -30,6 +30,7 @@ export type WhatsAppAdapter = {
   start(): Promise<void>;
   stop(): Promise<void>;
   sendText(peerId: string, text: string): Promise<void>;
+  sendFile(peerId: string, filePath: string, caption?: string): Promise<void>;
   sendTyping(peerId: string): Promise<void>;
 };
 
@@ -217,6 +218,46 @@ export function createWhatsAppAdapter(
       if (!socket) throw new Error("WhatsApp socket not initialized");
       const sent = await socket.sendMessage(peerId, { text });
       recordSentMessage(sent?.key?.id);
+    },
+    async sendFile(peerId: string, filePath: string, caption = "") {
+      if (!socket) throw new Error("WhatsApp socket not initialized");
+
+      const ext = path.extname(filePath).toLowerCase();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let msgContent: any = {};
+
+      try {
+        if (!fs.existsSync(filePath)) {
+          await socket.sendMessage(peerId, {
+            text: `⚠️ Error: File not found at ${filePath}`,
+          });
+          return;
+        }
+
+        if ([".jpg", ".jpeg", ".png", ".gif"].includes(ext)) {
+          msgContent = { image: { url: filePath }, caption: caption };
+        } else {
+          let mimetype = "application/octet-stream";
+          if (ext === ".pdf") mimetype = "application/pdf";
+          if (ext === ".txt") mimetype = "text/plain";
+
+          msgContent = {
+            document: { url: filePath },
+            mimetype: mimetype,
+            fileName: path.basename(filePath),
+            caption: caption,
+          };
+        }
+
+        const sent = await socket.sendMessage(peerId, msgContent);
+        recordSentMessage(sent?.key?.id);
+      } catch (err: unknown) {
+        log.error({ error: err, filePath }, "failed to send file");
+        await socket.sendMessage(peerId, {
+            // @ts-ignore - TS doesn't know about error.message on unknown
+          text: `⚠️ Error sending file: ${err?.message || "Unknown error"}`,
+        });
+      }
     },
     async sendTyping(peerId: string) {
       if (!socket) return;


### PR DESCRIPTION
## Description
This PR introduces the ability for Owpenbot to send local files (PDFs, images, text) directly to WhatsApp chats. Currently, the bot can only send plain text, limiting capabilities like sharing generated CVs or reports.

### Changes implemented:

- **WhatsApp Adapter (`whatsapp.ts`)**: 
  - Added a `sendFile` method to the adapter interface.
  - Implemented logic to detect file extensions (PDF, JPG, PNG, TXT) and send the appropriate Baileys message type (`image` or `document`).
  - Added error handling for missing files.

- **Bridge Logic (`bridge.ts`)**: 
  - Modified the `sendText` function to intercept outbound messages.
  - Implemented a check for the `FILE:` prefix.
  - **Behavior**: If the LLM response starts with `FILE: /path/to/file`, the bridge extracts the file path and invokes `adapter.sendFile()` instead of sending the raw text string.

### How to test:
1. Run the bot using this branch.
2. Instruct the agent to generate a file (e.g., *"Create a text file named hello.txt"*).
3. Ensure the agent or the system prompt outputs the path with the prefix, e.g., `FILE: /app/hello.txt`.
4. Verify that the file is received as a genuine attachment in the WhatsApp chat.

### Why this matters:
This feature is critical for "worker" agents (like CV editors or researchers) that produce deliverables. It allows users to receive their work products directly in the chat interface without needing to access the server filesystem.
