### PR TITLE
fix: keep step cluster collapse consistent

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -109,7 +109,7 @@ export default function MessageList(props: MessageListProps) {
       } else {
         // Currently expanded -> collapse by adding to set
         next.add(id);
-        relatedIds.forEach((relatedId) => next.delete(relatedId));
+        relatedIds.forEach((relatedId) => next.add(relatedId));
       }
       return next;
     });


### PR DESCRIPTION
## Summary
- collapse or expand all related step IDs together so clustered steps stay in sync
- remove inconsistent toggle behavior when multiple step groups share a cluster