### PR TITLE
fix: keep long sessions responsive in session view

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -686,7 +686,10 @@ export default function App() {
     setPendingPermissions,
   } = sessionStore;
 
-  const artifacts = createMemo(() => deriveArtifacts(messages()));
+  const ARTIFACT_SCAN_MESSAGE_WINDOW = 220;
+  const artifacts = createMemo(() =>
+    deriveArtifacts(messages(), { maxMessages: ARTIFACT_SCAN_MESSAGE_WINDOW }),
+  );
   const workingFiles = createMemo(() => deriveWorkingFiles(artifacts()));
   const activeSessionId = createMemo(() => selectedSessionId());
   const activeSessions = createMemo(() => sessions());

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -4,7 +4,7 @@ import type { Part } from "@opencode-ai/sdk/v2/client";
 import { Check, ChevronDown, ChevronRight, Copy, Eye, File, FileEdit, FolderSearch, Pencil, Search, Sparkles, Terminal } from "lucide-solid";
 
 import type { MessageGroup, MessageWithParts } from "../../types";
-import { classifyTool, groupMessageParts, summarizeStep } from "../../utils";
+import { groupMessageParts, summarizeStep } from "../../utils";
 import PartView from "../part-view";
 
 export type MessageListProps = {
@@ -242,21 +242,9 @@ export default function MessageList(props: MessageListProps) {
 
   /** Compact single-line step row */
   const StepRow = (rowProps: { part: Part; isUser: boolean }) => {
-    const summary = () => summarizeStep(rowProps.part);
-    const category = () => {
-      if (rowProps.part.type === "tool") {
-        const toolName = (rowProps.part as any).tool ? String((rowProps.part as any).tool) : "";
-        return classifyTool(toolName);
-      }
-      return "tool";
-    };
-    const status = () => {
-      if (rowProps.part.type === "tool") {
-        const state = (rowProps.part as any).state ?? {};
-        return state.status ? String(state.status) : undefined;
-      }
-      return undefined;
-    };
+    const summary = createMemo(() => summarizeStep(rowProps.part));
+    const category = createMemo(() => summary().toolCategory ?? "tool");
+    const status = createMemo(() => summary().status);
 
     return (
       <div class="flex items-center gap-2.5 py-1.5 min-h-[28px] group/step">

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -223,6 +223,7 @@ const SOUL_SETUP_TEMPLATE = (() => {
 })();
 
 const INITIAL_MESSAGE_WINDOW = 140;
+const MESSAGE_WINDOW_LOAD_CHUNK = 120;
 
 export default function SessionView(props: SessionViewProps) {
   let messagesEndEl: HTMLDivElement | undefined;
@@ -381,6 +382,22 @@ export default function SessionView(props: SessionViewProps) {
     const hidden = props.messages.length - renderedMessages().length;
     return hidden > 0 ? hidden : 0;
   });
+
+  const nextRevealCount = createMemo(() => {
+    const hidden = hiddenMessageCount();
+    if (hidden <= 0) return 0;
+    return Math.min(hidden, MESSAGE_WINDOW_LOAD_CHUNK);
+  });
+
+  const revealEarlierMessages = () => {
+    const hidden = hiddenMessageCount();
+    if (hidden <= 0) return;
+    const nextStart = Math.max(0, messageWindowStart() - MESSAGE_WINDOW_LOAD_CHUNK);
+    setMessageWindowStart(nextStart);
+    if (nextStart === 0) {
+      setMessageWindowExpanded(true);
+    }
+  };
 
   const canUndoLastMessage = createMemo(() => {
     if (!props.selectedSessionId) return false;
@@ -2424,13 +2441,10 @@ export default function SessionView(props: SessionViewProps) {
               <button
                 type="button"
                 class="rounded-full border border-dls-border bg-dls-hover/70 px-3 py-1 text-xs text-dls-secondary transition-colors hover:bg-dls-active hover:text-dls-text"
-                onClick={() => {
-                  setMessageWindowExpanded(true);
-                  setMessageWindowStart(0);
-                }}
+                onClick={revealEarlierMessages}
               >
-                Show {hiddenMessageCount().toLocaleString()} earlier message
-                {hiddenMessageCount() === 1 ? "" : "s"}
+                Show {nextRevealCount().toLocaleString()} earlier message
+                {nextRevealCount() === 1 ? "" : "s"}
               </button>
             </div>
           </Show>

--- a/packages/app/src/app/utils/index.ts
+++ b/packages/app/src/app/utils/index.ts
@@ -743,9 +743,11 @@ function buildToolDetail(state: any, toolName: string): string | undefined {
   }
 
   // For completed tools with output, show a very short summary
-  const output = typeof state?.output === "string" && state.output.trim() ? state.output.trim() : null;
-  if (output) {
+  const outputRaw = typeof state?.output === "string" ? state.output.trim() : "";
+  if (outputRaw) {
     if (lower === "read") return undefined;
+
+    const output = outputRaw.length > 3000 ? outputRaw.slice(0, 3000) : outputRaw;
 
     // Extract just the first meaningful line (skip line numbers and raw file markers)
     const lines = output.split("\n").filter((l: string) => {
@@ -775,6 +777,15 @@ function buildToolDetail(state: any, toolName: string): string | undefined {
 
   return undefined;
 }
+
+const ARTIFACT_PATH_PATTERN =
+  /(?:^|[\s"'`([{])((?:[a-zA-Z]:[/\\]|\.{1,2}[/\\]|~[/\\]|[/\\])[\w./\\\-]*\.[a-z][a-z0-9]{0,9}|[\w.\-]+[/\\][\w./\\\-]*\.[a-z][a-z0-9]{0,9})/gi;
+const ARTIFACT_OUTPUT_SCAN_LIMIT = 4000;
+const ARTIFACT_OUTPUT_SKIP_TOOLS = new Set(["webfetch"]);
+
+type DeriveArtifactsOptions = {
+  maxMessages?: number;
+};
 
 export function summarizeStep(part: Part): { title: string; detail?: string; isSkill?: boolean; skillName?: string; toolCategory?: string; status?: string } {
   if (part.type === "tool") {
@@ -817,10 +828,15 @@ export function summarizeStep(part: Part): { title: string; detail?: string; isS
   return { title: "Step", toolCategory: "tool" };
 }
 
-export function deriveArtifacts(list: MessageWithParts[]): ArtifactItem[] {
+export function deriveArtifacts(list: MessageWithParts[], options: DeriveArtifactsOptions = {}): ArtifactItem[] {
   const results = new Map<string, ArtifactItem>();
+  const maxMessages =
+    typeof options.maxMessages === "number" && Number.isFinite(options.maxMessages) && options.maxMessages > 0
+      ? Math.floor(options.maxMessages)
+      : null;
+  const source = maxMessages && list.length > maxMessages ? list.slice(list.length - maxMessages) : list;
 
-  list.forEach((message) => {
+  source.forEach((message) => {
     const messageId = String((message.info as any)?.id ?? "");
 
     message.parts.forEach((part) => {
@@ -849,15 +865,23 @@ export function deriveArtifacts(list: MessageWithParts[]): ArtifactItem[] {
         }
       });
 
-      const text = [state.title, state.output]
-        .filter((v): v is string => typeof v === "string")
+      const toolName =
+        typeof record.tool === "string" && record.tool.trim()
+          ? record.tool.trim().toLowerCase()
+          : "";
+      const titleText = typeof state.title === "string" ? state.title : "";
+      const outputText =
+        typeof state.output === "string" && !ARTIFACT_OUTPUT_SKIP_TOOLS.has(toolName)
+          ? state.output.slice(0, ARTIFACT_OUTPUT_SCAN_LIMIT)
+          : "";
+
+      const text = [titleText, outputText]
+        .filter((v): v is string => Boolean(v))
         .join(" ");
 
       if (text) {
-        const pathPattern =
-          /(?:^|[\s"'`([{])((?:[a-zA-Z]:[/\\]|\.{1,2}[/\\]|~[/\\]|[/\\])[\w./\\\-]*\.[a-z][a-z0-9]{0,9}|[\w.\-]+[/\\][\w./\\\-]*\.[a-z][a-z0-9]{0,9})/gi;
-
-        Array.from(text.matchAll(pathPattern))
+        ARTIFACT_PATH_PATTERN.lastIndex = 0;
+        Array.from(text.matchAll(ARTIFACT_PATH_PATTERN))
           .map((m) => m[1])
           .filter((f) => f && f.length <= 500)
           .forEach((f) => matches.add(f));


### PR DESCRIPTION
## Summary
- keep long transcript expansion incremental by loading earlier messages in 120-message chunks instead of expanding the entire hidden history in one click
- reduce per-render work for step rows and tool summaries by memoizing summaries and capping expensive output scans
- speed up artifact extraction for long sessions by scanning only recent messages, skipping `webfetch` output payloads, and capping tool-output scan length

## Validation
- ✅ `pnpm --filter @different-ai/openwork-ui typecheck`
- ✅ `pnpm --filter @different-ai/openwork-ui build`
- ❌ `pnpm --filter @different-ai/openwork-ui test:health` (fails in this environment with `Timed out waiting for /global/health: Unauthorized`)
- ❌ `pnpm --filter @different-ai/openwork-ui test:browser-entry` (fails in this environment with `Timed out waiting for /global/health: Unauthorized`)

## Debug Context
- reproduced against the provided OpenWork web endpoint/workspace and inspected the `YC Interview Prep` session payload
- the inspected session carried large tool outputs (notably `webfetch`), which amplified UI work during transcript and artifact recomputation