### PR TITLE
Enable attachments for remote sessions

### DIFF
--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -186,6 +186,17 @@ export default function SessionView(props: SessionViewProps) {
   const commandNeedsDetails = (command: { template: string }) => COMMAND_ARGS_RE.test(command.template);
 
   const agentLabel = createMemo(() => props.selectedSessionAgent ?? "Default agent");
+  const attachmentsEnabled = createMemo(() => {
+    if (props.activeWorkspaceDisplay.workspaceType !== "remote") return true;
+    return props.openworkServerStatus === "connected";
+  });
+  const attachmentsDisabledReason = createMemo(() => {
+    if (attachmentsEnabled()) return null;
+    if (props.openworkServerStatus === "limited") {
+      return "Add a server token to attach files.";
+    }
+    return "Connect to OpenWork server to attach files.";
+  });
 
   const isNearBottom = (el: HTMLElement, threshold = 80) => {
     const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
@@ -1534,6 +1545,8 @@ export default function SessionView(props: SessionViewProps) {
           recentFiles={props.workingFiles}
           searchFiles={props.searchFiles}
           isRemoteWorkspace={props.activeWorkspaceDisplay.workspaceType === "remote"}
+          attachmentsEnabled={attachmentsEnabled()}
+          attachmentsDisabledReason={attachmentsDisabledReason()}
         />
 
         <Show when={unreadCount() > 0}>


### PR DESCRIPTION
## Summary
- enable attachments in remote sessions when the OpenWork server is connected
- provide clear disable reasons when the server is unavailable or token-limited
- align drag/drop and tooltip behavior with attachment availability

## Testing
- Chrome MCP: connected web dev app to OpenWork server at http://127.0.0.1:8888, uploaded `ux-improvement-05-attachments-disabled.png`, and sent "Attachment test" in a remote session
- Screenshot: /tmp/openwork-attachments-remote.png