### PR TITLE
openwrk: download sidecars from release assets

### DIFF
--- a/.opencode/skills/openwrk-npm-publish/SKILL.md
+++ b/.opencode/skills/openwrk-npm-publish/SKILL.md
@@ -14,13 +14,23 @@ description: |
 1. Ensure you are on the default branch and the tree is clean.
 2. Bump the version in `packages/headless/package.json`.
 3. Commit the bump.
-4. Publish the package.
+4. Build sidecar artifacts and publish them to a release tag.
+
+```bash
+pnpm --filter openwrk build:sidecars
+gh release create openwrk-vX.Y.Z packages/headless/dist/sidecars/* \
+  --repo different-ai/openwork \
+  --title "openwrk vX.Y.Z sidecars" \
+  --notes "Sidecar binaries and manifest for openwrk vX.Y.Z"
+```
+
+5. Publish the package.
 
 ```bash
 pnpm --filter openwrk publish --access public
 ```
 
-5. Verify the published version.
+6. Verify the published version.
 
 ```bash
 npm view openwrk version
@@ -52,3 +62,4 @@ Alternatively, export an npm token in your environment (see `.env.example`).
 
 - `pnpm publish` requires a clean git tree.
 - This publish flow is separate from app release tags.
+- openwrk downloads sidecars from `openwrk-vX.Y.Z` release assets by default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,10 @@ This is separate from app release tags. Use `.opencode/skills/openwrk-npm-publis
 1.  Ensure the default branch is up to date and clean.
 2.  Bump `packages/headless/package.json` (`version`).
 3.  Commit the bump.
-4.  Publish:
+4.  Build and upload sidecar assets for the same version tag:
+    * `pnpm --filter openwrk build:sidecars`
+    * `gh release create openwrk-vX.Y.Z packages/headless/dist/sidecars/* --repo different-ai/openwork`
+5.  Publish:
     * `pnpm --filter openwrk publish --access public`
-5.  Verify:
+6.  Verify:
     * `npm view openwrk version`

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -11,9 +11,12 @@ openwrk start --workspace /path/to/workspace --approval auto
 
 `openwrk` ships as a compiled binary, so Bun is not required at runtime.
 
-`openwrk` bundles and validates exact versions of `openwork-server` + `owpenbot` from the
-monorepo using a SHA-256 manifest. It will refuse to start if the bundled binaries are missing
-or tampered with.
+`openwrk` downloads and caches the `openwork-server`, `owpenbot`, and `opencode` sidecars on
+first run using a SHA-256 manifest. Use `--sidecar-dir` or `OPENWRK_SIDECAR_DIR` to control the
+cache location, and `--sidecar-base-url` / `--sidecar-manifest` to point at a custom host.
+
+By default the manifest is fetched from
+`https://github.com/different-ai/openwork/releases/download/openwrk-v<openwrk-version>/openwrk-sidecars.json`.
 
 Owpenbot is optional. If it exits, `openwrk` continues running unless you pass
 `--owpenbot-required` or set `OPENWRK_OWPENBOT_REQUIRED=1`.

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -3,23 +3,23 @@
   "version": "0.1.11",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
+  "opencodeVersion": "1.1.45",
   "bin": {
     "openwrk": "dist/openwrk"
   },
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "build:bin": "node ../desktop/scripts/prepare-sidecar.mjs --outdir dist && bun build --compile src/cli.ts --outfile dist/openwrk",
+    "build:bin": "node scripts/clean-dist.mjs && bun build --compile src/cli.ts --outfile dist/openwrk",
+    "build:bin:bundled": "node scripts/clean-dist.mjs && node ../desktop/scripts/prepare-sidecar.mjs --outdir dist && bun build --compile src/cli.ts --outfile dist/openwrk && bun scripts/build-bin.ts",
+    "build:sidecars": "node scripts/build-sidecars.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:router": "pnpm build && node scripts/router.mjs",
     "prepublishOnly": "pnpm build:bin"
   },
   "files": [
     "dist",
-    "README.md",
-    "dist/openwork-server",
-    "dist/owpenbot",
-    "dist/versions.json"
+    "README.md"
   ],
   "repository": {
     "type": "git",

--- a/packages/headless/scripts/build-sidecars.mjs
+++ b/packages/headless/scripts/build-sidecars.mjs
@@ -1,0 +1,96 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const repoRoot = resolve(root, "..", "..");
+const outdir = resolve(root, "dist", "sidecars");
+
+const openwrkPkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const openwrkVersion = String(openwrkPkg.version ?? "").trim();
+if (!openwrkVersion) {
+  throw new Error("openwrk version missing in packages/headless/package.json");
+}
+
+const serverPkg = JSON.parse(readFileSync(resolve(repoRoot, "packages", "server", "package.json"), "utf8"));
+const serverVersion = String(serverPkg.version ?? "").trim();
+if (!serverVersion) {
+  throw new Error("openwork-server version missing in packages/server/package.json");
+}
+
+const owpenbotPkg = JSON.parse(readFileSync(resolve(repoRoot, "packages", "owpenbot", "package.json"), "utf8"));
+const owpenbotVersion = String(owpenbotPkg.version ?? "").trim();
+if (!owpenbotVersion) {
+  throw new Error("owpenbot version missing in packages/owpenbot/package.json");
+}
+
+const run = (command, args, cwd) => {
+  const result = spawnSync(command, args, { cwd, stdio: "inherit" });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+};
+
+run("pnpm", ["--filter", "openwork-server", "build:bin:all"], repoRoot);
+run("pnpm", ["--filter", "owpenwork", "build:bin:all"], repoRoot);
+
+const targets = [
+  { id: "darwin-arm64", bun: "bun-darwin-arm64" },
+  { id: "darwin-x64", bun: "bun-darwin-x64" },
+  { id: "linux-x64", bun: "bun-linux-x64" },
+  { id: "linux-arm64", bun: "bun-linux-arm64" },
+  { id: "windows-x64", bun: "bun-windows-x64" },
+];
+
+const sha256File = (path) => {
+  const data = readFileSync(path);
+  return createHash("sha256").update(data).digest("hex");
+};
+
+const serverDir = resolve(repoRoot, "packages", "server", "dist", "bin");
+const owpenbotDir = resolve(repoRoot, "packages", "owpenbot", "dist", "bin");
+
+mkdirSync(outdir, { recursive: true });
+
+const entries = {
+  "openwork-server": { version: serverVersion, targets: {} },
+  owpenbot: { version: owpenbotVersion, targets: {} },
+};
+
+for (const target of targets) {
+  const ext = target.id.startsWith("windows") ? ".exe" : "";
+  const serverSrc = join(serverDir, `openwork-server-${target.bun}${ext}`);
+  if (!existsSync(serverSrc)) {
+    throw new Error(`Missing openwork-server binary at ${serverSrc}`);
+  }
+  const serverDest = join(outdir, `openwork-server-${target.id}${ext}`);
+  copyFileSync(serverSrc, serverDest);
+
+  const owpenbotSrc = join(owpenbotDir, `owpenbot-${target.bun}${ext}`);
+  if (!existsSync(owpenbotSrc)) {
+    throw new Error(`Missing owpenbot binary at ${owpenbotSrc}`);
+  }
+  const owpenbotDest = join(outdir, `owpenbot-${target.id}${ext}`);
+  copyFileSync(owpenbotSrc, owpenbotDest);
+
+  entries["openwork-server"].targets[target.id] = {
+    asset: basename(serverDest),
+    sha256: sha256File(serverDest),
+    size: statSync(serverDest).size,
+  };
+  entries.owpenbot.targets[target.id] = {
+    asset: basename(owpenbotDest),
+    sha256: sha256File(owpenbotDest),
+    size: statSync(owpenbotDest).size,
+  };
+}
+
+const manifest = {
+  version: openwrkVersion,
+  generatedAt: new Date().toISOString(),
+  entries,
+};
+
+writeFileSync(join(outdir, "openwrk-sidecars.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");

--- a/packages/headless/scripts/clean-dist.mjs
+++ b/packages/headless/scripts/clean-dist.mjs
@@ -1,0 +1,6 @@
+import { rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+await rm(resolve(root, "dist"), { recursive: true, force: true });

--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -30,7 +30,7 @@
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/owpenbot",
-    "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-windows-x64",
+    "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
     "build:binary": "bun ./script/build.ts --outdir dist/bin",
     "start": "bun dist/cli.js start",
     "whatsapp:login": "bun dist/cli.js whatsapp login",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,7 @@
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
-    "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-windows-x64",
+    "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
     "start": "bun dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepublishOnly": "pnpm build:bin"


### PR DESCRIPTION
## Summary
- download openwork-server/owpenbot/opencode sidecars on demand with manifest-based caching and new CLI overrides
- slim npm publish by cleaning dist and adding sidecar build artifacts workflow
- document the openwrk sidecar release + publish steps

## Testing
- Not run (not requested)