### PR TITLE
feat(app): add guided OpenCode Browser install instructions

### DIFF
--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -14,6 +14,45 @@ export const DEFAULT_MODEL: ModelRef = {
 
 export const SUGGESTED_PLUGINS: SuggestedPlugin[] = [
   {
+    name: "OpenCode Browser Automation",
+    packageName: "@different-ai/opencode-browser",
+    description:
+      "Control real browser tabs from OpenWork. Includes a guided setup flow for unpacked extension installs while the store listing is pending.",
+    tags: ["browser", "automation", "guided"],
+    aliases: ["opencode-browser"],
+    installMode: "guided",
+    steps: [
+      {
+        title: "Add plugin",
+        description:
+          "Click Add on this card to include @different-ai/opencode-browser in your OpenCode plugin config.",
+      },
+      {
+        title: "Run installer",
+        description:
+          "In your workspace terminal, run the installer. This path does not require Chrome Web Store approval.",
+        command: "bunx @different-ai/opencode-browser@latest install",
+      },
+      {
+        title: "Load unpacked extension",
+        description:
+          "Open chrome://extensions, enable Developer mode, click Load unpacked, then select the extension folder.",
+        path: "~/.opencode-browser/extension",
+        note: "The installer writes the native host manifest and prompts for the extension ID when needed.",
+      },
+      {
+        title: "Verify in OpenWork",
+        description: "Start a session and run a quick check command to confirm browser automation is connected.",
+        command: "use browser_status",
+      },
+      {
+        title: "Keep it updated",
+        description: "After updates, refresh the local files and reload the extension from chrome://extensions.",
+        command: "bunx @different-ai/opencode-browser@latest update",
+      },
+    ],
+  },
+  {
     name: "opencode-scheduler",
     packageName: "opencode-scheduler",
     description: "Run scheduled jobs with the OpenCode scheduler plugin.",

--- a/packages/app/src/app/pages/plugins.tsx
+++ b/packages/app/src/app/pages/plugins.tsx
@@ -96,6 +96,9 @@ export default function PluginsView(props: PluginsViewProps) {
 
         <div class="space-y-3">
           <div class="text-xs font-medium text-gray-11 uppercase tracking-wider">Suggested plugins</div>
+          <div class="text-xs text-gray-10">
+            Use <span class="font-medium text-gray-11">Setup</span> for plugins that require local companion install steps.
+          </div>
           <div class="grid gap-3">
             <For each={props.suggestedPlugins}>
               {(plugin) => {


### PR DESCRIPTION
## Summary
- add `@different-ai/opencode-browser` as a guided suggested plugin in the OpenWork Plugins tab
- include step-by-step setup instructions for the current pre-store flow (install command, unpacked extension path, verify command, update command)
- add helper copy text in the Suggested plugins area so users know to use Setup for companion installs

## Testing
- pnpm --filter @different-ai/openwork-ui typecheck
- pnpm --filter @different-ai/openwork-ui build