### PR TITLE
feat(headless): publish openwrk npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The goal: make “agentic work” feel like a product, not a terminal.
   - `curl -fsSL https://raw.githubusercontent.com/different-ai/openwork/dev/packages/owpenbot/install.sh | bash`
   - run `owpenbot setup`, then `owpenbot whatsapp login`, then `owpenbot start`
   - full setup: [packages/owpenbot/README.md](./packages/owpenbot/README.md)
-- **OpenWork Headless (CLI host)**: run OpenCode + OpenWork server without the desktop UI.
+- **Openwrk (CLI host)**: run OpenCode + OpenWork server without the desktop UI.
   - docs: [packages/headless/README.md](./packages/headless/README.md)
 
 

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -1,11 +1,18 @@
-# OpenWork Headless
+# Openwrk
 
 Headless host orchestrator for OpenCode + OpenWork server + Owpenbot. This is a CLI-first way to run host mode without the desktop UI.
 
 ## Quick start
 
 ```bash
-pnpm --filter @different-ai/openwork-headless dev -- \
+npm install -g openwrk
+openwrk start --workspace /path/to/workspace --approval auto
+```
+
+Or from source:
+
+```bash
+pnpm --filter openwrk dev -- \
   start --workspace /path/to/workspace --approval auto
 ```
 
@@ -19,11 +26,11 @@ The command prints pairing details (OpenWork server URL + token, OpenCode URL + 
 ## Approvals (manual mode)
 
 ```bash
-openwork-headless approvals list \
+openwrk approvals list \
   --openwork-url http://<host>:8787 \
   --host-token <token>
 
-openwork-headless approvals reply <id> --allow \
+openwrk approvals reply <id> --allow \
   --openwork-url http://<host>:8787 \
   --host-token <token>
 ```
@@ -31,7 +38,7 @@ openwork-headless approvals reply <id> --allow \
 ## Health checks
 
 ```bash
-openwork-headless status \
+openwrk status \
   --openwork-url http://<host>:8787 \
   --opencode-url http://<host>:4096
 ```
@@ -39,7 +46,7 @@ openwork-headless status \
 ## Smoke checks
 
 ```bash
-openwork-headless start --workspace /path/to/workspace --check --check-events
+openwrk start --workspace /path/to/workspace --check --check-events
 ```
 
 This starts the services, verifies health + SSE events, then exits cleanly.
@@ -49,7 +56,7 @@ This starts the services, verifies health + SSE events, then exits cleanly.
 Point to source CLIs for fast iteration:
 
 ```bash
-openwork-headless start \
+openwrk start \
   --workspace /path/to/workspace \
   --openwork-server-bin packages/server/src/cli.ts \
   --owpenbot-bin packages/owpenbot/src/cli.ts

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,15 +1,39 @@
 {
-  "name": "@different-ai/openwork-headless",
+  "name": "openwrk",
   "version": "0.1.0",
-  "private": true,
+  "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {
-    "openwork-headless": "dist/cli.js"
+    "openwrk": "dist/cli.js"
   },
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/different-ai/openwork.git",
+    "directory": "packages/headless"
+  },
+  "homepage": "https://github.com/different-ai/openwork/tree/dev/packages/headless",
+  "bugs": {
+    "url": "https://github.com/different-ai/openwork/issues"
+  },
+  "keywords": [
+    "openwork",
+    "opencode",
+    "headless",
+    "cli",
+    "agent"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.1.31"

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -343,13 +343,13 @@ async function waitForOpencodeHealthy(client: ReturnType<typeof createOpencodeCl
 
 function printHelp(): void {
   const message = [
-    "openwork-headless",
+    "openwrk",
     "",
     "Usage:",
-    "  openwork-headless start [--workspace <path>] [options]",
-    "  openwork-headless approvals list --openwork-url <url> --host-token <token>",
-    "  openwork-headless approvals reply <id> --allow|--deny --openwork-url <url> --host-token <token>",
-    "  openwork-headless status [--openwork-url <url>] [--opencode-url <url>]",
+    "  openwrk start [--workspace <path>] [options]",
+    "  openwrk approvals list --openwork-url <url> --host-token <token>",
+    "  openwrk approvals reply <id> --allow|--deny --openwork-url <url> --host-token <token>",
+    "  openwrk status [--openwork-url <url>] [--opencode-url <url>]",
     "",
     "Commands:",
     "  start                   Start OpenCode + OpenWork server + Owpenbot",
@@ -429,7 +429,7 @@ async function startOpencode(options: {
     stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
-      OPENCODE_CLIENT: "openwork-headless",
+      OPENCODE_CLIENT: "openwrk",
       OPENWORK: "1",
       ...(options.username ? { OPENCODE_SERVER_USERNAME: options.username } : {}),
       ...(options.password ? { OPENCODE_SERVER_PASSWORD: options.password } : {}),
@@ -886,7 +886,7 @@ async function runStart(args: ParsedArgs) {
   if (outputJson) {
     console.log(JSON.stringify(payload, null, 2));
   } else {
-    console.log("OpenWork Headless running");
+    console.log("Openwrk running");
     console.log(`Workspace: ${payload.workspace}`);
     console.log(`OpenCode: ${payload.opencode.baseUrl}`);
     console.log(`OpenCode connect URL: ${payload.opencode.connectUrl}`);


### PR DESCRIPTION
## Summary
- publish the headless host CLI as the `openwrk` npm package
- rename the CLI surface + docs to use `openwrk`
- add npm metadata (repository, keywords, publishConfig)

## Testing
- pnpm --filter openwrk typecheck
- pnpm --filter openwrk build

## Release
- npm publish --access public (openwrk@0.1.0)