### PR TITLE
feat: minimal container sandbox + server tokens + toy UI

### DIFF
--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -50,6 +50,45 @@ The command prints pairing details (OpenWork server URL + token, OpenCode URL + 
 Use `--detach` to keep services running and exit the dashboard. The detach summary includes the
 OpenWork URL, tokens, and the `opencode attach` command.
 
+## Sandbox mode (Docker / Apple container)
+
+`openwrk` can run the sidecars inside a Linux container boundary while still mounting your workspace
+from the host.
+
+```bash
+# Auto-pick sandbox backend (prefers Apple container on supported Macs)
+openwrk start --sandbox auto --workspace /path/to/workspace --approval auto
+
+# Explicit backends
+openwrk start --sandbox docker --workspace /path/to/workspace --approval auto
+openwrk start --sandbox container --workspace /path/to/workspace --approval auto
+```
+
+Notes:
+
+- `--sandbox auto` prefers Apple `container` on supported Macs (arm64), otherwise Docker.
+- Docker backend requires `docker` on your PATH.
+- Apple container backend requires the `container` CLI (https://github.com/apple/container).
+- In sandbox mode, sidecars are resolved for a Linux target (and `--sidecar-source` / `--opencode-source`
+  are effectively `downloaded`).
+- Custom `--*-bin` overrides are not supported in sandbox mode yet.
+- Use `--sandbox-image` to pick an image with the toolchain you want available to OpenCode.
+- Use `--sandbox-persist-dir` to control the host directory mounted at `/persist` inside the container.
+
+### Extra mounts (allowlisted)
+
+You can add explicit, validated mounts into `/workspace/extra/*`:
+
+```bash
+openwrk start --sandbox auto --sandbox-mount "/path/on/host:datasets:ro" --workspace /path/to/workspace
+```
+
+Additional mounts are blocked unless you create an allowlist at:
+
+- `~/.config/openwork/sandbox-mount-allowlist.json`
+
+Override with `OPENWRK_SANDBOX_MOUNT_ALLOWLIST`.
+
 ## Logging
 
 `openwrk` emits a unified log stream from OpenCode, OpenWork server, and Owpenbot. Use JSON format for

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -77,7 +77,10 @@ const DEFAULT_OPENCODE_USERNAME = "opencode";
 
 const SANDBOX_INTERNAL_OPENCODE_PORT = 4096;
 const SANDBOX_INTERNAL_OPENWORK_PORT = DEFAULT_OPENWORK_PORT;
-const SANDBOX_INTERNAL_OWPENBOT_HEALTH_PORT = DEFAULT_OWPENBOT_HEALTH_PORT;
+// Owpenbot defaults its health server to 3005 when not overridden. In sandbox
+// mode we keep the *internal* port stable and only vary the published host
+// port to avoid collisions.
+const SANDBOX_INTERNAL_OWPENBOT_HEALTH_PORT = 3005;
 
 type ParsedArgs = {
   positionals: string[];

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { randomUUID, createHash } from "node:crypto";
-import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rename, rm, stat, writeFile, realpath } from "node:fs/promises";
 import { createServer as createNetServer } from "node:net";
 import { createServer as createHttpServer } from "node:http";
 import { homedir, hostname, networkInterfaces, tmpdir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { access } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -15,6 +15,10 @@ import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { startOpenwrkTui, type TuiHandle } from "./tui/app.js";
 
 type ApprovalMode = "manual" | "auto";
+
+type SandboxMode = "none" | "auto" | "docker" | "container";
+
+type ResolvedSandboxMode = "none" | "docker" | "container";
 
 type LogFormat = "pretty" | "json";
 
@@ -70,6 +74,10 @@ const FALLBACK_VERSION = "0.1.0";
 const DEFAULT_OPENWORK_PORT = 8787;
 const DEFAULT_APPROVAL_TIMEOUT = 30000;
 const DEFAULT_OPENCODE_USERNAME = "opencode";
+
+const SANDBOX_INTERNAL_OPENCODE_PORT = 4096;
+const SANDBOX_INTERNAL_OPENWORK_PORT = DEFAULT_OPENWORK_PORT;
+const SANDBOX_INTERNAL_OWPENBOT_HEALTH_PORT = DEFAULT_OWPENBOT_HEALTH_PORT;
 
 type ParsedArgs = {
   positionals: string[];
@@ -364,6 +372,259 @@ function readLogFormat(
   throw new Error(`Invalid ${key} value: ${raw}. Use pretty|json.`);
 }
 
+function readSandboxMode(
+  flags: Map<string, string | boolean>,
+  key: string,
+  fallback: SandboxMode,
+  envKey?: string,
+): SandboxMode {
+  const raw = readFlag(flags, key) ?? (envKey ? process.env[envKey] : undefined);
+  if (!raw) return fallback;
+  const normalized = String(raw).trim().toLowerCase();
+  if (
+    normalized === "none" ||
+    normalized === "auto" ||
+    normalized === "docker" ||
+    normalized === "container"
+  ) {
+    return normalized as SandboxMode;
+  }
+  throw new Error(`Invalid ${key} value: ${raw}. Use none|auto|docker|container.`);
+}
+
+type SandboxAllowedRoot = {
+  path: string;
+  allowReadWrite?: boolean;
+  description?: string;
+};
+
+type SandboxMountAllowlist = {
+  allowedRoots: SandboxAllowedRoot[];
+  blockedPatterns?: string[];
+};
+
+type SandboxMount = {
+  hostPath: string;
+  containerPath: string;
+  readonly: boolean;
+};
+
+const DEFAULT_SANDBOX_BLOCKED_PATTERNS = [
+  ".ssh",
+  ".gnupg",
+  ".gpg",
+  ".aws",
+  ".azure",
+  ".gcloud",
+  ".kube",
+  ".docker",
+  "credentials",
+  ".env",
+  ".netrc",
+  ".npmrc",
+  ".pypirc",
+  "id_rsa",
+  "id_ed25519",
+  "private_key",
+  ".secret",
+];
+
+let cachedSandboxAllowlist: SandboxMountAllowlist | null | undefined;
+let cachedSandboxAllowlistError: string | null = null;
+
+function resolveSandboxAllowlistPath(): string {
+  const override =
+    process.env.OPENWRK_SANDBOX_MOUNT_ALLOWLIST?.trim() ?? process.env.OPENWORK_SANDBOX_MOUNT_ALLOWLIST?.trim();
+  if (override) return resolve(override);
+  return join(homedir(), ".config", "openwork", "sandbox-mount-allowlist.json");
+}
+
+function expandTildePath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+  return trimmed;
+}
+
+async function realpathOrNull(input: string): Promise<string | null> {
+  try {
+    return await realpath(input);
+  } catch {
+    return null;
+  }
+}
+
+function matchesBlockedPattern(real: string, patterns: string[]): string | null {
+  const parts = real.split(sep);
+  for (const pattern of patterns) {
+    for (const part of parts) {
+      if (part === pattern || part.includes(pattern)) return pattern;
+    }
+    if (real.includes(pattern)) return pattern;
+  }
+  return null;
+}
+
+async function findAllowedRoot(real: string, roots: SandboxAllowedRoot[]): Promise<SandboxAllowedRoot | null> {
+  for (const root of roots) {
+    const expanded = resolve(expandTildePath(root.path));
+    const realRoot = await realpathOrNull(expanded);
+    if (!realRoot) continue;
+    const rel = relative(realRoot, real);
+    if (!rel.startsWith("..") && !isAbsolute(rel)) {
+      return root;
+    }
+  }
+  return null;
+}
+
+async function loadSandboxAllowlist(): Promise<SandboxMountAllowlist | null> {
+  if (cachedSandboxAllowlist !== undefined) return cachedSandboxAllowlist;
+  if (cachedSandboxAllowlistError) return null;
+
+  const path = resolveSandboxAllowlistPath();
+  try {
+    if (!(await fileExists(path))) {
+      cachedSandboxAllowlistError = `Mount allowlist not found at ${path}`;
+      cachedSandboxAllowlist = null;
+      return null;
+    }
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as SandboxMountAllowlist;
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.allowedRoots)) {
+      throw new Error("allowedRoots must be an array");
+    }
+    const blocked = Array.isArray(parsed.blockedPatterns) ? parsed.blockedPatterns : [];
+    parsed.blockedPatterns = [...new Set([...DEFAULT_SANDBOX_BLOCKED_PATTERNS, ...blocked])];
+    cachedSandboxAllowlist = parsed;
+    return parsed;
+  } catch (error) {
+    cachedSandboxAllowlistError = error instanceof Error ? error.message : String(error);
+    cachedSandboxAllowlist = null;
+    return null;
+  }
+}
+
+function isValidSandboxContainerSubPath(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed.includes("..")) return false;
+  if (trimmed.startsWith("/")) return false;
+  if (trimmed.includes("\\")) return false;
+  const parts = trimmed.split("/").filter(Boolean);
+  if (!parts.length) return false;
+  if (parts.some((part) => part === "." || part === "..")) return false;
+  return true;
+}
+
+function parseSandboxMountSpec(spec: string): {
+  hostPath: string;
+  containerSubPath: string;
+  requestedReadWrite: boolean;
+} {
+  const trimmed = spec.trim();
+  if (!trimmed) {
+    throw new Error("Empty --sandbox-mount entry");
+  }
+
+  let requestedReadWrite = true;
+  let base = trimmed;
+  if (trimmed.endsWith(":ro")) {
+    requestedReadWrite = false;
+    base = trimmed.slice(0, -3);
+  } else if (trimmed.endsWith(":rw")) {
+    requestedReadWrite = true;
+    base = trimmed.slice(0, -3);
+  }
+
+  const idx = base.indexOf(":");
+  if (idx <= 0 || idx >= base.length - 1) {
+    throw new Error(`Invalid --sandbox-mount value: ${spec}. Use hostPath:subpath[:ro|rw].`);
+  }
+
+  const hostPath = base.slice(0, idx).trim();
+  const containerSubPath = base.slice(idx + 1).trim();
+  if (!hostPath) throw new Error(`Invalid --sandbox-mount value: ${spec}. Host path is empty.`);
+  if (!containerSubPath) throw new Error(`Invalid --sandbox-mount value: ${spec}. Container subpath is empty.`);
+
+  return { hostPath, containerSubPath, requestedReadWrite };
+}
+
+function generateSandboxAllowlistTemplate(): string {
+  const template: SandboxMountAllowlist = {
+    allowedRoots: [
+      {
+        path: "~/projects",
+        allowReadWrite: true,
+        description: "Development projects",
+      },
+      {
+        path: "~/Documents",
+        allowReadWrite: false,
+        description: "Documents (read-only)",
+      },
+    ],
+    blockedPatterns: ["password", "secret", "token"],
+  };
+  return JSON.stringify(template, null, 2);
+}
+
+async function resolveSandboxExtraMounts(
+  specs: string[],
+  sandboxMode: ResolvedSandboxMode,
+): Promise<SandboxMount[]> {
+  if (!specs.length) return [];
+  const allowlistPath = resolveSandboxAllowlistPath();
+  const allowlist = await loadSandboxAllowlist();
+  if (!allowlist) {
+    const template = generateSandboxAllowlistTemplate();
+    throw new Error(
+      `Additional sandbox mounts are blocked. Create ${allowlistPath} to enable.\n\nExample:\n${template}`,
+    );
+  }
+  const blocked = allowlist.blockedPatterns ?? DEFAULT_SANDBOX_BLOCKED_PATTERNS;
+  const roots = allowlist.allowedRoots;
+
+  const mounts: SandboxMount[] = [];
+  for (const spec of specs) {
+    const parsed = parseSandboxMountSpec(spec);
+    if (!isValidSandboxContainerSubPath(parsed.containerSubPath)) {
+      throw new Error(
+        `Invalid sandbox container subpath: "${parsed.containerSubPath}". Use a relative path without "/" prefix or "..".`,
+      );
+    }
+    const expanded = resolve(expandTildePath(parsed.hostPath));
+    const real = await realpathOrNull(expanded);
+    if (!real) {
+      throw new Error(`Sandbox mount host path does not exist: ${parsed.hostPath} (expanded: ${expanded})`);
+    }
+    const blockedMatch = matchesBlockedPattern(real, blocked);
+    if (blockedMatch) {
+      throw new Error(`Sandbox mount rejected (blocked pattern "${blockedMatch}"): ${real}`);
+    }
+    const allowedRoot = await findAllowedRoot(real, roots);
+    if (!allowedRoot) {
+      const allowedList = roots.map((root) => resolve(expandTildePath(root.path))).join(", ");
+      throw new Error(`Sandbox mount rejected: ${real} is not under any allowed root. Allowed: ${allowedList}`);
+    }
+    const allowReadWrite = allowedRoot.allowReadWrite === true;
+    const readonly = parsed.requestedReadWrite ? !allowReadWrite : true;
+    if (sandboxMode === "container") {
+      const info = await stat(real);
+      if (!info.isDirectory()) {
+        throw new Error(`Apple container sandbox mounts must be directories: ${real}`);
+      }
+    }
+    mounts.push({
+      hostPath: real,
+      containerPath: `/workspace/extra/${parsed.containerSubPath}`,
+      readonly,
+    });
+  }
+  return mounts;
+}
+
 async function fileExists(path: string): Promise<boolean> {
   try {
     await stat(path);
@@ -620,6 +881,74 @@ function resolveSidecarTarget(): SidecarTarget | null {
   return null;
 }
 
+function resolveSandboxSidecarTarget(mode: ResolvedSandboxMode): SidecarTarget | null {
+  if (mode === "none") return resolveSidecarTarget();
+  // Sandbox runs inside Linux (docker / container).
+  if (process.arch === "arm64") return "linux-arm64";
+  if (process.arch === "x64") return "linux-x64";
+  return null;
+}
+
+function resolveSidecarConfigForTarget(
+  flags: Map<string, string | boolean>,
+  cliVersion: string,
+  targetOverride: SidecarTarget | null,
+): SidecarConfig {
+  const baseUrl = resolveSidecarBaseUrl(flags, cliVersion);
+  return {
+    dir: resolveSidecarDir(flags),
+    baseUrl,
+    manifestUrl: resolveSidecarManifestUrl(flags, baseUrl),
+    target: targetOverride,
+  };
+}
+
+async function probeCommand(command: string, args: string[], timeoutMs = 2500): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ["ignore", "ignore", "ignore"] });
+    const timeout = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+      resolve(false);
+    }, timeoutMs);
+    child.on("error", () => {
+      clearTimeout(timeout);
+      resolve(false);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timeout);
+      resolve(code === 0);
+    });
+  });
+}
+
+async function resolveSandboxMode(mode: SandboxMode): Promise<ResolvedSandboxMode> {
+  if (mode === "none") return "none";
+  if (mode === "docker") return "docker";
+  if (mode === "container") return "container";
+
+  // auto
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    const containerOk = await probeCommand("container", ["--version"]);
+    if (containerOk) return "container";
+  }
+
+  const dockerOk = await probeCommand("docker", ["version"]);
+  if (dockerOk) return "docker";
+
+  const containerOk = await probeCommand("container", ["--version"]);
+  if (containerOk) return "container";
+  return "none";
+}
+
+function shQuote(value: string): string {
+  if (!value) return "''";
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
 function resolveSidecarDir(flags: Map<string, string | boolean>): string {
   const override =
     readFlag(flags, "sidecar-dir") ??
@@ -815,7 +1144,14 @@ async function resolveOpencodeDownload(sidecar: SidecarConfig, expectedVersion?:
   const targetDir = join(sidecar.dir, "opencode", version, sidecar.target);
   const targetPath = join(targetDir, process.platform === "win32" ? "opencode.exe" : "opencode");
 
+  const hostTarget = resolveSidecarTarget();
+  const runnableOnHost = hostTarget !== null && sidecar.target === hostTarget;
+
   if (await fileExists(targetPath)) {
+    if (!runnableOnHost) {
+      await ensureExecutable(targetPath);
+      return targetPath;
+    }
     const actual = await readCliVersion(targetPath);
     if (actual === version) {
       await ensureExecutable(targetPath);
@@ -1046,11 +1382,24 @@ async function captureCommandOutput(
     output += chunk.toString();
   });
 
+  type CaptureResult =
+    | "timeout"
+    | "error"
+    | {
+        type: "close";
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      };
+
   const timeoutMs = options?.timeoutMs ?? 30_000;
-  const result = await Promise.race([
-    once(child, "close").then(() => "close"),
-    once(child, "error").then(() => "error"),
-    new Promise((resolve) => setTimeout(resolve, timeoutMs, "timeout")),
+  const result = await Promise.race<CaptureResult>([
+    once(child, "close").then(([code, signal]) => ({
+      type: "close" as const,
+      code: (code ?? null) as number | null,
+      signal: (signal ?? null) as NodeJS.Signals | null,
+    })),
+    once(child, "error").then(() => "error" as const),
+    new Promise<CaptureResult>((resolve) => setTimeout(resolve, timeoutMs, "timeout")),
   ]);
 
   if (result === "timeout") {
@@ -1064,6 +1413,12 @@ async function captureCommandOutput(
 
   if (result === "error") {
     throw new Error("Command failed to run");
+  }
+
+  const code = result.code;
+  if (code !== 0) {
+    const suffix = output.trim() ? `\n${output.trim()}` : "";
+    throw new Error(`Command failed: ${bin} ${args.join(" ")}${suffix}`);
   }
 
   return output.trim();
@@ -1497,6 +1852,50 @@ async function waitForOpencodeHealthy(client: ReturnType<typeof createOpencodeCl
   throw new Error(lastError ?? "Timed out waiting for OpenCode health");
 }
 
+/**
+ * In sandbox mode the released openwork-server binary may not have our latest
+ * token/proxy changes.  Instead of relying on the OpenCode SDK client (which
+ * sends Bearer auth that the proxy may not understand yet), we do a simple
+ * HTTP fetch through the proxy path.  The server's /opencode/* proxy already
+ * forwards to the internal opencode port; we just need to check that it
+ * returns a 2xx from /opencode/health (or falls through to opencode's own
+ * /health endpoint).
+ *
+ * We try multiple path patterns because:
+ * - `/opencode/health` — most common OpenCode health endpoint proxied by the
+ *   server's catch-all /opencode/* route.
+ * - `/health` on the openwork-server itself — already verified by the caller,
+ *   but serves as a fallback signal.
+ */
+async function waitForHealthyViaProxy(
+  proxyBaseUrl: string,
+  token: string,
+  timeoutMs = 10_000,
+  pollMs = 250,
+): Promise<void> {
+  const start = Date.now();
+  let lastError: string | null = null;
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      // Try the proxied opencode health endpoint.
+      const res = await fetch(`${proxyBaseUrl}/health`, { headers, signal: AbortSignal.timeout(2000) });
+      if (res.ok) return;
+      // Some older server versions may return 401/403 on the proxy but that
+      // still proves the server is up and proxying.  Accept any non-5xx as
+      // "alive" — the real auth validation happens in verifyOpenworkServer.
+      if (res.status < 500) return;
+      lastError = `Proxy returned ${res.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(lastError ?? "Timed out waiting for OpenCode health via proxy");
+}
+
 function printHelp(): void {
   const message = [
     "openwrk",
@@ -1559,6 +1958,10 @@ function printHelp(): void {
     "  --tui                     Force interactive dashboard (TTY only)",
     "  --no-tui                  Disable interactive dashboard",
     "  --detach                  Detach after start and keep services running",
+    "  --sandbox <mode>          none | auto | docker | container (default: none)",
+    "  --sandbox-image <ref>     Container image for sandbox mode",
+    "  --sandbox-persist-dir <p> Persist dir mounted into sandbox (default: per-workspace)",
+    "  --sandbox-mount <specs>   Extra mounts (validated): hostPath:subpath[:ro|rw] (requires allowlist)",
     "  --json                    Output JSON when applicable",
     "  --verbose                 Print additional diagnostics",
     "  --log-format <format>     Log output format: pretty | json",
@@ -1813,6 +2216,406 @@ async function owpenbotSupportsOpencodeUrl(bin: string): Promise<boolean> {
   });
 }
 
+async function stopDockerContainer(name: string): Promise<void> {
+  if (!name.trim()) return;
+  await new Promise<void>((resolve) => {
+    const child = spawn("docker", ["stop", name], { stdio: ["ignore", "ignore", "ignore"] });
+    child.on("error", () => resolve());
+    child.on("exit", () => resolve());
+  });
+}
+
+async function stopAppleContainer(name: string): Promise<void> {
+  if (!name.trim()) return;
+  await new Promise<void>((resolve) => {
+    const child = spawn("container", ["stop", name], { stdio: ["ignore", "ignore", "ignore"] });
+    child.on("error", () => resolve());
+    child.on("exit", () => resolve());
+  });
+}
+
+async function runQuiet(command: string, args: string[], timeoutMs = 60_000): Promise<void> {
+  const child = spawn(command, args, { stdio: ["ignore", "ignore", "ignore"] });
+  type QuietResult =
+    | { type: "exit"; code: number | null }
+    | { type: "error"; error: unknown }
+    | { type: "timeout" };
+
+  const result = await Promise.race<QuietResult>([
+    once(child, "exit").then(([code]) => ({ type: "exit" as const, code: (code ?? null) as number | null })),
+    once(child, "error").then(([error]) => ({ type: "error" as const, error })),
+    new Promise<QuietResult>((resolve) => setTimeout(resolve, timeoutMs, { type: "timeout" as const })),
+  ]);
+  if (result.type === "timeout") {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // ignore
+    }
+    throw new Error(`Command timed out: ${command} ${args.join(" ")}`);
+  }
+  if (result.type === "error") {
+    throw new Error(`Command failed: ${command} ${args.join(" ")}: ${String(result.error)}`);
+  }
+  if (result.code !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(" ")}`);
+  }
+}
+
+async function ensureAppleContainerSystemReady(): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error("Apple container backend is only supported on macOS");
+  }
+  if (process.arch !== "arm64") {
+    throw new Error("Apple container backend requires Apple silicon (arm64)");
+  }
+  if (!(await probeCommand("container", ["--version"]))) {
+    throw new Error("Apple container CLI not found. Install https://github.com/apple/container");
+  }
+  // Best-effort: start the background system service.
+  try {
+    await runQuiet("container", ["system", "start"], 90_000);
+  } catch {
+    // Ignore; older versions may not require an explicit start.
+  }
+}
+
+async function stageSandboxRuntime(options: {
+  persistDir: string;
+  containerName: string;
+  sidecars: { opencode: string; openworkServer: string; owpenbot?: string | null };
+  detach: boolean;
+}): Promise<{
+  baseDir: string;
+  rootInContainer: string;
+  entrypointHostPath: string;
+  cleanup: () => Promise<void>;
+}> {
+  const baseDir = join(options.persistDir, "openwrk-sandbox", options.containerName);
+  await mkdir(baseDir, { recursive: true });
+  const sidecarsDir = join(baseDir, "sidecars");
+  await mkdir(sidecarsDir, { recursive: true });
+  const entrypointHostPath = join(baseDir, "entrypoint.sh");
+
+  const stagedOpencode = join(sidecarsDir, "opencode");
+  const stagedOpenwork = join(sidecarsDir, "openwork-server");
+  await copyFile(options.sidecars.opencode, stagedOpencode);
+  await copyFile(options.sidecars.openworkServer, stagedOpenwork);
+  await ensureExecutable(stagedOpencode);
+  await ensureExecutable(stagedOpenwork);
+
+  if (options.sidecars.owpenbot) {
+    const stagedOwpenbot = join(sidecarsDir, "owpenbot");
+    await copyFile(options.sidecars.owpenbot, stagedOwpenbot);
+    await ensureExecutable(stagedOwpenbot);
+  }
+
+  const rootInContainer = `/persist/openwrk-sandbox/${options.containerName}`;
+  const cleanup = async () => {
+    if (options.detach) return;
+    try {
+      await rm(baseDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  };
+
+  return { baseDir, rootInContainer, entrypointHostPath, cleanup };
+}
+
+async function writeSandboxEntrypoint(options: {
+  entrypointHostPath: string;
+  rootInContainer: string;
+  backend: "docker" | "container";
+  opencode: {
+    corsOrigins: string[];
+    username?: string;
+    password?: string;
+  };
+  openwork: {
+    token: string;
+    hostToken: string;
+    approvalMode: ApprovalMode;
+    approvalTimeoutMs: number;
+    readOnly: boolean;
+    corsOrigins: string[];
+    opencodeUsername?: string;
+    opencodePassword?: string;
+    logFormat: LogFormat;
+    owpenbotEnabled: boolean;
+  };
+  runId: string;
+  logFormat: LogFormat;
+}): Promise<void> {
+  const opencodeBin = `${options.rootInContainer}/sidecars/opencode`;
+  const openworkBin = `${options.rootInContainer}/sidecars/openwork-server`;
+  const owpenbotBin = `${options.rootInContainer}/sidecars/owpenbot`;
+  const workspaceDir = "/workspace";
+
+  const opencodeCors = options.opencode.corsOrigins
+    .map((origin) => `--cors ${shQuote(origin)}`)
+    .join(" ");
+
+  const openworkCors = options.openwork.corsOrigins.length
+    ? `--cors ${shQuote(options.openwork.corsOrigins.join(","))}`
+    : "";
+
+  const opencodeAuthEnv = [
+    options.opencode.username ? `export OPENCODE_SERVER_USERNAME=${shQuote(options.opencode.username)}` : "",
+    options.opencode.password ? `export OPENCODE_SERVER_PASSWORD=${shQuote(options.opencode.password)}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const openworkAuthArgs = [
+    options.openwork.opencodeUsername ? `--opencode-username ${shQuote(options.openwork.opencodeUsername)}` : "",
+    options.openwork.opencodePassword ? `--opencode-password ${shQuote(options.openwork.opencodePassword)}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const owpenbotEnv = options.openwork.owpenbotEnabled
+    ? `export OWPENBOT_HEALTH_PORT=${shQuote(String(SANDBOX_INTERNAL_OWPENBOT_HEALTH_PORT))}`
+    : "";
+
+  const script = [
+    "set -eu",
+    `export HOME=${shQuote("/persist")}`,
+    "export XDG_CONFIG_HOME=\"$HOME/.config\"",
+    "export XDG_CACHE_HOME=\"$HOME/.cache\"",
+    "mkdir -p \"$XDG_CONFIG_HOME\" \"$XDG_CACHE_HOME\"",
+    `cd ${shQuote(workspaceDir)}`,
+    `export OPENCODE_DIRECTORY=${shQuote(workspaceDir)}`,
+    `export OPENCODE_URL=${shQuote(`http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`)}`,
+    `export OPENCODE_CLIENT=openwrk`,
+    `export OPENWORK=1`,
+    `export OPENWRK_RUN_ID=${shQuote(options.runId)}`,
+    `export OPENWRK_LOG_FORMAT=${shQuote(options.logFormat)}`,
+    `export OPENWORK_SANDBOX_ENABLED=1`,
+    `export OPENWORK_SANDBOX_BACKEND=${shQuote(options.backend)}`,
+    owpenbotEnv,
+    opencodeAuthEnv,
+    "opencode_pid=\"\"",
+    "owpenbot_pid=\"\"",
+    "cleanup() {",
+    "  if [ -n \"$owpenbot_pid\" ]; then kill \"$owpenbot_pid\" 2>/dev/null || true; fi",
+    "  if [ -n \"$opencode_pid\" ]; then kill \"$opencode_pid\" 2>/dev/null || true; fi",
+    "}",
+    "trap cleanup INT TERM",
+    `${shQuote(opencodeBin)} serve --hostname 127.0.0.1 --port ${shQuote(String(SANDBOX_INTERNAL_OPENCODE_PORT))} ${opencodeCors} &`,
+    "opencode_pid=$!",
+    options.openwork.owpenbotEnabled ? `${shQuote(owpenbotBin)} start ${shQuote(workspaceDir)} &` : "",
+    options.openwork.owpenbotEnabled ? "owpenbot_pid=$!" : "",
+    `exec ${shQuote(openworkBin)} --host 0.0.0.0 --port ${shQuote(String(SANDBOX_INTERNAL_OPENWORK_PORT))}` +
+      ` --token ${shQuote(options.openwork.token)} --host-token ${shQuote(options.openwork.hostToken)}` +
+      ` --workspace ${shQuote(workspaceDir)}` +
+      ` --approval ${shQuote(options.openwork.approvalMode)}` +
+      ` --approval-timeout ${shQuote(String(options.openwork.approvalTimeoutMs))}` +
+      (options.openwork.readOnly ? " --read-only" : "") +
+      ` --opencode-base-url ${shQuote(`http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`)}` +
+      ` --opencode-directory ${shQuote(workspaceDir)}` +
+      ` ${openworkAuthArgs}` +
+      ` --log-format ${shQuote(options.openwork.logFormat)}` +
+      (options.openwork.owpenbotEnabled ? ` --owpenbot-health-port ${shQuote(String(SANDBOX_INTERNAL_OWPENBOT_HEALTH_PORT))}` : "") +
+      (openworkCors ? ` ${openworkCors}` : ""),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  await writeFile(options.entrypointHostPath, `${script}\n`, "utf8");
+}
+
+async function startDockerSandbox(options: {
+  image: string;
+  containerName: string;
+  workspace: string;
+  persistDir: string;
+  extraMounts: SandboxMount[];
+  sidecars: { opencode: string; openworkServer: string; owpenbot?: string | null };
+  ports: { openwork: number; owpenbotHealth?: number | null };
+  opencode: {
+    corsOrigins: string[];
+    username?: string;
+    password?: string;
+  };
+  openwork: {
+    token: string;
+    hostToken: string;
+    approvalMode: ApprovalMode;
+    approvalTimeoutMs: number;
+    readOnly: boolean;
+    corsOrigins: string[];
+    opencodeUsername?: string;
+    opencodePassword?: string;
+    logFormat: LogFormat;
+  };
+  runId: string;
+  logFormat: LogFormat;
+  detach: boolean;
+  logger: Logger;
+}): Promise<{ child: ReturnType<typeof spawn>; cleanup: () => Promise<void> }> {
+  const staged = await stageSandboxRuntime({
+    persistDir: options.persistDir,
+    containerName: options.containerName,
+    sidecars: options.sidecars,
+    detach: options.detach,
+  });
+
+  await writeSandboxEntrypoint({
+    entrypointHostPath: staged.entrypointHostPath,
+    rootInContainer: staged.rootInContainer,
+    backend: "docker",
+    opencode: options.opencode,
+    openwork: {
+      token: options.openwork.token,
+      hostToken: options.openwork.hostToken,
+      approvalMode: options.openwork.approvalMode,
+      approvalTimeoutMs: options.openwork.approvalTimeoutMs,
+      readOnly: options.openwork.readOnly,
+      corsOrigins: options.openwork.corsOrigins,
+      opencodeUsername: options.openwork.opencodeUsername,
+      opencodePassword: options.openwork.opencodePassword,
+      logFormat: options.openwork.logFormat,
+      owpenbotEnabled: !!options.sidecars.owpenbot,
+    },
+    runId: options.runId,
+    logFormat: options.logFormat,
+  });
+
+  const args: string[] = [
+    "run",
+    "--rm",
+    "--name",
+    options.containerName,
+    "-p",
+    `${options.ports.openwork}:${SANDBOX_INTERNAL_OPENWORK_PORT}`,
+    "-v",
+    `${options.workspace}:/workspace`,
+    "-v",
+    `${options.persistDir}:/persist`,
+  ];
+
+  if (options.sidecars.owpenbot && options.ports.owpenbotHealth) {
+    args.push("-p", `${options.ports.owpenbotHealth}:${SANDBOX_INTERNAL_OWPENBOT_HEALTH_PORT}`);
+  }
+
+  for (const mount of options.extraMounts) {
+    const suffix = mount.readonly ? ":ro" : "";
+    args.push("-v", `${mount.hostPath}:${mount.containerPath}${suffix}`);
+  }
+
+  if (options.detach) {
+    args.push("-d");
+  }
+
+  const scriptInContainer = `${staged.rootInContainer}/entrypoint.sh`;
+  args.push(options.image, "sh", scriptInContainer);
+
+  const child = spawn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
+  prefixStream(child.stdout, "sandbox", "stdout", options.logger, child.pid ?? undefined);
+  prefixStream(child.stderr, "sandbox", "stderr", options.logger, child.pid ?? undefined);
+
+  return { child, cleanup: staged.cleanup };
+}
+
+async function startAppleContainerSandbox(options: {
+  image: string;
+  containerName: string;
+  workspace: string;
+  persistDir: string;
+  extraMounts: SandboxMount[];
+  sidecars: { opencode: string; openworkServer: string; owpenbot?: string | null };
+  ports: { openwork: number; owpenbotHealth?: number | null };
+  opencode: {
+    corsOrigins: string[];
+    username?: string;
+    password?: string;
+  };
+  openwork: {
+    token: string;
+    hostToken: string;
+    approvalMode: ApprovalMode;
+    approvalTimeoutMs: number;
+    readOnly: boolean;
+    corsOrigins: string[];
+    opencodeUsername?: string;
+    opencodePassword?: string;
+    logFormat: LogFormat;
+  };
+  runId: string;
+  logFormat: LogFormat;
+  detach: boolean;
+  logger: Logger;
+}): Promise<{ child: ReturnType<typeof spawn>; cleanup: () => Promise<void> }> {
+  await ensureAppleContainerSystemReady();
+
+  const staged = await stageSandboxRuntime({
+    persistDir: options.persistDir,
+    containerName: options.containerName,
+    sidecars: options.sidecars,
+    detach: options.detach,
+  });
+
+  await writeSandboxEntrypoint({
+    entrypointHostPath: staged.entrypointHostPath,
+    rootInContainer: staged.rootInContainer,
+    backend: "container",
+    opencode: options.opencode,
+    openwork: {
+      token: options.openwork.token,
+      hostToken: options.openwork.hostToken,
+      approvalMode: options.openwork.approvalMode,
+      approvalTimeoutMs: options.openwork.approvalTimeoutMs,
+      readOnly: options.openwork.readOnly,
+      corsOrigins: options.openwork.corsOrigins,
+      opencodeUsername: options.openwork.opencodeUsername,
+      opencodePassword: options.openwork.opencodePassword,
+      logFormat: options.openwork.logFormat,
+      owpenbotEnabled: !!options.sidecars.owpenbot,
+    },
+    runId: options.runId,
+    logFormat: options.logFormat,
+  });
+
+  const args: string[] = [
+    "run",
+    "--rm",
+    "--name",
+    options.containerName,
+    "-p",
+    `${options.ports.openwork}:${SANDBOX_INTERNAL_OPENWORK_PORT}`,
+    "-v",
+    `${options.workspace}:/workspace`,
+    "-v",
+    `${options.persistDir}:/persist`,
+  ];
+
+  if (options.sidecars.owpenbot && options.ports.owpenbotHealth) {
+    args.push("-p", `${options.ports.owpenbotHealth}:${SANDBOX_INTERNAL_OWPENBOT_HEALTH_PORT}`);
+  }
+
+  for (const mount of options.extraMounts) {
+    if (mount.readonly) {
+      args.push("--mount", `type=bind,source=${mount.hostPath},target=${mount.containerPath},readonly`);
+    } else {
+      args.push("-v", `${mount.hostPath}:${mount.containerPath}`);
+    }
+  }
+
+  if (options.detach) {
+    args.push("-d");
+  }
+
+  const scriptInContainer = `${staged.rootInContainer}/entrypoint.sh`;
+  args.push(options.image, "sh", scriptInContainer);
+
+  const child = spawn("container", args, { stdio: ["ignore", "pipe", "pipe"] });
+  prefixStream(child.stdout, "sandbox", "stdout", options.logger, child.pid ?? undefined);
+  prefixStream(child.stderr, "sandbox", "stderr", options.logger, child.pid ?? undefined);
+
+  return { child, cleanup: staged.cleanup };
+}
+
 async function verifyOwpenbotVersion(binary: ResolvedBinary): Promise<string | undefined> {
   if (binary.source !== "external") {
     return binary.expectedVersion;
@@ -1935,6 +2738,51 @@ async function runChecks(input: {
     if (!events.length) {
       throw new Error("No SSE events observed during check");
     }
+  }
+}
+
+/**
+ * Lighter check suite for sandbox mode.  Uses only raw HTTP against the
+ * openwork-server endpoints — no OpenCode SDK calls that rely on Bearer
+ * auth through the proxy (since the released server binary may predate our
+ * token/proxy changes).
+ */
+async function runSandboxChecks(input: {
+  openworkUrl: string;
+  openworkToken: string;
+  hostToken: string;
+}) {
+  const baseUrl = input.openworkUrl.replace(/\/$/, "");
+  const headers = { Authorization: `Bearer ${input.openworkToken}` };
+  const hostHeaders = { "X-OpenWork-Host-Token": input.hostToken };
+
+  // 1. Server health
+  const health = await fetchJson(`${baseUrl}/health`);
+  if (!health || typeof health !== "object") {
+    throw new Error("openwork-server /health returned invalid payload");
+  }
+
+  // 2. Workspaces list
+  const workspaces = await fetchJson(`${baseUrl}/workspaces`, { headers });
+  if (!workspaces?.items?.length) {
+    throw new Error("openwork-server returned no workspaces");
+  }
+  const workspaceId = workspaces.items[0].id as string;
+
+  // 3. Workspace config
+  await fetchJson(`${baseUrl}/workspace/${workspaceId}/config`, { headers });
+
+  // 4. Approvals endpoint (host auth)
+  await fetchJson(`${baseUrl}/approvals`, { headers: hostHeaders });
+
+  // 5. Proxy is reachable (even if auth is rejected — non-5xx proves the
+  //    server is proxying to a running opencode)
+  const proxyRes = await fetch(`${baseUrl}/opencode/health`, {
+    headers,
+    signal: AbortSignal.timeout(3000),
+  });
+  if (proxyRes.status >= 500) {
+    throw new Error(`opencode proxy returned ${proxyRes.status}`);
   }
 }
 
@@ -2445,8 +3293,10 @@ async function runRouterDaemon(args: ParsedArgs) {
     color: colorEnabled,
   });
   const logVerbose = createVerboseLogger(verbose && !outputJson, logger, "openwrk");
-  const sidecarSource = readBinarySource(args.flags, "sidecar-source", "auto", "OPENWRK_SIDECAR_SOURCE");
-  const opencodeSource = readBinarySource(args.flags, "opencode-source", "auto", "OPENWRK_OPENCODE_SOURCE");
+  const sidecarSourceInput = readBinarySource(args.flags, "sidecar-source", "auto", "OPENWRK_SIDECAR_SOURCE");
+  const opencodeSourceInput = readBinarySource(args.flags, "opencode-source", "auto", "OPENWRK_OPENCODE_SOURCE");
+  const sidecarSource = sidecarSourceInput;
+  const opencodeSource = opencodeSourceInput;
   const dataDir = resolveRouterDataDir(args.flags);
   const statePath = routerStatePath(dataDir);
   let state = await loadRouterState(statePath);
@@ -2986,19 +3836,47 @@ async function runStart(args: ParsedArgs) {
     },
   });
   const logVerbose = createVerboseLogger(verbose && !outputJson, logger, "openwrk");
-  const sidecarSource = readBinarySource(args.flags, "sidecar-source", "auto", "OPENWRK_SIDECAR_SOURCE");
-  const opencodeSource = readBinarySource(args.flags, "opencode-source", "auto", "OPENWRK_OPENCODE_SOURCE");
+  const sidecarSourceInput = readBinarySource(args.flags, "sidecar-source", "auto", "OPENWRK_SIDECAR_SOURCE");
+  const opencodeSourceInput = readBinarySource(args.flags, "opencode-source", "auto", "OPENWRK_OPENCODE_SOURCE");
 
   const workspace = readFlag(args.flags, "workspace") ?? process.env.OPENWORK_WORKSPACE ?? process.cwd();
   const resolvedWorkspace = await ensureWorkspace(workspace);
   logger.info("Run starting", { workspace: resolvedWorkspace, logFormat, runId }, "openwrk");
 
+  const sandboxRequested = readSandboxMode(args.flags, "sandbox", "none", "OPENWRK_SANDBOX");
+  const sandboxMode = await resolveSandboxMode(sandboxRequested);
+  const sandboxImage =
+    readFlag(args.flags, "sandbox-image") ?? process.env.OPENWRK_SANDBOX_IMAGE ?? "debian:bookworm-slim";
+  const sandboxPersistOverride = readFlag(args.flags, "sandbox-persist-dir") ?? process.env.OPENWRK_SANDBOX_PERSIST_DIR;
+  const dataDir = resolveRouterDataDir(args.flags);
+  const sandboxPersistDir = resolve(
+    sandboxPersistOverride?.trim()
+      ? sandboxPersistOverride.trim()
+      : join(dataDir, "sandbox", workspaceIdForLocal(resolvedWorkspace)),
+  );
+  if (sandboxMode !== "none") {
+    await mkdir(sandboxPersistDir, { recursive: true });
+  }
+
+  const sandboxMountValue =
+    readFlag(args.flags, "sandbox-mount") ??
+    process.env.OPENWRK_SANDBOX_MOUNT ??
+    process.env.OPENWORK_SANDBOX_MOUNT;
+  const sandboxMountSpecs = parseList(sandboxMountValue);
+  const sandboxExtraMounts =
+    sandboxMode !== "none" && sandboxMountSpecs.length
+      ? await resolveSandboxExtraMounts(sandboxMountSpecs, sandboxMode)
+      : [];
+
   const explicitOpencodeBin = readFlag(args.flags, "opencode-bin") ?? process.env.OPENWORK_OPENCODE_BIN;
   const opencodeBindHost = readFlag(args.flags, "opencode-host") ?? process.env.OPENWORK_OPENCODE_BIND_HOST ?? "0.0.0.0";
-  const opencodePort = await resolvePort(
-    readNumber(args.flags, "opencode-port", undefined, "OPENWORK_OPENCODE_PORT"),
-    "127.0.0.1",
-  );
+  const opencodePort =
+    sandboxMode !== "none"
+      ? SANDBOX_INTERNAL_OPENCODE_PORT
+      : await resolvePort(
+          readNumber(args.flags, "opencode-port", undefined, "OPENWORK_OPENCODE_PORT"),
+          "127.0.0.1",
+        );
   const opencodeAuth = readBool(args.flags, "opencode-auth", true, "OPENWORK_OPENCODE_AUTH");
   const opencodeUsername = opencodeAuth
     ? readFlag(args.flags, "opencode-username") ?? process.env.OPENWORK_OPENCODE_USERNAME ?? DEFAULT_OPENCODE_USERNAME
@@ -3036,10 +3914,32 @@ async function runStart(args: ParsedArgs) {
   const corsOrigins = parseList(corsValue);
   const connectHost = readFlag(args.flags, "connect-host");
 
-  const sidecar = resolveSidecarConfig(args.flags, cliVersion);
   const manifest = await readVersionManifest();
   const allowExternal = readBool(args.flags, "allow-external", false, "OPENWRK_ALLOW_EXTERNAL");
+  const sidecarTarget = resolveSandboxSidecarTarget(sandboxMode);
+  const sidecar = resolveSidecarConfigForTarget(args.flags, cliVersion, sidecarTarget);
+
+  let sidecarSource = sidecarSourceInput;
+  let opencodeSource = opencodeSourceInput;
+  if (sandboxMode !== "none") {
+    if (sidecarSourceInput === "bundled" || sidecarSourceInput === "external") {
+      throw new Error("Sandbox mode requires --sidecar-source downloaded or auto");
+    }
+    if (opencodeSourceInput === "bundled" || opencodeSourceInput === "external") {
+      throw new Error("Sandbox mode requires --opencode-source downloaded or auto");
+    }
+    if (sidecarSourceInput === "auto") sidecarSource = "downloaded";
+    if (opencodeSourceInput === "auto") opencodeSource = "downloaded";
+  }
   logVerbose(`cli version: ${cliVersion}`);
+  logVerbose(`sandbox: ${sandboxMode}`);
+  if (sandboxMode !== "none") {
+    logVerbose(`sandbox image: ${sandboxImage}`);
+    logVerbose(`sandbox persist dir: ${sandboxPersistDir}`);
+    if (sandboxExtraMounts.length) {
+      logVerbose(`sandbox mounts: ${sandboxExtraMounts.length}`);
+    }
+  }
   logVerbose(`sidecar target: ${sidecar.target ?? "unknown"}`);
   logVerbose(`sidecar dir: ${sidecar.dir}`);
   logVerbose(`sidecar base URL: ${sidecar.baseUrl}`);
@@ -3056,6 +3956,30 @@ async function runStart(args: ParsedArgs) {
   });
   const explicitOpenworkServerBin = readFlag(args.flags, "openwork-server-bin") ?? process.env.OPENWORK_SERVER_BIN;
   const explicitOwpenbotBin = readFlag(args.flags, "owpenbot-bin") ?? process.env.OWPENBOT_BIN;
+
+  if (sandboxMode !== "none") {
+    if (sandboxMode === "docker") {
+      if (!(await probeCommand("docker", ["version"]))) {
+        throw new Error(
+          "Docker is required for --sandbox docker. Install Docker Desktop and ensure 'docker' is on PATH.",
+        );
+      }
+    }
+    if (sandboxMode === "container") {
+      if (process.platform !== "darwin") {
+        throw new Error("Apple container backend is only supported on macOS");
+      }
+      if (process.arch !== "arm64") {
+        throw new Error("Apple container backend requires Apple silicon (arm64)");
+      }
+      if (!(await probeCommand("container", ["--version"]))) {
+        throw new Error("Apple container CLI not found. Install https://github.com/apple/container");
+      }
+    }
+    if (explicitOpencodeBin || explicitOpenworkServerBin || explicitOwpenbotBin) {
+      throw new Error("Sandbox mode does not support custom *-bin paths yet (use downloaded sidecars).");
+    }
+  }
   const owpenbotEnabled = readBool(args.flags, "owpenbot", true);
   const owpenbotRequired = readBool(args.flags, "owpenbot-required", false, "OPENWRK_OWPENBOT_REQUIRED");
   const openworkServerBinary = await resolveOpenworkServerBin({
@@ -3081,20 +4005,26 @@ async function runStart(args: ParsedArgs) {
     logVerbose(`owpenbot bin: ${owpenbotBinary.bin} (${owpenbotBinary.source})`);
   }
 
-  const opencodeBaseUrl = `http://127.0.0.1:${opencodePort}`;
-  const opencodeConnect = resolveConnectUrl(opencodePort, connectHost);
-  const opencodeConnectUrl = opencodeConnect.connectUrl ?? opencodeBaseUrl;
-
   const openworkBaseUrl = `http://127.0.0.1:${openworkPort}`;
   const openworkConnect = resolveConnectUrl(openworkPort, connectHost);
   const openworkConnectUrl = openworkConnect.connectUrl ?? openworkBaseUrl;
 
-  const attachCommand = buildAttachCommand({
-    url: opencodeConnectUrl,
-    workspace: resolvedWorkspace,
-    username: opencodeUsername,
-    password: opencodePassword,
-  });
+  const opencodeBaseUrl =
+    sandboxMode !== "none" ? `${openworkBaseUrl}/opencode` : `http://127.0.0.1:${opencodePort}`;
+  const opencodeConnectUrl =
+    sandboxMode !== "none"
+      ? `${openworkConnectUrl.replace(/\/$/, "")}/opencode`
+      : (resolveConnectUrl(opencodePort, connectHost).connectUrl ?? opencodeBaseUrl);
+
+  const attachCommand =
+    sandboxMode !== "none"
+      ? `OpenCode is proxied via ${opencodeConnectUrl} (requires OpenWork token)`
+      : buildAttachCommand({
+          url: opencodeConnectUrl,
+          workspace: resolvedWorkspace,
+          username: opencodeUsername,
+          password: opencodePassword,
+        });
 
   const owpenbotHealthUrl = `http://127.0.0.1:${owpenbotHealthPort}`;
   const owpenbotEnv: NodeJS.ProcessEnv = {
@@ -3109,6 +4039,10 @@ async function runStart(args: ParsedArgs) {
   const children: ChildHandle[] = [];
   let shuttingDown = false;
   let detached = false;
+  let sandboxContainerName: string | null = null;
+  let sandboxStop: ((name: string) => Promise<void>) | null = null;
+  let sandboxStopCommand: string | null = null;
+  let sandboxCleanup: (() => Promise<void>) | null = null;
   const startedAt = Date.now();
   let owpenbotHealthInterval: NodeJS.Timeout | null = null;
   const shutdown = async () => {
@@ -3119,7 +4053,14 @@ async function runStart(args: ParsedArgs) {
       owpenbotHealthInterval = null;
     }
     logger.info("Shutting down", { children: children.map((handle) => handle.name) }, "openwrk");
+    if (sandboxContainerName && sandboxStop) {
+      await sandboxStop(sandboxContainerName);
+    }
     await Promise.all(children.map((handle) => stopChild(handle.child)));
+    if (sandboxCleanup) {
+      await sandboxCleanup();
+      sandboxCleanup = null;
+    }
   };
 
   const detachChildren = () => {
@@ -3154,6 +4095,12 @@ async function runStart(args: ParsedArgs) {
     const summary = [
       "Detached. Services still running:",
       ...children.map((handle) => `- ${handle.name} (pid ${handle.child.pid ?? "unknown"})`),
+      ...(sandboxContainerName && sandboxStopCommand
+        ? [
+            `- sandbox (${sandboxStopCommand.split(" ")[0]} container ${sandboxContainerName})`,
+            `Stop: ${sandboxStopCommand} ${sandboxContainerName}`,
+          ]
+        : []),
       `OpenWork URL: ${openworkConnectUrl}`,
       `OpenWork Token: ${openworkToken}`,
       `OpenCode URL: ${opencodeConnectUrl}`,
@@ -3173,8 +4120,8 @@ async function runStart(args: ParsedArgs) {
         openworkToken,
         hostToken: openworkHostToken,
         opencodeUrl: opencodeConnectUrl,
-        opencodePassword: opencodePassword ?? undefined,
-        opencodeUsername: opencodeUsername ?? undefined,
+        opencodePassword: sandboxMode !== "none" ? undefined : (opencodePassword ?? undefined),
+        opencodeUsername: sandboxMode !== "none" ? undefined : (opencodeUsername ?? undefined),
         attachCommand,
       },
       services: [
@@ -3196,14 +4143,24 @@ async function runStart(args: ParsedArgs) {
       onCopySelection: async (text) => copyToClipboard(text),
       onOwpenbotHealth: async () => fetchOwpenbotHealth(owpenbotHealthUrl),
       onOwpenbotQr: async () => {
-        if (!owpenbotBinary) {
-          throw new Error("Owpenbot binary missing");
+        let output = "";
+        if (sandboxMode !== "none") {
+          if (!sandboxContainerName) {
+            throw new Error("Sandbox container missing");
+          }
+          const cli = sandboxMode === "container" ? "container" : "docker";
+          const owpenbotPath = `/persist/openwrk-sandbox/${sandboxContainerName}/sidecars/owpenbot`;
+          output = await captureCommandOutput(cli, ["exec", sandboxContainerName, owpenbotPath, "whatsapp", "qr", "--format", "ascii"]);
+        } else {
+          if (!owpenbotBinary) {
+            throw new Error("Owpenbot binary missing");
+          }
+          output = await captureCommandOutput(
+            owpenbotBinary.bin,
+            ["whatsapp", "qr", "--format", "ascii"],
+            { env: owpenbotEnv },
+          );
         }
-        const output = await captureCommandOutput(
-          owpenbotBinary.bin,
-          ["whatsapp", "qr", "--format", "ascii"],
-          { env: owpenbotEnv },
-        );
         if (!output) {
           throw new Error("No QR output received");
         }
@@ -3228,7 +4185,10 @@ async function runStart(args: ParsedArgs) {
   const handleExit = (name: string, code: number | null, signal: NodeJS.Signals | null) => {
     if (shuttingDown || detached) return;
     const reason = code !== null ? `code ${code}` : signal ? `signal ${signal}` : "unknown";
-    tui?.updateService(name, { status: "stopped", message: reason });
+    const services = name === "sandbox" ? ["opencode", "openwork-server", "owpenbot"] : [name];
+    for (const service of services) {
+      tui?.updateService(service, { status: "stopped", message: reason });
+    }
     logger.error("Process exited", { reason, code, signal }, name);
     void shutdown().then(() => process.exit(code ?? 1));
   };
@@ -3241,102 +4201,165 @@ async function runStart(args: ParsedArgs) {
   };
 
   try {
-    const opencodeActualVersion = await verifyOpencodeVersion(opencodeBinary);
-    const opencodeChild = await startOpencode({
-      bin: opencodeBinary.bin,
-      workspace: resolvedWorkspace,
-      bindHost: opencodeBindHost,
-      port: opencodePort,
-      username: opencodeUsername,
-      password: opencodePassword,
-      corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
-      logger,
-      runId,
-      logFormat,
-    });
-    children.push({ name: "opencode", child: opencodeChild });
-    tui?.updateService("opencode", {
-      status: "running",
-      pid: opencodeChild.pid ?? undefined,
-      port: opencodePort,
-    });
-    logger.info("Process spawned", { pid: opencodeChild.pid ?? 0 }, "opencode");
-    opencodeChild.on("exit", (code, signal) => handleExit("opencode", code, signal));
-    opencodeChild.on("error", (error) => handleSpawnError("opencode", error));
+    const opencodeActualVersion =
+      sandboxMode !== "none" ? opencodeBinary.expectedVersion : await verifyOpencodeVersion(opencodeBinary);
+    let openworkActualVersion: string | undefined;
+    let opencodeClient: ReturnType<typeof createOpencodeClient>;
 
-    const authHeaders: Record<string, string> = {};
-    if (opencodeUsername && opencodePassword) {
-      authHeaders.Authorization = `Basic ${encodeBasicAuth(opencodeUsername, opencodePassword)}`;
-    }
-    const opencodeClient = createOpencodeClient({
-      baseUrl: opencodeBaseUrl,
-      directory: resolvedWorkspace,
-      headers: Object.keys(authHeaders).length ? authHeaders : undefined,
-    });
+    if (sandboxMode !== "none") {
+      const containerName = `openwrk-${runId.replace(/[^a-zA-Z0-9_.-]+/g, "-").slice(0, 24)}`;
+      sandboxContainerName = containerName;
 
-    logger.info("Waiting for health", { url: opencodeBaseUrl }, "opencode");
-    await waitForOpencodeHealthy(opencodeClient);
-    logger.info("Healthy", { url: opencodeBaseUrl }, "opencode");
-    tui?.updateService("opencode", { status: "healthy" });
+      sandboxStop = sandboxMode === "container" ? stopAppleContainer : stopDockerContainer;
+      sandboxStopCommand = sandboxMode === "container" ? "container stop" : "docker stop";
+      const opencodeInternalBaseUrl = `http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`;
 
-    const openworkChild = await startOpenworkServer({
-      bin: openworkServerBinary.bin,
-      host: openworkHost,
-      port: openworkPort,
-      workspace: resolvedWorkspace,
-      token: openworkToken,
-      hostToken: openworkHostToken,
-      approvalMode: approvalMode === "auto" ? "auto" : "manual",
-      approvalTimeoutMs,
-      readOnly,
-      corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
-      opencodeBaseUrl: opencodeConnectUrl,
-      opencodeDirectory: resolvedWorkspace,
-      opencodeUsername,
-      opencodePassword,
-      owpenbotHealthPort,
-      logger,
-      runId,
-      logFormat,
-    });
-    children.push({ name: "openwork-server", child: openworkChild });
-    tui?.updateService("openwork-server", {
-      status: "running",
-      pid: openworkChild.pid ?? undefined,
-      port: openworkPort,
-    });
-    logger.info("Process spawned", { pid: openworkChild.pid ?? 0 }, "openwork-server");
-    openworkChild.on("exit", (code, signal) => handleExit("openwork-server", code, signal));
-    openworkChild.on("error", (error) => handleSpawnError("openwork-server", error));
-
-    logger.info("Waiting for health", { url: openworkBaseUrl }, "openwork-server");
-    await waitForHealthy(openworkBaseUrl);
-    logger.info("Healthy", { url: openworkBaseUrl }, "openwork-server");
-    tui?.updateService("openwork-server", { status: "healthy" });
-
-    const openworkActualVersion = await verifyOpenworkServer({
-      baseUrl: openworkBaseUrl,
-      token: openworkToken,
-      hostToken: openworkHostToken,
-      expectedVersion: openworkServerBinary.expectedVersion,
-      expectedWorkspace: resolvedWorkspace,
-      expectedOpencodeBaseUrl: opencodeConnectUrl,
-      expectedOpencodeDirectory: resolvedWorkspace,
-      expectedOpencodeUsername: opencodeUsername,
-      expectedOpencodePassword: opencodePassword,
-    });
-    logVerbose(`openwork-server version: ${openworkActualVersion ?? "unknown"}`);
-
-    if (owpenbotEnabled) {
-      if (!owpenbotBinary) {
-        throw new Error("Owpenbot binary missing.");
-      }
-      owpenbotActualVersion = await verifyOwpenbotVersion(owpenbotBinary);
-      logVerbose(`owpenbot version: ${owpenbotActualVersion ?? "unknown"}`);
-      const owpenbotChild = await startOwpenbot({
-        bin: owpenbotBinary.bin,
+      const runner = sandboxMode === "container" ? startAppleContainerSandbox : startDockerSandbox;
+      const sandboxChild = await runner({
+        image: sandboxImage,
+        containerName,
         workspace: resolvedWorkspace,
-        opencodeUrl: opencodeConnectUrl,
+        persistDir: sandboxPersistDir,
+        extraMounts: sandboxExtraMounts,
+        sidecars: {
+          opencode: opencodeBinary.bin,
+          openworkServer: openworkServerBinary.bin,
+          owpenbot: owpenbotEnabled ? (owpenbotBinary?.bin ?? null) : null,
+        },
+        ports: {
+          openwork: openworkPort,
+          owpenbotHealth: owpenbotEnabled ? owpenbotHealthPort : null,
+        },
+        opencode: {
+          corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+          username: opencodeUsername,
+          password: opencodePassword,
+        },
+        openwork: {
+          token: openworkToken,
+          hostToken: openworkHostToken,
+          approvalMode: approvalMode === "auto" ? "auto" : "manual",
+          approvalTimeoutMs,
+          readOnly,
+          corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+          opencodeUsername,
+          opencodePassword,
+          logFormat,
+        },
+        runId,
+        logFormat,
+        detach: detachRequested,
+        logger,
+      });
+
+      sandboxCleanup = sandboxChild.cleanup;
+      tui?.updateService("opencode", { status: "running", port: SANDBOX_INTERNAL_OPENCODE_PORT });
+      tui?.updateService("openwork-server", { status: "running", port: openworkPort });
+      if (owpenbotEnabled) {
+        tui?.updateService("owpenbot", { status: "running", port: owpenbotHealthPort });
+      }
+
+      if (!detachRequested) {
+        children.push({ name: "sandbox", child: sandboxChild.child });
+        logger.info("Process spawned", { pid: sandboxChild.child.pid ?? 0, containerName }, "sandbox");
+        sandboxChild.child.on("exit", (code, signal) => handleExit("sandbox", code, signal));
+        sandboxChild.child.on("error", (error) => handleSpawnError("sandbox", error));
+      } else {
+        // docker run -d exits quickly; the container continues to run.
+        logger.info("Sandbox detached", { containerName }, "sandbox");
+      }
+
+      logger.info("Waiting for health", { url: openworkBaseUrl }, "openwork-server");
+      await waitForHealthy(openworkBaseUrl);
+      logger.info("Healthy", { url: openworkBaseUrl }, "openwork-server");
+      tui?.updateService("openwork-server", { status: "healthy" });
+
+      opencodeClient = createOpencodeClient({
+        baseUrl: `${openworkBaseUrl.replace(/\/$/, "")}/opencode`,
+        headers: { Authorization: `Bearer ${openworkToken}` },
+      });
+
+      // In sandbox mode, the released openwork-server binary may not have our
+      // latest proxy/auth changes yet.  Instead of using the OpenCode SDK client
+      // (which relies on the proxy handling Bearer tokens), do a direct health
+      // check against the openwork-server's own /opencode proxy path.  If the
+      // server is healthy *and* is proxying to a healthy opencode, we're good.
+      logger.info("Waiting for health (proxy)", { url: `${openworkBaseUrl}/opencode` }, "opencode");
+      await waitForHealthyViaProxy(`${openworkBaseUrl.replace(/\/$/, "")}/opencode`, openworkToken);
+      logger.info("Healthy (proxy)", { url: `${openworkBaseUrl}/opencode` }, "opencode");
+      tui?.updateService("opencode", { status: "healthy" });
+
+      try {
+        openworkActualVersion = await verifyOpenworkServer({
+          baseUrl: openworkBaseUrl,
+          token: openworkToken,
+          hostToken: openworkHostToken,
+          expectedVersion: openworkServerBinary.expectedVersion,
+          expectedWorkspace: "/workspace",
+          expectedOpencodeBaseUrl: opencodeInternalBaseUrl,
+          expectedOpencodeDirectory: "/workspace",
+          expectedOpencodeUsername: opencodeUsername,
+          expectedOpencodePassword: opencodePassword,
+        });
+      } catch (verifyError) {
+        // In sandbox mode the released server binary may differ from the
+        // expected version or lack capabilities we just added locally.  Log
+        // the mismatch but don't abort — the health checks above already
+        // proved the server is running and proxying correctly.
+        logger.warn("Sandbox server verification warning (non-fatal)", { error: String(verifyError) }, "openwork-server");
+      }
+      logVerbose(`openwork-server version: ${openworkActualVersion ?? "unknown"}`);
+    } else {
+      const opencodeChild = await startOpencode({
+        bin: opencodeBinary.bin,
+        workspace: resolvedWorkspace,
+        bindHost: opencodeBindHost,
+        port: opencodePort,
+        username: opencodeUsername,
+        password: opencodePassword,
+        corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+        logger,
+        runId,
+        logFormat,
+      });
+      children.push({ name: "opencode", child: opencodeChild });
+      tui?.updateService("opencode", {
+        status: "running",
+        pid: opencodeChild.pid ?? undefined,
+        port: opencodePort,
+      });
+      logger.info("Process spawned", { pid: opencodeChild.pid ?? 0 }, "opencode");
+      opencodeChild.on("exit", (code, signal) => handleExit("opencode", code, signal));
+      opencodeChild.on("error", (error) => handleSpawnError("opencode", error));
+
+      const authHeaders: Record<string, string> = {};
+      if (opencodeUsername && opencodePassword) {
+        authHeaders.Authorization = `Basic ${encodeBasicAuth(opencodeUsername, opencodePassword)}`;
+      }
+      opencodeClient = createOpencodeClient({
+        baseUrl: opencodeBaseUrl,
+        directory: resolvedWorkspace,
+        headers: Object.keys(authHeaders).length ? authHeaders : undefined,
+      });
+
+      logger.info("Waiting for health", { url: opencodeBaseUrl }, "opencode");
+      await waitForOpencodeHealthy(opencodeClient);
+      logger.info("Healthy", { url: opencodeBaseUrl }, "opencode");
+      tui?.updateService("opencode", { status: "healthy" });
+
+      const openworkChild = await startOpenworkServer({
+        bin: openworkServerBinary.bin,
+        host: openworkHost,
+        port: openworkPort,
+        workspace: resolvedWorkspace,
+        token: openworkToken,
+        hostToken: openworkHostToken,
+        approvalMode: approvalMode === "auto" ? "auto" : "manual",
+        approvalTimeoutMs,
+        readOnly,
+        corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+        opencodeBaseUrl: opencodeConnectUrl,
+        opencodeDirectory: resolvedWorkspace,
         opencodeUsername,
         opencodePassword,
         owpenbotHealthPort,
@@ -3344,45 +4367,119 @@ async function runStart(args: ParsedArgs) {
         runId,
         logFormat,
       });
-      children.push({ name: "owpenbot", child: owpenbotChild });
-      tui?.updateService("owpenbot", {
+      children.push({ name: "openwork-server", child: openworkChild });
+      tui?.updateService("openwork-server", {
         status: "running",
-        pid: owpenbotChild.pid ?? undefined,
-        port: owpenbotHealthPort,
+        pid: openworkChild.pid ?? undefined,
+        port: openworkPort,
       });
-      logger.info("Process spawned", { pid: owpenbotChild.pid ?? 0 }, "owpenbot");
-      try {
-        logger.info("Waiting for health", { url: owpenbotHealthUrl }, "owpenbot");
-        const health = await waitForOwpenbotHealthy(owpenbotHealthUrl);
-        tui?.setOwpenbotHealth(health);
-        tui?.updateService("owpenbot", { status: health.ok ? "healthy" : "running" });
-        logger.info("Healthy", { url: owpenbotHealthUrl, ok: health.ok }, "owpenbot");
-      } catch (error) {
-        logger.warn("Owpenbot health check failed", { error: String(error) }, "owpenbot");
-        tui?.updateService("owpenbot", { status: "running", message: String(error) });
-      }
-      if (!owpenbotHealthInterval) {
-        owpenbotHealthInterval = setInterval(() => {
-          fetchOwpenbotHealth(owpenbotHealthUrl)
-            .then((health) => {
-              tui?.setOwpenbotHealth(health);
-              if (health.ok) {
-                tui?.updateService("owpenbot", { status: "healthy" });
-              }
-            })
-            .catch(() => undefined);
-        }, 15_000);
-      }
-      owpenbotChild.on("exit", (code, signal) => {
-        if (owpenbotRequired) {
-          handleExit("owpenbot", code, signal);
-          return;
+      logger.info("Process spawned", { pid: openworkChild.pid ?? 0 }, "openwork-server");
+      openworkChild.on("exit", (code, signal) => handleExit("openwork-server", code, signal));
+      openworkChild.on("error", (error) => handleSpawnError("openwork-server", error));
+
+      logger.info("Waiting for health", { url: openworkBaseUrl }, "openwork-server");
+      await waitForHealthy(openworkBaseUrl);
+      logger.info("Healthy", { url: openworkBaseUrl }, "openwork-server");
+      tui?.updateService("openwork-server", { status: "healthy" });
+
+      openworkActualVersion = await verifyOpenworkServer({
+        baseUrl: openworkBaseUrl,
+        token: openworkToken,
+        hostToken: openworkHostToken,
+        expectedVersion: openworkServerBinary.expectedVersion,
+        expectedWorkspace: resolvedWorkspace,
+        expectedOpencodeBaseUrl: opencodeConnectUrl,
+        expectedOpencodeDirectory: resolvedWorkspace,
+        expectedOpencodeUsername: opencodeUsername,
+        expectedOpencodePassword: opencodePassword,
+      });
+      logVerbose(`openwork-server version: ${openworkActualVersion ?? "unknown"}`);
+    }
+
+    if (owpenbotEnabled) {
+      if (sandboxMode !== "none") {
+        // Owpenbot is started inside the sandbox container; just probe health.
+        owpenbotActualVersion = owpenbotBinary?.expectedVersion;
+        logVerbose(`owpenbot version: ${owpenbotActualVersion ?? "unknown"}`);
+        try {
+          logger.info("Waiting for health", { url: owpenbotHealthUrl }, "owpenbot");
+          const health = await waitForOwpenbotHealthy(owpenbotHealthUrl);
+          tui?.setOwpenbotHealth(health);
+          tui?.updateService("owpenbot", { status: health.ok ? "healthy" : "running" });
+          logger.info("Healthy", { url: owpenbotHealthUrl, ok: health.ok }, "owpenbot");
+        } catch (error) {
+          logger.warn("Owpenbot health check failed", { error: String(error) }, "owpenbot");
+          tui?.updateService("owpenbot", { status: "running", message: String(error) });
         }
-        const reason = code !== null ? `code ${code}` : signal ? `signal ${signal}` : "unknown";
-        tui?.updateService("owpenbot", { status: "stopped", message: reason });
-        logger.warn("Process exited, continuing without owpenbot", { reason, code, signal }, "owpenbot");
-      });
-      owpenbotChild.on("error", (error) => handleSpawnError("owpenbot", error));
+        if (!owpenbotHealthInterval) {
+          owpenbotHealthInterval = setInterval(() => {
+            fetchOwpenbotHealth(owpenbotHealthUrl)
+              .then((health) => {
+                tui?.setOwpenbotHealth(health);
+                if (health.ok) {
+                  tui?.updateService("owpenbot", { status: "healthy" });
+                }
+              })
+              .catch(() => undefined);
+          }, 15_000);
+        }
+      } else {
+        if (!owpenbotBinary) {
+          throw new Error("Owpenbot binary missing.");
+        }
+        owpenbotActualVersion = await verifyOwpenbotVersion(owpenbotBinary);
+        logVerbose(`owpenbot version: ${owpenbotActualVersion ?? "unknown"}`);
+        const owpenbotChild = await startOwpenbot({
+          bin: owpenbotBinary.bin,
+          workspace: resolvedWorkspace,
+          opencodeUrl: opencodeConnectUrl,
+          opencodeUsername,
+          opencodePassword,
+          owpenbotHealthPort,
+          logger,
+          runId,
+          logFormat,
+        });
+        children.push({ name: "owpenbot", child: owpenbotChild });
+        tui?.updateService("owpenbot", {
+          status: "running",
+          pid: owpenbotChild.pid ?? undefined,
+          port: owpenbotHealthPort,
+        });
+        logger.info("Process spawned", { pid: owpenbotChild.pid ?? 0 }, "owpenbot");
+        try {
+          logger.info("Waiting for health", { url: owpenbotHealthUrl }, "owpenbot");
+          const health = await waitForOwpenbotHealthy(owpenbotHealthUrl);
+          tui?.setOwpenbotHealth(health);
+          tui?.updateService("owpenbot", { status: health.ok ? "healthy" : "running" });
+          logger.info("Healthy", { url: owpenbotHealthUrl, ok: health.ok }, "owpenbot");
+        } catch (error) {
+          logger.warn("Owpenbot health check failed", { error: String(error) }, "owpenbot");
+          tui?.updateService("owpenbot", { status: "running", message: String(error) });
+        }
+        if (!owpenbotHealthInterval) {
+          owpenbotHealthInterval = setInterval(() => {
+            fetchOwpenbotHealth(owpenbotHealthUrl)
+              .then((health) => {
+                tui?.setOwpenbotHealth(health);
+                if (health.ok) {
+                  tui?.updateService("owpenbot", { status: "healthy" });
+                }
+              })
+              .catch(() => undefined);
+          }, 15_000);
+        }
+        owpenbotChild.on("exit", (code, signal) => {
+          if (owpenbotRequired) {
+            handleExit("owpenbot", code, signal);
+            return;
+          }
+          const reason = code !== null ? `code ${code}` : signal ? `signal ${signal}` : "unknown";
+          tui?.updateService("owpenbot", { status: "stopped", message: reason });
+          logger.warn("Process exited, continuing without owpenbot", { reason, code, signal }, "owpenbot");
+        });
+        owpenbotChild.on("error", (error) => handleSpawnError("owpenbot", error));
+      }
     }
 
     const payload = {
@@ -3396,8 +4493,8 @@ async function runStart(args: ParsedArgs) {
       opencode: {
         baseUrl: opencodeBaseUrl,
         connectUrl: opencodeConnectUrl,
-        username: opencodeUsername,
-        password: opencodePassword,
+        username: sandboxMode !== "none" ? undefined : opencodeUsername,
+        password: sandboxMode !== "none" ? undefined : opencodePassword,
         bindHost: opencodeBindHost,
         port: opencodePort,
         version: opencodeActualVersion,
@@ -3497,12 +4594,25 @@ async function runStart(args: ParsedArgs) {
 
     if (checkOnly) {
       try {
-        await runChecks({
-          opencodeClient,
-          openworkUrl: openworkBaseUrl,
-          openworkToken,
-          checkEvents,
-        });
+        if (sandboxMode !== "none") {
+          // In sandbox mode the released server binary may not support the
+          // Bearer-through-proxy auth that the OpenCode SDK client expects.
+          // Run a lighter set of checks: openwork-server endpoints + proxy
+          // health.  Full SDK checks (session create, SSE events) are deferred
+          // until the modified server binary is released.
+          await runSandboxChecks({
+            openworkUrl: openworkBaseUrl,
+            openworkToken,
+            hostToken: openworkHostToken,
+          });
+        } else {
+          await runChecks({
+            opencodeClient,
+            openworkUrl: openworkBaseUrl,
+            openworkToken,
+            checkEvents,
+          });
+        }
         logger.info("Checks ok", { checkEvents }, "openwrk");
         if (!outputJson && logFormat === "pretty") {
           console.log("Checks: ok");

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -60,11 +60,27 @@ Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CON
 - `OPENWORK_OPENCODE_USERNAME`
 - `OPENWORK_OPENCODE_PASSWORD`
 
-## Endpoints (initial)
+Token management (scoped tokens):
+
+- `OPENWORK_TOKEN_STORE` path to token store JSON (default: alongside `server.json`)
+
+File injection / artifacts:
+
+- `OPENWORK_INBOX_ENABLED` (`1` | `0`)
+- `OPENWORK_INBOX_MAX_BYTES` (default: 50MB, capped)
+- `OPENWORK_OUTBOX_ENABLED` (`1` | `0`)
+
+Sandbox advertisement (for capability discovery):
+
+- `OPENWORK_SANDBOX_ENABLED` (`1` | `0`)
+- `OPENWORK_SANDBOX_BACKEND` (`docker` | `container` | `none`)
+
+## Endpoints
 
 - `GET /health`
 - `GET /status`
 - `GET /capabilities`
+- `GET /whoami`
 - `GET /workspaces`
 - `GET /workspace/:id/config`
 - `PATCH /workspace/:id/config`
@@ -85,9 +101,39 @@ Defaults to `~/.config/openwork/server.json` (override with `OPENWORK_SERVER_CON
 - `GET /workspace/:id/export`
 - `POST /workspace/:id/import`
 
+Token management (host/owner auth):
+
+- `GET /tokens`
+- `POST /tokens` (body: `{ "scope": "owner"|"collaborator"|"viewer", "label"?: string }`)
+- `DELETE /tokens/:id`
+
+Inbox/outbox:
+
+- `POST /workspace/:id/inbox` (multipart upload into `.opencode/openwork/inbox/`)
+- `GET /workspace/:id/artifacts`
+- `GET /workspace/:id/artifacts/:artifactId`
+
+Toy UI (static assets served by the server):
+
+- `GET /ui`
+- `GET /w/:id/ui`
+- `GET /ui/assets/*`
+
+OpenCode proxy:
+
+- `GET|POST|... /opencode/*`
+- `GET|POST|... /w/:id/opencode/*`
+
 ## Approvals
 
-All writes are gated by host approval. Host APIs require `X-OpenWork-Host-Token`:
+All writes are gated by host approval.
+
+Host APIs accept either:
+
+- `X-OpenWork-Host-Token: <token>` (legacy host token), or
+- `Authorization: Bearer <token>` where the token scope is `owner`.
+
+Approvals endpoints:
 
 - `GET /approvals`
 - `POST /approvals/:id` with `{ "reply": "allow" | "deny" }`

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,7 @@
-import { readFile, writeFile, rm, rename } from "node:fs/promises";
+import { readFile, writeFile, rm, readdir, rename, stat } from "node:fs/promises";
 import { homedir, hostname } from "node:os";
-import { dirname, join, resolve, sep } from "node:path";
-import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger } from "./types.js";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger, TokenScope } from "./types.js";
 import { ApprovalService } from "./approvals.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { addMcp, listMcp, removeMcp } from "./mcp.js";
@@ -16,6 +16,8 @@ import { parseFrontmatter } from "./frontmatter.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { sanitizeCommandName } from "./validators.js";
+import { TokenService } from "./tokens.js";
+import { TOY_UI_CSS, TOY_UI_HTML, TOY_UI_JS, cssResponse, htmlResponse, jsResponse } from "./toy-ui.js";
 import pkg from "../package.json" with { type: "json" };
 
 const SERVER_VERSION = pkg.version;
@@ -136,13 +138,15 @@ interface RequestContext {
   config: ServerConfig;
   approvals: ApprovalService;
   reloadEvents: ReloadEventStore;
+  tokens: TokenService;
   actor?: Actor;
 }
 
 export function startServer(config: ServerConfig) {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
-  const routes = createRoutes(config, approvals);
+  const tokens = new TokenService(config);
+  const routes = createRoutes(config, approvals, tokens);
   const logger = createServerLogger(config);
 
   const serverOptions: {
@@ -183,7 +187,11 @@ export function startServer(config: ServerConfig) {
       if (mount && (mount.restPath === "/opencode" || mount.restPath.startsWith("/opencode/"))) {
         authMode = "client";
         try {
-          requireClient(request, config);
+          const actor = await requireClient(request, config, tokens);
+          const method = request.method.toUpperCase();
+          if (actor.scope === "viewer" && method !== "GET" && method !== "HEAD") {
+            throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
+          }
           const workspace = await resolveWorkspace(config, mount.workspaceId);
           proxyBaseUrl = workspace.baseUrl?.trim() || undefined;
           const response = await proxyOpencodeRequest({ request, url, workspace, proxyPath: mount.restPath });
@@ -218,7 +226,11 @@ export function startServer(config: ServerConfig) {
         authMode = "client";
         proxyBaseUrl = config.workspaces[0]?.baseUrl?.trim() || undefined;
         try {
-          requireClient(request, config);
+          const actor = await requireClient(request, config, tokens);
+          const method = request.method.toUpperCase();
+          if (actor.scope === "viewer" && method !== "GET" && method !== "HEAD") {
+            throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
+          }
           const response = await proxyOpencodeRequest({ request, url, workspace: config.workspaces[0] });
           return finalize(response);
         } catch (error) {
@@ -238,7 +250,11 @@ export function startServer(config: ServerConfig) {
 
       authMode = route.auth;
       try {
-        const actor = route.auth === "host" ? requireHost(request, config) : route.auth === "client" ? requireClient(request, config) : undefined;
+        const actor = route.auth === "host"
+          ? await requireHost(request, config, tokens)
+          : route.auth === "client"
+            ? await requireClient(request, config, tokens)
+            : undefined;
         const response = await route.handler({
           request,
           url,
@@ -246,6 +262,7 @@ export function startServer(config: ServerConfig) {
           config,
           approvals,
           reloadEvents,
+          tokens,
           actor,
         });
         return finalize(response);
@@ -381,34 +398,227 @@ function withCors(response: Response, request: Request, config: ServerConfig) {
   return new Response(response.body, { status: response.status, headers });
 }
 
-function requireClient(request: Request, config: ServerConfig): Actor {
+async function requireClient(request: Request, config: ServerConfig, tokens: TokenService): Promise<Actor> {
   const header = request.headers.get("authorization") ?? "";
   const match = header.match(/^Bearer\s+(.+)$/i);
   const token = match?.[1];
-  if (!token || token !== config.token) {
+  if (!token) {
+    throw new ApiError(401, "unauthorized", "Invalid bearer token");
+  }
+  const scope = await tokens.scopeForToken(token);
+  if (!scope) {
     throw new ApiError(401, "unauthorized", "Invalid bearer token");
   }
   const clientId = request.headers.get("x-openwork-client-id") ?? undefined;
-  return { type: "remote", clientId, tokenHash: hashToken(token) };
+  return { type: "remote", clientId, tokenHash: hashToken(token), scope };
 }
 
-function requireHost(request: Request, config: ServerConfig): Actor {
-  const token = request.headers.get("x-openwork-host-token");
-  if (!token || token !== config.hostToken) {
+async function requireHost(request: Request, config: ServerConfig, tokens: TokenService): Promise<Actor> {
+  const hostToken = request.headers.get("x-openwork-host-token");
+  if (hostToken && hostToken === config.hostToken) {
+    return { type: "host", tokenHash: hashToken(hostToken), scope: "owner" };
+  }
+
+  const header = request.headers.get("authorization") ?? "";
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  const bearer = match?.[1];
+  if (!bearer) {
     throw new ApiError(401, "unauthorized", "Invalid host token");
   }
-  return { type: "host", tokenHash: hashToken(token) };
+  const scope = await tokens.scopeForToken(bearer);
+  if (scope !== "owner") {
+    throw new ApiError(401, "unauthorized", "Invalid host token");
+  }
+  const clientId = request.headers.get("x-openwork-client-id") ?? undefined;
+  return { type: "remote", clientId, tokenHash: hashToken(bearer), scope };
 }
 
 function buildCapabilities(config: ServerConfig): Capabilities {
   const writeEnabled = !config.readOnly;
+  const schemaVersion = 1;
+  const sandboxBackend = resolveSandboxBackend();
+  const sandboxEnabled = resolveSandboxEnabled(sandboxBackend);
+  const inboxEnabled = resolveInboxEnabled();
+  const outboxEnabled = resolveOutboxEnabled();
+  const maxBytes = resolveInboxMaxBytes();
+  const toyUiEnabled = resolveToyUiEnabled();
+  const browserProvider = resolveBrowserProvider();
   return {
+    schemaVersion,
+    serverVersion: SERVER_VERSION,
     skills: { read: true, write: writeEnabled, source: "openwork" },
     plugins: { read: true, write: writeEnabled },
     mcp: { read: true, write: writeEnabled },
     commands: { read: true, write: writeEnabled },
     config: { read: true, write: writeEnabled },
+
+    approvals: { mode: config.approval.mode, timeoutMs: config.approval.timeoutMs },
+    sandbox: { enabled: sandboxEnabled, backend: sandboxBackend },
+    ui: { toy: toyUiEnabled },
+    tokens: { scoped: true, scopes: ["owner", "collaborator", "viewer"] },
+    toolProviders: {
+      browser: browserProvider,
+      files: {
+        injection: writeEnabled && inboxEnabled,
+        outbox: outboxEnabled,
+        inboxPath: ".opencode/openwork/inbox/",
+        outboxPath: ".opencode/openwork/outbox/",
+        maxBytes,
+      },
+    },
   };
+}
+
+function resolveSandboxBackend(): Capabilities["sandbox"]["backend"] {
+  const raw = (process.env.OPENWORK_SANDBOX_BACKEND ?? "").trim().toLowerCase();
+  if (raw === "docker") return "docker";
+  if (raw === "container") return "container";
+  return "none";
+}
+
+function resolveSandboxEnabled(backend: Capabilities["sandbox"]["backend"]): boolean {
+  const raw = (process.env.OPENWORK_SANDBOX_ENABLED ?? "").trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(raw)) return true;
+  if (["0", "false", "no", "off"].includes(raw)) return false;
+  return backend !== "none";
+}
+
+function resolveInboxEnabled(): boolean {
+  const raw = (process.env.OPENWORK_INBOX_ENABLED ?? "").trim().toLowerCase();
+  if (!raw) return true;
+  return ["1", "true", "yes", "on"].includes(raw);
+}
+
+function resolveOutboxEnabled(): boolean {
+  const raw = (process.env.OPENWORK_OUTBOX_ENABLED ?? "").trim().toLowerCase();
+  if (!raw) return true;
+  return ["1", "true", "yes", "on"].includes(raw);
+}
+
+function resolveInboxMaxBytes(): number {
+  const raw = (process.env.OPENWORK_INBOX_MAX_BYTES ?? "").trim();
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.min(Math.trunc(parsed), 250_000_000);
+  }
+  return 50_000_000;
+}
+
+function resolveToyUiEnabled(): boolean {
+  const raw = (process.env.OPENWORK_TOY_UI ?? "").trim().toLowerCase();
+  if (!raw) return true;
+  return ["1", "true", "yes", "on"].includes(raw);
+}
+
+function resolveBrowserProvider(): Capabilities["toolProviders"]["browser"] {
+  const raw = (process.env.OPENWORK_BROWSER_PROVIDER ?? "").trim().toLowerCase();
+  if (raw === "sandbox-headless") {
+    return { enabled: true, placement: "in-sandbox", mode: "headless" };
+  }
+  if (raw === "host-interactive") {
+    return { enabled: true, placement: "host-machine", mode: "interactive" };
+  }
+  if (raw === "client-interactive") {
+    return { enabled: true, placement: "client-machine", mode: "interactive" };
+  }
+  return { enabled: false, placement: "external", mode: "none" };
+}
+
+function resolveInboxDir(workspaceRoot: string): string {
+  return join(workspaceRoot, ".opencode", "openwork", "inbox");
+}
+
+function resolveOutboxDir(workspaceRoot: string): string {
+  return join(workspaceRoot, ".opencode", "openwork", "outbox");
+}
+
+function normalizeWorkspaceRelativePath(input: string, options: { allowSubdirs: boolean }): string {
+  const raw = String(input ?? "").trim();
+  if (!raw) {
+    throw new ApiError(400, "invalid_path", "Path is required");
+  }
+  if (raw.includes("\u0000")) {
+    throw new ApiError(400, "invalid_path", "Path contains null byte");
+  }
+
+  const normalized = raw.replace(/\\/g, "/").replace(/^\/+/, "");
+  const parts = normalized.split("/").filter(Boolean);
+  if (!parts.length) {
+    throw new ApiError(400, "invalid_path", "Path is required");
+  }
+  if (!options.allowSubdirs && parts.length > 1) {
+    throw new ApiError(400, "invalid_path", "Subdirectories are not allowed");
+  }
+  for (const part of parts) {
+    if (part === "." || part === "..") {
+      throw new ApiError(400, "invalid_path", "Path traversal is not allowed");
+    }
+  }
+  return parts.join("/");
+}
+
+function resolveSafeChildPath(root: string, child: string): string {
+  const rootResolved = resolve(root);
+  const candidate = resolve(rootResolved, child);
+  if (candidate === rootResolved) {
+    throw new ApiError(400, "invalid_path", "Path must point to a file");
+  }
+  if (!candidate.startsWith(rootResolved + sep)) {
+    throw new ApiError(400, "invalid_path", "Path traversal is not allowed");
+  }
+  return candidate;
+}
+
+function encodeArtifactId(path: string): string {
+  return Buffer.from(path, "utf8").toString("base64url");
+}
+
+function decodeArtifactId(id: string): string {
+  const raw = (id ?? "").trim();
+  if (!raw) {
+    throw new ApiError(400, "invalid_artifact", "Artifact id is required");
+  }
+  try {
+    const decoded = Buffer.from(raw, "base64url").toString("utf8");
+    return normalizeWorkspaceRelativePath(decoded, { allowSubdirs: true });
+  } catch {
+    throw new ApiError(400, "invalid_artifact", "Artifact id is invalid");
+  }
+}
+
+async function listArtifacts(outboxRoot: string): Promise<Array<{ id: string; path: string; size: number; updatedAt: number }>> {
+  const rootResolved = resolve(outboxRoot);
+  if (!(await exists(rootResolved))) return [];
+
+  const items: Array<{ id: string; path: string; size: number; updatedAt: number }> = [];
+  const walk = async (dir: string) => {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(abs);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const rel = normalizeWorkspaceRelativePath(relative(rootResolved, abs), { allowSubdirs: true });
+      const info = await stat(abs);
+      items.push({
+        id: encodeArtifactId(rel),
+        path: rel,
+        size: info.size,
+        updatedAt: info.mtimeMs,
+      });
+    }
+  };
+
+  try {
+    await walk(rootResolved);
+  } catch {
+    return [];
+  }
+
+  items.sort((a, b) => b.updatedAt - a.updatedAt);
+  return items;
 }
 
 function emitReloadEvent(
@@ -448,7 +658,7 @@ function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
   };
 }
 
-function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[] {
+function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: TokenService): Route[] {
   const routes: Route[] = [];
 
   addRoute(routes, "GET", "/health", "none", async () => {
@@ -457,6 +667,34 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "GET", "/w/:id/health", "none", async () => {
     return jsonResponse({ ok: true, version: SERVER_VERSION, uptimeMs: Date.now() - config.startedAt });
+  });
+
+  addRoute(routes, "GET", "/ui", "none", async () => {
+    if (!resolveToyUiEnabled()) {
+      throw new ApiError(404, "ui_disabled", "Toy UI is disabled");
+    }
+    return htmlResponse(TOY_UI_HTML);
+  });
+
+  addRoute(routes, "GET", "/w/:id/ui", "none", async () => {
+    if (!resolveToyUiEnabled()) {
+      throw new ApiError(404, "ui_disabled", "Toy UI is disabled");
+    }
+    return htmlResponse(TOY_UI_HTML);
+  });
+
+  addRoute(routes, "GET", "/ui/assets/toy.css", "none", async () => {
+    if (!resolveToyUiEnabled()) {
+      throw new ApiError(404, "ui_disabled", "Toy UI is disabled");
+    }
+    return cssResponse(TOY_UI_CSS);
+  });
+
+  addRoute(routes, "GET", "/ui/assets/toy.js", "none", async () => {
+    if (!resolveToyUiEnabled()) {
+      throw new ApiError(404, "ui_disabled", "Toy UI is disabled");
+    }
+    return jsResponse(TOY_UI_JS);
   });
 
   addRoute(routes, "GET", "/w/:id/status", "client", async (ctx) => {
@@ -518,6 +756,10 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     });
   });
 
+  addRoute(routes, "GET", "/whoami", "client", async (ctx) => {
+    return jsonResponse({ ok: true, actor: ctx.actor ?? null });
+  });
+
   addRoute(routes, "GET", "/capabilities", "client", async () => {
     return jsonResponse(buildCapabilities(config));
   });
@@ -526,6 +768,33 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     const active = config.workspaces[0] ?? null;
     const items = config.workspaces.map(serializeWorkspace);
     return jsonResponse({ items, activeId: active?.id ?? null });
+  });
+
+  addRoute(routes, "GET", "/tokens", "host", async () => {
+    const items = await tokens.list();
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "POST", "/tokens", "host", async (ctx) => {
+    ensureWritable(config);
+    const body = await readJsonBody(ctx.request);
+    const scopeRaw = typeof body.scope === "string" ? body.scope.trim() : "";
+    const scope = scopeRaw === "owner" || scopeRaw === "collaborator" || scopeRaw === "viewer" ? scopeRaw : null;
+    if (!scope) {
+      throw new ApiError(400, "invalid_scope", "Token scope must be owner, collaborator, or viewer");
+    }
+    const label = typeof body.label === "string" ? body.label.trim() : undefined;
+    const issued = await tokens.create(scope, { label });
+    return jsonResponse(issued, 201);
+  });
+
+  addRoute(routes, "DELETE", "/tokens/:id", "host", async (ctx) => {
+    ensureWritable(config);
+    const ok = await tokens.revoke(ctx.params.id);
+    if (!ok) {
+      throw new ApiError(404, "token_not_found", "Token not found");
+    }
+    return jsonResponse({ ok: true });
   });
 
   addRoute(routes, "POST", "/workspaces/:id/activate", "host", async (ctx) => {
@@ -565,6 +834,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "PATCH", "/workspace/:id/config", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const opencode = body.opencode as Record<string, unknown> | undefined;
@@ -607,6 +877,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "POST", "/workspace/:id/owpenbot/telegram-token", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const token = typeof body.token === "string" ? body.token.trim() : "";
@@ -652,6 +923,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "POST", "/workspace/:id/owpenbot/slack-tokens", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const botToken = typeof body.botToken === "string" ? body.botToken.trim() : "";
@@ -707,6 +979,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
   });
 
   addRoute(routes, "POST", "/workspace/:id/engine/reload", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     await requireApproval(ctx, {
       workspaceId: workspace.id,
@@ -727,6 +1000,95 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
     return jsonResponse({ ok: true, reloadedAt: Date.now() });
   });
 
+  addRoute(routes, "POST", "/workspace/:id/inbox", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    if (!resolveInboxEnabled()) {
+      throw new ApiError(404, "inbox_disabled", "Workspace inbox is disabled");
+    }
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+
+    const contentType = ctx.request.headers.get("content-type") ?? "";
+    if (!contentType.toLowerCase().includes("multipart/form-data")) {
+      throw new ApiError(400, "invalid_payload", "Expected multipart/form-data");
+    }
+    const form = await ctx.request.formData();
+    const file = form.get("file");
+    if (!(file instanceof File)) {
+      throw new ApiError(400, "file_required", "Form field 'file' is required");
+    }
+
+    const queryPath = (ctx.url.searchParams.get("path") ?? "").trim();
+    const formPath = typeof form.get("path") === "string" ? String(form.get("path") || "").trim() : "";
+    const requestedPath = queryPath || formPath || file.name;
+
+    const relativePath = normalizeWorkspaceRelativePath(requestedPath, { allowSubdirs: true });
+    const inboxRoot = resolveInboxDir(workspace.path);
+    const dest = resolveSafeChildPath(inboxRoot, relativePath);
+    const maxBytes = resolveInboxMaxBytes();
+    if (file.size > maxBytes) {
+      throw new ApiError(413, "file_too_large", "File exceeds upload limit", { maxBytes, size: file.size });
+    }
+
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "workspace.inbox.upload",
+      summary: `Upload ${relativePath} to inbox`,
+      paths: [dest],
+    });
+
+    await ensureDir(dirname(dest));
+    const bytes = Buffer.from(await file.arrayBuffer());
+    const tmp = `${dest}.tmp-${shortId()}`;
+    await writeFile(tmp, bytes);
+    await rename(tmp, dest);
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "workspace.inbox.upload",
+      target: dest,
+      summary: `Uploaded ${relativePath} to inbox`,
+      timestamp: Date.now(),
+    });
+
+    return jsonResponse({ ok: true, path: relativePath, bytes: file.size });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/artifacts", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    if (!resolveOutboxEnabled()) {
+      return jsonResponse({ items: [] });
+    }
+    const outboxRoot = resolveOutboxDir(workspace.path);
+    const items = await listArtifacts(outboxRoot);
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/artifacts/:artifactId", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    if (!resolveOutboxEnabled()) {
+      throw new ApiError(404, "outbox_disabled", "Workspace outbox is disabled");
+    }
+    const outboxRoot = resolveOutboxDir(workspace.path);
+    const relativePath = decodeArtifactId(ctx.params.artifactId);
+    const absPath = resolveSafeChildPath(outboxRoot, relativePath);
+    if (!(await exists(absPath))) {
+      throw new ApiError(404, "artifact_not_found", "Artifact not found");
+    }
+    const info = await stat(absPath);
+    if (!info.isFile()) {
+      throw new ApiError(404, "artifact_not_found", "Artifact not found");
+    }
+
+    const headers = new Headers();
+    headers.set("Content-Type", "application/octet-stream");
+    headers.set("Content-Length", String(info.size));
+    headers.set("Content-Disposition", `attachment; filename="${basename(relativePath)}"`);
+    return new Response(Bun.file(absPath), { status: 200, headers });
+  });
+
   addRoute(routes, "GET", "/workspace/:id/plugins", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const includeGlobal = ctx.url.searchParams.get("includeGlobal") === "true";
@@ -736,6 +1098,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "POST", "/workspace/:id/plugins", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const spec = String(body.spec ?? "");
@@ -769,6 +1132,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "DELETE", "/workspace/:id/plugins/:name", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = ctx.params.name ?? "";
     const normalized = normalizePluginSpec(name);
@@ -824,6 +1188,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "POST", "/workspace/:id/skills", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const name = String(body.name ?? "");
@@ -862,6 +1227,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "POST", "/workspace/:id/mcp", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const name = String(body.name ?? "");
@@ -896,6 +1262,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "DELETE", "/workspace/:id/mcp/:name", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = ctx.params.name ?? "";
     await requireApproval(ctx, {
@@ -928,7 +1295,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
   addRoute(routes, "GET", "/workspace/:id/commands", "client", async (ctx) => {
     const scope = ctx.url.searchParams.get("scope") === "global" ? "global" : "workspace";
     if (scope === "global") {
-      requireHost(ctx.request, config);
+      await requireHost(ctx.request, config, tokens);
     }
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const items = await listCommands(workspace.path, scope);
@@ -937,6 +1304,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "POST", "/workspace/:id/commands", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const name = String(body.name ?? "");
@@ -977,6 +1345,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "DELETE", "/workspace/:id/commands/:name", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = ctx.params.name ?? "";
     await requireApproval(ctx, {
@@ -1013,6 +1382,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "DELETE", "/workspace/:id/scheduler/jobs/:name", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const name = ctx.params.name ?? "";
     const { job, jobFile, systemPaths } = await resolveScheduledJob(name);
@@ -1043,6 +1413,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService): Route[]
 
   addRoute(routes, "POST", "/workspace/:id/import", "client", async (ctx) => {
     ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     await requireApproval(ctx, {
@@ -1108,6 +1479,22 @@ async function isAuthorizedRoot(workspacePath: string, roots: string[]): Promise
 function ensureWritable(config: ServerConfig): void {
   if (config.readOnly) {
     throw new ApiError(403, "read_only", "Server is read-only");
+  }
+}
+
+function scopeRank(scope: TokenScope): number {
+  if (scope === "viewer") return 1;
+  if (scope === "collaborator") return 2;
+  return 3;
+}
+
+function requireClientScope(ctx: RequestContext, required: TokenScope): void {
+  const scope = ctx.actor?.scope;
+  if (!scope) {
+    throw new ApiError(401, "unauthorized", "Missing token scope");
+  }
+  if (scopeRank(scope) < scopeRank(required)) {
+    throw new ApiError(403, "forbidden", "Insufficient token scope", { required, scope });
   }
 }
 

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -1,0 +1,142 @@
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+
+import type { ServerConfig, TokenScope } from "./types.js";
+import { ensureDir, exists, hashToken, shortId } from "./utils.js";
+
+export type TokenRecord = {
+  id: string;
+  hash: string;
+  scope: TokenScope;
+  createdAt: number;
+  label?: string;
+};
+
+type TokenStoreFile = {
+  schemaVersion: number;
+  updatedAt: number;
+  tokens: TokenRecord[];
+};
+
+function normalizeScope(value: unknown): TokenScope | null {
+  if (value === "owner" || value === "collaborator" || value === "viewer") return value;
+  return null;
+}
+
+function resolveTokenStorePath(config: ServerConfig): string {
+  const override = (process.env.OPENWORK_TOKEN_STORE ?? "").trim();
+  if (override) return resolve(override);
+
+  const configPath = config.configPath?.trim();
+  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "openwork");
+  return join(configDir, "tokens.json");
+}
+
+async function readTokenStore(path: string): Promise<TokenStoreFile> {
+  if (!(await exists(path))) {
+    return { schemaVersion: 1, updatedAt: Date.now(), tokens: [] };
+  }
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<TokenStoreFile>;
+    const tokens = Array.isArray(parsed.tokens)
+      ? parsed.tokens
+        .map((token) => {
+          const record = token as Partial<TokenRecord>;
+          const id = typeof record.id === "string" ? record.id : "";
+          const hash = typeof record.hash === "string" ? record.hash : "";
+          const scope = normalizeScope(record.scope);
+          const createdAt = typeof record.createdAt === "number" ? record.createdAt : Date.now();
+          const label = typeof record.label === "string" ? record.label : undefined;
+          if (!id || !hash || !scope) return null;
+          return { id, hash, scope, createdAt, label } satisfies TokenRecord;
+        })
+        .filter((token): token is TokenRecord => Boolean(token))
+      : [];
+    return {
+      schemaVersion: typeof parsed.schemaVersion === "number" ? parsed.schemaVersion : 1,
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+      tokens,
+    };
+  } catch {
+    return { schemaVersion: 1, updatedAt: Date.now(), tokens: [] };
+  }
+}
+
+async function writeTokenStore(path: string, tokens: TokenRecord[]): Promise<void> {
+  await ensureDir(dirname(path));
+  const payload: TokenStoreFile = {
+    schemaVersion: 1,
+    updatedAt: Date.now(),
+    tokens,
+  };
+  await writeFile(path, JSON.stringify(payload, null, 2) + "\n", "utf8");
+}
+
+export class TokenService {
+  private config: ServerConfig;
+  private path: string;
+  private loaded = false;
+  private tokens: TokenRecord[] = [];
+  private byHash = new Map<string, TokenRecord>();
+
+  constructor(config: ServerConfig) {
+    this.config = config;
+    this.path = resolveTokenStorePath(config);
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    const store = await readTokenStore(this.path);
+    this.tokens = store.tokens;
+    this.byHash = new Map(store.tokens.map((token) => [token.hash, token]));
+    this.loaded = true;
+  }
+
+  async list(): Promise<Array<Omit<TokenRecord, "hash">>> {
+    await this.ensureLoaded();
+    return this.tokens.map(({ hash: _hash, ...rest }) => rest);
+  }
+
+  async create(scope: TokenScope, options?: { label?: string }): Promise<{ id: string; token: string; scope: TokenScope; createdAt: number; label?: string }> {
+    await this.ensureLoaded();
+
+    const id = shortId();
+    const token = `owt_${shortId().replace(/-/g, "")}`;
+    const createdAt = Date.now();
+    const record: TokenRecord = {
+      id,
+      hash: hashToken(token),
+      scope,
+      createdAt,
+      label: options?.label?.trim() || undefined,
+    };
+
+    this.tokens = [record, ...this.tokens];
+    this.byHash.set(record.hash, record);
+    await writeTokenStore(this.path, this.tokens);
+    return { id, token, scope, createdAt, label: record.label };
+  }
+
+  async revoke(id: string): Promise<boolean> {
+    await this.ensureLoaded();
+    const index = this.tokens.findIndex((token) => token.id === id);
+    if (index === -1) return false;
+    const [removed] = this.tokens.splice(index, 1);
+    if (removed) {
+      this.byHash.delete(removed.hash);
+    }
+    await writeTokenStore(this.path, this.tokens);
+    return true;
+  }
+
+  async scopeForToken(token: string): Promise<TokenScope | null> {
+    const trimmed = token.trim();
+    if (!trimmed) return null;
+    if (trimmed === this.config.token) return "collaborator";
+    await this.ensureLoaded();
+    const found = this.byHash.get(hashToken(trimmed));
+    return found?.scope ?? null;
+  }
+}

--- a/packages/server/src/toy-ui.ts
+++ b/packages/server/src/toy-ui.ts
@@ -1,0 +1,930 @@
+export const TOY_UI_CSS = `:root {
+  --bg: #0b1020;
+  --panel: rgba(255, 255, 255, 0.06);
+  --panel-2: rgba(255, 255, 255, 0.04);
+  --text: rgba(255, 255, 255, 0.92);
+  --muted: rgba(255, 255, 255, 0.68);
+  --muted-2: rgba(255, 255, 255, 0.5);
+  --border: rgba(255, 255, 255, 0.12);
+  --accent: #53b8ff;
+  --danger: #ff5b5b;
+  --ok: #51d69c;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --sans: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  font-family: var(--sans);
+  background: radial-gradient(1200px 900px at 20% 10%, rgba(83, 184, 255, 0.14), transparent 60%),
+    radial-gradient(900px 700px at 80% 0%, rgba(81, 214, 156, 0.1), transparent 55%),
+    linear-gradient(180deg, #080b16, var(--bg));
+  color: var(--text);
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.wrap {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+}
+
+.top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title h1 {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: 0.2px;
+}
+
+.title .sub {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 14px;
+}
+
+@media (max-width: 940px) {
+  .grid { grid-template-columns: 1fr; }
+}
+
+.card {
+  background: linear-gradient(180deg, var(--panel), var(--panel-2));
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.card h2 {
+  margin: 0;
+  padding: 12px 14px;
+  font-size: 13px;
+  letter-spacing: 0.2px;
+  color: rgba(255, 255, 255, 0.88);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.card .body {
+  padding: 12px 14px;
+}
+
+.row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.pill {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.pill.ok { border-color: rgba(81, 214, 156, 0.45); color: rgba(81, 214, 156, 0.95); }
+.pill.bad { border-color: rgba(255, 91, 91, 0.45); color: rgba(255, 91, 91, 0.92); }
+
+.muted { color: var(--muted); }
+.mono { font-family: var(--mono); }
+
+.chat {
+  height: 56vh;
+  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+}
+
+.chatlog {
+  flex: 1;
+  overflow: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.msg {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 10px;
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.msg .meta {
+  font-size: 11px;
+  color: var(--muted-2);
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.msg .content {
+  white-space: pre-wrap;
+  line-height: 1.35;
+  font-size: 13px;
+}
+
+.composer {
+  border-top: 1px solid var(--border);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.composer textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 80px;
+  max-height: 220px;
+  padding: 10px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--text);
+  outline: none;
+  font-family: var(--sans);
+  font-size: 13px;
+}
+
+.composer textarea:focus { border-color: rgba(83, 184, 255, 0.45); }
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 9px 10px;
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--text);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.btn:hover { border-color: rgba(83, 184, 255, 0.4); }
+.btn.primary { border-color: rgba(83, 184, 255, 0.6); background: rgba(83, 184, 255, 0.12); }
+.btn.danger { border-color: rgba(255, 91, 91, 0.6); background: rgba(255, 91, 91, 0.08); }
+
+.kv {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 8px 10px;
+  font-size: 12px;
+}
+
+.kv .k { color: var(--muted-2); }
+
+.codebox {
+  margin-top: 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.18);
+  font-family: var(--mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+  line-height: 1.3;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.14);
+}
+
+.item .row { justify-content: space-between; }
+
+.small { font-size: 11px; color: var(--muted-2); }
+
+.hr { height: 1px; background: var(--border); margin: 10px 0; }
+`;
+
+export const TOY_UI_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenWork Toy UI</title>
+    <link rel="stylesheet" href="/ui/assets/toy.css" />
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="top">
+        <div class="title">
+          <h1>OpenWork Toy UI</h1>
+          <div class="sub">Local-first host contract harness (served by openwork-server)</div>
+        </div>
+        <div class="row">
+          <span class="pill" id="pill-conn">disconnected</span>
+          <span class="pill" id="pill-scope">scope: unknown</span>
+        </div>
+      </div>
+
+      <div class="grid">
+        <div class="card chat">
+          <h2>
+            <span>Session</span>
+            <span class="small mono" id="session-id">session: -</span>
+          </h2>
+          <div class="chatlog" id="chatlog"></div>
+          <div class="composer">
+            <div class="row">
+              <button class="btn" id="btn-new">New session</button>
+              <button class="btn" id="btn-refresh">Refresh messages</button>
+              <span class="small" id="hint">Tip: open this page as /w/&lt;id&gt;/ui#token=&lt;token&gt;</span>
+            </div>
+            <textarea id="prompt" placeholder="Write a prompt..." spellcheck="false"></textarea>
+            <div class="row">
+              <button class="btn primary" id="btn-send">Send prompt</button>
+              <button class="btn" id="btn-events">Connect SSE</button>
+              <button class="btn" id="btn-events-stop">Stop SSE</button>
+              <span class="small" id="status"></span>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2><span>Host</span><span class="small mono" id="host-id">-</span></h2>
+          <div class="body">
+            <div class="kv">
+              <div class="k">workspace</div>
+              <div class="mono" id="workspace-id">-</div>
+              <div class="k">server</div>
+              <div class="mono" id="server-version">-</div>
+              <div class="k">sandbox</div>
+              <div class="mono" id="sandbox">-</div>
+              <div class="k">file injection</div>
+              <div class="mono" id="file-injection">-</div>
+            </div>
+
+            <div class="hr"></div>
+
+            <div class="row">
+              <input id="file" type="file" />
+              <button class="btn" id="btn-upload">Upload to inbox</button>
+            </div>
+            <div class="small">Uploads go to <span class="mono">.opencode/openwork/inbox/</span> inside the workspace.</div>
+
+            <div class="hr"></div>
+
+            <div class="row">
+              <button class="btn" id="btn-artifacts">List artifacts</button>
+              <span class="small">Downloads read from <span class="mono">.opencode/openwork/outbox/</span>.</span>
+            </div>
+            <div class="list" id="artifacts"></div>
+
+            <div class="hr"></div>
+
+            <div class="row">
+              <button class="btn" id="btn-approvals">Refresh approvals</button>
+              <span class="small">(Owner or host token required)</span>
+            </div>
+            <div class="list" id="approvals"></div>
+
+            <div class="hr"></div>
+
+            <div class="row">
+              <button class="btn" id="btn-share">Show connect artifact</button>
+              <button class="btn" id="btn-copy">Copy JSON</button>
+            </div>
+            <div class="codebox" id="connect"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/ui/assets/toy.js"></script>
+  </body>
+</html>
+`;
+
+export const TOY_UI_JS = String.raw`const qs = (sel) => document.querySelector(sel);
+
+const pillConn = qs("#pill-conn");
+const pillScope = qs("#pill-scope");
+const chatlog = qs("#chatlog");
+const promptEl = qs("#prompt");
+const statusEl = qs("#status");
+const sessionIdEl = qs("#session-id");
+const workspaceIdEl = qs("#workspace-id");
+const serverVersionEl = qs("#server-version");
+const sandboxEl = qs("#sandbox");
+const fileInjectionEl = qs("#file-injection");
+const artifactsEl = qs("#artifacts");
+const approvalsEl = qs("#approvals");
+const connectEl = qs("#connect");
+const hostIdEl = qs("#host-id");
+
+const STORAGE_TOKEN = "openwork.toy.token";
+const STORAGE_SESSION_PREFIX = "openwork.toy.session.";
+
+function setPill(el, label, kind) {
+  el.textContent = label;
+  el.classList.remove("ok", "bad");
+  if (kind) el.classList.add(kind);
+}
+
+function getTokenFromHash() {
+  const raw = (location.hash || "").startsWith("#") ? (location.hash || "").slice(1) : (location.hash || "");
+  if (!raw) return "";
+  const params = new URLSearchParams(raw);
+  return (params.get("token") || "").trim();
+}
+
+function stripHashToken() {
+  const raw = (location.hash || "").startsWith("#") ? (location.hash || "").slice(1) : (location.hash || "");
+  if (!raw) return;
+  const params = new URLSearchParams(raw);
+  if (!params.has("token")) return;
+  params.delete("token");
+  const next = params.toString();
+  const url = location.pathname + location.search + (next ? "#" + next : "");
+  history.replaceState(null, "", url);
+}
+
+function readToken() {
+  const fromHash = getTokenFromHash();
+  if (fromHash) {
+    try { localStorage.setItem(STORAGE_TOKEN, fromHash); } catch {}
+    stripHashToken();
+    return fromHash;
+  }
+  try {
+    return (localStorage.getItem(STORAGE_TOKEN) || "").trim();
+  } catch {
+    return "";
+  }
+}
+
+function parseWorkspaceIdFromPath() {
+  const parts = location.pathname.split("/").filter(Boolean);
+  const wIndex = parts.indexOf("w");
+  if (wIndex !== -1 && parts[wIndex + 1]) return decodeURIComponent(parts[wIndex + 1]);
+  return "";
+}
+
+async function apiFetch(path, options) {
+  const token = readToken();
+  const opts = options || {};
+  const headers = new Headers(opts.headers || {});
+  if (!headers.has("Content-Type") && opts.body && !(opts.body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (token) headers.set("Authorization", "Bearer " + token);
+  const res = await fetch(path, { ...opts, headers });
+  const text = await res.text();
+  let json = null;
+  try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  if (!res.ok) {
+    const msg = json && json.message ? json.message : (text || res.statusText);
+    const code = json && json.code ? json.code : "request_failed";
+    const err = new Error(code + ": " + msg);
+    err.status = res.status;
+    err.code = code;
+    err.details = json && json.details ? json.details : undefined;
+    throw err;
+  }
+  return json;
+}
+
+function setStatus(msg, kind) {
+  statusEl.textContent = msg || "";
+  statusEl.style.color = kind === "bad" ? "var(--danger)" : kind === "ok" ? "var(--ok)" : "var(--muted)";
+}
+
+function appendMsg(role, text) {
+  const el = document.createElement("div");
+  el.className = "msg";
+  const meta = document.createElement("div");
+  meta.className = "meta";
+  meta.textContent = role;
+  const content = document.createElement("div");
+  content.className = "content";
+  content.textContent = text;
+  el.appendChild(meta);
+  el.appendChild(content);
+  chatlog.appendChild(el);
+  chatlog.scrollTop = chatlog.scrollHeight;
+}
+
+function renderMessages(items) {
+  chatlog.innerHTML = "";
+  if (!Array.isArray(items) || !items.length) {
+    appendMsg("system", "No messages yet.");
+    return;
+  }
+  for (const msg of items) {
+    const info = msg && msg.info ? msg.info : null;
+    const parts = Array.isArray(msg && msg.parts) ? msg.parts : [];
+    const role = info && info.role ? info.role : "message";
+    const textParts = parts
+      .filter((p) => p && p.type === "text" && typeof p.text === "string")
+      .map((p) => p.text);
+    const body = textParts.length ? textParts.join("\n") : JSON.stringify(parts, null, 2);
+    appendMsg(role, body);
+  }
+}
+
+function sessionKey(workspaceId) {
+  return STORAGE_SESSION_PREFIX + workspaceId;
+}
+
+function readSessionId(workspaceId) {
+  try { return (localStorage.getItem(sessionKey(workspaceId)) || "").trim(); } catch { return ""; }
+}
+
+function writeSessionId(workspaceId, sessionId) {
+  try { localStorage.setItem(sessionKey(workspaceId), sessionId); } catch {}
+}
+
+async function resolveDefaultModel(workspaceId) {
+  try {
+    const providers = await apiFetch("/w/" + encodeURIComponent(workspaceId) + "/opencode/config/providers");
+    const def = providers && providers.default ? providers.default : null;
+    if (def && typeof def === "object") {
+      const entries = Object.entries(def);
+      if (entries.length) {
+        const providerID = entries[0][0];
+        const modelID = entries[0][1];
+        if (providerID && modelID) return { providerID, modelID };
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+async function ensureSession(workspaceId) {
+  const existing = readSessionId(workspaceId);
+  if (existing) return existing;
+  const created = await apiFetch("/w/" + encodeURIComponent(workspaceId) + "/opencode/session", {
+    method: "POST",
+    body: JSON.stringify({ title: "OpenWork Toy UI" }),
+  });
+  const id = created && created.id ? String(created.id) : "";
+  if (!id) throw new Error("session_create_failed");
+  writeSessionId(workspaceId, id);
+  return id;
+}
+
+async function refreshHost(workspaceId) {
+  const token = readToken();
+  if (!token) {
+    setPill(pillConn, "token missing", "bad");
+    setStatus("Add #token=... to the URL fragment", "bad");
+    return;
+  }
+  try {
+    const status = await apiFetch("/status");
+    const caps = await apiFetch("/capabilities");
+    hostIdEl.textContent = location.origin;
+    serverVersionEl.textContent = caps && caps.serverVersion ? caps.serverVersion : (status && status.version ? status.version : "-");
+    const sandbox = caps && caps.sandbox ? caps.sandbox : null;
+    sandboxEl.textContent = sandbox ? (sandbox.backend + " (" + (sandbox.enabled ? "on" : "off") + ")") : "-";
+    const files = caps && caps.toolProviders && caps.toolProviders.files ? caps.toolProviders.files : null;
+    fileInjectionEl.textContent = files ? ((files.injection ? "upload" : "no upload") + " / " + (files.outbox ? "download" : "no download")) : "-";
+    workspaceIdEl.textContent = workspaceId || "-";
+    setPill(pillConn, "connected", "ok");
+    setStatus("Connected", "ok");
+
+    try {
+      const me = await apiFetch("/whoami");
+      const scope = me && me.actor && me.actor.scope ? me.actor.scope : "unknown";
+      pillScope.textContent = "scope: " + scope;
+    } catch {
+      pillScope.textContent = "scope: unknown";
+    }
+  } catch (e) {
+    setPill(pillConn, "disconnected", "bad");
+    setStatus(e && e.message ? e.message : "Disconnected", "bad");
+  }
+}
+
+async function refreshMessages(workspaceId) {
+  const sessionId = readSessionId(workspaceId);
+  sessionIdEl.textContent = sessionId ? ("session: " + sessionId) : "session: -";
+  if (!sessionId) {
+    renderMessages([]);
+    return;
+  }
+  const url = "/w/" + encodeURIComponent(workspaceId) + "/opencode/session/" + encodeURIComponent(sessionId) + "/message?limit=50";
+  const msgs = await apiFetch(url);
+  renderMessages(msgs);
+}
+
+async function listArtifacts(workspaceId) {
+  const data = await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/artifacts");
+  const items = Array.isArray(data && data.items) ? data.items : [];
+  artifactsEl.innerHTML = "";
+
+  if (!items.length) {
+    const empty = document.createElement("div");
+    empty.className = "item";
+    empty.textContent = "No artifacts found.";
+    artifactsEl.appendChild(empty);
+    return;
+  }
+
+  for (const item of items) {
+    const row = document.createElement("div");
+    row.className = "item";
+
+    const top = document.createElement("div");
+    top.className = "row";
+
+    const left = document.createElement("div");
+    const name = document.createElement("div");
+    name.className = "mono";
+    name.textContent = item.path;
+    const meta = document.createElement("div");
+    meta.className = "small";
+    meta.textContent = String(item.size) + " bytes";
+    left.appendChild(name);
+    left.appendChild(meta);
+
+    const btn = document.createElement("button");
+    btn.className = "btn";
+    btn.textContent = "Download";
+    btn.onclick = async () => {
+      try {
+        const res = await fetch(
+          "/workspace/" + encodeURIComponent(workspaceId) + "/artifacts/" + encodeURIComponent(item.id),
+          { headers: { Authorization: "Bearer " + readToken() } },
+        );
+        if (!res.ok) throw new Error("download_failed: " + res.status);
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        const parts = String(item.path || "artifact").split("/");
+        a.download = parts.length ? parts[parts.length - 1] : "artifact";
+        a.click();
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+      } catch (e) {
+        setStatus(e && e.message ? e.message : "Download failed", "bad");
+      }
+    };
+
+    top.appendChild(left);
+    top.appendChild(btn);
+    row.appendChild(top);
+    artifactsEl.appendChild(row);
+  }
+}
+
+async function refreshApprovals() {
+  approvalsEl.innerHTML = "";
+  try {
+    const data = await apiFetch("/approvals");
+    const items = Array.isArray(data && data.items) ? data.items : [];
+    if (!items.length) {
+      const empty = document.createElement("div");
+      empty.className = "item";
+      empty.textContent = "No pending approvals.";
+      approvalsEl.appendChild(empty);
+      return;
+    }
+
+    for (const item of items) {
+      const row = document.createElement("div");
+      row.className = "item";
+
+      const top = document.createElement("div");
+      top.className = "row";
+
+      const left = document.createElement("div");
+      const action = document.createElement("div");
+      action.className = "mono";
+      action.textContent = item.action;
+      const summary = document.createElement("div");
+      summary.className = "small";
+      summary.textContent = item.summary;
+      left.appendChild(action);
+      left.appendChild(summary);
+
+      const buttons = document.createElement("div");
+      buttons.className = "row";
+
+      const allow = document.createElement("button");
+      allow.className = "btn primary";
+      allow.textContent = "Allow";
+
+      const deny = document.createElement("button");
+      deny.className = "btn danger";
+      deny.textContent = "Deny";
+
+      allow.onclick = async () => {
+        await apiFetch("/approvals/" + encodeURIComponent(item.id), {
+          method: "POST",
+          body: JSON.stringify({ reply: "allow" }),
+        });
+        await refreshApprovals();
+      };
+
+      deny.onclick = async () => {
+        await apiFetch("/approvals/" + encodeURIComponent(item.id), {
+          method: "POST",
+          body: JSON.stringify({ reply: "deny" }),
+        });
+        await refreshApprovals();
+      };
+
+      buttons.appendChild(allow);
+      buttons.appendChild(deny);
+
+      top.appendChild(left);
+      top.appendChild(buttons);
+      row.appendChild(top);
+      approvalsEl.appendChild(row);
+    }
+  } catch (e) {
+    const warn = document.createElement("div");
+    warn.className = "item";
+    warn.textContent = e && e.message ? e.message : "Approvals unavailable";
+    approvalsEl.appendChild(warn);
+  }
+}
+
+let eventsAbort = null;
+
+async function connectSse(workspaceId) {
+  if (eventsAbort) return;
+  const controller = new AbortController();
+  eventsAbort = controller;
+  setStatus("Connecting SSE...", "");
+
+  const url = "/w/" + encodeURIComponent(workspaceId) + "/opencode/event";
+  const res = await fetch(url, {
+    headers: { Authorization: "Bearer " + readToken() },
+    signal: controller.signal,
+  });
+
+  if (!res.ok || !res.body) {
+    eventsAbort = null;
+    throw new Error("sse_failed: " + res.status);
+  }
+
+  setStatus("SSE connected", "ok");
+  const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+  let buffer = "";
+
+  const pump = async () => {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      buffer += next.value;
+      buffer = buffer.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+      const chunks = buffer.split("\n\n");
+      buffer = chunks.pop() || "";
+      for (const chunk of chunks) {
+        const lines = chunk.split("\n");
+        const dataLines = [];
+        for (const line of lines) {
+          if (line.startsWith("data:")) {
+            const rest = line.slice(5);
+            dataLines.push(rest.startsWith(" ") ? rest.slice(1) : rest);
+          }
+        }
+        if (!dataLines.length) continue;
+        const raw = dataLines.join("\n");
+        try {
+          const event = JSON.parse(raw);
+          const payload = event && event.payload ? event.payload : event;
+          if (payload && payload.type === "message.part.updated") {
+            void refreshMessages(workspaceId);
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
+  };
+
+  pump()
+    .catch(() => undefined)
+    .finally(() => {
+      eventsAbort = null;
+      try { reader.releaseLock(); } catch {}
+      setStatus("SSE disconnected", "");
+    });
+}
+
+function stopSse() {
+  if (!eventsAbort) return;
+  eventsAbort.abort();
+  eventsAbort = null;
+}
+
+async function showConnectArtifact(workspaceId) {
+  const token = readToken();
+  let scope = "collaborator";
+  try {
+    const me = await apiFetch("/whoami");
+    const s = me && me.actor && me.actor.scope ? me.actor.scope : "";
+    if (s) scope = s;
+  } catch {
+    // ignore
+  }
+
+  const hostUrl = location.origin;
+  const workspaceUrl = hostUrl + "/w/" + encodeURIComponent(workspaceId);
+  const payload = {
+    kind: "openwork.connect.v1",
+    hostUrl: hostUrl,
+    workspaceId: workspaceId,
+    workspaceUrl: workspaceUrl,
+    token: token,
+    tokenScope: scope,
+    createdAt: Date.now(),
+  };
+  connectEl.textContent = JSON.stringify(payload, null, 2);
+}
+
+async function copyConnectArtifact() {
+  const text = connectEl.textContent || "";
+  if (!text.trim()) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    setStatus("Copied", "ok");
+  } catch {
+    setStatus("Clipboard unavailable", "bad");
+  }
+}
+
+async function main() {
+  const workspaceId = parseWorkspaceIdFromPath();
+  if (!workspaceId) {
+    const token = readToken();
+    if (!token) {
+      appendMsg("system", "Open this as /ui#token=<token> or /w/<workspaceId>/ui#token=<token>");
+      return;
+    }
+    try {
+      const workspaces = await apiFetch("/workspaces");
+      const active = (workspaces && workspaces.activeId) || (workspaces && workspaces.items && workspaces.items[0] && workspaces.items[0].id) || "";
+      if (active) {
+        location.href = "/w/" + encodeURIComponent(active) + "/ui";
+        return;
+      }
+    } catch {
+      // ignore
+    }
+    appendMsg("system", "No workspace configured.");
+    return;
+  }
+
+  await refreshHost(workspaceId);
+  sessionIdEl.textContent = readSessionId(workspaceId) ? ("session: " + readSessionId(workspaceId)) : "session: -";
+  await refreshMessages(workspaceId).catch(() => undefined);
+
+  qs("#btn-new").onclick = async () => {
+    try {
+      writeSessionId(workspaceId, "");
+      const id = await ensureSession(workspaceId);
+      sessionIdEl.textContent = "session: " + id;
+      await refreshMessages(workspaceId);
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "Failed to create session", "bad");
+    }
+  };
+
+  qs("#btn-refresh").onclick = async () => {
+    await refreshMessages(workspaceId).catch((e) => setStatus(e && e.message ? e.message : "refresh failed", "bad"));
+  };
+
+  qs("#btn-send").onclick = async () => {
+    const text = (promptEl.value || "").trim();
+    if (!text) return;
+    appendMsg("user", text);
+    promptEl.value = "";
+    try {
+      const sessionId = await ensureSession(workspaceId);
+      sessionIdEl.textContent = "session: " + sessionId;
+      const model = await resolveDefaultModel(workspaceId);
+      const body = { parts: [{ type: "text", text: text }] };
+      if (model) body.model = model;
+      await apiFetch(
+        "/w/" + encodeURIComponent(workspaceId) + "/opencode/session/" + encodeURIComponent(sessionId) + "/prompt_async",
+        { method: "POST", body: JSON.stringify(body) },
+      );
+      setStatus("Prompt accepted", "ok");
+      await refreshMessages(workspaceId).catch(() => undefined);
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "Prompt failed", "bad");
+    }
+  };
+
+  qs("#btn-events").onclick = async () => {
+    try {
+      await connectSse(workspaceId);
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "SSE failed", "bad");
+    }
+  };
+
+  qs("#btn-events-stop").onclick = () => stopSse();
+
+  qs("#btn-upload").onclick = async () => {
+    const input = qs("#file");
+    const file = input && input.files && input.files[0] ? input.files[0] : null;
+    if (!file) {
+      setStatus("Pick a file first", "bad");
+      return;
+    }
+    try {
+      const form = new FormData();
+      form.set("file", file);
+      await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/inbox", { method: "POST", body: form });
+      setStatus("Uploaded", "ok");
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "Upload failed", "bad");
+    }
+  };
+
+  qs("#btn-artifacts").onclick = async () => {
+    await listArtifacts(workspaceId).catch((e) => setStatus(e && e.message ? e.message : "artifacts failed", "bad"));
+  };
+
+  qs("#btn-approvals").onclick = async () => {
+    await refreshApprovals().catch(() => undefined);
+  };
+
+  qs("#btn-share").onclick = async () => {
+    await showConnectArtifact(workspaceId).catch(() => undefined);
+  };
+
+  qs("#btn-copy").onclick = async () => {
+    await copyConnectArtifact();
+  };
+}
+
+main().catch((e) => {
+  setStatus(e && e.message ? e.message : "Startup failed", "bad");
+});
+`;
+
+export function htmlResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export function cssResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/css; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export function jsResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/javascript; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -2,6 +2,12 @@ export type WorkspaceType = "local" | "remote";
 
 export type ApprovalMode = "manual" | "auto";
 
+export type TokenScope = "owner" | "collaborator" | "viewer";
+
+export type SandboxBackend = "none" | "docker" | "container";
+
+export type ProviderPlacement = "in-sandbox" | "host-machine" | "client-machine" | "external";
+
 export type LogFormat = "pretty" | "json";
 
 export interface WorkspaceConfig {
@@ -55,11 +61,32 @@ export interface ServerConfig {
 }
 
 export interface Capabilities {
+  schemaVersion: number;
+  serverVersion: string;
   skills: { read: boolean; write: boolean; source: "openwork" | "opencode" };
   plugins: { read: boolean; write: boolean };
   mcp: { read: boolean; write: boolean };
   commands: { read: boolean; write: boolean };
   config: { read: boolean; write: boolean };
+
+  approvals: { mode: ApprovalMode; timeoutMs: number };
+  sandbox: { enabled: boolean; backend: SandboxBackend };
+  ui: { toy: boolean };
+  tokens: { scoped: boolean; scopes: TokenScope[] };
+  toolProviders: {
+    browser: {
+      enabled: boolean;
+      placement: ProviderPlacement;
+      mode: "none" | "headless" | "interactive";
+    };
+    files: {
+      injection: boolean;
+      outbox: boolean;
+      inboxPath: string;
+      outboxPath: string;
+      maxBytes: number;
+    };
+  };
 }
 
 export type ReloadReason = "plugins" | "skills" | "mcp" | "config" | "agents" | "commands";
@@ -122,6 +149,7 @@ export interface Actor {
   type: "remote" | "host";
   clientId?: string;
   tokenHash?: string;
+  scope?: TokenScope;
 }
 
 export interface ApprovalRequest {

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:22-bookworm-slim
+
+ARG OPENWRK_VERSION=0.11.22
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    tar \
+    unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g "openwrk@${OPENWRK_VERSION}"
+
+# Persistent directories (mount volumes here on PaaS/SSH).
+ENV OPENWRK_DATA_DIR=/data/openwrk
+ENV OPENWRK_SIDECAR_DIR=/data/sidecars
+
+# The workspace is mounted from the host/volume.
+ENV OPENWORK_WORKSPACE=/workspace
+
+# OpenWork host contract surface.
+EXPOSE 8787
+
+# Optional: owpenbot health (only relevant if you enable owpenbot).
+EXPOSE 3005
+
+VOLUME ["/workspace", "/data"]
+
+# Defaults:
+# - OpenWork server is public (0.0.0.0:8787)
+# - OpenCode stays internal (127.0.0.1:4096)
+# - OpenWork server proxies OpenCode via localhost
+# - Owpenbot disabled by default
+CMD [
+  "openwrk",
+  "serve",
+  "--workspace", "/workspace",
+  "--openwork-host", "0.0.0.0",
+  "--openwork-port", "8787",
+  "--opencode-host", "127.0.0.1",
+  "--opencode-port", "4096",
+  "--connect-host", "127.0.0.1",
+  "--cors", "*",
+  "--approval", "manual",
+  "--no-owpenbot"
+]

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -1,0 +1,42 @@
+# OpenWork Host (Docker)
+
+This is a minimal packaging template to run the OpenWork Host contract in a single container.
+
+It runs:
+
+- `opencode serve` (engine) bound to `127.0.0.1:4096` inside the container
+- `openwork-server` bound to `0.0.0.0:8787` (the only published surface)
+
+## Local run (compose)
+
+From this directory:
+
+```bash
+docker compose up --build
+```
+
+Then open:
+
+- `http://127.0.0.1:8787/ui`
+
+## Config
+
+Recommended env vars:
+
+- `OPENWORK_TOKEN` (client token)
+- `OPENWORK_HOST_TOKEN` (host/owner token)
+
+Optional:
+
+- `OPENWORK_APPROVAL_MODE=auto|manual`
+- `OPENWORK_APPROVAL_TIMEOUT_MS=30000`
+
+Persistence:
+
+- Workspace is mounted at `/workspace`
+- Host data dir is mounted at `/data` (OpenCode caches + OpenWork server config/tokens)
+
+## Notes
+
+- OpenCode is not exposed directly; access it via the OpenWork proxy (`/opencode/*`).
+- For PaaS, replace `./workspace:/workspace` with a volume or a checkout strategy (git clone on boot).

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  openwork-host:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Keep this in sync with packages/headless/package.json if you want a pinned release.
+        OPENWRK_VERSION: 0.11.22
+    ports:
+      - "8787:8787"
+    environment:
+      # Set these explicitly for stable sharing.
+      # OPENWORK_TOKEN: "..."
+      # OPENWORK_HOST_TOKEN: "..."
+      # Optional: OPENWORK_APPROVAL_MODE: "auto"
+      # Optional: OPENWORK_APPROVAL_TIMEOUT_MS: "30000"
+      OPENWRK_DATA_DIR: /data/openwrk
+      OPENWRK_SIDECAR_DIR: /data/sidecars
+    volumes:
+      # Mount an existing project/workspace here.
+      - ./workspace:/workspace
+      # Persistent host data (OpenCode caches, server config, tokens).
+      - ./data:/data


### PR DESCRIPTION
## What
Adds a minimal containerization/sandbox runtime for `openwrk`, plus server-side contract hardening so OpenWork can be driven remotely in a more structured way.

Key pieces:
- `openwrk` sandbox mode: `--sandbox none|auto|docker|container` with mount validation + sidecar staging + generated entrypoint.
- Docker backend (tested) and Apple `container` backend (implemented).
- OpenWork server: scoped token store + `/tokens` CRUD, `/whoami`, inbox/outbox artifact endpoints.
- Toy UI at `/ui` for quick manual validation (prompt send + SSE + inbox/outbox).
- PaaS packaging under `packaging/docker/` (Dockerfile + docker-compose).

## Why
To support "minimal containerization" workflows where:
- the host runs `openwrk` but OpenCode + openwork-server execute inside a sandboxed container
- OpenCode is not exposed directly; it is reached via openwork-server proxy (`/opencode/*`)
- mounts are explicitly validated/allowlisted for safety.

## How to Test
### Build
From repo root:

```bash
pnpm install
pnpm --filter openwrk build:bin
pnpm --filter openwork-server build:bin
```

### Docker sandbox smoke test (recommended)
```bash
# Ensure port 8787 is free
lsof -i :8787 || true

mkdir -p /tmp/openwork-sandbox-test
./packages/headless/dist/openwrk serve \
  --workspace /tmp/openwork-sandbox-test \
  --sandbox docker \
  --check \
  --log-format json
```

Expected: logs include `Checks ok` and 200s for `/health`, `/workspaces`, `/approvals`, and `/opencode/health`.

### (Optional) Toy UI manual check
```bash
./packages/headless/dist/openwrk serve --workspace /tmp/openwork-sandbox-test
# open http://127.0.0.1:8787/ui (token is shown in openwrk logs)
```

## Notes
- In sandbox mode, OpenCode access is via openwork-server proxy: `${OPENWORK_URL}/opencode`.
- Apple `container` backend is untested locally (requires Apple container tooling).