### PR TITLE
Propagate owpenbot health port to server

### DIFF
--- a/packages/desktop/src-tauri/src/openwork_server/mod.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/mod.rs
@@ -47,6 +47,7 @@ pub fn start_openwork_server(
     opencode_base_url: Option<&str>,
     opencode_username: Option<&str>,
     opencode_password: Option<&str>,
+    owpenbot_health_port: Option<u16>,
 ) -> Result<OpenworkServerInfo, String> {
     let mut state = manager.inner.lock().map_err(|_| "openwork server mutex poisoned".to_string())?;
     OpenworkServerManager::stop_locked(&mut state);
@@ -75,6 +76,7 @@ pub fn start_openwork_server(
         },
         opencode_username,
         opencode_password,
+        owpenbot_health_port,
     )?;
 
     state.child = Some(child);

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -81,6 +81,7 @@ pub fn spawn_openwork_server(
     opencode_directory: Option<&str>,
     opencode_username: Option<&str>,
     opencode_password: Option<&str>,
+    owpenbot_health_port: Option<u16>,
 ) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
     let command = match app.shell().sidecar("openwork-server") {
         Ok(command) => command,
@@ -101,6 +102,10 @@ pub fn spawn_openwork_server(
         .map(|path| Path::new(path))
         .unwrap_or_else(|| Path::new("."));
     let mut command = command.args(args).current_dir(cwd);
+
+    if let Some(port) = owpenbot_health_port {
+        command = command.env("OWPENBOT_HEALTH_PORT", port.to_string());
+    }
 
     if let Some(username) = opencode_username {
         if !username.trim().is_empty() {

--- a/packages/desktop/src-tauri/src/owpenbot/manager.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/manager.rs
@@ -16,6 +16,7 @@ pub struct OwpenbotState {
     pub version: Option<String>,
     pub workspace_path: Option<String>,
     pub opencode_url: Option<String>,
+    pub health_port: Option<u16>,
     pub qr_data: Option<String>,
     pub whatsapp_linked: bool,
     pub telegram_configured: bool,
@@ -59,6 +60,7 @@ impl OwpenbotManager {
         state.qr_data = None;
         state.whatsapp_linked = false;
         state.telegram_configured = false;
+        state.health_port = None;
         state.last_stdout = None;
         state.last_stderr = None;
     }


### PR DESCRIPTION
## Summary
- allocate a free owpenbot health port per host run and reuse it for both owpenbot + openwork-server
- surface the runtime port via owpenbot status to keep UI/server in sync
- pass the health port through openwrk sidecar env and CLI output

## Tests
- `bun /Users/benjaminshafii/openwork-enterprise/outputs/owpenbot-proxy-smoke.mjs`