### PR TITLE
chore(headless): bump openwrk to 0.1.7

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwrk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {

--- a/packages/headless/scripts/build-owpenbot.mjs
+++ b/packages/headless/scripts/build-owpenbot.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -48,5 +48,13 @@ function run(command, args, cwd) {
 }
 
 const owpenbotRepo = resolveOwpenbotRepo();
-run("pnpm", ["install"], owpenbotRepo);
-run("pnpm", ["build:bin"], owpenbotRepo);
+run("bun", ["install"], owpenbotRepo);
+const pkg = JSON.parse(readFileSync(resolve(owpenbotRepo, "package.json"), "utf8"));
+const scripts = pkg?.scripts ?? {};
+if (scripts["build:bin"]) {
+  run("bun", ["run", "build:bin"], owpenbotRepo);
+} else if (scripts["build:binary"]) {
+  run("bun", ["run", "build:binary"], owpenbotRepo);
+} else {
+  run("bun", ["build", "--compile", "src/cli.ts", "--outfile", "dist/bin/owpenbot"], owpenbotRepo);
+}


### PR DESCRIPTION
## Summary
- bump openwrk to 0.1.7
- build owpenbot with bun for external repo compatibility

## Testing
- pnpm --filter openwrk build:bin

## Release
- npm publish --access public (openwrk@0.1.7)