### PR TITLE
feat(app): show touched files in right sidebar

### DIFF
--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -603,7 +603,10 @@ export default function Composer(props: ComposerProps) {
     // Limit Set size to prevent memory leak (though unlikely to grow huge)
     if (recentEmits.size > 20) {
       const it = recentEmits.values();
-      recentEmits.delete(it.next().value);
+      const first = it.next();
+      if (!first.done) {
+        recentEmits.delete(first.value);
+      }
     }
 
     const resolvedText = normalizeText(partsToResolvedText(parts));

--- a/packages/app/src/app/components/session/touched-files-panel.tsx
+++ b/packages/app/src/app/components/session/touched-files-panel.tsx
@@ -1,0 +1,152 @@
+import { For, Show, createMemo, createSignal } from "solid-js";
+import { FileText } from "lucide-solid";
+
+export type TouchedFilesPanelProps = {
+  files: string[];
+  workspaceRoot?: string;
+  onFileClick?: (path: string) => void;
+  maxPreview?: number;
+  id?: string;
+};
+
+const normalizePath = (value: string) => value.trim().replace(/[\\/]+/g, "/");
+const splitPathSegments = (value: string) => value.split(/[/\\]/).filter(Boolean);
+
+const toWorkspaceRelative = (file: string, root?: string) => {
+  const normalizedRoot = (root ?? "").trim().replace(/[\\/]+/g, "/").replace(/\/+$/, "");
+  if (!normalizedRoot) return file;
+
+  const normalizedFile = file.replace(/[\\/]+/g, "/");
+  const rootKey = normalizedRoot.toLowerCase();
+  const fileKey = normalizedFile.toLowerCase();
+
+  if (fileKey === rootKey) return normalizedFile.split("/").pop() ?? normalizedFile;
+  if (fileKey.startsWith(`${rootKey}/`)) return normalizedFile.slice(normalizedRoot.length + 1);
+  return normalizedFile;
+};
+
+const getBasename = (value: string) => {
+  const segments = splitPathSegments(value);
+  return segments[segments.length - 1] ?? value;
+};
+
+const getDirname = (value: string) => {
+  const segments = splitPathSegments(value);
+  if (segments.length <= 1) return "";
+  return segments.slice(0, -1).join("/");
+};
+
+const isMarkdown = (value: string) => /\.(md|mdx|markdown)$/i.test(value);
+
+export default function TouchedFilesPanel(props: TouchedFilesPanelProps) {
+  const [showAll, setShowAll] = createSignal(false);
+  const maxPreview = createMemo(() => {
+    const raw = props.maxPreview ?? 6;
+    if (!Number.isFinite(raw)) return 6;
+    return Math.min(12, Math.max(3, Math.floor(raw)));
+  });
+
+  const normalizedFiles = createMemo(() => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+
+    for (const entry of props.files ?? []) {
+      const normalized = normalizePath(String(entry ?? ""));
+      if (!normalized) continue;
+      const key = normalized.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(normalized);
+      if (out.length >= 48) break;
+    }
+
+    return out;
+  });
+
+  const visibleFiles = createMemo(() => {
+    const list = normalizedFiles();
+    return showAll() ? list : list.slice(0, maxPreview());
+  });
+
+  const hiddenCount = createMemo(() => {
+    const total = normalizedFiles().length;
+    const shown = visibleFiles().length;
+    return Math.max(0, total - shown);
+  });
+
+  const canOpen = createMemo(() => typeof props.onFileClick === "function");
+  const prettyPath = (file: string) => toWorkspaceRelative(file, props.workspaceRoot);
+
+  return (
+    <div id={props.id} class="rounded-xl border border-dls-border bg-dls-hover px-3 py-2.5">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-2 min-w-0">
+          <FileText size={14} class="text-dls-secondary" />
+          <div class="min-w-0">
+            <div class="text-[11px] font-bold tracking-tight text-dls-secondary uppercase">
+              Touched files
+            </div>
+          </div>
+        </div>
+        <Show when={normalizedFiles().length > 0}>
+          <div class="text-[11px] text-dls-secondary font-mono">{normalizedFiles().length}</div>
+        </Show>
+      </div>
+
+      <div class="mt-2 space-y-1">
+        <Show
+          when={visibleFiles().length > 0}
+          fallback={<div class="text-xs text-dls-secondary px-1 py-1">None yet.</div>}
+        >
+          <For each={visibleFiles()}>
+            {(file) => {
+              const display = () => prettyPath(file);
+              const base = () => getBasename(display());
+              const dir = () => getDirname(display());
+              const md = () => isMarkdown(base());
+              return (
+                <button
+                  type="button"
+                  class={`w-full flex items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${
+                    canOpen() ? "hover:bg-dls-active" : "cursor-default"
+                  }`}
+                  onClick={() => props.onFileClick?.(file)}
+                  disabled={!canOpen()}
+                  title={display()}
+                  aria-label={canOpen() ? `Open ${display()}` : display()}
+                >
+                  <div class="mt-0.5 shrink-0">
+                    <span class="h-1.5 w-1.5 rounded-full bg-dls-border inline-block" />
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <div class="truncate text-xs font-medium text-dls-text">{base()}</div>
+                      <Show when={md()}>
+                        <span class="shrink-0 rounded-md border border-dls-border bg-dls-surface px-1.5 py-0.5 text-[10px] font-mono text-dls-secondary">
+                          MD
+                        </span>
+                      </Show>
+                    </div>
+                    <Show when={dir()}>
+                      <div class="truncate text-[11px] text-dls-secondary">{dir()}</div>
+                    </Show>
+                  </div>
+                </button>
+              );
+            }}
+          </For>
+        </Show>
+
+        <Show when={hiddenCount() > 0}>
+          <button
+            type="button"
+            class="w-full mt-1 rounded-lg px-2 py-1.5 text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-active transition-colors"
+            onClick={() => setShowAll((prev) => !prev)}
+          >
+            {showAll() ? "Show fewer" : `Show ${hiddenCount()} more`}
+          </button>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -58,6 +58,7 @@ import Composer from "../components/session/composer";
 import type { SidebarSectionState } from "../components/session/sidebar";
 import FlyoutItem from "../components/flyout-item";
 import QuestionModal from "../components/question-modal";
+import TouchedFilesPanel from "../components/session/touched-files-panel";
 
 export type SessionViewProps = {
   selectedSessionId: string | null;
@@ -210,6 +211,36 @@ export default function SessionView(props: SessionViewProps) {
   const todoCompletedCount = createMemo(() =>
     todoList().filter((todo) => todo.status === "completed").length
   );
+
+  const touchedFiles = createMemo(() => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    const add = (value: string) => {
+      const normalized = String(value ?? "").trim().replace(/[\\/]+/g, "/");
+      if (!normalized) return;
+      const key = normalized.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push(normalized);
+    };
+
+    const artifacts = props.artifacts;
+    for (let idx = artifacts.length - 1; idx >= 0; idx -= 1) {
+      const item = artifacts[idx];
+      add(item?.path ?? item?.name ?? "");
+      if (out.length >= 48) break;
+    }
+
+    if (out.length === 0) {
+      const working = props.workingFiles;
+      for (let idx = working.length - 1; idx >= 0; idx -= 1) {
+        add(working[idx] ?? "");
+        if (out.length >= 48) break;
+      }
+    }
+
+    return out;
+  });
   const todoLabel = createMemo(() => {
     const total = todoCount();
     if (!total) return "";
@@ -1788,7 +1819,14 @@ export default function SessionView(props: SessionViewProps) {
       </main>
 
       <aside class="w-56 hidden md:flex flex-col bg-dls-sidebar border-l border-dls-border p-4">
-        <div class="space-y-1 pt-2">
+        <div class="flex-1 overflow-y-auto space-y-3 pt-2">
+          <TouchedFilesPanel
+            id="sidebar-context"
+            files={touchedFiles()}
+            workspaceRoot={props.activeWorkspaceRoot}
+          />
+
+          <div class="space-y-1">
           <button
             type="button"
             class={`w-full h-10 flex items-center gap-3 px-3 rounded-lg text-sm font-medium transition-colors ${
@@ -1876,9 +1914,8 @@ export default function SessionView(props: SessionViewProps) {
             <SlidersHorizontal size={18} />
             Config
           </button>
+          </div>
         </div>
-
-        <div class="flex-1" />
 
         <div class="pt-4 border-t border-dls-border">
           <button


### PR DESCRIPTION
## Summary
- Add a \"Touched files\" panel to the session right sidebar, using recent tool artifacts (most recent first) and showing workspace-relative paths.
- Keep the right sidebar scrollable while preserving the Settings affordance at the bottom.
- Fix a small TS type-safety issue in composer recentEmits eviction (no behavior change).

## Why
This makes file context visible where people look first, and sets up the next PR to open + edit markdown directly from the sidebar.

## Testing
- pnpm --filter @different-ai/openwork-ui typecheck
- pnpm --filter @different-ai/openwork-ui build