### PR TITLE
Improve OpenWork server auth handling

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -294,7 +294,10 @@ export default function App() {
     const client = createOpenworkServerClient({ baseUrl: url, token });
     try {
       await client.health();
-    } catch {
+    } catch (error) {
+      if (error instanceof OpenworkServerError && (error.status === 401 || error.status === 403)) {
+        return { status: "limited" as OpenworkServerStatus, capabilities: null };
+      }
       return { status: "disconnected" as OpenworkServerStatus, capabilities: null };
     }
 

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -182,6 +182,8 @@ export function createWorkspaceStore(options: {
 
     const client = createOpenworkServerClient({ baseUrl: normalized, token: input.token ?? undefined });
 
+    const trimmedToken = input.token?.trim() ?? "";
+
     try {
       const health = await client.health();
       if (!health?.ok) {
@@ -189,12 +191,15 @@ export function createWorkspaceStore(options: {
       }
     } catch (error) {
       if (error instanceof OpenworkServerError && (error.status === 401 || error.status === 403)) {
-        throw error;
+        if (!trimmedToken) {
+          throw new Error("Access token required for OpenWork host.");
+        }
+        throw new Error("OpenWork host rejected the client token.");
       }
       return { kind: "fallback" as const };
     }
 
-    if (!input.token?.trim()) {
+    if (!trimmedToken) {
       throw new Error("Access token required for OpenWork host.");
     }
 

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -238,7 +238,8 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
   return {
     baseUrl,
     token,
-    health: () => requestJson<{ ok: boolean; version: string; uptimeMs: number }>(baseUrl, "/health"),
+    health: () =>
+      requestJson<{ ok: boolean; version: string; uptimeMs: number }>(baseUrl, "/health", { token, hostToken }),
     capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken }),
     listWorkspaces: () => requestJson<{ items: OpenworkWorkspaceInfo[] }>(baseUrl, "/workspaces", { token, hostToken }),
     getConfig: (workspaceId: string) =>


### PR DESCRIPTION
## Summary
- send auth headers on OpenWork server health checks
- treat unauthorized health responses as limited access instead of disconnected
- provide clearer OpenWork host token errors during remote host resolution

## Testing
- not run (not requested)