### PR TITLE
fix(app): gate MCP connection tips to Apps

### DIFF
--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -12,6 +12,8 @@ type StatusBarProps = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
   developerMode: boolean;
+  /** If true, the rotating tip bubble may include MCP connection CTAs (e.g., Notion). */
+  allowMcpTips?: boolean;
   onOpenSettings: () => void;
   onOpenMessaging: () => void;
   onOpenProviders: () => Promise<void> | void;
@@ -98,7 +100,7 @@ export default function StatusBar(props: StatusBarProps) {
     {
       id: "notion",
       label: "Connect Notion MCP",
-      enabled: () => notionStatus() !== "connected",
+      enabled: () => Boolean(props.allowMcpTips) && notionStatus() !== "connected",
       action: () => runAction(props.onOpenMcp),
     },
     {

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -1403,6 +1403,7 @@ export default function DashboardView(props: DashboardViewProps) {
               clientConnected={props.clientConnected}
               openworkServerStatus={props.openworkServerStatus}
               developerMode={props.developerMode}
+              allowMcpTips={props.tab === "mcp"}
               onOpenSettings={() => openSettings("general")}
               onOpenMessaging={openConfig}
               onOpenProviders={() => props.openProviderAuthModal()}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -2150,6 +2150,7 @@ export default function SessionView(props: SessionViewProps) {
           clientConnected={props.clientConnected}
           openworkServerStatus={props.openworkServerStatus}
           developerMode={props.developerMode}
+          allowMcpTips={false}
           onOpenSettings={() => openSettings("general")}
           onOpenMessaging={openConfig}
           onOpenProviders={openProviderAuth}


### PR DESCRIPTION
## Why
The rotating status-bar tip bubble could surface \"Connect Notion MCP\" on unrelated surfaces (sessions, Automations, Skills, Settings), which reads as a random interrupt and distracts from core task execution.

## What changed
- Gate MCP connection tips (Notion) behind the Apps tab (Dashboard -> Apps).
- Keep other tips (providers / messaging) available globally.

## Evidence (screens)
- Before (Notion CTA shown during a session): https://files.catbox.moe/xxyin4.png
- After (Automations tab; no Notion CTA): https://files.catbox.moe/fa3kph.png
- Apps tab still offers Notion connect entry point: https://files.catbox.moe/wylfaf.png

## Test
- Docker dev stack: open `.../session`, `.../dashboard/scheduled`, confirm no Notion tip bubble appears.
- Navigate to `.../dashboard/mcp` (Apps) and confirm Notion connect card is present.