### PR TITLE
feat: proxy owpenbot via openwork-server

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2269,9 +2269,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -3594,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4466,7 +4466,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4700,7 +4700,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -5475,9 +5475,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6326,18 +6326,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/desktop/src-tauri/src/commands/owpenbot.rs
+++ b/packages/desktop/src-tauri/src/commands/owpenbot.rs
@@ -3,6 +3,7 @@ use tauri_plugin_shell::process::CommandEvent;
 
 use crate::owpenbot::manager::OwpenbotManager;
 use crate::owpenbot::spawn::{resolve_owpenbot_health_port, spawn_owpenbot, DEFAULT_OWPENBOT_HEALTH_PORT};
+use crate::openwork_server::manager::OpenworkServerManager;
 use crate::types::OwpenbotInfo;
 use crate::utils::truncate_output;
 
@@ -217,47 +218,59 @@ pub fn owpenbot_stop(manager: State<OwpenbotManager>) -> Result<OwpenbotInfo, St
 }
 
 #[tauri::command]
-pub async fn owpenbot_qr(app: AppHandle) -> Result<String, String> {
-    use tauri_plugin_shell::ShellExt;
+pub async fn owpenbot_qr(
+    _app: AppHandle,
+    openwork: State<'_, OpenworkServerManager>,
+) -> Result<String, String> {
     use base64::engine::general_purpose;
     use base64::Engine as _;
     use image::{DynamicImage, ImageFormat, Luma};
     use qrcode::QrCode;
     use std::io::Cursor;
 
-    let command = match app.shell().sidecar("owpenbot") {
-        Ok(command) => command,
-        Err(_) => app.shell().command("owpenbot"),
+    let snapshot = {
+        let mut state = openwork
+            .inner
+            .lock()
+            .map_err(|_| "openwork-server mutex poisoned".to_string())?;
+        OpenworkServerManager::snapshot_locked(&mut state)
     };
+    let base_url = snapshot
+        .base_url
+        .or(snapshot.connect_url)
+        .ok_or_else(|| "OpenWork server is not running".to_string())?;
+    let host_token = snapshot
+        .host_token
+        .ok_or_else(|| "OpenWork host token missing".to_string())?;
 
-    let output = command
-        .args(["whatsapp", "qr", "--format", "ascii", "--json"])
-        .output()
-        .await
+    let url = format!("{}/owpenbot/whatsapp/qr?format=raw", base_url.trim_end_matches('/'));
+    let agent = ureq::AgentBuilder::new()
+        .timeout(std::time::Duration::from_secs(8))
+        .build();
+
+    let response = agent
+        .get(&url)
+        .set("X-OpenWork-Host-Token", &host_token)
+        .call()
         .map_err(|e| format!("Failed to get QR code: {e}"))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Failed to get QR code: {stderr}"));
+    let payload: serde_json::Value = response
+        .into_json()
+        .map_err(|e| format!("Failed to parse QR response: {e}"))?;
+
+    if payload.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        let message = payload
+            .get("error")
+            .and_then(|v| v.as_str())
+            .or_else(|| payload.get("message").and_then(|v| v.as_str()))
+            .unwrap_or("Failed to get QR code");
+        return Err(message.to_string());
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // Parse JSON response
-    #[derive(serde::Deserialize)]
-    struct QrResponse {
-        qr: Option<String>,
-        error: Option<String>,
-    }
-
-    let response: QrResponse =
-        serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse QR response: {e}"))?;
-
-    if let Some(error) = response.error {
-        return Err(error);
-    }
-
-    let qr_data = response.qr.ok_or_else(|| "No QR code returned".to_string())?;
+    let qr_data = payload
+        .get("qr")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "No QR code returned".to_string())?;
     let code = QrCode::new(qr_data.as_bytes()).map_err(|e| format!("Failed to encode QR: {e}"))?;
     let image = code
         .render::<Luma<u8>>()

--- a/packages/desktop/src-tauri/src/owpenbot/spawn.rs
+++ b/packages/desktop/src-tauri/src/owpenbot/spawn.rs
@@ -19,7 +19,7 @@ pub fn resolve_owpenbot_health_port() -> Result<u16, String> {
 }
 
 pub fn build_owpenbot_args(workspace_path: &str, opencode_url: Option<&str>) -> Vec<String> {
-    let mut args = vec!["start".to_string(), workspace_path.to_string()];
+    let mut args = vec!["serve".to_string(), workspace_path.to_string()];
 
     if let Some(url) = opencode_url {
         let trimmed = url.trim();

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -1449,6 +1449,28 @@ function resolveBinPath(bin: string): string {
   return bin;
 }
 
+function isPathLikeBinary(bin: string): boolean {
+  return bin.includes("/") || bin.startsWith(".");
+}
+
+async function assertSandboxBinaryFile(name: string, bin: string): Promise<void> {
+  const lower = bin.toLowerCase();
+  if (lower.endsWith(".js") || lower.endsWith(".ts")) {
+    throw new Error(
+      `Sandbox mode requires ${name} to be a native binary (got ${bin}). Use downloaded sidecars or pass a Linux binary path.`,
+    );
+  }
+  if (!isPathLikeBinary(bin)) {
+    throw new Error(
+      `Sandbox mode requires ${name} to be a file path (got ${bin}). Use downloaded sidecars or pass --${name}-bin with a Linux binary path.`,
+    );
+  }
+  const resolved = resolve(process.cwd(), bin);
+  if (!(await fileExists(resolved))) {
+    throw new Error(`Sandbox mode could not find ${name} binary at ${resolved}.`);
+  }
+}
+
 async function resolveOpenworkServerBin(options: {
   explicit?: string;
   manifest: VersionManifest | null;
@@ -1821,6 +1843,15 @@ async function fetchOwpenbotHealth(baseUrl: string): Promise<OwpenbotHealthSnaps
   return (await fetchJson(`${baseUrl.replace(/\/$/, "")}/health`)) as OwpenbotHealthSnapshot;
 }
 
+async function fetchOwpenbotHealthViaOpenwork(openworkUrl: string, token: string): Promise<OwpenbotHealthSnapshot> {
+  const url = `${openworkUrl.replace(/\/$/, "")}/owpenbot/health`;
+  return (await fetchJson(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })) as OwpenbotHealthSnapshot;
+}
+
 async function waitForOwpenbotHealthy(baseUrl: string, timeoutMs = 10_000, pollMs = 500) {
   const start = Date.now();
   let lastError: string | null = null;
@@ -1837,6 +1868,34 @@ async function waitForOwpenbotHealthy(baseUrl: string, timeoutMs = 10_000, pollM
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
   throw new Error(lastError ?? "Timed out waiting for owpenbot health");
+}
+
+async function waitForOwpenbotHealthyViaOpenwork(
+  openworkUrl: string,
+  token: string,
+  timeoutMs = 10_000,
+  pollMs = 500,
+): Promise<OwpenbotHealthSnapshot> {
+  const url = `${openworkUrl.replace(/\/$/, "")}/owpenbot/health`;
+  const start = Date.now();
+  let lastError: string | null = null;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (response.ok) {
+        return (await response.json()) as OwpenbotHealthSnapshot;
+      }
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  throw new Error(lastError ?? "Timed out waiting for owpenbot health via openwork-server");
 }
 
 async function waitForOpencodeHealthy(client: ReturnType<typeof createOpencodeClient>, timeoutMs = 10_000, pollMs = 250) {
@@ -2148,7 +2207,7 @@ async function startOwpenbot(options: {
   runId: string;
   logFormat: LogFormat;
 }) {
-  const args = ["start", options.workspace];
+  const args = ["serve", options.workspace];
   if (options.opencodeUrl) {
     const supports = await owpenbotSupportsOpencodeUrl(options.bin);
     if (supports) {
@@ -2407,7 +2466,7 @@ async function writeSandboxEntrypoint(options: {
     "trap cleanup INT TERM",
     `${shQuote(opencodeBin)} serve --hostname 127.0.0.1 --port ${shQuote(String(SANDBOX_INTERNAL_OPENCODE_PORT))} ${opencodeCors} &`,
     "opencode_pid=$!",
-    options.openwork.owpenbotEnabled ? `${shQuote(owpenbotBin)} start ${shQuote(workspaceDir)} &` : "",
+    options.openwork.owpenbotEnabled ? `${shQuote(owpenbotBin)} serve ${shQuote(workspaceDir)} &` : "",
     options.openwork.owpenbotEnabled ? "owpenbot_pid=$!" : "",
     `exec ${shQuote(openworkBin)} --host 0.0.0.0 --port ${shQuote(String(SANDBOX_INTERNAL_OPENWORK_PORT))}` +
       ` --token ${shQuote(options.openwork.token)} --host-token ${shQuote(options.openwork.hostToken)}` +
@@ -2701,16 +2760,55 @@ async function runChecks(input: {
   opencodeClient: ReturnType<typeof createOpencodeClient>;
   openworkUrl: string;
   openworkToken: string;
+  hostToken: string;
   checkEvents: boolean;
 }) {
+  const baseUrl = input.openworkUrl.replace(/\/$/, "");
   const headers = { Authorization: `Bearer ${input.openworkToken}` };
-  const workspaces = await fetchJson(`${input.openworkUrl}/workspaces`, { headers });
+  const hostHeaders = { "X-OpenWork-Host-Token": input.hostToken };
+  const workspaces = await fetchJson(`${baseUrl}/workspaces`, { headers });
   if (!workspaces?.items?.length) {
     throw new Error("OpenWork server returned no workspaces");
   }
 
   const workspaceId = workspaces.items[0].id as string;
-  await fetchJson(`${input.openworkUrl}/workspace/${workspaceId}/config`, { headers });
+  await fetchJson(`${baseUrl}/workspace/${workspaceId}/config`, { headers });
+
+  // Smoke test: mounted owpenbot proxy and auth behavior.
+  // - /w/:id/owpenbot/health is client-readable
+  // - other /w/:id/owpenbot/* requires host/owner auth
+  const owMountBase = `${baseUrl}/w/${encodeURIComponent(workspaceId)}/owpenbot`;
+  const owHealthRes = await fetch(`${owMountBase}/health`, {
+    headers,
+    signal: AbortSignal.timeout(3000),
+  });
+  if (owHealthRes.status >= 500) {
+    throw new Error(`owpenbot mount proxy returned ${owHealthRes.status}`);
+  }
+  const owConfigured = owHealthRes.status !== 404;
+  if (owConfigured) {
+    const clientRes = await fetch(`${owMountBase}/config/groups`, {
+      headers,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (clientRes.status === 200) {
+      throw new Error("owpenbot mount proxy /config/groups should require host auth");
+    }
+    if (clientRes.status !== 401 && clientRes.status !== 403) {
+      throw new Error(`owpenbot mount proxy /config/groups unexpected status: ${clientRes.status}`);
+    }
+
+    const hostRes = await fetch(`${owMountBase}/config/groups`, {
+      headers: hostHeaders,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (hostRes.status >= 500) {
+      throw new Error(`owpenbot mount proxy (host auth) returned ${hostRes.status}`);
+    }
+    if (hostRes.status === 401 || hostRes.status === 403) {
+      throw new Error("owpenbot mount proxy /config/groups rejected host auth");
+    }
+  }
 
   const created = await input.opencodeClient.session.create({ title: "OpenWork headless check" });
   const createdSession = unwrap(created);
@@ -2786,6 +2884,47 @@ async function runSandboxChecks(input: {
   });
   if (proxyRes.status >= 500) {
     throw new Error(`opencode proxy returned ${proxyRes.status}`);
+  }
+
+  // 6. owpenbot proxy is reachable (if configured)
+  const owRes = await fetch(`${baseUrl}/owpenbot/health`, {
+    headers,
+    signal: AbortSignal.timeout(3000),
+  });
+  if (owRes.status >= 500) {
+    throw new Error(`owpenbot proxy returned ${owRes.status}`);
+  }
+
+  // 7. Mounted owpenbot proxy + auth behavior (if configured)
+  if (owRes.status !== 404) {
+    const owMountBase = `${baseUrl}/w/${encodeURIComponent(workspaceId)}/owpenbot`;
+    const mountHealth = await fetch(`${owMountBase}/health`, {
+      headers,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (mountHealth.status >= 500) {
+      throw new Error(`owpenbot mount proxy returned ${mountHealth.status}`);
+    }
+    const mountClient = await fetch(`${owMountBase}/config/groups`, {
+      headers,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (mountClient.status === 200) {
+      throw new Error("owpenbot mount proxy /config/groups should require host auth");
+    }
+    if (mountClient.status !== 401 && mountClient.status !== 403) {
+      throw new Error(`owpenbot mount proxy /config/groups unexpected status: ${mountClient.status}`);
+    }
+    const mountHost = await fetch(`${owMountBase}/config/groups`, {
+      headers: hostHeaders,
+      signal: AbortSignal.timeout(3000),
+    });
+    if (mountHost.status >= 500) {
+      throw new Error(`owpenbot mount proxy (host auth) returned ${mountHost.status}`);
+    }
+    if (mountHost.status === 401 || mountHost.status === 403) {
+      throw new Error("owpenbot mount proxy /config/groups rejected host auth");
+    }
   }
 }
 
@@ -3872,6 +4011,8 @@ async function runStart(args: ParsedArgs) {
       : [];
 
   const explicitOpencodeBin = readFlag(args.flags, "opencode-bin") ?? process.env.OPENWORK_OPENCODE_BIN;
+  const explicitOpenworkServerBin = readFlag(args.flags, "openwork-server-bin") ?? process.env.OPENWORK_SERVER_BIN;
+  const explicitOwpenbotBin = readFlag(args.flags, "owpenbot-bin") ?? process.env.OWPENBOT_BIN;
   const opencodeBindHost = readFlag(args.flags, "opencode-host") ?? process.env.OPENWORK_OPENCODE_BIND_HOST ?? "0.0.0.0";
   const opencodePort =
     sandboxMode !== "none"
@@ -3925,14 +4066,21 @@ async function runStart(args: ParsedArgs) {
   let sidecarSource = sidecarSourceInput;
   let opencodeSource = opencodeSourceInput;
   if (sandboxMode !== "none") {
-    if (sidecarSourceInput === "bundled" || sidecarSourceInput === "external") {
-      throw new Error("Sandbox mode requires --sidecar-source downloaded or auto");
+    if (sidecarSourceInput === "bundled") {
+      throw new Error("Sandbox mode does not support --sidecar-source bundled");
     }
-    if (opencodeSourceInput === "bundled" || opencodeSourceInput === "external") {
-      throw new Error("Sandbox mode requires --opencode-source downloaded or auto");
+    if (opencodeSourceInput === "bundled") {
+      throw new Error("Sandbox mode does not support --opencode-source bundled");
     }
-    if (sidecarSourceInput === "auto") sidecarSource = "downloaded";
-    if (opencodeSourceInput === "auto") opencodeSource = "downloaded";
+    // In sandbox mode, we must run Linux binaries inside the container. When
+    // custom *-bin paths are provided, treat the source as external so we don't
+    // accidentally pick host (darwin) bundled binaries.
+    if (sidecarSourceInput === "auto") {
+      sidecarSource = explicitOpenworkServerBin || explicitOwpenbotBin ? "external" : "downloaded";
+    }
+    if (opencodeSourceInput === "auto") {
+      opencodeSource = explicitOpencodeBin ? "external" : "downloaded";
+    }
   }
   logVerbose(`cli version: ${cliVersion}`);
   logVerbose(`sandbox: ${sandboxMode}`);
@@ -3957,8 +4105,6 @@ async function runStart(args: ParsedArgs) {
     sidecar,
     source: opencodeSource,
   });
-  const explicitOpenworkServerBin = readFlag(args.flags, "openwork-server-bin") ?? process.env.OPENWORK_SERVER_BIN;
-  const explicitOwpenbotBin = readFlag(args.flags, "owpenbot-bin") ?? process.env.OWPENBOT_BIN;
 
   if (sandboxMode !== "none") {
     if (sandboxMode === "docker") {
@@ -3979,9 +4125,6 @@ async function runStart(args: ParsedArgs) {
         throw new Error("Apple container CLI not found. Install https://github.com/apple/container");
       }
     }
-    if (explicitOpencodeBin || explicitOpenworkServerBin || explicitOwpenbotBin) {
-      throw new Error("Sandbox mode does not support custom *-bin paths yet (use downloaded sidecars).");
-    }
   }
   const owpenbotEnabled = readBool(args.flags, "owpenbot", true);
   const owpenbotRequired = readBool(args.flags, "owpenbot-required", false, "OPENWRK_OWPENBOT_REQUIRED");
@@ -4001,6 +4144,15 @@ async function runStart(args: ParsedArgs) {
         source: sidecarSource,
       })
     : null;
+
+  if (sandboxMode !== "none") {
+    // Ensure the binaries we stage into the container are actual files.
+    await assertSandboxBinaryFile("opencode", opencodeBinary.bin);
+    await assertSandboxBinaryFile("openwork-server", openworkServerBinary.bin);
+    if (owpenbotBinary) {
+      await assertSandboxBinaryFile("owpenbot", owpenbotBinary.bin);
+    }
+  }
   let owpenbotActualVersion: string | undefined;
   logVerbose(`opencode bin: ${opencodeBinary.bin} (${opencodeBinary.source})`);
   logVerbose(`openwork-server bin: ${openworkServerBinary.bin} (${openworkServerBinary.source})`);
@@ -4036,7 +4188,7 @@ async function runStart(args: ParsedArgs) {
     OPENCODE_URL: opencodeConnectUrl,
     ...(opencodeUsername ? { OPENCODE_SERVER_USERNAME: opencodeUsername } : {}),
     ...(opencodePassword ? { OPENCODE_SERVER_PASSWORD: opencodePassword } : {}),
-    ...(owpenbotHealthPort ? { OWPENBOT_HEALTH_PORT: String(owpenbotHealthPort) } : {}),
+    ...(owpenbotEnabled ? { OWPENBOT_HEALTH_PORT: String(owpenbotHealthPort) } : {}),
   };
 
   const children: ChildHandle[] = [];
@@ -4134,7 +4286,7 @@ async function runStart(args: ParsedArgs) {
           name: "owpenbot",
           label: "owpenbot",
           status: owpenbotEnabled ? "starting" : "disabled",
-          port: owpenbotHealthPort,
+          port: sandboxMode !== "none" ? undefined : owpenbotHealthPort,
         },
       ],
       onQuit: handleQuit,
@@ -4144,36 +4296,29 @@ async function runStart(args: ParsedArgs) {
         return { command: attachCommand, ...result };
       },
       onCopySelection: async (text) => copyToClipboard(text),
-      onOwpenbotHealth: async () => fetchOwpenbotHealth(owpenbotHealthUrl),
+      onOwpenbotHealth: async () => fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken),
       onOwpenbotQr: async () => {
-        let output = "";
-        if (sandboxMode !== "none") {
-          if (!sandboxContainerName) {
-            throw new Error("Sandbox container missing");
-          }
-          const cli = sandboxMode === "container" ? "container" : "docker";
-          const owpenbotPath = `/persist/openwrk-sandbox/${sandboxContainerName}/sidecars/owpenbot`;
-          output = await captureCommandOutput(cli, ["exec", sandboxContainerName, owpenbotPath, "whatsapp", "qr", "--format", "ascii"]);
-        } else {
-          if (!owpenbotBinary) {
-            throw new Error("Owpenbot binary missing");
-          }
-          output = await captureCommandOutput(
-            owpenbotBinary.bin,
-            ["whatsapp", "qr", "--format", "ascii"],
-            { env: owpenbotEnv },
-          );
-        }
-        if (!output) {
+        const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/whatsapp/qr?format=ascii`;
+        const result = await fetchJson(url, {
+          headers: {
+            "X-OpenWork-Host-Token": openworkHostToken,
+          },
+        });
+        const qr = typeof result?.qr === "string" ? result.qr : "";
+        if (!qr.trim()) {
           throw new Error("No QR output received");
         }
-        return output;
+        return qr;
       },
       onOwpenbotSetTelegramToken: async (token) => {
         try {
-          await fetchJson(`${owpenbotHealthUrl}/config/telegram-token`, {
+          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/config/telegram-token`;
+          await fetchJson(url, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: {
+              "Content-Type": "application/json",
+              "X-OpenWork-Host-Token": openworkHostToken,
+            },
             body: JSON.stringify({ token }),
           });
           return { ok: true };
@@ -4231,7 +4376,9 @@ async function runStart(args: ParsedArgs) {
         },
         ports: {
           openwork: openworkPort,
-          owpenbotHealth: owpenbotEnabled ? owpenbotHealthPort : null,
+          // In sandbox mode, owpenbot is only reachable via openwork-server
+          // proxy (/owpenbot/*). Do not publish a separate host port.
+          owpenbotHealth: null,
         },
         opencode: {
           corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
@@ -4259,7 +4406,7 @@ async function runStart(args: ParsedArgs) {
       tui?.updateService("opencode", { status: "running", port: SANDBOX_INTERNAL_OPENCODE_PORT });
       tui?.updateService("openwork-server", { status: "running", port: openworkPort });
       if (owpenbotEnabled) {
-        tui?.updateService("owpenbot", { status: "running", port: owpenbotHealthPort });
+        tui?.updateService("owpenbot", { status: "running", port: sandboxMode !== "none" ? undefined : owpenbotHealthPort });
       }
 
       if (!detachRequested) {
@@ -4365,7 +4512,7 @@ async function runStart(args: ParsedArgs) {
         opencodeDirectory: resolvedWorkspace,
         opencodeUsername,
         opencodePassword,
-        owpenbotHealthPort,
+        owpenbotHealthPort: owpenbotEnabled ? owpenbotHealthPort : undefined,
         logger,
         runId,
         logFormat,
@@ -4405,18 +4552,19 @@ async function runStart(args: ParsedArgs) {
         owpenbotActualVersion = owpenbotBinary?.expectedVersion;
         logVerbose(`owpenbot version: ${owpenbotActualVersion ?? "unknown"}`);
         try {
-          logger.info("Waiting for health", { url: owpenbotHealthUrl }, "owpenbot");
-          const health = await waitForOwpenbotHealthy(owpenbotHealthUrl);
+          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/health`;
+          logger.info("Waiting for health", { url }, "owpenbot");
+          const health = await waitForOwpenbotHealthyViaOpenwork(openworkBaseUrl, openworkToken);
           tui?.setOwpenbotHealth(health);
           tui?.updateService("owpenbot", { status: health.ok ? "healthy" : "running" });
-          logger.info("Healthy", { url: owpenbotHealthUrl, ok: health.ok }, "owpenbot");
+          logger.info("Healthy", { url, ok: health.ok }, "owpenbot");
         } catch (error) {
           logger.warn("Owpenbot health check failed", { error: String(error) }, "owpenbot");
           tui?.updateService("owpenbot", { status: "running", message: String(error) });
         }
         if (!owpenbotHealthInterval) {
           owpenbotHealthInterval = setInterval(() => {
-            fetchOwpenbotHealth(owpenbotHealthUrl)
+            fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken)
               .then((health) => {
                 tui?.setOwpenbotHealth(health);
                 if (health.ok) {
@@ -4444,25 +4592,26 @@ async function runStart(args: ParsedArgs) {
           logFormat,
         });
         children.push({ name: "owpenbot", child: owpenbotChild });
-        tui?.updateService("owpenbot", {
-          status: "running",
-          pid: owpenbotChild.pid ?? undefined,
-          port: owpenbotHealthPort,
-        });
+          tui?.updateService("owpenbot", {
+            status: "running",
+            pid: owpenbotChild.pid ?? undefined,
+            port: owpenbotHealthPort,
+          });
         logger.info("Process spawned", { pid: owpenbotChild.pid ?? 0 }, "owpenbot");
         try {
-          logger.info("Waiting for health", { url: owpenbotHealthUrl }, "owpenbot");
-          const health = await waitForOwpenbotHealthy(owpenbotHealthUrl);
+          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/health`;
+          logger.info("Waiting for health", { url }, "owpenbot");
+          const health = await waitForOwpenbotHealthyViaOpenwork(openworkBaseUrl, openworkToken);
           tui?.setOwpenbotHealth(health);
           tui?.updateService("owpenbot", { status: health.ok ? "healthy" : "running" });
-          logger.info("Healthy", { url: owpenbotHealthUrl, ok: health.ok }, "owpenbot");
+          logger.info("Healthy", { url, ok: health.ok }, "owpenbot");
         } catch (error) {
           logger.warn("Owpenbot health check failed", { error: String(error) }, "owpenbot");
           tui?.updateService("owpenbot", { status: "running", message: String(error) });
         }
         if (!owpenbotHealthInterval) {
           owpenbotHealthInterval = setInterval(() => {
-            fetchOwpenbotHealth(owpenbotHealthUrl)
+            fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken)
               .then((health) => {
                 tui?.setOwpenbotHealth(health);
                 if (health.ok) {
@@ -4514,7 +4663,7 @@ async function runStart(args: ParsedArgs) {
       owpenbot: {
         enabled: owpenbotEnabled,
         version: owpenbotEnabled ? owpenbotActualVersion : undefined,
-        healthPort: owpenbotHealthPort,
+        healthPort: sandboxMode !== "none" ? null : owpenbotHealthPort,
       },
       diagnostics: {
         cliVersion,
@@ -4613,6 +4762,7 @@ async function runStart(args: ParsedArgs) {
             opencodeClient,
             openworkUrl: openworkBaseUrl,
             openworkToken,
+            hostToken: openworkHostToken,
             checkEvents,
           });
         }

--- a/packages/owpenbot/src/bridge.ts
+++ b/packages/owpenbot/src/bridge.ts
@@ -306,6 +306,11 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
   let opencodeHealthy = false;
   let opencodeVersion: string | undefined;
 
+  const HEALTH_SLOW_INTERVAL_MS = 30_000;
+  const HEALTH_FAST_INTERVAL_MS = 1_000;
+  let healthIntervalMs = HEALTH_FAST_INTERVAL_MS;
+  let healthTimer: NodeJS.Timeout | null = null;
+
   async function refreshHealth() {
     try {
       const health = await rootClient.global.health();
@@ -315,10 +320,19 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       logger.warn({ error }, "failed to reach opencode health");
       opencodeHealthy = false;
     }
+
+    // After initial startup, switch to a slower poll once OpenCode is healthy.
+    if (opencodeHealthy && healthIntervalMs !== HEALTH_SLOW_INTERVAL_MS) {
+      healthIntervalMs = HEALTH_SLOW_INTERVAL_MS;
+      if (healthTimer) {
+        clearInterval(healthTimer);
+      }
+      healthTimer = setInterval(refreshHealth, healthIntervalMs);
+    }
   }
 
   await refreshHealth();
-  const healthTimer = setInterval(refreshHealth, 30_000);
+  healthTimer = setInterval(refreshHealth, healthIntervalMs);
 
   // Mutable runtime state for groups (persisted to config file)
   let groupsEnabled = config.groupsEnabled;

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -251,6 +251,13 @@ program
   .option("--opencode-url <url>", "OpenCode server URL")
   .action((pathArg?: string, options?: { opencodeUrl?: string }) => runStart(pathArg, options));
 
+program
+  .command("serve")
+  .description("Start the bridge (headless)")
+  .argument("[path]", "OpenCode workspace path")
+  .option("--opencode-url <url>", "OpenCode server URL")
+  .action((pathArg?: string, options?: { opencodeUrl?: string }) => runStart(pathArg, options));
+
 // -----------------------------------------------------------------------------
 // health command
 // -----------------------------------------------------------------------------

--- a/packages/owpenbot/src/config.ts
+++ b/packages/owpenbot/src/config.ts
@@ -222,7 +222,7 @@ export function loadConfig(
   const dbPath = expandHome(env.OWPENBOT_DB_PATH ?? path.join(dataDir, "owpenbot.db"));
   const logFile = expandHome(env.OWPENBOT_LOG_FILE ?? path.join(dataDir, "logs", "owpenbot.log"));
   const configPath = resolveConfigPath(dataDir, env);
-  const { config: configFile } = readConfigFile(configPath);
+  let { config: configFile } = readConfigFile(configPath);
   const opencodeDirectory = env.OPENCODE_DIRECTORY?.trim() || configFile.opencodeDirectory || "";
   if (!opencodeDirectory && requireOpencode) {
     throw new Error("OPENCODE_DIRECTORY is required");
@@ -256,9 +256,9 @@ export function loadConfig(
   const healthPort = parseInteger(env.OWPENBOT_HEALTH_PORT) ?? 3005;
   const model = parseModel(env.OWPENBOT_MODEL);
 
-  // Preserve existing installs that are already paired by auto-enabling WhatsApp
-  // when creds are present, but avoid auto-onboarding (QR printing) on fresh
-  // installs.
+  // WhatsApp should be config-driven (default disabled). To avoid breaking
+  // existing installs that already have creds, do a one-time migration that
+  // persists `channels.whatsapp.enabled=true` when creds are detected.
   const whatsappCredsPresent = (() => {
     try {
       return fs.existsSync(path.join(whatsappAuthDir, "creds.json"));
@@ -266,7 +266,29 @@ export function loadConfig(
       return false;
     }
   })();
-  const whatsappEnabledDefault = configFile.channels?.whatsapp?.enabled ?? whatsappCredsPresent;
+
+  const whatsappEnabledFromConfig = configFile.channels?.whatsapp?.enabled;
+  if (whatsappEnabledFromConfig === undefined && whatsappCredsPresent) {
+    try {
+      const next: OwpenbotConfigFile = {
+        ...configFile,
+        channels: {
+          ...configFile.channels,
+          whatsapp: {
+            ...configFile.channels?.whatsapp,
+            enabled: true,
+          },
+        },
+      };
+      next.version = next.version ?? 1;
+      writeConfigFile(configPath, next);
+      configFile = next;
+    } catch {
+      // ignore (read-only config path, etc.)
+    }
+  }
+
+  const whatsappEnabledDefault = configFile.channels?.whatsapp?.enabled ?? false;
 
   return {
     configPath,

--- a/packages/owpenbot/src/health.ts
+++ b/packages/owpenbot/src/health.ts
@@ -300,9 +300,26 @@ export function startHealthServer(
           return;
         }
         try {
+          const parsed = req.url ? new URL(req.url, "http://localhost") : null;
+          const format = (parsed?.searchParams.get("format") ?? "raw").trim().toLowerCase();
+          if (format && format !== "raw" && format !== "ascii") {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Invalid format (use raw|ascii)" }));
+            return;
+          }
+
           const result = await handlers.getWhatsAppQr();
+          if (format === "ascii") {
+            const qrcode = await import("qrcode-terminal");
+            const ascii = await new Promise<string>((resolve) => {
+              qrcode.default.generate(result.qr, { small: true }, (out: string) => resolve(out));
+            });
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true, qr: ascii, format: "ascii" }));
+            return;
+          }
           res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ ok: true, ...result }));
+          res.end(JSON.stringify({ ok: true, ...result, format: "raw" }));
           return;
         } catch (error) {
           res.writeHead(500, { "Content-Type": "application/json" });

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -124,6 +124,15 @@ OpenCode proxy:
 - `GET|POST|... /opencode/*`
 - `GET|POST|... /w/:id/opencode/*`
 
+Owpenbot proxy:
+
+- `GET|POST|... /owpenbot/*`
+- `GET|POST|... /w/:id/owpenbot/*`
+
+Auth policy:
+- `GET /owpenbot/health` requires client auth.
+- All other `/owpenbot/*` endpoints require host/owner auth.
+
 ## Approvals
 
 All writes are gated by host approval.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -82,15 +82,17 @@ function logRequest(input: {
   response: Response;
   durationMs: number;
   authMode: AuthMode;
+  proxyService?: "opencode" | "owpenbot";
   proxyBaseUrl?: string;
   error?: string;
 }) {
-  const { logger, request, response, durationMs, authMode, proxyBaseUrl, error } = input;
+  const { logger, request, response, durationMs, authMode, proxyService, proxyBaseUrl, error } = input;
   const status = response.status;
   const level: LogLevel = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
   const url = new URL(request.url);
   const method = request.method.toUpperCase();
-  const message = `${method} ${url.pathname} ${status} ${durationMs}ms${proxyBaseUrl ? " (opencode)" : ""}`;
+  const proxyLabel = proxyBaseUrl ? ` (${proxyService ?? "proxy"})` : "";
+  const message = `${method} ${url.pathname} ${status} ${durationMs}ms${proxyLabel}`;
   const attributes: LogAttributes = {
     method,
     path: url.pathname,
@@ -99,7 +101,8 @@ function logRequest(input: {
     auth: authMode,
   };
   if (proxyBaseUrl) {
-    attributes["opencode.base_url"] = proxyBaseUrl;
+    attributes["proxy.base_url"] = proxyBaseUrl;
+    if (proxyService) attributes["proxy.service"] = proxyService;
   }
   if (error) {
     attributes.error = error;
@@ -160,21 +163,23 @@ export function startServer(config: ServerConfig) {
       const url = new URL(request.url);
       const startedAt = Date.now();
       let authMode: AuthMode = "none";
+      let proxyService: "opencode" | "owpenbot" | undefined;
       let proxyBaseUrl: string | undefined;
       let errorMessage: string | undefined;
 
       const finalize = (response: Response) => {
         const wrapped = withCors(response, request, config);
         if (config.logRequests) {
-          logRequest({
-            logger,
-            request,
-            response: wrapped,
-            durationMs: Date.now() - startedAt,
-            authMode,
-            proxyBaseUrl,
-            error: errorMessage,
-          });
+            logRequest({
+              logger,
+              request,
+              response: wrapped,
+              durationMs: Date.now() - startedAt,
+              authMode,
+              proxyService,
+              proxyBaseUrl,
+              error: errorMessage,
+            });
         }
         return wrapped;
       };
@@ -193,8 +198,33 @@ export function startServer(config: ServerConfig) {
             throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
           }
           const workspace = await resolveWorkspace(config, mount.workspaceId);
+          proxyService = "opencode";
           proxyBaseUrl = workspace.baseUrl?.trim() || undefined;
           const response = await proxyOpencodeRequest({ request, url, workspace, proxyPath: mount.restPath });
+          return finalize(response);
+        } catch (error) {
+          const apiError = error instanceof ApiError
+            ? error
+            : new ApiError(500, "internal_error", "Unexpected server error");
+          errorMessage = apiError.message;
+          return finalize(jsonResponse(formatError(apiError), apiError.status));
+        }
+      }
+
+      if (mount && (mount.restPath === "/owpenbot" || mount.restPath.startsWith("/owpenbot/"))) {
+        const isHealth =
+          request.method === "GET" &&
+          (mount.restPath === "/owpenbot" || mount.restPath === "/owpenbot/" || mount.restPath === "/owpenbot/health");
+        authMode = isHealth ? "client" : "host";
+        try {
+          if (authMode === "host") {
+            await requireHost(request, config, tokens);
+          } else {
+            await requireClient(request, config, tokens);
+          }
+          proxyService = "owpenbot";
+          proxyBaseUrl = resolveOwpenbotBaseUrl();
+          const response = await proxyOwpenbotRequest({ request, url, proxyPath: mount.restPath });
           return finalize(response);
         } catch (error) {
           const apiError = error instanceof ApiError
@@ -231,7 +261,32 @@ export function startServer(config: ServerConfig) {
           if (actor.scope === "viewer" && method !== "GET" && method !== "HEAD") {
             throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
           }
+          proxyService = "opencode";
           const response = await proxyOpencodeRequest({ request, url, workspace: config.workspaces[0] });
+          return finalize(response);
+        } catch (error) {
+          const apiError = error instanceof ApiError
+            ? error
+            : new ApiError(500, "internal_error", "Unexpected server error");
+          errorMessage = apiError.message;
+          return finalize(jsonResponse(formatError(apiError), apiError.status));
+        }
+      }
+
+      if (url.pathname === "/owpenbot" || url.pathname.startsWith("/owpenbot/")) {
+        const isHealth =
+          request.method === "GET" &&
+          (url.pathname === "/owpenbot" || url.pathname === "/owpenbot/" || url.pathname === "/owpenbot/health");
+        authMode = isHealth ? "client" : "host";
+        try {
+          if (authMode === "host") {
+            await requireHost(request, config, tokens);
+          } else {
+            await requireClient(request, config, tokens);
+          }
+          proxyService = "owpenbot";
+          proxyBaseUrl = resolveOwpenbotBaseUrl();
+          const response = await proxyOwpenbotRequest({ request, url });
           return finalize(response);
         } catch (error) {
           const apiError = error instanceof ApiError
@@ -319,6 +374,15 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   return target.toString();
 }
 
+function buildOwpenbotProxyUrl(baseUrl: string, path: string, search: string) {
+  const target = new URL(baseUrl);
+  const trimmedPath = path.replace(/^\/owpenbot/, "");
+  const normalized = trimmedPath.startsWith("/") ? trimmedPath : `/${trimmedPath}`;
+  target.pathname = normalized === "/" ? "/" : normalized;
+  target.search = search;
+  return target.toString();
+}
+
 async function proxyOpencodeRequest(input: {
   request: Request;
   url: URL;
@@ -335,6 +399,8 @@ async function proxyOpencodeRequest(input: {
   const targetUrl = buildOpencodeProxyUrl(baseUrl, proxyPath, input.url.search);
   const headers = new Headers(input.request.headers);
   headers.delete("authorization");
+  headers.delete("x-openwork-host-token");
+  headers.delete("x-openwork-client-id");
   headers.delete("host");
   headers.delete("origin");
 
@@ -356,6 +422,39 @@ async function proxyOpencodeRequest(input: {
     body,
   });
 
+  return response;
+}
+
+function resolveOwpenbotBaseUrl(): string {
+  const port = parseInteger(process.env.OWPENBOT_HEALTH_PORT);
+  if (!port) {
+    throw new ApiError(404, "owpenbot_unconfigured", "Owpenbot is not configured on this host");
+  }
+  return `http://127.0.0.1:${port}`;
+}
+
+async function proxyOwpenbotRequest(input: {
+  request: Request;
+  url: URL;
+  proxyPath?: string;
+}) {
+  const baseUrl = resolveOwpenbotBaseUrl();
+  const proxyPath = input.proxyPath ?? input.url.pathname;
+  const targetUrl = buildOwpenbotProxyUrl(baseUrl, proxyPath, input.url.search);
+  const headers = new Headers(input.request.headers);
+  headers.delete("authorization");
+  headers.delete("x-openwork-host-token");
+  headers.delete("x-openwork-client-id");
+  headers.delete("host");
+  headers.delete("origin");
+
+  const method = input.request.method.toUpperCase();
+  const body = method === "GET" || method === "HEAD" ? undefined : input.request.body;
+  const response = await fetch(targetUrl, {
+    method,
+    headers,
+    body,
+  });
   return response;
 }
 
@@ -443,6 +542,8 @@ function buildCapabilities(config: ServerConfig): Capabilities {
   const maxBytes = resolveInboxMaxBytes();
   const toyUiEnabled = resolveToyUiEnabled();
   const browserProvider = resolveBrowserProvider();
+  const owpenbotConfigured = Boolean(parseInteger(process.env.OWPENBOT_HEALTH_PORT));
+  const opencodeConfigured = config.workspaces.some((workspace) => Boolean(workspace.baseUrl?.trim()));
   return {
     schemaVersion,
     serverVersion: SERVER_VERSION,
@@ -456,6 +557,10 @@ function buildCapabilities(config: ServerConfig): Capabilities {
     sandbox: { enabled: sandboxEnabled, backend: sandboxBackend },
     ui: { toy: toyUiEnabled },
     tokens: { scoped: true, scopes: ["owner", "collaborator", "viewer"] },
+    proxy: {
+      opencode: opencodeConfigured,
+      owpenbot: owpenbotConfigured,
+    },
     toolProviders: {
       browser: browserProvider,
       files: {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -73,6 +73,10 @@ export interface Capabilities {
   sandbox: { enabled: boolean; backend: SandboxBackend };
   ui: { toy: boolean };
   tokens: { scoped: boolean; scopes: TokenScope[] };
+  proxy: {
+    opencode: boolean;
+    owpenbot: boolean;
+  };
   toolProviders: {
     browser: {
       enabled: boolean;


### PR DESCRIPTION
## What changed
- Route owpenbot through `openwork-server` so clients only need the edge surface:
  - host-level proxy: `/owpenbot/*`
  - workspace-mounted proxy: `/w/:id/owpenbot/*`
- Move onboarding/config flows off interactive owpenbot CLI calls:
  - openwrk TUI fetches WhatsApp QR via `GET /owpenbot/whatsapp/qr?format=ascii`
  - openwrk TUI sets Telegram token via `POST /owpenbot/config/telegram-token`
  - desktop QR command now calls `openwork-server` (no `owpenbot whatsapp qr` shellout)
- Sandbox: keep owpenbot internal (no extra published port); health/config reachable only via proxy through port `8787`.

## Auth policy
- `GET /owpenbot/health` (and mounted `/w/:id/owpenbot/health`) requires client auth.
- All other `/owpenbot/*` endpoints require host/owner auth.

## Capabilities
- `GET /capabilities` now includes `proxy: { opencode, owpenbot }` so clients can feature-detect proxy availability.

## Verification
- Host-mode:
  - `pnpm --filter openwork-server build:bin`
  - `pnpm --filter owpenwork build:bin`
  - `pnpm --filter openwrk build:bin`
  - `./packages/headless/dist/openwrk serve --workspace /tmp/openwrk-host-ws2 --check --log-format json --allow-external --sidecar-source external --openwork-server-bin ./packages/server/dist/bin/openwork-server --owpenbot-bin ./packages/owpenbot/dist/bin/owpenbot`
- Docker sandbox (custom Linux sidecars; only port 8787 published):
  - `./packages/headless/dist/openwrk serve --workspace /tmp/openwrk-sandbox-ws --sandbox docker --check --log-format json --allow-external --sidecar-source external --openwork-server-bin ./packages/server/dist/bin/openwork-server-bun-linux-arm64 --owpenbot-bin ./packages/owpenbot/dist/bin/owpenbot-bun-linux-arm64`
- Desktop compile check:
  - `cargo check` (requires local sidecars present under `packages/desktop/src-tauri/sidecars/`)

## Notes
- Apple Container backend (`--sandbox container`) not validated here because the `container` CLI is not installed in this environment.