### PR TITLE
fix: use latest step label in collapsed steps row

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -363,18 +363,6 @@ export default function MessageList(props: MessageListProps) {
           </Show>
         </button>
 
-        <Show when={!expanded()}>
-          <div
-            class={`mt-1 ml-1 pl-3 border-l-2 ${
-              containerProps.isUser ? "border-gray-6" : "border-gray-6/60"
-            }`}
-          >
-            <Show when={latestStep()}>
-              {(part) => <StepRow part={part()} isUser={containerProps.isUser} />}
-            </Show>
-          </div>
-        </Show>
-
         {/* Expanded content */}
         <Show when={expanded()}>
           <div

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -79,11 +79,6 @@ function statusDotClass(status?: string): string {
   }
 }
 
-/** Count total steps in a parts group array */
-function countSteps(partsGroups: Part[][]): number {
-  return partsGroups.reduce((sum, parts) => sum + parts.length, 0);
-}
-
 function latestStepPart(partsGroups: Part[][]): Part | undefined {
   for (let groupIndex = partsGroups.length - 1; groupIndex >= 0; groupIndex -= 1) {
     const parts = partsGroups[groupIndex] ?? [];
@@ -327,8 +322,12 @@ export default function MessageList(props: MessageListProps) {
   }) => {
     const relatedIds = () => containerProps.relatedIds ?? [];
     const expanded = () => isStepsExpanded(containerProps.id, relatedIds());
-    const totalSteps = () => countSteps(containerProps.partsGroups);
     const latestStep = () => latestStepPart(containerProps.partsGroups);
+    const collapsedLabel = () => {
+      const part = latestStep();
+      if (!part) return "View steps";
+      return summarizeStep(part).title;
+    };
     const hasRunning = () =>
       containerProps.partsGroups.some((parts) =>
         parts.some((part) => {
@@ -354,7 +353,7 @@ export default function MessageList(props: MessageListProps) {
             class={`transition-transform duration-200 ${expanded() ? "rotate-90" : ""}`}
           />
           <span class="font-medium">
-            {expanded() ? "Hide steps" : `Show ${totalSteps()} step${totalSteps() === 1 ? "" : "s"}`}
+            {expanded() ? "Hide steps" : collapsedLabel()}
           </span>
           <Show when={hasRunning()}>
             <span class="flex items-center gap-1.5 text-[11px] text-blue-11">


### PR DESCRIPTION
## Summary
- replace collapsed "Show N steps" copy with a latest-step label from the most recent step
- keep expand/collapse behavior unchanged so expanding still shows the full tool-call list
- preserve the running indicator in the collapsed row to keep active state visible

## Validation
- pnpm typecheck
- pnpm build:web