### PR TITLE
fix(release): gate notarization + bump 0.8.1

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -82,6 +82,7 @@ jobs:
       RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
       RELEASE_NAME: ${{ needs.prepare-release.outputs.release_name }}
       RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}
+      MACOS_NOTARIZE: ${{ vars.MACOS_NOTARIZE || 'false' }}
 
     strategy:
       fail-fast: false
@@ -227,7 +228,7 @@ jobs:
           chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
 
       - name: Write notary API key
-        if: matrix.os_type == 'macos'
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
         env:
           APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
         run: |
@@ -239,7 +240,8 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build + upload
+      - name: Build + upload (notarized)
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
         uses: tauri-apps/tauri-action@v0.5.17
         env:
           CI: true
@@ -258,6 +260,33 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
           APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
+        with:
+          tagName: ${{ env.RELEASE_TAG }}
+          releaseName: ${{ env.RELEASE_NAME }}
+          releaseBody: ${{ env.RELEASE_BODY }}
+          prerelease: true
+          releaseDraft: false
+          projectPath: packages/desktop
+          tauriScript: pnpm exec tauri -vvv
+          args: ${{ matrix.args }}
+          retryAttempts: 3
+          includeUpdaterJson: true
+
+      - name: Build + upload
+        if: matrix.os_type != 'macos' || env.MACOS_NOTARIZE != 'true'
+        uses: tauri-apps/tauri-action@v0.5.17
+        env:
+          CI: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # Tauri updater signing
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+          # macOS signing
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: ${{ env.RELEASE_NAME }}

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: boolean
         default: false
+      notarize:
+        description: "Notarize macOS builds (requires Apple team configured)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -126,6 +131,8 @@ jobs:
     needs: prepare-release
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 360
+    env:
+      MACOS_NOTARIZE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.notarize || vars.MACOS_NOTARIZE || 'false' }}
 
     strategy:
       fail-fast: false
@@ -325,7 +332,7 @@ jobs:
           chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
 
       - name: Write notary API key
-        if: matrix.os_type == 'macos'
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
         env:
           APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
         run: |
@@ -337,7 +344,8 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build + upload
+      - name: Build + upload (notarized)
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
         uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
         env:
           CI: true
@@ -356,6 +364,35 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
           APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
+        with:
+          tagName: ${{ env.RELEASE_TAG }}
+          releaseName: ${{ env.RELEASE_NAME }}
+          releaseBody: ${{ env.RELEASE_BODY }}
+          releaseDraft: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.draft == 'true' }}
+          prerelease: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prerelease == 'true' }}
+          projectPath: packages/desktop
+          tauriScript: pnpm exec tauri -vvv
+          args: ${{ matrix.args }}
+          retryAttempts: 3
+          includeUpdaterJson: true
+          updaterJsonPreferNsis: true
+          releaseAssetNamePattern: openwork-desktop-[platform]-[arch][ext]
+
+      - name: Build + upload
+        if: matrix.os_type != 'macos' || env.MACOS_NOTARIZE != 'true'
+        uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
+        env:
+          CI: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # Tauri updater signing
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+          # macOS signing
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: ${{ env.RELEASE_NAME }}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@different-ai/openwork-ui",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@different-ai/openwork",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "opencodeVersion": "1.1.45",
   "type": "module",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwork"
-version = "0.8.0"
+version = "0.8.1"
 description = "OpenWork"
 authors = ["Different AI"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenWork",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.differentai.openwork",
   "build": {
     "beforeDevCommand": "pnpm -C ../.. --filter @different-ai/openwork run prepare:sidecar && pnpm -w dev:ui",


### PR DESCRIPTION
## Summary
- gate macOS notarization behind a repo variable or workflow input
- keep macOS signing intact while allowing release assets to upload
- bump OpenWork version to 0.8.1 for the new release

## Notes
- Set repo variable MACOS_NOTARIZE=true or pass notarize=true on workflow_dispatch once Apple team config is fixed.