### PR TITLE
fix(desktop): bundle openwrk as sidecar and add --allow-external flag

### DIFF
--- a/packages/desktop/src-tauri/src/openwrk/mod.rs
+++ b/packages/desktop/src-tauri/src/openwrk/mod.rs
@@ -162,6 +162,7 @@ pub fn spawn_openwrk_daemon(
         options.opencode_host.clone(),
         "--opencode-workdir".to_string(),
         options.opencode_workdir.clone(),
+        "--allow-external".to_string(),
     ];
 
     if let Some(port) = options.opencode_port {

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -37,7 +37,8 @@
     "externalBin": [
       "sidecars/opencode",
       "sidecars/openwork-server",
-      "sidecars/owpenbot"
+      "sidecars/owpenbot",
+      "sidecars/openwrk"
     ]
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- Add `openwrk` to `externalBin` in `tauri.conf.json`
- Update `prepare-sidecar.mjs` to build `openwrk` binary alongside other sidecars
- Add `--allow-external` flag when spawning openwrk daemon to allow custom `opencode-bin` path

## Problem
When selecting "Openwrk orchestrator" mode in the desktop app, users got:
1. `Failed to start openwrk: No such file or directory (os error 2)` - because `openwrk` wasn't bundled
2. `Failed to start openwrk: http://127.0.0.1:XXXXX/health: Connection Failed` - because `--allow-external` was missing when passing `--opencode-bin`

## Solution
The `openwrk` binary (from `packages/headless`) is now built and bundled as a Tauri sidecar, just like `opencode`, `openwork-server`, and `owpenbot`.