### PR TITLE
feat: OpenCode hot reload wiring + engine binary selector

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -32,7 +32,6 @@ import CreateRemoteWorkspaceModal from "./components/create-remote-workspace-mod
 import CreateWorkspaceModal from "./components/create-workspace-modal";
 import RenameWorkspaceModal from "./components/rename-workspace-modal";
 import McpAuthModal from "./components/mcp-auth-modal";
-import ReloadWorkspaceToast from "./components/reload-workspace-toast";
 import OnboardingView from "./pages/onboarding";
 import DashboardView from "./pages/dashboard";
 import SessionView from "./pages/session";
@@ -148,6 +147,11 @@ import {
 } from "./lib/openwork-server";
 
 export default function App() {
+  const envOpenworkWorkspaceId =
+    typeof import.meta.env?.VITE_OPENWORK_WORKSPACE_ID === "string"
+      ? import.meta.env.VITE_OPENWORK_WORKSPACE_ID.trim() || null
+      : null;
+
   // Workspace switch tracing is noisy, so only emit in developer mode.
   // (OpenWork already has a developer mode toggle in Settings.)
   const wsDebugEnabled = () => developerMode();
@@ -572,8 +576,6 @@ export default function App() {
   const [lastKnownConfigSnapshot, setLastKnownConfigSnapshot] = createSignal("");
   const [developerMode, setDeveloperMode] = createSignal(false);
   const [documentVisible, setDocumentVisible] = createSignal(true);
-  let markReloadRequiredRef: (reason: ReloadReason, trigger?: ReloadTrigger) => void = () => { };
-  let setReloadLastFinishedAtRef: (value: number) => void = () => { };
 
   const [selectedSessionId, setSelectedSessionId] = createSignal<string | null>(
     null
@@ -637,7 +639,11 @@ export default function App() {
     developerMode,
     setError,
     setSseConnected,
-    markReloadRequired: (reason, trigger) => markReloadRequiredRef(reason, trigger),
+    onHotReloadApplied: () => {
+      void refreshSkills({ force: true });
+      void refreshPlugins(pluginScope());
+      void refreshMcpServers();
+    },
   });
 
   const {
@@ -1349,7 +1355,6 @@ export default function App() {
     setBusyLabel,
     setBusyStartedAt,
     setError,
-    markReloadRequired: (reason, trigger) => markReloadRequiredRef(reason, trigger),
     onNotionSkillInstalled: () => {
       setNotionSkillInstalled(true);
       try {
@@ -1587,7 +1592,7 @@ export default function App() {
     openworkServerSettings,
     updateOpenworkServerSettings,
     openworkServerClient,
-    onEngineStable: () => setReloadLastFinishedAtRef(Date.now()),
+    onEngineStable: () => {},
     engineRuntime,
     developerMode,
   });
@@ -1930,7 +1935,7 @@ export default function App() {
         parseOpenworkWorkspaceIdFromUrl(active.openworkHostUrl ?? "") ??
         parseOpenworkWorkspaceIdFromUrl(active.baseUrl ?? "") ??
         parseOpenworkWorkspaceIdFromUrl(openworkUrl);
-      const storedId = active.openworkWorkspaceId?.trim() || inferredWorkspaceId || null;
+      const storedId = active.openworkWorkspaceId?.trim() || inferredWorkspaceId || envOpenworkWorkspaceId || null;
       if (storedId) {
         setOpenworkServerWorkspaceId(storedId);
         return;
@@ -2278,55 +2283,14 @@ export default function App() {
     setView("dashboard");
   };
 
-  const [openworkReloadCursor, setOpenworkReloadCursor] = createSignal<number | null>(null);
-  const [openworkReloadUnsupported, setOpenworkReloadUnsupported] = createSignal(false);
-
-  const resolveOpenworkReloadTarget = () => {
-    if (workspaceStore.activeWorkspaceDisplay().workspaceType !== "remote") return null;
-    if (openworkServerStatus() !== "connected") return null;
-    const client = openworkServerClient();
-    if (!client) return null;
-    const workspaceId = openworkServerWorkspaceId();
-    if (!workspaceId) return null;
-    return { client, workspaceId };
-  };
-
-  const canReloadViaOpenworkServer = createMemo(() => Boolean(resolveOpenworkReloadTarget()));
   const canReloadLocalEngine = () =>
     isTauriRuntime() && workspaceStore.activeWorkspaceDisplay().workspaceType === "local";
 
-  const canReloadWorkspace = createMemo(() => {
-    if (canReloadViaOpenworkServer()) return true;
-    return canReloadLocalEngine();
-  });
+  const canReloadWorkspace = createMemo(() => canReloadLocalEngine());
 
   const reloadWorkspaceEngineFromUi = async () => {
-    const target = resolveOpenworkReloadTarget();
-    if (target) {
-      try {
-        await target.client.reloadEngine(target.workspaceId);
-        return true;
-      } catch (error) {
-        if (error instanceof OpenworkServerError && error.status === 404) {
-          if (error.code === "workspace_not_found") {
-            const response = await target.client.listWorkspaces();
-            const workspaceId = response.items?.[0]?.id;
-            if (workspaceId) {
-              setOpenworkServerWorkspaceId(workspaceId);
-              await target.client.reloadEngine(workspaceId);
-              return true;
-            }
-          }
-          if (canReloadLocalEngine()) {
-            return workspaceStore.reloadWorkspaceEngine();
-          }
-          throw new Error("OpenWork server reload endpoint not found. Update the host to enable reloads.");
-        }
-        throw error;
-      }
-    }
     if (!canReloadLocalEngine()) {
-      throw new Error("Reload is unavailable for this workspace.");
+      return false;
     }
     return workspaceStore.reloadWorkspaceEngine();
   };
@@ -2355,17 +2319,8 @@ export default function App() {
   });
 
   const {
-    reloadRequired,
-    reloadReasons,
-    reloadLastTriggeredAt,
-    reloadLastFinishedAt,
-    setReloadLastFinishedAt,
-    reloadTrigger,
     reloadBusy,
     reloadError,
-    canReloadEngine,
-    markReloadRequired: markReloadRequiredRaw,
-    clearReloadRequired,
     reloadWorkspaceEngine,
     cacheRepairBusy,
     cacheRepairResult,
@@ -2410,15 +2365,8 @@ export default function App() {
     return Date.now() - lastCheckedAt >= UPDATE_AUTO_CHECK_EVERY_MS;
   };
 
-  const [pendingReloadReasons, setPendingReloadReasons] = createSignal<ReloadReason[]>([]);
-  const [pendingReloadTrigger, setPendingReloadTrigger] = createSignal<ReloadTrigger | null>(null);
-  const [pendingReloadResume, setPendingReloadResume] = createSignal<
-    Array<{ sessionID: string; model: ModelRef; agent: string | null }>
-  >([]);
-  const [autoReloadInFlight, setAutoReloadInFlight] = createSignal(false);
-
   const workspaceAutoReloadAvailable = createMemo(() =>
-    isTauriRuntime() && workspaceStore.activeWorkspaceDisplay().workspaceType === "local",
+    false,
   );
 
   const workspaceAutoReloadEnabled = createMemo(() => {
@@ -2447,386 +2395,21 @@ export default function App() {
     await workspaceStore.persistReloadSettings({ auto, resume: auto ? next : false });
   };
 
-  const resumeSessionsAfterReload = async (entries: Array<{ sessionID: string; model: ModelRef; agent: string | null }>) => {
-    if (!entries.length) return;
-    const c = client();
-    if (!c) return;
-    const reasons = reloadReasons();
-    const label = reasons.length ? reasons.join(", ") : "config";
-    const text = `Hot reload applied (${label}). Continue where you left off.`;
-    for (const entry of entries) {
-      try {
-        await c.session.promptAsync({
-          sessionID: entry.sessionID,
-          model: entry.model,
-          agent: entry.agent ?? undefined,
-          variant: modelVariant() ?? undefined,
-          parts: [{ type: "text", text }],
-        });
-      } catch {
-        // ignore
-      }
-    }
-  };
-
   const reloadWorkspaceEngineAndResume = async () => {
-    const snapshot = pendingReloadResume();
     await reloadWorkspaceEngine();
-
-    // If reload failed, keep the snapshot for a later retry.
-    if (reloadRequired() || reloadError()) return;
-
-    if (workspaceAutoReloadResumeEnabled() && snapshot.length) {
-      await resumeSessionsAfterReload(snapshot);
-    }
-    setPendingReloadResume([]);
   };
 
   const markReloadRequired = (
-    reason: ReloadReason,
-    options?: { force?: boolean; trigger?: ReloadTrigger },
+    _reason: ReloadReason,
+    _options?: { force?: boolean; trigger?: ReloadTrigger },
   ) => {
-    if (booting() || reloadBusy()) return;
-
-    if (!options?.force && anyActiveRuns()) {
-      setPendingReloadReasons((current) => (current.includes(reason) ? current : [...current, reason]));
-      if (options?.trigger) {
-        setPendingReloadTrigger(options.trigger);
-      }
-
-      const statuses = sessionStatusById();
-      const running = sessions().filter(
-        (s) => statuses[s.id] === "running" || statuses[s.id] === "retry",
-      );
-      if (running.length) {
-        setPendingReloadResume((current) => {
-          const existing = new Set(current.map((entry) => entry.sessionID));
-          const next = current.slice();
-          for (const s of running) {
-            if (!s?.id || existing.has(s.id)) continue;
-            const model = sessionModelOverrideById()[s.id] ?? sessionModelById()[s.id] ?? defaultModel();
-            const agent = sessionAgentById()[s.id] ?? null;
-            existing.add(s.id);
-            next.push({ sessionID: s.id, model, agent });
-          }
-          return next;
-        });
-      }
-      return;
-    }
-
-    if (!options?.force) {
-      const existingReasons = reloadReasons();
-      if (reloadRequired() && existingReasons.includes(reason)) return;
-      if (reloadRequired() && reason === "config" && existingReasons.includes("mcp")) {
-        return;
-      }
-    }
-    if (!options?.force) {
-      const label = busyLabel();
-      if (
-        busy() &&
-        label &&
-        (label.includes("engine") || label.includes("workspace") || label.includes("connecting"))
-      ) {
-        return;
-      }
-      const now = Date.now();
-      if (now - mountTime < 3000) return;
-
-      const lastFinishedAt = reloadLastFinishedAt();
-      if (lastFinishedAt && now - lastFinishedAt < 2000) return;
-    }
-    markReloadRequiredRaw(reason, options?.trigger);
+    return;
   };
-
-  createEffect(() => {
-    if (anyActiveRuns()) return;
-    if (reloadBusy()) return;
-    if (booting()) return;
-
-    const pending = pendingReloadReasons();
-    if (!pending.length) return;
-
-    // Promote queued reload signals only after active sessions finish.
-    const trigger = pendingReloadTrigger();
-    for (let i = 0; i < pending.length; i += 1) {
-      markReloadRequiredRaw(pending[i], i === 0 ? trigger ?? undefined : undefined);
-    }
-    setPendingReloadReasons([]);
-    setPendingReloadTrigger(null);
-  });
-
-  createEffect(() => {
-    if (typeof window === "undefined") return;
-    if (!workspaceAutoReloadEnabled()) return;
-    if (anyActiveRuns()) return;
-    if (!reloadRequired()) return;
-    if (!canReloadEngine()) return;
-    if (reloadBusy() || autoReloadInFlight()) return;
-
-    const lastTriggeredAt = reloadLastTriggeredAt();
-    if (lastTriggeredAt && Date.now() - lastTriggeredAt < 600) return;
-
-    const timer = window.setTimeout(() => {
-      if (autoReloadInFlight()) return;
-      setAutoReloadInFlight(true);
-      void reloadWorkspaceEngineAndResume().finally(() => setAutoReloadInFlight(false));
-    }, 450);
-
-    onCleanup(() => {
-      window.clearTimeout(timer);
-    });
-  });
-
-  const openworkReloadKey = createMemo(
-    () => `${workspaceStore.activeWorkspaceDisplay().workspaceType}|${openworkServerWorkspaceId() ?? ""}|${openworkServerUrl().trim()}`,
-  );
-
-  const reloadScopeKey = createMemo(() => {
-    const workspaceId = workspaceStore.activeWorkspaceId() ?? "";
-    return `${workspaceId}|${openworkReloadKey()}`;
-  });
-
-  createEffect(() => {
-    // Prevent reload toasts / queued reloads from bleeding across workspaces.
-    reloadScopeKey();
-    clearReloadRequired();
-    setPendingReloadReasons([]);
-    setPendingReloadTrigger(null);
-    setPendingReloadResume([]);
-  });
-
-  createEffect(() => {
-    openworkReloadKey();
-    setOpenworkReloadCursor(null);
-    setOpenworkReloadUnsupported(false);
-  });
-
-  createEffect(() => {
-    if (typeof window === "undefined") return;
-    if (!documentVisible()) return;
-    if (openworkReloadUnsupported()) return;
-    const target = resolveOpenworkReloadTarget();
-    if (!target || openworkServerStatus() !== "connected") return;
-    const client = target.client;
-    const workspaceId = target.workspaceId;
-
-    let active = true;
-    let busy = false;
-
-    const run = async () => {
-      if (busy) return;
-      busy = true;
-      try {
-        const response = await client.listReloadEvents(workspaceId, {
-          since: openworkReloadCursor() ?? undefined,
-        });
-        if (!active) return;
-        const items = Array.isArray(response.items) ? response.items : [];
-        for (const entry of items) {
-          if (reloadReasons().includes(entry.reason)) {
-            markReloadRequiredRaw(entry.reason, entry.trigger);
-          } else {
-            markReloadRequired(entry.reason, { trigger: entry.trigger });
-          }
-        }
-        if (typeof response.cursor === "number") {
-          setOpenworkReloadCursor(response.cursor);
-        } else if (items.length) {
-          setOpenworkReloadCursor(items[items.length - 1].seq);
-        }
-      } catch (error) {
-        if (error instanceof OpenworkServerError && error.status === 404) {
-          if (error.code === "workspace_not_found") {
-            try {
-              const response = await client.listWorkspaces();
-              const nextWorkspaceId = response.items?.[0]?.id ?? null;
-              setOpenworkServerWorkspaceId(nextWorkspaceId);
-            } catch {
-              setOpenworkServerWorkspaceId(null);
-            }
-          } else {
-            setOpenworkReloadUnsupported(true);
-          }
-        }
-      } finally {
-        busy = false;
-      }
-    };
-
-    run();
-    const interval = window.setInterval(run, 8_000);
-    onCleanup(() => {
-      active = false;
-      window.clearInterval(interval);
-    });
-  });
-
-  const extractReloadTriggerFromPath = (reason: ReloadReason, rawPath?: string): ReloadTrigger | null => {
-    if (!rawPath) return null;
-    const normalized = rawPath.replace(/\\/g, "/");
-    const fileName = normalized.split("/").filter(Boolean).pop();
-
-    if (reason === "skills") {
-      const match = normalized.match(/\/\.opencode\/(?:skill|skills)\/([^/]+)/i);
-      return {
-        type: "skill",
-        name: match?.[1],
-        action: "updated",
-        path: rawPath,
-      };
-    }
-
-    if (reason === "plugins") {
-      return {
-        type: "plugin",
-        action: "updated",
-        path: rawPath,
-      };
-    }
-
-    if (reason === "mcp") {
-      return {
-        type: "mcp",
-        action: "updated",
-        path: rawPath,
-      };
-    }
-
-    if (reason === "agents") {
-      const match = normalized.match(/\/\.opencode\/(?:agent|agents)\/([^/]+)/i);
-      return {
-        type: "agent",
-        name: match?.[1],
-        action: "updated",
-        path: rawPath,
-      };
-    }
-
-    if (reason === "commands") {
-      const match = normalized.match(/\/\.opencode\/(?:command|commands)\/([^/]+)/i);
-      return {
-        type: "command",
-        name: match?.[1]?.replace(/\.md$/i, ""),
-        action: "updated",
-        path: rawPath,
-      };
-    }
-
-    return {
-      type: "config",
-      name: fileName,
-      action: "updated",
-      path: rawPath,
-    };
-  };
-
-  const [reloadToastDismissedAt, setReloadToastDismissedAt] = createSignal<number | null>(null);
-
-  const reloadToastVisible = createMemo(() => {
-    if (!reloadRequired()) return false;
-    const lastTriggeredAt = reloadLastTriggeredAt();
-    const dismissedAt = reloadToastDismissedAt();
-    if (!lastTriggeredAt) return true;
-    if (!dismissedAt) return true;
-    return dismissedAt < lastTriggeredAt;
-  });
-
-  createEffect(() => {
-    if (!developerMode()) return;
-    console.log("[ReloadToast] reloadRequired:", reloadRequired());
-    console.log("[ReloadToast] lastTriggeredAt:", reloadLastTriggeredAt());
-    console.log("[ReloadToast] dismissedAt:", reloadToastDismissedAt());
-    console.log("[ReloadToast] trigger:", reloadTrigger());
-  });
-
-  const reloadWarning = createMemo(() =>
-    anyActiveRuns()
-      ? t("reload.toast_warning_active", currentLocale())
-      : t("reload.toast_warning", currentLocale()),
-  );
-
-  const reloadBlockedReason = createMemo(() => {
-    if (!reloadRequired()) return null;
-    if (!client()) return t("reload.toast_blocked_connect", currentLocale());
-    if (!canReloadWorkspace()) return t("reload.toast_blocked_host", currentLocale());
-    if (anyActiveRuns()) return t("reload.toast_blocked_runs", currentLocale());
-    return null;
-  });
-
-  const reloadActionLabel = createMemo(() =>
-    reloadBusy()
-      ? t("reload.toast_reloading", currentLocale())
-      : t("reload.toast_reload", currentLocale()),
-  );
-
-  createEffect(() => {
-    if (!reloadRequired()) {
-      setReloadToastDismissedAt(null);
-    }
-  });
 
   onMount(() => {
-    if (!isTauriRuntime()) return;
-    let unlisten: (() => void) | null = null;
-    void listen(
-      "openwork://reload-required",
-      async (event: TauriEvent<{ reason?: string; path?: string }>) => {
-        const rawReason = event.payload?.reason;
-        const reason: ReloadReason =
-          rawReason === "plugins" ||
-            rawReason === "skills" ||
-            rawReason === "config" ||
-            rawReason === "mcp" ||
-            rawReason === "agents" ||
-            rawReason === "commands"
-            ? rawReason
-            : "config";
-
-        if (reason === "config") {
-          const root = workspaceStore.activeWorkspacePath().trim();
-          if (root) {
-            try {
-              const configFile = await readOpencodeConfig("project", root);
-              const nextSnapshot = getConfigSnapshot(configFile.content);
-              if (nextSnapshot === untrack(lastKnownConfigSnapshot)) {
-                // Only model (or nothing) changed. Update UI but skip reload toast.
-                const nextModel = parseDefaultModelFromConfig(configFile.content);
-                if (nextModel && !modelEquals(untrack(defaultModel), nextModel)) {
-                  setDefaultModel(nextModel);
-                }
-                return;
-              }
-              setLastKnownConfigSnapshot(nextSnapshot);
-            } catch {
-              // If we can't read/parse, fall back to showing the toast
-            }
-          }
-        }
-
-        const trigger =
-          extractReloadTriggerFromPath(reason, event.payload?.path) ??
-          {
-            type: reason === "plugins" ? "plugin" : reason === "skills" ? "skill" : reason === "agents" ? "agent" : reason === "commands" ? "command" : reason,
-            action: "updated",
-          };
-
-        markReloadRequired(reason, { force: false, trigger });
-      },
-    )
-      .then((stop) => {
-        unlisten = stop;
-      })
-      .catch(() => undefined);
-
-    onCleanup(() => {
-      unlisten?.();
-    });
+    // OpenCode hot reload drives freshness now; OpenWork no longer listens for
+    // legacy reload-required events.
   });
-
-  markReloadRequiredRef = (reason, trigger) => markReloadRequired(reason, { force: true, trigger });
-  setReloadLastFinishedAtRef = (value) => setReloadLastFinishedAt(value);
 
   const {
     engine,
@@ -3223,7 +2806,7 @@ export default function App() {
     setNotionBusy(true);
     setNotionError(null);
     setNotionStatus("connecting");
-    setNotionStatusDetail(t("settings.reload_required", currentLocale()));
+    setNotionStatusDetail(t("mcp.connecting", currentLocale()));
     setNotionSkillInstalled(false);
 
     try {
@@ -3261,11 +2844,11 @@ export default function App() {
         }
       }
 
-      markReloadRequired("mcp", { trigger: { type: "mcp", name: "notion", action: "added" } });
-      setNotionStatusDetail(t("settings.reload_required", currentLocale()));
+      await refreshMcpServers();
+      setNotionStatusDetail(t("mcp.connecting", currentLocale()));
       try {
         window.localStorage.setItem("openwork.notionStatus", "connecting");
-        window.localStorage.setItem("openwork.notionStatusDetail", t("settings.reload_required", currentLocale()));
+        window.localStorage.setItem("openwork.notionStatusDetail", t("mcp.connecting", currentLocale()));
         window.localStorage.setItem("openwork.notionSkillInstalled", "0");
       } catch {
         // ignore
@@ -3614,11 +3197,8 @@ export default function App() {
         setMcpAuthEntry(entry);
         setMcpAuthModalOpen(true);
       } else {
-        setMcpStatus(t("mcp.reload_required_after_add", currentLocale()));
+        setMcpStatus(t("mcp.connected", currentLocale()));
       }
-
-      markReloadRequired("mcp", { trigger: { type: "mcp", name: slug, action: "added" } });
-      console.log("[connectMcp] ✓ marked reload required, refreshing servers");
 
       await refreshMcpServers();
       console.log("[connectMcp] ✓ done");
@@ -3754,12 +3334,11 @@ export default function App() {
         await removeMcpFromConfig(projectDir, name);
       }
 
-      markReloadRequired("mcp", { trigger: { type: "mcp", name, action: "removed" } });
       await refreshMcpServers();
       if (selectedMcp() === name) {
         setSelectedMcp(null);
       }
-      setMcpStatus(t("mcp.reload_required_after_add", currentLocale()));
+      setMcpStatus(null);
     } catch (e) {
       setMcpStatus(e instanceof Error ? e.message : t("mcp.remove_failed", currentLocale()));
     }
@@ -4052,11 +3631,7 @@ export default function App() {
         if (storedNotionDetail) {
           setNotionStatusDetail(storedNotionDetail);
         } else if (storedNotionStatus === "connecting") {
-          setNotionStatusDetail("Reload required");
-        }
-
-        if (storedNotionStatus === "connecting") {
-          markReloadRequired("mcp", { trigger: { type: "mcp", name: "notion", action: "added" } });
+          setNotionStatusDetail(t("mcp.connecting", currentLocale()));
         }
 
         await refreshMcpServers();
@@ -4814,7 +4389,7 @@ export default function App() {
       logoutMcpAuth,
       removeMcp,
       refreshMcpServers,
-      showMcpReloadBanner: reloadRequired() && reloadReasons().includes("mcp"),
+      showMcpReloadBanner: false,
       mcpReloadBlocked: anyActiveRuns(),
       reloadMcpEngine: () => reloadWorkspaceEngineAndResume(),
       language: currentLocale(),
@@ -5133,7 +4708,7 @@ export default function App() {
         entry={mcpAuthEntry()}
         projectDir={workspaceProjectDir()}
         language={currentLocale()}
-        reloadRequired={reloadRequired() && reloadReasons().includes("mcp")}
+        reloadRequired={false}
         reloadBlocked={anyActiveRuns()}
         isRemoteWorkspace={activeWorkspaceDisplay().workspaceType === "remote"}
         onClose={() => {
@@ -5146,23 +4721,6 @@ export default function App() {
           await refreshMcpServers();
         }}
         onReloadEngine={() => reloadWorkspaceEngineAndResume()}
-      />
-
-      <ReloadWorkspaceToast
-        open={reloadToastVisible()}
-        title={t("reload.toast_title", currentLocale())}
-        description={t("reload.toast_description", currentLocale())}
-        trigger={reloadTrigger()}
-        warning={reloadWarning()}
-        blockedReason={reloadBlockedReason()}
-        error={reloadError()}
-        reloadLabel={reloadActionLabel()}
-        dismissLabel={t("reload.toast_dismiss", currentLocale())}
-        busy={reloadBusy()}
-        canReload={canReloadEngine()}
-        hasActiveRuns={anyActiveRuns()}
-        onReload={() => reloadWorkspaceEngineAndResume()}
-        onDismiss={() => setReloadToastDismissedAt(Date.now())}
       />
 
       <CreateWorkspaceModal

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -248,9 +248,11 @@ export default function App() {
   const [rememberStartupChoice, setRememberStartupChoice] = createSignal(false);
   const [themeMode, setThemeMode] = createSignal<ThemeMode>(getInitialThemeMode());
 
-  const [engineSource, setEngineSource] = createSignal<"path" | "sidecar">(
+  const [engineSource, setEngineSource] = createSignal<"path" | "sidecar" | "custom">(
     isTauriRuntime() ? "sidecar" : "path"
   );
+
+  const [engineCustomBinPath, setEngineCustomBinPath] = createSignal("");
 
   const [engineRuntime, setEngineRuntime] = createSignal<EngineRuntime>("openwrk");
 
@@ -1585,6 +1587,7 @@ export default function App() {
     refreshSkills,
     refreshPlugins,
     engineSource,
+    engineCustomBinPath,
     setEngineSource,
     setView,
     setTab,
@@ -3528,8 +3531,22 @@ export default function App() {
         const storedEngineSource = window.localStorage.getItem(
           "openwork.engineSource"
         );
-        if (storedEngineSource === "path" || storedEngineSource === "sidecar") {
-          setEngineSource(storedEngineSource);
+        const storedEngineCustomBinPath = window.localStorage.getItem(
+          "openwork.engineCustomBinPath"
+        );
+        if (storedEngineCustomBinPath) {
+          setEngineCustomBinPath(storedEngineCustomBinPath);
+        }
+        if (
+          storedEngineSource === "path" ||
+          storedEngineSource === "sidecar" ||
+          storedEngineSource === "custom"
+        ) {
+          if (storedEngineSource === "custom" && !(storedEngineCustomBinPath ?? "").trim()) {
+            setEngineSource(isTauriRuntime() ? "sidecar" : "path");
+          } else {
+            setEngineSource(storedEngineSource);
+          }
         }
 
         const storedEngineRuntime = window.localStorage.getItem(
@@ -3881,6 +3898,20 @@ export default function App() {
     if (typeof window === "undefined") return;
     try {
       window.localStorage.setItem("openwork.engineSource", engineSource());
+    } catch {
+      // ignore
+    }
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const value = engineCustomBinPath().trim();
+      if (value) {
+        window.localStorage.setItem("openwork.engineCustomBinPath", value);
+      } else {
+        window.localStorage.removeItem("openwork.engineCustomBinPath");
+      }
     } catch {
       // ignore
     }
@@ -4349,6 +4380,8 @@ export default function App() {
       anyActiveRuns: anyActiveRuns(),
       engineSource: engineSource(),
       setEngineSource,
+      engineCustomBinPath: engineCustomBinPath(),
+      setEngineCustomBinPath,
       engineRuntime: engineRuntime(),
       setEngineRuntime,
       isWindows: isWindowsPlatform(),

--- a/packages/app/src/app/context/extensions.ts
+++ b/packages/app/src/app/context/extensions.ts
@@ -46,7 +46,7 @@ export function createExtensionsStore(options: {
   setBusyLabel: (value: string | null) => void;
   setBusyStartedAt: (value: number | null) => void;
   setError: (value: string | null) => void;
-  markReloadRequired: (reason: ReloadReason, trigger?: ReloadTrigger) => void;
+  markReloadRequired?: (reason: ReloadReason, trigger?: ReloadTrigger) => void;
   onNotionSkillInstalled?: () => void;
 }) {
   // Translation helper that uses current language from i18n
@@ -601,7 +601,7 @@ export function createExtensionsStore(options: {
           plugin: [pluginName],
         };
         await writeOpencodeConfig(scope, targetDir, `${JSON.stringify(payload, null, 2)}\n`);
-        options.markReloadRequired("plugins", { type: "plugin", name: triggerName, action: "added" });
+        options.markReloadRequired?.("plugins", { type: "plugin", name: triggerName, action: "added" });
         if (isManualInput) {
           setPluginInput("");
         }
@@ -624,7 +624,7 @@ export function createExtensionsStore(options: {
       const updated = applyEdits(raw, edits);
 
       await writeOpencodeConfig(scope, targetDir, updated);
-      options.markReloadRequired("plugins", { type: "plugin", name: triggerName, action: "added" });
+      options.markReloadRequired?.("plugins", { type: "plugin", name: triggerName, action: "added" });
       if (isManualInput) {
         setPluginInput("");
       }
@@ -671,7 +671,7 @@ export function createExtensionsStore(options: {
         setSkillsStatus(result.stderr || result.stdout || translate("skills.import_failed").replace("{status}", String(result.status)));
       } else {
         setSkillsStatus(result.stdout || translate("skills.imported"));
-        options.markReloadRequired("skills", {
+        options.markReloadRequired?.("skills", {
           type: "skill",
           name: inferredName,
           action: "added",
@@ -712,7 +712,7 @@ export function createExtensionsStore(options: {
         });
         const message = translate("skills.skill_creator_installed");
         setSkillsStatus(message);
-        options.markReloadRequired("skills", { type: "skill", name: "skill-creator", action: "added" });
+        options.markReloadRequired?.("skills", { type: "skill", name: "skill-creator", action: "added" });
         await refreshSkills({ force: true });
         return { ok: true, message };
       } catch (e) {
@@ -774,7 +774,7 @@ export function createExtensionsStore(options: {
       } else {
         const message = result.stdout || translate("skills.skill_creator_installed");
         setSkillsStatus(message);
-        options.markReloadRequired("skills", { type: "skill", name: "skill-creator", action: "added" });
+        options.markReloadRequired?.("skills", { type: "skill", name: "skill-creator", action: "added" });
         await refreshSkills({ force: true });
         return { ok: true, message };
       }
@@ -861,7 +861,7 @@ export function createExtensionsStore(options: {
         setSkillsStatus(result.stderr || result.stdout || translate("skills.uninstall_failed"));
       } else {
         setSkillsStatus(result.stdout || translate("skills.uninstalled"));
-        options.markReloadRequired("skills", { type: "skill", name: trimmed, action: "removed" });
+        options.markReloadRequired?.("skills", { type: "skill", name: trimmed, action: "removed" });
       }
 
       await refreshSkills({ force: true });
@@ -970,7 +970,7 @@ export function createExtensionsStore(options: {
           content: input.content,
           description: input.description,
         });
-        options.markReloadRequired("skills", { type: "skill", name: trimmed, action: "updated" });
+        options.markReloadRequired?.("skills", { type: "skill", name: trimmed, action: "updated" });
         await refreshSkills({ force: true });
         setSkillsStatus("Saved.");
       } catch (e) {
@@ -1006,7 +1006,7 @@ export function createExtensionsStore(options: {
         setSkillsStatus(result.stderr || result.stdout || translate("skills.unknown_error"));
       } else {
         setSkillsStatus(result.stdout || "Saved.");
-        options.markReloadRequired("skills", { type: "skill", name: trimmed, action: "updated" });
+        options.markReloadRequired?.("skills", { type: "skill", name: trimmed, action: "updated" });
       }
       await refreshSkills({ force: true });
     } catch (e) {

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -117,6 +117,7 @@ export function createSessionStore(options: {
   setError: (message: string | null) => void;
   setSseConnected: (connected: boolean) => void;
   markReloadRequired?: (reason: ReloadReason, trigger?: ReloadTrigger) => void;
+  onHotReloadApplied?: () => void;
 }) {
 
   const sessionDebugEnabled = () => options.developerMode();
@@ -721,6 +722,10 @@ export function createSessionStore(options: {
           setStore("sessionStatus", sessionID, "idle");
         }
       }
+    }
+
+    if (event.type === "opencode.hotreload.applied") {
+      options.onHotReloadApplied?.();
     }
 
     if (event.type === "session.error") {

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -127,8 +127,9 @@ export function createWorkspaceStore(options: {
   modelVariant: () => string | null;
   refreshSkills: (options?: { force?: boolean }) => Promise<void>;
   refreshPlugins: () => Promise<void>;
-  engineSource: () => "path" | "sidecar";
-  setEngineSource: (value: "path" | "sidecar") => void;
+  engineSource: () => "path" | "sidecar" | "custom";
+  engineCustomBinPath?: () => string;
+  setEngineSource: (value: "path" | "sidecar" | "custom") => void;
   setView: (value: any) => void;
   setTab: (value: any) => void;
   isWindowsPlatform: () => boolean;
@@ -598,7 +599,11 @@ export function createWorkspaceStore(options: {
     if (!isTauriRuntime()) return;
 
     try {
-      const result = await engineDoctor({ preferSidecar: options.engineSource() === "sidecar" });
+      const source = options.engineSource();
+      const result = await engineDoctor({
+        preferSidecar: source === "sidecar",
+        opencodeBinPath: source === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
+      });
       setEngineDoctorResult(result);
       setEngineDoctorCheckedAt(Date.now());
     } catch (e) {
@@ -1033,6 +1038,8 @@ export function createWorkspaceStore(options: {
           // Start engine with new workspace directory
           const newInfo = await engineStart(next.path, {
             preferSidecar: options.engineSource() === "sidecar",
+            opencodeBinPath:
+              options.engineSource() === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
             runtime,
             workspacePaths: resolveWorkspacePaths(),
           });
@@ -2033,10 +2040,14 @@ export function createWorkspaceStore(options: {
       return false;
     }
 
-    try {
-      const result = await engineDoctor({ preferSidecar: options.engineSource() === "sidecar" });
-      setEngineDoctorResult(result);
-      setEngineDoctorCheckedAt(Date.now());
+      try {
+        const source = options.engineSource();
+        const result = await engineDoctor({
+          preferSidecar: source === "sidecar",
+          opencodeBinPath: source === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
+        });
+        setEngineDoctorResult(result);
+        setEngineDoctorCheckedAt(Date.now());
 
       if (!result.found) {
         options.setError(
@@ -2074,6 +2085,8 @@ export function createWorkspaceStore(options: {
 
       const info = await engineStart(dir, {
         preferSidecar: options.engineSource() === "sidecar",
+        opencodeBinPath:
+          options.engineSource() === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
         runtime: resolveEngineRuntime(),
         workspacePaths: resolveWorkspacePaths(),
       });
@@ -2243,6 +2256,8 @@ export function createWorkspaceStore(options: {
 
       const nextInfo = await engineStart(root, {
         preferSidecar: options.engineSource() === "sidecar",
+        opencodeBinPath:
+          options.engineSource() === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
         runtime,
         workspacePaths: resolveWorkspacePaths(),
       });

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -138,11 +138,17 @@ export type WorkspaceExportSummary = {
 
 export async function engineStart(
   projectDir: string,
-  options?: { preferSidecar?: boolean; runtime?: "direct" | "openwrk"; workspacePaths?: string[] },
+  options?: {
+    preferSidecar?: boolean;
+    runtime?: "direct" | "openwrk";
+    workspacePaths?: string[];
+    opencodeBinPath?: string | null;
+  },
 ): Promise<EngineInfo> {
   return invoke<EngineInfo>("engine_start", {
     projectDir,
     preferSidecar: options?.preferSidecar ?? false,
+    opencodeBinPath: options?.opencodeBinPath ?? null,
     runtime: options?.runtime ?? null,
     workspacePaths: options?.workspacePaths ?? null,
   });
@@ -433,9 +439,11 @@ export async function engineInfo(): Promise<EngineInfo> {
 
 export async function engineDoctor(options?: {
   preferSidecar?: boolean;
+  opencodeBinPath?: string | null;
 }): Promise<EngineDoctorResult> {
   return invoke<EngineDoctorResult>("engine_doctor", {
     preferSidecar: options?.preferSidecar ?? false,
+    opencodeBinPath: options?.opencodeBinPath ?? null,
   });
 }
 

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -232,8 +232,10 @@ export type DashboardViewProps = {
   downloadUpdate: () => void;
   installUpdateAndRestart: () => void;
   anyActiveRuns: boolean;
-  engineSource: "path" | "sidecar";
-  setEngineSource: (value: "path" | "sidecar") => void;
+  engineSource: "path" | "sidecar" | "custom";
+  setEngineSource: (value: "path" | "sidecar" | "custom") => void;
+  engineCustomBinPath: string;
+  setEngineCustomBinPath: (value: string) => void;
   engineRuntime: "direct" | "openwrk";
   setEngineRuntime: (value: "direct" | "openwrk") => void;
   isWindows: boolean;
@@ -1298,6 +1300,8 @@ export default function DashboardView(props: DashboardViewProps) {
                   stopHost={props.stopHost}
                   engineSource={props.engineSource}
                   setEngineSource={props.setEngineSource}
+                  engineCustomBinPath={props.engineCustomBinPath}
+                  setEngineCustomBinPath={props.setEngineCustomBinPath}
                   engineRuntime={props.engineRuntime}
                   setEngineRuntime={props.setEngineRuntime}
                   isWindows={props.isWindows}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -24,6 +24,7 @@ import {
   appBuildInfo,
   owpenbotRestart,
   owpenbotStop,
+  pickFile,
 } from "../lib/tauri";
 
 export type SettingsViewProps = {
@@ -55,8 +56,10 @@ export type SettingsViewProps = {
   developerMode: boolean;
   toggleDeveloperMode: () => void;
   stopHost: () => void;
-  engineSource: "path" | "sidecar";
-  setEngineSource: (value: "path" | "sidecar") => void;
+  engineSource: "path" | "sidecar" | "custom";
+  setEngineSource: (value: "path" | "sidecar" | "custom") => void;
+  engineCustomBinPath: string;
+  setEngineCustomBinPath: (value: string) => void;
   engineRuntime: "direct" | "openwrk";
   setEngineRuntime: (value: "direct" | "openwrk") => void;
   isWindows: boolean;
@@ -137,6 +140,21 @@ export function OwpenbotSettings(_props: {
 
 
 export default function SettingsView(props: SettingsViewProps) {
+  const engineCustomBinPathLabel = () => props.engineCustomBinPath.trim() || "No binary selected.";
+
+  const handlePickEngineBinary = async () => {
+    if (!isTauriRuntime()) return;
+    try {
+      const selected = await pickFile({ title: "Select OpenCode binary" });
+      const path = Array.isArray(selected) ? selected[0] : selected;
+      const trimmed = (path ?? "").trim();
+      if (!trimmed) return;
+      props.setEngineCustomBinPath(trimmed);
+      props.setEngineSource("custom");
+    } catch {
+      // ignore
+    }
+  };
   const [buildInfo, setBuildInfo] = createSignal<AppBuildInfo | null>(null);
   const updateState = () => props.updateStatus?.state ?? "idle";
   const updateNotes = () => props.updateStatus?.notes ?? null;
@@ -1004,7 +1022,7 @@ export default function SettingsView(props: SettingsViewProps) {
 
                 <div class="space-y-3">
                   <div class="text-xs text-gray-10">Engine source</div>
-                  <div class="grid grid-cols-2 gap-2">
+                  <div class={props.developerMode ? "grid grid-cols-3 gap-2" : "grid grid-cols-2 gap-2"}>
                     <Button
                       variant={props.engineSource === "sidecar" ? "secondary" : "outline"}
                       onClick={() => props.setEngineSource("sidecar")}
@@ -1019,11 +1037,54 @@ export default function SettingsView(props: SettingsViewProps) {
                     >
                       System install (PATH)
                     </Button>
+                    <Show when={props.developerMode}>
+                      <Button
+                        variant={props.engineSource === "custom" ? "secondary" : "outline"}
+                        onClick={() => props.setEngineSource("custom")}
+                        disabled={props.busy}
+                      >
+                        Custom binary
+                      </Button>
+                    </Show>
                   </div>
                   <div class="text-[11px] text-gray-7">
                     Bundled engine is the most reliable option. Use System install only if you manage OpenCode yourself.
                   </div>
                 </div>
+
+                <Show when={props.developerMode && props.engineSource === "custom"}>
+                  <div class="space-y-2">
+                    <div class="text-xs text-gray-10">Custom OpenCode binary</div>
+                    <div class="flex items-center gap-2">
+                      <div
+                        class="flex-1 min-w-0 text-[11px] text-gray-7 font-mono truncate bg-gray-1 p-3 rounded-xl border border-gray-6"
+                        title={engineCustomBinPathLabel()}
+                      >
+                        {engineCustomBinPathLabel()}
+                      </div>
+                      <Button
+                        variant="outline"
+                        class="text-xs h-10 px-3 shrink-0"
+                        onClick={handlePickEngineBinary}
+                        disabled={props.busy}
+                      >
+                        Choose
+                      </Button>
+                      <Button
+                        variant="outline"
+                        class="text-xs h-10 px-3 shrink-0"
+                        onClick={() => props.setEngineCustomBinPath("")}
+                        disabled={props.busy || !props.engineCustomBinPath.trim()}
+                        title={!props.engineCustomBinPath.trim() ? "No custom path set" : "Clear"}
+                      >
+                        Clear
+                      </Button>
+                    </div>
+                    <div class="text-[11px] text-gray-7">
+                      Use this to point OpenWork at a local OpenCode build (e.g. your fork). Applies next time the engine starts or reloads.
+                    </div>
+                  </div>
+                </Show>
 
                 <Show when={props.developerMode}>
                   <div class="space-y-3">

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -2,6 +2,7 @@
   "name": "@different-ai/openwork",
   "private": true,
   "version": "0.11.62",
+  "opencodeVersion": "1.1.60",
   "owpenbotVersion": "0.11.62",
   "type": "module",
   "scripts": {

--- a/packages/desktop/src-tauri/src/commands/engine.rs
+++ b/packages/desktop/src-tauri/src/commands/engine.rs
@@ -18,6 +18,35 @@ use serde_json::json;
 use tauri_plugin_shell::process::CommandEvent;
 use uuid::Uuid;
 
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn apply(key: &'static str, value: Option<&str>) -> Self {
+        let original = std::env::var_os(key);
+        match value {
+            Some(next) if !next.trim().is_empty() => {
+                std::env::set_var(key, next.trim());
+            }
+            _ => {
+                std::env::remove_var(key);
+            }
+        }
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 #[derive(Default)]
 struct OutputState {
     stdout: String,
@@ -110,13 +139,19 @@ pub fn engine_stop(
 }
 
 #[tauri::command]
-pub fn engine_doctor(app: AppHandle, prefer_sidecar: Option<bool>) -> EngineDoctorResult {
+pub fn engine_doctor(
+    app: AppHandle,
+    prefer_sidecar: Option<bool>,
+    opencode_bin_path: Option<String>,
+) -> EngineDoctorResult {
     let prefer_sidecar = prefer_sidecar.unwrap_or(false);
     let resource_dir = app.path().resource_dir().ok();
 
     let current_bin_dir = tauri::process::current_binary(&app.env())
         .ok()
         .and_then(|path| path.parent().map(|parent| parent.to_path_buf()));
+
+    let _guard = EnvVarGuard::apply("OPENCODE_BIN_PATH", opencode_bin_path.as_deref());
 
     let (resolved, in_path, notes) = resolve_engine_path(
         prefer_sidecar,
@@ -197,6 +232,7 @@ pub fn engine_start(
     owpenbot_manager: State<OwpenbotManager>,
     project_dir: String,
     prefer_sidecar: Option<bool>,
+    opencode_bin_path: Option<String>,
     runtime: Option<EngineRuntime>,
     workspace_paths: Option<Vec<String>>,
 ) -> Result<EngineInfo, String> {
@@ -262,6 +298,7 @@ pub fn engine_start(
         .ok()
         .and_then(|path| path.parent().map(|parent| parent.to_path_buf()));
     let prefer_sidecar = prefer_sidecar.unwrap_or(false);
+    let _guard = EnvVarGuard::apply("OPENCODE_BIN_PATH", opencode_bin_path.as_deref());
     let (program, _in_path, notes) =
         resolve_engine_path(prefer_sidecar, resource_dir.as_deref(), current_bin_dir.as_deref());
     let Some(program) = program else {

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -38,6 +38,22 @@ locally installed `openwork-server` or `owpenbot` binaries.
 
 Add `--verbose` (or `OPENWRK_VERBOSE=1`) to print extra diagnostics about resolved binaries.
 
+OpenCode hot reload is enabled by default when launched via `openwrk`.
+Tune it with:
+
+- `--opencode-hot-reload` / `--no-opencode-hot-reload`
+- `--opencode-hot-reload-debounce-ms <ms>`
+- `--opencode-hot-reload-cooldown-ms <ms>`
+
+Equivalent env vars:
+
+- `OPENWRK_OPENCODE_HOT_RELOAD` (router mode)
+- `OPENWRK_OPENCODE_HOT_RELOAD_DEBOUNCE_MS`
+- `OPENWRK_OPENCODE_HOT_RELOAD_COOLDOWN_MS`
+- `OPENWORK_OPENCODE_HOT_RELOAD` (start/serve mode)
+- `OPENWORK_OPENCODE_HOT_RELOAD_DEBOUNCE_MS`
+- `OPENWORK_OPENCODE_HOT_RELOAD_COOLDOWN_MS`
+
 Or from source:
 
 ```bash

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,7 @@
 {
   "name": "openwrk",
   "version": "0.11.62",
+  "opencodeVersion": "1.1.60",
   "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
   "private": true,
   "type": "module",

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -53,6 +53,12 @@ type LogEvent = {
   attributes?: LogAttributes;
 };
 
+type OpencodeHotReload = {
+  enabled: boolean;
+  debounceMs: number;
+  cooldownMs: number;
+};
+
 type OwpenbotHealthSnapshot = {
   ok: boolean;
   opencode: {
@@ -76,6 +82,8 @@ declare const __OPENWRK_VERSION__: string | undefined;
 const DEFAULT_OPENWORK_PORT = 8787;
 const DEFAULT_APPROVAL_TIMEOUT = 30000;
 const DEFAULT_OPENCODE_USERNAME = "opencode";
+const DEFAULT_OPENCODE_HOT_RELOAD_DEBOUNCE_MS = 700;
+const DEFAULT_OPENCODE_HOT_RELOAD_COOLDOWN_MS = 1500;
 
 const SANDBOX_INTERNAL_OPENCODE_PORT = 4096;
 const SANDBOX_INTERNAL_OPENWORK_PORT = DEFAULT_OPENWORK_PORT;
@@ -346,6 +354,43 @@ function readNumber(
     }
   }
   return fallback;
+}
+
+function readOpencodeHotReload(
+  flags: Map<string, string | boolean>,
+  defaults?: Partial<OpencodeHotReload>,
+  env?: {
+    enabled?: string;
+    debounceMs?: string;
+    cooldownMs?: string;
+  },
+): OpencodeHotReload {
+  const enabled = readBool(flags, "opencode-hot-reload", defaults?.enabled ?? true, env?.enabled);
+  const debounceRaw = readNumber(
+    flags,
+    "opencode-hot-reload-debounce-ms",
+    defaults?.debounceMs ?? DEFAULT_OPENCODE_HOT_RELOAD_DEBOUNCE_MS,
+    env?.debounceMs,
+  );
+  const cooldownRaw = readNumber(
+    flags,
+    "opencode-hot-reload-cooldown-ms",
+    defaults?.cooldownMs ?? DEFAULT_OPENCODE_HOT_RELOAD_COOLDOWN_MS,
+    env?.cooldownMs,
+  );
+  const debounceMs =
+    typeof debounceRaw === "number" && Number.isFinite(debounceRaw) && debounceRaw >= 50
+      ? Math.floor(debounceRaw)
+      : DEFAULT_OPENCODE_HOT_RELOAD_DEBOUNCE_MS;
+  const cooldownMs =
+    typeof cooldownRaw === "number" && Number.isFinite(cooldownRaw) && cooldownRaw >= 100
+      ? Math.floor(cooldownRaw)
+      : DEFAULT_OPENCODE_HOT_RELOAD_COOLDOWN_MS;
+  return {
+    enabled,
+    debounceMs,
+    cooldownMs,
+  };
 }
 
 function readBinarySource(
@@ -2084,6 +2129,9 @@ function printHelp(): void {
     "  --opencode-workdir <p>    Workdir for router-managed opencode serve",
     "  --opencode-auth           Enable OpenCode basic auth (default: true)",
     "  --no-opencode-auth        Disable OpenCode basic auth",
+    "  --opencode-hot-reload     Enable OpenCode hot reload (default: true)",
+    "  --opencode-hot-reload-debounce-ms <ms>  Debounce window for hot reload triggers (default: 700)",
+    "  --opencode-hot-reload-cooldown-ms <ms>  Minimum interval between hot reloads (default: 1500)",
     "  --opencode-username <u>   OpenCode basic auth username",
     "  --opencode-password <p>   OpenCode basic auth password",
     "  --openwork-host <host>    Bind host for openwork-server (default: 0.0.0.0)",
@@ -2154,6 +2202,7 @@ async function startOpencode(options: {
   bin: string;
   workspace: string;
   configDir?: string;
+  hotReload: OpencodeHotReload;
   bindHost: string;
   port: number;
   username?: string;
@@ -2188,6 +2237,9 @@ async function startOpencode(options: {
       ...(options.username ? { OPENCODE_SERVER_USERNAME: options.username } : {}),
       ...(options.password ? { OPENCODE_SERVER_PASSWORD: options.password } : {}),
       ...(options.configDir ? { OPENCODE_CONFIG_DIR: options.configDir } : {}),
+      OPENCODE_HOT_RELOAD: options.hotReload.enabled ? "1" : "0",
+      OPENCODE_HOT_RELOAD_DEBOUNCE_MS: String(options.hotReload.debounceMs),
+      OPENCODE_HOT_RELOAD_COOLDOWN_MS: String(options.hotReload.cooldownMs),
       ...(options.owpenbotHealthPort ? { OWPENBOT_HEALTH_PORT: String(options.owpenbotHealthPort) } : {}),
     },
   });
@@ -2497,6 +2549,7 @@ async function writeSandboxEntrypoint(options: {
     corsOrigins: string[];
     username?: string;
     password?: string;
+    hotReload: OpencodeHotReload;
   };
   openwork: {
     token: string;
@@ -2556,6 +2609,9 @@ async function writeSandboxEntrypoint(options: {
     `export OPENCODE_CONFIG_DIR=${shQuote(opencodeConfigDir)}`,
     `export OPENCODE_URL=${shQuote(`http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`)}`,
     `export OPENCODE_CLIENT=openwrk`,
+    `export OPENCODE_HOT_RELOAD=${shQuote(options.opencode.hotReload.enabled ? "1" : "0")}`,
+    `export OPENCODE_HOT_RELOAD_DEBOUNCE_MS=${shQuote(String(options.opencode.hotReload.debounceMs))}`,
+    `export OPENCODE_HOT_RELOAD_COOLDOWN_MS=${shQuote(String(options.opencode.hotReload.cooldownMs))}`,
     `export OPENWORK=1`,
     `export OPENWRK_RUN_ID=${shQuote(options.runId)}`,
     `export OPENWRK_LOG_FORMAT=${shQuote(options.logFormat)}`,
@@ -2605,6 +2661,7 @@ async function startDockerSandbox(options: {
     corsOrigins: string[];
     username?: string;
     password?: string;
+    hotReload: OpencodeHotReload;
   };
   openwork: {
     token: string;
@@ -2698,6 +2755,7 @@ async function startAppleContainerSandbox(options: {
     corsOrigins: string[];
     username?: string;
     password?: string;
+    hotReload: OpencodeHotReload;
   };
   openwork: {
     token: string;
@@ -3344,6 +3402,18 @@ async function spawnRouterDaemon(args: ParsedArgs, dataDir: string, host: string
   const opencodeHost = readFlag(args.flags, "opencode-host") ?? process.env.OPENWRK_OPENCODE_HOST;
   const opencodePort = readFlag(args.flags, "opencode-port") ?? process.env.OPENWRK_OPENCODE_PORT;
   const opencodeWorkdir = readFlag(args.flags, "opencode-workdir") ?? process.env.OPENWRK_OPENCODE_WORKDIR;
+  const opencodeHotReload =
+    readFlag(args.flags, "opencode-hot-reload") ??
+    process.env.OPENWRK_OPENCODE_HOT_RELOAD ??
+    process.env.OPENWORK_OPENCODE_HOT_RELOAD;
+  const opencodeHotReloadDebounceMs =
+    readFlag(args.flags, "opencode-hot-reload-debounce-ms") ??
+    process.env.OPENWRK_OPENCODE_HOT_RELOAD_DEBOUNCE_MS ??
+    process.env.OPENWORK_OPENCODE_HOT_RELOAD_DEBOUNCE_MS;
+  const opencodeHotReloadCooldownMs =
+    readFlag(args.flags, "opencode-hot-reload-cooldown-ms") ??
+    process.env.OPENWRK_OPENCODE_HOT_RELOAD_COOLDOWN_MS ??
+    process.env.OPENWORK_OPENCODE_HOT_RELOAD_COOLDOWN_MS;
   const opencodeUsername = readFlag(args.flags, "opencode-username") ?? process.env.OPENWORK_OPENCODE_USERNAME;
   const opencodePassword = readFlag(args.flags, "opencode-password") ?? process.env.OPENWORK_OPENCODE_PASSWORD;
   const corsValue = readFlag(args.flags, "cors") ?? process.env.OPENWRK_OPENCODE_CORS;
@@ -3358,6 +3428,9 @@ async function spawnRouterDaemon(args: ParsedArgs, dataDir: string, host: string
   if (opencodeHost) commandArgs.push("--opencode-host", opencodeHost);
   if (opencodePort) commandArgs.push("--opencode-port", String(opencodePort));
   if (opencodeWorkdir) commandArgs.push("--opencode-workdir", opencodeWorkdir);
+  if (opencodeHotReload) commandArgs.push("--opencode-hot-reload", opencodeHotReload);
+  if (opencodeHotReloadDebounceMs) commandArgs.push("--opencode-hot-reload-debounce-ms", String(opencodeHotReloadDebounceMs));
+  if (opencodeHotReloadCooldownMs) commandArgs.push("--opencode-hot-reload-cooldown-ms", String(opencodeHotReloadCooldownMs));
   if (opencodeUsername) commandArgs.push("--opencode-username", opencodeUsername);
   if (opencodePassword) commandArgs.push("--opencode-password", opencodePassword);
   if (corsValue) commandArgs.push("--cors", corsValue);
@@ -3584,6 +3657,19 @@ async function runRouterDaemon(args: ParsedArgs) {
     "127.0.0.1",
     state.opencode?.port,
   );
+  const opencodeHotReload = readOpencodeHotReload(
+    args.flags,
+    {
+      enabled: true,
+      debounceMs: DEFAULT_OPENCODE_HOT_RELOAD_DEBOUNCE_MS,
+      cooldownMs: DEFAULT_OPENCODE_HOT_RELOAD_COOLDOWN_MS,
+    },
+    {
+      enabled: "OPENWRK_OPENCODE_HOT_RELOAD",
+      debounceMs: "OPENWRK_OPENCODE_HOT_RELOAD_DEBOUNCE_MS",
+      cooldownMs: "OPENWRK_OPENCODE_HOT_RELOAD_COOLDOWN_MS",
+    },
+  );
   const corsValue = readFlag(args.flags, "cors") ?? process.env.OPENWRK_OPENCODE_CORS ?? "http://localhost:5173,tauri://localhost,http://tauri.localhost";
   const corsOrigins = parseList(corsValue);
   const opencodeWorkdirFlag = readFlag(args.flags, "opencode-workdir") ?? process.env.OPENWRK_OPENCODE_WORKDIR;
@@ -3608,6 +3694,9 @@ async function runRouterDaemon(args: ParsedArgs) {
   logVerbose(`sidecar manifest: ${sidecar.manifestUrl}`);
   logVerbose(`sidecar source: ${sidecarSource}`);
   logVerbose(`opencode source: ${opencodeSource}`);
+  logVerbose(
+    `opencode hot reload: ${opencodeHotReload.enabled ? "on" : "off"} (debounce=${opencodeHotReload.debounceMs}ms cooldown=${opencodeHotReload.cooldownMs}ms)`,
+  );
   logVerbose(`allow external: ${allowExternal ? "true" : "false"}`);
   const opencodeBinary = await resolveOpencodeBin({
     explicit: opencodeBin,
@@ -3671,6 +3760,7 @@ async function runRouterDaemon(args: ParsedArgs) {
       bin: opencodeBinary.bin,
       workspace: resolvedWorkdir,
       configDir: opencodeConfigDir,
+      hotReload: opencodeHotReload,
       bindHost: opencodeHost,
       port: opencodePort,
       username: opencodePassword ? opencodeUsername : undefined,
@@ -4170,6 +4260,19 @@ async function runStart(args: ParsedArgs) {
           readNumber(args.flags, "opencode-port", undefined, "OPENWORK_OPENCODE_PORT"),
           "127.0.0.1",
         );
+  const opencodeHotReload = readOpencodeHotReload(
+    args.flags,
+    {
+      enabled: true,
+      debounceMs: DEFAULT_OPENCODE_HOT_RELOAD_DEBOUNCE_MS,
+      cooldownMs: DEFAULT_OPENCODE_HOT_RELOAD_COOLDOWN_MS,
+    },
+    {
+      enabled: "OPENWORK_OPENCODE_HOT_RELOAD",
+      debounceMs: "OPENWORK_OPENCODE_HOT_RELOAD_DEBOUNCE_MS",
+      cooldownMs: "OPENWORK_OPENCODE_HOT_RELOAD_COOLDOWN_MS",
+    },
+  );
   const opencodeAuth = readBool(args.flags, "opencode-auth", true, "OPENWORK_OPENCODE_AUTH");
   const opencodeUsername = opencodeAuth
     ? readFlag(args.flags, "opencode-username") ?? process.env.OPENWORK_OPENCODE_USERNAME ?? DEFAULT_OPENCODE_USERNAME
@@ -4245,6 +4348,9 @@ async function runStart(args: ParsedArgs) {
   logVerbose(`sidecar manifest: ${sidecar.manifestUrl}`);
   logVerbose(`sidecar source: ${sidecarSource}`);
   logVerbose(`opencode source: ${opencodeSource}`);
+  logVerbose(
+    `opencode hot reload: ${opencodeHotReload.enabled ? "on" : "off"} (debounce=${opencodeHotReload.debounceMs}ms cooldown=${opencodeHotReload.cooldownMs}ms)`,
+  );
   logVerbose(`allow external: ${allowExternal ? "true" : "false"}`);
   const opencodeBinary = await resolveOpencodeBin({
     explicit: explicitOpencodeBin,
@@ -4559,6 +4665,7 @@ async function runStart(args: ParsedArgs) {
           corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
           username: opencodeUsername,
           password: opencodePassword,
+          hotReload: opencodeHotReload,
         },
         openwork: {
           token: openworkToken,
@@ -4639,6 +4746,7 @@ async function runStart(args: ParsedArgs) {
         bin: opencodeBinary.bin,
         workspace: resolvedWorkspace,
         configDir: opencodeConfigDir,
+        hotReload: opencodeHotReload,
         bindHost: opencodeBindHost,
         port: opencodePort,
         username: opencodeUsername,
@@ -4852,6 +4960,7 @@ async function runStart(args: ParsedArgs) {
         password: sandboxMode !== "none" ? undefined : opencodePassword,
         bindHost: opencodeBindHost,
         port: opencodePort,
+        hotReload: opencodeHotReload,
         version: opencodeActualVersion,
       },
       openwork: {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -14,7 +14,6 @@ import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
 import { ReloadEventStore } from "./events.js";
 import { parseFrontmatter } from "./frontmatter.js";
-import { startReloadWatchers } from "./reload-watcher.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { workspaceIdForPath } from "./workspaces.js";
@@ -232,15 +231,6 @@ export function startServer(config: ServerConfig) {
   const routes = createRoutes(config, approvals, tokens);
   const logger = createServerLogger(config);
 
-  let reloadWatcher: { close: () => void } | null = null;
-  try {
-    reloadWatcher = startReloadWatchers({ config, reloadEvents, logger });
-  } catch (error) {
-    logger.log("warn", "Reload watcher failed to initialize", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
   const serverOptions: {
     hostname: string;
     port: number;
@@ -428,10 +418,6 @@ export function startServer(config: ServerConfig) {
   (serverOptions as { idleTimeout?: number }).idleTimeout = 120;
 
   const server = Bun.serve(serverOptions);
-
-  if (reloadWatcher) {
-    (server as any).reloadWatcher = reloadWatcher;
-  }
 
   return server;
 }
@@ -1006,7 +992,10 @@ function emitReloadEvent(
   reason: ReloadReason,
   trigger?: ReloadTrigger,
 ) {
-  reloadEvents.recordDebounced(workspace.id, reason, trigger);
+  void reloadEvents;
+  void workspace;
+  void reason;
+  void trigger;
 }
 
 function buildConfigTrigger(path: string): ReloadTrigger {
@@ -2138,33 +2127,16 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
 
   addRoute(routes, "GET", "/workspace/:id/events", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    const sinceParam = ctx.url.searchParams.get("since");
-    const parsedSince = sinceParam ? Number(sinceParam) : NaN;
-    const since = Number.isFinite(parsedSince) ? parsedSince : undefined;
-    const items = ctx.reloadEvents.list(workspace.id, since);
-    return jsonResponse({ items, cursor: ctx.reloadEvents.cursor() });
+    void ctx;
+    return jsonResponse({ items: [], cursor: 0, workspaceId: workspace.id, disabled: true });
   });
 
   addRoute(routes, "POST", "/workspace/:id/engine/reload", "client", async (ctx) => {
-    requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    await requireApproval(ctx, {
+    throw new ApiError(410, "engine_reload_deprecated", "OpenWork-managed engine reload is disabled", {
       workspaceId: workspace.id,
-      action: "engine.reload",
-      summary: "Reload OpenCode engine",
-      paths: [opencodeConfigPath(workspace.path)],
+      guidance: "Use OpenCode hot reload instead",
     });
-    await reloadOpencodeEngine(workspace);
-    await recordAudit(workspace.path, {
-      id: shortId(),
-      workspaceId: workspace.id,
-      actor: ctx.actor ?? { type: "remote" },
-      action: "engine.reload",
-      target: "opencode.instance",
-      summary: "Reloaded OpenCode engine",
-      timestamp: Date.now(),
-    });
-    return jsonResponse({ ok: true, reloadedAt: Date.now() });
   });
 
   addRoute(routes, "POST", "/workspace/:id/inbox", "client", async (ctx) => {

--- a/packaging/docker/docker-compose.dev.yml
+++ b/packaging/docker/docker-compose.dev.yml
@@ -59,12 +59,26 @@ services:
         export OWPENBOT_BIN="/tmp/openwork-bins/owpenbot"
         mkdir -p /tmp/openwork-bins
 
+        # --- Compile sidecars for the container architecture ---
+        case "$(uname -m)" in
+          x86_64|amd64)
+            BUN_TARGET="bun-linux-x64"
+            ;;
+          aarch64|arm64)
+            BUN_TARGET="bun-linux-arm64"
+            ;;
+          *)
+            echo "Unsupported container architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+
         echo "[headless] Building openwork-server binary (linux)..."
-        cd /app/packages/server && bun build --compile src/cli.ts --outfile "$$OPENWORK_SERVER_BIN"
+        cd /app/packages/server && bun build --compile --target "$$BUN_TARGET" src/cli.ts --outfile "$$OPENWORK_SERVER_BIN"
 
         echo "[headless] Building owpenbot binary (linux)..."
         OWPENBOT_VERSION=$$(node -p "require('/app/packages/owpenbot/package.json').version")
-        cd /app/packages/owpenbot && bun build --compile src/cli.ts \
+        cd /app/packages/owpenbot && bun build --compile --target "$$BUN_TARGET" src/cli.ts \
           --define "__OWPENBOT_VERSION__=\"$${OWPENBOT_VERSION}\"" --outfile "$$OWPENBOT_BIN"
 
         cd /app


### PR DESCRIPTION
## What
- Remove the legacy 'reload required' flow in the desktop UI and stop calling the OpenWork-managed engine reload endpoints.
- Deprecate the old server reload endpoints/events (410) so we have a single hot-reload mechanism.
- Wire OpenCode hot reload env/flags through `openwrk`.
- Pin OpenCode sidecar version for dev runs (avoid implicit 'latest').
- Add a developer-mode engine option to select a custom OpenCode binary (easy switching between bundled vs local fork builds).
- Fix Docker dev sidecar compilation to target the container arch.

## Why
- Skills/plugins/MCP/config changes should be immediately usable without forcing a full engine reload or breaking sessions.
- Dev needs a first-class way to switch between upstream (bundled) OpenCode and a fork build without PATH/env hacks.

## How to test
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwrk typecheck`
- `cargo check` in `packages/desktop/src-tauri`

## Notes
- The new engine source option `Custom binary` is developer-mode only and is applied on the next engine start/restart.
- Investigation ongoing: task/step UI sometimes appears to hang during file creation runs; I started an A/B baseline (origin/dev) desktop instance to compare behavior, but this PR does not attempt to fix that issue.