### PR TITLE
fix: render file mentions in chat

### DIFF
--- a/packages/app/src/app/utils/index.ts
+++ b/packages/app/src/app/utils/index.ts
@@ -448,14 +448,8 @@ export function groupMessageParts(parts: Part[], messageId: string): MessageGrou
     }
 
     if (part.type === "file") {
-      const record = part as { label?: string; path?: string; filename?: string; url?: string };
-      const url = record.url;
-      if (typeof url === "string" && !url.startsWith("file://")) {
-        flushText();
-        return;
-      }
-      const label = record.label ?? record.path ?? record.filename ?? "";
-      textBuffer += label ? `@${label}` : "@file";
+      flushText();
+      groups.push({ kind: "text", part });
       return;
     }
 


### PR DESCRIPTION
## Summary
- render file parts in the message list so file mentions stay visible
- add a file part view that surfaces name/path and mime details
- group file parts as content instead of hiding them in steps