### PR TITLE
Fix reload-required spam; add auto-reload + resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,25 @@ Read INFRASTRUCTURE.md
 
 * **Purpose-first UI**: prioritize clarity, safety, and approachability for non-technical users.
 * **Parity with OpenCode**: anything the UI can do must map cleanly to OpenCode tools.
-* **Prefer OpenCode primitives**: represent concepts using OpenCode’s native surfaces first (folders/projects, `.opencode`, `opencode.json`, skills, plugins) before introducing new abstractions.
+* **Prefer OpenCode primitives**: represent concepts using OpenCode's native surfaces first (folders/projects, `.opencode`, `opencode.json`, skills, plugins) before introducing new abstractions.
 * **Self-referential**: maintain a gitignored mirror of OpenCode at `vendor/opencode` for inspection.
 * **Self-building**: prefer prompts, skills, and composable primitives over bespoke logic.
 * **Open source**: keep the repo portable; no secrets committed.
 * **Slick and fluid**: 60fps animations, micro-interactions, premium feel.
 * **Mobile-native**: touch targets, gestures, and layouts optimized for small screens.
+
+## Living Systems
+
+OpenWork aims to be a **living system**: agents, skills, commands, and config are hot-reloadable while sessions are running. This enables agents to create new skills or update their own configuration and have changes take effect immediately, without tearing down active sessions.
+
+Design principles for hot reload:
+
+* **Conservative triggers**: only reload when a file that OpenCode reads at startup actually changes inside `.opencode/` or `opencode.json`. Ignore metadata files like `openwork.json`, `.DS_Store`, etc.
+* **Workspace-scoped**: reload state is keyed per workspace. Switching workspaces never leaks reload signals from one workspace to another.
+* **Session-aware**: when sessions are actively running, queue reload signals. Promote to visible reload (toast or auto-reload) only after all active sessions finish. This avoids interrupting in-flight tool calls.
+* **Auto-reload setting**: each workspace can opt into automatic reload via `.opencode/openwork.json` (`reload.auto`). When enabled, the engine reloads automatically once queued signals are ready and no sessions are active.
+* **Session continuity**: before reload, capture running session IDs, agents, and models. After reload, optionally relaunch those sessions so the user experiences seamless continuity.
+* **Per-workspace isolation**: the desktop file watcher only watches the active workspace root and its `.opencode/` directory. The server reload event store is already keyed by `workspaceId`.
 
 ## Technology Stack
 

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -598,6 +598,7 @@ export default function App() {
 
   const sessionStore = createSessionStore({
     client,
+    activeWorkspaceRoot: () => workspaceStore.activeWorkspaceRoot().trim(),
     selectedSessionId,
     setSelectedSessionId,
     sessionModelState: () => ({
@@ -1706,6 +1707,7 @@ export default function App() {
   const [openworkReloadUnsupported, setOpenworkReloadUnsupported] = createSignal(false);
 
   const resolveOpenworkReloadTarget = () => {
+    if (workspaceStore.activeWorkspaceDisplay().workspaceType !== "remote") return null;
     if (openworkServerStatus() !== "connected") return null;
     const client = openworkServerClient();
     if (!client) return null;
@@ -1816,11 +1818,111 @@ export default function App() {
     anyActiveRuns,
   } = systemState;
 
+  const [pendingReloadReasons, setPendingReloadReasons] = createSignal<ReloadReason[]>([]);
+  const [pendingReloadTrigger, setPendingReloadTrigger] = createSignal<ReloadTrigger | null>(null);
+  const [pendingReloadResume, setPendingReloadResume] = createSignal<
+    Array<{ sessionID: string; model: ModelRef; agent: string | null }>
+  >([]);
+  const [autoReloadInFlight, setAutoReloadInFlight] = createSignal(false);
+
+  const workspaceAutoReloadAvailable = createMemo(() =>
+    isTauriRuntime() && workspaceStore.activeWorkspaceDisplay().workspaceType === "local",
+  );
+
+  const workspaceAutoReloadEnabled = createMemo(() => {
+    if (!workspaceAutoReloadAvailable()) return false;
+    const cfg = workspaceStore.workspaceConfig();
+    return Boolean(cfg?.reload?.auto);
+  });
+
+  const workspaceAutoReloadResumeEnabled = createMemo(() => {
+    if (!workspaceAutoReloadAvailable()) return false;
+    const cfg = workspaceStore.workspaceConfig();
+    return Boolean(cfg?.reload?.resume);
+  });
+
+  const setWorkspaceAutoReloadEnabled = async (next: boolean) => {
+    if (!workspaceAutoReloadAvailable()) return;
+    const cfg = workspaceStore.workspaceConfig();
+    const resume = Boolean(cfg?.reload?.resume);
+    await workspaceStore.persistReloadSettings({ auto: next, resume: next ? resume : false });
+  };
+
+  const setWorkspaceAutoReloadResumeEnabled = async (next: boolean) => {
+    if (!workspaceAutoReloadAvailable()) return;
+    const cfg = workspaceStore.workspaceConfig();
+    const auto = Boolean(cfg?.reload?.auto);
+    await workspaceStore.persistReloadSettings({ auto, resume: auto ? next : false });
+  };
+
+  const resumeSessionsAfterReload = async (entries: Array<{ sessionID: string; model: ModelRef; agent: string | null }>) => {
+    if (!entries.length) return;
+    const c = client();
+    if (!c) return;
+    const reasons = reloadReasons();
+    const label = reasons.length ? reasons.join(", ") : "config";
+    const text = `Hot reload applied (${label}). Continue where you left off.`;
+    for (const entry of entries) {
+      try {
+        await c.session.promptAsync({
+          sessionID: entry.sessionID,
+          model: entry.model,
+          agent: entry.agent ?? undefined,
+          variant: modelVariant() ?? undefined,
+          parts: [{ type: "text", text }],
+        });
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const reloadWorkspaceEngineAndResume = async () => {
+    const snapshot = pendingReloadResume();
+    await reloadWorkspaceEngine();
+
+    // If reload failed, keep the snapshot for a later retry.
+    if (reloadRequired() || reloadError()) return;
+
+    if (workspaceAutoReloadResumeEnabled() && snapshot.length) {
+      await resumeSessionsAfterReload(snapshot);
+    }
+    setPendingReloadResume([]);
+  };
+
   const markReloadRequired = (
     reason: ReloadReason,
     options?: { force?: boolean; trigger?: ReloadTrigger },
   ) => {
     if (booting() || reloadBusy()) return;
+
+    if (!options?.force && anyActiveRuns()) {
+      setPendingReloadReasons((current) => (current.includes(reason) ? current : [...current, reason]));
+      if (options?.trigger) {
+        setPendingReloadTrigger(options.trigger);
+      }
+
+      const statuses = sessionStatusById();
+      const running = sessions().filter(
+        (s) => statuses[s.id] === "running" || statuses[s.id] === "retry",
+      );
+      if (running.length) {
+        setPendingReloadResume((current) => {
+          const existing = new Set(current.map((entry) => entry.sessionID));
+          const next = current.slice();
+          for (const s of running) {
+            if (!s?.id || existing.has(s.id)) continue;
+            const model = sessionModelOverrideById()[s.id] ?? sessionModelById()[s.id] ?? defaultModel();
+            const agent = sessionAgentById()[s.id] ?? null;
+            existing.add(s.id);
+            next.push({ sessionID: s.id, model, agent });
+          }
+          return next;
+        });
+      }
+      return;
+    }
+
     if (!options?.force) {
       const existingReasons = reloadReasons();
       if (reloadRequired() && existingReasons.includes(reason)) return;
@@ -1846,9 +1948,62 @@ export default function App() {
     markReloadRequiredRaw(reason, options?.trigger);
   };
 
+  createEffect(() => {
+    if (anyActiveRuns()) return;
+    if (reloadBusy()) return;
+    if (booting()) return;
+
+    const pending = pendingReloadReasons();
+    if (!pending.length) return;
+
+    // Promote queued reload signals only after active sessions finish.
+    const trigger = pendingReloadTrigger();
+    for (let i = 0; i < pending.length; i += 1) {
+      markReloadRequiredRaw(pending[i], i === 0 ? trigger ?? undefined : undefined);
+    }
+    setPendingReloadReasons([]);
+    setPendingReloadTrigger(null);
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!workspaceAutoReloadEnabled()) return;
+    if (anyActiveRuns()) return;
+    if (!reloadRequired()) return;
+    if (!canReloadEngine()) return;
+    if (reloadBusy() || autoReloadInFlight()) return;
+
+    const lastTriggeredAt = reloadLastTriggeredAt();
+    if (lastTriggeredAt && Date.now() - lastTriggeredAt < 600) return;
+
+    const timer = window.setTimeout(() => {
+      if (autoReloadInFlight()) return;
+      setAutoReloadInFlight(true);
+      void reloadWorkspaceEngineAndResume().finally(() => setAutoReloadInFlight(false));
+    }, 450);
+
+    onCleanup(() => {
+      window.clearTimeout(timer);
+    });
+  });
+
   const openworkReloadKey = createMemo(
-    () => `${openworkServerWorkspaceId() ?? ""}|${openworkServerUrl().trim()}`,
+    () => `${workspaceStore.activeWorkspaceDisplay().workspaceType}|${openworkServerWorkspaceId() ?? ""}|${openworkServerUrl().trim()}`,
   );
+
+  const reloadScopeKey = createMemo(() => {
+    const workspaceId = workspaceStore.activeWorkspaceId() ?? "";
+    return `${workspaceId}|${openworkReloadKey()}`;
+  });
+
+  createEffect(() => {
+    // Prevent reload toasts / queued reloads from bleeding across workspaces.
+    reloadScopeKey();
+    clearReloadRequired();
+    setPendingReloadReasons([]);
+    setPendingReloadTrigger(null);
+    setPendingReloadResume([]);
+  });
 
   createEffect(() => {
     openworkReloadKey();
@@ -1860,9 +2015,10 @@ export default function App() {
     if (typeof window === "undefined") return;
     if (!documentVisible()) return;
     if (openworkReloadUnsupported()) return;
-    const client = openworkServerClient();
-    const workspaceId = openworkServerWorkspaceId();
-    if (!client || openworkServerStatus() !== "connected" || !workspaceId) return;
+    const target = resolveOpenworkReloadTarget();
+    if (!target || openworkServerStatus() !== "connected") return;
+    const client = target.client;
+    const workspaceId = target.workspaceId;
 
     let active = true;
     let busy = false;
@@ -1946,6 +2102,26 @@ export default function App() {
       };
     }
 
+    if (reason === "agents") {
+      const match = normalized.match(/\/\.opencode\/(?:agent|agents)\/([^/]+)/i);
+      return {
+        type: "agent",
+        name: match?.[1],
+        action: "updated",
+        path: rawPath,
+      };
+    }
+
+    if (reason === "commands") {
+      const match = normalized.match(/\/\.opencode\/(?:command|commands)\/([^/]+)/i);
+      return {
+        type: "command",
+        name: match?.[1]?.replace(/\.md$/i, ""),
+        action: "updated",
+        path: rawPath,
+      };
+    }
+
     return {
       type: "config",
       name: fileName,
@@ -2010,7 +2186,9 @@ export default function App() {
           rawReason === "plugins" ||
             rawReason === "skills" ||
             rawReason === "config" ||
-            rawReason === "mcp"
+            rawReason === "mcp" ||
+            rawReason === "agents" ||
+            rawReason === "commands"
             ? rawReason
             : "config";
 
@@ -2038,7 +2216,7 @@ export default function App() {
         const trigger =
           extractReloadTriggerFromPath(reason, event.payload?.path) ??
           {
-            type: reason === "plugins" ? "plugin" : reason === "skills" ? "skill" : reason,
+            type: reason === "plugins" ? "plugin" : reason === "skills" ? "skill" : reason === "agents" ? "agent" : reason === "commands" ? "command" : reason,
             action: "updated",
           };
 
@@ -2756,7 +2934,7 @@ export default function App() {
         }
         mcpEntryConfig["command"] = entry.command;
       }
-      if (canUseOpenworkServer) {
+      if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
         await openworkClient.addMcp(openworkWorkspaceId, {
           name: slug,
           config: mcpEntryConfig,
@@ -3675,9 +3853,14 @@ export default function App() {
       resetOpenworkServerSettings,
       testOpenworkServerConnection,
       canReloadWorkspace: canReloadWorkspace(),
-      reloadWorkspaceEngine,
+      reloadWorkspaceEngine: reloadWorkspaceEngineAndResume,
       reloadBusy: reloadBusy(),
       reloadError: reloadError(),
+      workspaceAutoReloadAvailable: workspaceAutoReloadAvailable(),
+      workspaceAutoReloadEnabled: workspaceAutoReloadEnabled(),
+      setWorkspaceAutoReloadEnabled,
+      workspaceAutoReloadResumeEnabled: workspaceAutoReloadResumeEnabled(),
+      setWorkspaceAutoReloadResumeEnabled,
       activeWorkspaceDisplay: activeWorkspaceDisplay(),
       workspaces: workspaceStore.workspaces(),
       activeWorkspaceId: workspaceStore.activeWorkspaceId(),
@@ -3796,7 +3979,7 @@ export default function App() {
       refreshMcpServers,
       showMcpReloadBanner: reloadRequired() && reloadReasons().includes("mcp"),
       mcpReloadBlocked: anyActiveRuns(),
-      reloadMcpEngine: () => reloadWorkspaceEngine(),
+      reloadMcpEngine: () => reloadWorkspaceEngineAndResume(),
       language: currentLocale(),
       setLanguage: setLocale,
     };
@@ -3826,6 +4009,7 @@ export default function App() {
   const sessionProps = () => ({
     selectedSessionId: activeSessionId(),
     setView,
+    tab: tab(),
     setTab,
     setSettingsTab,
     activeWorkspaceDisplay: activeWorkspaceDisplay(),
@@ -4094,7 +4278,7 @@ export default function App() {
           setMcpAuthEntry(null);
           await refreshMcpServers();
         }}
-        onReloadEngine={() => reloadWorkspaceEngine()}
+        onReloadEngine={() => reloadWorkspaceEngineAndResume()}
       />
 
       <ReloadWorkspaceToast
@@ -4110,7 +4294,7 @@ export default function App() {
         busy={reloadBusy()}
         canReload={canReloadEngine()}
         hasActiveRuns={anyActiveRuns()}
-        onReload={() => reloadWorkspaceEngine()}
+        onReload={() => reloadWorkspaceEngineAndResume()}
         onDismiss={() => setReloadToastDismissedAt(Date.now())}
       />
 

--- a/packages/app/src/app/components/reload-workspace-toast.tsx
+++ b/packages/app/src/app/components/reload-workspace-toast.tsx
@@ -59,6 +59,18 @@ export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
         : "Config changed. Reload to apply.";
     }
 
+    if (type === "agent") {
+      return trimmedName
+        ? `Agent '${trimmedName}' ${verb}. Reload to use it.`
+        : "Agents changed. Reload to apply.";
+    }
+
+    if (type === "command") {
+      return trimmedName
+        ? `Command '${trimmedName}' ${verb}. Reload to use it.`
+        : "Commands changed. Reload to apply.";
+    }
+
     return "Config changed. Reload to apply.";
   };
 

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -277,7 +277,7 @@ export default function Composer(props: ComposerProps) {
   const mentionGroups = createMemo<MentionGroup[]>(() => {
     if (!mentionOpen()) return [];
     const query = mentionQuery().trim().toLowerCase();
-    const agents = agentOptions().map((agent: Agent) => ({
+    const agents: MentionOption[] = agentOptions().map((agent: Agent) => ({
       id: `agent:${agent.name}`,
       kind: "agent" as const,
       label: agent.name,
@@ -285,7 +285,7 @@ export default function Composer(props: ComposerProps) {
       display: agent.name,
     }));
     const seen = new Set<string>();
-    const recentFiles = props.recentFiles
+    const recentFiles: MentionOption[] = props.recentFiles
       .filter((file: string) => {
         if (!file) return false;
         if (seen.has(file)) return false;
@@ -300,7 +300,7 @@ export default function Composer(props: ComposerProps) {
         display: file,
         recent: true,
       }));
-    const searchFiles = searchResults()
+    const searchFiles: MentionOption[] = searchResults()
       .filter((file: string) => file && !seen.has(file))
       .map((file: string) => ({
         id: `file:${file}`,

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -107,6 +107,7 @@ const removePartInfo = (list: Part[], partID: string) => list.filter((part) => p
 
 export function createSessionStore(options: {
   client: () => Client | null;
+  activeWorkspaceRoot: () => string;
   selectedSessionId: () => string | null;
   setSelectedSessionId: (id: string | null) => void;
   sessionModelState: () => SessionModelState;
@@ -132,8 +133,13 @@ export function createSessionStore(options: {
 
   const skillPathPattern = /[\\/]\.opencode[\\/](skill|skills)[\\/]/i;
   const skillNamePattern = /[\\/]\.opencode[\\/](?:skill|skills)[\\/]+([^\\/]+)/i;
+  const commandPathPattern = /[\\/]\.opencode[\\/](command|commands)[\\/]/i;
+  const commandNamePattern = /[\\/]\.opencode[\\/](?:command|commands)[\\/]+([^\\/]+)/i;
+  const agentPathPattern = /[\\/]\.opencode[\\/](agent|agents)[\\/]/i;
+  const agentNamePattern = /[\\/]\.opencode[\\/](?:agent|agents)[\\/]+([^\\/]+)/i;
   const opencodeConfigPattern = /(?:^|[\\/])opencode\.jsonc?\b/i;
   const opencodePathPattern = /(?:^|[\\/])\.opencode[\\/]/i;
+  const openworkConfigPattern = /[\\/]\.opencode[\\/]openwork\.json\b/i;
   const mutatingTools = new Set(["write", "edit", "apply_patch"]);
 
   const extractSearchText = (value: unknown) => {
@@ -146,13 +152,19 @@ export function createSessionStore(options: {
   const detectReloadReason = (value: unknown): ReloadReason | null => {
     const text = extractSearchText(value);
     if (!text) return null;
+    if (openworkConfigPattern.test(text)) return null;
     if (skillPathPattern.test(text)) return "skills";
+    if (commandPathPattern.test(text)) return "commands";
+    if (agentPathPattern.test(text)) return "agents";
     if (opencodeConfigPattern.test(text)) return "config";
     if (opencodePathPattern.test(text)) return "config";
     return null;
   };
 
   const detectReloadTriggerFromText = (text: string): ReloadTrigger | null => {
+    if (openworkConfigPattern.test(text)) {
+      return null;
+    }
     if (skillPathPattern.test(text)) {
       const match = text.match(skillNamePattern);
       return {
@@ -162,6 +174,29 @@ export function createSessionStore(options: {
         path: match?.[0],
       };
     }
+
+    if (commandPathPattern.test(text)) {
+      const match = text.match(commandNamePattern);
+      const raw = match?.[1];
+      const name = raw ? raw.replace(/\.md$/i, "") : undefined;
+      return {
+        type: "command",
+        name,
+        action: "updated",
+        path: match?.[0],
+      };
+    }
+
+    if (agentPathPattern.test(text)) {
+      const match = text.match(agentNamePattern);
+      return {
+        type: "agent",
+        name: match?.[1],
+        action: "updated",
+        path: match?.[0],
+      };
+    }
+
     if (opencodeConfigPattern.test(text) || opencodePathPattern.test(text)) {
       return {
         type: "config",
@@ -234,6 +269,16 @@ export function createSessionStore(options: {
   const maybeMarkReloadRequired = (part: Part) => {
     if (!options.markReloadRequired) return;
     if (!part?.id || !part.messageID) return;
+
+    const root = normalizeDirectoryPath(options.activeWorkspaceRoot());
+    if (root) {
+      const session = store.sessions.find((candidate) => candidate.id === part.sessionID) ?? null;
+      const sessionRoot = normalizeDirectoryPath(session?.directory ?? "");
+      if (!sessionRoot || sessionRoot !== root) {
+        return;
+      }
+    }
+
     const key = `${part.messageID}:${part.id}`;
     if (reloadDetectionSet.has(key)) return;
     const detection = detectReloadFromPart(part);

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -1745,6 +1745,28 @@ export function createWorkspaceStore(options: {
       version: existing?.version ?? 1,
       workspace: existing?.workspace ?? null,
       authorizedRoots: nextRoots,
+      reload: existing?.reload ?? null,
+    };
+
+    await workspaceOpenworkWrite({ workspacePath: root, config: cfg });
+    setWorkspaceConfig(cfg);
+  }
+
+  async function persistReloadSettings(next: { auto?: boolean; resume?: boolean }) {
+    if (!isTauriRuntime()) return;
+    if (activeWorkspaceInfo()?.workspaceType === "remote") return;
+    const root = activeWorkspacePath().trim();
+    if (!root) return;
+
+    const existing = workspaceConfig();
+    const cfg: WorkspaceOpenworkConfig = {
+      version: existing?.version ?? 1,
+      workspace: existing?.workspace ?? null,
+      authorizedRoots: Array.isArray(existing?.authorizedRoots) ? existing!.authorizedRoots : authorizedDirs(),
+      reload: {
+        auto: Boolean(next.auto),
+        resume: Boolean(next.resume),
+      },
     };
 
     await workspaceOpenworkWrite({ workspacePath: root, config: cfg });
@@ -2054,6 +2076,7 @@ export function createWorkspaceStore(options: {
     addAuthorizedDirFromPicker,
     removeAuthorizedDir,
     removeAuthorizedDirAtIndex,
+    persistReloadSettings,
     setEngineInstallLogs,
   };
 }

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -110,7 +110,7 @@ export type OpenworkAuditEntry = {
 };
 
 export type OpenworkReloadTrigger = {
-  type: "skill" | "plugin" | "config" | "mcp";
+  type: "skill" | "plugin" | "config" | "mcp" | "agent" | "command";
   name?: string;
   action?: "added" | "removed" | "updated";
   path?: string;
@@ -120,7 +120,7 @@ export type OpenworkReloadEvent = {
   id: string;
   seq: number;
   workspaceId: string;
-  reason: "plugins" | "skills" | "mcp" | "config";
+  reason: "plugins" | "skills" | "mcp" | "config" | "agents" | "commands";
   trigger?: OpenworkReloadTrigger;
   timestamp: number;
 };

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -267,6 +267,10 @@ export type WorkspaceOpenworkConfig = {
     preset?: string | null;
   } | null;
   authorizedRoots: string[];
+  reload?: {
+    auto?: boolean;
+    resume?: boolean;
+  } | null;
 };
 
 export async function workspaceOpenworkRead(input: {

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -90,6 +90,11 @@ export type DashboardViewProps = {
   reloadWorkspaceEngine: () => Promise<void>;
   reloadBusy: boolean;
   reloadError: string | null;
+  workspaceAutoReloadAvailable: boolean;
+  workspaceAutoReloadEnabled: boolean;
+  setWorkspaceAutoReloadEnabled: (value: boolean) => void | Promise<void>;
+  workspaceAutoReloadResumeEnabled: boolean;
+  setWorkspaceAutoReloadResumeEnabled: (value: boolean) => void | Promise<void>;
   activeWorkspaceDisplay: WorkspaceInfo;
   workspaces: WorkspaceInfo[];
   activeWorkspaceId: string;
@@ -765,6 +770,11 @@ export default function DashboardView(props: DashboardViewProps) {
                   reloadWorkspaceEngine={props.reloadWorkspaceEngine}
                   reloadBusy={props.reloadBusy}
                   reloadError={props.reloadError}
+                  workspaceAutoReloadAvailable={props.workspaceAutoReloadAvailable}
+                  workspaceAutoReloadEnabled={props.workspaceAutoReloadEnabled}
+                  setWorkspaceAutoReloadEnabled={props.setWorkspaceAutoReloadEnabled}
+                  workspaceAutoReloadResumeEnabled={props.workspaceAutoReloadResumeEnabled}
+                  setWorkspaceAutoReloadResumeEnabled={props.setWorkspaceAutoReloadResumeEnabled}
                   openworkAuditEntries={props.openworkAuditEntries}
                   openworkAuditStatus={props.openworkAuditStatus}
                   openworkAuditError={props.openworkAuditError}

--- a/packages/app/src/app/pages/proto-v1-ux.tsx
+++ b/packages/app/src/app/pages/proto-v1-ux.tsx
@@ -260,7 +260,7 @@ const SkillCard = (props: {
         aria-label={props.type === "add" ? "Install skill" : "Edit skill"}
         class="rounded-lg p-2 text-gray-8 transition-colors hover:bg-gray-2 hover:text-gray-12"
       >
-        <Show when={props.type === "add"} fallback={<Edit2 size={14} />}>
+        <Show when={props.type === "add"} fallback={<Pencil size={14} />}>
           <Plus size={16} />
         </Show>
       </button>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -53,6 +53,7 @@ import QuestionModal from "../components/question-modal";
 export type SessionViewProps = {
   selectedSessionId: string | null;
   setView: (view: View, sessionId?: string) => void;
+  tab: DashboardTab;
   setTab: (tab: DashboardTab) => void;
   setSettingsTab: (tab: SettingsTab) => void;
   activeWorkspaceDisplay: WorkspaceDisplay;

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -109,6 +109,11 @@ export type SettingsViewProps = {
   downloadUpdate: () => void;
   installUpdateAndRestart: () => void;
   anyActiveRuns: boolean;
+  workspaceAutoReloadAvailable: boolean;
+  workspaceAutoReloadEnabled: boolean;
+  setWorkspaceAutoReloadEnabled: (value: boolean) => void | Promise<void>;
+  workspaceAutoReloadResumeEnabled: boolean;
+  setWorkspaceAutoReloadResumeEnabled: (value: boolean) => void | Promise<void>;
   onResetStartupPreference: () => void;
   openResetModal: (mode: "onboarding" | "all") => void;
   resetModalBusy: boolean;
@@ -1986,6 +1991,44 @@ export default function SettingsView(props: SettingsViewProps) {
                   >
                     <RefreshCcw size={14} class={props.reloadBusy ? "animate-spin" : ""} />
                     {reloadButtonLabel()}
+                  </Button>
+                </div>
+
+                <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                  <div class="min-w-0 space-y-1">
+                    <div class="text-sm text-gray-12">Auto reload (local)</div>
+                    <div class="text-xs text-gray-7">
+                      Reload automatically after agents/skills/commands/config change (only when idle).
+                    </div>
+                    <Show when={!props.workspaceAutoReloadAvailable}>
+                      <div class="text-[11px] text-gray-9">Available for local workspaces in the desktop app.</div>
+                    </Show>
+                  </div>
+                  <Button
+                    variant="outline"
+                    class="text-xs h-8 py-0 px-3 shrink-0"
+                    onClick={() => props.setWorkspaceAutoReloadEnabled(!props.workspaceAutoReloadEnabled)}
+                    disabled={props.busy || !props.workspaceAutoReloadAvailable}
+                  >
+                    {props.workspaceAutoReloadEnabled ? "On" : "Off"}
+                  </Button>
+                </div>
+
+                <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                  <div class="min-w-0 space-y-1">
+                    <div class="text-sm text-gray-12">Resume sessions after auto reload</div>
+                    <div class="text-xs text-gray-7">
+                      If a reload was queued while tasks were running, send a resume message afterward.
+                    </div>
+                  </div>
+                  <Button
+                    variant="outline"
+                    class="text-xs h-8 py-0 px-3 shrink-0"
+                    onClick={() => props.setWorkspaceAutoReloadResumeEnabled(!props.workspaceAutoReloadResumeEnabled)}
+                    disabled={props.busy || !props.workspaceAutoReloadAvailable || !props.workspaceAutoReloadEnabled}
+                    title={props.workspaceAutoReloadEnabled ? "" : "Enable auto reload first"}
+                  >
+                    {props.workspaceAutoReloadResumeEnabled ? "On" : "Off"}
                   </Button>
                 </div>
               </div>

--- a/packages/app/src/app/system-state.ts
+++ b/packages/app/src/app/system-state.ts
@@ -148,7 +148,16 @@ export function createSystemState(options: {
       setReloadTrigger(trigger);
     } else {
       setReloadTrigger({
-        type: reason === "plugins" ? "plugin" : reason === "skills" ? "skill" : reason,
+        type:
+          reason === "plugins"
+            ? "plugin"
+            : reason === "skills"
+              ? "skill"
+              : reason === "agents"
+                ? "agent"
+                : reason === "commands"
+                  ? "command"
+                  : reason,
       });
     }
   }
@@ -180,6 +189,20 @@ export function createSystemState(options: {
       return {
         title: "Reload required",
         body: "OpenCode can cache skill discovery/state. Reload the engine to make newly installed skills available.",
+      };
+    }
+
+    if (reasons.length === 1 && reasons[0] === "agents") {
+      return {
+        title: "Reload required",
+        body: "OpenCode loads agents at startup. Reload the engine to make updated agents available.",
+      };
+    }
+
+    if (reasons.length === 1 && reasons[0] === "commands") {
+      return {
+        title: "Reload required",
+        body: "OpenCode loads commands at startup. Reload the engine to make updated commands available.",
       };
     }
 

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -143,6 +143,10 @@ export type WorkspaceOpenworkConfig = {
     preset?: string | null;
   } | null;
   authorizedRoots: string[];
+  reload?: {
+    auto?: boolean;
+    resume?: boolean;
+  } | null;
 };
 
 export type SkillCard = {
@@ -198,7 +202,7 @@ export type McpStatus =
 
 export type McpStatusMap = Record<string, McpStatus>;
 
-export type ReloadReason = "plugins" | "skills" | "mcp" | "config";
+export type ReloadReason = "plugins" | "skills" | "mcp" | "config" | "agents" | "commands";
 
 export type OpencodeConnectStatus = {
   at: number;
@@ -210,7 +214,7 @@ export type OpencodeConnectStatus = {
 };
 
 export type ReloadTrigger = {
-  type: "skill" | "plugin" | "config" | "mcp";
+  type: "skill" | "plugin" | "config" | "mcp" | "agent" | "command";
   name?: string;
   action?: "added" | "removed" | "updated";
   path?: string;

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.11.10"
+version = "0.11.13"
 dependencies = [
  "base64 0.22.1",
  "gethostname",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "openwork"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "base64 0.22.1",
  "gethostname",

--- a/packages/desktop/src-tauri/src/types.rs
+++ b/packages/desktop/src-tauri/src/types.rs
@@ -7,6 +7,8 @@ pub struct WorkspaceOpenworkConfig {
     pub workspace: Option<WorkspaceOpenworkWorkspace>,
     #[serde(default, alias = "authorizedRoots")]
     pub authorized_roots: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reload: Option<WorkspaceOpenworkReload>,
 }
 
 impl Default for WorkspaceOpenworkConfig {
@@ -15,8 +17,16 @@ impl Default for WorkspaceOpenworkConfig {
             version: 1,
             workspace: None,
             authorized_roots: Vec::new(),
+            reload: None,
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceOpenworkReload {
+    pub auto: Option<bool>,
+    pub resume: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -46,6 +56,7 @@ impl WorkspaceOpenworkConfig {
                 preset: Some(preset.to_string()),
             }),
             authorized_roots: vec![workspace_path.to_string()],
+            reload: None,
         }
     }
 }

--- a/packages/desktop/src-tauri/src/workspace/watch.rs
+++ b/packages/desktop/src-tauri/src/workspace/watch.rs
@@ -24,15 +24,39 @@ fn normalize_path(path: &Path) -> String {
 fn reason_for_path(path: &Path) -> Option<&'static str> {
     let normalized = normalize_path(path);
     let lower = normalized.to_lowercase();
+
+    // Ignore OpenWork metadata files — they don't affect the OpenCode engine.
+    if lower.ends_with("/openwork.json") {
+        return None;
+    }
+
+    // Specific .opencode subdirectories map to distinct reasons.
     if lower.contains("/.opencode/skills/") || lower.ends_with("/.opencode/skills") {
         return Some("skills");
     }
-    if lower.contains("/.opencode/") || lower.ends_with("/.opencode") {
-        return Some("config");
+    if lower.contains("/.opencode/agents/") || lower.contains("/.opencode/agent/") {
+        return Some("agents");
     }
+    if lower.contains("/.opencode/commands/") || lower.contains("/.opencode/command/") {
+        return Some("commands");
+    }
+    if lower.contains("/.opencode/plugins/") {
+        return Some("plugins");
+    }
+
+    // opencode.json / opencode.jsonc at the workspace root or inside .opencode/
     if lower.ends_with("/opencode.json") || lower.ends_with("/opencode.jsonc") {
         return Some("config");
     }
+
+    // AGENTS.md at the workspace root triggers agent reload.
+    if lower.ends_with("/agents.md") && !lower.contains("/.opencode/") {
+        return Some("agents");
+    }
+
+    // Any other file inside .opencode/ that isn't already matched above
+    // (e.g. .opencode/opencode.db, .opencode/opencode.json handled above).
+    // We intentionally do NOT emit for unknown .opencode files to be conservative.
     None
 }
 
@@ -109,6 +133,10 @@ pub fn update_workspace_watch(
             if lower.ends_with(".ds_store")
                 || lower.ends_with("desktop.ini")
                 || lower.ends_with(".localized")
+                || lower.ends_with(".db")
+                || lower.ends_with(".db-journal")
+                || lower.ends_with(".db-wal")
+                || lower.ends_with(".db-shm")
             {
                 continue;
             }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -808,6 +808,13 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       summary: `Upserted command ${name}`,
       timestamp: Date.now(),
     });
+
+    emitReloadEvent(ctx.reloadEvents, workspace, "commands", {
+      type: "command",
+      name: sanitizeCommandName(name),
+      action: "updated",
+      path,
+    });
     const items = await listCommands(workspace.path, "workspace");
     return jsonResponse({ items });
   });
@@ -831,6 +838,13 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
       target: join(workspace.path, ".opencode", "commands"),
       summary: `Deleted command ${name}`,
       timestamp: Date.now(),
+    });
+
+    emitReloadEvent(ctx.reloadEvents, workspace, "commands", {
+      type: "command",
+      name: sanitizeCommandName(name),
+      action: "removed",
+      path: join(workspace.path, ".opencode", "commands", `${sanitizeCommandName(name)}.md`),
     });
     return jsonResponse({ ok: true });
   });

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -62,10 +62,10 @@ export interface Capabilities {
   config: { read: boolean; write: boolean };
 }
 
-export type ReloadReason = "plugins" | "skills" | "mcp" | "config";
+export type ReloadReason = "plugins" | "skills" | "mcp" | "config" | "agents" | "commands";
 
 export type ReloadTrigger = {
-  type: "skill" | "plugin" | "config" | "mcp";
+  type: "skill" | "plugin" | "config" | "mcp" | "agent" | "command";
   name?: string;
   action?: "added" | "removed" | "updated";
   path?: string;


### PR DESCRIPTION
## Why
The reload toast was firing too often (e.g. creating a new workspace writes `.opencode/openwork.json`, which should not require an OpenCode reload). For a self-referential OpenWork, we want hot reload to be conservative, workspace-scoped, and session-aware.

Related context: anomalyco/opencode#8751 (hot-reload agents/skills/commands).

## What changed
- Desktop file watcher is more precise:
  - Ignore `.opencode/openwork.json` and common noise (`.db*`, `.DS_Store`, etc.)
  - Emit targeted reasons for `.opencode/{skills,agents,commands,plugins}` and `opencode.json{,c}`
- Reload detection is workspace-scoped + session-aware:
  - Gate tool-based detection to the active workspace root
  - Queue reload signals while sessions are running; promote to toast only after sessions go idle
  - Do not poll OpenWork server reload events unless the active workspace is `remote`
- Auto reload settings (per workspace, stored in `.opencode/openwork.json`):
  - `reload.auto`: automatically reload once idle
  - `reload.resume`: after reload, optionally inject a resume message into sessions that were running when the reload was queued
- Server emits reload events for command writes/deletes (`reason=commands`)

## Testing
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
- `pnpm --filter openwork-server typecheck`
- Manual: started `openwrk` (from source) with opencode + openwork-server + owpenbot and verified health + detach output.

## Notes
- I didn’t run `cargo check` for the desktop crate because the local build script requires sidecar binaries to be present (or env overrides like `OPENWORK_SERVER_BIN_PATH`).