### PR TITLE
fix web GitHub callback and reconcile Polar paid users by email

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -27,6 +27,8 @@ Frontend for `app.openwork.software`.
 - `NEXT_PUBLIC_OPENWORK_APP_CONNECT_URL` (client): Base URL for "Open in App" links.
   - Example: `https://openwork.software/app`
   - The web panel appends `/connect-remote` and injects worker URL/token params automatically.
+- `NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL` (client): Canonical URL used for GitHub auth callback redirects.
+  - default: `https://app.openwork.software`
 
 ## Deploy on Vercel
 

--- a/packages/web/components/cloud-control.tsx
+++ b/packages/web/components/cloud-control.tsx
@@ -71,6 +71,15 @@ const LAST_WORKER_STORAGE_KEY = "openwork:web:last-worker";
 const WORKER_STATUS_POLL_MS = 5000;
 const DEFAULT_AUTH_NAME = "OpenWork User";
 const OPENWORK_APP_CONNECT_BASE_URL = (process.env.NEXT_PUBLIC_OPENWORK_APP_CONNECT_URL ?? "").trim();
+const OPENWORK_AUTH_CALLBACK_BASE_URL = (process.env.NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL ?? "https://app.openwork.software").trim();
+
+function getGithubCallbackUrl(): string {
+  try {
+    return new URL("/", OPENWORK_AUTH_CALLBACK_BASE_URL || "https://app.openwork.software").toString();
+  } catch {
+    return "https://app.openwork.software/";
+  }
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -1073,7 +1082,7 @@ export function CloudControlPanel() {
     setAuthInfo("Redirecting to GitHub...");
 
     try {
-      const callbackURL = window.location.href;
+      const callbackURL = getGithubCallbackUrl();
       const { response, payload } = await requestJson("/api/auth/sign-in/social", {
         method: "POST",
         body: JSON.stringify({

--- a/services/den/README.md
+++ b/services/den/README.md
@@ -73,6 +73,7 @@ pnpm db:migrate
 - `POST /v1/workers`
   - Cloud launches return `202` quickly with worker `status=provisioning` and continue provisioning asynchronously.
   - Returns `402 payment_required` with Polar checkout URL when paywall is enabled and entitlement is missing.
+  - Existing Polar customers are matched by `external_customer_id` first, then by email to preserve access for pre-existing paid users.
 - `GET /v1/workers/:id`
   - Includes latest instance metadata when available.
 - `POST /v1/workers/:id/tokens`

--- a/services/den/src/billing/polar.ts
+++ b/services/den/src/billing/polar.ts
@@ -10,6 +10,16 @@ type PolarCheckoutSession = {
   url?: string
 }
 
+type PolarCustomer = {
+  id?: string
+  email?: string
+  external_id?: string | null
+}
+
+type PolarCustomerList = {
+  items?: PolarCustomer[]
+}
+
 export type CloudWorkerAccess =
   | {
       allowed: true
@@ -27,6 +37,14 @@ type CloudAccessInput = {
 
 function sanitizeApiBase(value: string) {
   return value.replace(/\/+$/, "")
+}
+
+function parseJson<T>(text: string): T | null {
+  if (!text) {
+    return null
+  }
+
+  return JSON.parse(text) as T
 }
 
 async function polarFetch(path: string, init: RequestInit = {}) {
@@ -61,7 +79,7 @@ function assertPaywallConfig() {
   }
 }
 
-async function getCustomerState(externalCustomerId: string): Promise<PolarCustomerState | null> {
+async function getCustomerStateByExternalId(externalCustomerId: string): Promise<PolarCustomerState | null> {
   const encodedExternalId = encodeURIComponent(externalCustomerId)
   const response = await polarFetch(`/v1/customers/external/${encodedExternalId}/state`, {
     method: "GET",
@@ -76,7 +94,64 @@ async function getCustomerState(externalCustomerId: string): Promise<PolarCustom
     throw new Error(`Polar customer state lookup failed (${response.status}): ${text.slice(0, 400)}`)
   }
 
-  return text ? (JSON.parse(text) as PolarCustomerState) : null
+  return parseJson<PolarCustomerState>(text)
+}
+
+async function getCustomerStateById(customerId: string): Promise<PolarCustomerState | null> {
+  const encodedCustomerId = encodeURIComponent(customerId)
+  const response = await polarFetch(`/v1/customers/${encodedCustomerId}/state`, {
+    method: "GET",
+  })
+
+  if (response.status === 404) {
+    return null
+  }
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`Polar customer state lookup by ID failed (${response.status}): ${text.slice(0, 400)}`)
+  }
+
+  return parseJson<PolarCustomerState>(text)
+}
+
+async function getCustomerByEmail(email: string): Promise<PolarCustomer | null> {
+  const normalizedEmail = email.trim().toLowerCase()
+  if (!normalizedEmail) {
+    return null
+  }
+
+  const encodedEmail = encodeURIComponent(normalizedEmail)
+  const response = await polarFetch(`/v1/customers/?email=${encodedEmail}`, {
+    method: "GET",
+  })
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`Polar customer lookup by email failed (${response.status}): ${text.slice(0, 400)}`)
+  }
+
+  const payload = parseJson<PolarCustomerList>(text)
+  const customers = payload?.items ?? []
+  const exact = customers.find((customer) => customer.email?.trim().toLowerCase() === normalizedEmail)
+  return exact ?? customers[0] ?? null
+}
+
+async function linkCustomerExternalId(customer: PolarCustomer, externalCustomerId: string): Promise<void> {
+  if (!customer.id) {
+    return
+  }
+
+  if (typeof customer.external_id === "string" && customer.external_id.length > 0) {
+    return
+  }
+
+  const encodedCustomerId = encodeURIComponent(customer.id)
+  await polarFetch(`/v1/customers/${encodedCustomerId}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      external_id: externalCustomerId,
+    }),
+  })
 }
 
 function hasRequiredBenefit(state: PolarCustomerState | null) {
@@ -122,9 +197,18 @@ export async function requireCloudWorkerAccess(input: CloudAccessInput): Promise
 
   assertPaywallConfig()
 
-  const state = await getCustomerState(input.userId)
-  if (hasRequiredBenefit(state)) {
+  const externalState = await getCustomerStateByExternalId(input.userId)
+  if (hasRequiredBenefit(externalState)) {
     return { allowed: true }
+  }
+
+  const customer = await getCustomerByEmail(input.email)
+  if (customer?.id) {
+    const emailState = await getCustomerStateById(customer.id)
+    if (hasRequiredBenefit(emailState)) {
+      await linkCustomerExternalId(customer, input.userId).catch(() => undefined)
+      return { allowed: true }
+    }
   }
 
   const checkoutUrl = await createCheckoutSession(input)


### PR DESCRIPTION
## Summary
- Force GitHub social sign-in callbacks from the web cloud panel to the canonical `https://app.openwork.software/` URL (with optional `NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL` override).
- Update Den Polar paywall checks to preserve access for existing paid users by falling back to Polar customer lookup by email, then checking customer state by ID.
- When an email-matched customer is entitled, best-effort backfill Polar `external_id` with the OpenWork user ID so future checks resolve on external ID directly.
- Document the new callback env var and Polar entitlement reconciliation behavior.

## Testing
- `pnpm install`
- `pnpm --filter @openwork/den build`
- `pnpm --filter @different-ai/openwork-web build`
- `packaging/docker/dev-up.sh` (stack booted successfully; web/server endpoints healthy)
- Manual Chrome DevTools check on `http://localhost:3015`:
  - clicked **Continue with GitHub**
  - verified request body to `/api/den/api/auth/sign-in/social` uses:
    - `"callbackURL":"https://app.openwork.software/"`
    - `"errorCallbackURL":"https://app.openwork.software/"`

## Notes
- Full GitHub OAuth + Polar entitlement E2E could not be completed locally without production auth/trusted-origin credentials (`INVALID_ORIGIN` in local env).