### PR TITLE
OpenCode Router: update openwrk TUI + add opencode-router alias

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -2,7 +2,7 @@
   "name": "openwrk",
   "version": "0.11.67",
   "opencodeVersion": "1.1.60",
-  "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + Owpenbot",
+  "description": "Headless OpenWork host orchestrator for OpenCode + OpenWork server + OpenCode Router (owpenbot)",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -12,7 +12,7 @@ import { createRequire } from "node:module";
 import { once } from "node:events";
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
-import { startOpenwrkTui, type TuiHandle } from "./tui/app.js";
+import type { TuiHandle } from "./tui/app.js";
 
 type ApprovalMode = "manual" | "auto";
 
@@ -4177,10 +4177,11 @@ async function runStart(args: ParsedArgs) {
     onLog: (event: LogEvent) => {
       if (!tui) return;
       const component = event.component ?? "openwrk";
+      const tuiComponent = component === "owpenbot" ? "router" : component;
       tui.pushLog({
         time: event.time,
         level: event.level,
-        component,
+        component: tuiComponent,
         message: event.message,
       });
     },
@@ -4544,6 +4545,7 @@ async function runStart(args: ParsedArgs) {
       };
     }
     try {
+      const { startOpenwrkTui } = await import("./tui/app.js");
       tui = startOpenwrkTui({
         version: cliVersion,
         connect: {
@@ -4561,8 +4563,8 @@ async function runStart(args: ParsedArgs) {
           { name: "opencode", label: "opencode", status: "starting", port: opencodePort },
           { name: "openwork-server", label: "openwork-server", status: "starting", port: openworkPort },
           {
-            name: "owpenbot",
-            label: "owpenbot",
+            name: "router",
+            label: "opencode-router",
             status: owpenbotEnabled ? "starting" : "disabled",
             port: sandboxMode !== "none" ? undefined : owpenbotHealthPort,
           },
@@ -4574,30 +4576,69 @@ async function runStart(args: ParsedArgs) {
           return { command: attachCommand, ...result };
         },
         onCopySelection: async (text) => copyToClipboard(text),
-        onOwpenbotHealth: async () => fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken),
-        onOwpenbotQr: async () => {
-          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/whatsapp/qr?format=ascii`;
+        onRouterHealth: async () => fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken),
+        onRouterTelegramIdentities: async () => {
+          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/identities/telegram`;
           const result = await fetchJson(url, {
             headers: {
               "X-OpenWork-Host-Token": openworkHostToken,
             },
           });
-          const qr = typeof result?.qr === "string" ? result.qr : "";
-          if (!qr.trim()) {
-            throw new Error("No QR output received");
-          }
-          return qr;
+          const items = Array.isArray(result?.items) ? result.items : [];
+          return { items };
         },
-        onOwpenbotSetTelegramToken: async (token) => {
+        onRouterSlackIdentities: async () => {
+          const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/identities/slack`;
+          const result = await fetchJson(url, {
+            headers: {
+              "X-OpenWork-Host-Token": openworkHostToken,
+            },
+          });
+          const items = Array.isArray(result?.items) ? result.items : [];
+          return { items };
+        },
+        onRouterSetGroupsEnabled: async (enabled) => {
           try {
-            const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/config/telegram-token`;
+            const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/config/groups`;
             await fetchJson(url, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
                 "X-OpenWork-Host-Token": openworkHostToken,
               },
-              body: JSON.stringify({ token }),
+              body: JSON.stringify({ enabled }),
+            });
+            return { ok: true };
+          } catch (error) {
+            return { ok: false, error: error instanceof Error ? error.message : String(error) };
+          }
+        },
+        onRouterSetTelegramToken: async (token) => {
+          try {
+            const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/identities/telegram`;
+            await fetchJson(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-OpenWork-Host-Token": openworkHostToken,
+              },
+              body: JSON.stringify({ id: "default", token, enabled: true }),
+            });
+            return { ok: true };
+          } catch (error) {
+            return { ok: false, error: error instanceof Error ? error.message : String(error) };
+          }
+        },
+        onRouterSetSlackTokens: async (botToken, appToken) => {
+          try {
+            const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/identities/slack`;
+            await fetchJson(url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-OpenWork-Host-Token": openworkHostToken,
+              },
+              body: JSON.stringify({ id: "default", botToken, appToken, enabled: true }),
             });
             return { ok: true };
           } catch (error) {
@@ -4611,10 +4652,15 @@ async function runStart(args: ParsedArgs) {
     }
   }
 
+  const tuiServiceName = (name: string) => (name === "owpenbot" ? "router" : name);
+
   const handleExit = (name: string, code: number | null, signal: NodeJS.Signals | null) => {
     if (shuttingDown || detached) return;
     const reason = code !== null ? `code ${code}` : signal ? `signal ${signal}` : "unknown";
-    const services = name === "sandbox" ? ["opencode", "openwork-server", "owpenbot"] : [name];
+    const services =
+      name === "sandbox"
+        ? ["opencode", "openwork-server", "router"]
+        : [tuiServiceName(name)];
     for (const service of services) {
       tui?.updateService(service, { status: "stopped", message: reason });
     }
@@ -4624,7 +4670,7 @@ async function runStart(args: ParsedArgs) {
 
   const handleSpawnError = (name: string, error: unknown) => {
     if (shuttingDown || detached) return;
-    tui?.updateService(name, { status: "error", message: String(error) });
+    tui?.updateService(tuiServiceName(name), { status: "error", message: String(error) });
     logger.error("Process failed to start", { error: String(error) }, name);
     void shutdown().then(() => process.exit(1));
   };
@@ -4688,7 +4734,7 @@ async function runStart(args: ParsedArgs) {
       tui?.updateService("opencode", { status: "running", port: SANDBOX_INTERNAL_OPENCODE_PORT });
       tui?.updateService("openwork-server", { status: "running", port: openworkPort });
       if (owpenbotEnabled) {
-        tui?.updateService("owpenbot", { status: "running", port: undefined });
+        tui?.updateService("router", { status: "running", port: undefined });
       }
 
       if (!detachRequested) {
@@ -4805,7 +4851,7 @@ async function runStart(args: ParsedArgs) {
             logFormat,
           });
           children.push({ name: "owpenbot", child: owpenbotChild });
-          tui?.updateService("owpenbot", {
+          tui?.updateService("router", {
             status: "running",
             pid: owpenbotChild.pid ?? undefined,
             port: owpenbotHealthPort,
@@ -4817,7 +4863,7 @@ async function runStart(args: ParsedArgs) {
               return;
             }
             const reason = code !== null ? `code ${code}` : signal ? `signal ${signal}` : "unknown";
-            tui?.updateService("owpenbot", { status: "stopped", message: reason });
+            tui?.updateService("router", { status: "stopped", message: reason });
             logger.warn("Process exited, continuing without owpenbot", { reason, code, signal }, "owpenbot");
           });
           owpenbotChild.on("error", (error) => handleSpawnError("owpenbot", error));
@@ -4825,8 +4871,8 @@ async function runStart(args: ParsedArgs) {
           const healthBaseUrl = `http://127.0.0.1:${owpenbotHealthPort}`;
           logger.info("Waiting for health", { url: healthBaseUrl }, "owpenbot");
           const health = await waitForOwpenbotHealthy(healthBaseUrl, 10_000, 400);
-          tui?.setOwpenbotHealth(health);
-          tui?.updateService("owpenbot", { status: health.ok ? "healthy" : "running" });
+          tui?.setRouterHealth(health);
+          tui?.updateService("router", { status: health.ok ? "healthy" : "running" });
           logger.info("Healthy", { url: healthBaseUrl, ok: health.ok }, "owpenbot");
           owpenbotReady = true;
         } catch (error) {
@@ -4835,7 +4881,7 @@ async function runStart(args: ParsedArgs) {
           }
           const message = error instanceof Error ? error.message : String(error);
           logger.warn("Owpenbot failed to start, continuing without it", { error: message }, "owpenbot");
-          tui?.updateService("owpenbot", { status: "stopped", message });
+          tui?.updateService("router", { status: "stopped", message });
           if (owpenbotChild) {
             try {
               owpenbotChild.kill();
@@ -4901,9 +4947,9 @@ async function runStart(args: ParsedArgs) {
         owpenbotHealthInterval = setInterval(() => {
           fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken)
             .then((health) => {
-              tui?.setOwpenbotHealth(health);
+              tui?.setRouterHealth(health);
               if (health.ok) {
-                tui?.updateService("owpenbot", { status: "healthy" });
+                tui?.updateService("router", { status: "healthy" });
               }
             })
             .catch(() => undefined);
@@ -4920,20 +4966,20 @@ async function runStart(args: ParsedArgs) {
           const url = `${openworkBaseUrl.replace(/\/$/, "")}/owpenbot/health`;
           logger.info("Waiting for health", { url }, "owpenbot");
           const health = await waitForOwpenbotHealthyViaOpenwork(openworkBaseUrl, openworkToken);
-          tui?.setOwpenbotHealth(health);
-          tui?.updateService("owpenbot", { status: health.ok ? "healthy" : "running" });
+          tui?.setRouterHealth(health);
+          tui?.updateService("router", { status: health.ok ? "healthy" : "running" });
           logger.info("Healthy", { url, ok: health.ok }, "owpenbot");
         } catch (error) {
           logger.warn("Owpenbot health check failed", { error: String(error) }, "owpenbot");
-          tui?.updateService("owpenbot", { status: "running", message: String(error) });
+          tui?.updateService("router", { status: "running", message: String(error) });
         }
         if (!owpenbotHealthInterval) {
           owpenbotHealthInterval = setInterval(() => {
             fetchOwpenbotHealthViaOpenwork(openworkBaseUrl, openworkToken)
               .then((health) => {
-                tui?.setOwpenbotHealth(health);
+                tui?.setRouterHealth(health);
                 if (health.ok) {
-                  tui?.updateService("owpenbot", { status: "healthy" });
+                  tui?.updateService("router", { status: "healthy" });
                 }
               })
               .catch(() => undefined);

--- a/packages/headless/src/tui/app.tsx
+++ b/packages/headless/src/tui/app.tsx
@@ -28,7 +28,7 @@ export type TuiConnectInfo = {
   attachCommand: string;
 };
 
-export type TuiOwpenbotHealth = {
+export type TuiRouterHealth = {
   ok: boolean;
   opencode: {
     url: string;
@@ -37,12 +37,26 @@ export type TuiOwpenbotHealth = {
   };
   channels: {
     telegram: boolean;
-    whatsapp: boolean;
     slack: boolean;
+    // Legacy field (kept for backward compatibility with older builds).
+    whatsapp?: boolean;
   };
   config: {
     groupsEnabled: boolean;
   };
+};
+
+// Backward-compatible name (older logs + code paths still say owpenbot).
+export type TuiOwpenbotHealth = TuiRouterHealth;
+
+export type TuiRouterIdentityItem = {
+  id: string;
+  enabled: boolean;
+  running: boolean;
+};
+
+export type TuiRouterIdentityList = {
+  items: TuiRouterIdentityItem[];
 };
 
 export type TuiLogEntry = {
@@ -55,7 +69,7 @@ export type TuiLogEntry = {
 export type TuiHandle = {
   updateService: (name: string, update: Partial<TuiService>) => void;
   setConnectInfo: (info: Partial<TuiConnectInfo>) => void;
-  setOwpenbotHealth: (health: TuiOwpenbotHealth | null) => void;
+  setRouterHealth: (health: TuiRouterHealth | null) => void;
   pushLog: (entry: TuiLogEntry) => void;
   setUptimeStart: (time: number) => void;
   stop: () => void;
@@ -69,12 +83,15 @@ type TuiOptions = {
   onDetach: () => void | Promise<void>;
   onCopyAttach: () => Promise<{ command: string; copied: boolean; error?: string }>;
   onCopySelection?: (text: string) => Promise<{ copied: boolean; error?: string }>;
-  onOwpenbotHealth: () => Promise<TuiOwpenbotHealth>;
-  onOwpenbotQr: () => Promise<string>;
-  onOwpenbotSetTelegramToken: (token: string) => Promise<{ ok: boolean; error?: string }>;
+  onRouterHealth: () => Promise<TuiRouterHealth>;
+  onRouterTelegramIdentities: () => Promise<TuiRouterIdentityList>;
+  onRouterSlackIdentities: () => Promise<TuiRouterIdentityList>;
+  onRouterSetGroupsEnabled: (enabled: boolean) => Promise<{ ok: boolean; error?: string }>;
+  onRouterSetTelegramToken: (token: string) => Promise<{ ok: boolean; error?: string }>;
+  onRouterSetSlackTokens: (botToken: string, appToken: string) => Promise<{ ok: boolean; error?: string }>;
 };
 
-type ViewName = "overview" | "logs" | "help" | "owpenbot";
+type ViewName = "overview" | "logs" | "help" | "router";
 
 const MAX_LOGS = 800;
 
@@ -116,12 +133,12 @@ const levelColor: Record<TuiLogLevel, RGBA> = {
 
 const levelCycle: Array<"all" | TuiLogLevel> = ["all", "info", "warn", "error", "debug"];
 
-const serviceCycle = ["all", "openwrk", "opencode", "openwork-server", "owpenbot"];
+const serviceCycle = ["all", "openwrk", "opencode", "openwork-server", "router"];
 
 const viewTabs: Array<{ name: string; description: string; value: ViewName }> = [
   { name: "Overview", description: "Overview", value: "overview" },
   { name: "Logs", description: "Logs", value: "logs" },
-  { name: "Owpenbot", description: "Owpenbot", value: "owpenbot" },
+  { name: "Router", description: "opencode-router", value: "router" },
   { name: "Help", description: "Help", value: "help" },
 ];
 
@@ -152,7 +169,7 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
   const api: TuiHandle = {
     updateService: () => undefined,
     setConnectInfo: () => undefined,
-    setOwpenbotHealth: () => undefined,
+    setRouterHealth: () => undefined,
     pushLog: () => undefined,
     setUptimeStart: () => undefined,
     stop: () => stop?.(),
@@ -173,11 +190,14 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
         logs: [] as TuiLogEntry[],
         services: options.services as TuiService[],
         connect: options.connect,
-        owpenbotHealth: null as TuiOwpenbotHealth | null,
-        owpenbotQr: "",
-        owpenbotQrError: "",
-        owpenbotToken: "",
-        owpenbotEditing: false,
+        routerHealth: null as TuiRouterHealth | null,
+        routerTelegramIdentities: null as TuiRouterIdentityList | null,
+        routerSlackIdentities: null as TuiRouterIdentityList | null,
+        routerTelegramToken: "",
+        routerSlackTokens: "",
+        routerTelegramEditing: false,
+        routerSlackEditing: false,
+        routerAutoLoaded: false,
         uptimeStart: Date.now(),
       });
 
@@ -191,8 +211,8 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
         setState("connect", (prev) => ({ ...prev, ...info }));
       };
 
-      api.setOwpenbotHealth = (health) => {
-        setState("owpenbotHealth", health);
+      api.setRouterHealth = (health) => {
+        setState("routerHealth", health);
       };
 
       api.pushLog = (entry) => {
@@ -228,10 +248,56 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
 
       const setView = (view: ViewName) => {
         setState("view", view);
-        if (view !== "owpenbot") {
-          setState("owpenbotEditing", false);
+        if (view !== "router") {
+          setState("routerTelegramEditing", false);
+          setState("routerSlackEditing", false);
         }
       };
+
+      const refreshRouter = async (opts: { toastOnSuccess?: string } = {}) => {
+        const [health, telegram, slack] = await Promise.allSettled([
+          options.onRouterHealth(),
+          options.onRouterTelegramIdentities(),
+          options.onRouterSlackIdentities(),
+        ]);
+
+        const errors: string[] = [];
+        if (health.status === "fulfilled") {
+          api.setRouterHealth(health.value);
+        } else {
+          errors.push(`health: ${String(health.reason)}`);
+        }
+
+        if (telegram.status === "fulfilled") {
+          setState("routerTelegramIdentities", telegram.value);
+        } else {
+          setState("routerTelegramIdentities", null);
+          errors.push(`telegram: ${String(telegram.reason)}`);
+        }
+
+        if (slack.status === "fulfilled") {
+          setState("routerSlackIdentities", slack.value);
+        } else {
+          setState("routerSlackIdentities", null);
+          errors.push(`slack: ${String(slack.reason)}`);
+        }
+
+        if (errors.length) {
+          showToast(`Router refresh error: ${errors[0]}`);
+          return;
+        }
+
+        if (opts.toastOnSuccess) {
+          showToast(opts.toastOnSuccess);
+        }
+      };
+
+      createEffect(() => {
+        if (state.view !== "router") return;
+        if (state.routerAutoLoaded) return;
+        setState("routerAutoLoaded", true);
+        void refreshRouter();
+      });
 
       let tabSelect: TabSelectRenderable | undefined;
       const tabWidth = createMemo(() => {
@@ -287,7 +353,8 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
         void copySelection(text);
       });
 
-      let tokenInput: InputRenderable | undefined;
+      let telegramTokenInput: InputRenderable | undefined;
+      let slackTokensInput: InputRenderable | undefined;
 
       const logHeight = createMemo(() => {
         const height = dimensions().height;
@@ -322,9 +389,9 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
         return healthy ? "All green" : "Starting";
       });
 
-      const owpenbotStatus = createMemo(() => {
-        if (!state.owpenbotHealth) return "Pending";
-        return state.owpenbotHealth.ok ? "Healthy" : "Needs attention";
+      const routerStatus = createMemo(() => {
+        if (!state.routerHealth) return "Pending";
+        return state.routerHealth.ok ? "Healthy" : "Needs attention";
       });
 
       const actions = (view: ViewName) => {
@@ -334,10 +401,10 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
         if (view === "help") {
           return "[B] Back  [D] Detach  [Q] Quit";
         }
-        if (view === "owpenbot") {
-          return "[B] Back  [G] QR  [T] Telegram token  [R] Refresh  [D] Detach  [Q] Quit";
+        if (view === "router") {
+          return "[B] Back  [R] Refresh  [T] Telegram token  [S] Slack tokens  [G] Toggle groups  [D] Detach  [Q] Quit";
         }
-        return "[L] Logs  [W] Owpenbot  [C] Copy attach command  [D] Detach  [Q] Quit";
+        return "[L] Logs  [W] Router  [C] Copy attach command  [D] Detach  [Q] Quit";
       };
 
       useKeyboard((evt: KeyEvent) => {
@@ -356,11 +423,13 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
           void options.onDetach();
           return;
         }
-        if (state.owpenbotEditing) {
+        if (state.routerTelegramEditing || state.routerSlackEditing) {
           if (evt.name === "escape") {
             evt.preventDefault();
-            setState("owpenbotEditing", false);
-            tokenInput?.blur();
+            setState("routerTelegramEditing", false);
+            setState("routerSlackEditing", false);
+            telegramTokenInput?.blur();
+            slackTokensInput?.blur();
           }
           return;
         }
@@ -371,7 +440,7 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
         }
         if (evt.name === "w") {
           evt.preventDefault();
-          setView("owpenbot");
+          setView("router");
           return;
         }
         if (evt.name === "h" || evt.name === "?") {
@@ -399,45 +468,52 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
             });
           return;
         }
-        if (state.view === "owpenbot") {
+        if (state.view === "router") {
           if (evt.name === "b" || evt.name === "o") {
             evt.preventDefault();
             setView("overview");
             return;
           }
-          if (evt.name === "g") {
-            evt.preventDefault();
-            setState("owpenbotQr", "");
-            setState("owpenbotQrError", "");
-            options
-              .onOwpenbotQr()
-              .then((qr) => {
-                setState("owpenbotQr", qr.trim());
-                showToast("WhatsApp QR loaded");
-              })
-              .catch((error) => {
-                setState("owpenbotQrError", String(error));
-                showToast("WhatsApp QR failed");
-              });
-            return;
-          }
           if (evt.name === "r") {
             evt.preventDefault();
+            void refreshRouter({ toastOnSuccess: "Router refreshed" });
+            return;
+          }
+          if (evt.name === "g") {
+            evt.preventDefault();
+            const current = state.routerHealth?.config?.groupsEnabled;
+            if (typeof current !== "boolean") {
+              showToast("Refresh router first");
+              return;
+            }
+            const next = !current;
             options
-              .onOwpenbotHealth()
-              .then((health) => {
-                api.setOwpenbotHealth(health);
-                showToast("Owpenbot health refreshed");
+              .onRouterSetGroupsEnabled(next)
+              .then((result) => {
+                if (!result.ok) {
+                  showToast(result.error ? `Groups error: ${result.error}` : "Groups update failed");
+                  return;
+                }
+                showToast(next ? "Groups enabled" : "Groups disabled");
+                void refreshRouter();
               })
               .catch((error) => {
-                showToast(`Owpenbot health error: ${String(error)}`);
+                showToast(`Groups error: ${String(error)}`);
               });
             return;
           }
           if (evt.name === "t") {
             evt.preventDefault();
-            setState("owpenbotEditing", true);
-            setTimeout(() => tokenInput?.focus(), 1);
+            setState("routerSlackEditing", false);
+            setState("routerTelegramEditing", true);
+            setTimeout(() => telegramTokenInput?.focus(), 1);
+            return;
+          }
+          if (evt.name === "s") {
+            evt.preventDefault();
+            setState("routerTelegramEditing", false);
+            setState("routerSlackEditing", true);
+            setTimeout(() => slackTokensInput?.focus(), 1);
             return;
           }
         }
@@ -598,62 +674,88 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
             </box>
           </Show>
 
-          <Show when={state.view === "owpenbot"}>
+          <Show when={state.view === "router"}>
             <box flexDirection="column" paddingTop={1} gap={1}>
               <text fg={theme.text} attributes={TextAttributes.BOLD}>
-                Owpenbot
+                opencode-router
               </text>
-              <text fg={theme.textMuted}>Health: {owpenbotStatus()}</text>
-              <Show when={state.owpenbotHealth}>
+
+              <text fg={theme.textMuted}>Health: {routerStatus()}</text>
+              <Show when={state.routerHealth}>
                 <text fg={theme.textMuted}>
-                  OpenCode: {state.owpenbotHealth?.opencode.healthy ? "healthy" : "down"}
+                  OpenCode: {state.routerHealth?.opencode.healthy ? "healthy" : "down"}
+                  {state.routerHealth?.opencode.version ? ` (${state.routerHealth?.opencode.version})` : ""}
                 </text>
                 <text fg={theme.textMuted}>
-                  WhatsApp: {state.owpenbotHealth?.channels.whatsapp ? "connected" : "not connected"}
+                  Telegram: {state.routerHealth?.channels.telegram ? "enabled" : "not configured"}
                 </text>
+                <text fg={theme.textMuted}>Slack: {state.routerHealth?.channels.slack ? "enabled" : "not configured"}</text>
                 <text fg={theme.textMuted}>
-                  Telegram: {state.owpenbotHealth?.channels.telegram ? "enabled" : "not configured"}
-                </text>
-                <text fg={theme.textMuted}>
-                  Slack: {state.owpenbotHealth?.channels.slack ? "enabled" : "not configured"}
-                </text>
-                <text fg={theme.textMuted}>
-                  Groups enabled: {state.owpenbotHealth?.config.groupsEnabled ? "yes" : "no"}
+                  Groups enabled: {state.routerHealth?.config.groupsEnabled ? "yes" : "no"} (press [G] to toggle)
                 </text>
               </Show>
-              <Show when={!state.owpenbotHealth}>
-                <text fg={theme.textMuted}>Press [R] to refresh owpenbot health.</text>
+              <Show when={!state.routerHealth}>
+                <text fg={theme.textMuted}>Press [R] to refresh router status.</text>
               </Show>
 
               <box paddingTop={1}>
                 <text fg={theme.text} attributes={TextAttributes.BOLD}>
-                  WhatsApp QR
+                  Identities
                 </text>
               </box>
-              <Show when={state.owpenbotQr}>
-                <box flexDirection="column" gap={0}>
-                  <For each={state.owpenbotQr.split(/\r?\n/)}>
-                    {(line) => <text fg={theme.textMuted}>{line}</text>}
-                  </For>
+
+              <box flexDirection="row" gap={4}>
+                <box width={Math.floor(dimensions().width / 2) - 4} flexDirection="column" gap={0}>
+                  <text fg={theme.textMuted}>Telegram</text>
+                  <Show when={state.routerTelegramIdentities}>
+                    <For each={state.routerTelegramIdentities?.items ?? []}>
+                      {(item) => (
+                        <text fg={item.running ? theme.success : theme.textMuted}>
+                          {item.running ? "●" : "○"} {item.id} {item.enabled ? "" : "(disabled)"}
+                        </text>
+                      )}
+                    </For>
+                    <Show when={(state.routerTelegramIdentities?.items ?? []).length === 0}>
+                      <text fg={theme.textMuted}>(none)</text>
+                    </Show>
+                  </Show>
+                  <Show when={!state.routerTelegramIdentities}>
+                    <text fg={theme.textMuted}>Press [R] to load identities.</text>
+                  </Show>
                 </box>
-              </Show>
-              <Show when={!state.owpenbotQr && !state.owpenbotQrError}>
-                <text fg={theme.textMuted}>Press [G] to fetch a QR code.</text>
-              </Show>
-              <Show when={state.owpenbotQrError}>
-                <text fg={theme.error}>{state.owpenbotQrError}</text>
-              </Show>
+
+                <box width={Math.floor(dimensions().width / 2) - 4} flexDirection="column" gap={0}>
+                  <text fg={theme.textMuted}>Slack</text>
+                  <Show when={state.routerSlackIdentities}>
+                    <For each={state.routerSlackIdentities?.items ?? []}>
+                      {(item) => (
+                        <text fg={item.running ? theme.success : theme.textMuted}>
+                          {item.running ? "●" : "○"} {item.id} {item.enabled ? "" : "(disabled)"}
+                        </text>
+                      )}
+                    </For>
+                    <Show when={(state.routerSlackIdentities?.items ?? []).length === 0}>
+                      <text fg={theme.textMuted}>(none)</text>
+                    </Show>
+                  </Show>
+                  <Show when={!state.routerSlackIdentities}>
+                    <text fg={theme.textMuted}>Press [R] to load identities.</text>
+                  </Show>
+                </box>
+              </box>
 
               <box paddingTop={1}>
                 <text fg={theme.text} attributes={TextAttributes.BOLD}>
-                  Telegram token
+                  Configure
                 </text>
               </box>
+
+              <text fg={theme.textMuted}>Telegram token (default identity)</text>
               <input
-                value={state.owpenbotToken}
+                value={state.routerTelegramToken}
                 placeholder="Paste token and press enter"
-                focused={state.owpenbotEditing}
-                onInput={(value) => setState("owpenbotToken", value)}
+                focused={state.routerTelegramEditing}
+                onInput={(value) => setState("routerTelegramToken", value)}
                 onSubmit={(value) => {
                   const token = typeof value === "string" ? value.trim() : "";
                   if (!token) {
@@ -661,25 +763,72 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
                     return;
                   }
                   options
-                    .onOwpenbotSetTelegramToken(token)
+                    .onRouterSetTelegramToken(token)
                     .then((result) => {
                       if (!result.ok) {
                         showToast(result.error ? `Telegram error: ${result.error}` : "Telegram token failed");
                         return;
                       }
-                      setState("owpenbotToken", "");
-                      setState("owpenbotEditing", false);
-                      tokenInput?.blur();
-                      showToast("Telegram token saved");
+                      setState("routerTelegramToken", "");
+                      setState("routerTelegramEditing", false);
+                      telegramTokenInput?.blur();
+                      showToast("Telegram identity saved");
+                      void refreshRouter();
                     })
                     .catch((error) => {
                       showToast(`Telegram error: ${String(error)}`);
                     });
                 }}
                 ref={(node) => {
-                  tokenInput = node;
-                  if (state.owpenbotEditing) {
-                    setTimeout(() => tokenInput?.focus(), 1);
+                  telegramTokenInput = node;
+                  if (state.routerTelegramEditing) {
+                    setTimeout(() => telegramTokenInput?.focus(), 1);
+                  }
+                }}
+              />
+
+              <text fg={theme.textMuted}>Slack tokens (default identity)</text>
+              <input
+                value={state.routerSlackTokens}
+                placeholder="Paste xoxb-... xapp-... and press enter"
+                focused={state.routerSlackEditing}
+                onInput={(value) => setState("routerSlackTokens", value)}
+                onSubmit={(value) => {
+                  const raw = typeof value === "string" ? value.trim() : "";
+                  if (!raw) {
+                    showToast("Slack tokens required");
+                    return;
+                  }
+
+                  const parts = raw.split(/[\s,]+/).map((p) => p.trim()).filter(Boolean);
+                  const botToken = parts.find((p) => p.startsWith("xoxb-")) ?? parts[0];
+                  const appToken = parts.find((p) => p.startsWith("xapp-")) ?? parts[1];
+                  if (!botToken || !appToken) {
+                    showToast("Expected: xoxb-... xapp-...");
+                    return;
+                  }
+
+                  options
+                    .onRouterSetSlackTokens(botToken, appToken)
+                    .then((result) => {
+                      if (!result.ok) {
+                        showToast(result.error ? `Slack error: ${result.error}` : "Slack tokens failed");
+                        return;
+                      }
+                      setState("routerSlackTokens", "");
+                      setState("routerSlackEditing", false);
+                      slackTokensInput?.blur();
+                      showToast("Slack identity saved");
+                      void refreshRouter();
+                    })
+                    .catch((error) => {
+                      showToast(`Slack error: ${String(error)}`);
+                    });
+                }}
+                ref={(node) => {
+                  slackTokensInput = node;
+                  if (state.routerSlackEditing) {
+                    setTimeout(() => slackTokensInput?.focus(), 1);
                   }
                 }}
               />
@@ -692,10 +841,12 @@ export function startOpenwrkTui(options: TuiOptions): TuiHandle {
                 Shortcuts
               </text>
               <text fg={theme.textMuted}>L: Logs</text>
-              <text fg={theme.textMuted}>W: Owpenbot</text>
+              <text fg={theme.textMuted}>W: Router</text>
               <text fg={theme.textMuted}>C: Copy attach command</text>
-              <text fg={theme.textMuted}>G: WhatsApp QR (owpenbot)</text>
-              <text fg={theme.textMuted}>T: Telegram token (owpenbot)</text>
+              <text fg={theme.textMuted}>R: Refresh router</text>
+              <text fg={theme.textMuted}>G: Toggle groups (router)</text>
+              <text fg={theme.textMuted}>T: Telegram token (router)</text>
+              <text fg={theme.textMuted}>S: Slack tokens (router)</text>
               <text fg={theme.textMuted}>D: Detach</text>
               <text fg={theme.textMuted}>Q: Quit</text>
               <text fg={theme.textMuted}>Mouse: click tabs</text>

--- a/packages/owpenbot/.env.example
+++ b/packages/owpenbot/.env.example
@@ -13,6 +13,8 @@ SLACK_ENABLED=true
 OWPENBOT_DATA_DIR=~/.openwork/owpenbot
 OWPENBOT_DB_PATH=~/.openwork/owpenbot/owpenbot.db
 OWPENBOT_CONFIG_PATH=~/.openwork/owpenbot/owpenbot.json
+# Alias for OWPENBOT_HEALTH_PORT (preferred name)
+OPENCODE_ROUTER_HEALTH_PORT=
 OWPENBOT_HEALTH_PORT=3005
 TOOL_UPDATES_ENABLED=false
 GROUPS_ENABLED=false

--- a/packages/owpenbot/README.md
+++ b/packages/owpenbot/README.md
@@ -1,6 +1,6 @@
-# Owpenbot
+# OpenCode Router (formerly Owpenbot)
 
-Simple Slack + Telegram bridge for a running OpenCode server.
+Simple Slack + Telegram bridge + directory router for a running OpenCode server.
 
 ## Install + Run
 
@@ -10,13 +10,13 @@ One-command install (recommended):
 curl -fsSL https://raw.githubusercontent.com/different-ai/openwork/dev/packages/owpenbot/install.sh | bash
 ```
 
-Or install from npm:
+Or install from npm (package name is still `owpenwork`):
 
 ```bash
 npm install -g owpenwork
 ```
 
-Quick run without install:
+Quick run without install (runs the legacy `owpenwork` alias):
 
 ```bash
 npx owpenwork
@@ -40,10 +40,14 @@ Recommended:
 - `OPENCODE_SERVER_USERNAME`
 - `OPENCODE_SERVER_PASSWORD`
 
-3) Run owpenwork:
+3) Run the router:
 
 ```bash
+opencode-router
+
+# (legacy aliases)
 owpenwork
+owpenbot
 ```
 
 ## Telegram
@@ -53,8 +57,8 @@ Telegram support is configured via identities. You can either:
 - Or add multiple bots to the config file (`owpenbot.json`) using the CLI:
 
 ```bash
-owpenbot telegram add <token> --id default
-owpenbot telegram list
+opencode-router telegram add <token> --id default
+opencode-router telegram list
 ```
 
 ## Slack (Socket Mode)
@@ -70,7 +74,7 @@ Slack support uses Socket Mode and replies in threads when @mentioned in channel
 4) Subscribe to events (bot events):
    - `app_mention`
    - `message.im`
-5) Set env vars (or save via `owpenbot slack add ...`):
+5) Set env vars (or save via `opencode-router slack add ...`):
     - `SLACK_BOT_TOKEN=xoxb-...`
     - `SLACK_APP_TOKEN=xapp-...`
     - `SLACK_ENABLED=true`
@@ -78,24 +82,25 @@ Slack support uses Socket Mode and replies in threads when @mentioned in channel
 To add multiple Slack apps:
 
 ```bash
-owpenbot slack add <xoxb> <xapp> --id default
-owpenbot slack list
+opencode-router slack add <xoxb> <xapp> --id default
+opencode-router slack list
 ```
 
 ## Identity-Scoped Routing
 
-Owpenbot routes messages based on `(channel, identityId, peerId) -> directory` bindings.
+The router routes messages based on `(channel, identityId, peerId) -> directory` bindings.
 
 ```bash
-owpenbot bindings set --channel telegram --identity default --peer <chatId> --dir /path/to/workdir
-owpenbot bindings list
+opencode-router bindings set --channel telegram --identity default --peer <chatId> --dir /path/to/workdir
+opencode-router bindings list
 ```
 
 ## Health Server (Local HTTP)
 
-Owpenbot can expose a small local HTTP server for health/config and simple message dispatch.
+The router can expose a small local HTTP server for health/config and simple message dispatch.
 
-- `OWPENBOT_HEALTH_PORT` controls the port (OpenWork defaults to a random free port when using `openwrk`).
+- `OPENCODE_ROUTER_HEALTH_PORT` or `OWPENBOT_HEALTH_PORT` controls the port (OpenWork defaults to a random free port when using `openwrk`).
+- `PORT` is also accepted as a convenience if the above are unset.
 - `OWPENBOT_HEALTH_HOST` controls bind host (default: `127.0.0.1`).
 
 Send a message to all peers bound to a directory:
@@ -109,17 +114,17 @@ curl -sS "http://127.0.0.1:${OWPENBOT_HEALTH_PORT:-3005}/send" \
 ## Commands
 
 ```bash
-owpenbot start
-owpenbot status
+opencode-router start
+opencode-router status
 
-owpenbot telegram list
-owpenbot telegram add <token> --id default
+opencode-router telegram list
+opencode-router telegram add <token> --id default
 
-owpenbot slack list
-owpenbot slack add <xoxb> <xapp> --id default
+opencode-router slack list
+opencode-router slack add <xoxb> <xapp> --id default
 
-owpenbot bindings list
-owpenbot bindings set --channel telegram --identity default --peer <chatId> --dir /path/to/workdir
+opencode-router bindings list
+opencode-router bindings set --channel telegram --identity default --peer <chatId> --dir /path/to/workdir
 ```
 
 ## Defaults

--- a/packages/owpenbot/install.sh
+++ b/packages/owpenbot/install.sh
@@ -9,13 +9,13 @@ OWPENBOT_INSTALL_METHOD="${OWPENBOT_INSTALL_METHOD:-npm}"
 
 usage() {
   cat <<'EOF'
-Owpenbot installer (WhatsApp-first)
+OpenCode Router installer (formerly owpenbot)
 
 Environment variables:
   OWPENBOT_INSTALL_DIR  Install directory (default: ~/.openwork/owpenbot/openwork)
   OWPENBOT_REPO         Git repo (default: https://github.com/different-ai/openwork.git)
   OWPENBOT_REF          Git ref/branch (default: dev)
-  OWPENBOT_BIN_DIR      Bin directory for owpenbot shim (default: ~/.local/bin)
+  OWPENBOT_BIN_DIR      Bin directory for shims (default: ~/.local/bin)
   OWPENBOT_INSTALL_METHOD  Install method: npm|git (default: npm)
 
 Example:
@@ -35,10 +35,10 @@ require_bin() {
   fi
 }
 
-require_bin node
+  require_bin node
 
 if [[ "$OWPENBOT_INSTALL_METHOD" == "npm" ]]; then
-  echo "Installing owpenwork via npm..."
+  echo "Installing owpenwork via npm (provides opencode-router)..."
   npm install -g owpenwork
 else
   require_bin git
@@ -89,7 +89,7 @@ else
   echo "Installing dependencies..."
   pnpm -C "$OWPENBOT_INSTALL_DIR" install
 
-  echo "Building owpenbot..."
+  echo "Building opencode-router..."
   pnpm -C "$OWPENBOT_INSTALL_DIR/packages/owpenbot" build
 
   ENV_PATH="$OWPENBOT_INSTALL_DIR/packages/owpenbot/.env"
@@ -117,6 +117,13 @@ set -euo pipefail
 node "$OWPENBOT_INSTALL_DIR/packages/owpenbot/dist/cli.js" "$@"
 EOF
   chmod 755 "$OWPENBOT_BIN_DIR/owpenbot"
+
+  cat <<EOF > "$OWPENBOT_BIN_DIR/opencode-router"
+#!/usr/bin/env bash
+set -euo pipefail
+node "$OWPENBOT_INSTALL_DIR/packages/owpenbot/dist/cli.js" "$@"
+EOF
+  chmod 755 "$OWPENBOT_BIN_DIR/opencode-router"
 fi
 
 if ! echo ":$PATH:" | grep -q ":$OWPENBOT_BIN_DIR:"; then
@@ -139,9 +146,12 @@ fi
 
 cat <<EOF
 
-Owpenbot installed.
+OpenCode Router installed.
 
 Next steps:
 1) Edit: $ENV_PATH
-2) Run: owpenbot start
+2) Run: opencode-router start
+
+Legacy alias:
+- owpenbot start
 EOF

--- a/packages/owpenbot/package.json
+++ b/packages/owpenbot/package.json
@@ -1,10 +1,11 @@
 {
   "name": "owpenwork",
   "version": "0.11.67",
-  "description": "Slack + Telegram bridge for a running OpenCode server",
+  "description": "OpenCode Router (formerly owpenbot): Slack + Telegram bridge + directory routing for a running OpenCode server",
   "private": false,
   "type": "module",
   "bin": {
+    "opencode-router": "dist/cli.js",
     "owpenwork": "dist/cli.js",
     "owpenbot": "dist/cli.js"
   },
@@ -30,9 +31,9 @@
   "scripts": {
     "dev": "bun src/cli.ts",
     "build": "tsc -p tsconfig.json",
-    "build:bin": "bun build --compile src/cli.ts --define __OWPENBOT_VERSION__=\\\"$npm_package_version\\\" --outfile dist/bin/owpenbot",
-    "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
-    "build:binary": "bun ./script/build.ts --outdir dist/bin",
+    "build:bin": "bun ./script/build.ts --outdir dist/bin --filename owpenbot && bun ./script/build.ts --outdir dist/bin --filename opencode-router",
+    "build:bin:all": "bun ./script/build.ts --outdir dist/bin --filename owpenbot --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 && bun ./script/build.ts --outdir dist/bin --filename opencode-router --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
+    "build:binary": "bun ./script/build.ts --outdir dist/bin --filename owpenbot && bun ./script/build.ts --outdir dist/bin --filename opencode-router",
     "start": "bun dist/cli.js start",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "setup": "bun scripts/setup.mjs",

--- a/packages/owpenbot/src/bridge.ts
+++ b/packages/owpenbot/src/bridge.ts
@@ -522,7 +522,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
 
   let stopHealthServer: (() => void) | null = null;
   if (!deps.disableHealthServer && config.healthPort) {
-    stopHealthServer = startHealthServer(
+    stopHealthServer = await startHealthServer(
       config.healthPort,
       (): HealthSnapshot => ({
         ok: opencodeHealthy,

--- a/packages/owpenbot/src/cli.ts
+++ b/packages/owpenbot/src/cli.ts
@@ -169,7 +169,7 @@ async function runStart(pathOverride?: string, options?: { opencodeUrl?: string 
   }
   const bridge = await startBridge(config, logger, reporter);
   if (process.stdout.isTTY) {
-    reporter.onStatus?.("Commands: owpenwork identities, owpenwork bindings, owpenwork status");
+    reporter.onStatus?.("Commands: opencode-router identities, opencode-router bindings, opencode-router status");
   }
 
   const shutdown = async () => {
@@ -185,9 +185,9 @@ async function runStart(pathOverride?: string, options?: { opencodeUrl?: string 
 const program = new Command();
 
 program
-  .name("owpenbot")
+  .name("opencode-router")
   .version(VERSION)
-  .description("Slack + Telegram bridge for a running OpenCode server")
+  .description("OpenCode Router (formerly owpenbot): Slack + Telegram bridge + directory routing")
   .option("--json", "Output in JSON format", false);
 
 program

--- a/packages/owpenbot/src/config.ts
+++ b/packages/owpenbot/src/config.ts
@@ -240,7 +240,12 @@ export function loadConfig(
   if (envSlackBot && envSlackApp && !slackApps.some((app) => app.botToken === envSlackBot && app.appToken === envSlackApp)) {
     slackApps.unshift({ id: "env", botToken: envSlackBot, appToken: envSlackApp, enabled: true });
   }
-  const healthPort = parseInteger(env.OWPENBOT_HEALTH_PORT) ?? 3005;
+  const healthPort =
+    parseInteger(env.OPENCODE_ROUTER_HEALTH_PORT) ??
+    parseInteger(env.OWPENBOT_HEALTH_PORT) ??
+    // Convenience alias (common on PaaS / local experiments)
+    parseInteger(env.PORT) ??
+    3005;
   const model = parseModel(env.OWPENBOT_MODEL);
 
   const telegramEnabledDefault = configFile.channels?.telegram?.enabled ?? true;

--- a/packages/owpenbot/src/health.ts
+++ b/packages/owpenbot/src/health.ts
@@ -135,7 +135,7 @@ export type HealthHandlers = {
   sendMessage?: (input: SendMessageInput) => Promise<SendMessageResult>;
 };
 
-export function startHealthServer(
+export async function startHealthServer(
   port: number,
   getStatus: () => HealthSnapshot,
   logger: Logger,
@@ -630,9 +630,35 @@ export function startHealthServer(
   });
 
   const host = (process.env.OWPENBOT_HEALTH_HOST ?? "").trim() || "127.0.0.1";
-  server.listen(port, host, () => {
-    logger.info({ host, port }, "health server listening");
-  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: unknown) => {
+        server.removeListener("listening", onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        server.removeListener("error", onError);
+        resolve();
+      };
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen(port, host);
+    });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EADDRINUSE") {
+      throw new Error(
+        `Failed to start health server on ${host}:${port}. Port is in use. ` +
+          `Set OPENCODE_ROUTER_HEALTH_PORT, OWPENBOT_HEALTH_PORT, or PORT to a free port.`,
+      );
+    }
+    throw error;
+  }
+
+  const address = server.address();
+  const actualPort = typeof address === "object" && address ? address.port : port;
+  logger.info({ host, port: actualPort }, "health server listening");
 
   return () => {
     server.close();


### PR DESCRIPTION
## Summary
- Update OpenWork headless TUI to show `opencode-router` (formerly owpenbot): refreshable health, Telegram/Slack identity lists, token inputs, and a groups toggle; remove the dead WhatsApp QR flow.
- Lazy-load the OpenTUI UI module so non-TUI commands (daemon/router scripts) can run under Node without importing TSX output.
- Add the `opencode-router` CLI alias (keeping `owpenbot`/`owpenwork`), accept `OPENCODE_ROUTER_HEALTH_PORT`/`PORT`, and improve the EADDRINUSE health-port error message.

## Testing
- `pnpm -C packages/headless typecheck`
- `pnpm -C packages/headless test:router`
- `pnpm -C packages/owpenbot typecheck`
- `pnpm -C packages/owpenbot test:cli`