### PR TITLE
feat(owpenbot): add operator TUI

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openwork"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "base64 0.22.1",
  "gethostname",

--- a/packages/owpenbot/src/bridge.ts
+++ b/packages/owpenbot/src/bridge.ts
@@ -1157,7 +1157,10 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
   return {
     async stop() {
-      clearInterval(healthTimer);
+      if (healthTimer) {
+        clearInterval(healthTimer);
+        healthTimer = null;
+      }
       if (stopHealthServer) stopHealthServer();
       for (const abort of eventSubscriptions.values()) {
         abort.abort();

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import { createInterface } from "node:readline/promises";
 
 import { Command } from "commander";
 
@@ -229,6 +230,272 @@ async function getWhatsAppQr(config: ReturnType<typeof loadConfig>, format: "asc
 }
 
 // -----------------------------------------------------------------------------
+// Operator TUI (TTY-first, talks to local API)
+// -----------------------------------------------------------------------------
+
+type OperatorApiTarget = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  mode: "direct" | "openwork";
+};
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+function resolveOperatorTarget(options: {
+  url?: string;
+  openworkUrl?: string;
+  hostToken?: string;
+}): OperatorApiTarget {
+  const openworkUrl = options.openworkUrl?.trim();
+  if (openworkUrl) {
+    const hostToken =
+      options.hostToken?.trim() ||
+      process.env.OPENWORK_HOST_TOKEN?.trim() ||
+      process.env.OPENWRK_OPENWORK_HOST_TOKEN?.trim() ||
+      "";
+    if (!hostToken) {
+      throw new Error("--host-token is required when using --openwork-url (or set OPENWORK_HOST_TOKEN)");
+    }
+
+    const base = normalizeBaseUrl(openworkUrl);
+    const baseUrl = base.endsWith("/owpenbot") ? base : `${base}/owpenbot`;
+    return {
+      baseUrl,
+      headers: {
+        "X-OpenWork-Host-Token": hostToken,
+      },
+      mode: "openwork",
+    };
+  }
+
+  const port = process.env.OWPENBOT_HEALTH_PORT?.trim() || "3005";
+  const baseUrl = normalizeBaseUrl(options.url?.trim() || `http://127.0.0.1:${port}`);
+  return { baseUrl, headers: {}, mode: "direct" };
+}
+
+async function fetchOwpenbotJson(target: OperatorApiTarget, pathname: string, init?: RequestInit) {
+  const url = `${target.baseUrl}${pathname.startsWith("/") ? "" : "/"}${pathname}`;
+  const headers = {
+    ...target.headers,
+    ...(init?.headers ?? {}),
+  } as Record<string, string>;
+  const res = await fetch(url, {
+    ...init,
+    headers,
+  });
+  const text = await res.text();
+  let payload: any = null;
+  if (text.trim()) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = { raw: text };
+    }
+  }
+  if (!res.ok) {
+    const message = typeof payload?.error === "string" ? payload.error : text.trim() || `HTTP ${res.status}`;
+    throw new Error(message);
+  }
+  return payload;
+}
+
+function formatYesNo(value: unknown): string {
+  return value ? "yes" : "no";
+}
+
+async function runOperatorTui(options: { url?: string; openworkUrl?: string; hostToken?: string }) {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error("tui requires an interactive TTY");
+  }
+
+  const target = resolveOperatorTarget(options);
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  const pause = async () => {
+    await rl.question("\nPress Enter to continue...");
+  };
+
+  try {
+    // Initial probe
+    await fetchOwpenbotJson(target, "/health");
+
+    while (true) {
+      console.clear();
+      const health = await fetchOwpenbotJson(target, "/health");
+      const opencode = health?.opencode ?? {};
+      const channels = health?.channels ?? {};
+      const config = health?.config ?? {};
+
+      console.log(`Owpenbot Operator TUI (${target.mode})`);
+      console.log(`API: ${target.baseUrl}`);
+      console.log(`OpenCode healthy: ${formatYesNo(opencode.healthy)}`);
+      console.log(`Telegram adapter: ${formatYesNo(channels.telegram)}`);
+      console.log(`WhatsApp adapter: ${formatYesNo(channels.whatsapp)}`);
+      console.log(`Slack adapter: ${formatYesNo(channels.slack)}`);
+      console.log(`Groups enabled: ${formatYesNo(config.groupsEnabled)}`);
+      console.log("");
+      console.log("1) Refresh");
+      console.log("2) Show WhatsApp QR (ASCII)");
+      console.log("3) Toggle WhatsApp enabled");
+      console.log("4) Toggle groups enabled");
+      console.log("5) Set Telegram token");
+      console.log("6) Set Slack tokens");
+      console.log("7) List bindings");
+      console.log("8) Set binding");
+      console.log("9) Clear binding");
+      console.log("0) Exit");
+
+      const choice = (await rl.question("\nSelect> ")).trim().toLowerCase();
+      if (choice === "0" || choice === "q" || choice === "quit" || choice === "exit") {
+        return;
+      }
+
+      try {
+        if (choice === "1" || choice === "r" || choice === "refresh") {
+          continue;
+        }
+
+        if (choice === "2") {
+          const qr = await fetchOwpenbotJson(target, "/whatsapp/qr?format=ascii");
+          console.clear();
+          const out = typeof qr?.qr === "string" ? qr.qr : JSON.stringify(qr, null, 2);
+          process.stdout.write(`${out}\n`);
+          await pause();
+          continue;
+        }
+
+        if (choice === "3") {
+          const current = await fetchOwpenbotJson(target, "/config/whatsapp-enabled");
+          const enabled = Boolean(current?.enabled);
+          const next = await fetchOwpenbotJson(target, "/config/whatsapp-enabled", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ enabled: !enabled }),
+          });
+          console.log(`\nWhatsApp enabled: ${formatYesNo(!enabled)}`);
+          if (next?.error) console.log(`Error: ${String(next.error)}`);
+          await pause();
+          continue;
+        }
+
+        if (choice === "4") {
+          const current = await fetchOwpenbotJson(target, "/config/groups");
+          const enabled = Boolean(current?.groupsEnabled);
+          const next = await fetchOwpenbotJson(target, "/config/groups", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ enabled: !enabled }),
+          });
+          console.log(`\nGroups enabled: ${formatYesNo(!enabled)}`);
+          if (next?.error) console.log(`Error: ${String(next.error)}`);
+          await pause();
+          continue;
+        }
+
+        if (choice === "5") {
+          const token = (await rl.question("Telegram bot token> ")).trim();
+          if (!token) {
+            await pause();
+            continue;
+          }
+          const next = await fetchOwpenbotJson(target, "/config/telegram-token", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token }),
+          });
+          console.log("\nTelegram updated.");
+          if (next?.telegram?.error) console.log(`Error: ${String(next.telegram.error)}`);
+          await pause();
+          continue;
+        }
+
+        if (choice === "6") {
+          const botToken = (await rl.question("Slack bot token> ")).trim();
+          const appToken = (await rl.question("Slack app token> ")).trim();
+          if (!botToken || !appToken) {
+            await pause();
+            continue;
+          }
+          const next = await fetchOwpenbotJson(target, "/config/slack-tokens", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ botToken, appToken }),
+          });
+          console.log("\nSlack updated.");
+          if (next?.slack?.error) console.log(`Error: ${String(next.slack.error)}`);
+          await pause();
+          continue;
+        }
+
+        if (choice === "7") {
+          const bindings = await fetchOwpenbotJson(target, "/bindings");
+          console.clear();
+          console.log("Bindings:\n");
+          const items = Array.isArray(bindings?.items) ? bindings.items : [];
+          if (!items.length) {
+            console.log("(none)");
+          } else {
+            for (const item of items) {
+              const channel = String(item.channel ?? "");
+              const peerId = String(item.peerId ?? "");
+              const directory = String(item.directory ?? "");
+              console.log(`${channel} ${peerId} -> ${directory}`);
+            }
+          }
+          await pause();
+          continue;
+        }
+
+        if (choice === "8") {
+          const channel = (await rl.question("Channel (whatsapp|telegram|slack)> ")).trim();
+          const peerId = (await rl.question("Peer ID> ")).trim();
+          const directory = (await rl.question("OpenCode directory path> ")).trim();
+          if (!channel || !peerId || !directory) {
+            await pause();
+            continue;
+          }
+          await fetchOwpenbotJson(target, "/bindings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ channel, peerId, directory }),
+          });
+          console.log("\nBinding saved.");
+          await pause();
+          continue;
+        }
+
+        if (choice === "9") {
+          const channel = (await rl.question("Channel (whatsapp|telegram|slack)> ")).trim();
+          const peerId = (await rl.question("Peer ID> ")).trim();
+          if (!channel || !peerId) {
+            await pause();
+            continue;
+          }
+          await fetchOwpenbotJson(target, "/bindings", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ channel, peerId, directory: "" }),
+          });
+          console.log("\nBinding cleared.");
+          await pause();
+          continue;
+        }
+
+        console.log("\nUnknown choice.");
+        await pause();
+      } catch (error) {
+        console.log(`\nError: ${error instanceof Error ? error.message : String(error)}`);
+        await pause();
+      }
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+// -----------------------------------------------------------------------------
 // Commander setup
 // -----------------------------------------------------------------------------
 
@@ -354,6 +621,27 @@ program
       console.log(`Slack configured: ${config.slackBotToken && config.slackAppToken ? "yes" : "no"}`);
       console.log(`Auth dir: ${config.whatsappAuthDir}`);
       console.log(`OpenCode URL: ${config.opencodeUrl}`);
+    }
+  });
+
+// -----------------------------------------------------------------------------
+// tui command
+// -----------------------------------------------------------------------------
+
+program
+  .command("tui")
+  .description("Interactive operator UI (requires a running owpenbot health API)")
+  .option("--url <url>", "Owpenbot API base URL (default: http://127.0.0.1:$OWPENBOT_HEALTH_PORT)")
+  .option("--openwork-url <url>", "OpenWork server URL to proxy owpenbot through (uses /owpenbot/*)")
+  .option("--host-token <token>", "OpenWork host token (required with --openwork-url; or set OPENWORK_HOST_TOKEN)")
+  .action(async (opts: { url?: string; openworkUrl?: string; hostToken?: string }) => {
+    if (program.opts().json) {
+      outputError("tui does not support --json (use health/status/config commands instead)");
+    }
+    try {
+      await runOperatorTui(opts);
+    } catch (error) {
+      outputError(error instanceof Error ? error.message : String(error));
     }
   });
 

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -246,25 +246,33 @@ function normalizeBaseUrl(url: string): string {
 function resolveOperatorTarget(options: {
   url?: string;
   openworkUrl?: string;
+  token?: string;
   hostToken?: string;
 }): OperatorApiTarget {
   const openworkUrl = options.openworkUrl?.trim();
   if (openworkUrl) {
+    const token =
+      options.token?.trim() ||
+      process.env.OPENWORK_TOKEN?.trim() ||
+      process.env.OPENWRK_OPENWORK_TOKEN?.trim() ||
+      "";
+    if (!token) {
+      throw new Error("--token is required when using --openwork-url (or set OPENWORK_TOKEN)");
+    }
+
     const hostToken =
       options.hostToken?.trim() ||
       process.env.OPENWORK_HOST_TOKEN?.trim() ||
       process.env.OPENWRK_OPENWORK_HOST_TOKEN?.trim() ||
       "";
-    if (!hostToken) {
-      throw new Error("--host-token is required when using --openwork-url (or set OPENWORK_HOST_TOKEN)");
-    }
 
     const base = normalizeBaseUrl(openworkUrl);
     const baseUrl = base.endsWith("/owpenbot") ? base : `${base}/owpenbot`;
     return {
       baseUrl,
       headers: {
-        "X-OpenWork-Host-Token": hostToken,
+        Authorization: `Bearer ${token}`,
+        ...(hostToken ? { "X-OpenWork-Host-Token": hostToken } : {}),
       },
       mode: "openwork",
     };
@@ -305,7 +313,7 @@ function formatYesNo(value: unknown): string {
   return value ? "yes" : "no";
 }
 
-async function runOperatorTui(options: { url?: string; openworkUrl?: string; hostToken?: string }) {
+async function runOperatorTui(options: { url?: string; openworkUrl?: string; token?: string; hostToken?: string }) {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("tui requires an interactive TTY");
   }
@@ -633,8 +641,9 @@ program
   .description("Interactive operator UI (requires a running owpenbot health API)")
   .option("--url <url>", "Owpenbot API base URL (default: http://127.0.0.1:$OWPENBOT_HEALTH_PORT)")
   .option("--openwork-url <url>", "OpenWork server URL to proxy owpenbot through (uses /owpenbot/*)")
-  .option("--host-token <token>", "OpenWork host token (required with --openwork-url; or set OPENWORK_HOST_TOKEN)")
-  .action(async (opts: { url?: string; openworkUrl?: string; hostToken?: string }) => {
+  .option("--token <token>", "OpenWork client token (required with --openwork-url; or set OPENWORK_TOKEN)")
+  .option("--host-token <token>", "OpenWork host token (required for admin actions; or use an owner token)")
+  .action(async (opts: { url?: string; openworkUrl?: string; token?: string; hostToken?: string }) => {
     if (program.opts().json) {
       outputError("tui does not support --json (use health/status/config commands instead)");
     }


### PR DESCRIPTION
## What changed
- Add `owpenbot tui`: a TTY-first interactive operator menu.
- The TUI talks to the owpenbot health/control API:
  - Direct mode (default): `--url http://127.0.0.1:$OWPENBOT_HEALTH_PORT`
  - Proxy mode: `--openwork-url <openwork-server-url>` + `--host-token <token>` (uses `/owpenbot/*`)
- Actions supported:
  - View `/health` snapshot
  - Fetch WhatsApp QR as ASCII (`GET /whatsapp/qr?format=ascii`)
  - Toggle WhatsApp enabled (`/config/whatsapp-enabled`)
  - Toggle groups enabled (`/config/groups`)
  - Set Telegram token (`/config/telegram-token`)
  - Set Slack tokens (`/config/slack-tokens`)
  - List/set/clear bindings (`/bindings`)

## Fix included
- Guard `clearInterval` against a null timer so `pnpm --filter owpenwork build` succeeds.

## Usage
- Local (direct):
  - `owpenbot tui --url http://127.0.0.1:3005`
- Via OpenWork edge (recommended when running under openwrk):
  - `owpenbot tui --openwork-url http://127.0.0.1:8787 --host-token <HOST_TOKEN>`

## Verification
- `pnpm install`
- `pnpm --filter owpenwork build`
- `bun packages/owpenbot/dist/cli.js tui --help`