### PR TITLE
Improve session catch-up cues

### DIFF
--- a/packages/app/src/app/components/session/sidebar.tsx
+++ b/packages/app/src/app/components/session/sidebar.tsx
@@ -96,45 +96,54 @@ export default function SessionSidebar(props: SidebarProps) {
         <div>
           <div class="text-xs text-gray-10 font-semibold mb-3 px-2 truncate">{props.workspaceName}</div>
           <div class="space-y-1">
-            <For each={props.sessions.slice(0, 8)}>
-              {(session) => (
-                <button
-                  class={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
-                    session.id === props.selectedSessionId
-                      ? "bg-gray-3 text-gray-12 font-medium"
-                      : "text-gray-11 hover:text-gray-12 hover:bg-gray-2"
-                  }`}
-                  onClick={() => props.onSelectSession(session.id)}
-                  onContextMenu={(event) => openContextMenu(event, session.id)}
-                >
-                    <div class="flex items-center justify-between gap-2 w-full overflow-hidden">
-                      <div class="truncate">{session.title}</div>
-                      <Show
-                        when={
-                          props.sessionStatusById[session.id] &&
-                          props.sessionStatusById[session.id] !== "idle"
-                        }
-                      >
-                      <span
-                        class={`shrink-0 text-[10px] px-1.5 py-0.5 rounded-full border flex items-center gap-1 ${
-                          props.sessionStatusById[session.id] === "running"
-                            ? "border-amber-7/50 text-amber-11 bg-amber-2/50"
-                            : "border-gray-7/50 text-gray-10 bg-gray-2/50"
-                        }`}
-                      >
-                        <div
-                          class={`w-1 h-1 rounded-full ${
+            <Show
+              when={props.sessions.length > 0}
+              fallback={
+                <div class="px-3 py-2 rounded-lg border border-dashed border-gray-6 text-xs text-gray-9">
+                  No sessions yet. Start a task to see your work here.
+                </div>
+              }
+            >
+              <For each={props.sessions.slice(0, 8)}>
+                {(session) => (
+                  <button
+                    class={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                      session.id === props.selectedSessionId
+                        ? "bg-gray-3 text-gray-12 font-medium"
+                        : "text-gray-11 hover:text-gray-12 hover:bg-gray-2"
+                    }`}
+                    onClick={() => props.onSelectSession(session.id)}
+                    onContextMenu={(event) => openContextMenu(event, session.id)}
+                  >
+                      <div class="flex items-center justify-between gap-2 w-full overflow-hidden">
+                        <div class="truncate">{session.title}</div>
+                        <Show
+                          when={
+                            props.sessionStatusById[session.id] &&
+                            props.sessionStatusById[session.id] !== "idle"
+                          }
+                        >
+                        <span
+                          class={`shrink-0 text-[10px] px-1.5 py-0.5 rounded-full border flex items-center gap-1 ${
                             props.sessionStatusById[session.id] === "running"
-                              ? "bg-amber-9 animate-pulse"
-                              : "bg-gray-9"
+                              ? "border-amber-7/50 text-amber-11 bg-amber-2/50"
+                              : "border-gray-7/50 text-gray-10 bg-gray-2/50"
                           }`}
-                        />
-                      </span>
-                    </Show>
-                  </div>
-                </button>
-              )}
-            </For>
+                        >
+                          <div
+                            class={`w-1 h-1 rounded-full ${
+                              props.sessionStatusById[session.id] === "running"
+                                ? "bg-amber-9 animate-pulse"
+                                : "bg-gray-9"
+                            }`}
+                          />
+                        </span>
+                      </Show>
+                    </div>
+                  </button>
+                )}
+              </For>
+            </Show>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add an empty state message in the session sidebar when there are no sessions
- surface unread message count and a jump-to-latest affordance when auto-scroll is off