### PR TITLE
Guard mention search races

### DIFF
--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -258,6 +258,7 @@ export default function Composer(props: ComposerProps) {
   let editorRef: HTMLDivElement | undefined;
   let fileInputRef: HTMLInputElement | undefined;
   let variantPickerRef: HTMLDivElement | undefined;
+  let mentionSearchRun = 0;
   let suppressPromptSync = false;
   const [commandIndex, setCommandIndex] = createSignal(0);
   const [mentionIndex, setMentionIndex] = createSignal(0);
@@ -734,21 +735,40 @@ export default function Composer(props: ComposerProps) {
   });
 
   createEffect(() => {
-    if (!mentionOpen()) return;
+    if (!mentionOpen()) {
+      setSearchResults([]);
+      setSearchLoading(false);
+      return;
+    }
     const query = mentionQuery().trim();
     if (!query) {
       setSearchResults([]);
       return;
     }
+    const runId = (mentionSearchRun += 1);
     setSearchLoading(true);
     const timeout = window.setTimeout(() => {
       props
         .searchFiles(query)
-        .then((results) => setSearchResults(results))
-        .catch(() => setSearchResults([]))
-        .finally(() => setSearchLoading(false));
+        .then((results) => {
+          if (runId !== mentionSearchRun) return;
+          setSearchResults(results);
+        })
+        .catch(() => {
+          if (runId !== mentionSearchRun) return;
+          setSearchResults([]);
+        })
+        .finally(() => {
+          if (runId !== mentionSearchRun) return;
+          setSearchLoading(false);
+        });
     }, 150);
-    onCleanup(() => window.clearTimeout(timeout));
+    onCleanup(() => {
+      window.clearTimeout(timeout);
+      if (runId === mentionSearchRun) {
+        setSearchLoading(false);
+      }
+    });
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary
- discard stale mention search results when the query changes or menu closes
- keep mention search loading state aligned with the latest request

## Testing
- not run (UI-only change)