### PR TITLE
Reduce Notion reload friction

### DIFF
--- a/packages/app/pr/notion-connection-fix.md
+++ b/packages/app/pr/notion-connection-fix.md
@@ -1,0 +1,145 @@
+# Notion Connection: Investigate Double-Restart Issue
+
+**Branch:** `feat/notion-connection-fix`
+**Priority:** P2
+
+---
+
+## Problem
+
+From demo: "First time we connect Notion just didn't work. It says no write access... Second time we got CSRF error and third time it worked"
+
+The connection flow requires multiple restart attempts:
+1. Connect → "Write request denied"
+2. Restart → CSRF error
+3. Restart again → Finally works
+
+---
+
+## Hypothesis
+
+The config needs to restart twice:
+- Once to detect the MCP is configured
+- Second time to actually activate the connection with valid tokens
+
+### Code findings
+- MCP auth modal: `packages/app/src/app/components/mcp-auth-modal.tsx:12`
+- Auth flow calls OpenCode MCP endpoints: `mcp-auth-modal.tsx:155,180,311`
+- Auth modal blocks when reload required: `mcp-auth-modal.tsx:139`
+- Notion quick-connect flow: `packages/app/src/app/app.tsx:2177`
+  - Writes Notion MCP config: `app.tsx:2222`
+  - Marks reload required: `app.tsx:2246`
+  - Sets localStorage `openwork.notionStatus`: `app.tsx:2246`
+- On startup, `openwork.notionStatus === "connecting"` triggers reload-required: `app.tsx:2817`
+- MCP status refresh uses OpenCode `client.mcp.status`: `app.tsx:2294`
+- File watcher emits reload-required for config changes: `packages/desktop/src-tauri/src/workspace/watch.rs:99-124`
+- UI listener converts event to `markReloadRequired`: `packages/app/src/app/app.tsx:1868`
+
+---
+
+## Investigation Steps
+
+### 1. Trace the OAuth flow
+
+**Files to check:**
+- `packages/app/src/app/components/mcp-auth-modal.tsx`
+- Server-side MCP handling
+
+Questions:
+- When OAuth completes, where is the token saved?
+- Does the app know the token is saved?
+- Is there a race condition between token save and config reload?
+
+Add checks around `openwork.notionStatus` transitions to confirm if status ever clears after the first reload.
+
+### 2. Check what happens on first restart
+
+Add logging:
+```tsx
+// In MCP status handling
+console.log('[MCP] Notion config:', notionConfig);
+console.log('[MCP] Notion status:', notionStatus);
+console.log('[MCP] Has token:', !!notionToken);
+```
+
+### 3. Check CSRF error source
+
+- Is this from Notion's OAuth?
+- Is this from OpenWork server?
+- Is there stale state from previous connection attempt?
+
+Check if reload-required is firing twice (explicit `markReloadRequired("mcp")` + file watcher event) right after OAuth.
+
+### 4. Check server restart logic
+
+**Files:**
+- `packages/desktop/src-tauri/src/openwork_server/spawn.rs`
+- OpenCode server handling
+
+Questions:
+- Does restart fully clear MCP state?
+- Is there caching that persists across restarts?
+
+---
+
+## Potential Fixes
+
+### Option A: Auto-restart after OAuth
+
+After OAuth token is saved, automatically trigger a server reload:
+```tsx
+const handleOAuthComplete = async () => {
+  await saveToken();
+  // Automatically reload to pick up new token
+  await reloadWorkspace();
+};
+```
+
+### Option B: Hot-reload MCP connections
+
+Instead of full restart, implement hot-reload for MCP:
+```tsx
+const refreshMcpConnection = async (name: string) => {
+  // Disconnect existing
+  await mcpDisconnect(name);
+  // Reconnect with new config
+  await mcpConnect(name);
+};
+```
+
+### Option C: Fix the state mismatch
+
+If the issue is stale state, ensure clean state on connection attempt:
+```tsx
+const connectNotion = async () => {
+  // Clear any cached state
+  clearMcpCache("notion");
+  // Proceed with fresh connection
+  await initiateOAuth("notion");
+};
+```
+
+**Also consider:** clearing `openwork.notionStatus` after successful engine reload to avoid repeated reload prompts on startup.
+
+---
+
+## Reproduction Steps
+
+1. Fresh install or clear Notion connection
+2. Go to MCP settings
+3. Click "Connect Notion"
+4. Complete OAuth flow
+5. Observe error
+6. Click Reload
+7. Check if working
+8. If not, reload again
+
+Track what state changes at each step.
+
+---
+
+## Success Criteria
+
+- Notion connection works on first attempt after OAuth
+- No need to restart multiple times
+- Clear error messages if something goes wrong

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1810,6 +1810,13 @@ export default function App() {
   const markReloadRequired = (reason: ReloadReason, options?: { force?: boolean }) => {
     if (booting() || reloadBusy()) return;
     if (!options?.force) {
+      const existingReasons = reloadReasons();
+      if (reloadRequired() && existingReasons.includes(reason)) return;
+      if (reloadRequired() && reason === "config" && existingReasons.includes("mcp")) {
+        return;
+      }
+    }
+    if (!options?.force) {
       const label = busyLabel();
       if (
         busy() &&

--- a/packages/app/src/app/components/mcp-auth-modal.tsx
+++ b/packages/app/src/app/components/mcp-auth-modal.tsx
@@ -136,7 +136,8 @@ export default function McpAuthModal(props: McpAuthModalProps) {
     setAuthInProgress(true);
 
     try {
-      if (props.reloadRequired) {
+      const statusEntry = await fetchMcpStatus(slug);
+      if (props.reloadRequired && !statusEntry) {
         setNeedsReload(true);
         setReloadNotice(
           props.reloadBlocked
@@ -146,7 +147,6 @@ export default function McpAuthModal(props: McpAuthModalProps) {
         return;
       }
 
-      const statusEntry = await fetchMcpStatus(slug);
       if (statusEntry?.status === "connected") {
         setAlreadyConnected(true);
         return;

--- a/packages/app/src/app/system-state.ts
+++ b/packages/app/src/app/system-state.ts
@@ -262,16 +262,25 @@ export function createSystemState(options: {
         if (nextStatus === "connecting") {
           nextStatus = "connected";
           options.notion.setStatus(nextStatus);
+          options.notion.setStatusDetail("Workspace connected");
         }
 
         if (nextStatus === "connected") {
-          options.notion.setStatusDetail(options.notion.statusDetail() ?? "Workspace connected");
+          const detail = options.notion.statusDetail();
+          if (!detail || detail.toLowerCase().includes("reload")) {
+            options.notion.setStatusDetail("Workspace connected");
+          }
         }
 
         try {
           window.localStorage.setItem("openwork.notionStatus", nextStatus);
-          if (nextStatus === "connected" && options.notion.statusDetail()) {
-            window.localStorage.setItem("openwork.notionStatusDetail", options.notion.statusDetail() || "");
+          if (nextStatus === "connected") {
+            const detail = options.notion.statusDetail();
+            if (detail) {
+              window.localStorage.setItem("openwork.notionStatusDetail", detail);
+            } else {
+              window.localStorage.removeItem("openwork.notionStatusDetail");
+            }
           }
         } catch {
           // ignore


### PR DESCRIPTION
## Summary
- avoid redundant reload-required flags on Notion connect
- only block auth when reload required and no status is available
- normalize stored Notion status detail after connection