### PR TITLE
feat(updates): auto-update toggle + update pill

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1807,6 +1807,8 @@ export default function App() {
     repairOpencodeCache,
     updateAutoCheck,
     setUpdateAutoCheck,
+    updateAutoDownload,
+    setUpdateAutoDownload,
     updateStatus,
     setUpdateStatus,
     pendingUpdate,
@@ -3274,6 +3276,17 @@ export default function App() {
           setUpdateAutoCheck(storedUpdateAutoCheck === "1");
         }
 
+        const storedUpdateAutoDownload = window.localStorage.getItem(
+          "openwork.updateAutoDownload"
+        );
+        if (storedUpdateAutoDownload === "0" || storedUpdateAutoDownload === "1") {
+          const enabled = storedUpdateAutoDownload === "1";
+          setUpdateAutoDownload(enabled);
+          if (enabled) {
+            setUpdateAutoCheck(true);
+          }
+        }
+
         const storedUpdateCheckedAt = window.localStorage.getItem(
           "openwork.updateLastCheckedAt"
         );
@@ -3603,6 +3616,18 @@ export default function App() {
     if (typeof window === "undefined") return;
     try {
       window.localStorage.setItem(
+        "openwork.updateAutoDownload",
+        updateAutoDownload() ? "1" : "0"
+      );
+    } catch {
+      // ignore
+    }
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(
         THINKING_PREF_KEY,
         JSON.stringify(showThinking())
       );
@@ -3655,6 +3680,17 @@ export default function App() {
         // ignore
       }
     }
+  });
+
+  createEffect(() => {
+    if (!isTauriRuntime()) return;
+    if (!updateAutoDownload()) return;
+
+    const state = updateStatus();
+    if (state.state !== "available") return;
+    if (!pendingUpdate()) return;
+
+    downloadUpdate().catch(() => undefined);
   });
 
   const headerStatus = createMemo(() => {
@@ -3942,6 +3978,15 @@ export default function App() {
       editModelVariant: handleEditModelVariant,
       updateAutoCheck: updateAutoCheck(),
       toggleUpdateAutoCheck: () => setUpdateAutoCheck((v) => !v),
+      updateAutoDownload: updateAutoDownload(),
+      toggleUpdateAutoDownload: () =>
+        setUpdateAutoDownload((v) => {
+          const next = !v;
+          if (next) {
+            setUpdateAutoCheck(true);
+          }
+          return next;
+        }),
       updateStatus: updateStatus(),
       updateEnv: updateEnv(),
       appVersion: appVersion(),
@@ -4041,6 +4086,10 @@ export default function App() {
     stopHost,
     headerStatus: headerStatus(),
     busyHint: busyHint(),
+    updateStatus: updateStatus(),
+    updateEnv: updateEnv(),
+    anyActiveRuns: anyActiveRuns(),
+    installUpdateAndRestart,
     selectedSessionModelLabel: selectedSessionModelLabel(),
     openSessionModelPicker: openSessionModelPicker,
     modelVariantLabel: formatModelVariantLabel(modelVariant()),

--- a/packages/app/src/app/context/updater.ts
+++ b/packages/app/src/app/context/updater.ts
@@ -22,6 +22,7 @@ export type PendingUpdate = { update: UpdateHandle; version: string; notes?: str
 
 export function createUpdaterState() {
   const [updateAutoCheck, setUpdateAutoCheck] = createSignal(true);
+  const [updateAutoDownload, setUpdateAutoDownload] = createSignal(false);
   const [updateStatus, setUpdateStatus] = createSignal<UpdateStatus>({ state: "idle", lastCheckedAt: null });
   const [pendingUpdate, setPendingUpdate] = createSignal<PendingUpdate>(null);
   const [updateEnv, setUpdateEnv] = createSignal<UpdaterEnvironment | null>(null);
@@ -29,6 +30,8 @@ export function createUpdaterState() {
   return {
     updateAutoCheck,
     setUpdateAutoCheck,
+    updateAutoDownload,
+    setUpdateAutoDownload,
     updateStatus,
     setUpdateStatus,
     pendingUpdate,

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -14,7 +14,7 @@ import type {
   View,
 } from "../types";
 import type { McpDirectoryInfo } from "../constants";
-import { formatRelativeTime } from "../utils";
+import { formatRelativeTime, isTauriRuntime } from "../utils";
 import type {
   OpenworkAuditEntry,
   OpenworkServerCapabilities,
@@ -188,6 +188,8 @@ export type DashboardViewProps = {
   editModelVariant: () => void;
   updateAutoCheck: boolean;
   toggleUpdateAutoCheck: () => void;
+  updateAutoDownload: boolean;
+  toggleUpdateAutoDownload: () => void;
   themeMode: "light" | "dark" | "system";
   setThemeMode: (value: "light" | "dark" | "system") => void;
   updateStatus: {
@@ -424,10 +426,74 @@ export default function DashboardView(props: DashboardViewProps) {
     props.setTab("settings");
   };
 
+  const showUpdatePill = createMemo(() => {
+    if (!isTauriRuntime()) return false;
+    const state = props.updateStatus?.state;
+    return state === "available" || state === "downloading" || state === "ready";
+  });
+
+  const updatePillLabel = createMemo(() => {
+    const state = props.updateStatus?.state;
+    if (state === "ready") {
+      return props.anyActiveRuns ? "Update ready" : "Restart";
+    }
+    if (state === "downloading") return "Downloading";
+    return "Update";
+  });
+
+  const updatePillTitle = createMemo(() => {
+    const version = props.updateStatus?.version ? `v${props.updateStatus.version}` : "";
+    const state = props.updateStatus?.state;
+    if (state === "ready") {
+      return props.anyActiveRuns
+        ? `Update ready ${version}. Stop active runs to restart.`
+        : `Restart to apply update ${version}`;
+    }
+    if (state === "downloading") return `Downloading update ${version}`;
+    return `Update available ${version}`;
+  });
+
+  const handleUpdatePillClick = () => {
+    const state = props.updateStatus?.state;
+    if (state === "ready" && !props.anyActiveRuns) {
+      props.installUpdateAndRestart();
+      return;
+    }
+    openSettings("advanced");
+  };
+
   return (
     <div class="flex h-screen w-full bg-dls-surface text-dls-text font-sans overflow-hidden">
       <aside class="w-64 hidden md:flex flex-col bg-dls-sidebar border-r border-dls-border p-4">
         <div class="flex-1 overflow-y-auto">
+          <Show when={showUpdatePill()}>
+            <button
+              type="button"
+              class="mb-3 w-full flex h-9 items-center gap-2 rounded-xl border border-dls-border bg-dls-hover px-3 text-xs text-dls-secondary shadow-sm transition-colors hover:bg-dls-active hover:text-dls-text"
+              onClick={handleUpdatePillClick}
+              title={updatePillTitle()}
+              aria-label={updatePillTitle()}
+            >
+              <Show
+                when={props.updateStatus?.state === "downloading"}
+                fallback={
+                  <span
+                    class={`w-2 h-2 rounded-full ${
+                      props.updateStatus?.state === "ready" ? "bg-green-9" : "bg-amber-9"
+                    }`}
+                  />
+                }
+              >
+                <Loader2 size={14} class="animate-spin text-dls-secondary" />
+              </Show>
+              <span class="text-[11px] font-medium text-dls-text">{updatePillLabel()}</span>
+              <Show when={props.updateStatus?.version}>
+                {(version) => (
+                  <span class="ml-auto text-[11px] text-dls-secondary font-mono">v{version()}</span>
+                )}
+              </Show>
+            </button>
+          </Show>
           <div class="flex items-center text-[11px] font-bold text-dls-secondary uppercase px-3 mb-3 pt-2 tracking-tight">
             <span>Tasks</span>
           </div>
@@ -658,6 +724,34 @@ export default function DashboardView(props: DashboardViewProps) {
       <main class="flex-1 overflow-y-auto relative pb-24 md:pb-12 bg-dls-surface">
         <header class="h-14 flex items-center justify-between px-6 md:px-10 border-b border-dls-border sticky top-0 bg-dls-surface z-10">
           <div class="flex items-center gap-3">
+            <Show when={showUpdatePill()}>
+              <button
+                type="button"
+                class="md:hidden flex h-8 items-center gap-2 rounded-full border border-dls-border bg-dls-hover px-3 text-xs text-dls-secondary shadow-sm transition-colors hover:bg-dls-active hover:text-dls-text"
+                onClick={handleUpdatePillClick}
+                title={updatePillTitle()}
+                aria-label={updatePillTitle()}
+              >
+                <Show
+                  when={props.updateStatus?.state === "downloading"}
+                  fallback={
+                    <span
+                      class={`w-2 h-2 rounded-full ${
+                        props.updateStatus?.state === "ready" ? "bg-green-9" : "bg-amber-9"
+                      }`}
+                    />
+                  }
+                >
+                  <Loader2 size={14} class="animate-spin text-dls-secondary" />
+                </Show>
+                <span class="text-[11px] font-medium text-dls-text">{updatePillLabel()}</span>
+                <Show when={props.updateStatus?.version}>
+                  {(version) => (
+                    <span class="hidden sm:inline text-[11px] text-dls-secondary font-mono">v{version()}</span>
+                  )}
+                </Show>
+              </button>
+            </Show>
             <div class="px-3 py-1.5 rounded-xl bg-dls-hover text-xs text-dls-secondary font-medium">
               {props.activeWorkspaceDisplay.name}
             </div>
@@ -808,6 +902,8 @@ export default function DashboardView(props: DashboardViewProps) {
                   editModelVariant={props.editModelVariant}
                   updateAutoCheck={props.updateAutoCheck}
                   toggleUpdateAutoCheck={props.toggleUpdateAutoCheck}
+                  updateAutoDownload={props.updateAutoDownload}
+                  toggleUpdateAutoDownload={props.toggleUpdateAutoDownload}
                   themeMode={props.themeMode}
                   setThemeMode={props.setThemeMode}
                   updateStatus={props.updateStatus}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -78,6 +78,19 @@ export type SessionViewProps = {
   stopHost: () => void;
   headerStatus: string;
   busyHint: string | null;
+  updateStatus: {
+    state: string;
+    lastCheckedAt?: number | null;
+    version?: string;
+    date?: string;
+    notes?: string;
+    totalBytes?: number | null;
+    downloadedBytes?: number;
+    message?: string;
+  } | null;
+  updateEnv: { supported?: boolean; reason?: string | null } | null;
+  anyActiveRuns: boolean;
+  installUpdateAndRestart: () => void;
   createSessionAndOpen: () => void;
   sendPromptAsync: (draft: ComposerDraft) => Promise<void>;
   newTaskDisabled: boolean;
@@ -805,6 +818,42 @@ export default function SessionView(props: SessionViewProps) {
     props.setView("dashboard");
   };
 
+  const showUpdatePill = createMemo(() => {
+    if (!isTauriRuntime()) return false;
+    const state = props.updateStatus?.state;
+    return state === "available" || state === "downloading" || state === "ready";
+  });
+
+  const updatePillLabel = createMemo(() => {
+    const state = props.updateStatus?.state;
+    if (state === "ready") {
+      return props.anyActiveRuns ? "Update ready" : "Restart";
+    }
+    if (state === "downloading") return "Downloading";
+    return "Update";
+  });
+
+  const updatePillTitle = createMemo(() => {
+    const version = props.updateStatus?.version ? `v${props.updateStatus.version}` : "";
+    const state = props.updateStatus?.state;
+    if (state === "ready") {
+      return props.anyActiveRuns
+        ? `Update ready ${version}. Stop active runs to restart.`
+        : `Restart to apply update ${version}`;
+    }
+    if (state === "downloading") return `Downloading update ${version}`;
+    return `Update available ${version}`;
+  });
+
+  const handleUpdatePillClick = () => {
+    const state = props.updateStatus?.state;
+    if (state === "ready" && !props.anyActiveRuns) {
+      props.installUpdateAndRestart();
+      return;
+    }
+    openSettings("advanced");
+  };
+
   const openMcp = () => {
     props.setTab("mcp");
     props.setView("dashboard");
@@ -827,6 +876,34 @@ export default function SessionView(props: SessionViewProps) {
     <div class="flex h-screen w-full bg-dls-surface text-dls-text font-sans overflow-hidden">
       <aside class="w-64 hidden md:flex flex-col bg-dls-sidebar border-r border-dls-border p-4">
         <div class="flex-1 overflow-y-auto">
+          <Show when={showUpdatePill()}>
+            <button
+              type="button"
+              class="mb-3 w-full flex h-9 items-center gap-2 rounded-xl border border-dls-border bg-dls-hover px-3 text-xs text-dls-secondary shadow-sm transition-colors hover:bg-dls-active hover:text-dls-text"
+              onClick={handleUpdatePillClick}
+              title={updatePillTitle()}
+              aria-label={updatePillTitle()}
+            >
+              <Show
+                when={props.updateStatus?.state === "downloading"}
+                fallback={
+                  <span
+                    class={`w-2 h-2 rounded-full ${
+                      props.updateStatus?.state === "ready" ? "bg-green-9" : "bg-amber-9"
+                    }`}
+                  />
+                }
+              >
+                <Loader2 size={14} class="animate-spin text-dls-secondary" />
+              </Show>
+              <span class="text-[11px] font-medium text-dls-text">{updatePillLabel()}</span>
+              <Show when={props.updateStatus?.version}>
+                {(version) => (
+                  <span class="ml-auto text-[11px] text-dls-secondary font-mono">v{version()}</span>
+                )}
+              </Show>
+            </button>
+          </Show>
           <div class="flex items-center text-[11px] font-bold text-dls-secondary uppercase px-3 mb-3 pt-2 tracking-tight">
             <span>Tasks</span>
           </div>
@@ -1059,6 +1136,34 @@ export default function SessionView(props: SessionViewProps) {
       <main class="flex-1 flex flex-col relative pb-16 md:pb-12 bg-dls-surface">
         <header class="h-14 border-b border-dls-border flex items-center justify-between px-6 bg-dls-surface z-10 sticky top-0">
           <div class="flex items-center gap-3">
+            <Show when={showUpdatePill()}>
+              <button
+                type="button"
+                class="md:hidden flex h-8 items-center gap-2 rounded-full border border-dls-border bg-dls-hover px-3 text-xs text-dls-secondary shadow-sm transition-colors hover:bg-dls-active hover:text-dls-text"
+                onClick={handleUpdatePillClick}
+                title={updatePillTitle()}
+                aria-label={updatePillTitle()}
+              >
+                <Show
+                  when={props.updateStatus?.state === "downloading"}
+                  fallback={
+                    <span
+                      class={`w-2 h-2 rounded-full ${
+                        props.updateStatus?.state === "ready" ? "bg-green-9" : "bg-amber-9"
+                      }`}
+                    />
+                  }
+                >
+                  <Loader2 size={14} class="animate-spin text-dls-secondary" />
+                </Show>
+                <span class="text-[11px] font-medium text-dls-text">{updatePillLabel()}</span>
+                <Show when={props.updateStatus?.version}>
+                  {(version) => (
+                    <span class="hidden sm:inline text-[11px] text-dls-secondary font-mono">v{version()}</span>
+                  )}
+                </Show>
+              </button>
+            </Show>
             <h1 class="text-sm font-semibold text-dls-text">
               {selectedSessionTitle() || "New task"}
             </h1>

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -93,6 +93,8 @@ export type SettingsViewProps = {
   setThemeMode: (value: "light" | "dark" | "system") => void;
   updateAutoCheck: boolean;
   toggleUpdateAutoCheck: () => void;
+  updateAutoDownload: boolean;
+  toggleUpdateAutoDownload: () => void;
   updateStatus: {
     state: string;
     lastCheckedAt?: number | null;
@@ -1486,6 +1488,23 @@ export default function SettingsView(props: SettingsViewProps) {
                             onClick={props.toggleUpdateAutoCheck}
                           >
                             {props.updateAutoCheck ? "On" : "Off"}
+                          </button>
+                        </div>
+
+                        <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6">
+                          <div class="space-y-0.5">
+                            <div class="text-sm text-gray-12">Auto-update</div>
+                            <div class="text-xs text-gray-7">Download updates automatically (prompts to restart)</div>
+                          </div>
+                          <button
+                            class={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                              props.updateAutoDownload
+                                ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
+                                : "text-gray-10 border-gray-6 hover:text-gray-12"
+                            }`}
+                            onClick={props.toggleUpdateAutoDownload}
+                          >
+                            {props.updateAutoDownload ? "On" : "Off"}
                           </button>
                         </div>
 

--- a/packages/app/src/app/system-state.ts
+++ b/packages/app/src/app/system-state.ts
@@ -59,6 +59,8 @@ export function createSystemState(options: {
   const {
     updateAutoCheck,
     setUpdateAutoCheck,
+    updateAutoDownload,
+    setUpdateAutoDownload,
     updateStatus,
     setUpdateStatus,
     pendingUpdate,
@@ -433,9 +435,10 @@ export function createSystemState(options: {
     const pending = pendingUpdate();
     if (!pending) return;
 
-    options.setError(null);
-
     const state = updateStatus();
+    if (state.state === "downloading" || state.state === "ready") return;
+
+    options.setError(null);
     const lastCheckedAt = state.state === "available" ? state.lastCheckedAt : Date.now();
 
     setUpdateStatus({
@@ -522,6 +525,8 @@ export function createSystemState(options: {
     repairOpencodeCache,
     updateAutoCheck,
     setUpdateAutoCheck,
+    updateAutoDownload,
+    setUpdateAutoDownload,
     updateStatus,
     setUpdateStatus,
     pendingUpdate,


### PR DESCRIPTION
## What changed
- Added an **Auto-update** toggle in Settings → Advanced → Updates. When enabled, OpenWork auto-downloads updates when they become available (and keeps automatic checks on).
- Added a small **update pill** in the top-left (sidebar on desktop, header on mobile) whenever an update is available/downloading/ready.
  - Click opens the Updates settings.
  - If the update is ready and there are no active runs, click installs + restarts.

## Testing
- pnpm -w typecheck
- pnpm -w test:health
- pnpm -w test:session-switch
- pnpm -w build:ui