### PR TITLE
fix(desktop): prevent sidecar crashes from AVX and DNS config

### DIFF
--- a/packages/desktop/scripts/prepare-sidecar.mjs
+++ b/packages/desktop/scripts/prepare-sidecar.mjs
@@ -131,13 +131,13 @@ const bunTarget = (() => {
     case "aarch64-apple-darwin":
       return "bun-darwin-arm64";
     case "x86_64-apple-darwin":
-      return "bun-darwin-x64";
+      return "bun-darwin-x64-baseline";
     case "aarch64-unknown-linux-gnu":
       return "bun-linux-arm64";
     case "x86_64-unknown-linux-gnu":
-      return "bun-linux-x64";
+      return "bun-linux-x64-baseline";
     case "x86_64-pc-windows-msvc":
-      return "bun-windows-x64";
+      return "bun-windows-x64-baseline";
     default:
       return null;
   }

--- a/packages/desktop/src-tauri/src/bun_env.rs
+++ b/packages/desktop/src-tauri/src/bun_env.rs
@@ -1,0 +1,153 @@
+const SAFE_DNS_RESULT_ORDER: &str = "verbatim";
+
+fn is_valid_dns_result_order(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_lowercase();
+    normalized == "ipv4first" || normalized == "verbatim"
+}
+
+fn sanitize_dns_result_order_args(raw: &str) -> Option<String> {
+    let tokens: Vec<&str> = raw.split_whitespace().collect();
+    let mut kept = Vec::new();
+    let mut changed = false;
+    let mut index = 0usize;
+
+    while index < tokens.len() {
+        let token = tokens[index];
+
+        if let Some(order) = token.strip_prefix("--dns-result-order=") {
+            if is_valid_dns_result_order(order) {
+                kept.push(token.to_string());
+            } else {
+                changed = true;
+            }
+            index += 1;
+            continue;
+        }
+
+        if token == "--dns-result-order" {
+            match tokens.get(index + 1).copied() {
+                Some(order) if is_valid_dns_result_order(order) => {
+                    kept.push(token.to_string());
+                    kept.push(order.to_string());
+                }
+                Some(_) | None => {
+                    changed = true;
+                }
+            }
+            index += 2;
+            continue;
+        }
+
+        kept.push(token.to_string());
+        index += 1;
+    }
+
+    if !changed {
+        return None;
+    }
+
+    Some(kept.join(" "))
+}
+
+pub fn bun_env_overrides() -> Vec<(&'static str, String)> {
+    let mut overrides = vec![(
+        "BUN_CONFIG_DNS_RESULT_ORDER",
+        SAFE_DNS_RESULT_ORDER.to_string(),
+    )];
+
+    if let Ok(value) = std::env::var("BUN_OPTIONS") {
+        if let Some(sanitized) = sanitize_dns_result_order_args(&value) {
+            overrides.push(("BUN_OPTIONS", sanitized));
+        }
+    }
+
+    if let Ok(value) = std::env::var("NODE_OPTIONS") {
+        if let Some(sanitized) = sanitize_dns_result_order_args(&value) {
+            overrides.push(("NODE_OPTIONS", sanitized));
+        }
+    }
+
+    overrides
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn clear(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn strips_invalid_dns_result_order_from_bun_options() {
+        let _lock = ENV_LOCK.lock().expect("lock env");
+        let _bun_options =
+            EnvVarGuard::set("BUN_OPTIONS", "--smol --dns-result-order=ipv6first --hot");
+        let _node_options = EnvVarGuard::clear("NODE_OPTIONS");
+
+        let overrides = bun_env_overrides();
+        let bun_override = overrides
+            .iter()
+            .find(|(key, _)| *key == "BUN_OPTIONS")
+            .map(|(_, value)| value.clone());
+
+        assert_eq!(bun_override.as_deref(), Some("--smol --hot"));
+    }
+
+    #[test]
+    fn strips_invalid_split_dns_result_order_from_node_options() {
+        let _lock = ENV_LOCK.lock().expect("lock env");
+        let _bun_options = EnvVarGuard::clear("BUN_OPTIONS");
+        let _node_options = EnvVarGuard::set(
+            "NODE_OPTIONS",
+            "--max-old-space-size=4096 --dns-result-order weird",
+        );
+
+        let overrides = bun_env_overrides();
+        let node_override = overrides
+            .iter()
+            .find(|(key, _)| *key == "NODE_OPTIONS")
+            .map(|(_, value)| value.clone());
+
+        assert_eq!(node_override.as_deref(), Some("--max-old-space-size=4096"));
+    }
+
+    #[test]
+    fn keeps_valid_dns_result_order_flags() {
+        let _lock = ENV_LOCK.lock().expect("lock env");
+        let _bun_options = EnvVarGuard::set("BUN_OPTIONS", "--dns-result-order=ipv4first");
+        let _node_options = EnvVarGuard::set("NODE_OPTIONS", "--dns-result-order verbatim");
+
+        let overrides = bun_env_overrides();
+
+        assert!(!overrides.iter().any(|(key, _)| *key == "BUN_OPTIONS"));
+        assert!(!overrides.iter().any(|(key, _)| *key == "NODE_OPTIONS"));
+    }
+}

--- a/packages/desktop/src-tauri/src/commands/misc.rs
+++ b/packages/desktop/src-tauri/src/commands/misc.rs
@@ -264,7 +264,12 @@ pub fn opencode_mcp_auth(
     ));
     };
 
-    let output = command_for_program(&program)
+    let mut command = command_for_program(&program);
+    for (key, value) in crate::bun_env::bun_env_overrides() {
+        command.env(key, value);
+    }
+
+    let output = command
         .arg("mcp")
         .arg("auth")
         .arg(server_name)

--- a/packages/desktop/src-tauri/src/engine/doctor.rs
+++ b/packages/desktop/src-tauri/src/engine/doctor.rs
@@ -2,18 +2,18 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use crate::engine::paths::{
-  resolve_opencode_env_override,
-  resolve_opencode_executable,
-  resolve_opencode_executable_without_override,
+    resolve_opencode_env_override, resolve_opencode_executable,
+    resolve_opencode_executable_without_override,
 };
 use crate::platform::command_for_program;
 use crate::utils::truncate_output;
 
 pub fn opencode_version(program: &OsStr) -> Option<String> {
-    let output = command_for_program(Path::new(program))
-        .arg("--version")
-        .output()
-        .ok()?;
+    let mut command = command_for_program(Path::new(program));
+    for (key, value) in crate::bun_env::bun_env_overrides() {
+        command.env(key, value);
+    }
+    let output = command.arg("--version").output().ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
 
@@ -28,11 +28,12 @@ pub fn opencode_version(program: &OsStr) -> Option<String> {
 }
 
 pub fn opencode_serve_help(program: &OsStr) -> (bool, Option<i32>, Option<String>, Option<String>) {
-    match command_for_program(Path::new(program))
-        .arg("serve")
-        .arg("--help")
-        .output()
-    {
+    let mut command = command_for_program(Path::new(program));
+    for (key, value) in crate::bun_env::bun_env_overrides() {
+        command.env(key, value);
+    }
+
+    match command.arg("serve").arg("--help").output() {
         Ok(output) => {
             let status = output.status.code();
             let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -240,7 +241,9 @@ mod tests {
         let (resolved, _in_path, notes) =
             resolve_engine_path(true, None, Some(sidecar_dir.as_path()));
         assert_eq!(resolved.as_ref(), Some(&override_path));
-        assert!(notes.iter().any(|note| note.contains("Using OPENCODE_BIN_PATH")));
+        assert!(notes
+            .iter()
+            .any(|note| note.contains("Using OPENCODE_BIN_PATH")));
 
         let _ = std::fs::remove_dir_all(&override_dir);
         let _ = std::fs::remove_dir_all(&sidecar_dir);

--- a/packages/desktop/src-tauri/src/engine/spawn.rs
+++ b/packages/desktop/src-tauri/src/engine/spawn.rs
@@ -78,6 +78,10 @@ pub fn spawn_engine(
     command = command.env("OPENCODE_CLIENT", "openwork");
     command = command.env("OPENWORK", "1");
 
+    for (key, value) in crate::bun_env::bun_env_overrides() {
+        command = command.env(key, value);
+    }
+
     let resource_dir = app.path().resource_dir().ok();
     let current_bin_dir = tauri::process::current_binary(&app.env())
         .ok()

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod bun_env;
 mod commands;
 mod config;
 mod engine;

--- a/packages/desktop/src-tauri/src/opencode_router/spawn.rs
+++ b/packages/desktop/src-tauri/src/opencode_router/spawn.rs
@@ -64,6 +64,10 @@ pub fn spawn_opencode_router(
         }
     }
 
+    for (key, value) in crate::bun_env::bun_env_overrides() {
+        command = command.env(key, value);
+    }
+
     command
         .spawn()
         .map_err(|e| format!("Failed to start opencodeRouter: {e}"))

--- a/packages/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/packages/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -119,6 +119,10 @@ pub fn spawn_openwork_server(
         }
     }
 
+    for (key, value) in crate::bun_env::bun_env_overrides() {
+        command = command.env(key, value);
+    }
+
     command
         .spawn()
         .map_err(|e| format!("Failed to start OpenWork server: {e}"))

--- a/packages/desktop/src-tauri/src/orchestrator/mod.rs
+++ b/packages/desktop/src-tauri/src/orchestrator/mod.rs
@@ -248,6 +248,10 @@ pub fn spawn_orchestrator_daemon(
         command = command.env("PATH", path_env);
     }
 
+    for (key, value) in crate::bun_env::bun_env_overrides() {
+        command = command.env(key, value);
+    }
+
     command
         .spawn()
         .map_err(|e| format!("Failed to start orchestrator: {e}"))


### PR DESCRIPTION
## Summary
- Build desktop x64 sidecars with Bun baseline targets so `chrome-devtools-mcp`, `openwork-server`, `opencode-router`, and `openwork-orchestrator` run on CPUs without AVX support.
- Add a Bun env sanitizer in desktop Tauri runtime that strips invalid `--dns-result-order` flags from inherited `BUN_OPTIONS`/`NODE_OPTIONS` and pins a safe `BUN_CONFIG_DNS_RESULT_ORDER` value.
- Apply those env overrides to all OpenCode and sidecar spawn paths (engine run/doctor/auth, orchestrator, OpenWork server, OpenCodeRouter) to prevent `error: Invalid DNS result order` startup failures.
- Fixes #570.

## Testing
- `cargo test` (from `packages/desktop/src-tauri`) ✅
- `bun build packages/desktop/scripts/chrome-devtools-mcp-shim.ts --compile --target bun-darwin-x64-baseline --outfile /tmp/openwork-chrome-devtools-mcp-darwin-baseline` ✅
- `bun build packages/desktop/scripts/chrome-devtools-mcp-shim.ts --compile --target bun-linux-x64-baseline --outfile /tmp/openwork-chrome-devtools-mcp-linux-baseline` ✅
- `bun build packages/desktop/scripts/chrome-devtools-mcp-shim.ts --compile --target bun-windows-x64-baseline --outfile /tmp/openwork-chrome-devtools-mcp-windows-baseline.exe` ✅
- `pnpm --filter @different-ai/openwork run prepare:sidecar -- --force --outdir /tmp/openwork-sidecars-smoke` ❌ (worktree has no `node_modules`; build-time deps missing in this environment)