### PR TITLE
feat(config): split workspace settings out of Settings

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1817,8 +1817,7 @@ export default function App() {
       setEditRemoteWorkspaceOpen(true);
       return;
     }
-    setSettingsTab("remote");
-    setTab("settings");
+    setTab("config");
     setView("dashboard");
   };
 
@@ -4288,6 +4287,7 @@ export default function App() {
     "skills",
     "plugins",
     "mcp",
+    "config",
     "settings",
   ]);
 

--- a/packages/app/src/app/pages/config.tsx
+++ b/packages/app/src/app/pages/config.tsx
@@ -1,0 +1,466 @@
+import { Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
+
+import { isTauriRuntime } from "../utils";
+
+import Button from "../components/button";
+import TextInput from "../components/text-input";
+import { OwpenbotSettings } from "./settings";
+
+import { RefreshCcw } from "lucide-solid";
+
+import type { OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
+import type { OpenworkServerInfo } from "../lib/tauri";
+
+export type ConfigViewProps = {
+  busy: boolean;
+  clientConnected: boolean;
+  anyActiveRuns: boolean;
+
+  openworkServerStatus: OpenworkServerStatus;
+  openworkServerUrl: string;
+  openworkServerSettings: OpenworkServerSettings;
+  openworkServerHostInfo: OpenworkServerInfo | null;
+  openworkServerWorkspaceId: string | null;
+
+  updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
+  resetOpenworkServerSettings: () => void;
+  testOpenworkServerConnection: (next: OpenworkServerSettings) => Promise<boolean>;
+
+  canReloadWorkspace: boolean;
+  reloadWorkspaceEngine: () => Promise<void>;
+  reloadBusy: boolean;
+  reloadError: string | null;
+
+  workspaceAutoReloadAvailable: boolean;
+  workspaceAutoReloadEnabled: boolean;
+  setWorkspaceAutoReloadEnabled: (value: boolean) => void | Promise<void>;
+  workspaceAutoReloadResumeEnabled: boolean;
+  setWorkspaceAutoReloadResumeEnabled: (value: boolean) => void | Promise<void>;
+
+  developerMode: boolean;
+};
+
+export default function ConfigView(props: ConfigViewProps) {
+  const [openworkUrl, setOpenworkUrl] = createSignal("");
+  const [openworkToken, setOpenworkToken] = createSignal("");
+  const [openworkTokenVisible, setOpenworkTokenVisible] = createSignal(false);
+  const [openworkTestState, setOpenworkTestState] = createSignal<"idle" | "testing" | "success" | "error">("idle");
+  const [openworkTestMessage, setOpenworkTestMessage] = createSignal<string | null>(null);
+  const [clientTokenVisible, setClientTokenVisible] = createSignal(false);
+  const [hostTokenVisible, setHostTokenVisible] = createSignal(false);
+  const [copyingField, setCopyingField] = createSignal<string | null>(null);
+  let copyTimeout: number | undefined;
+
+  createEffect(() => {
+    setOpenworkUrl(props.openworkServerSettings.urlOverride ?? "");
+    setOpenworkToken(props.openworkServerSettings.token ?? "");
+  });
+
+  createEffect(() => {
+    openworkUrl();
+    openworkToken();
+    setOpenworkTestState("idle");
+    setOpenworkTestMessage(null);
+  });
+
+  const openworkStatusLabel = createMemo(() => {
+    switch (props.openworkServerStatus) {
+      case "connected":
+        return "Connected";
+      case "limited":
+        return "Limited";
+      default:
+        return "Not connected";
+    }
+  });
+
+  const openworkStatusStyle = createMemo(() => {
+    switch (props.openworkServerStatus) {
+      case "connected":
+        return "bg-green-7/10 text-green-11 border-green-7/20";
+      case "limited":
+        return "bg-amber-7/10 text-amber-11 border-amber-7/20";
+      default:
+        return "bg-gray-4/60 text-gray-11 border-gray-7/50";
+    }
+  });
+
+  const reloadAvailabilityReason = createMemo(() => {
+    if (!props.clientConnected) return "Connect to this workspace to reload.";
+    if (!props.canReloadWorkspace) {
+      return "Reloading is only available for local workspaces or connected OpenWork servers.";
+    }
+    return null;
+  });
+
+  const reloadButtonLabel = createMemo(() => (props.reloadBusy ? "Reloading..." : "Reload engine"));
+  const reloadButtonTone = createMemo(() => (props.anyActiveRuns ? "danger" : "secondary"));
+  const reloadButtonDisabled = createMemo(() => props.reloadBusy || Boolean(reloadAvailabilityReason()));
+
+  const buildOpenworkSettings = () => ({
+    ...props.openworkServerSettings,
+    urlOverride: openworkUrl().trim() || undefined,
+    token: openworkToken().trim() || undefined,
+  });
+
+  const hasOpenworkChanges = createMemo(() => {
+    const currentUrl = props.openworkServerSettings.urlOverride ?? "";
+    const currentToken = props.openworkServerSettings.token ?? "";
+    return openworkUrl().trim() !== currentUrl || openworkToken().trim() !== currentToken;
+  });
+
+  const hostInfo = createMemo(() => props.openworkServerHostInfo);
+  const hostStatusLabel = createMemo(() => {
+    if (!hostInfo()?.running) return "Offline";
+    return "Available";
+  });
+  const hostStatusStyle = createMemo(() => {
+    if (!hostInfo()?.running) return "bg-gray-4/60 text-gray-11 border-gray-7/50";
+    return "bg-green-7/10 text-green-11 border-green-7/20";
+  });
+  const hostConnectUrl = createMemo(() => {
+    const info = hostInfo();
+    return info?.connectUrl ?? info?.mdnsUrl ?? info?.lanUrl ?? info?.baseUrl ?? "";
+  });
+  const hostConnectUrlUsesMdns = createMemo(() => hostConnectUrl().includes(".local"));
+
+  const handleCopy = async (value: string, field: string) => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyingField(field);
+      if (copyTimeout !== undefined) {
+        window.clearTimeout(copyTimeout);
+      }
+      copyTimeout = window.setTimeout(() => {
+        setCopyingField(null);
+        copyTimeout = undefined;
+      }, 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  onCleanup(() => {
+    if (copyTimeout !== undefined) {
+      window.clearTimeout(copyTimeout);
+    }
+  });
+
+  return (
+    <section class="space-y-6">
+      <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-2">
+        <div class="text-sm font-medium text-gray-12">Workspace config</div>
+        <div class="text-xs text-gray-10">
+          These settings affect the active workspace (sharing, reload, bots). Global app behavior lives in Settings.
+        </div>
+        <Show when={props.openworkServerWorkspaceId}>
+          <div class="text-[11px] text-gray-7 font-mono truncate">
+            Workspace: {props.openworkServerWorkspaceId}
+          </div>
+        </Show>
+      </div>
+
+      <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
+        <div>
+          <div class="text-sm font-medium text-gray-12">Engine reload</div>
+          <div class="text-xs text-gray-10">Restart the OpenCode server for this workspace.</div>
+        </div>
+
+        <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+          <div class="min-w-0 space-y-1">
+            <div class="text-sm text-gray-12">Reload now</div>
+            <div class="text-xs text-gray-7">Applies config updates and reconnects your session.</div>
+            <Show when={props.anyActiveRuns}>
+              <div class="text-[11px] text-amber-11">Reloading will stop active tasks.</div>
+            </Show>
+            <Show when={props.reloadError}>
+              <div class="text-[11px] text-red-11">{props.reloadError}</div>
+            </Show>
+            <Show when={reloadAvailabilityReason()}>
+              <div class="text-[11px] text-gray-9">{reloadAvailabilityReason()}</div>
+            </Show>
+          </div>
+          <Button
+            variant={reloadButtonTone()}
+            class="text-xs h-8 py-0 px-3 shrink-0"
+            onClick={props.reloadWorkspaceEngine}
+            disabled={reloadButtonDisabled()}
+          >
+            <RefreshCcw size={14} class={props.reloadBusy ? "animate-spin" : ""} />
+            {reloadButtonLabel()}
+          </Button>
+        </div>
+
+        <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+          <div class="min-w-0 space-y-1">
+            <div class="text-sm text-gray-12">Auto reload (local)</div>
+            <div class="text-xs text-gray-7">Reload automatically after agents/skills/commands/config change (only when idle).</div>
+            <Show when={!props.workspaceAutoReloadAvailable}>
+              <div class="text-[11px] text-gray-9">Available for local workspaces in the desktop app.</div>
+            </Show>
+          </div>
+          <Button
+            variant="outline"
+            class="text-xs h-8 py-0 px-3 shrink-0"
+            onClick={() => props.setWorkspaceAutoReloadEnabled(!props.workspaceAutoReloadEnabled)}
+            disabled={props.busy || !props.workspaceAutoReloadAvailable}
+          >
+            {props.workspaceAutoReloadEnabled ? "On" : "Off"}
+          </Button>
+        </div>
+
+        <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+          <div class="min-w-0 space-y-1">
+            <div class="text-sm text-gray-12">Resume sessions after auto reload</div>
+            <div class="text-xs text-gray-7">
+              If a reload was queued while tasks were running, send a resume message afterward.
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            class="text-xs h-8 py-0 px-3 shrink-0"
+            onClick={() => props.setWorkspaceAutoReloadResumeEnabled(!props.workspaceAutoReloadResumeEnabled)}
+            disabled={
+              props.busy ||
+              !props.workspaceAutoReloadAvailable ||
+              !props.workspaceAutoReloadEnabled
+            }
+            title={props.workspaceAutoReloadEnabled ? "" : "Enable auto reload first"}
+          >
+            {props.workspaceAutoReloadResumeEnabled ? "On" : "Off"}
+          </Button>
+        </div>
+      </div>
+
+      <Show when={hostInfo()}>
+        <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div class="text-sm font-medium text-gray-12">OpenWork server sharing</div>
+              <div class="text-xs text-gray-10">
+                Share these details with a trusted device. Keep the server on the same network for the fastest setup.
+              </div>
+            </div>
+            <div class={`text-xs px-2 py-1 rounded-full border ${hostStatusStyle()}`}>
+              {hostStatusLabel()}
+            </div>
+          </div>
+
+          <div class="grid gap-3">
+            <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+              <div class="min-w-0">
+                <div class="text-xs font-medium text-gray-11">OpenWork Server URL</div>
+                <div class="text-xs text-gray-7 font-mono truncate">{hostConnectUrl() || "Starting server…"}</div>
+                <Show when={hostConnectUrl()}>
+                  <div class="text-[11px] text-gray-8 mt-1">
+                    {hostConnectUrlUsesMdns()
+                      ? ".local names are easier to remember but may not resolve on all networks."
+                      : "Use your local IP on the same Wi-Fi for the fastest connection."}
+                  </div>
+                </Show>
+              </div>
+              <Button
+                variant="outline"
+                class="text-xs h-8 py-0 px-3 shrink-0"
+                onClick={() => handleCopy(hostConnectUrl(), "host-url")}
+                disabled={!hostConnectUrl()}
+              >
+                {copyingField() === "host-url" ? "Copied" : "Copy"}
+              </Button>
+            </div>
+
+            <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+              <div class="min-w-0">
+                <div class="text-xs font-medium text-gray-11">Access token</div>
+                <div class="text-xs text-gray-7 font-mono truncate">
+                  {clientTokenVisible()
+                    ? hostInfo()?.clientToken || "—"
+                    : hostInfo()?.clientToken
+                      ? "••••••••••••"
+                      : "—"}
+                </div>
+                <div class="text-[11px] text-gray-8 mt-1">Use on phones or laptops connecting to this server.</div>
+              </div>
+              <div class="flex items-center gap-2 shrink-0">
+                <Button
+                  variant="outline"
+                  class="text-xs h-8 py-0 px-3"
+                  onClick={() => setClientTokenVisible((prev) => !prev)}
+                  disabled={!hostInfo()?.clientToken}
+                >
+                  {clientTokenVisible() ? "Hide" : "Show"}
+                </Button>
+                <Button
+                  variant="outline"
+                  class="text-xs h-8 py-0 px-3"
+                  onClick={() => handleCopy(hostInfo()?.clientToken ?? "", "client-token")}
+                  disabled={!hostInfo()?.clientToken}
+                >
+                  {copyingField() === "client-token" ? "Copied" : "Copy"}
+                </Button>
+              </div>
+            </div>
+
+            <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+              <div class="min-w-0">
+                <div class="text-xs font-medium text-gray-11">Server token</div>
+                <div class="text-xs text-gray-7 font-mono truncate">
+                  {hostTokenVisible()
+                    ? hostInfo()?.hostToken || "—"
+                    : hostInfo()?.hostToken
+                      ? "••••••••••••"
+                      : "—"}
+                </div>
+                <div class="text-[11px] text-gray-8 mt-1">Keep private. Required for approval actions.</div>
+              </div>
+              <div class="flex items-center gap-2 shrink-0">
+                <Button
+                  variant="outline"
+                  class="text-xs h-8 py-0 px-3"
+                  onClick={() => setHostTokenVisible((prev) => !prev)}
+                  disabled={!hostInfo()?.hostToken}
+                >
+                  {hostTokenVisible() ? "Hide" : "Show"}
+                </Button>
+                <Button
+                  variant="outline"
+                  class="text-xs h-8 py-0 px-3"
+                  onClick={() => handleCopy(hostInfo()?.hostToken ?? "", "host-token")}
+                  disabled={!hostInfo()?.hostToken}
+                >
+                  {copyingField() === "host-token" ? "Copied" : "Copy"}
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div class="text-xs text-gray-9">
+            For per-workspace sharing links, use <span class="font-medium">Share...</span> in the workspace menu.
+          </div>
+        </div>
+      </Show>
+
+      <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
+        <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <div class="text-sm font-medium text-gray-12">OpenWork server</div>
+            <div class="text-xs text-gray-10">
+              Connect to an OpenWork server. Use the URL and access token from your server admin.
+            </div>
+          </div>
+          <div class={`text-xs px-2 py-1 rounded-full border ${openworkStatusStyle()}`}>{openworkStatusLabel()}</div>
+        </div>
+
+        <div class="grid gap-3">
+          <TextInput
+            label="OpenWork server URL"
+            value={openworkUrl()}
+            onInput={(event) => setOpenworkUrl(event.currentTarget.value)}
+            placeholder="http://127.0.0.1:8787"
+            hint="Use the URL shared by your OpenWork server."
+            disabled={props.busy}
+          />
+
+          <label class="block">
+            <div class="mb-1 text-xs font-medium text-gray-11">Access token</div>
+            <div class="flex items-center gap-2">
+              <input
+                type={openworkTokenVisible() ? "text" : "password"}
+                value={openworkToken()}
+                onInput={(event) => setOpenworkToken(event.currentTarget.value)}
+                placeholder="Paste your token"
+                disabled={props.busy}
+                class="w-full rounded-xl bg-gray-2/60 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-10 shadow-[0_0_0_1px_rgba(255,255,255,0.08)] focus:outline-none focus:ring-2 focus:ring-gray-6/20"
+              />
+              <Button
+                variant="outline"
+                class="text-xs h-9 px-3 shrink-0"
+                onClick={() => setOpenworkTokenVisible((prev) => !prev)}
+                disabled={props.busy}
+              >
+                {openworkTokenVisible() ? "Hide" : "Show"}
+              </Button>
+            </div>
+            <div class="mt-1 text-xs text-gray-10">Optional. Paste the access token to authenticate.</div>
+          </label>
+        </div>
+
+        <div class="text-[11px] text-gray-7 font-mono truncate">Resolved server: {openworkUrl().trim() || "Not set"}</div>
+
+        <div class="flex flex-wrap gap-2">
+          <Button
+            variant="secondary"
+            onClick={async () => {
+              if (openworkTestState() === "testing") return;
+              const next = buildOpenworkSettings();
+              props.updateOpenworkServerSettings(next);
+              setOpenworkTestState("testing");
+              setOpenworkTestMessage(null);
+              try {
+                const ok = await props.testOpenworkServerConnection(next);
+                setOpenworkTestState(ok ? "success" : "error");
+                setOpenworkTestMessage(
+                  ok ? "Connection successful." : "Connection failed. Check the host URL and token.",
+                );
+              } catch (error) {
+                const message = error instanceof Error ? error.message : "Connection failed.";
+                setOpenworkTestState("error");
+                setOpenworkTestMessage(message);
+              }
+            }}
+            disabled={props.busy || openworkTestState() === "testing"}
+          >
+            {openworkTestState() === "testing" ? "Testing..." : "Test connection"}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => props.updateOpenworkServerSettings(buildOpenworkSettings())}
+            disabled={props.busy || !hasOpenworkChanges()}
+          >
+            Save
+          </Button>
+          <Button variant="ghost" onClick={props.resetOpenworkServerSettings} disabled={props.busy}>
+            Reset
+          </Button>
+        </div>
+
+        <Show when={openworkTestState() !== "idle"}>
+          <div
+            class={`text-xs ${
+              openworkTestState() === "success"
+                ? "text-green-11"
+                : openworkTestState() === "error"
+                  ? "text-red-11"
+                  : "text-gray-9"
+            }`}
+            role="status"
+            aria-live="polite"
+          >
+            {openworkTestState() === "testing" ? "Testing connection..." : openworkTestMessage() ?? "Connection status updated."}
+          </div>
+        </Show>
+
+        <Show when={openworkStatusLabel() !== "Connected"}>
+          <div class="text-xs text-gray-9">OpenWork server connection needed to sync skills, plugins, and commands.</div>
+        </Show>
+      </div>
+
+      <OwpenbotSettings
+        busy={props.busy}
+        openworkServerStatus={props.openworkServerStatus}
+        openworkServerUrl={props.openworkServerUrl}
+        openworkServerSettings={props.openworkServerSettings}
+        openworkServerWorkspaceId={props.openworkServerWorkspaceId}
+        openworkServerHostInfo={props.openworkServerHostInfo}
+        developerMode={props.developerMode}
+      />
+
+      <Show when={!isTauriRuntime()}>
+        <div class="text-xs text-gray-9">
+          Some config features (local server sharing + messaging bridge) require the desktop app.
+        </div>
+      </Show>
+    </section>
+  );
+}

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -29,6 +29,7 @@ import Button from "../components/button";
 import McpView from "./mcp";
 import PluginsView from "./plugins";
 import ScheduledTasksView from "./scheduled";
+import ConfigView from "./config";
 import SettingsView from "./settings";
 import SkillsView from "./skills";
 import StatusBar from "../components/status-bar";
@@ -41,6 +42,7 @@ import {
   MoreHorizontal,
   Plus,
   Settings,
+  SlidersHorizontal,
   Zap,
 } from "lucide-solid";
 
@@ -247,6 +249,8 @@ export default function DashboardView(props: DashboardViewProps) {
         return "Plugins";
       case "mcp":
         return "Apps";
+      case "config":
+        return "Config";
       case "settings":
         return "Settings";
       default:
@@ -431,6 +435,10 @@ export default function DashboardView(props: DashboardViewProps) {
     props.setTab("settings");
   };
 
+  const openConfig = () => {
+    props.setTab("config");
+  };
+
   const shareWorkspace = createMemo(() => {
     const id = shareWorkspaceId();
     if (!id) return null;
@@ -508,7 +516,7 @@ export default function DashboardView(props: DashboardViewProps) {
           label: "Access token",
           value: token,
           secret: true,
-          placeholder: token ? undefined : "Set token in Settings",
+          placeholder: token ? undefined : "Set token in Config",
           hint: "This token grants access to the workspace on that host.",
         },
       ];
@@ -978,6 +986,32 @@ export default function DashboardView(props: DashboardViewProps) {
               />
             </Match>
 
+            <Match when={props.tab === "config"}>
+              <ConfigView
+                busy={props.busy}
+                clientConnected={props.clientConnected}
+                anyActiveRuns={props.anyActiveRuns}
+                openworkServerStatus={props.openworkServerStatus}
+                openworkServerUrl={props.openworkServerUrl}
+                openworkServerSettings={props.openworkServerSettings}
+                openworkServerHostInfo={props.openworkServerHostInfo}
+                openworkServerWorkspaceId={props.openworkServerWorkspaceId}
+                updateOpenworkServerSettings={props.updateOpenworkServerSettings}
+                resetOpenworkServerSettings={props.resetOpenworkServerSettings}
+                testOpenworkServerConnection={props.testOpenworkServerConnection}
+                canReloadWorkspace={props.canReloadWorkspace}
+                reloadWorkspaceEngine={props.reloadWorkspaceEngine}
+                reloadBusy={props.reloadBusy}
+                reloadError={props.reloadError}
+                workspaceAutoReloadAvailable={props.workspaceAutoReloadAvailable}
+                workspaceAutoReloadEnabled={props.workspaceAutoReloadEnabled}
+                setWorkspaceAutoReloadEnabled={props.setWorkspaceAutoReloadEnabled}
+                workspaceAutoReloadResumeEnabled={props.workspaceAutoReloadResumeEnabled}
+                setWorkspaceAutoReloadResumeEnabled={props.setWorkspaceAutoReloadResumeEnabled}
+                developerMode={props.developerMode}
+              />
+            </Match>
+
             <Match when={props.tab === "settings"}>
                 <SettingsView
                   startupPreference={props.startupPreference}
@@ -992,21 +1026,10 @@ export default function DashboardView(props: DashboardViewProps) {
                   openProviderAuthModal={props.openProviderAuthModal}
                   openworkServerStatus={props.openworkServerStatus}
                   openworkServerUrl={props.openworkServerUrl}
-                  openworkServerSettings={props.openworkServerSettings}
                   openworkServerHostInfo={props.openworkServerHostInfo}
                   openworkServerCapabilities={props.openworkServerCapabilities}
                   openworkServerDiagnostics={props.openworkServerDiagnostics}
                   openworkServerWorkspaceId={props.openworkServerWorkspaceId}
-                  clientConnected={props.clientConnected}
-                  canReloadWorkspace={props.canReloadWorkspace}
-                  reloadWorkspaceEngine={props.reloadWorkspaceEngine}
-                  reloadBusy={props.reloadBusy}
-                  reloadError={props.reloadError}
-                  workspaceAutoReloadAvailable={props.workspaceAutoReloadAvailable}
-                  workspaceAutoReloadEnabled={props.workspaceAutoReloadEnabled}
-                  setWorkspaceAutoReloadEnabled={props.setWorkspaceAutoReloadEnabled}
-                  workspaceAutoReloadResumeEnabled={props.workspaceAutoReloadResumeEnabled}
-                  setWorkspaceAutoReloadResumeEnabled={props.setWorkspaceAutoReloadResumeEnabled}
                   openworkAuditEntries={props.openworkAuditEntries}
                   openworkAuditStatus={props.openworkAuditStatus}
                   openworkAuditError={props.openworkAuditError}
@@ -1015,9 +1038,6 @@ export default function DashboardView(props: DashboardViewProps) {
                   openwrkStatus={props.openwrkStatus}
                   owpenbotInfo={props.owpenbotInfo}
                   engineDoctorVersion={props.engineDoctorVersion}
-                  updateOpenworkServerSettings={props.updateOpenworkServerSettings}
-                  resetOpenworkServerSettings={props.resetOpenworkServerSettings}
-                  testOpenworkServerConnection={props.testOpenworkServerConnection}
                   developerMode={props.developerMode}
                   toggleDeveloperMode={props.toggleDeveloperMode}
                   stopHost={props.stopHost}
@@ -1131,23 +1151,23 @@ export default function DashboardView(props: DashboardViewProps) {
               }
           }
           exportDisabledReason={exportDisabledReason()}
-          onOpenBots={() => openSettings("messaging")}
+          onOpenBots={openConfig}
         />
 
         <div class="fixed bottom-0 left-0 right-0">
-          <StatusBar
-            clientConnected={props.clientConnected}
-            openworkServerStatus={props.openworkServerStatus}
-            developerMode={props.developerMode}
-            onOpenSettings={() => openSettings("general")}
-            onOpenMessaging={() => openSettings("messaging")}
-            onOpenProviders={() => props.openProviderAuthModal()}
-            onOpenMcp={() => props.setTab("mcp")}
-            providerConnectedIds={props.providerConnectedIds}
-            mcpStatuses={props.mcpStatuses}
-          />
+            <StatusBar
+              clientConnected={props.clientConnected}
+              openworkServerStatus={props.openworkServerStatus}
+              developerMode={props.developerMode}
+              onOpenSettings={() => openSettings("general")}
+              onOpenMessaging={openConfig}
+              onOpenProviders={() => props.openProviderAuthModal()}
+              onOpenMcp={() => props.setTab("mcp")}
+              providerConnectedIds={props.providerConnectedIds}
+              mcpStatuses={props.mcpStatuses}
+            />
           <nav class="md:hidden border-t border-dls-border bg-dls-surface">
-            <div class="mx-auto max-w-5xl px-4 py-3 grid grid-cols-3 gap-2">
+            <div class="mx-auto max-w-5xl px-4 py-3 grid grid-cols-4 gap-2">
               <button
                 class={`flex flex-col items-center gap-1 text-xs ${
                   props.tab === "scheduled" ? "text-gray-12" : "text-gray-10"
@@ -1175,6 +1195,15 @@ export default function DashboardView(props: DashboardViewProps) {
                 <Box size={18} />
                 Apps
               </button>
+              <button
+                class={`flex flex-col items-center gap-1 text-xs ${
+                  props.tab === "config" ? "text-gray-12" : "text-gray-10"
+                }`}
+                onClick={() => props.setTab("config")}
+              >
+                <SlidersHorizontal size={18} />
+                Config
+              </button>
             </div>
           </nav>
         </div>
@@ -1185,6 +1214,7 @@ export default function DashboardView(props: DashboardViewProps) {
           {navItem("scheduled", "Automations", <History size={18} />)}
           {navItem("skills", "Skills", <Zap size={18} />)}
           {navItem("mcp", "Apps", <Box size={18} />)}
+          {navItem("config", "Config", <SlidersHorizontal size={18} />)}
         </div>
 
         <div class="flex-1" />

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -36,6 +36,7 @@ import {
   Plus,
   Settings,
   Shield,
+  SlidersHorizontal,
   Zap,
 } from "lucide-solid";
 
@@ -871,7 +872,7 @@ export default function SessionView(props: SessionViewProps) {
           label: "Access token",
           value: token,
           secret: true,
-          placeholder: token ? undefined : "Set token in Settings",
+          placeholder: token ? undefined : "Set token in Config",
           hint: "This token grants access to the workspace on that host.",
         },
       ];
@@ -940,6 +941,11 @@ export default function SessionView(props: SessionViewProps) {
   const openSettings = (tab: SettingsTab = "general") => {
     props.setSettingsTab(tab);
     props.setTab("settings");
+    props.setView("dashboard");
+  };
+
+  const openConfig = () => {
+    props.setTab("config");
     props.setView("dashboard");
   };
 
@@ -1623,6 +1629,18 @@ export default function SessionView(props: SessionViewProps) {
             <Box size={18} />
             Apps
           </button>
+          <button
+            type="button"
+            class={`w-full h-10 flex items-center gap-3 px-3 rounded-lg text-sm font-medium transition-colors ${
+              props.tab === "config"
+                ? "bg-dls-active text-dls-text"
+                : "text-dls-secondary hover:text-dls-text hover:bg-dls-hover"
+            }`}
+            onClick={openConfig}
+          >
+            <SlidersHorizontal size={18} />
+            Config
+          </button>
         </div>
 
         <div class="flex-1" />
@@ -1645,7 +1663,7 @@ export default function SessionView(props: SessionViewProps) {
           openworkServerStatus={props.openworkServerStatus}
           developerMode={props.developerMode}
           onOpenSettings={() => openSettings("general")}
-          onOpenMessaging={() => openSettings("messaging")}
+          onOpenMessaging={openConfig}
           onOpenProviders={openProviderAuth}
           onOpenMcp={openMcp}
           providerConnectedIds={props.providerConnectedIds}
@@ -1693,7 +1711,7 @@ export default function SessionView(props: SessionViewProps) {
             }
         }
         exportDisabledReason={exportDisabledReason()}
-        onOpenBots={() => openSettings("messaging")}
+        onOpenBots={openConfig}
       />
 
       <Show when={props.activePermission}>

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -1,9 +1,8 @@
-import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onMount } from "solid-js";
 
 import { formatBytes, formatRelativeTime, isTauriRuntime } from "../utils";
 
 import Button from "../components/button";
-import TextInput from "../components/text-input";
 import { HardDrive, MessageCircle, PlugZap, RefreshCcw, Shield, Smartphone, X } from "lucide-solid";
 import type { OpencodeConnectStatus, ProviderListItem, SettingsTab, StartupPreference } from "../types";
 import { createOpenworkServerClient } from "../lib/openwork-server";
@@ -53,13 +52,10 @@ export type SettingsViewProps = {
   openProviderAuthModal: () => Promise<void>;
   openworkServerStatus: OpenworkServerStatus;
   openworkServerUrl: string;
-  openworkServerSettings: OpenworkServerSettings;
   openworkServerHostInfo: OpenworkServerInfo | null;
   openworkServerCapabilities: OpenworkServerCapabilities | null;
   openworkServerDiagnostics: OpenworkServerDiagnostics | null;
   openworkServerWorkspaceId: string | null;
-  clientConnected: boolean;
-  canReloadWorkspace: boolean;
   openworkAuditEntries: OpenworkAuditEntry[];
   openworkAuditStatus: "idle" | "loading" | "error";
   openworkAuditError: string | null;
@@ -67,12 +63,6 @@ export type SettingsViewProps = {
   engineInfo: EngineInfo | null;
   openwrkStatus: OpenwrkStatus | null;
   owpenbotInfo: OwpenbotInfo | null;
-  reloadWorkspaceEngine: () => Promise<void>;
-  reloadBusy: boolean;
-  reloadError: string | null;
-  updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
-  resetOpenworkServerSettings: () => void;
-  testOpenworkServerConnection: (next: OpenworkServerSettings) => Promise<boolean>;
   developerMode: boolean;
   toggleDeveloperMode: () => void;
   stopHost: () => void;
@@ -112,11 +102,6 @@ export type SettingsViewProps = {
   downloadUpdate: () => void;
   installUpdateAndRestart: () => void;
   anyActiveRuns: boolean;
-  workspaceAutoReloadAvailable: boolean;
-  workspaceAutoReloadEnabled: boolean;
-  setWorkspaceAutoReloadEnabled: (value: boolean) => void | Promise<void>;
-  workspaceAutoReloadResumeEnabled: boolean;
-  setWorkspaceAutoReloadResumeEnabled: (value: boolean) => void | Promise<void>;
   onResetStartupPreference: () => void;
   openResetModal: (mode: "onboarding" | "all") => void;
   resetModalBusy: boolean;
@@ -135,7 +120,7 @@ export type SettingsViewProps = {
 };
 
 // Owpenbot Settings Component
-function OwpenbotSettings(props: {
+export function OwpenbotSettings(props: {
   busy: boolean;
   openworkServerStatus: OpenworkServerStatus;
   openworkServerUrl: string;
@@ -1186,28 +1171,6 @@ export default function SettingsView(props: SettingsViewProps) {
     }
   };
 
-  const [openworkUrl, setOpenworkUrl] = createSignal("");
-  const [openworkToken, setOpenworkToken] = createSignal("");
-  const [openworkTokenVisible, setOpenworkTokenVisible] = createSignal(false);
-  const [openworkTestState, setOpenworkTestState] = createSignal<"idle" | "testing" | "success" | "error">("idle");
-  const [openworkTestMessage, setOpenworkTestMessage] = createSignal<string | null>(null);
-  const [clientTokenVisible, setClientTokenVisible] = createSignal(false);
-  const [hostTokenVisible, setHostTokenVisible] = createSignal(false);
-  const [copyingField, setCopyingField] = createSignal<string | null>(null);
-  let copyTimeout: number | undefined;
-
-  createEffect(() => {
-    setOpenworkUrl(props.openworkServerSettings.urlOverride ?? "");
-    setOpenworkToken(props.openworkServerSettings.token ?? "");
-  });
-
-  createEffect(() => {
-    openworkUrl();
-    openworkToken();
-    setOpenworkTestState("idle");
-    setOpenworkTestMessage(null);
-  });
-
   const openworkStatusLabel = createMemo(() => {
     switch (props.openworkServerStatus) {
       case "connected":
@@ -1229,18 +1192,6 @@ export default function SettingsView(props: SettingsViewProps) {
         return "bg-gray-4/60 text-gray-11 border-gray-7/50";
     }
   });
-
-  const reloadAvailabilityReason = createMemo(() => {
-    if (!props.clientConnected) return "Connect to this workspace to reload.";
-    if (!props.canReloadWorkspace) {
-      return "Reloading is only available for local workspaces or connected OpenWork servers.";
-    }
-    return null;
-  });
-
-  const reloadButtonLabel = createMemo(() => (props.reloadBusy ? "Reloading..." : "Reload engine"));
-  const reloadButtonTone = createMemo(() => (props.anyActiveRuns ? "danger" : "secondary"));
-  const reloadButtonDisabled = createMemo(() => props.reloadBusy || Boolean(reloadAvailabilityReason()));
 
   const engineStatusLabel = createMemo(() => {
     if (!isTauriRuntime()) return "Unavailable";
@@ -1370,10 +1321,6 @@ export default function SettingsView(props: SettingsViewProps) {
         return "Model";
       case "advanced":
         return "Advanced";
-      case "remote":
-        return "Remote";
-      case "messaging":
-        return "Messaging Bridge";
       case "debug":
         return "Debug";
       default:
@@ -1382,7 +1329,7 @@ export default function SettingsView(props: SettingsViewProps) {
   };
 
   const availableTabs = createMemo<SettingsTab[]>(() => {
-    const tabs: SettingsTab[] = ["general", "model", "messaging", "remote", "advanced"];
+    const tabs: SettingsTab[] = ["general", "model", "advanced"];
     if (props.developerMode) tabs.push("debug");
     return tabs;
   });
@@ -1479,57 +1426,6 @@ export default function SettingsView(props: SettingsViewProps) {
     if (!uptimeMs) return "—";
     return formatRelativeTime(Date.now() - uptimeMs);
   };
-
-  const buildOpenworkSettings = () => ({
-    ...props.openworkServerSettings,
-    urlOverride: openworkUrl().trim() || undefined,
-    token: openworkToken().trim() || undefined,
-  });
-
-  const hasOpenworkChanges = createMemo(() => {
-    const currentUrl = props.openworkServerSettings.urlOverride ?? "";
-    const currentToken = props.openworkServerSettings.token ?? "";
-    return openworkUrl().trim() !== currentUrl || openworkToken().trim() !== currentToken;
-  });
-
-  const hostInfo = createMemo(() => props.openworkServerHostInfo);
-  const hostStatusLabel = createMemo(() => {
-    if (!hostInfo()?.running) return "Offline";
-    return "Available";
-  });
-  const hostStatusStyle = createMemo(() => {
-    if (!hostInfo()?.running) return "bg-gray-4/60 text-gray-11 border-gray-7/50";
-    return "bg-green-7/10 text-green-11 border-green-7/20";
-  });
-  const hostConnectUrl = createMemo(() => {
-    const info = hostInfo();
-    return info?.connectUrl ?? info?.mdnsUrl ?? info?.lanUrl ?? info?.baseUrl ?? "";
-  });
-  const hostConnectUrlUsesMdns = createMemo(() => hostConnectUrl().includes(".local"));
-
-  const handleCopy = async (value: string, field: string) => {
-    if (!value) return;
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopyingField(field);
-      if (copyTimeout !== undefined) {
-        window.clearTimeout(copyTimeout);
-      }
-      copyTimeout = window.setTimeout(() => {
-        setCopyingField(null);
-        copyTimeout = undefined;
-      }, 2000);
-    } catch {
-      // ignore
-    }
-  };
-
-  onCleanup(() => {
-    if (copyTimeout !== undefined) {
-      window.clearTimeout(copyTimeout);
-    }
-  });
-
 
   return (
     <section class="space-y-6">
@@ -2025,324 +1921,6 @@ export default function SettingsView(props: SettingsViewProps) {
                 Requires typing <span class="font-mono text-gray-11">RESET</span> and will restart the app.
               </div>
             </div>
-          </div>
-        </Match>
-
-        <Match when={activeTab() === "remote"}>
-          <div class="space-y-6">
-            <Show when={hostInfo()}>
-              <div class="space-y-4">
-                <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
-                  <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                    <div>
-                      <div class="text-sm font-medium text-gray-12">OpenWork server sharing</div>
-                      <div class="text-xs text-gray-10">
-                        Share these details with a trusted device. Keep the server on the same network for the fastest setup.
-                      </div>
-                    </div>
-                    <div class={`text-xs px-2 py-1 rounded-full border ${hostStatusStyle()}`}>
-                      {hostStatusLabel()}
-                    </div>
-                  </div>
-
-                  <div class="grid gap-3">
-                    <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                      <div class="min-w-0">
-                        <div class="text-xs font-medium text-gray-11">OpenWork Server URL</div>
-                        <div class="text-xs text-gray-7 font-mono truncate">
-                          {hostConnectUrl() || "Starting server…"}
-                        </div>
-                        <Show when={hostConnectUrl()}>
-                          <div class="text-[11px] text-gray-8 mt-1">
-                            {hostConnectUrlUsesMdns()
-                              ? ".local names are easier to remember but may not resolve on all networks."
-                              : "Use your local IP on the same Wi-Fi for the fastest connection."}
-                          </div>
-                        </Show>
-                      </div>
-                      <Button
-                        variant="outline"
-                        class="text-xs h-8 py-0 px-3 shrink-0"
-                        onClick={() => handleCopy(hostConnectUrl(), "host-url")}
-                        disabled={!hostConnectUrl()}
-                      >
-                        {copyingField() === "host-url" ? "Copied" : "Copy"}
-                      </Button>
-                    </div>
-
-                    <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                      <div class="min-w-0">
-                        <div class="text-xs font-medium text-gray-11">Access token</div>
-                        <div class="text-xs text-gray-7 font-mono truncate">
-                          {clientTokenVisible()
-                            ? hostInfo()?.clientToken || "—"
-                            : hostInfo()?.clientToken
-                              ? "••••••••••••"
-                              : "—"}
-                        </div>
-                        <div class="text-[11px] text-gray-8 mt-1">Use on phones or laptops connecting to this server.</div>
-                      </div>
-                      <div class="flex items-center gap-2 shrink-0">
-                        <Button
-                          variant="outline"
-                          class="text-xs h-8 py-0 px-3"
-                          onClick={() => setClientTokenVisible((prev) => !prev)}
-                          disabled={!hostInfo()?.clientToken}
-                        >
-                          {clientTokenVisible() ? "Hide" : "Show"}
-                        </Button>
-                        <Button
-                          variant="outline"
-                          class="text-xs h-8 py-0 px-3"
-                          onClick={() => handleCopy(hostInfo()?.clientToken ?? "", "client-token")}
-                          disabled={!hostInfo()?.clientToken}
-                        >
-                          {copyingField() === "client-token" ? "Copied" : "Copy"}
-                        </Button>
-                      </div>
-                    </div>
-
-                    <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                      <div class="min-w-0">
-                        <div class="text-xs font-medium text-gray-11">Server token</div>
-                        <div class="text-xs text-gray-7 font-mono truncate">
-                          {hostTokenVisible()
-                            ? hostInfo()?.hostToken || "—"
-                            : hostInfo()?.hostToken
-                              ? "••••••••••••"
-                              : "—"}
-                        </div>
-                        <div class="text-[11px] text-gray-8 mt-1">Keep private. Required for approval actions.</div>
-                      </div>
-                      <div class="flex items-center gap-2 shrink-0">
-                        <Button
-                          variant="outline"
-                          class="text-xs h-8 py-0 px-3"
-                          onClick={() => setHostTokenVisible((prev) => !prev)}
-                          disabled={!hostInfo()?.hostToken}
-                        >
-                          {hostTokenVisible() ? "Hide" : "Show"}
-                        </Button>
-                        <Button
-                          variant="outline"
-                          class="text-xs h-8 py-0 px-3"
-                          onClick={() => handleCopy(hostInfo()?.hostToken ?? "", "host-token")}
-                          disabled={!hostInfo()?.hostToken}
-                        >
-                          {copyingField() === "host-token" ? "Copied" : "Copy"}
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </Show>
-
-            <div class="space-y-4">
-              <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
-                <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                  <div>
-                    <div class="text-sm font-medium text-gray-12">OpenWork server</div>
-                    <div class="text-xs text-gray-10">
-                      Connect to an OpenWork server. Use the URL and access token from your server admin.
-                    </div>
-                  </div>
-                  <div class={`text-xs px-2 py-1 rounded-full border ${openworkStatusStyle()}`}>
-                    {openworkStatusLabel()}
-                  </div>
-                </div>
-
-                <div class="grid gap-3">
-                  <TextInput
-                    label="OpenWork server URL"
-                    value={openworkUrl()}
-                    onInput={(event) => setOpenworkUrl(event.currentTarget.value)}
-                    placeholder="http://127.0.0.1:8787"
-                    hint="Use the URL shared by your OpenWork server."
-                    disabled={props.busy}
-                  />
-
-                  <label class="block">
-                    <div class="mb-1 text-xs font-medium text-gray-11">Access token</div>
-                    <div class="flex items-center gap-2">
-                      <input
-                        type={openworkTokenVisible() ? "text" : "password"}
-                        value={openworkToken()}
-                        onInput={(event) => setOpenworkToken(event.currentTarget.value)}
-                        placeholder="Paste your token"
-                        disabled={props.busy}
-                        class="w-full rounded-xl bg-gray-2/60 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-10 shadow-[0_0_0_1px_rgba(255,255,255,0.08)] focus:outline-none focus:ring-2 focus:ring-gray-6/20"
-                      />
-                      <Button
-                        variant="outline"
-                        class="text-xs h-9 px-3 shrink-0"
-                        onClick={() => setOpenworkTokenVisible((prev) => !prev)}
-                        disabled={props.busy}
-                      >
-                        {openworkTokenVisible() ? "Hide" : "Show"}
-                      </Button>
-                    </div>
-                    <div class="mt-1 text-xs text-gray-10">Optional. Paste the access token to authenticate.</div>
-                  </label>
-                </div>
-
-                <div class="text-[11px] text-gray-7 font-mono truncate">
-                  Resolved server: {openworkUrl().trim() || "Not set"}
-                </div>
-
-                <div class="flex flex-wrap gap-2">
-                  <Button
-                    variant="secondary"
-                    onClick={async () => {
-                      if (openworkTestState() === "testing") return;
-                      const next = buildOpenworkSettings();
-                      props.updateOpenworkServerSettings(next);
-                      setOpenworkTestState("testing");
-                      setOpenworkTestMessage(null);
-                      try {
-                        const ok = await props.testOpenworkServerConnection(next);
-                        setOpenworkTestState(ok ? "success" : "error");
-                        setOpenworkTestMessage(
-                          ok
-                            ? "Connection successful."
-                            : "Connection failed. Check the host URL and token."
-                        );
-                      } catch (error) {
-                        const message = error instanceof Error ? error.message : "Connection failed.";
-                        setOpenworkTestState("error");
-                        setOpenworkTestMessage(message);
-                      }
-                    }}
-                    disabled={props.busy || openworkTestState() === "testing"}
-                  >
-                    {openworkTestState() === "testing" ? "Testing..." : "Test connection"}
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() => props.updateOpenworkServerSettings(buildOpenworkSettings())}
-                    disabled={props.busy || !hasOpenworkChanges()}
-                  >
-                    Save
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    onClick={props.resetOpenworkServerSettings}
-                    disabled={props.busy}
-                  >
-                    Reset
-                  </Button>
-                </div>
-
-                <Show when={openworkTestState() !== "idle"}>
-                  <div
-                    class={`text-xs ${
-                      openworkTestState() === "success"
-                        ? "text-green-11"
-                        : openworkTestState() === "error"
-                          ? "text-red-11"
-                          : "text-gray-9"
-                    }`}
-                    role="status"
-                    aria-live="polite"
-                  >
-                    {openworkTestState() === "testing"
-                      ? "Testing connection..."
-                      : openworkTestMessage() ?? "Connection status updated."}
-                  </div>
-                </Show>
-
-                <Show when={openworkStatusLabel() !== "Connected"}>
-                  <div class="text-xs text-gray-9">
-                    OpenWork server connection needed to sync skills, plugins, and commands.
-                  </div>
-                </Show>
-              </div>
-
-              <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
-                <div>
-                  <div class="text-sm font-medium text-gray-12">Engine reload</div>
-                  <div class="text-xs text-gray-10">Restart the OpenCode server for this workspace.</div>
-                </div>
-
-                <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                  <div class="min-w-0 space-y-1">
-                    <div class="text-sm text-gray-12">Reload now</div>
-                    <div class="text-xs text-gray-7">Applies config updates and reconnects your session.</div>
-                    <Show when={props.anyActiveRuns}>
-                      <div class="text-[11px] text-amber-11">Reloading will stop active tasks.</div>
-                    </Show>
-                    <Show when={props.reloadError}>
-                      <div class="text-[11px] text-red-11">{props.reloadError}</div>
-                    </Show>
-                    <Show when={reloadAvailabilityReason()}>
-                      <div class="text-[11px] text-gray-9">{reloadAvailabilityReason()}</div>
-                    </Show>
-                  </div>
-                  <Button
-                    variant={reloadButtonTone()}
-                    class="text-xs h-8 py-0 px-3 shrink-0"
-                    onClick={props.reloadWorkspaceEngine}
-                    disabled={reloadButtonDisabled()}
-                  >
-                    <RefreshCcw size={14} class={props.reloadBusy ? "animate-spin" : ""} />
-                    {reloadButtonLabel()}
-                  </Button>
-                </div>
-
-                <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                  <div class="min-w-0 space-y-1">
-                    <div class="text-sm text-gray-12">Auto reload (local)</div>
-                    <div class="text-xs text-gray-7">
-                      Reload automatically after agents/skills/commands/config change (only when idle).
-                    </div>
-                    <Show when={!props.workspaceAutoReloadAvailable}>
-                      <div class="text-[11px] text-gray-9">Available for local workspaces in the desktop app.</div>
-                    </Show>
-                  </div>
-                  <Button
-                    variant="outline"
-                    class="text-xs h-8 py-0 px-3 shrink-0"
-                    onClick={() => props.setWorkspaceAutoReloadEnabled(!props.workspaceAutoReloadEnabled)}
-                    disabled={props.busy || !props.workspaceAutoReloadAvailable}
-                  >
-                    {props.workspaceAutoReloadEnabled ? "On" : "Off"}
-                  </Button>
-                </div>
-
-                <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                  <div class="min-w-0 space-y-1">
-                    <div class="text-sm text-gray-12">Resume sessions after auto reload</div>
-                    <div class="text-xs text-gray-7">
-                      If a reload was queued while tasks were running, send a resume message afterward.
-                    </div>
-                  </div>
-                  <Button
-                    variant="outline"
-                    class="text-xs h-8 py-0 px-3 shrink-0"
-                    onClick={() => props.setWorkspaceAutoReloadResumeEnabled(!props.workspaceAutoReloadResumeEnabled)}
-                    disabled={props.busy || !props.workspaceAutoReloadAvailable || !props.workspaceAutoReloadEnabled}
-                    title={props.workspaceAutoReloadEnabled ? "" : "Enable auto reload first"}
-                  >
-                    {props.workspaceAutoReloadResumeEnabled ? "On" : "Off"}
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </Match>
-
-        <Match when={activeTab() === "messaging"}>
-          <div class="space-y-6">
-            <OwpenbotSettings
-              busy={props.busy}
-              openworkServerStatus={props.openworkServerStatus}
-              openworkServerUrl={props.openworkServerUrl}
-              openworkServerSettings={props.openworkServerSettings}
-              openworkServerWorkspaceId={props.openworkServerWorkspaceId}
-              openworkServerHostInfo={props.openworkServerHostInfo}
-              developerMode={props.developerMode}
-            />
           </div>
         </Match>
 

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -128,9 +128,10 @@ export type DashboardTab =
   | "skills"
   | "plugins"
   | "mcp"
+  | "config"
   | "settings";
 
-export type SettingsTab = "general" | "model" | "advanced" | "remote" | "messaging" | "debug";
+export type SettingsTab = "general" | "model" | "advanced" | "debug";
 
 export type WorkspacePreset = "starter" | "automation" | "minimal";
 


### PR DESCRIPTION
## What
- Add a new top-level `Config` page (sidebar + mobile tab)
- Move workspace-scoped controls from Settings into Config:
  - OpenWork server sharing + connect URL/token
  - OpenWork server connection (URL + access token)
  - Engine reload + auto reload toggles
  - Messaging bridge (Owpenbot) setup
- Keep Settings focused on global app behavior (appearance, updates, startup, engine source/runtime, etc.)

## Why
- Settings was mixing global app preferences with workspace-scoped configuration.
- This makes it clearer what changes affect “this device/app” vs “this workspace”.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`