### PR TITLE
Add auto-update flow for new app releases

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -2043,6 +2043,8 @@ export default function App() {
     setPendingUpdate,
     updateEnv,
     setUpdateEnv,
+    updateChannel,
+    setUpdateChannel,
     checkForUpdates,
     downloadUpdate,
     installUpdateAndRestart,
@@ -3340,6 +3342,11 @@ export default function App() {
           }
         }
 
+        const storedUpdateChannel = window.localStorage.getItem("openwork.updateChannel");
+        if (storedUpdateChannel === "stable" || storedUpdateChannel === "prerelease") {
+          setUpdateChannel(storedUpdateChannel);
+        }
+
         const storedNotionStatus = window.localStorage.getItem("openwork.notionStatus");
         if (
           storedNotionStatus === "disconnected" ||
@@ -3650,6 +3657,15 @@ export default function App() {
         "openwork.updateAutoCheck",
         updateAutoCheck() ? "1" : "0"
       );
+    } catch {
+      // ignore
+    }
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem("openwork.updateChannel", updateChannel());
     } catch {
       // ignore
     }
@@ -4059,6 +4075,8 @@ export default function App() {
     checkForUpdates: () => checkForUpdates(),
     downloadUpdate: () => downloadUpdate(),
     installUpdateAndRestart,
+    updateChannel: updateChannel(),
+    setUpdateChannel,
     anyActiveRuns: anyActiveRuns(),
     engineSource: engineSource(),
     setEngineSource,

--- a/packages/app/src/app/context/updater.ts
+++ b/packages/app/src/app/context/updater.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 
 import type { UpdateHandle } from "../types";
-import type { UpdaterEnvironment } from "../lib/tauri";
+import type { UpdateChannel, UpdaterEnvironment } from "../lib/tauri";
 
 export type UpdateStatus =
   | { state: "idle"; lastCheckedAt: number | null }
@@ -16,15 +16,18 @@ export type UpdateStatus =
       notes?: string;
     }
   | { state: "ready"; lastCheckedAt: number; version: string; notes?: string }
+  | { state: "applying"; lastCheckedAt: number; version: string; notes?: string }
+  | { state: "restart-required"; lastCheckedAt: number; version: string; notes?: string }
   | { state: "error"; lastCheckedAt: number | null; message: string };
 
-export type PendingUpdate = { update: UpdateHandle; version: string; notes?: string } | null;
+export type PendingUpdate = { version: string; notes?: string; date?: string } | null;
 
 export function createUpdaterState() {
   const [updateAutoCheck, setUpdateAutoCheck] = createSignal(true);
   const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>({ state: "idle", lastCheckedAt: null });
   const [pendingUpdate, setPendingUpdate] = createSignal<PendingUpdate>(null);
   const [updateEnv, setUpdateEnv] = createSignal<UpdaterEnvironment | null>(null);
+  const [updateChannel, setUpdateChannel] = createSignal<UpdateChannel>("stable");
 
   return {
     updateAutoCheck,
@@ -35,5 +38,7 @@ export function createUpdaterState() {
     setPendingUpdate,
     updateEnv,
     setUpdateEnv,
+    updateChannel,
+    setUpdateChannel,
   } as const;
 }

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { isTauriRuntime } from "../utils";
 import { validateMcpServerName } from "../mcp";
@@ -496,8 +496,38 @@ export type UpdaterEnvironment = {
   appBundlePath: string | null;
 };
 
+export type UpdateChannel = "stable" | "prerelease";
+
+export type UpdaterCheckResult = {
+  version: string;
+  currentVersion: string;
+  date?: string;
+  notes?: string;
+} | null;
+
+export type UpdaterDownloadEvent =
+  | { event: "Started"; data: { contentLength?: number | null } }
+  | { event: "Progress"; data: { chunkLength: number } }
+  | { event: "Finished"; data: Record<string, never> };
+
 export async function updaterEnvironment(): Promise<UpdaterEnvironment> {
   return invoke<UpdaterEnvironment>("updater_environment");
+}
+
+export async function updaterCheck(channel: UpdateChannel): Promise<UpdaterCheckResult> {
+  return invoke<UpdaterCheckResult>("updater_check", { channel });
+}
+
+export async function updaterDownload(
+  onEvent: (event: UpdaterDownloadEvent) => void,
+): Promise<void> {
+  const channel = new Channel<UpdaterDownloadEvent>();
+  channel.onmessage = onEvent;
+  await invoke("updater_download", { onEvent: channel });
+}
+
+export async function updaterInstall(): Promise<void> {
+  await invoke("updater_install");
 }
 
 export async function readOpencodeConfig(

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -228,6 +228,8 @@ export type DashboardViewProps = {
     downloadedBytes?: number;
     message?: string;
   } | null;
+  updateChannel: "stable" | "prerelease";
+  setUpdateChannel: (value: "stable" | "prerelease") => void;
   updateEnv: { supported?: boolean; reason?: string | null } | null;
   appVersion: string | null;
   checkForUpdates: () => void;
@@ -1025,6 +1027,8 @@ export default function DashboardView(props: DashboardViewProps) {
                   downloadUpdate={props.downloadUpdate}
                   installUpdateAndRestart={props.installUpdateAndRestart}
                   anyActiveRuns={props.anyActiveRuns}
+                  updateChannel={props.updateChannel}
+                  setUpdateChannel={props.setUpdateChannel}
                   onResetStartupPreference={props.onResetStartupPreference}
                   openResetModal={props.openResetModal}
                   resetModalBusy={props.resetModalBusy}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -96,16 +96,18 @@ export type SettingsViewProps = {
   setThemeMode: (value: "light" | "dark" | "system") => void;
   updateAutoCheck: boolean;
   toggleUpdateAutoCheck: () => void;
-  updateStatus: {
-    state: string;
-    lastCheckedAt?: number | null;
-    version?: string;
-    date?: string;
-    notes?: string;
-    totalBytes?: number | null;
-    downloadedBytes?: number;
-    message?: string;
-  } | null;
+   updateStatus: {
+     state: string;
+     lastCheckedAt?: number | null;
+     version?: string;
+     date?: string;
+     notes?: string;
+     totalBytes?: number | null;
+     downloadedBytes?: number;
+     message?: string;
+   } | null;
+   updateChannel: "stable" | "prerelease";
+   setUpdateChannel: (value: "stable" | "prerelease") => void;
   updateEnv: { supported?: boolean; reason?: string | null } | null;
   appVersion: string | null;
   checkForUpdates: () => void;
@@ -744,7 +746,7 @@ function OwpenbotSettings(props: {
 }
 
 export default function SettingsView(props: SettingsViewProps) {
-  const updateState = () => props.updateStatus?.state ?? "idle";
+   const updateState = () => props.updateStatus?.state ?? "idle";
   const updateNotes = () => props.updateStatus?.notes ?? null;
   const updateVersion = () => props.updateStatus?.version ?? null;
   const updateDate = () => props.updateStatus?.date ?? null;
@@ -782,13 +784,16 @@ export default function SettingsView(props: SettingsViewProps) {
         return "bg-red-7/10 text-red-11 border-red-7/20";
       case "checking":
       case "downloading":
+      case "applying":
         return "bg-gray-4/60 text-gray-11 border-gray-7/50";
       default:
         return "bg-gray-4/60 text-gray-11 border-gray-7/50";
     }
   });
 
-  const updateToolbarSpinning = createMemo(() => updateState() === "checking" || updateState() === "downloading");
+  const updateToolbarSpinning = createMemo(
+    () => updateState() === "checking" || updateState() === "downloading" || updateState() === "applying",
+  );
 
   const updateToolbarLabel = createMemo(() => {
     const state = updateState();
@@ -799,11 +804,17 @@ export default function SettingsView(props: SettingsViewProps) {
     if (state === "ready") {
       return `Ready to install${version ? ` · v${version}` : ""}`;
     }
+    if (state === "restart-required") {
+      return `Restart to finish${version ? ` · v${version}` : ""}`;
+    }
     if (state === "downloading") {
       const downloaded = updateDownloadedBytes() ?? 0;
       const total = updateTotalBytes();
       const progress = total != null ? `${formatBytes(downloaded)} / ${formatBytes(total)}` : formatBytes(downloaded);
       return `Downloading ${progress}`;
+    }
+    if (state === "applying") {
+      return "Applying update";
     }
     if (state === "checking") {
       return "Checking for updates";
@@ -817,7 +828,7 @@ export default function SettingsView(props: SettingsViewProps) {
   const updateToolbarActionLabel = createMemo(() => {
     const state = updateState();
     if (state === "available") return "Download";
-    if (state === "ready") return "Install";
+    if (state === "ready" || state === "restart-required") return "Install";
     if (state === "error") return "Retry";
     if (state === "idle") return "Check";
     return null;
@@ -825,7 +836,7 @@ export default function SettingsView(props: SettingsViewProps) {
 
   const updateToolbarDisabled = createMemo(() => {
     const state = updateState();
-    if (state === "checking" || state === "downloading") return true;
+     if (state === "checking" || state === "downloading" || state === "applying") return true;
     if (state === "ready" && props.anyActiveRuns) return true;
     return props.busy;
   });
@@ -837,7 +848,7 @@ export default function SettingsView(props: SettingsViewProps) {
       props.downloadUpdate();
       return;
     }
-    if (state === "ready") {
+     if (state === "ready" || state === "restart-required") {
       props.installUpdateAndRestart();
       return;
     }
@@ -1480,22 +1491,59 @@ export default function SettingsView(props: SettingsViewProps) {
                     when={props.updateEnv && props.updateEnv.supported === false}
                     fallback={
                       <>
-                        <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6">
-                          <div class="space-y-0.5">
-                            <div class="text-sm text-gray-12">Automatic checks</div>
-                            <div class="text-xs text-gray-7">Once per day (quiet)</div>
-                          </div>
-                          <button
-                            class={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
-                              props.updateAutoCheck
-                                ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
-                                : "text-gray-10 border-gray-6 hover:text-gray-12"
-                            }`}
-                            onClick={props.toggleUpdateAutoCheck}
-                          >
-                            {props.updateAutoCheck ? "On" : "Off"}
-                          </button>
-                        </div>
+                         <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                           <div class="space-y-0.5">
+                             <div class="text-sm text-gray-12">Automatic checks</div>
+                             <div class="text-xs text-gray-7">Once per day (quiet)</div>
+                           </div>
+                           <button
+                             class={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                               props.updateAutoCheck
+                                 ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
+                                 : "text-gray-10 border-gray-6 hover:text-gray-12"
+                             }`}
+                             onClick={props.toggleUpdateAutoCheck}
+                           >
+                             {props.updateAutoCheck ? "On" : "Off"}
+                           </button>
+                         </div>
+
+                         <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                           <div class="space-y-0.5">
+                             <div class="text-sm text-gray-12">Update channel</div>
+                             <div class="text-xs text-gray-7">
+                               {props.updateChannel === "stable" ? "Stable releases only" : "Include prereleases"}
+                             </div>
+                           </div>
+                           <div class="flex items-center gap-2">
+                             <Button
+                               variant={props.updateChannel === "stable" ? "secondary" : "outline"}
+                               class="text-xs h-8 py-0 px-3"
+                               onClick={() => props.setUpdateChannel("stable")}
+                               disabled={
+                                 props.busy ||
+                                 updateState() === "checking" ||
+                                 updateState() === "downloading" ||
+                                 updateState() === "applying"
+                               }
+                             >
+                               Stable
+                             </Button>
+                             <Button
+                               variant={props.updateChannel === "prerelease" ? "secondary" : "outline"}
+                               class="text-xs h-8 py-0 px-3"
+                               onClick={() => props.setUpdateChannel("prerelease")}
+                               disabled={
+                                 props.busy ||
+                                 updateState() === "checking" ||
+                                 updateState() === "downloading" ||
+                                 updateState() === "applying"
+                               }
+                             >
+                               Prerelease
+                             </Button>
+                           </div>
+                         </div>
 
                         <div class="flex items-center justify-between gap-3 bg-gray-1 p-3 rounded-xl border border-gray-6">
                           <div class="space-y-0.5">
@@ -1503,8 +1551,10 @@ export default function SettingsView(props: SettingsViewProps) {
                               <Switch>
                                 <Match when={updateState() === "checking"}>Checking...</Match>
                                 <Match when={updateState() === "available"}>Update available: v{updateVersion()}</Match>
-                                <Match when={updateState() === "downloading"}>Downloading...</Match>
-                                <Match when={updateState() === "ready"}>Ready to install: v{updateVersion()}</Match>
+                               <Match when={updateState() === "downloading"}>Downloading...</Match>
+                               <Match when={updateState() === "ready"}>Ready to install: v{updateVersion()}</Match>
+                               <Match when={updateState() === "applying"}>Applying update...</Match>
+                               <Match when={updateState() === "restart-required"}>Restart required: v{updateVersion()}</Match>
                                 <Match when={updateState() === "error"}>Update check failed</Match>
                                 <Match when={true}>Up to date</Match>
                               </Switch>
@@ -1531,36 +1581,43 @@ export default function SettingsView(props: SettingsViewProps) {
                           </div>
 
                           <div class="flex items-center gap-2">
-                            <Button
-                              variant="outline"
-                              class="text-xs h-8 py-0 px-3"
-                              onClick={props.checkForUpdates}
-                              disabled={props.busy || updateState() === "checking" || updateState() === "downloading"}
-                            >
-                              Check
-                            </Button>
+                             <Button
+                               variant="outline"
+                               class="text-xs h-8 py-0 px-3"
+                               onClick={props.checkForUpdates}
+                               disabled={
+                                 props.busy ||
+                                 updateState() === "checking" ||
+                                 updateState() === "downloading" ||
+                                 updateState() === "applying"
+                               }
+                             >
+                               Check
+                             </Button>
 
                             <Show when={updateState() === "available"}>
-                              <Button
-                                variant="secondary"
-                                class="text-xs h-8 py-0 px-3"
-                                onClick={props.downloadUpdate}
-                                disabled={props.busy || updateState() === "downloading"}
-                              >
-                                Download
-                              </Button>
+                             <Button
+                               variant="secondary"
+                               class="text-xs h-8 py-0 px-3"
+                               onClick={props.downloadUpdate}
+                               disabled={
+                                 props.busy || updateState() === "downloading" || updateState() === "applying"
+                               }
+                             >
+                               Download
+                             </Button>
                             </Show>
 
                             <Show when={updateState() === "ready"}>
-                              <Button
-                                variant="secondary"
-                                class="text-xs h-8 py-0 px-3"
-                                onClick={props.installUpdateAndRestart}
-                                disabled={props.busy || props.anyActiveRuns}
-                                title={props.anyActiveRuns ? "Stop active runs to update" : ""}
-                              >
-                                Install & Restart
-                              </Button>
+                               <Button
+                                 variant="secondary"
+                                 class="text-xs h-8 py-0 px-3"
+                                 onClick={props.installUpdateAndRestart}
+                                 disabled={props.busy || props.anyActiveRuns || updateState() === "applying"}
+                                 title={props.anyActiveRuns ? "Stop active runs to update" : ""}
+                               >
+                                 Install & Restart
+                               </Button>
                             </Show>
                           </div>
                         </div>

--- a/packages/app/src/app/system-state.ts
+++ b/packages/app/src/app/system-state.ts
@@ -3,7 +3,6 @@ import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 import type { Session } from "@opencode-ai/sdk/v2/client";
 import type { ProviderListItem } from "./types";
 
-import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 
 import type {
@@ -12,12 +11,17 @@ import type {
   ReloadReason,
   ReloadTrigger,
   ResetOpenworkMode,
-  UpdateHandle,
 } from "./types";
 import { addOpencodeCacheHint, isTauriRuntime, safeStringify } from "./utils";
 import { mapConfigProvidersToList } from "./utils/providers";
 import { createUpdaterState } from "./context/updater";
-import { resetOpenworkState, resetOpencodeCache } from "./lib/tauri";
+import {
+  resetOpenworkState,
+  resetOpencodeCache,
+  updaterCheck,
+  updaterDownload,
+  updaterInstall,
+} from "./lib/tauri";
 import { unwrap, waitForHealthy } from "./lib/opencode";
 
 export type NotionState = {
@@ -65,6 +69,8 @@ export function createSystemState(options: {
     setPendingUpdate,
     updateEnv,
     setUpdateEnv,
+    updateChannel,
+    setUpdateChannel,
   } = updater;
 
   const [resetModalOpen, setResetModalOpen] = createSignal(false);
@@ -375,7 +381,8 @@ export function createSystemState(options: {
     setUpdateStatus({ state: "checking", startedAt: Date.now() });
 
     try {
-      const update = (await check({ timeout: 8_000 })) as unknown as UpdateHandle | null;
+      const channel = updateChannel();
+      const update = await updaterCheck(channel);
       const checkedAt = Date.now();
 
       if (!update) {
@@ -384,14 +391,13 @@ export function createSystemState(options: {
         return;
       }
 
-      const notes = typeof update.body === "string" ? update.body : undefined;
-      setPendingUpdate({ update, version: update.version, notes });
+      setPendingUpdate({ version: update.version, notes: update.notes, date: update.date });
       setUpdateStatus({
         state: "available",
         lastCheckedAt: checkedAt,
         version: update.version,
         date: update.date,
-        notes,
+        notes: update.notes,
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
@@ -425,21 +431,18 @@ export function createSystemState(options: {
     });
 
     try {
-      await pending.update.download((event: any) => {
-        if (!event || typeof event !== "object") return;
-        const record = event as Record<string, any>;
-
+      await updaterDownload((event) => {
         setUpdateStatus((current) => {
           if (current.state !== "downloading") return current;
 
-          if (record.event === "Started") {
+          if (event.event === "Started") {
             const total =
-              record.data && typeof record.data.contentLength === "number" ? record.data.contentLength : null;
+              event.data && typeof event.data.contentLength === "number" ? event.data.contentLength : null;
             return { ...current, totalBytes: total };
           }
 
-          if (record.event === "Progress") {
-            const chunk = record.data && typeof record.data.chunkLength === "number" ? record.data.chunkLength : 0;
+          if (event.event === "Progress") {
+            const chunk = event.data && typeof event.data.chunkLength === "number" ? event.data.chunkLength : 0;
             return { ...current, downloadedBytes: current.downloadedBytes + chunk };
           }
 
@@ -470,8 +473,15 @@ export function createSystemState(options: {
 
     options.setError(null);
     try {
-      await pending.update.install();
-      await pending.update.close();
+      setUpdateStatus((current) => {
+        if (current.state !== "ready") return current;
+        return { ...current, state: "applying" } as UpdateStatus;
+      });
+      await updaterInstall();
+      setUpdateStatus((current) => {
+        if (current.state !== "applying") return current;
+        return { ...current, state: "restart-required" } as UpdateStatus;
+      });
       await relaunch();
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
@@ -505,6 +515,8 @@ export function createSystemState(options: {
     setPendingUpdate,
     updateEnv,
     setUpdateEnv,
+    updateChannel,
+    setUpdateChannel,
     checkForUpdates,
     downloadUpdate,
     installUpdateAndRestart,

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2746,6 +2746,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "ureq",
+ "url",
  "uuid",
  "walkdir",
  "zip 0.6.6",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-opener = "2.5.3"
 tauri-plugin-shell = "2"
 uuid = { version = "1", features = ["v4"] }
 ureq = { version = "2.10", features = ["json"] }
+url = "2.5"
 gethostname = "0.4"
 local-ip-address = "0.5"
 walkdir = "2.5"

--- a/packages/desktop/src-tauri/src/commands/updater.rs
+++ b/packages/desktop/src-tauri/src/commands/updater.rs
@@ -1,7 +1,192 @@
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use tauri::ipc::Channel;
+use tauri::{AppHandle, State};
+use tauri_plugin_updater::{Update, UpdaterExt};
+use url::Url;
+
 use crate::types::UpdaterEnvironment;
 use crate::updater::updater_environment as updater_environment_inner;
+
+const UPDATE_ENDPOINT_STABLE: &str =
+    "https://github.com/different-ai/openwork/releases/latest/download/latest.json";
+const UPDATE_RELEASES_API: &str =
+    "https://api.github.com/repos/different-ai/openwork/releases?per_page=20";
+
+#[derive(Default)]
+pub struct PendingUpdateState {
+    update: Mutex<Option<Update>>,
+    bytes: Mutex<Option<Vec<u8>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    prerelease: bool,
+    draft: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateMetadata {
+    pub version: String,
+    pub current_version: String,
+    pub date: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event", content = "data")]
+pub enum DownloadEvent {
+    Started {
+        #[serde(rename = "contentLength")]
+        content_length: Option<u64>,
+    },
+    Progress {
+        #[serde(rename = "chunkLength")]
+        chunk_length: usize,
+    },
+    Finished,
+}
+
+fn normalize_channel(channel: Option<String>) -> String {
+    match channel.as_deref() {
+        Some("prerelease") => "prerelease".to_string(),
+        _ => "stable".to_string(),
+    }
+}
+
+fn fetch_prerelease_tag() -> Result<String, String> {
+    let response = ureq::get(UPDATE_RELEASES_API)
+        .set("User-Agent", "openwork-updater")
+        .call()
+        .map_err(|e| format!("Failed to load release list: {e}"))?;
+    let releases: Vec<GitHubRelease> = response
+        .into_json()
+        .map_err(|e| format!("Failed to parse release list: {e}"))?;
+
+    releases
+        .into_iter()
+        .find(|release| release.prerelease && !release.draft)
+        .map(|release| release.tag_name)
+        .ok_or_else(|| "No prerelease releases found.".to_string())
+}
+
+fn resolve_update_endpoint(channel: &str) -> Result<String, String> {
+    if channel == "stable" {
+        return Ok(UPDATE_ENDPOINT_STABLE.to_string());
+    }
+
+    let tag = fetch_prerelease_tag()?;
+    Ok(format!(
+        "https://github.com/different-ai/openwork/releases/download/{tag}/latest.json"
+    ))
+}
 
 #[tauri::command]
 pub fn updater_environment(_app: tauri::AppHandle) -> UpdaterEnvironment {
     updater_environment_inner()
+}
+
+#[tauri::command]
+pub async fn updater_check(
+    app: AppHandle,
+    channel: Option<String>,
+    pending: State<'_, PendingUpdateState>,
+) -> Result<Option<UpdateMetadata>, String> {
+    let channel = normalize_channel(channel);
+    let endpoint = Url::parse(&resolve_update_endpoint(&channel)?)
+        .map_err(|e: url::ParseError| e.to_string())?;
+
+    let update = app
+        .updater_builder()
+        .endpoints(vec![endpoint])
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?
+        .check()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let meta = update.as_ref().map(|update| UpdateMetadata {
+        version: update.version.clone(),
+        current_version: update.current_version.clone(),
+        date: update.date.map(|date| date.to_string()),
+        notes: update.body.clone(),
+    });
+
+    *pending
+        .update
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = update;
+    *pending
+        .bytes
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+
+    Ok(meta)
+}
+
+#[tauri::command]
+pub async fn updater_download(
+    pending: State<'_, PendingUpdateState>,
+    on_event: Channel<DownloadEvent>,
+) -> Result<(), String> {
+    let update = pending
+        .update
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+
+    let Some(update) = update else {
+        return Err("No pending update.".to_string());
+    };
+
+    let mut started = false;
+    let bytes = update
+        .download(
+            |chunk_length, content_length| {
+                if !started {
+                    started = true;
+                    let _ = on_event.send(DownloadEvent::Started { content_length });
+                }
+                let _ = on_event.send(DownloadEvent::Progress { chunk_length });
+            },
+            || {
+                let _ = on_event.send(DownloadEvent::Finished);
+            },
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+    *pending
+        .bytes
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(bytes);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn updater_install(pending: State<'_, PendingUpdateState>) -> Result<(), String> {
+    let update = pending
+        .update
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take();
+    let bytes = pending
+        .bytes
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take();
+
+    let Some(update) = update else {
+        return Err("No pending update.".to_string());
+    };
+    let Some(bytes) = bytes else {
+        return Err("No downloaded update available.".to_string());
+    };
+
+    update.install(bytes).map_err(|e| e.to_string())?;
+    Ok(())
 }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -30,7 +30,7 @@ use commands::owpenbot::{
     owpenbot_pairing_list, owpenbot_qr, owpenbot_start, owpenbot_status, owpenbot_stop,
 };
 use commands::skills::{install_skill_template, list_local_skills, uninstall_skill};
-use commands::updater::updater_environment;
+use commands::updater::{updater_check, updater_download, updater_environment, updater_install, PendingUpdateState};
 use commands::workspace::{
     workspace_add_authorized_root, workspace_bootstrap, workspace_create, workspace_create_remote,
     workspace_export_config, workspace_forget, workspace_import_config, workspace_openwork_read,
@@ -60,6 +60,7 @@ pub fn run() {
         .manage(OpenworkServerManager::default())
         .manage(OwpenbotManager::default())
         .manage(WorkspaceWatchState::default())
+        .manage(PendingUpdateState::default())
         .invoke_handler(tauri::generate_handler![
             engine_start,
             engine_stop,
@@ -101,6 +102,9 @@ pub fn run() {
             read_opencode_config,
             write_opencode_config,
             updater_environment,
+            updater_check,
+            updater_download,
+            updater_install,
             reset_openwork_state,
             reset_opencode_cache,
             opencode_mcp_auth,


### PR DESCRIPTION
## Summary
- add Tauri updater command wiring and release-check logic
- integrate updater state into app/system state and UI surfaces
- expose update controls/status in Settings and related pages
