### PR TITLE
fix(app): preserve empty-session create flow and sync auto titles

### DIFF
--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -720,6 +720,15 @@ export function createSessionStore(options: {
         const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
         if (sessionID) {
           setStore("sessionStatus", sessionID, "idle");
+          const c = options.client();
+          if (c) {
+            try {
+              const latest = unwrap(await c.session.get({ sessionID }));
+              setStore("sessions", (current) => upsertSession(current, latest));
+            } catch {
+              // ignore
+            }
+          }
         }
       }
     }

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -1278,6 +1278,29 @@ export function createWorkspaceStore(options: {
     }
   }
 
+  const openEmptySession = async (scopeRoot?: string) => {
+    const root = (scopeRoot ?? activeWorkspaceRoot().trim()).trim();
+
+    // Load sessions scoped to the newly-active worker before we clear selection.
+    // This avoids briefly auto-selecting a session from the previously-active worker
+    // when the user is already on the /session route.
+    if (options.client()) {
+      try {
+        await options.loadSessions(root || undefined);
+      } catch {
+        // If session load fails, still proceed to show an empty session.
+      }
+    }
+
+    options.setSelectedSessionId(null);
+    options.setMessages([]);
+    options.setTodos([]);
+    options.setPendingPermissions([]);
+    options.setSessionStatusById({});
+
+    options.setView("session");
+  };
+
   async function createWorkspaceFlow(preset: WorkspacePreset, folder: string | null) {
     if (!isTauriRuntime()) {
       options.setError(t("app.error.tauri_required", currentLocale()));
@@ -1309,16 +1332,14 @@ export function createWorkspaceStore(options: {
         updateWorkspaceConnectionState(ws.activeId, { status: "connected", message: null });
       }
 
-      const active = ws.workspaces.find((w) => w.id === ws.activeId) ?? null;
-        if (active) {
-          setProjectDir(active.path);
-          setAuthorizedDirs([active.path]);
-        }
-
       setCreateWorkspaceOpen(false);
-      options.setTab("scheduled");
-      options.setView("dashboard");
       markOnboardingComplete();
+
+      if (ws.activeId) {
+        await activateWorkspace(ws.activeId);
+      }
+
+      await openEmptySession(ws.activeId ? activeWorkspaceRoot().trim() : resolvedFolder);
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
       options.setError(addOpencodeCacheHint(message));
@@ -1460,8 +1481,6 @@ export function createWorkspaceStore(options: {
 
         setSandboxStep("connect", { status: "active", detail: null });
 
-        options.setTab("scheduled");
-        options.setView("dashboard");
         markOnboardingComplete();
 
         const ok = await createRemoteWorkspaceFlow({
@@ -2008,13 +2027,13 @@ export function createWorkspaceStore(options: {
       syncActiveWorkspaceId(ws.activeId);
       setCreateWorkspaceOpen(false);
       setCreateRemoteWorkspaceOpen(false);
-      options.setTab("scheduled");
-      options.setView("dashboard");
       markOnboardingComplete();
 
       if (ws.activeId) {
         await activateWorkspace(ws.activeId);
       }
+
+      await openEmptySession(ws.activeId ? activeWorkspaceRoot().trim() : resolvedFolder);
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
       options.setError(addOpencodeCacheHint(message));


### PR DESCRIPTION
## Summary
- keep local and remote worker create flows in an explicit empty-session state instead of routing back to dashboard or a previously selected session
- preload sessions for the newly active workspace before clearing selection so `/session` does not briefly pick a session from the prior workspace
- refresh the session record on `session.idle` so OpenCode auto-generated titles appear in the OpenWork header/sidebar immediately after first prompt runs

## Validation
- `pnpm test:session-switch` ✅ pass
- `pnpm test:sessions` ✅ pass