### PR TITLE
docs(workflow): require gh status/checks before next issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,14 @@ If you cannot complete steps 4-8 (Docker, Chrome MCP, missing credentials, or en
 
 If you open a PR, you must run tests and report what you ran (commands + result).
 
+Before moving to the next issue/PR, check GitHub status for the current branch and PR:
+
+* `gh status`
+* `gh pr view <number> --repo different-ai/openwork`
+* `gh pr checks <number> --repo different-ai/openwork`
+
+If checks are failing, report whether they are code failures or external/auth/environment blockers.
+
 To maximize merge speed, include evidence of the end-to-end flow:
 
 * Ideally: attach a short video/screen recording showing the flow running successfully.


### PR DESCRIPTION
## Summary
- update `AGENTS.md` PR workflow rules to require checking GitHub status/checks before moving to the next issue
- standardize commands:
  - `gh status`
  - `gh pr view <number> --repo different-ai/openwork`
  - `gh pr checks <number> --repo different-ai/openwork`
- add explicit note to distinguish code failures vs external/auth/environment blockers when checks fail

## Why
This makes PR triage explicit in the workflow and prevents skipping unresolved PR status before starting new work.

## Testing
### Ran
- `pnpm typecheck`

### Result
- fails due pre-existing repo/toolchain issues unrelated to this docs-only patch:
  - `packages/app/src/app/context/global-sdk.tsx` (TS1005/TS1109/TS1128)
  - `packages/app/src/app/lib/openwork-server.ts` (TS1005)
  - `packages/app/tsconfig.json` (TS6046)

## CI status check
- `gh pr checks 706 --repo different-ai/openwork`
- current non-code blockers: `Vercel – openwork-app` / `Vercel – openwork-share` require authorization
- `Tauri Build (Linux)` passed

## E2E Evidence
- not applicable for this change (`AGENTS.md` docs-only workflow update; no UI/runtime behavior change)

## Reproduce
- `pnpm typecheck`
- `gh pr checks 706 --repo different-ai/openwork`
