### PR TITLE
chore(ci): support forked opencode sidecar

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -61,22 +61,31 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '' }}
         run: |
           set -euo pipefail
 
+          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
           version="${OPENCODE_VERSION:-}"
+
+          if [ -z "$version" ]; then
+            version="$(node -p "require('./packages/desktop/package.json').opencodeVersion || ''" 2>/dev/null || true)"
+          fi
+
+          version="$(echo "$version" | tr -d '\r\n' | sed 's/^v//')"
           if [ -z "$version" ] || [ "$version" = "latest" ]; then
             latest=""
             if [ -n "${GITHUB_TOKEN:-}" ]; then
               latest=$(curl -fsSL \
                 -H "Authorization: Bearer ${GITHUB_TOKEN}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/anomalyco/opencode/releases/latest \
+                "https://api.github.com/repos/${repo}/releases/latest" \
                 | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
             else
               latest=$(curl -fsSL \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/anomalyco/opencode/releases/latest \
+                "https://api.github.com/repos/${repo}/releases/latest" \
                 | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
             fi
             if [ -n "$latest" ]; then
@@ -93,12 +102,17 @@ jobs:
           echo "OPENCODE_VERSION=$version" >> "$GITHUB_ENV"
 
           opencode_asset="opencode-linux-x64-baseline.tar.gz"
-          url="https://github.com/anomalyco/opencode/releases/download/v${version}/${opencode_asset}"
+          url="https://github.com/${repo}/releases/download/v${version}/${opencode_asset}"
           tmp_dir="$RUNNER_TEMP/opencode"
           extract_dir="$tmp_dir/extracted"
           rm -rf "$tmp_dir"
           mkdir -p "$extract_dir"
-          curl -fsSL -o "$tmp_dir/$opencode_asset" "$url"
+
+          curl_headers=()
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            curl_headers+=( -H "Authorization: Bearer ${GITHUB_TOKEN}" )
+          fi
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "${curl_headers[@]}" -o "$tmp_dir/$opencode_asset" "$url"
           tar -xzf "$tmp_dir/$opencode_asset" -C "$extract_dir"
 
           if [ -f "$extract_dir/opencode" ]; then

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,10 +38,19 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '' }}
         run: |
           set -euo pipefail
 
+          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
           version="${OPENCODE_VERSION:-}"
+
+          if [ -z "$version" ]; then
+            version="$(node -p "require('./packages/desktop/package.json').opencodeVersion || ''" 2>/dev/null || true)"
+          fi
+
+          version="$(echo "$version" | tr -d '\r\n' | sed 's/^v//')"
 
           if [ -z "$version" ] || [ "$version" = "latest" ]; then
             latest=""
@@ -49,12 +58,12 @@ jobs:
               latest=$(curl -fsSL \
                 -H "Authorization: Bearer ${GITHUB_TOKEN}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/anomalyco/opencode/releases/latest \
+                "https://api.github.com/repos/${repo}/releases/latest" \
                 | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
             else
               latest=$(curl -fsSL \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/anomalyco/opencode/releases/latest \
+                "https://api.github.com/repos/${repo}/releases/latest" \
                 | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
             fi
             if [ -n "$latest" ]; then
@@ -67,8 +76,62 @@ jobs:
             exit 1
           fi
 
-          curl -fsSL https://opencode.ai/install | bash -s -- --version "$version"
-          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+          arch="$(uname -m)"
+          case "${RUNNER_OS}" in
+            Linux)
+              if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+                opencode_asset="opencode-linux-arm64.tar.gz"
+              else
+                opencode_asset="opencode-linux-x64-baseline.tar.gz"
+              fi
+              ;;
+            macOS)
+              if [ "$arch" = "arm64" ]; then
+                opencode_asset="opencode-darwin-arm64.zip"
+              else
+                opencode_asset="opencode-darwin-x64-baseline.zip"
+              fi
+              ;;
+            *)
+              echo "Unsupported OS: ${RUNNER_OS}" >&2
+              exit 1
+              ;;
+          esac
+
+          url="https://github.com/${repo}/releases/download/v${version}/${opencode_asset}"
+          tmp_dir="$RUNNER_TEMP/opencode"
+          extract_dir="$tmp_dir/extracted"
+          rm -rf "$tmp_dir"
+          mkdir -p "$extract_dir"
+
+          curl_headers=()
+          if [ -n "${GITHUB_TOKEN:-}" ]; then
+            curl_headers+=( -H "Authorization: Bearer ${GITHUB_TOKEN}" )
+          fi
+
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "${curl_headers[@]}" -o "$tmp_dir/$opencode_asset" "$url"
+
+          if [[ "$opencode_asset" == *.tar.gz ]]; then
+            tar -xzf "$tmp_dir/$opencode_asset" -C "$extract_dir"
+          else
+            unzip -q "$tmp_dir/$opencode_asset" -d "$extract_dir"
+          fi
+
+          if [ -f "$extract_dir/opencode" ]; then
+            bin_path="$extract_dir/opencode"
+          elif [ -f "$extract_dir/opencode.exe" ]; then
+            bin_path="$extract_dir/opencode.exe"
+          else
+            echo "OpenCode binary not found in archive" >&2
+            ls -la "$extract_dir"
+            exit 1
+          fi
+
+          install_dir="$HOME/.opencode/bin"
+          mkdir -p "$install_dir"
+          cp "$bin_path" "$install_dir/opencode"
+          chmod 755 "$install_dir/opencode"
+          echo "$install_dir" >> "$GITHUB_PATH"
 
       - name: Verify OpenCode
         run: opencode --version

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -83,6 +83,8 @@ jobs:
       RELEASE_NAME: ${{ needs.prepare-release.outputs.release_name }}
       RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}
       MACOS_NOTARIZE: ${{ vars.MACOS_NOTARIZE || 'false' }}
+      OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+      OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '' }}
 
     strategy:
       fail-fast: false
@@ -161,6 +163,7 @@ jobs:
         run: |
           node <<'NODE' >> "$GITHUB_OUTPUT"
           const fs = require('fs');
+          const repo = (process.env.OPENCODE_GITHUB_REPO || 'anomalyco/opencode').trim() || 'anomalyco/opencode';
 
           async function resolveLatest() {
             const token = (process.env.GITHUB_TOKEN || '').trim();
@@ -173,7 +176,7 @@ jobs:
 
             // Prefer API, but fall back to the web "latest" redirect if rate-limited (403) or otherwise blocked.
             try {
-              const res = await fetch('https://api.github.com/repos/anomalyco/opencode/releases/latest', { headers });
+              const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
               if (res.ok) {
                 const data = await res.json();
                 const tag = (typeof data.tag_name === 'string' ? data.tag_name : '').trim();
@@ -188,7 +191,7 @@ jobs:
               // continue to fallback
             }
 
-            const web = await fetch('https://github.com/anomalyco/opencode/releases/latest', {
+            const web = await fetch(`https://github.com/${repo}/releases/latest`, {
               headers: { 'User-Agent': 'openwork-ci' },
               redirect: 'follow',
             });
@@ -249,7 +252,8 @@ jobs:
               ;;
           esac
 
-          url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
+          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
+          url="https://github.com/${repo}/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
           tmp_dir="$RUNNER_TEMP/opencode"
           extract_dir="$tmp_dir/extracted"
           rm -rf "$tmp_dir"

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -321,9 +321,12 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '' }}
         run: |
           node <<'NODE' >> "$GITHUB_OUTPUT"
           const fs = require('fs');
+          const repo = (process.env.OPENCODE_GITHUB_REPO || 'anomalyco/opencode').trim() || 'anomalyco/opencode';
 
           async function resolveLatest() {
             const token = (process.env.GITHUB_TOKEN || '').trim();
@@ -336,7 +339,7 @@ jobs:
 
             // Prefer API, but fall back to the web "latest" redirect if rate-limited (403) or otherwise blocked.
             try {
-              const res = await fetch('https://api.github.com/repos/anomalyco/opencode/releases/latest', { headers });
+              const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
               if (res.ok) {
                 const data = await res.json();
                 const tag = (typeof data.tag_name === 'string' ? data.tag_name : '').trim();
@@ -351,7 +354,7 @@ jobs:
               // continue to fallback
             }
 
-            const web = await fetch('https://github.com/anomalyco/opencode/releases/latest', {
+            const web = await fetch(`https://github.com/${repo}/releases/latest`, {
               headers: { 'User-Agent': 'openwork-ci' },
               redirect: 'follow',
             });
@@ -390,6 +393,7 @@ jobs:
         shell: bash
         env:
           OPENCODE_VERSION: ${{ steps.opencode-version.outputs.version }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
         run: |
           set -euo pipefail
 
@@ -412,7 +416,8 @@ jobs:
               ;;
           esac
 
-          url="https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
+          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
+          url="https://github.com/${repo}/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
           tmp_dir="$RUNNER_TEMP/opencode"
           extract_dir="$tmp_dir/extracted"
           rm -rf "$tmp_dir"

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -606,8 +606,8 @@ export default function SettingsView(props: SettingsViewProps) {
     return sha.length > 12 ? sha.slice(0, 12) : sha;
   };
   const opencodeVersionLabel = () => {
-    const fromOrchestrator = formatOrchestratorBinaryVersion(props.orchestratorStatus?.binaries?.opencode ?? null);
-    if (fromOrchestrator !== "—") return fromOrchestrator;
+    const binary = props.orchestratorStatus?.binaries?.opencode ?? null;
+    if (binary) return formatOrchestratorBinary(binary);
     return props.engineDoctorVersion ?? "—";
   };
   const openworkServerVersionLabel = () => props.openworkServerDiagnostics?.version ?? "—";


### PR DESCRIPTION
## What\n- Allow OpenWork CI/release workflows to download the OpenCode CLI sidecar from a configurable GitHub repo + pinned version (via Actions vars).\n- Make the Settings → Debug pane show the OpenCode binary source + version (e.g. "bundled · 1.1.60-openwork.1") so it’s obvious which build is running.\n\n## How to turn it on\n- Set Actions variables on different-ai/openwork:\n  - OPENCODE_GITHUB_REPO=different-ai/opencode\n  - OPENCODE_VERSION=<your fork tag without leading v>\n\n## Notes\n- Default remains anomalyco/opencode when vars are unset.\n- Download steps include retries; build-desktop also adds auth header when GITHUB_TOKEN is available.