### PR TITLE
fix(cloud): return workspace-scoped connect URL in token response

### DIFF
--- a/packages/web/components/cloud-control.tsx
+++ b/packages/web/components/cloud-control.tsx
@@ -35,6 +35,8 @@ type WorkerSummary = {
 type WorkerTokens = {
   clientToken: string | null;
   hostToken: string | null;
+  openworkUrl: string | null;
+  workspaceId: string | null;
 };
 
 type WorkerListItem = {
@@ -185,14 +187,17 @@ function getWorkerTokens(payload: unknown): WorkerTokens | null {
   }
 
   const tokens = payload.tokens;
+  const connect = isRecord(payload.connect) ? payload.connect : null;
   const clientToken = typeof tokens.client === "string" ? tokens.client : null;
   const hostToken = typeof tokens.host === "string" ? tokens.host : null;
+  const openworkUrl = connect && typeof connect.openworkUrl === "string" ? connect.openworkUrl : null;
+  const workspaceId = connect && typeof connect.workspaceId === "string" ? connect.workspaceId : null;
 
   if (!clientToken && !hostToken) {
     return null;
   }
 
-  return { clientToken, hostToken };
+  return { clientToken, hostToken, openworkUrl, workspaceId };
 }
 
 function parseWorkerListItem(value: unknown): WorkerListItem | null {
@@ -525,6 +530,16 @@ export function CloudControlPanel() {
   }
 
   async function withResolvedOpenworkCredentials(candidate: WorkerLaunch, options: { quiet?: boolean } = {}) {
+    const existingConnectUrl = candidate.openworkUrl?.trim() ?? "";
+    const existingWorkspaceId = candidate.workspaceId?.trim() ?? "";
+    if (existingConnectUrl && existingWorkspaceId) {
+      return {
+        ...candidate,
+        openworkUrl: existingConnectUrl,
+        workspaceId: existingWorkspaceId
+      };
+    }
+
     const instanceUrl = candidate.instanceUrl?.trim() ?? "";
     if (!instanceUrl) {
       return {
@@ -1018,6 +1033,8 @@ export function CloudControlPanel() {
         worker && worker.workerId === id
           ? {
               ...worker,
+              openworkUrl: tokens.openworkUrl ?? worker.openworkUrl,
+              workspaceId: tokens.workspaceId ?? worker.workspaceId,
               clientToken: tokens.clientToken,
               hostToken: tokens.hostToken
             }
@@ -1027,8 +1044,8 @@ export function CloudControlPanel() {
               status: "unknown",
               provider: null,
               instanceUrl: null,
-              openworkUrl: null,
-              workspaceId: null,
+              openworkUrl: tokens.openworkUrl,
+              workspaceId: tokens.workspaceId,
               clientToken: tokens.clientToken,
               hostToken: tokens.hostToken
             };

--- a/services/den/src/http/workers.ts
+++ b/services/den/src/http/workers.ts
@@ -29,6 +29,72 @@ const token = () => randomBytes(32).toString("hex")
 type WorkerRow = typeof WorkerTable.$inferSelect
 type WorkerInstanceRow = typeof WorkerInstanceTable.$inferSelect
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function normalizeUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "")
+}
+
+function parseWorkspaceSelection(payload: unknown): { workspaceId: string; openworkUrl: string } | null {
+  if (!isRecord(payload) || !Array.isArray(payload.items)) {
+    return null
+  }
+
+  const activeId = typeof payload.activeId === "string" ? payload.activeId : null
+  let workspaceId = activeId
+
+  if (!workspaceId) {
+    for (const item of payload.items) {
+      if (isRecord(item) && typeof item.id === "string" && item.id.trim()) {
+        workspaceId = item.id
+        break
+      }
+    }
+  }
+
+  const baseUrl = typeof payload.baseUrl === "string" ? normalizeUrl(payload.baseUrl) : ""
+  if (!workspaceId || !baseUrl) {
+    return null
+  }
+
+  return {
+    workspaceId,
+    openworkUrl: `${baseUrl}/w/${encodeURIComponent(workspaceId)}`,
+  }
+}
+
+async function resolveConnectUrlFromWorker(instanceUrl: string, clientToken: string) {
+  const baseUrl = normalizeUrl(instanceUrl)
+  if (!baseUrl || !clientToken.trim()) {
+    return null
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/workspaces`, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${clientToken.trim()}`,
+      },
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const payload = (await response.json()) as unknown
+    const selected = parseWorkspaceSelection({
+      ...(isRecord(payload) ? payload : {}),
+      baseUrl,
+    })
+    return selected
+  } catch {
+    return null
+  }
+}
+
 async function requireSession(req: express.Request, res: express.Response) {
   const session = await auth.api.getSession({
     headers: fromNodeHeaders(req.headers),
@@ -335,10 +401,14 @@ workersRouter.post("/:id/tokens", async (req, res) => {
     return
   }
 
+  const instance = await getLatestWorkerInstance(rows[0].id)
+  const connect = instance?.url ? await resolveConnectUrlFromWorker(instance.url, clientToken) : null
+
   res.json({
     tokens: {
       host: hostToken,
       client: clientToken,
     },
+    connect: connect ?? (instance?.url ? { openworkUrl: instance.url, workspaceId: null } : null),
   })
 })


### PR DESCRIPTION
## Summary
- update Den token endpoint to return the worker's existing active token pair plus a workspace-scoped OpenWork URL when available
- resolve `/w/ws_*` URL server-side from the worker's `/workspaces` endpoint to avoid client-side CORS/compat issues
- update web token parsing to use backend-provided connect URL and workspace id before client fallback

## Why
Recovered workers could show host-only URLs and previously-issued fresh tokens that weren't compatible with the live worker env, causing remote connect to silently fail.

## Testing
- `pnpm --filter @openwork/den build`
- `pnpm --filter @different-ai/openwork-web build`