### PR TITLE
fix(release): skip npm/AUR publish when secrets missing

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -569,7 +569,7 @@ jobs:
   publish-npm:
     name: Publish npm packages
     needs: [resolve-release, verify-release]
-    if: needs.resolve-release.outputs.publish_npm == 'true'
+    if: needs.resolve-release.outputs.publish_npm == 'true' && secrets.NPM_TOKEN != ''
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -724,7 +724,13 @@ jobs:
               commit -m "chore(aur): update PKGBUILD for ${version}"
           git push origin HEAD:dev
 
+      - name: Skip AUR publish (missing key)
+        if: secrets.AUR_SSH_PRIVATE_KEY == ''
+        run: |
+          echo "AUR_SSH_PRIVATE_KEY not set; skipping publish to AUR."
+
       - name: Publish to AUR
+        if: secrets.AUR_SSH_PRIVATE_KEY != ''
         env:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           AUR_REPO: ${{ vars.AUR_REPO || 'openwork' }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,3 +52,11 @@ Required repo config:
 
 - GitHub Actions secret: `AUR_SSH_PRIVATE_KEY` (SSH key with push access to the AUR package repo)
 - Optional repo variable: `AUR_REPO` (defaults to `openwork`)
+
+## npm publishing
+
+If you want `Release App` to publish `openwrk`, `openwork-server`, and `owpenwork` to npm, configure:
+
+- GitHub Actions secret: `NPM_TOKEN` (npm automation token)
+
+If `NPM_TOKEN` is not set, the npm publish job is skipped.


### PR DESCRIPTION
## Summary
- Skip npm publishing when the Actions secret NPM_TOKEN is not configured
- Skip the AUR publish step when the Actions secret AUR_SSH_PRIVATE_KEY is not configured (still updates/commits packaging in dev)
- Document required secrets in RELEASE.md

## Why
Missing publishing secrets should not make a tag release fail; we still want desktop assets uploaded and releases marked green.