### PR TITLE
chore(headless): bump openwrk to 0.1.6

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwrk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump openwrk version to 0.1.6 for npm publish

## Testing
- pnpm --filter openwork-server build
- pnpm --filter owpenwork build
- pnpm --filter openwrk build
- pnpm --filter openwrk build:bin

## Release
- npm publish --access public (openwrk@0.1.6)