### PR TITLE
fix(session): remove noisy reasoning markdown from steps

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -341,7 +341,7 @@ export default function MessageList(props: MessageListProps) {
         {(part) => (
           <div>
             <StepRow part={part} isUser={listProps.isUser} />
-            <Show when={props.developerMode && (part.type !== "tool" || props.showThinking)}>
+            <Show when={props.developerMode && part.type !== "reasoning" && (part.type !== "tool" || props.showThinking)}>
               <div class="pl-6 pb-2 text-xs text-gray-10">
                 <PartView
                   part={part}

--- a/packages/app/src/app/utils/index.ts
+++ b/packages/app/src/app/utils/index.ts
@@ -829,8 +829,7 @@ export function summarizeStep(part: Part): { title: string; detail?: string; isS
     const record = part as any;
     const text = typeof record.text === "string" ? record.text.trim() : "";
     if (!text) return { title: "Planning", toolCategory: "tool" };
-    const short = text.length > 80 ? `${text.slice(0, 77)}...` : text;
-    return { title: "Thinking", detail: short, toolCategory: "tool" };
+    return { title: "Thinking", toolCategory: "tool" };
   }
 
   if (part.type === "step-start" || part.type === "step-finish") {


### PR DESCRIPTION
## Summary
- Remove reasoning text details from the step timeline so rows only show `Thinking` without raw `**...**` markdown.
- Keep developer step detail rendering for tool steps, but suppress the extra reasoning detail block that added noise.

## Testing
- `pnpm typecheck`