### PR TITLE
Add view-all link for session sidebar

### DIFF
--- a/packages/app/src/app/components/session/sidebar.tsx
+++ b/packages/app/src/app/components/session/sidebar.tsx
@@ -21,6 +21,7 @@ export type SidebarProps = {
   sessions: Array<{ id: string; title: string; slug?: string | null }>;
   selectedSessionId: string | null;
   onSelectSession: (id: string) => void;
+  onViewAllSessions: () => void;
   sessionStatusById: Record<string, string>;
   onCreateSession: () => void;
   onDeleteSession: (id: string) => void;
@@ -29,6 +30,9 @@ export type SidebarProps = {
 
 export default function SessionSidebar(props: SidebarProps) {
   const realTodos = createMemo(() => props.todos.filter((todo) => todo.content.trim()));
+  const sessionLimit = 8;
+  const visibleSessions = createMemo(() => props.sessions.slice(0, sessionLimit));
+  const hasMoreSessions = createMemo(() => props.sessions.length > sessionLimit);
 
   const progressDots = createMemo(() => {
     const activeTodos = realTodos();
@@ -96,7 +100,7 @@ export default function SessionSidebar(props: SidebarProps) {
         <div>
           <div class="text-xs text-gray-10 font-semibold mb-3 px-2 truncate">{props.workspaceName}</div>
           <div class="space-y-1">
-            <For each={props.sessions.slice(0, 8)}>
+            <For each={visibleSessions()}>
               {(session) => (
                 <button
                   class={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
@@ -135,6 +139,14 @@ export default function SessionSidebar(props: SidebarProps) {
                 </button>
               )}
             </For>
+            <Show when={hasMoreSessions()}>
+              <button
+                class="w-full text-left px-3 py-2 rounded-lg text-xs text-gray-10 hover:text-gray-12 hover:bg-gray-2 transition-colors"
+                onClick={props.onViewAllSessions}
+              >
+                View all sessions ({props.sessions.length})
+              </button>
+            </Show>
           </div>
         </div>
 

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1125,6 +1125,11 @@ export default function SessionView(props: SessionViewProps) {
     props.setView("dashboard");
   };
 
+  const openSessionsList = () => {
+    props.setTab("sessions");
+    props.setView("dashboard");
+  };
+
   const openMcp = () => {
     props.setTab("mcp");
     props.setView("dashboard");
@@ -1178,25 +1183,26 @@ export default function SessionView(props: SessionViewProps) {
 
         <div class="flex-1 flex overflow-hidden">
           <aside class="hidden lg:flex w-72 border-r border-gray-6 bg-gray-1 flex-col">
-              <SessionSidebar
-                todos={props.todos}
-                expandedSections={props.expandedSidebarSections}
-                onToggleSection={(section) => {
-                  props.setExpandedSidebarSections((curr) => ({...curr, [section]: !curr[section]}));
-                }}
-                workspaceName={workspaceLabel()}
-                sessions={props.sessions}
-                selectedSessionId={props.selectedSessionId}
-                 onSelectSession={async (id) => {
-                   await props.selectSession(id);
-                   props.setView("session", id);
-                   props.setTab("sessions");
-                 }}
-                sessionStatusById={props.sessionStatusById}
-                onCreateSession={props.createSessionAndOpen}
-                onDeleteSession={handleDeleteSession}
-                newTaskDisabled={props.newTaskDisabled}
-              />
+                <SessionSidebar
+                  todos={props.todos}
+                  expandedSections={props.expandedSidebarSections}
+                  onToggleSection={(section) => {
+                    props.setExpandedSidebarSections((curr) => ({...curr, [section]: !curr[section]}));
+                  }}
+                  workspaceName={workspaceLabel()}
+                  sessions={props.sessions}
+                  selectedSessionId={props.selectedSessionId}
+                  onSelectSession={async (id) => {
+                    await props.selectSession(id);
+                    props.setView("session", id);
+                    props.setTab("sessions");
+                  }}
+                  onViewAllSessions={openSessionsList}
+                  sessionStatusById={props.sessionStatusById}
+                  onCreateSession={props.createSessionAndOpen}
+                  onDeleteSession={handleDeleteSession}
+                  newTaskDisabled={props.newTaskDisabled}
+                />
           </aside>
 
           <div


### PR DESCRIPTION
## Summary
- show a View all sessions action when the sidebar is truncated
- route the action to the full sessions list on the dashboard