### PR TITLE
fix(app): skill-creator install CTA feedback

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4238,12 +4238,12 @@ export default function App() {
     const canUseGlobalPluginScope = !isRemoteWorkspace && isTauriRuntime();
     const skillsAccessHint = isRemoteWorkspace
       ? openworkStatus === "disconnected"
-        ? "OpenWork server unavailable. Connect to manage skills."
+        ? "OpenWork server unavailable. Add the server URL/token in Config to manage skills."
         : openworkStatus === "limited"
-          ? "OpenWork server needs a token to manage skills."
+          ? "OpenWork server needs a host token to install/update skills. Add it in Config and reconnect."
           : openworkServerCanWriteSkills()
             ? null
-            : "OpenWork server is read-only for skills."
+            : "OpenWork server is read-only for skills. Add a host token in Config to enable installs."
       : null;
     const pluginsAccessHint = isRemoteWorkspace
       ? openworkStatus === "disconnected"

--- a/packages/app/src/app/context/extensions.ts
+++ b/packages/app/src/app/context/extensions.ts
@@ -562,7 +562,7 @@ export function createExtensionsStore(options: {
     }
   }
 
-  async function installSkillCreator() {
+  async function installSkillCreator(): Promise<{ ok: boolean; message: string }> {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
     const openworkClient = options.openworkServerClient();
@@ -585,37 +585,48 @@ export function createExtensionsStore(options: {
           name: "skill-creator",
           content: skillCreatorTemplate,
         });
-        setSkillsStatus(translate("skills.skill_creator_installed"));
+        const message = translate("skills.skill_creator_installed");
+        setSkillsStatus(message);
+        options.markReloadRequired("skills", { type: "skill", name: "skill-creator", action: "added" });
         await refreshSkills({ force: true });
+        return { ok: true, message };
       } catch (e) {
-        const message = e instanceof Error ? e.message : translate("skills.unknown_error");
-        options.setError(addOpencodeCacheHint(message));
+        const raw = e instanceof Error ? e.message : translate("skills.unknown_error");
+        const message = addOpencodeCacheHint(raw);
+        // Ensure we show feedback on the Skills page (not just the global error banner).
+        setSkillsStatus(message);
+        options.setError(message);
+        return { ok: false, message };
       } finally {
         options.setBusy(false);
       }
-      return;
     }
 
     // Remote workspace without server
     if (isRemoteWorkspace) {
-      setSkillsStatus("OpenWork server unavailable. Connect to install skills.");
-      return;
+      const message = "OpenWork server unavailable. Connect to install skills.";
+      setSkillsStatus(message);
+      return { ok: false, message };
     }
 
     if (!isTauriRuntime()) {
-      setSkillsStatus(translate("skills.desktop_required"));
-      return;
+      const message = translate("skills.desktop_required");
+      setSkillsStatus(message);
+      return { ok: false, message };
     }
 
     if (!isLocalWorkspace) {
-      options.setError("Local workspaces are required to install skills.");
-      return;
+      const message = "Local workspaces are required to install skills.";
+      options.setError(message);
+      setSkillsStatus(message);
+      return { ok: false, message };
     }
 
     const targetDir = options.activeWorkspaceRoot().trim();
     if (!targetDir) {
-      setSkillsStatus(translate("skills.pick_workspace_first"));
-      return;
+      const message = translate("skills.pick_workspace_first");
+      setSkillsStatus(message);
+      return { ok: false, message };
     }
 
     options.setBusy(true);
@@ -626,21 +637,34 @@ export function createExtensionsStore(options: {
       const result = await installSkillTemplate(targetDir, "skill-creator", skillCreatorTemplate, { overwrite: false });
 
       if (!result.ok && /already exists/i.test(result.stderr)) {
-        setSkillsStatus(translate("skills.skill_creator_already_installed"));
+        const message = translate("skills.skill_creator_already_installed");
+        setSkillsStatus(message);
+        await refreshSkills({ force: true });
+        return { ok: true, message };
       } else if (!result.ok) {
-        setSkillsStatus(result.stderr || result.stdout || translate("skills.install_failed"));
+        const message = result.stderr || result.stdout || translate("skills.install_failed");
+        setSkillsStatus(message);
+        await refreshSkills({ force: true });
+        return { ok: false, message };
       } else {
-        setSkillsStatus(result.stdout || translate("skills.skill_creator_installed"));
+        const message = result.stdout || translate("skills.skill_creator_installed");
+        setSkillsStatus(message);
         options.markReloadRequired("skills", { type: "skill", name: "skill-creator", action: "added" });
+        await refreshSkills({ force: true });
+        return { ok: true, message };
       }
-
-      await refreshSkills({ force: true });
     } catch (e) {
-      const message = e instanceof Error ? e.message : translate("skills.unknown_error");
-      options.setError(addOpencodeCacheHint(message));
+      const raw = e instanceof Error ? e.message : translate("skills.unknown_error");
+      const message = addOpencodeCacheHint(raw);
+      setSkillsStatus(message);
+      options.setError(message);
+      return { ok: false, message };
     } finally {
       options.setBusy(false);
     }
+
+    // Should be unreachable, but keep TS happy.
+    return { ok: false, message: translate("skills.install_failed") };
   }
 
   async function revealSkillsFolder() {

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -140,7 +140,7 @@ export type DashboardViewProps = {
   canInstallSkillCreator: boolean;
   canUseDesktopTools: boolean;
   importLocalSkill: () => void;
-  installSkillCreator: () => void;
+  installSkillCreator: () => Promise<{ ok: boolean; message: string }>;
   revealSkillsFolder: () => void;
   uninstallSkill: (name: string) => void;
   readSkill: (name: string) => Promise<{ name: string; path: string; content: string } | null>;

--- a/packages/app/src/app/pages/skills.tsx
+++ b/packages/app/src/app/pages/skills.tsx
@@ -1,10 +1,12 @@
-import { For, Show, createMemo, createSignal } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 import type { SkillCard } from "../types";
 
 import Button from "../components/button";
-import { Edit2, FolderOpen, Package, Plus, RefreshCw, Search, Sparkles, Trash2, Upload } from "lucide-solid";
+import { Edit2, FolderOpen, Loader2, Package, Plus, RefreshCw, Search, Sparkles, Trash2, Upload } from "lucide-solid";
 import { currentLocale, t } from "../../i18n";
+
+type InstallResult = { ok: boolean; message: string };
 
 export type SkillsViewProps = {
   busy: boolean;
@@ -15,7 +17,7 @@ export type SkillsViewProps = {
   skills: SkillCard[];
   skillsStatus: string | null;
   importLocalSkill: () => void;
-  installSkillCreator: () => void;
+  installSkillCreator: () => Promise<InstallResult>;
   revealSkillsFolder: () => void;
   uninstallSkill: (name: string) => void;
   readSkill: (name: string) => Promise<{ name: string; path: string; content: string } | null>;
@@ -42,6 +44,16 @@ export default function SkillsView(props: SkillsViewProps) {
   const [selectedDirty, setSelectedDirty] = createSignal(false);
   const [selectedError, setSelectedError] = createSignal<string | null>(null);
 
+  const [toast, setToast] = createSignal<string | null>(null);
+  const [installingSkillCreator, setInstallingSkillCreator] = createSignal(false);
+
+  createEffect(() => {
+    const message = toast();
+    if (!message) return;
+    const id = window.setTimeout(() => setToast(null), 2400);
+    onCleanup(() => window.clearTimeout(id));
+  });
+
   const filteredSkills = createMemo(() => {
     const query = searchQuery().trim().toLowerCase();
     if (!query) return props.skills;
@@ -54,14 +66,32 @@ export default function SkillsView(props: SkillsViewProps) {
     });
   });
 
+  const installSkillCreator = async () => {
+    if (props.busy || installingSkillCreator()) return;
+    if (!props.canInstallSkillCreator) {
+      setToast(props.accessHint ?? translate("skills.host_only_error"));
+      return;
+    }
+    setInstallingSkillCreator(true);
+    setToast(translate("skills.installing_skill_creator"));
+    try {
+      const result = await props.installSkillCreator();
+      setToast(result.message);
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : translate("skills.install_failed"));
+    } finally {
+      setInstallingSkillCreator(false);
+    }
+  };
+
   const recommendedSkills = createMemo(() => [
     {
       id: "skill-creator",
       title: translate("skills.install_skill_creator"),
       description: translate("skills.install_skill_creator_hint"),
       icon: Sparkles,
-      onClick: () => props.installSkillCreator(),
-      disabled: props.busy || skillCreatorInstalled() || !props.canInstallSkillCreator,
+      onClick: installSkillCreator,
+      disabled: props.busy || installingSkillCreator() || skillCreatorInstalled() || !props.canInstallSkillCreator,
     },
     {
       id: "import-local",
@@ -85,11 +115,28 @@ export default function SkillsView(props: SkillsViewProps) {
     if (props.busy) return;
     // Ensure skill-creator exists when we can.
     if (props.canInstallSkillCreator && !skillCreatorInstalled()) {
-      await Promise.resolve(props.installSkillCreator());
+      await installSkillCreator();
     }
     // Open a new session and preselect /skill-creator.
     await Promise.resolve(props.createSessionAndOpen());
     props.setPrompt("/skill-creator");
+  };
+
+  const recommendedDisabledReason = (id: string) => {
+    if (id === "skill-creator") {
+      if (skillCreatorInstalled()) return translate("skills.installed_label");
+      if (props.busy || installingSkillCreator()) return translate("skills.installing_skill_creator");
+      if (!props.canInstallSkillCreator) {
+        return props.accessHint ?? translate("skills.host_only_error");
+      }
+      return null;
+    }
+
+    if (!props.canUseDesktopTools) {
+      return translate("skills.desktop_required");
+    }
+
+    return null;
   };
 
   const openSkill = async (skill: SkillCard) => {
@@ -148,6 +195,11 @@ export default function SkillsView(props: SkillsViewProps) {
 
   return (
     <section class="space-y-10">
+      <Show when={toast()}>
+        <div class="fixed bottom-6 right-6 z-50 max-w-sm rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-xs text-dls-text shadow-2xl">
+          {toast()}
+        </div>
+      </Show>
       <div class="flex flex-wrap items-center justify-end gap-4 border-b border-dls-border pb-4">
         <button
           type="button"
@@ -355,7 +407,33 @@ export default function SkillsView(props: SkillsViewProps) {
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <For each={recommendedSkills()}>
             {(item) => (
-              <div class="bg-dls-surface border border-dls-border rounded-xl p-4 flex items-start justify-between group hover:border-dls-border transition-all">
+              <div
+                role="button"
+                tabindex="0"
+                class={`bg-dls-surface border border-dls-border rounded-xl p-4 flex items-start justify-between group transition-all text-left ${
+                  item.disabled ? "opacity-80" : "hover:border-dls-border"
+                }`}
+                onClick={() => {
+                  if (item.disabled) {
+                    const reason = recommendedDisabledReason(item.id);
+                    if (reason) setToast(reason);
+                    return;
+                  }
+                  void item.onClick();
+                }}
+                onKeyDown={(e) => {
+                  if (e.key !== "Enter" && e.key !== " ") return;
+                  if (e.isComposing || e.keyCode === 229) return;
+                  e.preventDefault();
+                  if (item.disabled) {
+                    const reason = recommendedDisabledReason(item.id);
+                    if (reason) setToast(reason);
+                    return;
+                  }
+                  void item.onClick();
+                }}
+                title={item.disabled ? (recommendedDisabledReason(item.id) ?? item.title) : item.title}
+              >
                 <div class="flex gap-4">
                   <div class="w-10 h-10 rounded-lg flex items-center justify-center shadow-sm border border-dls-border bg-dls-hover">
                     <item.icon size={20} class="text-dls-secondary" />
@@ -365,6 +443,11 @@ export default function SkillsView(props: SkillsViewProps) {
                       <h4 class="text-sm font-semibold text-dls-text">{item.title}</h4>
                     </div>
                     <p class="text-xs text-dls-secondary line-clamp-1">{item.description}</p>
+                    <Show when={item.id === "skill-creator" && !props.canInstallSkillCreator && !skillCreatorInstalled()}>
+                      <div class="mt-1 text-[11px] text-dls-secondary">
+                        {props.accessHint ?? translate("skills.host_only_error")}
+                      </div>
+                    </Show>
                   </div>
                 </div>
                 <button
@@ -374,14 +457,25 @@ export default function SkillsView(props: SkillsViewProps) {
                       ? "text-dls-secondary opacity-40"
                       : "text-dls-secondary hover:text-dls-text hover:bg-dls-hover"
                   }`}
-                  onClick={() => {
-                    if (item.disabled) return;
-                    item.onClick();
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (item.disabled) {
+                      const reason = recommendedDisabledReason(item.id);
+                      if (reason) setToast(reason);
+                      return;
+                    }
+                    void item.onClick();
                   }}
                   disabled={item.disabled}
                   title={item.title}
                 >
-                  <Plus size={16} />
+                  <Show
+                    when={item.id === "skill-creator" && installingSkillCreator()}
+                    fallback={<Plus size={16} />}
+                  >
+                    <Loader2 size={16} class="animate-spin" />
+                  </Show>
                 </button>
               </div>
             )}


### PR DESCRIPTION
## What
Fixes the Skills page empty-state CTA so \"Install skill creator\" never silently does nothing.

## Why
On remote workspaces the recommended CTA can be disabled (no write capability) or fail to install, but the UI provided no actionable feedback. This is high-confusion on the first-run empty state.

## Changes
- Make the recommended cards clickable and show a toast when an action is unavailable (disabled), instead of failing silently.
- Show an inline, actionable hint under \"Install skill creator\" when the server is read-only / disconnected.
- Add install progress + spinner while installing skill-creator.
- Ensure install errors also update `skillsStatus` (not just the global error banner) and return a structured result.

## How to test
1. Open `Skills` on a remote workspace.
2. If the server lacks `skills.write`, click the card/button: you should see a toast + inline hint explaining why.
3. If `skills.write` is enabled, click \"Install skill creator\": you should see installing toast + spinner, then a success toast and the skill appears.

## Evidence
- UX reference: `research/ux-audit-core-flows/media/02-skills-empty-recommended.png`

## Notes
- Docker dev stack validation was attempted but `packaging/docker/dev-up.sh` failed locally with headless container exit 137 (OOM during pnpm install). UI changes were typechecked via `pnpm --filter @different-ai/openwork-ui typecheck`.