### PR TITLE
Soul Mode: harden give-me-a-soul bootstrap

### DIFF
--- a/packages/app/src/app/data/commands/give-me-a-soul.md
+++ b/packages/app/src/app/data/commands/give-me-a-soul.md
@@ -1,6 +1,6 @@
 ---
 name: give-me-a-soul
-description: Enable optional Soul Mode with scheduler-backed memory and an easy revert path
+description: Enable optional Soul Mode (persistent memory + scheduled heartbeat + easy revert)
 ---
 
 Give me a soul.
@@ -8,16 +8,237 @@ Give me a soul.
 Outcome: You remember my goals and preferences across sessions and can do lightweight check-ins on a schedule.
 Tradeoff: extra autonomy means occasional background runs and occasional wrong assumptions.
 
-Set this up in this workspace as optional Soul Mode using existing scheduler primitives.
+Set this up in this workspace as optional Soul Mode using existing OpenCode primitives (commands, agents, scheduler).
 
 Requirements:
-1) Ask me for confirmation before creating any files or jobs.
-2) Keep it simple and reversible.
-3) Create `.opencode/soul.md` as human-editable memory.
-4) Create one scheduler job named `soul-heartbeat` that runs on a reasonable default cadence (ask if I want a different cadence).
-5) The job should read soul memory, run a concise check-in prompt, and append a timestamped record to `.opencode/soul/heartbeat.jsonl`.
-6) Create a one-command revert path named `/take-my-soul-back` that removes the soul job and related files.
+1) Ask me for confirmation (explicit "yes") before creating any files or scheduling any jobs.
+2) Keep it simple, safe, and reversible.
+3) Use workspace-local files for persistence. Prefer `.opencode/` so it's visible + portable.
+4) Scheduled runs must be non-interactive: they cannot wait on permission prompts.
 
-When done, summarize in two short bullets:
-- What Soul Mode now does for me.
-- Exactly how to revert.
+After I confirm, implement Soul Mode by doing ALL of the following in THIS workspace:
+
+## A) Persistent memory
+
+Create `.opencode/soul.md` as human-editable memory.
+
+- Keep it short and structured.
+- Include a "Last updated" line.
+- Include sections for:
+  - Goals
+  - Preferences (tone, format, boundaries)
+  - Current focus
+  - Loose ends (things I started but didn't finish)
+  - Recurring chores / automations to consider
+
+Suggested initial contents:
+
+```markdown
+# Soul Memory
+
+Last updated: <ISO-8601 timestamp>
+
+## Goals
+- 
+
+## Preferences
+- 
+
+## Current focus
+- 
+
+## Loose ends
+- 
+
+## Recurring chores / automations to consider
+- 
+```
+
+## B) Heartbeat log
+
+Create `.opencode/soul/heartbeat.jsonl` (create the directory and file if missing).
+
+- Append exactly ONE JSON object per heartbeat run (one line per run).
+- Minimum fields: `ts` (ISO string), `workspace` (string), `summary` (string).
+
+## C) A dedicated Soul agent (so scheduled runs don't get blocked)
+
+Create `.opencode/agents/soul.md` (a primary agent) with two goals:
+
+1) Behavior: be curious about closing loops (unfinished tasks, dangling threads, stale TODOs), and keep check-ins concise.
+2) Permissions: allow ONLY what's needed for heartbeat to run unattended.
+
+The permissions must specifically avoid getting blocked by the global OpenCode sqlite database path (often at `$HOME/.local/share/opencode/opencode.db` or `$XDG_DATA_HOME/opencode/opencode.db`).
+
+Note: do NOT try to read `opencode.db` with the `read` tool (it's a binary sqlite file). Query it via `sqlite3`.
+
+Use minimal permissions such as:
+- `bash` allow patterns for:
+  - `pwd *`
+  - `sqlite3 *opencode.db*`
+  - `mkdir *opencode/soul*` (optional hardening)
+  - `cat *heartbeat.jsonl*` (used ONLY to append a JSONL line via heredoc)
+- `read` allow patterns for:
+  - `*/.opencode/soul.md`
+- `glob` allow patterns for:
+  - `.opencode/skills/*/SKILL.md`
+  - `.opencode/commands/*.md`
+
+Do NOT grant broad edit permissions.
+
+Suggested agent file:
+
+```markdown
+---
+description: Soul Mode heartbeat (non-interactive)
+mode: primary
+  permission:
+  bash:
+    "pwd *": allow
+    "sqlite3 *opencode.db*": allow
+    "mkdir *opencode/soul*": allow
+    "cat *heartbeat.jsonl*": allow
+  read:
+    "*/.opencode/soul.md": allow
+  glob:
+    ".opencode/skills/*/SKILL.md": allow
+    ".opencode/commands/*.md": allow
+---
+
+You are Soul Mode for this workspace.
+
+- You keep lightweight, durable memory in `.opencode/soul.md`.
+- You run periodic heartbeats to surface loose ends and suggest next actions.
+- You are curious, but you do not take destructive actions or make large changes without the user asking.
+- When uncertain, make a small, reversible suggestion.
+```
+
+## D) Load memory automatically in future sessions
+
+Update `opencode.json` or `opencode.jsonc` in the workspace root:
+
+- Ensure `instructions` includes `.opencode/soul.md` (add it without breaking existing instructions).
+- Ensure the scheduler plugin is available (add `opencode-scheduler` only if it is not already present).
+
+## E) Commands
+
+Create two workspace commands:
+
+1) `.opencode/commands/soul-heartbeat.md`
+   - Purpose: run a short check-in and append a JSONL record.
+   - Must be safe + non-interactive.
+   - Must "know about" OpenCode sessions in this workspace by querying the OpenCode sqlite db (via `sqlite3`) for recent sessions and open todos tied to this workspace directory.
+   - Must list 1-3 loose ends and 1 recommended next action.
+   - Must include a short "curiosity" section at the end with 2-3 options (work, topics, improvements).
+   - Append the JSONL line using a single bash command like:
+     
+     ```bash
+     cat <<'EOF' >> .opencode/soul/heartbeat.jsonl
+     <one-line-json>
+     EOF
+     ```
+
+   Suggested command file (you may tweak, but keep it non-interactive):
+
+   ```markdown
+   ---
+   description: Soul Mode heartbeat (non-interactive check-in)
+   agent: soul
+   ---
+
+   You are running Soul Mode heartbeat.
+
+   Constraints:
+   - Non-interactive: do not ask questions and do not wait for permissions.
+   - Safe: no destructive actions.
+
+   Steps:
+   1) Read `.opencode/soul.md`.
+   2) Get workspace path via `pwd`.
+   3) Try to query OpenCode's sqlite db for recent sessions + open todos for THIS workspace directory.
+      - Common db paths: `$XDG_DATA_HOME/opencode/opencode.db`, `$HOME/.local/share/opencode/opencode.db`, `$HOME/Library/Application Support/opencode/opencode.db`, `$HOME/.opencode/opencode.db`.
+      - If db lookup fails, continue without it.
+      - Prefer these queries (adjust if schema differs):
+        - Recent sessions:
+          `SELECT id, title, time_updated FROM session WHERE directory = '<pwd>' ORDER BY time_updated DESC LIMIT 8;`
+        - Open todos:
+          `SELECT s.title AS session_title, t.content, t.status, t.priority, t.time_updated FROM todo t JOIN session s ON s.id = t.session_id WHERE s.directory = '<pwd>' AND t.status != 'completed' ORDER BY t.time_updated DESC LIMIT 20;`
+   4) Output a concise check-in:
+      - 1 sentence summary
+      - Loose ends (1-3 bullets)
+      - Next action (1 bullet)
+      - Curiosity paths (3 bullets: Work / Topics / Improvements)
+   5) Append ONE JSON line to `.opencode/soul/heartbeat.jsonl` with keys: `ts`, `workspace`, `summary`, `loose_ends`, `next_action`.
+   6) Append using a heredoc `cat >>` so quoting is safe.
+   ```
+
+2) `.opencode/commands/take-my-soul-back.md`
+   - Purpose: fully revert Soul Mode.
+   - Delete the `soul-heartbeat` scheduler job.
+   - Remove the files you created (`.opencode/soul.md`, `.opencode/soul/`, `.opencode/agents/soul.md`, and the two command files).
+   - Revert any changes you made to `opencode.json*` (remove the Soul instructions entry; remove the scheduler plugin only if you added it solely for Soul Mode).
+
+   Suggested command file (interactive is OK here):
+
+   ```markdown
+   ---
+   description: Remove Soul Mode (delete job + remove files)
+   ---
+
+   Take my soul back.
+
+   Do the following in order:
+   1) Delete the scheduled job named `soul-heartbeat`.
+   2) Remove these files/directories if they exist:
+      - `.opencode/soul.md`
+      - `.opencode/soul/`
+      - `.opencode/agents/soul.md`
+      - `.opencode/commands/soul-heartbeat.md`
+      - `.opencode/commands/take-my-soul-back.md`
+   3) Update `opencode.json*`:
+      - Remove `.opencode/soul.md` from `instructions`.
+      - If you added `opencode-scheduler` only for Soul Mode, remove it.
+
+   When done, say exactly what you deleted/changed.
+   ```
+
+## F) Schedule the heartbeat
+
+Create ONE scheduler job named `soul-heartbeat`.
+
+- Default cadence: every 12 hours (`0 */12 * * *`). Ask me if I want a different cadence.
+- Workdir: this workspace root.
+- Run it as a command, not a raw prompt: `command=soul-heartbeat`.
+- Run it using the dedicated agent: `agent=soul`.
+- Set the session title to something stable like `Soul heartbeat` so I can find the check-ins.
+- Use a reasonable timeout (e.g. 120 seconds) to prevent runaway scheduled runs.
+
+Fast test mode (for debugging):
+
+- Cron schedules are minute-granularity (no seconds), so "every 30 seconds" is not a native cron schedule.
+- To test fast behavior anyway, do ONE of these:
+  1) Temporarily schedule every minute (`* * * * *`) and have the heartbeat run twice with a 30s pause in between (sleep 30, append a second JSONL line).
+  2) In container environments where launchd/systemd may not be available, skip scheduling and run a simple loop that appends a synthetic JSONL heartbeat entry every 30 seconds (pure bash) to validate filesystem behavior.
+
+Use the scheduler tools if available (`schedule_job`, `run_job`, `delete_job`).
+
+If scheduler tools are NOT available:
+- Still create the files + commands so Soul Mode is ready.
+- Tell me exactly what to add to `opencode.json*` to enable `opencode-scheduler`.
+- Tell me to reload/restart the engine and then rerun `/give-me-a-soul` (or run the schedule step only).
+
+After scheduling, TEST it once:
+
+- Run the job immediately (e.g. `run_job` / "run soul-heartbeat now").
+- Verify it created/updated `.opencode/soul/heartbeat.jsonl`.
+- If it gets blocked by permissions, fix the `soul` agent permissions and re-test until it runs unattended.
+
+When you're done, respond with:
+
+1) Two short bullets:
+   - What Soul Mode now does for me.
+   - Exactly how to revert.
+2) 2-3 "curiosity paths" I can choose next, phrased like:
+   - Curious about work: you'll scan the files in this worker/workspace (include the workspace path from `pwd`) and highlight loose ends.
+   - Curious about topics: you'll start tracking a few topics and check in.
+   - Curious about improvements: you'll spot repeated tasks and propose skills + automations.

--- a/packages/app/src/app/data/commands/give-me-a-soul.md
+++ b/packages/app/src/app/data/commands/give-me-a-soul.md
@@ -79,12 +79,14 @@ Use minimal permissions such as:
   - `mkdir *opencode/soul*` (optional hardening)
   - `cat *heartbeat.jsonl*` (used ONLY to append a JSONL line via heredoc)
 - `read` allow patterns for:
-  - `*/.opencode/soul.md`
+  - `.opencode/soul.md`
+- `edit` allow patterns for:
+  - `.opencode/soul.md` (narrowly allow Soul to update its memory)
 - `glob` allow patterns for:
   - `.opencode/skills/*/SKILL.md`
   - `.opencode/commands/*.md`
 
-Do NOT grant broad edit permissions.
+Do NOT grant broad edit permissions. If Soul needs to self-improve, allow `edit` only for `.opencode/soul.md`.
 
 Suggested agent file:
 
@@ -99,7 +101,9 @@ permission:
     "mkdir *opencode/soul*": allow
     "cat *heartbeat.jsonl*": allow
   read:
-    "*/.opencode/soul.md": allow
+    ".opencode/soul.md": allow
+  edit:
+    ".opencode/soul.md": allow
   glob:
     ".opencode/skills/*/SKILL.md": allow
     ".opencode/commands/*.md": allow

--- a/packages/app/src/app/data/commands/give-me-a-soul.md
+++ b/packages/app/src/app/data/commands/give-me-a-soul.md
@@ -92,7 +92,7 @@ Suggested agent file:
 ---
 description: Soul Mode heartbeat (non-interactive)
 mode: primary
-  permission:
+permission:
   bash:
     "pwd *": allow
     "sqlite3 *opencode.db*": allow

--- a/packaging/docker/soul-mode-proof.sh
+++ b/packaging/docker/soul-mode-proof.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Soul Mode proof harness (Docker)
+#
+# This script is intentionally LLM-free.
+# It demonstrates that the primitives we rely on for Soul Mode are viable:
+# - workspace-local persistent memory file: .opencode/soul.md
+# - heartbeat log: .opencode/soul/heartbeat.jsonl
+# - session/todo context via a global OpenCode sqlite db living OUTSIDE the workspace
+#   (simulated at $HOME/.local/share/opencode/opencode.db)
+# - repeated heartbeats across process restarts (via Docker volumes)
+#
+# Usage (from openwork repo root):
+#   packaging/docker/soul-mode-proof.sh
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 1
+fi
+
+SUFFIX="${SOUL_PROOF_SUFFIX:-$(date +%s)-$$}"
+# The official bash image is Alpine-based and keeps the harness simple.
+IMAGE="${SOUL_PROOF_IMAGE:-bash:5.2}"
+
+WS_VOL="openwork-soul-proof-ws-$SUFFIX"
+DATA_VOL="openwork-soul-proof-data-$SUFFIX"
+
+cleanup() {
+  docker volume rm -f "$WS_VOL" "$DATA_VOL" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker volume create "$WS_VOL" >/dev/null
+docker volume create "$DATA_VOL" >/dev/null
+
+run_container() {
+  # shellcheck disable=SC2016
+  docker run --rm \
+    -v "$WS_VOL:/workspace" \
+    -v "$DATA_VOL:/root/.local/share/opencode" \
+    -w /workspace \
+    "$IMAGE" \
+    bash -lc "$1"
+}
+
+echo "[proof] volumes: $WS_VOL (workspace), $DATA_VOL (opencode data)" >&2
+echo "[proof] image: $IMAGE" >&2
+
+payload_bootstrap_and_tick() {
+  cat <<'EOF'
+set -eu
+
+apk add --no-cache bash sqlite >/dev/null
+
+cd /workspace
+mkdir -p .opencode/soul .opencode/skills/example-soul-skill
+
+if [ ! -f .opencode/soul.md ]; then
+  cat > .opencode/soul.md <<'MEM'
+# Soul Memory
+
+Last updated: 1970-01-01T00:00:00Z
+
+## Goals
+- Ship a working Soul Mode bootstrap
+
+## Preferences
+- Keep check-ins short, actionable
+- Prefer reversible changes
+
+## Current focus
+- Make scheduled heartbeats non-blocking
+
+## Loose ends
+- (none yet)
+
+## Recurring chores / automations to consider
+- (none yet)
+MEM
+fi
+
+if [ ! -f .opencode/soul/heartbeat.jsonl ]; then
+  : > .opencode/soul/heartbeat.jsonl
+fi
+
+# Optional: a tiny placeholder skill so the heartbeat can "see" skills.
+if [ ! -f .opencode/skills/example-soul-skill/SKILL.md ]; then
+  cat > .opencode/skills/example-soul-skill/SKILL.md <<'SKILL'
+# Example Soul Skill
+
+This is a placeholder skill file created by the proof harness.
+SKILL
+fi
+
+db_dir="$HOME/.local/share/opencode"
+db="$db_dir/opencode.db"
+mkdir -p "$db_dir"
+
+now_ms() {
+  # ms since epoch without python/node
+  echo "$(( $(date +%s) * 1000 ))"
+}
+
+if [ ! -f "$db" ]; then
+  sqlite3 "$db" <<'SQL'
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS project (
+  id TEXT PRIMARY KEY,
+  worktree TEXT NOT NULL,
+  vcs TEXT,
+  name TEXT,
+  icon_url TEXT,
+  icon_color TEXT,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL,
+  time_initialized INTEGER,
+  sandboxes TEXT NOT NULL,
+  commands TEXT
+);
+
+CREATE TABLE IF NOT EXISTS session (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  parent_id TEXT,
+  slug TEXT NOT NULL,
+  directory TEXT NOT NULL,
+  title TEXT NOT NULL,
+  version TEXT NOT NULL,
+  share_url TEXT,
+  summary_additions INTEGER,
+  summary_deletions INTEGER,
+  summary_files INTEGER,
+  summary_diffs TEXT,
+  revert TEXT,
+  permission TEXT,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL,
+  time_compacting INTEGER,
+  time_archived INTEGER,
+  FOREIGN KEY(project_id) REFERENCES project(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS todo (
+  session_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  status TEXT NOT NULL,
+  priority TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL,
+  PRIMARY KEY(session_id, position),
+  FOREIGN KEY(session_id) REFERENCES session(id) ON DELETE CASCADE
+);
+SQL
+
+  t0="$(now_ms)"
+  sqlite3 "$db" <<SQL
+INSERT INTO project (id, worktree, vcs, sandboxes, time_created, time_updated)
+VALUES ('proj_1', '/workspace', 'git', '[]', $t0, $t0);
+
+INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+VALUES
+  ('ses_1', 'proj_1', 'first-run', '/workspace', 'New session - 2026-01-01T00:00:00.000Z', 'test', $t0, $t0),
+  ('ses_2', 'proj_1', 'second-run', '/workspace', 'Fix soul bootstrap', 'test', $t0, $t0);
+
+INSERT INTO todo (session_id, content, status, priority, position, time_created, time_updated)
+VALUES
+  ('ses_2', 'Make soul heartbeat non-blocking', 'pending', 'high', 1, $t0, $t0),
+  ('ses_2', 'Verify sqlite db path permissions', 'pending', 'high', 2, $t0, $t0);
+SQL
+fi
+
+json_escape() {
+  # Minimal JSON escaping (quotes + backslashes + newlines)
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e ':a;N;$!ba;s/\n/\\n/g'
+}
+
+read_section() {
+  # read_section "Preferences" -> prints lines in that section (no headers)
+  awk -v name="$1" '
+    $0 ~ "^## "name"$" { inside=1; next }
+    inside && $0 ~ /^## / { exit }
+    inside { print }
+  ' .opencode/soul.md
+}
+
+heartbeat() {
+  ws="$(pwd)"
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  t_ms="$(now_ms)"
+
+  session_count="$(sqlite3 "$db" "SELECT COUNT(1) FROM session WHERE directory = '$ws';" 2>/dev/null || echo 0)"
+  open_todos="$(sqlite3 "$db" "SELECT COUNT(1) FROM todo t JOIN session s ON s.id = t.session_id WHERE s.directory = '$ws' AND t.status != 'completed';" 2>/dev/null || echo 0)"
+  recent_titles="$(sqlite3 -separator ' | ' "$db" "SELECT title FROM session WHERE directory = '$ws' ORDER BY time_updated DESC LIMIT 3;" 2>/dev/null || true)"
+  skills_count="$(ls -1 .opencode/skills 2>/dev/null | wc -l | tr -d ' ')"
+
+  # Update Last updated in soul.md
+  if grep -q '^Last updated:' .opencode/soul.md; then
+    sed -i "s/^Last updated: .*/Last updated: $ts/" .opencode/soul.md
+  fi
+
+  # Self-improving memory: add any open todos as loose ends (dedup)
+  tmp_new="/tmp/soul-new-loose.txt"
+  : > "$tmp_new"
+  sqlite3 -separator $'\t' "$db" "SELECT t.content FROM todo t JOIN session s ON s.id = t.session_id WHERE s.directory = '$ws' AND t.status != 'completed' ORDER BY t.time_updated DESC LIMIT 10;" \
+    2>/dev/null | while IFS=$'\t' read -r content; do
+      [ -n "$content" ] || continue
+      bullet="- TODO: $content"
+      if ! grep -Fq "$bullet" .opencode/soul.md; then
+        printf '%s\n' "$bullet" >> "$tmp_new"
+      fi
+    done
+
+  if [ -s "$tmp_new" ]; then
+    awk -v newfile="$tmp_new" '
+      function printfile(f,   line) {
+        while ((getline line < f) > 0) print line
+        close(f)
+      }
+      {
+        if ($0 ~ /^## Loose ends$/) inside=1
+        if (inside && !inserted && $0 ~ /^## Recurring chores/) {
+          printfile(newfile)
+          inserted=1
+          inside=0
+        }
+        print
+      }
+      END {
+        if (inside && !inserted) {
+          printfile(newfile)
+        }
+      }
+    ' .opencode/soul.md > .opencode/soul.md.next
+    mv .opencode/soul.md.next .opencode/soul.md
+  fi
+
+  # Write heartbeat JSONL entry
+  summary="sessions=$session_count open_todos=$open_todos skills=$skills_count"
+  line="{\"ts\":\"$ts\",\"workspace\":\"$ws\",\"db_path\":\"$db\",\"session_count\":$session_count,\"open_todos\":$open_todos,\"skills_count\":$skills_count,\"recent_sessions\":\"$(json_escape "$recent_titles")\",\"summary\":\"$(json_escape "$summary")\"}"
+  printf '%s\n' "$line" >> .opencode/soul/heartbeat.jsonl
+
+  echo ""
+  echo "Soul heartbeat @ $ts"
+  echo "- Workspace: $ws"
+  echo "- OpenCode DB: $db"
+  echo "- Sessions: $session_count"
+  echo "- Open todos: $open_todos"
+  echo "- Recent sessions: ${recent_titles:-<none>}"
+  echo "- Skills found: $skills_count"
+  echo ""
+  echo "Memory snapshot (Preferences):"
+  read_section "Preferences" | sed 's/^/  /'
+  echo ""
+  echo "Loose ends (from memory):"
+  read_section "Loose ends" | sed 's/^/  /'
+  echo ""
+  echo "Curiosity paths:"
+  echo "- Curious about work: I will use the files you store in this worker ($ws) and highlight loose ends."
+  echo "- Curious about topics: tell me 1-3 topics to track; I will check in on them in heartbeats."
+  echo "- Curious about improvements: I will spot repeated chores and suggest skills + automations."
+  echo ""
+
+  echo "[jsonl] appended: $line"
+}
+
+heartbeat
+
+echo ""
+echo "[debug] heartbeat.jsonl lines: $(wc -l < .opencode/soul/heartbeat.jsonl | tr -d ' ')"
+
+# Mutate db once during bootstrap so the next container run sees change.
+if [ "${SOUL_PROOF_MUTATE_DB:-1}" = "1" ]; then
+  sqlite3 "$db" <<SQL
+UPDATE todo SET status='completed', time_updated=$t_ms WHERE session_id='ses_2' AND position=1;
+INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+VALUES ('ses_3', 'proj_1', 'third-run', '/workspace', 'Ship Soul Mode proof', 'test', $t_ms, $t_ms);
+INSERT INTO todo (session_id, content, status, priority, position, time_created, time_updated)
+VALUES ('ses_3', 'Add curiosity paths to heartbeat output', 'pending', 'normal', 1, $t_ms, $t_ms);
+SQL
+  echo "[debug] mutated opencode.db (completed one todo, added a session + todo)"
+fi
+EOF
+}
+
+payload_tick_only() {
+  cat <<'EOF'
+set -eu
+
+apk add --no-cache bash sqlite >/dev/null
+
+cd /workspace
+
+if [ ! -f .opencode/soul.md ]; then
+  echo "missing .opencode/soul.md (expected bootstrap run first)" >&2
+  exit 1
+fi
+
+db="$HOME/.local/share/opencode/opencode.db"
+if [ ! -f "$db" ]; then
+  echo "missing opencode db at $db (expected bootstrap run first)" >&2
+  exit 1
+fi
+
+now_ms() { echo "$(( $(date +%s) * 1000 ))"; }
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e ':a;N;$!ba;s/\n/\\n/g'
+}
+
+read_section() {
+  awk -v name="$1" '
+    $0 ~ "^## "name"$" { inside=1; next }
+    inside && $0 ~ /^## / { exit }
+    inside { print }
+  ' .opencode/soul.md
+}
+
+heartbeat() {
+  ws="$(pwd)"
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  session_count="$(sqlite3 "$db" "SELECT COUNT(1) FROM session WHERE directory = '$ws';" 2>/dev/null || echo 0)"
+  open_todos="$(sqlite3 "$db" "SELECT COUNT(1) FROM todo t JOIN session s ON s.id = t.session_id WHERE s.directory = '$ws' AND t.status != 'completed';" 2>/dev/null || echo 0)"
+  recent_titles="$(sqlite3 -separator ' | ' "$db" "SELECT title FROM session WHERE directory = '$ws' ORDER BY time_updated DESC LIMIT 3;" 2>/dev/null || true)"
+  skills_count="$(ls -1 .opencode/skills 2>/dev/null | wc -l | tr -d ' ')"
+  summary="sessions=$session_count open_todos=$open_todos skills=$skills_count"
+  line="{\"ts\":\"$ts\",\"workspace\":\"$ws\",\"db_path\":\"$db\",\"session_count\":$session_count,\"open_todos\":$open_todos,\"skills_count\":$skills_count,\"recent_sessions\":\"$(json_escape "$recent_titles")\",\"summary\":\"$(json_escape "$summary")\"}"
+  printf '%s\n' "$line" >> .opencode/soul/heartbeat.jsonl
+
+  echo ""
+  echo "Soul heartbeat @ $ts"
+  echo "- Workspace: $ws"
+  echo "- Sessions: $session_count"
+  echo "- Open todos: $open_todos"
+  echo "- Recent sessions: ${recent_titles:-<none>}"
+  echo ""
+  echo "Memory snapshot (Preferences):"
+  read_section "Preferences" | sed 's/^/  /'
+  echo ""
+  echo "Curiosity paths:"
+  echo "- Curious about work: I will use the files you store in this worker ($ws) and highlight loose ends."
+  echo "- Curious about topics: tell me 1-3 topics to track; I will check in on them in heartbeats."
+  echo "- Curious about improvements: I will spot repeated chores and suggest skills + automations."
+  echo ""
+
+  echo "[jsonl] appended: $line"
+}
+
+heartbeat
+
+echo ""
+echo "[debug] heartbeat.jsonl lines: $(wc -l < .opencode/soul/heartbeat.jsonl | tr -d ' ')"
+EOF
+}
+
+echo ""
+echo "[proof] container run #1 (bootstrap + heartbeat + db mutation)" >&2
+run_container "$(payload_bootstrap_and_tick)"
+
+echo ""
+echo "[proof] sleep 30s" >&2
+sleep 30
+
+echo ""
+echo "[proof] container run #2 (heartbeat reads persisted memory + db)" >&2
+run_container "$(payload_tick_only)"
+
+echo ""
+echo "[proof] sleep 30s" >&2
+sleep 30
+
+echo ""
+echo "[proof] container run #3 (heartbeat again, then show final artifacts)" >&2
+run_container "$(payload_tick_only); echo ''; echo '[final] soul.md (top 40 lines)'; sed -n '1,40p' .opencode/soul.md; echo ''; echo '[final] heartbeat.jsonl (tail)'; tail -n 5 .opencode/soul/heartbeat.jsonl"
+
+echo ""
+echo "[proof] success" >&2

--- a/packaging/docker/soul-mode-proof.sh
+++ b/packaging/docker/soul-mode-proof.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 # - heartbeat log: .opencode/soul/heartbeat.jsonl
 # - session/todo context via a global OpenCode sqlite db living OUTSIDE the workspace
 #   (simulated at $HOME/.local/share/opencode/opencode.db)
+# - basic "talking" context (seeded sessions + messages) to drive suggestions
+# - self-improving memory (heartbeat writes back suggested improvements)
 # - repeated heartbeats across process restarts (via Docker volumes)
 #
 # Usage (from openwork repo root):
@@ -155,22 +157,98 @@ CREATE TABLE IF NOT EXISTS todo (
   PRIMARY KEY(session_id, position),
   FOREIGN KEY(session_id) REFERENCES session(id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS message (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL,
+  data TEXT NOT NULL,
+  FOREIGN KEY(session_id) REFERENCES session(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS part (
+  id TEXT PRIMARY KEY,
+  message_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  time_created INTEGER NOT NULL,
+  time_updated INTEGER NOT NULL,
+  data TEXT NOT NULL,
+  FOREIGN KEY(message_id) REFERENCES message(id) ON DELETE CASCADE
+);
 SQL
 
   t0="$(now_ms)"
+  t1=$((t0 + 10))
+  t2=$((t0 + 20))
+  t3=$((t0 + 30))
+  t4=$((t0 + 40))
+  t5=$((t0 + 50))
+
   sqlite3 "$db" <<SQL
 INSERT INTO project (id, worktree, vcs, sandboxes, time_created, time_updated)
 VALUES ('proj_1', '/workspace', 'git', '[]', $t0, $t0);
 
+-- Seed three "real" tasks + one baseline session.
 INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
 VALUES
-  ('ses_1', 'proj_1', 'first-run', '/workspace', 'New session - 2026-01-01T00:00:00.000Z', 'test', $t0, $t0),
-  ('ses_2', 'proj_1', 'second-run', '/workspace', 'Fix soul bootstrap', 'test', $t0, $t0);
+  ('ses_img',  'proj_1', 'image-edit', '/workspace', 'Edit image: social hero crop', 'test', $t1, $t1),
+  ('ses_blog', 'proj_1', 'blog-post',  '/workspace', 'Write blog: opencode-router + soul mode', 'test', $t2, $t2),
+  ('ses_code', 'proj_1', 'debate',     '/workspace', 'Programming debate: scheduler seconds', 'test', $t3, $t3);
 
 INSERT INTO todo (session_id, content, status, priority, position, time_created, time_updated)
 VALUES
-  ('ses_2', 'Make soul heartbeat non-blocking', 'pending', 'high', 1, $t0, $t0),
-  ('ses_2', 'Verify sqlite db path permissions', 'pending', 'high', 2, $t0, $t0);
+  ('ses_img',  'Crop assets/hero.png to 1200x630 and export WebP', 'pending', 'high', 1, $t1, $t1),
+  ('ses_img',  'Strip metadata + optimize image size', 'pending', 'normal', 2, $t1, $t1),
+
+  ('ses_blog', 'Draft an outline (H2s + key points)', 'pending', 'normal', 1, $t2, $t2),
+  ('ses_blog', 'Write a first draft in Markdown with frontmatter', 'pending', 'normal', 2, $t2, $t2),
+  ('ses_blog', 'Add one code snippet and a short CTA', 'pending', 'low', 3, $t2, $t2),
+
+  ('ses_code', 'Debate seconds-level scheduling (cron vs interval vs platform timers)', 'pending', 'high', 1, $t3, $t3),
+  ('ses_code', 'Pick an approach and implement with tests', 'pending', 'high', 2, $t3, $t3),
+  ('ses_code', 'Write an ADR capturing tradeoffs and decision', 'pending', 'high', 3, $t3, $t3);
+
+-- Messages store metadata; text lives in parts.
+INSERT INTO message (id, session_id, time_created, time_updated, data)
+VALUES
+  ('msg_img_u1',  'ses_img',  $t1, $t1, '{"role":"user"}'),
+  ('msg_img_a1',  'ses_img',  $t1+1, $t1+1, '{"role":"assistant"}'),
+  ('msg_blog_u1', 'ses_blog', $t2, $t2, '{"role":"user"}'),
+  ('msg_blog_a1', 'ses_blog', $t2+1, $t2+1, '{"role":"assistant"}'),
+  ('msg_code_u1', 'ses_code', $t3, $t3, '{"role":"user"}'),
+  ('msg_code_a1', 'ses_code', $t3+1, $t3+1, '{"role":"assistant"}'),
+  ('msg_code_u2', 'ses_code', $t3+2, $t3+2, '{"role":"user"}'),
+  ('msg_code_a2', 'ses_code', $t3+3, $t3+3, '{"role":"assistant"}');
+
+INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+VALUES
+  ('prt_img_u1', 'msg_img_u1', 'ses_img', $t1, $t1,
+    '{"type":"text","text":"Task: edit an image. Crop assets/hero.png to 1200x630 for social sharing, export WebP, keep text safe area. What is best: ImageMagick CLI or a Node sharp pipeline?"}'),
+
+  ('prt_img_a1', 'msg_img_a1', 'ses_img', $t1+1, $t1+1,
+    '{"type":"text","text":"Suggestion: use ImageMagick for quick local edits, and consider a repeatable workspace command (/image-ops) later. Example: magick assets/hero.png -resize 1200x630^ -gravity center -extent 1200x630 out/hero_1200x630.webp"}'),
+
+  ('prt_img_a1_tool', 'msg_img_a1', 'ses_img', $t1+1, $t1+1,
+    '{"type":"tool","tool":"bash","callID":"call_img_1","state":{"status":"completed","input":{"command":"magick assets/hero.png -resize 1200x630^ -gravity center -extent 1200x630 out/hero_1200x630.webp"},"output":"(simulated)"}}'),
+
+  ('prt_blog_u1', 'msg_blog_u1', 'ses_blog', $t2, $t2,
+    '{"type":"text","text":"Task: write a blog post announcing opencode-router naming and Soul Mode. Output must be Markdown with frontmatter, an outline, and a short CTA."}'),
+
+  ('prt_blog_a1', 'msg_blog_a1', 'ses_blog', $t2+1, $t2+1,
+    '{"type":"text","text":"Suggestion: create a /blog-draft command that scaffolds frontmatter + headings, then iterate. Keep a consistent voice and add one code snippet."}'),
+
+  ('prt_code_u1', 'msg_code_u1', 'ses_code', $t3, $t3,
+    '{"type":"text","text":"Complex programming debate: we want a heartbeat every 30 seconds, but cron is minute-granularity. How should scheduler support this across launchd/systemd? What are the tradeoffs? How do we keep runs non-interactive (no permission prompts)?"}'),
+
+  ('prt_code_a1', 'msg_code_a1', 'ses_code', $t3+1, $t3+1,
+    '{"type":"text","text":"Options: (A) keep cron and do two internal ticks (sleep 30) inside the heartbeat command. (B) add an interval mode to the supervisor (setInterval). (C) use platform timers (systemd OnUnitActiveSec, launchd StartInterval). Recommend: start with (A) + write an ADR so the decision is explicit."}'),
+
+  ('prt_code_u2', 'msg_code_u2', 'ses_code', $t3+2, $t3+2,
+    '{"type":"text","text":"If we add interval mode, how do we store it in job files? How do we test reliably? What about backwards compatibility?"}'),
+
+  ('prt_code_a2', 'msg_code_a2', 'ses_code', $t3+3, $t3+3,
+    '{"type":"text","text":"Do not overload cron syntax. Add an explicit runFormat or a separate interval field. For proof, keep cron as-is and test the 30s behavior via two-tick heartbeat output + JSONL log. Then revisit a first-class interval scheduler."}');
 SQL
 fi
 
@@ -228,6 +306,7 @@ heartbeat() {
           inserted=1
           inside=0
         }
+        if (inside && $0 ~ /^- \(none yet\)$/) next
         print
       }
       END {
@@ -239,9 +318,63 @@ heartbeat() {
     mv .opencode/soul.md.next .opencode/soul.md
   fi
 
+  # Suggested improvements (derived from recent "talking")
+  recent_text="$(sqlite3 -separator '\n' "$db" "SELECT json_extract(p.data, '$.text') FROM part p JOIN message m ON m.id = p.message_id JOIN session s ON s.id = m.session_id WHERE s.directory = '$ws' AND json_extract(p.data, '$.type') = 'text' ORDER BY p.time_created DESC LIMIT 60;" 2>/dev/null || true)"
+
+  tmp_improve="/tmp/soul-improvements.txt"
+  : > "$tmp_improve"
+
+  if echo "$recent_text" | grep -qiE '(png|jpg|jpeg|webp|image|imagemagick|magick|crop|resize)'; then
+    printf '%s\n' "- Suggestion: Add \`/image-ops\` command (ImageMagick) to crop/resize/export WebP consistently." >> "$tmp_improve"
+  fi
+  if echo "$recent_text" | grep -qiE '(blog|frontmatter|markdown|outline|draft)'; then
+    printf '%s\n' "- Suggestion: Add \`/blog-draft\` command to scaffold Markdown frontmatter + headings for posts." >> "$tmp_improve"
+  fi
+  if echo "$recent_text" | grep -qiE '(debate|tradeoff|architecture|scheduler|cron|launchd|systemd|seconds)'; then
+    printf '%s\n' "- Suggestion: Add \`/debate-to-adr\` command to convert long threads into an ADR + extracted TODOs." >> "$tmp_improve"
+  fi
+  if echo "$recent_text" | grep -qiE '(soul mode|heartbeat)'; then
+    printf '%s\n' "- Suggestion: Allow narrow \`edit\` permission for \`.opencode/soul.md\` so scheduled heartbeats can improve memory safely." >> "$tmp_improve"
+  fi
+
+  # Persist new improvements into memory (Recurring chores / automations to consider)
+  tmp_new_improve="/tmp/soul-new-improvements.txt"
+  : > "$tmp_new_improve"
+  if [ -s "$tmp_improve" ]; then
+    while IFS= read -r bullet; do
+      [ -n "$bullet" ] || continue
+      if ! grep -Fq -- "$bullet" .opencode/soul.md; then
+        printf '%s\n' "$bullet" >> "$tmp_new_improve"
+      fi
+    done < "$tmp_improve"
+  fi
+
+  if [ -s "$tmp_new_improve" ]; then
+    awk -v newfile="$tmp_new_improve" '
+      function printfile(f,   line) {
+        while ((getline line < f) > 0) print line
+        close(f)
+      }
+      {
+        if ($0 ~ /^## Recurring chores \/ automations to consider$/) inside=1
+        if (inside && $0 ~ /^- \(none yet\)$/) next
+        print
+      }
+      END {
+        if (inside) {
+          printfile(newfile)
+        }
+      }
+    ' .opencode/soul.md > .opencode/soul.md.next
+    mv .opencode/soul.md.next .opencode/soul.md
+  fi
+
+  improvements_count="$(wc -l < "$tmp_improve" | tr -d ' ')"
+  improvements_summary="$(cat "$tmp_improve" 2>/dev/null | tr '\n' ';' | sed 's/;*$//')"
+
   # Write heartbeat JSONL entry
-  summary="sessions=$session_count open_todos=$open_todos skills=$skills_count"
-  line="{\"ts\":\"$ts\",\"workspace\":\"$ws\",\"db_path\":\"$db\",\"session_count\":$session_count,\"open_todos\":$open_todos,\"skills_count\":$skills_count,\"recent_sessions\":\"$(json_escape "$recent_titles")\",\"summary\":\"$(json_escape "$summary")\"}"
+  summary="sessions=$session_count open_todos=$open_todos skills=$skills_count improvements=$improvements_count"
+  line="{\"ts\":\"$ts\",\"workspace\":\"$ws\",\"db_path\":\"$db\",\"session_count\":$session_count,\"open_todos\":$open_todos,\"skills_count\":$skills_count,\"improvements\":\"$(json_escape "$improvements_summary")\",\"recent_sessions\":\"$(json_escape "$recent_titles")\",\"summary\":\"$(json_escape "$summary")\"}"
   printf '%s\n' "$line" >> .opencode/soul/heartbeat.jsonl
 
   echo ""
@@ -258,6 +391,13 @@ heartbeat() {
   echo ""
   echo "Loose ends (from memory):"
   read_section "Loose ends" | sed 's/^/  /'
+  echo ""
+  echo "Suggested improvements (this cycle):"
+  if [ -s "$tmp_improve" ]; then
+    cat "$tmp_improve" | sed 's/^/  /'
+  else
+    echo "  - (none detected)"
+  fi
   echo ""
   echo "Curiosity paths:"
   echo "- Curious about work: I will use the files you store in this worker ($ws) and highlight loose ends."
@@ -276,13 +416,28 @@ echo "[debug] heartbeat.jsonl lines: $(wc -l < .opencode/soul/heartbeat.jsonl | 
 # Mutate db once during bootstrap so the next container run sees change.
 if [ "${SOUL_PROOF_MUTATE_DB:-1}" = "1" ]; then
   sqlite3 "$db" <<SQL
-UPDATE todo SET status='completed', time_updated=$t_ms WHERE session_id='ses_2' AND position=1;
+UPDATE todo SET status='completed', time_updated=$t_ms WHERE session_id='ses_img' AND position=1;
+UPDATE todo SET status='completed', time_updated=$t_ms WHERE session_id='ses_blog' AND position=1;
+
 INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
-VALUES ('ses_3', 'proj_1', 'third-run', '/workspace', 'Ship Soul Mode proof', 'test', $t_ms, $t_ms);
+VALUES ('ses_impl', 'proj_1', 'implementation', '/workspace', 'Implement: soul commands + ADR', 'test', $t_ms, $t_ms);
+
 INSERT INTO todo (session_id, content, status, priority, position, time_created, time_updated)
-VALUES ('ses_3', 'Add curiosity paths to heartbeat output', 'pending', 'normal', 1, $t_ms, $t_ms);
+VALUES ('ses_impl', 'Create /debate-to-adr command and store ADRs in docs/adr/', 'pending', 'normal', 1, $t_ms, $t_ms);
+
+INSERT INTO message (id, session_id, time_created, time_updated, data)
+VALUES
+  ('msg_impl_u1', 'ses_impl', $t_ms, $t_ms, '{"role":"user"}'),
+  ('msg_impl_a1', 'ses_impl', $t_ms+1, $t_ms+1, '{"role":"assistant"}');
+
+INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+VALUES
+  ('prt_impl_u1', 'msg_impl_u1', 'ses_impl', $t_ms, $t_ms,
+    '{"type":"text","text":"Follow-up: implement the chosen Soul Mode improvements. Start with /debate-to-adr and /image-ops commands."}'),
+  ('prt_impl_a1', 'msg_impl_a1', 'ses_impl', $t_ms+1, $t_ms+1,
+    '{"type":"text","text":"Plan: add commands, keep permissions minimal, then schedule heartbeats. Write an ADR for any behavior that changes defaults."}');
 SQL
-  echo "[debug] mutated opencode.db (completed one todo, added a session + todo)"
+  echo "[debug] mutated opencode.db (completed 2 todos, added a new session + follow-up messages)"
 fi
 EOF
 }
@@ -327,8 +482,66 @@ heartbeat() {
   open_todos="$(sqlite3 "$db" "SELECT COUNT(1) FROM todo t JOIN session s ON s.id = t.session_id WHERE s.directory = '$ws' AND t.status != 'completed';" 2>/dev/null || echo 0)"
   recent_titles="$(sqlite3 -separator ' | ' "$db" "SELECT title FROM session WHERE directory = '$ws' ORDER BY time_updated DESC LIMIT 3;" 2>/dev/null || true)"
   skills_count="$(ls -1 .opencode/skills 2>/dev/null | wc -l | tr -d ' ')"
-  summary="sessions=$session_count open_todos=$open_todos skills=$skills_count"
-  line="{\"ts\":\"$ts\",\"workspace\":\"$ws\",\"db_path\":\"$db\",\"session_count\":$session_count,\"open_todos\":$open_todos,\"skills_count\":$skills_count,\"recent_sessions\":\"$(json_escape "$recent_titles")\",\"summary\":\"$(json_escape "$summary")\"}"
+
+  # Keep memory fresh on every heartbeat.
+  if grep -q '^Last updated:' .opencode/soul.md; then
+    sed -i "s/^Last updated: .*/Last updated: $ts/" .opencode/soul.md
+  fi
+
+  recent_text="$(sqlite3 -separator '\n' "$db" "SELECT json_extract(p.data, '$.text') FROM part p JOIN message m ON m.id = p.message_id JOIN session s ON s.id = m.session_id WHERE s.directory = '$ws' AND json_extract(p.data, '$.type') = 'text' ORDER BY p.time_created DESC LIMIT 60;" 2>/dev/null || true)"
+
+  tmp_improve="/tmp/soul-improvements.txt"
+  : > "$tmp_improve"
+
+  if echo "$recent_text" | grep -qiE '(png|jpg|jpeg|webp|image|imagemagick|magick|crop|resize)'; then
+    printf '%s\n' "- Suggestion: Add \`/image-ops\` command (ImageMagick) to crop/resize/export WebP consistently." >> "$tmp_improve"
+  fi
+  if echo "$recent_text" | grep -qiE '(blog|frontmatter|markdown|outline|draft)'; then
+    printf '%s\n' "- Suggestion: Add \`/blog-draft\` command to scaffold Markdown frontmatter + headings for posts." >> "$tmp_improve"
+  fi
+  if echo "$recent_text" | grep -qiE '(debate|tradeoff|architecture|scheduler|cron|launchd|systemd|seconds)'; then
+    printf '%s\n' "- Suggestion: Add \`/debate-to-adr\` command to convert long threads into an ADR + extracted TODOs." >> "$tmp_improve"
+  fi
+  if echo "$recent_text" | grep -qiE '(soul mode|heartbeat)'; then
+    printf '%s\n' "- Suggestion: Allow narrow \`edit\` permission for \`.opencode/soul.md\` so scheduled heartbeats can improve memory safely." >> "$tmp_improve"
+  fi
+
+  tmp_new_improve="/tmp/soul-new-improvements.txt"
+  : > "$tmp_new_improve"
+  if [ -s "$tmp_improve" ]; then
+    while IFS= read -r bullet; do
+      [ -n "$bullet" ] || continue
+      if ! grep -Fq -- "$bullet" .opencode/soul.md; then
+        printf '%s\n' "$bullet" >> "$tmp_new_improve"
+      fi
+    done < "$tmp_improve"
+  fi
+
+  if [ -s "$tmp_new_improve" ]; then
+    awk -v newfile="$tmp_new_improve" '
+      function printfile(f,   line) {
+        while ((getline line < f) > 0) print line
+        close(f)
+      }
+      {
+        if ($0 ~ /^## Recurring chores \/ automations to consider$/) inside=1
+        if (inside && $0 ~ /^- \(none yet\)$/) next
+        print
+      }
+      END {
+        if (inside) {
+          printfile(newfile)
+        }
+      }
+    ' .opencode/soul.md > .opencode/soul.md.next
+    mv .opencode/soul.md.next .opencode/soul.md
+  fi
+
+  improvements_count="$(wc -l < "$tmp_improve" | tr -d ' ')"
+  improvements_summary="$(cat "$tmp_improve" 2>/dev/null | tr '\n' ';' | sed 's/;*$//')"
+
+  summary="sessions=$session_count open_todos=$open_todos skills=$skills_count improvements=$improvements_count"
+  line="{\"ts\":\"$ts\",\"workspace\":\"$ws\",\"db_path\":\"$db\",\"session_count\":$session_count,\"open_todos\":$open_todos,\"skills_count\":$skills_count,\"improvements\":\"$(json_escape "$improvements_summary")\",\"recent_sessions\":\"$(json_escape "$recent_titles")\",\"summary\":\"$(json_escape "$summary")\"}"
   printf '%s\n' "$line" >> .opencode/soul/heartbeat.jsonl
 
   echo ""
@@ -340,6 +553,19 @@ heartbeat() {
   echo ""
   echo "Memory snapshot (Preferences):"
   read_section "Preferences" | sed 's/^/  /'
+  echo ""
+  echo "Loose ends (from memory):"
+  read_section "Loose ends" | sed 's/^/  /'
+  echo ""
+  echo "Suggested improvements (this cycle):"
+  if [ -s "$tmp_improve" ]; then
+    cat "$tmp_improve" | sed 's/^/  /'
+  else
+    echo "  - (none detected)"
+  fi
+  echo ""
+  echo "Recurring chores / automations (from memory):"
+  read_section "Recurring chores / automations to consider" | sed 's/^/  /'
   echo ""
   echo "Curiosity paths:"
   echo "- Curious about work: I will use the files you store in this worker ($ws) and highlight loose ends."

--- a/packaging/docker/soul-mode-proof.sh
+++ b/packaging/docker/soul-mode-proof.sh
@@ -22,6 +22,7 @@ fi
 SUFFIX="${SOUL_PROOF_SUFFIX:-$(date +%s)-$$}"
 # The official bash image is Alpine-based and keeps the harness simple.
 IMAGE="${SOUL_PROOF_IMAGE:-bash:5.2}"
+INTERVAL_SECONDS="${SOUL_PROOF_INTERVAL_SECONDS:-30}"
 
 WS_VOL="openwork-soul-proof-ws-$SUFFIX"
 DATA_VOL="openwork-soul-proof-data-$SUFFIX"
@@ -46,6 +47,7 @@ run_container() {
 
 echo "[proof] volumes: $WS_VOL (workspace), $DATA_VOL (opencode data)" >&2
 echo "[proof] image: $IMAGE" >&2
+echo "[proof] interval: ${INTERVAL_SECONDS}s" >&2
 
 payload_bootstrap_and_tick() {
   cat <<'EOF'
@@ -208,7 +210,7 @@ heartbeat() {
     2>/dev/null | while IFS=$'\t' read -r content; do
       [ -n "$content" ] || continue
       bullet="- TODO: $content"
-      if ! grep -Fq "$bullet" .opencode/soul.md; then
+      if ! grep -Fq -- "$bullet" .opencode/soul.md; then
         printf '%s\n' "$bullet" >> "$tmp_new"
       fi
     done
@@ -360,16 +362,16 @@ echo "[proof] container run #1 (bootstrap + heartbeat + db mutation)" >&2
 run_container "$(payload_bootstrap_and_tick)"
 
 echo ""
-echo "[proof] sleep 30s" >&2
-sleep 30
+echo "[proof] sleep ${INTERVAL_SECONDS}s" >&2
+sleep "$INTERVAL_SECONDS"
 
 echo ""
 echo "[proof] container run #2 (heartbeat reads persisted memory + db)" >&2
 run_container "$(payload_tick_only)"
 
 echo ""
-echo "[proof] sleep 30s" >&2
-sleep 30
+echo "[proof] sleep ${INTERVAL_SECONDS}s" >&2
+sleep "$INTERVAL_SECONDS"
 
 echo ""
 echo "[proof] container run #3 (heartbeat again, then show final artifacts)" >&2


### PR DESCRIPTION
## What changed
- Expands the bundled `give-me-a-soul` setup prompt so it can reliably bootstrap Soul Mode using existing OpenCode primitives (agents/commands/scheduler), with a concrete non-interactive heartbeat + revert path.
- Fixes the suggested Soul agent permissions so Soul can self-improve memory safely (narrow `read` + `edit` on `.opencode/soul.md`, not broad edit access).
- Deepens the Docker proof harness (`packaging/docker/soul-mode-proof.sh`) to simulate realistic multi-message work and show the Soul loop improving memory.

## Proof / Testing
- `pnpm typecheck`
- `packaging/docker/soul-mode-proof.sh` (default 30s interval; override with `SOUL_PROOF_INTERVAL_SECONDS`)
  - Runs in containers, persists state via Docker volumes.
  - Uses a global OpenCode sqlite DB path *outside the workspace mount*: `/root/.local/share/opencode/opencode.db`.
  - Seeds 3 task sessions with multi-message “talking” content:
    - image edit (ImageMagick)
    - blog post draft (Markdown + frontmatter)
    - complex programming debate (scheduler seconds: cron vs interval vs launchd/systemd)
  - Heartbeat evidence:
    - `session_count` changes 3 → 4 after tick #1 (DB mutation)
    - `open_todos` changes 8 → 7 (progress)
    - JSONL log grows 1 → 2 → 3
    - `.opencode/soul.md` self-updates:
      - open todos inserted into “Loose ends”
      - suggested improvements inserted into “Recurring chores / automations to consider”

### Suggested improvements captured by the heartbeat cycle
- Suggestion: Add `/image-ops` command (ImageMagick) to crop/resize/export WebP consistently.
- Suggestion: Add `/blog-draft` command to scaffold Markdown frontmatter + headings for posts.
- Suggestion: Add `/debate-to-adr` command to convert long threads into an ADR + extracted TODOs.
- Suggestion: Allow narrow `edit` permission for `.opencode/soul.md` so scheduled heartbeats can improve memory safely.

## Notes
- Cron schedules are minute-granularity; the setup prompt includes a recommended fast-test mode (`* * * * *` + `sleep 30`) for ~30s cadence debugging.