### PR TITLE
feat(agent-lab): multi-instance host + Agent Lab Toy UI

### DIFF
--- a/packages/agent-lab/README.md
+++ b/packages/agent-lab/README.md
@@ -1,0 +1,40 @@
+# OpenWork Agent Lab (toy)
+
+This package is a CLI-first instance manager for the Agent Lab concept.
+
+It is intentionally small and experimental.
+
+Agent Lab reuses existing OpenWork infrastructure:
+
+- `openwrk` orchestrator (sandboxing + sidecars)
+- `openwork-server` edge API + Toy UI
+- `opencode` engine
+
+## Local development
+
+From the repo root:
+
+```bash
+pnpm -C packages/agent-lab dev -- --help
+```
+
+## Commands (MVP)
+
+```bash
+# Create an instance directory + workspace
+pnpm -C packages/agent-lab dev -- create --name Scout
+
+# Start services (sandbox) for that instance
+pnpm -C packages/agent-lab dev -- start <instanceId>
+
+# Open the Toy UI for that instance
+pnpm -C packages/agent-lab dev -- open <instanceId>
+
+# Stop the sandbox container
+pnpm -C packages/agent-lab dev -- stop <instanceId>
+```
+
+Notes:
+
+- This is macOS-first and assumes Bun is available.
+- Multi-instance is achieved by per-instance ports + per-instance directories.

--- a/packages/agent-lab/package.json
+++ b/packages/agent-lab/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "openwork-agent-lab",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Agent Lab instance manager (toy) for OpenWork",
+  "type": "module",
+  "bin": {
+    "openwork-agent-lab": "dist/bin/openwork-agent-lab"
+  },
+  "scripts": {
+    "dev": "bun src/cli.ts",
+    "build": "tsc -p tsconfig.json",
+    "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-agent-lab",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "bun-types": "^1.3.6",
+    "typescript": "^5.6.3"
+  },
+  "packageManager": "pnpm@10.27.0"
+}

--- a/packages/agent-lab/src/cli.ts
+++ b/packages/agent-lab/src/cli.ts
@@ -3,9 +3,10 @@
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer as createNetServer } from "node:net";
 
 type SandboxMode = "none" | "auto" | "docker" | "container";
 type ApprovalMode = "manual" | "auto";
@@ -13,6 +14,7 @@ type ApprovalMode = "manual" | "auto";
 type Entrypoint = {
   path: string;
   rw: boolean;
+  label: string;
 };
 
 type Instance = {
@@ -29,13 +31,35 @@ type Instance = {
     url: string;
     token: string;
     hostToken: string;
+    ownerToken?: string;
     approval: ApprovalMode;
   };
   openwrk?: {
     sandbox: SandboxMode;
+    sandboxImage?: string;
+    sandboxAllowlistPath?: string;
     stopCommand?: string;
     startedAt?: number;
   };
+};
+
+type AgentLabSchedule =
+  | { kind: "interval"; seconds: number }
+  | { kind: "daily"; hour: number; minute: number }
+  | { kind: "weekly"; weekday: number; hour: number; minute: number };
+
+type AgentLabAutomation = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: AgentLabSchedule;
+  prompt: string;
+};
+
+type AgentLabAutomationStore = {
+  schemaVersion: number;
+  updatedAt: number;
+  items: AgentLabAutomation[];
 };
 
 type ConnectArtifact = {
@@ -44,7 +68,7 @@ type ConnectArtifact = {
   workspaceId: string;
   workspaceUrl: string;
   token: string;
-  tokenScope: "collaborator";
+  tokenScope: "owner" | "collaborator" | "viewer";
   createdAt: number;
 };
 
@@ -59,6 +83,7 @@ function usage(): string {
     "  stop     Stop an instance (stops sandbox container)",
     "  status   Show instance status (health + workspace id)",
     "  open     Print Toy UI URL for an instance",
+    "  scheduler Manage scheduled automations (launchd)",
     "  delete   Delete an instance directory (danger)",
     "",
     "Options:",
@@ -68,6 +93,9 @@ function usage(): string {
     "  --port <port>        OpenWork server port (create/start)",
     "  --approval <mode>    manual|auto (default: manual)",
     "  --sandbox <mode>     none|auto|docker|container (default: auto)",
+    "  --sandbox-image <id> Sandbox image (default: openwrk default)",
+    "  --entrypoint <spec>  Extra mount: /path[:label][:ro|rw] (repeatable)",
+    "  --scope <scope>      owner|collaborator (open)",
     "  --start              Start immediately after create",
     "  --help               Show help",
   ].join("\n");
@@ -79,6 +107,17 @@ function readFlag(argv: string[], name: string): string | undefined {
   const next = argv[idx + 1];
   if (!next || next.startsWith("--")) return undefined;
   return next;
+}
+
+function readFlags(argv: string[], name: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] !== name) continue;
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) continue;
+    out.push(next);
+  }
+  return out;
 }
 
 function hasFlag(argv: string[], name: string): boolean {
@@ -106,6 +145,97 @@ function normalizeSandbox(raw: string | undefined): SandboxMode {
 function baseDirFromArgs(argv: string[]): string {
   const override = readFlag(argv, "--dir") ?? process.env.OPENWORK_AGENT_LAB_DIR;
   return resolve(override?.trim() ? override.trim() : join(homedir(), ".openwork", "agent-lab"));
+}
+
+function expandTildePath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+  return trimmed;
+}
+
+function sanitizeMountLabel(input: string): string {
+  const raw = input.trim().toLowerCase();
+  let out = "";
+  let dash = false;
+  for (const ch of raw) {
+    if ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9")) {
+      out += ch;
+      dash = false;
+      continue;
+    }
+    if (ch === "_" || ch === "-") {
+      out += ch;
+      dash = false;
+      continue;
+    }
+    if (!dash) {
+      out += "-";
+      dash = true;
+    }
+  }
+  out = out.replace(/^-+/, "").replace(/-+$/, "");
+  return out || "mount";
+}
+
+function uniqueLabel(label: string, used: Set<string>): string {
+  let candidate = label;
+  let i = 2;
+  while (used.has(candidate)) {
+    candidate = `${label}-${i}`;
+    i++;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+function parseEntrypointSpec(spec: string, usedLabels: Set<string>): Entrypoint {
+  const trimmed = spec.trim();
+  if (!trimmed) throw new Error("invalid_entrypoint: empty");
+
+  let rw = false;
+  let base = trimmed;
+  if (trimmed.endsWith(":ro")) {
+    rw = false;
+    base = trimmed.slice(0, -3);
+  } else if (trimmed.endsWith(":rw")) {
+    rw = true;
+    base = trimmed.slice(0, -3);
+  }
+
+  const idx = base.indexOf(":");
+  const rawPath = (idx > 0 ? base.slice(0, idx) : base).trim();
+  const rawLabel = (idx > 0 ? base.slice(idx + 1) : "").trim();
+  if (!rawPath) throw new Error(`invalid_entrypoint: ${spec}`);
+
+  const expanded = expandTildePath(rawPath);
+  const absPath = resolve(expanded);
+  const derived = sanitizeMountLabel(rawLabel || basename(absPath));
+  const label = uniqueLabel(derived, usedLabels);
+  return { path: absPath, rw, label };
+}
+
+async function canBind(host: string, port: number): Promise<boolean> {
+  return await new Promise((resolveResult) => {
+    const server = createNetServer();
+    server.once("error", () => {
+      try { server.close(); } catch {}
+      resolveResult(false);
+    });
+    server.listen(port, host, () => {
+      server.close(() => resolveResult(true));
+    });
+  });
+}
+
+async function allocatePort(host: string, preferred: number | undefined, avoid: Set<number>): Promise<number> {
+  if (preferred) return preferred;
+  for (let port = 8787; port < 9800; port++) {
+    if (avoid.has(port)) continue;
+    if (await canBind(host, port)) return port;
+  }
+  throw new Error("no_free_port");
 }
 
 function instanceDir(baseDir: string, id: string): string {
@@ -171,7 +301,10 @@ function defaultBehavior(): string {
   ].join("\n");
 }
 
-async function provisionWorkspace(workspaceDir: string, name: string): Promise<void> {
+async function provisionWorkspace(
+  workspaceDir: string,
+  agent: { id: string; name: string; avatarSeed: string; entrypoints: Entrypoint[] },
+): Promise<void> {
   await ensureDir(workspaceDir);
   await ensureDir(join(workspaceDir, ".opencode"));
   await ensureDir(join(workspaceDir, ".opencode", "agent"));
@@ -180,8 +313,26 @@ async function provisionWorkspace(workspaceDir: string, name: string): Promise<v
   await ensureDir(join(workspaceDir, ".opencode", "openwork", "inbox"));
   await ensureDir(join(workspaceDir, ".opencode", "openwork", "outbox"));
 
-  await writeIfMissing(join(workspaceDir, ".opencode", "agent", "personality.md"), defaultPersonality(name));
+  await writeIfMissing(
+    join(workspaceDir, ".opencode", "agent", "personality.md"),
+    defaultPersonality(agent.name),
+  );
   await writeIfMissing(join(workspaceDir, ".opencode", "agent", "behavior.md"), defaultBehavior());
+
+  const openworkConfigPath = join(workspaceDir, ".opencode", "openwork.json");
+  if (!existsSync(openworkConfigPath)) {
+    const payload = {
+      agentLab: {
+        agent: {
+          id: agent.id,
+          name: agent.name,
+          avatarSeed: agent.avatarSeed,
+        },
+        entrypoints: agent.entrypoints.map((e) => ({ path: e.path, rw: e.rw, label: e.label })),
+      },
+    };
+    await writeFile(openworkConfigPath, JSON.stringify(payload, null, 2) + "\n", "utf8");
+  }
 
   const configPath = join(workspaceDir, "opencode.json");
   if (!existsSync(configPath)) {
@@ -210,10 +361,32 @@ async function listInstanceDirs(baseDir: string): Promise<string[]> {
   }
 }
 
-async function fetchJson(url: string, options?: { token?: string }): Promise<any> {
-  const headers: Record<string, string> = {};
-  if (options?.token) headers.Authorization = `Bearer ${options.token}`;
-  const res = await fetch(url, { headers, signal: AbortSignal.timeout(4000) });
+async function requestJson(
+  url: string,
+  options?: {
+    token?: string;
+    method?: string;
+    headers?: Record<string, string>;
+    body?: unknown;
+    timeoutMs?: number;
+  },
+): Promise<any> {
+  const headers: Record<string, string> = { ...(options?.headers ?? {}) };
+  if (options?.token && !headers.Authorization) headers.Authorization = `Bearer ${options.token}`;
+
+  const method = (options?.method ?? (options?.body ? "POST" : "GET")).toUpperCase();
+  let body: BodyInit | undefined;
+  if (options?.body !== undefined && method !== "GET" && method !== "HEAD") {
+    if (typeof options.body === "string") {
+      body = options.body;
+    } else {
+      if (!headers["Content-Type"]) headers["Content-Type"] = "application/json";
+      body = JSON.stringify(options.body);
+    }
+  }
+
+  const timeoutMs = options?.timeoutMs ?? 4000;
+  const res = await fetch(url, { method, headers, body, signal: AbortSignal.timeout(timeoutMs) });
   const text = await res.text();
   let json: any = null;
   try {
@@ -250,12 +423,144 @@ function openwrkBin(): string {
   return "openwrk";
 }
 
+function sandboxAllowlistPath(instance: Instance): string {
+  return join(instance.dir, "sandbox-mount-allowlist.json");
+}
+
+async function writeSandboxAllowlistFile(path: string, entrypoints: Entrypoint[]): Promise<void> {
+  const payload = {
+    allowedRoots: entrypoints.map((e) => ({
+      path: e.path,
+      allowReadWrite: e.rw,
+      description: `Agent Lab entrypoint (${e.label})`,
+    })),
+  };
+  await writeFile(path, JSON.stringify(payload, null, 2) + "\n", "utf8");
+}
+
+function buildSandboxMountSpecs(entrypoints: Entrypoint[]): string[] {
+  return entrypoints.map((e) => `${e.path}:${e.label}:${e.rw ? "rw" : "ro"}`);
+}
+
+function launchAgentsDir(): string {
+  return join(homedir(), "Library", "LaunchAgents");
+}
+
+function agentLabAutomationsPath(workspaceDir: string): string {
+  return join(workspaceDir, ".opencode", "openwork", "agentlab", "automations.json");
+}
+
+function agentLabLogsDir(workspaceDir: string): string {
+  return join(workspaceDir, ".opencode", "openwork", "agentlab", "logs");
+}
+
+function bashQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function launchdLabel(instanceId: string, automationId: string): string {
+  return `com.openwork.agentlab.${instanceId}.${automationId}`;
+}
+
+function launchdPlistPath(label: string): string {
+  return join(launchAgentsDir(), `${label}.plist`);
+}
+
+function schedulerScriptPath(instance: Instance, automationId: string): string {
+  return join(instance.dir, "scheduler", `${automationId}.sh`);
+}
+
+function launchdLogPath(instance: Instance, automationId: string): string {
+  return join(agentLabLogsDir(instance.workspaceDir), `${automationId}.log`);
+}
+
+async function readAutomationsFromWorkspace(workspaceDir: string): Promise<AgentLabAutomationStore> {
+  const path = agentLabAutomationsPath(workspaceDir);
+  if (!existsSync(path)) {
+    return { schemaVersion: 1, updatedAt: Date.now(), items: [] };
+  }
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<AgentLabAutomationStore>;
+    const items = Array.isArray(parsed.items) ? parsed.items : [];
+    const normalized: AgentLabAutomation[] = [];
+    for (const item of items) {
+      const record = item as Partial<AgentLabAutomation>;
+      const id = typeof record.id === "string" ? record.id.trim() : "";
+      const name = typeof record.name === "string" ? record.name.trim() : "";
+      const prompt = typeof record.prompt === "string" ? record.prompt : "";
+      const enabled = typeof record.enabled === "boolean" ? record.enabled : true;
+      const schedule = record.schedule as AgentLabSchedule | undefined;
+      if (!id || !name || !prompt || !schedule || typeof (schedule as any).kind !== "string") continue;
+      normalized.push({ id, name, enabled, schedule, prompt });
+    }
+    return {
+      schemaVersion: typeof parsed.schemaVersion === "number" ? parsed.schemaVersion : 1,
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+      items: normalized,
+    };
+  } catch {
+    return { schemaVersion: 1, updatedAt: Date.now(), items: [] };
+  }
+}
+
+function buildLaunchdPlistXml(input: {
+  label: string;
+  scriptPath: string;
+  schedule: AgentLabSchedule;
+  logPath: string;
+}): string {
+  const header = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    "<dict>",
+    `  <key>Label</key><string>${input.label}</string>`,
+    "  <key>ProgramArguments</key>",
+    "  <array>",
+    "    <string>/bin/bash</string>",
+    `    <string>${input.scriptPath}</string>`,
+    "  </array>",
+    `  <key>StandardOutPath</key><string>${input.logPath}</string>`,
+    `  <key>StandardErrorPath</key><string>${input.logPath}</string>`,
+  ];
+
+  const schedule = input.schedule;
+  const scheduleLines: string[] = [];
+  if (schedule.kind === "interval") {
+    scheduleLines.push(`  <key>StartInterval</key><integer>${schedule.seconds}</integer>`);
+  } else if (schedule.kind === "daily") {
+    scheduleLines.push("  <key>StartCalendarInterval</key>");
+    scheduleLines.push("  <dict>");
+    scheduleLines.push(`    <key>Hour</key><integer>${schedule.hour}</integer>`);
+    scheduleLines.push(`    <key>Minute</key><integer>${schedule.minute}</integer>`);
+    scheduleLines.push("  </dict>");
+  } else if (schedule.kind === "weekly") {
+    scheduleLines.push("  <key>StartCalendarInterval</key>");
+    scheduleLines.push("  <dict>");
+    scheduleLines.push(`    <key>Weekday</key><integer>${schedule.weekday}</integer>`);
+    scheduleLines.push(`    <key>Hour</key><integer>${schedule.hour}</integer>`);
+    scheduleLines.push(`    <key>Minute</key><integer>${schedule.minute}</integer>`);
+    scheduleLines.push("  </dict>");
+  }
+
+  const footer = ["</dict>", "</plist>"];
+  return [...header, ...scheduleLines, ...footer].join("\n") + "\n";
+}
+
+function runLaunchctl(args: string[]): void {
+  spawnSync("launchctl", args, { stdio: "ignore" });
+}
+
 async function runOpenwrkStart(options: {
   workspaceDir: string;
   dataDir: string;
   sidecarDir: string;
   sandboxPersistDir: string;
   sandbox: SandboxMode;
+  sandboxImage?: string;
+  sandboxMounts?: string[];
+  sandboxAllowlistPath?: string;
   openworkHost: string;
   openworkPort: number;
   token: string;
@@ -271,6 +576,10 @@ async function runOpenwrkStart(options: {
     options.runId,
     "--sandbox",
     options.sandbox,
+    ...(options.sandbox !== "none" && options.sandboxImage ? ["--sandbox-image", options.sandboxImage] : []),
+    ...(options.sandbox !== "none" && options.sandboxMounts && options.sandboxMounts.length
+      ? ["--sandbox-mount", options.sandboxMounts.join(",")]
+      : []),
     "--workspace",
     options.workspaceDir,
     "--data-dir",
@@ -296,7 +605,13 @@ async function runOpenwrkStart(options: {
     const child = spawn(openwrkBin(), args, {
       cwd: options.workspaceDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, OPENWRK_COLOR: "0" },
+      env: {
+        ...process.env,
+        OPENWRK_COLOR: "0",
+        ...(options.sandboxAllowlistPath
+          ? { OPENWRK_SANDBOX_MOUNT_ALLOWLIST: options.sandboxAllowlistPath }
+          : {}),
+      },
     });
     let out = "";
     let err = "";
@@ -326,27 +641,47 @@ async function create(argv: string[]) {
   const baseDir = baseDirFromArgs(argv);
   const name = readFlag(argv, "--name") ?? "Scout";
   const id = (readFlag(argv, "--id") ?? "").trim() || `agent_${randomUUID().slice(0, 8)}`;
-  const port = readNumberFlag(argv, "--port") ?? 8787;
   const approval = normalizeApproval(readFlag(argv, "--approval"));
   const sandbox = normalizeSandbox(readFlag(argv, "--sandbox"));
+  const sandboxImage = readFlag(argv, "--sandbox-image")?.trim() || undefined;
+
+  const usedPorts = new Set<number>();
+  const existingDirs = await listInstanceDirs(baseDir);
+  for (const dir of existingDirs) {
+    const path = agentPath(dir);
+    if (!existsSync(path)) continue;
+    try {
+      const inst = await loadInstance(dir);
+      const port = inst.openwork?.port;
+      if (typeof port === "number" && Number.isFinite(port)) usedPorts.add(port);
+    } catch {
+      // ignore
+    }
+  }
+  const port = await allocatePort("127.0.0.1", readNumberFlag(argv, "--port") ?? undefined, usedPorts);
+
+  const usedLabels = new Set<string>();
+  const entrypoints = readFlags(argv, "--entrypoint")
+    .map((spec) => parseEntrypointSpec(spec, usedLabels));
 
   const dir = instanceDir(baseDir, id);
   const workspaceDir = join(dir, "workspace");
   await ensureDir(join(baseDir, "instances"));
   await ensureDir(dir);
 
-  await provisionWorkspace(workspaceDir, name);
+  const avatarSeed = `${id}:${name}`;
+  await provisionWorkspace(workspaceDir, { id, name, avatarSeed, entrypoints });
 
   const token = randomToken();
   const hostToken = randomToken();
   const instance: Instance = {
     id,
     name,
-    avatarSeed: `${id}:${name}`,
+    avatarSeed,
     createdAt: Date.now(),
     dir,
     workspaceDir,
-    entrypoints: [],
+    entrypoints,
     openwork: {
       host: "127.0.0.1",
       port,
@@ -357,6 +692,7 @@ async function create(argv: string[]) {
     },
     openwrk: {
       sandbox,
+      sandboxImage,
     },
   };
   await saveInstance(dir, instance);
@@ -394,12 +730,14 @@ async function start(argv: string[]) {
   const port = readNumberFlag(argv, "--port") ?? instance.openwork.port;
   const approval = normalizeApproval(readFlag(argv, "--approval")) ?? instance.openwork.approval;
   const sandbox = normalizeSandbox(readFlag(argv, "--sandbox")) ?? (instance.openwrk?.sandbox ?? "auto");
+  const sandboxImage = readFlag(argv, "--sandbox-image")?.trim() || instance.openwrk?.sandboxImage;
 
   instance.openwork.port = port;
   instance.openwork.url = `http://${instance.openwork.host}:${port}`;
   instance.openwork.approval = approval;
   if (!instance.openwrk) instance.openwrk = { sandbox };
   instance.openwrk.sandbox = sandbox;
+  instance.openwrk.sandboxImage = sandboxImage;
 
   const dataDir = join(instance.dir, "openwrk-data");
   const sidecarDir = join(instance.dir, "sidecars");
@@ -408,12 +746,33 @@ async function start(argv: string[]) {
   await ensureDir(sidecarDir);
   await ensureDir(sandboxPersistDir);
 
+  for (const entrypoint of instance.entrypoints) {
+    if (!existsSync(entrypoint.path)) {
+      throw new Error(`entrypoint_missing: ${entrypoint.path}`);
+    }
+  }
+
+  const sandboxMounts = sandbox !== "none" && instance.entrypoints.length
+    ? buildSandboxMountSpecs(instance.entrypoints)
+    : [];
+  const allowlistPath = sandbox !== "none" && instance.entrypoints.length
+    ? sandboxAllowlistPath(instance)
+    : undefined;
+
+  if (allowlistPath && sandboxMounts.length) {
+    await writeSandboxAllowlistFile(allowlistPath, instance.entrypoints);
+    instance.openwrk.sandboxAllowlistPath = allowlistPath;
+  }
+
   const result = await runOpenwrkStart({
     workspaceDir: instance.workspaceDir,
     dataDir,
     sidecarDir,
     sandboxPersistDir,
     sandbox,
+    sandboxImage,
+    sandboxMounts,
+    sandboxAllowlistPath: allowlistPath,
     openworkHost: instance.openwork.host,
     openworkPort: instance.openwork.port,
     token: instance.openwork.token,
@@ -428,10 +787,39 @@ async function start(argv: string[]) {
 
   await waitForOpenwork(instance.openwork.url);
 
-  const workspaces = await fetchJson(`${instance.openwork.url.replace(/\/$/, "")}/workspaces`, { token: instance.openwork.token });
+  const workspaces = await requestJson(`${instance.openwork.url.replace(/\/$/, "")}/workspaces`, { token: instance.openwork.token });
   const workspaceId = String(workspaces?.activeId || (workspaces?.items?.[0]?.id ?? ""));
   if (!workspaceId) throw new Error("workspace_id_missing");
-  const connect: ConnectArtifact = {
+
+  const ownerTokenExisting = (instance.openwork.ownerToken ?? "").trim();
+  let ownerToken: string | undefined;
+  if (ownerTokenExisting) {
+    try {
+      const who = await requestJson(`${instance.openwork.url.replace(/\/$/, "")}/whoami`, { token: ownerTokenExisting });
+      const scope = who?.actor?.scope;
+      if (scope === "owner") {
+        ownerToken = ownerTokenExisting;
+      }
+    } catch {
+      ownerToken = undefined;
+    }
+  }
+
+  if (!ownerToken) {
+    const issued = await requestJson(`${instance.openwork.url.replace(/\/$/, "")}/tokens`, {
+      method: "POST",
+      headers: { "X-OpenWork-Host-Token": instance.openwork.hostToken },
+      body: { scope: "owner", label: `agent-lab:${instance.id}` },
+      timeoutMs: 8000,
+    });
+    const token = String(issued?.token ?? "").trim();
+    if (!token) throw new Error("owner_token_missing");
+    ownerToken = token;
+    instance.openwork.ownerToken = token;
+    await saveInstance(dir, instance);
+  }
+
+  const collaboratorConnect: ConnectArtifact = {
     kind: "openwork.connect.v1",
     hostUrl: instance.openwork.url,
     workspaceId,
@@ -441,7 +829,37 @@ async function start(argv: string[]) {
     createdAt: Date.now(),
   };
 
-  console.log(JSON.stringify({ ok: true, connect, ui: `${instance.openwork.url}/ui#token=${instance.openwork.token}` }, null, 2));
+  const ownerConnect: ConnectArtifact = {
+    kind: "openwork.connect.v1",
+    hostUrl: instance.openwork.url,
+    workspaceId,
+    workspaceUrl: `${instance.openwork.url.replace(/\/$/, "")}/w/${encodeURIComponent(workspaceId)}`,
+    token: ownerToken,
+    tokenScope: "owner",
+    createdAt: Date.now(),
+  };
+
+  const connectPath = join(instance.dir, "connect.json");
+  await writeFile(connectPath, JSON.stringify(collaboratorConnect, null, 2) + "\n", "utf8");
+
+  console.log(JSON.stringify({
+    ok: true,
+    workspaceId,
+    connect: {
+      collaborator: collaboratorConnect,
+      owner: ownerConnect,
+    },
+    ui: {
+      collaborator: `${instance.openwork.url}/ui#token=${instance.openwork.token}`,
+      owner: `${instance.openwork.url}/ui#token=${ownerToken}`,
+    },
+    scheduler: {
+      automationsPath: agentLabAutomationsPath(instance.workspaceDir),
+      logsDir: agentLabLogsDir(instance.workspaceDir),
+      sync: `openwork-agent-lab --dir ${baseDir} scheduler sync ${instance.id}`,
+      uninstall: `openwork-agent-lab --dir ${baseDir} scheduler uninstall ${instance.id}`,
+    },
+  }, null, 2));
 }
 
 async function stop(argv: string[]) {
@@ -480,10 +898,10 @@ async function status(argv: string[]) {
   const dir = instanceDir(baseDir, id);
   const instance = await loadInstance(dir);
   const url = instance.openwork.url.replace(/\/$/, "");
-  const health = await fetchJson(`${url}/health`).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }));
+  const health = await requestJson(`${url}/health`).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }));
   let workspaceId: string | null = null;
   try {
-    const workspaces = await fetchJson(`${url}/workspaces`, { token: instance.openwork.token });
+    const workspaces = await requestJson(`${url}/workspaces`, { token: instance.openwork.token });
     workspaceId = String(workspaces?.activeId || (workspaces?.items?.[0]?.id ?? "")) || null;
   } catch {
     workspaceId = null;
@@ -497,7 +915,12 @@ async function open(argv: string[]) {
   if (!id) throw new Error("missing_instance_id");
   const dir = instanceDir(baseDir, id);
   const instance = await loadInstance(dir);
-  const url = `${instance.openwork.url.replace(/\/$/, "")}/ui#token=${instance.openwork.token}`;
+  const requested = (readFlag(argv, "--scope") ?? "").trim();
+  const scope = requested === "collaborator" || requested === "owner" ? requested : "owner";
+  const token = scope === "owner"
+    ? (instance.openwork.ownerToken?.trim() || instance.openwork.token)
+    : instance.openwork.token;
+  const url = `${instance.openwork.url.replace(/\/$/, "")}/ui#token=${token}`;
   console.log(url);
 }
 
@@ -511,6 +934,151 @@ async function del(argv: string[]) {
   }
   await rm(dir, { recursive: true, force: true });
   console.log(JSON.stringify({ ok: true }, null, 2));
+}
+
+async function scheduler(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const sub = (argv[0] ?? "").trim();
+  const id = argv[1];
+  const dryRun = argv.includes("--dry-run");
+  if (!sub || sub === "--help" || sub === "-h") {
+    throw new Error("usage: scheduler <list|sync|uninstall|run|logs> <instanceId> [...]");
+  }
+  if (!id) throw new Error("missing_instance_id");
+
+  const dir = instanceDir(baseDir, id);
+  const instance = await loadInstance(dir);
+  const prefix = `com.openwork.agentlab.${instance.id}.`;
+
+  if (sub === "list") {
+    const store = await readAutomationsFromWorkspace(instance.workspaceDir);
+    const items = store.items.map((item) => {
+      const label = launchdLabel(instance.id, item.id);
+      const plist = launchdPlistPath(label);
+      return {
+        id: item.id,
+        name: item.name,
+        enabled: item.enabled,
+        schedule: item.schedule,
+        promptPreview: item.prompt.length > 160 ? item.prompt.slice(0, 160) + "..." : item.prompt,
+        label,
+        plist,
+        installed: existsSync(plist),
+        logPath: launchdLogPath(instance, item.id),
+      };
+    });
+    console.log(JSON.stringify({ ok: true, items }, null, 2));
+    return;
+  }
+
+  if (sub === "uninstall") {
+    await ensureDir(launchAgentsDir());
+    const entries = await readdir(launchAgentsDir(), { withFileTypes: true });
+    const removed: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.startsWith(prefix) || !entry.name.endsWith(".plist")) continue;
+      const plist = join(launchAgentsDir(), entry.name);
+      if (!dryRun) {
+        runLaunchctl(["unload", plist]);
+        await rm(plist, { force: true });
+      }
+      removed.push(plist);
+    }
+    console.log(JSON.stringify({ ok: true, removed, dryRun }, null, 2));
+    return;
+  }
+
+  if (sub === "sync") {
+    await ensureDir(launchAgentsDir());
+    await ensureDir(join(instance.dir, "scheduler"));
+    await ensureDir(agentLabLogsDir(instance.workspaceDir));
+
+    const store = await readAutomationsFromWorkspace(instance.workspaceDir);
+    const desired = store.items.filter((item) => item.enabled);
+    const desiredLabels = new Set(desired.map((item) => launchdLabel(instance.id, item.id)));
+
+    // Remove stale plists.
+    const entries = await readdir(launchAgentsDir(), { withFileTypes: true });
+    const removed: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.startsWith(prefix) || !entry.name.endsWith(".plist")) continue;
+      const label = entry.name.slice(0, -6);
+      if (desiredLabels.has(label)) continue;
+      const plist = join(launchAgentsDir(), entry.name);
+      if (!dryRun) {
+        runLaunchctl(["unload", plist]);
+        await rm(plist, { force: true });
+      }
+      removed.push(plist);
+    }
+
+    const applied: string[] = [];
+    for (const automation of desired) {
+      const label = launchdLabel(instance.id, automation.id);
+      const scriptPath = schedulerScriptPath(instance, automation.id);
+      const plistPath = launchdPlistPath(label);
+      const logPath = launchdLogPath(instance, automation.id);
+
+      const script = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `OPENWORK_URL=${bashQuote(instance.openwork.url.replace(/\/$/, ""))}`,
+        `TOKEN=${bashQuote(instance.openwork.token)}`,
+        `AUTOMATION_ID=${bashQuote(automation.id)}`,
+        "",
+        "WS_ID=$(curl -fsS -H \"Authorization: Bearer ${TOKEN}\" \"${OPENWORK_URL}/workspaces\" | node -e 'const fs=require(\"fs\"); const j=JSON.parse(fs.readFileSync(0,\"utf8\")); process.stdout.write(String(j.activeId||j.items?.[0]?.id||\"\"));')",
+        "if [ -z \"${WS_ID}\" ]; then echo \"workspace_id_missing\" 1>&2; exit 1; fi",
+        "curl -fsS -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type: application/json\" -X POST \"${OPENWORK_URL}/workspace/${WS_ID}/agentlab/automations/${AUTOMATION_ID}/run\" -d '{}' >/dev/null",
+        "echo \"ok $(date -u +%Y-%m-%dT%H:%M:%SZ) automation=${AUTOMATION_ID} workspace=${WS_ID}\"",
+        "",
+      ].join("\n");
+      const plist = buildLaunchdPlistXml({ label, scriptPath, schedule: automation.schedule, logPath });
+
+      if (!dryRun) {
+        await ensureDir(dirname(scriptPath));
+        await writeFile(scriptPath, script, "utf8");
+        await writeFile(plistPath, plist, "utf8");
+        runLaunchctl(["unload", plistPath]);
+        runLaunchctl(["load", plistPath]);
+      }
+
+      applied.push(plistPath);
+    }
+
+    console.log(JSON.stringify({ ok: true, applied, removed, dryRun }, null, 2));
+    return;
+  }
+
+  if (sub === "run") {
+    const automationId = argv[2];
+    if (!automationId) throw new Error("missing_automation_id");
+    const baseUrl = instance.openwork.url.replace(/\/$/, "");
+    const workspaces = await requestJson(`${baseUrl}/workspaces`, { token: instance.openwork.token, timeoutMs: 8000 });
+    const workspaceId = String(workspaces?.activeId || (workspaces?.items?.[0]?.id ?? ""));
+    if (!workspaceId) throw new Error("workspace_id_missing");
+    const result = await requestJson(`${baseUrl}/workspace/${encodeURIComponent(workspaceId)}/agentlab/automations/${encodeURIComponent(automationId)}/run`, {
+      token: instance.openwork.token,
+      method: "POST",
+      body: {},
+      timeoutMs: 15_000,
+    });
+    console.log(JSON.stringify({ ok: true, result }, null, 2));
+    return;
+  }
+
+  if (sub === "logs") {
+    const automationId = argv[2];
+    if (!automationId) throw new Error("missing_automation_id");
+    const path = launchdLogPath(instance, automationId);
+    if (!existsSync(path)) throw new Error("log_not_found");
+    const content = await readFile(path, "utf8");
+    console.log(content);
+    return;
+  }
+
+  throw new Error(`unknown_scheduler_command: ${sub}`);
 }
 
 async function main() {
@@ -527,6 +1095,7 @@ async function main() {
     if (cmd === "stop") return await stop(rest);
     if (cmd === "status") return await status(rest);
     if (cmd === "open") return await open(rest);
+    if (cmd === "scheduler") return await scheduler(rest);
     if (cmd === "delete") return await del(rest);
     throw new Error(`unknown_command: ${cmd}`);
   } catch (error) {

--- a/packages/agent-lab/src/cli.ts
+++ b/packages/agent-lab/src/cli.ts
@@ -1,0 +1,539 @@
+#!/usr/bin/env bun
+
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+
+type SandboxMode = "none" | "auto" | "docker" | "container";
+type ApprovalMode = "manual" | "auto";
+
+type Entrypoint = {
+  path: string;
+  rw: boolean;
+};
+
+type Instance = {
+  id: string;
+  name: string;
+  avatarSeed: string;
+  createdAt: number;
+  dir: string;
+  workspaceDir: string;
+  entrypoints: Entrypoint[];
+  openwork: {
+    host: string;
+    port: number;
+    url: string;
+    token: string;
+    hostToken: string;
+    approval: ApprovalMode;
+  };
+  openwrk?: {
+    sandbox: SandboxMode;
+    stopCommand?: string;
+    startedAt?: number;
+  };
+};
+
+type ConnectArtifact = {
+  kind: "openwork.connect.v1";
+  hostUrl: string;
+  workspaceId: string;
+  workspaceUrl: string;
+  token: string;
+  tokenScope: "collaborator";
+  createdAt: number;
+};
+
+function usage(): string {
+  return [
+    "openwork-agent-lab",
+    "",
+    "Commands:",
+    "  create   Create a new Agent Lab instance",
+    "  list     List existing instances",
+    "  start    Start an instance (spawns openwrk)",
+    "  stop     Stop an instance (stops sandbox container)",
+    "  status   Show instance status (health + workspace id)",
+    "  open     Print Toy UI URL for an instance",
+    "  delete   Delete an instance directory (danger)",
+    "",
+    "Options:",
+    "  --dir <path>         Base directory (default: ~/.openwork/agent-lab)",
+    "  --name <name>        Agent name (create)",
+    "  --id <id>            Instance id (create)",
+    "  --port <port>        OpenWork server port (create/start)",
+    "  --approval <mode>    manual|auto (default: manual)",
+    "  --sandbox <mode>     none|auto|docker|container (default: auto)",
+    "  --start              Start immediately after create",
+    "  --help               Show help",
+  ].join("\n");
+}
+
+function readFlag(argv: string[], name: string): string | undefined {
+  const idx = argv.indexOf(name);
+  if (idx === -1) return undefined;
+  const next = argv[idx + 1];
+  if (!next || next.startsWith("--")) return undefined;
+  return next;
+}
+
+function hasFlag(argv: string[], name: string): boolean {
+  return argv.includes(name);
+}
+
+function readNumberFlag(argv: string[], name: string): number | undefined {
+  const raw = readFlag(argv, name);
+  if (!raw) return undefined;
+  const num = Number(raw);
+  if (!Number.isFinite(num)) return undefined;
+  return Math.trunc(num);
+}
+
+function normalizeApproval(raw: string | undefined): ApprovalMode {
+  if (raw === "auto") return "auto";
+  return "manual";
+}
+
+function normalizeSandbox(raw: string | undefined): SandboxMode {
+  if (raw === "none" || raw === "auto" || raw === "docker" || raw === "container") return raw;
+  return "auto";
+}
+
+function baseDirFromArgs(argv: string[]): string {
+  const override = readFlag(argv, "--dir") ?? process.env.OPENWORK_AGENT_LAB_DIR;
+  return resolve(override?.trim() ? override.trim() : join(homedir(), ".openwork", "agent-lab"));
+}
+
+function instanceDir(baseDir: string, id: string): string {
+  return join(baseDir, "instances", id);
+}
+
+function agentPath(dir: string): string {
+  return join(dir, "agent.json");
+}
+
+async function loadInstance(dir: string): Promise<Instance> {
+  const raw = await readFile(agentPath(dir), "utf8");
+  return JSON.parse(raw) as Instance;
+}
+
+async function saveInstance(dir: string, instance: Instance): Promise<void> {
+  await writeFile(agentPath(dir), JSON.stringify(instance, null, 2));
+}
+
+function randomToken(): string {
+  // URL-safe enough for a toy: UUID without dashes.
+  return randomUUID().replaceAll("-", "");
+}
+
+async function ensureDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+}
+
+async function writeIfMissing(path: string, content: string): Promise<void> {
+  if (existsSync(path)) return;
+  await ensureDir(dirname(path));
+  await writeFile(path, content);
+}
+
+function defaultPersonality(name: string): string {
+  return [
+    "# Personality",
+    "",
+    `You are ${name}, a calm and serious AI co-worker.`,
+    "",
+    "- Tone: professional, direct, not overly friendly.",
+    "- Be transparent about what you are doing.",
+    "- Prefer short checkpoints over long monologues.",
+    "",
+    "When unsure, ask one clarifying question.",
+    "",
+  ].join("\n");
+}
+
+function defaultBehavior(): string {
+  return [
+    "# Behavior",
+    "",
+    "Conversation-first configuration:",
+    "- The user configures you by talking to you.",
+    "- After completing a task, if the user says 'turn this into a skill', create a new skill in .opencode/skills/<name>/SKILL.md.",
+    "",
+    "Checkpoints and progress:",
+    "- Respond quickly with an acknowledgement and what you will do next.",
+    "- For long tasks, do a quick preflight step first, then the heavy step.",
+    "- If something will take minutes, say so before you start.",
+    "",
+  ].join("\n");
+}
+
+async function provisionWorkspace(workspaceDir: string, name: string): Promise<void> {
+  await ensureDir(workspaceDir);
+  await ensureDir(join(workspaceDir, ".opencode"));
+  await ensureDir(join(workspaceDir, ".opencode", "agent"));
+  await ensureDir(join(workspaceDir, ".opencode", "skills"));
+  await ensureDir(join(workspaceDir, ".opencode", "commands"));
+  await ensureDir(join(workspaceDir, ".opencode", "openwork", "inbox"));
+  await ensureDir(join(workspaceDir, ".opencode", "openwork", "outbox"));
+
+  await writeIfMissing(join(workspaceDir, ".opencode", "agent", "personality.md"), defaultPersonality(name));
+  await writeIfMissing(join(workspaceDir, ".opencode", "agent", "behavior.md"), defaultBehavior());
+
+  const configPath = join(workspaceDir, "opencode.json");
+  if (!existsSync(configPath)) {
+    const opencodeConfig = {
+      $schema: "https://opencode.ai/config.json",
+      instructions: [
+        ".opencode/agent/personality.md",
+        ".opencode/agent/behavior.md",
+      ],
+      // Sandbox provides the primary filesystem safety boundary.
+      permission: {
+        external_directory: "deny",
+      },
+    };
+    await writeFile(configPath, JSON.stringify(opencodeConfig, null, 2));
+  }
+}
+
+async function listInstanceDirs(baseDir: string): Promise<string[]> {
+  const root = join(baseDir, "instances");
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => join(root, e.name));
+  } catch {
+    return [];
+  }
+}
+
+async function fetchJson(url: string, options?: { token?: string }): Promise<any> {
+  const headers: Record<string, string> = {};
+  if (options?.token) headers.Authorization = `Bearer ${options.token}`;
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(4000) });
+  const text = await res.text();
+  let json: any = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  if (!res.ok) {
+    const msg = json && json.message ? json.message : (text || res.statusText);
+    throw new Error(`http_${res.status}: ${msg}`);
+  }
+  return json;
+}
+
+async function waitForOpenwork(url: string, timeoutMs = 12_000): Promise<void> {
+  const start = Date.now();
+  let last = "waiting";
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${url.replace(/\/$/, "")}/health`, { signal: AbortSignal.timeout(1500) });
+      if (res.ok) return;
+      last = `status_${res.status}`;
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err);
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`openwork_server_unhealthy: ${last}`);
+}
+
+function openwrkBin(): string {
+  const override = (process.env.OPENWORK_AGENT_LAB_OPENWRK_BIN ?? "").trim();
+  if (override) return override;
+  return "openwrk";
+}
+
+async function runOpenwrkStart(options: {
+  workspaceDir: string;
+  dataDir: string;
+  sidecarDir: string;
+  sandboxPersistDir: string;
+  sandbox: SandboxMode;
+  openworkHost: string;
+  openworkPort: number;
+  token: string;
+  hostToken: string;
+  approval: ApprovalMode;
+  runId: string;
+}): Promise<{ stopCommand?: string }>{
+  const args = [
+    "start",
+    "--no-tui",
+    "--detach",
+    "--run-id",
+    options.runId,
+    "--sandbox",
+    options.sandbox,
+    "--workspace",
+    options.workspaceDir,
+    "--data-dir",
+    options.dataDir,
+    "--sidecar-dir",
+    options.sidecarDir,
+    "--sandbox-persist-dir",
+    options.sandboxPersistDir,
+    "--openwork-host",
+    options.openworkHost,
+    "--openwork-port",
+    String(options.openworkPort),
+    "--openwork-token",
+    options.token,
+    "--openwork-host-token",
+    options.hostToken,
+    "--approval",
+    options.approval,
+    "--no-owpenbot",
+  ];
+
+  return await new Promise((resolveResult, reject) => {
+    const child = spawn(openwrkBin(), args, {
+      cwd: options.workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, OPENWRK_COLOR: "0" },
+    });
+    let out = "";
+    let err = "";
+    child.stdout?.on("data", (chunk) => {
+      out += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      err += String(chunk);
+    });
+    child.on("error", (error) => reject(error));
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        reject(new Error(`openwrk_failed_${code}: ${err || out}`));
+        return;
+      }
+      const stopLine = out
+        .split("\n")
+        .map((l) => l.trim())
+        .find((l) => l.startsWith("Stop:"));
+      const stopCommand = stopLine ? stopLine.replace(/^Stop:\s*/, "").trim() : undefined;
+      resolveResult({ stopCommand });
+    });
+  });
+}
+
+async function create(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const name = readFlag(argv, "--name") ?? "Scout";
+  const id = (readFlag(argv, "--id") ?? "").trim() || `agent_${randomUUID().slice(0, 8)}`;
+  const port = readNumberFlag(argv, "--port") ?? 8787;
+  const approval = normalizeApproval(readFlag(argv, "--approval"));
+  const sandbox = normalizeSandbox(readFlag(argv, "--sandbox"));
+
+  const dir = instanceDir(baseDir, id);
+  const workspaceDir = join(dir, "workspace");
+  await ensureDir(join(baseDir, "instances"));
+  await ensureDir(dir);
+
+  await provisionWorkspace(workspaceDir, name);
+
+  const token = randomToken();
+  const hostToken = randomToken();
+  const instance: Instance = {
+    id,
+    name,
+    avatarSeed: `${id}:${name}`,
+    createdAt: Date.now(),
+    dir,
+    workspaceDir,
+    entrypoints: [],
+    openwork: {
+      host: "127.0.0.1",
+      port,
+      url: `http://127.0.0.1:${port}`,
+      token,
+      hostToken,
+      approval,
+    },
+    openwrk: {
+      sandbox,
+    },
+  };
+  await saveInstance(dir, instance);
+
+  console.log(JSON.stringify({ ok: true, instance }, null, 2));
+
+  if (hasFlag(argv, "--start")) {
+    await start([id, ...argv.filter((x) => x !== "--start")]);
+  }
+}
+
+async function list(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const dirs = await listInstanceDirs(baseDir);
+  const items: Instance[] = [];
+  for (const dir of dirs) {
+    const path = agentPath(dir);
+    if (!existsSync(path)) continue;
+    try {
+      items.push(await loadInstance(dir));
+    } catch {
+      // ignore broken entries
+    }
+  }
+  console.log(JSON.stringify({ ok: true, items }, null, 2));
+}
+
+async function start(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const id = argv[0];
+  if (!id) throw new Error("missing_instance_id");
+  const dir = instanceDir(baseDir, id);
+  const instance = await loadInstance(dir);
+
+  const port = readNumberFlag(argv, "--port") ?? instance.openwork.port;
+  const approval = normalizeApproval(readFlag(argv, "--approval")) ?? instance.openwork.approval;
+  const sandbox = normalizeSandbox(readFlag(argv, "--sandbox")) ?? (instance.openwrk?.sandbox ?? "auto");
+
+  instance.openwork.port = port;
+  instance.openwork.url = `http://${instance.openwork.host}:${port}`;
+  instance.openwork.approval = approval;
+  if (!instance.openwrk) instance.openwrk = { sandbox };
+  instance.openwrk.sandbox = sandbox;
+
+  const dataDir = join(instance.dir, "openwrk-data");
+  const sidecarDir = join(instance.dir, "sidecars");
+  const sandboxPersistDir = join(instance.dir, "sandbox-persist");
+  await ensureDir(dataDir);
+  await ensureDir(sidecarDir);
+  await ensureDir(sandboxPersistDir);
+
+  const result = await runOpenwrkStart({
+    workspaceDir: instance.workspaceDir,
+    dataDir,
+    sidecarDir,
+    sandboxPersistDir,
+    sandbox,
+    openworkHost: instance.openwork.host,
+    openworkPort: instance.openwork.port,
+    token: instance.openwork.token,
+    hostToken: instance.openwork.hostToken,
+    approval: instance.openwork.approval,
+    runId: instance.id,
+  });
+
+  instance.openwrk.stopCommand = result.stopCommand;
+  instance.openwrk.startedAt = Date.now();
+  await saveInstance(dir, instance);
+
+  await waitForOpenwork(instance.openwork.url);
+
+  const workspaces = await fetchJson(`${instance.openwork.url.replace(/\/$/, "")}/workspaces`, { token: instance.openwork.token });
+  const workspaceId = String(workspaces?.activeId || (workspaces?.items?.[0]?.id ?? ""));
+  if (!workspaceId) throw new Error("workspace_id_missing");
+  const connect: ConnectArtifact = {
+    kind: "openwork.connect.v1",
+    hostUrl: instance.openwork.url,
+    workspaceId,
+    workspaceUrl: `${instance.openwork.url.replace(/\/$/, "")}/w/${encodeURIComponent(workspaceId)}`,
+    token: instance.openwork.token,
+    tokenScope: "collaborator",
+    createdAt: Date.now(),
+  };
+
+  console.log(JSON.stringify({ ok: true, connect, ui: `${instance.openwork.url}/ui#token=${instance.openwork.token}` }, null, 2));
+}
+
+async function stop(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const id = argv[0];
+  if (!id) throw new Error("missing_instance_id");
+  const dir = instanceDir(baseDir, id);
+  const instance = await loadInstance(dir);
+  const stopCommand = instance.openwrk?.stopCommand;
+  if (!stopCommand) {
+    throw new Error("missing_stop_command");
+  }
+
+  const parts = stopCommand.split(" ").filter(Boolean);
+  const cmd = parts[0];
+  const args = parts.slice(1);
+  await new Promise<void>((resolveResult, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("error", (err) => reject(err));
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        reject(new Error(`stop_failed_${code}`));
+        return;
+      }
+      resolveResult();
+    });
+  });
+
+  console.log(JSON.stringify({ ok: true }, null, 2));
+}
+
+async function status(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const id = argv[0];
+  if (!id) throw new Error("missing_instance_id");
+  const dir = instanceDir(baseDir, id);
+  const instance = await loadInstance(dir);
+  const url = instance.openwork.url.replace(/\/$/, "");
+  const health = await fetchJson(`${url}/health`).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }));
+  let workspaceId: string | null = null;
+  try {
+    const workspaces = await fetchJson(`${url}/workspaces`, { token: instance.openwork.token });
+    workspaceId = String(workspaces?.activeId || (workspaces?.items?.[0]?.id ?? "")) || null;
+  } catch {
+    workspaceId = null;
+  }
+  console.log(JSON.stringify({ ok: true, instance: { id: instance.id, name: instance.name }, openwork: { url, health }, workspaceId }, null, 2));
+}
+
+async function open(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const id = argv[0];
+  if (!id) throw new Error("missing_instance_id");
+  const dir = instanceDir(baseDir, id);
+  const instance = await loadInstance(dir);
+  const url = `${instance.openwork.url.replace(/\/$/, "")}/ui#token=${instance.openwork.token}`;
+  console.log(url);
+}
+
+async function del(argv: string[]) {
+  const baseDir = baseDirFromArgs(argv);
+  const id = argv[0];
+  if (!id) throw new Error("missing_instance_id");
+  const dir = instanceDir(baseDir, id);
+  if (!dir.startsWith(resolve(baseDir))) {
+    throw new Error("unsafe_delete");
+  }
+  await rm(dir, { recursive: true, force: true });
+  console.log(JSON.stringify({ ok: true }, null, 2));
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || hasFlag(argv, "--help") || hasFlag(argv, "-h")) {
+    console.log(usage());
+    return;
+  }
+  const [cmd, ...rest] = argv;
+  try {
+    if (cmd === "create") return await create(rest);
+    if (cmd === "list") return await list(rest);
+    if (cmd === "start") return await start(rest);
+    if (cmd === "stop") return await stop(rest);
+    if (cmd === "status") return await status(rest);
+    if (cmd === "open") return await open(rest);
+    if (cmd === "delete") return await del(rest);
+    throw new Error(`unknown_command: ${cmd}`);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(msg);
+    process.exit(1);
+  }
+}
+
+await main();

--- a/packages/agent-lab/tsconfig.json
+++ b/packages/agent-lab/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["bun-types", "node"]
+  },
+  "include": ["src"]
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -126,6 +126,31 @@ function parseWorkspaceMount(pathname: string): { workspaceId: string; restPath:
   return { workspaceId: decodeURIComponent(workspaceId), restPath };
 }
 
+function normalizeOpencodeProxyPath(proxyPath: string): string {
+  const raw = (proxyPath ?? "").trim() || "/";
+  const withoutPrefix = raw.startsWith("/opencode") ? raw.slice("/opencode".length) : raw;
+  const normalized = (withoutPrefix || "/").replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+function assertOpencodeProxyAllowed(actor: Actor, method: string, proxyPath: string) {
+  const m = method.toUpperCase();
+  const scope = actor.scope ?? "viewer";
+
+  if (scope === "viewer" && m !== "GET" && m !== "HEAD") {
+    throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
+  }
+
+  // Prevent collaborators/viewers from self-approving OpenCode permission requests via the proxy.
+  // OpenCode uses /permission/:requestId/reply (and historically also a session-scoped variant).
+  if (scope !== "owner" && m !== "GET" && m !== "HEAD") {
+    const normalized = normalizeOpencodeProxyPath(proxyPath);
+    if (/\/permission\/[^/]+\/reply$/.test(normalized)) {
+      throw new ApiError(403, "forbidden", "Only owner tokens can reply to permission requests");
+    }
+  }
+}
+
 interface Route {
   method: string;
   regex: RegExp;
@@ -193,10 +218,7 @@ export function startServer(config: ServerConfig) {
         authMode = "client";
         try {
           const actor = await requireClient(request, config, tokens);
-          const method = request.method.toUpperCase();
-          if (actor.scope === "viewer" && method !== "GET" && method !== "HEAD") {
-            throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
-          }
+          assertOpencodeProxyAllowed(actor, request.method, mount.restPath);
           const workspace = await resolveWorkspace(config, mount.workspaceId);
           proxyService = "opencode";
           proxyBaseUrl = workspace.baseUrl?.trim() || undefined;
@@ -257,10 +279,7 @@ export function startServer(config: ServerConfig) {
         proxyBaseUrl = config.workspaces[0]?.baseUrl?.trim() || undefined;
         try {
           const actor = await requireClient(request, config, tokens);
-          const method = request.method.toUpperCase();
-          if (actor.scope === "viewer" && method !== "GET" && method !== "HEAD") {
-            throw new ApiError(403, "forbidden", "Viewer tokens are read-only");
-          }
+          assertOpencodeProxyAllowed(actor, request.method, url.pathname);
           proxyService = "opencode";
           const response = await proxyOpencodeRequest({ request, url, workspace: config.workspaces[0] });
           return finalize(response);
@@ -1191,7 +1210,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     headers.set("Content-Type", "application/octet-stream");
     headers.set("Content-Length", String(info.size));
     headers.set("Content-Disposition", `attachment; filename="${basename(relativePath)}"`);
-    return new Response(Bun.file(absPath), { status: 200, headers });
+    return new Response((Bun as any).file(absPath), { status: 200, headers });
   });
 
   addRoute(routes, "GET", "/workspace/:id/plugins", "client", async (ctx) => {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -5,7 +5,7 @@ import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor,
 import { ApprovalService } from "./approvals.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { addMcp, listMcp, removeMcp } from "./mcp.js";
-import { listSkills, upsertSkill } from "./skills.js";
+import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { deleteCommand, listCommands, upsertCommand } from "./commands.js";
 import { deleteScheduledJob, listScheduledJobs, resolveScheduledJob } from "./scheduler.js";
 import { ApiError, formatError } from "./errors.js";
@@ -169,6 +169,29 @@ interface RequestContext {
   tokens: TokenService;
   actor?: Actor;
 }
+
+type AgentLabSchedule =
+  | { kind: "interval"; seconds: number }
+  | { kind: "daily"; hour: number; minute: number }
+  | { kind: "weekly"; weekday: number; hour: number; minute: number };
+
+type AgentLabAutomation = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: AgentLabSchedule;
+  prompt: string;
+  createdAt: number;
+  updatedAt?: number;
+  lastRunAt?: number;
+  lastRunSessionId?: string;
+};
+
+type AgentLabAutomationStore = {
+  schemaVersion: number;
+  updatedAt: number;
+  items: AgentLabAutomation[];
+};
 
 export function startServer(config: ServerConfig) {
   const approvals = new ApprovalService(config.approval);
@@ -391,6 +414,52 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   target.pathname = trimmedPath.startsWith("/") ? trimmedPath : `/${trimmedPath}`;
   target.search = search;
   return target.toString();
+}
+
+async function fetchOpencodeJson(workspace: WorkspaceInfo, path: string, init: { method: string; body?: unknown }) {
+  const baseUrl = workspace.baseUrl?.trim() ?? "";
+  if (!baseUrl) {
+    throw new ApiError(400, "opencode_unconfigured", "OpenCode base URL is missing for this workspace");
+  }
+
+  const url = new URL(baseUrl);
+  url.pathname = path.startsWith("/") ? path : `/${path}`;
+  url.search = "";
+
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json");
+
+  const directory = resolveOpencodeDirectory(workspace);
+  if (directory) {
+    headers.set("x-opencode-directory", directory);
+  }
+
+  const auth = buildOpencodeAuthHeader(workspace);
+  if (auth) {
+    headers.set("Authorization", auth);
+  }
+
+  const response = await fetch(url.toString(), {
+    method: init.method,
+    headers,
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+
+  const text = await response.text();
+  let json: any = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  if (!response.ok) {
+    throw new ApiError(502, "opencode_request_failed", "OpenCode request failed", {
+      status: response.status,
+      body: json ?? text,
+      path,
+    });
+  }
+  return json;
 }
 
 function buildOwpenbotProxyUrl(baseUrl: string, path: string, search: string) {
@@ -654,6 +723,119 @@ function resolveInboxDir(workspaceRoot: string): string {
 
 function resolveOutboxDir(workspaceRoot: string): string {
   return join(workspaceRoot, ".opencode", "openwork", "outbox");
+}
+
+function resolveAgentLabDir(workspaceRoot: string): string {
+  return join(workspaceRoot, ".opencode", "openwork", "agentlab");
+}
+
+function resolveAgentLabAutomationsPath(workspaceRoot: string): string {
+  return join(resolveAgentLabDir(workspaceRoot), "automations.json");
+}
+
+function resolveAgentLabLogsDir(workspaceRoot: string): string {
+  return join(resolveAgentLabDir(workspaceRoot), "logs");
+}
+
+function clampInt(value: unknown, options: { min: number; max: number; name: string }): number {
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) {
+    throw new ApiError(400, "invalid_payload", `${options.name} must be a number`);
+  }
+  const int = Math.trunc(num);
+  if (int < options.min || int > options.max) {
+    throw new ApiError(400, "invalid_payload", `${options.name} must be between ${options.min} and ${options.max}`);
+  }
+  return int;
+}
+
+function parseAgentLabSchedule(value: unknown): AgentLabSchedule {
+  if (!value || typeof value !== "object") {
+    throw new ApiError(400, "invalid_payload", "schedule is required");
+  }
+  const schedule = value as Record<string, unknown>;
+  const kind = typeof schedule.kind === "string" ? schedule.kind.trim() : "";
+  if (kind === "interval") {
+    const seconds = clampInt(schedule.seconds, { min: 60, max: 7 * 24 * 60 * 60, name: "schedule.seconds" });
+    return { kind: "interval", seconds };
+  }
+  if (kind === "daily") {
+    const hour = clampInt(schedule.hour, { min: 0, max: 23, name: "schedule.hour" });
+    const minute = clampInt(schedule.minute, { min: 0, max: 59, name: "schedule.minute" });
+    return { kind: "daily", hour, minute };
+  }
+  if (kind === "weekly") {
+    const weekday = clampInt(schedule.weekday, { min: 1, max: 7, name: "schedule.weekday" });
+    const hour = clampInt(schedule.hour, { min: 0, max: 23, name: "schedule.hour" });
+    const minute = clampInt(schedule.minute, { min: 0, max: 59, name: "schedule.minute" });
+    return { kind: "weekly", weekday, hour, minute };
+  }
+  throw new ApiError(400, "invalid_payload", "schedule.kind must be interval, daily, or weekly");
+}
+
+function validateAgentLabAutomationId(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw) {
+    throw new ApiError(400, "invalid_payload", "automation id is required");
+  }
+  if (raw.length > 80) {
+    throw new ApiError(400, "invalid_payload", "automation id is too long");
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(raw)) {
+    throw new ApiError(400, "invalid_payload", "automation id must match /^[a-zA-Z0-9_-]+$/");
+  }
+  return raw;
+}
+
+async function readAgentLabAutomations(workspaceRoot: string): Promise<AgentLabAutomationStore> {
+  const path = resolveAgentLabAutomationsPath(workspaceRoot);
+  if (!(await exists(path))) {
+    return { schemaVersion: 1, updatedAt: Date.now(), items: [] };
+  }
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<AgentLabAutomationStore>;
+    const items = Array.isArray(parsed.items) ? parsed.items : [];
+    const normalized: AgentLabAutomation[] = [];
+    for (const item of items) {
+      const record = item as Partial<AgentLabAutomation>;
+      const id = typeof record.id === "string" ? record.id.trim() : "";
+      const name = typeof record.name === "string" ? record.name.trim() : "";
+      const prompt = typeof record.prompt === "string" ? record.prompt : "";
+      const enabled = typeof record.enabled === "boolean" ? record.enabled : true;
+      if (!id || !name || !prompt) continue;
+      let schedule: AgentLabSchedule;
+      try {
+        schedule = parseAgentLabSchedule(record.schedule);
+      } catch {
+        continue;
+      }
+      normalized.push({
+        id,
+        name,
+        enabled,
+        schedule,
+        prompt,
+        createdAt: typeof record.createdAt === "number" ? record.createdAt : Date.now(),
+        updatedAt: typeof record.updatedAt === "number" ? record.updatedAt : undefined,
+        lastRunAt: typeof record.lastRunAt === "number" ? record.lastRunAt : undefined,
+        lastRunSessionId: typeof record.lastRunSessionId === "string" ? record.lastRunSessionId : undefined,
+      });
+    }
+    return {
+      schemaVersion: typeof parsed.schemaVersion === "number" ? parsed.schemaVersion : 1,
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+      items: normalized,
+    };
+  } catch {
+    throw new ApiError(422, "invalid_json", "Failed to parse Agent Lab automations");
+  }
+}
+
+async function writeAgentLabAutomations(workspaceRoot: string, store: AgentLabAutomationStore): Promise<void> {
+  const path = resolveAgentLabAutomationsPath(workspaceRoot);
+  await ensureDir(dirname(path));
+  await writeFile(path, JSON.stringify({ ...store, updatedAt: Date.now() }, null, 2) + "\n", "utf8");
 }
 
 function normalizeWorkspaceRelativePath(input: string, options: { allowSubdirs: boolean }): string {
@@ -1343,6 +1525,41 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     return jsonResponse({ name, path: result.path, description: description ?? "", scope: "project" });
   });
 
+  addRoute(routes, "DELETE", "/workspace/:id/skills/:name", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const name = String(ctx.params.name ?? "").trim();
+    if (!name) {
+      throw new ApiError(400, "invalid_skill_name", "Skill name is required");
+    }
+
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "skills.delete",
+      summary: `Delete skill ${name}`,
+      paths: [join(workspace.path, ".opencode", "skills", name)],
+    });
+
+    const result = await deleteSkill(workspace.path, name);
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "skills.delete",
+      target: result.path,
+      summary: `Deleted skill ${name}`,
+      timestamp: Date.now(),
+    });
+    emitReloadEvent(ctx.reloadEvents, workspace, "skills", {
+      type: "skill",
+      name,
+      action: "removed",
+      path: result.path,
+    });
+    return jsonResponse({ ok: true, name, path: result.path });
+  });
+
   addRoute(routes, "GET", "/workspace/:id/mcp", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const items = await listMcp(workspace.path);
@@ -1496,6 +1713,196 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
       path: join(workspace.path, ".opencode", "commands", `${sanitizeCommandName(name)}.md`),
     });
     return jsonResponse({ ok: true });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/agentlab/automations", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const store = await readAgentLabAutomations(workspace.path);
+    return jsonResponse({ items: store.items, updatedAt: store.updatedAt });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/agentlab/automations", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
+    const enabled = typeof body.enabled === "boolean" ? body.enabled : true;
+    if (!name) {
+      throw new ApiError(400, "invalid_payload", "name is required");
+    }
+    if (!prompt) {
+      throw new ApiError(400, "invalid_payload", "prompt is required");
+    }
+
+    const schedule = parseAgentLabSchedule(body.schedule);
+    const id = body.id ? validateAgentLabAutomationId(body.id) : `agentlab_${shortId().replace(/-/g, "")}`;
+
+    const path = resolveAgentLabAutomationsPath(workspace.path);
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "agentlab.automations.upsert",
+      summary: `Upsert automation ${name}`,
+      paths: [path],
+    });
+
+    const store = await readAgentLabAutomations(workspace.path);
+    const now = Date.now();
+    const existingIndex = store.items.findIndex((item) => item.id === id);
+    if (existingIndex !== -1) {
+      const prev = store.items[existingIndex];
+      store.items[existingIndex] = {
+        ...prev,
+        id,
+        name,
+        enabled,
+        schedule,
+        prompt,
+        updatedAt: now,
+      };
+    } else {
+      store.items.unshift({
+        id,
+        name,
+        enabled,
+        schedule,
+        prompt,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    await writeAgentLabAutomations(workspace.path, store);
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "agentlab.automations.upsert",
+      target: path,
+      summary: `Upserted automation ${name}`,
+      timestamp: now,
+    });
+
+    const next = await readAgentLabAutomations(workspace.path);
+    return jsonResponse({ items: next.items, updatedAt: next.updatedAt }, 201);
+  });
+
+  addRoute(routes, "DELETE", "/workspace/:id/agentlab/automations/:automationId", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const automationId = validateAgentLabAutomationId(ctx.params.automationId);
+
+    const path = resolveAgentLabAutomationsPath(workspace.path);
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "agentlab.automations.delete",
+      summary: `Delete automation ${automationId}`,
+      paths: [path],
+    });
+
+    const store = await readAgentLabAutomations(workspace.path);
+    const before = store.items.length;
+    store.items = store.items.filter((item) => item.id !== automationId);
+    if (store.items.length === before) {
+      throw new ApiError(404, "automation_not_found", "Automation not found");
+    }
+    await writeAgentLabAutomations(workspace.path, store);
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "agentlab.automations.delete",
+      target: path,
+      summary: `Deleted automation ${automationId}`,
+      timestamp: Date.now(),
+    });
+    return jsonResponse({ ok: true });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/agentlab/automations/:automationId/run", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const automationId = validateAgentLabAutomationId(ctx.params.automationId);
+
+    const store = await readAgentLabAutomations(workspace.path);
+    const automation = store.items.find((item) => item.id === automationId);
+    if (!automation) {
+      throw new ApiError(404, "automation_not_found", "Automation not found");
+    }
+
+    const now = Date.now();
+    const created = await fetchOpencodeJson(workspace, "/session", {
+      method: "POST",
+      body: { title: `Automation: ${automation.name}` },
+    });
+    const sessionId = typeof created?.id === "string" ? created.id : String(created?.id ?? "");
+    if (!sessionId.trim()) {
+      throw new ApiError(502, "opencode_failed", "OpenCode session did not return an id");
+    }
+
+    await fetchOpencodeJson(workspace, `/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+      method: "POST",
+      body: {
+        parts: [{ type: "text", text: automation.prompt }],
+      },
+    });
+
+    automation.lastRunAt = now;
+    automation.lastRunSessionId = sessionId;
+    automation.updatedAt = now;
+    if (!config.readOnly) {
+      await writeAgentLabAutomations(workspace.path, store);
+    }
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "agentlab.automations.run",
+      target: resolveAgentLabAutomationsPath(workspace.path),
+      summary: `Ran automation ${automation.name}`,
+      timestamp: now,
+    });
+
+    return jsonResponse({ ok: true, automationId, sessionId, ranAt: now });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/agentlab/automations/logs", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const logsDir = resolveAgentLabLogsDir(workspace.path);
+    if (!(await exists(logsDir))) {
+      return jsonResponse({ items: [] });
+    }
+    const entries = await readdir(logsDir, { withFileTypes: true });
+    const items: Array<{ id: string; path: string; size: number; updatedAt: number }> = [];
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".log")) continue;
+      const id = entry.name.slice(0, -4);
+      const abs = join(logsDir, entry.name);
+      try {
+        const info = await stat(abs);
+        items.push({ id, path: entry.name, size: info.size, updatedAt: info.mtimeMs });
+      } catch {
+        // ignore
+      }
+    }
+    items.sort((a, b) => b.updatedAt - a.updatedAt);
+    return jsonResponse({ items });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/agentlab/automations/logs/:automationId", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const automationId = validateAgentLabAutomationId(ctx.params.automationId);
+    const logsDir = resolveAgentLabLogsDir(workspace.path);
+    const abs = join(logsDir, `${automationId}.log`);
+    if (!(await exists(abs))) {
+      throw new ApiError(404, "log_not_found", "Log not found");
+    }
+    const content = await readFile(abs, "utf8");
+    return jsonResponse({ id: automationId, content });
   });
 
   addRoute(routes, "GET", "/workspace/:id/scheduler/jobs", "client", async (ctx) => {

--- a/packages/server/src/skills.ts
+++ b/packages/server/src/skills.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
+import { readdir, readFile, writeFile, mkdir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type { SkillItem } from "./types.js";
@@ -149,4 +149,17 @@ export async function upsertSkill(
   const existed = await exists(skillPath);
   await writeFile(skillPath, content.endsWith("\n") ? content : content + "\n", "utf8");
   return { path: skillPath, action: existed ? "updated" : "added" };
+}
+
+export async function deleteSkill(workspaceRoot: string, name: string): Promise<{ path: string }> {
+  const trimmed = name.trim();
+  validateSkillName(trimmed);
+  const baseDir = projectSkillsDir(workspaceRoot);
+  const skillDir = join(baseDir, trimmed);
+  const skillPath = join(skillDir, "SKILL.md");
+  if (!(await exists(skillPath))) {
+    throw new ApiError(404, "skill_not_found", `Skill not found: ${trimmed}`);
+  }
+  await rm(skillDir, { recursive: true, force: true });
+  return { path: skillDir };
 }

--- a/packages/server/src/tokens.ts
+++ b/packages/server/src/tokens.ts
@@ -50,7 +50,14 @@ async function readTokenStore(path: string): Promise<TokenStoreFile> {
           const createdAt = typeof record.createdAt === "number" ? record.createdAt : Date.now();
           const label = typeof record.label === "string" ? record.label : undefined;
           if (!id || !hash || !scope) return null;
-          return { id, hash, scope, createdAt, label } satisfies TokenRecord;
+          const parsedRecord: TokenRecord = {
+            id,
+            hash,
+            scope,
+            createdAt,
+            ...(label ? { label } : {}),
+          };
+          return parsedRecord;
         })
         .filter((token): token is TokenRecord => Boolean(token))
       : [];

--- a/packages/server/src/toy-ui.ts
+++ b/packages/server/src/toy-ui.ts
@@ -131,6 +131,19 @@ a:hover { text-decoration: underline; }
   gap: 10px;
 }
 
+.timeline {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.timeline .list {
+  max-height: 160px;
+  overflow: auto;
+}
+
 .msg {
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -177,6 +190,19 @@ a:hover { text-decoration: underline; }
 }
 
 .composer textarea:focus { border-color: rgba(83, 184, 255, 0.45); }
+
+.input {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 9px 10px;
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+}
+
+.input:focus { border-color: rgba(83, 184, 255, 0.45); }
 
 .btn {
   appearance: none;
@@ -261,6 +287,13 @@ export const TOY_UI_HTML = `<!doctype html>
             <span>Session</span>
             <span class="small mono" id="session-id">session: -</span>
           </h2>
+          <div class="timeline">
+            <div class="row">
+              <span class="pill" id="pill-run">idle</span>
+              <span class="small" id="timeline-hint">Checkpoints stream from SSE events.</span>
+            </div>
+            <div class="list" id="timeline"></div>
+          </div>
           <div class="chatlog" id="chatlog"></div>
           <div class="composer">
             <div class="row">
@@ -271,6 +304,7 @@ export const TOY_UI_HTML = `<!doctype html>
             <textarea id="prompt" placeholder="Write a prompt..." spellcheck="false"></textarea>
             <div class="row">
               <button class="btn primary" id="btn-send">Send prompt</button>
+              <button class="btn" id="btn-skill">Turn into skill</button>
               <button class="btn" id="btn-events">Connect SSE</button>
               <button class="btn" id="btn-events-stop">Stop SSE</button>
               <span class="small" id="status"></span>
@@ -284,6 +318,8 @@ export const TOY_UI_HTML = `<!doctype html>
             <div class="kv">
               <div class="k">workspace</div>
               <div class="mono" id="workspace-id">-</div>
+              <div class="k">workspace url</div>
+              <div><a class="mono" id="workspace-url" href="#" target="_blank" rel="noreferrer">-</a></div>
               <div class="k">server</div>
               <div class="mono" id="server-version">-</div>
               <div class="k">sandbox</div>
@@ -319,7 +355,20 @@ export const TOY_UI_HTML = `<!doctype html>
             <div class="hr"></div>
 
             <div class="row">
-              <button class="btn" id="btn-share">Show connect artifact</button>
+              <select class="input" id="share-scope">
+                <option value="collaborator">collaborator</option>
+                <option value="viewer">viewer</option>
+              </select>
+              <input class="input" id="share-label" type="text" placeholder="label (optional)" />
+              <button class="btn" id="btn-mint">Mint token</button>
+              <button class="btn" id="btn-deploy">Deploy (Beta)</button>
+            </div>
+            <div class="small">Minting tokens requires an owner token (or host access).</div>
+
+            <div class="hr"></div>
+
+            <div class="row">
+              <button class="btn" id="btn-share">Connect artifact (current token)</button>
               <button class="btn" id="btn-copy">Copy JSON</button>
             </div>
             <div class="codebox" id="connect"></div>
@@ -349,6 +398,11 @@ const artifactsEl = qs("#artifacts");
 const approvalsEl = qs("#approvals");
 const connectEl = qs("#connect");
 const hostIdEl = qs("#host-id");
+const pillRun = qs("#pill-run");
+const timelineEl = qs("#timeline");
+const workspaceUrlEl = qs("#workspace-url");
+const shareScopeEl = qs("#share-scope");
+const shareLabelEl = qs("#share-label");
 
 const STORAGE_TOKEN = "openwork.toy.token";
 const STORAGE_SESSION_PREFIX = "openwork.toy.session.";
@@ -357,6 +411,64 @@ function setPill(el, label, kind) {
   el.textContent = label;
   el.classList.remove("ok", "bad");
   if (kind) el.classList.add(kind);
+}
+
+function setRun(label, kind) {
+  if (!pillRun) return;
+  setPill(pillRun, label, kind);
+}
+
+function clearTimeline() {
+  if (!timelineEl) return;
+  timelineEl.innerHTML = "";
+}
+
+function summarizeEvent(payload) {
+  if (!payload || typeof payload !== "object") return "";
+  const keys = ["name", "tool", "action", "summary", "status", "message"];
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function addCheckpoint(label, detail) {
+  if (!timelineEl) return;
+
+  const row = document.createElement("div");
+  row.className = "item";
+
+  const top = document.createElement("div");
+  top.className = "row";
+
+  const left = document.createElement("div");
+  const name = document.createElement("div");
+  name.className = "mono";
+  name.textContent = label;
+
+  const meta = document.createElement("div");
+  meta.className = "small";
+  meta.textContent = new Date().toLocaleTimeString();
+
+  left.appendChild(name);
+  left.appendChild(meta);
+  top.appendChild(left);
+  row.appendChild(top);
+
+  if (detail) {
+    const d = document.createElement("div");
+    d.className = "small";
+    d.textContent = detail;
+    row.appendChild(d);
+  }
+
+  timelineEl.appendChild(row);
+  timelineEl.scrollTop = timelineEl.scrollHeight;
+
+  while (timelineEl.children.length > 80) {
+    timelineEl.removeChild(timelineEl.firstChild);
+  }
 }
 
 function getTokenFromHash() {
@@ -688,6 +800,7 @@ async function connectSse(workspaceId) {
   const controller = new AbortController();
   eventsAbort = controller;
   setStatus("Connecting SSE...", "");
+  addCheckpoint("sse.connecting");
 
   const url = "/w/" + encodeURIComponent(workspaceId) + "/opencode/event";
   const res = await fetch(url, {
@@ -701,6 +814,7 @@ async function connectSse(workspaceId) {
   }
 
   setStatus("SSE connected", "ok");
+  addCheckpoint("sse.connected");
   const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
   let buffer = "";
 
@@ -726,6 +840,11 @@ async function connectSse(workspaceId) {
         try {
           const event = JSON.parse(raw);
           const payload = event && event.payload ? event.payload : event;
+          const type = payload && payload.type ? String(payload.type) : (event && event.type ? String(event.type) : "event");
+          addCheckpoint(type, summarizeEvent(payload));
+          if (type.endsWith(".completed") || type.endsWith(".finished") || type.endsWith(".stopped")) {
+            setRun("idle");
+          }
           if (payload && payload.type === "message.part.updated") {
             void refreshMessages(workspaceId);
           }
@@ -742,6 +861,8 @@ async function connectSse(workspaceId) {
       eventsAbort = null;
       try { reader.releaseLock(); } catch {}
       setStatus("SSE disconnected", "");
+      addCheckpoint("sse.disconnected");
+      setRun("idle");
     });
 }
 
@@ -751,17 +872,7 @@ function stopSse() {
   eventsAbort = null;
 }
 
-async function showConnectArtifact(workspaceId) {
-  const token = readToken();
-  let scope = "collaborator";
-  try {
-    const me = await apiFetch("/whoami");
-    const s = me && me.actor && me.actor.scope ? me.actor.scope : "";
-    if (s) scope = s;
-  } catch {
-    // ignore
-  }
-
+function renderConnectArtifact(workspaceId, token, scope) {
   const hostUrl = location.origin;
   const workspaceUrl = hostUrl + "/w/" + encodeURIComponent(workspaceId);
   const payload = {
@@ -774,6 +885,33 @@ async function showConnectArtifact(workspaceId) {
     createdAt: Date.now(),
   };
   connectEl.textContent = JSON.stringify(payload, null, 2);
+}
+
+async function showConnectArtifact(workspaceId) {
+  const token = readToken();
+  let scope = "collaborator";
+  try {
+    const me = await apiFetch("/whoami");
+    const s = me && me.actor && me.actor.scope ? me.actor.scope : "";
+    if (s) scope = s;
+  } catch {
+    // ignore
+  }
+  renderConnectArtifact(workspaceId, token, scope);
+}
+
+async function mintShareToken(workspaceId) {
+  const scope = shareScopeEl && shareScopeEl.value ? String(shareScopeEl.value) : "collaborator";
+  const label = shareLabelEl && shareLabelEl.value ? String(shareLabelEl.value).trim() : "";
+  const issued = await apiFetch("/tokens", {
+    method: "POST",
+    body: JSON.stringify({ scope, label: label || undefined }),
+  });
+  const token = issued && issued.token ? String(issued.token) : "";
+  const tokenScope = issued && issued.scope ? String(issued.scope) : scope;
+  if (!token) throw new Error("token_missing");
+  renderConnectArtifact(workspaceId, token, tokenScope);
+  setStatus("Token minted: " + tokenScope, "ok");
 }
 
 async function copyConnectArtifact() {
@@ -809,6 +947,14 @@ async function main() {
     return;
   }
 
+  setRun("idle");
+  clearTimeline();
+  if (workspaceUrlEl) {
+    const wsUrl = location.origin + "/w/" + encodeURIComponent(workspaceId);
+    workspaceUrlEl.textContent = wsUrl;
+    workspaceUrlEl.href = wsUrl;
+  }
+
   await refreshHost(workspaceId);
   sessionIdEl.textContent = readSessionId(workspaceId) ? ("session: " + readSessionId(workspaceId)) : "session: -";
   await refreshMessages(workspaceId).catch(() => undefined);
@@ -831,6 +977,10 @@ async function main() {
   qs("#btn-send").onclick = async () => {
     const text = (promptEl.value || "").trim();
     if (!text) return;
+    clearTimeline();
+    addCheckpoint("prompt.submitted", text.length > 120 ? (text.slice(0, 120) + "...") : text);
+    setRun("running");
+    void connectSse(workspaceId).catch(() => undefined);
     appendMsg("user", text);
     promptEl.value = "";
     try {
@@ -844,10 +994,41 @@ async function main() {
         { method: "POST", body: JSON.stringify(body) },
       );
       setStatus("Prompt accepted", "ok");
+      addCheckpoint("prompt.accepted");
       await refreshMessages(workspaceId).catch(() => undefined);
     } catch (e) {
       setStatus(e && e.message ? e.message : "Prompt failed", "bad");
+      addCheckpoint("prompt.failed", e && e.message ? e.message : "Prompt failed");
+      setRun("idle");
     }
+  };
+
+  qs("#btn-skill").onclick = () => {
+    const template = [
+      "Turn this into a skill.",
+      "",
+      "Requirements:",
+      "- Skill name: my-skill",
+      "- Write to .opencode/skills/my-skill/SKILL.md",
+      "- Include usage, inputs, steps, and examples",
+      "",
+      "Use the most recent conversation as source material.",
+    ].join("\n");
+    const existing = (promptEl.value || "").trim();
+    promptEl.value = existing ? (existing + "\n\n" + template) : template;
+    promptEl.focus();
+  };
+
+  qs("#btn-mint").onclick = async () => {
+    try {
+      await mintShareToken(workspaceId);
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "Token mint failed", "bad");
+    }
+  };
+
+  qs("#btn-deploy").onclick = () => {
+    setStatus("Deploy (Beta) is not implemented in the Toy UI yet", "");
   };
 
   qs("#btn-events").onclick = async () => {

--- a/packages/server/src/toy-ui.ts
+++ b/packages/server/src/toy-ui.ts
@@ -258,6 +258,51 @@ a:hover { text-decoration: underline; }
 .small { font-size: 11px; color: var(--muted-2); }
 
 .hr { height: 1px; background: var(--border); margin: 10px 0; }
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.tab {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.12);
+  color: var(--muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.tab.active {
+  border-color: rgba(83, 184, 255, 0.6);
+  background: rgba(83, 184, 255, 0.12);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.panel { display: block; margin-top: 10px; }
+.panel.hidden { display: none; }
+.hidden { display: none !important; }
+
+.inputarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 90px;
+  max-height: 260px;
+  padding: 10px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--text);
+  outline: none;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.inputarea:focus { border-color: rgba(83, 184, 255, 0.45); }
 `;
 
 export const TOY_UI_HTML = `<!doctype html>
@@ -330,48 +375,149 @@ export const TOY_UI_HTML = `<!doctype html>
 
             <div class="hr"></div>
 
-            <div class="row">
-              <input id="file" type="file" />
-              <button class="btn" id="btn-upload">Upload to inbox</button>
+            <div class="tabs" id="tabs">
+              <button class="tab active" data-tab="share">Share</button>
+              <button class="tab" data-tab="automations">Automations</button>
+              <button class="tab" data-tab="skills">Skills</button>
+              <button class="tab" data-tab="plugins">Plugins</button>
+              <button class="tab" data-tab="apps">Apps</button>
+              <button class="tab" data-tab="config">Config</button>
             </div>
-            <div class="small">Uploads go to <span class="mono">.opencode/openwork/inbox/</span> inside the workspace.</div>
 
-            <div class="hr"></div>
+            <div class="panel" data-panel="share">
+              <div class="row">
+                <select class="input" id="share-scope">
+                  <option value="collaborator">collaborator</option>
+                  <option value="viewer">viewer</option>
+                </select>
+                <input class="input" id="share-label" type="text" placeholder="label (optional)" />
+                <button class="btn" id="btn-mint">Mint token</button>
+                <button class="btn" id="btn-deploy">Deploy (Beta)</button>
+              </div>
+              <div class="small">Minting tokens requires an owner token (or host access).</div>
 
-            <div class="row">
-              <button class="btn" id="btn-artifacts">List artifacts</button>
-              <span class="small">Downloads read from <span class="mono">.opencode/openwork/outbox/</span>.</span>
+              <div class="hr"></div>
+
+              <div class="row">
+                <button class="btn" id="btn-share">Connect artifact (current token)</button>
+                <button class="btn" id="btn-copy">Copy JSON</button>
+                <button class="btn" id="btn-tokens">List tokens</button>
+              </div>
+              <div class="codebox" id="connect"></div>
+              <div class="list" id="tokens"></div>
+
+              <div class="hr"></div>
+
+              <div class="row">
+                <button class="btn" id="btn-export">Export workspace</button>
+              </div>
+              <div class="codebox" id="export"></div>
+
+              <div class="hr"></div>
+
+              <div class="row">
+                <button class="btn" id="btn-import">Import workspace</button>
+                <span class="small">(pastes JSON below)</span>
+              </div>
+              <textarea class="inputarea" id="import" placeholder="Paste export JSON..." spellcheck="false"></textarea>
             </div>
-            <div class="list" id="artifacts"></div>
 
-            <div class="hr"></div>
+            <div class="panel hidden" data-panel="automations">
+              <div class="row">
+                <button class="btn" id="btn-auto-refresh">Refresh</button>
+                <span class="small">Apply schedule on host via <span class="mono">openwork-agent-lab scheduler sync</span>.</span>
+              </div>
+              <div class="list" id="automations"></div>
 
-            <div class="row">
-              <button class="btn" id="btn-approvals">Refresh approvals</button>
-              <span class="small">(Owner or host token required)</span>
+              <div class="codebox" id="auto-log"></div>
+
+              <div class="hr"></div>
+
+              <div class="small">Create automation</div>
+              <div class="row">
+                <input class="input" id="auto-name" type="text" placeholder="name" />
+                <select class="input" id="auto-kind">
+                  <option value="interval">interval</option>
+                  <option value="daily">daily</option>
+                  <option value="weekly">weekly</option>
+                </select>
+              </div>
+              <div class="row" id="auto-interval-row">
+                <input class="input" id="auto-interval" type="number" min="60" step="60" placeholder="seconds" />
+                <span class="small">StartInterval</span>
+              </div>
+              <div class="row hidden" id="auto-daily-row">
+                <input class="input" id="auto-hour" type="number" min="0" max="23" placeholder="hour" />
+                <input class="input" id="auto-minute" type="number" min="0" max="59" placeholder="minute" />
+                <span class="small">local time</span>
+              </div>
+              <div class="row hidden" id="auto-weekly-row">
+                <select class="input" id="auto-weekday">
+                  <option value="1">Sun</option>
+                  <option value="2">Mon</option>
+                  <option value="3">Tue</option>
+                  <option value="4">Wed</option>
+                  <option value="5">Thu</option>
+                  <option value="6">Fri</option>
+                  <option value="7">Sat</option>
+                </select>
+                <input class="input" id="auto-weekly-hour" type="number" min="0" max="23" placeholder="hour" />
+                <input class="input" id="auto-weekly-minute" type="number" min="0" max="59" placeholder="minute" />
+              </div>
+              <textarea class="inputarea" id="auto-prompt" placeholder="Prompt..." spellcheck="false"></textarea>
+              <div class="row">
+                <button class="btn primary" id="btn-auto-save">Save automation</button>
+              </div>
             </div>
-            <div class="list" id="approvals"></div>
 
-            <div class="hr"></div>
-
-            <div class="row">
-              <select class="input" id="share-scope">
-                <option value="collaborator">collaborator</option>
-                <option value="viewer">viewer</option>
-              </select>
-              <input class="input" id="share-label" type="text" placeholder="label (optional)" />
-              <button class="btn" id="btn-mint">Mint token</button>
-              <button class="btn" id="btn-deploy">Deploy (Beta)</button>
+            <div class="panel hidden" data-panel="skills">
+              <div class="row">
+                <button class="btn" id="btn-skills-refresh">Refresh</button>
+                <span class="small">Managed in <span class="mono">.opencode/skills/</span></span>
+              </div>
+              <div class="list" id="skills"></div>
             </div>
-            <div class="small">Minting tokens requires an owner token (or host access).</div>
 
-            <div class="hr"></div>
-
-            <div class="row">
-              <button class="btn" id="btn-share">Connect artifact (current token)</button>
-              <button class="btn" id="btn-copy">Copy JSON</button>
+            <div class="panel hidden" data-panel="plugins">
+              <div class="row">
+                <input class="input" id="plugin-spec" type="text" placeholder="plugin spec" />
+                <button class="btn" id="btn-plugin-add">Add</button>
+                <button class="btn" id="btn-plugins-refresh">Refresh</button>
+              </div>
+              <div class="list" id="plugins"></div>
             </div>
-            <div class="codebox" id="connect"></div>
+
+            <div class="panel hidden" data-panel="apps">
+              <div class="row">
+                <button class="btn" id="btn-mcp-refresh">Refresh</button>
+                <span class="small">MCP servers from <span class="mono">opencode.json</span></span>
+              </div>
+              <div class="list" id="mcp"></div>
+            </div>
+
+            <div class="panel hidden" data-panel="config">
+              <div class="row">
+                <input id="file" type="file" />
+                <button class="btn" id="btn-upload">Upload to inbox</button>
+              </div>
+              <div class="small">Uploads go to <span class="mono">.opencode/openwork/inbox/</span> inside the workspace.</div>
+
+              <div class="hr"></div>
+
+              <div class="row">
+                <button class="btn" id="btn-artifacts">List artifacts</button>
+                <span class="small">Downloads read from <span class="mono">.opencode/openwork/outbox/</span>.</span>
+              </div>
+              <div class="list" id="artifacts"></div>
+
+              <div class="hr"></div>
+
+              <div class="row">
+                <button class="btn" id="btn-approvals">Refresh approvals</button>
+                <span class="small">(Owner or host token required)</span>
+              </div>
+              <div class="list" id="approvals"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -397,12 +543,35 @@ const fileInjectionEl = qs("#file-injection");
 const artifactsEl = qs("#artifacts");
 const approvalsEl = qs("#approvals");
 const connectEl = qs("#connect");
+const tokensEl = qs("#tokens");
+const exportEl = qs("#export");
+const importEl = qs("#import");
+const automationsEl = qs("#automations");
+const skillsEl = qs("#skills");
+const pluginsEl = qs("#plugins");
+const pluginSpecEl = qs("#plugin-spec");
+const mcpEl = qs("#mcp");
 const hostIdEl = qs("#host-id");
 const pillRun = qs("#pill-run");
 const timelineEl = qs("#timeline");
 const workspaceUrlEl = qs("#workspace-url");
 const shareScopeEl = qs("#share-scope");
 const shareLabelEl = qs("#share-label");
+const tabsEl = qs("#tabs");
+
+const autoNameEl = qs("#auto-name");
+const autoKindEl = qs("#auto-kind");
+const autoIntervalEl = qs("#auto-interval");
+const autoHourEl = qs("#auto-hour");
+const autoMinuteEl = qs("#auto-minute");
+const autoWeekdayEl = qs("#auto-weekday");
+const autoWeeklyHourEl = qs("#auto-weekly-hour");
+const autoWeeklyMinuteEl = qs("#auto-weekly-minute");
+const autoPromptEl = qs("#auto-prompt");
+const autoIntervalRow = qs("#auto-interval-row");
+const autoDailyRow = qs("#auto-daily-row");
+const autoWeeklyRow = qs("#auto-weekly-row");
+const autoLogEl = qs("#auto-log");
 
 const STORAGE_TOKEN = "openwork.toy.token";
 const STORAGE_SESSION_PREFIX = "openwork.toy.session.";
@@ -469,6 +638,25 @@ function addCheckpoint(label, detail) {
   while (timelineEl.children.length > 80) {
     timelineEl.removeChild(timelineEl.firstChild);
   }
+}
+
+let activeTab = "share";
+
+function setTab(tab) {
+  activeTab = tab;
+  if (tabsEl) {
+    const buttons = tabsEl.querySelectorAll(".tab");
+    buttons.forEach((btn) => {
+      const t = btn.getAttribute("data-tab") || "";
+      btn.classList.toggle("active", t === tab);
+    });
+  }
+
+  const panels = document.querySelectorAll(".panel");
+  panels.forEach((panel) => {
+    const t = panel.getAttribute("data-panel") || "";
+    panel.classList.toggle("hidden", t !== tab);
+  });
 }
 
 function getTokenFromHash() {
@@ -914,6 +1102,390 @@ async function mintShareToken(workspaceId) {
   setStatus("Token minted: " + tokenScope, "ok");
 }
 
+async function refreshTokens() {
+  if (!tokensEl) return;
+  tokensEl.innerHTML = "";
+  try {
+    const data = await apiFetch("/tokens");
+    const items = Array.isArray(data && data.items) ? data.items : [];
+    if (!items.length) {
+      const empty = document.createElement("div");
+      empty.className = "item";
+      empty.textContent = "No tokens.";
+      tokensEl.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("div");
+      row.className = "item";
+      const top = document.createElement("div");
+      top.className = "row";
+
+      const left = document.createElement("div");
+      const title = document.createElement("div");
+      title.className = "mono";
+      title.textContent = (item.scope ? String(item.scope) : "token") + "  " + (item.id ? String(item.id) : "");
+      const meta = document.createElement("div");
+      meta.className = "small";
+      meta.textContent = item.label ? String(item.label) : "";
+      left.appendChild(title);
+      if (meta.textContent) left.appendChild(meta);
+
+      const revoke = document.createElement("button");
+      revoke.className = "btn danger";
+      revoke.textContent = "Revoke";
+      revoke.onclick = async () => {
+        try {
+          await apiFetch("/tokens/" + encodeURIComponent(String(item.id || "")), { method: "DELETE" });
+          await refreshTokens();
+        } catch (e) {
+          setStatus(e && e.message ? e.message : "Revoke failed", "bad");
+        }
+      };
+
+      top.appendChild(left);
+      top.appendChild(revoke);
+      row.appendChild(top);
+      tokensEl.appendChild(row);
+    }
+  } catch (e) {
+    const warn = document.createElement("div");
+    warn.className = "item";
+    warn.textContent = e && e.message ? e.message : "Tokens unavailable";
+    tokensEl.appendChild(warn);
+  }
+}
+
+async function exportWorkspace(workspaceId) {
+  if (!exportEl) return;
+  exportEl.textContent = "";
+  const data = await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/export");
+  exportEl.textContent = JSON.stringify(data, null, 2);
+}
+
+async function importWorkspace(workspaceId) {
+  if (!importEl) return;
+  const raw = (importEl.value || "").trim();
+  if (!raw) throw new Error("import_json_missing");
+  let payload = null;
+  try { payload = JSON.parse(raw); } catch { payload = null; }
+  if (!payload) throw new Error("import_json_invalid");
+  await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/import", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+function scheduleSummary(schedule) {
+  if (!schedule || typeof schedule !== "object") return "";
+  const kind = String(schedule.kind || "");
+  const pad2 = (n) => String(n).padStart(2, "0");
+  if (kind === "interval") {
+    const seconds = Number(schedule.seconds || 0);
+    return seconds ? ("every " + seconds + "s") : "interval";
+  }
+  if (kind === "daily") {
+    return "daily " + pad2(schedule.hour) + ":" + pad2(schedule.minute);
+  }
+  if (kind === "weekly") {
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    const weekday = Number(schedule.weekday || 1);
+    const day = days[Math.max(1, Math.min(7, weekday)) - 1] || "?";
+    return "weekly " + day + " " + pad2(schedule.hour) + ":" + pad2(schedule.minute);
+  }
+  return kind || "schedule";
+}
+
+let automationsCache = [];
+
+async function refreshAutomations(workspaceId) {
+  if (!automationsEl) return;
+  if (autoLogEl) autoLogEl.textContent = "";
+  automationsEl.innerHTML = "";
+  try {
+    const data = await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/agentlab/automations");
+    const items = Array.isArray(data && data.items) ? data.items : [];
+    automationsCache = items;
+    if (!items.length) {
+      const empty = document.createElement("div");
+      empty.className = "item";
+      empty.textContent = "No automations yet.";
+      automationsEl.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("div");
+      row.className = "item";
+
+      const top = document.createElement("div");
+      top.className = "row";
+
+      const left = document.createElement("div");
+      const name = document.createElement("div");
+      name.className = "mono";
+      name.textContent = item.name + "  (" + item.id + ")";
+      const meta = document.createElement("div");
+      meta.className = "small";
+      meta.textContent = (item.enabled ? "enabled" : "disabled") + " - " + scheduleSummary(item.schedule);
+      left.appendChild(name);
+      left.appendChild(meta);
+
+      const buttons = document.createElement("div");
+      buttons.className = "row";
+
+      const runBtn = document.createElement("button");
+      runBtn.className = "btn";
+      runBtn.textContent = "Run";
+      runBtn.onclick = async () => {
+        try {
+          const res = await apiFetch(
+            "/workspace/" + encodeURIComponent(workspaceId) + "/agentlab/automations/" + encodeURIComponent(item.id) + "/run",
+            { method: "POST", body: JSON.stringify({}) },
+          );
+          const sessionId = res && res.sessionId ? String(res.sessionId) : "";
+          if (sessionId) {
+            writeSessionId(workspaceId, sessionId);
+            sessionIdEl.textContent = "session: " + sessionId;
+            await refreshMessages(workspaceId).catch(() => undefined);
+          }
+          setStatus("Automation started", "ok");
+        } catch (e) {
+          setStatus(e && e.message ? e.message : "Automation failed", "bad");
+        }
+      };
+
+      const logBtn = document.createElement("button");
+      logBtn.className = "btn";
+      logBtn.textContent = "Logs";
+      logBtn.onclick = async () => {
+        if (!autoLogEl) return;
+        autoLogEl.textContent = "";
+        try {
+          const data = await apiFetch(
+            "/workspace/" + encodeURIComponent(workspaceId) + "/agentlab/automations/logs/" + encodeURIComponent(item.id),
+          );
+          autoLogEl.textContent = data && data.content ? String(data.content) : "";
+        } catch (e) {
+          autoLogEl.textContent = e && e.message ? e.message : "Log not available";
+        }
+      };
+
+      const delBtn = document.createElement("button");
+      delBtn.className = "btn danger";
+      delBtn.textContent = "Delete";
+      delBtn.onclick = async () => {
+        try {
+          await apiFetch(
+            "/workspace/" + encodeURIComponent(workspaceId) + "/agentlab/automations/" + encodeURIComponent(item.id),
+            { method: "DELETE" },
+          );
+          await refreshAutomations(workspaceId);
+        } catch (e) {
+          setStatus(e && e.message ? e.message : "Delete failed", "bad");
+        }
+      };
+
+      buttons.appendChild(runBtn);
+      buttons.appendChild(logBtn);
+      buttons.appendChild(delBtn);
+
+      top.appendChild(left);
+      top.appendChild(buttons);
+      row.appendChild(top);
+      automationsEl.appendChild(row);
+    }
+  } catch (e) {
+    const warn = document.createElement("div");
+    warn.className = "item";
+    warn.textContent = e && e.message ? e.message : "Automations unavailable";
+    automationsEl.appendChild(warn);
+  }
+}
+
+function updateAutomationScheduleUI() {
+  const kind = autoKindEl && autoKindEl.value ? String(autoKindEl.value) : "interval";
+  if (autoIntervalRow) autoIntervalRow.classList.toggle("hidden", kind !== "interval");
+  if (autoDailyRow) autoDailyRow.classList.toggle("hidden", kind !== "daily");
+  if (autoWeeklyRow) autoWeeklyRow.classList.toggle("hidden", kind !== "weekly");
+}
+
+async function saveAutomation(workspaceId) {
+  const name = autoNameEl && autoNameEl.value ? String(autoNameEl.value).trim() : "";
+  const prompt = autoPromptEl && autoPromptEl.value ? String(autoPromptEl.value).trim() : "";
+  if (!name) throw new Error("name_required");
+  if (!prompt) throw new Error("prompt_required");
+  const kind = autoKindEl && autoKindEl.value ? String(autoKindEl.value) : "interval";
+  let schedule = null;
+  if (kind === "interval") {
+    schedule = { kind: "interval", seconds: Number(autoIntervalEl && autoIntervalEl.value ? autoIntervalEl.value : 3600) };
+  } else if (kind === "daily") {
+    schedule = {
+      kind: "daily",
+      hour: Number(autoHourEl && autoHourEl.value ? autoHourEl.value : 9),
+      minute: Number(autoMinuteEl && autoMinuteEl.value ? autoMinuteEl.value : 0),
+    };
+  } else {
+    schedule = {
+      kind: "weekly",
+      weekday: Number(autoWeekdayEl && autoWeekdayEl.value ? autoWeekdayEl.value : 2),
+      hour: Number(autoWeeklyHourEl && autoWeeklyHourEl.value ? autoWeeklyHourEl.value : 9),
+      minute: Number(autoWeeklyMinuteEl && autoWeeklyMinuteEl.value ? autoWeeklyMinuteEl.value : 0),
+    };
+  }
+  await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/agentlab/automations", {
+    method: "POST",
+    body: JSON.stringify({ name, prompt, enabled: true, schedule }),
+  });
+}
+
+async function refreshSkills(workspaceId) {
+  if (!skillsEl) return;
+  skillsEl.innerHTML = "";
+  try {
+    const data = await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/skills");
+    const items = Array.isArray(data && data.items) ? data.items : [];
+    if (!items.length) {
+      const empty = document.createElement("div");
+      empty.className = "item";
+      empty.textContent = "No skills found.";
+      skillsEl.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("div");
+      row.className = "item";
+      const top = document.createElement("div");
+      top.className = "row";
+      const left = document.createElement("div");
+      const name = document.createElement("div");
+      name.className = "mono";
+      name.textContent = item.name;
+      const meta = document.createElement("div");
+      meta.className = "small";
+      meta.textContent = item.description || (item.scope ? String(item.scope) : "");
+      left.appendChild(name);
+      if (meta.textContent) left.appendChild(meta);
+
+      const delBtn = document.createElement("button");
+      delBtn.className = "btn danger";
+      delBtn.textContent = "Delete";
+      delBtn.disabled = item.scope !== "project";
+      delBtn.onclick = async () => {
+        try {
+          await apiFetch(
+            "/workspace/" + encodeURIComponent(workspaceId) + "/skills/" + encodeURIComponent(item.name),
+            { method: "DELETE" },
+          );
+          await refreshSkills(workspaceId);
+        } catch (e) {
+          setStatus(e && e.message ? e.message : "Delete failed", "bad");
+        }
+      };
+
+      top.appendChild(left);
+      top.appendChild(delBtn);
+      row.appendChild(top);
+      skillsEl.appendChild(row);
+    }
+  } catch (e) {
+    const warn = document.createElement("div");
+    warn.className = "item";
+    warn.textContent = e && e.message ? e.message : "Skills unavailable";
+    skillsEl.appendChild(warn);
+  }
+}
+
+async function refreshPlugins(workspaceId) {
+  if (!pluginsEl) return;
+  pluginsEl.innerHTML = "";
+  try {
+    const data = await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/plugins");
+    const items = Array.isArray(data && data.items) ? data.items : [];
+    if (!items.length) {
+      const empty = document.createElement("div");
+      empty.className = "item";
+      empty.textContent = "No plugins.";
+      pluginsEl.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("div");
+      row.className = "item";
+      const top = document.createElement("div");
+      top.className = "row";
+      const left = document.createElement("div");
+      const spec = document.createElement("div");
+      spec.className = "mono";
+      spec.textContent = item.spec;
+      const meta = document.createElement("div");
+      meta.className = "small";
+      meta.textContent = (item.source ? String(item.source) : "") + (item.scope ? " / " + String(item.scope) : "");
+      left.appendChild(spec);
+      if (meta.textContent) left.appendChild(meta);
+
+      const delBtn = document.createElement("button");
+      delBtn.className = "btn danger";
+      delBtn.textContent = "Remove";
+      delBtn.disabled = item.source !== "config";
+      delBtn.onclick = async () => {
+        try {
+          await apiFetch(
+            "/workspace/" + encodeURIComponent(workspaceId) + "/plugins/" + encodeURIComponent(item.spec),
+            { method: "DELETE" },
+          );
+          await refreshPlugins(workspaceId);
+        } catch (e) {
+          setStatus(e && e.message ? e.message : "Remove failed", "bad");
+        }
+      };
+
+      top.appendChild(left);
+      top.appendChild(delBtn);
+      row.appendChild(top);
+      pluginsEl.appendChild(row);
+    }
+  } catch (e) {
+    const warn = document.createElement("div");
+    warn.className = "item";
+    warn.textContent = e && e.message ? e.message : "Plugins unavailable";
+    pluginsEl.appendChild(warn);
+  }
+}
+
+async function refreshMcp(workspaceId) {
+  if (!mcpEl) return;
+  mcpEl.innerHTML = "";
+  try {
+    const data = await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/mcp");
+    const items = Array.isArray(data && data.items) ? data.items : [];
+    if (!items.length) {
+      const empty = document.createElement("div");
+      empty.className = "item";
+      empty.textContent = "No MCP servers.";
+      mcpEl.appendChild(empty);
+      return;
+    }
+    for (const item of items) {
+      const row = document.createElement("div");
+      row.className = "item";
+      const name = document.createElement("div");
+      name.className = "mono";
+      name.textContent = item.name;
+      const meta = document.createElement("div");
+      meta.className = "small";
+      meta.textContent = item.disabledByTools ? "disabled" : "enabled";
+      row.appendChild(name);
+      row.appendChild(meta);
+      mcpEl.appendChild(row);
+    }
+  } catch (e) {
+    const warn = document.createElement("div");
+    warn.className = "item";
+    warn.textContent = e && e.message ? e.message : "MCP unavailable";
+    mcpEl.appendChild(warn);
+  }
+}
+
 async function copyConnectArtifact() {
   const text = connectEl.textContent || "";
   if (!text.trim()) return;
@@ -958,6 +1530,30 @@ async function main() {
   await refreshHost(workspaceId);
   sessionIdEl.textContent = readSessionId(workspaceId) ? ("session: " + readSessionId(workspaceId)) : "session: -";
   await refreshMessages(workspaceId).catch(() => undefined);
+
+  setTab(activeTab);
+  if (tabsEl) {
+    const buttons = tabsEl.querySelectorAll(".tab");
+    buttons.forEach((btn) => {
+      btn.onclick = async () => {
+        const tab = btn.getAttribute("data-tab") || "share";
+        setTab(tab);
+        try {
+          if (tab === "automations") await refreshAutomations(workspaceId);
+          if (tab === "skills") await refreshSkills(workspaceId);
+          if (tab === "plugins") await refreshPlugins(workspaceId);
+          if (tab === "apps") await refreshMcp(workspaceId);
+          if (tab === "share") await refreshTokens().catch(() => undefined);
+        } catch {
+          // ignore
+        }
+      };
+    });
+  }
+  if (autoKindEl) {
+    autoKindEl.onchange = () => updateAutomationScheduleUI();
+    updateAutomationScheduleUI();
+  }
 
   qs("#btn-new").onclick = async () => {
     try {
@@ -1072,6 +1668,75 @@ async function main() {
 
   qs("#btn-copy").onclick = async () => {
     await copyConnectArtifact();
+  };
+
+  qs("#btn-tokens").onclick = async () => {
+    await refreshTokens().catch((e) => setStatus(e && e.message ? e.message : "tokens failed", "bad"));
+  };
+
+  qs("#btn-export").onclick = async () => {
+    try {
+      await exportWorkspace(workspaceId);
+      setStatus("Exported", "ok");
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "export failed", "bad");
+    }
+  };
+
+  qs("#btn-import").onclick = async () => {
+    try {
+      await importWorkspace(workspaceId);
+      setStatus("Import requested (check approvals)", "ok");
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "import failed", "bad");
+    }
+  };
+
+  qs("#btn-auto-refresh").onclick = async () => {
+    await refreshAutomations(workspaceId).catch((e) => setStatus(e && e.message ? e.message : "automations failed", "bad"));
+  };
+
+  qs("#btn-auto-save").onclick = async () => {
+    try {
+      await saveAutomation(workspaceId);
+      if (autoNameEl) autoNameEl.value = "";
+      if (autoPromptEl) autoPromptEl.value = "";
+      await refreshAutomations(workspaceId);
+      setStatus("Automation saved (apply schedule on host)", "ok");
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "automation save failed", "bad");
+    }
+  };
+
+  qs("#btn-skills-refresh").onclick = async () => {
+    await refreshSkills(workspaceId).catch((e) => setStatus(e && e.message ? e.message : "skills failed", "bad"));
+  };
+
+  qs("#btn-plugins-refresh").onclick = async () => {
+    await refreshPlugins(workspaceId).catch((e) => setStatus(e && e.message ? e.message : "plugins failed", "bad"));
+  };
+
+  qs("#btn-plugin-add").onclick = async () => {
+    const spec = pluginSpecEl && pluginSpecEl.value ? String(pluginSpecEl.value).trim() : "";
+    if (!spec) {
+      setStatus("plugin spec required", "bad");
+      return;
+    }
+    try {
+      await apiFetch("/workspace/" + encodeURIComponent(workspaceId) + "/plugins", {
+        method: "POST",
+        body: JSON.stringify({ spec }),
+      });
+      if (pluginSpecEl) pluginSpecEl.value = "";
+      await refreshPlugins(workspaceId);
+      setStatus("Plugin added", "ok");
+    } catch (e) {
+      setStatus(e && e.message ? e.message : "plugin add failed", "bad");
+    }
+  };
+
+  qs("#btn-mcp-refresh").onclick = async () => {
+    await refreshMcp(workspaceId).catch((e) => setStatus(e && e.message ? e.message : "mcp failed", "bad"));
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,18 @@ importers:
 
   .: {}
 
+  packages/agent-lab:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.7
+      bun-types:
+        specifier: ^1.3.6
+        version: 1.3.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
   packages/app:
     dependencies:
       '@opencode-ai/sdk':


### PR DESCRIPTION
## What
Implements the first end-to-end Agent Lab (toy) flow on top of existing OpenWork primitives:

- Adds `packages/agent-lab` CLI to provision and run per-instance hosts via `openwrk`.
- Evolves `openwork-server` Toy UI into an Agent Lab surface with Share / Automations / Skills / Plugins / Apps / Config panels.
- Adds Agent Lab automation storage + run endpoints and macOS launchd integration (applied by the instance manager).
- Hardens `/opencode/*` proxy so collaborators cannot self-approve OpenCode permission replies.

## Why
Provides a controlled harness to validate:
- conversation-first configuration
- scoped sharing (tokens + connect artifacts)
- multi-instance isolation
- scheduler mechanics compatible with sandbox constraints

## Testing
- `pnpm --filter openwork-agent-lab typecheck`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwork-server build:bin`
- Manual curl smoke:
  - verify collaborator gets 403 on `/w/:id/opencode/permission/<req>/reply`
  - verify owner token can mint tokens via `POST /tokens`
  - verify `POST /workspace/:id/agentlab/automations` and `/run` create a session + prompt

## Notes
- Scheduler jobs are applied on macOS via `openwork-agent-lab scheduler sync <instanceId>`.