### PR TITLE
fix(skills): detect ~/.agents global skill directory

### DIFF
--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -226,7 +226,7 @@ export default {
   "skills.install_package": "Install",
   "skills.registry_notice": "Publishing to the OpenPackage registry (`opkg push`) requires authentication today. A registry search + curated list sync is planned.",
   "skills.installed": "Installed skills",
-  "skills.no_skills": "No skills detected in `.opencode/skills` or `.claude/skills`.",
+  "skills.no_skills": "No skills detected in `.opencode/skills`, `.claude/skills`, or `~/.agents/skills`.",
   "skills.desktop_required": "Skill management requires the desktop app.",
   "skills.host_only_error": "Skill management requires a local worker or connected OpenWork server.",
   "skills.install_skill_creator": "Install skill creator",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -227,7 +227,7 @@ export default {
   "skills.install_package": "安装",
   "skills.registry_notice": "发布到 OpenPackage 注册表（`opkg push`）目前需要身份验证。计划添加注册表搜索和精选列表同步。",
   "skills.installed": "已安装的 skills",
-  "skills.no_skills": "在 `.opencode/skills` 或 `.claude/skills` 中未检测到 skills。",
+  "skills.no_skills": "在 `.opencode/skills`、`.claude/skills` 或 `~/.agents/skills` 中未检测到 skills。",
   "skills.desktop_required": "技能管理需要桌面应用。",
   "skills.host_only_error": "技能管理需要本地工作区或已连接的 OpenWork 服务器。",
   "skills.install_skill_creator": "安装 skill creator",

--- a/packages/desktop/src-tauri/src/commands/skills.rs
+++ b/packages/desktop/src-tauri/src/commands/skills.rs
@@ -75,6 +75,16 @@ fn collect_global_skill_roots() -> Vec<PathBuf> {
         if claude_root.is_dir() {
             roots.push(claude_root);
         }
+
+        let agents_root = home.join(".agents").join("skills");
+        if agents_root.is_dir() {
+            roots.push(agents_root);
+        }
+
+        let legacy_agents_root = home.join(".agent").join("skills");
+        if legacy_agents_root.is_dir() {
+            roots.push(legacy_agents_root);
+        }
     }
 
     roots

--- a/packages/server/src/skills.ts
+++ b/packages/server/src/skills.ts
@@ -129,8 +129,12 @@ export async function listSkills(workspaceRoot: string, includeGlobal: boolean):
   if (includeGlobal) {
     const globalOpenWork = join(homedir(), ".config", "opencode", "skills");
     const globalClaude = join(homedir(), ".claude", "skills");
+    const globalAgents = join(homedir(), ".agents", "skills");
+    const globalAgentLegacy = join(homedir(), ".agent", "skills");
     items.push(...(await listSkillsInDir(globalOpenWork, "global")));
     items.push(...(await listSkillsInDir(globalClaude, "global")));
+    items.push(...(await listSkillsInDir(globalAgents, "global")));
+    items.push(...(await listSkillsInDir(globalAgentLegacy, "global")));
   }
 
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- include `~/.agents/skills` in global skill discovery for OpenWork server mode
- include `~/.agents/skills` in desktop/Tauri local skill discovery
- add compatibility fallback for legacy `~/.agent/skills`
- update Skills empty-state copy to mention `~/.agents/skills`

Fixes #670.

## Why
OpenWork currently scans `.opencode/skills`, `.claude/skills`, and `~/.config/opencode/skills` for skills. Skills placed in `~/.agents/skills` are ignored in practice.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `HOME=$(mktemp -d) ... bun -e 'import { listSkills } from "./packages/server/src/skills.ts"; ...'` (confirmed `~/.agents/skills` returns `demo-skill`)

## Notes
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml` is blocked locally because Xcode license is not accepted on this machine (`sudo xcodebuild -license`).
