### PR TITLE
chore(session): add compaction loop diagnostics

### DIFF
--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -60,6 +60,12 @@ const sortSessionsByActivity = (list: Session[]) =>
       return a.id.localeCompare(b.id);
     });
 
+const SYNTHETIC_CONTINUE_CONTROL_PATTERN =
+  /^\s*continue if you have next steps,\s*or stop and ask for clarification if you are unsure how to proceed\.?\s*$/i;
+const COMPACTION_DIAGNOSTIC_WINDOW_MS = 60_000;
+const COMPACTION_LOOP_WARN_THRESHOLD = 3;
+const COMPACTION_LOOP_WARN_MIN_INTERVAL_MS = 10_000;
+
 const createPlaceholderMessage = (part: Part): PlaceholderAssistantMessage => ({
   id: part.messageID,
   sessionID: part.sessionID,
@@ -150,6 +156,8 @@ export function createSessionStore(options: {
   const [permissionReplyBusy, setPermissionReplyBusy] = createSignal(false);
   const reloadDetectionSet = new Set<string>();
   const invalidToolDetectionSet = new Set<string>();
+  const syntheticContinueEventTimesBySession = new Map<string, number[]>();
+  const syntheticContinueLoopLastWarnAtBySession = new Map<string, number>();
 
   const skillPathPattern = /[\\/]\.opencode[\\/](skill|skills)[\\/]/i;
   const skillNamePattern = /[\\/]\.opencode[\\/](?:skill|skills)[\\/]+([^\\/]+)/i;
@@ -359,6 +367,52 @@ export function createSessionStore(options: {
     const tool = typeof record.tool === "string" && record.tool.trim() ? record.tool.trim() : "(unknown tool)";
     const hint = invalidToolNextStepHint(part);
     options.setError(`Invalid tool call: ${tool}.\n\n${hint}`);
+  };
+
+  const isSyntheticContinueControlPart = (part: Part) => {
+    if (part.type !== "text") return false;
+    const record = part as Part & { text?: unknown; synthetic?: unknown; ignored?: unknown };
+    if (record.synthetic !== true) return false;
+    if (record.ignored === true) return false;
+    const text = typeof record.text === "string" ? record.text.trim() : "";
+    if (!text) return false;
+    return SYNTHETIC_CONTINUE_CONTROL_PATTERN.test(text);
+  };
+
+  const recordSyntheticContinueDiagnostic = (part: Part) => {
+    if (!isSyntheticContinueControlPart(part)) return;
+    const sessionID = part.sessionID;
+    const now = Date.now();
+    const windowStart = now - COMPACTION_DIAGNOSTIC_WINDOW_MS;
+    const previous = syntheticContinueEventTimesBySession.get(sessionID) ?? [];
+    const next = previous.filter((timestamp) => timestamp >= windowStart);
+    next.push(now);
+    syntheticContinueEventTimesBySession.set(sessionID, next);
+
+    const countInWindow = next.length;
+    recordPerfLog(sessionDebugEnabled(), "session.compaction", "synthetic-continue", {
+      sessionID,
+      messageID: part.messageID,
+      partID: part.id,
+      countPerMinute: countInWindow,
+      windowMs: COMPACTION_DIAGNOSTIC_WINDOW_MS,
+    });
+
+    if (countInWindow < COMPACTION_LOOP_WARN_THRESHOLD) return;
+
+    const lastWarnAt = syntheticContinueLoopLastWarnAtBySession.get(sessionID) ?? 0;
+    if (now - lastWarnAt < COMPACTION_LOOP_WARN_MIN_INTERVAL_MS) return;
+    syntheticContinueLoopLastWarnAtBySession.set(sessionID, now);
+    sessionDebug("compaction:synthetic-continue-loop", {
+      sessionID,
+      countPerMinute: countInWindow,
+    });
+    recordPerfLog(sessionDebugEnabled(), "session.compaction", "synthetic-continue-loop-suspected", {
+      sessionID,
+      countPerMinute: countInWindow,
+      threshold: COMPACTION_LOOP_WARN_THRESHOLD,
+      windowMs: COMPACTION_DIAGNOSTIC_WINDOW_MS,
+    });
   };
 
   const addError = (error: unknown, fallback = "Unknown error") => {
@@ -893,6 +947,8 @@ export function createSessionStore(options: {
         const record = event.properties as Record<string, unknown>;
         const info = record.info as Session | undefined;
         if (info?.id) {
+          syntheticContinueEventTimesBySession.delete(info.id);
+          syntheticContinueLoopLastWarnAtBySession.delete(info.id);
           setStore("sessions", (current) => removeSession(current, info.id));
         }
       }
@@ -1022,6 +1078,10 @@ export function createSessionStore(options: {
               draft.parts[part.messageID] = upsertPartInfo(parts, part);
             }),
           );
+          const resolvedPart =
+            store.parts[part.messageID]?.find((item) => item.id === part.id) ??
+            part;
+          recordSyntheticContinueDiagnostic(resolvedPart);
           const partUpdatedMs = Math.round((perfNow() - partUpdatedStartedAt) * 100) / 100;
           if (sessionDebugEnabled() && (partUpdatedMs >= 8 || (delta?.length ?? 0) >= 120)) {
             const textLength =

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -141,6 +141,19 @@ export function createSessionStore(options: {
       // ignore
     }
   };
+
+  const sessionWarn = (label: string, payload?: unknown) => {
+    if (!sessionDebugEnabled()) return;
+    try {
+      if (payload === undefined) {
+        console.warn(`[WSWARN] ${label}`);
+      } else {
+        console.warn(`[WSWARN] ${label}`, payload);
+      }
+    } catch {
+      // ignore
+    }
+  };
   const MAX_RELOAD_DETECTION_KEYS = 5000;
 
   const [store, setStore] = createStore<StoreState>({
@@ -403,7 +416,7 @@ export function createSessionStore(options: {
     const lastWarnAt = syntheticContinueLoopLastWarnAtBySession.get(sessionID) ?? 0;
     if (now - lastWarnAt < COMPACTION_LOOP_WARN_MIN_INTERVAL_MS) return;
     syntheticContinueLoopLastWarnAtBySession.set(sessionID, now);
-    sessionDebug("compaction:synthetic-continue-loop", {
+    sessionWarn("compaction:synthetic-continue-loop", {
       sessionID,
       countPerMinute: countInWindow,
     });

--- a/packages/app/src/app/lib/perf-log.ts
+++ b/packages/app/src/app/lib/perf-log.ts
@@ -20,6 +20,7 @@ const HOT_EVENT_KEYS = new Set([
   "session.sse:flush",
   "session.sse:arrival-gap",
   "session.event:message.part.updated",
+  "session.compaction:synthetic-continue",
   "session.input:draft-flush",
   "session.render:message-blocks",
   "session.render:tool-summary",


### PR DESCRIPTION
## Summary
- add app-side diagnostics for synthetic compaction control turns in the session event pipeline
- track per-session synthetic "Continue..." control text frequency in a 60s rolling window
- emit warning-level perf logs when repeated synthetic continue events exceed a loop-suspect threshold
- clear per-session diagnostic state when a session is deleted

## Why
Issue #700 tracks an upstream auto-compaction loop condition. Until upstream runtime fixes land, OpenWork needs local observability to detect potential runaway patterns early.

This patch does not change prompt/runtime behavior. It only adds diagnostics for repeated synthetic continue control text.

Closes #700.

## What is logged
When a `message.part.updated` event contains a synthetic text part matching the compaction control message:
- `session.compaction:synthetic-continue`
  - includes `sessionID`, `messageID`, `partID`, `countPerMinute`, `windowMs`

If count crosses threshold (>=3 within 60s), throttled warnings are emitted:
- `session.compaction:synthetic-continue-loop-suspected`
  - includes `sessionID`, `countPerMinute`, `threshold`, `windowMs`

## Testing
### Ran
- `pnpm typecheck`

### Result
- Fails due pre-existing repo/toolchain issues unrelated to this patch:
  - `packages/app/src/app/context/global-sdk.tsx` (TS1005/TS1109/TS1128)
  - `packages/app/src/app/lib/openwork-server.ts` (TS1005)
  - `packages/app/tsconfig.json` (TS6046)
  - warning: local `package.json` exists but `node_modules` missing

No direct diagnostics were reported in changed file:
- `packages/app/src/app/context/session.ts`

## Manual verification
1. Enable developer mode.
2. Reproduce a compaction-heavy long session.
3. Confirm `[OWPERF] session.compaction:synthetic-continue` appears when synthetic continue control text is emitted.
4. If repeated quickly, confirm `[OWPERF] session.compaction:synthetic-continue-loop-suspected` appears with per-minute counts.
