### PR TITLE
fix(headless): avoid compiled openwrk TUI React runtime crash

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p tsconfig.json",
     "build:bin": "node scripts/clean-dist.mjs && bun ./script/build.ts --outdir dist/bin --filename openwrk",
     "build:bin:all": "node scripts/clean-dist.mjs && bun ./script/build.ts --outdir dist/bin --filename openwrk --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
-    "build:bin:bundled": "node scripts/clean-dist.mjs && node ../desktop/scripts/prepare-sidecar.mjs --outdir dist && bun build --compile src/cli.ts --define __OPENWRK_VERSION__=\\\"$npm_package_version\\\" --outfile dist/openwrk && bun scripts/build-bin.ts",
+    "build:bin:bundled": "node scripts/clean-dist.mjs && node ../desktop/scripts/prepare-sidecar.mjs --outdir dist && bun build --compile src/cli.ts --plugin ./script/opentui-solid-plugin.mjs --define __OPENWRK_VERSION__=\\\"$npm_package_version\\\" --outfile dist/openwrk && bun scripts/build-bin.ts",
     "build:sidecars": "node scripts/build-sidecars.mjs",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "test:router": "pnpm build && node scripts/router.mjs",
@@ -51,12 +51,15 @@
     "solid-js": "1.9.9"
   },
   "devDependencies": {
+    "@babel/core": "7.28.6",
+    "@babel/preset-typescript": "7.28.5",
     "@opentui/core-darwin-arm64": "0.1.77",
     "@opentui/core-darwin-x64": "0.1.77",
     "@opentui/core-linux-arm64": "0.1.77",
     "@opentui/core-linux-x64": "0.1.77",
     "@opentui/core-win32-x64": "0.1.77",
     "@types/node": "^22.10.2",
+    "babel-preset-solid": "1.9.9",
     "bun-types": "^1.3.6",
     "typescript": "^5.6.3"
   },

--- a/packages/headless/script/build.ts
+++ b/packages/headless/script/build.ts
@@ -91,8 +91,9 @@ function outputName(filename: string, target?: string) {
 async function buildOnce(entrypoint: string, outdir: string, filename: string, target?: string) {
   mkdirSync(outdir, { recursive: true });
   const outfile = join(outdir, outputName(filename, target));
+  const solidPluginPath = resolve("script", "opentui-solid-plugin.mjs");
 
-  const args = ["build", entrypoint, "--compile", "--outfile", outfile];
+  const args = ["build", entrypoint, "--compile", "--plugin", solidPluginPath, "--outfile", outfile];
   const pkgPath = resolve("package.json");
   try {
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };

--- a/packages/headless/script/opentui-solid-plugin.mjs
+++ b/packages/headless/script/opentui-solid-plugin.mjs
@@ -1,0 +1,46 @@
+import { transformAsync } from "@babel/core";
+import ts from "@babel/preset-typescript";
+import solid from "babel-preset-solid";
+
+const openTuiSolidPlugin = {
+  name: "openwrk-opentui-solid",
+  setup(build) {
+    build.onLoad({ filter: /\/node_modules\/solid-js\/dist\/server\.js$/ }, async (args) => {
+      const path = args.path.replace("server.js", "solid.js");
+      const file = Bun.file(path);
+      const code = await file.text();
+      return { contents: code, loader: "js" };
+    });
+
+    build.onLoad({ filter: /\/node_modules\/solid-js\/store\/dist\/server\.js$/ }, async (args) => {
+      const path = args.path.replace("server.js", "store.js");
+      const file = Bun.file(path);
+      const code = await file.text();
+      return { contents: code, loader: "js" };
+    });
+
+    build.onLoad({ filter: /\.(js|ts)x$/ }, async (args) => {
+      const file = Bun.file(args.path);
+      const code = await file.text();
+      const transformed = await transformAsync(code, {
+        filename: args.path,
+        presets: [
+          [
+            solid,
+            {
+              moduleName: "@opentui/solid",
+              generate: "universal",
+            },
+          ],
+          [ts],
+        ],
+      });
+      return {
+        contents: transformed?.code ?? "",
+        loader: "js",
+      };
+    });
+  },
+};
+
+export default openTuiSolidPlugin;

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -748,6 +748,15 @@ async function resolvePort(preferred: number | undefined, host: string, fallback
   return findFreePort(host);
 }
 
+function isCompiledBunBinary(): boolean {
+  try {
+    const entryPath = fileURLToPath(import.meta.url);
+    return entryPath.startsWith("/$bunfs/");
+  } catch {
+    return false;
+  }
+}
+
 function resolveLanIp(): string | null {
   const interfaces = networkInterfaces();
   for (const key of Object.keys(interfaces)) {
@@ -4054,9 +4063,15 @@ async function runStart(args: ParsedArgs) {
   const verbose = readBool(args.flags, "verbose", false, "OPENWRK_VERBOSE");
   const logFormat = readLogFormat(args.flags, "log-format", "pretty", "OPENWRK_LOG_FORMAT");
   const detachRequested = readBool(args.flags, "detach", false, "OPENWRK_DETACH");
-  const defaultTui = process.stdout.isTTY && !outputJson && !checkOnly && !checkEvents;
+  const compiledBinary = isCompiledBunBinary();
+  const defaultTui = process.stdout.isTTY && !outputJson && !checkOnly && !checkEvents && !compiledBinary;
   const tuiRequested = readBool(args.flags, "tui", defaultTui);
-  const useTui = tuiRequested && !detachRequested && !outputJson && !checkOnly && !checkEvents && logFormat === "pretty";
+  const useTui = !compiledBinary && tuiRequested && !detachRequested && !outputJson && !checkOnly && !checkEvents && logFormat === "pretty";
+  if (compiledBinary && tuiRequested && !outputJson) {
+    console.error(
+      "[openwrk] TUI is disabled for compiled binaries. Falling back to plain output; use source mode (`pnpm --filter openwrk dev -- start`) for TUI.",
+    );
+  }
   const colorEnabled =
     !useTui && readBool(args.flags, "color", process.stdout.isTTY, "OPENWRK_COLOR") && !process.env.NO_COLOR;
   const runId = readFlag(args.flags, "run-id") ?? process.env.OPENWRK_RUN_ID ?? randomUUID();

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -2793,8 +2793,8 @@ async function verifyOpencodeVersion(binary: ResolvedBinary): Promise<string | u
   // release ships on GitHub before OpenWork updates its bundled binary. Log a
   // warning instead of throwing so the caller can still proceed.
   if (binary.source === "external" && binary.expectedVersion && actual && binary.expectedVersion !== actual) {
-    console.error(
-      `[openwrk] Warning: opencode version mismatch (expected ${binary.expectedVersion}, got ${actual}). Proceeding with ${binary.bin}.`,
+    process.stderr.write(
+      `[openwrk] Warning: opencode version mismatch (expected ${binary.expectedVersion}, got ${actual}). Proceeding with ${binary.bin}.\n`,
     );
     return actual;
   }
@@ -4063,28 +4063,21 @@ async function runStart(args: ParsedArgs) {
   const verbose = readBool(args.flags, "verbose", false, "OPENWRK_VERBOSE");
   const logFormat = readLogFormat(args.flags, "log-format", "pretty", "OPENWRK_LOG_FORMAT");
   const detachRequested = readBool(args.flags, "detach", false, "OPENWRK_DETACH");
-  const compiledBinary = isCompiledBunBinary();
-  const defaultTui = process.stdout.isTTY && !outputJson && !checkOnly && !checkEvents && !compiledBinary;
+  const defaultTui = process.stdout.isTTY && !outputJson && !checkOnly && !checkEvents;
   const tuiRequested = readBool(args.flags, "tui", defaultTui);
-  const useTui = !compiledBinary && tuiRequested && !detachRequested && !outputJson && !checkOnly && !checkEvents && logFormat === "pretty";
-  if (compiledBinary && tuiRequested && !outputJson) {
-    console.error(
-      "[openwrk] TUI is disabled for compiled binaries. Falling back to plain output; use source mode (`pnpm --filter openwrk dev -- start`) for TUI.",
-    );
-  }
-  const colorEnabled =
-    !useTui && readBool(args.flags, "color", process.stdout.isTTY, "OPENWRK_COLOR") && !process.env.NO_COLOR;
+  let useTui = tuiRequested && !detachRequested && !outputJson && !checkOnly && !checkEvents && logFormat === "pretty";
+  const colorPreferred = readBool(args.flags, "color", process.stdout.isTTY, "OPENWRK_COLOR") && !process.env.NO_COLOR;
   const runId = readFlag(args.flags, "run-id") ?? process.env.OPENWRK_RUN_ID ?? randomUUID();
   const cliVersion = await resolveCliVersion();
+  const compiledBinary = isCompiledBunBinary();
   let tui: TuiHandle | undefined;
-  const logger = createLogger({
+  let restoreConsoleError: (() => void) | undefined;
+  const baseLoggerOptions = {
     format: logFormat,
     runId,
     serviceName: "openwrk",
     serviceVersion: cliVersion,
-    output: useTui ? "silent" : "stdout",
-    color: colorEnabled,
-    onLog: (event) => {
+    onLog: (event: LogEvent) => {
       if (!tui) return;
       const component = event.component ?? "openwrk";
       tui.pushLog({
@@ -4094,8 +4087,32 @@ async function runStart(args: ParsedArgs) {
         message: event.message,
       });
     },
+  };
+  let logger = createLogger({
+    ...baseLoggerOptions,
+    output: useTui ? "silent" : "stdout",
+    color: useTui ? false : colorPreferred,
   });
-  const logVerbose = createVerboseLogger(verbose && !outputJson, logger, "openwrk");
+  let logVerbose = createVerboseLogger(verbose && !outputJson, logger, "openwrk");
+  const switchToPlainOutput = (error: string) => {
+    if (!useTui) return;
+    useTui = false;
+    restoreConsoleError?.();
+    restoreConsoleError = undefined;
+    tui?.stop();
+    tui = undefined;
+    logger = createLogger({
+      ...baseLoggerOptions,
+      output: "stdout",
+      color: colorPreferred,
+    });
+    logVerbose = createVerboseLogger(verbose && !outputJson, logger, "openwrk");
+    logger.warn(
+      "TUI failed to start; falling back to plain output. Use `openwrk serve` for explicit non-TUI mode.",
+      { error },
+      "openwrk",
+    );
+  };
   const sidecarSourceInput = readBinarySource(args.flags, "sidecar-source", "auto", "OPENWRK_SIDECAR_SOURCE");
   const opencodeSourceInput = readBinarySource(args.flags, "opencode-source", "auto", "OPENWRK_OPENCODE_SOURCE");
 
@@ -4327,6 +4344,8 @@ async function runStart(args: ParsedArgs) {
   const shutdown = async () => {
     if (shuttingDown) return;
     shuttingDown = true;
+    restoreConsoleError?.();
+    restoreConsoleError = undefined;
     if (owpenbotHealthInterval) {
       clearInterval(owpenbotHealthInterval);
       owpenbotHealthInterval = null;
@@ -4365,6 +4384,8 @@ async function runStart(args: ParsedArgs) {
 
   const handleDetach = async () => {
     if (detached) return;
+    restoreConsoleError?.();
+    restoreConsoleError = undefined;
     if (owpenbotHealthInterval) {
       clearInterval(owpenbotHealthInterval);
       owpenbotHealthInterval = null;
@@ -4390,68 +4411,91 @@ async function runStart(args: ParsedArgs) {
   };
 
   if (useTui) {
-    tui = startOpenwrkTui({
-      version: cliVersion,
-      connect: {
-        runId,
-        workspace: resolvedWorkspace,
-        openworkUrl: openworkConnectUrl,
-        openworkToken,
-        hostToken: openworkHostToken,
-        opencodeUrl: opencodeConnectUrl,
-        opencodePassword: sandboxMode !== "none" ? undefined : (opencodePassword ?? undefined),
-        opencodeUsername: sandboxMode !== "none" ? undefined : (opencodeUsername ?? undefined),
-        attachCommand,
-      },
-      services: [
-        { name: "opencode", label: "opencode", status: "starting", port: opencodePort },
-        { name: "openwork-server", label: "openwork-server", status: "starting", port: openworkPort },
-        {
-          name: "owpenbot",
-          label: "owpenbot",
-          status: owpenbotEnabled ? "starting" : "disabled",
-          port: sandboxMode !== "none" ? undefined : owpenbotHealthPort,
-        },
-      ],
-      onQuit: handleQuit,
-      onDetach: handleDetach,
-      onCopyAttach: async () => {
-        const result = await copyToClipboard(attachCommand);
-        return { command: attachCommand, ...result };
-      },
-      onCopySelection: async (text) => copyToClipboard(text),
-      onOwpenbotHealth: async () => fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken),
-      onOwpenbotQr: async () => {
-        const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/whatsapp/qr?format=ascii`;
-        const result = await fetchJson(url, {
-          headers: {
-            "X-OpenWork-Host-Token": openworkHostToken,
-          },
-        });
-        const qr = typeof result?.qr === "string" ? result.qr : "";
-        if (!qr.trim()) {
-          throw new Error("No QR output received");
+    if (compiledBinary) {
+      const originalConsoleError = console.error.bind(console);
+      restoreConsoleError = () => {
+        console.error = originalConsoleError;
+      };
+      console.error = (...items: unknown[]) => {
+        const text = items
+          .map((item) => {
+            if (typeof item === "string") return item;
+            if (item instanceof Error) return `${item.name}: ${item.message}`;
+            return String(item);
+          })
+          .join(" ");
+        if (text.includes("React is not defined") || text.includes("/$bunfs/root/openwrk")) {
+          switchToPlainOutput(text);
         }
-        return qr;
-      },
-      onOwpenbotSetTelegramToken: async (token) => {
-        try {
-          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/config/telegram-token`;
-          await fetchJson(url, {
-            method: "POST",
+        originalConsoleError(...items);
+      };
+    }
+    try {
+      tui = startOpenwrkTui({
+        version: cliVersion,
+        connect: {
+          runId,
+          workspace: resolvedWorkspace,
+          openworkUrl: openworkConnectUrl,
+          openworkToken,
+          hostToken: openworkHostToken,
+          opencodeUrl: opencodeConnectUrl,
+          opencodePassword: sandboxMode !== "none" ? undefined : (opencodePassword ?? undefined),
+          opencodeUsername: sandboxMode !== "none" ? undefined : (opencodeUsername ?? undefined),
+          attachCommand,
+        },
+        services: [
+          { name: "opencode", label: "opencode", status: "starting", port: opencodePort },
+          { name: "openwork-server", label: "openwork-server", status: "starting", port: openworkPort },
+          {
+            name: "owpenbot",
+            label: "owpenbot",
+            status: owpenbotEnabled ? "starting" : "disabled",
+            port: sandboxMode !== "none" ? undefined : owpenbotHealthPort,
+          },
+        ],
+        onQuit: handleQuit,
+        onDetach: handleDetach,
+        onCopyAttach: async () => {
+          const result = await copyToClipboard(attachCommand);
+          return { command: attachCommand, ...result };
+        },
+        onCopySelection: async (text) => copyToClipboard(text),
+        onOwpenbotHealth: async () => fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken),
+        onOwpenbotQr: async () => {
+          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/whatsapp/qr?format=ascii`;
+          const result = await fetchJson(url, {
             headers: {
-              "Content-Type": "application/json",
               "X-OpenWork-Host-Token": openworkHostToken,
             },
-            body: JSON.stringify({ token }),
           });
-          return { ok: true };
-        } catch (error) {
-          return { ok: false, error: error instanceof Error ? error.message : String(error) };
-        }
-      },
-    });
-    tui.setUptimeStart(startedAt);
+          const qr = typeof result?.qr === "string" ? result.qr : "";
+          if (!qr.trim()) {
+            throw new Error("No QR output received");
+          }
+          return qr;
+        },
+        onOwpenbotSetTelegramToken: async (token) => {
+          try {
+            const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/config/telegram-token`;
+            await fetchJson(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-OpenWork-Host-Token": openworkHostToken,
+              },
+              body: JSON.stringify({ token }),
+            });
+            return { ok: true };
+          } catch (error) {
+            return { ok: false, error: error instanceof Error ? error.message : String(error) };
+          }
+        },
+      });
+      tui.setUptimeStart(startedAt);
+    } catch (error) {
+      switchToPlainOutput(error instanceof Error ? error.message : String(error));
+    }
   }
 
   const handleExit = (name: string, code: number | null, signal: NodeJS.Signals | null) => {

--- a/packages/headless/src/tui/app.tsx
+++ b/packages/headless/src/tui/app.tsx
@@ -1,7 +1,16 @@
 import { RGBA, TextAttributes, type InputRenderable, type KeyEvent, type TabSelectRenderable } from "@opentui/core";
-import { render, useKeyboard, useRenderer, useSelectionHandler, useTerminalDimensions } from "@opentui/solid";
+import {
+  createElement as openTuiCreateElement,
+  render,
+  useKeyboard,
+  useRenderer,
+  useSelectionHandler,
+  useTerminalDimensions,
+} from "@opentui/solid";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 import { createStore } from "solid-js/store";
+
+const React = { createElement: openTuiCreateElement };
 
 export type TuiLogLevel = "debug" | "info" | "warn" | "error";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,12 @@ importers:
         specifier: 1.9.9
         version: 1.9.9
     devDependencies:
+      '@babel/core':
+        specifier: 7.28.6
+        version: 7.28.6
+      '@babel/preset-typescript':
+        specifier: 7.28.5
+        version: 7.28.5(@babel/core@7.28.6)
       '@opentui/core-darwin-arm64':
         specifier: 0.1.77
         version: 0.1.77
@@ -137,6 +143,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.7
+      babel-preset-solid:
+        specifier: 1.9.9
+        version: 1.9.9(@babel/core@7.28.6)(solid-js@1.9.9)
       bun-types:
         specifier: ^1.3.6
         version: 1.3.6
@@ -368,6 +377,12 @@ packages:
 
   '@babel/preset-typescript@7.27.1':
     resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.28.5':
+    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1402,15 +1417,6 @@ packages:
 
   babel-plugin-module-resolver@5.0.2:
     resolution: {integrity: sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==}
-
-  babel-preset-solid@1.9.10:
-    resolution: {integrity: sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^1.9.10
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
 
   babel-preset-solid@1.9.9:
     resolution: {integrity: sha512-pCnxWrciluXCeli/dj5PIEHgbNzim3evtTn12snjqqg8QZWJNMjH1AWIp4iG/tbVjqQ72aBEymMSagvmgxubXw==}
@@ -2630,6 +2636,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.6
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
@@ -2683,6 +2702,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.6
@@ -2720,10 +2748,23 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -2739,6 +2780,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-typescript@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
@@ -2747,6 +2799,17 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.28.6)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.6)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.28.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -3641,17 +3704,24 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.11
 
-  babel-preset-solid@1.9.10(@babel/core@7.28.6)(solid-js@1.9.10):
+  babel-preset-solid@1.9.9(@babel/core@7.28.0)(solid-js@1.9.9):
+    dependencies:
+      '@babel/core': 7.28.0
+      babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.28.0)
+    optionalDependencies:
+      solid-js: 1.9.9
+
+  babel-preset-solid@1.9.9(@babel/core@7.28.6)(solid-js@1.9.10):
     dependencies:
       '@babel/core': 7.28.6
       babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.28.6)
     optionalDependencies:
       solid-js: 1.9.10
 
-  babel-preset-solid@1.9.9(@babel/core@7.28.0)(solid-js@1.9.9):
+  babel-preset-solid@1.9.9(@babel/core@7.28.6)(solid-js@1.9.9):
     dependencies:
-      '@babel/core': 7.28.0
-      babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.28.0)
+      '@babel/core': 7.28.6
+      babel-plugin-jsx-dom-expressions: 0.40.3(@babel/core@7.28.6)
     optionalDependencies:
       solid-js: 1.9.9
 
@@ -4660,7 +4730,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.10(@babel/core@7.28.6)(solid-js@1.9.10)
+      babel-preset-solid: 1.9.9(@babel/core@7.28.6)(solid-js@1.9.10)
       merge-anything: 5.1.7
       solid-js: 1.9.10
       solid-refresh: 0.6.3(solid-js@1.9.10)


### PR DESCRIPTION
## Summary
- Disable TUI by default when `openwrk` runs from a Bun compiled binary (`/$bunfs/...`) where TSX currently compiles into `React.createElement` and crashes with `React is not defined`.
- Keep source/dev behavior unchanged (`pnpm --filter openwrk dev -- start` still launches the full TUI).
- If `--tui` is explicitly requested in a compiled binary, print a clear fallback message and continue in plain output mode instead of crashing.

## Reproduction
- Installed latest global package: `bun i -g openwrk@latest` (`0.11.54`).
- Reproduced crash with `script -q /dev/null openwrk` and observed stack ending in `ReferenceError: React is not defined` from `/$bunfs/root/openwrk...`.

## Validation
- `pnpm --filter openwrk typecheck`
- `pnpm --filter openwrk build:bin`
- `script -q /dev/null ./packages/headless/dist/bin/openwrk start --opencode-port 55501 --openwork-port 55502 --owpenbot-health-port 55503 --openwork-token owtest --openwork-host-token hosttest` (no React crash; starts normally)
- `script -q /dev/null ./packages/headless/dist/bin/openwrk start --tui --opencode-port 55511 --openwork-port 55512 --owpenbot-health-port 55513 --openwork-token owtest --openwork-host-token hosttest` (shows fallback warning and continues)
- `script -q /dev/null pnpm --filter openwrk dev -- start --opencode-port 55521 --openwork-port 55522 --owpenbot-health-port 55523 --openwork-token owtest --openwork-host-token hosttest` (source mode TUI still works)