### PR TITLE
docs: clarify Host mode and fix incomplete README sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's an **extensible, open-source alternative** to “Claude Work”.
 <img width="1292" height="932" alt="Screenshot 2026-01-13 at 7 19 02 PM" src="https://github.com/user-attachments/assets/7a1b8662-19a0-4327-87c9-c0295a0d54f1" />
 
 
-Openwork is desgined around the idea that you can easily ship your
+OpenWork is designed around the idea that you can easily ship your agentic workflows as a repeatable, productized process.
 
 It’s a native desktop app that runs **OpenCode** under the hood, but presents it as a clean, guided workflow:
 - pick a workspace
@@ -107,12 +107,18 @@ yay -s opencode # Releases version
 - In **Host mode**, OpenWork spawns:
   - `opencode serve --hostname 127.0.0.1 --port <free-port>`
   - with your selected project folder as the process working directory.
+In Host mode, OpenWork starts an OpenCode server directly on your own computer in the background.
+When you select a project folder, OpenWork runs OpenCode locally using that folder and connects the desktop UI to it.
+This allows you to run agentic workflows, send prompts, and see progress entirely on your machine without relying on a remote server.
+
 - The UI uses `@opencode-ai/sdk/v2/client` to:
   - connect to the server
   - list/create sessions
   - send prompts
-  - subscribe to SSE events
+  - subscribe to SSE events(Server-Sent Events are used to stream real-time updates from the server to the UI.)
   - read todos and permission requests
+
+
 
 ## Folder Picker
 


### PR DESCRIPTION
What this PR does
Fixes an incomplete sentence in the README that currently ends mid-thought.
Adds a short, plain-English explanation of "Host mode" under the Architecture section to improve onboarding for new users.

Why this change is needed
As a new user reading the README, I found that the Host mode description assumes prior familiarity with OpenCode and local server concepts.
This small clarification helps first-time users understand what is running locally and how the OpenWork UI connects to it, without changing any technical behavior.

Scope
Documentation only
No functional or architectural changes