### PR TITLE
feat(headless): enforce bundled sidecar versions

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -11,7 +11,11 @@ openwrk start --workspace /path/to/workspace --approval auto
 
 `openwrk` ships as a compiled binary, so Bun is not required at runtime.
 
-`openwrk` installs the OpenWork server dependency automatically. No extra install needed.
+`openwrk` bundles and validates exact versions of `openwork-server` + `owpenbot` using a
+SHA-256 manifest. It will refuse to start if the bundled binaries are missing or tampered with.
+
+For development overrides only, set `OPENWRK_ALLOW_EXTERNAL=1` to use locally installed
+`openwork-server` or `owpenbot` binaries.
 
 Or from source:
 

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwrk",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {
@@ -9,14 +9,16 @@
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "build:bin": "pnpm --filter openwork-server build:bin && bun build --compile src/cli.ts --outfile dist/openwrk && bun scripts/build-bin.ts",
+    "build:bin": "pnpm --filter openwork-server build:bin && pnpm --filter owpenwork build:bin && bun build --compile src/cli.ts --outfile dist/openwrk && bun scripts/build-bin.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepublishOnly": "pnpm build:bin"
   },
   "files": [
     "dist",
     "README.md",
-    "dist/openwork-server"
+    "dist/openwork-server",
+    "dist/owpenbot",
+    "dist/versions.json"
   ],
   "repository": {
     "type": "git",

--- a/packages/headless/scripts/build-bin.ts
+++ b/packages/headless/scripts/build-bin.ts
@@ -1,11 +1,44 @@
-import { copyFile, mkdir } from "node:fs/promises";
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+type VersionInfo = {
+  version: string;
+  sha256: string;
+};
+
 const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
-const source = resolve(root, "..", "server", "dist", "bin", "openwork-server");
 const targetDir = resolve(root, "dist");
-const target = resolve(targetDir, "openwork-server");
+
+const serverBin = resolve(root, "..", "server", "dist", "bin", "openwork-server");
+const owpenbotBin = resolve(root, "..", "owpenbot", "dist", "bin", "owpenbot");
+
+const serverPkg = JSON.parse(
+  await readFile(resolve(root, "..", "server", "package.json"), "utf8"),
+) as { version: string };
+const owpenbotPkg = JSON.parse(
+  await readFile(resolve(root, "..", "owpenbot", "package.json"), "utf8"),
+) as { version: string };
 
 await mkdir(targetDir, { recursive: true });
-await copyFile(source, target);
+await copyFile(serverBin, resolve(targetDir, "openwork-server"));
+await copyFile(owpenbotBin, resolve(targetDir, "owpenbot"));
+
+const sha256 = async (path: string) => {
+  const data = await readFile(path);
+  return createHash("sha256").update(data).digest("hex");
+};
+
+const versions = {
+  "openwork-server": {
+    version: serverPkg.version,
+    sha256: await sha256(resolve(targetDir, "openwork-server")),
+  },
+  owpenbot: {
+    version: owpenbotPkg.version,
+    sha256: await sha256(resolve(targetDir, "owpenbot")),
+  },
+} as Record<string, VersionInfo>;
+
+await writeFile(resolve(targetDir, "versions.json"), `${JSON.stringify(versions, null, 2)}\n`, "utf8");

--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "build:bin": "bun ./script/build.ts --outdir dist/bin",
+    "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/owpenbot",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-windows-x64",
     "build:binary": "bun ./script/build.ts --outdir dist/bin",
     "start": "bun dist/cli.js start",


### PR DESCRIPTION
## Summary
- bundle `openwork-server` + `owpenbot` binaries and write a SHA-256 manifest
- enforce bundled sidecar integrity at runtime (refuse to start on mismatch)
- build/publish flow now compiles and copies owpenbot alongside openwrk

## Testing
- pnpm --filter openwork-server build
- pnpm --filter owpenwork build
- pnpm --filter openwrk build
- pnpm --filter openwrk build:bin
- packages/headless/dist/openwrk start --workspace tmp/openwrk-test --approval auto --no-owpenbot --check --json

## Release
- npm publish --access public (openwrk@0.1.5)