### PR TITLE
fix(session): surface pending subagent prompts across sessions

### DIFF
--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -792,7 +792,8 @@ export function createSessionStore(options: {
   const activePermission = createMemo(() => {
     const id = options.selectedSessionId();
     if (id) {
-      return store.pendingPermissions.find((perm) => perm.sessionID === id) ?? null;
+      const scoped = store.pendingPermissions.find((perm) => perm.sessionID === id) ?? null;
+      if (scoped) return scoped;
     }
     return store.pendingPermissions[0] ?? null;
   });
@@ -800,7 +801,8 @@ export function createSessionStore(options: {
   const activeQuestion = createMemo(() => {
     const id = options.selectedSessionId();
     if (id) {
-      return store.pendingQuestions.find((q) => q.sessionID === id) ?? null;
+      const scoped = store.pendingQuestions.find((q) => q.sessionID === id) ?? null;
+      if (scoped) return scoped;
     }
     return store.pendingQuestions[0] ?? null;
   });


### PR DESCRIPTION
## Summary
- fix pending prompt selection to avoid subagent requests being hidden when parent session is selected
- for both permission and question prompts:
  - prefer prompt from selected session when available
  - otherwise fall back to first pending prompt across all sessions

## Why
Issue #688 reports broken primary/subagent communication. A concrete app-side failure mode was that pending subagent questions/permissions were effectively invisible unless the user manually switched into the subagent session.

This patch ensures pending prompts remain actionable from the current UI context.

Closes #688.

## Testing
### Ran
- `pnpm typecheck`

### Result
- Fails due existing repo/toolchain issues unrelated to this patch.
- No diagnostics reported in changed file:
  - `packages/app/src/app/context/session.ts`

## Manual verification
1. Start a parent session and trigger a subagent task that requests permission or asks a question.
2. Keep parent session selected.
3. Confirm prompt modal is still surfaced (fallback to global pending prompt).
4. Answer/reply and confirm flow resumes.
