### PR TITLE
CI: prepare desktop sidecars

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           version: 10.27.0
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.5
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -93,6 +98,9 @@ jobs:
           mkdir -p packages/desktop/src-tauri/sidecars
           cp "$bin_path" "packages/desktop/src-tauri/sidecars/${target_name}"
           chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
+
+      - name: Prepare desktop sidecars
+        run: pnpm -C packages/desktop prepare:sidecar
 
       - name: Run Rust tests (engine + sidecar resolution)
         run: cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml --locked


### PR DESCRIPTION
## Summary
- install Bun in desktop CI builds
- run `prepare:sidecar` so openwrk/openwork-server/owpenbot sidecars exist for Tauri

## Testing
- not run (CI workflow change)