### PR TITLE
feat: multi-workspace hosting + workspace-scoped tasks sidebar

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -38,7 +38,7 @@ import DashboardView from "./pages/dashboard";
 import SessionView from "./pages/session";
 import ProtoWorkspacesView from "./pages/proto-workspaces";
 import ProtoV1UxView from "./pages/proto-v1-ux";
-import { createClient, unwrap, waitForHealthy } from "./lib/opencode";
+import { createClient, unwrap, waitForHealthy, type OpencodeAuth } from "./lib/opencode";
 import {
   DEFAULT_MODEL,
   HIDE_TITLEBAR_PREF_KEY,
@@ -230,7 +230,7 @@ export default function App() {
     isTauriRuntime() ? "sidecar" : "path"
   );
 
-  const [engineRuntime, setEngineRuntime] = createSignal<EngineRuntime>("direct");
+  const [engineRuntime, setEngineRuntime] = createSignal<EngineRuntime>("openwrk");
 
   const [baseUrl, setBaseUrl] = createSignal("http://127.0.0.1:4096");
   const [clientDirectory, setClientDirectory] = createSignal("");
@@ -670,30 +670,10 @@ export default function App() {
         return a.id.localeCompare(b.id);
       });
 
-  const [sidebarSessions, setSidebarSessions] = createSignal<Session[]>([]);
-  const refreshSidebarSessions = async () => {
-    const c = client();
-    if (!c) {
-      setSidebarSessions([]);
-      return;
-    }
-    const list = unwrap(await c.session.list());
-    setSidebarSessions(sortSessionsByActivity(list));
-  };
-
-  createEffect(() => {
-    if (!client()) {
-      setSidebarSessions([]);
-      return;
-    }
-    refreshSidebarSessions().catch(() => undefined);
-  });
-
   const [sessionsLoaded, setSessionsLoaded] = createSignal(false);
   const loadSessionsWithReady = async (scopeRoot?: string) => {
     await loadSessions(scopeRoot);
     setSessionsLoaded(true);
-    await refreshSidebarSessions().catch(() => undefined);
   };
 
   createEffect(() => {
@@ -927,9 +907,9 @@ export default function App() {
     if (!trimmed) {
       throw new Error("Session name is required");
     }
-
+    
     await renameSession(sessionID, trimmed);
-    await refreshSidebarSessions().catch(() => undefined);
+    await refreshSidebarWorkspaceSessions(workspaceStore.activeWorkspaceId()).catch(() => undefined);
   }
 
   async function deleteSessionById(sessionID: string) {
@@ -944,7 +924,7 @@ export default function App() {
     const params = root ? { sessionID: trimmed, directory: root } : { sessionID: trimmed };
     unwrap(await c.session.delete(params));
     await loadSessions(root || undefined).catch(() => undefined);
-    await refreshSidebarSessions().catch(() => undefined);
+    await refreshSidebarWorkspaceSessions(workspaceStore.activeWorkspaceId()).catch(() => undefined);
 
     const nextStatus = { ...sessionStatusById() };
     if (nextStatus[trimmed]) {
@@ -1444,33 +1424,195 @@ export default function App() {
     engineRuntime,
   });
 
+  type SidebarWorkspaceSessionsStatus = WorkspaceSessionGroup["status"];
+  const [sidebarSessionsByWorkspaceId, setSidebarSessionsByWorkspaceId] = createSignal<
+    Record<string, Session[]>
+  >({});
+  const [sidebarSessionStatusByWorkspaceId, setSidebarSessionStatusByWorkspaceId] = createSignal<
+    Record<string, SidebarWorkspaceSessionsStatus>
+  >({});
+  const [sidebarSessionErrorByWorkspaceId, setSidebarSessionErrorByWorkspaceId] = createSignal<
+    Record<string, string | null>
+  >({});
+
+  const pruneSidebarSessionState = (workspaceIds: Set<string>) => {
+    setSidebarSessionsByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, Session[]> = {};
+      for (const [id, list] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = list;
+      }
+      return changed ? next : prev;
+    });
+    setSidebarSessionStatusByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, SidebarWorkspaceSessionsStatus> = {};
+      for (const [id, status] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = status;
+      }
+      return changed ? next : prev;
+    });
+    setSidebarSessionErrorByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, string | null> = {};
+      for (const [id, error] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = error;
+      }
+      return changed ? next : prev;
+    });
+  };
+
+  const resolveSidebarClientConfig = (workspaceId: string) => {
+    const workspace = workspaceStore.workspaces().find((entry) => entry.id === workspaceId) ?? null;
+    if (!workspace) return null;
+
+    if (workspace.workspaceType === "local") {
+      const info = workspaceStore.engine();
+      const baseUrl = info?.baseUrl?.trim() ?? "";
+      const directory = workspace.path?.trim() ?? "";
+      const username = info?.opencodeUsername?.trim() ?? "";
+      const password = info?.opencodePassword?.trim() ?? "";
+      const auth: OpencodeAuth | undefined = username && password ? { username, password } : undefined;
+      return {
+        baseUrl,
+        directory,
+        auth,
+      };
+    }
+
+    const baseUrl = workspace.baseUrl?.trim() ?? "";
+    const directory = workspace.directory?.trim() ?? "";
+    if (workspace.remoteType === "openwork") {
+      const token = workspace.openworkToken?.trim() || openworkServerSettings().token?.trim() || "";
+      const auth: OpencodeAuth | undefined = token ? { token, mode: "openwork" } : undefined;
+      return {
+        baseUrl,
+        directory,
+        auth,
+      };
+    }
+    return {
+      baseUrl,
+      directory,
+      auth: undefined as OpencodeAuth | undefined,
+    };
+  };
+
+  const sidebarRefreshSeqByWorkspaceId: Record<string, number> = {};
+  const refreshSidebarWorkspaceSessions = async (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+
+    const config = resolveSidebarClientConfig(id);
+    if (!config) return;
+
+    // For local workspaces, avoid thrashing UI with errors if the engine is offline.
+    if (!config.baseUrl) {
+      setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "idle" }));
+      setSidebarSessionErrorByWorkspaceId((prev) => ({ ...prev, [id]: null }));
+      return;
+    }
+
+    sidebarRefreshSeqByWorkspaceId[id] = (sidebarRefreshSeqByWorkspaceId[id] ?? 0) + 1;
+    const seq = sidebarRefreshSeqByWorkspaceId[id];
+
+    setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "loading" }));
+    setSidebarSessionErrorByWorkspaceId((prev) => ({ ...prev, [id]: null }));
+
+    try {
+      let directory = config.directory;
+      let c = createClient(config.baseUrl, directory || undefined, config.auth);
+
+      if (!directory) {
+        try {
+          const pathInfo = unwrap(await c.path.get());
+          const discovered = normalizeDirectoryPath(pathInfo.directory ?? "");
+          if (discovered) {
+            directory = discovered;
+            c = createClient(config.baseUrl, directory, config.auth);
+          }
+        } catch {
+          // ignore
+        }
+      }
+
+      const list = unwrap(await c.session.list());
+      if (sidebarRefreshSeqByWorkspaceId[id] !== seq) return;
+      setSidebarSessionsByWorkspaceId((prev) => ({ ...prev, [id]: sortSessionsByActivity(list) }));
+      setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
+    } catch (error) {
+      if (sidebarRefreshSeqByWorkspaceId[id] !== seq) return;
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "error" }));
+      setSidebarSessionErrorByWorkspaceId((prev) => ({ ...prev, [id]: message }));
+    }
+  };
+
+  const refreshAllSidebarWorkspaceSessions = async (prioritizeWorkspaceId?: string | null) => {
+    const list = workspaceStore.workspaces();
+    if (!list.length) return;
+    const prioritize = (prioritizeWorkspaceId ?? "").trim();
+    const ordered = prioritize
+      ? [...list.filter((ws) => ws.id === prioritize), ...list.filter((ws) => ws.id !== prioritize)]
+      : list;
+    for (const ws of ordered) {
+      await refreshSidebarWorkspaceSessions(ws.id);
+    }
+  };
+
+  let lastSidebarRefreshKey = "";
+  createEffect(() => {
+    const engineInfo = workspaceStore.engine();
+    const engineBaseUrl = engineInfo?.baseUrl?.trim() ?? "";
+    const engineUser = engineInfo?.opencodeUsername?.trim() ?? "";
+    const enginePass = engineInfo?.opencodePassword?.trim() ?? "";
+    const tokenFallback = openworkServerSettings().token?.trim() ?? "";
+    const workspaceKey = workspaceStore
+      .workspaces()
+      .map((ws) => {
+        const root = ws.workspaceType === "local" ? ws.path?.trim() ?? "" : ws.directory?.trim() ?? "";
+        const base = ws.workspaceType === "local" ? "" : ws.baseUrl?.trim() ?? "";
+        const remoteType = ws.workspaceType === "remote" ? (ws.remoteType ?? "") : "";
+        const token = ws.remoteType === "openwork" ? (ws.openworkToken?.trim() ?? "") : "";
+        return [ws.id, ws.workspaceType, remoteType, root, base, token].join("|");
+      })
+      .join(";");
+
+    const key = [engineBaseUrl, engineUser, enginePass, tokenFallback, workspaceKey].join("::");
+    if (key === lastSidebarRefreshKey) return;
+    lastSidebarRefreshKey = key;
+
+    pruneSidebarSessionState(new Set(workspaceStore.workspaces().map((ws) => ws.id)));
+    void refreshAllSidebarWorkspaceSessions(workspaceStore.activeWorkspaceId()).catch(() => undefined);
+  });
+
+  createEffect(() => {
+    const id = workspaceStore.activeWorkspaceId().trim();
+    if (!id) return;
+    const status = sidebarSessionStatusByWorkspaceId()[id];
+    if (status === "ready" || status === "loading") return;
+    refreshSidebarWorkspaceSessions(id).catch(() => undefined);
+  });
+
   const sidebarWorkspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
     const workspaces = workspaceStore.workspaces();
-    const sessionList = sidebarSessions();
-    const workspaceByRoot = new Map<string, string>();
-    const sessionsByWorkspaceId = new Map<string, Session[]>();
-
-    for (const workspace of workspaces) {
-      const root = normalizeDirectoryPath(
-        workspace.workspaceType === "remote" ? workspace.directory ?? "" : workspace.path
-      );
-      if (root) {
-        workspaceByRoot.set(root, workspace.id);
-      }
-      sessionsByWorkspaceId.set(workspace.id, []);
-    }
-
-    for (const session of sessionList) {
-      const root = normalizeDirectoryPath(session.directory ?? "");
-      if (!root) continue;
-      const workspaceId = workspaceByRoot.get(root);
-      if (!workspaceId) continue;
-      const bucket = sessionsByWorkspaceId.get(workspaceId);
-      if (bucket) bucket.push(session);
-    }
-
+    const sessionsById = sidebarSessionsByWorkspaceId();
+    const statusById = sidebarSessionStatusByWorkspaceId();
+    const errorById = sidebarSessionErrorByWorkspaceId();
     return workspaces.map((workspace) => {
-      const groupSessions = sortSessionsByActivity(sessionsByWorkspaceId.get(workspace.id) ?? []);
+      const groupSessions = sessionsById[workspace.id] ?? [];
       return {
         workspace,
         sessions: groupSessions.map((session) => ({
@@ -1480,6 +1622,8 @@ export default function App() {
           time: session.time,
           directory: session.directory,
         })),
+        status: statusById[workspace.id] ?? "idle",
+        error: errorById[workspace.id] ?? null,
       };
     });
   });
@@ -1562,7 +1706,7 @@ export default function App() {
           if (cancelled) return;
           const items = Array.isArray(response.items) ? response.items : [];
           const match = items.find((entry) => normalizeDirectoryPath(entry.path) === root);
-          setOpenworkServerWorkspaceId(response.activeId ?? match?.id ?? null);
+          setOpenworkServerWorkspaceId(match?.id ?? response.activeId ?? null);
         } catch {
           if (!cancelled) setOpenworkServerWorkspaceId(null);
         }

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1,7 +1,7 @@
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
 import fuzzysort from "fuzzysort";
-import { ArrowUp, AtSign, ChevronDown, File, Paperclip, Terminal, X, Zap } from "lucide-solid";
+import { ArrowUp, AtSign, ChevronDown, File as FileIcon, Paperclip, Terminal, X, Zap } from "lucide-solid";
 
 import type { ComposerAttachment, ComposerDraft, ComposerPart, PromptMode, SlashCommandOption } from "../../types";
 
@@ -1074,7 +1074,7 @@ export default function Composer(props: ComposerProps) {
                               when={option.kind === "agent"}
                               fallback={
                                 <>
-                                  <File size={14} class="text-dls-secondary" />
+                                  <FileIcon size={14} class="text-dls-secondary" />
                                   <div class="flex items-center min-w-0 text-xs">
                                     {(() => {
                                       const value = option.value;
@@ -1176,7 +1176,7 @@ export default function Composer(props: ComposerProps) {
                     <div class="flex items-center gap-2 rounded-2xl border border-dls-border bg-dls-hover px-3 py-2 text-xs text-dls-secondary">
                       <Show
                         when={attachment.kind === "image"}
-                        fallback={<File size={14} class="text-dls-secondary" />}
+                        fallback={<FileIcon size={14} class="text-dls-secondary" />}
                       >
                         <div class="h-10 w-10 rounded-xl bg-dls-surface overflow-hidden border border-dls-border">
                           <img src={attachment.dataUrl} alt={attachment.name} class="h-full w-full object-cover" />

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -228,14 +228,36 @@ export function createWorkspaceStore(options: {
     });
   });
 
-  const resolveOpenworkHost = async (input: { hostUrl: string; token?: string | null; workspaceId?: string | null }) => {
-    const normalizedHostUrl = normalizeOpenworkServerUrl(input.hostUrl) ?? "";
+  const resolveOpenworkHost = async (input: {
+    hostUrl: string;
+    token?: string | null;
+    workspaceId?: string | null;
+    directoryHint?: string | null;
+  }) => {
+    let normalizedHostUrl = normalizeOpenworkServerUrl(input.hostUrl) ?? "";
     if (!normalizedHostUrl) {
       return { kind: "fallback" as const };
     }
 
-    const workspaceBaseUrl =
-      buildOpenworkWorkspaceBaseUrl(normalizedHostUrl, input.workspaceId) ?? normalizedHostUrl;
+    let inferredWorkspaceId: string | null = null;
+    try {
+      const url = new URL(normalizedHostUrl);
+      const segments = url.pathname.split("/").filter(Boolean);
+      const last = segments[segments.length - 1] ?? "";
+      const prev = segments[segments.length - 2] ?? "";
+      const alreadyMounted = prev === "w" && Boolean(last);
+      if (alreadyMounted) {
+        inferredWorkspaceId = decodeURIComponent(last);
+        const baseSegments = segments.slice(0, -2);
+        url.pathname = `/${baseSegments.join("/")}`;
+        normalizedHostUrl = url.toString().replace(/\/+$/, "");
+      }
+    } catch {
+      // ignore
+    }
+
+    const requestedWorkspaceId = (input.workspaceId?.trim() || inferredWorkspaceId || "").trim();
+    const workspaceBaseUrl = buildOpenworkWorkspaceBaseUrl(normalizedHostUrl, requestedWorkspaceId) ?? normalizedHostUrl;
 
     const client = createOpenworkServerClient({ baseUrl: workspaceBaseUrl, token: input.token ?? undefined });
 
@@ -262,8 +284,29 @@ export function createWorkspaceStore(options: {
 
     const response = await client.listWorkspaces();
     const items = Array.isArray(response.items) ? response.items : [];
-    const workspace = items[0] as OpenworkWorkspaceInfo | undefined;
-    if (!workspace) {
+    const hint = normalizeDirectoryPath(input.directoryHint ?? "");
+    const selectByHint = (entry: OpenworkWorkspaceInfo) => {
+      if (!hint) return false;
+      const entryPath = normalizeDirectoryPath(
+        (entry.opencode?.directory as string | undefined) ?? (entry.path as string | undefined) ?? "",
+      );
+      return Boolean(entryPath && entryPath === hint);
+    };
+    const selectById = (entry: OpenworkWorkspaceInfo) => Boolean(requestedWorkspaceId && entry?.id === requestedWorkspaceId);
+
+    const workspaceById = requestedWorkspaceId
+      ? (items.find((item) => item?.id && selectById(item as any)) as OpenworkWorkspaceInfo | undefined)
+      : undefined;
+    if (requestedWorkspaceId && !workspaceById) {
+      throw new Error("OpenWork workspace not found on that host.");
+    }
+
+    const workspaceByHint = hint
+      ? (items.find((item) => item?.id && selectByHint(item as any)) as OpenworkWorkspaceInfo | undefined)
+      : undefined;
+
+    const workspace = (workspaceById ?? workspaceByHint ?? items[0]) as OpenworkWorkspaceInfo | undefined;
+    if (!workspace?.id) {
       throw new Error("OpenWork server did not return a workspace.");
     }
     const opencodeUpstreamBaseUrl = workspace.opencode?.baseUrl?.trim() ?? workspace.baseUrl?.trim() ?? "";
@@ -271,7 +314,9 @@ export function createWorkspaceStore(options: {
       throw new Error("OpenWork server did not provide an OpenCode URL.");
     }
 
-    const opencodeBaseUrl = `${workspaceBaseUrl.replace(/\/+$/, "")}/opencode`;
+    const workspaceScopedBaseUrl =
+      buildOpenworkWorkspaceBaseUrl(normalizedHostUrl, workspace.id) ?? workspaceBaseUrl;
+    const opencodeBaseUrl = `${workspaceScopedBaseUrl.replace(/\/+$/, "")}/opencode`;
     const opencodeAuth: OpencodeAuth | undefined = trimmedToken
       ? { token: trimmedToken, mode: "openwork" }
       : undefined;
@@ -286,7 +331,7 @@ export function createWorkspaceStore(options: {
     };
   };
 
-  const resolveEngineRuntime = () => options.engineRuntime?.() ?? "direct";
+  const resolveEngineRuntime = () => options.engineRuntime?.() ?? "openwrk";
 
   const resolveWorkspacePaths = () => {
     const active = activeWorkspacePath().trim();
@@ -511,6 +556,7 @@ export function createWorkspaceStore(options: {
               hostUrl,
               token,
               workspaceId: next.openworkWorkspaceId ?? null,
+              directoryHint: next.directory ?? null,
             });
             if (resolved.kind === "openwork") {
               resolvedBaseUrl = resolved.opencodeBaseUrl;
@@ -1003,6 +1049,7 @@ export function createWorkspaceStore(options: {
       const resolved = await resolveOpenworkHost({
         hostUrl,
         token,
+        directoryHint: directory || null,
       });
       if (resolved.kind !== "openwork") {
         options.setError("OpenWork server unavailable. Check the URL and token.");
@@ -1163,6 +1210,7 @@ export function createWorkspaceStore(options: {
         hostUrl,
         token,
         workspaceId: workspace.openworkWorkspaceId ?? null,
+        directoryHint: directory || null,
       });
       if (resolved.kind !== "openwork") {
         options.setError("OpenWork server unavailable. Check the URL and token.");

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -14,8 +14,8 @@ import type {
   View,
 } from "../types";
 import type { McpDirectoryInfo } from "../constants";
-import { formatRelativeTime, isTauriRuntime } from "../utils";
-import { buildOpenworkWorkspaceBaseUrl } from "../lib/openwork-server";
+import { formatRelativeTime, isTauriRuntime, normalizeDirectoryPath } from "../utils";
+import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../lib/openwork-server";
 import type {
   OpenworkAuditEntry,
   OpenworkServerCapabilities,
@@ -37,6 +37,8 @@ import ProviderAuthModal from "../components/provider-auth-modal";
 import ShareWorkspaceModal from "../components/share-workspace-modal";
 import {
   Box,
+  ChevronDown,
+  ChevronRight,
   History,
   Loader2,
   MoreHorizontal,
@@ -284,19 +286,71 @@ export default function DashboardView(props: DashboardViewProps) {
     }, 0);
   };
 
+  const createTaskInWorkspace = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    expandWorkspace(id);
+    if (id === props.activeWorkspaceId) {
+      props.createSessionAndOpen();
+      return;
+    }
+    void (async () => {
+      await Promise.resolve(props.activateWorkspace(id));
+      props.createSessionAndOpen();
+    })();
+  };
+
   // Track last refreshed tab to avoid duplicate calls
   const [lastRefreshedTab, setLastRefreshedTab] = createSignal<string | null>(null);
   const [refreshInProgress, setRefreshInProgress] = createSignal(false);
   const [providerAuthActionBusy, setProviderAuthActionBusy] = createSignal(false);
   const MAX_SESSIONS_PREVIEW = 3;
+  const COLLAPSED_SESSIONS_PREVIEW = 1;
+  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = createSignal<Set<string>>(
+    new Set()
+  );
+  const isWorkspaceExpanded = (workspaceId: string) =>
+    expandedWorkspaceIds().has(workspaceId);
+  const expandWorkspace = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((prev) => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  };
+  const toggleWorkspaceExpanded = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  createEffect(() => {
+    expandWorkspace(props.activeWorkspaceId);
+  });
   const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = createSignal<
     Record<string, number>
   >({});
-  const previewCount = (workspaceId: string) =>
-    previewCountByWorkspaceId()[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+  const previewCount = (workspaceId: string) => {
+    const base = previewCountByWorkspaceId()[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+    return isWorkspaceExpanded(workspaceId)
+      ? base
+      : Math.min(COLLAPSED_SESSIONS_PREVIEW, base);
+  };
   const previewSessions = (workspaceId: string, sessions: WorkspaceSessionGroup["sessions"]) =>
     sessions.slice(0, previewCount(workspaceId));
   const showMoreSessions = (workspaceId: string, total: number) => {
+    expandWorkspace(workspaceId);
     setPreviewCountByWorkspaceId((current) => {
       const next = { ...current };
       const existing = next[workspaceId] ?? MAX_SESSIONS_PREVIEW;
@@ -464,6 +518,41 @@ export default function DashboardView(props: DashboardViewProps) {
     return ws.path?.trim() || "";
   });
 
+  const [shareLocalOpenworkWorkspaceId, setShareLocalOpenworkWorkspaceId] = createSignal<string | null>(null);
+
+  createEffect(() => {
+    const ws = shareWorkspace();
+    const baseUrl = props.openworkServerHostInfo?.baseUrl?.trim() ?? "";
+    const token = props.openworkServerHostInfo?.clientToken?.trim() ?? "";
+    const workspacePath = ws?.workspaceType === "local" ? ws.path?.trim() ?? "" : "";
+
+    if (!ws || ws.workspaceType !== "local" || !workspacePath || !baseUrl || !token) {
+      setShareLocalOpenworkWorkspaceId(null);
+      return;
+    }
+
+    let cancelled = false;
+    setShareLocalOpenworkWorkspaceId(null);
+
+    void (async () => {
+      try {
+        const client = createOpenworkServerClient({ baseUrl, token });
+        const response = await client.listWorkspaces();
+        if (cancelled) return;
+        const items = Array.isArray(response.items) ? response.items : [];
+        const targetPath = normalizeDirectoryPath(workspacePath);
+        const match = items.find((entry) => normalizeDirectoryPath(entry.path) === targetPath);
+        setShareLocalOpenworkWorkspaceId(match?.id ?? null);
+      } catch {
+        if (!cancelled) setShareLocalOpenworkWorkspaceId(null);
+      }
+    })();
+
+    onCleanup(() => {
+      cancelled = true;
+    });
+  });
+
   const shareFields = createMemo(() => {
     const ws = shareWorkspace();
     if (!ws) {
@@ -477,25 +566,36 @@ export default function DashboardView(props: DashboardViewProps) {
     }
 
     if (ws.workspaceType !== "remote") {
-      const url =
+      const hostUrl =
         props.openworkServerHostInfo?.connectUrl?.trim() ||
         props.openworkServerHostInfo?.lanUrl?.trim() ||
         props.openworkServerHostInfo?.mdnsUrl?.trim() ||
         props.openworkServerHostInfo?.baseUrl?.trim() ||
         "";
+      const mountedUrl = shareLocalOpenworkWorkspaceId()
+        ? buildOpenworkWorkspaceBaseUrl(hostUrl, shareLocalOpenworkWorkspaceId())
+        : null;
+      const url = mountedUrl || hostUrl;
       const token = props.openworkServerHostInfo?.clientToken?.trim() || "";
       return [
         {
-          label: "OpenWork server URL",
+          label: "OpenWork workspace URL",
           value: url,
-          placeholder: isTauriRuntime() ? "Starting server..." : "Desktop app required",
+          placeholder: !isTauriRuntime() ? "Desktop app required" : "Starting server...",
+          hint: mountedUrl
+            ? "Use on phones or laptops connecting to this workspace."
+            : hostUrl
+              ? "Workspace URL is resolving; host URL shown as fallback."
+              : undefined,
         },
         {
           label: "Access token",
           value: token,
           secret: true,
           placeholder: isTauriRuntime() ? "-" : "Desktop app required",
-          hint: "Use on phones or laptops connecting to this host.",
+          hint: mountedUrl
+            ? "Use on phones or laptops connecting to this workspace."
+            : "Use on phones or laptops connecting to this host.",
         },
       ];
     }
@@ -641,19 +741,55 @@ export default function DashboardView(props: DashboardViewProps) {
                         role="button"
                         tabIndex={0}
                         class="w-full flex items-center justify-between h-10 px-3 rounded-lg text-left transition-colors text-dls-text hover:bg-dls-hover"
-                        onClick={() => props.activateWorkspace(workspace().id)}
+                        onClick={() => {
+                          expandWorkspace(workspace().id);
+                          props.activateWorkspace(workspace().id);
+                        }}
                         onKeyDown={(event) => {
                           if (event.key !== "Enter" && event.key !== " ") return;
                           event.preventDefault();
+                          expandWorkspace(workspace().id);
                           props.activateWorkspace(workspace().id);
                         }}
                       >
+                        <button
+                          type="button"
+                          class="mr-2 -ml-1 p-1 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-active"
+                          aria-label={isWorkspaceExpanded(workspace().id) ? "Collapse" : "Expand"}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            toggleWorkspaceExpanded(workspace().id);
+                          }}
+                        >
+                          <Show
+                            when={isWorkspaceExpanded(workspace().id)}
+                            fallback={<ChevronRight size={14} />}
+                          >
+                            <ChevronDown size={14} />
+                          </Show>
+                        </button>
                         <div class="min-w-0 flex-1">
                           <div class="text-sm font-medium truncate">{workspaceLabel(workspace())}</div>
                           <div class="text-[11px] text-dls-secondary">
                             {workspaceKindLabel(workspace())}
                           </div>
                         </div>
+                        <Show when={group.status === "loading"}>
+                          <Loader2 size={14} class="animate-spin text-dls-secondary mr-1" />
+                        </Show>
+                        <Show when={group.status === "error"}>
+                          <span
+                            class="text-[10px] px-2 py-0.5 rounded-full border border-red-7/50 text-red-11 bg-red-3/30"
+                            title={group.error ?? "Failed to load tasks"}
+                          >
+                            Error
+                          </span>
+                        </Show>
+                        <Show when={group.status === "ready" && group.sessions.length > 0}>
+                          <span class="text-[10px] px-2 py-0.5 rounded-full border border-dls-border text-dls-secondary bg-dls-hover">
+                            {group.sessions.length}
+                          </span>
+                        </Show>
                         <Show when={isConnecting()}>
                           <Loader2 size={14} class="animate-spin text-dls-secondary" />
                         </Show>
@@ -664,7 +800,7 @@ export default function DashboardView(props: DashboardViewProps) {
                           class="p-1 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-active"
                           onClick={(event) => {
                             event.stopPropagation();
-                            props.createSessionAndOpen();
+                            createTaskInWorkspace(workspace().id);
                           }}
                           disabled={props.newTaskDisabled}
                           aria-label="New task"
@@ -739,56 +875,114 @@ export default function DashboardView(props: DashboardViewProps) {
 
                     <div class="mt-0.5 space-y-0.5 border-l border-dls-border ml-2">
                       <Show
-                        when={group.sessions.length > 0}
+                        when={isWorkspaceExpanded(workspace().id)}
                         fallback={
-                          <button
-                            type="button"
-                            class="group/empty w-full px-3 py-2 text-xs text-dls-secondary ml-2 text-left rounded-lg hover:bg-dls-hover hover:text-dls-text transition-colors"
-                            onClick={() => props.createSessionAndOpen()}
-                            disabled={props.newTaskDisabled}
-                          >
-                            <span class="group-hover/empty:hidden">No tasks yet.</span>
-                            <span class="hidden group-hover/empty:inline font-medium">+ New task</span>
-                          </button>
+                          <Show when={group.sessions.length > 0}>
+                            <For each={previewSessions(workspace().id, group.sessions)}>
+                              {(session) => {
+                                const isSelected = () => props.selectedSessionId === session.id;
+                                return (
+                                  <div
+                                    role="button"
+                                    tabIndex={0}
+                                    class={`group flex items-center justify-between h-8 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
+                                      isSelected()
+                                        ? "bg-dls-active text-dls-text"
+                                        : "hover:bg-dls-hover"
+                                    }`}
+                                    onClick={() => openSessionFromList(workspace().id, session.id)}
+                                    onKeyDown={(event) => {
+                                      if (event.key !== "Enter" && event.key !== " ") return;
+                                      event.preventDefault();
+                                      openSessionFromList(workspace().id, session.id);
+                                    }}
+                                  >
+                                    <span class="text-sm text-dls-text truncate mr-2 font-medium">
+                                      {session.title}
+                                    </span>
+                                    <span class="text-xs text-dls-secondary whitespace-nowrap">
+                                      {formatRelativeTime(session.time?.updated ?? Date.now())}
+                                    </span>
+                                  </div>
+                                );
+                              }}
+                            </For>
+                          </Show>
                         }
                       >
-                        <For each={previewSessions(workspace().id, group.sessions)}>
-                          {(session) => {
-                            const isSelected = () => props.selectedSessionId === session.id;
-                            return (
-                              <div
-                                role="button"
-                                tabIndex={0}
-                                class={`group flex items-center justify-between h-8 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
-                                  isSelected()
-                                    ? "bg-dls-active text-dls-text"
-                                    : "hover:bg-dls-hover"
-                                }`}
-                                onClick={() => openSessionFromList(workspace().id, session.id)}
-                                onKeyDown={(event) => {
-                                  if (event.key !== "Enter" && event.key !== " ") return;
-                                  event.preventDefault();
-                                  openSessionFromList(workspace().id, session.id);
+                        <Show
+                          when={group.status === "loading" && group.sessions.length === 0}
+                          fallback={
+                            <Show
+                              when={group.sessions.length > 0}
+                              fallback={
+                                <Show when={group.status === "error"}>
+                                  <div
+                                    class="w-full px-3 py-2 text-xs text-red-11 ml-2 text-left rounded-lg bg-red-3/20 border border-red-7/40"
+                                    title={group.error ?? "Failed to load tasks"}
+                                  >
+                                    Failed to load tasks
+                                  </div>
+                                </Show>
+                              }
+                            >
+                              <For each={previewSessions(workspace().id, group.sessions)}>
+                                {(session) => {
+                                  const isSelected = () => props.selectedSessionId === session.id;
+                                  return (
+                                    <div
+                                      role="button"
+                                      tabIndex={0}
+                                      class={`group flex items-center justify-between h-8 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
+                                        isSelected()
+                                          ? "bg-dls-active text-dls-text"
+                                          : "hover:bg-dls-hover"
+                                      }`}
+                                      onClick={() => openSessionFromList(workspace().id, session.id)}
+                                      onKeyDown={(event) => {
+                                        if (event.key !== "Enter" && event.key !== " ") return;
+                                        event.preventDefault();
+                                        openSessionFromList(workspace().id, session.id);
+                                      }}
+                                    >
+                                      <span class="text-sm text-dls-text truncate mr-2 font-medium">
+                                        {session.title}
+                                      </span>
+                                      <span class="text-xs text-dls-secondary whitespace-nowrap">
+                                        {formatRelativeTime(session.time?.updated ?? Date.now())}
+                                      </span>
+                                    </div>
+                                  );
                                 }}
-                              >
-                                <span class="text-sm text-dls-text truncate mr-2 font-medium">
-                                  {session.title}
-                                </span>
-                                <span class="text-xs text-dls-secondary whitespace-nowrap">
-                                  {formatRelativeTime(session.time?.updated ?? Date.now())}
-                                </span>
-                              </div>
-                            );
-                          }}
-                        </For>
-                        <Show when={group.sessions.length > previewCount(workspace().id)}>
-                          <button
-                            type="button"
-                            class="ml-2 w-[calc(100%-0.5rem)] px-3 py-2 text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover rounded-lg transition-colors text-left"
-                            onClick={() => showMoreSessions(workspace().id, group.sessions.length)}
-                          >
-                            {showMoreLabel(workspace().id, group.sessions.length)}
-                          </button>
+                              </For>
+
+                              <Show when={group.sessions.length === 0 && group.status === "ready"}>
+                                <button
+                                  type="button"
+                                  class="group/empty w-full px-3 py-2 text-xs text-dls-secondary ml-2 text-left rounded-lg hover:bg-dls-hover hover:text-dls-text transition-colors"
+                                  onClick={() => createTaskInWorkspace(workspace().id)}
+                                  disabled={props.newTaskDisabled}
+                                >
+                                  <span class="group-hover/empty:hidden">No tasks yet.</span>
+                                  <span class="hidden group-hover/empty:inline font-medium">+ New task</span>
+                                </button>
+                              </Show>
+
+                              <Show when={group.sessions.length > previewCount(workspace().id)}>
+                                <button
+                                  type="button"
+                                  class="ml-2 w-[calc(100%-0.5rem)] px-3 py-2 text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover rounded-lg transition-colors text-left"
+                                  onClick={() => showMoreSessions(workspace().id, group.sessions.length)}
+                                >
+                                  {showMoreLabel(workspace().id, group.sessions.length)}
+                                </button>
+                              </Show>
+                            </Show>
+                          }
+                        >
+                          <div class="w-full px-3 py-2 text-xs text-dls-secondary ml-2 text-left rounded-lg">
+                            Loading tasks...
+                          </div>
                         </Show>
                       </Show>
                     </div>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -26,6 +26,7 @@ import {
   Box,
   Check,
   ChevronDown,
+  ChevronRight,
   HardDrive,
   History,
   ListTodo,
@@ -45,10 +46,10 @@ import RenameSessionModal from "../components/rename-session-modal";
 import ProviderAuthModal from "../components/provider-auth-modal";
 import ShareWorkspaceModal from "../components/share-workspace-modal";
 import StatusBar from "../components/status-bar";
-import { buildOpenworkWorkspaceBaseUrl } from "../lib/openwork-server";
+import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../lib/openwork-server";
 import type { OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
 import { join } from "@tauri-apps/api/path";
-import { formatRelativeTime, isTauriRuntime } from "../utils";
+import { formatRelativeTime, isTauriRuntime, normalizeDirectoryPath } from "../utils";
 
 import MessageList from "../components/session/message-list";
 import Composer from "../components/session/composer";
@@ -211,14 +212,56 @@ export default function SessionView(props: SessionViewProps) {
     return `${todoCompletedCount()} out of ${total} tasks completed`;
   });
   const MAX_SESSIONS_PREVIEW = 3;
+  const COLLAPSED_SESSIONS_PREVIEW = 1;
+  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = createSignal<Set<string>>(
+    new Set()
+  );
+  const isWorkspaceExpanded = (workspaceId: string) =>
+    expandedWorkspaceIds().has(workspaceId);
+  const expandWorkspace = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((prev) => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  };
+  const toggleWorkspaceExpanded = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  onMount(() => {
+    expandWorkspace(props.activeWorkspaceId);
+  });
+
+  createEffect(() => {
+    expandWorkspace(props.activeWorkspaceId);
+  });
   const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = createSignal<
     Record<string, number>
   >({});
-  const previewCount = (workspaceId: string) =>
-    previewCountByWorkspaceId()[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+  const previewCount = (workspaceId: string) => {
+    const base = previewCountByWorkspaceId()[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+    return isWorkspaceExpanded(workspaceId)
+      ? base
+      : Math.min(COLLAPSED_SESSIONS_PREVIEW, base);
+  };
   const previewSessions = (workspaceId: string, sessions: WorkspaceSessionGroup["sessions"]) =>
     sessions.slice(0, previewCount(workspaceId));
   const showMoreSessions = (workspaceId: string, total: number) => {
+    expandWorkspace(workspaceId);
     setPreviewCountByWorkspaceId((current) => {
       const next = { ...current };
       const existing = next[workspaceId] ?? MAX_SESSIONS_PREVIEW;
@@ -802,6 +845,41 @@ export default function SessionView(props: SessionViewProps) {
     return ws.path?.trim() || "";
   });
 
+  const [shareLocalOpenworkWorkspaceId, setShareLocalOpenworkWorkspaceId] = createSignal<string | null>(null);
+
+  createEffect(() => {
+    const ws = shareWorkspace();
+    const baseUrl = props.openworkServerHostInfo?.baseUrl?.trim() ?? "";
+    const token = props.openworkServerHostInfo?.clientToken?.trim() ?? "";
+    const workspacePath = ws?.workspaceType === "local" ? ws.path?.trim() ?? "" : "";
+
+    if (!ws || ws.workspaceType !== "local" || !workspacePath || !baseUrl || !token) {
+      setShareLocalOpenworkWorkspaceId(null);
+      return;
+    }
+
+    let cancelled = false;
+    setShareLocalOpenworkWorkspaceId(null);
+
+    void (async () => {
+      try {
+        const client = createOpenworkServerClient({ baseUrl, token });
+        const response = await client.listWorkspaces();
+        if (cancelled) return;
+        const items = Array.isArray(response.items) ? response.items : [];
+        const targetPath = normalizeDirectoryPath(workspacePath);
+        const match = items.find((entry) => normalizeDirectoryPath(entry.path) === targetPath);
+        setShareLocalOpenworkWorkspaceId(match?.id ?? null);
+      } catch {
+        if (!cancelled) setShareLocalOpenworkWorkspaceId(null);
+      }
+    })();
+
+    onCleanup(() => {
+      cancelled = true;
+    });
+  });
+
   const shareFields = createMemo(() => {
     const ws = shareWorkspace();
     if (!ws) {
@@ -815,25 +893,36 @@ export default function SessionView(props: SessionViewProps) {
     }
 
     if (ws.workspaceType !== "remote") {
-      const url =
+      const hostUrl =
         props.openworkServerHostInfo?.connectUrl?.trim() ||
         props.openworkServerHostInfo?.lanUrl?.trim() ||
         props.openworkServerHostInfo?.mdnsUrl?.trim() ||
         props.openworkServerHostInfo?.baseUrl?.trim() ||
         "";
+      const mountedUrl = shareLocalOpenworkWorkspaceId()
+        ? buildOpenworkWorkspaceBaseUrl(hostUrl, shareLocalOpenworkWorkspaceId())
+        : null;
+      const url = mountedUrl || hostUrl;
       const token = props.openworkServerHostInfo?.clientToken?.trim() || "";
       return [
         {
-          label: "OpenWork server URL",
+          label: "OpenWork workspace URL",
           value: url,
-          placeholder: isTauriRuntime() ? "Starting server..." : "Desktop app required",
+          placeholder: !isTauriRuntime() ? "Desktop app required" : "Starting server...",
+          hint: mountedUrl
+            ? "Use on phones or laptops connecting to this workspace."
+            : hostUrl
+              ? "Workspace URL is resolving; host URL shown as fallback."
+              : undefined,
         },
         {
           label: "Access token",
           value: token,
           secret: true,
           placeholder: isTauriRuntime() ? "-" : "Desktop app required",
-          hint: "Use on phones or laptops connecting to this host.",
+          hint: mountedUrl
+            ? "Use on phones or laptops connecting to this workspace."
+            : "Use on phones or laptops connecting to this host.",
         },
       ];
     }
@@ -917,6 +1006,20 @@ export default function SessionView(props: SessionViewProps) {
       await Promise.resolve(props.activateWorkspace(workspaceId));
       void props.selectSession(sessionId);
       props.setView("session", sessionId);
+    })();
+  };
+
+  const createTaskInWorkspace = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    expandWorkspace(id);
+    if (id === props.activeWorkspaceId) {
+      props.createSessionAndOpen();
+      return;
+    }
+    void (async () => {
+      await Promise.resolve(props.activateWorkspace(id));
+      props.createSessionAndOpen();
     })();
   };
 
@@ -1025,34 +1128,70 @@ export default function SessionView(props: SessionViewProps) {
                 return (
                   <div class="space-y-1">
                     <div class="relative group">
-                      <div
-                        role="button"
-                        tabIndex={0}
-                        class="w-full flex items-center justify-between h-10 px-3 rounded-lg text-left transition-colors text-dls-text hover:bg-dls-hover"
-                        onClick={() => props.activateWorkspace(workspace().id)}
-                        onKeyDown={(event) => {
-                          if (event.key !== "Enter" && event.key !== " ") return;
-                          event.preventDefault();
-                          props.activateWorkspace(workspace().id);
-                        }}
-                      >
-                        <div class="min-w-0 flex-1">
-                          <div class="text-sm font-medium truncate">{workspaceLabel(workspace())}</div>
-                          <div class="text-[11px] text-dls-secondary">
-                            {workspaceKindLabel(workspace())}
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          class="w-full flex items-center justify-between h-10 px-3 rounded-lg text-left transition-colors text-dls-text hover:bg-dls-hover"
+                          onClick={() => {
+                            expandWorkspace(workspace().id);
+                            props.activateWorkspace(workspace().id);
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key !== "Enter" && event.key !== " ") return;
+                            event.preventDefault();
+                            expandWorkspace(workspace().id);
+                            props.activateWorkspace(workspace().id);
+                          }}
+                        >
+                          <button
+                            type="button"
+                            class="mr-2 -ml-1 p-1 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-active"
+                            aria-label={isWorkspaceExpanded(workspace().id) ? "Collapse" : "Expand"}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              toggleWorkspaceExpanded(workspace().id);
+                            }}
+                          >
+                            <Show
+                              when={isWorkspaceExpanded(workspace().id)}
+                              fallback={<ChevronRight size={14} />}
+                            >
+                              <ChevronDown size={14} />
+                            </Show>
+                          </button>
+                          <div class="min-w-0 flex-1">
+                            <div class="text-sm font-medium truncate">{workspaceLabel(workspace())}</div>
+                            <div class="text-[11px] text-dls-secondary">
+                              {workspaceKindLabel(workspace())}
+                            </div>
                           </div>
+                          <Show when={group.status === "loading"}>
+                            <Loader2 size={14} class="animate-spin text-dls-secondary mr-1" />
+                          </Show>
+                          <Show when={group.status === "error"}>
+                            <span
+                              class="text-[10px] px-2 py-0.5 rounded-full border border-red-7/50 text-red-11 bg-red-3/30"
+                              title={group.error ?? "Failed to load tasks"}
+                            >
+                              Error
+                            </span>
+                          </Show>
+                          <Show when={group.status === "ready" && group.sessions.length > 0}>
+                            <span class="text-[10px] px-2 py-0.5 rounded-full border border-dls-border text-dls-secondary bg-dls-hover">
+                              {group.sessions.length}
+                            </span>
+                          </Show>
+                          <Show when={isConnecting()}>
+                            <Loader2 size={14} class="animate-spin text-dls-secondary" />
+                          </Show>
                         </div>
-                        <Show when={isConnecting()}>
-                          <Loader2 size={14} class="animate-spin text-dls-secondary" />
-                        </Show>
-                      </div>
                       <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
                         <button
                           type="button"
                           class="p-1 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-active"
                           onClick={(event) => {
                             event.stopPropagation();
-                            props.createSessionAndOpen();
+                            createTaskInWorkspace(workspace().id);
                           }}
                           disabled={props.newTaskDisabled}
                           aria-label="New task"
@@ -1127,58 +1266,118 @@ export default function SessionView(props: SessionViewProps) {
 
                     <div class="mt-0.5 space-y-0.5 border-l border-dls-border ml-2">
                       <Show
-                        when={group.sessions.length > 0}
+                        when={isWorkspaceExpanded(workspace().id)}
                         fallback={
-                          <button
-                            type="button"
-                            class="group/empty w-full px-3 py-2 text-xs text-dls-secondary ml-2 text-left rounded-lg hover:bg-dls-hover hover:text-dls-text transition-colors"
-                            onClick={() => props.createSessionAndOpen()}
-                            disabled={props.newTaskDisabled}
-                          >
-                            <span class="group-hover/empty:hidden">No tasks yet.</span>
-                            <span class="hidden group-hover/empty:inline font-medium">+ New task</span>
-                          </button>
+                          <Show when={group.sessions.length > 0}>
+                            <For each={previewSessions(workspace().id, group.sessions)}>
+                              {(session) => {
+                                const isSelected = () => props.selectedSessionId === session.id;
+                                return (
+                                  <div
+                                    role="button"
+                                    tabIndex={0}
+                                    class={`group flex items-center justify-between h-8 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
+                                      isSelected()
+                                        ? "bg-dls-active text-dls-text"
+                                        : "hover:bg-dls-hover"
+                                    }`}
+                                    onClick={() => openSessionFromList(workspace().id, session.id)}
+                                    onKeyDown={(event) => {
+                                      if (event.key !== "Enter" && event.key !== " ") return;
+                                      event.preventDefault();
+                                      openSessionFromList(workspace().id, session.id);
+                                    }}
+                                  >
+                                    <span class="text-sm text-dls-text truncate mr-2 font-medium">
+                                      {session.title}
+                                    </span>
+                                    <Show when={session.time?.updated}>
+                                      <span class="text-xs text-dls-secondary whitespace-nowrap">
+                                        {formatRelativeTime(session.time?.updated ?? Date.now())}
+                                      </span>
+                                    </Show>
+                                  </div>
+                                );
+                              }}
+                            </For>
+                          </Show>
                         }
                       >
-                        <For each={previewSessions(workspace().id, group.sessions)}>
-                          {(session) => {
-                            const isSelected = () => props.selectedSessionId === session.id;
-                            return (
-                              <div
-                                role="button"
-                                tabIndex={0}
-                                class={`group flex items-center justify-between h-8 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
-                                  isSelected()
-                                    ? "bg-dls-active text-dls-text"
-                                    : "hover:bg-dls-hover"
-                                }`}
-                                onClick={() => openSessionFromList(workspace().id, session.id)}
-                                onKeyDown={(event) => {
-                                  if (event.key !== "Enter" && event.key !== " ") return;
-                                  event.preventDefault();
-                                  openSessionFromList(workspace().id, session.id);
-                                }}
-                              >
-                                <span class="text-sm text-dls-text truncate mr-2 font-medium">
-                                  {session.title}
-                                </span>
-                                <Show when={session.time?.updated}>
-                                  <span class="text-xs text-dls-secondary whitespace-nowrap">
-                                    {formatRelativeTime(session.time?.updated ?? Date.now())}
-                                  </span>
+                        <Show
+                          when={group.status === "loading" && group.sessions.length === 0}
+                          fallback={
+                            <Show
+                              when={group.sessions.length > 0}
+                              fallback={
+                                <Show when={group.status === "error"}>
+                                  <div
+                                    class="w-full px-3 py-2 text-xs text-red-11 ml-2 text-left rounded-lg bg-red-3/20 border border-red-7/40"
+                                    title={group.error ?? "Failed to load tasks"}
+                                  >
+                                    Failed to load tasks
+                                  </div>
                                 </Show>
-                              </div>
-                            );
-                          }}
-                        </For>
-                        <Show when={group.sessions.length > previewCount(workspace().id)}>
-                          <button
-                            type="button"
-                            class="ml-2 w-[calc(100%-0.5rem)] px-3 py-2 text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover rounded-lg transition-colors text-left"
-                            onClick={() => showMoreSessions(workspace().id, group.sessions.length)}
-                          >
-                            {showMoreLabel(workspace().id, group.sessions.length)}
-                          </button>
+                              }
+                            >
+                              <For each={previewSessions(workspace().id, group.sessions)}>
+                                {(session) => {
+                                  const isSelected = () => props.selectedSessionId === session.id;
+                                  return (
+                                    <div
+                                      role="button"
+                                      tabIndex={0}
+                                      class={`group flex items-center justify-between h-8 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
+                                        isSelected()
+                                          ? "bg-dls-active text-dls-text"
+                                          : "hover:bg-dls-hover"
+                                      }`}
+                                      onClick={() => openSessionFromList(workspace().id, session.id)}
+                                      onKeyDown={(event) => {
+                                        if (event.key !== "Enter" && event.key !== " ") return;
+                                        event.preventDefault();
+                                        openSessionFromList(workspace().id, session.id);
+                                      }}
+                                    >
+                                      <span class="text-sm text-dls-text truncate mr-2 font-medium">
+                                        {session.title}
+                                      </span>
+                                      <Show when={session.time?.updated}>
+                                        <span class="text-xs text-dls-secondary whitespace-nowrap">
+                                          {formatRelativeTime(session.time?.updated ?? Date.now())}
+                                        </span>
+                                      </Show>
+                                    </div>
+                                  );
+                                }}
+                              </For>
+
+                              <Show when={group.sessions.length === 0 && group.status === "ready"}>
+                                <button
+                                  type="button"
+                                  class="group/empty w-full px-3 py-2 text-xs text-dls-secondary ml-2 text-left rounded-lg hover:bg-dls-hover hover:text-dls-text transition-colors"
+                                  onClick={() => createTaskInWorkspace(workspace().id)}
+                                  disabled={props.newTaskDisabled}
+                                >
+                                  <span class="group-hover/empty:hidden">No tasks yet.</span>
+                                  <span class="hidden group-hover/empty:inline font-medium">+ New task</span>
+                                </button>
+                              </Show>
+
+                              <Show when={group.sessions.length > previewCount(workspace().id)}>
+                                <button
+                                  type="button"
+                                  class="ml-2 w-[calc(100%-0.5rem)] px-3 py-2 text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover rounded-lg transition-colors text-left"
+                                  onClick={() => showMoreSessions(workspace().id, group.sessions.length)}
+                                >
+                                  {showMoreLabel(workspace().id, group.sessions.length)}
+                                </button>
+                              </Show>
+                            </Show>
+                          }
+                        >
+                          <div class="w-full px-3 py-2 text-xs text-dls-secondary ml-2 text-left rounded-lg">
+                            Loading tasks...
+                          </div>
                         </Show>
                       </Show>
                     </div>

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -1856,26 +1856,28 @@ export default function SettingsView(props: SettingsViewProps) {
                   </div>
                 </div>
 
-                <div class="space-y-3">
-                  <div class="text-xs text-gray-10">Engine runtime</div>
-                  <div class="grid grid-cols-2 gap-2">
-                    <Button
-                      variant={props.engineRuntime === "direct" ? "secondary" : "outline"}
-                      onClick={() => props.setEngineRuntime("direct")}
-                      disabled={props.busy}
-                    >
-                      Direct (OpenCode)
-                    </Button>
-                    <Button
-                      variant={props.engineRuntime === "openwrk" ? "secondary" : "outline"}
-                      onClick={() => props.setEngineRuntime("openwrk")}
-                      disabled={props.busy}
-                    >
-                      Openwrk orchestrator
-                    </Button>
+                <Show when={props.developerMode}>
+                  <div class="space-y-3">
+                    <div class="text-xs text-gray-10">Engine runtime</div>
+                    <div class="grid grid-cols-2 gap-2">
+                      <Button
+                        variant={props.engineRuntime === "direct" ? "secondary" : "outline"}
+                        onClick={() => props.setEngineRuntime("direct")}
+                        disabled={props.busy}
+                      >
+                        Direct (OpenCode)
+                      </Button>
+                      <Button
+                        variant={props.engineRuntime === "openwrk" ? "secondary" : "outline"}
+                        onClick={() => props.setEngineRuntime("openwrk")}
+                        disabled={props.busy}
+                      >
+                        Openwrk orchestrator
+                      </Button>
+                    </div>
+                    <div class="text-[11px] text-gray-7">Applies the next time the engine starts or reloads.</div>
                   </div>
-                  <div class="text-[11px] text-gray-7">Applies the next time the engine starts or reloads.</div>
-                </div>
+                </Show>
               </div>
             </Show>
 

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -27,6 +27,8 @@ export type SidebarSessionItem = {
 export type WorkspaceSessionGroup = {
   workspace: WorkspaceInfo;
   sessions: SidebarSessionItem[];
+  status: "idle" | "loading" | "ready" | "error";
+  error?: string | null;
 };
 
 export type PlaceholderAssistantMessage = {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openwork"
-version = "0.11.22"
+version = "0.11.24"
 dependencies = [
  "base64 0.22.1",
  "gethostname",

--- a/packages/desktop/src-tauri/src/commands/engine.rs
+++ b/packages/desktop/src-tauri/src/commands/engine.rs
@@ -209,7 +209,7 @@ pub fn engine_start(
         }
     }
 
-    let runtime = runtime.unwrap_or(EngineRuntime::Direct);
+    let runtime = runtime.unwrap_or(EngineRuntime::Openwrk);
     let mut workspace_paths = workspace_paths.unwrap_or_default();
     workspace_paths.retain(|path| !path.trim().is_empty());
     workspace_paths.retain(|path| path.trim() != project_dir);

--- a/packages/owpenbot/scripts/test-cli.mjs
+++ b/packages/owpenbot/scripts/test-cli.mjs
@@ -46,7 +46,7 @@ function run(cmd, args, options = {}) {
 }
 
 async function runHelp() {
-  const result = await run("node", [cliPath, "--help"], { timeoutMs: 3000 });
+  const result = await run("bun", [cliPath, "--help"], { timeoutMs: 3000 });
   if (result.code !== 0) {
     throw new Error(`Help failed: ${result.stderr}`);
   }
@@ -55,7 +55,7 @@ async function runHelp() {
   }
 }
 
-async function runSetupNonInteractive() {
+async function runConfigCommands() {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "owpenbot-"));
   const env = {
     ...process.env,
@@ -64,46 +64,37 @@ async function runSetupNonInteractive() {
     OWPENBOT_CONFIG_PATH: path.join(tempDir, "owpenbot.json"),
     OPENCODE_DIRECTORY: tempDir,
   };
-  const result = await run("node", [cliPath, "--non-interactive"], {
-    env,
-    timeoutMs: 5000,
-  });
-  if (result.code !== 0) {
-    throw new Error(`Setup failed: ${result.stderr}`);
-  }
-  const cfg = await fs.readFile(path.join(tempDir, "owpenbot.json"), "utf-8");
-  if (!cfg.includes("whatsapp")) {
-    throw new Error("Config missing whatsapp section");
-  }
-}
 
-async function runSetupInteractive() {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "owpenbot-"));
-  const env = {
-    ...process.env,
-    OWPENBOT_DATA_DIR: tempDir,
-    OWPENBOT_DB_PATH: path.join(tempDir, "owpenbot.db"),
-    OWPENBOT_CONFIG_PATH: path.join(tempDir, "owpenbot.json"),
-    OPENCODE_DIRECTORY: tempDir,
-    OWPENWORK_TEST_SELECTIONS: "config",
-    OWPENWORK_TEST_SETUP: "personal",
-    OWPENWORK_FORCE_TUI: "1",
-  };
-  const result = await run("node", ["--no-warnings", cliPath], {
+  const setResult = await run("bun", [cliPath, "config", "set", "channels.whatsapp.dmPolicy", "\"disabled\""], {
     env,
     timeoutMs: 5000,
   });
-  const output = `${result.stdout}${result.stderr}`;
-  if (!output.includes("Owpenwork Setup")) {
-    throw new Error("Interactive setup prompt not detected");
+  if (setResult.code !== 0) {
+    throw new Error(`Config set failed: ${setResult.stderr}`);
   }
-  const cfg = await fs.readFile(path.join(tempDir, "owpenbot.json"), "utf-8");
-  if (!cfg.includes("+15551234567")) {
-    throw new Error("Interactive config missing allowlist number");
+
+  const getResult = await run("bun", [cliPath, "config", "get", "channels.whatsapp.dmPolicy"], {
+    env,
+    timeoutMs: 5000,
+  });
+  if (getResult.code !== 0) {
+    throw new Error(`Config get failed: ${getResult.stderr}`);
+  }
+  if (!(`${getResult.stdout}${getResult.stderr}`.includes("disabled"))) {
+    throw new Error("Config get output missing expected value");
+  }
+
+  const statusResult = await run("bun", [cliPath, "status", "--json"], { env, timeoutMs: 5000 });
+  if (statusResult.code !== 0) {
+    throw new Error(`Status failed: ${statusResult.stderr}`);
+  }
+
+  const pairingResult = await run("bun", [cliPath, "pairing", "list", "--json"], { env, timeoutMs: 5000 });
+  if (pairingResult.code !== 0) {
+    throw new Error(`Pairing list failed: ${pairingResult.stderr}`);
   }
 }
 
 await runHelp();
-await runSetupNonInteractive();
-await runSetupInteractive();
+await runConfigCommands();
 console.log("CLI smoke tests passed");

--- a/packages/owpenbot/src/bridge.ts
+++ b/packages/owpenbot/src/bridge.ts
@@ -27,6 +27,7 @@ type OutboundKind = "reply" | "system" | "tool";
 
 type BridgeDeps = {
   client?: ReturnType<typeof createClient>;
+  clientFactory?: (directory: string) => ReturnType<typeof createClient>;
   store?: BridgeStore;
   adapters?: Map<ChannelName, Adapter>;
   disableEventStream?: boolean;
@@ -53,9 +54,12 @@ type ModelRef = {
 };
 
 type RunState = {
+  key: string;
+  directory: string;
   sessionID: string;
   channel: ChannelName;
   peerId: string;
+  peerKey: string;
   toolUpdatesEnabled: boolean;
   seenToolStates: Map<string, string>;
   thinkingLabel?: string;
@@ -112,7 +116,22 @@ function setUserModel(channel: ChannelName, peerId: string, model: ModelRef | un
 
 export async function startBridge(config: Config, logger: Logger, reporter?: BridgeReporter, deps: BridgeDeps = {}) {
   const reportStatus = reporter?.onStatus;
-  const client = deps.client ?? createClient(config);
+  const clients = new Map<string, ReturnType<typeof createClient>>();
+  const defaultDirectory = config.opencodeDirectory;
+
+  const getClient = (directory?: string | null) => {
+    const resolved = (directory ?? "").trim() || defaultDirectory;
+    if (deps.client && resolved === defaultDirectory) {
+      return deps.client;
+    }
+    const existing = clients.get(resolved);
+    if (existing) return existing;
+    const next = deps.clientFactory ? deps.clientFactory(resolved) : createClient(config, resolved);
+    clients.set(resolved, next);
+    return next;
+  };
+
+  const rootClient = getClient(defaultDirectory);
   const store = deps.store ?? new BridgeStore(config.dbPath);
   store.seedAllowlist("telegram", config.allowlist.telegram);
   store.seedAllowlist("slack", config.allowlist.slack);
@@ -172,6 +191,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     }
   }
 
+  const keyForSession = (directory: string, sessionID: string) => `${directory}::${sessionID}`;
+
   const sessionQueue = new Map<string, Promise<void>>();
   const activeRuns = new Map<string, RunState>();
   const sessionModels = new Map<string, ModelRef>();
@@ -179,6 +200,15 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
   const formatPeer = (channel: ChannelName, peerId: string) =>
     channel === "whatsapp" ? normalizeWhatsAppId(peerId) : peerId;
+
+  const normalizeDirectory = (input: string) => {
+    const trimmed = input.trim();
+    if (!trimmed) return "";
+    const unified = trimmed.replace(/\\/g, "/");
+    const withoutTrailing = unified.replace(/\/+$/, "");
+    const normalized = withoutTrailing || "/";
+    return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+  };
 
   const formatModelLabel = (model?: ModelRef) =>
     model ? `${model.providerID}/${model.modelID}` : null;
@@ -195,7 +225,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
   const reportThinking = (run: RunState) => {
     if (!reportStatus) return;
-    const modelLabel = formatModelLabel(sessionModels.get(run.sessionID));
+    const modelLabel = formatModelLabel(sessionModels.get(run.key));
     const nextLabel = modelLabel ? `Thinking (${modelLabel})` : "Thinking...";
     if (run.thinkingLabel === nextLabel && run.thinkingActive) return;
     run.thinkingLabel = nextLabel;
@@ -205,7 +235,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
   const reportDone = (run: RunState) => {
     if (!reportStatus || !run.thinkingActive) return;
-    const modelLabel = formatModelLabel(sessionModels.get(run.sessionID));
+    const modelLabel = formatModelLabel(sessionModels.get(run.key));
     const suffix = modelLabel ? ` (${modelLabel})` : "";
     reportStatus(`[${CHANNEL_LABELS[run.channel]}] ${formatPeer(run.channel, run.peerId)} Done${suffix}`);
     run.thinkingActive = false;
@@ -214,7 +244,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
   const startTyping = (run: RunState) => {
     const adapter = adapters.get(run.channel);
     if (!adapter?.sendTyping) return;
-    if (typingLoops.has(run.sessionID)) return;
+    if (typingLoops.has(run.key)) return;
     const sendTyping = async () => {
       try {
         await adapter.sendTyping?.(run.peerId);
@@ -224,14 +254,14 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     };
     void sendTyping();
     const timer = setInterval(sendTyping, TYPING_INTERVAL_MS);
-    typingLoops.set(run.sessionID, timer);
+    typingLoops.set(run.key, timer);
   };
 
-  const stopTyping = (sessionID: string) => {
-    const timer = typingLoops.get(sessionID);
+  const stopTyping = (key: string) => {
+    const timer = typingLoops.get(key);
     if (!timer) return;
     clearInterval(timer);
-    typingLoops.delete(sessionID);
+    typingLoops.delete(key);
   };
 
   let opencodeHealthy = false;
@@ -239,7 +269,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
   async function refreshHealth() {
     try {
-      const health = await client.global.health();
+      const health = await rootClient.global.health();
       opencodeHealthy = Boolean((health as { healthy?: boolean }).healthy);
       opencodeVersion = (health as { version?: string }).version;
     } catch (error) {
@@ -384,108 +414,161 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             enabled: true,
           };
         },
+        listBindings: async () => {
+          const bindings = store.listBindings();
+          return {
+            items: bindings.map((entry) => ({
+              channel: entry.channel,
+              peerId: entry.peer_id,
+              directory: entry.directory,
+              updatedAt: entry.updated_at,
+            })),
+          };
+        },
+        setBinding: async (input: { channel: string; peerId: string; directory: string }) => {
+          const channel = input.channel.trim().toLowerCase();
+          if (channel !== "whatsapp" && channel !== "telegram" && channel !== "slack") {
+            throw new Error("Invalid channel");
+          }
+          const peerKey = channel === "whatsapp" ? normalizeWhatsAppId(input.peerId) : input.peerId.trim();
+          const directory = input.directory.trim();
+          if (!peerKey || !directory) {
+            throw new Error("peerId and directory are required");
+          }
+          const normalizedDir = normalizeDirectory(directory);
+          store.upsertBinding(channel as ChannelName, peerKey, normalizedDir);
+          store.deleteSession(channel as ChannelName, peerKey);
+          ensureEventSubscription(normalizedDir);
+        },
+        clearBinding: async (input: { channel: string; peerId: string }) => {
+          const channel = input.channel.trim().toLowerCase();
+          if (channel !== "whatsapp" && channel !== "telegram" && channel !== "slack") {
+            throw new Error("Invalid channel");
+          }
+          const peerKey = channel === "whatsapp" ? normalizeWhatsAppId(input.peerId) : input.peerId.trim();
+          if (!peerKey) {
+            throw new Error("peerId is required");
+          }
+          store.deleteBinding(channel as ChannelName, peerKey);
+          store.deleteSession(channel as ChannelName, peerKey);
+        },
       },
     );
   }
 
-  const eventAbort = new AbortController();
-  if (!deps.disableEventStream) {
+  const eventSubscriptions = new Map<string, AbortController>();
+
+  const ensureEventSubscription = (directory: string) => {
+    if (deps.disableEventStream) return;
+    const resolved = directory.trim() || defaultDirectory;
+    if (!resolved) return;
+    if (eventSubscriptions.has(resolved)) return;
+
+    const abort = new AbortController();
+    eventSubscriptions.set(resolved, abort);
+    const client = getClient(resolved);
+
     void (async () => {
-      const subscription = await client.event.subscribe(undefined, { signal: eventAbort.signal });
+      const subscription = await client.event.subscribe(undefined, { signal: abort.signal });
       for await (const raw of subscription.stream as AsyncIterable<unknown>) {
         const event = normalizeEvent(raw as any);
         if (!event) continue;
 
-      if (event.type === "message.updated") {
-        if (event.properties && typeof event.properties === "object") {
-          const record = event.properties as Record<string, unknown>;
-          const info = record.info as Record<string, unknown> | undefined;
-          const sessionID = typeof info?.sessionID === "string" ? (info.sessionID as string) : null;
-          const model = extractModelRef(info);
-          if (sessionID && model) {
-            sessionModels.set(sessionID, model);
-            const run = activeRuns.get(sessionID);
-            if (run) reportThinking(run);
+        if (event.type === "message.updated") {
+          if (event.properties && typeof event.properties === "object") {
+            const record = event.properties as Record<string, unknown>;
+            const info = record.info as Record<string, unknown> | undefined;
+            const sessionID = typeof info?.sessionID === "string" ? (info.sessionID as string) : null;
+            const model = extractModelRef(info);
+            if (sessionID && model) {
+              const key = keyForSession(resolved, sessionID);
+              sessionModels.set(key, model);
+              const run = activeRuns.get(key);
+              if (run) reportThinking(run);
+            }
           }
         }
-      }
 
-      if (event.type === "session.status") {
-        if (event.properties && typeof event.properties === "object") {
-          const record = event.properties as Record<string, unknown>;
-          const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
-          const status = record.status as { type?: unknown } | undefined;
-          if (sessionID && (status?.type === "busy" || status?.type === "retry")) {
-            const run = activeRuns.get(sessionID);
+        if (event.type === "session.status") {
+          if (event.properties && typeof event.properties === "object") {
+            const record = event.properties as Record<string, unknown>;
+            const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
+            const status = record.status as { type?: unknown } | undefined;
+            if (sessionID && (status?.type === "busy" || status?.type === "retry")) {
+              const run = activeRuns.get(keyForSession(resolved, sessionID));
+              if (run) {
+                reportThinking(run);
+                startTyping(run);
+              }
+            }
+          }
+        }
+
+        if (event.type === "session.idle") {
+          if (event.properties && typeof event.properties === "object") {
+            const record = event.properties as Record<string, unknown>;
+            const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
+            if (sessionID) {
+              const key = keyForSession(resolved, sessionID);
+              stopTyping(key);
+              const run = activeRuns.get(key);
+              if (run) reportDone(run);
+            }
+          }
+        }
+
+        if (event.type === "message.part.updated") {
+          const part = (event.properties as { part?: any })?.part;
+          if (!part?.sessionID) continue;
+          const run = activeRuns.get(keyForSession(resolved, part.sessionID));
+          if (!run || !run.toolUpdatesEnabled) continue;
+          if (part.type !== "tool") continue;
+
+          const callId = part.callID as string | undefined;
+          if (!callId) continue;
+          const state = part.state as { status?: string; input?: Record<string, unknown>; output?: string; title?: string };
+          const status = state?.status ?? "unknown";
+          if (run.seenToolStates.get(callId) === status) continue;
+          run.seenToolStates.set(callId, status);
+
+          const label = TOOL_LABELS[part.tool] ?? part.tool;
+          const title = state.title || truncateText(formatInputSummary(state.input ?? {}), 120) || "running";
+          let message = `[tool] ${label} ${status}: ${title}`;
+
+          if (status === "completed" && state.output) {
+            const output = truncateText(state.output.trim(), config.toolOutputLimit);
+            if (output) message += `\n${output}`;
+          }
+
+          await sendText(run.channel, run.peerId, message, { kind: "tool" });
+        }
+
+        if (event.type === "permission.asked") {
+          const permission = event.properties as { id?: string; sessionID?: string };
+          if (!permission?.id || !permission.sessionID) continue;
+          const response = config.permissionMode === "deny" ? "reject" : "always";
+          await client.permission.respond({
+            sessionID: permission.sessionID,
+            permissionID: permission.id,
+            response,
+          });
+          if (response === "reject") {
+            const run = activeRuns.get(keyForSession(resolved, permission.sessionID));
             if (run) {
-              reportThinking(run);
-              startTyping(run);
+              await sendText(run.channel, run.peerId, "Permission denied. Update configuration to allow tools.", {
+                kind: "system",
+              });
             }
           }
         }
       }
-
-      if (event.type === "session.idle") {
-        if (event.properties && typeof event.properties === "object") {
-          const record = event.properties as Record<string, unknown>;
-          const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
-          if (sessionID) {
-            stopTyping(sessionID);
-            const run = activeRuns.get(sessionID);
-            if (run) reportDone(run);
-          }
-        }
-      }
-
-      if (event.type === "message.part.updated") {
-        const part = (event.properties as { part?: any })?.part;
-        if (!part?.sessionID) continue;
-        const run = activeRuns.get(part.sessionID);
-        if (!run || !run.toolUpdatesEnabled) continue;
-        if (part.type !== "tool") continue;
-
-        const callId = part.callID as string | undefined;
-        if (!callId) continue;
-        const state = part.state as { status?: string; input?: Record<string, unknown>; output?: string; title?: string };
-        const status = state?.status ?? "unknown";
-        if (run.seenToolStates.get(callId) === status) continue;
-        run.seenToolStates.set(callId, status);
-
-        const label = TOOL_LABELS[part.tool] ?? part.tool;
-        const title = state.title || truncateText(formatInputSummary(state.input ?? {}), 120) || "running";
-        let message = `[tool] ${label} ${status}: ${title}`;
-
-        if (status === "completed" && state.output) {
-          const output = truncateText(state.output.trim(), config.toolOutputLimit);
-          if (output) message += `\n${output}`;
-        }
-
-        await sendText(run.channel, run.peerId, message, { kind: "tool" });
-      }
-
-      if (event.type === "permission.asked") {
-        const permission = event.properties as { id?: string; sessionID?: string };
-        if (!permission?.id || !permission.sessionID) continue;
-        const response = config.permissionMode === "deny" ? "reject" : "always";
-        await client.permission.respond({
-          sessionID: permission.sessionID,
-          permissionID: permission.id,
-          response,
-        });
-        if (response === "reject") {
-          const run = activeRuns.get(permission.sessionID);
-          if (run) {
-            await sendText(run.channel, run.peerId, "Permission denied. Update configuration to allow tools.", {
-              kind: "system",
-            });
-          }
-        }
-        }
-      }
     })().catch((error) => {
-      logger.error({ error }, "event stream closed");
+      if (abort.signal.aborted) return;
+      logger.error({ error, directory: resolved }, "event stream closed");
     });
-  }
+  };
+
+  ensureEventSubscription(defaultDirectory);
 
   async function sendText(
     channel: ChannelName,
@@ -595,7 +678,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     // Handle bot commands
     const trimmedText = inbound.text.trim();
     if (trimmedText.startsWith("/")) {
-      const commandHandled = await handleCommand(inbound.channel, inbound.peerId, trimmedText);
+      const commandHandled = await handleCommand(inbound.channel, peerKey, inbound.peerId, trimmedText);
       if (commandHandled) return;
     }
 
@@ -606,8 +689,33 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       fromMe: inbound.fromMe,
     });
 
+    const binding = store.getBinding(inbound.channel, peerKey);
     const session = store.getSession(inbound.channel, peerKey);
-    const sessionID = session?.session_id ?? (await createSession({ ...inbound, peerId: peerKey }));
+
+    const boundDirectory =
+      binding?.directory?.trim() || session?.directory?.trim() || defaultDirectory;
+
+    if (!boundDirectory) {
+      await sendText(inbound.channel, inbound.peerId, "No workspace directory configured.", { kind: "system" });
+      return;
+    }
+
+    if (!binding?.directory?.trim()) {
+      store.upsertBinding(inbound.channel, peerKey, boundDirectory);
+    }
+
+    ensureEventSubscription(boundDirectory);
+
+    const sessionID =
+      session?.session_id && normalizeDirectory(session?.directory ?? "") === normalizeDirectory(boundDirectory)
+        ? session.session_id
+        : await createSession({
+            channel: inbound.channel,
+            peerId: inbound.peerId,
+            peerKey,
+            directory: boundDirectory,
+          });
+    const key = keyForSession(boundDirectory, sessionID);
     logger.debug(
       {
         sessionID,
@@ -618,21 +726,24 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       "session resolved",
     );
 
-    enqueue(sessionID, async () => {
+    enqueue(key, async () => {
       const runState: RunState = {
+        key,
+        directory: boundDirectory,
         sessionID,
         channel: inbound.channel,
         peerId: inbound.peerId,
+        peerKey,
         toolUpdatesEnabled: config.toolUpdatesEnabled,
         seenToolStates: new Map(),
       };
-      activeRuns.set(sessionID, runState);
+      activeRuns.set(key, runState);
       reportThinking(runState);
       startTyping(runState);
       try {
         const effectiveModel = getUserModel(inbound.channel, peerKey, config.model);
         logger.debug({ sessionID, length: inbound.text.length, model: effectiveModel }, "prompt start");
-        const response = await client.session.prompt({
+        const response = await getClient(boundDirectory).session.prompt({
           sessionID,
           parts: [{ type: "text", text: inbound.text }],
           ...(effectiveModel ? { model: effectiveModel } : {}),
@@ -704,14 +815,14 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
           kind: "system",
         });
       } finally {
-        stopTyping(sessionID);
+        stopTyping(key);
         reportDone(runState);
-        activeRuns.delete(sessionID);
+        activeRuns.delete(key);
       }
     });
   }
 
-  async function handleCommand(channel: ChannelName, peerId: string, text: string): Promise<boolean> {
+  async function handleCommand(channel: ChannelName, peerKey: string, peerId: string, text: string): Promise<boolean> {
     const parts = text.slice(1).split(/\s+/);
     const command = parts[0]?.toLowerCase();
     const args = parts.slice(1);
@@ -719,15 +830,15 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     // Model switching commands
     if (command && MODEL_PRESETS[command]) {
       const model = MODEL_PRESETS[command];
-      setUserModel(channel, peerId, model);
+      setUserModel(channel, peerKey, model);
       await sendText(channel, peerId, `Model switched to ${model.providerID}/${model.modelID}`, { kind: "system" });
-      logger.info({ channel, peerId, model }, "model switched via command");
+      logger.info({ channel, peerId: peerKey, model }, "model switched via command");
       return true;
     }
 
     // /model command - show current model
     if (command === "model") {
-      const current = getUserModel(channel, peerId, config.model);
+      const current = getUserModel(channel, peerKey, config.model);
       const modelStr = current ? `${current.providerID}/${current.modelID}` : "default";
       await sendText(channel, peerId, `Current model: ${modelStr}`, { kind: "system" });
       return true;
@@ -735,16 +846,32 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
     // /reset command - clear model override and session
     if (command === "reset") {
-      setUserModel(channel, peerId, undefined);
-      store.deleteSession(channel, peerId);
+      setUserModel(channel, peerKey, undefined);
+      store.deleteSession(channel, peerKey);
       await sendText(channel, peerId, "Session and model reset. Send a message to start fresh.", { kind: "system" });
-      logger.info({ channel, peerId }, "session and model reset");
+      logger.info({ channel, peerId: peerKey }, "session and model reset");
+      return true;
+    }
+
+    if (command === "dir" || command === "cd") {
+      const next = args.join(" ").trim();
+      if (!next) {
+        const binding = store.getBinding(channel, peerKey);
+        const current = binding?.directory?.trim() || store.getSession(channel, peerKey)?.directory?.trim() || defaultDirectory;
+        await sendText(channel, peerId, `Current directory: ${current || "(none)"}`, { kind: "system" });
+        return true;
+      }
+      const normalized = normalizeDirectory(next);
+      store.upsertBinding(channel, peerKey, normalized);
+      store.deleteSession(channel, peerKey);
+      ensureEventSubscription(normalized);
+      await sendText(channel, peerId, `Directory set to: ${normalized}`, { kind: "system" });
       return true;
     }
 
     // /help command
     if (command === "help") {
-      const helpText = `/opus - Claude Opus 4.5\n/codex - GPT 5.2 Codex\n/model - show current\n/reset - start fresh\n/help - this`;
+      const helpText = `/opus - Claude Opus 4.5\n/codex - GPT 5.2 Codex\n/dir <path> - bind this chat to a directory\n/dir - show current directory\n/model - show current\n/reset - start fresh\n/help - this`;
       await sendText(channel, peerId, helpText, { kind: "system" });
       return true;
     }
@@ -753,36 +880,41 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     return false;
   }
 
-  async function createSession(message: InboundMessage): Promise<string> {
-    const title = `owpenbot ${message.channel} ${message.peerId}`;
-    const session = await client.session.create({
+  async function createSession(input: {
+    channel: ChannelName;
+    peerId: string;
+    peerKey: string;
+    directory: string;
+  }): Promise<string> {
+    const title = `owpenbot ${input.channel} ${input.peerId}`;
+    const session = await getClient(input.directory).session.create({
       title,
       permission: buildPermissionRules(config.permissionMode),
     });
     const sessionID = (session as { id?: string }).id;
     if (!sessionID) throw new Error("Failed to create session");
-    store.upsertSession(message.channel, message.peerId, sessionID);
-    logger.info({ sessionID, channel: message.channel, peerId: message.peerId }, "session created");
+    store.upsertSession(input.channel, input.peerKey, sessionID, input.directory);
+    logger.info({ sessionID, channel: input.channel, peerId: input.peerKey, directory: input.directory }, "session created");
     reportStatus?.(
-      `${CHANNEL_LABELS[message.channel]} session created for ${formatPeer(message.channel, message.peerId)} (ID: ${sessionID}).`,
+      `${CHANNEL_LABELS[input.channel]} session created for ${formatPeer(input.channel, input.peerId)} (ID: ${sessionID}).`,
     );
-    await sendText(message.channel, message.peerId, "🧭 Session started.", { kind: "system" });
+    await sendText(input.channel, input.peerId, "🧭 Session started.", { kind: "system" });
     return sessionID;
   }
 
-  function enqueue(sessionID: string, task: () => Promise<void>) {
-    const previous = sessionQueue.get(sessionID) ?? Promise.resolve();
+  function enqueue(key: string, task: () => Promise<void>) {
+    const previous = sessionQueue.get(key) ?? Promise.resolve();
     const next = previous
       .then(task)
       .catch((error) => {
         logger.error({ error }, "session task failed");
       })
       .finally(() => {
-        if (sessionQueue.get(sessionID) === next) {
-          sessionQueue.delete(sessionID);
+        if (sessionQueue.get(key) === next) {
+          sessionQueue.delete(key);
         }
       });
-    sessionQueue.set(sessionID, next);
+    sessionQueue.set(key, next);
   }
 
   for (const adapter of adapters.values()) {
@@ -795,9 +927,12 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
   return {
     async stop() {
-      eventAbort.abort();
       clearInterval(healthTimer);
       if (stopHealthServer) stopHealthServer();
+      for (const abort of eventSubscriptions.values()) {
+        abort.abort();
+      }
+      eventSubscriptions.clear();
       for (const timer of typingLoops.values()) {
         clearInterval(timer);
       }
@@ -821,7 +956,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       const peerKey = message.channel === "whatsapp" ? normalizeWhatsAppId(message.peerId) : message.peerId;
       const session = store.getSession(message.channel, peerKey);
       const sessionID = session?.session_id;
-      const pending = sessionID ? sessionQueue.get(sessionID) : null;
+      const directory = session?.directory?.trim() || store.getBinding(message.channel, peerKey)?.directory?.trim() || defaultDirectory;
+      const pending = sessionID && directory ? sessionQueue.get(keyForSession(directory, sessionID)) : null;
       if (pending) {
         await pending;
       }

--- a/packages/owpenbot/src/db.ts
+++ b/packages/owpenbot/src/db.ts
@@ -9,6 +9,15 @@ type SessionRow = {
   channel: ChannelName;
   peer_id: string;
   session_id: string;
+  directory?: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+type BindingRow = {
+  channel: ChannelName;
+  peer_id: string;
+  directory: string;
   created_at: number;
   updated_at: number;
 };
@@ -49,6 +58,14 @@ export class BridgeStore {
         created_at INTEGER NOT NULL,
         PRIMARY KEY (channel, peer_id)
       );
+      CREATE TABLE IF NOT EXISTS bindings (
+        channel TEXT NOT NULL,
+        peer_id TEXT NOT NULL,
+        directory TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (channel, peer_id)
+      );
       CREATE TABLE IF NOT EXISTS settings (
         key TEXT PRIMARY KEY,
         value TEXT NOT NULL
@@ -62,6 +79,18 @@ export class BridgeStore {
         PRIMARY KEY (channel, peer_id)
       );
     `);
+
+    this.migrate();
+  }
+
+  private migrate() {
+    const columns = this.db
+      .prepare("PRAGMA table_info(sessions)")
+      .all() as Array<{ name?: string }>;
+    const hasDirectory = columns.some((column) => column.name === "directory");
+    if (!hasDirectory) {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN directory TEXT");
+    }
   }
 
   private ensureDir() {
@@ -71,26 +100,63 @@ export class BridgeStore {
 
   getSession(channel: ChannelName, peerId: string): SessionRow | null {
     const stmt = this.db.prepare(
-      "SELECT channel, peer_id, session_id, created_at, updated_at FROM sessions WHERE channel = ? AND peer_id = ?",
+      "SELECT channel, peer_id, session_id, directory, created_at, updated_at FROM sessions WHERE channel = ? AND peer_id = ?",
     );
     const row = stmt.get(channel, peerId) as SessionRow | null;
     return row ?? null;
   }
 
-  upsertSession(channel: ChannelName, peerId: string, sessionId: string) {
+  upsertSession(channel: ChannelName, peerId: string, sessionId: string, directory?: string | null) {
     const now = Date.now();
     const stmt = this.db.prepare(
-      `INSERT INTO sessions (channel, peer_id, session_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?)
-       ON CONFLICT(channel, peer_id) DO UPDATE SET session_id = excluded.session_id, updated_at = excluded.updated_at`,
+      `INSERT INTO sessions (channel, peer_id, session_id, directory, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(channel, peer_id) DO UPDATE SET session_id = excluded.session_id, directory = excluded.directory, updated_at = excluded.updated_at`,
     );
-    stmt.run(channel, peerId, sessionId, now, now);
+    stmt.run(channel, peerId, sessionId, directory ?? null, now, now);
   }
 
   deleteSession(channel: ChannelName, peerId: string): boolean {
     const stmt = this.db.prepare("DELETE FROM sessions WHERE channel = ? AND peer_id = ?");
     const result = stmt.run(channel, peerId);
     return result.changes > 0;
+  }
+
+  getBinding(channel: ChannelName, peerId: string): BindingRow | null {
+    const stmt = this.db.prepare(
+      "SELECT channel, peer_id, directory, created_at, updated_at FROM bindings WHERE channel = ? AND peer_id = ?",
+    );
+    const row = stmt.get(channel, peerId) as BindingRow | null;
+    return row ?? null;
+  }
+
+  upsertBinding(channel: ChannelName, peerId: string, directory: string) {
+    const now = Date.now();
+    const stmt = this.db.prepare(
+      `INSERT INTO bindings (channel, peer_id, directory, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(channel, peer_id) DO UPDATE SET directory = excluded.directory, updated_at = excluded.updated_at`,
+    );
+    stmt.run(channel, peerId, directory, now, now);
+  }
+
+  deleteBinding(channel: ChannelName, peerId: string): boolean {
+    const stmt = this.db.prepare("DELETE FROM bindings WHERE channel = ? AND peer_id = ?");
+    const result = stmt.run(channel, peerId);
+    return result.changes > 0;
+  }
+
+  listBindings(channel?: ChannelName): BindingRow[] {
+    if (channel) {
+      const stmt = this.db.prepare(
+        "SELECT channel, peer_id, directory, created_at, updated_at FROM bindings WHERE channel = ? ORDER BY updated_at DESC",
+      );
+      return stmt.all(channel) as BindingRow[];
+    }
+    const stmt = this.db.prepare(
+      "SELECT channel, peer_id, directory, created_at, updated_at FROM bindings ORDER BY updated_at DESC",
+    );
+    return stmt.all() as BindingRow[];
   }
 
   isAllowed(channel: ChannelName, peerId: string): boolean {

--- a/packages/owpenbot/src/health.ts
+++ b/packages/owpenbot/src/health.ts
@@ -33,11 +33,25 @@ export type GroupsConfigResult = {
   groupsEnabled: boolean;
 };
 
+export type BindingItem = {
+  channel: string;
+  peerId: string;
+  directory: string;
+  updatedAt?: number;
+};
+
+export type BindingsListResult = {
+  items: BindingItem[];
+};
+
 export type HealthHandlers = {
   setTelegramToken?: (token: string) => Promise<TelegramTokenResult>;
   setSlackTokens?: (tokens: { botToken: string; appToken: string }) => Promise<SlackTokensResult>;
   setGroupsEnabled?: (enabled: boolean) => Promise<GroupsConfigResult>;
   getGroupsEnabled?: () => boolean;
+  listBindings?: () => Promise<BindingsListResult>;
+  setBinding?: (input: { channel: string; peerId: string; directory: string }) => Promise<void>;
+  clearBinding?: (input: { channel: string; peerId: string }) => Promise<void>;
 };
 
 export function startHealthServer(
@@ -201,6 +215,82 @@ export function startHealthServer(
           const result = await handlers.setGroupsEnabled(enabled);
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ ok: true, ...result }));
+          return;
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: String(error) }));
+          return;
+        }
+      }
+
+      if (pathname === "/bindings" && req.method === "GET") {
+        if (!handlers.listBindings) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+          return;
+        }
+
+        try {
+          const result = await handlers.listBindings();
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, ...result }));
+          return;
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: String(error) }));
+          return;
+        }
+      }
+
+      if (pathname === "/bindings" && req.method === "POST") {
+        if (!handlers.setBinding && !handlers.clearBinding) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+          return;
+        }
+
+        let raw = "";
+        for await (const chunk of req) {
+          raw += chunk.toString();
+          if (raw.length > 1024 * 1024) {
+            res.writeHead(413, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+            return;
+          }
+        }
+
+        try {
+          const payload = JSON.parse(raw || "{}");
+          const channel = typeof payload.channel === "string" ? payload.channel.trim() : "";
+          const peerId = typeof payload.peerId === "string" ? payload.peerId.trim() : "";
+          const directory = typeof payload.directory === "string" ? payload.directory.trim() : "";
+
+          if (!channel || !peerId) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "channel and peerId are required" }));
+            return;
+          }
+
+          if (!directory) {
+            if (!handlers.clearBinding) {
+              res.writeHead(404, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+              return;
+            }
+            await handlers.clearBinding({ channel, peerId });
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+            return;
+          }
+
+          if (!handlers.setBinding) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+            return;
+          }
+          await handlers.setBinding({ channel, peerId, directory });
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
           return;
         } catch (error) {
           res.writeHead(500, { "Content-Type": "application/json" });

--- a/packages/owpenbot/src/opencode.ts
+++ b/packages/owpenbot/src/opencode.ts
@@ -6,7 +6,7 @@ import type { Config } from "./config.js";
 
 type Client = ReturnType<typeof createOpencodeClient>;
 
-export function createClient(config: Config): Client {
+export function createClient(config: Config, directory?: string): Client {
   const headers: Record<string, string> = {};
   if (config.opencodeUsername && config.opencodePassword) {
     const token = Buffer.from(`${config.opencodeUsername}:${config.opencodePassword}`).toString("base64");
@@ -15,7 +15,7 @@ export function createClient(config: Config): Client {
 
   return createOpencodeClient({
     baseUrl: config.opencodeUrl,
-    directory: config.opencodeDirectory,
+    directory: directory ?? config.opencodeDirectory,
     headers: Object.keys(headers).length ? headers : undefined,
     responseStyle: "data",
     throwOnError: true,

--- a/packages/owpenbot/test/bridge-multiworkspace.test.js
+++ b/packages/owpenbot/test/bridge-multiworkspace.test.js
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { startBridge } from "../dist/bridge.js";
+
+function createLoggerStub() {
+  const base = {
+    child() {
+      return base;
+    },
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+  return base;
+}
+
+test("bridge: routes sessions per peer directory binding", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "owpenbot-multiws-"));
+  const wsA = path.join(dir, "ws-a");
+  const wsB = path.join(dir, "ws-b");
+  fs.mkdirSync(wsA, { recursive: true });
+  fs.mkdirSync(wsB, { recursive: true });
+
+  const dbPath = path.join(dir, "owpenbot.db");
+  const sent = [];
+  const created = [];
+  const prompted = [];
+
+  const slackAdapter = {
+    name: "slack",
+    maxTextLength: 39_000,
+    async start() {},
+    async stop() {},
+    async sendText(peerId, text) {
+      sent.push({ peerId, text });
+    },
+  };
+
+  const clientFactory = (directory) => {
+    const dirLabel = directory;
+    return {
+      global: {
+        health: async () => ({ healthy: true, version: "test" }),
+      },
+      session: {
+        create: async () => {
+          created.push(dirLabel);
+          return { id: `session-${created.length}` };
+        },
+        prompt: async () => {
+          prompted.push(dirLabel);
+          return { parts: [{ type: "text", text: `pong:${path.basename(dirLabel)}` }] };
+        },
+      },
+    };
+  };
+
+  const bridge = await startBridge(
+    {
+      configPath: path.join(dir, "owpenbot.json"),
+      configFile: { version: 1 },
+      opencodeUrl: "http://127.0.0.1:4096",
+      opencodeDirectory: wsA,
+      telegramEnabled: false,
+      whatsappEnabled: false,
+      slackEnabled: false,
+      whatsappAuthDir: dir,
+      whatsappAccountId: "default",
+      whatsappDmPolicy: "disabled",
+      whatsappAllowFrom: new Set(),
+      whatsappSelfChatMode: false,
+      dataDir: dir,
+      dbPath,
+      logFile: path.join(dir, "owpenbot.log"),
+      allowlist: {
+        telegram: new Set(),
+        whatsapp: new Set(),
+        slack: new Set(),
+      },
+      toolUpdatesEnabled: false,
+      groupsEnabled: false,
+      permissionMode: "allow",
+      toolOutputLimit: 1200,
+      logLevel: "silent",
+    },
+    createLoggerStub(),
+    undefined,
+    {
+      clientFactory,
+      adapters: new Map([["slack", slackAdapter]]),
+      disableEventStream: true,
+      disableHealthServer: true,
+    },
+  );
+
+  // Bind peer A to ws-a
+  await bridge.dispatchInbound({ channel: "slack", peerId: "D-A", text: `/dir ${wsA}`, raw: {} });
+  await bridge.dispatchInbound({ channel: "slack", peerId: "D-A", text: "ping", raw: {} });
+
+  // Bind peer B to ws-b
+  await bridge.dispatchInbound({ channel: "slack", peerId: "D-B", text: `/dir ${wsB}`, raw: {} });
+  await bridge.dispatchInbound({ channel: "slack", peerId: "D-B", text: "ping", raw: {} });
+
+  // Ensure prompts were routed to different directories
+  assert.ok(prompted.includes(wsA));
+  assert.ok(prompted.includes(wsB));
+
+  // Ensure output includes per-directory pong
+  const output = sent.map((m) => `${m.peerId}:${m.text}`).join("\n");
+  assert.ok(output.includes("D-A:pong:ws-a"));
+  assert.ok(output.includes("D-B:pong:ws-b"));
+
+  await bridge.stop();
+});

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -197,6 +197,23 @@ export function startServer(config: ServerConfig) {
         }
       }
 
+      // Allow clients to use a mounted base URL (e.g. http://host:8787/w/<id>) while
+      // still calling the existing /workspace/:id/* API surface.
+      // Example: baseUrl + "/workspace/<id>/plugins" => "/w/<id>/workspace/<id>/plugins".
+      // We strip the mount prefix and route-match on the rest path.
+      //
+      // Important: when using a mounted base URL, enforce that the nested /workspace/:id
+      // matches the mount workspace id to preserve the "single-workspace" mental model.
+      if (mount && mount.restPath.startsWith("/workspace/")) {
+        const match = mount.restPath.match(/^\/workspace\/([^/]+)/);
+        const nestedId = match?.[1] ? decodeURIComponent(match[1]) : null;
+        if (nestedId && nestedId !== mount.workspaceId) {
+          errorMessage = "not_found";
+          return finalize(jsonResponse({ code: "not_found", message: "Not found" }, 404));
+        }
+        url.pathname = mount.restPath;
+      }
+
       if (url.pathname === "/opencode" || url.pathname.startsWith("/opencode/")) {
         authMode = "client";
         proxyBaseUrl = config.workspaces[0]?.baseUrl?.trim() || undefined;
@@ -506,8 +523,8 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
   });
 
   addRoute(routes, "GET", "/workspaces", "client", async () => {
-    const active = config.workspaces[0];
-    const items = active ? [serializeWorkspace(active)] : [];
+    const active = config.workspaces[0] ?? null;
+    const items = config.workspaces.map(serializeWorkspace);
     return jsonResponse({ items, activeId: active?.id ?? null });
   });
 


### PR DESCRIPTION
## What changed
- OpenWork server now returns all configured workspaces from `GET /workspaces`, and supports mounted base URLs (`/w/:id`) calling existing `/workspace/:id/*` routes with a guardrail to prevent cross-workspace access.
- UI now keeps tasks visible across workspaces:
  - Sidebar loads/caches session lists per workspace (collapsed groups + counts), so switching workspaces no longer makes previous tasks disappear.
  - "New task" from a workspace row creates the task in that workspace (activates first if needed).
- Local share modal prefers a stable workspace URL (`.../w/<id>`) by resolving the workspace id via `GET /workspaces`.
- Desktop engine now defaults to the Openwrk runtime.
- Owpenbot gains multi-workspace routing via persisted bindings `(channel, peerId) -> directory`, plus `/dir` command and health endpoints to manage bindings.

## Why
Multi-workspace hosting only feels correct if:
- clients can connect to a specific workspace via `/w/:id`, and
- the UI stays multi-workspace-native (tasks remain visible and navigable across workspaces).

## Testing
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwork-server build:bin`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter owpenwork typecheck`
- `pnpm --filter owpenwork test:unit`
- `pnpm --filter owpenwork test:cli`

## Notes
- Mounted URL compatibility currently focuses on allowing a mounted baseUrl to call `/workspace/:id/*` routes without client-side special casing.