### PR TITLE
feat(app): add option to hide window titlebar on Linux

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -41,6 +41,7 @@ import ProtoV1UxView from "./pages/proto-v1-ux";
 import { createClient, unwrap, waitForHealthy } from "./lib/opencode";
 import {
   DEFAULT_MODEL,
+  HIDE_TITLEBAR_PREF_KEY,
   MCP_QUICK_CONNECT,
   MODEL_PREF_KEY,
   SESSION_MODEL_PREF_KEY,
@@ -124,6 +125,7 @@ import {
   openworkServerInfo,
   openwrkStatus,
   owpenbotInfo,
+  setWindowDecorations,
   type OpenwrkStatus,
   type OpenworkServerInfo,
   type OwpenbotInfo,
@@ -1240,6 +1242,7 @@ export default function App() {
   const [modelPickerQuery, setModelPickerQuery] = createSignal("");
 
   const [showThinking, setShowThinking] = createSignal(false);
+  const [hideTitlebar, setHideTitlebar] = createSignal(false);
   const [modelVariant, setModelVariant] = createSignal<string | null>(null);
 
   const MODEL_VARIANT_OPTIONS = [
@@ -3056,6 +3059,18 @@ export default function App() {
           }
         }
 
+        const storedHideTitlebar = window.localStorage.getItem(HIDE_TITLEBAR_PREF_KEY);
+        if (storedHideTitlebar != null) {
+          try {
+            const parsed = JSON.parse(storedHideTitlebar);
+            if (typeof parsed === "boolean") {
+              setHideTitlebar(parsed);
+            }
+          } catch {
+            // ignore
+          }
+        }
+
         const storedVariant = window.localStorage.getItem(VARIANT_PREF_KEY);
         if (storedVariant && storedVariant.trim()) {
           const normalized = normalizeModelVariant(storedVariant);
@@ -3408,7 +3423,22 @@ export default function App() {
     }
   });
 
-
+  // Persist and apply hideTitlebar setting
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    const hide = hideTitlebar();
+    try {
+      window.localStorage.setItem(HIDE_TITLEBAR_PREF_KEY, JSON.stringify(hide));
+    } catch {
+      // ignore
+    }
+    // Apply to window decorations (only in Tauri desktop environment)
+    if (isTauriRuntime()) {
+      setWindowDecorations(!hide).catch(() => {
+        // ignore errors (e.g., window not ready)
+      });
+    }
+  });
 
   createEffect(() => {
     if (typeof window === "undefined") return;
@@ -3710,6 +3740,8 @@ export default function App() {
       openDefaultModelPicker,
       showThinking: showThinking(),
       toggleShowThinking: () => setShowThinking((v) => !v),
+      hideTitlebar: hideTitlebar(),
+      toggleHideTitlebar: () => setHideTitlebar((v) => !v),
       modelVariantLabel: formatModelVariantLabel(modelVariant()),
       editModelVariant: handleEditModelVariant,
       updateAutoCheck: updateAutoCheck(),

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -5,6 +5,7 @@ export const SESSION_MODEL_PREF_KEY = "openwork.sessionModels";
 export const THINKING_PREF_KEY = "openwork.showThinking";
 export const VARIANT_PREF_KEY = "openwork.modelVariant";
 export const LANGUAGE_PREF_KEY = "openwork.language";
+export const HIDE_TITLEBAR_PREF_KEY = "openwork.hideTitlebar";
 
 export const DEFAULT_MODEL: ModelRef = {
   providerID: "opencode",

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -802,3 +802,12 @@ export async function owpenbotRestart(options: {
   await owpenbotStop();
   return owpenbotStart(options);
 }
+
+/**
+ * Set window decorations (titlebar) visibility.
+ * When `decorations` is false, the native titlebar is hidden.
+ * Useful for tiling window managers on Linux (e.g., Hyprland, i3, sway).
+ */
+export async function setWindowDecorations(decorations: boolean): Promise<void> {
+  return invoke<void>("set_window_decorations", { decorations });
+}

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -175,6 +175,8 @@ export type DashboardViewProps = {
   openDefaultModelPicker: () => void;
   showThinking: boolean;
   toggleShowThinking: () => void;
+  hideTitlebar: boolean;
+  toggleHideTitlebar: () => void;
   modelVariantLabel: string;
   editModelVariant: () => void;
   updateAutoCheck: boolean;
@@ -746,6 +748,8 @@ export default function DashboardView(props: DashboardViewProps) {
                   openDefaultModelPicker={props.openDefaultModelPicker}
                   showThinking={props.showThinking}
                   toggleShowThinking={props.toggleShowThinking}
+                  hideTitlebar={props.hideTitlebar}
+                  toggleHideTitlebar={props.toggleHideTitlebar}
                   modelVariantLabel={props.modelVariantLabel}
                   editModelVariant={props.editModelVariant}
                   updateAutoCheck={props.updateAutoCheck}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -85,6 +85,8 @@ export type SettingsViewProps = {
   openDefaultModelPicker: () => void;
   showThinking: boolean;
   toggleShowThinking: () => void;
+  hideTitlebar: boolean;
+  toggleHideTitlebar: () => void;
   modelVariantLabel: string;
   editModelVariant: () => void;
   themeMode: "light" | "dark" | "system";
@@ -1600,6 +1602,32 @@ export default function SettingsView(props: SettingsViewProps) {
                 This clears your saved preference and shows the connection choice on next launch.
               </p>
             </div>
+
+            <Show when={isTauriRuntime()}>
+              <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-3">
+                <div>
+                  <div class="text-sm font-medium text-gray-12">Appearance</div>
+                  <div class="text-xs text-gray-10">Customize window appearance.</div>
+                </div>
+
+                <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                  <div class="min-w-0">
+                    <div class="text-sm text-gray-12">Hide titlebar</div>
+                    <div class="text-xs text-gray-7">
+                      Hide the window titlebar. Useful for tiling window managers on Linux (Hyprland, i3, sway).
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    class="text-xs h-8 py-0 px-3 shrink-0"
+                    onClick={props.toggleHideTitlebar}
+                    disabled={props.busy}
+                  >
+                    {props.hideTitlebar ? "On" : "Off"}
+                  </Button>
+                </div>
+              </div>
+            </Show>
 
             <Show when={isTauriRuntime() && isLocalPreference()}>
               <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">

--- a/packages/desktop/src-tauri/src/commands/mod.rs
+++ b/packages/desktop/src-tauri/src/commands/mod.rs
@@ -9,4 +9,5 @@ pub mod owpenbot;
 pub mod scheduler;
 pub mod skills;
 pub mod updater;
+pub mod window;
 pub mod workspace;

--- a/packages/desktop/src-tauri/src/commands/window.rs
+++ b/packages/desktop/src-tauri/src/commands/window.rs
@@ -1,0 +1,15 @@
+use tauri::{AppHandle, Manager};
+
+/// Set window decorations (titlebar) visibility.
+/// When `decorations` is false, the native titlebar is hidden.
+/// This is useful for tiling window managers on Linux (e.g., Hyprland, i3, sway).
+#[tauri::command]
+pub fn set_window_decorations(app: AppHandle, decorations: bool) -> Result<(), String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "Main window not found".to_string())?;
+
+    window
+        .set_decorations(decorations)
+        .map_err(|e| format!("Failed to set decorations: {e}"))
+}

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ use commands::owpenbot::{
 };
 use commands::skills::{install_skill_template, list_local_skills, uninstall_skill};
 use commands::updater::updater_environment;
+use commands::window::set_window_decorations;
 use commands::workspace::{
     workspace_add_authorized_root, workspace_bootstrap, workspace_create, workspace_create_remote,
     workspace_export_config, workspace_forget, workspace_import_config, workspace_openwork_read,
@@ -106,7 +107,8 @@ pub fn run() {
             reset_opencode_cache,
             opencode_mcp_auth,
             scheduler_list_jobs,
-            scheduler_delete_job
+            scheduler_delete_job,
+            set_window_decorations
         ])
         .run(tauri::generate_context!())
         .expect("error while running OpenWork");


### PR DESCRIPTION
Add a setting in Settings → Advanced → Appearance to hide the native window titlebar. This is useful for tiling window managers on Linux (Hyprland, i3, sway, etc.) where window controls are typically handled via keybinds, making the titlebar redundant.

Implementation:
- Add HIDE_TITLEBAR_PREF_KEY constant for localStorage persistence
- Add Tauri command `set_window_decorations` to toggle decorations
- Add TypeScript binding for the new Tauri command
- Add UI toggle in Settings → Advanced → Appearance section
- Apply setting on change and restore from localStorage on startup

The setting is only shown in the desktop (Tauri) environment and persists across sessions via localStorage.

Closes #441