### PR TITLE
fix(headless): random owpenbot health port by default

### DIFF
--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -68,7 +68,6 @@ type OwpenbotHealthSnapshot = {
 
 const FALLBACK_VERSION = "0.1.0";
 const DEFAULT_OPENWORK_PORT = 8787;
-const DEFAULT_OWPENBOT_HEALTH_PORT = 3005;
 const DEFAULT_APPROVAL_TIMEOUT = 30000;
 const DEFAULT_OPENCODE_USERNAME = "opencode";
 
@@ -1546,7 +1545,7 @@ function printHelp(): void {
     "  --connect-host <host>     Override LAN host used for pairing URLs",
     "  --openwork-server-bin <p> Path to openwork-server binary (requires --allow-external)",
     "  --owpenbot-bin <path>     Path to owpenbot binary (requires --allow-external)",
-    "  --owpenbot-health-port <p> Health server port for owpenbot (default: 3005)",
+    "  --owpenbot-health-port <p> Health server port for owpenbot (default: random)",
     "  --no-owpenbot             Disable owpenbot sidecar",
     "  --owpenbot-required       Exit if owpenbot stops",
     "  --allow-external          Allow external sidecar binaries (dev only, required for custom bins)",
@@ -3014,10 +3013,11 @@ async function runStart(args: ParsedArgs) {
     "127.0.0.1",
     DEFAULT_OPENWORK_PORT,
   );
+  // Always choose a free owpenbot health port by default (avoid conflicts with
+  // other local processes using 3005).
   const owpenbotHealthPort = await resolvePort(
     readNumber(args.flags, "owpenbot-health-port", undefined, "OWPENBOT_HEALTH_PORT"),
     "127.0.0.1",
-    DEFAULT_OWPENBOT_HEALTH_PORT,
   );
   const openworkToken = readFlag(args.flags, "openwork-token") ?? process.env.OPENWORK_TOKEN ?? randomUUID();
   const openworkHostToken = readFlag(args.flags, "openwork-host-token") ?? process.env.OPENWORK_HOST_TOKEN ?? randomUUID();


### PR DESCRIPTION
## What
Changes `openwrk` so owpenbot's health server port is chosen randomly (free port) by default, instead of defaulting to 3005.

- Still supports explicit overrides via `--owpenbot-health-port` or `OWPENBOT_HEALTH_PORT`.
- If an explicit port is busy, `openwrk` falls back to a free port (instead of failing).

## Why
We want to avoid cases where `PORT 3005` is already in use, causing owpenbot health checks (and therefore `openwrk --check` / overall startup) to fail.

## How to Test
From repo root:

```bash
pnpm install
pnpm --filter openwrk build:bin
```

### 1) Default behavior (should be random)
```bash
mkdir -p /tmp/openwork-owpenbot-port-test
./packages/headless/dist/openwrk serve --workspace /tmp/openwork-owpenbot-port-test --check --log-format json
```
Expected:
- logs include `Checks ok`
- the `Ready` JSON log shows `owpenbot.healthPort` is not hard-coded to 3005 (it should be some free port).

### 2) Port collision behavior (3005 busy)
```bash
# occupy 3005
nc -l 3005 >/dev/null &
NC_PID=$!

./packages/headless/dist/openwrk serve --workspace /tmp/openwork-owpenbot-port-test --check --log-format json

kill $NC_PID
```
Expected:
- still `Checks ok`
- `Ready` JSON log shows `owpenbot.healthPort` is not 3005.