### PR TITLE
Persist reload toast with change details

### DIFF
--- a/packages/app/pr/reload-toast-persist.md
+++ b/packages/app/pr/reload-toast-persist.md
@@ -1,0 +1,157 @@
+# Reload Toast: Persist + Show What Changed
+
+**Branch:** `feat/reload-toast-persist`
+**Priority:** P0
+
+---
+
+## Problems
+
+1. Toast disappears before user can click
+2. Toast is vague - just says "Reload required" without specifics
+
+---
+
+## Current Code
+
+**File:** `packages/app/src/app/app.tsx` L1799-1834
+
+```tsx
+const [reloadToastDismissedAt, setReloadToastDismissedAt] = createSignal<number | null>(null);
+
+const reloadToastVisible = createMemo(() => {
+  if (!reloadRequired()) return false;  // <-- Hides when reload not required
+  const lastTriggeredAt = reloadLastTriggeredAt();
+  const dismissedAt = reloadToastDismissedAt();
+  if (!lastTriggeredAt) return true;
+  if (!dismissedAt) return true;
+  return dismissedAt < lastTriggeredAt;
+});
+```
+
+### Code findings
+- Reload state + reasons live in `packages/app/src/app/system-state.ts:40-45` (`reloadRequired`, `reloadReasons`, `reloadLastTriggeredAt`)
+- `markReloadRequired(reason)` only stores the reason string: `packages/app/src/app/system-state.ts:135-139`
+- `ReloadReason` is a fixed union: `packages/app/src/app/types.ts:202` (`"plugins" | "skills" | "mcp" | "config"`)
+- Tauri watcher emits `openwork://reload-required` with `{ reason, path }`: `packages/desktop/src-tauri/src/workspace/watch.rs:99-124`
+- UI listener drops `path` and only maps `reason`: `packages/app/src/app/app.tsx:1870-1902`
+- Explicit triggers:
+  - Skills/plugins: `packages/app/src/app/context/extensions.ts:526,549,588,669,750`
+  - MCP: `packages/app/src/app/app.tsx:2557`
+  - Config/model change: `packages/app/src/app/app.tsx:3020,3034`
+  - Tool-driven file writes: `packages/app/src/app/context/session.ts:141-193`
+
+---
+
+## Changes Required
+
+### 1. Investigate why toast disappears
+
+Add logging to track state changes:
+```tsx
+createEffect(() => {
+  console.log('[ReloadToast] reloadRequired:', reloadRequired());
+  console.log('[ReloadToast] lastTriggeredAt:', reloadLastTriggeredAt());
+  console.log('[ReloadToast] dismissedAt:', reloadToastDismissedAt());
+});
+```
+
+Possible causes:
+- `reloadRequired()` becomes false prematurely (auto-reload?)
+- Page navigation clears state
+- Effect at L1830-1834 clears state
+
+**Other auto-clear sites:**
+- `clearReloadRequired()` in `packages/app/src/app/system-state.ts:141-145`
+- Successful reload clears state in `packages/app/src/app/system-state.ts:281-282`
+- Workspace change clears reload state in `packages/app/src/app/app.tsx:1928-1933`
+
+### 2. Track what triggered the reload
+
+**Update `markReloadRequired` to accept details:**
+
+```tsx
+type ReloadTrigger = {
+  type: "skill" | "plugin" | "config" | "mcp";
+  name?: string;
+};
+
+const [reloadTrigger, setReloadTrigger] = createSignal<ReloadTrigger | null>(null);
+
+const markReloadRequired = (reason: ReloadReason, trigger?: ReloadTrigger) => {
+  markReloadRequiredRaw(reason);
+  if (trigger) {
+    setReloadTrigger(trigger);
+  }
+};
+```
+
+**Note:** There is already a `path` in the Tauri event payload (`workspace/watch.rs:119-121`). We can parse it to a name (skill/plugin) and pass it as `trigger.name`.
+
+### 3. Update toast to show specific change
+
+**File:** `packages/app/src/app/components/reload-workspace-toast.tsx`
+
+Add `trigger` prop:
+```tsx
+export type ReloadWorkspaceToastProps = {
+  // ... existing props
+  trigger?: { type: string; name?: string } | null;
+};
+```
+
+Update description display:
+```tsx
+const getDescription = () => {
+  if (!props.trigger) return props.description;
+  const { type, name } = props.trigger;
+  switch (type) {
+    case "skill":
+      return `Skill '${name}' was added. Reload to use it.`;
+    case "plugin":
+      return `Plugin '${name}' was added. Reload to activate.`;
+    case "mcp":
+      return `MCP '${name}' was added. Reload to connect.`;
+    default:
+      return "Config changed. Reload to apply.";
+  }
+};
+```
+
+### 4. Update callers to pass trigger info
+
+Find all places that call `markReloadRequired` and add trigger details:
+- When skill is created: `markReloadRequired("skills", { type: "skill", name: skillName })`
+- When plugin is added: `markReloadRequired("plugins", { type: "plugin", name: pluginName })`
+- When MCP is added: `markReloadRequired("mcp", { type: "mcp", name: mcpName })`
+
+**Concrete hook points:**
+- Skills: `packages/app/src/app/context/extensions.ts:588,669,750`
+- Plugins: `packages/app/src/app/context/extensions.ts:526,549`
+- MCP: `packages/app/src/app/app.tsx:2557`
+- Config/model changes: `packages/app/src/app/app.tsx:3020,3034`
+- File watcher: `packages/app/src/app/app.tsx:1870-1902` (parse `event.payload.path`)
+
+---
+
+## Toast behavior rules
+
+Toast should ONLY hide when:
+1. User clicks "Dismiss"
+2. User clicks "Reload" AND reload completes successfully
+
+Toast should NOT auto-hide on:
+- Timeout
+- Navigation
+- Any automatic state change
+
+---
+
+## Testing
+
+1. Create a skill → verify toast shows "Skill 'X' was added"
+2. Add a plugin → verify toast shows "Plugin 'X' was added"
+3. Change config → verify toast shows "Config changed"
+4. Wait 30 seconds → verify toast still visible
+5. Click Dismiss → verify toast hides
+6. Trigger again → verify toast reappears

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -61,6 +61,7 @@ import type {
   OnboardingStep,
   PluginScope,
   ReloadReason,
+  ReloadTrigger,
   ResetOpenworkMode,
   SettingsTab,
   SkillCard,
@@ -462,7 +463,7 @@ export default function App() {
   const mountTime = Date.now();
   const [lastKnownConfigSnapshot, setLastKnownConfigSnapshot] = createSignal("");
   const [developerMode, setDeveloperMode] = createSignal(false);
-  let markReloadRequiredRef: (reason: ReloadReason) => void = () => {};
+  let markReloadRequiredRef: (reason: ReloadReason, trigger?: ReloadTrigger) => void = () => {};
   let setReloadLastFinishedAtRef: (value: number) => void = () => {};
 
   const [selectedSessionId, setSelectedSessionId] = createSignal<string | null>(
@@ -505,7 +506,7 @@ export default function App() {
     developerMode,
     setError,
     setSseConnected,
-    markReloadRequired: (reason) => markReloadRequiredRef(reason),
+    markReloadRequired: (reason, trigger) => markReloadRequiredRef(reason, trigger),
   });
 
   const {
@@ -912,7 +913,7 @@ export default function App() {
     setBusyLabel,
     setBusyStartedAt,
     setError,
-    markReloadRequired: (reason) => markReloadRequiredRef(reason),
+    markReloadRequired: (reason, trigger) => markReloadRequiredRef(reason, trigger),
     onNotionSkillInstalled: () => {
       setNotionSkillInstalled(true);
       try {
@@ -1775,6 +1776,7 @@ export default function App() {
     reloadLastTriggeredAt,
     reloadLastFinishedAt,
     setReloadLastFinishedAt,
+    reloadTrigger,
     reloadBusy,
     reloadError,
     canReloadEngine,
@@ -1807,7 +1809,10 @@ export default function App() {
     anyActiveRuns,
   } = systemState;
 
-  const markReloadRequired = (reason: ReloadReason, options?: { force?: boolean }) => {
+  const markReloadRequired = (
+    reason: ReloadReason,
+    options?: { force?: boolean; trigger?: ReloadTrigger },
+  ) => {
     if (booting() || reloadBusy()) return;
     if (!options?.force) {
       const label = busyLabel();
@@ -1824,7 +1829,46 @@ export default function App() {
       const lastFinishedAt = reloadLastFinishedAt();
       if (lastFinishedAt && now - lastFinishedAt < 2000) return;
     }
-    markReloadRequiredRaw(reason);
+    markReloadRequiredRaw(reason, options?.trigger);
+  };
+
+  const extractReloadTriggerFromPath = (reason: ReloadReason, rawPath?: string): ReloadTrigger | null => {
+    if (!rawPath) return null;
+    const normalized = rawPath.replace(/\\/g, "/");
+    const fileName = normalized.split("/").filter(Boolean).pop();
+
+    if (reason === "skills") {
+      const match = normalized.match(/\/\.opencode\/(?:skill|skills)\/([^/]+)/i);
+      return {
+        type: "skill",
+        name: match?.[1],
+        action: "updated",
+        path: rawPath,
+      };
+    }
+
+    if (reason === "plugins") {
+      return {
+        type: "plugin",
+        action: "updated",
+        path: rawPath,
+      };
+    }
+
+    if (reason === "mcp") {
+      return {
+        type: "mcp",
+        action: "updated",
+        path: rawPath,
+      };
+    }
+
+    return {
+      type: "config",
+      name: fileName,
+      action: "updated",
+      path: rawPath,
+    };
   };
 
   const [reloadToastDismissedAt, setReloadToastDismissedAt] = createSignal<number | null>(null);
@@ -1836,6 +1880,14 @@ export default function App() {
     if (!lastTriggeredAt) return true;
     if (!dismissedAt) return true;
     return dismissedAt < lastTriggeredAt;
+  });
+
+  createEffect(() => {
+    if (!developerMode()) return;
+    console.log("[ReloadToast] reloadRequired:", reloadRequired());
+    console.log("[ReloadToast] lastTriggeredAt:", reloadLastTriggeredAt());
+    console.log("[ReloadToast] dismissedAt:", reloadToastDismissedAt());
+    console.log("[ReloadToast] trigger:", reloadTrigger());
   });
 
   const reloadWarning = createMemo(() =>
@@ -1867,39 +1919,49 @@ export default function App() {
   onMount(() => {
     if (!isTauriRuntime()) return;
     let unlisten: (() => void) | null = null;
-    void listen("openwork://reload-required", async (event: TauriEvent<{ reason?: string }>) => {
-      const rawReason = event.payload?.reason;
-      const reason: ReloadReason =
-        rawReason === "plugins" ||
-        rawReason === "skills" ||
-        rawReason === "config" ||
-        rawReason === "mcp"
-          ? rawReason
-          : "config";
+    void listen(
+      "openwork://reload-required",
+      async (event: TauriEvent<{ reason?: string; path?: string }>) => {
+        const rawReason = event.payload?.reason;
+        const reason: ReloadReason =
+          rawReason === "plugins" ||
+          rawReason === "skills" ||
+          rawReason === "config" ||
+          rawReason === "mcp"
+            ? rawReason
+            : "config";
 
-      if (reason === "config") {
-        const root = workspaceStore.activeWorkspacePath().trim();
-        if (root) {
-          try {
-            const configFile = await readOpencodeConfig("project", root);
-            const nextSnapshot = getConfigSnapshot(configFile.content);
-            if (nextSnapshot === untrack(lastKnownConfigSnapshot)) {
-              // Only model (or nothing) changed. Update UI but skip reload toast.
-              const nextModel = parseDefaultModelFromConfig(configFile.content);
-              if (nextModel && !modelEquals(untrack(defaultModel), nextModel)) {
-                setDefaultModel(nextModel);
+        if (reason === "config") {
+          const root = workspaceStore.activeWorkspacePath().trim();
+          if (root) {
+            try {
+              const configFile = await readOpencodeConfig("project", root);
+              const nextSnapshot = getConfigSnapshot(configFile.content);
+              if (nextSnapshot === untrack(lastKnownConfigSnapshot)) {
+                // Only model (or nothing) changed. Update UI but skip reload toast.
+                const nextModel = parseDefaultModelFromConfig(configFile.content);
+                if (nextModel && !modelEquals(untrack(defaultModel), nextModel)) {
+                  setDefaultModel(nextModel);
+                }
+                return;
               }
-              return;
+              setLastKnownConfigSnapshot(nextSnapshot);
+            } catch {
+              // If we can't read/parse, fall back to showing the toast
             }
-            setLastKnownConfigSnapshot(nextSnapshot);
-          } catch {
-            // If we can't read/parse, fall back to showing the toast
           }
         }
-      }
 
-      markReloadRequired(reason, { force: false });
-    })
+        const trigger =
+          extractReloadTriggerFromPath(reason, event.payload?.path) ??
+          {
+            type: reason === "plugins" ? "plugin" : reason === "skills" ? "skill" : reason,
+            action: "updated",
+          };
+
+        markReloadRequired(reason, { force: false, trigger });
+      },
+    )
       .then((stop) => {
         unlisten = stop;
       })
@@ -1910,7 +1972,7 @@ export default function App() {
     });
   });
 
-  markReloadRequiredRef = (reason) => markReloadRequired(reason, { force: true });
+  markReloadRequiredRef = (reason, trigger) => markReloadRequired(reason, { force: true, trigger });
   setReloadLastFinishedAtRef = (value) => setReloadLastFinishedAt(value);
 
   const {
@@ -1929,7 +1991,6 @@ export default function App() {
     if (!isTauriRuntime()) return;
     workspaceStore.activeWorkspaceId();
     workspaceProjectDir();
-    clearReloadRequired();
     void refreshMcpServers();
   });
 
@@ -2243,7 +2304,7 @@ export default function App() {
         }
       }
 
-      markReloadRequired("mcp");
+      markReloadRequired("mcp", { trigger: { type: "mcp", name: "notion", action: "added" } });
       setNotionStatusDetail(t("settings.reload_required", currentLocale()));
       try {
         window.localStorage.setItem("openwork.notionStatus", "connecting");
@@ -2554,7 +2615,7 @@ export default function App() {
         setMcpStatus(t("mcp.reload_required_after_add", currentLocale()));
       }
 
-      markReloadRequired("mcp");
+      markReloadRequired("mcp", { trigger: { type: "mcp", name: slug, action: "added" } });
       console.log("[connectMcp] ✓ marked reload required, refreshing servers");
 
       await refreshMcpServers();
@@ -2832,7 +2893,7 @@ export default function App() {
         }
 
         if (storedNotionStatus === "connecting") {
-          markReloadRequired("mcp");
+          markReloadRequired("mcp", { trigger: { type: "mcp", name: "notion", action: "added" } });
         }
 
         await refreshMcpServers();
@@ -3017,7 +3078,9 @@ export default function App() {
           await openworkClient.patchConfig(openworkWorkspaceId, {
             opencode: { model: formatModelRef(nextModel) },
           });
-          markReloadRequired("config");
+          markReloadRequired("config", {
+            trigger: { type: "config", name: "opencode.json", action: "updated" },
+          });
           return;
         }
 
@@ -3031,7 +3094,9 @@ export default function App() {
           throw new Error(result.stderr || result.stdout || "Failed to update opencode.json");
         }
         setLastKnownConfigSnapshot(getConfigSnapshot(content));
-        markReloadRequired("config");
+        markReloadRequired("config", {
+          trigger: { type: "config", name: "opencode.json", action: "updated" },
+        });
       } catch (error) {
         if (cancelled) return;
         const message = error instanceof Error ? error.message : safeStringify(error);
@@ -3874,6 +3939,7 @@ export default function App() {
         open={reloadToastVisible()}
         title={t("reload.toast_title", currentLocale())}
         description={t("reload.toast_description", currentLocale())}
+        trigger={reloadTrigger()}
         warning={reloadWarning()}
         blockedReason={reloadBlockedReason()}
         error={reloadError()}

--- a/packages/app/src/app/components/reload-workspace-toast.tsx
+++ b/packages/app/src/app/components/reload-workspace-toast.tsx
@@ -2,11 +2,13 @@ import { Show } from "solid-js";
 import { AlertTriangle, RefreshCcw, X } from "lucide-solid";
 
 import Button from "./button";
+import type { ReloadTrigger } from "../types";
 
 export type ReloadWorkspaceToastProps = {
   open: boolean;
   title: string;
   description: string;
+  trigger?: ReloadTrigger | null;
   warning?: string;
   blockedReason?: string | null;
   error?: string | null;
@@ -20,6 +22,40 @@ export type ReloadWorkspaceToastProps = {
 };
 
 export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
+  const getDescription = () => {
+    if (!props.trigger) return props.description;
+    const { type, name, action } = props.trigger;
+    const trimmedName = name?.trim();
+    const verb =
+      action === "removed"
+        ? "was removed"
+        : action === "added"
+        ? "was added"
+        : action === "updated"
+        ? "was updated"
+        : "changed";
+
+    if (type === "skill") {
+      return trimmedName
+        ? `Skill '${trimmedName}' ${verb}. Reload to use it.`
+        : "Skills changed. Reload to apply.";
+    }
+
+    if (type === "plugin") {
+      return trimmedName
+        ? `Plugin '${trimmedName}' ${verb}. Reload to activate.`
+        : "Plugins changed. Reload to apply.";
+    }
+
+    if (type === "mcp") {
+      return trimmedName
+        ? `MCP '${trimmedName}' ${verb}. Reload to connect.`
+        : "MCP config changed. Reload to apply.";
+    }
+
+    return "Config changed. Reload to apply.";
+  };
+
   return (
     <Show when={props.open}>
       <div class="fixed top-6 left-1/2 -translate-x-1/2 z-50 w-[min(480px,calc(100vw-2rem))]">
@@ -57,7 +93,7 @@ export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
                   ? <span class="text-amber-11 font-medium">Reloading will stop active tasks.</span>
                   : props.error 
                   ? <span class="text-red-9 font-medium">{props.error}</span>
-                  : props.description
+                  : getDescription()
                 }
               </div>
             </Show>

--- a/packages/app/src/app/context/extensions.ts
+++ b/packages/app/src/app/context/extensions.ts
@@ -4,7 +4,7 @@ import { applyEdits, modify } from "jsonc-parser";
 import { join } from "@tauri-apps/api/path";
 import { currentLocale, t } from "../../i18n";
 
-import type { Client, Mode, PluginScope, ReloadReason, SkillCard } from "../types";
+import type { Client, Mode, PluginScope, ReloadReason, ReloadTrigger, SkillCard } from "../types";
 import { addOpencodeCacheHint, isTauriRuntime } from "../utils";
 import skillCreatorTemplate from "../data/skill-creator.md?raw";
 import {
@@ -45,7 +45,7 @@ export function createExtensionsStore(options: {
   setBusyLabel: (value: string | null) => void;
   setBusyStartedAt: (value: number | null) => void;
   setError: (value: string | null) => void;
-  markReloadRequired: (reason: ReloadReason) => void;
+  markReloadRequired: (reason: ReloadReason, trigger?: ReloadTrigger) => void;
   onNotionSkillInstalled?: () => void;
 }) {
   // Translation helper that uses current language from i18n
@@ -442,6 +442,7 @@ export function createExtensionsStore(options: {
   async function addPlugin(pluginNameOverride?: string) {
     const pluginName = (pluginNameOverride ?? pluginInput()).trim();
     const isManualInput = pluginNameOverride == null;
+    const triggerName = stripPluginVersion(pluginName);
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isHostMode = options.mode() === "host";
@@ -523,7 +524,7 @@ export function createExtensionsStore(options: {
           plugin: [pluginName],
         };
         await writeOpencodeConfig(scope, targetDir, `${JSON.stringify(payload, null, 2)}\n`);
-        options.markReloadRequired("plugins");
+        options.markReloadRequired("plugins", { type: "plugin", name: triggerName, action: "added" });
         if (isManualInput) {
           setPluginInput("");
         }
@@ -546,7 +547,7 @@ export function createExtensionsStore(options: {
       const updated = applyEdits(raw, edits);
 
       await writeOpencodeConfig(scope, targetDir, updated);
-      options.markReloadRequired("plugins");
+      options.markReloadRequired("plugins", { type: "plugin", name: triggerName, action: "added" });
       if (isManualInput) {
         setPluginInput("");
       }
@@ -580,12 +581,17 @@ export function createExtensionsStore(options: {
         return;
       }
 
+      const inferredName = sourceDir.split(/[\\/]/).filter(Boolean).pop();
       const result = await importSkill(targetDir, sourceDir, { overwrite: false });
       if (!result.ok) {
         setSkillsStatus(result.stderr || result.stdout || translate("skills.import_failed").replace("{status}", String(result.status)));
       } else {
         setSkillsStatus(result.stdout || translate("skills.imported"));
-        options.markReloadRequired("skills");
+        options.markReloadRequired("skills", {
+          type: "skill",
+          name: inferredName,
+          action: "added",
+        });
       }
 
       await refreshSkills({ force: true });
@@ -666,7 +672,7 @@ export function createExtensionsStore(options: {
         setSkillsStatus(result.stderr || result.stdout || translate("skills.install_failed"));
       } else {
         setSkillsStatus(result.stdout || translate("skills.skill_creator_installed"));
-        options.markReloadRequired("skills");
+        options.markReloadRequired("skills", { type: "skill", name: "skill-creator", action: "added" });
       }
 
       await refreshSkills({ force: true });
@@ -747,7 +753,7 @@ export function createExtensionsStore(options: {
         setSkillsStatus(result.stderr || result.stdout || translate("skills.uninstall_failed"));
       } else {
         setSkillsStatus(result.stdout || translate("skills.uninstalled"));
-        options.markReloadRequired("skills");
+        options.markReloadRequired("skills", { type: "skill", name: trimmed, action: "removed" });
       }
 
       await refreshSkills({ force: true });

--- a/packages/app/src/app/system-state.ts
+++ b/packages/app/src/app/system-state.ts
@@ -6,7 +6,15 @@ import type { ProviderListItem } from "./types";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 
-import type { Client, Mode, PluginScope, ReloadReason, ResetOpenworkMode, UpdateHandle } from "./types";
+import type {
+  Client,
+  Mode,
+  PluginScope,
+  ReloadReason,
+  ReloadTrigger,
+  ResetOpenworkMode,
+  UpdateHandle,
+} from "./types";
 import { addOpencodeCacheHint, isTauriRuntime, safeStringify } from "./utils";
 import { mapConfigProvidersToList } from "./utils/providers";
 import { createUpdaterState } from "./context/updater";
@@ -41,6 +49,7 @@ export function createSystemState(options: {
   const [reloadReasons, setReloadReasons] = createSignal<ReloadReason[]>([]);
   const [reloadLastTriggeredAt, setReloadLastTriggeredAt] = createSignal<number | null>(null);
   const [reloadLastFinishedAt, setReloadLastFinishedAt] = createSignal<number | null>(null);
+  const [reloadTrigger, setReloadTrigger] = createSignal<ReloadTrigger | null>(null);
   const [reloadBusy, setReloadBusy] = createSignal(false);
   const [reloadError, setReloadError] = createSignal<string | null>(null);
 
@@ -132,16 +141,24 @@ export function createSystemState(options: {
     }
   }
 
-  function markReloadRequired(reason: ReloadReason) {
+  function markReloadRequired(reason: ReloadReason, trigger?: ReloadTrigger) {
     setReloadRequired(true);
     setReloadLastTriggeredAt(Date.now());
     setReloadReasons((current) => (current.includes(reason) ? current : [...current, reason]));
+    if (trigger) {
+      setReloadTrigger(trigger);
+    } else {
+      setReloadTrigger({
+        type: reason === "plugins" ? "plugin" : reason === "skills" ? "skill" : reason,
+      });
+    }
   }
 
   function clearReloadRequired() {
     setReloadRequired(false);
     setReloadReasons([]);
     setReloadError(null);
+    setReloadTrigger(null);
   }
 
   const reloadCopy = createMemo(() => {
@@ -457,6 +474,7 @@ export function createSystemState(options: {
     reloadLastTriggeredAt,
     reloadLastFinishedAt,
     setReloadLastFinishedAt,
+    reloadTrigger,
     reloadBusy,
     reloadError,
     reloadCopy,

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -201,6 +201,13 @@ export type McpStatusMap = Record<string, McpStatus>;
 
 export type ReloadReason = "plugins" | "skills" | "mcp" | "config";
 
+export type ReloadTrigger = {
+  type: "skill" | "plugin" | "config" | "mcp";
+  name?: string;
+  action?: "added" | "removed" | "updated";
+  path?: string;
+};
+
 export type PendingPermission = ApiPermissionRequest & {
   receivedAt: number;
 };


### PR DESCRIPTION
## Summary
- track reload triggers (skills/plugins/mcp/config) and surface in toast copy
- keep reload toast visible until dismiss or reload completes
- detect reload trigger details from tool writes and filesystem events