### PR TITLE
ci: unify Release App with openwrk publishing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -153,25 +153,18 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Resolve OpenCode version
+        id: opencode-version
+        shell: bash
+        run: |
+          node -e "const pkg=require('./packages/desktop/package.json'); if (!pkg.opencodeVersion) { throw new Error('opencodeVersion missing'); } console.log('version=' + pkg.opencodeVersion);" >> "$GITHUB_OUTPUT"
+
       - name: Download OpenCode sidecar
         shell: bash
         env:
-          OPENCODE_VERSION: 1.1.36
-          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_VERSION: ${{ steps.opencode-version.outputs.version }}
         run: |
           set -euo pipefail
-
-          version="${OPENCODE_VERSION}"
-          if [ -n "${GITHUB_TOKEN:-}" ]; then
-            latest=$(curl -fsSL \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/anomalyco/opencode/releases/latest \
-              | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-            if [ -n "$latest" ]; then
-              version="$latest"
-            fi
-          fi
 
           case "${{ matrix.target }}" in
             aarch64-apple-darwin)
@@ -192,12 +185,12 @@ jobs:
               ;;
           esac
 
-          url="https://github.com/anomalyco/opencode/releases/download/v${version}/${opencode_asset}"
+          url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
           tmp_dir="$RUNNER_TEMP/opencode"
           extract_dir="$tmp_dir/extracted"
           rm -rf "$tmp_dir"
           mkdir -p "$extract_dir"
-          curl -fsSL -o "$tmp_dir/$opencode_asset" "$url"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o "$tmp_dir/$opencode_asset" "$url"
 
           if [[ "$opencode_asset" == *.tar.gz ]]; then
             tar -xzf "$tmp_dir/$opencode_asset" -C "$extract_dir"

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: boolean
         default: false
+      publish_sidecars:
+        description: "Build + upload openwrk sidecar release assets"
+        required: false
+        type: boolean
+        default: true
+      publish_npm:
+        description: "Publish openwrk/openwork-server/owpenwork to npm if versions changed"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -43,16 +53,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare-release:
-    name: Prepare GitHub Release
+  resolve-release:
+    name: Resolve Release Metadata
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
+      release_name: ${{ steps.resolve.outputs.release_name }}
+      release_body: ${{ steps.resolve.outputs.release_body }}
+      draft: ${{ steps.resolve.outputs.draft }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
+      notarize: ${{ steps.resolve.outputs.notarize }}
+      publish_sidecars: ${{ steps.resolve.outputs.publish_sidecars }}
+      publish_npm: ${{ steps.resolve.outputs.publish_npm }}
     steps:
-      - name: Set release metadata
+      - name: Resolve metadata
+        id: resolve
         shell: bash
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
           INPUT_RELEASE_NAME: ${{ github.event.inputs.release_name }}
           INPUT_RELEASE_BODY: ${{ github.event.inputs.release_body }}
+          INPUT_DRAFT: ${{ github.event.inputs.draft }}
+          INPUT_PRERELEASE: ${{ github.event.inputs.prerelease }}
+          INPUT_NOTARIZE: ${{ github.event.inputs.notarize }}
+          INPUT_PUBLISH_SIDECARS: ${{ github.event.inputs.publish_sidecars }}
+          INPUT_PUBLISH_NPM: ${{ github.event.inputs.publish_npm }}
+          DEFAULT_PUBLISH_SIDECARS: ${{ vars.RELEASE_PUBLISH_SIDECARS }}
+          DEFAULT_PUBLISH_NPM: ${{ vars.RELEASE_PUBLISH_NPM }}
+          DEFAULT_NOTARIZE: ${{ vars.MACOS_NOTARIZE }}
         run: |
           set -euo pipefail
 
@@ -65,6 +93,11 @@ jobs:
             fi
           else
             TAG="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: $TAG (expected vX.Y.Z)" >&2
+            exit 1
           fi
 
           RELEASE_NAME_INPUT="${INPUT_RELEASE_NAME:-}"
@@ -81,20 +114,39 @@ jobs:
             RELEASE_BODY="See the assets to download this version and install."
           fi
 
-          # Guard against multiline env var injection
+          draft="${INPUT_DRAFT:-false}"
+          prerelease="${INPUT_PRERELEASE:-false}"
+          notarize="${INPUT_NOTARIZE:-}"
+          if [ -z "$notarize" ]; then
+            notarize="${DEFAULT_NOTARIZE:-true}"
+          fi
+
+          publish_sidecars="${INPUT_PUBLISH_SIDECARS:-}"
+          if [ -z "$publish_sidecars" ]; then
+            publish_sidecars="${DEFAULT_PUBLISH_SIDECARS:-true}"
+          fi
+          publish_npm="${INPUT_PUBLISH_NPM:-}"
+          if [ -z "$publish_npm" ]; then
+            publish_npm="${DEFAULT_PUBLISH_NPM:-true}"
+          fi
+
           TAG="${TAG//$'\n'/}"
           TAG="${TAG//$'\r'/}"
           RELEASE_NAME="${RELEASE_NAME//$'\n'/ }"
           RELEASE_NAME="${RELEASE_NAME//$'\r'/ }"
 
-          echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
-          echo "RELEASE_NAME=$RELEASE_NAME" >> "$GITHUB_ENV"
-
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "release_name=$RELEASE_NAME" >> "$GITHUB_OUTPUT"
+          echo "draft=$draft" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "notarize=$notarize" >> "$GITHUB_OUTPUT"
+          echo "publish_sidecars=$publish_sidecars" >> "$GITHUB_OUTPUT"
+          echo "publish_npm=$publish_npm" >> "$GITHUB_OUTPUT"
           {
-            echo "RELEASE_BODY<<__OPENWORK_RELEASE_BODY_EOF__"
+            echo "release_body<<__OPENWORK_RELEASE_BODY_EOF__"
             printf '%s\n' "$RELEASE_BODY"
             echo "__OPENWORK_RELEASE_BODY_EOF__"
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create release if missing
         shell: bash
@@ -104,35 +156,64 @@ jobs:
           set -euo pipefail
 
           BODY_FILE="$RUNNER_TEMP/release_body.md"
-          printf '%s\n' "$RELEASE_BODY" > "$BODY_FILE"
+          printf '%s\n' "${{ steps.resolve.outputs.release_body }}" > "$BODY_FILE"
 
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists; skipping create."
+          if gh release view "${{ steps.resolve.outputs.release_tag }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release ${{ steps.resolve.outputs.release_tag }} already exists; skipping create."
             exit 0
           fi
 
           DRAFT_FLAG=""
           PRERELEASE_FLAG=""
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.draft }}" == "true" ]]; then
+          if [ "${{ steps.resolve.outputs.draft }}" = "true" ]; then
             DRAFT_FLAG="--draft"
           fi
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.prerelease }}" == "true" ]]; then
+          if [ "${{ steps.resolve.outputs.prerelease }}" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
           fi
 
-          gh release create "$RELEASE_TAG" \
+          gh release create "${{ steps.resolve.outputs.release_tag }}" \
             --repo "$GITHUB_REPOSITORY" \
-            --title "$RELEASE_NAME" \
+            --title "${{ steps.resolve.outputs.release_name }}" \
             --notes-file "$BODY_FILE" \
             $DRAFT_FLAG $PRERELEASE_FLAG
 
+  verify-release:
+    name: Verify Release Versions
+    needs: resolve-release
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Verify tag matches app versions
+        run: node scripts/release/verify-tag.mjs --tag "$RELEASE_TAG"
+
+      - name: Release review (strict)
+        run: node scripts/release/review.mjs --strict
+
   publish-tauri:
     name: Build + Publish (${{ matrix.target }})
-    needs: prepare-release
+    needs: [resolve-release, verify-release]
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 360
     env:
-      MACOS_NOTARIZE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.notarize || vars.MACOS_NOTARIZE || 'true' }}
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+      RELEASE_NAME: ${{ needs.resolve-release.outputs.release_name }}
+      RELEASE_BODY: ${{ needs.resolve-release.outputs.release_body }}
+      RELEASE_DRAFT: ${{ needs.resolve-release.outputs.draft }}
+      RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
+      MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
 
     strategy:
       fail-fast: false
@@ -156,55 +237,6 @@ jobs:
             args: "--target x86_64-pc-windows-msvc --bundles msi"
 
     steps:
-      - name: Set release metadata
-        shell: bash
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          INPUT_RELEASE_NAME: ${{ github.event.inputs.release_name }}
-          INPUT_RELEASE_BODY: ${{ github.event.inputs.release_body }}
-        run: |
-          set -euo pipefail
-
-          TAG_INPUT="${INPUT_TAG:-}"
-          if [ -n "$TAG_INPUT" ]; then
-            if [[ "$TAG_INPUT" == v* ]]; then
-              TAG="$TAG_INPUT"
-            else
-              TAG="v$TAG_INPUT"
-            fi
-          else
-            TAG="${GITHUB_REF_NAME}"
-          fi
-
-          RELEASE_NAME_INPUT="${INPUT_RELEASE_NAME:-}"
-          if [ -n "$RELEASE_NAME_INPUT" ]; then
-            RELEASE_NAME="$RELEASE_NAME_INPUT"
-          else
-            RELEASE_NAME="OpenWork $TAG"
-          fi
-
-          RELEASE_BODY_INPUT="${INPUT_RELEASE_BODY:-}"
-          if [ -n "$RELEASE_BODY_INPUT" ]; then
-            RELEASE_BODY="$RELEASE_BODY_INPUT"
-          else
-            RELEASE_BODY="See the assets to download this version and install."
-          fi
-
-          # Guard against multiline env var injection
-          TAG="${TAG//$'\n'/}"
-          TAG="${TAG//$'\r'/}"
-          RELEASE_NAME="${RELEASE_NAME//$'\n'/ }"
-          RELEASE_NAME="${RELEASE_NAME//$'\r'/ }"
-
-          echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
-          echo "RELEASE_NAME=$RELEASE_NAME" >> "$GITHUB_ENV"
-
-          {
-            echo "RELEASE_BODY<<__OPENWORK_RELEASE_BODY_EOF__"
-            printf '%s\n' "$RELEASE_BODY"
-            echo "__OPENWORK_RELEASE_BODY_EOF__"
-          } >> "$GITHUB_ENV"
-
       - name: Enable git long paths (Windows)
         if: matrix.os_type == 'windows'
         shell: pwsh
@@ -214,6 +246,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -230,8 +263,34 @@ jobs:
         with:
           bun-version: "1.3.6"
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/desktop/src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/desktop/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install OpenTUI x64 core (macOS x86_64)
         if: matrix.os_type == 'macos' && matrix.target == 'x86_64-apple-darwin'
@@ -257,25 +316,18 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Resolve OpenCode version
+        id: opencode-version
+        shell: bash
+        run: |
+          node -e "const pkg=require('./packages/desktop/package.json'); if (!pkg.opencodeVersion) { throw new Error('opencodeVersion missing'); } console.log('version=' + pkg.opencodeVersion);" >> "$GITHUB_OUTPUT"
+
       - name: Download OpenCode sidecar
         shell: bash
         env:
-          OPENCODE_VERSION: 1.1.36
-          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_VERSION: ${{ steps.opencode-version.outputs.version }}
         run: |
           set -euo pipefail
-
-          version="${OPENCODE_VERSION}"
-          if [ -n "${GITHUB_TOKEN:-}" ]; then
-            latest=$(curl -fsSL \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/anomalyco/opencode/releases/latest \
-              | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-            if [ -n "$latest" ]; then
-              version="$latest"
-            fi
-          fi
 
           case "${{ matrix.target }}" in
             aarch64-apple-darwin)
@@ -291,17 +343,17 @@ jobs:
               opencode_asset="opencode-windows-x64-baseline.zip"
               ;;
             *)
-              echo "Unsupported target: ${{ matrix.target }}"
+              echo "Unsupported target: ${{ matrix.target }}" >&2
               exit 1
               ;;
           esac
 
-          url="https://github.com/anomalyco/opencode/releases/download/v${version}/${opencode_asset}"
+          url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
           tmp_dir="$RUNNER_TEMP/opencode"
           extract_dir="$tmp_dir/extracted"
           rm -rf "$tmp_dir"
           mkdir -p "$extract_dir"
-          curl -fsSL -o "$tmp_dir/$opencode_asset" "$url"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o "$tmp_dir/$opencode_asset" "$url"
 
           if [[ "$opencode_asset" == *.tar.gz ]]; then
             tar -xzf "$tmp_dir/$opencode_asset" -C "$extract_dir"
@@ -311,7 +363,7 @@ jobs:
             elif command -v 7z >/dev/null 2>&1; then
               7z x "$tmp_dir/$opencode_asset" -o"$extract_dir" >/dev/null
             else
-              echo "No unzip utility available"
+              echo "No unzip utility available" >&2
               exit 1
             fi
           fi
@@ -321,7 +373,7 @@ jobs:
           elif [ -f "$extract_dir/opencode.exe" ]; then
             bin_path="$extract_dir/opencode.exe"
           else
-            echo "OpenCode binary not found in archive"
+            echo "OpenCode binary not found in archive" >&2
             ls -la "$extract_dir"
             exit 1
           fi
@@ -372,8 +424,8 @@ jobs:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: ${{ env.RELEASE_NAME }}
           releaseBody: ${{ env.RELEASE_BODY }}
-          releaseDraft: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.draft == 'true' }}
-          prerelease: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prerelease == 'true' }}
+          releaseDraft: ${{ env.RELEASE_DRAFT == 'true' }}
+          prerelease: ${{ env.RELEASE_PRERELEASE == 'true' }}
           projectPath: packages/desktop
           tauriScript: pnpm exec tauri -vvv
           args: ${{ matrix.args }}
@@ -401,8 +453,8 @@ jobs:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: ${{ env.RELEASE_NAME }}
           releaseBody: ${{ env.RELEASE_BODY }}
-          releaseDraft: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.draft == 'true' }}
-          prerelease: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prerelease == 'true' }}
+          releaseDraft: ${{ env.RELEASE_DRAFT == 'true' }}
+          prerelease: ${{ env.RELEASE_PRERELEASE == 'true' }}
           projectPath: packages/desktop
           tauriScript: pnpm exec tauri -vvv
           args: ${{ matrix.args }}
@@ -411,44 +463,247 @@ jobs:
           updaterJsonPreferNsis: true
           releaseAssetNamePattern: openwork-desktop-[platform]-[arch][ext]
 
-  aur-pr:
-    name: Open AUR update PR
-    needs: publish-tauri
+  release-openwrk-sidecars:
+    name: Build + Upload openwrk Sidecars
+    needs: [resolve-release, verify-release]
+    if: needs.resolve-release.outputs.publish_sidecars == 'true'
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      pull-requests: write
-
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
     steps:
-      - name: Set release metadata
-        shell: bash
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-
-          TAG_INPUT="${INPUT_TAG:-}"
-          if [ -n "$TAG_INPUT" ]; then
-            if [[ "$TAG_INPUT" == v* ]]; then
-              TAG="$TAG_INPUT"
-            else
-              TAG="v$TAG_INPUT"
-            fi
-          else
-            TAG="${GITHUB_REF_NAME}"
-          fi
-
-          # Guard against multiline env var injection
-          TAG="${TAG//$'\n'/}"
-          TAG="${TAG//$'\r'/}"
-
-          echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.3.6"
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ubuntu-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ubuntu-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Resolve sidecar versions
+        id: sidecar-versions
+        shell: bash
+        run: |
+          node -e "const fs=require('fs'); const headless=JSON.parse(fs.readFileSync('packages/headless/package.json','utf8')); const server=JSON.parse(fs.readFileSync('packages/server/package.json','utf8')); const owpenbot=JSON.parse(fs.readFileSync('packages/owpenbot/package.json','utf8')); console.log('openwrk=' + headless.version); console.log('server=' + server.version); console.log('owpenbot=' + owpenbot.version);" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve SOURCE_DATE_EPOCH
+        id: source-date
+        shell: bash
+        run: |
+          epoch=$(git show -s --format=%ct "${RELEASE_TAG}")
+          echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
+
+      - name: Check openwrk release
+        id: openwrk-release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="openwrk-v${{ steps.sidecar-versions.outputs.openwrk }}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build sidecar artifacts
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.source-date.outputs.epoch }}
+        run: pnpm --filter openwrk build:sidecars
+
+      - name: Release review (strict)
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.source-date.outputs.epoch }}
+        run: node scripts/release/review.mjs --strict
+
+      - name: Create openwrk release
+        if: steps.openwrk-release.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${{ steps.sidecar-versions.outputs.openwrk }}"
+          tag="openwrk-v${version}"
+          notes="Sidecar bundle for openwrk v${version}.\n\nopenwork-server: ${{ steps.sidecar-versions.outputs.server }}\nowpenbot: ${{ steps.sidecar-versions.outputs.owpenbot }}"
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "openwrk v${version}" \
+            --notes "$notes"
+
+      - name: Upload sidecar assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="openwrk-v${{ steps.sidecar-versions.outputs.openwrk }}"
+          gh release upload "$tag" packages/headless/dist/sidecars/* --repo "$GITHUB_REPOSITORY" --clobber
+
+  publish-npm:
+    name: Publish npm packages
+    needs: [resolve-release, verify-release]
+    if: needs.resolve-release.outputs.publish_npm == 'true'
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.3.6"
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ubuntu-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ubuntu-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Resolve package versions
+        id: package-versions
+        shell: bash
+        run: |
+          node -e "const fs=require('fs'); const headless=JSON.parse(fs.readFileSync('packages/headless/package.json','utf8')); const server=JSON.parse(fs.readFileSync('packages/server/package.json','utf8')); const owpenbot=JSON.parse(fs.readFileSync('packages/owpenbot/package.json','utf8')); console.log('openwrk=' + headless.version); console.log('server=' + server.version); console.log('owpenbot=' + owpenbot.version);" >> "$GITHUB_OUTPUT"
+
+      - name: Check npm versions
+        id: npm-versions
+        shell: bash
+        env:
+          OPENWRK_VERSION: ${{ steps.package-versions.outputs.openwrk }}
+          SERVER_VERSION: ${{ steps.package-versions.outputs.server }}
+          OWPENBOT_VERSION: ${{ steps.package-versions.outputs.owpenbot }}
+        run: |
+          set -euo pipefail
+          openwrk_current=$(npm view openwrk version)
+          server_current=$(npm view openwork-server version)
+          owpenbot_current=$(npm view owpenwork version)
+
+          if [ "$openwrk_current" = "$OPENWRK_VERSION" ]; then
+            echo "publish_openwrk=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_openwrk=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$server_current" = "$SERVER_VERSION" ]; then
+            echo "publish_server=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_server=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$owpenbot_current" = "$OWPENBOT_VERSION" ]; then
+            echo "publish_owpenbot=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_owpenbot=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          publish_any=false
+          if [ "$openwrk_current" != "$OPENWRK_VERSION" ] || [ "$server_current" != "$SERVER_VERSION" ] || [ "$owpenbot_current" != "$OWPENBOT_VERSION" ]; then
+            publish_any=true
+          fi
+          echo "publish_any=$publish_any" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure npm auth
+        if: steps.npm-versions.outputs.publish_any == 'true'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is required to publish packages." >&2
+            exit 1
+          fi
+          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+
+      - name: Publish openwork-server
+        if: steps.npm-versions.outputs.publish_server == 'true'
+        run: pnpm --filter openwork-server publish --access public --no-git-checks
+
+      - name: Publish owpenwork
+        if: steps.npm-versions.outputs.publish_owpenbot == 'true'
+        run: pnpm --filter owpenwork publish --access public --no-git-checks
+
+      - name: Publish openwrk
+        if: steps.npm-versions.outputs.publish_openwrk == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OPENWRK_VERSION: ${{ steps.package-versions.outputs.openwrk }}
+        run: |
+          set -euo pipefail
+          tag="openwrk-v${OPENWRK_VERSION}"
+          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "openwrk sidecar release $tag not found. Publish sidecars before openwrk." >&2
+            exit 1
+          fi
+          pnpm --filter openwrk publish --access public --no-git-checks
+
+  aur-pr:
+    name: Open AUR update PR
+    needs: [resolve-release, publish-tauri]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
 
       - name: Open AUR update PR
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ This captures OpenWork’s preferred reactivity + UI state patterns (avoid globa
 ## Skill: Trigger a Release
 
 OpenWork releases are built by GitHub Actions (`Release App`). A release is triggered by pushing a `v*` tag (e.g. `v0.1.6`).
+`Release App` can also publish openwrk sidecars and npm packages when enabled via workflow inputs or repo vars (`RELEASE_PUBLISH_SIDECARS`, `RELEASE_PUBLISH_NPM`).
 
 ### Standard release (recommended)
 
@@ -145,7 +146,7 @@ Confirm the DMG assets are attached and versioned correctly.
 
 ## Skill: Publish openwrk (npm)
 
-This is separate from app release tags. Use `.opencode/skills/openwrk-npm-publish/SKILL.md`.
+This is usually covered by `Release App` when `publish_sidecars` + `publish_npm` are enabled. Use `.opencode/skills/openwrk-npm-publish/SKILL.md` for manual recovery or one-off publishing.
 
 1.  Ensure the default branch is up to date and clean.
 2.  Bump `packages/headless/package.json` (`version`).

--- a/scripts/release/verify-tag.mjs
+++ b/scripts/release/verify-tag.mjs
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const args = process.argv.slice(2);
+const tagIndex = args.indexOf("--tag");
+const tagArg = tagIndex >= 0 ? args[tagIndex + 1] : null;
+const tag = (tagArg || process.env.RELEASE_TAG || "").trim();
+
+if (!tag) {
+  console.error("Release tag missing. Provide --tag or set RELEASE_TAG.");
+  process.exit(1);
+}
+
+const version = tag.startsWith("v") ? tag.slice(1) : tag;
+
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
+const readText = (path) => readFileSync(path, "utf8");
+
+const readCargoVersion = (path) => {
+  const content = readText(path);
+  const match = content.match(/^version\s*=\s*"([^"]+)"/m);
+  return match ? match[1] : null;
+};
+
+const appVersion = readJson(resolve(root, "packages", "app", "package.json")).version ?? null;
+const desktopVersion = readJson(resolve(root, "packages", "desktop", "package.json")).version ?? null;
+const tauriVersion = readJson(resolve(root, "packages", "desktop", "src-tauri", "tauri.conf.json")).version ?? null;
+const cargoVersion = readCargoVersion(resolve(root, "packages", "desktop", "src-tauri", "Cargo.toml"));
+
+const mismatches = [];
+const check = (label, actual) => {
+  if (!actual) {
+    mismatches.push(`${label} missing`);
+    return;
+  }
+  if (actual !== version) {
+    mismatches.push(`${label}=${actual} (expected ${version})`);
+  }
+};
+
+check("app", appVersion);
+check("desktop", desktopVersion);
+check("tauri", tauriVersion);
+check("cargo", cargoVersion);
+
+if (mismatches.length) {
+  console.error(`Release tag ${tag} does not match package versions:`);
+  for (const mismatch of mismatches) {
+    console.error(`- ${mismatch}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Release tag ${tag} matches app/desktop versions.`);


### PR DESCRIPTION
## Summary
- unify Release App to resolve metadata once, verify tags, and use cached installs for faster builds
- add openwrk sidecar release + npm publish steps with explicit toggles and safety checks
- align prerelease Opencode sidecar downloads to the pinned version and add a tag-version verifier

## Testing
- not run (workflow changes)