### PR TITLE
Default macOS notarization for releases

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 360
     env:
-      MACOS_NOTARIZE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.notarize || vars.MACOS_NOTARIZE || 'false' }}
+      MACOS_NOTARIZE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.notarize || vars.MACOS_NOTARIZE || 'true' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- default the Release App workflow to notarize macOS builds when no override is provided
- keep existing workflow_dispatch input and repo variable override behavior intact

## Testing
- not run (workflow change only)