### PR TITLE
feat(auth): secure opencode server access

### DIFF
--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -24,6 +24,8 @@ export type OpenworkWorkspaceInfo = {
   opencode?: {
     baseUrl?: string;
     directory?: string;
+    username?: string;
+    password?: string;
   };
 };
 

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -7,6 +7,8 @@ export type EngineInfo = {
   projectDir: string | null;
   hostname: string | null;
   port: number | null;
+  opencodeUsername: string | null;
+  opencodePassword: string | null;
   pid: number | null;
   lastStdout: string | null;
   lastStderr: string | null;

--- a/packages/desktop/src-tauri/src/commands/owpenbot.rs
+++ b/packages/desktop/src-tauri/src/commands/owpenbot.rs
@@ -64,6 +64,8 @@ pub fn owpenbot_start(
     manager: State<OwpenbotManager>,
     workspace_path: String,
     opencode_url: Option<String>,
+    opencode_username: Option<String>,
+    opencode_password: Option<String>,
 ) -> Result<OwpenbotInfo, String> {
     let mut state = manager
         .inner
@@ -71,7 +73,13 @@ pub fn owpenbot_start(
         .map_err(|_| "owpenbot mutex poisoned".to_string())?;
     OwpenbotManager::stop_locked(&mut state);
 
-    let (mut rx, child) = spawn_owpenbot(&app, &workspace_path, opencode_url.as_deref())?;
+    let (mut rx, child) = spawn_owpenbot(
+        &app,
+        &workspace_path,
+        opencode_url.as_deref(),
+        opencode_username.as_deref(),
+        opencode_password.as_deref(),
+    )?;
 
     state.child = Some(child);
     state.child_exited = false;

--- a/packages/desktop/src-tauri/src/engine/manager.rs
+++ b/packages/desktop/src-tauri/src/engine/manager.rs
@@ -17,6 +17,8 @@ pub struct EngineState {
     pub hostname: Option<String>,
     pub port: Option<u16>,
     pub base_url: Option<String>,
+    pub opencode_username: Option<String>,
+    pub opencode_password: Option<String>,
     pub last_stdout: Option<String>,
     pub last_stderr: Option<String>,
 }
@@ -38,6 +40,8 @@ impl EngineManager {
             project_dir: state.project_dir.clone(),
             hostname: state.hostname.clone(),
             port: state.port,
+            opencode_username: state.opencode_username.clone(),
+            opencode_password: state.opencode_password.clone(),
             pid,
             last_stdout: state.last_stdout.clone(),
             last_stderr: state.last_stderr.clone(),
@@ -53,6 +57,8 @@ impl EngineManager {
         state.project_dir = None;
         state.hostname = None;
         state.port = None;
+        state.opencode_username = None;
+        state.opencode_password = None;
         state.last_stdout = None;
         state.last_stderr = None;
     }

--- a/packages/desktop/src-tauri/src/engine/spawn.rs
+++ b/packages/desktop/src-tauri/src/engine/spawn.rs
@@ -34,6 +34,8 @@ pub fn spawn_engine(
     port: u16,
     project_dir: &str,
     use_sidecar: bool,
+    opencode_username: Option<&str>,
+    opencode_password: Option<&str>,
 ) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
     let args = build_engine_args(hostname, port);
 
@@ -74,6 +76,18 @@ pub fn spawn_engine(
 
     command = command.env("OPENCODE_CLIENT", "openwork");
     command = command.env("OPENWORK", "1");
+
+    if let Some(username) = opencode_username {
+        if !username.trim().is_empty() {
+            command = command.env("OPENCODE_SERVER_USERNAME", username);
+        }
+    }
+
+    if let Some(password) = opencode_password {
+        if !password.trim().is_empty() {
+            command = command.env("OPENCODE_SERVER_PASSWORD", password);
+        }
+    }
 
     command
         .spawn()

--- a/packages/desktop/src-tauri/src/openwork_server/mod.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/mod.rs
@@ -45,6 +45,8 @@ pub fn start_openwork_server(
     manager: &OpenworkServerManager,
     workspace_path: &str,
     opencode_base_url: Option<&str>,
+    opencode_username: Option<&str>,
+    opencode_password: Option<&str>,
 ) -> Result<OpenworkServerInfo, String> {
     let mut state = manager.inner.lock().map_err(|_| "openwork server mutex poisoned".to_string())?;
     OpenworkServerManager::stop_locked(&mut state);
@@ -63,6 +65,8 @@ pub fn start_openwork_server(
         &host_token,
         opencode_base_url,
         Some(workspace_path),
+        opencode_username,
+        opencode_password,
     )?;
 
     state.child = Some(child);

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -70,6 +70,8 @@ pub fn spawn_openwork_server(
     host_token: &str,
     opencode_base_url: Option<&str>,
     opencode_directory: Option<&str>,
+    opencode_username: Option<&str>,
+    opencode_password: Option<&str>,
 ) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
     let command = match app.shell().sidecar("openwork-server") {
         Ok(command) => command,
@@ -85,9 +87,21 @@ pub fn spawn_openwork_server(
         opencode_base_url,
         opencode_directory,
     );
+    let mut command = command.args(args).current_dir(Path::new(workspace_path));
+
+    if let Some(username) = opencode_username {
+        if !username.trim().is_empty() {
+            command = command.env("OPENWORK_OPENCODE_USERNAME", username);
+        }
+    }
+
+    if let Some(password) = opencode_password {
+        if !password.trim().is_empty() {
+            command = command.env("OPENWORK_OPENCODE_PASSWORD", password);
+        }
+    }
+
     command
-        .args(args)
-        .current_dir(Path::new(workspace_path))
         .spawn()
         .map_err(|e| format!("Failed to start OpenWork server: {e}"))
 }

--- a/packages/desktop/src-tauri/src/owpenbot/spawn.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/spawn.rs
@@ -26,6 +26,8 @@ pub fn spawn_owpenbot(
     app: &AppHandle,
     workspace_path: &str,
     opencode_url: Option<&str>,
+    opencode_username: Option<&str>,
+    opencode_password: Option<&str>,
 ) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
     let command = match app.shell().sidecar("owpenbot") {
         Ok(command) => command,
@@ -34,9 +36,21 @@ pub fn spawn_owpenbot(
 
     let args = build_owpenbot_args(workspace_path, opencode_url);
     
+    let mut command = command.args(args).current_dir(Path::new(workspace_path));
+
+    if let Some(username) = opencode_username {
+        if !username.trim().is_empty() {
+            command = command.env("OPENCODE_SERVER_USERNAME", username);
+        }
+    }
+
+    if let Some(password) = opencode_password {
+        if !password.trim().is_empty() {
+            command = command.env("OPENCODE_SERVER_PASSWORD", password);
+        }
+    }
+
     command
-        .args(args)
-        .current_dir(Path::new(workspace_path))
         .spawn()
         .map_err(|e| format!("Failed to start owpenbot: {e}"))
 }

--- a/packages/desktop/src-tauri/src/types.rs
+++ b/packages/desktop/src-tauri/src/types.rs
@@ -58,6 +58,8 @@ pub struct EngineInfo {
     pub project_dir: Option<String>,
     pub hostname: Option<String>,
     pub port: Option<u16>,
+    pub opencode_username: Option<String>,
+    pub opencode_password: Option<String>,
     pub pid: Option<u32>,
     pub last_stdout: Option<String>,
     pub last_stderr: Option<String>,

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -22,7 +22,13 @@ Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CON
   "port": 8787,
   "approval": { "mode": "manual", "timeoutMs": 30000 },
   "workspaces": [
-    { "path": "/Users/susan/Finance", "name": "Finance", "workspaceType": "local" }
+    {
+      "path": "/Users/susan/Finance",
+      "name": "Finance",
+      "workspaceType": "local",
+      "baseUrl": "http://127.0.0.1:4096",
+      "directory": "/Users/susan/Finance"
+    }
   ],
   "corsOrigins": ["http://localhost:5173"]
 }
@@ -38,6 +44,10 @@ Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CON
 - `OPENWORK_APPROVAL_TIMEOUT_MS`
 - `OPENWORK_WORKSPACES` (JSON array or comma-separated list of paths)
 - `OPENWORK_CORS_ORIGINS` (comma-separated list or `*`)
+- `OPENWORK_OPENCODE_BASE_URL`
+- `OPENWORK_OPENCODE_DIRECTORY`
+- `OPENWORK_OPENCODE_USERNAME`
+- `OPENWORK_OPENCODE_PASSWORD`
 
 ## Endpoints (initial)
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -14,6 +14,8 @@ interface CliArgs {
   approvalTimeoutMs?: number;
   opencodeBaseUrl?: string;
   opencodeDirectory?: string;
+  opencodeUsername?: string;
+  opencodePassword?: string;
   workspaces: string[];
   corsOrigins?: string[];
   readOnly?: boolean;
@@ -30,6 +32,8 @@ interface FileConfig {
   corsOrigins?: string[];
   authorizedRoots?: string[];
   readOnly?: boolean;
+  opencodeUsername?: string;
+  opencodePassword?: string;
 }
 
 const DEFAULT_PORT = 8787;
@@ -93,6 +97,16 @@ export function parseCliArgs(argv: string[]): CliArgs {
       index += 1;
       continue;
     }
+    if (value === "--opencode-username") {
+      args.opencodeUsername = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (value === "--opencode-password") {
+      args.opencodePassword = argv[index + 1];
+      index += 1;
+      continue;
+    }
     if (value === "--workspace") {
       const path = argv[index + 1];
       if (path) args.workspaces.push(path);
@@ -126,6 +140,8 @@ export function printHelp(): void {
     "  --approval-timeout <ms>  Approval timeout",
     "  --opencode-base-url <url> OpenCode base URL to share",
     "  --opencode-directory <path> OpenCode workspace directory to share",
+    "  --opencode-username <user> OpenCode server username",
+    "  --opencode-password <pass> OpenCode server password",
     "  --workspace <path>       Workspace root (repeatable)",
     "  --cors <origins>          Comma-separated origins or *",
     "  --read-only              Disable writes",
@@ -154,14 +170,20 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
 
   const envOpencodeBaseUrl = process.env.OPENWORK_OPENCODE_BASE_URL;
   const envOpencodeDirectory = process.env.OPENWORK_OPENCODE_DIRECTORY;
+  const envOpencodeUsername = process.env.OPENWORK_OPENCODE_USERNAME;
+  const envOpencodePassword = process.env.OPENWORK_OPENCODE_PASSWORD;
   const opencodeBaseUrl = cli.opencodeBaseUrl ?? envOpencodeBaseUrl;
   const opencodeDirectory = cli.opencodeDirectory ?? envOpencodeDirectory;
+  const opencodeUsername = cli.opencodeUsername ?? envOpencodeUsername ?? fileConfig.opencodeUsername;
+  const opencodePassword = cli.opencodePassword ?? envOpencodePassword ?? fileConfig.opencodePassword;
 
-  if (workspaceConfigs.length > 0 && (opencodeBaseUrl || opencodeDirectory)) {
+  if (workspaceConfigs.length > 0 && (opencodeBaseUrl || opencodeDirectory || opencodeUsername || opencodePassword)) {
     workspaceConfigs[0] = {
       ...workspaceConfigs[0],
       baseUrl: opencodeBaseUrl ?? workspaceConfigs[0].baseUrl,
       directory: opencodeDirectory ?? workspaceConfigs[0].directory,
+      opencodeUsername: opencodeUsername ?? workspaceConfigs[0].opencodeUsername,
+      opencodePassword: opencodePassword ?? workspaceConfigs[0].opencodePassword,
     };
   }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -152,15 +152,18 @@ function buildCapabilities(config: ServerConfig): Capabilities {
 }
 
 function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
+  const { opencodeUsername, opencodePassword, ...rest } = workspace;
   const opencode =
-    workspace.baseUrl || workspace.directory
+    workspace.baseUrl || workspace.directory || opencodeUsername || opencodePassword
       ? {
           baseUrl: workspace.baseUrl,
           directory: workspace.directory,
+          username: opencodeUsername,
+          password: opencodePassword,
         }
       : undefined;
   return {
-    ...workspace,
+    ...rest,
     opencode,
   };
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -8,6 +8,8 @@ export interface WorkspaceConfig {
   workspaceType?: WorkspaceType;
   baseUrl?: string;
   directory?: string;
+  opencodeUsername?: string;
+  opencodePassword?: string;
 }
 
 export interface WorkspaceInfo {
@@ -17,9 +19,13 @@ export interface WorkspaceInfo {
   workspaceType: WorkspaceType;
   baseUrl?: string;
   directory?: string;
+  opencodeUsername?: string;
+  opencodePassword?: string;
   opencode?: {
     baseUrl?: string;
     directory?: string;
+    username?: string;
+    password?: string;
   };
 }
 

--- a/packages/server/src/workspaces.ts
+++ b/packages/server/src/workspaces.ts
@@ -20,6 +20,8 @@ export function buildWorkspaceInfos(
       workspaceType: workspace.workspaceType ?? "local",
       baseUrl: workspace.baseUrl,
       directory: workspace.directory,
+      opencodeUsername: workspace.opencodeUsername,
+      opencodePassword: workspace.opencodePassword,
     };
   });
 }


### PR DESCRIPTION
## Summary
- generate per-session OpenCode basic auth credentials and wire them into the engine, OpenWork server, and Owpenbot
- send OpenCode username/password to desktop and remote clients so connections authenticate automatically
- extend OpenWork server config/env support for OpenCode auth and document the new settings