### PR TITLE
fix(desktop): ship Control Chrome sidecar executable

### DIFF
--- a/packages/desktop/scripts/chrome-devtools-mcp-shim.ts
+++ b/packages/desktop/scripts/chrome-devtools-mcp-shim.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const packageSpec =
+  process.env.OPENWORK_CHROME_DEVTOOLS_MCP_SPEC?.trim() ||
+  process.env.CHROME_DEVTOOLS_MCP_SPEC?.trim() ||
+  "chrome-devtools-mcp@0.17.0";
+
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const args = ["exec", "--yes", packageSpec, "--", ...process.argv.slice(2)];
+
+const child = spawn(npmCommand, args, {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    npm_config_yes: "true",
+  },
+});
+
+child.on("error", (error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("ENOENT")) {
+    console.error(
+      "Control Chrome requires npm (Node.js). Install Node.js or configure mcp.control-chrome.command to a local chrome-devtools-mcp binary."
+    );
+  } else {
+    console.error(`Failed to start chrome-devtools-mcp via npm exec: ${message}`);
+  }
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/packages/desktop/scripts/prepare-sidecar.mjs
+++ b/packages/desktop/scripts/prepare-sidecar.mjs
@@ -87,6 +87,10 @@ const owpenbotVersion = (() => {
   }
   return null;
 })();
+const chromeDevtoolsMcpVersion =
+  process.env.CHROME_DEVTOOLS_MCP_VERSION?.trim() ||
+  process.env.OPENWORK_CHROME_DEVTOOLS_MCP_VERSION?.trim() ||
+  "0.17.0";
 
 // Target triple for native platform binaries
 const resolvedTargetTriple = (() => {
@@ -187,6 +191,21 @@ const openwrkTargetName = openwrkTargetTriple
   : null;
 const openwrkTargetPath = openwrkTargetName ? join(sidecarDir, openwrkTargetName) : null;
 const openwrkDir = resolve(__dirname, "..", "..", "headless");
+
+// chrome-devtools-mcp shim sidecar
+const chromeDevtoolsBaseName = "chrome-devtools-mcp";
+const chromeDevtoolsName = process.platform === "win32" ? `${chromeDevtoolsBaseName}.exe` : chromeDevtoolsBaseName;
+const chromeDevtoolsPath = join(sidecarDir, chromeDevtoolsName);
+const chromeDevtoolsBuildName = bunTarget
+  ? `${chromeDevtoolsBaseName}-${bunTarget}${bunTarget.includes("windows") ? ".exe" : ""}`
+  : chromeDevtoolsName;
+const chromeDevtoolsBuildPath = join(sidecarDir, chromeDevtoolsBuildName);
+const chromeDevtoolsTargetTriple = resolvedTargetTriple;
+const chromeDevtoolsTargetName = chromeDevtoolsTargetTriple
+  ? `${chromeDevtoolsBaseName}-${chromeDevtoolsTargetTriple}${chromeDevtoolsTargetTriple.includes("windows") ? ".exe" : ""}`
+  : null;
+const chromeDevtoolsTargetPath = chromeDevtoolsTargetName ? join(sidecarDir, chromeDevtoolsTargetName) : null;
+const chromeDevtoolsShimPath = resolve(__dirname, "chrome-devtools-mcp-shim.ts");
 
 const readHeader = (filePath, length = 256) => {
   const fd = openSync(filePath, "r");
@@ -622,6 +641,80 @@ if (existsSync(openwrkBuildPath)) {
   }
 }
 
+// Build chrome-devtools-mcp shim sidecar
+let didBuildChromeDevtools = false;
+const shouldBuildChromeDevtools =
+  forceBuild || !existsSync(chromeDevtoolsBuildPath) || isStubBinary(chromeDevtoolsBuildPath);
+if (shouldBuildChromeDevtools) {
+  mkdirSync(sidecarDir, { recursive: true });
+  if (existsSync(chromeDevtoolsBuildPath)) {
+    try {
+      unlinkSync(chromeDevtoolsBuildPath);
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!existsSync(chromeDevtoolsShimPath)) {
+    console.error(`Chrome DevTools MCP shim source not found at ${chromeDevtoolsShimPath}`);
+    process.exit(1);
+  }
+
+  const chromeDevtoolsArgs = [
+    "build",
+    "--compile",
+    chromeDevtoolsShimPath,
+    "--outfile",
+    chromeDevtoolsBuildPath,
+  ];
+  if (bunTarget) {
+    chromeDevtoolsArgs.push("--target", bunTarget);
+  }
+
+  const result = spawnSync("bun", chromeDevtoolsArgs, {
+    cwd: __dirname,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      NODE_ENV: "production",
+      BUN_ENV: "production",
+    },
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+
+  didBuildChromeDevtools = true;
+}
+
+if (existsSync(chromeDevtoolsBuildPath)) {
+  const shouldCopyCanonical =
+    didBuildChromeDevtools || !existsSync(chromeDevtoolsPath) || isStubBinary(chromeDevtoolsPath);
+  if (shouldCopyCanonical && chromeDevtoolsBuildPath !== chromeDevtoolsPath) {
+    try {
+      if (existsSync(chromeDevtoolsPath)) unlinkSync(chromeDevtoolsPath);
+    } catch {
+      // ignore
+    }
+    copyFileSync(chromeDevtoolsBuildPath, chromeDevtoolsPath);
+  }
+
+  if (chromeDevtoolsTargetPath) {
+    const shouldCopyTarget =
+      didBuildChromeDevtools ||
+      !existsSync(chromeDevtoolsTargetPath) ||
+      isStubBinary(chromeDevtoolsTargetPath);
+    if (shouldCopyTarget && chromeDevtoolsBuildPath !== chromeDevtoolsTargetPath) {
+      try {
+        if (existsSync(chromeDevtoolsTargetPath)) unlinkSync(chromeDevtoolsTargetPath);
+      } catch {
+        // ignore
+      }
+      copyFileSync(chromeDevtoolsBuildPath, chromeDevtoolsTargetPath);
+    }
+  }
+}
+
 const openworkServerVersion = (() => {
   try {
     const raw = readFileSync(resolve(openworkServerDir, "package.json"), "utf8");
@@ -656,6 +749,10 @@ const versions = {
   openwrk: {
     version: openwrkVersion,
     sha256: existsSync(openwrkPath) ? sha256File(openwrkPath) : null,
+  },
+  "chrome-devtools-mcp": {
+    version: chromeDevtoolsMcpVersion,
+    sha256: existsSync(chromeDevtoolsPath) ? sha256File(chromeDevtoolsPath) : null,
   },
 };
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -39,6 +39,7 @@
       "sidecars/openwork-server",
       "sidecars/owpenbot",
       "sidecars/openwrk",
+      "sidecars/chrome-devtools-mcp",
       "sidecars/versions.json"
     ]
   },


### PR DESCRIPTION
## Summary
- Add a bundled `chrome-devtools-mcp` sidecar shim executable for desktop builds so `mcp.control-chrome.command = [\"chrome-devtools-mcp\"]` resolves in app runtime.
- Update `prepare-sidecar` to compile and stage the shim (canonical + target-specific filenames) and include it in `versions.json` integrity metadata.
- Include `sidecars/chrome-devtools-mcp` in Tauri `externalBin` so packaged apps carry the executable.

## Why
Users were seeing `Executable not found in $PATH: \"chrome-devtools-mcp\"` after switching away from `npx`. This keeps the human-readable **Control Chrome** entry while restoring a resolvable local command in desktop runtime.

## Validation
- `pnpm install --frozen-lockfile`
- `node packages/desktop/scripts/prepare-sidecar.mjs --force`
- `packages/desktop/src-tauri/sidecars/chrome-devtools-mcp --version`
- `cargo check` (in `packages/desktop/src-tauri`)
- `pnpm typecheck`

## Notes
- The shim intentionally avoids `npx` and runs `npm exec --yes chrome-devtools-mcp@0.17.0`.
- Docker + Chrome MCP end-to-end UI verification was not run in this pass; this PR focuses on desktop-side command resolution + bundling.