### PR TITLE
fix(desktop): remove shell: true from spawnSync to handle paths with spaces

### DIFF
--- a/packages/desktop/scripts/prepare-sidecar.mjs
+++ b/packages/desktop/scripts/prepare-sidecar.mjs
@@ -343,7 +343,6 @@ if (shouldBuildOpenworkServer) {
   const buildResult = spawnSync("bun", openworkServerArgs, {
     cwd: openworkServerDir,
     stdio: "inherit",
-    shell: true,
   });
 
   if (buildResult.status !== 0) {
@@ -561,7 +560,7 @@ if (shouldBuildOpenCodeRouter) {
   if (bunTarget) {
     opencodeRouterArgs.push("--target", bunTarget);
   }
-  const result = spawnSync("bun", opencodeRouterArgs, { cwd: opencodeRouterDir, stdio: "inherit", shell: true });
+  const result = spawnSync("bun", opencodeRouterArgs, { cwd: opencodeRouterDir, stdio: "inherit" });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
@@ -624,7 +623,6 @@ if (shouldBuildOrchestrator) {
   const result = spawnSync("bun", orchestratorArgs, {
     cwd: orchestratorDir,
     stdio: "inherit",
-    shell: true,
     env: {
       ...process.env,
       NODE_ENV: "production",
@@ -699,7 +697,6 @@ if (shouldBuildChromeDevtools) {
   const result = spawnSync("bun", chromeDevtoolsArgs, {
     cwd: __dirname,
     stdio: "inherit",
-    shell: true,
     env: {
       ...process.env,
       NODE_ENV: "production",


### PR DESCRIPTION
## Summary
Fix build failures when repository path contains spaces (e.g., "Operational CoWork") by removing "shell: true" from spawnSync calls in prepare-sidecar.mjs.

## Changes
- packages/desktop/scripts/prepare-sidecar.mjs: Removed "shell: true" from 4 spawnSync calls (lines ~343, ~564, ~624, ~699)

## Impact
Developers with spaces in their file paths can now build the desktop app successfully. Without this fix, Bun commands fail because the shell splits arguments on spaces.

## Related
Fixes shell escaping issues with Bun commands in prepare-sidecar.mjs.

## Checklist
- [x] PR description is complete
- [x] Changes follow vault structure guidelines
- [x] Knowledge is properly categorized (client vs internal)
- [x] Links to related knowledge included (if applicable)
- [x] Date-stamped appropriately (YYYY-MM-DD format)