### PR TITLE
chore(headless): bump openwrk to 0.1.8

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwrk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump openwrk to 0.1.8
- avoid passing --opencode-url to older owpenbot; use OPENCODE_URL env instead

## Testing
- pnpm --filter openwrk build:bin

## Release
- npm publish --access public (openwrk@0.1.8)