### PR TITLE
Fix openwrk opencode port in desktop

### DIFF
--- a/packages/desktop/src-tauri/src/commands/engine.rs
+++ b/packages/desktop/src-tauri/src/commands/engine.rs
@@ -277,7 +277,7 @@ pub fn engine_start(
             opencode_bin,
             opencode_host: bind_host.clone(),
             opencode_workdir: project_dir.clone(),
-            opencode_port: None,
+            opencode_port: Some(port),
             opencode_username: opencode_username.clone(),
             opencode_password: opencode_password.clone(),
             cors: Some("*".to_string()),


### PR DESCRIPTION
## Summary
- pass an explicit free opencode port to the openwrk daemon so desktop orchestration doesn't reuse stale ports

## Testing
- manual: dev web + headless message send via Chrome DevTools MCP
- not run (desktop runtime)