### PR TITLE
fix(owpenbot): make token saves fast and resilient

### DIFF
--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -92,17 +92,31 @@ export type OpenworkMcpItem = {
 
 export type OpenworkOwpenbotTelegramResult = {
   ok: boolean;
+  persisted?: boolean;
+  applied?: boolean;
+  applyError?: string;
+  applyStatus?: number;
   telegram?: {
     configured: boolean;
     enabled: boolean;
+    applied?: boolean;
+    starting?: boolean;
+    error?: string;
   };
 };
 
 export type OpenworkOwpenbotSlackResult = {
   ok: boolean;
+  persisted?: boolean;
+  applied?: boolean;
+  applyError?: string;
+  applyStatus?: number;
   slack?: {
     configured: boolean;
     enabled: boolean;
+    applied?: boolean;
+    starting?: boolean;
+    error?: string;
   };
 };
 

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -387,8 +387,9 @@ export function OwpenbotSettings(props: {
         }
 
         setTelegramFeedback("checking", "Saving token on the host...");
+        let remoteResult: Awaited<ReturnType<typeof serverClient.setOwpenbotTelegramToken>> | null = null;
         try {
-          await serverClient.setOwpenbotTelegramToken(
+          remoteResult = await serverClient.setOwpenbotTelegramToken(
             workspaceId,
             token,
             latestStatus?.healthPort ?? owpenbotStatus()?.healthPort ?? null,
@@ -401,8 +402,65 @@ export function OwpenbotSettings(props: {
           return;
         }
 
-        setTelegramFeedback("success", "Telegram token saved.");
         setTelegramToken("");
+
+        // Keep UI in sync: refresh status after host mutation.
+        await refreshStatus();
+
+        const status = owpenbotStatus();
+        const applyError = remoteResult?.applyError || remoteResult?.telegram?.error || null;
+        const applied = remoteResult?.applied ?? remoteResult?.telegram?.applied;
+        const starting = Boolean(remoteResult?.telegram?.starting);
+
+        if (status) {
+          if (!status.telegram.configured) {
+            setTelegramFeedback(
+              "error",
+              "Token saved, but Telegram is still unconfigured.",
+              applyError || "Check the token and try again.",
+            );
+            return;
+          }
+          if (!status.running) {
+            setTelegramFeedback(
+              "warning",
+              "Token saved, but the messaging bridge is offline.",
+              applyError || "Restart owpenbot (or start OpenWork) to activate Telegram.",
+            );
+            return;
+          }
+          if (!status.telegram.enabled) {
+            setTelegramFeedback(
+              "warning",
+              "Token saved, but Telegram is disabled.",
+              applyError || "Enable the bot or review owpenbot settings.",
+            );
+            return;
+          }
+
+          if (applied === false || starting) {
+            setTelegramFeedback(
+              "warning",
+              "Token saved, but Telegram is still applying.",
+              applyError || "Give it a moment or restart owpenbot.",
+            );
+            return;
+          }
+
+          setTelegramFeedback("success", "Telegram connected.");
+          return;
+        }
+
+        if (applied === false || applyError || starting) {
+          setTelegramFeedback(
+            "warning",
+            "Telegram token saved.",
+            applyError || "Owpenbot will pick this up when it starts.",
+          );
+          return;
+        }
+
+        setTelegramFeedback("success", "Telegram token saved.");
         return;
       }
 
@@ -494,8 +552,9 @@ export function OwpenbotSettings(props: {
         }
 
         setSlackFeedback("checking", "Saving tokens on the host...");
+        let remoteResult: Awaited<ReturnType<typeof serverClient.setOwpenbotSlackTokens>> | null = null;
         try {
-          await serverClient.setOwpenbotSlackTokens(
+          remoteResult = await serverClient.setOwpenbotSlackTokens(
             workspaceId,
             botToken,
             appToken,
@@ -509,9 +568,65 @@ export function OwpenbotSettings(props: {
           return;
         }
 
-        setSlackFeedback("success", "Slack tokens saved.");
         setSlackBotToken("");
         setSlackAppToken("");
+
+        await refreshStatus();
+
+        const status = owpenbotStatus();
+        const applyError = remoteResult?.applyError || remoteResult?.slack?.error || null;
+        const applied = remoteResult?.applied ?? remoteResult?.slack?.applied;
+        const starting = Boolean(remoteResult?.slack?.starting);
+
+        if (status) {
+          if (!status.slack.configured) {
+            setSlackFeedback(
+              "error",
+              "Tokens saved, but Slack is still unconfigured.",
+              applyError || "Check the tokens and try again.",
+            );
+            return;
+          }
+          if (!status.running) {
+            setSlackFeedback(
+              "warning",
+              "Tokens saved, but the messaging bridge is offline.",
+              applyError || "Restart owpenbot (or start OpenWork) to activate Slack.",
+            );
+            return;
+          }
+          if (!status.slack.enabled) {
+            setSlackFeedback(
+              "warning",
+              "Tokens saved, but Slack is disabled.",
+              applyError || "Enable the bot or review owpenbot settings.",
+            );
+            return;
+          }
+
+          if (applied === false || starting) {
+            setSlackFeedback(
+              "warning",
+              "Tokens saved, but Slack is still applying.",
+              applyError || "Give it a moment or restart owpenbot.",
+            );
+            return;
+          }
+
+          setSlackFeedback("success", "Slack connected.");
+          return;
+        }
+
+        if (applied === false || applyError || starting) {
+          setSlackFeedback(
+            "warning",
+            "Slack tokens saved.",
+            applyError || "Owpenbot will pick this up when it starts.",
+          );
+          return;
+        }
+
+        setSlackFeedback("success", "Slack tokens saved.");
         return;
       }
 

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openwork"
-version = "0.11.24"
+version = "0.11.27"
 dependencies = [
  "base64 0.22.1",
  "gethostname",

--- a/packages/owpenbot/src/bridge.ts
+++ b/packages/owpenbot/src/bridge.ts
@@ -13,7 +13,7 @@ import { createSlackAdapter } from "./slack.js";
 import { createTelegramAdapter } from "./telegram.js";
 import { createWhatsAppAdapter } from "./whatsapp.js";
 
-   type Adapter = {
+type Adapter = {
   name: ChannelName;
   maxTextLength: number;
   start(): Promise<void>;
@@ -22,6 +22,38 @@ import { createWhatsAppAdapter } from "./whatsapp.js";
   sendFile?: (peerId: string, filePath: string, caption?: string) => Promise<void>;
   sendTyping?: (peerId: string) => Promise<void>;
 };
+
+type AdapterStartResult =
+  | { status: "started" }
+  | { status: "timeout" }
+  | { status: "error"; error: unknown };
+
+async function startAdapterBounded(
+  adapter: Adapter,
+  options: { timeoutMs: number; onError?: (error: unknown) => void },
+): Promise<AdapterStartResult> {
+  const outcome = adapter
+    .start()
+    .then(() => ({ ok: true as const }))
+    .catch((error) => ({ ok: false as const, error }));
+
+  if (options.onError) {
+    void outcome.then((result) => {
+      if (!result.ok) {
+        options.onError?.(result.error);
+      }
+    });
+  }
+
+  const winner = await Promise.race([
+    outcome.then((result) => ({ kind: "outcome" as const, result })),
+    delay(options.timeoutMs).then(() => ({ kind: "timeout" as const })),
+  ]);
+
+  if (winner.kind === "timeout") return { status: "timeout" };
+  if (winner.result.ok) return { status: "started" };
+  return { status: "error", error: winner.result.error };
+}
 
 type OutboundKind = "reply" | "system" | "tool";
 
@@ -361,11 +393,38 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
           const adapter = createTelegramAdapter(config, logger, handleInbound);
           adapters.set("telegram", adapter);
-          await adapter.start();
+
+          const startResult = await startAdapterBounded(adapter, {
+            timeoutMs: 2_500,
+            onError: (error) => {
+              logger.error({ error }, "telegram adapter start failed");
+              adapters.delete("telegram");
+            },
+          });
+
+          if (startResult.status === "timeout") {
+            logger.warn({ timeoutMs: 2_500 }, "telegram adapter start timed out");
+            return {
+              configured: true,
+              enabled: true,
+              applied: false,
+              starting: true,
+            };
+          }
+
+          if (startResult.status === "error") {
+            return {
+              configured: true,
+              enabled: true,
+              applied: false,
+              error: String(startResult.error),
+            };
+          }
 
           return {
             configured: true,
             enabled: true,
+            applied: true,
           };
         },
         setSlackTokens: async (tokens: { botToken: string; appToken: string }) => {
@@ -407,11 +466,38 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
           const adapter = createSlackAdapter(config, logger, handleInbound);
           adapters.set("slack", adapter);
-          await adapter.start();
+
+          const startResult = await startAdapterBounded(adapter, {
+            timeoutMs: 2_500,
+            onError: (error) => {
+              logger.error({ error }, "slack adapter start failed");
+              adapters.delete("slack");
+            },
+          });
+
+          if (startResult.status === "timeout") {
+            logger.warn({ timeoutMs: 2_500 }, "slack adapter start timed out");
+            return {
+              configured: true,
+              enabled: true,
+              applied: false,
+              starting: true,
+            };
+          }
+
+          if (startResult.status === "error") {
+            return {
+              configured: true,
+              enabled: true,
+              applied: false,
+              error: String(startResult.error),
+            };
+          }
 
           return {
             configured: true,
             enabled: true,
+            applied: true,
           };
         },
         listBindings: async () => {
@@ -917,9 +1003,27 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     sessionQueue.set(key, next);
   }
 
-  for (const adapter of adapters.values()) {
-    await adapter.start();
-    reportStatus?.(`${CHANNEL_LABELS[adapter.name]} adapter started.`);
+  for (const [channel, adapter] of Array.from(adapters.entries())) {
+    const startResult = await startAdapterBounded(adapter, {
+      timeoutMs: 8_000,
+      onError: (error) => {
+        logger.error({ error, channel }, "adapter start failed");
+        adapters.delete(channel);
+      },
+    });
+
+    if (startResult.status === "timeout") {
+      logger.warn({ channel, timeoutMs: 8_000 }, "adapter start timed out");
+      reportStatus?.(`${CHANNEL_LABELS[channel]} adapter starting...`);
+      continue;
+    }
+
+    if (startResult.status === "error") {
+      reportStatus?.(`${CHANNEL_LABELS[channel]} adapter failed to start.`);
+      continue;
+    }
+
+    reportStatus?.(`${CHANNEL_LABELS[channel]} adapter started.`);
   }
 
   logger.info({ channels: Array.from(adapters.keys()) }, "bridge started");

--- a/packages/owpenbot/src/health.ts
+++ b/packages/owpenbot/src/health.ts
@@ -22,11 +22,21 @@ export type HealthSnapshot = {
 export type TelegramTokenResult = {
   configured: boolean;
   enabled: boolean;
+  // Whether owpenbot applied the token to a running adapter.
+  // If false, the token is still persisted but may require a restart.
+  applied?: boolean;
+  // True when adapter start is still in flight (timeout).
+  starting?: boolean;
+  // Apply/start failure detail (best-effort, for UI/debugging).
+  error?: string;
 };
 
 export type SlackTokensResult = {
   configured: boolean;
   enabled: boolean;
+  applied?: boolean;
+  starting?: boolean;
+  error?: string;
 };
 
 export type GroupsConfigResult = {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,6 @@
-import { readFile, writeFile, rm } from "node:fs/promises";
+import { readFile, writeFile, rm, rename } from "node:fs/promises";
 import { homedir, hostname } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger } from "./types.js";
 import { ApprovalService } from "./approvals.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
@@ -631,7 +631,11 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     });
 
     const result = await updateOwpenbotTelegramToken(token, healthPort, requestHost);
-    logOwpenbotDebug("telegram-token:updated", { workspaceId: workspace.id });
+    logOwpenbotDebug("telegram-token:updated", {
+      workspaceId: workspace.id,
+      applied: typeof result.applied === "boolean" ? result.applied : null,
+      applyError: typeof result.applyError === "string" ? result.applyError : null,
+    });
 
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -674,7 +678,11 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     });
 
     const result = await updateOwpenbotSlackTokens(botToken, appToken, healthPort, requestHost);
-    logOwpenbotDebug("slack-tokens:updated", { workspaceId: workspace.id });
+    logOwpenbotDebug("slack-tokens:updated", {
+      workspaceId: workspace.id,
+      applied: typeof result.applied === "boolean" ? result.applied : null,
+      applyError: typeof result.applyError === "string" ? result.applyError : null,
+    });
 
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -1153,57 +1161,250 @@ function normalizeHealthPort(value: unknown): number | null {
   return port;
 }
 
+type OwpenbotConfigFile = Record<string, unknown> & {
+  version?: number;
+  channels?: Record<string, unknown> & {
+    telegram?: Record<string, unknown>;
+    slack?: Record<string, unknown>;
+  };
+};
+
+function ensurePlainObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+async function readOwpenbotConfigFile(configPath: string): Promise<OwpenbotConfigFile> {
+  if (!(await exists(configPath))) {
+    return { version: 1 };
+  }
+
+  let raw = "";
+  try {
+    raw = await readFile(configPath, "utf8");
+  } catch (error) {
+    throw new ApiError(500, "owpenbot_config_read_failed", "Failed to read owpenbot.json", {
+      path: configPath,
+      error: String(error),
+    });
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return ensurePlainObject(parsed) as OwpenbotConfigFile;
+  } catch (error) {
+    throw new ApiError(422, "invalid_json", "Failed to parse owpenbot.json", {
+      path: configPath,
+      error: String(error),
+    });
+  }
+}
+
+async function writeOwpenbotConfigFile(configPath: string, config: OwpenbotConfigFile): Promise<void> {
+  await ensureDir(dirname(configPath));
+  const next: OwpenbotConfigFile = {
+    ...config,
+    version: typeof config.version === "number" && Number.isFinite(config.version) ? config.version : 1,
+  };
+  const tmpPath = `${configPath}.tmp.${shortId()}`;
+  try {
+    await writeFile(tmpPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+    await rename(tmpPath, configPath);
+  } finally {
+    // Best-effort cleanup if rename failed.
+    try {
+      await rm(tmpPath);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+async function persistOwpenbotTelegramToken(token: string): Promise<void> {
+  const configPath = resolveOwpenbotConfigPath();
+  const current = await readOwpenbotConfigFile(configPath);
+  const channels = ensurePlainObject(current.channels);
+  const telegram = ensurePlainObject(channels.telegram);
+  const next: OwpenbotConfigFile = {
+    ...current,
+    channels: {
+      ...channels,
+      telegram: {
+        ...telegram,
+        token,
+        enabled: true,
+      },
+    },
+  };
+  await writeOwpenbotConfigFile(configPath, next);
+}
+
+async function persistOwpenbotSlackTokens(botToken: string, appToken: string): Promise<void> {
+  const configPath = resolveOwpenbotConfigPath();
+  const current = await readOwpenbotConfigFile(configPath);
+  const channels = ensurePlainObject(current.channels);
+  const slack = ensurePlainObject(channels.slack);
+  const next: OwpenbotConfigFile = {
+    ...current,
+    channels: {
+      ...channels,
+      slack: {
+        ...slack,
+        botToken,
+        appToken,
+        enabled: true,
+      },
+    },
+  };
+  await writeOwpenbotConfigFile(configPath, next);
+}
+
+type OwpenbotApplyAttempt = {
+  applied: boolean;
+  port: number;
+  hosts: string[];
+  host?: string;
+  status?: number;
+  error?: string;
+  body?: unknown;
+};
+
+async function tryPostOwpenbotHealth(
+  pathname: string,
+  payload: unknown,
+  options: { port: number; requestHost?: string | null; timeoutMs: number },
+): Promise<OwpenbotApplyAttempt> {
+  const candidates = Array.from(
+    new Set(
+      ["127.0.0.1", options.requestHost].filter(
+        (host): host is string => Boolean(host && host.trim()),
+      ),
+    ),
+  );
+  const port = options.port;
+
+  let lastError: OwpenbotApplyAttempt | null = null;
+  for (const host of candidates) {
+    const url = `http://${host}:${port}${pathname}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+
+      const text = await response.text();
+      const parsed = parseJsonResponse(text);
+
+      if (response.ok) {
+        return {
+          applied: true,
+          port,
+          hosts: candidates,
+          host,
+          status: response.status,
+          body: parsed,
+        };
+      }
+
+      const detail =
+        typeof parsed === "object" && parsed && "error" in parsed
+          ? String((parsed as Record<string, unknown>).error)
+          : response.statusText || "Owpenbot request failed";
+      lastError = {
+        applied: false,
+        port,
+        hosts: candidates,
+        host,
+        status: response.status,
+        error: detail,
+        body: parsed,
+      };
+    } catch (error) {
+      clearTimeout(timer);
+      const message =
+        error instanceof Error && error.name === "AbortError"
+          ? `Timeout after ${options.timeoutMs}ms`
+          : String(error);
+      lastError = {
+        applied: false,
+        port,
+        hosts: candidates,
+        host,
+        error: message,
+      };
+    }
+  }
+
+  return (
+    lastError ?? {
+      applied: false,
+      port,
+      hosts: candidates,
+      error: "Owpenbot health server is unavailable",
+    }
+  );
+}
+
 async function updateOwpenbotTelegramToken(
   token: string,
   healthPortOverride?: number | null,
   requestHost?: string | null,
 ): Promise<Record<string, unknown>> {
-  const port = healthPortOverride ?? resolveOwpenbotHealthPort();
-  const candidates = ["127.0.0.1", requestHost].filter(
-    (host): host is string => Boolean(host && host.trim()),
-  );
-  let response: Response | null = null;
-  let lastError: unknown = null;
+  // Always persist first so the token is saved even if owpenbot is offline.
+  await persistOwpenbotTelegramToken(token);
 
-  for (const host of candidates) {
-    const url = `http://${host}:${port}/config/telegram-token`;
-    try {
-      response = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token }),
-      });
-      break;
-    } catch (error) {
-      lastError = error;
+  const port = healthPortOverride ?? resolveOwpenbotHealthPort();
+  const apply = await tryPostOwpenbotHealth(
+    "/config/telegram-token",
+    { token },
+    { port, requestHost, timeoutMs: 3_000 },
+  );
+
+  const response: Record<string, unknown> = {
+    ok: true,
+    persisted: true,
+    applied: apply.applied,
+    telegram: { configured: true, enabled: true },
+  };
+
+  // Prefer owpenbot's response payload when available.
+  if (apply.body && typeof apply.body === "object") {
+    const record = apply.body as Record<string, unknown>;
+    if (record.telegram && typeof record.telegram === "object") {
+      response.telegram = record.telegram;
     }
   }
 
-  if (!response) {
-    throw new ApiError(502, "owpenbot_unreachable", "Owpenbot health server is unavailable", {
-      error: lastError ? String(lastError) : "no response",
-      port,
-      hosts: candidates,
-    });
+  // If owpenbot reports apply status, reflect it at the top-level.
+  let telegramStarting = false;
+  if (response.telegram && typeof response.telegram === "object") {
+    const telegram = response.telegram as Record<string, unknown>;
+    if (typeof telegram.applied === "boolean") {
+      response.applied = telegram.applied;
+    }
+    if (typeof telegram.starting === "boolean") {
+      telegramStarting = telegram.starting;
+    }
+    if (!response.applyError && typeof telegram.error === "string" && telegram.error.trim()) {
+      response.applyError = telegram.error;
+    }
   }
 
-  const text = await response.text();
-  const parsed = parseJsonResponse(text);
-
-  if (!response.ok) {
-    const detail = typeof parsed === "object" && parsed && "error" in parsed
-      ? String((parsed as Record<string, unknown>).error)
-      : "Owpenbot request failed";
-    throw new ApiError(response.status, "owpenbot_request_failed", detail, {
-      status: response.status,
-      body: parsed,
-    });
+  if (!apply.applied) {
+    response.applyError = (typeof response.applyError === "string" && response.applyError.trim())
+      ? response.applyError
+      : apply.error ?? "Owpenbot did not apply the update";
+    if (typeof apply.status === "number") response.applyStatus = apply.status;
+  } else if (response.applied === false && !telegramStarting && !response.applyError) {
+    response.applyError = "Owpenbot did not apply the update";
   }
 
-  if (parsed && typeof parsed === "object") {
-    return parsed as Record<string, unknown>;
-  }
-  return { ok: true };
+  return response;
 }
 
 async function updateOwpenbotSlackTokens(
@@ -1212,53 +1413,53 @@ async function updateOwpenbotSlackTokens(
   healthPortOverride?: number | null,
   requestHost?: string | null,
 ): Promise<Record<string, unknown>> {
-  const port = healthPortOverride ?? resolveOwpenbotHealthPort();
-  const candidates = ["127.0.0.1", requestHost].filter(
-    (host): host is string => Boolean(host && host.trim()),
-  );
-  let response: Response | null = null;
-  let lastError: unknown = null;
+  await persistOwpenbotSlackTokens(botToken, appToken);
 
-  for (const host of candidates) {
-    const url = `http://${host}:${port}/config/slack-tokens`;
-    try {
-      response = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ botToken, appToken }),
-      });
-      break;
-    } catch (error) {
-      lastError = error;
+  const port = healthPortOverride ?? resolveOwpenbotHealthPort();
+  const apply = await tryPostOwpenbotHealth(
+    "/config/slack-tokens",
+    { botToken, appToken },
+    { port, requestHost, timeoutMs: 3_000 },
+  );
+
+  const response: Record<string, unknown> = {
+    ok: true,
+    persisted: true,
+    applied: apply.applied,
+    slack: { configured: true, enabled: true },
+  };
+
+  if (apply.body && typeof apply.body === "object") {
+    const record = apply.body as Record<string, unknown>;
+    if (record.slack && typeof record.slack === "object") {
+      response.slack = record.slack;
     }
   }
 
-  if (!response) {
-    throw new ApiError(502, "owpenbot_unreachable", "Owpenbot health server is unavailable", {
-      error: lastError ? String(lastError) : "no response",
-      port,
-      hosts: candidates,
-    });
+  let slackStarting = false;
+  if (response.slack && typeof response.slack === "object") {
+    const slack = response.slack as Record<string, unknown>;
+    if (typeof slack.applied === "boolean") {
+      response.applied = slack.applied;
+    }
+    if (typeof slack.starting === "boolean") {
+      slackStarting = slack.starting;
+    }
+    if (!response.applyError && typeof slack.error === "string" && slack.error.trim()) {
+      response.applyError = slack.error;
+    }
   }
 
-  const text = await response.text();
-  const parsed = parseJsonResponse(text);
-
-  if (!response.ok) {
-    const detail =
-      typeof parsed === "object" && parsed && "error" in parsed
-        ? String((parsed as Record<string, unknown>).error)
-        : "Owpenbot request failed";
-    throw new ApiError(response.status, "owpenbot_request_failed", detail, {
-      status: response.status,
-      body: parsed,
-    });
+  if (!apply.applied) {
+    response.applyError = (typeof response.applyError === "string" && response.applyError.trim())
+      ? response.applyError
+      : apply.error ?? "Owpenbot did not apply the update";
+    if (typeof apply.status === "number") response.applyStatus = apply.status;
+  } else if (response.applied === false && !slackStarting && !response.applyError) {
+    response.applyError = "Owpenbot did not apply the update";
   }
 
-  if (parsed && typeof parsed === "object") {
-    return parsed as Record<string, unknown>;
-  }
-  return { ok: true };
+  return response;
 }
 
 async function readOpencodeConfig(workspaceRoot: string): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## What changed
- OpenWork server now persists owpenbot Telegram/Slack tokens to the owpenbot config file first, then best-effort applies them via the health endpoint with a short timeout; returns `persisted/applied/applyError` instead of hard-failing when owpenbot is offline.
- Owpenbot health handlers restart Telegram/Slack adapters with a bounded start budget and report `applied/starting/error` without blocking the caller.
- Owpenbot Settings UI refreshes status after remote saves and surfaces apply/offline warnings so it doesn’t stay stuck in `Saving...`.

## Why
Token saves could hang for ~90s+ (Telegram adapter start) and/or throw when owpenbot was unreachable, leaving the UI stuck and the state out of sync.

## Testing
- `pnpm --filter owpenwork typecheck`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @different-ai/openwork-ui typecheck`

## Notes
If you change `packages/server/src`, rebuild the server binary for local runs: `pnpm --filter openwork-server build:bin`.