### PR TITLE
Allow partial matching for / command search

### DIFF
--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1185,10 +1185,28 @@ export default function SessionView(props: SessionViewProps) {
     if (!value.startsWith("/")) return [];
     const token = value.slice(1).trim().split(/\s+/)[0]?.toLowerCase() ?? "";
     const list = slashCommands();
-    const matches = token
-      ? list.filter((command) => command.slash?.toLowerCase().startsWith(token))
-      : list;
-    return matches.map((command) => ({
+    if (!token) {
+      return list.map((command) => ({
+        id: command.slash!,
+        description: command.description || "Run a command",
+        needsArgs: commandNeedsArgs().get(command.slash ?? "") ?? false,
+      }));
+    }
+
+    const matches = list
+      .map((command, index) => {
+        const slash = command.slash?.toLowerCase() ?? "";
+        if (slash === token) return { command, index, tier: 0 };
+        if (slash.startsWith(token)) return { command, index, tier: 1 };
+        if (slash.includes(token)) return { command, index, tier: 2 };
+        return null;
+      })
+      .filter((entry): entry is { command: CommandRegistryItem; index: number; tier: number } =>
+        Boolean(entry),
+      )
+      .sort((a, b) => (a.tier - b.tier) || (a.index - b.index));
+
+    return matches.map(({ command }) => ({
       id: command.slash!,
       description: command.description || "Run a command",
       needsArgs: commandNeedsArgs().get(command.slash ?? "") ?? false,


### PR DESCRIPTION
## Summary
- rank slash command matches by exact > prefix > substring
- keep existing slash command ordering as tie-breaker

Existing behaviour of typing `/skill` does not match `/learn-skills`, new behaviour adds partial matching.

<img width="642" height="184" alt="image" src="https://github.com/user-attachments/assets/d61a13be-85d2-4c00-a498-39a963baeb4f" />
