### PR TITLE
docs: add OpenWork 10x audit and quality pass

### DIFF
--- a/packages/app/pr/openwork-10x-audit.md
+++ b/packages/app/pr/openwork-10x-audit.md
@@ -1,0 +1,88 @@
+# OpenWork 10x Audit Research
+
+**Date:** 2026-02-03
+**Scope:** App UI, session/workspace state, background polling
+
+---
+
+## Context
+
+OpenWork is an open-source alternative to Claude Cowork. It is mobile-first, premium-feeling, and a thin UI layer on top of OpenCode primitives. Target users include:
+
+- Bob (IT/power user) who already uses OpenCode and wants to share workflows.
+- Susan (non-technical) who wants a polished experience that just works.
+
+---
+
+## Audit summary
+
+The core experience is strong, but several stale-data issues, debug artifacts, and UI inconsistencies prevent the app from feeling "10x" premium and trustworthy. Most fixes are localized and can be split into atomic worktrees.
+
+---
+
+## Findings and opportunities
+
+### 1) Dashboard tab refresh runs only once per tab
+- Evidence: `packages/app/src/app/pages/dashboard.tsx:295-421`
+- Impact: Skills, plugins, MCP, and scheduled tasks can go stale after the first visit.
+- Potential fix: Track per-tab refresh timestamps and refresh on tab revisit after a TTL; add an explicit refresh action.
+
+### 2) Debug logging left in production UI flows
+- Evidence: `packages/app/src/app/pages/dashboard.tsx:537` (debug pointer log), `packages/app/src/app/context/workspace.ts:667-671`, `packages/app/src/app/context/session.ts:349-365`
+- Impact: Noise in console, potential leakage of workspace info in production logs.
+- Potential fix: Gate logging behind `developerMode()` or remove entirely.
+
+### 3) Step cluster collapse does not collapse related steps
+- Evidence: `packages/app/src/app/components/session/message-list.tsx:99-113`
+- Impact: "Hide steps" behaves inconsistently for clustered step groups.
+- Potential fix: When collapsing, add related step IDs to the collapsed set instead of removing them.
+
+### 4) Session sidebar truncates sessions without a "show more"
+- Evidence: `packages/app/src/app/components/session/sidebar.tsx:348-394`
+- Impact: Users cannot access older sessions from the sidebar.
+- Potential fix: Add "Show all" or "View more" with a count; link to Sessions tab.
+
+### 5) Session context menu placement is hard-coded
+- Evidence: `packages/app/src/app/components/session/sidebar.tsx:174-188`
+- Impact: Menu can overflow or mis-position with localization or font changes.
+- Potential fix: Measure actual menu size and clamp to viewport at render time.
+
+### 6) Background polling is always on
+- Evidence: `packages/app/src/app/app.tsx:340-510`, `packages/app/src/app/components/status-bar.tsx:160-174`
+- Impact: Unnecessary network work and battery drain, especially when hidden.
+- Potential fix: Use `document.visibilityState` to pause intervals; consolidate polling with backoff when disconnected.
+
+### 7) Blocking browser prompts in primary flows
+- Evidence: `packages/app/src/app/app.tsx:1231-1243` (model variant), `packages/app/src/app/pages/session.tsx:739-756` (delete confirm), `packages/app/src/app/pages/session.tsx:1016-1039` (agent prompt)
+- Impact: Inconsistent UI, poor mobile behavior, breaks flow.
+- Potential fix: Replace with in-app modals or inline confirmations.
+
+### 8) Mention search results can race
+- Evidence: `packages/app/src/app/components/session/composer.tsx:736-750`
+- Impact: Stale results can surface if earlier search resolves after a newer query.
+- Potential fix: Add request tokens or abort controllers to discard stale results.
+
+### 9) Stale sessions for inactive workspaces
+- Evidence: `packages/app/src/app/pages/session.tsx:673-685`
+- Impact: Sidebar workspace groups show outdated sessions until the workspace is re-activated.
+- Potential fix: Refresh sessions per workspace on demand or group from a global session list keyed by directory.
+
+### 10) OpenWork server checks have no disconnect backoff
+- Evidence: `packages/app/src/app/app.tsx:340-370`
+- Impact: Repeated failures while disconnected; noisy and wasteful.
+- Potential fix: Apply exponential backoff or suspend checks until the user changes connection settings.
+
+---
+
+## Notes
+
+- `ISSUES.md` was not found in the repo; no centralized issue list to reference.
+
+---
+
+## Proposed 10x themes
+
+- Freshness: fix stale data and refresh behavior.
+- Trust: remove debug artifacts and avoid blocking prompts.
+- Performance: pause background polling when hidden.
+- Discoverability: surface older sessions and state changes clearly.

--- a/packages/app/pr/openwork-10x.md
+++ b/packages/app/pr/openwork-10x.md
@@ -1,0 +1,127 @@
+# OpenWork 10x Quality Pass
+
+**Priority:** P0
+**Related research:** `packages/app/pr/openwork-10x-audit.md`
+
+---
+
+## Summary
+
+Deliver a focused quality pass that makes OpenWork feel 10x more premium and reliable by fixing stale data, removing debug artifacts, reducing background polling, and smoothing core session flows. Changes are intentionally small and atomic, aligned to OpenCode primitives and mobile-first UX.
+
+---
+
+## Problems
+
+1. Data goes stale across dashboard tabs and workspace lists.
+2. Debug logs and blocking prompts undermine a premium UX.
+3. Background polling is wasteful when the app is hidden or disconnected.
+4. Sidebar session navigation is truncated and inconsistent.
+
+---
+
+## Goals
+
+- Keep sessions, skills, plugins, MCPs, and scheduled tasks fresh without heavy polling.
+- Remove or gate debug artifacts in production flows.
+- Replace blocking browser prompts with in-app UI.
+- Improve session navigation and sidebar discoverability.
+
+---
+
+## Non-goals
+
+- No new backend endpoints.
+- No redesign of the overall layout or visual language.
+- No changes to OpenCode APIs or engine behavior.
+
+---
+
+## Personas
+
+- **Bob (IT/power user):** expects reliability, speed, and full visibility.
+- **Susan (non-technical):** needs clarity, confidence, and minimal friction.
+
+---
+
+## Scope (atomic workstreams)
+
+Each item should be implemented in its own worktree and then merged into a single PR.
+
+1. **Dashboard refresh TTL + manual refresh**
+   - Add per-tab refresh timestamps; refresh when re-entering a tab after a TTL.
+   - Add a small refresh action for Skills, Plugins, MCP, Scheduled.
+
+2. **Remove or gate debug logs**
+   - Strip `console.log` calls in Dashboard, Session store, Workspace store.
+   - Allow optional logging only when `developerMode()` is true.
+
+3. **Fix step cluster collapse behavior**
+   - Ensure related step IDs are collapsed together in MessageList.
+
+4. **Session sidebar "Show more"**
+   - Provide a visible affordance when sessions exceed the current cap.
+   - Route to Sessions tab or expand inline.
+
+5. **Context menu positioning**
+   - Replace hard-coded menu dimensions with measured bounds.
+   - Clamp to viewport to avoid overflow.
+
+6. **Visibility-aware polling**
+   - Pause polling intervals when document is hidden.
+   - Resume when visible; apply backoff for disconnected states.
+
+7. **Replace blocking prompts**
+   - Swap `window.confirm` / `window.prompt` usage for in-app modals.
+   - Maintain keyboard accessibility and mobile layout.
+
+8. **Mention search race guard**
+   - Add request tokens or abort logic to discard stale results.
+
+9. **Inactive workspace session freshness**
+   - Refresh per-workspace sessions when workspace list changes or on demand.
+   - Avoid expensive global reloads.
+
+10. **OpenWork server check backoff**
+   - When disconnected, use exponential backoff or pause until settings change.
+
+---
+
+## Acceptance criteria
+
+- Switching back to a dashboard tab after a TTL refreshes data without a full reload.
+- No debug logs appear unless developer mode is enabled.
+- "Hide steps" collapses all related steps in a cluster consistently.
+- Sidebar shows a clear path to older sessions.
+- Context menu never renders off-screen.
+- Polling pauses while the app is hidden and resumes on focus.
+- No browser-native prompts are used in session flows.
+- Mention search never shows stale results after rapid typing.
+- Session lists for inactive workspaces are not stale for long-lived sessions.
+- OpenWork server checks do not spam when disconnected.
+
+---
+
+## Success metrics
+
+- < 100ms input-to-feedback on session and dashboard actions.
+- 0 stale-dashboard regressions in repeated navigation.
+- Reduced background polling traffic when hidden.
+
+---
+
+## Risks and mitigations
+
+- **Risk:** Reduced polling may hide state updates.
+  - **Mitigation:** Use TTL-based refresh and manual refresh action.
+- **Risk:** Modal additions slow delivery.
+  - **Mitigation:** Reuse existing modal components and patterns.
+
+---
+
+## Validation
+
+- Manual: navigate between tabs, verify refresh TTL and manual refresh.
+- Manual: create/delete sessions, verify sidebar navigation.
+- Manual: verify no console noise in non-developer mode.
+- Optional: Chrome MCP smoke test for session and dashboard flows.


### PR DESCRIPTION
## Summary
- capture the 10x audit findings for stale data, polling, and UI polish
- document the scoped quality-pass workstreams with goals and acceptance criteria