### PR TITLE
Add jump-to-latest indicator for new messages

### DIFF
--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -143,6 +143,7 @@ export default function SessionView(props: SessionViewProps) {
   const [agentOptions, setAgentOptions] = createSignal<Agent[]>([]);
   const [autoScrollEnabled, setAutoScrollEnabled] = createSignal(false);
   const [scrollOnNextUpdate, setScrollOnNextUpdate] = createSignal(false);
+  const [unreadCount, setUnreadCount] = createSignal(0);
 
   const COMMAND_ARGS_RE = /\$(ARGUMENTS|\d+)/i;
 
@@ -525,6 +526,28 @@ export default function SessionView(props: SessionViewProps) {
       },
     ),
   );
+
+  createEffect(
+    on(
+      () => props.messages.length,
+      (current, previous) => {
+        if (previous == null) return;
+        if (current < previous) {
+          setUnreadCount(0);
+          return;
+        }
+        if (current > previous && !autoScrollEnabled()) {
+          setUnreadCount((count) => count + (current - previous));
+        }
+      },
+    ),
+  );
+
+  createEffect(() => {
+    if (autoScrollEnabled()) {
+      setUnreadCount(0);
+    }
+  });
 
   const triggerFlyout = (
     sourceEl: Element | null,
@@ -1137,6 +1160,12 @@ export default function SessionView(props: SessionViewProps) {
     });
   };
 
+  const jumpToLatest = () => {
+    setScrollOnNextUpdate(true);
+    scrollToLatest("smooth");
+    setUnreadCount(0);
+  };
+
   return (
     <div class="h-screen flex flex-col bg-gray-1 text-gray-12 relative pb-16 md:pb-12">
         <header class="h-16 border-b border-gray-6 flex items-center justify-between px-6 bg-gray-1/80 backdrop-blur-md z-10 sticky top-0">
@@ -1385,6 +1414,23 @@ export default function SessionView(props: SessionViewProps) {
           searchFiles={props.searchFiles}
           isRemoteWorkspace={props.activeWorkspaceDisplay.workspaceType === "remote"}
         />
+
+        <Show when={unreadCount() > 0}>
+          <div class="fixed bottom-24 right-6 z-40">
+            <button
+              type="button"
+              onClick={jumpToLatest}
+              class="flex items-center gap-2 rounded-full border border-gray-6 bg-gray-2/90 px-3 py-2 text-xs text-gray-11 shadow-lg shadow-gray-12/10 transition-all hover:text-gray-12 hover:border-gray-7"
+              aria-label="Jump to latest message"
+            >
+              <span>New messages</span>
+              <span class="rounded-full bg-gray-12/10 px-2 py-0.5 text-[10px] font-semibold text-gray-12">
+                {unreadCount()}
+              </span>
+              <ChevronDown size={12} class="text-gray-9" />
+            </button>
+          </div>
+        </Show>
 
         <div class="fixed bottom-0 left-0 right-0">
           <StatusBar


### PR DESCRIPTION
## Summary
- show a floating "New messages" button when the user scrolls away from the bottom
- track unread message count and clear it on jump/auto-scroll