### PR TITLE
fix: prevent Enter key during IME composition from triggering execution

### DIFF
--- a/packages/app/src/app/components/model-picker-modal.tsx
+++ b/packages/app/src/app/components/model-picker-modal.tsx
@@ -99,6 +99,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
       }
 
       if (event.key === "Enter") {
+        if (event.isComposing || event.keyCode === 229) return;
         const idx = activeIndex();
         const opt = props.filteredOptions[idx];
         if (!opt) return;

--- a/packages/app/src/app/components/question-modal.tsx
+++ b/packages/app/src/app/components/question-modal.tsx
@@ -109,6 +109,7 @@ export default function QuestionModal(props: QuestionModalProps) {
                 e.preventDefault();
                 setFocusedOptionIndex((prev) => (prev - 1 + optionsCount) % optionsCount);
             } else if (e.key === "Enter") {
+                if (e.isComposing || e.keyCode === 229) return;
                 e.preventDefault();
                 if (q.custom && document.activeElement?.tagName === "INPUT") {
                     handleNext();
@@ -195,6 +196,7 @@ export default function QuestionModal(props: QuestionModalProps) {
                                     placeholder="Type your answer here..."
                                     onKeyDown={(e) => {
                                         if (e.key === "Enter") {
+                                            if (e.isComposing || e.keyCode === 229) return;
                                             e.stopPropagation();
                                             handleNext();
                                         }

--- a/packages/app/src/app/components/rename-session-modal.tsx
+++ b/packages/app/src/app/components/rename-session-modal.tsx
@@ -55,6 +55,7 @@ export default function RenameSessionModal(props: RenameSessionModalProps) {
                 class="bg-gray-3"
                 onKeyDown={(event) => {
                   if (event.key !== "Enter") return;
+                  if (event.isComposing || event.keyCode === 229) return;
                   event.preventDefault();
                   if (props.canSave) props.onSave();
                 }}

--- a/packages/app/src/app/components/rename-workspace-modal.tsx
+++ b/packages/app/src/app/components/rename-workspace-modal.tsx
@@ -55,6 +55,7 @@ export default function RenameWorkspaceModal(props: RenameWorkspaceModalProps) {
                 class="bg-gray-3"
                 onKeyDown={(event) => {
                   if (event.key !== "Enter") return;
+                  if (event.isComposing || event.keyCode === 229) return;
                   event.preventDefault();
                   if (props.canSave) props.onSave();
                 }}

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -826,13 +826,15 @@ export default function Composer(props: ComposerProps) {
       }
     }
 
+    // Skip Enter during IME composition (e.g. Japanese, Chinese, Korean input)
+    if (event.key === "Enter" && (event.isComposing || event.keyCode === 229)) return;
+
     if (event.key === "Enter" && event.shiftKey) {
       event.preventDefault();
       document.execCommand("insertLineBreak");
       emitDraftChange();
       return;
     }
-    if (event.key === "Enter" && event.isComposing) return;
 
     if (mentionOpen()) {
       const options = mentionOptions();

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -747,6 +747,7 @@ export default function DashboardView(props: DashboardViewProps) {
                         }}
                         onKeyDown={(event) => {
                           if (event.key !== "Enter" && event.key !== " ") return;
+                          if (event.isComposing || event.keyCode === 229) return;
                           event.preventDefault();
                           expandWorkspace(workspace().id);
                           props.activateWorkspace(workspace().id);
@@ -889,6 +890,7 @@ export default function DashboardView(props: DashboardViewProps) {
                                     onClick={() => openSessionFromList(workspace().id, session.id)}
                                     onKeyDown={(event) => {
                                       if (event.key !== "Enter" && event.key !== " ") return;
+                                      if (event.isComposing || event.keyCode === 229) return;
                                       event.preventDefault();
                                       openSessionFromList(workspace().id, session.id);
                                     }}
@@ -937,6 +939,7 @@ export default function DashboardView(props: DashboardViewProps) {
                                       onClick={() => openSessionFromList(workspace().id, session.id)}
                                       onKeyDown={(event) => {
                                         if (event.key !== "Enter" && event.key !== " ") return;
+                                        if (event.isComposing || event.keyCode === 229) return;
                                         event.preventDefault();
                                         openSessionFromList(workspace().id, session.id);
                                       }}

--- a/packages/app/src/app/pages/onboarding.tsx
+++ b/packages/app/src/app/pages/onboarding.tsx
@@ -254,6 +254,7 @@ export default function OnboardingView(props: OnboardingViewProps) {
                       onInput={(e) => props.onSetAuthorizedDir(e.currentTarget.value)}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") {
+                          if (e.isComposing || e.keyCode === 229) return;
                           props.onAddAuthorizedDir();
                         }
                       }}

--- a/packages/app/src/app/pages/proto-v1-ux.tsx
+++ b/packages/app/src/app/pages/proto-v1-ux.tsx
@@ -163,6 +163,7 @@ const ProjectFolder = (props: { name: string; children: any }) => {
         onClick={toggleExpanded}
         onKeyDown={(event) => {
           if (event.key !== "Enter" && event.key !== " ") return;
+          if (event.isComposing || event.keyCode === 229) return;
           event.preventDefault();
           toggleExpanded();
         }}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1138,6 +1138,7 @@ export default function SessionView(props: SessionViewProps) {
                           }}
                           onKeyDown={(event) => {
                             if (event.key !== "Enter" && event.key !== " ") return;
+                            if (event.isComposing || event.keyCode === 229) return;
                             event.preventDefault();
                             expandWorkspace(workspace().id);
                             props.activateWorkspace(workspace().id);
@@ -1284,6 +1285,7 @@ export default function SessionView(props: SessionViewProps) {
                                     onClick={() => openSessionFromList(workspace().id, session.id)}
                                     onKeyDown={(event) => {
                                       if (event.key !== "Enter" && event.key !== " ") return;
+                                      if (event.isComposing || event.keyCode === 229) return;
                                       event.preventDefault();
                                       openSessionFromList(workspace().id, session.id);
                                     }}
@@ -1334,6 +1336,7 @@ export default function SessionView(props: SessionViewProps) {
                                       onClick={() => openSessionFromList(workspace().id, session.id)}
                                       onKeyDown={(event) => {
                                         if (event.key !== "Enter" && event.key !== " ") return;
+                                        if (event.isComposing || event.keyCode === 229) return;
                                         event.preventDefault();
                                         openSessionFromList(workspace().id, session.id);
                                       }}

--- a/packages/app/src/app/pages/skills.tsx
+++ b/packages/app/src/app/pages/skills.tsx
@@ -233,6 +233,7 @@ export default function SkillsView(props: SkillsViewProps) {
                   onClick={() => void openSkill(skill)}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
+                      if (e.isComposing || e.keyCode === 229) return;
                       e.preventDefault();
                       void openSkill(skill);
                     }


### PR DESCRIPTION
## Summary

Fixes #442

When using an IME (e.g. Japanese, Chinese, Korean input methods), pressing Enter to confirm character conversion was incorrectly triggering form submissions, message sends, and other actions. This happened because the keydown handlers did not check the `event.isComposing` property or the legacy `event.keyCode === 229` indicator.

## Changes

Added `if (event.isComposing || event.keyCode === 229) return;` guard to all Enter key handlers across **10 files**:

- **`composer.tsx`** — Main chat input (message send, mention select, slash command select). Consolidated the existing partial guard into a single early-return at the top of the keydown handler.
- **`model-picker-modal.tsx`** — Model selection on Enter
- **`question-modal.tsx`** — Option selection and custom input submission (2 handlers)
- **`rename-session-modal.tsx`** — Session rename on Enter
- **`rename-workspace-modal.tsx`** — Workspace rename on Enter
- **`dashboard.tsx`** — Keyboard-accessible workspace/session list items (3 handlers)
- **`session.tsx`** — Keyboard-accessible workspace/session list items (3 handlers)
- **`proto-v1-ux.tsx`** — Expandable section toggle
- **`skills.tsx`** — Skill card activation
- **`onboarding.tsx`** — Directory path input submission

## Why both checks?

- `event.isComposing` — The standard W3C property indicating active IME composition
- `event.keyCode === 229` — Legacy fallback for older browsers and some Android IMEs that don't set `isComposing` correctly

## Testing

- No unit test framework (vitest/jest) is configured for the frontend app package
- Manual testing recommended with Japanese/Chinese/Korean IME input