### PR TITLE
fix(docker): mount host OpenCode config for dev-up with safe fallback

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -18,6 +18,7 @@ What it does:
 - Auto-generates and shares auth tokens between services
 - Web waits for headless health check before starting
 - Builds Linux binaries inside the container (no host binary conflicts)
+- Auto-mounts host OpenCode config/auth into the stack when present, with safe empty-dir fallback
 
 Useful commands:
 - Logs: `docker compose -p <project> -f packaging/docker/docker-compose.dev.yml logs`
@@ -30,6 +31,8 @@ Optional env vars (via `.env` or `export`):
 - `OPENWORK_WORKSPACE` — host path to mount as workspace
 - `OPENWORK_PORT` — host port to map to container :8787
 - `WEB_PORT` — host port to map to container :5173
+- `OPENWORK_OPENCODE_CONFIG_DIR` — override host OpenCode config dir mount source
+- `OPENWORK_OPENCODE_DATA_DIR` — override host OpenCode data dir mount source
 
 ---
 

--- a/packaging/docker/dev-up.sh
+++ b/packaging/docker/dev-up.sh
@@ -14,6 +14,79 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/packaging/docker/docker-compose.dev.yml"
 WORKSPACE_DIR="$ROOT_DIR/packaging/docker/workspace"
+DEV_RUNTIME_DIR="$ROOT_DIR/tmp/docker-dev"
+
+resolve_opencode_config_dir() {
+  local override="${OPENWORK_OPENCODE_CONFIG_DIR:-}"
+  if [ -n "$override" ]; then
+    if [ -d "$override" ]; then
+      printf '%s\n' "$override"
+      return 0
+    fi
+    echo "warning: OPENWORK_OPENCODE_CONFIG_DIR is not a directory: $override" >&2
+  fi
+
+  local candidates=()
+  if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+    candidates+=("${XDG_CONFIG_HOME}/opencode")
+  fi
+  candidates+=("${HOME}/.config/opencode")
+  if [ "$(uname -s)" = "Darwin" ]; then
+    candidates+=("${HOME}/Library/Application Support/opencode")
+  fi
+
+  local files=("opencode.jsonc" "opencode.json" "config.json" "AGENTS.md")
+  local candidate file
+  for candidate in "${candidates[@]}"; do
+    [ -d "$candidate" ] || continue
+    for file in "${files[@]}"; do
+      if [ -f "$candidate/$file" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    done
+    if [ -n "$(ls -A "$candidate" 2>/dev/null)" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+resolve_opencode_data_dir() {
+  local override="${OPENWORK_OPENCODE_DATA_DIR:-}"
+  if [ -n "$override" ]; then
+    if [ -d "$override" ]; then
+      printf '%s\n' "$override"
+      return 0
+    fi
+    echo "warning: OPENWORK_OPENCODE_DATA_DIR is not a directory: $override" >&2
+  fi
+
+  local candidates=()
+  if [ -n "${XDG_DATA_HOME:-}" ]; then
+    candidates+=("${XDG_DATA_HOME}/opencode")
+  fi
+  candidates+=("${HOME}/.local/share/opencode")
+  if [ "$(uname -s)" = "Darwin" ]; then
+    candidates+=("${HOME}/Library/Application Support/opencode")
+  fi
+
+  local files=("auth.json" "mcp-auth.json")
+  local candidate file
+  for candidate in "${candidates[@]}"; do
+    [ -d "$candidate" ] || continue
+    for file in "${files[@]}"; do
+      if [ -f "$candidate/$file" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    done
+  done
+
+  return 1
+}
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required" >&2
@@ -36,6 +109,21 @@ DEV_ID="$(node -e "console.log(require('crypto').randomUUID().slice(0, 8))")"
 PROJECT="openwork-dev-$DEV_ID"
 
 mkdir -p "$WORKSPACE_DIR"
+mkdir -p "$DEV_RUNTIME_DIR"
+
+OPENCODE_CONFIG_FALLBACK_DIR="$DEV_RUNTIME_DIR/host-opencode-config"
+OPENCODE_DATA_FALLBACK_DIR="$DEV_RUNTIME_DIR/host-opencode-data"
+mkdir -p "$OPENCODE_CONFIG_FALLBACK_DIR" "$OPENCODE_DATA_FALLBACK_DIR"
+
+HOST_OPENCODE_CONFIG_DIR="$(resolve_opencode_config_dir || true)"
+HOST_OPENCODE_DATA_DIR="$(resolve_opencode_data_dir || true)"
+
+if [ -z "$HOST_OPENCODE_CONFIG_DIR" ]; then
+  HOST_OPENCODE_CONFIG_DIR="$OPENCODE_CONFIG_FALLBACK_DIR"
+fi
+if [ -z "$HOST_OPENCODE_DATA_DIR" ]; then
+  HOST_OPENCODE_DATA_DIR="$OPENCODE_DATA_FALLBACK_DIR"
+fi
 
 OPENWORK_PORT="$(pick_port)"
 WEB_PORT="$(pick_port)"
@@ -47,8 +135,34 @@ echo "Starting Docker Compose project: $PROJECT" >&2
 echo "- OPENWORK_PORT=$OPENWORK_PORT" >&2
 echo "- WEB_PORT=$WEB_PORT" >&2
 
-OPENWORK_DEV_ID="$DEV_ID" OPENWORK_PORT="$OPENWORK_PORT" WEB_PORT="$WEB_PORT" \
-  docker compose -p "$PROJECT" -f "$COMPOSE_FILE" up -d
+start_stack() {
+  local config_dir="$1"
+  local data_dir="$2"
+  OPENWORK_DEV_ID="$DEV_ID" OPENWORK_PORT="$OPENWORK_PORT" WEB_PORT="$WEB_PORT" \
+    OPENWORK_HOST_OPENCODE_CONFIG_DIR="$config_dir" \
+    OPENWORK_HOST_OPENCODE_DATA_DIR="$data_dir" \
+    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" up -d
+}
+
+ACTIVE_OPENCODE_CONFIG_DIR="$HOST_OPENCODE_CONFIG_DIR"
+ACTIVE_OPENCODE_DATA_DIR="$HOST_OPENCODE_DATA_DIR"
+
+echo "- OPENWORK_HOST_OPENCODE_CONFIG_DIR=$ACTIVE_OPENCODE_CONFIG_DIR" >&2
+echo "- OPENWORK_HOST_OPENCODE_DATA_DIR=$ACTIVE_OPENCODE_DATA_DIR" >&2
+
+if ! start_stack "$ACTIVE_OPENCODE_CONFIG_DIR" "$ACTIVE_OPENCODE_DATA_DIR"; then
+  if [ "$ACTIVE_OPENCODE_CONFIG_DIR" != "$OPENCODE_CONFIG_FALLBACK_DIR" ] || [ "$ACTIVE_OPENCODE_DATA_DIR" != "$OPENCODE_DATA_FALLBACK_DIR" ]; then
+    echo "Detected host OpenCode config mount failed; retrying with empty fallback dirs." >&2
+    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" down >/dev/null 2>&1 || true
+    ACTIVE_OPENCODE_CONFIG_DIR="$OPENCODE_CONFIG_FALLBACK_DIR"
+    ACTIVE_OPENCODE_DATA_DIR="$OPENCODE_DATA_FALLBACK_DIR"
+    echo "- OPENWORK_HOST_OPENCODE_CONFIG_DIR=$ACTIVE_OPENCODE_CONFIG_DIR" >&2
+    echo "- OPENWORK_HOST_OPENCODE_DATA_DIR=$ACTIVE_OPENCODE_DATA_DIR" >&2
+    start_stack "$ACTIVE_OPENCODE_CONFIG_DIR" "$ACTIVE_OPENCODE_DATA_DIR"
+  else
+    exit 1
+  fi
+fi
 
 echo "" >&2
 echo "OpenWork web UI:     http://localhost:$WEB_PORT" >&2

--- a/packaging/docker/docker-compose.dev.yml
+++ b/packaging/docker/docker-compose.dev.yml
@@ -12,6 +12,10 @@
 #   OPENWORK_PORT         — host port to map to container :8787 (default: 8787)
 #   WEB_PORT              — host port to map to container :5173 (default: 5173)
 #   OPENWORK_DEV_ID       — unique ID for this stack (default: default)
+#   OPENWORK_OPENCODE_CONFIG_DIR      — host OpenCode config dir detection override (read by dev-up.sh)
+#   OPENWORK_OPENCODE_DATA_DIR        — host OpenCode data dir detection override (read by dev-up.sh)
+#   OPENWORK_HOST_OPENCODE_CONFIG_DIR — resolved mount source for host OpenCode config (set by dev-up.sh)
+#   OPENWORK_HOST_OPENCODE_DATA_DIR   — resolved mount source for host OpenCode data (set by dev-up.sh)
 
 x-shared: &shared
   image: node:22-bookworm-slim
@@ -22,6 +26,8 @@ x-shared: &shared
     - pnpm-store:/root/.local/share/pnpm/store
     - bun-install:/root/.bun
     - ${OPENWORK_WORKSPACE:-./workspace}:/workspace
+    - ${OPENWORK_HOST_OPENCODE_CONFIG_DIR:-./workspace/.openwork-host-opencode-config}:/persist/.config/opencode:ro
+    - ${OPENWORK_HOST_OPENCODE_DATA_DIR:-./workspace/.openwork-host-opencode-data}:/persist/.openwork-host-opencode-data:ro
 
 services:
   orchestrator:
@@ -91,6 +97,16 @@ services:
         if [ -z "$$OPENWORK_HOST_TOKEN" ]; then
           OPENWORK_HOST_TOKEN=$$(cat /proc/sys/kernel/random/uuid)
           export OPENWORK_HOST_TOKEN
+        fi
+
+        # --- Import host OpenCode config + auth material when mounted ---
+        mkdir -p /root/.config/opencode /root/.local/share/opencode
+        if [ -d /persist/.config/opencode ]; then
+          cp -R /persist/.config/opencode/. /root/.config/opencode 2>/dev/null || true
+        fi
+        if [ -d /persist/.openwork-host-opencode-data ]; then
+          cp /persist/.openwork-host-opencode-data/auth.json /root/.local/share/opencode/auth.json 2>/dev/null || true
+          cp /persist/.openwork-host-opencode-data/mcp-auth.json /root/.local/share/opencode/mcp-auth.json 2>/dev/null || true
         fi
 
         # Write tokens so the web service can source them


### PR DESCRIPTION
## Summary
- update `packaging/docker/dev-up.sh` to auto-detect host OpenCode config/data dirs (with explicit override env vars) and pass them into the dev compose stack
- mount host OpenCode config/data into the dev containers and import config/auth material before starting the orchestrator so Docker dev runs mirror sandbox behavior
- add a safe fallback path in `dev-up.sh`: if startup with detected host config fails, retry with empty mounted dirs to preserve prior behavior
- document the new mount behavior and override env vars in `packaging/docker/README.md`

## Verification
- `bash -n packaging/docker/dev-up.sh`
- `docker compose -f packaging/docker/docker-compose.dev.yml config`
- Real integration verification using a local mock OpenAI-compatible endpoint:
  - `GET /opencode/provider` showed `openai/gpt-5.3-codex` supports `xhigh`
  - `POST /opencode/session/:id/message` with `variant: xhigh` persisted `variant: xhigh` in OpenCode session messages (OpenWork -> OpenCode)
  - captured upstream `/v1/responses` payload included `reasoning.effort: xhigh` (OpenCode -> provider)

## Notes
- This validates the #689 thinking-mode concern on current `dev`: OpenWork is passing `xhigh` through to OpenCode, and OpenCode is emitting `xhigh` upstream for `gpt-5.3-codex`.