### PR TITLE
fix(headless): warn instead of crash on opencode version mismatch for external binaries

### DIFF
--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -2704,6 +2704,16 @@ async function verifyOwpenbotVersion(binary: ResolvedBinary): Promise<string | u
 
 async function verifyOpencodeVersion(binary: ResolvedBinary): Promise<string | undefined> {
   const actual = await readCliVersion(binary.bin);
+  // When the binary was explicitly provided via --opencode-bin (source "external"),
+  // a strict version check would break desktop app users whenever a new opencode
+  // release ships on GitHub before OpenWork updates its bundled binary. Log a
+  // warning instead of throwing so the caller can still proceed.
+  if (binary.source === "external" && binary.expectedVersion && actual && binary.expectedVersion !== actual) {
+    console.error(
+      `[openwrk] Warning: opencode version mismatch (expected ${binary.expectedVersion}, got ${actual}). Proceeding with ${binary.bin}.`,
+    );
+    return actual;
+  }
   assertVersionMatch("opencode", binary.expectedVersion, actual, binary.bin);
   return actual;
 }


### PR DESCRIPTION
## Summary

Fixes the desktop app failing to start sessions because the openwrk daemon crashes on opencode version mismatch.

## Problem

When the Tauri desktop app spawns `openwrk daemon run` with `--opencode-bin /usr/bin/opencode` (the bundled binary), the daemon:

1. Resolves the expected opencode version by querying the **latest GitHub release** (e.g. `1.1.56`)
2. Reads the actual version of the bundled binary (e.g. `1.1.54`)
3. `assertVersionMatch()` does a strict equality check → **throws** and exits immediately

This means **every desktop user is broken** the moment a new opencode release ships on GitHub, until OpenWork ships an updated release with the new bundled binary.

## Fix

When the binary source is `"external"` (explicitly provided via `--opencode-bin`, as the desktop app does), downgrade the strict version assertion to a warning. The desktop app already validates the binary works via `engine_doctor` before passing it.

**Before:** hard crash → `opencode version mismatch: expected 1.1.56, got 1.1.54.`  
**After:** warning + proceed → `[openwrk] Warning: opencode version mismatch (expected 1.1.56, got 1.1.54). Proceeding with /usr/bin/opencode.`

## Testing

Reproduced with the v0.11.46 .deb on Linux (bundled opencode 1.1.54, latest release 1.1.56):

```
# Before fix:
[openwrk] Daemon starting
opencode version mismatch: expected 1.1.56, got 1.1.54.

# After fix:
[openwrk] Daemon starting
[openwrk] Warning: opencode version mismatch (expected 1.1.56, got 1.1.54). Proceeding with /usr/bin/opencode.
[opencode] Healthy
openwrk daemon running on 127.0.0.1:19880
```

## Related issues

- Fixes #121 (Host startup relies on manual OpenCode CLI install / sidecar gaps)
- Related to #97, #98 ("OpenCode exited immediately with status 0")