### PR TITLE
fix(app): make browser quickstart tool-safe

### DIFF
--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1743,8 +1743,13 @@ export default function SessionView(props: SessionViewProps) {
                   onClick={() => {
                     handleSendPrompt({
                       mode: "prompt",
-                      text: "Help me set up browser automation.",
-                      parts: [{ type: "text", text: "Help me set up browser automation." }],
+                      text: "Help me set up browser automation. Start by using the bash tool to run `ls` in the workspace and tell me what you find.",
+                      parts: [
+                        {
+                          type: "text",
+                          text: "Help me set up browser automation. Start by using the bash tool to run `ls` in the workspace and tell me what you find.",
+                        },
+                      ],
                       attachments: [],
                     });
                   }}


### PR DESCRIPTION
## Why
The "Automate your browser" entry point could immediately fail with an `Invalid Tool` error because the model tried to call the non-existent tool `ls` (instead of using the `bash` tool).

That breaks a headline onboarding flow.

## What changed
- Update the quickstart message to explicitly instruct the agent to use the `bash` tool for directory listing (`ls`).

## Evidence (screens)
- Before (Invalid Tool / attempted `ls` tool): https://files.catbox.moe/xxyin4.png
- After (lists files successfully, no Invalid Tool): https://files.catbox.moe/skzev3.png

## Test
- Docker dev stack: click "Automate your browser" on an empty session; confirm no Invalid Tool error appears.