### PR TITLE
feat: wire openwrk runtime for host switching

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1113,7 +1113,7 @@ export default function App() {
     }
     const job = await schedulerDeleteJob(name);
     setScheduledJobs((current) => current.filter((entry) => entry.slug !== job.slug));
-    return job;
+    return;
   };
   const globalSync = useGlobalSync();
   const providers = createMemo(() => globalSync.data.provider.all ?? []);

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -32,6 +32,11 @@ export type OpenworkWorkspaceInfo = {
   };
 };
 
+export type OpenworkWorkspaceList = {
+  items: OpenworkWorkspaceInfo[];
+  activeId?: string | null;
+};
+
 export type OpenworkPluginItem = {
   spec: string;
   source: "config" | "dir.project" | "dir.global";
@@ -248,7 +253,13 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     health: () =>
       requestJson<{ ok: boolean; version: string; uptimeMs: number }>(baseUrl, "/health", { token, hostToken }),
     capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken }),
-    listWorkspaces: () => requestJson<{ items: OpenworkWorkspaceInfo[] }>(baseUrl, "/workspaces", { token, hostToken }),
+    listWorkspaces: () => requestJson<OpenworkWorkspaceList>(baseUrl, "/workspaces", { token, hostToken }),
+    activateWorkspace: (workspaceId: string) =>
+      requestJson<{ activeId: string; workspace: OpenworkWorkspaceInfo }>(
+        baseUrl,
+        `/workspaces/${encodeURIComponent(workspaceId)}/activate`,
+        { token, hostToken, method: "POST" },
+      ),
     getConfig: (workspaceId: string) =>
       requestJson<{ opencode: Record<string, unknown>; openwork: Record<string, unknown>; updatedAt?: number | null }>(
         baseUrl,

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -3,6 +3,7 @@ import { validateMcpServerName } from "../mcp";
 
 export type EngineInfo = {
   running: boolean;
+  runtime: "direct" | "openwrk";
   baseUrl: string | null;
   projectDir: string | null;
   hostname: string | null;
@@ -27,6 +28,42 @@ export type OpenworkServerInfo = {
   pid: number | null;
   lastStdout: string | null;
   lastStderr: string | null;
+};
+
+export type OpenwrkDaemonState = {
+  pid: number;
+  port: number;
+  baseUrl: string;
+  startedAt: number;
+};
+
+export type OpenwrkOpencodeState = {
+  pid: number;
+  port: number;
+  baseUrl: string;
+  startedAt: number;
+};
+
+export type OpenwrkWorkspace = {
+  id: string;
+  name: string;
+  path: string;
+  workspaceType: string;
+  baseUrl?: string | null;
+  directory?: string | null;
+  createdAt?: number | null;
+  lastUsedAt?: number | null;
+};
+
+export type OpenwrkStatus = {
+  running: boolean;
+  dataDir: string;
+  daemon: OpenwrkDaemonState | null;
+  opencode: OpenwrkOpencodeState | null;
+  activeId: string | null;
+  workspaceCount: number;
+  workspaces: OpenwrkWorkspace[];
+  lastError: string | null;
 };
 
 export type EngineDoctorResult = {
@@ -69,11 +106,13 @@ export type WorkspaceExportSummary = {
 
 export async function engineStart(
   projectDir: string,
-  options?: { preferSidecar?: boolean },
+  options?: { preferSidecar?: boolean; runtime?: "direct" | "openwrk"; workspacePaths?: string[] },
 ): Promise<EngineInfo> {
   return invoke<EngineInfo>("engine_start", {
     projectDir,
     preferSidecar: options?.preferSidecar ?? false,
+    runtime: options?.runtime ?? null,
+    workspacePaths: options?.workspacePaths ?? null,
   });
 }
 
@@ -248,6 +287,24 @@ export async function opencodeCommandDelete(input: {
 
 export async function engineStop(): Promise<EngineInfo> {
   return invoke<EngineInfo>("engine_stop");
+}
+
+export async function openwrkStatus(): Promise<OpenwrkStatus> {
+  return invoke<OpenwrkStatus>("openwrk_status");
+}
+
+export async function openwrkWorkspaceActivate(input: {
+  workspacePath: string;
+  name?: string | null;
+}): Promise<OpenwrkWorkspace> {
+  return invoke<OpenwrkWorkspace>("openwrk_workspace_activate", {
+    workspacePath: input.workspacePath,
+    name: input.name ?? null,
+  });
+}
+
+export async function openwrkInstanceDispose(workspacePath: string): Promise<boolean> {
+  return invoke<boolean>("openwrk_instance_dispose", { workspacePath });
 }
 
 export async function openworkServerInfo(): Promise<OpenworkServerInfo> {

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -15,7 +15,7 @@ import type {
 import type { McpDirectoryInfo } from "../constants";
 import { formatRelativeTime, normalizeDirectoryPath } from "../utils";
 import type { OpenworkAuditEntry, OpenworkServerCapabilities, OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
-import type { EngineInfo, OpenworkServerInfo, OwpenbotInfo, WorkspaceInfo } from "../lib/tauri";
+import type { EngineInfo, OpenwrkStatus, OpenworkServerInfo, OwpenbotInfo, WorkspaceInfo } from "../lib/tauri";
 
 import Button from "../components/button";
 import OpenWorkLogo from "../components/openwork-logo";
@@ -77,6 +77,7 @@ export type DashboardViewProps = {
   openworkAuditError: string | null;
   opencodeConnectStatus: OpencodeConnectStatus | null;
   engineInfo: EngineInfo | null;
+  openwrkStatus: OpenwrkStatus | null;
   owpenbotInfo: OwpenbotInfo | null;
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
   resetOpenworkServerSettings: () => void;
@@ -218,6 +219,8 @@ export type DashboardViewProps = {
   anyActiveRuns: boolean;
   engineSource: "path" | "sidecar";
   setEngineSource: (value: "path" | "sidecar") => void;
+  engineRuntime: "direct" | "openwrk";
+  setEngineRuntime: (value: "direct" | "openwrk") => void;
   isWindows: boolean;
   toggleDeveloperMode: () => void;
   developerMode: boolean;
@@ -940,6 +943,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   openworkAuditError={props.openworkAuditError}
                   opencodeConnectStatus={props.opencodeConnectStatus}
                   engineInfo={props.engineInfo}
+                  openwrkStatus={props.openwrkStatus}
                   owpenbotInfo={props.owpenbotInfo}
                   updateOpenworkServerSettings={props.updateOpenworkServerSettings}
                   resetOpenworkServerSettings={props.resetOpenworkServerSettings}
@@ -949,6 +953,8 @@ export default function DashboardView(props: DashboardViewProps) {
                   stopHost={props.stopHost}
                   engineSource={props.engineSource}
                   setEngineSource={props.setEngineSource}
+                  engineRuntime={props.engineRuntime}
+                  setEngineRuntime={props.setEngineRuntime}
                   isWindows={props.isWindows}
                   defaultModelLabel={props.defaultModelLabel}
                   defaultModelRef={props.defaultModelRef}

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -93,6 +93,8 @@ export type View = "onboarding" | "dashboard" | "session" | "proto";
 
 export type Mode = "host" | "client";
 
+export type EngineRuntime = "direct" | "openwrk";
+
 export type OnboardingStep = "mode" | "host" | "client" | "connecting";
 
 export type DashboardTab =

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -5174,6 +5174,8 @@ dependencies = [
  "once_cell",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "url",
  "webpki-roots 0.26.11",
 ]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ tauri-plugin-http = "2.5.6"
 tauri-plugin-opener = "2.5.3"
 tauri-plugin-shell = "2"
 uuid = { version = "1", features = ["v4"] }
-ureq = "2.10"
+ureq = { version = "2.10", features = ["json"] }
 gethostname = "0.4"
 local-ip-address = "0.5"
 walkdir = "2.5"

--- a/packages/desktop/src-tauri/src/commands/mod.rs
+++ b/packages/desktop/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod command_files;
 pub mod config;
 pub mod engine;
 pub mod misc;
+pub mod openwrk;
 pub mod openwork_server;
 pub mod opkg;
 pub mod owpenbot;

--- a/packages/desktop/src-tauri/src/commands/openwrk.rs
+++ b/packages/desktop/src-tauri/src/commands/openwrk.rs
@@ -1,0 +1,114 @@
+use serde::Deserialize;
+use serde_json::json;
+use tauri::State;
+
+use crate::openwrk::{resolve_openwrk_data_dir, resolve_openwrk_status};
+use crate::openwrk::manager::OpenwrkManager;
+use crate::types::{OpenwrkStatus, OpenwrkWorkspace};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenwrkWorkspaceResponse {
+    pub workspace: OpenwrkWorkspace,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenwrkDisposeResponse {
+    pub disposed: bool,
+}
+
+fn resolve_data_dir(manager: &OpenwrkManager) -> String {
+    manager
+        .inner
+        .lock()
+        .ok()
+        .and_then(|state| state.data_dir.clone())
+        .unwrap_or_else(resolve_openwrk_data_dir)
+}
+
+fn resolve_base_url(manager: &OpenwrkManager) -> Result<String, String> {
+    let data_dir = resolve_data_dir(manager);
+    let status = resolve_openwrk_status(&data_dir, None);
+    status
+        .daemon
+        .map(|daemon| daemon.base_url)
+        .ok_or_else(|| "openwrk daemon is not running".to_string())
+}
+
+#[tauri::command]
+pub fn openwrk_status(manager: State<OpenwrkManager>) -> OpenwrkStatus {
+    let data_dir = resolve_data_dir(&manager);
+    let last_error = manager
+        .inner
+        .lock()
+        .ok()
+        .and_then(|state| state.last_stderr.clone());
+    resolve_openwrk_status(&data_dir, last_error)
+}
+
+#[tauri::command]
+pub fn openwrk_workspace_activate(
+    manager: State<OpenwrkManager>,
+    workspace_path: String,
+    name: Option<String>,
+) -> Result<OpenwrkWorkspace, String> {
+    let base_url = resolve_base_url(&manager)?;
+    let add_url = format!("{}/workspaces", base_url.trim_end_matches('/'));
+    let payload = json!({
+        "path": workspace_path,
+        "name": name,
+    });
+
+    let add_response = ureq::post(&add_url)
+        .set("Content-Type", "application/json")
+        .send_json(payload)
+        .map_err(|e| format!("Failed to add workspace: {e}"))?;
+    let added: OpenwrkWorkspaceResponse = add_response
+        .into_json()
+        .map_err(|e| format!("Failed to parse openwrk response: {e}"))?;
+
+    let id = added.workspace.id.clone();
+    let activate_url = format!("{}/workspaces/{}/activate", base_url.trim_end_matches('/'), id);
+    ureq::post(&activate_url)
+        .set("Content-Type", "application/json")
+        .send_string("")
+        .map_err(|e| format!("Failed to activate workspace: {e}"))?;
+
+    let path_url = format!("{}/workspaces/{}/path", base_url.trim_end_matches('/'), id);
+    let _ = ureq::get(&path_url).call();
+
+    Ok(added.workspace)
+}
+
+#[tauri::command]
+pub fn openwrk_instance_dispose(
+    manager: State<OpenwrkManager>,
+    workspace_path: String,
+) -> Result<bool, String> {
+    let base_url = resolve_base_url(&manager)?;
+    let add_url = format!("{}/workspaces", base_url.trim_end_matches('/'));
+    let payload = json!({
+        "path": workspace_path,
+    });
+
+    let add_response = ureq::post(&add_url)
+        .set("Content-Type", "application/json")
+        .send_json(payload)
+        .map_err(|e| format!("Failed to ensure workspace: {e}"))?;
+    let added: OpenwrkWorkspaceResponse = add_response
+        .into_json()
+        .map_err(|e| format!("Failed to parse openwrk response: {e}"))?;
+
+    let id = added.workspace.id;
+    let dispose_url = format!("{}/instances/{}/dispose", base_url.trim_end_matches('/'), id);
+    let response = ureq::post(&dispose_url)
+        .set("Content-Type", "application/json")
+        .send_string("")
+        .map_err(|e| format!("Failed to dispose instance: {e}"))?;
+    let result: OpenwrkDisposeResponse = response
+        .into_json()
+        .map_err(|e| format!("Failed to parse openwrk response: {e}"))?;
+
+    Ok(result.disposed)
+}

--- a/packages/desktop/src-tauri/src/engine/manager.rs
+++ b/packages/desktop/src-tauri/src/engine/manager.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use tauri_plugin_shell::process::CommandChild;
 
-use crate::types::EngineInfo;
+use crate::types::{EngineInfo, EngineRuntime};
 
 #[derive(Default)]
 pub struct EngineManager {
@@ -11,6 +11,7 @@ pub struct EngineManager {
 
 #[derive(Default)]
 pub struct EngineState {
+    pub runtime: EngineRuntime,
     pub child: Option<CommandChild>,
     pub child_exited: bool,
     pub project_dir: Option<String>,
@@ -36,6 +37,7 @@ impl EngineManager {
 
         EngineInfo {
             running,
+            runtime: state.runtime.clone(),
             base_url: state.base_url.clone(),
             project_dir: state.project_dir.clone(),
             hostname: state.hostname.clone(),
@@ -53,6 +55,7 @@ impl EngineManager {
             let _ = child.kill();
         }
         state.child_exited = true;
+        state.runtime = EngineRuntime::Direct;
         state.base_url = None;
         state.project_dir = None;
         state.hostname = None;

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 mod engine;
 mod fs;
 mod opkg;
+mod openwrk;
 mod openwork_server;
 mod owpenbot;
 mod paths;
@@ -20,6 +21,7 @@ use commands::command_files::{
 use commands::config::{read_opencode_config, write_opencode_config};
 use commands::engine::{engine_doctor, engine_info, engine_install, engine_start, engine_stop};
 use commands::misc::{opencode_mcp_auth, reset_opencode_cache, reset_openwork_state};
+use commands::openwrk::{openwrk_instance_dispose, openwrk_status, openwrk_workspace_activate};
 use commands::openwork_server::openwork_server_info;
 use commands::scheduler::{scheduler_delete_job, scheduler_list_jobs};
 use commands::opkg::{import_skill, opkg_install};
@@ -35,6 +37,7 @@ use commands::workspace::{
     workspace_openwork_write, workspace_set_active, workspace_update_remote,
 };
 use engine::manager::EngineManager;
+use openwrk::manager::OpenwrkManager;
 use openwork_server::manager::OpenworkServerManager;
 use owpenbot::manager::OwpenbotManager;
 use workspace::watch::WorkspaceWatchState;
@@ -53,6 +56,7 @@ pub fn run() {
 
     builder
         .manage(EngineManager::default())
+        .manage(OpenwrkManager::default())
         .manage(OpenworkServerManager::default())
         .manage(OwpenbotManager::default())
         .manage(WorkspaceWatchState::default())
@@ -62,6 +66,9 @@ pub fn run() {
             engine_info,
             engine_doctor,
             engine_install,
+            openwrk_status,
+            openwrk_workspace_activate,
+            openwrk_instance_dispose,
             openwork_server_info,
             owpenbot_info,
             owpenbot_start,

--- a/packages/desktop/src-tauri/src/openwork_server/mod.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/mod.rs
@@ -43,7 +43,7 @@ pub fn resolve_connect_url(port: u16) -> Option<String> {
 pub fn start_openwork_server(
     app: &AppHandle,
     manager: &OpenworkServerManager,
-    workspace_path: &str,
+    workspace_paths: &[String],
     opencode_base_url: Option<&str>,
     opencode_username: Option<&str>,
     opencode_password: Option<&str>,
@@ -55,16 +55,24 @@ pub fn start_openwork_server(
     let port = resolve_openwork_port()?;
     let client_token = generate_token();
     let host_token = generate_token();
+    let active_workspace = workspace_paths
+        .first()
+        .map(|path| path.as_str())
+        .unwrap_or("");
 
     let (mut rx, child) = spawn_openwork_server(
         app,
         &host,
         port,
-        workspace_path,
+        workspace_paths,
         &client_token,
         &host_token,
         opencode_base_url,
-        Some(workspace_path),
+        if active_workspace.is_empty() {
+            None
+        } else {
+            Some(active_workspace)
+        },
         opencode_username,
         opencode_password,
     )?;

--- a/packages/desktop/src-tauri/src/openwrk/manager.rs
+++ b/packages/desktop/src-tauri/src/openwrk/manager.rs
@@ -1,0 +1,28 @@
+use std::sync::{Arc, Mutex};
+
+use tauri_plugin_shell::process::CommandChild;
+
+#[derive(Default)]
+pub struct OpenwrkManager {
+    pub inner: Arc<Mutex<OpenwrkState>>,
+}
+
+#[derive(Default)]
+pub struct OpenwrkState {
+    pub child: Option<CommandChild>,
+    pub child_exited: bool,
+    pub data_dir: Option<String>,
+    pub last_stdout: Option<String>,
+    pub last_stderr: Option<String>,
+}
+
+impl OpenwrkManager {
+    pub fn stop_locked(state: &mut OpenwrkState) {
+        if let Some(child) = state.child.take() {
+            let _ = child.kill();
+        }
+        state.child_exited = true;
+        state.last_stdout = None;
+        state.last_stderr = None;
+    }
+}

--- a/packages/desktop/src-tauri/src/openwrk/mod.rs
+++ b/packages/desktop/src-tauri/src/openwrk/mod.rs
@@ -1,0 +1,254 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use tauri::AppHandle;
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+
+use crate::paths::home_dir;
+use crate::types::{OpenwrkDaemonState, OpenwrkOpencodeState, OpenwrkStatus, OpenwrkWorkspace};
+
+pub mod manager;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenwrkStateFile {
+    pub version: Option<u32>,
+    pub daemon: Option<OpenwrkDaemonState>,
+    pub opencode: Option<OpenwrkOpencodeState>,
+    pub active_id: Option<String>,
+    #[serde(default)]
+    pub workspaces: Vec<OpenwrkWorkspace>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenwrkHealth {
+    pub ok: bool,
+    pub daemon: Option<OpenwrkDaemonState>,
+    pub opencode: Option<OpenwrkOpencodeState>,
+    pub active_id: Option<String>,
+    pub workspace_count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenwrkWorkspaceList {
+    pub active_id: Option<String>,
+    #[serde(default)]
+    pub workspaces: Vec<OpenwrkWorkspace>,
+}
+
+pub struct OpenwrkSpawnOptions {
+    pub data_dir: String,
+    pub daemon_host: String,
+    pub daemon_port: u16,
+    pub opencode_bin: String,
+    pub opencode_host: String,
+    pub opencode_workdir: String,
+    pub opencode_port: Option<u16>,
+    pub opencode_username: Option<String>,
+    pub opencode_password: Option<String>,
+    pub cors: Option<String>,
+}
+
+pub fn resolve_openwrk_data_dir() -> String {
+    let env_dir = env::var("OPENWRK_DATA_DIR")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var("OPENWORK_DATA_DIR")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        });
+
+    if let Some(dir) = env_dir {
+        return dir;
+    }
+
+    if let Some(home) = home_dir() {
+        return home
+            .join(".openwork")
+            .join("openwrk")
+            .to_string_lossy()
+            .to_string();
+    }
+
+    ".openwork/openwrk".to_string()
+}
+
+fn openwrk_state_path(data_dir: &str) -> PathBuf {
+    Path::new(data_dir).join("openwrk-state.json")
+}
+
+pub fn read_openwrk_state(data_dir: &str) -> Option<OpenwrkStateFile> {
+    let path = openwrk_state_path(data_dir);
+    let payload = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&payload).ok()
+}
+
+fn fetch_json<T: DeserializeOwned>(url: &str) -> Result<T, String> {
+    let response = ureq::get(url)
+        .set("Accept", "application/json")
+        .call()
+        .map_err(|e| format!("{e}"))?;
+    response
+        .into_json::<T>()
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
+pub fn fetch_openwrk_health(base_url: &str) -> Result<OpenwrkHealth, String> {
+    let url = format!("{}/health", base_url.trim_end_matches('/'));
+    fetch_json(&url)
+}
+
+pub fn fetch_openwrk_workspaces(base_url: &str) -> Result<OpenwrkWorkspaceList, String> {
+    let url = format!("{}/workspaces", base_url.trim_end_matches('/'));
+    fetch_json(&url)
+}
+
+pub fn wait_for_openwrk(base_url: &str, timeout_ms: u64) -> Result<OpenwrkHealth, String> {
+    let start = std::time::Instant::now();
+    let mut last_error = None;
+    while start.elapsed().as_millis() < timeout_ms as u128 {
+        match fetch_openwrk_health(base_url) {
+            Ok(health) if health.ok => return Ok(health),
+            Ok(_) => last_error = Some("Openwrk reported unhealthy".to_string()),
+            Err(err) => last_error = Some(err),
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    Err(last_error.unwrap_or_else(|| "Timed out waiting for openwrk".to_string()))
+}
+
+pub fn spawn_openwrk_daemon(
+    app: &AppHandle,
+    options: &OpenwrkSpawnOptions,
+) -> Result<(tauri::async_runtime::Receiver<CommandEvent>, CommandChild), String> {
+    let command = match app.shell().sidecar("openwrk") {
+        Ok(command) => command,
+        Err(_) => app.shell().command("openwrk"),
+    };
+
+    let mut args = vec![
+        "daemon".to_string(),
+        "run".to_string(),
+        "--data-dir".to_string(),
+        options.data_dir.clone(),
+        "--daemon-host".to_string(),
+        options.daemon_host.clone(),
+        "--daemon-port".to_string(),
+        options.daemon_port.to_string(),
+        "--opencode-bin".to_string(),
+        options.opencode_bin.clone(),
+        "--opencode-host".to_string(),
+        options.opencode_host.clone(),
+        "--opencode-workdir".to_string(),
+        options.opencode_workdir.clone(),
+    ];
+
+    if let Some(port) = options.opencode_port {
+        args.push("--opencode-port".to_string());
+        args.push(port.to_string());
+    }
+
+    if let Some(username) = &options.opencode_username {
+        if !username.trim().is_empty() {
+            args.push("--opencode-username".to_string());
+            args.push(username.to_string());
+        }
+    }
+
+    if let Some(password) = &options.opencode_password {
+        if !password.trim().is_empty() {
+            args.push("--opencode-password".to_string());
+            args.push(password.to_string());
+        }
+    }
+
+    if let Some(cors) = &options.cors {
+        if !cors.trim().is_empty() {
+            args.push("--cors".to_string());
+            args.push(cors.to_string());
+        }
+    }
+
+    command
+        .args(args)
+        .spawn()
+        .map_err(|e| format!("Failed to start openwrk: {e}"))
+}
+
+pub fn openwrk_status_from_state(
+    data_dir: &str,
+    last_error: Option<String>,
+) -> OpenwrkStatus {
+    let state = read_openwrk_state(data_dir);
+    let workspaces = state
+        .as_ref()
+        .map(|state| state.workspaces.clone())
+        .unwrap_or_default();
+    let workspace_count = workspaces.len();
+    let active_id = state
+        .as_ref()
+        .and_then(|state| state.active_id.clone())
+        .filter(|id| !id.trim().is_empty());
+    OpenwrkStatus {
+        running: false,
+        data_dir: data_dir.to_string(),
+        daemon: state.as_ref().and_then(|state| state.daemon.clone()),
+        opencode: state.as_ref().and_then(|state| state.opencode.clone()),
+        active_id,
+        workspace_count,
+        workspaces,
+        last_error,
+    }
+}
+
+pub fn resolve_openwrk_status(data_dir: &str, last_error: Option<String>) -> OpenwrkStatus {
+    let fallback = openwrk_status_from_state(data_dir, last_error);
+    let base_url = fallback
+        .daemon
+        .as_ref()
+        .map(|daemon| daemon.base_url.clone());
+    let Some(base_url) = base_url else {
+        return fallback;
+    };
+
+    match fetch_openwrk_health(&base_url) {
+        Ok(health) => {
+            let workspace_payload = fetch_openwrk_workspaces(&base_url).ok();
+            let workspaces = workspace_payload
+                .as_ref()
+                .map(|payload| payload.workspaces.clone())
+                .unwrap_or_else(|| fallback.workspaces.clone());
+            let active_id = workspace_payload
+                .as_ref()
+                .and_then(|payload| payload.active_id.clone())
+                .or_else(|| health.active_id.clone())
+                .filter(|id| !id.trim().is_empty());
+            let workspace_count = workspace_payload
+                .as_ref()
+                .map(|payload| payload.workspaces.len())
+                .or(health.workspace_count)
+                .unwrap_or(workspaces.len());
+            OpenwrkStatus {
+                running: health.ok,
+                data_dir: data_dir.to_string(),
+                daemon: health.daemon,
+                opencode: health.opencode,
+                active_id,
+                workspace_count,
+                workspaces,
+                last_error: None,
+            }
+        }
+        Err(error) => OpenwrkStatus {
+            last_error: Some(error),
+            ..fallback
+        },
+    }
+}

--- a/packages/desktop/src-tauri/src/types.rs
+++ b/packages/desktop/src-tauri/src/types.rs
@@ -50,10 +50,24 @@ impl WorkspaceOpenworkConfig {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EngineRuntime {
+    Direct,
+    Openwrk,
+}
+
+impl Default for EngineRuntime {
+    fn default() -> Self {
+        EngineRuntime::Direct
+    }
+}
+
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EngineInfo {
     pub running: bool,
+    pub runtime: EngineRuntime,
     pub base_url: Option<String>,
     pub project_dir: Option<String>,
     pub hostname: Option<String>,
@@ -80,6 +94,50 @@ pub struct OpenworkServerInfo {
     pub pid: Option<u32>,
     pub last_stdout: Option<String>,
     pub last_stderr: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenwrkDaemonState {
+    pub pid: u32,
+    pub port: u16,
+    pub base_url: String,
+    pub started_at: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenwrkOpencodeState {
+    pub pid: u32,
+    pub port: u16,
+    pub base_url: String,
+    pub started_at: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenwrkWorkspace {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub workspace_type: String,
+    pub base_url: Option<String>,
+    pub directory: Option<String>,
+    pub created_at: Option<u64>,
+    pub last_used_at: Option<u64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenwrkStatus {
+    pub running: bool,
+    pub data_dir: String,
+    pub daemon: Option<OpenwrkDaemonState>,
+    pub opencode: Option<OpenwrkOpencodeState>,
+    pub active_id: Option<String>,
+    pub workspace_count: usize,
+    pub workspaces: Vec<OpenwrkWorkspace>,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -178,13 +178,18 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
   const opencodePassword = cli.opencodePassword ?? envOpencodePassword ?? fileConfig.opencodePassword;
 
   if (workspaceConfigs.length > 0 && (opencodeBaseUrl || opencodeDirectory || opencodeUsername || opencodePassword)) {
-    workspaceConfigs[0] = {
-      ...workspaceConfigs[0],
-      baseUrl: opencodeBaseUrl ?? workspaceConfigs[0].baseUrl,
-      directory: opencodeDirectory ?? workspaceConfigs[0].directory,
-      opencodeUsername: opencodeUsername ?? workspaceConfigs[0].opencodeUsername,
-      opencodePassword: opencodePassword ?? workspaceConfigs[0].opencodePassword,
-    };
+    const allowDirectoryOverride = workspaceConfigs.length === 1 && opencodeDirectory;
+    workspaceConfigs = workspaceConfigs.map((workspace, index) => {
+      const nextDirectory =
+        workspace.directory ?? (allowDirectoryOverride && index === 0 ? opencodeDirectory : undefined);
+      return {
+        ...workspace,
+        baseUrl: workspace.baseUrl ?? opencodeBaseUrl,
+        directory: nextDirectory,
+        opencodeUsername: workspace.opencodeUsername ?? opencodeUsername,
+        opencodePassword: workspace.opencodePassword ?? opencodePassword,
+      };
+    });
   }
 
   const workspaces = buildWorkspaceInfos(workspaceConfigs, configDir);


### PR DESCRIPTION
## Summary
- route host workspace switches through openwrk activation and OpenWork server workspace activation
- add engine runtime preference + pass runtime/workspace paths into host engine start/reload
- surface openwrk status details in developer settings/debug view
- normalize scheduled job delete handler return type

## Testing
- pnpm --filter openwrk test:router
- pnpm -C packages/app build
- pnpm -C packages/app typecheck