### PR TITLE
fix(app): prevent repeated inbox scans from auth memo churn

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -347,24 +347,30 @@ export default function App() {
     return hostInfo?.baseUrl ?? settingsUrl;
   });
 
-  const openworkServerAuth = createMemo(() => {
-    const pref = startupPreference();
-    const hostInfo = openworkServerHostInfo();
-    const settingsToken = openworkServerSettings().token?.trim() ?? "";
-    const clientToken = hostInfo?.clientToken?.trim() ?? "";
-    const hostToken = hostInfo?.hostToken?.trim() ?? "";
+  const openworkServerAuth = createMemo(
+    () => {
+      const pref = startupPreference();
+      const hostInfo = openworkServerHostInfo();
+      const settingsToken = openworkServerSettings().token?.trim() ?? "";
+      const clientToken = hostInfo?.clientToken?.trim() ?? "";
+      const hostToken = hostInfo?.hostToken?.trim() ?? "";
 
-    if (pref === "local") {
-      return { token: clientToken || undefined, hostToken: hostToken || undefined };
-    }
-    if (pref === "server") {
+      if (pref === "local") {
+        return { token: clientToken || undefined, hostToken: hostToken || undefined };
+      }
+      if (pref === "server") {
+        return { token: settingsToken || undefined, hostToken: undefined };
+      }
+      if (hostInfo?.baseUrl) {
+        return { token: clientToken || undefined, hostToken: hostToken || undefined };
+      }
       return { token: settingsToken || undefined, hostToken: undefined };
-    }
-    if (hostInfo?.baseUrl) {
-      return { token: clientToken || undefined, hostToken: hostToken || undefined };
-    }
-    return { token: settingsToken || undefined, hostToken: undefined };
-  });
+    },
+    undefined,
+    {
+      equals: (prev, next) => prev?.token === next.token && prev?.hostToken === next.hostToken,
+    },
+  );
 
   const openworkServerClient = createMemo(() => {
     const baseUrl = openworkServerBaseUrl().trim();


### PR DESCRIPTION
## Summary
- stabilize `openworkServerAuth` in `packages/app/src/app/app.tsx` with an equality check, so host-info heartbeats do not emit a new auth object when tokens are unchanged
- this keeps `openworkServerClient` identity stable and stops unintended inbox refresh loops that retrigger filesystem scans
- keep the existing auth-selection behavior unchanged (local/server/auto modes still choose the same token sources)

## Reasoning
Issue #644 reports UI freezes while the inbox scanner spins. On current `dev`, the inbox panel refreshes when its `client` prop changes. The app currently polls host info every 10s; `openworkServerAuth` created a fresh object each poll, which recreated the OpenWork client even when credentials stayed the same. That unnecessary client churn can repeatedly trigger inbox listing and keep the UI in a near-constant loading loop on heavier inboxes.

This is a left-side-of-the-curve fix: one small memo-stability change that removes repeated work rather than adding new polling controls, worker threads, or configuration surface area.

## Verification
- ✅ `pnpm --filter @different-ai/openwork-ui typecheck`
- ✅ `pnpm --filter @different-ai/openwork-ui build`
- ❌ `pnpm --filter @different-ai/openwork-ui test:health` (fails in this environment: `Timed out waiting for /global/health: Unauthorized`)
- ❌ Docker + Chrome MCP E2E gate could not complete: `packaging/docker/dev-up.sh` failed because `orchestrator` exited with code 137 (`Killed`) during dependency install

## How to reproduce and verify locally
1. Start OpenWork on a workspace with inbox enabled and many inbox files.
2. Keep the session page open with the Inbox panel visible.
3. On `dev` before this patch, inbox refreshes can recur as host-info polling cycles.
4. With this patch, inbox refresh should only occur on actual auth changes, workspace changes, manual refresh, or upload actions.

Refs #644