### PR TITLE
Improve openwrk observability and request logging

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -40,6 +40,20 @@ pnpm --filter openwrk dev -- \
 
 The command prints pairing details (OpenWork server URL + token, OpenCode URL + auth) so remote OpenWork clients can connect.
 
+## Logging
+
+`openwrk` emits a unified log stream from OpenCode, OpenWork server, and Owpenbot. Use JSON format for
+structured, OpenTelemetry-friendly logs and a stable run id for correlation.
+
+```bash
+OPENWRK_LOG_FORMAT=json openwrk start --workspace /path/to/workspace
+```
+
+Use `--run-id` or `OPENWRK_RUN_ID` to supply your own correlation id.
+
+OpenWork server logs every request with method, path, status, and duration. Disable this when running
+`openwork-server` directly by setting `OPENWORK_LOG_REQUESTS=0` or passing `--no-log-requests`.
+
 ## Router daemon (multi-workspace)
 
 The router keeps a single OpenCode process alive and switches workspaces JIT using the `directory` parameter.

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { parseCliArgs, printHelp, resolveServerConfig } from "./config.js";
-import { startServer } from "./server.js";
+import { createServerLogger, startServer } from "./server.js";
 import pkg from "../package.json" with { type: "json" };
 
 const args = parseCliArgs(process.argv.slice(2));
@@ -17,31 +17,32 @@ if (args.version) {
 }
 
 const config = await resolveServerConfig(args);
+const logger = createServerLogger(config);
 const server = startServer(config);
 
 const url = `http://${config.host}:${server.port}`;
-console.log(`OpenWork server listening on ${url}`);
+logger.log("info", `OpenWork server listening on ${url}`);
 
 if (config.tokenSource === "generated") {
-  console.log(`Client token: ${config.token}`);
+  logger.log("info", `Client token: ${config.token}`);
 }
 
 if (config.hostTokenSource === "generated") {
-  console.log(`Host token: ${config.hostToken}`);
+  logger.log("info", `Host token: ${config.hostToken}`);
 }
 
 if (config.workspaces.length === 0) {
-  console.log("No workspaces configured. Add --workspace or update server.json.");
+  logger.log("info", "No workspaces configured. Add --workspace or update server.json.");
 } else {
-  console.log(`Workspaces: ${config.workspaces.length}`);
+  logger.log("info", `Workspaces: ${config.workspaces.length}`);
 }
 
 if (args.verbose) {
-  console.log(`Config path: ${config.configPath ?? "unknown"}`);
-  console.log(`Read-only: ${config.readOnly ? "true" : "false"}`);
-  console.log(`Approval: ${config.approval.mode} (${config.approval.timeoutMs}ms)`);
-  console.log(`CORS origins: ${config.corsOrigins.join(", ")}`);
-  console.log(`Authorized roots: ${config.authorizedRoots.join(", ")}`);
-  console.log(`Token source: ${config.tokenSource}`);
-  console.log(`Host token source: ${config.hostTokenSource}`);
+  logger.log("info", `Config path: ${config.configPath ?? "unknown"}`);
+  logger.log("info", `Read-only: ${config.readOnly ? "true" : "false"}`);
+  logger.log("info", `Approval: ${config.approval.mode} (${config.approval.timeoutMs}ms)`);
+  logger.log("info", `CORS origins: ${config.corsOrigins.join(", ")}`);
+  logger.log("info", `Authorized roots: ${config.authorizedRoots.join(", ")}`);
+  logger.log("info", `Token source: ${config.tokenSource}`);
+  logger.log("info", `Host token source: ${config.hostTokenSource}`);
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, rm } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import { join, resolve, sep } from "node:path";
 import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger } from "./types.js";
 import { ApprovalService } from "./approvals.js";
@@ -19,6 +19,91 @@ import { sanitizeCommandName } from "./validators.js";
 import pkg from "../package.json" with { type: "json" };
 
 const SERVER_VERSION = pkg.version;
+
+type LogLevel = "info" | "warn" | "error";
+
+type LogAttributes = Record<string, unknown>;
+
+type ServerLogger = {
+  log: (level: LogLevel, message: string, attributes?: LogAttributes) => void;
+};
+
+const LOG_LEVEL_NUMBERS: Record<LogLevel, number> = {
+  info: 9,
+  warn: 13,
+  error: 17,
+};
+
+function toUnixNano(): string {
+  return (BigInt(Date.now()) * 1_000_000n).toString();
+}
+
+export function createServerLogger(config: ServerConfig): ServerLogger {
+  const runId = process.env.OPENWRK_RUN_ID ?? process.env.OPENWORK_RUN_ID ?? shortId();
+  const host = hostname().trim();
+  const resource: Record<string, string> = {
+    "service.name": "openwork-server",
+    "service.version": SERVER_VERSION,
+    "service.instance.id": runId,
+  };
+  if (host) {
+    resource["host.name"] = host;
+  }
+  const baseAttributes: LogAttributes = {
+    "run.id": runId,
+    "process.pid": process.pid,
+  };
+
+  const emit = (level: LogLevel, message: string, attributes?: LogAttributes) => {
+    const merged = { ...baseAttributes, ...(attributes ?? {}) };
+    if (config.logFormat === "json") {
+      const record = {
+        timeUnixNano: toUnixNano(),
+        severityText: level.toUpperCase(),
+        severityNumber: LOG_LEVEL_NUMBERS[level],
+        body: message,
+        attributes: merged,
+        resource,
+      };
+      process.stdout.write(`${JSON.stringify(record)}\n`);
+      return;
+    }
+    process.stdout.write(`${message}\n`);
+  };
+
+  return { log: emit };
+}
+
+function logRequest(input: {
+  logger: ServerLogger;
+  request: Request;
+  response: Response;
+  durationMs: number;
+  authMode: AuthMode;
+  proxyBaseUrl?: string;
+  error?: string;
+}) {
+  const { logger, request, response, durationMs, authMode, proxyBaseUrl, error } = input;
+  const status = response.status;
+  const level: LogLevel = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+  const message = `${method} ${url.pathname} ${status} ${durationMs}ms${proxyBaseUrl ? " (opencode)" : ""}`;
+  const attributes: LogAttributes = {
+    method,
+    path: url.pathname,
+    status,
+    durationMs,
+    auth: authMode,
+  };
+  if (proxyBaseUrl) {
+    attributes["opencode.base_url"] = proxyBaseUrl;
+  }
+  if (error) {
+    attributes.error = error;
+  }
+  logger.log(level, message, attributes);
+}
 
 type AuthMode = "none" | "client" | "host";
 
@@ -44,6 +129,7 @@ export function startServer(config: ServerConfig) {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
   const routes = createRoutes(config, approvals);
+  const logger = createServerLogger(config);
 
   const serverOptions: {
     hostname: string;
@@ -54,28 +140,54 @@ export function startServer(config: ServerConfig) {
     port: config.port,
     fetch: async (request: Request) => {
       const url = new URL(request.url);
+      const startedAt = Date.now();
+      let authMode: AuthMode = "none";
+      let proxyBaseUrl: string | undefined;
+      let errorMessage: string | undefined;
+
+      const finalize = (response: Response) => {
+        const wrapped = withCors(response, request, config);
+        if (config.logRequests) {
+          logRequest({
+            logger,
+            request,
+            response: wrapped,
+            durationMs: Date.now() - startedAt,
+            authMode,
+            proxyBaseUrl,
+            error: errorMessage,
+          });
+        }
+        return wrapped;
+      };
+
       if (request.method === "OPTIONS") {
-        return withCors(new Response(null, { status: 204 }), request, config);
+        return finalize(new Response(null, { status: 204 }));
       }
 
       if (url.pathname === "/opencode" || url.pathname.startsWith("/opencode/")) {
+        authMode = "client";
+        proxyBaseUrl = config.workspaces[0]?.baseUrl?.trim() || undefined;
         try {
           requireClient(request, config);
           const response = await proxyOpencodeRequest({ request, url, config });
-          return withCors(response, request, config);
+          return finalize(response);
         } catch (error) {
           const apiError = error instanceof ApiError
             ? error
             : new ApiError(500, "internal_error", "Unexpected server error");
-          return withCors(jsonResponse(formatError(apiError), apiError.status), request, config);
+          errorMessage = apiError.message;
+          return finalize(jsonResponse(formatError(apiError), apiError.status));
         }
       }
 
       const route = matchRoute(routes, request.method, url.pathname);
       if (!route) {
-        return withCors(jsonResponse({ code: "not_found", message: "Not found" }, 404), request, config);
+        errorMessage = "not_found";
+        return finalize(jsonResponse({ code: "not_found", message: "Not found" }, 404));
       }
 
+      authMode = route.auth;
       try {
         const actor = route.auth === "host" ? requireHost(request, config) : route.auth === "client" ? requireClient(request, config) : undefined;
         const response = await route.handler({
@@ -87,12 +199,13 @@ export function startServer(config: ServerConfig) {
           reloadEvents,
           actor,
         });
-        return withCors(response, request, config);
+        return finalize(response);
       } catch (error) {
         const apiError = error instanceof ApiError
           ? error
           : new ApiError(500, "internal_error", "Unexpected server error");
-        return withCors(jsonResponse(formatError(apiError), apiError.status), request, config);
+        errorMessage = apiError.message;
+        return finalize(jsonResponse(formatError(apiError), apiError.status));
       }
     },
   };

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -2,6 +2,8 @@ export type WorkspaceType = "local" | "remote";
 
 export type ApprovalMode = "manual" | "auto";
 
+export type LogFormat = "pretty" | "json";
+
 export interface WorkspaceConfig {
   path: string;
   name?: string;
@@ -48,6 +50,8 @@ export interface ServerConfig {
   startedAt: number;
   tokenSource: "cli" | "env" | "file" | "generated";
   hostTokenSource: "cli" | "env" | "file" | "generated";
+  logFormat: LogFormat;
+  logRequests: boolean;
 }
 
 export interface Capabilities {


### PR DESCRIPTION
## Summary
- emit unified, run-id-scoped logs for openwrk and child processes with optional JSON output
- add request access logging and log format controls to openwork-server
- document logging controls for headless runs

## Testing
- pnpm --filter openwork-server build:bin
- pnpm --filter openwrk test:router