### PR TITLE
Remove inactive compose/session list icons

### DIFF
--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1,6 +1,6 @@
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
-import { ArrowUp, AtSign, ChevronDown, File, History, Mic, Paperclip, X, Zap } from "lucide-solid";
+import { ArrowUp, AtSign, ChevronDown, File, Paperclip, X, Zap } from "lucide-solid";
 
 import type { ComposerAttachment, ComposerDraft, ComposerPart, PromptMode } from "../../types";
 
@@ -1007,12 +1007,6 @@ export default function Composer(props: ComposerProps) {
                         </div>
                       </div>
                       <div class="flex items-center gap-3 text-dls-secondary">
-                        <button type="button" class="cursor-pointer hover:text-dls-text">
-                          <History size={18} />
-                        </button>
-                        <button type="button" class="cursor-pointer hover:text-dls-text">
-                          <Mic size={18} />
-                        </button>
                         <button
                           type="button"
                           disabled={!props.prompt.trim() && !attachments().length}

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -34,7 +34,6 @@ import StatusBar from "../components/status-bar";
 import ProviderAuthModal from "../components/provider-auth-modal";
 import {
   Box,
-  Edit2,
   History,
   Loader2,
   MoreHorizontal,
@@ -541,30 +540,12 @@ export default function DashboardView(props: DashboardViewProps) {
                                   openSessionFromList(workspace().id, session.id);
                                 }}
                               >
-                                <span class="text-sm text-dls-text truncate mr-2 font-medium group-hover:pr-14 transition-all">
+                                <span class="text-sm text-dls-text truncate mr-2 font-medium">
                                   {session.title}
                                 </span>
-                                <span class="text-xs text-dls-secondary whitespace-nowrap group-hover:opacity-0 transition-opacity">
+                                <span class="text-xs text-dls-secondary whitespace-nowrap">
                                   {formatRelativeTime(session.time?.updated ?? Date.now())}
                                 </span>
-                                <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                  <button
-                                    type="button"
-                                    class="p-1 hover:bg-dls-active rounded-md text-dls-text transition-colors"
-                                    onClick={(event) => event.stopPropagation()}
-                                    aria-label="Session options"
-                                  >
-                                    <MoreHorizontal size={14} />
-                                  </button>
-                                  <button
-                                    type="button"
-                                    class="p-1 hover:bg-dls-active rounded-md text-dls-text transition-colors"
-                                    onClick={(event) => event.stopPropagation()}
-                                    aria-label="Rename session"
-                                  >
-                                    <Edit2 size={14} />
-                                  </button>
-                                </div>
                               </div>
                             );
                           }}

--- a/packages/app/src/app/pages/proto-v1-ux.tsx
+++ b/packages/app/src/app/pages/proto-v1-ux.tsx
@@ -8,7 +8,6 @@ import {
   ChevronDown,
   ChevronRight,
   Cloud,
-  Edit2,
   ExternalLink,
   FileCode,
   FileText,
@@ -16,7 +15,6 @@ import {
   History,
   Layout,
   MessageSquare,
-  Mic,
   MoreHorizontal,
   Pencil,
   Plus,
@@ -143,28 +141,12 @@ const SidebarItem = (props: {
 
 const ThreadItem = (props: { text: string; time: string }) => (
   <div class="group relative flex items-center justify-between rounded-xl px-3 py-2 transition-colors hover:bg-gray-2">
-    <span class="truncate pr-6 text-sm font-medium text-gray-11 group-hover:text-gray-12">
+    <span class="truncate text-sm font-medium text-gray-11 group-hover:text-gray-12">
       {props.text}
     </span>
-    <span class="text-xs text-gray-8 transition-opacity group-hover:opacity-0">
+    <span class="text-xs text-gray-8">
       {props.time}
     </span>
-    <div class="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-      <button
-        type="button"
-        aria-label="Thread options"
-        class="rounded-md p-1 text-gray-9 transition-colors hover:bg-gray-3 hover:text-gray-12"
-      >
-        <MoreHorizontal size={14} />
-      </button>
-      <button
-        type="button"
-        aria-label="Rename thread"
-        class="rounded-md p-1 text-gray-9 transition-colors hover:bg-gray-3 hover:text-gray-12"
-      >
-        <Edit2 size={14} />
-      </button>
-    </div>
   </div>
 );
 
@@ -669,20 +651,6 @@ export default function ProtoV1UxView() {
                           </button>
                         </div>
                         <div class="flex items-center gap-3">
-                          <button
-                            type="button"
-                            aria-label="Thread history"
-                            class="rounded-md p-1.5 text-gray-8 transition-colors hover:bg-gray-2 hover:text-gray-12"
-                          >
-                            <History size={18} />
-                          </button>
-                          <button
-                            type="button"
-                            aria-label="Voice input"
-                            class="rounded-md p-1.5 text-gray-8 transition-colors hover:bg-gray-2 hover:text-gray-12"
-                          >
-                            <Mic size={18} />
-                          </button>
                           <button
                             type="button"
                             aria-label="Send"

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -25,7 +25,6 @@ import type { WorkspaceInfo } from "../lib/tauri";
 import {
   Box,
   ChevronDown,
-  Edit2,
   HardDrive,
   History,
   Loader2,
@@ -966,32 +965,14 @@ export default function SessionView(props: SessionViewProps) {
                                   openSessionFromList(workspace().id, session.id);
                                 }}
                               >
-                                <span class="text-sm text-dls-text truncate mr-2 font-medium group-hover:pr-14 transition-all">
+                                <span class="text-sm text-dls-text truncate mr-2 font-medium">
                                   {session.title}
                                 </span>
                                 <Show when={session.time?.updated}>
-                                  <span class="text-xs text-dls-secondary whitespace-nowrap group-hover:opacity-0 transition-opacity">
+                                  <span class="text-xs text-dls-secondary whitespace-nowrap">
                                     {formatRelativeTime(session.time?.updated ?? Date.now())}
                                   </span>
                                 </Show>
-                                <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                  <button
-                                    type="button"
-                                    class="p-1 hover:bg-dls-active rounded-md text-dls-text transition-colors"
-                                    onClick={(event) => event.stopPropagation()}
-                                    aria-label="Session options"
-                                  >
-                                    <MoreHorizontal size={14} />
-                                  </button>
-                                  <button
-                                    type="button"
-                                    class="p-1 hover:bg-dls-active rounded-md text-dls-text transition-colors"
-                                    onClick={(event) => event.stopPropagation()}
-                                    aria-label="Rename session"
-                                  >
-                                    <Edit2 size={14} />
-                                  </button>
-                                </div>
                               </div>
                             );
                           }}


### PR DESCRIPTION
## Summary
- remove history/mic buttons from the composer in session and proto views
- drop the non-functional hover actions in session lists and keep timestamps visible

## Testing
- not run (ui-only change)