### PR TITLE
fix(desktop): cleanly stop orchestrator-managed OpenCode on close

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -55,6 +55,21 @@ use orchestrator::manager::OrchestratorManager;
 use tauri::Manager;
 use workspace::watch::WorkspaceWatchState;
 
+fn stop_managed_services(app_handle: &tauri::AppHandle) {
+    if let Ok(mut engine) = app_handle.state::<EngineManager>().inner.lock() {
+        EngineManager::stop_locked(&mut engine);
+    }
+    if let Ok(mut orchestrator) = app_handle.state::<OrchestratorManager>().inner.lock() {
+        OrchestratorManager::stop_locked(&mut orchestrator);
+    }
+    if let Ok(mut openwork_server) = app_handle.state::<OpenworkServerManager>().inner.lock() {
+        OpenworkServerManager::stop_locked(&mut openwork_server);
+    }
+    if let Ok(mut opencode_router) = app_handle.state::<OpenCodeRouterManager>().inner.lock() {
+        OpenCodeRouterManager::stop_locked(&mut opencode_router);
+    }
+}
+
 pub fn run() {
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
@@ -133,27 +148,16 @@ pub fn run() {
     // Best-effort cleanup on app exit. Without this, background sidecars can keep
     // running after the UI quits (especially during dev), leading to multiple
     // orchestrator/opencode/openwork-server processes and stale ports.
-    app.run(|app_handle, event| {
-        if matches!(
-            event,
-            tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
-        ) {
-            if let Ok(mut engine) = app_handle.state::<EngineManager>().inner.lock() {
-                EngineManager::stop_locked(&mut engine);
-            }
-            if let Ok(mut orchestrator) = app_handle.state::<OrchestratorManager>().inner.lock() {
-                OrchestratorManager::stop_locked(&mut orchestrator);
-            }
-            if let Ok(mut openwork_server) =
-                app_handle.state::<OpenworkServerManager>().inner.lock()
-            {
-                OpenworkServerManager::stop_locked(&mut openwork_server);
-            }
-            if let Ok(mut opencode_router) =
-                app_handle.state::<OpenCodeRouterManager>().inner.lock()
-            {
-                OpenCodeRouterManager::stop_locked(&mut opencode_router);
-            }
+    app.run(|app_handle, event| match event {
+        tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
+            stop_managed_services(&app_handle);
         }
+        tauri::RunEvent::WindowEvent {
+            event: tauri::WindowEvent::CloseRequested { .. },
+            ..
+        } => {
+            stop_managed_services(&app_handle);
+        }
+        _ => {}
     });
 }

--- a/packages/desktop/src-tauri/src/orchestrator/manager.rs
+++ b/packages/desktop/src-tauri/src/orchestrator/manager.rs
@@ -20,12 +20,28 @@ pub struct OrchestratorState {
 
 impl OrchestratorManager {
     pub fn stop_locked(state: &mut OrchestratorState) {
+        let data_dir = state
+            .data_dir
+            .clone()
+            .unwrap_or_else(orchestrator::resolve_orchestrator_data_dir);
+
+        let shutdown_requested = match orchestrator::request_orchestrator_shutdown(&data_dir) {
+            Ok(requested) => requested,
+            Err(error) => {
+                eprintln!("[orchestrator] Failed to request shutdown: {error}");
+                false
+            }
+        };
+
         if let Some(child) = state.child.take() {
-            let _ = child.kill();
+            // Prefer daemon-owned graceful shutdown so openwork-orchestrator can
+            // terminate its managed OpenCode child before exiting.
+            if !shutdown_requested {
+                let _ = child.kill();
+            }
         }
-        if let Some(dir) = state.data_dir.as_deref() {
-            orchestrator::clear_orchestrator_auth(dir);
-        }
+
+        orchestrator::clear_orchestrator_auth(&data_dir);
         state.child_exited = true;
         state.data_dir = None;
         state.last_stdout = None;

--- a/packages/desktop/src-tauri/src/orchestrator/mod.rs
+++ b/packages/desktop/src-tauri/src/orchestrator/mod.rs
@@ -183,6 +183,31 @@ pub fn wait_for_orchestrator(
     Err(last_error.unwrap_or_else(|| "Timed out waiting for orchestrator".to_string()))
 }
 
+pub fn request_orchestrator_shutdown(data_dir: &str) -> Result<bool, String> {
+    let base_url = read_orchestrator_state(data_dir)
+        .and_then(|state| state.daemon.map(|daemon| daemon.base_url))
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty());
+
+    let Some(base_url) = base_url else {
+        return Ok(false);
+    };
+
+    let url = format!("{}/shutdown", base_url.trim_end_matches('/'));
+    let agent = ureq::AgentBuilder::new()
+        .timeout(std::time::Duration::from_millis(1500))
+        .build();
+
+    agent
+        .post(&url)
+        .set("Accept", "application/json")
+        .set("Content-Type", "application/json")
+        .send_string("")
+        .map_err(|e| format!("Failed to request orchestrator shutdown at {url}: {e}"))?;
+
+    Ok(true)
+}
+
 pub fn spawn_orchestrator_daemon(
     app: &AppHandle,
     options: &OrchestratorSpawnOptions,
@@ -255,6 +280,69 @@ pub fn spawn_orchestrator_daemon(
     command
         .spawn()
         .map_err(|e| format!("Failed to start orchestrator: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::request_orchestrator_shutdown;
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use uuid::Uuid;
+
+    #[test]
+    fn request_shutdown_returns_false_without_state() {
+        let dir = std::env::temp_dir().join(format!(
+            "openwork-orchestrator-shutdown-missing-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&dir).expect("create test dir");
+
+        let stopped = request_orchestrator_shutdown(&dir.to_string_lossy()).expect("request");
+        assert!(!stopped);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn request_shutdown_posts_to_daemon_endpoint() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind shutdown listener");
+        let port = listener.local_addr().expect("listener addr").port();
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept shutdown request");
+            let mut buffer = [0u8; 2048];
+            let bytes = stream.read(&mut buffer).expect("read request");
+            let request = String::from_utf8_lossy(&buffer[..bytes]);
+            assert!(request.starts_with("POST /shutdown "));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"ok\":true}",
+                )
+                .expect("write response");
+        });
+
+        let dir = std::env::temp_dir().join(format!(
+            "openwork-orchestrator-shutdown-state-{}",
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&dir).expect("create state dir");
+        let state_path = dir.join("openwork-orchestrator-state.json");
+        fs::write(
+            &state_path,
+            format!(
+                "{{\"daemon\":{{\"pid\":1,\"port\":{port},\"baseUrl\":\"http://127.0.0.1:{port}\",\"startedAt\":1}}}}"
+            ),
+        )
+        .expect("write state file");
+
+        let stopped = request_orchestrator_shutdown(&dir.to_string_lossy()).expect("request");
+        assert!(stopped);
+
+        handle.join().expect("server thread");
+        let _ = fs::remove_dir_all(dir);
+    }
 }
 
 pub fn orchestrator_status_from_state(


### PR DESCRIPTION
## Summary
- Request `openwork-orchestrator` daemon shutdown via its `/shutdown` endpoint before force-killing tracked child processes.
- Run the same managed-service cleanup on both app exit and window close events in Tauri.
- Add orchestrator shutdown unit coverage to verify missing-state behavior and `/shutdown` POST behavior.

## Why
- The desktop app was force-killing orchestrator on close, which could orphan its managed OpenCode process.
- Re-opening and closing repeatedly could accumulate orphaned OpenCode instances and memory use on macOS.

## Intent
- Keep shutdown logic on the left side of the curve: ask the orchestrator daemon to shut itself down first, and only fall back to direct process kill when graceful shutdown is unavailable.
- Preserve current behavior for other managed sidecars while simplifying cleanup flow into one shared path.

## Testing
- `cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml`

Closes #652.