### PR TITLE
fix(session): auto-scroll live thinking updates

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -701,6 +701,7 @@ export default function MessageList(props: MessageListProps) {
         const state = (part as any).state ?? {};
         return state.status === "running" || state.status === "pending";
       });
+    const useInnerTimelineScroll = () => !(Boolean(props.isStreaming) && hasRunning());
 
     const collapsedLabel = () => {
       if (explorationOnly()) {
@@ -767,7 +768,7 @@ export default function MessageList(props: MessageListProps) {
         {/* Expanded content */}
         <Show when={expanded()}>
           <div
-            class={`mt-1 ml-1 pl-3 border-l-2 max-h-[480px] overflow-y-auto ${
+            class={`mt-1 ml-1 pl-3 border-l-2 ${useInnerTimelineScroll() ? "max-h-[480px] overflow-y-auto" : ""} ${
               containerProps.isUser
                 ? "border-gray-6"
                 : "border-gray-6/60"

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -1243,6 +1243,34 @@ export default function SessionView(props: SessionViewProps) {
     return null;
   });
 
+  const runProgressSignature = createMemo(() => {
+    if (!showRunIndicator()) return "";
+    const part = latestRunPart();
+    const partTotal = totalPartCount();
+    if (!part) {
+      return `messages:${props.messages.length}:parts:${partTotal}:todos:${props.todos.length}`;
+    }
+
+    if (part.type === "reasoning" || part.type === "text") {
+      const text = typeof (part as any).text === "string" ? (part as any).text : "";
+      return `${part.type}:${text.length}:${text.slice(-48)}:parts:${partTotal}:todos:${props.todos.length}`;
+    }
+
+    if (part.type === "tool") {
+      const state = (part as any).state ?? {};
+      const status = typeof state.status === "string" ? state.status : "";
+      const outputSize =
+        typeof state.output === "string"
+          ? state.output.length
+          : Array.isArray(state.output)
+            ? state.output.length
+            : 0;
+      return `tool:${status}:${outputSize}:parts:${partTotal}:todos:${props.todos.length}`;
+    }
+
+    return `${part.type}:parts:${partTotal}:todos:${props.todos.length}`;
+  });
+
   const runLabel = createMemo(() => {
     switch (runPhase()) {
       case "sending":
@@ -1468,6 +1496,13 @@ export default function SessionView(props: SessionViewProps) {
     setRunTick(Date.now());
     const id = window.setInterval(() => setRunTick(Date.now()), 50);
     onCleanup(() => window.clearInterval(id));
+  });
+
+  createEffect(() => {
+    if (!showRunIndicator()) return;
+    runProgressSignature();
+    if (!nearBottom()) return;
+    scheduleScrollToLatest("auto");
   });
 
   createEffect(


### PR DESCRIPTION
## Summary
- keep session auto-scrolled during active runs when the user is already near the bottom
- track live run progress changes (thinking/text/tool updates) and schedule bottom-follow scrolling
- avoid nested timeline scroll trapping during active streaming by disabling inner timeline overflow while running

## Problem solved
Issue #660 reports repeated manual scrolling while the model is thinking, plus occasional scroll reset/friction while content appends.

This patch ensures the main chat viewport continues to follow live updates and removes the inner timeline scroll trap during active execution.

Closes #660.

## Testing
### Ran
- `pnpm typecheck`

### Result
- Fails due pre-existing workspace/toolchain issues not introduced by this patch:
  - `packages/app/src/app/context/global-sdk.tsx` (TS1005/TS1109/TS1128)
  - `packages/app/src/app/lib/openwork-server.ts` (TS1005)
  - `packages/app/tsconfig.json` (TS6046)
  - warning: local `package.json` exists but `node_modules` missing

No diagnostics were reported in the two changed files:
- `packages/app/src/app/pages/session.tsx`
- `packages/app/src/app/components/session/message-list.tsx`

## Manual verification steps
1. Start a chat that produces multiple reasoning/tool updates.
2. Keep the viewport near bottom.
3. Confirm incoming updates auto-follow without manual scroll.
4. Expand "Execution timeline" during streaming and confirm it grows with page scroll instead of requiring inner-pane scroll.
