### PR TITLE
Rename sidebar Config tab to Advanced

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4210,12 +4210,12 @@ export default function App() {
     const canUseGlobalPluginScope = !isRemoteWorkspace && isTauriRuntime();
     const skillsAccessHint = isRemoteWorkspace
       ? openworkStatus === "disconnected"
-        ? "OpenWork server unavailable. Add the server URL/token in Config to manage skills."
+        ? "OpenWork server unavailable. Add the server URL/token in Advanced to manage skills."
         : openworkStatus === "limited"
-          ? "OpenWork server needs a host token to install/update skills. Add it in Config and reconnect."
+          ? "OpenWork server needs a host token to install/update skills. Add it in Advanced and reconnect."
           : openworkServerCanWriteSkills()
             ? null
-            : "OpenWork server is read-only for skills. Add a host token in Config to enable installs."
+            : "OpenWork server is read-only for skills. Add a host token in Advanced to enable installs."
       : null;
     const pluginsAccessHint = isRemoteWorkspace
       ? openworkStatus === "disconnected"

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -274,7 +274,7 @@ export default function DashboardView(props: DashboardViewProps) {
       case "identities":
         return "Identities";
       case "config":
-        return "Config";
+        return "Advanced";
       case "settings":
         return "Settings";
       default:
@@ -642,7 +642,7 @@ export default function DashboardView(props: DashboardViewProps) {
           label: "Access token",
           value: token,
           secret: true,
-          placeholder: token ? undefined : "Set token in Config",
+          placeholder: token ? undefined : "Set token in Advanced",
           hint: "This token grants access to the worker on that host.",
         },
       ];
@@ -1481,7 +1481,7 @@ export default function DashboardView(props: DashboardViewProps) {
               onClick={() => props.setTab("config")}
             >
               <SlidersHorizontal size={18} />
-              Config
+              Advanced
             </button>
           </div>
         </nav>
@@ -1494,7 +1494,7 @@ export default function DashboardView(props: DashboardViewProps) {
           {navItem("plugins", "Plugins", <Cpu size={18} />)}
           {navItem("mcp", "Apps", <Box size={18} />)}
           {navItem("identities", "Identities", <MessageCircle size={18} />)}
-          {navItem("config", "Config", <SlidersHorizontal size={18} />)}
+          {navItem("config", "Advanced", <SlidersHorizontal size={18} />)}
         </div>
       </aside>
     </div>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1431,7 +1431,7 @@ export default function SessionView(props: SessionViewProps) {
           label: "Access token",
           value: token,
           secret: true,
-          placeholder: token ? undefined : "Set token in Config",
+          placeholder: token ? undefined : "Set token in Advanced",
           hint: "This token grants access to the worker on that host.",
         },
       ];
@@ -2526,7 +2526,7 @@ export default function SessionView(props: SessionViewProps) {
             onClick={openConfig}
           >
             <SlidersHorizontal size={18} />
-            Config
+            Advanced
           </button>
           </div>
         </div>


### PR DESCRIPTION
## What changed
- Renamed the sidebar navigation label from \"Config\" to \"Advanced\" (keeps the internal route key as `config`).
- Updated in-app copy that previously directed users to \"Config\" so it now points to \"Advanced\".

## Why
- Makes the sidebar wording match the fact this area contains advanced configuration rather than general settings.

## Test
- `pnpm typecheck`