### PR TITLE
CI: install OpenTUI x64 core for macOS builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -129,6 +129,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install OpenTUI x64 core (macOS x86_64)
+        if: matrix.os_type == 'macos' && matrix.target == 'x86_64-apple-darwin'
+        run: pnpm add -w --ignore-workspace-root-check --no-save @opentui/core-darwin-x64@0.1.77
+
       - name: Install Linux build dependencies
         if: matrix.os_type == 'linux'
         run: |

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -233,6 +233,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install OpenTUI x64 core (macOS x86_64)
+        if: matrix.os_type == 'macos' && matrix.target == 'x86_64-apple-darwin'
+        run: pnpm add -w --ignore-workspace-root-check --no-save @opentui/core-darwin-x64@0.1.77
+
       - name: Install Linux build dependencies
         if: matrix.os_type == 'linux'
         run: |


### PR DESCRIPTION
## Summary
- install @opentui/core-darwin-x64 for macOS x86_64 targets in prerelease and release workflows
- avoids openwrk sidecar compile failure when building cross-arch on macos-14

## Testing
- not run (workflow change)