### PR TITLE
fix: support domain-grouped skills and global MCP config

### DIFF
--- a/packages/desktop/src-tauri/src/commands/skills.rs
+++ b/packages/desktop/src-tauri/src/commands/skills.rs
@@ -142,16 +142,39 @@ fn gather_skills(
         }
 
         let path = entry.path();
-        if !path.join("SKILL.md").is_file() {
-            continue;
-        }
-
-        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
-            continue;
-        };
-
-        if seen.insert(name.to_string()) {
-            out.push(path);
+        if path.join("SKILL.md").is_file() {
+            // Direct skill: <root>/<name>/SKILL.md
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if seen.insert(name.to_string()) {
+                out.push(path);
+            }
+        } else {
+            // Domain/category folder: <root>/<domain>/<name>/SKILL.md – scan one level deeper.
+            // This supports the convention where global skills are organised as
+            //   skills/<domain>/<skill-name>/SKILL.md
+            // in addition to the flat   skills/<skill-name>/SKILL.md  layout.
+            if let Ok(sub_entries) = fs::read_dir(&path) {
+                for sub_entry in sub_entries.flatten() {
+                    let Ok(sub_ft) = sub_entry.file_type() else {
+                        continue;
+                    };
+                    if !sub_ft.is_dir() {
+                        continue;
+                    }
+                    let sub_path = sub_entry.path();
+                    if !sub_path.join("SKILL.md").is_file() {
+                        continue;
+                    }
+                    let Some(name) = sub_path.file_name().and_then(|s| s.to_str()) else {
+                        continue;
+                    };
+                    if seen.insert(name.to_string()) {
+                        out.push(sub_path);
+                    }
+                }
+            }
         }
     }
 

--- a/packages/desktop/src-tauri/src/commands/skills.rs
+++ b/packages/desktop/src-tauri/src/commands/skills.rs
@@ -181,6 +181,55 @@ fn gather_skills(
     Ok(())
 }
 
+fn find_skill_file_in_root(root: &Path, name: &str) -> Option<PathBuf> {
+    let direct = root.join(name).join("SKILL.md");
+    if direct.is_file() {
+        return Some(direct);
+    }
+
+    let entries = fs::read_dir(root).ok()?;
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let candidate = entry.path().join(name).join("SKILL.md");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn collect_skill_dirs_by_name(root: &Path, name: &str) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+
+    let direct = root.join(name);
+    if direct.join("SKILL.md").is_file() {
+        out.push(direct);
+    }
+
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let candidate = entry.path().join(name);
+            if candidate.join("SKILL.md").is_file() {
+                out.push(candidate);
+            }
+        }
+    }
+
+    out
+}
+
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalSkillCard {
@@ -364,10 +413,9 @@ pub fn read_local_skill(project_dir: String, name: String) -> Result<LocalSkillC
     let roots = collect_skill_roots(project_dir)?;
 
     for root in roots {
-        let path = root.join(&name).join("SKILL.md");
-        if !path.is_file() {
+        let Some(path) = find_skill_file_in_root(&root, &name) else {
             continue;
-        }
+        };
         let raw = fs::read_to_string(&path)
             .map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
         return Ok(LocalSkillContent {
@@ -395,8 +443,7 @@ pub fn write_local_skill(
     let mut target: Option<PathBuf> = None;
 
     for root in roots {
-        let path = root.join(&name).join("SKILL.md");
-        if path.is_file() {
+        if let Some(path) = find_skill_file_in_root(&root, &name) {
             target = Some(path);
             break;
         }
@@ -484,14 +531,11 @@ pub fn uninstall_skill(project_dir: String, name: String) -> Result<ExecResult, 
     let mut removed = false;
 
     for root in skill_roots {
-        let dest = root.join(&name);
-        if !dest.exists() {
-            continue;
+        for dest in collect_skill_dirs_by_name(&root, &name) {
+            fs::remove_dir_all(&dest)
+                .map_err(|e| format!("Failed to remove {}: {e}", dest.display()))?;
+            removed = true;
         }
-
-        fs::remove_dir_all(&dest)
-            .map_err(|e| format!("Failed to remove {}: {e}", dest.display()))?;
-        removed = true;
     }
 
     if !removed {

--- a/packages/server/src/mcp.ts
+++ b/packages/server/src/mcp.ts
@@ -1,8 +1,20 @@
 import { minimatch } from "minimatch";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import type { McpItem } from "./types.js";
 import { readJsoncFile, updateJsoncTopLevel } from "./jsonc.js";
 import { opencodeConfigPath } from "./workspace-files.js";
 import { validateMcpConfig, validateMcpName } from "./validators.js";
+
+function globalOpenCodeConfigPath(): string {
+  const base = join(homedir(), ".config", "opencode");
+  const jsonc = join(base, "opencode.jsonc");
+  const json = join(base, "opencode.json");
+  if (existsSync(jsonc)) return jsonc;
+  if (existsSync(json)) return json;
+  return jsonc; // fall back to jsonc (readJsoncFile handles missing files gracefully)
+}
 
 function getMcpConfig(config: Record<string, unknown>): Record<string, Record<string, unknown>> {
   const mcp = config.mcp;
@@ -27,13 +39,36 @@ function isMcpDisabledByTools(config: Record<string, unknown>, name: string): bo
 
 export async function listMcp(workspaceRoot: string): Promise<McpItem[]> {
   const { data: config } = await readJsoncFile(opencodeConfigPath(workspaceRoot), {} as Record<string, unknown>);
-  const mcpMap = getMcpConfig(config);
-  return Object.entries(mcpMap).map(([name, entry]) => ({
-    name,
-    config: entry,
-    source: "config.project",
-    disabledByTools: isMcpDisabledByTools(config, name) || undefined,
-  }));
+  const { data: globalConfig } = await readJsoncFile(globalOpenCodeConfigPath(), {} as Record<string, unknown>);
+
+  const projectMcpMap = getMcpConfig(config);
+  const globalMcpMap = getMcpConfig(globalConfig);
+
+  const items: McpItem[] = [];
+
+  // Global MCPs first; project-level entries override global ones with the same name.
+  for (const [name, entry] of Object.entries(globalMcpMap)) {
+    if (Object.prototype.hasOwnProperty.call(projectMcpMap, name)) continue;
+    items.push({
+      name,
+      config: entry,
+      source: "config.global",
+      disabledByTools:
+        (isMcpDisabledByTools(globalConfig, name) || isMcpDisabledByTools(config, name)) || undefined,
+    });
+  }
+
+  // Project MCPs (highest priority).
+  for (const [name, entry] of Object.entries(projectMcpMap)) {
+    items.push({
+      name,
+      config: entry,
+      source: "config.project",
+      disabledByTools: isMcpDisabledByTools(config, name) || undefined,
+    });
+  }
+
+  return items;
 }
 
 export async function addMcp(

--- a/packages/server/src/skills.ts
+++ b/packages/server/src/skills.ts
@@ -1,4 +1,5 @@
 import { readdir, readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import type { Dirent } from "node:fs";
 import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import type { SkillItem } from "./types.js";
@@ -49,6 +50,37 @@ const extractTriggerFromBody = (body: string) => {
   return "";
 };
 
+async function parseSkillEntry(
+  skillPath: string,
+  entryName: string,
+  scope: "project" | "global",
+): Promise<SkillItem | null> {
+  const content = await readFile(skillPath, "utf8");
+  const { data, body } = parseFrontmatter(content);
+  const name = typeof data.name === "string" ? data.name : entryName;
+  const description = typeof data.description === "string" ? data.description : "";
+  const trigger =
+    typeof data.trigger === "string"
+      ? data.trigger
+      : typeof data.when === "string"
+        ? data.when
+        : extractTriggerFromBody(body);
+  try {
+    validateSkillName(name);
+    validateDescription(description);
+  } catch {
+    return null;
+  }
+  if (name !== entryName) return null;
+  return {
+    name,
+    description,
+    path: skillPath,
+    scope,
+    trigger: trigger.trim() || undefined,
+  };
+}
+
 async function listSkillsInDir(dir: string, scope: "project" | "global"): Promise<SkillItem[]> {
   if (!(await exists(dir))) return [];
   const entries = await readdir(dir, { withFileTypes: true });
@@ -56,31 +88,30 @@ async function listSkillsInDir(dir: string, scope: "project" | "global"): Promis
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const skillPath = join(dir, entry.name, "SKILL.md");
-    if (!(await exists(skillPath))) continue;
-    const content = await readFile(skillPath, "utf8");
-    const { data, body } = parseFrontmatter(content);
-    const name = typeof data.name === "string" ? data.name : entry.name;
-    const description = typeof data.description === "string" ? data.description : "";
-    const trigger =
-      typeof data.trigger === "string"
-        ? data.trigger
-        : typeof data.when === "string"
-          ? data.when
-          : extractTriggerFromBody(body);
-    try {
-      validateSkillName(name);
-      validateDescription(description);
-    } catch {
-      continue;
+    if (await exists(skillPath)) {
+      // Direct skill: <dir>/<name>/SKILL.md
+      const item = await parseSkillEntry(skillPath, entry.name, scope);
+      if (item) items.push(item);
+    } else {
+      // Domain/category folder: <dir>/<domain>/<name>/SKILL.md – scan one level deeper.
+      // This supports the convention where global skills are organised as
+      //   skills/<domain>/<skill-name>/SKILL.md
+      // in addition to the flat   skills/<skill-name>/SKILL.md  layout.
+      const domainDir = join(dir, entry.name);
+      let subEntries: Dirent[];
+      try {
+        subEntries = await readdir(domainDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const subEntry of subEntries) {
+        if (!subEntry.isDirectory()) continue;
+        const subSkillPath = join(domainDir, subEntry.name, "SKILL.md");
+        if (!(await exists(subSkillPath))) continue;
+        const item = await parseSkillEntry(subSkillPath, subEntry.name, scope);
+        if (item) items.push(item);
+      }
     }
-    if (name !== entry.name) continue;
-    items.push({
-      name,
-      description,
-      path: skillPath,
-      scope,
-      trigger: trigger.trim() || undefined,
-    });
   }
   return items;
 }


### PR DESCRIPTION
## Summary

- **Fixes #621** – Skills organised as `skills/<domain>/<skill-name>/SKILL.md` were silently skipped
- **Fixes #622** – MCP servers from `~/.config/opencode/opencode.json` were completely ignored

---

## Problem

### 1. Skills – domain subfolder layout not supported

The OpenCode CLI convention groups global skills by domain:
\`\`\`
~/.config/opencode/skills/
├── automation/
│   └── my-skill/SKILL.md
└── web-development/
    └── ui-expert/SKILL.md
\`\`\`

Both `gather_skills()` (`skills.rs`) and `listSkillsInDir()` (`skills.ts`) only scanned **one level deep**, so any skill nested under a domain folder was invisible in OpenWork.

### 2. MCP – global config ignored

`listMcp()` (`mcp.ts`) read only the workspace-level `opencode.json(c)`.  
MCP servers defined in `~/.config/opencode/opencode.json` were completely ignored, forcing users to duplicate their configuration in every workspace.

---

## Changes

| File | Change |
|------|--------|
| `packages/desktop/src-tauri/src/commands/skills.rs` | `gather_skills()` – if a top-level dir has no `SKILL.md`, treat it as a domain folder and scan its children |
| `packages/server/src/skills.ts` | `listSkillsInDir()` – same logic; extracted `parseSkillEntry()` helper to avoid duplication |
| `packages/server/src/mcp.ts` | `listMcp()` – reads global config and merges it; project entries override global ones; `source` set to `"config.global"` / `"config.project"` accordingly |

All changes are **fully backwards-compatible** – the existing flat `skills/<name>/SKILL.md` layout continues to work unchanged.

---

## Testing

- TypeScript: `pnpm --filter openwork-server exec tsc --noEmit` → exit 0
- Rust: syntax verified manually (mirrors existing patterns in the same file)

> **Note:** Docker + Chrome MCP end-to-end testing was not run (environment limitation).  
> Reviewer can verify by placing a skill at `~/.config/opencode/skills/<domain>/<name>/SKILL.md` and opening the Skills panel, or by adding an MCP to `~/.config/opencode/opencode.json` and checking the MCP panel.