### PR TITLE
feat(headless): ship openwrk as compiled binary

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -9,6 +9,8 @@ npm install -g openwrk
 openwrk start --workspace /path/to/workspace --approval auto
 ```
 
+`openwrk` ships as a compiled binary, so Bun is not required at runtime.
+
 `openwrk` installs the OpenWork server dependency automatically. No extra install needed.
 
 Or from source:

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,19 +1,22 @@
 {
   "name": "openwrk",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {
-    "openwrk": "dist/cli.js"
+    "openwrk": "dist/openwrk"
   },
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "build:bin": "pnpm --filter openwork-server build:bin && bun build --compile src/cli.ts --outfile dist/openwrk && bun scripts/build-bin.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build:bin"
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "dist/openwork-server"
   ],
   "repository": {
     "type": "git",

--- a/packages/headless/scripts/build-bin.ts
+++ b/packages/headless/scripts/build-bin.ts
@@ -1,0 +1,11 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const source = resolve(root, "..", "server", "dist", "bin", "openwork-server");
+const targetDir = resolve(root, "dist");
+const target = resolve(targetDir, "openwork-server");
+
+await mkdir(targetDir, { recursive: true });
+await copyFile(source, target);

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -338,9 +338,25 @@ async function resolveOpenworkServerBin(explicit?: string): Promise<string> {
   try {
     const pkgPath = require.resolve("openwork-server/package.json");
     const pkgDir = dirname(pkgPath);
+    const binaryPath = join(pkgDir, "dist", "bin", "openwork-server");
+    if (await isExecutable(binaryPath)) {
+      return binaryPath;
+    }
     const cliPath = join(pkgDir, "dist", "cli.js");
     if (await isExecutable(cliPath)) {
       return cliPath;
+    }
+  } catch {
+    // ignore
+  }
+
+  try {
+    const selfPath = process.execPath || process.argv[0];
+    if (selfPath) {
+      const bundledServer = join(dirname(selfPath), "openwork-server");
+      if (await isExecutable(bundledServer)) {
+        return bundledServer;
+      }
     }
   } catch {
     // ignore

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -9,6 +9,8 @@ npm install -g openwork-server
 openwork-server --workspace /path/to/workspace --approval auto
 ```
 
+`openwork-server` ships as a compiled binary, so Bun is not required at runtime.
+
 Or from source:
 
 ```bash

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,18 +1,19 @@
 {
   "name": "openwork-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {
-    "openwork-server": "dist/cli.js"
+    "openwork-server": "dist/bin/openwork-server"
   },
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "build:bin": "bun ./script/build.ts --outdir dist/bin",
+    "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-windows-x64",
     "start": "bun dist/cli.js",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build:bin"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- compile `openwrk` into a standalone binary (no Bun runtime needed)
- bundle the compiled `openwork-server` binary alongside `openwrk`
- update docs + build scripts to publish compiled binaries

## Testing
- pnpm --filter openwork-server build
- pnpm --filter openwrk build
- pnpm --filter openwork-server build:bin
- pnpm --filter openwrk build:bin
- packages/headless/dist/openwrk start --workspace tmp/openwrk-test --approval auto --no-owpenbot --check --json

## Release
- npm publish --access public (openwork-server@0.1.1)
- npm publish --access public (openwrk@0.1.3)