### PR TITLE
fix: wire reload toast through OpenWork server

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1294,7 +1294,37 @@ export default function App() {
     if (mode() !== "client") return;
     const active = workspaceStore.activeWorkspaceDisplay();
     if (active.workspaceType === "remote" && active.remoteType === "openwork") {
-      setOpenworkServerWorkspaceId(active.openworkWorkspaceId ?? null);
+      const storedId = active.openworkWorkspaceId ?? null;
+      if (storedId) {
+        setOpenworkServerWorkspaceId(storedId);
+        return;
+      }
+
+      const client = openworkServerClient();
+      if (!client || openworkServerStatus() !== "connected") {
+        setOpenworkServerWorkspaceId(null);
+        return;
+      }
+
+      let cancelled = false;
+
+      const resolveWorkspace = async () => {
+        try {
+          const response = await client.listWorkspaces();
+          if (cancelled) return;
+          const match = response.items?.[0];
+          setOpenworkServerWorkspaceId(match?.id ?? null);
+        } catch {
+          if (!cancelled) setOpenworkServerWorkspaceId(null);
+        }
+      };
+
+      void resolveWorkspace();
+
+      onCleanup(() => {
+        cancelled = true;
+      });
+
       return;
     }
     setOpenworkServerWorkspaceId(null);
@@ -1890,6 +1920,9 @@ export default function App() {
 
   loadCommandsRef = loadCommands;
 
+  const [openworkReloadCursor, setOpenworkReloadCursor] = createSignal<number | null>(null);
+  const [openworkReloadUnsupported, setOpenworkReloadUnsupported] = createSignal(false);
+
   const resolveOpenworkReloadTarget = () => {
     if (openworkServerStatus() !== "connected") return null;
     const client = openworkServerClient();
@@ -1911,8 +1944,27 @@ export default function App() {
   const reloadWorkspaceEngineFromUi = async () => {
     const target = resolveOpenworkReloadTarget();
     if (target) {
-      await target.client.reloadEngine(target.workspaceId);
-      return true;
+      try {
+        await target.client.reloadEngine(target.workspaceId);
+        return true;
+      } catch (error) {
+        if (error instanceof OpenworkServerError && error.status === 404) {
+          if (error.code === "workspace_not_found") {
+            const response = await target.client.listWorkspaces();
+            const workspaceId = response.items?.[0]?.id;
+            if (workspaceId) {
+              setOpenworkServerWorkspaceId(workspaceId);
+              await target.client.reloadEngine(workspaceId);
+              return true;
+            }
+          }
+          if (mode() === "host" && isTauriRuntime()) {
+            return workspaceStore.reloadWorkspaceEngine();
+          }
+          throw new Error("OpenWork server reload endpoint not found. Update the host to enable reloads.");
+        }
+        throw error;
+      }
     }
     if (mode() !== "host" || !isTauriRuntime()) {
       throw new Error("Reload is unavailable for this workspace.");
@@ -2013,6 +2065,74 @@ export default function App() {
     markReloadRequiredRaw(reason, options?.trigger);
   };
 
+  const openworkReloadKey = createMemo(
+    () => `${openworkServerWorkspaceId() ?? ""}|${openworkServerUrl().trim()}`,
+  );
+
+  createEffect(() => {
+    openworkReloadKey();
+    setOpenworkReloadCursor(null);
+    setOpenworkReloadUnsupported(false);
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    if (openworkReloadUnsupported()) return;
+    const client = openworkServerClient();
+    const workspaceId = openworkServerWorkspaceId();
+    if (!client || openworkServerStatus() !== "connected" || !workspaceId) return;
+
+    let active = true;
+    let busy = false;
+
+    const run = async () => {
+      if (busy) return;
+      busy = true;
+      try {
+        const response = await client.listReloadEvents(workspaceId, {
+          since: openworkReloadCursor() ?? undefined,
+        });
+        if (!active) return;
+        const items = Array.isArray(response.items) ? response.items : [];
+        for (const entry of items) {
+          if (reloadReasons().includes(entry.reason)) {
+            markReloadRequiredRaw(entry.reason, entry.trigger);
+          } else {
+            markReloadRequired(entry.reason, { trigger: entry.trigger });
+          }
+        }
+        if (typeof response.cursor === "number") {
+          setOpenworkReloadCursor(response.cursor);
+        } else if (items.length) {
+          setOpenworkReloadCursor(items[items.length - 1].seq);
+        }
+      } catch (error) {
+        if (error instanceof OpenworkServerError && error.status === 404) {
+          if (error.code === "workspace_not_found") {
+            try {
+              const response = await client.listWorkspaces();
+              const nextWorkspaceId = response.items?.[0]?.id ?? null;
+              setOpenworkServerWorkspaceId(nextWorkspaceId);
+            } catch {
+              setOpenworkServerWorkspaceId(null);
+            }
+          } else {
+            setOpenworkReloadUnsupported(true);
+          }
+        }
+      } finally {
+        busy = false;
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 8_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
   const extractReloadTriggerFromPath = (reason: ReloadReason, rawPath?: string): ReloadTrigger | null => {
     if (!rawPath) return null;
     const normalized = rawPath.replace(/\\/g, "/");
@@ -2080,7 +2200,7 @@ export default function App() {
   const reloadBlockedReason = createMemo(() => {
     if (!reloadRequired()) return null;
     if (!client()) return t("reload.toast_blocked_connect", currentLocale());
-    if (mode() !== "host") return t("reload.toast_blocked_host", currentLocale());
+    if (!canReloadWorkspace()) return t("reload.toast_blocked_host", currentLocale());
     if (anyActiveRuns()) return t("reload.toast_blocked_runs", currentLocale());
     return null;
   });

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1890,6 +1890,36 @@ export default function App() {
 
   loadCommandsRef = loadCommands;
 
+  const resolveOpenworkReloadTarget = () => {
+    if (openworkServerStatus() !== "connected") return null;
+    const client = openworkServerClient();
+    if (!client) return null;
+    const workspaceId = openworkServerWorkspaceId();
+    if (!workspaceId) return null;
+    return { client, workspaceId };
+  };
+
+  const canReloadViaOpenworkServer = createMemo(() => Boolean(resolveOpenworkReloadTarget()));
+
+  const canReloadWorkspace = createMemo(() => {
+    if (canReloadViaOpenworkServer()) return true;
+    if (mode() !== "host") return false;
+    if (!isTauriRuntime()) return false;
+    return true;
+  });
+
+  const reloadWorkspaceEngineFromUi = async () => {
+    const target = resolveOpenworkReloadTarget();
+    if (target) {
+      await target.client.reloadEngine(target.workspaceId);
+      return true;
+    }
+    if (mode() !== "host" || !isTauriRuntime()) {
+      throw new Error("Reload is unavailable for this workspace.");
+    }
+    return workspaceStore.reloadWorkspaceEngine();
+  };
+
   const systemState = createSystemState({
     client,
     mode,
@@ -1898,7 +1928,8 @@ export default function App() {
     refreshPlugins,
     refreshSkills,
     refreshMcpServers,
-    reloadWorkspaceEngine: () => workspaceStore.reloadWorkspaceEngine(),
+    reloadWorkspaceEngine: reloadWorkspaceEngineFromUi,
+    canReloadWorkspaceEngine: () => canReloadWorkspace(),
     setProviders,
     setProviderDefaults,
     setProviderConnectedIds,

--- a/packages/app/src/app/components/reload-workspace-toast.tsx
+++ b/packages/app/src/app/components/reload-workspace-toast.tsx
@@ -53,6 +53,12 @@ export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
         : "MCP config changed. Reload to apply.";
     }
 
+    if (type === "config") {
+      return trimmedName
+        ? `Config '${trimmedName}' ${verb}. Reload to apply.`
+        : "Config changed. Reload to apply.";
+    }
+
     return "Config changed. Reload to apply.";
   };
 

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -86,6 +86,22 @@ export type OpenworkAuditEntry = {
   timestamp: number;
 };
 
+export type OpenworkReloadTrigger = {
+  type: "skill" | "plugin" | "config" | "mcp";
+  name?: string;
+  action?: "added" | "removed" | "updated";
+  path?: string;
+};
+
+export type OpenworkReloadEvent = {
+  id: string;
+  seq: number;
+  workspaceId: string;
+  reason: "plugins" | "skills" | "mcp" | "config";
+  trigger?: OpenworkReloadTrigger;
+  timestamp: number;
+};
+
 export const DEFAULT_OPENWORK_SERVER_PORT = 8787;
 
 const STORAGE_URL_OVERRIDE = "openwork.server.urlOverride";
@@ -274,6 +290,14 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         method: "PATCH",
         body: payload,
       }),
+    listReloadEvents: (workspaceId: string, options?: { since?: number }) => {
+      const query = typeof options?.since === "number" ? `?since=${options.since}` : "";
+      return requestJson<{ items: OpenworkReloadEvent[]; cursor?: number }>(
+        baseUrl,
+        `/workspace/${workspaceId}/events${query}`,
+        { token, hostToken },
+      );
+    },
     reloadEngine: (workspaceId: string) =>
       requestJson<{ ok: boolean; reloadedAt?: number }>(baseUrl, `/workspace/${workspaceId}/engine/reload`, {
         token,

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.8.5"
+version = "0.9.3"
 dependencies = [
  "base64 0.22.1",
  "gethostname",

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -40,6 +40,10 @@ pub fn build_openwork_args(
         // different origins (localhost dev servers, tauri apps, web browsers).
         "--cors".to_string(),
         "*".to_string(),
+        // Auto-approve write operations when running from the desktop app.
+        // The user is already authenticated as host and in control of the UI.
+        "--approval".to_string(),
+        "auto".to_string(),
     ];
 
     for workspace_path in workspace_paths {

--- a/packages/desktop/src-tauri/src/openwrk/mod.rs
+++ b/packages/desktop/src-tauri/src/openwrk/mod.rs
@@ -16,6 +16,7 @@ pub mod manager;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenwrkStateFile {
+    #[allow(dead_code)]
     pub version: Option<u32>,
     pub daemon: Option<OpenwrkDaemonState>,
     pub opencode: Option<OpenwrkOpencodeState>,
@@ -182,10 +183,7 @@ pub fn spawn_openwrk_daemon(
         .map_err(|e| format!("Failed to start openwrk: {e}"))
 }
 
-pub fn openwrk_status_from_state(
-    data_dir: &str,
-    last_error: Option<String>,
-) -> OpenwrkStatus {
+pub fn openwrk_status_from_state(data_dir: &str, last_error: Option<String>) -> OpenwrkStatus {
     let state = read_openwrk_state(data_dir);
     let workspaces = state
         .as_ref()

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -65,6 +65,7 @@ Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CON
 - `GET /workspaces`
 - `GET /workspace/:id/config`
 - `PATCH /workspace/:id/config`
+- `GET /workspace/:id/events`
 - `POST /workspace/:id/engine/reload`
 - `GET /workspace/:id/plugins`
 - `POST /workspace/:id/plugins`

--- a/packages/server/src/events.ts
+++ b/packages/server/src/events.ts
@@ -1,0 +1,39 @@
+import type { ReloadEvent, ReloadReason, ReloadTrigger } from "./types.js";
+import { shortId } from "./utils.js";
+
+export class ReloadEventStore {
+  private events: ReloadEvent[] = [];
+  private seq = 0;
+  private maxSize: number;
+
+  constructor(maxSize = 200) {
+    this.maxSize = maxSize;
+  }
+
+  record(workspaceId: string, reason: ReloadReason, trigger?: ReloadTrigger): ReloadEvent {
+    const event: ReloadEvent = {
+      id: shortId(),
+      seq: ++this.seq,
+      workspaceId,
+      reason,
+      trigger,
+      timestamp: Date.now(),
+    };
+
+    this.events.push(event);
+    if (this.events.length > this.maxSize) {
+      this.events.splice(0, this.events.length - this.maxSize);
+    }
+
+    return event;
+  }
+
+  list(workspaceId: string, since?: number): ReloadEvent[] {
+    const cursor = Number.isFinite(since) ? (since as number) : 0;
+    return this.events.filter((event) => event.workspaceId === workspaceId && event.seq > cursor);
+  }
+
+  cursor(): number {
+    return this.seq;
+  }
+}

--- a/packages/server/src/mcp.ts
+++ b/packages/server/src/mcp.ts
@@ -36,18 +36,26 @@ export async function listMcp(workspaceRoot: string): Promise<McpItem[]> {
   }));
 }
 
-export async function addMcp(workspaceRoot: string, name: string, config: Record<string, unknown>): Promise<void> {
+export async function addMcp(
+  workspaceRoot: string,
+  name: string,
+  config: Record<string, unknown>,
+): Promise<{ action: "added" | "updated" }> {
   validateMcpName(name);
   validateMcpConfig(config);
   const { data } = await readJsoncFile(opencodeConfigPath(workspaceRoot), {} as Record<string, unknown>);
   const mcpMap = getMcpConfig(data);
+  const existed = Object.prototype.hasOwnProperty.call(mcpMap, name);
   mcpMap[name] = config;
   await updateJsoncTopLevel(opencodeConfigPath(workspaceRoot), { mcp: mcpMap });
+  return { action: existed ? "updated" : "added" };
 }
 
-export async function removeMcp(workspaceRoot: string, name: string): Promise<void> {
+export async function removeMcp(workspaceRoot: string, name: string): Promise<boolean> {
   const { data } = await readJsoncFile(opencodeConfigPath(workspaceRoot), {} as Record<string, unknown>);
   const mcpMap = getMcpConfig(data);
+  if (!Object.prototype.hasOwnProperty.call(mcpMap, name)) return false;
   delete mcpMap[name];
   await updateJsoncTopLevel(opencodeConfigPath(workspaceRoot), { mcp: mcpMap });
+  return true;
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile, rm } from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
-import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor } from "./types.js";
+import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger } from "./types.js";
 import { ApprovalService } from "./approvals.js";
-import { addPlugin, listPlugins, removePlugin } from "./plugins.js";
+import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { addMcp, listMcp, removeMcp } from "./mcp.js";
 import { listSkills, upsertSkill } from "./skills.js";
 import { deleteCommand, listCommands, upsertCommand } from "./commands.js";
@@ -10,6 +10,7 @@ import { deleteScheduledJob, listScheduledJobs, resolveScheduledJob } from "./sc
 import { ApiError, formatError } from "./errors.js";
 import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
+import { ReloadEventStore } from "./events.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
@@ -34,11 +35,13 @@ interface RequestContext {
   params: Record<string, string>;
   config: ServerConfig;
   approvals: ApprovalService;
+  reloadEvents: ReloadEventStore;
   actor?: Actor;
 }
 
 export function startServer(config: ServerConfig) {
   const approvals = new ApprovalService(config.approval);
+  const reloadEvents = new ReloadEventStore();
   const routes = createRoutes(config, approvals);
 
   const server = Bun.serve({
@@ -57,7 +60,15 @@ export function startServer(config: ServerConfig) {
 
       try {
         const actor = route.auth === "host" ? requireHost(request, config) : route.auth === "client" ? requireClient(request, config) : undefined;
-        const response = await route.handler({ request, url, params: route.params, config, approvals, actor });
+        const response = await route.handler({
+          request,
+          url,
+          params: route.params,
+          config,
+          approvals,
+          reloadEvents,
+          actor,
+        });
         return withCors(response, request, config);
       } catch (error) {
         const apiError = error instanceof ApiError
@@ -152,6 +163,25 @@ function buildCapabilities(config: ServerConfig): Capabilities {
     mcp: { read: true, write: writeEnabled },
     commands: { read: true, write: writeEnabled },
     config: { read: true, write: writeEnabled },
+  };
+}
+
+function emitReloadEvent(
+  reloadEvents: ReloadEventStore,
+  workspace: WorkspaceInfo,
+  reason: ReloadReason,
+  trigger?: ReloadTrigger,
+) {
+  reloadEvents.record(workspace.id, reason, trigger);
+}
+
+function buildConfigTrigger(path: string): ReloadTrigger {
+  const name = path.split(/[\\/]/).filter(Boolean).pop();
+  return {
+    type: "config",
+    name: name || "opencode.json",
+    action: "updated",
+    path,
   };
 }
 
@@ -260,7 +290,20 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       timestamp: Date.now(),
     });
 
+    if (opencode) {
+      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
+    }
+
     return jsonResponse({ updatedAt: Date.now() });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/events", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const sinceParam = ctx.url.searchParams.get("since");
+    const parsedSince = sinceParam ? Number(sinceParam) : NaN;
+    const since = Number.isFinite(parsedSince) ? parsedSince : undefined;
+    const items = ctx.reloadEvents.list(workspace.id, since);
+    return jsonResponse({ items, cursor: ctx.reloadEvents.cursor() });
   });
 
   addRoute(routes, "POST", "/workspace/:id/engine/reload", "client", async (ctx) => {
@@ -296,13 +339,14 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const spec = String(body.spec ?? "");
+    const normalized = normalizePluginSpec(spec);
     await requireApproval(ctx, {
       workspaceId: workspace.id,
       action: "plugins.add",
       summary: `Add plugin ${spec}`,
       paths: [opencodeConfigPath(workspace.path)],
     });
-    await addPlugin(workspace.path, spec);
+    const changed = await addPlugin(workspace.path, spec);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -312,6 +356,13 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: `Added ${spec}`,
       timestamp: Date.now(),
     });
+    if (changed) {
+      emitReloadEvent(ctx.reloadEvents, workspace, "plugins", {
+        type: "plugin",
+        name: normalized,
+        action: "added",
+      });
+    }
     const result = await listPlugins(workspace.path, false);
     return jsonResponse(result);
   });
@@ -320,13 +371,14 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     ensureWritable(config);
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = ctx.params.name ?? "";
+    const normalized = normalizePluginSpec(name);
     await requireApproval(ctx, {
       workspaceId: workspace.id,
       action: "plugins.remove",
       summary: `Remove plugin ${name}`,
       paths: [opencodeConfigPath(workspace.path)],
     });
-    await removePlugin(workspace.path, name);
+    const removed = await removePlugin(workspace.path, name);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -336,6 +388,13 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: `Removed ${name}`,
       timestamp: Date.now(),
     });
+    if (removed) {
+      emitReloadEvent(ctx.reloadEvents, workspace, "plugins", {
+        type: "plugin",
+        name: normalized,
+        action: "removed",
+      });
+    }
     const result = await listPlugins(workspace.path, false);
     return jsonResponse(result);
   });
@@ -360,17 +419,23 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: `Upsert skill ${name}`,
       paths: [join(workspace.path, ".opencode", "skills", name, "SKILL.md")],
     });
-    const path = await upsertSkill(workspace.path, { name, content, description });
+    const result = await upsertSkill(workspace.path, { name, content, description });
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
       actor: ctx.actor ?? { type: "remote" },
       action: "skills.upsert",
-      target: path,
+      target: result.path,
       summary: `Upserted skill ${name}`,
       timestamp: Date.now(),
     });
-    return jsonResponse({ name, path, description: description ?? "", scope: "project" });
+    emitReloadEvent(ctx.reloadEvents, workspace, "skills", {
+      type: "skill",
+      name,
+      action: result.action,
+      path: result.path,
+    });
+    return jsonResponse({ name, path: result.path, description: description ?? "", scope: "project" });
   });
 
   addRoute(routes, "GET", "/workspace/:id/mcp", "client", async (ctx) => {
@@ -394,7 +459,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: `Add MCP ${name}`,
       paths: [opencodeConfigPath(workspace.path)],
     });
-    await addMcp(workspace.path, name, configPayload);
+    const result = await addMcp(workspace.path, name, configPayload);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -403,6 +468,11 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       target: "opencode.json",
       summary: `Added MCP ${name}`,
       timestamp: Date.now(),
+    });
+    emitReloadEvent(ctx.reloadEvents, workspace, "mcp", {
+      type: "mcp",
+      name,
+      action: result.action,
     });
     const items = await listMcp(workspace.path);
     return jsonResponse({ items });
@@ -418,7 +488,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: `Remove MCP ${name}`,
       paths: [opencodeConfigPath(workspace.path)],
     });
-    await removeMcp(workspace.path, name);
+    const removed = await removeMcp(workspace.path, name);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -428,6 +498,13 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: `Removed MCP ${name}`,
       timestamp: Date.now(),
     });
+    if (removed) {
+      emitReloadEvent(ctx.reloadEvents, workspace, "mcp", {
+        type: "mcp",
+        name,
+        action: "removed",
+      });
+    }
     const items = await listMcp(workspace.path);
     return jsonResponse({ items });
   });
@@ -554,6 +631,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: "Imported workspace config",
       timestamp: Date.now(),
     });
+    emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
     return jsonResponse({ ok: true });
   });
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -47,6 +47,7 @@ export function startServer(config: ServerConfig) {
   const server = Bun.serve({
     hostname: config.host,
     port: config.port,
+    idleTimeout: 120, // Allow long-running operations like engine reload
     fetch: async (request: Request) => {
       const url = new URL(request.url);
       if (request.method === "OPTIONS") {

--- a/packages/server/src/skills.ts
+++ b/packages/server/src/skills.ts
@@ -113,7 +113,7 @@ export async function listSkills(workspaceRoot: string, includeGlobal: boolean):
 export async function upsertSkill(
   workspaceRoot: string,
   payload: { name: string; content: string; description?: string },
-): Promise<string> {
+): Promise<{ path: string; action: "added" | "updated" }> {
   const name = payload.name.trim();
   validateSkillName(name);
   if (!payload.content) {
@@ -146,6 +146,7 @@ export async function upsertSkill(
   const skillDir = join(baseDir, name);
   await mkdir(skillDir, { recursive: true });
   const skillPath = join(skillDir, "SKILL.md");
+  const existed = await exists(skillPath);
   await writeFile(skillPath, content.endsWith("\n") ? content : content + "\n", "utf8");
-  return skillPath;
+  return { path: skillPath, action: existed ? "updated" : "added" };
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -57,6 +57,24 @@ export interface Capabilities {
   config: { read: boolean; write: boolean };
 }
 
+export type ReloadReason = "plugins" | "skills" | "mcp" | "config";
+
+export type ReloadTrigger = {
+  type: "skill" | "plugin" | "config" | "mcp";
+  name?: string;
+  action?: "added" | "removed" | "updated";
+  path?: string;
+};
+
+export interface ReloadEvent {
+  id: string;
+  seq: number;
+  workspaceId: string;
+  reason: ReloadReason;
+  trigger?: ReloadTrigger;
+  timestamp: number;
+}
+
 export interface ApiErrorBody {
   code: string;
   message: string;


### PR DESCRIPTION
## Summary

- Wire OpenWork server reload events + endpoint for config/skills/plugins/mcp changes
- Update app to resolve OpenWork server workspace, reload via server, and poll reload events for toast
- Fix Bun.serve() idle timeout (120s) for long-running reload operations
- Auto-approve writes when running from desktop app (user is already authenticated)

## Changes

1. **feat(app): reload via OpenWork server** - UI calls server instead of direct sidecar
2. **feat(server): emit reload events for UI** - Server tracks and emits reload events
3. **fix: resolve reload timeout and approval errors** - Timeout + approval mode fixes

## Testing

Trigger a config/skill/plugin change and click "Reload" in the toast.