### PR TITLE
feat(headless): bundle openwork server for openwrk

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The goal: make “agentic work” feel like a product, not a terminal.
   - `curl -fsSL https://raw.githubusercontent.com/different-ai/openwork/dev/packages/owpenbot/install.sh | bash`
   - run `owpenbot setup`, then `owpenbot whatsapp login`, then `owpenbot start`
   - full setup: [packages/owpenbot/README.md](./packages/owpenbot/README.md)
-- **Openwrk (CLI host)**: run OpenCode + OpenWork server without the desktop UI.
+- **Openwrk (CLI host)**: run OpenCode + OpenWork server without the desktop UI. Install with `npm install -g openwrk`.
   - docs: [packages/headless/README.md](./packages/headless/README.md)
 
 

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -9,6 +9,8 @@ npm install -g openwrk
 openwrk start --workspace /path/to/workspace --approval auto
 ```
 
+`openwrk` installs the OpenWork server dependency automatically. No extra install needed.
+
 Or from source:
 
 ```bash

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwrk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {
@@ -36,7 +36,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.1.31"
+    "@opencode-ai/sdk": "^1.1.31",
+    "openwork-server": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -5,7 +5,14 @@ Filesystem-backed API for OpenWork remote clients. This package provides the Ope
 ## Quick start
 
 ```bash
-pnpm --filter @different-ai/openwork-server dev -- \
+npm install -g openwork-server
+openwork-server --workspace /path/to/workspace --approval auto
+```
+
+Or from source:
+
+```bash
+pnpm --filter openwork-server dev -- \
   --workspace /path/to/workspace \
   --approval auto
 ```

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@different-ai/openwork-server",
+  "name": "openwork-server",
   "version": "0.1.0",
-  "private": true,
+  "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {
     "openwork-server": "dist/cli.js"
@@ -13,6 +13,30 @@
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-windows-x64",
     "start": "bun dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/different-ai/openwork.git",
+    "directory": "packages/server"
+  },
+  "homepage": "https://github.com/different-ai/openwork/tree/dev/packages/server",
+  "bugs": {
+    "url": "https://github.com/different-ai/openwork/issues"
+  },
+  "keywords": [
+    "openwork",
+    "server",
+    "opencode",
+    "headless",
+    "cli"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
     "jsonc-parser": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.1.31
         version: 1.1.39
+      openwork-server:
+        specifier: ^0.1.0
+        version: link:../server
     devDependencies:
       '@types/node':
         specifier: ^22.10.2


### PR DESCRIPTION
## Summary
- publish `openwork-server` to npm and wire `openwrk` to resolve/run it automatically
- add npm metadata + install instructions for openwork-server and openwrk
- teach openwrk to run the server with bun when using the bundled CLI

## Testing
- pnpm --filter openwork-server build
- pnpm --filter openwrk build
- node packages/headless/dist/cli.js start --workspace tmp/openwrk-test --approval auto --no-owpenbot --check --json

## Release
- npm publish --access public (openwork-server@0.1.0)
- npm publish --access public (openwrk@0.1.1)