### PR TITLE
feat(mcp): add OAuth logout action

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -49,7 +49,7 @@ import {
   THINKING_PREF_KEY,
   VARIANT_PREF_KEY,
 } from "./constants";
-import { parseMcpServersFromContent } from "./mcp";
+import { parseMcpServersFromContent, validateMcpServerName } from "./mcp";
 import type {
   Client,
   DashboardTab,
@@ -3434,6 +3434,106 @@ export default function App() {
     }
   }
 
+  async function logoutMcpAuth(name: string) {
+    const isRemoteWorkspace =
+      workspaceStore.activeWorkspaceDisplay().workspaceType === "remote" ||
+      (!isTauriRuntime() && openworkServerStatus() === "connected");
+    const projectDir = workspaceProjectDir().trim();
+
+    const openworkClient = openworkServerClient();
+    let openworkWorkspaceId = openworkServerWorkspaceId();
+    const openworkCapabilities = resolvedOpenworkCapabilities();
+    if (!openworkWorkspaceId && openworkClient && openworkServerStatus() === "connected") {
+      try {
+        const response = await openworkClient.listWorkspaces();
+        const match = response.items?.[0];
+        if (match?.id) {
+          openworkWorkspaceId = match.id;
+          setOpenworkServerWorkspaceId(match.id);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    const canUseOpenworkServer =
+      openworkServerStatus() === "connected" &&
+      openworkClient &&
+      openworkWorkspaceId &&
+      openworkCapabilities?.mcp?.write;
+
+    if (isRemoteWorkspace && !canUseOpenworkServer) {
+      setMcpStatus("OpenWork server unavailable. MCP auth is read-only.");
+      return;
+    }
+
+    if (!canUseOpenworkServer && !isTauriRuntime()) {
+      setMcpStatus(t("mcp.desktop_required", currentLocale()));
+      return;
+    }
+
+    let activeClient = client();
+    if (!activeClient) {
+      const openworkBaseUrl = openworkServerBaseUrl().trim();
+      const auth = openworkServerAuth();
+      if (openworkBaseUrl && auth.token) {
+        const opencodeUrl = `${openworkBaseUrl.replace(/\/+$/, "")}/opencode`;
+        activeClient = createClient(opencodeUrl, undefined, { token: auth.token, mode: "openwork" });
+        setClient(activeClient);
+      }
+    }
+    if (!activeClient) {
+      setMcpStatus(t("mcp.connect_server_first", currentLocale()));
+      return;
+    }
+
+    let resolvedProjectDir = projectDir;
+    if (!resolvedProjectDir) {
+      try {
+        const pathInfo = unwrap(await activeClient.path.get());
+        const discoveredRaw = normalizeDirectoryPath(pathInfo.directory ?? "");
+        const discovered = discoveredRaw.replace(/^\/private\/tmp(?=\/|$)/, "/tmp");
+        if (discovered) {
+          resolvedProjectDir = discovered;
+          workspaceStore.setProjectDir(discovered);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    if (!resolvedProjectDir) {
+      setMcpStatus(t("mcp.pick_workspace_first", currentLocale()));
+      return;
+    }
+
+    const safeName = validateMcpServerName(name);
+    setMcpStatus(null);
+
+    try {
+      if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
+        await openworkClient.logoutMcpAuth(openworkWorkspaceId, safeName);
+      } else {
+        try {
+          await activeClient.mcp.disconnect({ directory: resolvedProjectDir, name: safeName });
+        } catch {
+          // ignore
+        }
+        await activeClient.mcp.auth.remove({ directory: resolvedProjectDir, name: safeName });
+      }
+
+      try {
+        const status = unwrap(await activeClient.mcp.status({ directory: resolvedProjectDir }));
+        setMcpStatuses(status as McpStatusMap);
+      } catch {
+        // ignore
+      }
+
+      await refreshMcpServers();
+      setMcpStatus(t("mcp.logout_success", currentLocale()).replace("{server}", safeName));
+    } catch (e) {
+      setMcpStatus(e instanceof Error ? e.message : t("mcp.logout_failed", currentLocale()));
+    }
+  }
+
   async function createSessionAndOpen() {
     console.log("[DEBUG] createSessionAndOpen");
     console.log("[DEBUG] current baseUrl:", baseUrl());
@@ -4462,6 +4562,7 @@ export default function App() {
       setSelectedMcp,
       quickConnect: MCP_QUICK_CONNECT,
       connectMcp,
+      logoutMcpAuth,
       refreshMcpServers,
       showMcpReloadBanner: reloadRequired() && reloadReasons().includes("mcp"),
       mcpReloadBlocked: anyActiveRuns(),

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -1014,6 +1014,14 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         hostToken,
         method: "DELETE",
       }),
+
+    logoutMcpAuth: (workspaceId: string, name: string) =>
+      requestJson<{ ok: true }>(baseUrl, `/workspace/${workspaceId}/mcp/${encodeURIComponent(name)}/auth`, {
+        token,
+        hostToken,
+        method: "DELETE",
+      }),
+
     listCommands: (workspaceId: string, scope: "workspace" | "global" = "workspace") =>
       requestJson<{ items: OpenworkCommandItem[] }>(
         baseUrl,

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -184,6 +184,7 @@ export type DashboardViewProps = {
   setSelectedMcp: (value: string | null) => void;
   quickConnect: McpDirectoryInfo[];
   connectMcp: (entry: McpDirectoryInfo) => void;
+  logoutMcpAuth: (name: string) => Promise<void> | void;
   showMcpReloadBanner: boolean;
   mcpReloadBlocked: boolean;
   reloadMcpEngine: () => void;
@@ -1210,6 +1211,7 @@ export default function DashboardView(props: DashboardViewProps) {
                 setSelectedMcp={props.setSelectedMcp}
                 quickConnect={props.quickConnect}
                 connectMcp={props.connectMcp}
+                logoutMcpAuth={props.logoutMcpAuth}
                 showMcpReloadBanner={props.showMcpReloadBanner}
                 reloadBlocked={props.mcpReloadBlocked}
                 reloadMcpEngine={props.reloadMcpEngine}

--- a/packages/app/src/app/pages/mcp.tsx
+++ b/packages/app/src/app/pages/mcp.tsx
@@ -6,6 +6,7 @@ import { formatRelativeTime, isTauriRuntime, isWindowsPlatform } from "../utils"
 import { readOpencodeConfig, type OpencodeConfigFile } from "../lib/tauri";
 
 import Button from "../components/button";
+import ConfirmModal from "../components/confirm-modal";
 import {
   BookOpen,
   CheckCircle2,
@@ -39,6 +40,7 @@ export type McpViewProps = {
   setSelectedMcp: (name: string | null) => void;
   quickConnect: McpDirectoryInfo[];
   connectMcp: (entry: McpDirectoryInfo) => void;
+  logoutMcpAuth: (name: string) => Promise<void> | void;
   showMcpReloadBanner: boolean;
   reloadBlocked: boolean;
   reloadMcpEngine: () => void;
@@ -124,6 +126,10 @@ const serviceIconBg = (name: string) => {
 export default function McpView(props: McpViewProps) {
   const locale = () => currentLocale();
   const tr = (key: string) => t(key, locale());
+
+  const [logoutOpen, setLogoutOpen] = createSignal(false);
+  const [logoutTarget, setLogoutTarget] = createSignal<string | null>(null);
+  const [logoutBusy, setLogoutBusy] = createSignal(false);
 
   const [configScope, setConfigScope] = createSignal<"project" | "global">("project");
   const [projectConfig, setProjectConfig] = createSignal<OpencodeConfigFile | null>(null);
@@ -231,6 +237,25 @@ export default function McpView(props: McpViewProps) {
   const connectedCount = createMemo(() =>
     props.mcpServers.filter((e) => resolveStatus(e) === "connected").length,
   );
+
+  const requestLogout = (name: string) => {
+    if (!name.trim()) return;
+    setLogoutTarget(name);
+    setLogoutOpen(true);
+  };
+
+  const confirmLogout = async () => {
+    const name = logoutTarget();
+    if (!name || logoutBusy()) return;
+    setLogoutBusy(true);
+    try {
+      await props.logoutMcpAuth(name);
+    } finally {
+      setLogoutBusy(false);
+      setLogoutOpen(false);
+      setLogoutTarget(null);
+    }
+  };
 
   return (
     <section class="space-y-8 animate-in fade-in duration-300">
@@ -472,6 +497,25 @@ export default function McpView(props: McpViewProps) {
                               : entry.config.command?.join(" ")}
                           </div>
                         </details>
+
+                        <Show when={entry.config.type === "remote"}>
+                          <div class="pt-1 flex items-center justify-between gap-3">
+                            <div class="text-xs text-dls-secondary">
+                              {tr("mcp.logout_label")}
+                            </div>
+                            <Button
+                              variant="danger"
+                              class="px-3 py-1.5 text-xs"
+                              disabled={props.busy || logoutBusy()}
+                              onClick={() => requestLogout(entry.name)}
+                            >
+                              {logoutBusy() && logoutTarget() === entry.name ? tr("mcp.logout_working") : tr("mcp.logout_action")}
+                            </Button>
+                          </div>
+                          <div class="text-[11px] text-dls-secondary/70">
+                            {tr("mcp.logout_hint")}
+                          </div>
+                        </Show>
                       </div>
                     </Show>
                   </div>
@@ -481,6 +525,23 @@ export default function McpView(props: McpViewProps) {
           </div>
         </Show>
       </div>
+
+      <ConfirmModal
+        open={logoutOpen()}
+        title={tr("mcp.logout_modal_title")}
+        message={tr("mcp.logout_modal_message").replace("{server}", logoutTarget() ?? "")}
+        confirmLabel={logoutBusy() ? tr("mcp.logout_working") : tr("mcp.logout_action")}
+        cancelLabel={tr("common.cancel")}
+        variant="danger"
+        onCancel={() => {
+          if (logoutBusy()) return;
+          setLogoutOpen(false);
+          setLogoutTarget(null);
+        }}
+        onConfirm={() => {
+          void confirmLogout();
+        }}
+      />
 
       {/* ── Advanced: Config editor ───────────────────── */}
       <div class="rounded-xl border border-dls-border bg-dls-surface overflow-hidden">

--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -431,6 +431,15 @@ export default {
   "mcp.use_debug_command": "Run opencode mcp debug <name> to troubleshoot.",
   "mcp.add_failed": "Couldn't add the app.",
 
+  "mcp.logout_label": "OAuth",
+  "mcp.logout_action": "Log out",
+  "mcp.logout_working": "Logging out...",
+  "mcp.logout_hint": "Removes stored OAuth credentials. You'll need to sign in again.",
+  "mcp.logout_modal_title": "Log out of this app?",
+  "mcp.logout_modal_message": "This will remove stored OAuth credentials for {server}. You'll need to sign in again to use this app.",
+  "mcp.logout_success": "Logged out of {server}.",
+  "mcp.logout_failed": "Failed to log out.",
+
   // MCP Auth Modal
   "mcp.auth.open_browser_signin": "We'll open your browser to finish sign-in.",
   "mcp.auth.connect_server": "Connect {server}",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -404,6 +404,15 @@ export default {
   "mcp.use_debug_command": "使用 opencode mcp debug <name> 验证连接。",
   "mcp.add_failed": "添加 MCP 失败。",
 
+  "mcp.logout_label": "OAuth",
+  "mcp.logout_action": "退出登录",
+  "mcp.logout_working": "正在退出...",
+  "mcp.logout_hint": "将删除已保存的 OAuth 凭据。之后需要重新登录。",
+  "mcp.logout_modal_title": "退出登录？",
+  "mcp.logout_modal_message": "这将删除 {server} 的 OAuth 凭据。之后需要重新登录才能使用该应用。",
+  "mcp.logout_success": "{server} 已退出登录。",
+  "mcp.logout_failed": "退出登录失败。",
+
   // MCP Auth Modal
   "mcp.auth.open_browser_signin": "我们将打开您的浏览器完成登录。",
   "mcp.auth.connect_server": "连接 {server}",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -16,7 +16,7 @@ import { parseFrontmatter } from "./frontmatter.js";
 import { startReloadWatchers } from "./reload-watcher.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
-import { sanitizeCommandName } from "./validators.js";
+import { sanitizeCommandName, validateMcpName } from "./validators.js";
 import { TokenService } from "./tokens.js";
 import { TOY_UI_CSS, TOY_UI_HTML, TOY_UI_JS, cssResponse, htmlResponse, jsResponse } from "./toy-ui.js";
 import pkg from "../package.json" with { type: "json" };
@@ -2439,6 +2439,59 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     }
     const items = await listMcp(workspace.path);
     return jsonResponse({ items });
+  });
+
+  addRoute(routes, "DELETE", "/workspace/:id/mcp/:name/auth", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const name = String(ctx.params.name ?? "").trim();
+    validateMcpName(name);
+
+    const authStorePath = join(homedir(), ".config", "opencode", "mcp-auth.json");
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "mcp.auth.remove",
+      summary: `Logout MCP ${name}`,
+      paths: [authStorePath],
+    });
+
+    // Best-effort disconnect so any active connection is torn down.
+    try {
+      await fetchOpencodeJson(workspace, `/mcp/${encodeURIComponent(name)}/disconnect`, { method: "POST" });
+    } catch {
+      // ignore
+    }
+
+    try {
+      await fetchOpencodeJson(workspace, `/mcp/${encodeURIComponent(name)}/auth`, { method: "DELETE" });
+    } catch (error) {
+      // Treat missing credentials as a successful logout (idempotent).
+      if (
+        error instanceof ApiError &&
+        error.code === "opencode_request_failed" &&
+        error.details &&
+        typeof error.details === "object" &&
+        "status" in (error.details as Record<string, unknown>) &&
+        (error.details as { status?: unknown }).status === 404
+      ) {
+        // ok
+      } else {
+        throw error;
+      }
+    }
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "mcp.auth.remove",
+      target: authStorePath,
+      summary: `Logged out MCP ${name}`,
+      timestamp: Date.now(),
+    });
+
+    return jsonResponse({ ok: true });
   });
 
   addRoute(routes, "GET", "/workspace/:id/commands", "client", async (ctx) => {


### PR DESCRIPTION
## Why
MCP OAuth tokens can get stale/invalid (e.g. refresh token revoked). OpenWork needed a first-class way to force a clean re-auth by removing stored MCP OAuth credentials from the engine.

## What
- Adds an OpenWork server endpoint to remove MCP OAuth credentials (logout) for a workspace.
- Adds a UI action in the Apps (MCP) page to log out of a remote MCP app.

## Implementation Notes
- Server: `DELETE /workspace/:id/mcp/:name/auth` calls OpenCode `POST /mcp/:name/disconnect` (best-effort) then `DELETE /mcp/:name/auth` and treats 404 as idempotent success.
- App: MCP details panel includes a danger "Log out" action (remote MCP only). Uses OpenWork server when available; otherwise uses `client.mcp.auth.remove`.

## Testing
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @different-ai/openwork-ui typecheck`