### PR TITLE
feat(share): redesign share modal and bundle page styling to match openwork identity

### DIFF
--- a/packages/app/src/app/components/share-workspace-modal.tsx
+++ b/packages/app/src/app/components/share-workspace-modal.tsx
@@ -1,8 +1,6 @@
 import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
-import { Copy, X } from "lucide-solid";
-
-import Button from "./button";
+import { Boxes, Check, Copy, Download, Eye, EyeOff, FolderCode, Key, Link as LinkIcon, X } from "lucide-solid";
 
 type ShareField = {
   label: string;
@@ -35,20 +33,22 @@ export default function ShareWorkspaceModal(props: {
   exportDisabledReason?: string | null;
   onOpenBots?: () => void;
 }) {
-  let firstCopyRef: HTMLButtonElement | undefined;
+  const [activeTab, setActiveTab] = createSignal<"access" | "links">("access");
+  const [revealedByIndex, setRevealedByIndex] = createSignal<Record<number, boolean>>({});
+  const [copiedKey, setCopiedKey] = createSignal<string | null>(null);
 
   const title = createMemo(() => props.title ?? "Share worker");
   const detail = createMemo(() => props.workspaceDetail?.trim() ?? "");
   const note = createMemo(() => props.note?.trim() ?? "");
 
-  const [revealedByIndex, setRevealedByIndex] = createSignal<Record<number, boolean>>({});
-  const [copiedKey, setCopiedKey] = createSignal<string | null>(null);
+  // Derived initial character for avatar
+  const avatarLetter = createMemo(() => (props.workspaceName ? props.workspaceName.charAt(0).toUpperCase() : "M"));
 
   createEffect(() => {
     if (!props.open) return;
     setRevealedByIndex({});
     setCopiedKey(null);
-    requestAnimationFrame(() => firstCopyRef?.focus());
+    setActiveTab("access");
   });
 
   createEffect(() => {
@@ -62,15 +62,13 @@ export default function ShareWorkspaceModal(props: {
     onCleanup(() => window.removeEventListener("keydown", handleKeyDown));
   });
 
-  const maskValue = (value: string) => (value ? "************" : "");
-
   const handleCopy = async (value: string, key: string) => {
     const text = value?.trim() ?? "";
     if (!text) return;
     try {
       await navigator.clipboard.writeText(text);
       setCopiedKey(key);
-      window.setTimeout(() => setCopiedKey((current) => (current === key ? null : current)), 900);
+      window.setTimeout(() => setCopiedKey((current) => (current === key ? null : current)), 2000);
     } catch {
       // ignore
     }
@@ -78,235 +76,324 @@ export default function ShareWorkspaceModal(props: {
 
   return (
     <Show when={props.open}>
-      <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-1/60 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+      <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-1/60 backdrop-blur-sm p-4 font-sans animate-in fade-in duration-200">
         <div
-          class="bg-gray-2 border border-gray-6 w-full max-w-2xl rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]"
+          class="bg-white w-full max-w-lg rounded-2xl shadow-[0_20px_50px_-12px_rgba(0,0,0,0.15)] border border-gray-6 overflow-hidden animate-in fade-in zoom-in-95 duration-300 relative flex flex-col max-h-[90vh]"
           role="dialog"
           aria-modal="true"
         >
-          <div class="p-6 border-b border-gray-6 flex justify-between items-center bg-gray-1">
-            <div class="min-w-0">
-              <h3 class="font-semibold text-gray-12 text-lg">{title()}</h3>
-              <div class="text-sm text-gray-10 truncate">{props.workspaceName}</div>
-              <Show when={detail()}>
-                <div class="text-xs text-gray-8 font-mono truncate">{detail()}</div>
-              </Show>
-            </div>
+          {/* Header Section */}
+          <div class="px-6 pt-6 pb-4 relative border-b border-transparent shrink-0">
             <button
               onClick={props.onClose}
-              class="hover:bg-gray-4 p-1 rounded-full"
+              class="absolute top-6 right-6 p-1.5 text-gray-9 hover:text-gray-12 hover:bg-gray-4 rounded-lg transition-all"
               aria-label="Close"
               title="Close"
             >
-              <X size={20} class="text-gray-10" />
+              <X size={20} stroke-width={2.5} />
             </button>
-          </div>
 
-          <div class="p-6 flex-1 overflow-y-auto space-y-6">
-            <div class="space-y-2">
-              <div class="text-sm font-medium text-gray-12">Access</div>
-              <div class="text-xs text-gray-10">
-                Share with trusted people only. Anyone with these details can connect.
+            <div class="flex items-center gap-3">
+              <div class="w-10 h-10 bg-gray-12 rounded-xl flex items-center justify-center text-gray-1 font-bold text-lg">
+                {avatarLetter()}
+              </div>
+              <div>
+                <h2 class="text-[17px] font-bold text-gray-12 tracking-tight">{title()}</h2>
+                <div class="flex items-center gap-2 mt-0.5">
+                  <span class="text-[13px] font-semibold text-gray-11">{props.workspaceName}</span>
+                  <Show when={detail()}>
+                    <span class="w-1 h-1 rounded-full bg-gray-6"></span>
+                    <span class="text-[12px] text-gray-9 truncate max-w-[180px] font-mono">{detail()}</span>
+                  </Show>
+                </div>
               </div>
             </div>
 
-            <div class="grid gap-3">
-              <For each={props.fields}>
-                {(field, index) => {
-                  const key = () => `${field.label}:${index()}`;
-                  const isSecret = () => Boolean(field.secret);
-                  const revealed = () => Boolean(revealedByIndex()[index()]);
-                  const shownValue = () =>
-                    isSecret() && !revealed() ? maskValue(field.value) : field.value;
-
-                  return (
-                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                      <div class="min-w-0">
-                        <div class="text-xs font-medium text-gray-11">{field.label}</div>
-                        <div class="text-xs text-gray-7 font-mono break-all sm:break-normal sm:truncate">
-                          {shownValue() || field.placeholder || "-"}
-                        </div>
-                        <Show when={field.hint && field.hint.trim()}>
-                          <div class="text-[11px] text-gray-8 mt-1">{field.hint}</div>
-                        </Show>
-                      </div>
-                      <div class="flex items-center gap-2 shrink-0 self-end sm:self-auto">
-                        <Show when={isSecret()}>
-                          <Button
-                            variant="outline"
-                            class="text-xs h-8 py-0 px-3"
-                            onClick={() =>
-                              setRevealedByIndex((prev) => ({
-                                ...prev,
-                                [index()]: !prev[index()],
-                              }))
-                            }
-                            disabled={!field.value}
-                          >
-                            {revealed() ? "Hide" : "Show"}
-                          </Button>
-                        </Show>
-                        <Button
-                          ref={(el) => {
-                            if (index() === 0) firstCopyRef = el;
-                          }}
-                          variant="outline"
-                          class="text-xs h-8 py-0 px-3"
-                          onClick={() => handleCopy(field.value, key())}
-                          disabled={!field.value}
-                        >
-                          <Copy size={14} />
-                          {copiedKey() === key() ? "Copied" : "Copy"}
-                        </Button>
-                      </div>
-                    </div>
-                  );
-                }}
-              </For>
+            {/* Tab Switcher */}
+            <div class="flex p-1 bg-gray-2/80 rounded-xl mt-6">
+              <button
+                onClick={() => setActiveTab("access")}
+                class={`flex-1 flex items-center justify-center gap-2 text-[13px] font-bold py-2 px-3 rounded-lg transition-all ${
+                  activeTab() === "access"
+                    ? "bg-white shadow-sm text-gray-12"
+                    : "text-gray-9 hover:text-gray-11 hover:bg-gray-4/50"
+                }`}
+              >
+                <Key size={14} stroke-width={activeTab() === "access" ? 2.5 : 2} />
+                Live Access
+              </button>
+              <button
+                onClick={() => setActiveTab("links")}
+                class={`flex-1 flex items-center justify-center gap-2 text-[13px] font-bold py-2 px-3 rounded-lg transition-all ${
+                  activeTab() === "links"
+                    ? "bg-white shadow-sm text-gray-12"
+                    : "text-gray-9 hover:text-gray-11 hover:bg-gray-4/50"
+                }`}
+              >
+                <LinkIcon size={14} stroke-width={activeTab() === "links" ? 2.5 : 2} />
+                Public Links
+              </button>
             </div>
+          </div>
 
-            <Show when={note()}>
-              <div class="rounded-xl border border-gray-6 bg-gray-1/40 px-4 py-3 text-xs text-gray-10">
-                {note()}
+          {/* Main Content Area */}
+          <div class="px-6 pb-8 flex-1 overflow-y-auto scrollbar-hide">
+            {/* TAB: LIVE ACCESS */}
+            <Show when={activeTab() === "access"}>
+              <div class="space-y-6 pt-2 animate-in fade-in slide-in-from-bottom-3 duration-300">
+                <div class="bg-amber-2/50 border border-amber-6 p-3 rounded-xl">
+                  <p class="text-[13px] text-amber-11 leading-relaxed flex items-start gap-2">
+                    <span class="mt-0.5">⚠️</span>
+                    <span>Share with trusted people only. These credentials grant direct access to your local environment.</span>
+                  </p>
+                </div>
+
+                <div class="space-y-5">
+                  <For each={props.fields}>
+                    {(field, index) => {
+                      const key = () => `${field.label}:${index()}`;
+                      const isSecret = () => Boolean(field.secret);
+                      const revealed = () => Boolean(revealedByIndex()[index()]);
+
+                      return (
+                        <div class="group">
+                          <label class="text-[12px] font-bold text-gray-9 uppercase tracking-wider mb-2 block ml-1">
+                            {field.label}
+                          </label>
+                          <div class="relative flex items-center">
+                            <input
+                              type={isSecret() && !revealed() ? "password" : "text"}
+                              readonly
+                              value={field.value || field.placeholder || ""}
+                              class="w-full bg-gray-2 border border-gray-6 group-hover:border-gray-8 rounded-xl py-3 pl-4 pr-24 text-[13px] font-mono text-gray-12 transition-all outline-none focus:ring-2 focus:ring-gray-12/5 focus:bg-white"
+                            />
+                            <div class="absolute right-2 flex items-center gap-1">
+                              <Show when={isSecret()}>
+                                <button
+                                  onClick={() =>
+                                    setRevealedByIndex((prev) => ({
+                                      ...prev,
+                                      [index()]: !prev[index()],
+                                    }))
+                                  }
+                                  disabled={!field.value}
+                                  class="p-2 text-gray-9 hover:text-gray-12 hover:bg-gray-4/50 rounded-lg transition-all disabled:opacity-50"
+                                >
+                                  <Show when={revealed()} fallback={<Eye size={16} />}>
+                                    <EyeOff size={16} />
+                                  </Show>
+                                </button>
+                              </Show>
+                              <button
+                                onClick={() => handleCopy(field.value, key())}
+                                disabled={!field.value}
+                                class="p-2 text-gray-9 hover:text-gray-12 hover:bg-gray-4/50 rounded-lg transition-all disabled:opacity-50"
+                              >
+                                <Show when={copiedKey() === key()} fallback={<Copy size={16} />}>
+                                  <Check size={16} class="text-emerald-10" />
+                                </Show>
+                              </button>
+                            </div>
+                          </div>
+                          <Show when={field.hint && field.hint.trim()}>
+                            <p class="text-[12px] text-gray-9 mt-2 ml-1 italic">{field.hint}</p>
+                          </Show>
+                        </div>
+                      );
+                    }}
+                  </For>
+                </div>
+                
+                <Show when={note()}>
+                  <div class="rounded-xl border border-gray-6 bg-gray-2/40 px-4 py-3 text-[13px] text-gray-10 mt-6">
+                    {note()}
+                  </div>
+                </Show>
               </div>
             </Show>
 
-            <div class="rounded-2xl border border-gray-6 bg-gray-1/30 p-4 space-y-4">
-              <div>
-                <div class="text-sm font-medium text-gray-12">Share service links</div>
-                <div class="text-xs text-gray-10">
-                  Publish public links for this worker profile or all installed skills.
+            {/* TAB: PUBLIC LINKS */}
+            <Show when={activeTab() === "links"}>
+              <div class="space-y-4 pt-2 animate-in fade-in slide-in-from-bottom-3 duration-300">
+                <div class="mb-4">
+                  <p class="text-[14px] text-gray-11 font-medium">Publish snapshot configurations</p>
+                  <p class="text-[12px] text-gray-9 mt-0.5">Static links for sharing your setup with the community.</p>
+                  <Show when={props.publisherBaseUrl?.trim()}>
+                    <p class="text-[11px] text-gray-9 mt-1 font-mono">Publisher: {props.publisherBaseUrl}</p>
+                  </Show>
                 </div>
-                <Show when={props.publisherBaseUrl?.trim()}>
-                  <div class="text-[11px] text-gray-9 mt-1 font-mono">Publisher: {props.publisherBaseUrl}</div>
-                </Show>
-              </div>
 
-              <div class="rounded-xl border border-gray-6 bg-gray-1/40 p-3 space-y-2">
-                <div class="text-xs font-medium text-gray-11">Workspace profile</div>
-                <div class="text-[11px] text-gray-9">
-                  Includes config, MCP setup, commands, and skills in one OpenWork share URL.
-                </div>
-                <Show when={props.shareWorkspaceProfileError?.trim()}>
-                  <div class="rounded-md border border-red-7/20 bg-red-1/40 px-2 py-1.5 text-[11px] text-red-12">
-                    {props.shareWorkspaceProfileError}
+                {/* Card: Workspace Profile */}
+                <div class="bg-white border border-gray-6 rounded-2xl p-4 shadow-sm hover:shadow-md transition-all group">
+                  <div class="flex items-center gap-3 mb-3">
+                    <div class="p-2 bg-gray-2 rounded-lg text-gray-9 group-hover:text-gray-12 group-hover:bg-gray-3 transition-colors">
+                      <FolderCode size={18} />
+                    </div>
+                    <div class="flex-1">
+                      <h3 class="text-[14px] font-bold text-gray-12">Workspace profile</h3>
+                      <p class="text-[12px] text-gray-9 leading-tight">Config, MCP, and skill bundles.</p>
+                    </div>
                   </div>
-                </Show>
-                <Show when={props.shareWorkspaceProfileUrl?.trim()}>
-                  <div class="rounded-md border border-gray-6 bg-gray-1 px-2 py-1.5 text-[11px] font-mono text-gray-11 break-all">
-                    {props.shareWorkspaceProfileUrl}
-                  </div>
-                </Show>
-                <Show when={props.shareWorkspaceProfileDisabledReason?.trim()}>
-                  <div class="text-[11px] text-gray-9">{props.shareWorkspaceProfileDisabledReason}</div>
-                </Show>
-                <div class="flex items-center justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    class="text-xs h-8 py-0 px-3"
-                    onClick={() => handleCopy(props.shareWorkspaceProfileUrl ?? "", "share-workspace-profile")}
-                    disabled={!props.shareWorkspaceProfileUrl}
-                  >
-                    <Copy size={14} />
-                    {copiedKey() === "share-workspace-profile" ? "Copied" : "Copy"}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    class="text-xs h-8 py-0 px-3"
-                    onClick={() => props.onShareWorkspaceProfile?.()}
-                    disabled={Boolean(props.shareWorkspaceProfileDisabledReason) || !props.onShareWorkspaceProfile || props.shareWorkspaceProfileBusy}
-                  >
-                    {props.shareWorkspaceProfileBusy ? "Publishing..." : props.shareWorkspaceProfileUrl ? "Regenerate" : "Create link"}
-                  </Button>
-                </div>
-              </div>
+                  
+                  <Show when={props.shareWorkspaceProfileError?.trim()}>
+                    <div class="rounded-lg border border-red-6 bg-red-2 p-2 mb-3 text-[12px] text-red-11">
+                      {props.shareWorkspaceProfileError}
+                    </div>
+                  </Show>
+                  <Show when={props.shareWorkspaceProfileDisabledReason?.trim()}>
+                    <div class="text-[12px] text-gray-9 mb-3">{props.shareWorkspaceProfileDisabledReason}</div>
+                  </Show>
 
-              <div class="rounded-xl border border-gray-6 bg-gray-1/40 p-3 space-y-2">
-                <div class="text-xs font-medium text-gray-11">Skills set</div>
-                <div class="text-[11px] text-gray-9">
-                  Publish every installed skill as one link. OpenWork can import all skills at once.
-                </div>
-                <Show when={props.shareSkillsSetError?.trim()}>
-                  <div class="rounded-md border border-red-7/20 bg-red-1/40 px-2 py-1.5 text-[11px] text-red-12">
-                    {props.shareSkillsSetError}
-                  </div>
-                </Show>
-                <Show when={props.shareSkillsSetUrl?.trim()}>
-                  <div class="rounded-md border border-gray-6 bg-gray-1 px-2 py-1.5 text-[11px] font-mono text-gray-11 break-all">
-                    {props.shareSkillsSetUrl}
-                  </div>
-                </Show>
-                <Show when={props.shareSkillsSetDisabledReason?.trim()}>
-                  <div class="text-[11px] text-gray-9">{props.shareSkillsSetDisabledReason}</div>
-                </Show>
-                <div class="flex items-center justify-end gap-2">
-                  <Button
-                    variant="outline"
-                    class="text-xs h-8 py-0 px-3"
-                    onClick={() => handleCopy(props.shareSkillsSetUrl ?? "", "share-skills-set")}
-                    disabled={!props.shareSkillsSetUrl}
+                  <Show 
+                    when={props.shareWorkspaceProfileUrl?.trim()} 
+                    fallback={
+                      <button
+                        onClick={() => props.onShareWorkspaceProfile?.()}
+                        disabled={Boolean(props.shareWorkspaceProfileDisabledReason) || !props.onShareWorkspaceProfile || props.shareWorkspaceProfileBusy}
+                        class="w-full py-2.5 bg-gray-12 hover:bg-gray-11 text-white text-[13px] font-bold rounded-xl transition-all active:scale-[0.98] disabled:opacity-50"
+                      >
+                        {props.shareWorkspaceProfileBusy ? "Publishing..." : "Create Public Link"}
+                      </button>
+                    }
                   >
-                    <Copy size={14} />
-                    {copiedKey() === "share-skills-set" ? "Copied" : "Copy"}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    class="text-xs h-8 py-0 px-3"
-                    onClick={() => props.onShareSkillsSet?.()}
-                    disabled={Boolean(props.shareSkillsSetDisabledReason) || !props.onShareSkillsSet || props.shareSkillsSetBusy}
+                    <div class="flex items-center gap-2 animate-in fade-in zoom-in-95 duration-200">
+                      <input
+                        type="text"
+                        readonly
+                        value={props.shareWorkspaceProfileUrl!}
+                        class="flex-1 bg-gray-2 border border-gray-6 rounded-lg py-2 px-3 text-[12px] font-mono text-gray-11 outline-none"
+                      />
+                      <button
+                        onClick={() => handleCopy(props.shareWorkspaceProfileUrl ?? "", "share-workspace-profile")}
+                        class="p-2 bg-gray-12 text-white rounded-lg hover:bg-gray-11 transition-colors"
+                      >
+                        <Show when={copiedKey() === "share-workspace-profile"} fallback={<Copy size={16} />}>
+                          <Check size={16} />
+                        </Show>
+                      </button>
+                    </div>
+                    <button
+                      onClick={() => props.onShareWorkspaceProfile?.()}
+                      disabled={props.shareWorkspaceProfileBusy}
+                      class="mt-3 w-full py-2 bg-gray-2 hover:bg-gray-3 text-gray-11 hover:text-gray-12 text-[12px] font-bold rounded-lg transition-all"
+                    >
+                      {props.shareWorkspaceProfileBusy ? "Publishing..." : "Regenerate Link"}
+                    </button>
+                  </Show>
+                </div>
+
+                {/* Card: Skills Set */}
+                <div class="bg-white border border-gray-6 rounded-2xl p-4 shadow-sm hover:shadow-md transition-all group">
+                  <div class="flex items-center gap-3 mb-3">
+                    <div class="p-2 bg-gray-2 rounded-lg text-gray-9 group-hover:text-gray-12 group-hover:bg-gray-3 transition-colors">
+                      <Boxes size={18} />
+                    </div>
+                    <div class="flex-1">
+                      <h3 class="text-[14px] font-bold text-gray-12">Skills set</h3>
+                      <p class="text-[12px] text-gray-9 leading-tight">Publish all installed skills as one bundle.</p>
+                    </div>
+                  </div>
+                  
+                  <Show when={props.shareSkillsSetError?.trim()}>
+                    <div class="rounded-lg border border-red-6 bg-red-2 p-2 mb-3 text-[12px] text-red-11">
+                      {props.shareSkillsSetError}
+                    </div>
+                  </Show>
+                  <Show when={props.shareSkillsSetDisabledReason?.trim()}>
+                    <div class="text-[12px] text-gray-9 mb-3">{props.shareSkillsSetDisabledReason}</div>
+                  </Show>
+
+                  <Show 
+                    when={props.shareSkillsSetUrl?.trim()} 
+                    fallback={
+                      <button
+                        onClick={() => props.onShareSkillsSet?.()}
+                        disabled={Boolean(props.shareSkillsSetDisabledReason) || !props.onShareSkillsSet || props.shareSkillsSetBusy}
+                        class="w-full py-2.5 bg-gray-2 hover:bg-gray-3 text-gray-12 text-[13px] font-bold rounded-xl transition-all disabled:opacity-50"
+                      >
+                        {props.shareSkillsSetBusy ? "Publishing..." : "Create Skill Link"}
+                      </button>
+                    }
                   >
-                    {props.shareSkillsSetBusy ? "Publishing..." : props.shareSkillsSetUrl ? "Regenerate" : "Create link"}
-                  </Button>
+                    <div class="flex items-center gap-2 animate-in fade-in zoom-in-95 duration-200">
+                      <input
+                        type="text"
+                        readonly
+                        value={props.shareSkillsSetUrl!}
+                        class="flex-1 bg-gray-2 border border-gray-6 rounded-lg py-2 px-3 text-[12px] font-mono text-gray-11 outline-none"
+                      />
+                      <button
+                        onClick={() => handleCopy(props.shareSkillsSetUrl ?? "", "share-skills-set")}
+                        class="p-2 bg-gray-2 hover:bg-gray-3 text-gray-12 rounded-lg transition-colors border border-gray-6"
+                      >
+                        <Show when={copiedKey() === "share-skills-set"} fallback={<Copy size={16} />}>
+                          <Check size={16} class="text-emerald-10" />
+                        </Show>
+                      </button>
+                    </div>
+                    <button
+                      onClick={() => props.onShareSkillsSet?.()}
+                      disabled={props.shareSkillsSetBusy}
+                      class="mt-3 w-full py-2 bg-gray-2 hover:bg-gray-3 text-gray-11 hover:text-gray-12 text-[12px] font-bold rounded-lg transition-all"
+                    >
+                      {props.shareSkillsSetBusy ? "Publishing..." : "Regenerate Link"}
+                    </button>
+                  </Show>
                 </div>
-              </div>
-            </div>
 
-            <div class="rounded-2xl border border-gray-6 bg-gray-1/30 p-4 space-y-3">
-              <div>
-                <div class="text-sm font-medium text-gray-12">Config bundle</div>
-                <div class="text-xs text-gray-10">Export `.opencode/` and `opencode.json` for reuse.</div>
-              </div>
-              <div class="flex items-center justify-between gap-3">
-                <div class="text-xs text-gray-9">
-                  {props.exportDisabledReason?.trim() || "Export is available for local workers in the desktop app."}
+                {/* Section: Local Export */}
+                <div class="pt-4 mt-2 border-t border-gray-4">
+                  <div class="flex items-center justify-between p-3 bg-gray-2 rounded-2xl group hover:bg-gray-3/50 transition-all border border-transparent hover:border-gray-6">
+                    <div class="flex items-center gap-3">
+                      <div class="p-2 bg-white rounded-lg text-gray-9 shadow-sm">
+                        <Download size={18} />
+                      </div>
+                      <div>
+                        <h4 class="text-[13px] font-bold text-gray-12">Config bundle</h4>
+                        <p class="text-[12px] text-gray-10">{props.exportDisabledReason?.trim() || "Export .opencode local files"}</p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => props.onExportConfig?.()}
+                      disabled={!props.onExportConfig || Boolean(props.exportDisabledReason)}
+                      class="px-4 py-2 bg-white border border-gray-6 hover:border-gray-12 hover:text-gray-12 rounded-xl text-[12px] font-bold text-gray-11 transition-all shadow-sm disabled:opacity-50 disabled:hover:border-gray-6 disabled:hover:text-gray-11"
+                    >
+                      Export
+                    </button>
+                  </div>
                 </div>
-                <Button
-                  variant="outline"
-                  class="text-xs h-8 py-0 px-3 shrink-0"
-                  onClick={() => props.onExportConfig?.()}
-                  disabled={!props.onExportConfig || Boolean(props.exportDisabledReason)}
-                >
-                  Export
-                </Button>
-              </div>
-            </div>
 
-            <div class="rounded-2xl border border-gray-6 bg-gray-1/30 p-4 space-y-3">
-              <div class="flex items-center justify-between">
-                <div>
-                  <div class="text-sm font-medium text-gray-12">Bots</div>
-                  <div class="text-xs text-gray-10">Alpha. Configure messaging surfaces in Settings.</div>
+                {/* Section: Bots */}
+                <div class="pt-2">
+                  <div class="flex items-center justify-between p-3 bg-gray-2 rounded-2xl group hover:bg-gray-3/50 transition-all border border-transparent hover:border-gray-6">
+                    <div class="flex items-center gap-3">
+                      <div class="p-2 bg-white rounded-lg text-gray-9 shadow-sm relative overflow-hidden flex items-center justify-center font-bold font-mono">
+                        B
+                        <div class="absolute inset-0 bg-amber-400 opacity-20"></div>
+                      </div>
+                      <div>
+                        <div class="flex items-center gap-2">
+                          <h4 class="text-[13px] font-bold text-gray-12">Bots</h4>
+                          <span class="text-[9px] px-1.5 py-0.5 uppercase tracking-wider font-bold rounded-full border border-gray-6 text-gray-10 bg-white">alpha</span>
+                        </div>
+                        <p class="text-[12px] text-gray-10">Configure messaging surfaces</p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => props.onOpenBots?.()}
+                      disabled={!props.onOpenBots}
+                      class="px-4 py-2 bg-white border border-gray-6 hover:border-gray-12 hover:text-gray-12 rounded-xl text-[12px] font-bold text-gray-11 transition-all shadow-sm disabled:opacity-50 disabled:hover:border-gray-6 disabled:hover:text-gray-11"
+                    >
+                      Open setup
+                    </button>
+                  </div>
                 </div>
-                <span class="text-[10px] px-2 py-1 rounded-full border border-gray-6 text-gray-10">alpha</span>
               </div>
-              <div class="flex justify-end">
-                <Button
-                  variant="outline"
-                  class="text-xs h-8 py-0 px-3"
-                  onClick={() => props.onOpenBots?.()}
-                  disabled={!props.onOpenBots}
-                >
-                  Open bot settings
-                </Button>
-              </div>
-            </div>
+            </Show>
           </div>
 
-          <div class="p-6 border-t border-gray-6 bg-gray-1 flex justify-end">
-            <Button variant="ghost" onClick={props.onClose}>
-              Close
-            </Button>
-          </div>
+          {/* Persistent Footer Shadow Fade */}
+          <div class="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent pointer-events-none rounded-b-2xl" />
         </div>
       </div>
     </Show>

--- a/packages/openwork/docs/style-guide.md
+++ b/packages/openwork/docs/style-guide.md
@@ -1,0 +1,55 @@
+# OpenWork Style Guide
+
+## Principles
+1. **Premium & Native Feel**: The experience must feel polished, native to the OS, and not utilitarian. 
+2. **Subtle & Restrained**: Use restrained typography, subtle shadows, and neutral grays with deliberate, constrained accent colors.
+3. **Typography**: "Avenir Next", "Segoe UI Variable", "Segoe UI", "Inter", sans-serif. Focus on tight tracking (`tracking-tight`) for headers, readable (`leading-relaxed`) for body.
+4. **Shapes**: Pill shapes and heavily rounded corners for floating UI elements (`rounded-xl`, `rounded-2xl`).
+
+## Core Variables (Tailwind / CSS)
+
+### Colors
+- **Backgrounds**: 
+  - Canvas: `bg-neutral-100` (soft, gray-tinted canvas)
+  - Modals/Surfaces: `bg-white`
+  - Secondary/Hover: `bg-neutral-50`, `hover:bg-neutral-100/80`
+- **Text**:
+  - Primary: `text-neutral-900`
+  - Secondary/Muted: `text-neutral-500`, `text-neutral-400`
+- **Accents**:
+  - Primary buttons: `bg-neutral-900 text-white hover:bg-neutral-800`
+  - Primary links/accents: `text-emerald-600`
+  - Warning/Alert: `bg-amber-50/50 text-amber-800 border-amber-100`
+
+### Shadows & Borders
+- **Shadows**: 
+  - Modal: `shadow-[0_20px_50px_-12px_rgba(0,0,0,0.15)]`
+  - Cards: `shadow-sm hover:shadow-md`
+- **Borders**: 
+  - Primary borders: `border-neutral-200`
+  - Hover states: `hover:border-neutral-300`
+
+### Interactive States
+- **Hover**: Subtle background shifts (`hover:bg-neutral-100/50`), border color changes.
+- **Active/Focus**: Use `outline-none focus:ring-2 focus:ring-neutral-900/5`, or subtle scale downs (`active:scale-[0.98]`).
+
+## Shared Components & Layouts
+
+### Modals
+Modals should feel like lightweight, floating cards with strong shadows and clean separation of header, body, and footer areas.
+- Width constraint: `max-w-lg`
+- Border radius: `rounded-2xl`
+- Animation: `animate-in fade-in zoom-in-95 duration-300`
+
+### Cards/Rows
+List items or sections inside a view should be wrapped in bordered, rounded containers.
+- Border radius: `rounded-2xl`
+- Padding: `p-4` or `p-3`
+- Border: `border border-neutral-200`
+
+### Inputs
+Inputs should feel substantial but soft.
+- Padding: `py-3 pl-4`
+- Border radius: `rounded-xl`
+- Background: `bg-neutral-50`
+- Font: Use `font-mono` for tokens, URLs, IDs. `text-[13px]`.

--- a/services/openwork-share/api/b/render-bundle-page.js
+++ b/services/openwork-share/api/b/render-bundle-page.js
@@ -196,10 +196,12 @@ export function renderBundlePage({ id, rawJson, req }) {
   const description =
     bundle.description ||
     "OpenWork share links stay human-friendly for reading while still exposing a stable machine-readable JSON bundle.";
+  
   const workspaceSkills = listCount(bundle.workspace?.skills);
   const workspaceCommands = listCount(bundle.workspace?.commands);
   const workspaceHasConfig = Boolean(maybeObject(bundle.workspace?.opencode) || maybeObject(bundle.workspace?.openwork));
   const skillsSetCount = listCount(bundle.skills);
+  
   const installHint =
     bundle.type === "skill"
       ? "Use Open in app to create a new worker and install this skill."
@@ -208,6 +210,7 @@ export function renderBundlePage({ id, rawJson, req }) {
         : bundle.type === "workspace-profile"
           ? "Use Open in app to create a new worker from this full workspace profile (config, MCP, commands, and skills)."
           : "Use the JSON endpoint if you want to import this bundle programmatically.";
+          
   const contentLabel = bundle.type === "skill" && bundle.content.trim() ? "Skill content" : "Bundle payload";
   const contentPreview =
     bundle.type === "skill" && bundle.content.trim() ? truncate(bundle.content.trim()) : truncate(prettyBundleJson);
@@ -215,13 +218,28 @@ export function renderBundlePage({ id, rawJson, req }) {
   let metadataExtras = "";
   if (bundle.type === "workspace-profile") {
     metadataExtras = `
-          <div><dt>Skills</dt><dd>${escapeHtml(String(workspaceSkills))}</dd></div>
-          <div><dt>Commands</dt><dd>${escapeHtml(String(workspaceCommands))}</dd></div>
-          <div><dt>Config</dt><dd>${escapeHtml(workspaceHasConfig ? "yes" : "no")}</dd></div>`;
+          <div class="meta-row">
+            <dt class="meta-label">Skills</dt>
+            <dd class="meta-value">${escapeHtml(String(workspaceSkills))}</dd>
+          </div>
+          <div class="meta-row">
+            <dt class="meta-label">Commands</dt>
+            <dd class="meta-value">${escapeHtml(String(workspaceCommands))}</dd>
+          </div>
+          <div class="meta-row">
+            <dt class="meta-label">Config</dt>
+            <dd class="meta-value">${escapeHtml(workspaceHasConfig ? "yes" : "no")}</dd>
+          </div>`;
   } else if (bundle.type === "skills-set") {
     metadataExtras = `
-          <div><dt>Skills</dt><dd>${escapeHtml(String(skillsSetCount))}</dd></div>`;
+          <div class="meta-row">
+            <dt class="meta-label">Skills</dt>
+            <dd class="meta-value">${escapeHtml(String(skillsSetCount))}</dd>
+          </div>`;
   }
+
+  // Generate an avatar letter from the name
+  const avatarLetter = (bundle.name || "M").charAt(0).toUpperCase();
 
   return `<!doctype html>
 <html lang="en">
@@ -238,216 +256,520 @@ export function renderBundlePage({ id, rawJson, req }) {
   <style>
     :root {
       color-scheme: only light;
-      --bg-top: #f4f0e8;
-      --bg-bottom: #fdfbf8;
-      --panel: rgba(255, 255, 255, 0.9);
-      --panel-border: rgba(42, 38, 31, 0.12);
-      --text-strong: #1d1a16;
-      --text-muted: #5f5549;
-      --accent: #0f6f61;
-      --accent-ink: #f4fffc;
-      --code-bg: #f7f5f2;
-      --code-border: #dfd7cc;
+      --bg-canvas: #f5f5f5; /* neutral-100 */
+      --bg-surface: #ffffff; /* white */
+      --bg-secondary: #fafafa; /* neutral-50 */
+      --bg-hover: rgba(245, 245, 245, 0.8); /* neutral-100/80 */
+      
+      --text-primary: #171717; /* neutral-900 */
+      --text-secondary: #737373; /* neutral-500 */
+      --text-muted: #a3a3a3; /* neutral-400 */
+      
+      --accent-primary: #171717; /* neutral-900 */
+      --accent-hover: #262626; /* neutral-800 */
+      --accent-ink: #ffffff; /* white */
+      
+      --border-primary: #e5e5e5; /* neutral-200 */
+      --border-hover: #d4d4d4; /* neutral-300 */
+      
+      --code-bg: #fafafa; /* neutral-50 */
+      
+      --font-sans: "Avenir Next", "Segoe UI Variable", "Segoe UI", "Inter", sans-serif;
+      --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Mono", monospace;
     }
+    
     * { box-sizing: border-box; }
+    
     body {
       margin: 0;
       min-height: 100vh;
-      font-family: "Avenir Next", "Segoe UI Variable", "Segoe UI", "Inter", sans-serif;
-      color: var(--text-strong);
-      background:
-        radial-gradient(1200px 500px at 90% -100px, rgba(15, 111, 97, 0.14), transparent 70%),
-        radial-gradient(1000px 420px at -10% -60px, rgba(220, 168, 121, 0.2), transparent 72%),
-        linear-gradient(180deg, var(--bg-top), var(--bg-bottom));
-      padding: 28px 16px 48px;
-    }
-    .page {
-      margin: 0 auto;
-      max-width: 980px;
-      display: grid;
-      gap: 16px;
-    }
-    .card {
-      background: var(--panel);
-      border: 1px solid var(--panel-border);
-      border-radius: 18px;
-      box-shadow: 0 10px 30px rgba(37, 31, 21, 0.06);
-      backdrop-filter: blur(6px);
-      padding: 18px;
-    }
-    .topbar {
+      font-family: var(--font-sans);
+      color: var(--text-primary);
+      background-color: var(--bg-canvas);
       display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 12px;
-    }
-    .brand {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      text-decoration: none;
-      color: var(--text-strong);
-      font-weight: 700;
-      letter-spacing: 0.01em;
-    }
-    .brand-badge {
-      width: 28px;
-      height: 28px;
-      border-radius: 8px;
-      background: #111;
-      color: #fff;
-      display: inline-flex;
       align-items: center;
       justify-content: center;
-      font-size: 12px;
-      font-weight: 700;
+      padding: 1rem;
     }
-    .hero h1 {
-      margin: 0;
-      font-size: clamp(1.5rem, 2.4vw, 2.1rem);
-      line-height: 1.2;
-      letter-spacing: -0.02em;
+    
+    /* The Modal Container */
+    .modal-container {
+      background: var(--bg-surface);
+      width: 100%;
+      max-width: 32rem; /* max-w-lg (512px) */
+      border-radius: 1rem; /* rounded-2xl */
+      box-shadow: 0 20px 50px -12px rgba(0,0,0,0.15);
+      border: 1px solid var(--border-primary);
+      overflow: hidden;
+      animation: zoomIn 300ms cubic-bezier(0.16, 1, 0.3, 1);
     }
-    .hero p {
-      margin: 10px 0 0;
+    
+    @keyframes zoomIn {
+      from { opacity: 0; transform: scale(0.95); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    
+    /* Header Section */
+    .header {
+      padding: 1.5rem 1.5rem 1rem;
+      position: relative;
+      border-bottom: 1px solid transparent;
+    }
+    
+    .close-btn {
+      position: absolute;
+      top: 1.5rem;
+      right: 1.5rem;
+      padding: 0.375rem;
       color: var(--text-muted);
-      line-height: 1.5;
-    }
-    .chip {
-      display: inline-flex;
-      align-items: center;
-      font-size: 11px;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      font-weight: 700;
-      padding: 6px 10px;
-      border-radius: 999px;
-      background: #fff;
-      border: 1px solid var(--panel-border);
-      color: var(--text-muted);
-      margin-bottom: 10px;
-    }
-    .actions {
-      margin-top: 16px;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-    }
-    button,
-    .action-link {
-      border: 1px solid transparent;
-      border-radius: 10px;
-      font-size: 13px;
-      font-weight: 600;
+      background: transparent;
+      border: none;
+      border-radius: 0.5rem;
       cursor: pointer;
-      padding: 10px 12px;
-      text-decoration: none;
-      transition: transform 120ms ease, background 120ms ease, border-color 120ms ease;
+      transition: all 0.2s;
+      display: inline-flex;
     }
-    button:hover,
-    .action-link:hover {
-      transform: translateY(-1px);
+    
+    .close-btn:hover {
+      color: var(--text-secondary);
+      background: var(--bg-canvas);
     }
-    .primary {
-      background: var(--accent);
-      color: var(--accent-ink);
-    }
-    .secondary {
-      border-color: var(--panel-border);
-      color: var(--text-strong);
-      background: rgba(255, 255, 255, 0.84);
-    }
-    .grid {
-      display: grid;
-      gap: 14px;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    }
-    .card h2 {
-      margin: 0 0 10px;
-      font-size: 1rem;
-      letter-spacing: -0.01em;
-    }
-    .card ol {
-      margin: 0;
-      padding-left: 1.1rem;
-      color: var(--text-muted);
-      font-size: 14px;
-      line-height: 1.55;
-      display: grid;
-      gap: 3px;
-    }
-    .meta {
-      margin: 0;
-      display: grid;
-      gap: 9px;
-      font-size: 13px;
-    }
-    .meta div {
+    
+    .header-content {
       display: flex;
-      justify-content: space-between;
-      gap: 14px;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    
+    .avatar {
+      width: 2.5rem;
+      height: 2.5rem;
+      background: var(--accent-primary);
+      border-radius: 0.75rem; /* rounded-xl */
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--accent-ink);
+      font-weight: 700;
+      font-size: 1.125rem;
+    }
+    
+    .title-area h1 {
+      margin: 0;
+      font-size: 17px; /* text-[17px] */
+      font-weight: 700;
+      color: var(--text-primary);
+      letter-spacing: -0.025em; /* tracking-tight */
+    }
+    
+    .subtitle-area {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-top: 0.125rem;
+    }
+    
+    .subtitle-text {
+      font-size: 13px; /* text-[13px] */
+      font-weight: 600;
+      color: #404040; /* neutral-700 */
+    }
+    
+    .dot {
+      width: 4px;
+      height: 4px;
+      border-radius: 9999px;
+      background: #d4d4d4; /* neutral-300 */
+    }
+    
+    .subtitle-type {
+      font-size: 12px;
+      color: var(--text-muted);
+      font-family: var(--font-mono);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 180px;
+    }
+    
+    /* Main Content Area */
+    .main-content {
+      padding: 0 1.5rem 2rem;
+      max-height: 500px;
+      overflow-y: auto;
+      scrollbar-width: none; /* Firefox */
+      position: relative;
+    }
+    .main-content::-webkit-scrollbar {
+      display: none; /* Safari and Chrome */
+    }
+    
+    /* Tab Intro */
+    .tab-intro {
+      margin-top: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    
+    .tab-intro p {
+      margin: 0;
+      font-size: 14px;
+      color: #525252; /* neutral-600 */
+      font-weight: 500;
+    }
+    
+    .tab-intro span {
+      display: block;
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-top: 0.125rem;
+    }
+    
+    /* Cards */
+    .card {
+      background: var(--bg-surface);
+      border: 1px solid var(--border-primary);
+      border-radius: 1rem; /* rounded-2xl */
+      padding: 1rem;
+      box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05); /* shadow-sm */
+      transition: all 0.2s;
+      margin-bottom: 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    
+    .card:hover {
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1); /* shadow-md */
+      border-color: var(--border-hover);
+    }
+    
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+    }
+    
+    .card-icon {
+      padding: 0.5rem;
+      background: var(--bg-secondary);
+      border-radius: 0.5rem; /* rounded-lg */
+      color: var(--text-secondary);
+      transition: all 0.2s;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    
+    .card:hover .card-icon {
+      color: var(--text-primary);
+      background: var(--bg-hover);
+    }
+    
+    .card-title-area h3 {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+    
+    .card-title-area p {
+      margin: 0;
+      font-size: 12px;
+      color: var(--text-secondary);
+      line-height: 1.25; /* leading-tight */
+    }
+    
+    /* Buttons */
+    .btn-primary {
+      width: 100%;
+      padding: 0.625rem;
+      background: var(--accent-primary);
+      color: var(--accent-ink);
+      font-size: 13px;
+      font-weight: 700;
+      font-family: var(--font-sans);
+      border: none;
+      border-radius: 0.75rem; /* rounded-xl */
+      cursor: pointer;
+      transition: all 0.2s;
+      text-align: center;
+      text-decoration: none;
+      display: inline-block;
+    }
+    
+    .btn-primary:hover {
+      background: var(--accent-hover);
+    }
+    
+    .btn-primary:active {
+      transform: scale(0.98);
+    }
+    
+    .btn-secondary {
+      width: 100%;
+      padding: 0.625rem;
+      background: #f5f5f5; /* neutral-100 */
+      color: var(--text-primary);
+      font-size: 13px;
+      font-weight: 700;
+      font-family: var(--font-sans);
+      border: none;
+      border-radius: 0.75rem; /* rounded-xl */
+      cursor: pointer;
+      transition: all 0.2s;
+      text-align: center;
+      text-decoration: none;
+      display: inline-block;
+    }
+    
+    .btn-secondary:hover {
+      background: #e5e5e5; /* neutral-200 */
+    }
+    
+    /* Input Group */
+    .input-group {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      animation: fadeIn 200ms ease;
+    }
+    
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+    
+    .input-field {
+      flex: 1;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-primary);
+      border-radius: 0.5rem; /* rounded-lg */
+      padding: 0.5rem 0.75rem;
+      font-size: 12px;
+      font-family: var(--font-mono);
+      color: #525252; /* neutral-600 */
+      outline: none;
+      width: 100%;
+    }
+    
+    .input-field:focus {
+      border-color: var(--border-hover);
+    }
+    
+    .btn-icon {
+      padding: 0.5rem;
+      background: var(--accent-primary);
+      color: var(--accent-ink);
+      border: none;
+      border-radius: 0.5rem;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.2s;
+    }
+    
+    .btn-icon:hover {
+      background: var(--accent-hover);
+    }
+    
+    .btn-icon.secondary-icon {
+      background: transparent;
       color: var(--text-muted);
     }
-    .meta dt {
-      margin: 0;
-      font-weight: 600;
+    
+    .btn-icon.secondary-icon:hover {
+      background: var(--bg-hover);
+      color: var(--text-primary);
     }
-    .meta dd {
-      margin: 0;
-      color: var(--text-strong);
-      font-family: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Mono", monospace;
-      text-align: right;
+    
+    /* Download Section */
+    .download-section {
+      padding-top: 1rem;
+      margin-top: 0.5rem;
+      border-top: 1px solid #f5f5f5; /* neutral-100 */
     }
-    .mono {
-      margin: 12px 0 0;
-      padding: 10px;
-      border-radius: 10px;
-      border: 1px solid var(--code-border);
-      background: var(--code-bg);
-      font-family: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Mono", monospace;
+    
+    .download-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem;
+      background: var(--bg-secondary);
+      border-radius: 1rem; /* rounded-2xl */
+      border: 1px solid transparent;
+      transition: all 0.2s;
+      text-decoration: none;
+    }
+    
+    .download-row:hover {
+      background: rgba(245, 245, 245, 0.5); /* neutral-100/50 */
+      border-color: var(--border-primary);
+    }
+    
+    .download-info {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    
+    .download-icon {
+      padding: 0.5rem;
+      background: var(--bg-surface);
+      border-radius: 0.5rem;
+      color: var(--text-muted);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    
+    .download-text h4 {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+    
+    .download-text p {
+      margin: 0;
       font-size: 12px;
-      overflow-wrap: anywhere;
-      color: #2c241b;
+      color: var(--text-secondary);
     }
-    pre {
-      margin: 0;
-      max-height: 350px;
-      overflow: auto;
-      padding: 12px;
-      border-radius: 12px;
-      border: 1px solid var(--code-border);
-      background: var(--code-bg);
-      color: #1f1a15;
-      font-family: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Mono", monospace;
+    
+    .btn-outline {
+      padding: 0.5rem 1rem;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-primary);
+      border-radius: 0.75rem; /* rounded-xl */
       font-size: 12px;
-      line-height: 1.45;
+      font-weight: 700;
+      color: #525252; /* neutral-600 */
+      cursor: pointer;
+      transition: all 0.2s;
+      box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+      text-decoration: none;
+    }
+    
+    .download-row:hover .btn-outline {
+      border-color: var(--text-primary);
+      color: var(--text-primary);
+    }
+    
+    /* Raw Content Area */
+    .raw-content {
+      margin-top: 1rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--border-primary);
+    }
+    
+    .raw-content h3 {
+      font-size: 12px;
+      font-weight: 700;
+      color: var(--text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin: 0 0 0.5rem 0.25rem;
+    }
+    
+    .raw-content pre {
+      margin: 0;
+      padding: 1rem;
+      background: var(--code-bg);
+      border: 1px solid var(--border-primary);
+      border-radius: 0.75rem;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: #404040;
+      overflow-x: auto;
+      max-height: 200px;
       white-space: pre-wrap;
       word-break: break-word;
     }
-    .notice {
-      position: fixed;
-      right: 16px;
-      bottom: 16px;
-      padding: 10px 12px;
-      border-radius: 10px;
-      border: 1px solid rgba(15, 111, 97, 0.28);
-      background: rgba(255, 255, 255, 0.95);
-      color: #11453d;
-      font-size: 13px;
-      box-shadow: 0 8px 24px rgba(31, 25, 18, 0.12);
-      opacity: 0;
-      transform: translateY(10px);
+    
+    /* Footer fade */
+    .footer-fade {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 2rem;
+      background: linear-gradient(to top, var(--bg-surface), transparent);
       pointer-events: none;
-      transition: opacity 150ms ease, transform 150ms ease;
+      border-bottom-left-radius: 1rem;
+      border-bottom-right-radius: 1rem;
     }
-    .notice.visible {
+    
+    /* Meta Details Layout */
+    .meta-details {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+      padding-top: 0.5rem;
+      border-top: 1px dashed var(--border-primary);
+    }
+    
+    .meta-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    
+    .meta-label {
+      font-size: 12px;
+      color: var(--text-secondary);
+      margin: 0;
+    }
+    
+    .meta-value {
+      font-size: 12px;
+      font-family: var(--font-mono);
+      color: var(--text-primary);
+      margin: 0;
+      font-weight: 500;
+    }
+    
+    /* Toast */
+    .toast {
+      position: fixed;
+      bottom: 1.5rem;
+      left: 50%;
+      transform: translateX(-50%) translateY(1rem);
+      background: var(--text-primary);
+      color: var(--bg-surface);
+      padding: 0.5rem 1rem;
+      border-radius: 9999px;
+      font-size: 13px;
+      font-weight: 600;
+      box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+      opacity: 0;
+      pointer-events: none;
+      transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+      z-index: 50;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    
+    .toast.visible {
       opacity: 1;
-      transform: translateY(0);
+      transform: translateX(-50%) translateY(0);
     }
-    @media (max-width: 640px) {
-      body { padding: 16px 10px 36px; }
-      .card { padding: 14px; border-radius: 14px; }
-      .actions { display: grid; grid-template-columns: 1fr; }
+
+    svg {
+      width: 18px;
+      height: 18px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+    
+    .btn-icon svg {
+      width: 16px;
+      height: 16px;
     }
   </style>
 </head>
@@ -457,75 +779,105 @@ export function renderBundlePage({ id, rawJson, req }) {
   data-openwork-bundle-type="${escapeHtml(bundle.type || "unknown")}" 
   data-openwork-schema-version="${escapeHtml(schemaVersion)}"
 >
-  <main class="page">
-    <section class="card topbar">
-      <a class="brand" href="${OPENWORK_SITE_URL}" target="_blank" rel="noreferrer">
-        <span class="brand-badge">O</span>
-        <span>OpenWork Share</span>
+  <div class="modal-container">
+    <div class="header">
+      <a href="${OPENWORK_SITE_URL}" target="_blank" rel="noreferrer" class="close-btn" aria-label="Close">
+        <svg viewBox="0 0 24 24"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
       </a>
-      <a class="action-link secondary" href="${OPENWORK_DOWNLOAD_URL}" target="_blank" rel="noreferrer">Get OpenWork</a>
-    </section>
-
-    <section class="card hero">
-      <div class="chip">${escapeHtml(typeLabel)}</div>
-      <h1>${escapeHtml(title)}</h1>
-      <p>${escapeHtml(description)}</p>
-      <div class="actions">
-        <a class="action-link primary" href="${escapeHtml(openInAppDeepLink)}">Open in app (new worker)</a>
-        <a class="action-link secondary" href="${escapeHtml(openInWebAppUrl)}" target="_blank" rel="noreferrer">Open in web app</a>
-        <button type="button" class="secondary" id="copy-link-button">Copy share link</button>
-        <button type="button" class="secondary" id="copy-json-button">Copy bundle JSON</button>
-        <a class="action-link secondary" href="${escapeHtml(urls.jsonUrl)}" target="_blank" rel="noreferrer">View raw JSON</a>
-        <a class="action-link secondary" href="${escapeHtml(urls.downloadUrl)}">Download JSON</a>
+      
+      <div class="header-content">
+        <div class="avatar">${escapeHtml(avatarLetter)}</div>
+        <div class="title-area">
+          <h1>OpenWork Share</h1>
+          <div class="subtitle-area">
+            <span class="subtitle-text">${escapeHtml(title)}</span>
+            <span class="dot"></span>
+            <span class="subtitle-type">.../${escapeHtml(id.slice(-8))}</span>
+          </div>
+        </div>
       </div>
-    </section>
-
-    <div class="grid">
-      <section class="card">
-        <h2>Install in OpenWork</h2>
-        <ol>
-          <li>${escapeHtml(installHint)}</li>
-          <li>If you are using the API directly, call this link with <code>?format=json</code>.</li>
-        </ol>
-        <div class="mono">${escapeHtml(urls.shareUrl)}</div>
-      </section>
-
-      <section class="card">
-        <h2>Metadata</h2>
-        <dl class="meta">
-          <div><dt>Bundle id</dt><dd>${escapeHtml(id)}</dd></div>
-          <div><dt>Type</dt><dd>${escapeHtml(bundle.type || "unknown")}</dd></div>
-          <div><dt>Schema</dt><dd>${escapeHtml(schemaVersion)}</dd></div>
-          <div><dt>Name</dt><dd>${escapeHtml(bundle.name || "n/a")}</dd></div>
-          <div><dt>Trigger</dt><dd>${escapeHtml(bundle.trigger || "n/a")}</dd></div>
-${metadataExtras}
-        </dl>
-      </section>
     </div>
-
-    <section class="card">
-      <h2>${escapeHtml(contentLabel)}</h2>
-      <pre>${escapeHtml(contentPreview)}</pre>
-    </section>
-
-    <section class="card">
-      <h2>Bundle JSON</h2>
-      <pre>${escapeHtml(prettyBundleJson)}</pre>
-    </section>
-  </main>
+    
+    <div class="main-content">
+      <div class="tab-intro">
+        <p>Shared configuration bundle</p>
+        <span>${escapeHtml(description)}</span>
+      </div>
+      
+      <div class="card">
+        <div class="card-header">
+          <div class="card-icon">
+            <svg viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+          </div>
+          <div class="card-title-area">
+            <h3>${escapeHtml(typeLabel)}</h3>
+            <p>${escapeHtml(installHint)}</p>
+          </div>
+        </div>
+        
+        <a href="${escapeHtml(openInAppDeepLink)}" class="btn-primary">Open in App</a>
+        
+        <div class="input-group">
+          <input type="text" class="input-field" value="${escapeHtml(urls.shareUrl)}" readonly id="share-url-input" />
+          <button type="button" class="btn-icon" id="copy-link-btn" aria-label="Copy link">
+            <svg viewBox="0 0 24 24"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+          </button>
+        </div>
+        
+        <div class="meta-details">
+          <div class="meta-row">
+            <dt class="meta-label">ID</dt>
+            <dd class="meta-value">${escapeHtml(id)}</dd>
+          </div>
+          <div class="meta-row">
+            <dt class="meta-label">Type</dt>
+            <dd class="meta-value">${escapeHtml(bundle.type || "unknown")}</dd>
+          </div>
+          ${metadataExtras}
+        </div>
+      </div>
+      
+      <div class="download-section">
+        <a href="${escapeHtml(urls.downloadUrl)}" class="download-row">
+          <div class="download-info">
+            <div class="download-icon">
+              <svg viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+            </div>
+            <div class="download-text">
+              <h4>Download JSON</h4>
+              <p>Save configuration bundle locally</p>
+            </div>
+          </div>
+          <span class="btn-outline">Download</span>
+        </a>
+      </div>
+      
+      <div class="raw-content">
+        <h3>${escapeHtml(contentLabel)} Preview</h3>
+        <pre>${escapeHtml(contentPreview)}</pre>
+      </div>
+      
+    </div>
+    
+    <div class="footer-fade"></div>
+  </div>
 
   <script id="openwork-bundle-json" type="application/json">${escapeJsonForScript(rawJson)}</script>
-  <div class="notice" id="copy-notice" role="status" aria-live="polite"></div>
+  
+  <div class="toast" id="toast-message" role="status" aria-live="polite">
+    <svg viewBox="0 0 24 24" style="width: 14px; height: 14px;"><path d="M20 6 9 17l-5-5"/></svg>
+    <span>Copied</span>
+  </div>
+  
   <script>
     const shareUrl = ${JSON.stringify(urls.shareUrl)};
-    const jsonNode = document.getElementById("openwork-bundle-json");
-    const copyNotice = document.getElementById("copy-notice");
+    const toastNode = document.getElementById("toast-message");
 
-    function showNotice(text) {
-      if (!copyNotice) return;
-      copyNotice.textContent = text;
-      copyNotice.classList.add("visible");
-      window.setTimeout(() => copyNotice.classList.remove("visible"), 1800);
+    function showToast(text) {
+      if (!toastNode) return;
+      toastNode.querySelector('span').textContent = text;
+      toastNode.classList.add("visible");
+      window.setTimeout(() => toastNode.classList.remove("visible"), 2000);
     }
 
     async function copyText(value, label) {
@@ -543,18 +895,20 @@ ${metadataExtras}
           document.execCommand("copy");
           textarea.remove();
         }
-        showNotice(label + " copied");
+        showToast(label + " copied");
       } catch {
-        showNotice("Copy failed");
+        showToast("Copy failed");
       }
     }
 
-    document.getElementById("copy-link-button")?.addEventListener("click", () => {
+    document.getElementById("copy-link-btn")?.addEventListener("click", () => {
       copyText(shareUrl, "Link");
-    });
-
-    document.getElementById("copy-json-button")?.addEventListener("click", () => {
-      copyText(jsonNode ? jsonNode.textContent || "" : "", "JSON");
+      
+      // Select input text for visual feedback
+      const input = document.getElementById("share-url-input");
+      if (input) {
+        input.select();
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Added `packages/openwork/docs/style-guide.md` to capture the aesthetic details of OpenWork's UI guidelines.
- Redesigned the OpenWork share service `/api/b/[id].js` bundle page to reflect the app's clean, native, and premium styling with better spacing and shadows.
- Redesigned the in-app `ShareWorkspaceModal.tsx` to match the requested modern rounded UI aesthetic.

## Changes
- Modal matches `rounded-2xl` aesthetic, includes subtle shadow `shadow-[0_20px_50px_-12px_rgba(0,0,0,0.15)]`.
- Cleaned up tab switching with pill navigation.
- Extracted link outputs to distinct `rounded-xl` sections.
- Unified styling across the hosted share service and the local React share modal.

## Test Plan
- Run `pnpm typecheck` inside `packages/app`.
- Start local UI to inspect `ShareWorkspaceModal`.
- Tested the vanilla JS HTML/CSS on the share service handler.