### PR TITLE
fix(headless): verify sidecar integrity and auth handoff

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -14,14 +14,14 @@ openwrk start --workspace /path/to/workspace --approval auto
 `openwrk` bundles and validates exact versions of `openwork-server` + `owpenbot` using a
 SHA-256 manifest. It will refuse to start if the bundled binaries are missing or tampered with.
 
-For development overrides only, set `OPENWRK_ALLOW_EXTERNAL=1` to use locally installed
-`openwork-server` or `owpenbot` binaries.
+For development overrides only, set `OPENWRK_ALLOW_EXTERNAL=1` or pass `--allow-external` to use
+locally installed `openwork-server` or `owpenbot` binaries.
 
 Or from source:
 
 ```bash
 pnpm --filter openwrk dev -- \
-  start --workspace /path/to/workspace --approval auto
+  start --workspace /path/to/workspace --approval auto --allow-external
 ```
 
 The command prints pairing details (OpenWork server URL + token, OpenCode URL + auth) so remote OpenWork clients can connect.
@@ -81,6 +81,7 @@ Point to source CLIs for fast iteration:
 ```bash
 openwrk start \
   --workspace /path/to/workspace \
+  --allow-external \
   --openwork-server-bin packages/server/src/cli.ts \
   --owpenbot-bin packages/owpenbot/src/cli.ts
 ```

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -13,6 +13,9 @@ import { parseFrontmatter } from "./frontmatter.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { sanitizeCommandName } from "./validators.js";
+import pkg from "../package.json" with { type: "json" };
+
+const SERVER_VERSION = pkg.version;
 
 type AuthMode = "none" | "client" | "host";
 
@@ -172,7 +175,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
   const routes: Route[] = [];
 
   addRoute(routes, "GET", "/health", "none", async () => {
-    return jsonResponse({ ok: true, version: "0.1.0", uptimeMs: Date.now() - config.startedAt });
+    return jsonResponse({ ok: true, version: SERVER_VERSION, uptimeMs: Date.now() - config.startedAt });
   });
 
   addRoute(routes, "GET", "/capabilities", "client", async () => {


### PR DESCRIPTION
## Summary
- verify openwork-server/owpenbot versions and token handoff before running checks
- require bundled sidecars by default and gate external binaries behind --allow-external
- report openwork-server package version in /health for reliable verification

## Testing
- `pnpm --filter openwork-server build`
- `pnpm --filter openwrk test:router`
- `pnpm --filter openwrk dev -- start --workspace /tmp/openwrk-integrity-XXXXXX --check --check-events --allow-external --openwork-host 127.0.0.1 --openwork-port <free port> --openwork-server-bin ../server/src/cli.ts --owpenbot-bin ../owpenbot/src/cli.ts`