### PR TITLE
Align sidecar bundle parity for openwrk

### DIFF
--- a/packages/desktop/src-tauri/src/commands/owpenbot.rs
+++ b/packages/desktop/src-tauri/src/commands/owpenbot.rs
@@ -241,6 +241,9 @@ pub async fn owpenbot_status(
         .and_then(|value| value.get("url"))
         .and_then(|value| value.as_str())
         .unwrap_or_default();
+    let health_port = status
+        .get("healthPort")
+        .and_then(|value| value.as_u64());
 
     let whatsapp_linked = whatsapp
         .get("linked")
@@ -268,6 +271,7 @@ pub async fn owpenbot_status(
     Ok(serde_json::json!({
         "running": running,
         "config": config_path,
+        "healthPort": health_port,
         "whatsapp": {
             "linked": whatsapp_linked,
             "dmPolicy": whatsapp_dm_policy,

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "build:bin": "pnpm --filter openwork-server build:bin && node scripts/build-owpenbot.mjs && bun build --compile src/cli.ts --outfile dist/openwrk && bun scripts/build-bin.ts",
+    "build:bin": "node ../desktop/scripts/prepare-sidecar.mjs --outdir dist && bun build --compile src/cli.ts --outfile dist/openwrk",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:router": "pnpm build && node scripts/router.mjs",
     "prepublishOnly": "pnpm build:bin"

--- a/packages/owpenbot/.env.example
+++ b/packages/owpenbot/.env.example
@@ -6,9 +6,9 @@ OPENCODE_SERVER_PASSWORD=
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_ENABLED=true
 
-OWPENBOT_DATA_DIR=~/.owpenbot
-OWPENBOT_DB_PATH=~/.owpenbot/owpenbot.db
-OWPENBOT_CONFIG_PATH=~/.owpenbot/owpenbot.json
+OWPENBOT_DATA_DIR=~/.openwork/owpenbot
+OWPENBOT_DB_PATH=~/.openwork/owpenbot/owpenbot.db
+OWPENBOT_CONFIG_PATH=~/.openwork/owpenbot/owpenbot.json
 OWPENBOT_HEALTH_PORT=3005
 
 WHATSAPP_ACCOUNT_ID=default

--- a/packages/owpenbot/README.md
+++ b/packages/owpenbot/README.md
@@ -97,8 +97,8 @@ owpenwork doctor --reset
 
 ## Defaults
 
-- SQLite at `~/.owpenbot/owpenbot.db` unless overridden.
-- Config stored at `~/.owpenbot/owpenbot.json` (created by `owpenwork` or `owpenwork setup`).
+- SQLite at `~/.openwork/owpenbot/owpenbot.db` unless overridden.
+- Config stored at `~/.openwork/owpenbot/owpenbot.json` (created by `owpenwork` or `owpenwork setup`).
 - DM policy defaults to `pairing` unless changed in setup.
 - Group chats are disabled unless `GROUPS_ENABLED=true`.
 

--- a/packages/owpenbot/install.sh
+++ b/packages/owpenbot/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 OWPENBOT_REF="${OWPENBOT_REF:-dev}"
 OWPENBOT_REPO="${OWPENBOT_REPO:-https://github.com/different-ai/openwork.git}"
-OWPENBOT_INSTALL_DIR="${OWPENBOT_INSTALL_DIR:-$HOME/.owpenbot/openwork}"
+OWPENBOT_INSTALL_DIR="${OWPENBOT_INSTALL_DIR:-$HOME/.openwork/owpenbot/openwork}"
 OWPENBOT_BIN_DIR="${OWPENBOT_BIN_DIR:-$HOME/.local/bin}"
 OWPENBOT_INSTALL_METHOD="${OWPENBOT_INSTALL_METHOD:-npm}"
 
@@ -12,7 +12,7 @@ usage() {
 Owpenbot installer (WhatsApp-first)
 
 Environment variables:
-  OWPENBOT_INSTALL_DIR  Install directory (default: ~/.owpenbot/openwork)
+  OWPENBOT_INSTALL_DIR  Install directory (default: ~/.openwork/owpenbot/openwork)
   OWPENBOT_REPO         Git repo (default: https://github.com/different-ai/openwork.git)
   OWPENBOT_REF          Git ref/branch (default: dev)
   OWPENBOT_BIN_DIR      Bin directory for owpenbot shim (default: ~/.local/bin)
@@ -102,7 +102,7 @@ else
       cat <<EOF > "$ENV_PATH"
 OPENCODE_URL=http://127.0.0.1:4096
 OPENCODE_DIRECTORY=
-WHATSAPP_AUTH_DIR=~/.owpenbot/whatsapp
+WHATSAPP_AUTH_DIR=~/.openwork/owpenbot/whatsapp
 EOF
       echo "Created $ENV_PATH (minimal)"
     fi

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -294,6 +294,7 @@ program
     if (useJson) {
       outputJson({
         config: config.configPath,
+        healthPort: config.healthPort ?? null,
         whatsapp: {
           linked: whatsappLinked,
           dmPolicy: config.whatsappDmPolicy,
@@ -311,6 +312,7 @@ program
       });
     } else {
       console.log(`Config: ${config.configPath}`);
+      console.log(`Health port: ${config.healthPort ?? "(not set)"}`);
       console.log(`WhatsApp linked: ${whatsappLinked ? "yes" : "no"}`);
       console.log(`WhatsApp DM policy: ${config.whatsappDmPolicy}`);
       console.log(`Telegram configured: ${config.telegramToken ? "yes" : "no"}`);

--- a/packages/owpenbot/src/config.ts
+++ b/packages/owpenbot/src/config.ts
@@ -218,6 +218,7 @@ export function loadConfig(
   const permissionMode = env.PERMISSION_MODE?.toLowerCase() === "deny" ? "deny" : "allow";
 
   const telegramToken = env.TELEGRAM_BOT_TOKEN?.trim() || configFile.channels?.telegram?.token || undefined;
+  const healthPort = parseInteger(env.OWPENBOT_HEALTH_PORT) ?? 3005;
 
   return {
     configPath,
@@ -245,7 +246,7 @@ export function loadConfig(
     groupsEnabled: parseBoolean(env.GROUPS_ENABLED, false),
     permissionMode,
     toolOutputLimit,
-    healthPort: parseInteger(env.OWPENBOT_HEALTH_PORT),
+    healthPort,
     logLevel: env.LOG_LEVEL?.trim() || "info",
   };
 }

--- a/packages/owpenbot/src/config.ts
+++ b/packages/owpenbot/src/config.ts
@@ -184,7 +184,8 @@ export function loadConfig(
 ): Config {
   const requireOpencode = options.requireOpencode ?? false;
 
-  const dataDir = expandHome(env.OWPENBOT_DATA_DIR ?? "~/.owpenbot");
+  const defaultDataDir = path.join(os.homedir(), ".openwork", "owpenbot");
+  const dataDir = expandHome(env.OWPENBOT_DATA_DIR ?? defaultDataDir);
   const dbPath = expandHome(env.OWPENBOT_DB_PATH ?? path.join(dataDir, "owpenbot.db"));
   const logFile = expandHome(env.OWPENBOT_LOG_FILE ?? path.join(dataDir, "logs", "owpenbot.log"));
   const configPath = resolveConfigPath(dataDir, env);

--- a/packages/owpenbot/src/health.ts
+++ b/packages/owpenbot/src/health.ts
@@ -15,23 +15,86 @@ export type HealthSnapshot = {
   };
 };
 
+export type TelegramTokenResult = {
+  configured: boolean;
+  enabled: boolean;
+};
+
+export type HealthHandlers = {
+  setTelegramToken?: (token: string) => Promise<TelegramTokenResult>;
+};
+
 export function startHealthServer(
   port: number,
   getStatus: () => HealthSnapshot,
   logger: Logger,
+  handlers: HealthHandlers = {},
 ) {
   const server = http.createServer((req, res) => {
-    if (!req.url || req.url === "/health") {
-      const snapshot = getStatus();
-      res.writeHead(snapshot.ok ? 200 : 503, {
-        "Content-Type": "application/json",
-      });
-      res.end(JSON.stringify(snapshot));
-      return;
-    }
+    void (async () => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+      res.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
-    res.writeHead(404, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ ok: false, error: "Not found" }));
+      if (req.method === "OPTIONS") {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      if (!req.url || req.url === "/health") {
+        const snapshot = getStatus();
+        res.writeHead(snapshot.ok ? 200 : 503, {
+          "Content-Type": "application/json",
+        });
+        res.end(JSON.stringify(snapshot));
+        return;
+      }
+
+      if (req.url === "/config/telegram-token" && req.method === "POST") {
+        if (!handlers.setTelegramToken) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+          return;
+        }
+
+        let raw = "";
+        for await (const chunk of req) {
+          raw += chunk.toString();
+          if (raw.length > 1024 * 1024) {
+            res.writeHead(413, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+            return;
+          }
+        }
+
+        try {
+          const payload = JSON.parse(raw || "{}");
+          const token = typeof payload.token === "string" ? payload.token.trim() : "";
+          if (!token) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Token is required" }));
+            return;
+          }
+
+          const result = await handlers.setTelegramToken(token);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, telegram: result }));
+          return;
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: String(error) }));
+          return;
+        }
+      }
+
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Not found" }));
+    })().catch((error) => {
+      logger.error({ error }, "health server request failed");
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Internal error" }));
+    });
   });
 
   server.listen(port, "0.0.0.0", () => {


### PR DESCRIPTION
## Summary
- build headless sidecar payloads via the desktop bundler and emit a shared versions manifest
- verify bundled opencode/owpenbot/openwork-server versions + shas at runtime and fix openwrk version reporting
- move owpenbot default data directory under ~/.openwork for compiled runtime consistency