### PR TITLE
Surface reload warnings in more detail

### DIFF
--- a/packages/app/src/app/components/reload-workspace-toast.tsx
+++ b/packages/app/src/app/components/reload-workspace-toast.tsx
@@ -93,14 +93,22 @@ export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
               </Show>
             </div>
             
-            <Show when={props.description || props.error}>
-              <div class="text-xs text-gray-10 truncate leading-none mt-0.5">
-                {props.hasActiveRuns 
-                  ? <span class="text-amber-11 font-medium">Reloading will stop active tasks.</span>
-                  : props.error 
-                  ? <span class="text-red-9 font-medium">{props.error}</span>
-                  : getDescription()
-                }
+            <Show when={props.description || props.error || props.warning || props.blockedReason}>
+              <div class="text-xs text-gray-10 leading-snug mt-0.5 space-y-1">
+                <div>
+                  {props.hasActiveRuns 
+                    ? <span class="text-amber-11 font-medium">Reloading will stop active tasks.</span>
+                    : props.error 
+                    ? <span class="text-red-9 font-medium">{props.error}</span>
+                    : getDescription()
+                  }
+                </div>
+                <Show when={props.warning}>
+                  <div class="text-amber-11">{props.warning}</div>
+                </Show>
+                <Show when={props.blockedReason}>
+                  <div class="text-gray-9">Blocked: {props.blockedReason}</div>
+                </Show>
               </div>
             </Show>
           </div>

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1133,6 +1133,12 @@ export default function Composer(props: ComposerProps) {
                       </Show>
                     </div>
 
+                    <Show when={!props.prompt.trim() && !attachments().length}>
+                      <div class="mt-2 text-[10px] text-gray-8">
+                        Enter to send · Shift+Enter for newline
+                      </div>
+                    </Show>
+
                     <div class="absolute bottom-0 right-0 z-20 flex items-center gap-2">
                       <input
                         ref={fileInputRef}


### PR DESCRIPTION
## Summary
- show warning and blocked-reason details in the reload workspace toast
- display a send shortcut hint when the composer is empty