### PR TITLE
Clarify reset confirmations

### DIFF
--- a/packages/app/src/app/components/reset-modal.tsx
+++ b/packages/app/src/app/components/reset-modal.tsx
@@ -49,17 +49,26 @@ export default function ResetModal(props: ResetModalProps) {
 
             <div class="mt-6 space-y-4">
               <div class="rounded-xl bg-gray-1/20 border border-gray-6 p-3 text-xs text-gray-11">
-                <Switch>
-                  <Match when={props.mode === "onboarding"}>
-                    {translate("settings.reset_onboarding_warning")}
-                  </Match>
-                  <Match when={true}>{translate("settings.reset_app_data_warning")}</Match>
-                </Switch>
+                <ul class="space-y-2">
+                  <li class="flex items-start gap-2">
+                    <span class="mt-1 h-1.5 w-1.5 rounded-full bg-gray-8/70" />
+                    <span>
+                      <Switch>
+                        <Match when={props.mode === "onboarding"}>
+                          {translate("settings.reset_onboarding_warning")}
+                        </Match>
+                        <Match when={true}>{translate("settings.reset_app_data_warning")}</Match>
+                      </Switch>
+                    </span>
+                  </li>
+                  <Show when={props.hasActiveRuns}>
+                    <li class="flex items-start gap-2 text-red-11">
+                      <span class="mt-1 h-1.5 w-1.5 rounded-full bg-red-9/80" />
+                      <span>{translate("settings.reset_stop_active_runs")}</span>
+                    </li>
+                  </Show>
+                </ul>
               </div>
-
-              <Show when={props.hasActiveRuns}>
-                <div class="text-xs text-red-11">{translate("settings.reset_stop_active_runs")}</div>
-              </Show>
 
               <TextInput
                 label={translate("settings.reset_confirmation_label")}

--- a/packages/app/src/app/components/workspace-picker.tsx
+++ b/packages/app/src/app/components/workspace-picker.tsx
@@ -1,9 +1,10 @@
-import { For, Show, createEffect, createMemo } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 
 import { Check, Globe, Loader2, Plus, Search, Trash2, Upload } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
 
 import type { WorkspaceInfo } from "../lib/tauri";
+import ConfirmModal from "./confirm-modal";
 
 export default function WorkspacePicker(props: {
   open: boolean;
@@ -36,6 +37,7 @@ export default function WorkspacePicker(props: {
 
   const totalCount = createMemo(() => props.workspaces.length);
   let searchInputRef: HTMLInputElement | undefined;
+  const [forgetTarget, setForgetTarget] = createSignal<WorkspaceInfo | null>(null);
 
   createEffect(() => {
     if (props.open) {
@@ -136,7 +138,7 @@ export default function WorkspacePicker(props: {
                     type="button"
                     onClick={(event) => {
                       event.stopPropagation();
-                      props.onForget(ws.id);
+                      setForgetTarget(ws);
                     }}
                     class="p-1 rounded-md text-gray-9 hover:text-gray-12 hover:bg-gray-3 transition-colors"
                     title={translate("dashboard.forget_workspace")}
@@ -184,6 +186,21 @@ export default function WorkspacePicker(props: {
             </div>
           </div>
         </div>
+        <ConfirmModal
+          open={Boolean(forgetTarget())}
+          title={translate("dashboard.forget_workspace_confirm_title")}
+          message={translate("dashboard.forget_workspace_confirm_message")}
+          confirmLabel={translate("dashboard.forget_workspace")}
+          cancelLabel={translate("common.cancel")}
+          variant="danger"
+          onCancel={() => setForgetTarget(null)}
+          onConfirm={() => {
+            const target = forgetTarget();
+            if (!target) return;
+            props.onForget(target.id);
+            setForgetTarget(null);
+          }}
+        />
       </div>
     </Show>
   );

--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -19,6 +19,8 @@ export default {
   "dashboard.new_workspace": "New Workspace...",
   "dashboard.new_remote_workspace": "Add Remote Workspace...",
   "dashboard.forget_workspace": "Forget workspace",
+  "dashboard.forget_workspace_confirm_title": "Forget workspace?",
+  "dashboard.forget_workspace_confirm_message": "This removes it from your list. You can add it again later.",
   "dashboard.remote": "Remote",
   "dashboard.connection": "Connection",
   "dashboard.local_engine": "Local Engine",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -19,6 +19,8 @@ export default {
   "dashboard.new_workspace": "新建工作区...",
   "dashboard.new_remote_workspace": "添加远程工作区...",
   "dashboard.forget_workspace": "忘记工作区",
+  "dashboard.forget_workspace_confirm_title": "忘记这个工作区？",
+  "dashboard.forget_workspace_confirm_message": "这会把它从列表中移除，你可以稍后再添加。",
   "dashboard.remote": "远程",
   "dashboard.connection": "连接",
   "dashboard.local_engine": "本地引擎",


### PR DESCRIPTION
## Summary
- restyle reset warnings into a bullet list with an active-run callout
- require confirmation before forgetting a workspace