### PR TITLE
Add OpenWork server engine reload endpoint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,6 +177,13 @@ OpenWork exposes two extension surfaces:
    - The format is the same as OpenCode CLI uses today.
    - OpenWork should show plugin status and instructions; a native plugin manager is planned.
 
+### Engine reload (config refresh)
+
+- OpenWork server exposes `POST /workspace/:id/engine/reload`.
+- It calls OpenCode `POST /instance/dispose` with the workspace directory to force a config re-read.
+- Use after skills/plugins/MCP/config edits; reloads can interrupt active sessions.
+- Reload requests follow OpenWork server approval rules.
+
 ### OpenPackage Registry (Current + Future)
 
 - Today, OpenWork only supports **curated lists + manual sources**.

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -255,6 +255,12 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         method: "PATCH",
         body: payload,
       }),
+    reloadEngine: (workspaceId: string) =>
+      requestJson<{ ok: boolean; reloadedAt?: number }>(baseUrl, `/workspace/${workspaceId}/engine/reload`, {
+        token,
+        hostToken,
+        method: "POST",
+      }),
     listPlugins: (workspaceId: string, options?: { includeGlobal?: boolean }) => {
       const query = options?.includeGlobal ? "?includeGlobal=true" : "";
       return requestJson<{ items: OpenworkPluginItem[]; loadOrder: string[] }>(

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -65,6 +65,7 @@ Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CON
 - `GET /workspaces`
 - `GET /workspace/:id/config`
 - `PATCH /workspace/:id/config`
+- `POST /workspace/:id/engine/reload`
 - `GET /workspace/:id/plugins`
 - `POST /workspace/:id/plugins`
 - `DELETE /workspace/:id/plugins/:name`

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -240,6 +240,27 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     return jsonResponse({ updatedAt: Date.now() });
   });
 
+  addRoute(routes, "POST", "/workspace/:id/engine/reload", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "engine.reload",
+      summary: "Reload OpenCode engine",
+      paths: [opencodeConfigPath(workspace.path)],
+    });
+    await reloadOpencodeEngine(workspace);
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "engine.reload",
+      target: "opencode.instance",
+      summary: "Reloaded OpenCode engine",
+      timestamp: Date.now(),
+    });
+    return jsonResponse({ ok: true, reloadedAt: Date.now() });
+  });
+
   addRoute(routes, "GET", "/workspace/:id/plugins", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const includeGlobal = ctx.url.searchParams.get("includeGlobal") === "true";
@@ -552,6 +573,65 @@ async function readOpenworkConfig(workspaceRoot: string): Promise<Record<string,
   } catch {
     throw new ApiError(422, "invalid_json", "Failed to parse openwork.json");
   }
+}
+
+function resolveOpencodeDirectory(workspace: WorkspaceInfo): string | null {
+  const explicit = workspace.directory?.trim() ?? "";
+  if (explicit) return explicit;
+  if (workspace.workspaceType === "local") return workspace.path;
+  return null;
+}
+
+function buildOpencodeReloadUrl(baseUrl: string, directory?: string | null): string {
+  try {
+    const url = new URL(baseUrl);
+    url.pathname = "/instance/dispose";
+    url.search = "";
+    if (directory) {
+      url.searchParams.set("directory", directory);
+    }
+    return url.toString();
+  } catch {
+    throw new ApiError(400, "opencode_url_invalid", "OpenCode base URL is invalid");
+  }
+}
+
+function buildOpencodeAuthHeader(workspace: WorkspaceInfo): string | null {
+  const username = workspace.opencodeUsername?.trim() ?? "";
+  const password = workspace.opencodePassword?.trim() ?? "";
+  if (!username || !password) return null;
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+
+function parseOpencodeErrorBody(input: string): unknown {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return trimmed;
+  }
+}
+
+async function reloadOpencodeEngine(workspace: WorkspaceInfo): Promise<void> {
+  const baseUrl = workspace.baseUrl?.trim() ?? "";
+  if (!baseUrl) {
+    throw new ApiError(400, "opencode_unconfigured", "OpenCode base URL is missing for this workspace");
+  }
+
+  const directory = resolveOpencodeDirectory(workspace);
+  const targetUrl = buildOpencodeReloadUrl(baseUrl, directory);
+  const headers: Record<string, string> = {};
+  const auth = buildOpencodeAuthHeader(workspace);
+  if (auth) headers.Authorization = auth;
+
+  const response = await fetch(targetUrl, { method: "POST", headers });
+  if (response.ok) return;
+  const body = parseOpencodeErrorBody(await response.text());
+  throw new ApiError(502, "opencode_reload_failed", "OpenCode reload failed", {
+    status: response.status,
+    body,
+  });
 }
 
 async function writeOpenworkConfig(workspaceRoot: string, payload: Record<string, unknown>, merge: boolean): Promise<void> {


### PR DESCRIPTION
## Summary
- add an OpenWork server endpoint to trigger OpenCode instance reloads with approvals and audit logging
- document the reload flow in the architecture guide and server README
- expose a reload helper on the OpenWork server client

## Testing
- Not run (not requested)