### PR TITLE
fix(build): create extract dir for opencode tarball

### DIFF
--- a/packages/desktop/scripts/prepare-sidecar.mjs
+++ b/packages/desktop/scripts/prepare-sidecar.mjs
@@ -359,6 +359,8 @@ if (process.platform === "win32") {
     process.exit(downloadResult.status ?? 1);
   }
 
+  mkdirSync(extractDir, { recursive: true });
+
   if (opencodeAsset.endsWith(".zip")) {
     const unzipResult = spawnSync("unzip", ["-q", archivePath, "-d", extractDir], {
       stdio: "inherit",


### PR DESCRIPTION
## Summary
- create the temp extract directory before unpacking OpenCode archives
- prevent Linux tar extraction from failing when the target directory is missing