### PR TITLE
Sandbox creation: stream startup progress

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4803,7 +4803,10 @@ export default function App() {
 
       <CreateWorkspaceModal
         open={workspaceStore.createWorkspaceOpen()}
-        onClose={() => workspaceStore.setCreateWorkspaceOpen(false)}
+        onClose={() => {
+          workspaceStore.setCreateWorkspaceOpen(false);
+          workspaceStore.clearSandboxCreateProgress?.();
+        }}
         onPickFolder={workspaceStore.pickWorkspaceFolder}
         onConfirm={(preset, folder) =>
           workspaceStore.createWorkspaceFlow(preset, folder)
@@ -4844,6 +4847,7 @@ export default function App() {
           void workspaceStore.refreshSandboxDoctor?.();
         }}
         submitting={busy() && busyLabel() === "status.creating_workspace"}
+        submittingProgress={workspaceStore.sandboxCreateProgress?.() ?? null}
       />
 
       <CreateRemoteWorkspaceModal

--- a/packages/app/src/app/components/create-workspace-modal.tsx
+++ b/packages/app/src/app/components/create-workspace-modal.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createSignal } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 import { CheckCircle2, FolderPlus, Loader2, X } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
@@ -25,6 +25,15 @@ export default function CreateWorkspaceModal(props: {
   onWorkerCta?: () => void;
   workerRetryLabel?: string;
   onWorkerRetry?: () => void;
+
+  submittingProgress?: {
+    runId: string;
+    startedAt: number;
+    stage: string;
+    error: string | null;
+    steps: Array<{ key: string; label: string; status: "pending" | "active" | "done" | "error"; detail?: string | null }>;
+    logs: string[];
+  } | null;
 }) {
   let pickFolderRef: HTMLButtonElement | undefined;
   const translate = (key: string) => t(key, currentLocale());
@@ -86,6 +95,26 @@ export default function CreateWorkspaceModal(props: {
   const workerLabel = () => props.workerLabel ?? translate("dashboard.create_sandbox_confirm");
   const isInline = () => props.inline ?? false;
   const submitting = () => props.submitting ?? false;
+
+  const progress = createMemo(() => props.submittingProgress ?? null);
+  const [showProgressDetails, setShowProgressDetails] = createSignal(false);
+  const [now, setNow] = createSignal(Date.now());
+
+  createEffect(() => {
+    if (!submitting()) {
+      setShowProgressDetails(false);
+      return;
+    }
+
+    const id = window.setInterval(() => setNow(Date.now()), 500);
+    onCleanup(() => window.clearInterval(id));
+  });
+
+  const elapsedSeconds = createMemo(() => {
+    const p = progress();
+    if (!p?.startedAt) return 0;
+    return Math.max(0, Math.floor((now() - p.startedAt) / 1000));
+  });
 
   const workerDisabled = () => Boolean(props.workerDisabled);
   const workerDisabledReason = () => (props.workerDisabledReason ?? "").trim();
@@ -192,6 +221,78 @@ export default function CreateWorkspaceModal(props: {
           </div>
 
       <div class="p-6 border-t border-gray-6 bg-gray-1 flex flex-col gap-3">
+        <Show when={submitting() && progress()}>
+          {(p) => (
+            <div class="rounded-xl border border-indigo-7/25 bg-indigo-2/40 px-4 py-3">
+              <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                  <div class="text-xs font-semibold text-indigo-12">Sandbox setup</div>
+                  <div class="mt-1 text-sm text-gray-12 leading-snug truncate">{p().stage}</div>
+                  <div class="mt-1 text-[11px] text-gray-10 font-mono">{elapsedSeconds()}s elapsed</div>
+                </div>
+                <button
+                  type="button"
+                  class="shrink-0 text-xs text-gray-10 hover:text-gray-12"
+                  onClick={() => setShowProgressDetails((prev) => !prev)}
+                >
+                  {showProgressDetails() ? "Hide" : "Details"}
+                </button>
+              </div>
+
+              <Show when={p().error}>
+                {(err) => (
+                  <div class="mt-3 rounded-lg border border-red-7/30 bg-red-2/40 px-3 py-2 text-xs text-red-11">
+                    {err()}
+                  </div>
+                )}
+              </Show>
+
+              <div class="mt-3 grid gap-2">
+                <For each={p().steps}>
+                  {(step) => {
+                    const dotClass = () => {
+                      if (step.status === "done") return "bg-emerald-9";
+                      if (step.status === "active") return "bg-indigo-9 animate-pulse";
+                      if (step.status === "error") return "bg-red-9";
+                      return "bg-gray-7";
+                    };
+                    const textClass = () => {
+                      if (step.status === "done") return "text-emerald-12";
+                      if (step.status === "active") return "text-indigo-12";
+                      if (step.status === "error") return "text-red-12";
+                      return "text-gray-11";
+                    };
+                    return (
+                      <div class="flex items-start gap-2">
+                        <span class={`mt-1.5 h-2 w-2 rounded-full ${dotClass()}`.trim()} />
+                        <div class="min-w-0 flex-1">
+                          <div class={`text-xs font-medium ${textClass()}`.trim()}>{step.label}</div>
+                          <Show when={(step.detail ?? "").trim()}>
+                            <div class="text-[11px] text-gray-10 font-mono truncate">{step.detail}</div>
+                          </Show>
+                        </div>
+                      </div>
+                    );
+                  }}
+                </For>
+              </div>
+
+              <Show when={showProgressDetails() && (p().logs?.length ?? 0) > 0}>
+                <div class="mt-3 rounded-lg border border-gray-6 bg-gray-2/60 px-3 py-2">
+                  <div class="text-[10px] uppercase tracking-wide font-semibold text-gray-10">Recent</div>
+                  <div class="mt-2 space-y-1">
+                    <For each={p().logs.slice(-6)}>
+                      {(line) => (
+                        <div class="text-[11px] text-gray-11 font-mono break-words">{line}</div>
+                      )}
+                    </For>
+                  </div>
+                </div>
+              </Show>
+            </div>
+          )}
+        </Show>
+
         <Show when={showWorkerCallout()}>
           <div class="rounded-xl border border-amber-7/30 bg-amber-2/40 px-4 py-3 text-xs text-amber-11">
             <div class="font-semibold text-amber-12">{translate("dashboard.sandbox_get_ready_title")}</div>

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -1,4 +1,5 @@
 import { createEffect, createMemo, createSignal } from "solid-js";
+import { listen, type Event as TauriEvent } from "@tauri-apps/api/event";
 
 import type {
   Client,
@@ -71,6 +72,24 @@ export type WorkspaceDebugEvent = {
   at: number;
   label: string;
   payload?: unknown;
+};
+
+export type SandboxCreateProgressStepStatus = "pending" | "active" | "done" | "error";
+
+export type SandboxCreateProgressStep = {
+  key: "docker" | "workspace" | "sandbox" | "health" | "connect";
+  label: string;
+  status: SandboxCreateProgressStepStatus;
+  detail?: string | null;
+};
+
+export type SandboxCreateProgressState = {
+  runId: string;
+  startedAt: number;
+  stage: string;
+  steps: SandboxCreateProgressStep[];
+  logs: string[];
+  error: string | null;
 };
 
 export function createWorkspaceStore(options: {
@@ -161,6 +180,50 @@ export function createWorkspaceStore(options: {
   const [sandboxDoctorResult, setSandboxDoctorResult] = createSignal<SandboxDoctorResult | null>(null);
   const [sandboxDoctorCheckedAt, setSandboxDoctorCheckedAt] = createSignal<number | null>(null);
   const [sandboxDoctorBusy, setSandboxDoctorBusy] = createSignal(false);
+
+  const [sandboxCreateProgress, setSandboxCreateProgress] = createSignal<SandboxCreateProgressState | null>(null);
+  const clearSandboxCreateProgress = () => setSandboxCreateProgress(null);
+
+  const pushSandboxCreateLog = (line: string) => {
+    const value = String(line ?? "").trim();
+    if (!value) return;
+    setSandboxCreateProgress((prev) => {
+      if (!prev) return prev;
+      const nextLogs = prev.logs.length ? prev.logs.slice(-119) : [];
+      // Avoid rapid duplicates.
+      const last = nextLogs[nextLogs.length - 1] ?? "";
+      if (last !== value) nextLogs.push(value);
+      return { ...prev, logs: nextLogs };
+    });
+  };
+
+  const setSandboxStep = (key: SandboxCreateProgressStep["key"], patch: Partial<SandboxCreateProgressStep>) => {
+    setSandboxCreateProgress((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        steps: prev.steps.map((step) => (step.key === key ? { ...step, ...patch } : step)),
+      };
+    });
+  };
+
+  const setSandboxStage = (stage: string) => {
+    const value = String(stage ?? "").trim();
+    if (!value) return;
+    setSandboxCreateProgress((prev) => (prev ? { ...prev, stage: value } : prev));
+  };
+
+  const setSandboxError = (message: string) => {
+    const value = String(message ?? "").trim() || "Sandbox failed to start";
+    setSandboxCreateProgress((prev) => (prev ? { ...prev, error: value } : prev));
+  };
+
+  const makeRunId = () => {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  };
   let lastEngineReconnectAt = 0;
   let reconnectingEngine = false;
 
@@ -1276,12 +1339,36 @@ export function createWorkspaceStore(options: {
       return;
     }
 
+    const runId = makeRunId();
+    const startedAt = Date.now();
+    setSandboxCreateProgress({
+      runId,
+      startedAt,
+      stage: "Checking Docker...",
+      error: null,
+      logs: [],
+      steps: [
+        { key: "docker", label: "Docker ready", status: "active", detail: null },
+        { key: "workspace", label: "Prepare workspace", status: "pending", detail: null },
+        { key: "sandbox", label: "Start sandbox services", status: "pending", detail: null },
+        { key: "health", label: "Wait for OpenWork", status: "pending", detail: null },
+        { key: "connect", label: "Connect in OpenWork", status: "pending", detail: null },
+      ],
+    });
+
     const doctor = await refreshSandboxDoctor();
     if (!doctor?.ready) {
-      const detail = doctor?.error?.trim() || "Docker is required for sandboxes. Install Docker Desktop, start it, then retry.";
+      const detail =
+        doctor?.error?.trim() ||
+        "Docker is required for sandboxes. Install Docker Desktop, start it, then retry.";
       options.setError(detail);
+      setSandboxStep("docker", { status: "error", detail });
+      setSandboxError(detail);
+      setSandboxStage("Docker not ready");
       return;
     }
+    setSandboxStep("docker", { status: "done", detail: doctor.serverVersion ?? null });
+    setSandboxStage("Preparing workspace...");
 
     options.setBusy(true);
     options.setBusyLabel("status.creating_workspace");
@@ -1292,44 +1379,118 @@ export function createWorkspaceStore(options: {
       const resolvedFolder = await resolveWorkspacePath(folder);
       if (!resolvedFolder) {
         options.setError(t("app.error.choose_folder", currentLocale()));
+        setSandboxStep("workspace", { status: "error", detail: "No folder selected" });
+        setSandboxError("No folder selected");
         return;
       }
 
       const name = resolvedFolder.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? "Workspace";
 
+      setSandboxStep("workspace", { status: "active", detail: name });
+      pushSandboxCreateLog(`Workspace: ${resolvedFolder}`);
+
       // Ensure the workspace folder has baseline OpenWork/OpenCode files.
       const created = await workspaceCreate({ folderPath: resolvedFolder, name, preset });
       setWorkspaces(created.workspaces);
       syncActiveWorkspaceId(created.activeId);
+      setSandboxStep("workspace", { status: "done", detail: null });
 
       // Remove the local workspace entry to avoid duplicate Local+Remote rows.
       const localId = created.activeId;
       if (localId) {
+        pushSandboxCreateLog("Removing local workspace row (will re-add as remote sandbox)...");
         const forgotten = await workspaceForget(localId);
         setWorkspaces(forgotten.workspaces);
         syncActiveWorkspaceId(forgotten.activeId);
       }
 
-      options.setBusyLabel("Starting sandbox...");
-      const host = await openwrkStartDetached({ workspacePath: resolvedFolder, sandboxBackend: "docker" });
+      setSandboxStep("sandbox", { status: "active", detail: null });
+      setSandboxStage("Starting sandbox services...");
 
-      setCreateWorkspaceOpen(false);
-      options.setTab("scheduled");
-      options.setView("dashboard");
-      markOnboardingComplete();
+      let stopListen: (() => void) | null = null;
+      try {
+        stopListen = await listen(
+          "openwork://sandbox-create-progress",
+          (event: TauriEvent<{ runId?: string; stage?: string; message?: string; payload?: any }>) => {
+            const payload = event.payload ?? {};
+            if ((payload.runId ?? "").trim() !== runId) return;
+            const stage = String(payload.stage ?? "").trim();
+            const message = String(payload.message ?? "").trim();
+            if (message) {
+              setSandboxStage(message);
+              pushSandboxCreateLog(message);
+            }
 
-      await createRemoteWorkspaceFlow({
-        openworkHostUrl: host.openworkUrl,
-        openworkToken: host.token,
-        directory: resolvedFolder,
-        displayName: name,
-        sandboxBackend: host.sandboxBackend ?? "docker",
-        sandboxRunId: host.sandboxRunId ?? null,
-        sandboxContainerName: host.sandboxContainerName ?? null,
-      });
+            if (stage === "docker.container") {
+              const state = String(payload.payload?.containerState ?? "").trim();
+              if (state) {
+                setSandboxStep("sandbox", { status: "active", detail: `Container: ${state}` });
+              }
+            }
+
+            if (stage === "openwork.waiting") {
+              const elapsedMs = Number(payload.payload?.elapsedMs ?? 0);
+              const seconds = elapsedMs > 0 ? Math.max(1, Math.floor(elapsedMs / 1000)) : 0;
+              setSandboxStep("health", { status: "active", detail: seconds ? `${seconds}s` : null });
+            }
+
+            if (stage === "openwork.healthy") {
+              setSandboxStep("sandbox", { status: "done" });
+              setSandboxStep("health", { status: "done", detail: null });
+            }
+
+            if (stage === "error") {
+              const err = String(payload.payload?.error ?? "").trim() || message || "Sandbox failed to start";
+              setSandboxStep("sandbox", { status: "error", detail: err });
+              setSandboxStep("health", { status: "error", detail: err });
+              setSandboxError(err);
+            }
+          },
+        );
+
+        const host = await openwrkStartDetached({
+          workspacePath: resolvedFolder,
+          sandboxBackend: "docker",
+          runId,
+        });
+        setSandboxStep("sandbox", { status: "done", detail: host.sandboxContainerName ?? null });
+        setSandboxStep("health", { status: "done" });
+        setSandboxStage("Connecting to sandbox...");
+
+        setSandboxStep("connect", { status: "active", detail: null });
+
+        options.setTab("scheduled");
+        options.setView("dashboard");
+        markOnboardingComplete();
+
+        const ok = await createRemoteWorkspaceFlow({
+          openworkHostUrl: host.openworkUrl,
+          openworkToken: host.token,
+          directory: resolvedFolder,
+          displayName: name,
+          sandboxBackend: host.sandboxBackend ?? "docker",
+          sandboxRunId: host.sandboxRunId ?? runId,
+          sandboxContainerName: host.sandboxContainerName ?? null,
+        });
+        if (!ok) {
+          const fallback = "Failed to connect to sandbox";
+          setSandboxStep("connect", { status: "error", detail: fallback });
+          setSandboxError(fallback);
+          return;
+        }
+
+        setSandboxStep("connect", { status: "done", detail: null });
+        setSandboxStage("Sandbox ready.");
+        setCreateWorkspaceOpen(false);
+        clearSandboxCreateProgress();
+      } finally {
+        stopListen?.();
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
       options.setError(addOpencodeCacheHint(message));
+      setSandboxError(message);
+      setSandboxStage("Sandbox failed");
     } finally {
       options.setBusy(false);
       options.setBusyLabel(null);
@@ -2544,6 +2705,8 @@ export function createWorkspaceStore(options: {
     persistReloadSettings,
     setEngineInstallLogs,
     refreshSandboxDoctor,
+    sandboxCreateProgress,
+    clearSandboxCreateProgress,
     workspaceDebugEvents,
     clearWorkspaceDebugEvents,
   };

--- a/packages/desktop/src-tauri/src/commands/openwrk.rs
+++ b/packages/desktop/src-tauri/src/commands/openwrk.rs
@@ -4,7 +4,9 @@ use serde_json::json;
 use std::net::TcpListener;
 use std::process::Command;
 use std::time::{Duration, Instant};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
+use tauri::Emitter;
 use tauri::State;
 use tauri_plugin_shell::ShellExt;
 use uuid::Uuid;
@@ -12,6 +14,8 @@ use uuid::Uuid;
 use crate::openwrk::manager::OpenwrkManager;
 use crate::openwrk::{resolve_openwrk_data_dir, resolve_openwrk_status};
 use crate::types::{ExecResult, OpenwrkStatus, OpenwrkWorkspace};
+
+const SANDBOX_PROGRESS_EVENT: &str = "openwork://sandbox-create-progress";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -101,18 +105,54 @@ fn allocate_free_port() -> Result<u16, String> {
     Ok(port)
 }
 
-fn wait_for_openwork_health(openwork_url: &str, timeout_ms: u64) -> Result<(), String> {
-    let start = Instant::now();
-    let mut last_error: Option<String> = None;
-    while start.elapsed() < Duration::from_millis(timeout_ms) {
-        match ureq::get(&format!("{}/health", openwork_url.trim_end_matches('/'))).call() {
-            Ok(response) if response.status() >= 200 && response.status() < 300 => return Ok(()),
-            Ok(response) => last_error = Some(format!("HTTP {}", response.status())),
-            Err(err) => last_error = Some(err.to_string()),
-        }
-        std::thread::sleep(Duration::from_millis(200));
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn emit_sandbox_progress(
+    app: &AppHandle,
+    run_id: &str,
+    stage: &str,
+    message: &str,
+    payload: serde_json::Value,
+) {
+    let event_payload = json!({
+        "runId": run_id,
+        "stage": stage,
+        "message": message,
+        "at": now_ms(),
+        "payload": payload,
+    });
+    let _ = app.emit(SANDBOX_PROGRESS_EVENT, event_payload);
+}
+
+fn docker_container_state(container_name: &str) -> Result<Option<String>, String> {
+    let (status, stdout, stderr) = run_local_command(
+        "docker",
+        &["inspect", "-f", "{{.State.Status}}", container_name],
+    )?;
+    if status == 0 {
+        let trimmed = stdout.trim().to_string();
+        return Ok(if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        });
     }
-    Err(last_error.unwrap_or_else(|| "Timed out waiting for OpenWork server".to_string()))
+
+    let combined = format!("{}\n{}", stdout.trim(), stderr.trim()).to_lowercase();
+    if combined.contains("no such object")
+        || combined.contains("not found")
+        || combined.contains("does not exist")
+    {
+        return Ok(None);
+    }
+
+    // If docker returned something unexpected, don't block progress reporting.
+    Ok(None)
 }
 
 #[derive(Debug, Deserialize)]
@@ -262,6 +302,20 @@ pub fn openwrk_start_detached(
     let host_token = Uuid::new_v4().to_string();
     let openwork_url = format!("http://127.0.0.1:{port}");
 
+    emit_sandbox_progress(
+        &app,
+        &sandbox_run_id,
+        "init",
+        "Starting sandbox...",
+        json!({
+            "workspacePath": workspace_path,
+            "openworkUrl": openwork_url,
+            "port": port,
+            "sandboxBackend": if wants_docker_sandbox { "docker" } else { "none" },
+            "containerName": sandbox_container_name,
+        }),
+    );
+
     let command = match app.shell().sidecar("openwrk") {
         Ok(command) => command,
         Err(_) => app.shell().command("openwrk"),
@@ -309,8 +363,111 @@ pub fn openwrk_start_detached(
             .map_err(|e| format!("Failed to start openwrk: {e}"))?;
     }
 
+    emit_sandbox_progress(
+        &app,
+        &sandbox_run_id,
+        "spawned",
+        "Sandbox process launched. Waiting for OpenWork server...",
+        json!({
+            "openworkUrl": openwork_url,
+        }),
+    );
+
     let health_timeout_ms = if wants_docker_sandbox { 90_000 } else { 12_000 };
-    wait_for_openwork_health(&openwork_url, health_timeout_ms)?;
+    let start = Instant::now();
+    let mut last_tick = Instant::now() - Duration::from_secs(5);
+    let mut last_container_check = Instant::now() - Duration::from_secs(10);
+    let mut last_container_state: Option<String> = None;
+    let mut last_error: Option<String> = None;
+
+    while start.elapsed() < Duration::from_millis(health_timeout_ms) {
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+
+        if wants_docker_sandbox {
+            if last_container_check.elapsed() > Duration::from_millis(1500) {
+                last_container_check = Instant::now();
+                if let Some(name) = sandbox_container_name.as_deref() {
+                    if let Ok(state) = docker_container_state(name) {
+                        if state != last_container_state {
+                            last_container_state = state.clone();
+                            let label = state.clone().unwrap_or_else(|| "not-created".to_string());
+                            emit_sandbox_progress(
+                                &app,
+                                &sandbox_run_id,
+                                "docker.container",
+                                &format!("Sandbox container: {label}"),
+                                json!({
+                                    "containerName": name,
+                                    "containerState": state,
+                                    "elapsedMs": elapsed_ms,
+                                }),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        match ureq::get(&format!("{}/health", openwork_url.trim_end_matches('/'))).call() {
+            Ok(response) if response.status() >= 200 && response.status() < 300 => {
+                emit_sandbox_progress(
+                    &app,
+                    &sandbox_run_id,
+                    "openwork.healthy",
+                    "OpenWork server is ready.",
+                    json!({
+                        "openworkUrl": openwork_url,
+                        "elapsedMs": elapsed_ms,
+                        "containerState": last_container_state,
+                    }),
+                );
+                last_error = None;
+                break;
+            }
+            Ok(response) => {
+                last_error = Some(format!("HTTP {}", response.status()));
+            }
+            Err(err) => {
+                last_error = Some(err.to_string());
+            }
+        }
+
+        if last_tick.elapsed() > Duration::from_millis(850) {
+            last_tick = Instant::now();
+            emit_sandbox_progress(
+                &app,
+                &sandbox_run_id,
+                "openwork.waiting",
+                "Waiting for OpenWork server...",
+                json!({
+                    "openworkUrl": openwork_url,
+                    "elapsedMs": elapsed_ms,
+                    "lastError": last_error,
+                    "containerState": last_container_state,
+                }),
+            );
+        }
+
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    if start.elapsed() >= Duration::from_millis(health_timeout_ms) {
+        let message =
+            last_error.unwrap_or_else(|| "Timed out waiting for OpenWork server".to_string());
+        emit_sandbox_progress(
+            &app,
+            &sandbox_run_id,
+            "error",
+            "Sandbox failed to start.",
+            json!({
+                "error": message,
+                "elapsedMs": start.elapsed().as_millis() as u64,
+                "openworkUrl": openwork_url,
+                "containerState": last_container_state,
+            }),
+        );
+        return Err(message);
+    }
 
     Ok(OpenwrkDetachedHost {
         openwork_url,


### PR DESCRIPTION
## Why
Creating a sandbox can take a while (first-run downloads, docker startup). The UI previously just showed a single loading state, which felt opaque.

## What changed
- Emit structured progress events from the desktop when `openwrk start --detach` is launched (`openwork://sandbox-create-progress`), including docker container state and OpenWork health wait ticks.
- Surface those events in the Create Workspace modal as a stepper + live stage text + optional recent logs, so users know what is happening while the sandbox boots.

## Testing
- `pnpm -C packages/app typecheck`
- `pnpm -C packages/app build`
- `pnpm -C packages/desktop prepare:sidecar`
- `cargo check` (packages/desktop/src-tauri)