### PR TITLE
fix(release): don't let openwrk releases override OpenWork updater

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -557,7 +557,8 @@ jobs:
           gh release create "$tag" \
             --repo "$GITHUB_REPOSITORY" \
             --title "openwrk v${version}" \
-            --notes "$notes"
+            --notes "$notes" \
+            --latest=false
 
       - name: Upload sidecar assets
         env:

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openwork"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "base64 0.22.1",
  "gethostname",


### PR DESCRIPTION
## Problem
OpenWork desktop updater points at:
- `https://github.com/different-ai/openwork/releases/latest/download/latest.json`

Our release workflow also creates `openwrk-v*` sidecar releases. Those were being marked as **Latest**, so `releases/latest` started pointing at the `openwrk-v*` release, which does **not** include `latest.json`.

Result in the app: **Update check failed** (404 fetching updater JSON).

## Fix
Create `openwrk-v*` releases with `--latest=false` so the OpenWork app release (`v*`) remains GitHub “Latest” and keeps serving `latest.json`.

## Notes
As an immediate mitigation I re-marked `v0.11.17` as Latest so updates work again right now.