### PR TITLE
chore(release): unify openwrk versioning + bump v0.11.14

### DIFF
--- a/.opencode/skills/openwrk-npm-publish/SKILL.md
+++ b/.opencode/skills/openwrk-npm-publish/SKILL.md
@@ -12,9 +12,19 @@ description: |
 ## Quick usage (already configured)
 
 1. Ensure you are on the default branch and the tree is clean.
-2. Bump the version in `packages/headless/package.json`.
+2. Bump versions via the shared release bump (this keeps `openwrk` aligned with the app/desktop release).
+
+```bash
+pnpm bump:patch
+# or: pnpm bump:minor
+# or: pnpm bump:major
+# or: pnpm bump:set -- X.Y.Z
+```
+
 3. Commit the bump.
-4. Build sidecar artifacts and publish them to a release tag.
+4. Preferred: publish via the "Release App" GitHub Actions workflow by tagging `vX.Y.Z`.
+
+Manual recovery path (sidecars + npm) below.
 
 ```bash
 pnpm --filter openwrk build:sidecars
@@ -61,5 +71,5 @@ Alternatively, export an npm token in your environment (see `.env.example`).
 ## Notes
 
 - `pnpm publish` requires a clean git tree.
-- This publish flow is separate from app release tags.
+- `openwrk` is versioned in lockstep with OpenWork app/desktop releases.
 - openwrk downloads sidecars from `openwrk-vX.Y.Z` release assets by default.

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -10,7 +10,7 @@ Confirm the repo is on `main` and clean. Keep changes aligned with OpenCode prim
 ---
 
 ## Bump
-Update versions in `packages/app/package.json`, `packages/desktop/package.json`, `packages/desktop/src-tauri/tauri.conf.json`, and `packages/desktop/src-tauri/Cargo.toml`. Use one of these commands.
+Update versions in `packages/app/package.json`, `packages/desktop/package.json`, `packages/headless/package.json` (publishes as `openwrk`), `packages/desktop/src-tauri/tauri.conf.json`, and `packages/desktop/src-tauri/Cargo.toml`. Use one of these commands.
 
 ```bash
 pnpm bump:patch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ OpenWork releases are built by GitHub Actions (`Release App`). A release is trig
 
 * `packages/app/package.json` (`version`)
 * `packages/desktop/package.json` (`version`)
+* `packages/headless/package.json` (`version`, publishes as `openwrk`)
 * `packages/desktop/src-tauri/tauri.conf.json` (`version`)
 * `packages/desktop/src-tauri/Cargo.toml` (`version`)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ OpenWork releases should be deterministic, easy to reproduce, and fully verifiab
 ## App release (desktop)
 
 1. Bump versions (app + desktop + Tauri + Cargo):
-   - `pnpm bump:patch` or `pnpm bump:minor` or `pnpm bump:major`
+    - `pnpm bump:patch` or `pnpm bump:minor` or `pnpm bump:major`
 2. Re-run `pnpm release:review`.
 3. Build sidecars for the desktop bundle:
    - `pnpm --filter @different-ai/openwork prepare:sidecar`
@@ -22,7 +22,8 @@ OpenWork releases should be deterministic, easy to reproduce, and fully verifiab
 
 ## openwrk (npm + sidecars)
 
-1. Bump `packages/headless/package.json`.
+1. Bump versions (includes `packages/headless/package.json`):
+   - `pnpm bump:patch` or `pnpm bump:minor` or `pnpm bump:major`
 2. Build sidecar assets and manifest:
    - `pnpm --filter openwrk build:sidecars`
 3. Create the GitHub release for sidecars:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@different-ai/openwork-ui",
   "private": true,
-  "version": "0.11.13",
+  "version": "0.11.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/app/scripts/bump-version.mjs
+++ b/packages/app/scripts/bump-version.mjs
@@ -56,13 +56,17 @@ const targetVersion = async () => {
 const updatePackageJson = async (nextVersion) => {
   const uiPath = path.join(ROOT, "package.json");
   const tauriPath = path.join(REPO_ROOT, "packages", "desktop", "package.json");
+  const headlessPath = path.join(REPO_ROOT, "packages", "headless", "package.json");
   const uiData = await readJson(uiPath);
   const tauriData = await readJson(tauriPath);
+  const headlessData = await readJson(headlessPath);
   uiData.version = nextVersion;
   tauriData.version = nextVersion;
+  headlessData.version = nextVersion;
   if (!isDryRun) {
     await writeFile(uiPath, JSON.stringify(uiData, null, 2) + "\n");
     await writeFile(tauriPath, JSON.stringify(tauriData, null, 2) + "\n");
+    await writeFile(headlessPath, JSON.stringify(headlessData, null, 2) + "\n");
   }
 };
 
@@ -106,6 +110,7 @@ const main = async () => {
         files: [
           "packages/app/package.json",
           "packages/desktop/package.json",
+          "packages/headless/package.json",
           "packages/desktop/src-tauri/Cargo.toml",
           "packages/desktop/src-tauri/tauri.conf.json",
         ],

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@different-ai/openwork",
   "private": true,
-  "version": "0.11.13",
+  "version": "0.11.14",
   "opencodeVersion": "1.1.51",
   "owpenbotVersion": "0.1.19",
   "type": "module",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwork"
-version = "0.11.13"
+version = "0.11.14"
 description = "OpenWork"
 authors = ["Different AI"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenWork",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "identifier": "com.differentai.openwork",
   "build": {
     "beforeDevCommand": "pnpm -C ../.. --filter @different-ai/openwork run prepare:sidecar && pnpm -w dev:ui",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwrk",
-  "version": "0.1.15",
+  "version": "0.11.14",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "type": "module",
   "opencodeVersion": "1.1.51",

--- a/scripts/release/review.mjs
+++ b/scripts/release/review.mjs
@@ -57,6 +57,11 @@ addCheck(
   `${versions.app ?? "?"} vs ${versions.desktop ?? "?"}`,
 );
 addCheck(
+  "App/openwrk versions match",
+  versions.app && versions.headless && versions.app === versions.headless,
+  `${versions.app ?? "?"} vs ${versions.headless ?? "?"}`,
+);
+addCheck(
   "Desktop/Tauri versions match",
   versions.desktop && versions.tauri && versions.desktop === versions.tauri,
   `${versions.desktop ?? "?"} vs ${versions.tauri ?? "?"}`,

--- a/scripts/release/verify-tag.mjs
+++ b/scripts/release/verify-tag.mjs
@@ -26,6 +26,7 @@ const readCargoVersion = (path) => {
 
 const appVersion = readJson(resolve(root, "packages", "app", "package.json")).version ?? null;
 const desktopVersion = readJson(resolve(root, "packages", "desktop", "package.json")).version ?? null;
+const headlessVersion = readJson(resolve(root, "packages", "headless", "package.json")).version ?? null;
 const tauriVersion = readJson(resolve(root, "packages", "desktop", "src-tauri", "tauri.conf.json")).version ?? null;
 const cargoVersion = readCargoVersion(resolve(root, "packages", "desktop", "src-tauri", "Cargo.toml"));
 
@@ -42,6 +43,7 @@ const check = (label, actual) => {
 
 check("app", appVersion);
 check("desktop", desktopVersion);
+check("openwrk", headlessVersion);
 check("tauri", tauriVersion);
 check("cargo", cargoVersion);
 
@@ -53,4 +55,4 @@ if (mismatches.length) {
   process.exit(1);
 }
 
-console.log(`Release tag ${tag} matches app/desktop versions.`);
+console.log(`Release tag ${tag} matches app/desktop/openwrk versions.`);


### PR DESCRIPTION
## What
- Unifies versioning so openwrk (packages/headless) ships with the same vX.Y.Z as app/desktop.
- Updates release verification (review + verify-tag) to enforce this lockstep.
- Bumps versions to v0.11.14 and tags v0.11.14.

## Why
We want each release to ship the whole stack together so `bun add -g openwrk@latest` lines up with the desktop/app release.