### PR TITLE
Confirm before forgetting a workspace

### DIFF
--- a/packages/app/src/app/components/workspace-picker.tsx
+++ b/packages/app/src/app/components/workspace-picker.tsx
@@ -1,9 +1,10 @@
-import { For, Show, createEffect, createMemo } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 
 import { Check, Globe, Loader2, Plus, Search, Trash2, Upload } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
 
 import type { WorkspaceInfo } from "../lib/tauri";
+import ConfirmModal from "./confirm-modal";
 
 export default function WorkspacePicker(props: {
   open: boolean;
@@ -36,6 +37,7 @@ export default function WorkspacePicker(props: {
 
   const totalCount = createMemo(() => props.workspaces.length);
   let searchInputRef: HTMLInputElement | undefined;
+  const [forgetTarget, setForgetTarget] = createSignal<WorkspaceInfo | null>(null);
 
   createEffect(() => {
     if (props.open) {
@@ -136,7 +138,7 @@ export default function WorkspacePicker(props: {
                     type="button"
                     onClick={(event) => {
                       event.stopPropagation();
-                      props.onForget(ws.id);
+                      setForgetTarget(ws);
                     }}
                     class="p-1 rounded-md text-gray-9 hover:text-gray-12 hover:bg-gray-3 transition-colors"
                     title={translate("dashboard.forget_workspace")}
@@ -184,6 +186,21 @@ export default function WorkspacePicker(props: {
             </div>
           </div>
         </div>
+        <ConfirmModal
+          open={Boolean(forgetTarget())}
+          title={translate("dashboard.forget_workspace_confirm_title")}
+          message={translate("dashboard.forget_workspace_confirm_message")}
+          confirmLabel={translate("dashboard.forget_workspace")}
+          cancelLabel={translate("common.cancel")}
+          variant="danger"
+          onCancel={() => setForgetTarget(null)}
+          onConfirm={() => {
+            const target = forgetTarget();
+            if (!target) return;
+            props.onForget(target.id);
+            setForgetTarget(null);
+          }}
+        />
       </div>
     </Show>
   );

--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -19,6 +19,8 @@ export default {
   "dashboard.new_workspace": "New Workspace...",
   "dashboard.new_remote_workspace": "Add Remote Workspace...",
   "dashboard.forget_workspace": "Forget workspace",
+  "dashboard.forget_workspace_confirm_title": "Forget workspace?",
+  "dashboard.forget_workspace_confirm_message": "This removes it from your list. You can add it again later.",
   "dashboard.remote": "Remote",
   "dashboard.connection": "Connection",
   "dashboard.local_engine": "Local Engine",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -19,6 +19,8 @@ export default {
   "dashboard.new_workspace": "新建工作区...",
   "dashboard.new_remote_workspace": "添加远程工作区...",
   "dashboard.forget_workspace": "忘记工作区",
+  "dashboard.forget_workspace_confirm_title": "忘记这个工作区？",
+  "dashboard.forget_workspace_confirm_message": "这会把它从列表中移除，你可以稍后再添加。",
   "dashboard.remote": "远程",
   "dashboard.connection": "连接",
   "dashboard.local_engine": "本地引擎",


### PR DESCRIPTION
## Summary
- add a confirmation modal before removing a workspace from the picker
- localize the new confirm copy