### PR TITLE
fix: do not restore stale baseUrl from localStorage in Tauri desktop …

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4717,9 +4717,15 @@ export default function App() {
 
     if (typeof window !== "undefined") {
       try {
-        const storedBaseUrl = window.localStorage.getItem("openwork.baseUrl");
-        if (storedBaseUrl) {
-          setBaseUrl(storedBaseUrl);
+        // In Tauri/desktop mode, do NOT restore the cached baseUrl from localStorage.
+        // OpenCode is assigned a random port on every restart, so the stored URL is
+        // always stale after a relaunch. The correct baseUrl is provided by engine_info().
+        // Web mode still needs the cached value since it connects to a fixed server URL.
+        if (!isTauriRuntime()) {
+          const storedBaseUrl = window.localStorage.getItem("openwork.baseUrl");
+          if (storedBaseUrl) {
+            setBaseUrl(storedBaseUrl);
+          }
         }
 
         const storedClientDir = window.localStorage.getItem(


### PR DESCRIPTION
## fix: don't restore stale `baseUrl` from localStorage in Tauri desktop mode

### Problem

After restarting the OpenWork desktop app, the sidebar showed **"Failed to load tasks"** for all local workspaces.

Root cause: on startup, the app restored the previously cached `baseUrl` from `localStorage` (e.g. `http://127.0.0.1:14095`) and immediately used it to fetch the session list. However, `opencode` is assigned a **random free port on every restart**, so the stored URL was always stale — causing every `session.list` request to fail with `ECONNREFUSED`.

The correct `baseUrl` is supplied by the Tauri `engine_info()` command after boot, but it arrived too late — after the stale value had already been applied.

### Fix

Skip restoring `baseUrl` from `localStorage` when running in Tauri/desktop mode. The correct value will always come from `engine_info()`.

Web mode is unchanged — it connects to a fixed server URL where caching the `baseUrl` is still useful.

```diff
- const storedBaseUrl = window.localStorage.getItem("openwork.baseUrl");
- if (storedBaseUrl) {
-   setBaseUrl(storedBaseUrl);
- }

+ // Desktop: baseUrl changes every restart (random port), rely on engine_info() instead.
+ // Web: server URL is fixed, so restoring from cache is still valid.
+ if (!isTauriRuntime()) {
+   const storedBaseUrl = window.localStorage.getItem("openwork.baseUrl");
+   if (storedBaseUrl) {
+     setBaseUrl(storedBaseUrl);
+   }
+ }
```

### Testing

1. Run `pnpm dev`, wait for the app to fully boot
2. Close and reopen the app (or restart the dev server)
3. Verify the sidebar shows the task list normally — no "Failed to load tasks" error

### Affected area

- `packages/app/src/app/app.tsx` (initialization / localStorage restore block)
- Desktop mode only; no impact on web mode or remote workspaces
