### PR TITLE
feat: add sandbox and target management

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -122,6 +122,7 @@ import { createSessionStore } from "./context/session";
 import { createExtensionsStore } from "./context/extensions";
 import { useGlobalSync } from "./context/global-sync";
 import { createWorkspaceStore } from "./context/workspace";
+import { createTargetStore, LocalTarget } from "./context/targets";
 import {
   updaterEnvironment,
   readOpencodeConfig,
@@ -1319,6 +1320,25 @@ export default function App() {
     openworkServerClient,
     onEngineStable: () => setReloadLastFinishedAtRef(Date.now()),
     engineRuntime,
+  });
+
+  const targetStore = createTargetStore();
+  const targetOptions = createMemo(() => [LocalTarget, ...targetStore.targets()]);
+  const activeTargetId = createMemo(() => targetStore.activeTargetId());
+  const defaultTargetId = createMemo(() => targetStore.defaultTargetId());
+  const activeSandbox = createMemo(() => {
+    const sandboxId = workspaceStore.activeSandboxId();
+    if (!sandboxId) return null;
+    return workspaceStore.sandboxes().find((sandbox) => sandbox.id === sandboxId) ?? null;
+  });
+  const activeTargetInfo = createMemo(() => workspaceStore.activeTargetInfo());
+
+  createEffect(() => {
+    const info = workspaceStore.activeTargetInfo();
+    if (!info) return;
+    if (info.type === "local") {
+      targetStore.setActiveTarget(LocalTarget.id);
+    }
   });
 
   createEffect(() => {
@@ -3236,6 +3256,38 @@ export default function App() {
     }
   }
 
+  const [targetSwitching, setTargetSwitching] = createSignal(false);
+
+  const handleSelectTarget = async (targetId: string) => {
+    if (targetSwitching()) return;
+    const target = targetOptions().find((option) => option.id === targetId);
+    if (!target) return;
+    if (targetStore.activeTargetId() === targetId) return;
+
+    setTargetSwitching(true);
+    try {
+      targetStore.setActiveTarget(targetId);
+      if (target.type === "remote") {
+        updateOpenworkServerSettings({
+          ...openworkServerSettings(),
+          urlOverride: target.baseUrl ?? "",
+          token: target.token ?? undefined,
+        });
+        setStartupPreference("server");
+        targetStore.updateTarget(targetId, { lastUsedAt: Date.now() });
+      } else {
+        setStartupPreference("local");
+      }
+
+      const ok = await workspaceStore.createSandbox({ source: "base" });
+      if (ok) {
+        await createSessionAndOpen();
+      }
+    } finally {
+      setTargetSwitching(false);
+    }
+  };
+
 
   onMount(async () => {
     const startupPref = readStartupPreference();
@@ -3982,6 +4034,14 @@ export default function App() {
     openwrkStatus: openwrkStatusState(),
     owpenbotInfo: owpenbotInfoState(),
     engineDoctorVersion: workspaceStore.engineDoctorResult()?.version ?? null,
+    targets: targetOptions(),
+    activeTargetId: activeTargetId(),
+    defaultTargetId: defaultTargetId(),
+    addTarget: targetStore.addTarget,
+    updateTarget: targetStore.updateTarget,
+    removeTarget: targetStore.removeTarget,
+    setDefaultTarget: targetStore.setDefaultTarget,
+    setActiveTarget: handleSelectTarget,
     updateOpenworkServerSettings,
     resetOpenworkServerSettings,
     testOpenworkServerConnection,
@@ -3996,6 +4056,11 @@ export default function App() {
     setWorkspacePickerOpen: workspaceStore.setWorkspacePickerOpen,
     connectingWorkspaceId: workspaceStore.connectingWorkspaceId(),
     workspaces: workspaceStore.workspaces(),
+    sandboxes: workspaceStore.sandboxes(),
+    activeSandboxId: workspaceStore.activeSandboxId(),
+    createSandbox: workspaceStore.createSandbox,
+    activateSandbox: workspaceStore.activateSandbox,
+    archiveSandbox: workspaceStore.archiveSandbox,
     filteredWorkspaces: workspaceStore.filteredWorkspaces(),
     activeWorkspaceId: workspaceStore.activeWorkspaceId(),
     activateWorkspace: workspaceStore.activateWorkspace,
@@ -4180,6 +4245,8 @@ export default function App() {
     activeWorkspaceRoot: workspaceStore.activeWorkspaceRoot().trim(),
     workspaces: workspaceStore.workspaces(),
     activeWorkspaceId: workspaceStore.activeWorkspaceId(),
+    activeSandbox: activeSandbox(),
+    activeTargetInfo: activeTargetInfo(),
     connectingWorkspaceId: workspaceStore.connectingWorkspaceId(),
     activateWorkspace: workspaceStore.activateWorkspace,
     setWorkspaceSearch: workspaceStore.setWorkspaceSearch,
@@ -4246,6 +4313,9 @@ export default function App() {
     providers: providers(),
     providerConnectedIds: providerConnectedIds(),
     listAgents: listAgents,
+    targetOptions: targetOptions(),
+    activeTargetId: activeTargetId(),
+    onSelectTarget: handleSelectTarget,
     selectedSessionAgent: selectedSessionAgent(),
     setSessionAgent: setSessionAgent,
     saveSession: saveSessionExport,

--- a/packages/app/src/app/components/sandbox-chip.tsx
+++ b/packages/app/src/app/components/sandbox-chip.tsx
@@ -1,0 +1,46 @@
+import type { OpenworkSandboxInfo, OpenworkTargetInfo } from "../lib/openwork-server";
+
+import { Box, ChevronDown, Globe, HardDrive, Loader2 } from "lucide-solid";
+
+const targetLabelFallback = (target: OpenworkTargetInfo | null) => {
+  if (!target) return "Target";
+  return target.type === "remote" ? "Remote" : "Local";
+};
+
+export default function SandboxChip(props: {
+  sandbox: OpenworkSandboxInfo | null;
+  target: OpenworkTargetInfo | null;
+  onClick: () => void;
+  connecting?: boolean;
+}) {
+  const TargetIcon = props.target?.type === "remote" ? Globe : HardDrive;
+  const status = () => props.sandbox?.status ?? "active";
+  const targetLabel = () => props.target?.label?.trim() || targetLabelFallback(props.target);
+
+  return (
+    <button
+      onClick={props.onClick}
+      class="flex items-center gap-2 pl-3 pr-2 py-1.5 bg-gray-2 border border-gray-6 rounded-lg hover:border-gray-7 hover:bg-gray-4 transition-all group"
+    >
+      <div class="p-1 rounded bg-amber-7/10 text-amber-6">
+        <Box size={14} />
+      </div>
+      <div class="flex flex-col items-start mr-2 min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-xs font-medium text-gray-12 leading-none truncate max-w-[9.5rem]">
+            {props.sandbox?.name ?? "Sandbox"}
+          </span>
+          <span class="text-[9px] uppercase tracking-wide px-1.5 py-0.5 rounded-full bg-gray-4 text-gray-11">
+            {status()}
+          </span>
+        </div>
+        <div class="flex items-center gap-1 text-[10px] text-gray-10 font-mono leading-none max-w-[140px] truncate">
+          <TargetIcon size={11} class="text-gray-8" />
+          <span class="truncate">{targetLabel()}</span>
+        </div>
+      </div>
+      <ChevronDown size={14} class="text-gray-10 group-hover:text-gray-11" />
+      {props.connecting ? <Loader2 size={14} class="text-gray-10 animate-spin" /> : null}
+    </button>
+  );
+}

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1,8 +1,8 @@
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
-import { ArrowRight, AtSign, ChevronDown, File, Paperclip, X, Zap } from "lucide-solid";
+import { ArrowRight, AtSign, ChevronDown, File, HardDrive, Paperclip, X, Zap } from "lucide-solid";
 
-import type { ComposerAttachment, ComposerDraft, ComposerPart, PromptMode } from "../../types";
+import type { ComposerAttachment, ComposerDraft, ComposerPart, PromptMode, TargetProfile } from "../../types";
 
 export type CommandItem = {
   id: string;
@@ -55,6 +55,9 @@ type ComposerProps = {
   isRemoteWorkspace: boolean;
   attachmentsEnabled: boolean;
   attachmentsDisabledReason: string | null;
+  targetOptions: TargetProfile[];
+  activeTargetId: string;
+  onSelectTarget: (targetId: string) => void | Promise<void>;
 };
 
 const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
@@ -276,8 +279,14 @@ export default function Composer(props: ComposerProps) {
   const [historyIndex, setHistoryIndex] = createSignal({ prompt: -1, shell: -1 });
   const [history, setHistory] = createSignal({ prompt: [] as ComposerDraft[], shell: [] as ComposerDraft[] });
   const [variantMenuOpen, setVariantMenuOpen] = createSignal(false);
+  const [targetPickerOpen, setTargetPickerOpen] = createSignal(false);
+  let targetPickerRef: HTMLDivElement | undefined;
   const activeVariant = createMemo(() => props.modelVariant ?? "none");
   const attachmentsDisabled = createMemo(() => !props.attachmentsEnabled);
+  const activeTarget = createMemo(() => {
+    const current = props.targetOptions.find((option) => option.id === props.activeTargetId);
+    return current ?? props.targetOptions[0] ?? null;
+  });
 
   onMount(() => {
     queueMicrotask(() => focusEditorEnd());
@@ -817,6 +826,17 @@ export default function Composer(props: ComposerProps) {
   });
 
   createEffect(() => {
+    if (!targetPickerOpen()) return;
+    const handler = (event: MouseEvent) => {
+      if (!targetPickerRef) return;
+      if (targetPickerRef.contains(event.target as Node)) return;
+      setTargetPickerOpen(false);
+    };
+    window.addEventListener("mousedown", handler);
+    onCleanup(() => window.removeEventListener("mousedown", handler));
+  });
+
+  createEffect(() => {
     const handler = () => {
       editorRef?.focus();
     };
@@ -1079,7 +1099,7 @@ export default function Composer(props: ComposerProps) {
                       class="bg-transparent border-none p-0 pb-12 pr-20 text-gray-12 focus:ring-0 text-[15px] leading-relaxed resize-none min-h-[24px] outline-none relative z-10"
                     />
 
-                    <div class="mt-3" ref={props.setAgentPickerRef}>
+                    <div class="mt-3 flex flex-wrap items-center gap-2" ref={props.setAgentPickerRef}>
                       <button
                         type="button"
                         class="flex items-center gap-2 pl-3 pr-2 py-1.5 bg-gray-1/70 border border-gray-6 rounded-lg hover:border-gray-7 hover:bg-gray-3 transition-all group"
@@ -1153,6 +1173,66 @@ export default function Composer(props: ComposerProps) {
                           <div class="border-t border-gray-6/40 px-4 py-2 text-[10px] text-gray-9">
                             Tip: use /agent-next or /agent-prev to cycle.
                           </div>
+                        </div>
+                      </Show>
+
+                      <Show when={props.targetOptions.length}>
+                        <div class="relative" ref={(el) => (targetPickerRef = el)}>
+                          <button
+                            type="button"
+                            class="flex items-center gap-2 pl-3 pr-2 py-1.5 bg-gray-1/70 border border-gray-6 rounded-lg hover:border-gray-7 hover:bg-gray-3 transition-all group"
+                            onClick={() => setTargetPickerOpen((open) => !open)}
+                            aria-expanded={targetPickerOpen()}
+                          >
+                            <div class="p-1 rounded bg-gray-4 text-gray-10">
+                              <HardDrive size={14} />
+                            </div>
+                            <div class="flex flex-col items-start mr-2 min-w-0">
+                              <span class="text-xs font-medium text-gray-12 leading-none truncate max-w-[10rem]">
+                                {activeTarget()?.label ?? "Run on"}
+                              </span>
+                              <span class="text-[10px] text-gray-10 font-mono leading-none">
+                                {activeTarget()?.type === "remote" ? "Remote" : "Local"}
+                              </span>
+                            </div>
+                            <ChevronDown size={14} class="text-gray-10 group-hover:text-gray-11" />
+                          </button>
+
+                          <Show when={targetPickerOpen()}>
+                            <div class="absolute left-0 bottom-full mb-2 w-64 rounded-2xl border border-gray-6 bg-gray-1/95 shadow-2xl backdrop-blur-md overflow-hidden">
+                              <div class="px-4 pt-3 pb-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-8 border-b border-gray-6/30">
+                                Run on
+                              </div>
+                              <div class="max-h-64 overflow-auto p-2 space-y-1">
+                                <For each={props.targetOptions}>
+                                  {(target) => (
+                                    <button
+                                      type="button"
+                                      class={`w-full flex items-center justify-between rounded-xl px-3 py-2 text-left text-xs transition-colors ${
+                                        props.activeTargetId === target.id
+                                          ? "bg-gray-12/10 text-gray-12"
+                                          : "text-gray-11 hover:bg-gray-12/5"
+                                      }`}
+                                      onClick={() => {
+                                        props.onSelectTarget(target.id);
+                                        setTargetPickerOpen(false);
+                                      }}
+                                    >
+                                      <div class="min-w-0">
+                                        <div class="truncate">{target.label}</div>
+                                        <div class="text-[10px] text-gray-9">
+                                          {target.type === "remote" ? "Remote" : "Local"}
+                                        </div>
+                                      </div>
+                                      <Show when={props.activeTargetId === target.id}>
+                                        <span class="text-[10px] uppercase tracking-wider text-gray-9">Active</span>
+                                      </Show>
+                                    </button>
+                                  )}
+                                </For>
+                              </div>
+                            </div>
+                          </Show>
                         </div>
                       </Show>
                     </div>

--- a/packages/app/src/app/context/targets.ts
+++ b/packages/app/src/app/context/targets.ts
@@ -1,0 +1,128 @@
+import { createEffect, createMemo, createSignal } from "solid-js";
+import { createStore } from "solid-js/store";
+import type { TargetProfile } from "../types";
+import { normalizeOpenworkServerUrl } from "../lib/openwork-server";
+
+export type TargetStore = ReturnType<typeof createTargetStore>;
+
+type TargetState = {
+  items: TargetProfile[];
+  defaultId?: string | null;
+  lastActiveId?: string | null;
+};
+
+const STORAGE_KEY = "openwork.executionTargets.v1";
+const LOCAL_TARGET_ID = "tgt-local";
+
+const readState = (): TargetState => {
+  if (typeof window === "undefined") return { items: [] };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { items: [] };
+    const parsed = JSON.parse(raw) as TargetState;
+    if (!parsed || !Array.isArray(parsed.items)) return { items: [] };
+    return parsed;
+  } catch {
+    return { items: [] };
+  }
+};
+
+const writeState = (state: TargetState) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore
+  }
+};
+
+const generateId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `tgt-${crypto.randomUUID()}`;
+  }
+  return `tgt-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export function createTargetStore() {
+  const [state, setState] = createStore<TargetState>(readState());
+  const [activeTargetId, setActiveTargetId] = createSignal(
+    state.lastActiveId ?? state.defaultId ?? LOCAL_TARGET_ID,
+  );
+
+  createEffect(() => {
+    writeState({ ...state, lastActiveId: activeTargetId() });
+  });
+
+  const targets = createMemo(() => state.items);
+
+  const addTarget = (input: { label: string; baseUrl: string; token?: string | null }) => {
+    const normalized = normalizeOpenworkServerUrl(input.baseUrl) ?? "";
+    if (!normalized) return null;
+    const next: TargetProfile = {
+      id: generateId(),
+      label: input.label.trim() || normalized,
+      type: "remote",
+      baseUrl: normalized,
+      token: input.token?.trim() || null,
+      lastUsedAt: Date.now(),
+      status: "unknown",
+    };
+    setState("items", (items) => [...items, next]);
+    return next;
+  };
+
+  const updateTarget = (id: string, input: Partial<Omit<TargetProfile, "id" | "type">>) => {
+    setState(
+      "items",
+      (items) =>
+        items.map((target) =>
+          target.id === id
+            ? {
+                ...target,
+                label: input.label?.trim() ?? target.label,
+                baseUrl: input.baseUrl ? normalizeOpenworkServerUrl(input.baseUrl) ?? target.baseUrl : target.baseUrl,
+                token: input.token !== undefined ? input.token : target.token,
+                lastUsedAt: input.lastUsedAt ?? target.lastUsedAt,
+                status: input.status ?? target.status,
+              }
+            : target,
+        ),
+    );
+  };
+
+  const removeTarget = (id: string) => {
+    setState("items", (items) => items.filter((target) => target.id !== id));
+    if (state.defaultId === id) {
+      setState("defaultId", null);
+    }
+    if (activeTargetId() === id) {
+      setActiveTargetId(LOCAL_TARGET_ID);
+    }
+  };
+
+  const setDefaultTarget = (id: string | null) => {
+    setState("defaultId", id);
+  };
+
+  const setActiveTarget = (id: string) => {
+    setActiveTargetId(id);
+  };
+
+  return {
+    targets,
+    activeTargetId,
+    setActiveTarget,
+    addTarget,
+    updateTarget,
+    removeTarget,
+    defaultTargetId: () => state.defaultId ?? null,
+    setDefaultTarget,
+    storageKey: STORAGE_KEY,
+  };
+}
+
+export const LocalTarget = {
+  id: LOCAL_TARGET_ID,
+  label: "Local (this device)",
+  type: "local" as const,
+};

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -1,4 +1,4 @@
-import { createMemo, createSignal } from "solid-js";
+import { createEffect, createMemo, createSignal } from "solid-js";
 
 import type {
   Client,
@@ -26,6 +26,9 @@ import {
   type OpenworkServerClient,
   type OpenworkServerSettings,
   type OpenworkWorkspaceInfo,
+  type OpenworkSandboxInfo,
+  type OpenworkConnectDescriptor,
+  type OpenworkTargetInfo,
 } from "../lib/openwork-server";
 import { downloadDir, homeDir } from "@tauri-apps/api/path";
 import {
@@ -120,6 +123,9 @@ export function createWorkspaceStore(options: {
   const [projectDir, setProjectDir] = createSignal("");
   const [workspaces, setWorkspaces] = createSignal<WorkspaceInfo[]>([]);
   const [activeWorkspaceId, setActiveWorkspaceId] = createSignal<string>("starter");
+  const [sandboxes, setSandboxes] = createSignal<OpenworkSandboxInfo[]>([]);
+  const [activeSandboxId, setActiveSandboxId] = createSignal<string | null>(null);
+  const [activeTargetInfo, setActiveTargetInfo] = createSignal<OpenworkTargetInfo | null>(null);
 
   const syncActiveWorkspaceId = (id: string) => {
     setActiveWorkspaceId(id);
@@ -188,6 +194,184 @@ export function createWorkspaceStore(options: {
       return haystack.includes(query);
     });
   });
+
+  const isSandboxWorkspace = (workspace: WorkspaceInfo | null) => {
+    if (!workspace) return false;
+    if (workspace.openworkWorkspaceId) return true;
+    const path = workspace.path?.replace(/\\/g, "/") ?? "";
+    const directory = workspace.directory?.replace(/\\/g, "/") ?? "";
+    return path.includes("/.openwork/sandboxes/") || directory.includes("/.openwork/sandboxes/");
+  };
+
+  const mapSandboxToWorkspace = (
+    sandbox: OpenworkSandboxInfo,
+    targetType: "local" | "remote",
+    openworkBaseUrl: string,
+  ): WorkspaceInfo => {
+    const isRemote = targetType === "remote";
+    return {
+      id: sandbox.id,
+      name: sandbox.name,
+      path: sandbox.path,
+      preset: "starter",
+      workspaceType: isRemote ? "remote" : "local",
+      remoteType: isRemote ? "openwork" : "opencode",
+      baseUrl: isRemote ? openworkBaseUrl : undefined,
+      directory: isRemote ? sandbox.path : undefined,
+      displayName: sandbox.name,
+      openworkHostUrl: isRemote ? openworkBaseUrl : undefined,
+      openworkWorkspaceId: sandbox.id,
+      openworkWorkspaceName: sandbox.name,
+    };
+  };
+
+  const descriptorAuth = (descriptor: OpenworkConnectDescriptor) => {
+    const username = descriptor.opencode.username?.trim() ?? "";
+    const password = descriptor.opencode.password?.trim() ?? "";
+    if (username && password) return { username, password } as OpencodeAuth;
+    if (descriptor.openwork?.token) {
+      return { token: descriptor.openwork.token, mode: "openwork" } as OpencodeAuth;
+    }
+    return undefined;
+  };
+
+  const refreshSandboxes = async () => {
+    const client = options.openworkServerClient?.();
+    if (!client) return;
+    try {
+      const response = await client.listSandboxes();
+      const items = Array.isArray(response.items) ? response.items : [];
+      setSandboxes(items);
+      const activeId = response.activeId ?? null;
+      setActiveSandboxId(activeId);
+      const targetType = activeTargetInfo()?.type ?? "local";
+      const mapped = items.map((sandbox) => mapSandboxToWorkspace(sandbox, targetType, client.baseUrl));
+      if (mapped.length) {
+        setWorkspaces(mapped);
+        if (activeId) {
+          syncActiveWorkspaceId(activeId);
+        }
+      }
+    } catch (error) {
+      console.warn("[workspace] sandbox refresh failed", error);
+    }
+  };
+
+  createEffect(() => {
+    const client = options.openworkServerClient?.();
+    if (!client) return;
+    void refreshSandboxes();
+  });
+
+  const connectUsingDescriptor = async (context?: { reason?: string; quiet?: boolean }) => {
+    const client = options.openworkServerClient?.();
+    if (!client) return false;
+    try {
+      const descriptor = await client.connectActive();
+      const opencodeUrl = descriptor.opencode.connectUrl ?? descriptor.opencode.baseUrl ?? "";
+      if (!opencodeUrl) {
+        options.setError("OpenCode URL missing from descriptor.");
+        return false;
+      }
+      const directory = descriptor.opencode.directory?.trim() ?? "";
+      const auth = descriptorAuth(descriptor);
+      setActiveTargetInfo(descriptor.target ?? null);
+      setActiveSandboxId(descriptor.sandbox?.id ?? null);
+      const ok = await connectToServer(
+        opencodeUrl,
+        directory || undefined,
+        {
+          workspaceId: descriptor.sandbox?.id ?? undefined,
+          workspaceType: descriptor.target?.type === "remote" ? "remote" : "local",
+          targetRoot: directory,
+          reason: context?.reason ?? "descriptor-connect",
+        },
+        auth,
+        { quiet: context?.quiet },
+      );
+      if (ok) {
+        if (directory) {
+          setProjectDir(directory);
+        }
+        await refreshSandboxes();
+      }
+      return ok;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      options.setError(addOpencodeCacheHint(message));
+      return false;
+    }
+  };
+
+  const createSandbox = async (input: { name?: string | null; source?: "base" | "sandbox" }) => {
+    const client = options.openworkServerClient?.();
+    if (!client) return false;
+    options.setBusy(true);
+    options.setBusyLabel("status.creating_workspace");
+    options.setBusyStartedAt(Date.now());
+    try {
+      await client.createSandbox({
+        name: input.name ?? null,
+        source: input.source ?? "base",
+        fromSandboxId: input.source === "sandbox" ? activeSandboxId() : null,
+      });
+      const ok = await connectUsingDescriptor({ reason: "sandbox-create" });
+      return ok;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      options.setError(addOpencodeCacheHint(message));
+      return false;
+    } finally {
+      options.setBusy(false);
+      options.setBusyLabel(null);
+      options.setBusyStartedAt(null);
+    }
+  };
+
+  const activateSandbox = async (sandboxId: string) => {
+    const client = options.openworkServerClient?.();
+    if (!client) return false;
+    setConnectingWorkspaceId(sandboxId);
+    try {
+      await client.activateSandbox(sandboxId);
+      const ok = await connectUsingDescriptor({ reason: "sandbox-activate", quiet: false });
+      return ok;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      options.setError(addOpencodeCacheHint(message));
+      return false;
+    } finally {
+      setConnectingWorkspaceId(null);
+    }
+  };
+
+  const archiveSandbox = async (sandboxId: string) => {
+    const client = options.openworkServerClient?.();
+    if (!client) return false;
+    try {
+      await client.archiveSandbox(sandboxId);
+      await refreshSandboxes();
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      options.setError(addOpencodeCacheHint(message));
+      return false;
+    }
+  };
+
+  const deleteSandbox = async (sandboxId: string) => {
+    const client = options.openworkServerClient?.();
+    if (!client) return false;
+    try {
+      await client.deleteSandbox(sandboxId);
+      await refreshSandboxes();
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      options.setError(addOpencodeCacheHint(message));
+      return false;
+    }
+  };
 
   const resolveOpenworkHost = async (input: { hostUrl: string; token?: string | null }) => {
     const normalized = normalizeOpenworkServerUrl(input.hostUrl) ?? "";
@@ -366,6 +550,9 @@ export function createWorkspaceStore(options: {
 
     const next = workspaces().find((w) => w.id === id) ?? null;
     if (!next) return false;
+    if (isSandboxWorkspace(next)) {
+      return activateSandbox(next.openworkWorkspaceId ?? next.id);
+    }
     const isRemote = next.workspaceType === "remote";
     console.log("[workspace] activate", { id: next.id, type: next.workspaceType });
 
@@ -397,6 +584,7 @@ export function createWorkspaceStore(options: {
           let resolvedDirectory = next.directory?.trim() ?? "";
           let workspaceInfo: OpenworkWorkspaceInfo | null = null;
           let resolvedAuth: OpencodeAuth | undefined = undefined;
+          let connectedByDescriptor = false;
 
           try {
             const resolved = await resolveOpenworkHost({
@@ -422,20 +610,23 @@ export function createWorkspaceStore(options: {
             return false;
           }
 
-          const ok = await connectToServer(
-            resolvedBaseUrl,
-            resolvedDirectory || undefined,
-            {
-              workspaceId: next.id,
-              workspaceType: next.workspaceType,
-              targetRoot: resolvedDirectory ?? "",
-              reason: "workspace-switch-openwork",
-            },
-            resolvedAuth,
-          );
+          connectedByDescriptor = await connectUsingDescriptor({ reason: "workspace-switch-openwork" });
+          if (!connectedByDescriptor) {
+            const ok = await connectToServer(
+              resolvedBaseUrl,
+              resolvedDirectory || undefined,
+              {
+                workspaceId: next.id,
+                workspaceType: next.workspaceType,
+                targetRoot: resolvedDirectory ?? "",
+                reason: "workspace-switch-openwork",
+              },
+              resolvedAuth,
+            );
 
-          if (!ok) {
-            return false;
+            if (!ok) {
+              return false;
+            }
           }
 
           if (isTauriRuntime()) {
@@ -457,7 +648,9 @@ export function createWorkspaceStore(options: {
           }
 
           syncActiveWorkspaceId(id);
-          setProjectDir(resolvedDirectory || "");
+          if (!connectedByDescriptor) {
+            setProjectDir(resolvedDirectory || "");
+          }
           setWorkspaceConfig(null);
           setWorkspaceConfigLoaded(true);
           setAuthorizedDirs([]);
@@ -901,19 +1094,23 @@ export function createWorkspaceStore(options: {
       return false;
     }
 
-    const ok = await connectToServer(
-      resolvedBaseUrl,
-      resolvedDirectory || undefined,
-      {
-        workspaceType: "remote",
-        targetRoot: resolvedDirectory ?? "",
-        reason: "workspace-create-remote",
-      },
-      resolvedAuth,
-    );
+    let connectedByDescriptor = false;
+    connectedByDescriptor = await connectUsingDescriptor({ reason: "workspace-create-remote" });
+    if (!connectedByDescriptor) {
+      const ok = await connectToServer(
+        resolvedBaseUrl,
+        resolvedDirectory || undefined,
+        {
+          workspaceType: "remote",
+          targetRoot: resolvedDirectory ?? "",
+          reason: "workspace-create-remote",
+        },
+        resolvedAuth,
+      );
 
-    if (!ok) {
-      return false;
+      if (!ok) {
+        return false;
+      }
     }
 
     const finalDirectory = options.clientDirectory().trim() || resolvedDirectory || "";
@@ -959,7 +1156,9 @@ export function createWorkspaceStore(options: {
         syncActiveWorkspaceId(workspaceId);
       }
 
-      setProjectDir(finalDirectory);
+      if (!connectedByDescriptor) {
+        setProjectDir(finalDirectory);
+      }
       setWorkspaceConfig(null);
       setWorkspaceConfigLoaded(true);
       setAuthorizedDirs([]);
@@ -1705,6 +1904,9 @@ export function createWorkspaceStore(options: {
     projectDir,
     workspaces,
     activeWorkspaceId,
+    sandboxes,
+    activeSandboxId,
+    activeTargetInfo,
     authorizedDirs,
     newAuthorizedDir,
     workspaceConfig,
@@ -1733,14 +1935,20 @@ export function createWorkspaceStore(options: {
     syncActiveWorkspaceId: syncActiveWorkspaceId,
     refreshEngine,
     refreshEngineDoctor,
+    refreshSandboxes,
     activateWorkspace,
     connectToServer,
+    connectUsingDescriptor,
     createWorkspaceFlow,
     createRemoteWorkspaceFlow,
     forgetWorkspace,
     pickWorkspaceFolder,
     exportWorkspaceConfig,
     importWorkspaceConfig,
+    createSandbox,
+    activateSandbox,
+    archiveSandbox,
+    deleteSandbox,
     startHost,
     stopHost,
     reloadWorkspaceEngine,

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -22,6 +22,9 @@ export type OpenworkServerDiagnostics = {
   workspaceCount: number;
   activeWorkspaceId: string | null;
   workspace: OpenworkWorkspaceInfo | null;
+  sandboxCount?: number;
+  activeSandboxId?: string | null;
+  sandbox?: { id: string; name: string; path: string; status: string } | null;
   authorizedRoots: string[];
   server: { host: string; port: number; configPath?: string | null };
   tokenSource: { client: string; host: string };
@@ -51,6 +54,51 @@ export type OpenworkWorkspaceInfo = {
 export type OpenworkWorkspaceList = {
   items: OpenworkWorkspaceInfo[];
   activeId?: string | null;
+};
+
+export type OpenworkTargetInfo = {
+  id: string;
+  label: string;
+  type: "local" | "remote";
+};
+
+export type OpenworkSandboxInfo = {
+  id: string;
+  name: string;
+  targetId: string;
+  baseWorkspaceId: string;
+  path: string;
+  createdAt: number;
+  updatedAt: number;
+  status: "active" | "idle" | "archived";
+  sizeBytes?: number;
+};
+
+export type OpenworkSandboxList = {
+  items: OpenworkSandboxInfo[];
+  activeId?: string | null;
+};
+
+export type OpenworkConnectDescriptor = {
+  updatedAt: number;
+  sandbox: { id: string; name: string; path: string; status: string } | null;
+  target: OpenworkTargetInfo;
+  opencode: {
+    baseUrl?: string;
+    connectUrl?: string;
+    directory?: string;
+    username?: string;
+    password?: string;
+    port?: number;
+  };
+  openwork: {
+    baseUrl: string;
+    connectUrl: string;
+    token: string;
+    hostToken: string;
+    port: number;
+  };
+  owpenbot: { healthUrl: string; healthPort: number };
 };
 
 export type OpenworkPluginItem = {
@@ -294,6 +342,38 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       requestJson<{ ok: boolean; version: string; uptimeMs: number }>(baseUrl, "/health", { token, hostToken }),
     status: () => requestJson<OpenworkServerDiagnostics>(baseUrl, "/status", { token, hostToken }),
     capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken }),
+    connectActive: () => requestJson<OpenworkConnectDescriptor>(baseUrl, "/connect/active", { token, hostToken }),
+    listSandboxes: () => requestJson<OpenworkSandboxList>(baseUrl, "/sandboxes", { token, hostToken }),
+    createSandbox: (payload: { name?: string | null; source?: "base" | "sandbox"; fromSandboxId?: string | null }) =>
+      requestJson<{ activeId: string; sandbox: OpenworkSandboxInfo }>(baseUrl, "/sandboxes", {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload,
+      }),
+    getSandbox: (sandboxId: string) =>
+      requestJson<{ sandbox: OpenworkSandboxInfo }>(baseUrl, `/sandboxes/${encodeURIComponent(sandboxId)}`, {
+        token,
+        hostToken,
+      }),
+    archiveSandbox: (sandboxId: string) =>
+      requestJson<{ sandbox: OpenworkSandboxInfo }>(baseUrl, `/sandboxes/${encodeURIComponent(sandboxId)}/archive`, {
+        token,
+        hostToken,
+        method: "POST",
+      }),
+    deleteSandbox: (sandboxId: string) =>
+      requestJson<{ deleted: boolean; sandbox: OpenworkSandboxInfo }>(baseUrl, `/sandboxes/${encodeURIComponent(sandboxId)}/delete`, {
+        token,
+        hostToken,
+        method: "POST",
+      }),
+    activateSandbox: (sandboxId: string) =>
+      requestJson<{ activeId: string; sandbox: OpenworkSandboxInfo }>(baseUrl, `/sandboxes/${encodeURIComponent(sandboxId)}/activate`, {
+        token,
+        hostToken,
+        method: "POST",
+      }),
     listWorkspaces: () => requestJson<OpenworkWorkspaceList>(baseUrl, "/workspaces", { token, hostToken }),
     activateWorkspace: (workspaceId: string) =>
       requestJson<{ activeId: string; workspace: OpenworkWorkspaceInfo }>(

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -10,17 +10,19 @@ import type {
   ScheduledJob,
   SkillCard,
   StartupPreference,
+  TargetProfile,
   WorkspaceCommand,
   View,
 } from "../types";
 import type { McpDirectoryInfo } from "../constants";
-import { formatRelativeTime } from "../utils";
+import { formatBytes, formatRelativeTime } from "../utils";
 import type {
   OpenworkAuditEntry,
   OpenworkServerCapabilities,
   OpenworkServerDiagnostics,
   OpenworkServerSettings,
   OpenworkServerStatus,
+  OpenworkSandboxInfo,
 } from "../lib/openwork-server";
 import type { EngineInfo, OpenwrkStatus, OpenworkServerInfo, OwpenbotInfo, WorkspaceInfo } from "../lib/tauri";
 
@@ -88,6 +90,14 @@ export type DashboardViewProps = {
   opencodeConnectStatus: OpencodeConnectStatus | null;
   engineInfo: EngineInfo | null;
   engineDoctorVersion: string | null;
+  targets: TargetProfile[];
+  activeTargetId: string;
+  defaultTargetId: string | null;
+  addTarget: (input: { label: string; baseUrl: string; token?: string | null }) => TargetProfile | null;
+  updateTarget: (id: string, input: Partial<Omit<TargetProfile, "id" | "type">>) => void;
+  removeTarget: (id: string) => void;
+  setDefaultTarget: (id: string | null) => void;
+  setActiveTarget: (id: string) => void;
   openwrkStatus: OpenwrkStatus | null;
   owpenbotInfo: OwpenbotInfo | null;
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
@@ -108,6 +118,11 @@ export type DashboardViewProps = {
   setWorkspacePickerOpen: (open: boolean) => void;
   connectingWorkspaceId: string | null;
   workspaces: WorkspaceInfo[];
+  sandboxes: OpenworkSandboxInfo[];
+  activeSandboxId: string | null;
+  createSandbox: (input: { name?: string | null; source?: "base" | "sandbox" }) => Promise<boolean> | boolean;
+  activateSandbox: (sandboxId: string) => Promise<boolean> | boolean;
+  archiveSandbox: (sandboxId: string) => Promise<boolean> | boolean;
   filteredWorkspaces: WorkspaceInfo[];
   activeWorkspaceId: string;
   activateWorkspace: (id: string) => Promise<boolean> | boolean;
@@ -282,6 +297,8 @@ export default function DashboardView(props: DashboardViewProps) {
 
   const quickCommands = createMemo(() => props.workspaceCommands.slice(0, 3));
   const canExportWorkspace = createMemo(() => props.activeWorkspaceDisplay.workspaceType !== "remote");
+  const showSandboxes = createMemo(() => props.sandboxes.length > 0);
+  const activeSandboxId = createMemo(() => props.activeSandboxId);
 
   const openSessionFromList = (sessionId: string) => {
     // Defer view switch to avoid click-through on the same event frame.
@@ -667,88 +684,164 @@ export default function DashboardView(props: DashboardViewProps) {
               </section>
 
               <section>
-                <div class="flex items-center justify-between mb-4">
-                  <h3 class="text-sm font-medium text-gray-11 uppercase tracking-wider">
-                    Workspaces
-                  </h3>
-                  <div class="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      class="text-xs h-8 px-3"
-                      onClick={props.exportWorkspaceConfig}
-                      disabled={!canExportWorkspace() || props.exportWorkspaceBusy}
-                      title={
-                        !canExportWorkspace()
-                          ? "Export is only available for local workspaces"
-                          : "Export workspace config"
-                      }
-                    >
-                      Share config
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      class="text-xs h-8 px-3"
-                      onClick={() => props.setWorkspacePickerOpen(true)}
-                    >
-                      <Plus size={14} />
-                      Add workspace
-                    </Button>
-                  </div>
-                </div>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <For each={props.workspaces}>
-                    {(workspace) => (
-                      <div class="rounded-2xl border border-gray-6/60 bg-gray-1/40 p-4 space-y-3">
-                        <div class="flex items-start justify-between">
-                          <div class="space-y-1 min-w-0">
-                            <div class="text-sm font-semibold text-gray-12 truncate">
-                              {workspace.displayName ?? workspace.name}
-                            </div>
-                            <div class="flex items-center gap-2 text-xs text-gray-10 font-mono">
-                              <span class="truncate min-w-0">
-                                {workspacePathLabel(workspace)}
-                              </span>
-                              <button
-                                type="button"
-                                class="shrink-0 rounded-md p-1 text-gray-9 hover:text-gray-12 hover:bg-gray-3 transition-colors"
-                                onClick={() => handleCopyWorkspace(workspace)}
-                                title={copiedWorkspaceId() === workspace.id ? "Copied" : "Copy path"}
-                                aria-label="Copy workspace path"
-                              >
-                                <Show when={copiedWorkspaceId() === workspace.id} fallback={<Copy size={12} />}>
-                                  <Check size={12} class="text-green-11" />
-                                </Show>
-                              </button>
-                            </div>
-                          </div>
-                          <span class="text-[11px] text-gray-9">
-                            {workspace.workspaceType === "remote" ? "Remote" : "Local"}
-                          </span>
-                        </div>
-                        <div class="flex items-center justify-end text-xs text-gray-9 h-8">
-                          <Show when={workspace.id === props.activeWorkspaceId}>
-                            <span class="text-green-11 font-medium flex items-center gap-1.5 !px-2">
-                              Active
-                            </span>
-                          </Show>
-                          <Show when={workspace.id !== props.activeWorkspaceId}>
-                            <Button
-                              variant="ghost"
-                              class="text-xs !px-2 py-1"
-                              onClick={() => props.activateWorkspace(workspace.id)}
-                              disabled={props.connectingWorkspaceId === workspace.id}
-                            >
-                              {props.connectingWorkspaceId === workspace.id
-                                ? "Switching..."
-                                : "Switch"}
-                            </Button>
-                          </Show>
+                <Show
+                  when={showSandboxes()}
+                  fallback={
+                    <>
+                      <div class="flex items-center justify-between mb-4">
+                        <h3 class="text-sm font-medium text-gray-11 uppercase tracking-wider">
+                          Workspaces
+                        </h3>
+                        <div class="flex items-center gap-2">
+                          <Button
+                            variant="outline"
+                            class="text-xs h-8 px-3"
+                            onClick={props.exportWorkspaceConfig}
+                            disabled={!canExportWorkspace() || props.exportWorkspaceBusy}
+                            title={
+                              !canExportWorkspace()
+                                ? "Export is only available for local workspaces"
+                                : "Export workspace config"
+                            }
+                          >
+                            Share config
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            class="text-xs h-8 px-3"
+                            onClick={() => props.setWorkspacePickerOpen(true)}
+                          >
+                            <Plus size={14} />
+                            Add workspace
+                          </Button>
                         </div>
                       </div>
-                    )}
-                  </For>
-                </div>
+
+                      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <For each={props.workspaces}>
+                          {(workspace) => (
+                            <div class="rounded-2xl border border-gray-6/60 bg-gray-1/40 p-4 space-y-3">
+                              <div class="flex items-start justify-between">
+                                <div class="space-y-1 min-w-0">
+                                  <div class="text-sm font-semibold text-gray-12 truncate">
+                                    {workspace.displayName ?? workspace.name}
+                                  </div>
+                                  <div class="flex items-center gap-2 text-xs text-gray-10 font-mono">
+                                    <span class="truncate min-w-0">
+                                      {workspacePathLabel(workspace)}
+                                    </span>
+                                    <button
+                                      type="button"
+                                      class="shrink-0 rounded-md p-1 text-gray-9 hover:text-gray-12 hover:bg-gray-3 transition-colors"
+                                      onClick={() => handleCopyWorkspace(workspace)}
+                                      title={copiedWorkspaceId() === workspace.id ? "Copied" : "Copy path"}
+                                      aria-label="Copy workspace path"
+                                    >
+                                      <Show
+                                        when={copiedWorkspaceId() === workspace.id}
+                                        fallback={<Copy size={12} />}
+                                      >
+                                        <Check size={12} class="text-green-11" />
+                                      </Show>
+                                    </button>
+                                  </div>
+                                </div>
+                                <span class="text-[11px] text-gray-9">
+                                  {workspace.workspaceType === "remote" ? "Remote" : "Local"}
+                                </span>
+                              </div>
+                              <div class="flex items-center justify-end text-xs text-gray-9 h-8">
+                                <Show when={workspace.id === props.activeWorkspaceId}>
+                                  <span class="text-green-11 font-medium flex items-center gap-1.5 !px-2">
+                                    Active
+                                  </span>
+                                </Show>
+                                <Show when={workspace.id !== props.activeWorkspaceId}>
+                                  <Button
+                                    variant="ghost"
+                                    class="text-xs !px-2 py-1"
+                                    onClick={() => props.activateWorkspace(workspace.id)}
+                                    disabled={props.connectingWorkspaceId === workspace.id}
+                                  >
+                                    {props.connectingWorkspaceId === workspace.id ? "Switching..." : "Switch"}
+                                  </Button>
+                                </Show>
+                              </div>
+                            </div>
+                          )}
+                        </For>
+                      </div>
+                    </>
+                  }
+                >
+                  <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-sm font-medium text-gray-11 uppercase tracking-wider">Sandboxes</h3>
+                    <div class="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        class="text-xs h-8 px-3"
+                        onClick={() => props.createSandbox({ source: "sandbox" })}
+                        disabled={!activeSandboxId()}
+                        title={!activeSandboxId() ? "Pick a sandbox first" : "Copy current sandbox"}
+                      >
+                        Copy current
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        class="text-xs h-8 px-3"
+                        onClick={() => props.createSandbox({ source: "base" })}
+                      >
+                        <Plus size={14} />
+                        New sandbox
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <For each={props.sandboxes}>
+                      {(sandbox) => (
+                        <div class="rounded-2xl border border-gray-6/60 bg-gray-1/40 p-4 space-y-3">
+                          <div class="flex items-start justify-between">
+                            <div class="space-y-1 min-w-0">
+                              <div class="text-sm font-semibold text-gray-12 truncate">{sandbox.name}</div>
+                              <div class="flex items-center gap-2 text-xs text-gray-10 font-mono">
+                                <span class="truncate min-w-0">{sandbox.path}</span>
+                                <Show when={sandbox.sizeBytes}>
+                                  <span class="text-[10px] text-gray-8">
+                                    {formatBytes(sandbox.sizeBytes ?? 0)}
+                                  </span>
+                                </Show>
+                              </div>
+                            </div>
+                            <span class="text-[11px] text-gray-9">{sandbox.status}</span>
+                          </div>
+                          <div class="flex items-center justify-end text-xs text-gray-9 h-8 gap-2">
+                            <Show when={sandbox.id === props.activeSandboxId}>
+                              <span class="text-green-11 font-medium flex items-center gap-1.5 !px-2">Active</span>
+                            </Show>
+                            <Show when={sandbox.id !== props.activeSandboxId}>
+                              <Button
+                                variant="ghost"
+                                class="text-xs !px-2 py-1"
+                                onClick={() => props.activateSandbox(sandbox.id)}
+                                disabled={props.connectingWorkspaceId === sandbox.id}
+                              >
+                                {props.connectingWorkspaceId === sandbox.id ? "Switching..." : "Switch"}
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                class="text-xs !px-2 py-1"
+                                onClick={() => props.archiveSandbox(sandbox.id)}
+                              >
+                                Archive
+                              </Button>
+                            </Show>
+                          </div>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                </Show>
               </section>
 
               <section>
@@ -992,6 +1085,14 @@ export default function DashboardView(props: DashboardViewProps) {
                   openwrkStatus={props.openwrkStatus}
                   owpenbotInfo={props.owpenbotInfo}
                   engineDoctorVersion={props.engineDoctorVersion}
+                  targets={props.targets}
+                  activeTargetId={props.activeTargetId}
+                  defaultTargetId={props.defaultTargetId}
+                  addTarget={props.addTarget}
+                  updateTarget={props.updateTarget}
+                  removeTarget={props.removeTarget}
+                  setDefaultTarget={props.setDefaultTarget}
+                  setActiveTarget={props.setActiveTarget}
                   updateOpenworkServerSettings={props.updateOpenworkServerSettings}
                   resetOpenworkServerSettings={props.resetOpenworkServerSettings}
                   testOpenworkServerConnection={props.testOpenworkServerConnection}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -18,6 +18,7 @@ import type {
   View,
   WorkspaceCommand,
   WorkspaceDisplay,
+  TargetProfile,
 } from "../types";
 
 import type { WorkspaceInfo } from "../lib/tauri";
@@ -27,9 +28,10 @@ import { ArrowRight, ChevronDown, HardDrive, Shield, Zap } from "lucide-solid";
 import Button from "../components/button";
 import RenameSessionModal from "../components/rename-session-modal";
 import WorkspaceChip from "../components/workspace-chip";
+import SandboxChip from "../components/sandbox-chip";
 import ProviderAuthModal from "../components/provider-auth-modal";
 import StatusBar from "../components/status-bar";
-import type { OpenworkServerStatus } from "../lib/openwork-server";
+import type { OpenworkSandboxInfo, OpenworkServerStatus, OpenworkTargetInfo } from "../lib/openwork-server";
 import { join } from "@tauri-apps/api/path";
 import browserSetupCommandTemplate from "../data/commands/browser-setup.md?raw";
 import { opencodeCommandWrite } from "../lib/tauri";
@@ -50,6 +52,8 @@ export type SessionViewProps = {
   activeWorkspaceRoot: string;
   workspaces: WorkspaceInfo[];
   activeWorkspaceId: string;
+  activeSandbox: OpenworkSandboxInfo | null;
+  activeTargetInfo: OpenworkTargetInfo | null;
   connectingWorkspaceId: string | null;
   activateWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   setWorkspaceSearch: (value: string) => void;
@@ -128,6 +132,9 @@ export type SessionViewProps = {
   commandRegistryItems: () => CommandRegistryItem[];
   registerCommand: (command: CommandRegistryItem) => () => void;
   deleteSession: (sessionId: string) => Promise<void>;
+  targetOptions: TargetProfile[];
+  activeTargetId: string;
+  onSelectTarget: (targetId: string) => void | Promise<void>;
 };
 
 type SessionSummary = { id: string; title: string; slug?: string | null };
@@ -1302,11 +1309,23 @@ export default function SessionView(props: SessionViewProps) {
               <ArrowRight class="rotate-180 w-5 h-5" />
               <span class="hidden md:inline text-xs">Back</span>
             </Button>
-              <WorkspaceChip
-                workspace={props.activeWorkspaceDisplay}
-                connecting={props.connectingWorkspaceId === props.activeWorkspaceDisplay.id}
-                onClick={openWorkspacePicker}
-              />
+              <Show
+                when={props.activeSandbox || props.activeTargetInfo}
+                fallback={
+                  <WorkspaceChip
+                    workspace={props.activeWorkspaceDisplay}
+                    connecting={props.connectingWorkspaceId === props.activeWorkspaceDisplay.id}
+                    onClick={openWorkspacePicker}
+                  />
+                }
+              >
+                <SandboxChip
+                  sandbox={props.activeSandbox}
+                  target={props.activeTargetInfo}
+                  connecting={props.connectingWorkspaceId === props.activeWorkspaceDisplay.id}
+                  onClick={openWorkspacePicker}
+                />
+              </Show>
              <Show when={props.developerMode}>
                <span class="text-xs text-gray-7">{props.headerStatus}</span>
              </Show>
@@ -1547,6 +1566,9 @@ export default function SessionView(props: SessionViewProps) {
           isRemoteWorkspace={props.activeWorkspaceDisplay.workspaceType === "remote"}
           attachmentsEnabled={attachmentsEnabled()}
           attachmentsDisabledReason={attachmentsDisabledReason()}
+          targetOptions={props.targetOptions}
+          activeTargetId={props.activeTargetId}
+          onSelectTarget={props.onSelectTarget}
         />
 
         <Show when={unreadCount() > 0}>

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -6,7 +6,7 @@ import Button from "../components/button";
 import TextInput from "../components/text-input";
 import SettingsKeybinds, { type KeybindSetting } from "../components/settings-keybinds";
 import { HardDrive, MessageCircle, PlugZap, RefreshCcw, Shield, Smartphone, X } from "lucide-solid";
-import type { OpencodeConnectStatus, ProviderListItem, SettingsTab, StartupPreference } from "../types";
+import type { OpencodeConnectStatus, ProviderListItem, SettingsTab, StartupPreference, TargetProfile } from "../types";
 import { createOpenworkServerClient } from "../lib/openwork-server";
 import type {
   OpenworkAuditEntry,
@@ -127,6 +127,14 @@ export type SettingsViewProps = {
   notionBusy: boolean;
   connectNotion: () => void;
   engineDoctorVersion: string | null;
+  targets: TargetProfile[];
+  activeTargetId: string;
+  defaultTargetId: string | null;
+  addTarget: (input: { label: string; baseUrl: string; token?: string | null }) => TargetProfile | null;
+  updateTarget: (id: string, input: Partial<Omit<TargetProfile, "id" | "type">>) => void;
+  removeTarget: (id: string) => void;
+  setDefaultTarget: (id: string | null) => void;
+  setActiveTarget: (id: string) => void;
 };
 
 // Owpenbot Settings Component
@@ -910,6 +918,11 @@ export default function SettingsView(props: SettingsViewProps) {
   const [clientTokenVisible, setClientTokenVisible] = createSignal(false);
   const [hostTokenVisible, setHostTokenVisible] = createSignal(false);
   const [copyingField, setCopyingField] = createSignal<string | null>(null);
+  const [targetLabel, setTargetLabel] = createSignal("");
+  const [targetUrl, setTargetUrl] = createSignal("");
+  const [targetToken, setTargetToken] = createSignal("");
+  const [targetTokenVisible, setTargetTokenVisible] = createSignal(false);
+  const [targetError, setTargetError] = createSignal<string | null>(null);
   let copyTimeout: number | undefined;
 
   createEffect(() => {
@@ -945,6 +958,36 @@ export default function SettingsView(props: SettingsViewProps) {
         return "bg-gray-4/60 text-gray-11 border-gray-7/50";
     }
   });
+
+  const handleAddTarget = () => {
+    setTargetError(null);
+    const label = targetLabel().trim();
+    const baseUrl = targetUrl().trim();
+    if (!baseUrl) {
+      setTargetError("Target URL is required.");
+      return;
+    }
+    const added = props.addTarget({
+      label: label || baseUrl,
+      baseUrl,
+      token: targetToken().trim() || null,
+    });
+    if (!added) {
+      setTargetError("Enter a valid OpenWork URL.");
+      return;
+    }
+    setTargetLabel("");
+    setTargetUrl("");
+    setTargetToken("");
+    setTargetTokenVisible(false);
+  };
+
+  const targetStatusLabel = (target: TargetProfile) => {
+    if (target.type === "local") return "Local";
+    if (target.status === "online") return "Online";
+    if (target.status === "offline") return "Offline";
+    return "Unknown";
+  };
 
   const reloadAvailabilityReason = createMemo(() => {
     if (!props.clientConnected) return "Connect to this workspace to reload.";
@@ -1943,6 +1986,125 @@ export default function SettingsView(props: SettingsViewProps) {
                     OpenWork server connection needed to sync skills, plugins, and commands.
                   </div>
                 </Show>
+              </div>
+
+              <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
+                <div>
+                  <div class="text-sm font-medium text-gray-12">Execution targets</div>
+                  <div class="text-xs text-gray-10">
+                    Add remote OpenWork targets for the Run on selector.
+                  </div>
+                </div>
+
+                <div class="grid gap-3">
+                  <TextInput
+                    label="Target label"
+                    value={targetLabel()}
+                    onInput={(event) => setTargetLabel(event.currentTarget.value)}
+                    placeholder="Remote build agent"
+                    hint="Optional name for this target."
+                    disabled={props.busy}
+                  />
+                  <TextInput
+                    label="OpenWork server URL"
+                    value={targetUrl()}
+                    onInput={(event) => setTargetUrl(event.currentTarget.value)}
+                    placeholder="http://10.0.0.12:8787"
+                    hint="Paste the OpenWork server URL for this target."
+                    disabled={props.busy}
+                  />
+                  <label class="block">
+                    <div class="mb-1 text-xs font-medium text-gray-11">Access token</div>
+                    <div class="flex items-center gap-2">
+                      <input
+                        type={targetTokenVisible() ? "text" : "password"}
+                        value={targetToken()}
+                        onInput={(event) => setTargetToken(event.currentTarget.value)}
+                        placeholder="Paste token if required"
+                        disabled={props.busy}
+                        class="w-full rounded-xl bg-gray-2/60 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-10 shadow-[0_0_0_1px_rgba(255,255,255,0.08)] focus:outline-none focus:ring-2 focus:ring-gray-6/20"
+                      />
+                      <Button
+                        variant="outline"
+                        class="text-xs h-9 px-3 shrink-0"
+                        onClick={() => setTargetTokenVisible((prev) => !prev)}
+                        disabled={props.busy}
+                      >
+                        {targetTokenVisible() ? "Hide" : "Show"}
+                      </Button>
+                    </div>
+                    <div class="mt-1 text-xs text-gray-10">Optional. Required if the target needs auth.</div>
+                  </label>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                  <Button variant="secondary" onClick={handleAddTarget} disabled={props.busy}>
+                    Add target
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      setTargetLabel("");
+                      setTargetUrl("");
+                      setTargetToken("");
+                      setTargetTokenVisible(false);
+                      setTargetError(null);
+                    }}
+                    disabled={props.busy}
+                  >
+                    Clear
+                  </Button>
+                </div>
+
+                <Show when={targetError()}>
+                  <div class="text-xs text-red-11">{targetError()}</div>
+                </Show>
+
+                <div class="border-t border-gray-6/40 pt-4 space-y-2">
+                  <For each={props.targets}>
+                    {(target) => (
+                      <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                        <div class="min-w-0">
+                          <div class="text-sm text-gray-12 truncate">{target.label}</div>
+                          <div class="text-xs text-gray-8 font-mono truncate">
+                            {target.baseUrl ?? (target.type === "local" ? "Local device" : "")}
+                          </div>
+                          <div class="text-[11px] text-gray-8 mt-1">
+                            {targetStatusLabel(target)}
+                            <Show when={props.defaultTargetId === target.id}>
+                              <span class="ml-2 text-[10px] uppercase tracking-wide text-gray-9">Default</span>
+                            </Show>
+                          </div>
+                        </div>
+                        <div class="flex items-center gap-2 shrink-0">
+                          <Button
+                            variant="ghost"
+                            class="text-xs h-8 py-0 px-3"
+                            onClick={() => props.setActiveTarget(target.id)}
+                          >
+                            {props.activeTargetId === target.id ? "Active" : "Use"}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            class="text-xs h-8 py-0 px-3"
+                            onClick={() => props.setDefaultTarget(target.id)}
+                          >
+                            {props.defaultTargetId === target.id ? "Default" : "Set default"}
+                          </Button>
+                          <Show when={target.type === "remote"}>
+                            <Button
+                              variant="ghost"
+                              class="text-xs h-8 py-0 px-3"
+                              onClick={() => props.removeTarget(target.id)}
+                            >
+                              Remove
+                            </Button>
+                          </Show>
+                        </div>
+                      </div>
+                    )}
+                  </For>
+                </div>
               </div>
 
               <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -284,6 +284,27 @@ export type WorkspaceDisplay = WorkspaceInfo & {
   name: string;
 };
 
+export type TargetProfile = {
+  id: string;
+  label: string;
+  type: "local" | "remote";
+  baseUrl?: string | null;
+  token?: string | null;
+  lastUsedAt?: number | null;
+  status?: "online" | "offline" | "unknown";
+};
+
+export type SandboxSummary = {
+  id: string;
+  name: string;
+  targetId: string;
+  path: string;
+  createdAt: number;
+  updatedAt: number;
+  status: "active" | "idle" | "archived";
+  sizeBytes?: number;
+};
+
 export type UpdateHandle = {
   available: boolean;
   currentVersion: string;

--- a/packages/desktop/src-tauri/src/openwork_server/mod.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/mod.rs
@@ -60,6 +60,10 @@ pub fn start_openwork_server(
         .first()
         .map(|path| path.as_str())
         .unwrap_or("");
+    let (connect_url, mdns_url, lan_url) = build_urls(port);
+    let target_id = "tgt-local".to_string();
+    let target_label = "Local (this device)".to_string();
+    let target_type = "local".to_string();
 
     let (mut rx, child) = spawn_openwork_server(
         app,
@@ -77,6 +81,11 @@ pub fn start_openwork_server(
         opencode_username,
         opencode_password,
         owpenbot_health_port,
+        opencode_base_url,
+        connect_url.as_deref(),
+        Some(&target_id),
+        Some(&target_label),
+        Some(&target_type),
     )?;
 
     state.child = Some(child);
@@ -84,7 +93,6 @@ pub fn start_openwork_server(
     state.host = Some(host.clone());
     state.port = Some(port);
     state.base_url = Some(format!("http://127.0.0.1:{port}"));
-    let (connect_url, mdns_url, lan_url) = build_urls(port);
     state.connect_url = connect_url;
     state.mdns_url = mdns_url;
     state.lan_url = lan_url;

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -25,6 +25,11 @@ pub fn build_openwork_args(
     host_token: &str,
     opencode_base_url: Option<&str>,
     opencode_directory: Option<&str>,
+    opencode_connect_url: Option<&str>,
+    connect_url: Option<&str>,
+    target_id: Option<&str>,
+    target_label: Option<&str>,
+    target_type: Option<&str>,
 ) -> Vec<String> {
     let mut args = vec![
         "--host".to_string(),
@@ -60,10 +65,45 @@ pub fn build_openwork_args(
         }
     }
 
+    if let Some(connect_url) = opencode_connect_url {
+        if !connect_url.trim().is_empty() {
+            args.push("--opencode-connect-url".to_string());
+            args.push(connect_url.to_string());
+        }
+    }
+
     if let Some(directory) = opencode_directory {
         if !directory.trim().is_empty() {
             args.push("--opencode-directory".to_string());
             args.push(directory.to_string());
+        }
+    }
+
+    if let Some(connect_url) = connect_url {
+        if !connect_url.trim().is_empty() {
+            args.push("--connect-url".to_string());
+            args.push(connect_url.to_string());
+        }
+    }
+
+    if let Some(target_id) = target_id {
+        if !target_id.trim().is_empty() {
+            args.push("--target-id".to_string());
+            args.push(target_id.to_string());
+        }
+    }
+
+    if let Some(target_label) = target_label {
+        if !target_label.trim().is_empty() {
+            args.push("--target-label".to_string());
+            args.push(target_label.to_string());
+        }
+    }
+
+    if let Some(target_type) = target_type {
+        if !target_type.trim().is_empty() {
+            args.push("--target-type".to_string());
+            args.push(target_type.to_string());
         }
     }
 
@@ -82,6 +122,11 @@ pub fn spawn_openwork_server(
     opencode_username: Option<&str>,
     opencode_password: Option<&str>,
     owpenbot_health_port: Option<u16>,
+    opencode_connect_url: Option<&str>,
+    connect_url: Option<&str>,
+    target_id: Option<&str>,
+    target_label: Option<&str>,
+    target_type: Option<&str>,
 ) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
     let command = match app.shell().sidecar("openwork-server") {
         Ok(command) => command,
@@ -96,6 +141,11 @@ pub fn spawn_openwork_server(
         host_token,
         opencode_base_url,
         opencode_directory,
+        opencode_connect_url,
+        connect_url,
+        target_id,
+        target_label,
+        target_type,
     );
     let cwd = workspace_paths
         .first()

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -1374,6 +1374,9 @@ function printHelp(): void {
     "  --read-only               Start OpenWork server in read-only mode",
     "  --cors <origins>          Comma-separated CORS origins or *",
     "  --connect-host <host>     Override LAN host used for pairing URLs",
+    "  --target-id <id>          Target id for descriptor",
+    "  --target-label <label>    Target label for descriptor",
+    "  --target-type <type>      local | remote",
     "  --openwork-server-bin <p> Path to openwork-server binary (requires --allow-external)",
     "  --owpenbot-bin <path>     Path to owpenbot binary (requires --allow-external)",
     "  --owpenbot-health-port <p> Health server port for owpenbot (default: 3005)",
@@ -1462,10 +1465,15 @@ async function startOpenworkServer(options: {
   readOnly: boolean;
   corsOrigins: string[];
   opencodeBaseUrl?: string;
+  opencodeConnectUrl?: string;
   opencodeDirectory?: string;
   opencodeUsername?: string;
   opencodePassword?: string;
   owpenbotHealthPort?: number;
+  targetId?: string;
+  targetLabel?: string;
+  targetType?: "local" | "remote";
+  connectUrl?: string;
 }) {
   const args = [
     "--host",
@@ -1495,6 +1503,9 @@ async function startOpenworkServer(options: {
   if (options.opencodeBaseUrl) {
     args.push("--opencode-base-url", options.opencodeBaseUrl);
   }
+  if (options.opencodeConnectUrl) {
+    args.push("--opencode-connect-url", options.opencodeConnectUrl);
+  }
   if (options.opencodeDirectory) {
     args.push("--opencode-directory", options.opencodeDirectory);
   }
@@ -1503,6 +1514,18 @@ async function startOpenworkServer(options: {
   }
   if (options.opencodePassword) {
     args.push("--opencode-password", options.opencodePassword);
+  }
+  if (options.targetId) {
+    args.push("--target-id", options.targetId);
+  }
+  if (options.targetLabel) {
+    args.push("--target-label", options.targetLabel);
+  }
+  if (options.targetType) {
+    args.push("--target-type", options.targetType);
+  }
+  if (options.connectUrl) {
+    args.push("--connect-url", options.connectUrl);
   }
 
   const resolved = resolveBinCommand(options.bin);
@@ -1515,9 +1538,14 @@ async function startOpenworkServer(options: {
       OPENWORK_HOST_TOKEN: options.hostToken,
       ...(options.owpenbotHealthPort ? { OWPENBOT_HEALTH_PORT: String(options.owpenbotHealthPort) } : {}),
       ...(options.opencodeBaseUrl ? { OPENWORK_OPENCODE_BASE_URL: options.opencodeBaseUrl } : {}),
+      ...(options.opencodeConnectUrl ? { OPENWORK_OPENCODE_CONNECT_URL: options.opencodeConnectUrl } : {}),
       ...(options.opencodeDirectory ? { OPENWORK_OPENCODE_DIRECTORY: options.opencodeDirectory } : {}),
       ...(options.opencodeUsername ? { OPENWORK_OPENCODE_USERNAME: options.opencodeUsername } : {}),
       ...(options.opencodePassword ? { OPENWORK_OPENCODE_PASSWORD: options.opencodePassword } : {}),
+      ...(options.targetId ? { OPENWORK_TARGET_ID: options.targetId } : {}),
+      ...(options.targetLabel ? { OPENWORK_TARGET_LABEL: options.targetLabel } : {}),
+      ...(options.targetType ? { OPENWORK_TARGET_TYPE: options.targetType } : {}),
+      ...(options.connectUrl ? { OPENWORK_CONNECT_URL: options.connectUrl } : {}),
     },
   });
 
@@ -2527,6 +2555,20 @@ async function runStart(args: ParsedArgs) {
   const corsValue = readFlag(args.flags, "cors") ?? process.env.OPENWORK_CORS_ORIGINS ?? "*";
   const corsOrigins = parseList(corsValue);
   const connectHost = readFlag(args.flags, "connect-host");
+  const targetTypeRaw = readFlag(args.flags, "target-type") ?? process.env.OPENWORK_TARGET_TYPE;
+  const targetType = targetTypeRaw === "remote" ? "remote" : "local";
+  const targetIdRaw = readFlag(args.flags, "target-id") ?? process.env.OPENWORK_TARGET_ID;
+  const targetLabelRaw = readFlag(args.flags, "target-label") ?? process.env.OPENWORK_TARGET_LABEL;
+  const targetId = typeof targetIdRaw === "string" && targetIdRaw.trim().length
+    ? targetIdRaw.trim()
+    : targetType === "remote"
+      ? "tgt-remote"
+      : "tgt-local";
+  const targetLabel = typeof targetLabelRaw === "string" && targetLabelRaw.trim().length
+    ? targetLabelRaw.trim()
+    : targetType === "remote"
+      ? "Remote target"
+      : "Local (this device)";
 
   const cliVersion = await resolveCliVersion();
   const sidecar = resolveSidecarConfig(args.flags, cliVersion);
@@ -2641,11 +2683,16 @@ async function runStart(args: ParsedArgs) {
       approvalTimeoutMs,
       readOnly,
       corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
-      opencodeBaseUrl: opencodeConnectUrl,
+      opencodeBaseUrl,
+      opencodeConnectUrl: opencodeConnectUrl,
       opencodeDirectory: resolvedWorkspace,
       opencodeUsername,
       opencodePassword,
       owpenbotHealthPort,
+      targetId,
+      targetLabel,
+      targetType,
+      connectUrl: openworkConnectUrl,
     });
     children.push({ name: "openwork-server", child: openworkChild });
     openworkChild.on("exit", (code, signal) => handleExit("openwork-server", code, signal));

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -17,7 +17,7 @@ if (args.version) {
 }
 
 const config = await resolveServerConfig(args);
-const server = startServer(config);
+const server = await startServer(config);
 
 const url = `http://${config.host}:${server.port}`;
 console.log(`OpenWork server listening on ${url}`);

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -13,12 +13,17 @@ interface CliArgs {
   approvalMode?: ApprovalMode;
   approvalTimeoutMs?: number;
   opencodeBaseUrl?: string;
+  opencodeConnectUrl?: string;
   opencodeDirectory?: string;
   opencodeUsername?: string;
   opencodePassword?: string;
   workspaces: string[];
   corsOrigins?: string[];
   readOnly?: boolean;
+  targetId?: string;
+  targetLabel?: string;
+  targetType?: "local" | "remote";
+  connectUrl?: string;
   verbose?: boolean;
   version?: boolean;
   help?: boolean;
@@ -36,6 +41,13 @@ interface FileConfig {
   readOnly?: boolean;
   opencodeUsername?: string;
   opencodePassword?: string;
+  target?: {
+    id?: string;
+    label?: string;
+    type?: "local" | "remote";
+  };
+  connectUrl?: string;
+  opencodeConnectUrl?: string;
 }
 
 const DEFAULT_PORT = 8787;
@@ -102,6 +114,11 @@ export function parseCliArgs(argv: string[]): CliArgs {
       index += 1;
       continue;
     }
+    if (value === "--opencode-connect-url") {
+      args.opencodeConnectUrl = argv[index + 1];
+      index += 1;
+      continue;
+    }
     if (value === "--opencode-directory") {
       args.opencodeDirectory = argv[index + 1];
       index += 1;
@@ -128,6 +145,29 @@ export function parseCliArgs(argv: string[]): CliArgs {
       index += 1;
       continue;
     }
+    if (value === "--target-id") {
+      args.targetId = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (value === "--target-label") {
+      args.targetLabel = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (value === "--target-type") {
+      const next = argv[index + 1] as "local" | "remote" | undefined;
+      if (next === "local" || next === "remote") {
+        args.targetType = next;
+      }
+      index += 1;
+      continue;
+    }
+    if (value === "--connect-url") {
+      args.connectUrl = argv[index + 1];
+      index += 1;
+      continue;
+    }
     if (value === "--read-only") {
       args.readOnly = true;
       continue;
@@ -149,11 +189,16 @@ export function printHelp(): void {
     "  --approval <mode>        manual | auto",
     "  --approval-timeout <ms>  Approval timeout",
     "  --opencode-base-url <url> OpenCode base URL to share",
+    "  --opencode-connect-url <url> OpenCode connect URL to share",
     "  --opencode-directory <path> OpenCode workspace directory to share",
     "  --opencode-username <user> OpenCode server username",
     "  --opencode-password <pass> OpenCode server password",
     "  --workspace <path>       Workspace root (repeatable)",
     "  --cors <origins>          Comma-separated origins or *",
+    "  --target-id <id>          Target id for descriptor",
+    "  --target-label <label>    Target label for descriptor",
+    "  --target-type <type>      local | remote",
+    "  --connect-url <url>       OpenWork connect URL",
     "  --read-only              Disable writes",
     "  --verbose                Print resolved config",
     "  --version                Show version",
@@ -181,10 +226,12 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
         : fileConfig.workspaces ?? [];
 
   const envOpencodeBaseUrl = process.env.OPENWORK_OPENCODE_BASE_URL;
+  const envOpencodeConnectUrl = process.env.OPENWORK_OPENCODE_CONNECT_URL;
   const envOpencodeDirectory = process.env.OPENWORK_OPENCODE_DIRECTORY;
   const envOpencodeUsername = process.env.OPENWORK_OPENCODE_USERNAME;
   const envOpencodePassword = process.env.OPENWORK_OPENCODE_PASSWORD;
   const opencodeBaseUrl = cli.opencodeBaseUrl ?? envOpencodeBaseUrl;
+  const opencodeConnectUrl = cli.opencodeConnectUrl ?? envOpencodeConnectUrl ?? fileConfig.opencodeConnectUrl;
   const opencodeDirectory = cli.opencodeDirectory ?? envOpencodeDirectory;
   const opencodeUsername = cli.opencodeUsername ?? envOpencodeUsername ?? fileConfig.opencodeUsername;
   const opencodePassword = cli.opencodePassword ?? envOpencodePassword ?? fileConfig.opencodePassword;
@@ -263,6 +310,18 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
   const host = cli.host ?? process.env.OPENWORK_HOST ?? fileConfig.host ?? DEFAULT_HOST;
   const port = cli.port ?? (process.env.OPENWORK_PORT ? Number(process.env.OPENWORK_PORT) : undefined) ?? fileConfig.port ?? DEFAULT_PORT;
 
+  const envTargetId = process.env.OPENWORK_TARGET_ID;
+  const envTargetLabel = process.env.OPENWORK_TARGET_LABEL;
+  const envTargetType = process.env.OPENWORK_TARGET_TYPE as "local" | "remote" | undefined;
+  const targetType = cli.targetType ?? envTargetType ?? fileConfig.target?.type ?? "local";
+  const defaultTargetLabel = targetType === "remote" ? "Remote target" : "Local (this device)";
+  const target = {
+    id: cli.targetId ?? envTargetId ?? fileConfig.target?.id ?? (targetType === "remote" ? "tgt-remote" : "tgt-local"),
+    label: cli.targetLabel ?? envTargetLabel ?? fileConfig.target?.label ?? defaultTargetLabel,
+    type: targetType,
+  };
+  const connectUrl = cli.connectUrl ?? process.env.OPENWORK_CONNECT_URL ?? fileConfig.connectUrl;
+
   return {
     host,
     port: Number.isNaN(port) ? DEFAULT_PORT : port,
@@ -277,5 +336,8 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
     startedAt: Date.now(),
     tokenSource,
     hostTokenSource,
+    target,
+    connectUrl: connectUrl?.trim() || undefined,
+    opencodeConnectUrl: opencodeConnectUrl?.trim() || undefined,
   };
 }

--- a/packages/server/src/sandboxes.ts
+++ b/packages/server/src/sandboxes.ts
@@ -1,0 +1,371 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { lstat, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { minimatch } from "minimatch";
+import type { SandboxInfo, SandboxStatus, TargetInfo, WorkspaceInfo } from "./types.js";
+import { ensureDir, exists, shortId } from "./utils.js";
+
+type SandboxState = {
+  version: number;
+  activeId: string;
+  sandboxes: SandboxInfo[];
+};
+
+export type SandboxStore = {
+  baseWorkspace: WorkspaceInfo;
+  target: TargetInfo;
+  root: string;
+  statePath: string;
+  state: SandboxState;
+};
+
+type SandboxCreateMode = "base" | "sandbox";
+
+type SandboxCreateOptions = {
+  name?: string | null;
+  source: { type: SandboxCreateMode; id?: string | null };
+};
+
+const DEFAULT_SANDBOX_NAME = "Sandbox";
+const SANDBOX_STATE_VERSION = 1;
+const DEFAULT_IGNORE_PATTERNS = [
+  ".git",
+  ".git/**",
+  ".openwork/sandboxes",
+  ".openwork/sandboxes/**",
+  "node_modules",
+  "node_modules/**",
+  ".DS_Store",
+];
+
+const toPosix = (value: string) => value.replace(/\\/g, "/");
+
+const normalizePattern = (raw: string) => {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+  const negated = trimmed.startsWith("!");
+  const body = (negated ? trimmed.slice(1) : trimmed).trim();
+  if (!body) return null;
+  let normalized = toPosix(body);
+  if (normalized.startsWith("/")) normalized = normalized.slice(1);
+  if (normalized.endsWith("/")) normalized = `${normalized}**`;
+  return negated ? `!${normalized}` : normalized;
+};
+
+const parseIgnoreFile = async (path: string) => {
+  try {
+    const raw = await readFile(path, "utf8");
+    return raw
+      .split(/\r?\n/)
+      .map(normalizePattern)
+      .filter((entry): entry is string => Boolean(entry));
+  } catch {
+    return [];
+  }
+};
+
+const buildIgnoreMatcher = async (root: string) => {
+  const sandboxIgnore = join(root, ".openwork", "sandbox-ignore");
+  const gitIgnore = join(root, ".gitignore");
+  const patterns = (await parseIgnoreFile(sandboxIgnore)).length
+    ? await parseIgnoreFile(sandboxIgnore)
+    : await parseIgnoreFile(gitIgnore);
+  const merged = [...DEFAULT_IGNORE_PATTERNS, ...patterns];
+
+  return (relPath: string) => {
+    const normalized = toPosix(relPath);
+    let ignored = false;
+    for (const pattern of merged) {
+      const negated = pattern.startsWith("!");
+      const body = negated ? pattern.slice(1) : pattern;
+      if (!body) continue;
+      if (minimatch(normalized, body, { dot: true, matchBase: true })) {
+        ignored = !negated;
+      }
+    }
+    return ignored;
+  };
+};
+
+const ensureSandboxRoot = async (baseWorkspacePath: string) => {
+  const root = join(baseWorkspacePath, ".openwork", "sandboxes");
+  await ensureDir(root);
+  return root;
+};
+
+const sandboxStatePath = (root: string) => join(root, "sandboxes.json");
+
+const nowMs = () => Date.now();
+
+const ensureBaseSandbox = (state: SandboxState, baseWorkspace: WorkspaceInfo, target: TargetInfo) => {
+  const existing = state.sandboxes.find((entry) => entry.id === baseWorkspace.id);
+  if (existing) return;
+  const createdAt = nowMs();
+  state.sandboxes.push({
+    id: baseWorkspace.id,
+    name: baseWorkspace.name || "Default",
+    targetId: target.id,
+    baseWorkspaceId: baseWorkspace.id,
+    path: baseWorkspace.path,
+    createdAt,
+    updatedAt: createdAt,
+    status: "active",
+  });
+  if (!state.activeId) state.activeId = baseWorkspace.id;
+};
+
+export const deriveSandboxStatus = (sandbox: SandboxInfo, activeId: string): SandboxStatus => {
+  if (sandbox.status === "archived") return "archived";
+  if (sandbox.id === activeId) return "active";
+  return "idle";
+};
+
+const runCommand = async (command: string, args: string[], cwd: string) => {
+  return new Promise<{ ok: boolean; stdout: string; stderr: string }>((resolve) => {
+    const child = spawn(command, args, { cwd });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk ?? "");
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk ?? "");
+    });
+    child.on("error", (error) => {
+      stderr += String(error ?? "");
+      resolve({ ok: false, stdout, stderr });
+    });
+    child.on("exit", (code) => {
+      resolve({ ok: code === 0, stdout, stderr });
+    });
+  });
+};
+
+const resolveGitRoot = async (root: string) => {
+  const result = await runCommand("git", ["rev-parse", "--show-toplevel"], root);
+  if (!result.ok) return null;
+  const trimmed = result.stdout.trim();
+  return trimmed ? resolve(trimmed) : null;
+};
+
+const isGitClean = async (root: string) => {
+  const result = await runCommand("git", ["status", "--porcelain"], root);
+  if (!result.ok) return false;
+  return result.stdout.trim().length === 0;
+};
+
+const attemptWorktree = async (root: string, dest: string) => {
+  const result = await runCommand("git", ["worktree", "add", "--detach", dest, "HEAD"], root);
+  return result.ok;
+};
+
+const attemptClone = async (root: string, dest: string) => {
+  const result = await runCommand("git", ["clone", "--depth", "1", root, dest], root);
+  return result.ok;
+};
+
+const copyWorkspace = async (
+  sourceRoot: string,
+  source: string,
+  dest: string,
+  ignore: (rel: string) => boolean,
+) => {
+  await ensureDir(dest);
+  const entries = await readdir(source, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = join(source, entry.name);
+    const relPath = toPosix(relative(sourceRoot, srcPath));
+    if (ignore(relPath)) continue;
+    const destPath = join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyWorkspace(sourceRoot, srcPath, destPath, ignore);
+      continue;
+    }
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isFile()) {
+      await ensureDir(dirname(destPath));
+      await Bun.write(destPath, Bun.file(srcPath));
+    }
+  }
+};
+
+const calculateDirectorySize = async (root: string, current: string, ignore: (rel: string) => boolean) => {
+  let total = 0;
+  const entries = await readdir(current, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = join(current, entry.name);
+    const relPath = toPosix(relative(root, entryPath));
+    if (ignore(relPath)) continue;
+    if (entry.isDirectory()) {
+      total += await calculateDirectorySize(root, entryPath, ignore);
+      continue;
+    }
+    if (entry.isFile()) {
+      const stats = await lstat(entryPath);
+      total += stats.size;
+    }
+  }
+  return total;
+};
+
+const persistState = async (store: SandboxStore) => {
+  await ensureDir(dirname(store.statePath));
+  await writeFile(store.statePath, JSON.stringify(store.state, null, 2) + "\n", "utf8");
+};
+
+export const loadSandboxStore = async (baseWorkspace: WorkspaceInfo, target: TargetInfo): Promise<SandboxStore> => {
+  const root = await ensureSandboxRoot(baseWorkspace.path);
+  const statePath = sandboxStatePath(root);
+  const existing = (await exists(statePath)) ? await readFile(statePath, "utf8").then((raw) => JSON.parse(raw) as SandboxState).catch(() => null) : null;
+  const state: SandboxState = existing && existing.version === SANDBOX_STATE_VERSION
+    ? existing
+    : {
+        version: SANDBOX_STATE_VERSION,
+        activeId: baseWorkspace.id,
+        sandboxes: [],
+      };
+  ensureBaseSandbox(state, baseWorkspace, target);
+  if (!state.activeId) state.activeId = baseWorkspace.id;
+  const store = { baseWorkspace, target, root, statePath, state };
+  await persistState(store);
+  return store;
+};
+
+export const listSandboxes = (store: SandboxStore) => {
+  const activeId = store.state.activeId;
+  return store.state.sandboxes.map((sandbox) => ({
+    ...sandbox,
+    status: deriveSandboxStatus(sandbox, activeId),
+  }));
+};
+
+export const getSandbox = (store: SandboxStore, id: string) =>
+  store.state.sandboxes.find((sandbox) => sandbox.id === id) ?? null;
+
+export const setActiveSandbox = async (store: SandboxStore, id: string) => {
+  const sandbox = getSandbox(store, id);
+  if (!sandbox) throw new Error("Sandbox not found");
+  if (sandbox.status === "archived") throw new Error("Sandbox is archived");
+  store.state.activeId = sandbox.id;
+  sandbox.updatedAt = nowMs();
+  await persistState(store);
+  return sandbox;
+};
+
+export const archiveSandbox = async (store: SandboxStore, id: string) => {
+  const sandbox = getSandbox(store, id);
+  if (!sandbox) throw new Error("Sandbox not found");
+  if (sandbox.id === store.baseWorkspace.id) {
+    throw new Error("Base sandbox cannot be archived");
+  }
+  sandbox.status = "archived";
+  sandbox.updatedAt = nowMs();
+  await persistState(store);
+  return sandbox;
+};
+
+export const deleteSandbox = async (store: SandboxStore, id: string) => {
+  const sandbox = getSandbox(store, id);
+  if (!sandbox) throw new Error("Sandbox not found");
+  if (sandbox.id === store.baseWorkspace.id) {
+    throw new Error("Base sandbox cannot be deleted");
+  }
+  if (sandbox.path && sandbox.path.startsWith(store.root)) {
+    if (existsSync(sandbox.path)) {
+      await rm(sandbox.path, { recursive: true, force: true });
+    }
+  }
+  store.state.sandboxes = store.state.sandboxes.filter((entry) => entry.id !== sandbox.id);
+  if (store.state.activeId === sandbox.id) {
+    store.state.activeId = store.baseWorkspace.id;
+  }
+  await persistState(store);
+  return sandbox;
+};
+
+export const createSandbox = async (store: SandboxStore, options: SandboxCreateOptions) => {
+  const nameInput = options.name?.trim();
+  const name = nameInput && nameInput.length ? nameInput : `${DEFAULT_SANDBOX_NAME} ${store.state.sandboxes.length + 1}`;
+  const id = `sbx_${shortId()}`;
+  const targetPath = join(store.root, id);
+  const sourceType = options.source.type;
+  const sourceSandbox =
+    sourceType === "sandbox" && options.source.id
+      ? getSandbox(store, options.source.id)
+      : null;
+  const sourcePath = sourceSandbox?.path ?? store.baseWorkspace.path;
+  const ignore = await buildIgnoreMatcher(sourcePath);
+
+  if (sourceType === "sandbox") {
+    await copyWorkspace(sourcePath, sourcePath, targetPath, ignore);
+  } else {
+    const gitRoot = await resolveGitRoot(sourcePath);
+    const isRoot = gitRoot && resolve(gitRoot) === resolve(sourcePath);
+    if (gitRoot && isRoot && (await isGitClean(sourcePath))) {
+      const ok = await attemptWorktree(sourcePath, targetPath);
+      if (!ok) {
+        const cloneOk = await attemptClone(sourcePath, targetPath);
+        if (!cloneOk) {
+          await copyWorkspace(sourcePath, sourcePath, targetPath, ignore);
+        }
+      }
+    } else if (gitRoot && isRoot) {
+      const cloneOk = await attemptClone(sourcePath, targetPath);
+      if (!cloneOk) {
+        await copyWorkspace(sourcePath, sourcePath, targetPath, ignore);
+      }
+    } else {
+      await copyWorkspace(sourcePath, sourcePath, targetPath, ignore);
+    }
+  }
+
+  const createdAt = nowMs();
+  const record: SandboxInfo = {
+    id,
+    name,
+    targetId: store.target.id,
+    baseWorkspaceId: store.baseWorkspace.id,
+    path: targetPath,
+    createdAt,
+    updatedAt: createdAt,
+    status: "active",
+  };
+  store.state.sandboxes.push(record);
+  store.state.activeId = record.id;
+  await persistState(store);
+  return record;
+};
+
+export const readSandboxSize = async (store: SandboxStore, sandbox: SandboxInfo) => {
+  const ignore = await buildIgnoreMatcher(sandbox.path);
+  return calculateDirectorySize(sandbox.path, sandbox.path, ignore);
+};
+
+export const syncSandboxStatuses = (store: SandboxStore) => {
+  const activeId = store.state.activeId;
+  store.state.sandboxes = store.state.sandboxes.map((sandbox) => ({
+    ...sandbox,
+    status: deriveSandboxStatus(sandbox, activeId),
+  }));
+};
+
+export const ensureSandboxRootsAuthorized = (roots: string[], sandboxPaths: string[]) => {
+  const next = new Set(roots.map((root) => resolve(root)));
+  for (const path of sandboxPaths) {
+    next.add(resolve(path));
+  }
+  return Array.from(next);
+};
+
+export const resolveSandboxByPath = (store: SandboxStore, path: string) => {
+  const normalized = resolve(path);
+  return store.state.sandboxes.find((sandbox) => resolve(sandbox.path) === normalized) ?? null;
+};
+
+export const isSandboxPath = (store: SandboxStore, path: string) => {
+  const resolved = resolve(path);
+  return resolved === resolve(store.root) || resolved.startsWith(resolve(store.root) + sep);
+};

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,16 @@
 import { readFile, writeFile, rm } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
-import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger } from "./types.js";
+import type {
+  ApprovalRequest,
+  Capabilities,
+  ServerConfig,
+  WorkspaceInfo,
+  Actor,
+  ReloadReason,
+  ReloadTrigger,
+  SandboxInfo,
+} from "./types.js";
 import { ApprovalService } from "./approvals.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { addMcp, listMcp, removeMcp } from "./mcp.js";
@@ -16,6 +25,20 @@ import { parseFrontmatter } from "./frontmatter.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { sanitizeCommandName } from "./validators.js";
+import {
+  archiveSandbox,
+  createSandbox,
+  deleteSandbox,
+  deriveSandboxStatus,
+  ensureSandboxRootsAuthorized,
+  getSandbox,
+  listSandboxes,
+  loadSandboxStore,
+  readSandboxSize,
+  setActiveSandbox,
+  syncSandboxStatuses,
+  type SandboxStore,
+} from "./sandboxes.js";
 import pkg from "../package.json" with { type: "json" };
 
 const SERVER_VERSION = pkg.version;
@@ -38,12 +61,21 @@ interface RequestContext {
   approvals: ApprovalService;
   reloadEvents: ReloadEventStore;
   actor?: Actor;
+  sandboxes?: SandboxStore | null;
 }
 
-export function startServer(config: ServerConfig) {
+export async function startServer(config: ServerConfig) {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
-  const routes = createRoutes(config, approvals);
+  const baseWorkspace = config.workspaces[0] ?? null;
+  const sandboxStore = baseWorkspace
+    ? await loadSandboxStore(baseWorkspace, config.target)
+    : null;
+  if (sandboxStore) {
+    syncSandboxStatuses(sandboxStore);
+    applySandboxState(config, sandboxStore);
+  }
+  const routes = createRoutes(config, approvals, sandboxStore);
 
   const serverOptions: {
     hostname: string;
@@ -86,6 +118,7 @@ export function startServer(config: ServerConfig) {
           approvals,
           reloadEvents,
           actor,
+          sandboxes: sandboxStore,
         });
         return withCors(response, request, config);
       } catch (error) {
@@ -284,7 +317,7 @@ function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
   };
 }
 
-function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[] {
+function createRoutes(config: ServerConfig, approvals: ApprovalService, sandboxStore: SandboxStore | null): Route[] {
   const routes: Route[] = [];
 
   addRoute(routes, "GET", "/health", "none", async () => {
@@ -293,6 +326,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "GET", "/status", "client", async () => {
     const active = config.workspaces[0];
+    const activeSandbox = sandboxStore ? getSandbox(sandboxStore, sandboxStore.state.activeId) : null;
     return jsonResponse({
       ok: true,
       version: SERVER_VERSION,
@@ -303,6 +337,16 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       workspaceCount: config.workspaces.length,
       activeWorkspaceId: active?.id ?? null,
       workspace: active ? serializeWorkspace(active) : null,
+      sandboxCount: sandboxStore ? sandboxStore.state.sandboxes.length : 0,
+      activeSandboxId: activeSandbox?.id ?? null,
+      sandbox: activeSandbox
+        ? {
+            id: activeSandbox.id,
+            name: activeSandbox.name,
+            path: activeSandbox.path,
+            status: activeSandbox.status,
+          }
+        : null,
       authorizedRoots: config.authorizedRoots,
       server: {
         host: config.host,
@@ -318,6 +362,153 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "GET", "/capabilities", "client", async () => {
     return jsonResponse(buildCapabilities(config));
+  });
+
+  addRoute(routes, "GET", "/connect/active", "client", async () => {
+    const activeSandbox = sandboxStore ? getSandbox(sandboxStore, sandboxStore.state.activeId) : null;
+    const activeWorkspace = activeSandbox
+      ? ({
+          id: activeSandbox.id,
+          name: activeSandbox.name,
+          path: activeSandbox.path,
+          workspaceType: "local",
+          baseUrl: config.workspaces[0]?.baseUrl,
+          directory: activeSandbox.path,
+          opencodeUsername: config.workspaces[0]?.opencodeUsername,
+          opencodePassword: config.workspaces[0]?.opencodePassword,
+        } as WorkspaceInfo)
+      : config.workspaces[0];
+    const opencodeBaseUrl = activeWorkspace?.baseUrl?.trim() ?? "";
+    const opencodeDirectory = activeWorkspace ? resolveOpencodeDirectory(activeWorkspace) : null;
+    const opencodePort = opencodeBaseUrl ? parseUrlPort(opencodeBaseUrl) : null;
+    const openworkBaseUrl = `http://${config.host}:${config.port}`;
+    const opencodeProxyUrl = `${openworkBaseUrl.replace(/\/$/, "")}/opencode`;
+    const opencodeConnectUrl = config.opencodeConnectUrl ?? opencodeProxyUrl ?? opencodeBaseUrl;
+    const owpenbotPort = resolveOwpenbotHealthPort();
+    return jsonResponse({
+      updatedAt: Date.now(),
+      sandbox: activeSandbox
+        ? {
+            id: activeSandbox.id,
+            name: activeSandbox.name,
+            path: activeSandbox.path,
+            status: deriveSandboxStatus(activeSandbox, sandboxStore?.state.activeId),
+          }
+        : null,
+      target: config.target,
+      opencode: {
+        baseUrl: opencodeBaseUrl || undefined,
+        connectUrl: opencodeConnectUrl || undefined,
+        directory: opencodeDirectory ?? undefined,
+        username: activeWorkspace?.opencodeUsername ?? undefined,
+        password: activeWorkspace?.opencodePassword ?? undefined,
+        port: opencodePort ?? undefined,
+      },
+      openwork: {
+        baseUrl: openworkBaseUrl,
+        connectUrl: config.connectUrl ?? openworkBaseUrl,
+        token: config.token,
+        hostToken: config.hostToken,
+        port: config.port,
+      },
+      owpenbot: {
+        healthUrl: `http://127.0.0.1:${owpenbotPort}`,
+        healthPort: owpenbotPort,
+      },
+    });
+  });
+
+  addRoute(routes, "GET", "/sandboxes", "client", async () => {
+    if (!sandboxStore) {
+      throw new ApiError(400, "sandbox_unavailable", "Sandboxes unavailable without a base workspace");
+    }
+    const items = listSandboxes(sandboxStore);
+    return jsonResponse({
+      activeId: sandboxStore.state.activeId,
+      items,
+    });
+  });
+
+  addRoute(routes, "POST", "/sandboxes", "client", async (ctx) => {
+    ensureWritable(config);
+    if (!sandboxStore) {
+      throw new ApiError(400, "sandbox_unavailable", "Sandboxes unavailable without a base workspace");
+    }
+    const body = await readJsonBody(ctx.request);
+    const name = typeof body.name === "string" ? body.name.trim() : null;
+    const source = typeof body.source === "string" ? body.source : "base";
+    const fromSandboxId = typeof body.fromSandboxId === "string" ? body.fromSandboxId : null;
+    const mode = source === "sandbox" ? "sandbox" : "base";
+    const sandbox = await createSandbox(sandboxStore, {
+      name,
+      source: { type: mode, id: fromSandboxId ?? sandboxStore.state.activeId },
+    });
+    syncSandboxStatuses(sandboxStore);
+    applySandboxState(config, sandboxStore);
+    return jsonResponse({ activeId: sandboxStore.state.activeId, sandbox });
+  });
+
+  addRoute(routes, "GET", "/sandboxes/:id", "client", async (ctx) => {
+    if (!sandboxStore) {
+      throw new ApiError(400, "sandbox_unavailable", "Sandboxes unavailable without a base workspace");
+    }
+    const sandbox = getSandbox(sandboxStore, ctx.params.id);
+    if (!sandbox) {
+      throw new ApiError(404, "sandbox_not_found", "Sandbox not found");
+    }
+    const sizeBytes = await readSandboxSize(sandboxStore, sandbox);
+    return jsonResponse({
+      sandbox: {
+        ...sandbox,
+        status: deriveSandboxStatus(sandbox, sandboxStore.state.activeId),
+        sizeBytes,
+      },
+    });
+  });
+
+  addRoute(routes, "POST", "/sandboxes/:id/archive", "client", async (ctx) => {
+    ensureWritable(config);
+    if (!sandboxStore) {
+      throw new ApiError(400, "sandbox_unavailable", "Sandboxes unavailable without a base workspace");
+    }
+    try {
+      const sandbox = await archiveSandbox(sandboxStore, ctx.params.id);
+      syncSandboxStatuses(sandboxStore);
+      applySandboxState(config, sandboxStore);
+      return jsonResponse({ sandbox });
+    } catch (error) {
+      throw new ApiError(400, "sandbox_archive_failed", error instanceof Error ? error.message : "Archive failed");
+    }
+  });
+
+  addRoute(routes, "POST", "/sandboxes/:id/delete", "client", async (ctx) => {
+    ensureWritable(config);
+    if (!sandboxStore) {
+      throw new ApiError(400, "sandbox_unavailable", "Sandboxes unavailable without a base workspace");
+    }
+    try {
+      const sandbox = await deleteSandbox(sandboxStore, ctx.params.id);
+      syncSandboxStatuses(sandboxStore);
+      applySandboxState(config, sandboxStore);
+      return jsonResponse({ deleted: true, sandbox });
+    } catch (error) {
+      throw new ApiError(400, "sandbox_delete_failed", error instanceof Error ? error.message : "Delete failed");
+    }
+  });
+
+  addRoute(routes, "POST", "/sandboxes/:id/activate", "client", async (ctx) => {
+    ensureWritable(config);
+    if (!sandboxStore) {
+      throw new ApiError(400, "sandbox_unavailable", "Sandboxes unavailable without a base workspace");
+    }
+    try {
+      const sandbox = await setActiveSandbox(sandboxStore, ctx.params.id);
+      syncSandboxStatuses(sandboxStore);
+      applySandboxState(config, sandboxStore);
+      return jsonResponse({ activeId: sandboxStore.state.activeId, sandbox });
+    } catch (error) {
+      throw new ApiError(400, "sandbox_activate_failed", error instanceof Error ? error.message : "Activate failed");
+    }
   });
 
   addRoute(routes, "GET", "/workspaces", "client", async () => {
@@ -797,6 +988,55 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
   });
 
   return routes;
+}
+
+function applySandboxState(config: ServerConfig, store: SandboxStore) {
+  const baseWorkspace = config.workspaces.find((entry) => entry.id === store.baseWorkspace.id) ?? store.baseWorkspace;
+  const sandboxEntries: WorkspaceInfo[] = store.state.sandboxes.map((sandbox) => ({
+    id: sandbox.id,
+    name: sandbox.name,
+    path: sandbox.path,
+    workspaceType: baseWorkspace.workspaceType,
+    baseUrl: baseWorkspace.baseUrl,
+    directory: sandbox.path,
+    opencodeUsername: baseWorkspace.opencodeUsername,
+    opencodePassword: baseWorkspace.opencodePassword,
+  }));
+  const byId = new Map<string, WorkspaceInfo>();
+  for (const entry of config.workspaces) {
+    byId.set(entry.id, entry);
+  }
+  for (const entry of sandboxEntries) {
+    const existing = byId.get(entry.id);
+    byId.set(entry.id, { ...existing, ...entry });
+  }
+  let merged = Array.from(byId.values());
+  const activeId = store.state.activeId;
+  if (activeId) {
+    merged = [
+      ...merged.filter((entry) => entry.id === activeId),
+      ...merged.filter((entry) => entry.id !== activeId),
+    ];
+  }
+  config.workspaces = merged;
+  config.authorizedRoots = ensureSandboxRootsAuthorized(
+    config.authorizedRoots,
+    store.state.sandboxes.map((sandbox) => sandbox.path),
+  );
+}
+
+function parseUrlPort(value: string): number | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.port) {
+      const port = Number(url.port);
+      return Number.isFinite(port) ? port : null;
+    }
+    return url.protocol === "https:" ? 443 : 80;
+  } catch {
+    return null;
+  }
 }
 
 async function resolveWorkspace(config: ServerConfig, id: string): Promise<WorkspaceInfo> {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,5 +1,9 @@
 export type WorkspaceType = "local" | "remote";
 
+export type TargetType = "local" | "remote";
+
+export type SandboxStatus = "active" | "idle" | "archived";
+
 export type ApprovalMode = "manual" | "auto";
 
 export interface WorkspaceConfig {
@@ -29,6 +33,24 @@ export interface WorkspaceInfo {
   };
 }
 
+export interface TargetInfo {
+  id: string;
+  label: string;
+  type: TargetType;
+}
+
+export interface SandboxInfo {
+  id: string;
+  name: string;
+  targetId: string;
+  baseWorkspaceId: string;
+  path: string;
+  createdAt: number;
+  updatedAt: number;
+  status: SandboxStatus;
+  sizeBytes?: number;
+}
+
 export interface ApprovalConfig {
   mode: ApprovalMode;
   timeoutMs: number;
@@ -48,6 +70,9 @@ export interface ServerConfig {
   startedAt: number;
   tokenSource: "cli" | "env" | "file" | "generated";
   hostTokenSource: "cli" | "env" | "file" | "generated";
+  target: TargetInfo;
+  connectUrl?: string;
+  opencodeConnectUrl?: string;
 }
 
 export interface Capabilities {


### PR DESCRIPTION
Expose OpenWork sandbox/target metadata to the UI so users can switch environments and run sessions against configured targets.