### PR TITLE
chore(headless): bump openwrk to 0.1.9

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -14,6 +14,9 @@ openwrk start --workspace /path/to/workspace --approval auto
 `openwrk` bundles and validates exact versions of `openwork-server` + `owpenbot` using a
 SHA-256 manifest. It will refuse to start if the bundled binaries are missing or tampered with.
 
+Owpenbot is optional. If it exits, `openwrk` continues running unless you pass
+`--owpenbot-required` or set `OPENWRK_OWPENBOT_REQUIRED=1`.
+
 For development overrides only, set `OPENWRK_ALLOW_EXTERNAL=1` or pass `--allow-external` to use
 locally installed `openwork-server` or `owpenbot` binaries.
 

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwrk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump openwrk to 0.1.9
- keep openwrk running if owpenbot exits unless explicitly required
- document owpenbot optional behavior

## Testing
- pnpm --filter openwrk build:bin

## Release
- npm publish --access public (openwrk@0.1.9)