### PR TITLE
feat(ui): share and install skills by link

### DIFF
--- a/packages/app/src/app/lib/publisher.ts
+++ b/packages/app/src/app/lib/publisher.ts
@@ -1,0 +1,77 @@
+export type OpenworkPublisherBundleType = "skill" | "workspace-profile";
+
+export type PublishBundleResult = {
+  url: string;
+};
+
+export const DEFAULT_OPENWORK_PUBLISHER_BASE_URL = "https://share.openwork.software";
+
+function normalizeBaseUrl(input: string): string {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) {
+    throw new Error("Publisher baseUrl is required");
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    if (!text.trim()) return "";
+    try {
+      const json = JSON.parse(text) as Record<string, unknown>;
+      if (json && typeof json.message === "string" && json.message.trim()) {
+        return json.message.trim();
+      }
+    } catch {
+      // ignore
+    }
+    return text.trim();
+  } catch {
+    return "";
+  }
+}
+
+export async function publishOpenworkBundleJson(input: {
+  payload: unknown;
+  bundleType: OpenworkPublisherBundleType;
+  name?: string;
+  baseUrl?: string;
+  timeoutMs?: number;
+}): Promise<PublishBundleResult> {
+  const baseUrl = normalizeBaseUrl(input.baseUrl ?? DEFAULT_OPENWORK_PUBLISHER_BASE_URL);
+  const timeoutMs = typeof input.timeoutMs === "number" && Number.isFinite(input.timeoutMs) ? input.timeoutMs : 15_000;
+
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), Math.max(1_000, timeoutMs));
+
+  try {
+    const response = await fetch(`${baseUrl}/v1/bundles`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "X-OpenWork-Bundle-Type": input.bundleType,
+        "X-OpenWork-Schema-Version": "v1",
+        ...(input.name?.trim() ? { "X-OpenWork-Name": input.name.trim() } : null),
+      },
+      body: JSON.stringify(input.payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const details = await readErrorMessage(response);
+      const suffix = details ? `: ${details}` : "";
+      throw new Error(`Publish failed (${response.status})${suffix}`);
+    }
+
+    const json = (await response.json()) as Record<string, unknown>;
+    const url = typeof json.url === "string" ? json.url.trim() : "";
+    if (!url) {
+      throw new Error("Publisher response missing url");
+    }
+    return { url };
+  } finally {
+    window.clearTimeout(timer);
+  }
+}

--- a/packages/app/src/app/pages/skills.tsx
+++ b/packages/app/src/app/pages/skills.tsx
@@ -3,10 +3,20 @@ import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount }
 import type { HubSkillCard, SkillCard } from "../types";
 
 import Button from "../components/button";
-import { Edit2, FolderOpen, Loader2, Package, Plus, RefreshCw, Search, Sparkles, Trash2, Upload } from "lucide-solid";
+import { Edit2, FolderOpen, Link2, Loader2, Package, Plus, RefreshCw, Search, Sparkles, Trash2, Upload } from "lucide-solid";
 import { currentLocale, t } from "../../i18n";
+import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL, publishOpenworkBundleJson } from "../lib/publisher";
 
 type InstallResult = { ok: boolean; message: string };
+
+type SkillBundleV1 = {
+  schemaVersion: 1;
+  type: "skill";
+  name: string;
+  content: string;
+  description?: string;
+  trigger?: string;
+};
 
 const OPENWORK_DEFAULT_SKILL_NAMES = new Set([
   "workspace-guide",
@@ -52,6 +62,18 @@ export default function SkillsView(props: SkillsViewProps) {
   const uninstallOpen = createMemo(() => uninstallTarget() != null);
   const [searchQuery, setSearchQuery] = createSignal("");
 
+  const [shareTarget, setShareTarget] = createSignal<SkillCard | null>(null);
+  const shareOpen = createMemo(() => shareTarget() != null);
+  const [shareBusy, setShareBusy] = createSignal(false);
+  const [shareUrl, setShareUrl] = createSignal<string | null>(null);
+  const [shareError, setShareError] = createSignal<string | null>(null);
+
+  const [installLinkOpen, setInstallLinkOpen] = createSignal(false);
+  const [installLinkUrl, setInstallLinkUrl] = createSignal("");
+  const [installLinkBusy, setInstallLinkBusy] = createSignal(false);
+  const [installLinkError, setInstallLinkError] = createSignal<string | null>(null);
+  const [installLinkBundle, setInstallLinkBundle] = createSignal<SkillBundleV1 | null>(null);
+
   const [selectedSkill, setSelectedSkill] = createSignal<SkillCard | null>(null);
   const [selectedContent, setSelectedContent] = createSignal("");
   const [selectedLoading, setSelectedLoading] = createSignal(false);
@@ -72,6 +94,26 @@ export default function SkillsView(props: SkillsViewProps) {
     const id = window.setTimeout(() => setToast(null), 2400);
     onCleanup(() => window.clearTimeout(id));
   });
+
+  const maskError = (value: unknown) => (value instanceof Error ? value.message : "Something went wrong");
+
+  const stripFrontmatter = (content: string) => {
+    const raw = String(content ?? "");
+    const match = raw.match(/^---\s*\r?\n[\s\S]*?\r?\n---\s*\r?\n?/);
+    if (!match) return raw;
+    return raw.slice(match[0].length);
+  };
+
+  const resolveUniqueSkillName = (base: string, taken: Set<string>) => {
+    const trimmed = String(base ?? "").trim();
+    if (!trimmed) return "";
+    if (!taken.has(trimmed)) return trimmed;
+    for (let i = 2; i < 1_000; i++) {
+      const candidate = `${trimmed}-${i}`;
+      if (!taken.has(candidate)) return candidate;
+    }
+    return `${trimmed}-${Date.now()}`;
+  };
 
   const filteredSkills = createMemo(() => {
     const query = searchQuery().trim().toLowerCase();
@@ -188,6 +230,164 @@ export default function SkillsView(props: SkillsViewProps) {
     // Open a new session and preselect /skill-creator.
     await Promise.resolve(props.createSessionAndOpen());
     props.setPrompt("/skill-creator");
+  };
+
+  const openShareLink = (skill: SkillCard) => {
+    if (props.busy) return;
+    setShareTarget(skill);
+    setShareBusy(false);
+    setShareUrl(null);
+    setShareError(null);
+  };
+
+  const closeShareLink = () => {
+    setShareTarget(null);
+    setShareBusy(false);
+    setShareUrl(null);
+    setShareError(null);
+  };
+
+  const publishShareLink = async () => {
+    const target = shareTarget();
+    if (!target) return;
+    if (props.busy || shareBusy()) return;
+    setShareBusy(true);
+    setShareUrl(null);
+    setShareError(null);
+
+    try {
+      const skill = await props.readSkill(target.name);
+      if (!skill) throw new Error("Failed to load skill");
+
+      const payload: SkillBundleV1 = {
+        schemaVersion: 1,
+        type: "skill",
+        name: target.name,
+        content: skill.content,
+        description: target.description ?? undefined,
+        trigger: target.trigger ?? undefined,
+      };
+
+      const result = await publishOpenworkBundleJson({
+        payload,
+        bundleType: "skill",
+        name: target.name,
+      });
+
+      setShareUrl(result.url);
+      try {
+        await navigator.clipboard.writeText(result.url);
+        setToast("Link copied");
+      } catch {
+        // ignore
+      }
+    } catch (e) {
+      setShareError(maskError(e));
+    } finally {
+      setShareBusy(false);
+    }
+  };
+
+  const openInstallFromLink = () => {
+    if (props.busy) return;
+    setInstallLinkOpen(true);
+    setInstallLinkUrl("");
+    setInstallLinkBusy(false);
+    setInstallLinkError(null);
+    setInstallLinkBundle(null);
+  };
+
+  const closeInstallFromLink = () => {
+    setInstallLinkOpen(false);
+    setInstallLinkBusy(false);
+    setInstallLinkError(null);
+    setInstallLinkBundle(null);
+  };
+
+  const previewInstallLink = async () => {
+    const raw = installLinkUrl().trim();
+    if (!raw) {
+      setInstallLinkError("Paste a link to preview");
+      return;
+    }
+    if (installLinkBusy()) return;
+
+    setInstallLinkBusy(true);
+    setInstallLinkError(null);
+    setInstallLinkBundle(null);
+    try {
+      const url = new URL(raw);
+      const controller = new AbortController();
+      const timer = window.setTimeout(() => controller.abort(), 15_000);
+      try {
+        const response = await fetch(url.toString(), {
+          method: "GET",
+          headers: { Accept: "application/json" },
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          const text = (await response.text()).trim();
+          const suffix = text ? `: ${text}` : "";
+          throw new Error(`Failed to fetch bundle (${response.status})${suffix}`);
+        }
+        const json = (await response.json()) as Record<string, unknown>;
+        const schemaVersion = typeof json.schemaVersion === "number" ? json.schemaVersion : null;
+        const type = typeof json.type === "string" ? json.type : "";
+        const name = typeof json.name === "string" ? json.name.trim() : "";
+        const content = typeof json.content === "string" ? json.content : "";
+        if (schemaVersion !== 1 || type !== "skill") {
+          throw new Error("This link is not an OpenWork skill bundle");
+        }
+        if (!name) throw new Error("Bundle is missing a skill name");
+        if (!content) throw new Error("Bundle is missing skill content");
+        setInstallLinkBundle({
+          schemaVersion: 1,
+          type: "skill",
+          name,
+          content,
+          description: typeof json.description === "string" ? json.description : undefined,
+          trigger: typeof json.trigger === "string" ? json.trigger : undefined,
+        });
+      } finally {
+        window.clearTimeout(timer);
+      }
+    } catch (e) {
+      setInstallLinkError(maskError(e));
+    } finally {
+      setInstallLinkBusy(false);
+    }
+  };
+
+  const installFromPreview = async (mode: "overwrite" | "keep-both") => {
+    const bundle = installLinkBundle();
+    if (!bundle) return;
+    if (props.busy || installLinkBusy()) return;
+    setInstallLinkBusy(true);
+    setInstallLinkError(null);
+
+    try {
+      const taken = installedNames();
+      const desiredName = bundle.name.trim();
+      const conflict = taken.has(desiredName);
+      const shouldRename = conflict && mode === "keep-both";
+      const finalName = shouldRename ? resolveUniqueSkillName(desiredName, taken) : desiredName;
+      const content = shouldRename ? stripFrontmatter(bundle.content) : bundle.content;
+
+      await Promise.resolve(
+        props.saveSkill({
+          name: finalName,
+          content,
+          description: bundle.description,
+        }),
+      );
+      props.refreshSkills({ force: true });
+      setToast(`Installed ${finalName}`);
+      closeInstallFromLink();
+    } catch (e) {
+      setInstallLinkError(maskError(e));
+    } finally {
+      setInstallLinkBusy(false);
+    }
   };
 
   const recommendedDisabledReason = (id: string) => {
@@ -373,6 +573,20 @@ export default function SkillsView(props: SkillsViewProps) {
           <Plus size={14} />
           New skill
         </button>
+        <button
+          type="button"
+          onClick={openInstallFromLink}
+          disabled={props.busy}
+          class={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors border ${
+            props.busy
+              ? "border-dls-border bg-dls-hover text-dls-secondary"
+              : "border-dls-border bg-dls-surface text-dls-text hover:bg-dls-active"
+          }`}
+          title="Install a skill from a link"
+        >
+          <Link2 size={14} />
+          Install from link
+        </button>
       </div>
 
       <Show when={props.accessHint}>
@@ -440,6 +654,19 @@ export default function SkillsView(props: SkillsViewProps) {
                     </div>
                   </div>
                   <div class="flex items-center gap-1">
+                    <button
+                      type="button"
+                      class="p-1.5 text-dls-secondary hover:text-dls-text hover:bg-dls-active rounded-md transition-colors"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        openShareLink(skill);
+                      }}
+                      disabled={props.busy}
+                      title="Share link"
+                    >
+                      <Link2 size={14} />
+                    </button>
                     <button
                       type="button"
                       class="p-1.5 text-dls-secondary hover:text-dls-text hover:bg-dls-active rounded-md transition-colors"
@@ -739,6 +966,163 @@ export default function SkillsView(props: SkillsViewProps) {
                 >
                   {translate("skills.uninstall")}
                 </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={shareOpen()}>
+        <div class="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm flex items-center justify-center p-4">
+          <div class="bg-dls-surface border border-dls-border w-full max-w-md rounded-2xl shadow-2xl overflow-hidden">
+            <div class="p-6 space-y-4">
+              <div>
+                <h3 class="text-lg font-semibold text-dls-text">Share link</h3>
+                <p class="text-sm text-dls-secondary mt-1">
+                  Publish a public link. Anyone with the URL can install this skill.
+                </p>
+              </div>
+
+              <div class="rounded-xl border border-dls-border bg-dls-hover px-4 py-3 text-xs text-dls-secondary">
+                <div class="font-semibold text-dls-text">{shareTarget()?.name}</div>
+                <div class="mt-1 font-mono break-all">Publisher: {DEFAULT_OPENWORK_PUBLISHER_BASE_URL}</div>
+              </div>
+
+              <Show when={shareError()}>
+                <div class="rounded-xl border border-red-7/20 bg-red-1/40 px-4 py-3 text-xs text-red-12">
+                  {shareError()}
+                </div>
+              </Show>
+
+              <Show
+                when={shareUrl()}
+                fallback={
+                  <div class="flex justify-end gap-2">
+                    <Button variant="outline" onClick={closeShareLink} disabled={shareBusy()}>
+                      {translate("common.cancel")}
+                    </Button>
+                    <Button variant="secondary" onClick={() => void publishShareLink()} disabled={shareBusy()}>
+                      {shareBusy() ? "Publishing…" : "Create link"}
+                    </Button>
+                  </div>
+                }
+              >
+                <div class="rounded-xl bg-dls-hover border border-dls-border p-3 text-xs text-dls-secondary font-mono break-all">
+                  {shareUrl()}
+                </div>
+                <div class="flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => void navigator.clipboard.writeText(shareUrl() ?? "")}
+                    disabled={!shareUrl()}
+                  >
+                    Copy link
+                  </Button>
+                  <Button variant="secondary" onClick={closeShareLink}>
+                    Done
+                  </Button>
+                </div>
+              </Show>
+            </div>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={installLinkOpen()}>
+        <div class="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm flex items-center justify-center p-4">
+          <div class="bg-dls-surface border border-dls-border w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden">
+            <div class="p-6 space-y-4">
+              <div>
+                <h3 class="text-lg font-semibold text-dls-text">Install from link</h3>
+                <p class="text-sm text-dls-secondary mt-1">Paste a skill bundle URL, preview it, then install.</p>
+              </div>
+
+              <div class="space-y-2">
+                <div class="text-xs font-semibold uppercase tracking-widest text-dls-secondary">Link</div>
+                <input
+                  type="url"
+                  value={installLinkUrl()}
+                  onInput={(e) => setInstallLinkUrl(e.currentTarget.value)}
+                  placeholder="https://share.openwork.software/b/..."
+                  class="w-full bg-dls-hover border border-dls-border rounded-lg px-3 py-2 text-xs font-mono text-dls-text focus:outline-none"
+                  spellcheck={false}
+                />
+              </div>
+
+              <Show when={installLinkError()}>
+                <div class="rounded-xl border border-red-7/20 bg-red-1/40 px-4 py-3 text-xs text-red-12">
+                  {installLinkError()}
+                </div>
+              </Show>
+
+              <Show when={installLinkBundle()}>
+                {(bundle) => {
+                  const taken = installedNames();
+                  const conflict = taken.has(bundle().name.trim());
+                  return (
+                    <div class="rounded-xl border border-dls-border bg-dls-hover p-4 space-y-2">
+                      <div class="text-xs font-semibold text-dls-text">Preview</div>
+                      <div class="text-xs text-dls-secondary">
+                        Skill: <span class="font-mono">{bundle().name}</span>
+                      </div>
+                      <Show when={bundle().description}>
+                        <div class="text-xs text-dls-secondary">{bundle().description}</div>
+                      </Show>
+                      <Show when={conflict}>
+                        <div class="text-xs text-amber-11">A skill with this name is already installed.</div>
+                      </Show>
+                    </div>
+                  );
+                }}
+              </Show>
+
+              <div class="flex justify-end gap-2">
+                <Button variant="outline" onClick={closeInstallFromLink} disabled={installLinkBusy()}>
+                  {translate("common.cancel")}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => void previewInstallLink()}
+                  disabled={installLinkBusy() || !installLinkUrl().trim()}
+                >
+                  {installLinkBusy() && !installLinkBundle() ? "Loading…" : "Preview"}
+                </Button>
+                <Show when={installLinkBundle()} keyed>
+                  {(bundle) => {
+                    const conflict = installedNames().has(bundle.name.trim());
+                    return (
+                      <Show
+                        when={conflict}
+                        fallback={
+                          <Button
+                            variant="secondary"
+                            onClick={() => void installFromPreview("overwrite")}
+                            disabled={installLinkBusy()}
+                          >
+                            {installLinkBusy() ? "Installing…" : "Install"}
+                          </Button>
+                        }
+                      >
+                        <div class="flex gap-2">
+                          <Button
+                            variant="outline"
+                            onClick={() => void installFromPreview("keep-both")}
+                            disabled={installLinkBusy()}
+                          >
+                            {installLinkBusy() ? "Installing…" : "Keep both"}
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            onClick={() => void installFromPreview("overwrite")}
+                            disabled={installLinkBusy()}
+                          >
+                            {installLinkBusy() ? "Installing…" : "Overwrite"}
+                          </Button>
+                        </div>
+                      </Show>
+                    );
+                  }}
+                </Show>
               </div>
             </div>
           </div>

--- a/services/openwork-share/.gitignore
+++ b/services/openwork-share/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.vercel/
+.vercel

--- a/services/openwork-share/README.md
+++ b/services/openwork-share/README.md
@@ -1,0 +1,46 @@
+# OpenWork Share Service (Publisher)
+
+This is a tiny publisher service for OpenWork "share link" bundles.
+
+It is designed to be deployed on Vercel and backed by Vercel Blob.
+
+## Endpoints
+
+- `POST /v1/bundles`
+  - Accepts JSON bundle payloads.
+  - Stores bytes in Vercel Blob.
+  - Returns `{ "url": "https://share.openwork.software/b/<id>" }`.
+
+- `GET /b/:id`
+  - Proxies the stored object back to the caller.
+
+## Required Environment Variables
+
+- `BLOB_READ_WRITE_TOKEN`
+  - Vercel Blob token with read/write permissions.
+
+## Optional Environment Variables
+
+- `PUBLIC_BASE_URL`
+  - Default: `https://share.openwork.software`
+  - Used to construct the returned share URL.
+
+- `MAX_BYTES`
+  - Default: `5242880` (5MB)
+  - Hard upload limit.
+
+## Local development
+
+This repo is intended for Vercel deployment.
+For local testing you can use:
+
+```bash
+cd services/openwork-share
+pnpm install
+vercel dev
+```
+
+## Notes
+
+- Links are public and unguessable (no auth, no encryption).
+- Do not publish secrets in bundles.

--- a/services/openwork-share/api/b/[id].js
+++ b/services/openwork-share/api/b/[id].js
@@ -1,0 +1,48 @@
+import { head } from "@vercel/blob";
+
+function setCors(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type,Accept");
+}
+
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return;
+  }
+  if (req.method !== "GET") {
+    res.status(405).json({ message: "Method not allowed" });
+    return;
+  }
+
+  const id = String(req.query?.id ?? "").trim();
+  if (!id) {
+    res.status(400).json({ message: "id is required" });
+    return;
+  }
+
+  const pathname = `bundles/${id}.json`;
+
+  let blob;
+  try {
+    blob = await head(pathname);
+  } catch {
+    res.status(404).json({ message: "Not found" });
+    return;
+  }
+
+  // Proxy through this service so CORS is controlled here.
+  const response = await fetch(blob.url, { method: "GET" });
+  if (!response.ok) {
+    res.status(502).json({ message: "Upstream blob fetch failed" });
+    return;
+  }
+
+  res.setHeader("Content-Type", blob.contentType || response.headers.get("content-type") || "application/json");
+  res.setHeader("Cache-Control", "public, max-age=3600");
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  res.status(200).send(buffer);
+}

--- a/services/openwork-share/api/health.js
+++ b/services/openwork-share/api/health.js
@@ -1,0 +1,4 @@
+export default function handler(req, res) {
+  res.setHeader("Content-Type", "application/json");
+  res.status(200).send(JSON.stringify({ ok: true }));
+}

--- a/services/openwork-share/api/v1/bundles.js
+++ b/services/openwork-share/api/v1/bundles.js
@@ -1,0 +1,87 @@
+import { put } from "@vercel/blob";
+import { ulid } from "ulid";
+
+function getEnv(name, fallback = "") {
+  const value = process.env[name];
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function normalizeBaseUrl(input) {
+  const trimmed = String(input ?? "").trim();
+  return trimmed.replace(/\/+$/, "");
+}
+
+function setCors(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type,Accept,X-OpenWork-Bundle-Type,X-OpenWork-Schema-Version,X-OpenWork-Name",
+  );
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return;
+  }
+  if (req.method !== "POST") {
+    res.status(405).json({ message: "Method not allowed" });
+    return;
+  }
+
+  const maxBytes = Number.parseInt(getEnv("MAX_BYTES", "5242880"), 10);
+  const baseUrl = normalizeBaseUrl(getEnv("PUBLIC_BASE_URL", "https://share.openwork.software"));
+
+  const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
+  if (!contentType.includes("application/json")) {
+    res.status(415).json({ message: "Expected application/json" });
+    return;
+  }
+
+  const raw = await readBody(req);
+  if (!raw || raw.length === 0) {
+    res.status(400).json({ message: "Body is required" });
+    return;
+  }
+  if (raw.length > maxBytes) {
+    res.status(413).json({ message: "Bundle exceeds upload limit", maxBytes });
+    return;
+  }
+
+  // Validate JSON at least parses.
+  try {
+    JSON.parse(raw.toString("utf8"));
+  } catch {
+    res.status(422).json({ message: "Invalid JSON" });
+    return;
+  }
+
+  const id = ulid();
+  const pathname = `bundles/${id}.json`;
+
+  try {
+    await put(pathname, raw, {
+      access: "public",
+      contentType: "application/json",
+      addRandomSuffix: false,
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Blob put failed";
+    res.status(500).json({ message });
+    return;
+  }
+
+  res.setHeader("Content-Type", "application/json");
+  res.status(200).send(JSON.stringify({ url: `${baseUrl}/b/${id}` }));
+}

--- a/services/openwork-share/package.json
+++ b/services/openwork-share/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "openwork-share-service",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "dependencies": {
+    "@vercel/blob": "^0.27.0",
+    "ulid": "^2.3.0"
+  }
+}

--- a/services/openwork-share/vercel.json
+++ b/services/openwork-share/vercel.json
@@ -1,0 +1,7 @@
+{
+  "rewrites": [
+    { "source": "/health", "destination": "/api/health" },
+    { "source": "/b/(.*)", "destination": "/api/b/$1" },
+    { "source": "/v1/(.*)", "destination": "/api/v1/$1" }
+  ]
+}


### PR DESCRIPTION
## What
- Add a per-skill \"Share link\" action that publishes a public JSON bundle and returns a URL.
- Add \"Install from link\" flow with preview + conflict handling (overwrite / keep both).
- Add a tiny default publisher service in `services/openwork-share` (Vercel Functions + Vercel Blob).

## Bundle format
- `schemaVersion: 1`
- `type: \"skill\"`
- `name`, `content`, optional `description`/`trigger`

## Publisher endpoints
- `POST /v1/bundles` -> `{ url }`
- `GET /b/:id` -> JSON bundle
- `GET /health` -> `{ ok: true }`

## Test plan
1. Skills -> click link icon on a skill -> Create link -> confirm URL + clipboard copy.
2. Skills -> Install from link -> paste URL -> Preview -> Install.
3. Re-install same skill to confirm Overwrite + Keep both behaviors.