### PR TITLE
fix(owpenbot): lazy WhatsApp onboarding + REST QR

### DIFF
--- a/packages/owpenbot/src/bridge.ts
+++ b/packages/owpenbot/src/bridge.ts
@@ -1,4 +1,6 @@
 import { setTimeout as delay } from "node:timers/promises";
+import fs from "node:fs";
+import path from "node:path";
 
 import type { Logger } from "pino";
 
@@ -11,7 +13,6 @@ import { buildPermissionRules, createClient } from "./opencode.js";
 import { chunkText, formatInputSummary, truncateText } from "./text.js";
 import { createSlackAdapter } from "./slack.js";
 import { createTelegramAdapter } from "./telegram.js";
-import { createWhatsAppAdapter } from "./whatsapp.js";
 
 type Adapter = {
   name: ChannelName;
@@ -205,9 +206,15 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
     if (config.whatsappEnabled) {
       logger.debug("whatsapp adapter enabled");
+      // Lazy-load WhatsApp adapter to avoid Bun WS warnings (Baileys) when the
+      // channel is disabled.
+      const { createWhatsAppAdapter } = await import("./whatsapp.js");
       adapters.set(
         "whatsapp",
-        createWhatsAppAdapter(config, logger, handleInbound, { printQr: true, onStatus: reportStatus }),
+        // Never print QR codes from the long-running bridge process.
+        // Pairing/onboarding should be driven by explicit user action (CLI
+        // subcommand or REST API) so `openwrk`/desktop startup stays quiet.
+        createWhatsAppAdapter(config, logger, handleInbound, { printQr: false, onStatus: reportStatus }),
       );
     } else {
       logger.info("whatsapp adapter disabled");
@@ -499,6 +506,111 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             enabled: true,
             applied: true,
           };
+        },
+        getWhatsAppEnabled: () => Boolean(config.whatsappEnabled),
+        setWhatsAppEnabled: async (enabled: boolean) => {
+          const nextEnabled = Boolean(enabled);
+          const { config: current } = readConfigFile(config.configPath);
+          const next: OwpenbotConfigFile = {
+            ...current,
+            channels: {
+              ...current.channels,
+              whatsapp: {
+                ...current.channels?.whatsapp,
+                enabled: nextEnabled,
+              },
+            },
+          };
+          next.version = next.version ?? 1;
+          writeConfigFile(config.configPath, next);
+          config.configFile = next;
+          config.whatsappEnabled = nextEnabled;
+
+          const existing = adapters.get("whatsapp");
+          if (!nextEnabled) {
+            if (existing) {
+              try {
+                await existing.stop();
+              } catch (error) {
+                logger.warn({ error }, "failed to stop existing whatsapp adapter");
+              }
+              adapters.delete("whatsapp");
+            }
+            return { enabled: false, applied: true };
+          }
+
+          if (existing) {
+            // Already enabled; no-op.
+            return { enabled: true, applied: true };
+          }
+
+          const { createWhatsAppAdapter } = await import("./whatsapp.js");
+          const adapter = createWhatsAppAdapter(config, logger, handleInbound, {
+            printQr: false,
+            onStatus: reportStatus,
+          });
+          adapters.set("whatsapp", adapter);
+
+          const startResult = await startAdapterBounded(adapter, {
+            timeoutMs: 5_000,
+            onError: (error) => {
+              logger.error({ error }, "whatsapp adapter start failed");
+              adapters.delete("whatsapp");
+            },
+          });
+
+          if (startResult.status === "timeout") {
+            logger.warn({ timeoutMs: 5_000 }, "whatsapp adapter start timed out");
+            return { enabled: true, applied: false, starting: true };
+          }
+
+          if (startResult.status === "error") {
+            return { enabled: true, applied: false, error: String(startResult.error) };
+          }
+
+          return { enabled: true, applied: true };
+        },
+        getWhatsAppQr: async () => {
+          // Avoid printing the QR to stdout; return the raw QR string so a UI
+          // can render it.
+          const credsPath = path.join(config.whatsappAuthDir, "creds.json");
+          if (fs.existsSync(credsPath)) {
+            throw new Error("WhatsApp already linked");
+          }
+
+          const { createWhatsAppSocket, closeWhatsAppSocket } = await import("./whatsapp-session.js");
+
+          return new Promise<{ qr: string }>((resolve, reject) => {
+            let resolved = false;
+            const timeout = setTimeout(() => {
+              if (resolved) return;
+              resolved = true;
+              reject(new Error("Timeout waiting for QR code"));
+            }, 30_000);
+
+            void createWhatsAppSocket({
+              authDir: config.whatsappAuthDir,
+              logger,
+              printQr: false,
+              onQr: (qr) => {
+                if (resolved) return;
+                resolved = true;
+                clearTimeout(timeout);
+                resolve({ qr });
+              },
+            })
+              .then((sock) => {
+                setTimeout(() => {
+                  closeWhatsAppSocket(sock);
+                }, resolved ? 500 : 30_500);
+              })
+              .catch((error) => {
+                if (resolved) return;
+                resolved = true;
+                clearTimeout(timeout);
+                reject(error);
+              });
+          });
         },
         listBindings: async () => {
           const bindings = store.listBindings();

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -163,7 +163,11 @@ async function runStart(pathOverride?: string, options?: { opencodeUrl?: string 
     process.env.OPENCODE_DIRECTORY = config.opencodeDirectory;
   }
   const bridge = await startBridge(config, logger, reporter);
-  reporter.onStatus?.("Commands: owpenwork whatsapp login, owpenwork slack status, owpenwork pairing list, owpenwork status");
+  // Avoid noisy startup output when running under openwrk/desktop (stdio is
+  // usually piped). Keep the hint for interactive CLI usage.
+  if (process.stdout.isTTY) {
+    reporter.onStatus?.("Commands: owpenwork whatsapp login, owpenwork slack status, owpenwork pairing list, owpenwork status");
+  }
 
   const shutdown = async () => {
     logger.info("shutting down");

--- a/packages/owpenbot/src/config.ts
+++ b/packages/owpenbot/src/config.ts
@@ -21,6 +21,7 @@ export type OwpenbotConfigFile = {
   groupsEnabled?: boolean;
   channels?: {
     whatsapp?: {
+      enabled?: boolean;
       dmPolicy?: DmPolicy;
       allowFrom?: string[];
       selfChatMode?: boolean;
@@ -255,6 +256,18 @@ export function loadConfig(
   const healthPort = parseInteger(env.OWPENBOT_HEALTH_PORT) ?? 3005;
   const model = parseModel(env.OWPENBOT_MODEL);
 
+  // Preserve existing installs that are already paired by auto-enabling WhatsApp
+  // when creds are present, but avoid auto-onboarding (QR printing) on fresh
+  // installs.
+  const whatsappCredsPresent = (() => {
+    try {
+      return fs.existsSync(path.join(whatsappAuthDir, "creds.json"));
+    } catch {
+      return false;
+    }
+  })();
+  const whatsappEnabledDefault = configFile.channels?.whatsapp?.enabled ?? whatsappCredsPresent;
+
   return {
     configPath,
     configFile,
@@ -279,7 +292,7 @@ export function loadConfig(
     whatsappDmPolicy: dmPolicy,
     whatsappAllowFrom,
     whatsappSelfChatMode: selfChatMode,
-    whatsappEnabled: parseBoolean(env.WHATSAPP_ENABLED, true),
+    whatsappEnabled: parseBoolean(env.WHATSAPP_ENABLED, whatsappEnabledDefault),
     dataDir,
     dbPath,
     logFile,

--- a/packages/owpenbot/src/health.ts
+++ b/packages/owpenbot/src/health.ts
@@ -39,6 +39,17 @@ export type SlackTokensResult = {
   error?: string;
 };
 
+export type WhatsAppEnabledResult = {
+  enabled: boolean;
+  applied?: boolean;
+  starting?: boolean;
+  error?: string;
+};
+
+export type WhatsAppQrResult = {
+  qr: string;
+};
+
 export type GroupsConfigResult = {
   groupsEnabled: boolean;
 };
@@ -59,6 +70,9 @@ export type HealthHandlers = {
   setSlackTokens?: (tokens: { botToken: string; appToken: string }) => Promise<SlackTokensResult>;
   setGroupsEnabled?: (enabled: boolean) => Promise<GroupsConfigResult>;
   getGroupsEnabled?: () => boolean;
+  getWhatsAppEnabled?: () => boolean;
+  setWhatsAppEnabled?: (enabled: boolean) => Promise<WhatsAppEnabledResult>;
+  getWhatsAppQr?: () => Promise<WhatsAppQrResult>;
   listBindings?: () => Promise<BindingsListResult>;
   setBinding?: (input: { channel: string; peerId: string; directory: string }) => Promise<void>;
   clearBinding?: (input: { channel: string; peerId: string }) => Promise<void>;
@@ -223,6 +237,70 @@ export function startHealthServer(
           const enabled = payload.enabled === true || payload.enabled === "true";
 
           const result = await handlers.setGroupsEnabled(enabled);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, ...result }));
+          return;
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: String(error) }));
+          return;
+        }
+      }
+
+      // GET /config/whatsapp-enabled - get current whatsapp enabled setting
+      if (pathname === "/config/whatsapp-enabled" && req.method === "GET") {
+        if (!handlers.getWhatsAppEnabled) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+          return;
+        }
+        const enabled = handlers.getWhatsAppEnabled();
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, enabled }));
+        return;
+      }
+
+      // POST /config/whatsapp-enabled - enable/disable whatsapp adapter
+      if (pathname === "/config/whatsapp-enabled" && req.method === "POST") {
+        if (!handlers.setWhatsAppEnabled) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+          return;
+        }
+
+        let raw = "";
+        for await (const chunk of req) {
+          raw += chunk.toString();
+          if (raw.length > 1024 * 1024) {
+            res.writeHead(413, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Payload too large" }));
+            return;
+          }
+        }
+
+        try {
+          const payload = JSON.parse(raw || "{}");
+          const enabled = payload.enabled === true || payload.enabled === "true";
+          const result = await handlers.setWhatsAppEnabled(enabled);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true, ...result }));
+          return;
+        } catch (error) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: String(error) }));
+          return;
+        }
+      }
+
+      // GET /whatsapp/qr - get a WhatsApp QR code for pairing (non-interactive)
+      if (pathname === "/whatsapp/qr" && req.method === "GET") {
+        if (!handlers.getWhatsAppQr) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Not supported" }));
+          return;
+        }
+        try {
+          const result = await handlers.getWhatsAppQr();
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ ok: true, ...result }));
           return;


### PR DESCRIPTION
## What
Makes `owpenbot` startup non-interactive and quiet by default:
- WhatsApp no longer auto-onboards / prints the huge ASCII QR code on bridge start.
- Avoids Bun `ws.WebSocket 'upgrade'` warnings at startup by lazy-loading the Baileys WhatsApp stack only when WhatsApp is actually enabled.
- Adds REST endpoints to drive WhatsApp pairing/enabling from a UI instead of stdout.

## Key Changes
- `WHATSAPP_ENABLED` default becomes **disabled unless already paired** (creds present) or explicitly enabled via config/env.
- Bridge never prints QR (`printQr=false`).
- New endpoints on the existing health server:
  - `GET /config/whatsapp-enabled`
  - `POST /config/whatsapp-enabled` `{ "enabled": true|false }`
  - `GET /whatsapp/qr` (returns raw QR string for UI rendering)
- CLI "Commands: ..." hint prints only when `stdout` is a TTY.

## How to Test
### 1) Verify openwrk startup is quiet (no QR, no Bun ws warnings)
```bash
pnpm install
pnpm --filter owpenwork build:bin
pnpm --filter openwrk build:bin

mkdir -p /tmp/openwork-quiet-test
./packages/headless/dist/openwrk serve --workspace /tmp/openwork-quiet-test --check
```
Expected:
- `Checks ok`
- No ASCII QR output
- No Bun ws warnings like `ws.WebSocket 'upgrade' event is not implemented`

### 2) REST-driven pairing flow (owpenbot directly)
```bash
export OWPENBOT_HEALTH_PORT=4013
export WHATSAPP_ENABLED=false
./packages/owpenbot/dist/bin/owpenbot start

curl http://127.0.0.1:4013/config/whatsapp-enabled
curl http://127.0.0.1:4013/whatsapp/qr
curl -X POST -H 'Content-Type: application/json' -d '{"enabled":true}' http://127.0.0.1:4013/config/whatsapp-enabled
```

## Notes
- Existing paired installs keep working: if `creds.json` exists in the WhatsApp auth dir, WhatsApp auto-enables on startup.