### PR TITLE
fix: handle sandbox workers gracefully when Docker is offline

### DIFF
--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -15,7 +15,12 @@ import type {
   View,
 } from "../types";
 import type { McpDirectoryInfo } from "../constants";
-import { formatRelativeTime, isTauriRuntime, normalizeDirectoryPath } from "../utils";
+import {
+  formatRelativeTime,
+  getWorkspaceTaskLoadErrorDisplay,
+  isTauriRuntime,
+  normalizeDirectoryPath,
+} from "../utils";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../lib/openwork-server";
 import type {
   OpenworkAuditEntry,
@@ -774,6 +779,7 @@ export default function DashboardView(props: DashboardViewProps) {
                 const workspace = () => group.workspace;
                 const isConnecting = () => props.connectingWorkspaceId === workspace().id;
                 const isMenuOpen = () => workspaceMenuId() === workspace().id;
+                const taskLoadError = () => getWorkspaceTaskLoadErrorDisplay(workspace(), group.error);
 
                 return (
                   <div class="space-y-1">
@@ -821,10 +827,14 @@ export default function DashboardView(props: DashboardViewProps) {
                         </Show>
                         <Show when={group.status === "error"}>
                           <span
-                            class="text-[10px] px-2 py-0.5 rounded-full border border-red-7/50 text-red-11 bg-red-3/30"
-                            title={group.error ?? "Failed to load tasks"}
+                            class={`text-[10px] px-2 py-0.5 rounded-full border ${
+                              taskLoadError().tone === "offline"
+                                ? "border-amber-7/50 text-amber-11 bg-amber-3/30"
+                                : "border-red-7/50 text-red-11 bg-red-3/30"
+                            }`}
+                            title={taskLoadError().title}
                           >
-                            Error
+                            {taskLoadError().label}
                           </span>
                         </Show>
                         {/* Session count intentionally hidden (not a useful signal and it can crowd the header actions). */}
@@ -981,10 +991,14 @@ export default function DashboardView(props: DashboardViewProps) {
                               fallback={
                                 <Show when={group.status === "error"}>
                                   <div
-                                    class="w-full px-3 py-2 text-xs text-red-11 ml-2 text-left rounded-lg bg-red-3/20 border border-red-7/40"
-                                    title={group.error ?? "Failed to load tasks"}
+                                    class={`w-full px-3 py-2 text-xs ml-2 text-left rounded-lg border ${
+                                      taskLoadError().tone === "offline"
+                                        ? "text-amber-11 bg-amber-3/20 border-amber-7/40"
+                                        : "text-red-11 bg-red-3/20 border-red-7/40"
+                                    }`}
+                                    title={taskLoadError().title}
                                   >
-                                    Failed to load tasks
+                                    {taskLoadError().message}
                                   </div>
                                 </Show>
                               }

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -56,7 +56,13 @@ import StatusBar from "../components/status-bar";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../lib/openwork-server";
 import type { OpenworkServerClient, OpenworkServerSettings, OpenworkServerStatus } from "../lib/openwork-server";
 import { join } from "@tauri-apps/api/path";
-import { formatRelativeTime, isTauriRuntime, normalizeDirectoryPath, parseTemplateFrontmatter } from "../utils";
+import {
+  formatRelativeTime,
+  getWorkspaceTaskLoadErrorDisplay,
+  isTauriRuntime,
+  normalizeDirectoryPath,
+  parseTemplateFrontmatter,
+} from "../utils";
 
 import browserSetupTemplate from "../data/commands/browser-setup.md?raw";
 import soulSetupTemplate from "../data/commands/give-me-a-soul.md?raw";
@@ -1793,6 +1799,7 @@ export default function SessionView(props: SessionViewProps) {
                 const workspace = () => group.workspace;
                 const isConnecting = () => props.connectingWorkspaceId === workspace().id;
                 const isMenuOpen = () => workspaceMenuId() === workspace().id;
+                const taskLoadError = () => getWorkspaceTaskLoadErrorDisplay(workspace(), group.error);
 
                 return (
                   <div class="space-y-1">
@@ -1840,10 +1847,14 @@ export default function SessionView(props: SessionViewProps) {
                           </Show>
                           <Show when={group.status === "error"}>
                             <span
-                              class="text-[10px] px-2 py-0.5 rounded-full border border-red-7/50 text-red-11 bg-red-3/30"
-                              title={group.error ?? "Failed to load tasks"}
+                              class={`text-[10px] px-2 py-0.5 rounded-full border ${
+                                taskLoadError().tone === "offline"
+                                  ? "border-amber-7/50 text-amber-11 bg-amber-3/30"
+                                  : "border-red-7/50 text-red-11 bg-red-3/30"
+                              }`}
+                              title={taskLoadError().title}
                             >
-                              Error
+                              {taskLoadError().label}
                             </span>
                           </Show>
                           <Show when={isConnecting()}>
@@ -1989,10 +2000,14 @@ export default function SessionView(props: SessionViewProps) {
                               fallback={
                                 <Show when={group.status === "error"}>
                                   <div
-                                    class="w-full px-3 py-2 text-xs text-red-11 ml-2 text-left rounded-lg bg-red-3/20 border border-red-7/40"
-                                    title={group.error ?? "Failed to load tasks"}
+                                    class={`w-full px-3 py-2 text-xs ml-2 text-left rounded-lg border ${
+                                      taskLoadError().tone === "offline"
+                                        ? "text-amber-11 bg-amber-3/20 border-amber-7/40"
+                                        : "text-red-11 bg-red-3/20 border-red-7/40"
+                                    }`}
+                                    title={taskLoadError().title}
                                   >
-                                    Failed to load tasks
+                                    {taskLoadError().message}
                                   </div>
                                 </Show>
                               }

--- a/packages/app/src/app/utils/index.ts
+++ b/packages/app/src/app/utils/index.ts
@@ -9,6 +9,7 @@ import type {
   PlaceholderAssistantMessage,
   ProviderListItem,
 } from "../types";
+import type { WorkspaceInfo } from "../lib/tauri";
 
 export function formatModelRef(model: ModelRef) {
   return `${model.providerID}/${model.modelID}`;
@@ -267,6 +268,78 @@ export function addOpencodeCacheHint(message: string) {
   }
 
   return message;
+}
+
+const SANDBOX_DOCKER_OFFLINE_HINTS = [
+  "cannot connect to the docker daemon",
+  "is the docker daemon running",
+  "docker daemon",
+  "docker desktop",
+  "docker engine",
+  "error during connect",
+  "docker.sock",
+  "docker_socket",
+  "open //./pipe/docker_engine",
+];
+
+const SANDBOX_NETWORK_HINTS = [
+  "failed to fetch",
+  "fetch failed",
+  "networkerror",
+  "request timed out",
+  "timeout",
+  "connection refused",
+  "econnrefused",
+  "connection reset",
+  "socket hang up",
+  "enotfound",
+  "getaddrinfo",
+  "could not connect",
+];
+
+export function isSandboxWorkspace(workspace: WorkspaceInfo) {
+  return (
+    workspace.workspaceType === "remote" &&
+    (workspace.sandboxBackend === "docker" ||
+      Boolean(workspace.sandboxRunId?.trim()) ||
+      Boolean(workspace.sandboxContainerName?.trim()))
+  );
+}
+
+export function getWorkspaceTaskLoadErrorDisplay(workspace: WorkspaceInfo, error?: string | null) {
+  const raw = error?.trim() ?? "";
+  const fallbackTitle = raw || "Failed to load tasks";
+  if (!raw || !isSandboxWorkspace(workspace)) {
+    return {
+      tone: "error" as const,
+      label: "Error",
+      message: "Failed to load tasks",
+      title: fallbackTitle,
+    };
+  }
+
+  const normalized = raw.toLowerCase();
+  const hasDockerHint = SANDBOX_DOCKER_OFFLINE_HINTS.some((hint) => normalized.includes(hint));
+  const hasNetworkHint = SANDBOX_NETWORK_HINTS.some((hint) => normalized.includes(hint));
+  const host = `${workspace.baseUrl ?? ""} ${workspace.openworkHostUrl ?? ""}`.toLowerCase();
+  const localHost = host.includes("localhost") || host.includes("127.0.0.1");
+
+  if (!hasDockerHint && !(localHost && hasNetworkHint)) {
+    return {
+      tone: "error" as const,
+      label: "Error",
+      message: "Failed to load tasks",
+      title: fallbackTitle,
+    };
+  }
+
+  const message = "Sandbox is offline. Start Docker Desktop, then test connection.";
+  return {
+    tone: "offline" as const,
+    label: "Offline",
+    message,
+    title: `${message}\n\n${raw}`,
+  };
 }
 
 export function parseTemplateFrontmatter(raw: string) {


### PR DESCRIPTION
## Summary
- detect Docker-offline and local sandbox network errors when task loading fails for sandbox workers.
- show an `Offline` state with actionable copy instead of a generic `Error`/`Failed to load tasks` message in both dashboard and session sidebars.
- keep the original backend error in the tooltip so detailed diagnostics are still available.

## Testing
- `pnpm install`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
- `docker info` *(fails here: Docker daemon is not reachable in this environment)*

## Verification Gap
- Could not run `packaging/docker/dev-up.sh` or complete Chrome MCP UI verification because Docker is offline on this machine.
- Reviewer repro once Docker is running:
  1. Start stack: `packaging/docker/dev-up.sh`
  2. Open OpenWork UI, select a sandbox worker, then stop Docker.
  3. Confirm the worker row switches to `Offline` and the task list message shows the Docker recovery hint.