### PR TITLE
fix: prevent Enter key during IME composition from triggering actions

### DIFF
--- a/packages/app/src/app/components/model-picker-modal.tsx
+++ b/packages/app/src/app/components/model-picker-modal.tsx
@@ -99,6 +99,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
       }
 
       if (event.key === "Enter") {
+        if (event.isComposing || event.keyCode === 229) return;
         const idx = activeIndex();
         const opt = props.filteredOptions[idx];
         if (!opt) return;

--- a/packages/app/src/app/components/question-modal.tsx
+++ b/packages/app/src/app/components/question-modal.tsx
@@ -109,6 +109,7 @@ export default function QuestionModal(props: QuestionModalProps) {
                 e.preventDefault();
                 setFocusedOptionIndex((prev) => (prev - 1 + optionsCount) % optionsCount);
             } else if (e.key === "Enter") {
+                if (e.isComposing || e.keyCode === 229) return;
                 e.preventDefault();
                 if (q.custom && document.activeElement?.tagName === "INPUT") {
                     handleNext();
@@ -195,6 +196,7 @@ export default function QuestionModal(props: QuestionModalProps) {
                                     placeholder="Type your answer here..."
                                     onKeyDown={(e) => {
                                         if (e.key === "Enter") {
+                                            if (e.isComposing || e.keyCode === 229) return;
                                             e.stopPropagation();
                                             handleNext();
                                         }

--- a/packages/app/src/app/components/rename-session-modal.tsx
+++ b/packages/app/src/app/components/rename-session-modal.tsx
@@ -54,7 +54,7 @@ export default function RenameSessionModal(props: RenameSessionModalProps) {
                 placeholder={translate("session.rename_placeholder")}
                 class="bg-gray-3"
                 onKeyDown={(event) => {
-                  if (event.key !== "Enter") return;
+                  if (event.key !== "Enter" || event.isComposing || event.keyCode === 229) return;
                   event.preventDefault();
                   if (props.canSave) props.onSave();
                 }}

--- a/packages/app/src/app/components/rename-workspace-modal.tsx
+++ b/packages/app/src/app/components/rename-workspace-modal.tsx
@@ -54,7 +54,7 @@ export default function RenameWorkspaceModal(props: RenameWorkspaceModalProps) {
                 placeholder={translate("workspace.rename_placeholder")}
                 class="bg-gray-3"
                 onKeyDown={(event) => {
-                  if (event.key !== "Enter") return;
+                  if (event.key !== "Enter" || event.isComposing || event.keyCode === 229) return;
                   event.preventDefault();
                   if (props.canSave) props.onSave();
                 }}

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -331,6 +331,9 @@ export default function Composer(props: ComposerProps) {
   let variantPickerRef: HTMLDivElement | undefined;
   let mentionSearchRun = 0;
   let suppressPromptSync = false;
+  // Track IME composition state so we can combine it with keyCode === 229 to
+  // reliably suppress Enter during CJK input across Chrome, Safari, and WebKit.
+  let imeComposing = false;
   const [mentionIndex, setMentionIndex] = createSignal(0);
   const [mentionQuery, setMentionQuery] = createSignal("");
   const [mentionOpen, setMentionOpen] = createSignal(false);
@@ -355,6 +358,20 @@ export default function Composer(props: ComposerProps) {
 
   onMount(() => {
     queueMicrotask(() => focusEditorEnd());
+
+    // Bind composition events directly via addEventListener because SolidJS
+    // does not delegate compositionstart/compositionend — the camelCase JSX
+    // form (onCompositionStart) may silently fail to attach.
+    if (editorRef) {
+      editorRef.addEventListener("compositionstart", () => {
+        imeComposing = true;
+      });
+      editorRef.addEventListener("compositionend", () => {
+        requestAnimationFrame(() => {
+          imeComposing = false;
+        });
+      });
+    }
   });
 
   const mentionGroups = createMemo<MentionGroup[]>(() => {
@@ -832,12 +849,17 @@ export default function Composer(props: ComposerProps) {
       emitDraftChange();
       return;
     }
-    if (event.key === "Enter" && event.isComposing) return;
+    // Block Enter while IME is composing. We check three signals:
+    // 1. event.isComposing — standard API (unreliable in some WebKit builds)
+    // 2. imeComposing — manual flag from compositionstart/end
+    // 3. event.keyCode === 229 — legacy but reliable IME indicator across all browsers
+    const imeActive = event.isComposing || imeComposing || event.keyCode === 229;
+    if (event.key === "Enter" && imeActive) return;
 
     if (mentionOpen()) {
       const options = mentionOptions();
       const ctrl = event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
-      if (event.key === "Enter" && !event.isComposing) {
+      if (event.key === "Enter" && !imeActive) {
         event.preventDefault();
         const active = options[mentionIndex()] ?? options[0];
         if (active) insertMention(active);
@@ -873,7 +895,7 @@ export default function Composer(props: ComposerProps) {
     if (slashOpen()) {
       const options = slashFiltered();
       const ctrl = event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey;
-      if (event.key === "Enter" && !event.isComposing) {
+      if (event.key === "Enter" && !imeActive) {
         event.preventDefault();
         const active = options[slashIndex()] ?? options[0];
         if (active) handleSlashSelect(active);

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -747,6 +747,7 @@ export default function DashboardView(props: DashboardViewProps) {
                         }}
                         onKeyDown={(event) => {
                           if (event.key !== "Enter" && event.key !== " ") return;
+                          if (event.isComposing || event.keyCode === 229) return;
                           event.preventDefault();
                           expandWorkspace(workspace().id);
                           props.activateWorkspace(workspace().id);
@@ -889,6 +890,7 @@ export default function DashboardView(props: DashboardViewProps) {
                                     onClick={() => openSessionFromList(workspace().id, session.id)}
                                     onKeyDown={(event) => {
                                       if (event.key !== "Enter" && event.key !== " ") return;
+                                      if (event.isComposing || event.keyCode === 229) return;
                                       event.preventDefault();
                                       openSessionFromList(workspace().id, session.id);
                                     }}
@@ -937,6 +939,7 @@ export default function DashboardView(props: DashboardViewProps) {
                                       onClick={() => openSessionFromList(workspace().id, session.id)}
                                       onKeyDown={(event) => {
                                         if (event.key !== "Enter" && event.key !== " ") return;
+                                        if (event.isComposing || event.keyCode === 229) return;
                                         event.preventDefault();
                                         openSessionFromList(workspace().id, session.id);
                                       }}

--- a/packages/app/src/app/pages/onboarding.tsx
+++ b/packages/app/src/app/pages/onboarding.tsx
@@ -254,6 +254,7 @@ export default function OnboardingView(props: OnboardingViewProps) {
                       onInput={(e) => props.onSetAuthorizedDir(e.currentTarget.value)}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") {
+                          if (e.isComposing || e.keyCode === 229) return;
                           props.onAddAuthorizedDir();
                         }
                       }}

--- a/packages/app/src/app/pages/proto-v1-ux.tsx
+++ b/packages/app/src/app/pages/proto-v1-ux.tsx
@@ -163,6 +163,7 @@ const ProjectFolder = (props: { name: string; children: any }) => {
         onClick={toggleExpanded}
         onKeyDown={(event) => {
           if (event.key !== "Enter" && event.key !== " ") return;
+          if (event.isComposing || event.keyCode === 229) return;
           event.preventDefault();
           toggleExpanded();
         }}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1138,6 +1138,7 @@ export default function SessionView(props: SessionViewProps) {
                           }}
                           onKeyDown={(event) => {
                             if (event.key !== "Enter" && event.key !== " ") return;
+                            if (event.isComposing || event.keyCode === 229) return;
                             event.preventDefault();
                             expandWorkspace(workspace().id);
                             props.activateWorkspace(workspace().id);
@@ -1284,6 +1285,7 @@ export default function SessionView(props: SessionViewProps) {
                                     onClick={() => openSessionFromList(workspace().id, session.id)}
                                     onKeyDown={(event) => {
                                       if (event.key !== "Enter" && event.key !== " ") return;
+                                      if (event.isComposing || event.keyCode === 229) return;
                                       event.preventDefault();
                                       openSessionFromList(workspace().id, session.id);
                                     }}
@@ -1334,6 +1336,7 @@ export default function SessionView(props: SessionViewProps) {
                                       onClick={() => openSessionFromList(workspace().id, session.id)}
                                       onKeyDown={(event) => {
                                         if (event.key !== "Enter" && event.key !== " ") return;
+                                        if (event.isComposing || event.keyCode === 229) return;
                                         event.preventDefault();
                                         openSessionFromList(workspace().id, session.id);
                                       }}

--- a/packages/app/src/app/pages/skills.tsx
+++ b/packages/app/src/app/pages/skills.tsx
@@ -233,6 +233,7 @@ export default function SkillsView(props: SkillsViewProps) {
                   onClick={() => void openSkill(skill)}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
+                      if (e.isComposing || e.keyCode === 229) return;
                       e.preventDefault();
                       void openSkill(skill);
                     }


### PR DESCRIPTION
When using an IME (e.g. Chinese, Japanese, Korean input methods), pressing Enter to confirm character conversion was incorrectly triggering form submissions, message sends, and other actions.

Changes across 10 files:

- composer.tsx: triple-check IME state (event.isComposing + manual compositionstart/end flag + keyCode === 229) with addEventListener binding to work around SolidJS event delegation limitations
- model-picker-modal.tsx: guard Enter for model selection
- question-modal.tsx: guard Enter for option/custom input (2 handlers)
- rename-session-modal.tsx: guard Enter for session rename
- rename-workspace-modal.tsx: guard Enter for workspace rename
- dashboard.tsx: guard Enter for workspace/session list items (3 handlers)
- session.tsx: guard Enter for workspace/session list items (3 handlers)
- proto-v1-ux.tsx: guard Enter for expandable section toggle
- skills.tsx: guard Enter for skill card activation
- onboarding.tsx: guard Enter for directory path input