### PR TITLE
fix(release): avoid latest.json outage during in-progress releases

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -122,7 +122,15 @@ jobs:
             RELEASE_BODY="See the assets to download this version and install."
           fi
 
-          draft="${INPUT_DRAFT:-false}"
+          draft="${INPUT_DRAFT:-}"
+          if [ -z "$draft" ]; then
+            if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+              # Keep tag-triggered releases out of /releases/latest until assets + latest.json are ready.
+              draft="true"
+            else
+              draft="false"
+            fi
+          fi
           prerelease="${INPUT_PRERELEASE:-false}"
           notarize="${INPUT_NOTARIZE:-}"
           if [ -z "$notarize" ]; then
@@ -926,3 +934,40 @@ jobs:
             exit 0
           fi
           scripts/aur/publish-aur.sh "$RELEASE_TAG"
+
+  publish-release:
+    name: Publish GitHub Release
+    needs:
+      - resolve-release
+      - verify-release
+      - publish-tauri
+      - publish-updater-json
+      - release-orchestrator-sidecars
+      - publish-npm
+      - aur-publish
+    if: |
+      always() &&
+      needs.resolve-release.outputs.draft == 'true' &&
+      needs.resolve-release.result == 'success' &&
+      needs.verify-release.result == 'success' &&
+      (needs.publish-tauri.result == 'success' || needs.publish-tauri.result == 'skipped') &&
+      (needs.publish-updater-json.result == 'success' || needs.publish-updater-json.result == 'skipped') &&
+      (needs.release-orchestrator-sidecars.result == 'success' || needs.release-orchestrator-sidecars.result == 'skipped') &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
+      (needs.aur-publish.result == 'success' || needs.aur-publish.result == 'skipped')
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+      RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
+    steps:
+      - name: Publish release after assets are ready
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "${RELEASE_PRERELEASE}" = "true" ]; then
+            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --prerelease
+          else
+            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest
+          fi


### PR DESCRIPTION
## Summary
- default tag-triggered release creation to draft mode so `/releases/latest` stays on the previous stable release while assets are uploading
- add a final `Publish GitHub Release` job that only publishes after `publish-tauri`, `publish-updater-json`, and downstream publish jobs have succeeded or been skipped
- publish non-prerelease tags with `--latest` only after `latest.json` has been uploaded, preventing updater 404 windows

## Root Cause
Release metadata was created as a published release at workflow start. GitHub immediately repointed `/releases/latest` to the new tag before `latest.json` existed, so in-app update checks could fail with "Could not fetch a valid release JSON from the remote" until late jobs completed.

## Validation
- Verified the current fixed pipeline behavior manually by checking release asset availability and updater endpoint responses.
- Confirmed updater endpoint returns valid JSON once `latest.json` is present (`curl -fsSL https://github.com/different-ai/openwork/releases/latest/download/latest.json`).

## Notes
- This change targets tag-push releases (the standard release path) by defaulting them to draft; workflow_dispatch can still explicitly control draft behavior via input.