### PR TITLE
feat(app): add desktop font zoom keyboard shortcuts

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -143,6 +143,13 @@ import {
   type OpenCodeRouterInfo,
 } from "./lib/tauri";
 import {
+  FONT_ZOOM_STEP,
+  applyFontZoom,
+  parseFontZoomShortcut,
+  persistFontZoom,
+  readStoredFontZoom,
+} from "./lib/font-zoom";
+import {
   parseOpenworkWorkspaceIdFromUrl,
   readOpenworkBundleInviteFromSearch,
   readOpenworkConnectInviteFromSearch,
@@ -774,6 +781,38 @@ export default function App() {
     update();
     document.addEventListener("visibilitychange", update);
     onCleanup(() => document.removeEventListener("visibilitychange", update));
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!isTauriRuntime()) return;
+
+    const applyAndPersistFontZoom = (value: number) => {
+      const next = applyFontZoom(document.documentElement.style, value);
+      persistFontZoom(window.localStorage, next);
+      return next;
+    };
+
+    let fontZoom = applyAndPersistFontZoom(readStoredFontZoom(window.localStorage) ?? 1);
+
+    const handleZoomShortcut = (event: KeyboardEvent) => {
+      const action = parseFontZoomShortcut(event);
+      if (!action) return;
+
+      if (action === "in") {
+        fontZoom = applyAndPersistFontZoom(fontZoom + FONT_ZOOM_STEP);
+      } else if (action === "out") {
+        fontZoom = applyAndPersistFontZoom(fontZoom - FONT_ZOOM_STEP);
+      } else {
+        fontZoom = applyAndPersistFontZoom(1);
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    window.addEventListener("keydown", handleZoomShortcut, true);
+    onCleanup(() => window.removeEventListener("keydown", handleZoomShortcut, true));
   });
 
   createEffect(() => {

--- a/packages/app/src/app/index.css
+++ b/packages/app/src/app/index.css
@@ -38,6 +38,10 @@ body {
   height: 100%;
 }
 
+html {
+  font-size: var(--openwork-font-size, 16px);
+}
+
 body {
   margin: 0;
   font-family:
@@ -56,7 +60,7 @@ body {
     "Noto Sans",
     "Apple Color Emoji",
     "Segoe UI Emoji";
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1.5;
   color: var(--dls-text-primary);
   background-color: var(--dls-surface);

--- a/packages/app/src/app/lib/font-zoom.ts
+++ b/packages/app/src/app/lib/font-zoom.ts
@@ -1,0 +1,75 @@
+export const FONT_ZOOM_STORAGE_KEY = "openwork.desktop-font-zoom.v1";
+export const FONT_ZOOM_BASE_PX = 16;
+export const FONT_ZOOM_STEP = 0.1;
+export const FONT_ZOOM_MIN = 0.8;
+export const FONT_ZOOM_MAX = 1.6;
+
+export type FontZoomShortcutAction = "in" | "out" | "reset";
+
+export function clampFontZoom(value: number): number {
+  return Math.min(FONT_ZOOM_MAX, Math.max(FONT_ZOOM_MIN, value));
+}
+
+export function normalizeFontZoom(value: number): number {
+  return Math.round(clampFontZoom(value) * 100) / 100;
+}
+
+export function parseFontZoomShortcut(event: {
+  key: string;
+  code: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+}): FontZoomShortcutAction | null {
+  const mod = event.metaKey || event.ctrlKey;
+  if (!mod || event.altKey) return null;
+
+  if (
+    event.code === "Equal" ||
+    event.code === "NumpadAdd" ||
+    event.key === "+" ||
+    event.key === "="
+  ) {
+    return "in";
+  }
+  if (
+    event.code === "Minus" ||
+    event.code === "NumpadSubtract" ||
+    event.key === "-" ||
+    event.key === "_"
+  ) {
+    return "out";
+  }
+  if (event.code === "Digit0" || event.code === "Numpad0" || event.key === "0") {
+    return "reset";
+  }
+
+  return null;
+}
+
+export function readStoredFontZoom(storage: Pick<Storage, "getItem">): number | null {
+  try {
+    const raw = storage.getItem(FONT_ZOOM_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return null;
+    return normalizeFontZoom(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function persistFontZoom(storage: Pick<Storage, "setItem">, value: number) {
+  try {
+    storage.setItem(FONT_ZOOM_STORAGE_KEY, String(value));
+  } catch {
+    // ignore storage failures
+  }
+}
+
+export function applyFontZoom(rootStyle: Pick<CSSStyleDeclaration, "setProperty">, value: number): number {
+  const normalized = normalizeFontZoom(value);
+  const px = FONT_ZOOM_BASE_PX * normalized;
+  rootStyle.setProperty("--openwork-font-size", `${px}px`);
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- add desktop-only keyboard handlers for font zoom (`Cmd/Ctrl+=`, `Cmd/Ctrl+-`, `Cmd/Ctrl+0`) in the app shell
- apply zoom through a root CSS variable and persist the zoom factor in local storage so it survives restarts
- factor shortcut parsing and zoom math into a dedicated `font-zoom` helper module for predictable behavior and testability

## Verification
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
- `bun -e '...font-zoom checks passed...'` (asserted shortcut parsing + CSS size application + storage parsing)