### PR TITLE
fix: allow data:image/* URLs in markdown renderer

### DIFF
--- a/packages/app/src/app/components/part-view.tsx
+++ b/packages/app/src/app/components/part-view.tsx
@@ -56,8 +56,12 @@ function createCustomRenderer(tone: "light" | "dark") {
     s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
   const isSafeUrl = (url: string) => {
-    const protocol = (url || "").trim().toLowerCase();
-    return !protocol.startsWith("javascript:") && !protocol.startsWith("data:");
+    const normalized = (url || "").trim().toLowerCase();
+    if (normalized.startsWith("javascript:")) return false;
+    // Allow data:image/* URIs (base64-encoded images from AI models) but block
+    // other data: schemes (e.g. data:text/html) which could be used for XSS.
+    if (normalized.startsWith("data:")) return normalized.startsWith("data:image/");
+    return true;
   };
 
   renderer.html = ({ text }) => escapeHtml(text);


### PR DESCRIPTION
The isSafeUrl function was blocking all data: URLs including data:image/jpeg;base64,... returned by AI image generation models. This caused markdown images like ![image](data:image/jpeg;base64,...) to render with empty src, showing only the alt text 'Image'.

Now data:image/* URIs are whitelisted while other data: schemes (e.g. data:text/html) remain blocked to prevent XSS.