### PR TITLE
fix(app): avoid localhost OpenCode calls in remote web

### DIFF
--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -196,7 +196,7 @@ export default function StatusBar(props: StatusBarProps) {
         >
           <span class={`w-2 h-2 rounded-full ${opencodeStatusMeta().dot}`} />
           <Cpu class="w-4 h-4 text-gray-11" />
-          <Show when={props.developerMode}>
+          <Show when={props.developerMode || !props.clientConnected}>
             <span class="text-gray-11 font-medium">OpenCode</span>
             <span class={opencodeStatusMeta().text}>{opencodeStatusMeta().label}</span>
           </Show>
@@ -208,7 +208,7 @@ export default function StatusBar(props: StatusBarProps) {
         >
           <span class={`w-2 h-2 rounded-full ${openworkStatusMeta().dot}`} />
           <Server class="w-4 h-4 text-gray-11" />
-          <Show when={props.developerMode}>
+          <Show when={props.developerMode || props.openworkServerStatus !== "connected"}>
             <span class="text-gray-11 font-medium">OpenWork</span>
             <span class={openworkStatusMeta().text}>{openworkStatusMeta().label}</span>
           </Show>

--- a/packages/app/src/app/context/global-sdk.tsx
+++ b/packages/app/src/app/context/global-sdk.tsx
@@ -36,22 +36,41 @@ export function GlobalSDKProvider(props: ParentProps) {
 
   createEffect(() => {
     const baseUrl = server.url;
+    const isHealthy = server.healthy() === true;
+
+    const token = (() => {
+      if (typeof window === "undefined") return "";
+      try {
+        return (window.localStorage.getItem("openwork.server.token") ?? "").trim();
+      } catch {
+        return "";
+      }
+    })();
+    const headers = token && baseUrl.includes("/opencode") ? { Authorization: `Bearer ${token}` } : undefined;
     setUrl(baseUrl);
 
-    const abort = new AbortController();
-    const eventClient = createOpencodeClient({
-      baseUrl,
-      signal: abort.signal,
-      fetch: platform.fetch,
-    });
-
+    // Always keep the request client in sync with the active URL.
     setClient(
       createOpencodeClient({
         baseUrl,
+        headers,
         fetch: platform.fetch,
         throwOnError: true,
       }),
     );
+
+    // Avoid silent retry loops (SSE reconnects) when the dependency is unavailable.
+    if (!baseUrl || !isHealthy) {
+      return;
+    }
+
+    const abort = new AbortController();
+    const eventClient = createOpencodeClient({
+      baseUrl,
+      headers,
+      signal: abort.signal,
+      fetch: platform.fetch,
+    });
 
     type Queued = { directory: string; payload: Event };
 

--- a/packages/app/src/app/context/server.tsx
+++ b/packages/app/src/app/context/server.tsx
@@ -57,8 +57,24 @@ export function ServerProvider(props: ParentProps & { defaultUrl: string }) {
     if (typeof window === "undefined") return;
     if (ready()) return;
 
-    const storedList = readStoredList();
     const fallback = normalizeServerUrl(props.defaultUrl) ?? "";
+
+    // In production web builds served by OpenWork (Docker "remote" mode), OpenCode
+    // traffic should go through the server proxy (usually same-origin `/opencode`).
+    // Do not reuse any persisted localhost targets.
+    const forceProxy =
+      !isTauriRuntime() &&
+      (import.meta.env.PROD ||
+        (typeof import.meta.env?.VITE_OPENWORK_URL === "string" &&
+          import.meta.env.VITE_OPENWORK_URL.trim().length > 0));
+    if (forceProxy && fallback) {
+      setList([fallback]);
+      setActiveRaw(fallback);
+      setReady(true);
+      return;
+    }
+
+    const storedList = readStoredList();
     const storedActive = normalizeServerUrl(readStoredActive());
 
     const initialList = storedList.length ? storedList : fallback ? [fallback] : [];
@@ -83,10 +99,21 @@ export function ServerProvider(props: ParentProps & { defaultUrl: string }) {
 
   const activeUrl = createMemo(() => active());
 
+  const readOpenworkToken = () => {
+    try {
+      return (window.localStorage.getItem("openwork.server.token") ?? "").trim();
+    } catch {
+      return "";
+    }
+  };
+
   const checkHealth = async (url: string) => {
     if (!url) return false;
+    const token = readOpenworkToken();
+    const headers = token && url.includes("/opencode") ? { Authorization: `Bearer ${token}` } : undefined;
     const client = createOpencodeClient({
       baseUrl: url,
+      headers,
       signal: AbortSignal.timeout(3000),
       fetch: isTauriRuntime() ? tauriFetch : undefined,
     });

--- a/packages/app/src/app/entry.tsx
+++ b/packages/app/src/app/entry.tsx
@@ -3,9 +3,36 @@ import { GlobalSDKProvider } from "./context/global-sdk";
 import { GlobalSyncProvider } from "./context/global-sync";
 import { LocalProvider } from "./context/local";
 import { ServerProvider } from "./context/server";
+import { isTauriRuntime } from "./utils";
 
 export default function AppEntry() {
-  const defaultUrl = "http://127.0.0.1:4096";
+  const defaultUrl = (() => {
+    // Desktop app connects to the local OpenCode engine.
+    if (isTauriRuntime()) return "http://127.0.0.1:4096";
+
+    // When running the web UI against an OpenWork server (e.g. Docker dev stack),
+    // use the server's `/opencode` proxy instead of loopback.
+    const openworkUrl =
+      typeof import.meta.env?.VITE_OPENWORK_URL === "string"
+        ? import.meta.env.VITE_OPENWORK_URL.trim()
+        : "";
+    if (openworkUrl) {
+      return `${openworkUrl.replace(/\/+$/, "")}/opencode`;
+    }
+
+    // When the UI is served by the OpenWork server (Docker "remote" mode),
+    // OpenCode is proxied at same-origin `/opencode`.
+    if (import.meta.env.PROD && typeof window !== "undefined") {
+      return `${window.location.origin}/opencode`;
+    }
+
+    // Dev fallback (Vite) - allow overriding for remote debugging.
+    const envUrl =
+      typeof import.meta.env?.VITE_OPENCODE_URL === "string"
+        ? import.meta.env.VITE_OPENCODE_URL.trim()
+        : "";
+    return envUrl || "http://127.0.0.1:4096";
+  })();
 
   return (
     <ServerProvider defaultUrl={defaultUrl}>


### PR DESCRIPTION
## Summary
- Prevent the web UI (server/remote mode) from targeting `http://127.0.0.1:4096` for OpenCode APIs; route through the OpenWork server `/opencode` proxy.
- Stop noisy retry loops by only starting the OpenCode event (SSE) subscription once the configured dependency is healthy.
- Surface a visible disconnected indicator in the status bar when OpenCode/OpenWork aren’t available.

## Why
When the UI is connected to a Docker/OpenWork "remote" server, loopback requests to `127.0.0.1:4096` always fail and spam the console/network, and can break features accidentally wired to local OpenCode.

## Testing
- Started Docker dev stack (`packaging/docker/dev-up.sh`).
- Verified via Chrome DevTools Network that there are no requests to `127.0.0.1:4096/*`.
- Verified OpenCode traffic goes to the OpenWork server proxy (`/opencode/*`) and session creation still works.