### PR TITLE
feat(owpenbot): make messaging behavior workspace-agent driven

### DIFF
--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -16,6 +16,21 @@ export type OpenworkServerCapabilities = {
   commands: { read: boolean; write: boolean };
   config: { read: boolean; write: boolean };
   sandbox?: { enabled: boolean; backend: "none" | "docker" | "container" };
+  proxy?: { opencode: boolean; owpenbot: boolean };
+  toolProviders?: {
+    browser?: {
+      enabled: boolean;
+      placement: "in-sandbox" | "host-machine" | "client-machine" | "external";
+      mode: "none" | "headless" | "interactive";
+    };
+    files?: {
+      injection: boolean;
+      outbox: boolean;
+      inboxPath: string;
+      outboxPath: string;
+      maxBytes: number;
+    };
+  };
 };
 
 export type OpenworkServerStatus = "connected" | "disconnected" | "limited";
@@ -208,6 +223,16 @@ export type OpenworkOwpenbotBindingsResult = {
 
 export type OpenworkOwpenbotBindingUpdateResult = {
   ok: boolean;
+};
+
+export type OpenworkOwpenbotSendResult = {
+  ok: boolean;
+  channel: string;
+  identityId?: string;
+  directory: string;
+  attempted: number;
+  sent: number;
+  failures?: Array<{ identityId: string; peerId: string; error: string }>;
 };
 
 export type OpenworkOwpenbotIdentityItem = {
@@ -973,6 +998,28 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
             ...(input.directory?.trim() ? { directory: input.directory.trim() } : {}),
             healthPort: options?.healthPort ?? null,
           },
+        },
+      ),
+    sendOwpenbotMessage: (
+      workspaceId: string,
+      input: { channel: "telegram" | "slack"; text: string; identityId?: string; directory?: string },
+      options?: { healthPort?: number | null },
+    ) =>
+      requestJson<OpenworkOwpenbotSendResult>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/owpenbot/send`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: {
+            channel: input.channel,
+            text: input.text,
+            ...(input.identityId?.trim() ? { identityId: input.identityId.trim() } : {}),
+            ...(input.directory?.trim() ? { directory: input.directory.trim() } : {}),
+            healthPort: options?.healthPort ?? null,
+          },
+          timeoutMs: timeouts.owpenbot,
         },
       ),
     setOwpenbotTelegramEnabled: (

--- a/packages/app/src/app/pages/identities.tsx
+++ b/packages/app/src/app/pages/identities.tsx
@@ -18,8 +18,10 @@ import {
 import type {
   OpenworkOwpenbotHealthSnapshot,
   OpenworkOwpenbotIdentityItem,
+  OpenworkOwpenbotSendResult,
   OpenworkServerSettings,
   OpenworkServerStatus,
+  OpenworkWorkspaceFileContent,
 } from "../lib/openwork-server";
 import type { OpenworkServerInfo } from "../lib/tauri";
 
@@ -33,6 +35,17 @@ export type IdentitiesViewProps = {
   activeWorkspaceRoot: string;
   developerMode: boolean;
 };
+
+const OWPENBOT_AGENT_FILE_PATH = ".opencode/agents/owpenbot.md";
+const OWPENBOT_AGENT_FILE_TEMPLATE = `# Owpenbot Messaging Agent
+
+Use this file to define how the assistant responds in Slack/Telegram for this workspace.
+
+Examples:
+- Keep responses concise and action-oriented.
+- Ask one clarifying question when requirements are ambiguous.
+- Prefer concrete tool use over speculation when troubleshooting.
+`;
 
 function formatRequestError(error: unknown): string {
   if (error instanceof OpenworkServerError) {
@@ -128,6 +141,23 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
 
   const [expandedChannel, setExpandedChannel] = createSignal<string | null>(null);
 
+  const [agentLoading, setAgentLoading] = createSignal(false);
+  const [agentSaving, setAgentSaving] = createSignal(false);
+  const [agentExists, setAgentExists] = createSignal(false);
+  const [agentContent, setAgentContent] = createSignal("");
+  const [agentDraft, setAgentDraft] = createSignal("");
+  const [agentBaseUpdatedAt, setAgentBaseUpdatedAt] = createSignal<number | null>(null);
+  const [agentStatus, setAgentStatus] = createSignal<string | null>(null);
+  const [agentError, setAgentError] = createSignal<string | null>(null);
+
+  const [sendChannel, setSendChannel] = createSignal<"telegram" | "slack">("telegram");
+  const [sendDirectory, setSendDirectory] = createSignal("");
+  const [sendText, setSendText] = createSignal("");
+  const [sendBusy, setSendBusy] = createSignal(false);
+  const [sendStatus, setSendStatus] = createSignal<string | null>(null);
+  const [sendError, setSendError] = createSignal<string | null>(null);
+  const [sendResult, setSendResult] = createSignal<OpenworkOwpenbotSendResult | null>(null);
+
   const workspaceId = createMemo(() => {
     const explicitId = props.openworkServerWorkspaceId?.trim() ?? "";
     if (explicitId) return explicitId;
@@ -181,6 +211,142 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
 
   const hasTelegramConnected = createMemo(() => telegramIdentities().some((i) => i.enabled));
   const hasSlackConnected = createMemo(() => slackIdentities().some((i) => i.enabled));
+  const agentDirty = createMemo(() => agentDraft() !== agentContent());
+
+  const resetAgentState = () => {
+    setAgentLoading(false);
+    setAgentSaving(false);
+    setAgentExists(false);
+    setAgentContent("");
+    setAgentDraft("");
+    setAgentBaseUpdatedAt(null);
+    setAgentStatus(null);
+    setAgentError(null);
+  };
+
+  const loadAgentFile = async () => {
+    if (agentLoading()) return;
+    if (!serverReady()) return;
+    const id = workspaceId();
+    if (!id) {
+      resetAgentState();
+      setAgentError("Workspace scope unavailable.");
+      return;
+    }
+    const client = openworkServerClient();
+    if (!client) return;
+
+    setAgentLoading(true);
+    setAgentError(null);
+    try {
+      const result = (await client.readWorkspaceFile(id, OWPENBOT_AGENT_FILE_PATH)) as OpenworkWorkspaceFileContent;
+      const nextContent = result.content ?? "";
+      setAgentExists(true);
+      setAgentContent(nextContent);
+      setAgentDraft(nextContent);
+      setAgentBaseUpdatedAt(typeof result.updatedAt === "number" ? result.updatedAt : null);
+    } catch (error) {
+      if (error instanceof OpenworkServerError && error.status === 404) {
+        setAgentExists(false);
+        setAgentContent("");
+        setAgentDraft("");
+        setAgentBaseUpdatedAt(null);
+        return;
+      }
+      setAgentError(formatRequestError(error));
+    } finally {
+      setAgentLoading(false);
+    }
+  };
+
+  const createDefaultAgentFile = async () => {
+    if (agentSaving()) return;
+    if (!serverReady()) return;
+    const id = workspaceId();
+    if (!id) return;
+    const client = openworkServerClient();
+    if (!client) return;
+
+    setAgentSaving(true);
+    setAgentStatus(null);
+    setAgentError(null);
+    try {
+      const result = await client.writeWorkspaceFile(id, {
+        path: OWPENBOT_AGENT_FILE_PATH,
+        content: OWPENBOT_AGENT_FILE_TEMPLATE,
+      });
+      setAgentExists(true);
+      setAgentContent(OWPENBOT_AGENT_FILE_TEMPLATE);
+      setAgentDraft(OWPENBOT_AGENT_FILE_TEMPLATE);
+      setAgentBaseUpdatedAt(typeof result.updatedAt === "number" ? result.updatedAt : null);
+      setAgentStatus("Created default messaging agent file.");
+    } catch (error) {
+      setAgentError(formatRequestError(error));
+    } finally {
+      setAgentSaving(false);
+    }
+  };
+
+  const saveAgentFile = async () => {
+    if (agentSaving()) return;
+    if (!serverReady()) return;
+    const id = workspaceId();
+    if (!id) return;
+    const client = openworkServerClient();
+    if (!client) return;
+
+    setAgentSaving(true);
+    setAgentStatus(null);
+    setAgentError(null);
+    try {
+      const result = await client.writeWorkspaceFile(id, {
+        path: OWPENBOT_AGENT_FILE_PATH,
+        content: agentDraft(),
+        baseUpdatedAt: agentBaseUpdatedAt(),
+      });
+      setAgentExists(true);
+      setAgentContent(agentDraft());
+      setAgentBaseUpdatedAt(typeof result.updatedAt === "number" ? result.updatedAt : null);
+      setAgentStatus("Saved messaging behavior.");
+    } catch (error) {
+      if (error instanceof OpenworkServerError && error.status === 409) {
+        setAgentError("File changed remotely. Reload and save again.");
+      } else {
+        setAgentError(formatRequestError(error));
+      }
+    } finally {
+      setAgentSaving(false);
+    }
+  };
+
+  const sendTestMessage = async () => {
+    if (sendBusy()) return;
+    if (!serverReady()) return;
+    const id = workspaceId();
+    if (!id) return;
+    const client = openworkServerClient();
+    if (!client) return;
+    const text = sendText().trim();
+    if (!text) return;
+
+    setSendBusy(true);
+    setSendStatus(null);
+    setSendError(null);
+    setSendResult(null);
+    try {
+      const result = await client.sendOwpenbotMessage(id, {
+        channel: sendChannel(),
+        text,
+        ...(sendDirectory().trim() ? { directory: sendDirectory().trim() } : {}),
+      });
+      setSendResult(result);
+      setSendStatus(`Dispatched ${result.sent}/${result.attempted} messages.`);
+    } catch (error) {
+      setSendError(formatRequestError(error));
+    } finally {
+      setSendBusy(false);
+    }
+  };
 
   const refreshAll = async (options?: { force?: boolean }) => {
     if (refreshing() && !options?.force) return;
@@ -202,6 +368,10 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
         setHealthError("Workspace scope unavailable. Reconnect using a workspace URL or switch to a known workspace.");
         setTelegramIdentitiesError("Workspace scope unavailable.");
         setSlackIdentitiesError("Workspace scope unavailable.");
+        resetAgentState();
+        setSendStatus(null);
+        setSendError(null);
+        setSendResult(null);
         setLastUpdatedAt(null);
         return;
       }
@@ -240,6 +410,9 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
       }
 
       setLastUpdatedAt(Date.now());
+      if (!agentDirty() && !agentSaving()) {
+        void loadAgentFile();
+      }
     } catch (error) {
       const message = formatRequestError(error);
       setHealth(null);
@@ -399,6 +572,10 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
     setTelegramIdentitiesError(null);
     setSlackIdentities([]);
     setSlackIdentitiesError(null);
+    resetAgentState();
+    setSendStatus(null);
+    setSendError(null);
+    setSendResult(null);
     setLastUpdatedAt(null);
   });
 
@@ -906,6 +1083,148 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
           <div class="text-xs text-gray-10 mt-2.5">
             Advanced: reply with <code class="text-[11px] font-mono bg-gray-3 px-1 py-0.5 rounded">/dir &lt;path&gt;</code> in Slack/Telegram to override the directory for a specific chat.
           </div>
+        </div>
+
+        {/* ---- Messaging agent behavior ---- */}
+        <div class="rounded-xl border border-gray-4 bg-gray-1 p-4 space-y-3">
+          <div class="flex items-center justify-between gap-2">
+            <div>
+              <div class="text-[13px] font-semibold text-gray-12">Messaging agent behavior</div>
+              <div class="text-[12px] text-gray-9 mt-0.5">
+                Edit the workspace instructions used before each inbound Telegram/Slack message.
+              </div>
+            </div>
+            <span class="rounded-md border border-gray-4 bg-gray-2/50 px-2 py-1 text-[11px] font-mono text-gray-10">
+              {OWPENBOT_AGENT_FILE_PATH}
+            </span>
+          </div>
+
+          <Show when={agentLoading()}>
+            <div class="text-[11px] text-gray-9">Loading agent file…</div>
+          </Show>
+
+          <Show when={!agentExists() && !agentLoading()}>
+            <div class="rounded-lg border border-amber-7/20 bg-amber-1/30 px-3 py-2 text-xs text-amber-12">
+              Agent file not found in this workspace yet.
+            </div>
+          </Show>
+
+          <textarea
+            class="min-h-[220px] w-full rounded-lg border border-gray-4 bg-gray-1 px-3 py-2.5 text-[13px] font-mono text-gray-12 placeholder:text-gray-8"
+            placeholder="Add messaging behavior instructions for owpenbot here..."
+            value={agentDraft()}
+            onInput={(e) => setAgentDraft(e.currentTarget.value)}
+          />
+
+          <div class="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              class="h-8 px-3 text-xs"
+              onClick={() => void loadAgentFile()}
+              disabled={agentLoading() || !workspaceId()}
+            >
+              Reload
+            </Button>
+            <Show when={!agentExists()}>
+              <Button
+                variant="outline"
+                class="h-8 px-3 text-xs"
+                onClick={() => void createDefaultAgentFile()}
+                disabled={agentSaving() || !workspaceId()}
+              >
+                Create default file
+              </Button>
+            </Show>
+            <Button
+              variant="secondary"
+              class="h-8 px-3 text-xs"
+              onClick={() => void saveAgentFile()}
+              disabled={agentSaving() || !workspaceId() || !agentDirty()}
+            >
+              {agentSaving() ? "Saving..." : "Save behavior"}
+            </Button>
+            <Show when={agentDirty() && !agentSaving()}>
+              <span class="text-[11px] text-gray-9">Unsaved changes</span>
+            </Show>
+          </div>
+
+          <Show when={agentStatus()}>
+            {(value) => <div class="text-[11px] text-gray-9">{value()}</div>}
+          </Show>
+          <Show when={agentError()}>
+            {(value) => <div class="text-[11px] text-red-12">{value()}</div>}
+          </Show>
+        </div>
+
+        {/* ---- Outbound send test ---- */}
+        <div class="rounded-xl border border-gray-4 bg-gray-1 p-4 space-y-3">
+          <div>
+            <div class="text-[13px] font-semibold text-gray-12">Send test message</div>
+            <div class="text-[12px] text-gray-9 mt-0.5">
+              Dispatch an outbound message via the workspace send route to validate bindings and channel wiring.
+            </div>
+          </div>
+
+          <div class="grid gap-2 sm:grid-cols-2">
+            <div>
+              <label class="text-[12px] text-gray-9 block mb-1">Channel</label>
+              <select
+                class="w-full rounded-lg border border-gray-4 bg-gray-1 px-3 py-2 text-sm text-gray-12"
+                value={sendChannel()}
+                onChange={(e) => setSendChannel(e.currentTarget.value === "slack" ? "slack" : "telegram")}
+              >
+                <option value="telegram">Telegram</option>
+                <option value="slack">Slack</option>
+              </select>
+            </div>
+            <div>
+              <label class="text-[12px] text-gray-9 block mb-1">Directory (optional)</label>
+              <input
+                class="w-full rounded-lg border border-gray-4 bg-gray-1 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-8"
+                placeholder={defaultRoutingDirectory()}
+                value={sendDirectory()}
+                onInput={(e) => setSendDirectory(e.currentTarget.value)}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label class="text-[12px] text-gray-9 block mb-1">Message</label>
+            <textarea
+              class="min-h-[90px] w-full rounded-lg border border-gray-4 bg-gray-1 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-8"
+              placeholder="Test message content"
+              value={sendText()}
+              onInput={(e) => setSendText(e.currentTarget.value)}
+            />
+          </div>
+
+          <div class="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              class="h-8 px-3 text-xs"
+              onClick={() => void sendTestMessage()}
+              disabled={sendBusy() || !workspaceId() || !sendText().trim()}
+            >
+              {sendBusy() ? "Sending..." : "Send test message"}
+            </Button>
+            <Show when={sendStatus()}>
+              {(value) => <span class="text-[11px] text-gray-9">{value()}</span>}
+            </Show>
+          </div>
+
+          <Show when={sendError()}>
+            {(value) => <div class="text-[11px] text-red-12">{value()}</div>}
+          </Show>
+          <Show when={sendResult()}>
+            {(value) => (
+              <div class="rounded-lg border border-gray-4 bg-gray-2/40 px-3 py-2 text-[11px] text-gray-10 font-mono">
+                sent={value().sent} attempted={value().attempted}
+                <Show when={value().failures?.length}>
+                  {(failures) => ` failures=${failures()}`}
+                </Show>
+              </div>
+            )}
+          </Show>
         </div>
 
       </Show>

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -1385,6 +1385,22 @@ export default function SettingsView(props: SettingsViewProps) {
                           <div>MCP: {formatCapability(caps().mcp)}</div>
                           <div>Commands: {formatCapability(caps().commands)}</div>
                           <div>Config: {formatCapability(caps().config)}</div>
+                          <div>Proxy (Owpenbot): {caps().proxy?.owpenbot ? "enabled" : "disabled"}</div>
+                          <div>
+                            Browser tools: {(() => {
+                              const browser = caps().toolProviders?.browser;
+                              if (!browser?.enabled) return "disabled";
+                              return `${browser.mode} · ${browser.placement}`;
+                            })()}
+                          </div>
+                          <div>
+                            File tools: {(() => {
+                              const files = caps().toolProviders?.files;
+                              if (!files) return "Unavailable";
+                              const parts = [files.injection ? "inbox on" : "inbox off", files.outbox ? "outbox on" : "outbox off"];
+                              return parts.join(" · ");
+                            })()}
+                          </div>
                           <div>
                             Sandbox: {(() => {
                               const sandbox = caps().sandbox;

--- a/packages/owpenbot/src/bridge.ts
+++ b/packages/owpenbot/src/bridge.ts
@@ -1,5 +1,8 @@
 import { setTimeout as delay } from "node:timers/promises";
 
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
 import type { Logger } from "pino";
 
 import type { Config, ChannelName, OwpenbotConfigFile } from "./config.js";
@@ -133,6 +136,8 @@ const CHANNEL_LABELS: Record<ChannelName, string> = {
 };
 
 const TYPING_INTERVAL_MS = 6000;
+const OWPENBOT_AGENT_FILE_RELATIVE_PATH = ".opencode/agents/owpenbot.md";
+const OWPENBOT_AGENT_MAX_CHARS = 16_000;
 
 // Model presets for quick switching
 const MODEL_PRESETS: Record<string, ModelRef> = {
@@ -177,6 +182,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
   const reportStatus = reporter?.onStatus;
   const clients = new Map<string, ReturnType<typeof createClient>>();
   const defaultDirectory = config.opencodeDirectory;
+  const agentPromptCache = new Map<string, { mtimeMs: number; content: string }>();
 
   const isDangerousRootDirectory = (dir: string) => {
     const normalized = dir.trim();
@@ -209,6 +215,46 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     const next = deps.clientFactory ? deps.clientFactory(resolved) : createClient(config, resolved);
     clients.set(resolved, next);
     return next;
+  };
+
+  const loadMessagingAgentPrompt = async (directory: string): Promise<string> => {
+    const base = directory.trim() || defaultDirectory;
+    if (!base) return "";
+
+    const filePath = join(base, OWPENBOT_AGENT_FILE_RELATIVE_PATH);
+    try {
+      const info = await stat(filePath);
+      if (!info.isFile()) {
+        agentPromptCache.delete(filePath);
+        return "";
+      }
+
+      const cached = agentPromptCache.get(filePath);
+      if (cached && cached.mtimeMs === info.mtimeMs) {
+        return cached.content;
+      }
+
+      const content = (await readFile(filePath, "utf8")).trim();
+      if (!content) {
+        agentPromptCache.set(filePath, { mtimeMs: info.mtimeMs, content: "" });
+        return "";
+      }
+
+      const next =
+        content.length > OWPENBOT_AGENT_MAX_CHARS
+          ? content.slice(0, OWPENBOT_AGENT_MAX_CHARS)
+          : content;
+      agentPromptCache.set(filePath, { mtimeMs: info.mtimeMs, content: next });
+      return next;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") {
+        agentPromptCache.delete(filePath);
+        return "";
+      }
+      logger.warn({ error, filePath }, "failed to load owpenbot agent file");
+      return "";
+    }
   };
 
   const rootClient = getClient(defaultDirectory);
@@ -1105,10 +1151,21 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       startTyping(runState);
       try {
         const effectiveModel = getUserModel(inbound.channel, inbound.identityId, peerKey, config.model);
+        const messagingAgentPrompt = await loadMessagingAgentPrompt(boundDirectory);
+        const promptText = messagingAgentPrompt
+          ? [
+              "You are handling a Slack/Telegram message via OpenWork.",
+              "Follow this workspace messaging agent file:",
+              messagingAgentPrompt,
+              "",
+              "Incoming user message:",
+              inbound.text,
+            ].join("\n")
+          : inbound.text;
         logger.debug({ sessionID, length: inbound.text.length, model: effectiveModel }, "prompt start");
         const response = await getClient(boundDirectory).session.prompt({
           sessionID,
-          parts: [{ type: "text", text: inbound.text }],
+          parts: [{ type: "text", text: promptText }],
           ...(effectiveModel ? { model: effectiveModel } : {}),
         });
         const parts = (response as { parts?: Array<{ type?: string; text?: string; ignored?: boolean }> }).parts ?? [];
@@ -1243,9 +1300,26 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       return true;
     }
 
+    if (command === "agent") {
+      const binding = store.getBinding(channel, identityId, peerKey);
+      const current =
+        binding?.directory?.trim() || store.getSession(channel, identityId, peerKey)?.directory?.trim() || defaultDirectory;
+      const resolved = current.trim() || defaultDirectory;
+      const filePath = join(resolved, OWPENBOT_AGENT_FILE_RELATIVE_PATH);
+      const loaded = await loadMessagingAgentPrompt(resolved);
+      await sendText(
+        channel,
+        identityId,
+        peerId,
+        `Agent file: ${filePath}\nStatus: ${loaded ? "loaded" : "missing or empty"}`,
+        { kind: "system" },
+      );
+      return true;
+    }
+
     // /help command
     if (command === "help") {
-      const helpText = `/opus - Claude Opus 4.5\n/codex - GPT 5.2 Codex\n/dir <path> - bind this chat to a directory\n/dir - show current directory\n/model - show current\n/reset - start fresh\n/help - this`;
+      const helpText = `/opus - Claude Opus 4.5\n/codex - GPT 5.2 Codex\n/dir <path> - bind this chat to a directory\n/dir - show current directory\n/agent - show workspace agent file path\n/model - show current\n/reset - start fresh\n/help - this`;
       await sendText(channel, identityId, peerId, helpText, { kind: "system" });
       return true;
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2055,6 +2055,83 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     return jsonResponse({ ok: true });
   });
 
+  addRoute(routes, "POST", "/workspace/:id/owpenbot/send", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const workspaceIdentityId = normalizeOwpenbotIdentityId(workspace.id);
+    const body = await readJsonBody(ctx.request);
+    const channel = typeof body.channel === "string" ? body.channel.trim().toLowerCase() : "";
+    const text = typeof body.text === "string" ? body.text : "";
+    const directoryInput = typeof body.directory === "string" ? body.directory.trim() : "";
+    const directory = directoryInput || workspace.path;
+    const healthPort = normalizeHealthPort(body.healthPort);
+    const requestHost = ctx.url.hostname;
+
+    const identityIdParam = typeof body.identityId === "string" ? body.identityId.trim() : "";
+    const requestedId = identityIdParam ? normalizeOwpenbotIdentityId(identityIdParam) : "";
+    if (requestedId && requestedId !== workspaceIdentityId) {
+      throw new ApiError(
+        400,
+        "identity_mismatch",
+        `Identity id is scoped to this workspace (${workspace.id}).`,
+        { expected: workspaceIdentityId, received: requestedId },
+      );
+    }
+    const identityId = workspaceIdentityId;
+
+    if (channel !== "telegram" && channel !== "slack") {
+      throw new ApiError(400, "invalid_channel", "channel must be 'telegram' or 'slack'");
+    }
+    if (!directory.trim()) {
+      throw new ApiError(400, "directory_required", "directory is required");
+    }
+    if (!text.trim()) {
+      throw new ApiError(400, "text_required", "text is required");
+    }
+
+    const port = healthPort ?? resolveOwpenbotHealthPort();
+    const apply = await tryPostOwpenbotHealth(
+      "/send",
+      {
+        channel,
+        identityId,
+        directory,
+        text,
+      },
+      { port, requestHost, timeoutMs: 5_000 },
+    );
+
+    if (!apply.applied) {
+      throw new ApiError(503, "owpenbot_unreachable", "Owpenbot did not send the message", {
+        port,
+        error: apply.error,
+        status: apply.status,
+      });
+    }
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "owpenbot.send",
+      target: `owpenbot.${channel}`,
+      summary: `Sent outbound ${channel} message for ${identityId}`,
+      timestamp: Date.now(),
+    });
+
+    if (apply.body && typeof apply.body === "object") {
+      return jsonResponse(apply.body);
+    }
+    return jsonResponse({
+      ok: true,
+      channel,
+      identityId,
+      directory,
+      attempted: 0,
+      sent: 0,
+    });
+  });
+
   addRoute(routes, "GET", "/workspace/:id/events", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const sinceParam = ctx.url.searchParams.get("since");


### PR DESCRIPTION
## Summary
- load `.opencode/agents/owpenbot.md` per bound workspace directory in owpenbot bridge, inject its instructions into inbound prompts, and add `/agent` helper visibility.
- add `POST /workspace/:id/owpenbot/send` in OpenWork server with workspace identity scoping, owpenbot forward/send behavior, and `owpenbot.send` audit logging.
- extend OpenWork UI capabilities + Identities with a new **Messaging agent behavior** editor (read/write workspace file with save/reload/default-template) and a **Send test message** panel using the new send API.

## Validation
- `pnpm install`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter owpenwork test:unit`
- `pnpm --filter openwork-server build:bin`

## Notes
- Could not run Docker + Chrome MCP verification in this environment because Docker daemon is unavailable (`Cannot connect to the Docker daemon at unix:///Users/benjaminshafii/.colima/default/docker.sock`).
- Because Docker stack was unavailable, no UI screenshots/video evidence were captured in this run.

## Repro for reviewer
1. Start Docker stack: `packaging/docker/dev-up.sh`
2. Open Identities page and verify:
   - messaging agent file loads/saves at `.opencode/agents/owpenbot.md`
   - default file creation works
   - send test dispatch returns attempted/sent response
3. Confirm outbound send route from mounted or non-mounted workspace base URL:
   - `POST /workspace/:id/owpenbot/send`