### PR TITLE
feat(opencode-router): add first-class media transport for Slack and Telegram

### DIFF
--- a/packages/docs/opencode-router.mdx
+++ b/packages/docs/opencode-router.mdx
@@ -10,6 +10,7 @@ description: "What opencode-router is and when to use it"
 - Routes messages using `(channel, identity, peer) -> directory` bindings.
 - Lets teams interact with workers from Slack or Telegram.
 - Keeps chat surfaces mapped to the correct workspace.
+- Handles text, files, images, and audio as first-class message parts.
 
 ## Quick start
 
@@ -38,6 +39,7 @@ opencode-router telegram list
 opencode-router slack list
 opencode-router bindings list
 opencode-router bindings set --channel telegram --identity default --peer <chatId> --dir /path/to/workdir
+opencode-router send --channel slack --identity default --to D123 --file ./report.pdf
 ```
 
 ## In OpenWork UI

--- a/packages/opencode-router/README.md
+++ b/packages/opencode-router/README.md
@@ -75,6 +75,8 @@ Slack support uses Socket Mode and replies in threads when @mentioned in channel
    - `chat:write`
    - `app_mentions:read`
    - `im:history`
+   - `files:read`
+   - `files:write`
 4) Subscribe to events (bot events):
    - `app_mention`
    - `message.im`
@@ -115,6 +117,33 @@ curl -sS "http://127.0.0.1:${OPENCODE_ROUTER_HEALTH_PORT:-3005}/send" \
   -d '{"channel":"telegram","directory":"/path/to/workdir","text":"hello"}'
 ```
 
+Send text + media in one request:
+
+```bash
+curl -sS "http://127.0.0.1:${OPENCODE_ROUTER_HEALTH_PORT:-3005}/send" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "channel":"slack",
+    "peerId":"D12345678",
+    "text":"Here is the export",
+    "parts":[
+      {"type":"file","filePath":"./artifacts/report.pdf"},
+      {"type":"image","filePath":"./artifacts/plot.png","caption":"latest trend"}
+    ]
+  }'
+```
+
+Supported media part types:
+- `image`
+- `audio`
+- `file`
+
+Each media part accepts:
+- `filePath` (absolute path, or relative to the send directory/workspace root)
+- optional `caption`
+- optional `filename`
+- optional `mimeType`
+
 ## Commands
 
 ```bash
@@ -129,6 +158,10 @@ opencode-router slack add <xoxb> <xapp> --id default
 
 opencode-router bindings list
 opencode-router bindings set --channel telegram --identity default --peer <chatId> --dir /path/to/workdir
+
+opencode-router send --channel telegram --identity default --to <chatId> --message "hello"
+opencode-router send --channel telegram --identity default --to <chatId> --image ./plot.png --caption "plot"
+opencode-router send --channel slack --identity default --to D123 --file ./report.pdf
 ```
 
 ## Defaults

--- a/packages/opencode-router/src/bridge.ts
+++ b/packages/opencode-router/src/bridge.ts
@@ -9,8 +9,11 @@ import type { Logger } from "pino";
 import type { Config, ChannelName, OpenCodeRouterConfigFile } from "./config.js";
 import { readConfigFile, writeConfigFile } from "./config.js";
 import { BridgeStore } from "./db.js";
+import { classifyDeliveryError } from "./delivery.js";
 import { normalizeEvent } from "./events.js";
 import { startHealthServer, type HealthSnapshot } from "./health.js";
+import { type InboundMessagePart, type MessageDeliveryResult, type OutboundMessagePart, normalizeOutboundParts, summarizeInboundPartsForPrompt, summarizeInboundPartsForReporter, textFromInboundParts } from "./media.js";
+import { MediaStore } from "./media-store.js";
 import { buildPermissionRules, createClient } from "./opencode.js";
 import { chunkText, formatInputSummary, truncateText } from "./text.js";
 import { createSlackAdapter } from "./slack.js";
@@ -23,6 +26,7 @@ type Adapter = {
   maxTextLength: number;
   start(): Promise<void>;
   stop(): Promise<void>;
+  sendMessage?: (peerId: string, message: { parts: OutboundMessagePart[] }) => Promise<MessageDeliveryResult>;
   sendText(peerId: string, text: string): Promise<void>;
   sendFile?: (peerId: string, filePath: string, caption?: string) => Promise<void>;
   sendTyping?: (peerId: string) => Promise<void>;
@@ -94,8 +98,17 @@ type InboundMessage = {
   identityId: string;
   peerId: string;
   text: string;
+  parts?: InboundMessagePart[];
   raw: unknown;
   fromMe?: boolean;
+};
+
+type SendTargetDelivery = {
+  identityId: string;
+  peerId: string;
+  attemptedParts: number;
+  sentParts: number;
+  partResults: MessageDeliveryResult["partResults"];
 };
 
 type ModelRef = {
@@ -236,6 +249,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
   const clients = new Map<string, ReturnType<typeof createClient>>();
   const defaultDirectory = config.opencodeDirectory;
   const workspaceRoot = resolve(defaultDirectory || process.cwd());
+  const mediaStore = new MediaStore(join(workspaceRoot, ".opencode-router", "media"));
+  await mediaStore.ensureReady();
   const workspaceAgentFilePath = join(workspaceRoot, OPENCODE_ROUTER_AGENT_FILE_RELATIVE_PATH);
   const agentPromptCache = new Map<string, { mtimeMs: number; config: MessagingAgentConfig }>();
   let latestAgentConfig: MessagingAgentConfig = {
@@ -401,7 +416,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     for (const bot of enabledTelegram) {
       const key = adapterKey("telegram", bot.id);
       logger.debug({ identityId: bot.id }, "telegram adapter enabled");
-      const base = createTelegramAdapter(bot, config, logger, handleInbound);
+      const base = createTelegramAdapter(bot, config, logger, handleInbound, mediaStore);
       adapters.set(key, { ...base, key });
     }
 
@@ -413,7 +428,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     for (const app of enabledSlack) {
       const key = adapterKey("slack", app.id);
       logger.debug({ identityId: app.id }, "slack adapter enabled");
-      const base = createSlackAdapter(app, config, logger, handleInbound);
+      const base = createSlackAdapter(app, config, logger, handleInbound, undefined, mediaStore);
       adapters.set(key, { ...base, key });
     }
   }
@@ -584,6 +599,139 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
   };
 
   await loadMessagingAgentConfig();
+
+  const outboundMediaMaxBytesRaw = Number.parseInt(process.env.OPENCODE_ROUTER_MAX_MEDIA_BYTES ?? "", 10);
+  const outboundMediaMaxBytes =
+    Number.isFinite(outboundMediaMaxBytesRaw) && outboundMediaMaxBytesRaw > 0
+      ? outboundMediaMaxBytesRaw
+      : 50 * 1024 * 1024;
+
+  const resolveOutboundParts = async (
+    baseDirectory: string,
+    input: { text?: string; parts?: unknown },
+  ): Promise<OutboundMessagePart[]> => {
+    const normalized = normalizeOutboundParts(input);
+    if (normalized.length === 0) {
+      const error = new Error("text or parts is required") as Error & { status?: number };
+      error.status = 400;
+      throw error;
+    }
+
+    const resolved: OutboundMessagePart[] = [];
+    for (const part of normalized) {
+      if (part.type === "text") {
+        resolved.push(part);
+        continue;
+      }
+
+      const file = await mediaStore.resolveOutboundFile({
+        filePath: part.filePath,
+        baseDirectory,
+        maxBytes: outboundMediaMaxBytes,
+      });
+      resolved.push({
+        ...part,
+        filePath: file.filePath,
+        ...(part.filename ? {} : { filename: file.filename }),
+      });
+    }
+
+    return resolved;
+  };
+
+  const deliverParts = async (
+    channel: ChannelName,
+    identityId: string,
+    peerId: string,
+    parts: OutboundMessagePart[],
+    options: { kind?: OutboundKind; display?: boolean } = {},
+  ): Promise<MessageDeliveryResult> => {
+    const adapter = adapters.get(adapterKey(channel, identityId));
+    if (!adapter) {
+      return {
+        attemptedParts: parts.length,
+        sentParts: 0,
+        partResults: parts.map((part, index) => ({
+          index,
+          type: part.type,
+          sent: false,
+          error: "Adapter not running",
+          code: "not_found",
+          retryable: false,
+        })),
+      };
+    }
+
+    const kind = options.kind ?? "system";
+    if (options.display !== false) {
+      for (const part of parts) {
+        const preview =
+          part.type === "text"
+            ? truncateText(part.text, 240)
+            : `[${part.type}] ${part.filename || part.filePath}`;
+        reporter?.onOutbound?.({ channel, identityId, peerId, text: preview, kind });
+      }
+    }
+
+    recordOutboundActivity(Date.now());
+
+    if (adapter.sendMessage) {
+      try {
+        return await adapter.sendMessage(peerId, { parts });
+      } catch (error) {
+        const classified = classifyDeliveryError(error);
+        return {
+          attemptedParts: parts.length,
+          sentParts: 0,
+          partResults: parts.map((part, index) => ({
+            index,
+            type: part.type,
+            sent: false,
+            error: classified.message,
+            code: classified.code,
+            retryable: classified.retryable,
+          })),
+        };
+      }
+    }
+
+    const partResults: MessageDeliveryResult["partResults"] = [];
+    let sentParts = 0;
+    for (let index = 0; index < parts.length; index += 1) {
+      const part = parts[index];
+      try {
+        if (part.type === "text") {
+          const chunks = chunkText(part.text, adapter.maxTextLength);
+          for (const chunk of chunks) {
+            await adapter.sendText(peerId, chunk);
+          }
+        } else if (adapter.sendFile) {
+          await adapter.sendFile(peerId, part.filePath, part.caption);
+        } else {
+          throw new Error(`Adapter does not support ${part.type} media`);
+        }
+
+        sentParts += 1;
+        partResults.push({ index, type: part.type, sent: true });
+      } catch (error) {
+        const classified = classifyDeliveryError(error);
+        partResults.push({
+          index,
+          type: part.type,
+          sent: false,
+          error: classified.message,
+          code: classified.code,
+          retryable: classified.retryable,
+        });
+      }
+    }
+
+    return {
+      attemptedParts: parts.length,
+      sentParts,
+      partResults,
+    };
+  };
 
   let stopHealthServer: (() => void) | null = null;
   if (!deps.disableHealthServer && config.healthPort) {
@@ -818,6 +966,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             config,
             logger,
             handleInbound,
+            mediaStore,
           );
           const adapter = { ...base, key };
           adapters.set(key, adapter);
@@ -1007,6 +1156,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             config,
             logger,
             handleInbound,
+            undefined,
+            mediaStore,
           );
           const adapter = { ...base, key };
           adapters.set(key, adapter);
@@ -1142,7 +1293,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
           identityId?: string;
           directory?: string;
           peerId?: string;
-          text: string;
+          text?: string;
+          parts?: OutboundMessagePart[];
           autoBind?: boolean;
         }) => {
           const channelRaw = input.channel.trim().toLowerCase();
@@ -1154,10 +1306,6 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
           const directoryInput = (input.directory ?? "").trim();
           const peerId = (input.peerId ?? "").trim();
           const autoBind = input.autoBind === true;
-          const text = input.text ?? "";
-          if (!text.trim()) {
-            throw new Error("text is required");
-          }
 
           if (!directoryInput && !peerId) {
             throw new Error("directory or peerId is required");
@@ -1175,6 +1323,38 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             }
             return scoped.directory;
           })() : "";
+
+          const baseDirectory = normalizedDir || workspaceRoot;
+          const outboundParts = await resolveOutboundParts(baseDirectory, {
+            text: input.text,
+            parts: input.parts,
+          });
+
+          const makeTargetError = (
+            targetIdentityId: string,
+            targetPeerId: string,
+            errorMessage: string,
+            errorCode = "not_found",
+          ): SendTargetDelivery => ({
+            identityId: targetIdentityId,
+            peerId: targetPeerId,
+            attemptedParts: outboundParts.length,
+            sentParts: 0,
+            partResults: outboundParts.map((part, index) => ({
+              index,
+              type: part.type,
+              sent: false,
+              error: errorMessage,
+              code: errorCode,
+              retryable: false,
+            })),
+          });
+
+          const deliveryFailed = (delivery: MessageDeliveryResult) =>
+            delivery.attemptedParts > 0 && delivery.sentParts < delivery.attemptedParts;
+
+          const primaryFailureMessage = (delivery: MessageDeliveryResult) =>
+            delivery.partResults.find((part) => !part.sent)?.error || "Delivery failed";
 
           const resolveSendIdentityId = () => {
             if (identityId) return identityId;
@@ -1199,12 +1379,14 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
               attempted: 0,
               sent: 0,
               reason: `No ${channel} adapter is running for direct send`,
+              targets: [],
             };
           }
 
           if (peerId && targetIdentityId) {
             const adapter = adapters.get(adapterKey(channel, targetIdentityId));
             if (!adapter) {
+              const target = makeTargetError(targetIdentityId, peerId, "Adapter not running");
               return {
                 channel,
                 directory: normalizedDir || workspaceRootNormalized,
@@ -1213,6 +1395,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
                 attempted: 1,
                 sent: 0,
                 failures: [{ identityId: targetIdentityId, peerId, error: "Adapter not running" }],
+                targets: [target],
               };
             }
 
@@ -1222,31 +1405,39 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
               ensureEventSubscription(normalizedDir);
             }
 
-            try {
-              await sendText(channel, targetIdentityId, peerId, text, { kind: "system", display: false });
-              return {
-                channel,
-                directory: normalizedDir || workspaceRootNormalized,
-                identityId: targetIdentityId,
-                peerId,
-                attempted: 1,
-                sent: 1,
-              };
-            } catch (error) {
-              return {
-                channel,
-                directory: normalizedDir || workspaceRootNormalized,
-                identityId: targetIdentityId,
-                peerId,
-                attempted: 1,
-                sent: 0,
-                failures: [{
+            const delivery = await deliverParts(channel, targetIdentityId, peerId, outboundParts, {
+              kind: "system",
+              display: false,
+            });
+            const failed = deliveryFailed(delivery);
+            return {
+              channel,
+              directory: normalizedDir || workspaceRootNormalized,
+              identityId: targetIdentityId,
+              peerId,
+              attempted: 1,
+              sent: failed ? 0 : 1,
+              ...(failed
+                ? {
+                    failures: [
+                      {
+                        identityId: targetIdentityId,
+                        peerId,
+                        error: primaryFailureMessage(delivery),
+                      },
+                    ],
+                  }
+                : {}),
+              targets: [
+                {
                   identityId: targetIdentityId,
                   peerId,
-                  error: error instanceof Error ? error.message : String(error),
-                }],
-              };
-            }
+                  attemptedParts: delivery.attemptedParts,
+                  sentParts: delivery.sentParts,
+                  partResults: delivery.partResults,
+                },
+              ],
+            };
           }
 
           const bindings = store.listBindings({
@@ -1262,10 +1453,12 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
               attempted: 0,
               sent: 0,
               reason: `No bound conversations for ${channel}${identityId ? `/${identityId}` : ""} at directory ${normalizedDir}`,
+              targets: [],
             };
           }
 
           const failures: Array<{ identityId: string; peerId: string; error: string }> = [];
+          const targets: SendTargetDelivery[] = [];
           let attempted = 0;
           let sent = 0;
           for (const binding of bindings) {
@@ -1273,6 +1466,13 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             if (channel === "telegram" && !isTelegramPeerId(binding.peer_id)) {
               store.deleteBinding(channel, binding.identity_id, binding.peer_id);
               store.deleteSession(channel, binding.identity_id, binding.peer_id);
+              const target = makeTargetError(
+                binding.identity_id,
+                binding.peer_id,
+                "Invalid Telegram peerId binding removed (expected numeric chat_id)",
+                "invalid_target",
+              );
+              targets.push(target);
               failures.push({
                 identityId: binding.identity_id,
                 peerId: binding.peer_id,
@@ -1282,6 +1482,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             }
             const adapter = adapters.get(adapterKey(channel, binding.identity_id));
             if (!adapter) {
+              const target = makeTargetError(binding.identity_id, binding.peer_id, "Adapter not running");
+              targets.push(target);
               failures.push({
                 identityId: binding.identity_id,
                 peerId: binding.peer_id,
@@ -1289,15 +1491,25 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
               });
               continue;
             }
-            try {
-              await sendText(channel, binding.identity_id, binding.peer_id, text, { kind: "system", display: false });
-              sent += 1;
-            } catch (error) {
+            const delivery = await deliverParts(channel, binding.identity_id, binding.peer_id, outboundParts, {
+              kind: "system",
+              display: false,
+            });
+            targets.push({
+              identityId: binding.identity_id,
+              peerId: binding.peer_id,
+              attemptedParts: delivery.attemptedParts,
+              sentParts: delivery.sentParts,
+              partResults: delivery.partResults,
+            });
+            if (deliveryFailed(delivery)) {
               failures.push({
                 identityId: binding.identity_id,
                 peerId: binding.peer_id,
-                error: error instanceof Error ? error.message : String(error),
+                error: primaryFailureMessage(delivery),
               });
+            } else {
+              sent += 1;
             }
           }
 
@@ -1308,6 +1520,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
             attempted,
             sent,
             ...(failures.length ? { failures } : {}),
+            targets,
           };
         },
       },
@@ -1435,28 +1648,14 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     text: string,
     options: { kind?: OutboundKind; display?: boolean } = {},
   ) {
-    const adapter = adapters.get(adapterKey(channel, identityId));
-    if (!adapter) return;
-    recordOutboundActivity(Date.now());
-    const kind = options.kind ?? "system";
-    logger.debug({ channel, identityId, peerId, kind, length: text.length }, "sendText requested");
-    if (options.display !== false) {
-      reporter?.onOutbound?.({ channel, identityId, peerId, text, kind });
-    }
-
-    // CHECK IF IT'S A FILE COMMAND
-    if (text.startsWith("FILE:")) {
-      const filePath = text.substring(5).trim();
-      if (adapter.sendFile) {
-        await adapter.sendFile(peerId, filePath);
-        return; // Stop here, don't send text
-      }
-    }
-
-    const chunks = chunkText(text, adapter.maxTextLength);
-    for (const chunk of chunks) {
-      logger.info({ channel, peerId, length: chunk.length }, "sending message");
-      await adapter.sendText(peerId, chunk);
+    const parts: OutboundMessagePart[] =
+      text.startsWith("FILE:") && text.substring(5).trim()
+        ? [{ type: "file", filePath: text.substring(5).trim() }]
+        : [{ type: "text", text }];
+    const delivery = await deliverParts(channel, identityId, peerId, parts, options);
+    if (delivery.sentParts < delivery.attemptedParts) {
+      const message = delivery.partResults.find((part) => !part.sent)?.error || "Failed to send message";
+      throw new Error(message);
     }
   }
 
@@ -1550,20 +1749,33 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
     const adapter = adapters.get(adapterKey(message.channel, message.identityId));
     if (!adapter) return;
     recordInboundActivity(Date.now());
-    let inbound = message;
+    const normalizedParts: InboundMessagePart[] =
+      Array.isArray(message.parts) && message.parts.length
+        ? message.parts
+        : message.text.trim()
+          ? [{ type: "text", text: message.text }]
+          : [];
+    const inboundText = textFromInboundParts(normalizedParts, message.text).trim();
+    let inbound: InboundMessage = {
+      ...message,
+      text: inboundText,
+      ...(normalizedParts.length ? { parts: normalizedParts } : {}),
+    };
+    const reporterInboundText =
+      inbound.text || summarizeInboundPartsForReporter(inbound.parts) || "[empty message]";
     logger.debug(
       {
         channel: inbound.channel,
         identityId: inbound.identityId,
         peerId: inbound.peerId,
         fromMe: inbound.fromMe,
-        length: inbound.text.length,
-        preview: truncateText(inbound.text.trim(), 120),
+        length: reporterInboundText.length,
+        preview: truncateText(reporterInboundText.trim(), 120),
       },
       "inbound received",
     );
     logger.info(
-      { channel: inbound.channel, identityId: inbound.identityId, peerId: inbound.peerId, length: inbound.text.length },
+      { channel: inbound.channel, identityId: inbound.identityId, peerId: inbound.peerId, length: reporterInboundText.length },
       "received message",
     );
     const peerKey = inbound.peerId;
@@ -1601,7 +1813,7 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       channel: inbound.channel,
       identityId: inbound.identityId,
       peerId: inbound.peerId,
-      text: inbound.text,
+      text: reporterInboundText,
       fromMe: inbound.fromMe,
     });
 
@@ -1682,6 +1894,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
           .map((value) => value.trim())
           .filter(Boolean)
           .join("\n\n");
+        const attachmentSummary = summarizeInboundPartsForPrompt(inbound.parts);
+        const incomingText = inbound.text || "(no text; user sent media)";
         const promptText = [
           "You are handling a Slack/Telegram message via OpenWork.",
           `Workspace agent file: ${messagingAgent.filePath}`,
@@ -1690,7 +1904,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
           effectiveInstructions,
           "",
           "Incoming user message:",
-          inbound.text,
+          incomingText,
+          ...(attachmentSummary.length ? ["", "Incoming attachments:", ...attachmentSummary] : []),
         ].join("\n");
         logger.debug(
           {
@@ -2018,7 +2233,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
       channel: ChannelName;
       identityId?: string;
       peerId: string;
-      text: string;
+      text?: string;
+      parts?: InboundMessagePart[];
       raw?: unknown;
       fromMe?: boolean;
     }) {
@@ -2027,7 +2243,8 @@ export async function startBridge(config: Config, logger: Logger, reporter?: Bri
         channel: message.channel,
         identityId,
         peerId: message.peerId,
-        text: message.text,
+        text: message.text ?? "",
+        ...(Array.isArray(message.parts) ? { parts: message.parts } : {}),
         raw: message.raw ?? null,
         fromMe: message.fromMe,
       });

--- a/packages/opencode-router/src/cli.ts
+++ b/packages/opencode-router/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 import fs from "node:fs";
+import { readFile as readFileAsync } from "node:fs/promises";
 import path from "node:path";
 
 import { Command } from "commander";
-import { Bot } from "grammy";
+import { Bot, InputFile } from "grammy";
 import { WebClient } from "@slack/web-api";
 
 import { startBridge, type BridgeReporter } from "./bridge.js";
@@ -513,12 +514,25 @@ bindings
 
 program
   .command("send")
-  .description("Send a test message")
+  .description("Send a test message and/or media")
   .requiredOption("--channel <channel>", "telegram or slack")
   .requiredOption("--identity <id>", "Identity id")
   .requiredOption("--to <recipient>", "Recipient ID (chat ID or peerId)")
-  .requiredOption("--message <text>", "Message text to send")
-  .action(async (opts: { channel: string; identity: string; to: string; message: string }) => {
+  .option("--message <text>", "Message text to send")
+  .option("--image <path>", "Image file path")
+  .option("--audio <path>", "Audio file path")
+  .option("--file <path>", "File path")
+  .option("--caption <text>", "Caption for media upload")
+  .action(async (opts: {
+    channel: string;
+    identity: string;
+    to: string;
+    message?: string;
+    image?: string;
+    audio?: string;
+    file?: string;
+    caption?: string;
+  }) => {
     const useJson = program.opts().json;
     const channelRaw = opts.channel.trim().toLowerCase();
     if (channelRaw !== "telegram" && channelRaw !== "slack") {
@@ -528,28 +542,78 @@ program
     const config = loadConfig(process.env, { requireOpencode: false });
     const identityId = normalizeIdentityId(opts.identity);
     const to = opts.to.trim();
-    const message = opts.message;
+    const message = typeof opts.message === "string" ? opts.message : "";
+    const media = [
+      ...(opts.image?.trim() ? [{ type: "image" as const, filePath: path.resolve(opts.image.trim()) }] : []),
+      ...(opts.audio?.trim() ? [{ type: "audio" as const, filePath: path.resolve(opts.audio.trim()) }] : []),
+      ...(opts.file?.trim() ? [{ type: "file" as const, filePath: path.resolve(opts.file.trim()) }] : []),
+    ];
+    const caption = typeof opts.caption === "string" ? opts.caption.trim() : "";
+
+    if (!message.trim() && media.length === 0) {
+      outputError("Provide at least one of --message, --image, --audio, or --file.");
+    }
 
     try {
       if (channelRaw === "telegram") {
         const bot = config.telegramBots.find((b) => b.id === identityId);
         if (!bot) throw new Error(`Telegram identity not found: ${identityId}`);
         const tg = new Bot(bot.token);
-        await tg.api.sendMessage(Number(to), message);
+        const chatId = Number(to);
+        if (!Number.isFinite(chatId)) {
+          throw new Error("Telegram recipient must be numeric chat_id.");
+        }
+        if (message.trim()) {
+          await tg.api.sendMessage(chatId, message);
+        }
+        for (const item of media) {
+          if (item.type === "image") {
+            await tg.api.sendPhoto(chatId, new InputFile(item.filePath), {
+              ...(caption ? { caption } : {}),
+            });
+          } else if (item.type === "audio") {
+            await tg.api.sendAudio(chatId, new InputFile(item.filePath), {
+              ...(caption ? { caption } : {}),
+            });
+          } else {
+            await tg.api.sendDocument(chatId, new InputFile(item.filePath), {
+              ...(caption ? { caption } : {}),
+            });
+          }
+        }
       } else {
         const app = config.slackApps.find((a) => a.id === identityId);
         if (!app) throw new Error(`Slack identity not found: ${identityId}`);
         const web = new WebClient(app.botToken);
         const peer = parseSlackPeerId(to);
         if (!peer.channelId) throw new Error("Invalid recipient for Slack.");
-        await web.chat.postMessage({
-          channel: peer.channelId,
-          text: message,
-          ...(peer.threadTs ? { thread_ts: peer.threadTs } : {}),
-        } as any);
+        if (message.trim()) {
+          await web.chat.postMessage({
+            channel: peer.channelId,
+            text: message,
+            ...(peer.threadTs ? { thread_ts: peer.threadTs } : {}),
+          } as any);
+        }
+        for (const item of media) {
+          const fileData = await readFileAsync(item.filePath);
+          await (web as any).files.uploadV2({
+            channel_id: peer.channelId,
+            file: fileData,
+            filename: path.basename(item.filePath),
+            ...(peer.threadTs ? { thread_ts: peer.threadTs } : {}),
+            ...(caption ? { initial_comment: caption } : {}),
+          });
+        }
       }
 
-      if (useJson) outputJson({ success: true });
+      if (useJson)
+        outputJson({
+          success: true,
+          sent: {
+            text: Boolean(message.trim()),
+            media: media.map((item) => ({ type: item.type, filePath: item.filePath })),
+          },
+        });
       else console.log("Message sent.");
       process.exit(0);
     } catch (error) {

--- a/packages/opencode-router/src/delivery.ts
+++ b/packages/opencode-router/src/delivery.ts
@@ -1,0 +1,157 @@
+export type DeliveryErrorCode =
+  | "auth"
+  | "forbidden"
+  | "not_found"
+  | "invalid_target"
+  | "rate_limited"
+  | "payload_too_large"
+  | "unsupported_media"
+  | "network"
+  | "timeout"
+  | "unknown";
+
+export type DeliveryError = {
+  code: DeliveryErrorCode;
+  message: string;
+  retryable: boolean;
+  status?: number;
+};
+
+const RETRYABLE_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EAI_AGAIN",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+]);
+
+function coerceStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const record = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    error_code?: unknown;
+    response?: { status?: unknown };
+    data?: { status?: unknown };
+  };
+
+  const maybe = [
+    record.status,
+    record.statusCode,
+    record.error_code,
+    record.response?.status,
+    record.data?.status,
+  ];
+
+  for (const value of maybe) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function coerceCode(error: unknown): string {
+  if (!error || typeof error !== "object") return "";
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code.trim().toUpperCase() : "";
+}
+
+function coerceMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Unknown delivery error";
+}
+
+export function classifyDeliveryError(error: unknown): DeliveryError {
+  const status = coerceStatus(error);
+  const code = coerceCode(error);
+  const message = coerceMessage(error);
+  const lower = message.toLowerCase();
+
+  if (status === 401 || lower.includes("invalid_auth") || lower.includes("unauthorized")) {
+    return { code: "auth", message, retryable: false, status };
+  }
+  if (status === 403 || lower.includes("forbidden") || lower.includes("not_in_channel")) {
+    return { code: "forbidden", message, retryable: false, status };
+  }
+  if (status === 404 || lower.includes("chat not found") || lower.includes("channel_not_found")) {
+    return { code: "not_found", message, retryable: false, status };
+  }
+  if (status === 400 && (lower.includes("chat_id") || lower.includes("invalid peer") || lower.includes("invalid slack peer"))) {
+    return { code: "invalid_target", message, retryable: false, status };
+  }
+  if (status === 429 || lower.includes("rate limit") || lower.includes("too many requests")) {
+    return { code: "rate_limited", message, retryable: true, status };
+  }
+  if (status === 413 || lower.includes("too large") || lower.includes("file_too_large")) {
+    return { code: "payload_too_large", message, retryable: false, status };
+  }
+  if (lower.includes("unsupported") || lower.includes("cannot upload") || lower.includes("not allowed for this message type")) {
+    return { code: "unsupported_media", message, retryable: false, status };
+  }
+  if (status === 408 || lower.includes("timeout") || lower.includes("timed out")) {
+    return { code: "timeout", message, retryable: true, status };
+  }
+  if ((status !== undefined && status >= 500) || RETRYABLE_NETWORK_CODES.has(code) || lower.includes("fetch failed")) {
+    return { code: "network", message, retryable: true, status };
+  }
+
+  return { code: "unknown", message, retryable: false, status };
+}
+
+type RetryLogger = {
+  warn?: (payload: unknown, message?: string) => void;
+};
+
+function withJitter(baseMs: number): number {
+  const jitter = Math.floor(Math.random() * Math.max(1, Math.floor(baseMs * 0.2)));
+  return baseMs + jitter;
+}
+
+export async function withDeliveryRetry<T>(
+  operation: string,
+  run: () => Promise<T>,
+  options: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+    logger?: RetryLogger;
+  } = {},
+): Promise<T> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 3);
+  const baseDelayMs = Math.max(50, options.baseDelayMs ?? 250);
+  const maxDelayMs = Math.max(baseDelayMs, options.maxDelayMs ?? 4_000);
+
+  let attempt = 0;
+  for (;;) {
+    attempt += 1;
+    try {
+      return await run();
+    } catch (error) {
+      const classified = classifyDeliveryError(error);
+      if (!classified.retryable || attempt >= maxAttempts) {
+        throw error;
+      }
+
+      const delayMs = Math.min(maxDelayMs, withJitter(baseDelayMs * 2 ** (attempt - 1)));
+      options.logger?.warn?.(
+        {
+          operation,
+          attempt,
+          maxAttempts,
+          delayMs,
+          code: classified.code,
+          status: classified.status,
+          message: classified.message,
+        },
+        "delivery operation failed; retrying",
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}

--- a/packages/opencode-router/src/health.ts
+++ b/packages/opencode-router/src/health.ts
@@ -2,6 +2,8 @@ import http from "node:http";
 
 import type { Logger } from "pino";
 
+import type { OutboundMessagePart, PartDeliveryResult } from "./media.js";
+
 export type HealthSnapshot = {
   ok: boolean;
   opencode: {
@@ -112,7 +114,8 @@ export type SendMessageInput = {
   directory?: string;
   peerId?: string;
   autoBind?: boolean;
-  text: string;
+  text?: string;
+  parts?: OutboundMessagePart[];
 };
 
 export type SendMessageResult = {
@@ -123,6 +126,13 @@ export type SendMessageResult = {
   attempted: number;
   sent: number;
   failures?: Array<{ identityId: string; peerId: string; error: string }>;
+  targets?: Array<{
+    identityId: string;
+    peerId: string;
+    attemptedParts: number;
+    sentParts: number;
+    partResults: PartDeliveryResult[];
+  }>;
   reason?: string;
 };
 
@@ -606,9 +616,17 @@ export async function startHealthServer(
           const peerId = typeof payload.peerId === "string" ? payload.peerId.trim() : "";
           const autoBind = payload.autoBind === true;
           const text = typeof payload.text === "string" ? payload.text : "";
-          if (!channel || !text.trim() || (!directory && !peerId)) {
+          const parts = Array.isArray(payload.parts) ? (payload.parts as OutboundMessagePart[]) : undefined;
+          const hasText = text.trim().length > 0;
+          const hasParts = Array.isArray(parts) && parts.length > 0;
+          if (!channel || (!hasText && !hasParts) || (!directory && !peerId)) {
             res.writeHead(400, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ ok: false, error: "channel, text, and either directory or peerId are required" }));
+            res.end(
+              JSON.stringify({
+                ok: false,
+                error: "channel, at least one of text/parts, and either directory or peerId are required",
+              }),
+            );
             return;
           }
 
@@ -618,7 +636,8 @@ export async function startHealthServer(
             ...(directory ? { directory } : {}),
             ...(peerId ? { peerId } : {}),
             ...(autoBind ? { autoBind: true } : {}),
-            text,
+            ...(hasText ? { text } : {}),
+            ...(hasParts ? { parts } : {}),
           });
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ ok: true, ...result }));

--- a/packages/opencode-router/src/media-store.ts
+++ b/packages/opencode-router/src/media-store.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { basename, extname, isAbsolute, join, resolve } from "node:path";
+
+import type { MediaKind } from "./media.js";
+
+export type StoredMediaFile = {
+  filePath: string;
+  filename: string;
+  sizeBytes: number;
+  mimeType?: string;
+};
+
+function sanitizeSegment(value: string): string {
+  const safe = value.replace(/[^a-zA-Z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
+  return safe || "unknown";
+}
+
+function extensionFromMime(mimeType: string | undefined, kind: MediaKind): string {
+  const value = (mimeType ?? "").toLowerCase();
+  if (value === "image/jpeg") return ".jpg";
+  if (value === "image/png") return ".png";
+  if (value === "image/webp") return ".webp";
+  if (value === "audio/ogg") return ".ogg";
+  if (value === "audio/mpeg") return ".mp3";
+  if (value === "audio/mp4") return ".m4a";
+  if (value === "application/pdf") return ".pdf";
+  if (kind === "image") return ".jpg";
+  if (kind === "audio") return ".ogg";
+  return ".bin";
+}
+
+function sanitizeFilename(filename: string, fallbackPrefix: string, fallbackExt: string): string {
+  const trimmed = filename.trim();
+  if (!trimmed) return `${fallbackPrefix}${fallbackExt}`;
+
+  const base = basename(trimmed)
+    .replace(/[^a-zA-Z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!base) return `${fallbackPrefix}${fallbackExt}`;
+  if (extname(base)) return base;
+  return `${base}${fallbackExt}`;
+}
+
+export class MediaStore {
+  constructor(private readonly rootDir: string) {}
+
+  async ensureReady(): Promise<void> {
+    await mkdir(this.rootDir, { recursive: true });
+  }
+
+  private inboundDir(channel: string, identityId: string, peerId: string): string {
+    const now = new Date();
+    const day = now.toISOString().slice(0, 10);
+    return join(
+      this.rootDir,
+      "inbound",
+      day,
+      sanitizeSegment(channel),
+      sanitizeSegment(identityId),
+      sanitizeSegment(peerId),
+    );
+  }
+
+  async saveInboundBuffer(input: {
+    channel: string;
+    identityId: string;
+    peerId: string;
+    kind: MediaKind;
+    buffer: Uint8Array;
+    filename?: string;
+    mimeType?: string;
+  }): Promise<StoredMediaFile> {
+    const dir = this.inboundDir(input.channel, input.identityId, input.peerId);
+    await mkdir(dir, { recursive: true });
+
+    const defaultExt = extensionFromMime(input.mimeType, input.kind);
+    const safeFilename = sanitizeFilename(
+      input.filename ?? "",
+      `${input.kind}-${Date.now()}-${randomUUID().slice(0, 8)}`,
+      defaultExt,
+    );
+    const filePath = join(dir, safeFilename);
+
+    await writeFile(filePath, input.buffer);
+
+    return {
+      filePath,
+      filename: safeFilename,
+      sizeBytes: input.buffer.byteLength,
+      ...(input.mimeType ? { mimeType: input.mimeType } : {}),
+    };
+  }
+
+  async downloadInbound(input: {
+    channel: string;
+    identityId: string;
+    peerId: string;
+    kind: MediaKind;
+    url: string;
+    headers?: Record<string, string>;
+    filename?: string;
+    mimeType?: string;
+  }): Promise<StoredMediaFile> {
+    const response = await fetch(input.url, {
+      headers: input.headers,
+    });
+
+    if (!response.ok) {
+      const error = new Error(`Failed to download media (${response.status})`) as Error & {
+        status?: number;
+      };
+      error.status = response.status;
+      throw error;
+    }
+
+    const mimeType = input.mimeType || response.headers.get("content-type") || undefined;
+    const arrayBuffer = await response.arrayBuffer();
+    return this.saveInboundBuffer({
+      channel: input.channel,
+      identityId: input.identityId,
+      peerId: input.peerId,
+      kind: input.kind,
+      buffer: new Uint8Array(arrayBuffer),
+      ...(input.filename ? { filename: input.filename } : {}),
+      ...(mimeType ? { mimeType } : {}),
+    });
+  }
+
+  async resolveOutboundFile(input: {
+    filePath: string;
+    baseDirectory: string;
+    maxBytes?: number;
+  }): Promise<StoredMediaFile> {
+    const raw = input.filePath.trim();
+    if (!raw) {
+      const error = new Error("filePath is required") as Error & { status?: number };
+      error.status = 400;
+      throw error;
+    }
+
+    const resolved = isAbsolute(raw) ? resolve(raw) : resolve(input.baseDirectory, raw);
+    let info;
+    try {
+      info = await stat(resolved);
+    } catch (error) {
+      const wrapped = new Error(`File not found: ${resolved}`) as Error & { status?: number };
+      wrapped.status = 404;
+      (wrapped as any).cause = error;
+      throw wrapped;
+    }
+
+    if (!info.isFile()) {
+      const error = new Error(`Not a file: ${resolved}`) as Error & { status?: number };
+      error.status = 400;
+      throw error;
+    }
+
+    if (typeof input.maxBytes === "number" && Number.isFinite(input.maxBytes) && info.size > input.maxBytes) {
+      const error = new Error(
+        `File exceeds maximum allowed size (${info.size} > ${Math.floor(input.maxBytes)} bytes): ${resolved}`,
+      ) as Error & { status?: number };
+      error.status = 413;
+      throw error;
+    }
+
+    return {
+      filePath: resolved,
+      filename: basename(resolved),
+      sizeBytes: info.size,
+    };
+  }
+}

--- a/packages/opencode-router/src/media.ts
+++ b/packages/opencode-router/src/media.ts
@@ -1,0 +1,163 @@
+import { basename } from "node:path";
+
+export type MediaKind = "image" | "audio" | "file";
+
+export type InboundMediaAttachment = {
+  id: string;
+  kind: MediaKind;
+  source: "telegram" | "slack";
+  status: "ready" | "failed";
+  filePath?: string;
+  filename?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  providerFileId?: string;
+  providerFileUniqueId?: string;
+  providerUrl?: string;
+  error?: string;
+};
+
+export type InboundMessagePart =
+  | { type: "text"; text: string }
+  | { type: "media"; media: InboundMediaAttachment; caption?: string };
+
+export type OutboundMessagePart =
+  | { type: "text"; text: string }
+  | {
+      type: MediaKind;
+      filePath: string;
+      caption?: string;
+      filename?: string;
+      mimeType?: string;
+    };
+
+export type PartDeliveryResult = {
+  index: number;
+  type: "text" | MediaKind;
+  sent: boolean;
+  error?: string;
+  code?: string;
+  retryable?: boolean;
+};
+
+export type MessageDeliveryResult = {
+  attemptedParts: number;
+  sentParts: number;
+  partResults: PartDeliveryResult[];
+};
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseTextPart(value: unknown): OutboundMessagePart | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as { type?: unknown; text?: unknown };
+  if (record.type !== "text") return null;
+  const text = typeof record.text === "string" ? record.text : "";
+  if (!text.trim()) return null;
+  return { type: "text", text };
+}
+
+function parseMediaPart(value: unknown): OutboundMessagePart | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as {
+    type?: unknown;
+    filePath?: unknown;
+    caption?: unknown;
+    filename?: unknown;
+    mimeType?: unknown;
+  };
+  if (record.type !== "image" && record.type !== "audio" && record.type !== "file") return null;
+  const filePath = asTrimmedString(record.filePath);
+  if (!filePath) return null;
+
+  const caption = typeof record.caption === "string" ? record.caption : undefined;
+  const filename = asTrimmedString(record.filename) || undefined;
+  const mimeType = asTrimmedString(record.mimeType) || undefined;
+
+  return {
+    type: record.type,
+    filePath,
+    ...(caption ? { caption } : {}),
+    ...(filename ? { filename } : {}),
+    ...(mimeType ? { mimeType } : {}),
+  };
+}
+
+export function normalizeOutboundParts(input: { text?: string; parts?: unknown }): OutboundMessagePart[] {
+  const normalized: OutboundMessagePart[] = [];
+  const text = typeof input.text === "string" ? input.text : "";
+
+  if (text.trim()) {
+    normalized.push({ type: "text", text });
+  }
+
+  if (Array.isArray(input.parts)) {
+    for (const item of input.parts) {
+      const textPart = parseTextPart(item);
+      if (textPart) {
+        normalized.push(textPart);
+        continue;
+      }
+
+      const mediaPart = parseMediaPart(item);
+      if (mediaPart) {
+        normalized.push(mediaPart);
+      }
+    }
+  }
+
+  return normalized;
+}
+
+export function textFromInboundParts(parts: InboundMessagePart[] | undefined, fallbackText = ""): string {
+  if (!Array.isArray(parts) || parts.length === 0) return fallbackText;
+  const texts = parts
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .filter((value) => value.trim().length > 0);
+  if (texts.length === 0) return fallbackText;
+  return texts.join("\n");
+}
+
+function formatBytes(sizeBytes: number | undefined): string {
+  if (typeof sizeBytes !== "number" || !Number.isFinite(sizeBytes) || sizeBytes < 0) return "";
+  if (sizeBytes < 1024) return `${sizeBytes}B`;
+  if (sizeBytes < 1024 * 1024) return `${(sizeBytes / 1024).toFixed(1)}KB`;
+  return `${(sizeBytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+export function summarizeInboundPartsForPrompt(parts: InboundMessagePart[] | undefined): string[] {
+  if (!Array.isArray(parts) || parts.length === 0) return [];
+
+  const mediaParts = parts.filter((part): part is { type: "media"; media: InboundMediaAttachment; caption?: string } => part.type === "media");
+  if (mediaParts.length === 0) return [];
+
+  return mediaParts.map((part, index) => {
+    const media = part.media;
+    const label = `[${media.kind}]`;
+    const filename = media.filename || (media.filePath ? basename(media.filePath) : "(unnamed)");
+    const details: string[] = [];
+    if (media.mimeType) details.push(media.mimeType);
+    const prettySize = formatBytes(media.sizeBytes);
+    if (prettySize) details.push(prettySize);
+
+    if (media.status === "ready") {
+      const pathLabel = media.filePath ? `path=${media.filePath}` : "path=(missing)";
+      if (part.caption?.trim()) details.push(`caption=${JSON.stringify(part.caption.trim())}`);
+      details.push(pathLabel);
+      return `${index + 1}. ${label} ${filename}${details.length ? ` (${details.join(", ")})` : ""}`;
+    }
+
+    const reason = media.error?.trim() || "download failed";
+    return `${index + 1}. ${label} ${filename} (failed: ${reason})`;
+  });
+}
+
+export function summarizeInboundPartsForReporter(parts: InboundMessagePart[] | undefined): string {
+  if (!Array.isArray(parts) || parts.length === 0) return "";
+  const mediaCount = parts.filter((part) => part.type === "media").length;
+  if (!mediaCount) return "";
+  return mediaCount === 1 ? "[1 media attachment]" : `[${mediaCount} media attachments]`;
+}

--- a/packages/opencode-router/src/slack.ts
+++ b/packages/opencode-router/src/slack.ts
@@ -1,15 +1,22 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
 import type { Logger } from "pino";
 
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
 
 import type { Config, SlackIdentity } from "./config.js";
+import { classifyDeliveryError, withDeliveryRetry } from "./delivery.js";
+import type { InboundMessagePart, MediaKind, MessageDeliveryResult, OutboundMessagePart } from "./media.js";
+import type { MediaStore } from "./media-store.js";
 
 export type InboundMessage = {
   channel: "slack";
   identityId: string;
   peerId: string;
   text: string;
+  parts?: InboundMessagePart[];
   raw: unknown;
 };
 
@@ -21,6 +28,7 @@ export type SlackAdapter = {
   maxTextLength: number;
   start(): Promise<void>;
   stop(): Promise<void>;
+  sendMessage(peerId: string, message: { parts: OutboundMessagePart[] }): Promise<MessageDeliveryResult>;
   sendText(peerId: string, text: string): Promise<void>;
 };
 
@@ -72,6 +80,16 @@ type SlackEvent = {
   subtype?: unknown;
   thread_ts?: unknown;
   ts?: unknown;
+  files?: unknown;
+};
+
+type SlackFileCandidate = {
+  id: string;
+  url: string;
+  filename?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  kind: MediaKind;
 };
 
 export function createSlackAdapter(
@@ -80,6 +98,7 @@ export function createSlackAdapter(
   logger: Logger,
   onMessage: MessageHandler,
   deps: SlackDeps = { WebClient, SocketModeClient },
+  mediaStore?: MediaStore,
 ): SlackAdapter {
   const botToken = identity.botToken?.trim() ?? "";
   const appToken = identity.appToken?.trim() ?? "";
@@ -97,6 +116,119 @@ export function createSlackAdapter(
   let botUserId: string | null = null;
   let started = false;
 
+  const parseSlackFiles = (value: unknown): SlackFileCandidate[] => {
+    if (!Array.isArray(value)) return [];
+    const files: SlackFileCandidate[] = [];
+    for (const item of value) {
+      if (!item || typeof item !== "object") continue;
+      const record = item as {
+        id?: unknown;
+        url_private_download?: unknown;
+        url_private?: unknown;
+        name?: unknown;
+        mimetype?: unknown;
+        size?: unknown;
+      };
+      const id = typeof record.id === "string" ? record.id : "";
+      const url =
+        typeof record.url_private_download === "string"
+          ? record.url_private_download
+          : typeof record.url_private === "string"
+            ? record.url_private
+            : "";
+      if (!id || !url) continue;
+      const mimeType = typeof record.mimetype === "string" ? record.mimetype : undefined;
+      const kind: MediaKind =
+        typeof mimeType === "string" && mimeType.startsWith("image/")
+          ? "image"
+          : typeof mimeType === "string" && mimeType.startsWith("audio/")
+            ? "audio"
+            : "file";
+      files.push({
+        id,
+        url,
+        kind,
+        ...(typeof record.name === "string" ? { filename: record.name } : {}),
+        ...(mimeType ? { mimeType } : {}),
+        ...(typeof record.size === "number" ? { sizeBytes: record.size } : {}),
+      });
+    }
+    return files;
+  };
+
+  const downloadSlackFile = async (peerId: string, candidate: SlackFileCandidate): Promise<InboundMessagePart> => {
+    if (!mediaStore) {
+      return {
+        type: "media",
+        media: {
+          id: candidate.id,
+          kind: candidate.kind,
+          source: "slack",
+          status: "failed",
+          ...(candidate.filename ? { filename: candidate.filename } : {}),
+          ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+          ...(typeof candidate.sizeBytes === "number" ? { sizeBytes: candidate.sizeBytes } : {}),
+          providerFileId: candidate.id,
+          providerUrl: candidate.url,
+          error: "media store unavailable",
+        },
+      };
+    }
+
+    try {
+      const stored = await withDeliveryRetry(
+        "slack.download",
+        () =>
+          mediaStore.downloadInbound({
+            channel: "slack",
+            identityId: identity.id,
+            peerId,
+            kind: candidate.kind,
+            url: candidate.url,
+            headers: {
+              Authorization: `Bearer ${botToken}`,
+            },
+            ...(candidate.filename ? { filename: candidate.filename } : {}),
+            ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+          }),
+        { logger: log },
+      );
+
+      return {
+        type: "media",
+        media: {
+          id: candidate.id,
+          kind: candidate.kind,
+          source: "slack",
+          status: "ready",
+          filePath: stored.filePath,
+          filename: stored.filename,
+          ...(stored.mimeType ? { mimeType: stored.mimeType } : {}),
+          sizeBytes: stored.sizeBytes,
+          providerFileId: candidate.id,
+          providerUrl: candidate.url,
+        },
+      };
+    } catch (error) {
+      const classified = classifyDeliveryError(error);
+      return {
+        type: "media",
+        media: {
+          id: candidate.id,
+          kind: candidate.kind,
+          source: "slack",
+          status: "failed",
+          ...(candidate.filename ? { filename: candidate.filename } : {}),
+          ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+          ...(typeof candidate.sizeBytes === "number" ? { sizeBytes: candidate.sizeBytes } : {}),
+          providerFileId: candidate.id,
+          providerUrl: candidate.url,
+          error: `${classified.code}: ${classified.message}`,
+        },
+      };
+    }
+  };
+
   const safeAck = async (ack: unknown) => {
     if (typeof ack !== "function") return;
     try {
@@ -106,20 +238,36 @@ export function createSlackAdapter(
     }
   };
 
-  const shouldIgnore = (event: SlackEvent): { ok: true } | { ok: false; channelId: string; textRaw: string; userId: string | null } => {
+  const shouldIgnore = (
+    event: SlackEvent,
+  ):
+    | { ok: true }
+    | {
+        ok: false;
+        channelId: string;
+        textRaw: string;
+        userId: string | null;
+        files: SlackFileCandidate[];
+        threadTs: string | null;
+        ts: string | null;
+      } => {
     const channelId = typeof event.channel === "string" ? event.channel : "";
     const textRaw = typeof event.text === "string" ? event.text : "";
     const userId = typeof event.user === "string" ? event.user : null;
     const botId = typeof event.bot_id === "string" ? event.bot_id : null;
     const subtype = typeof event.subtype === "string" ? event.subtype : null;
+    const files = parseSlackFiles(event.files);
+    const hasFiles = files.length > 0;
+    const threadTs = typeof event.thread_ts === "string" ? event.thread_ts : null;
+    const ts = typeof event.ts === "string" ? event.ts : null;
 
     // Avoid loops / non-user messages.
     if (botId) return { ok: true };
-    if (subtype && subtype !== "") return { ok: true };
+    if (subtype && subtype !== "" && subtype !== "file_share") return { ok: true };
     if (userId && botUserId && userId === botUserId) return { ok: true };
-    if (!channelId || !textRaw.trim()) return { ok: true };
+    if (!channelId || (!textRaw.trim() && !hasFiles)) return { ok: true };
 
-    return { ok: false, channelId, textRaw, userId };
+    return { ok: false, channelId, textRaw, userId, files, threadTs, ts };
   };
 
   socket.on("message", async (args: unknown) => {
@@ -135,15 +283,28 @@ export function createSlackAdapter(
     const isDm = filtered.channelId.startsWith("D");
     if (!isDm) return;
 
-    const threadTs = typeof event.thread_ts === "string" ? event.thread_ts : null;
-    const peerId = formatSlackPeerId({ channelId: filtered.channelId, ...(threadTs ? { threadTs } : {}) });
+    const peerId = formatSlackPeerId({ channelId: filtered.channelId, ...(filtered.threadTs ? { threadTs: filtered.threadTs } : {}) });
+    const parts: InboundMessagePart[] = [];
+    if (filtered.textRaw.trim()) {
+      parts.push({ type: "text", text: filtered.textRaw.trim() });
+    }
+    for (const file of filtered.files) {
+      parts.push(await downloadSlackFile(peerId, file));
+    }
+    if (parts.length === 0) return;
+    const text = parts
+      .filter((part): part is { type: "text"; text: string } => part.type === "text")
+      .map((part) => part.text)
+      .join("\n")
+      .trim();
 
     try {
       await onMessage({
         channel: "slack",
         identityId: identity.id,
         peerId,
-        text: filtered.textRaw.trim(),
+        text,
+        parts,
         raw: event,
       });
     } catch (error) {
@@ -160,25 +321,103 @@ export function createSlackAdapter(
     const filtered = shouldIgnore(event);
     if (filtered.ok) return;
 
-    const threadTs = typeof event.thread_ts === "string" ? event.thread_ts : null;
-    const ts = typeof event.ts === "string" ? event.ts : null;
-    const rootThread = threadTs || ts;
+    const rootThread = filtered.threadTs || filtered.ts;
     const peerId = formatSlackPeerId({ channelId: filtered.channelId, ...(rootThread ? { threadTs: rootThread } : {}) });
     const text = stripSlackMention(filtered.textRaw, botUserId);
-    if (!text) return;
+    const parts: InboundMessagePart[] = [];
+    if (text) {
+      parts.push({ type: "text", text });
+    }
+    for (const file of filtered.files) {
+      parts.push(await downloadSlackFile(peerId, file));
+    }
+    if (parts.length === 0) return;
+    const promptText = parts
+      .filter((part): part is { type: "text"; text: string } => part.type === "text")
+      .map((part) => part.text)
+      .join("\n")
+      .trim();
 
     try {
       await onMessage({
         channel: "slack",
         identityId: identity.id,
         peerId,
-        text,
+        text: promptText,
+        parts,
         raw: event,
       });
     } catch (error) {
       log.error({ error, peerId }, "slack inbound handler failed");
     }
   });
+
+  const sendMessageInternal = async (
+    peerId: string,
+    message: { parts: OutboundMessagePart[] },
+  ): Promise<MessageDeliveryResult> => {
+    const peer = parseSlackPeerId(peerId);
+    if (!peer.channelId) {
+      const error = new Error("Invalid Slack peerId") as Error & { status?: number };
+      error.status = 400;
+      throw error;
+    }
+
+    const partResults: MessageDeliveryResult["partResults"] = [];
+    let sentParts = 0;
+
+    for (let index = 0; index < message.parts.length; index += 1) {
+      const part = message.parts[index];
+      try {
+        if (part.type === "text") {
+          await withDeliveryRetry(
+            "slack.postMessage",
+            () =>
+              web.chat.postMessage({
+                channel: peer.channelId,
+                text: part.text,
+                ...(peer.threadTs ? { thread_ts: peer.threadTs } : {}),
+              } as any),
+            { logger: log },
+          );
+        } else {
+          const fileData = await readFile(part.filePath);
+          const filename = part.filename || basename(part.filePath);
+          await withDeliveryRetry(
+            "slack.uploadFile",
+            () =>
+              (web as any).files.uploadV2({
+                channel_id: peer.channelId,
+                file: fileData,
+                filename,
+                ...(peer.threadTs ? { thread_ts: peer.threadTs } : {}),
+                ...(part.caption?.trim() ? { initial_comment: part.caption.trim() } : {}),
+              }),
+            { logger: log },
+          );
+        }
+
+        sentParts += 1;
+        partResults.push({ index, type: part.type, sent: true });
+      } catch (error) {
+        const classified = classifyDeliveryError(error);
+        partResults.push({
+          index,
+          type: part.type,
+          sent: false,
+          error: classified.message,
+          code: classified.code,
+          retryable: classified.retryable,
+        });
+      }
+    }
+
+    return {
+      attemptedParts: message.parts.length,
+      sentParts,
+      partResults,
+    };
+  };
 
   return {
     name: "slack",
@@ -204,16 +443,17 @@ export function createSlackAdapter(
       }
       log.info("slack adapter stopped");
     },
+    async sendMessage(peerId: string, message: { parts: OutboundMessagePart[] }) {
+      return sendMessageInternal(peerId, message);
+    },
     async sendText(peerId: string, text: string) {
-      const peer = parseSlackPeerId(peerId);
-      if (!peer.channelId) throw new Error("Invalid Slack peerId");
-
-      const payload: Record<string, unknown> = {
-        channel: peer.channelId,
-        text,
-      };
-      if (peer.threadTs) payload.thread_ts = peer.threadTs;
-      await web.chat.postMessage(payload as any);
+      const result = await sendMessageInternal(peerId, {
+        parts: [{ type: "text", text }],
+      });
+      if (result.sentParts === 0) {
+        const firstError = result.partResults.find((part) => !part.sent)?.error;
+        throw new Error(firstError || "Failed to deliver Slack text message");
+      }
     },
   };
 }

--- a/packages/opencode-router/src/telegram.ts
+++ b/packages/opencode-router/src/telegram.ts
@@ -1,13 +1,18 @@
-import { Bot, type BotError, type Context } from "grammy";
+import { Bot, InputFile, type BotError, type Context } from "grammy";
 import type { Logger } from "pino";
 
 import type { Config, TelegramIdentity } from "./config.js";
+import { classifyDeliveryError, withDeliveryRetry } from "./delivery.js";
+import type { InboundMessagePart, MediaKind, MessageDeliveryResult, OutboundMessagePart } from "./media.js";
+import type { MediaStore } from "./media-store.js";
+import { chunkText } from "./text.js";
 
 export type InboundMessage = {
   channel: "telegram";
   identityId: string;
   peerId: string;
   text: string;
+  parts?: InboundMessagePart[];
   raw: unknown;
 };
 
@@ -19,6 +24,7 @@ export type TelegramAdapter = {
   maxTextLength: number;
   start(): Promise<void>;
   stop(): Promise<void>;
+  sendMessage(peerId: string, message: { parts: OutboundMessagePart[] }): Promise<MessageDeliveryResult>;
   sendText(peerId: string, text: string): Promise<void>;
 };
 
@@ -38,11 +44,21 @@ export function parseTelegramPeerId(peerId: string): number | null {
   return parsed;
 }
 
+function invalidTelegramPeerIdError(): Error & { status?: number } {
+  const error = new Error(
+    "Telegram peerId must be a numeric chat_id. Usernames like @name are not valid direct targets.",
+  ) as Error & { status?: number };
+  error.status = 400;
+  return error;
+}
+
 export function createTelegramAdapter(
   identity: TelegramIdentity,
   config: Config,
   logger: Logger,
   onMessage: MessageHandler,
+  mediaStore?: MediaStore,
+  deps: { Bot?: typeof Bot } = {},
 ): TelegramAdapter {
   const token = identity.token?.trim() ?? "";
   if (!token) {
@@ -51,7 +67,177 @@ export function createTelegramAdapter(
 
   const log = logger.child({ channel: "telegram", identityId: identity.id });
   log.debug({ tokenPresent: true }, "telegram adapter init");
-  const bot = new Bot(token);
+  const BotImpl = deps.Bot ?? Bot;
+  const bot = new BotImpl(token);
+
+  type TelegramMediaCandidate = {
+    kind: MediaKind;
+    fileId: string;
+    fileUniqueId?: string;
+    filename?: string;
+    mimeType?: string;
+    sizeBytes?: number;
+  };
+
+  const truncateCaption = (value: string | undefined) => {
+    const text = (value ?? "").trim();
+    if (!text) return undefined;
+    return text.length <= 1024 ? text : text.slice(0, 1024);
+  };
+
+  const extractMediaCandidates = (message: any): TelegramMediaCandidate[] => {
+    const candidates: TelegramMediaCandidate[] = [];
+
+    if (Array.isArray(message?.photo) && message.photo.length > 0) {
+      const largest = message.photo[message.photo.length - 1];
+      if (largest?.file_id) {
+        candidates.push({
+          kind: "image",
+          fileId: String(largest.file_id),
+          fileUniqueId: typeof largest.file_unique_id === "string" ? largest.file_unique_id : undefined,
+          filename:
+            typeof largest.file_unique_id === "string"
+              ? `photo-${largest.file_unique_id}.jpg`
+              : `photo-${String(largest.file_id)}.jpg`,
+          mimeType: "image/jpeg",
+          sizeBytes: typeof largest.file_size === "number" ? largest.file_size : undefined,
+        });
+      }
+    }
+
+    if (message?.document?.file_id) {
+      const document = message.document;
+      const mimeType = typeof document.mime_type === "string" ? document.mime_type : undefined;
+      const normalizedKind: MediaKind =
+        typeof mimeType === "string" && mimeType.startsWith("image/")
+          ? "image"
+          : typeof mimeType === "string" && mimeType.startsWith("audio/")
+            ? "audio"
+            : "file";
+      candidates.push({
+        kind: normalizedKind,
+        fileId: String(document.file_id),
+        fileUniqueId: typeof document.file_unique_id === "string" ? document.file_unique_id : undefined,
+        filename: typeof document.file_name === "string" ? document.file_name : undefined,
+        mimeType,
+        sizeBytes: typeof document.file_size === "number" ? document.file_size : undefined,
+      });
+    }
+
+    if (message?.audio?.file_id) {
+      const audio = message.audio;
+      candidates.push({
+        kind: "audio",
+        fileId: String(audio.file_id),
+        fileUniqueId: typeof audio.file_unique_id === "string" ? audio.file_unique_id : undefined,
+        filename: typeof audio.file_name === "string" ? audio.file_name : undefined,
+        mimeType: typeof audio.mime_type === "string" ? audio.mime_type : undefined,
+        sizeBytes: typeof audio.file_size === "number" ? audio.file_size : undefined,
+      });
+    }
+
+    if (message?.voice?.file_id) {
+      const voice = message.voice;
+      candidates.push({
+        kind: "audio",
+        fileId: String(voice.file_id),
+        fileUniqueId: typeof voice.file_unique_id === "string" ? voice.file_unique_id : undefined,
+        filename:
+          typeof voice.file_unique_id === "string"
+            ? `voice-${voice.file_unique_id}.ogg`
+            : `voice-${String(voice.file_id)}.ogg`,
+        mimeType: "audio/ogg",
+        sizeBytes: typeof voice.file_size === "number" ? voice.file_size : undefined,
+      });
+    }
+
+    return candidates;
+  };
+
+  const downloadCandidate = async (
+    chatId: string,
+    candidate: TelegramMediaCandidate,
+  ): Promise<InboundMessagePart> => {
+    if (!mediaStore) {
+      return {
+        type: "media",
+        media: {
+          id: candidate.fileUniqueId || candidate.fileId,
+          kind: candidate.kind,
+          source: "telegram",
+          status: "failed",
+          providerFileId: candidate.fileId,
+          ...(candidate.fileUniqueId ? { providerFileUniqueId: candidate.fileUniqueId } : {}),
+          ...(candidate.filename ? { filename: candidate.filename } : {}),
+          ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+          ...(typeof candidate.sizeBytes === "number" ? { sizeBytes: candidate.sizeBytes } : {}),
+          error: "media store unavailable",
+        },
+      };
+    }
+
+    try {
+      const file = await withDeliveryRetry(
+        "telegram.getFile",
+        () => bot.api.getFile(candidate.fileId),
+        { logger: log },
+      );
+      const filePath = typeof (file as any)?.file_path === "string" ? String((file as any).file_path) : "";
+      if (!filePath) {
+        throw new Error(`Telegram file path missing for file_id ${candidate.fileId}`);
+      }
+
+      const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
+      const stored = await withDeliveryRetry(
+        "telegram.download",
+        () =>
+          mediaStore.downloadInbound({
+            channel: "telegram",
+            identityId: identity.id,
+            peerId: chatId,
+            kind: candidate.kind,
+            url,
+            ...(candidate.filename ? { filename: candidate.filename } : {}),
+            ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+          }),
+        { logger: log },
+      );
+
+      return {
+        type: "media",
+        media: {
+          id: candidate.fileUniqueId || candidate.fileId,
+          kind: candidate.kind,
+          source: "telegram",
+          status: "ready",
+          filePath: stored.filePath,
+          filename: stored.filename,
+          ...(stored.mimeType ? { mimeType: stored.mimeType } : {}),
+          sizeBytes: stored.sizeBytes,
+          providerFileId: candidate.fileId,
+          ...(candidate.fileUniqueId ? { providerFileUniqueId: candidate.fileUniqueId } : {}),
+          providerUrl: url,
+        },
+      };
+    } catch (error) {
+      const classified = classifyDeliveryError(error);
+      return {
+        type: "media",
+        media: {
+          id: candidate.fileUniqueId || candidate.fileId,
+          kind: candidate.kind,
+          source: "telegram",
+          status: "failed",
+          providerFileId: candidate.fileId,
+          ...(candidate.fileUniqueId ? { providerFileUniqueId: candidate.fileUniqueId } : {}),
+          ...(candidate.filename ? { filename: candidate.filename } : {}),
+          ...(candidate.mimeType ? { mimeType: candidate.mimeType } : {}),
+          ...(typeof candidate.sizeBytes === "number" ? { sizeBytes: candidate.sizeBytes } : {}),
+          error: `${classified.code}: ${classified.message}`,
+        },
+      };
+    }
+  };
 
   bot.catch((err: BotError<Context>) => {
     log.error({ error: err.error }, "telegram bot error");
@@ -60,6 +246,8 @@ export function createTelegramAdapter(
   bot.on("message", async (ctx: Context) => {
     const msg = ctx.message;
     if (!msg?.chat) return;
+    const mediaCandidates = extractMediaCandidates(msg as any);
+    const hasMedia = mediaCandidates.length > 0;
 
     const chatType = msg.chat.type as string;
     const isGroup = chatType === "group" || chatType === "supergroup" || chatType === "channel";
@@ -71,7 +259,6 @@ export function createTelegramAdapter(
     }
 
     let text = msg.text ?? msg.caption ?? "";
-    if (!text.trim()) return;
 
     // In groups, only respond if the bot is @mentioned
     if (isGroup) {
@@ -89,14 +276,39 @@ export function createTelegramAdapter(
       
       // Strip the @mention from the message
       text = text.replace(mentionPattern, "").trim();
-      if (!text) {
+      if (!text && !hasMedia) {
         log.debug({ chatId: msg.chat.id }, "telegram message ignored (empty after removing mention)");
         return;
       }
     }
 
+    if (!text.trim() && !hasMedia) {
+      return;
+    }
+
+    const parts: InboundMessagePart[] = [];
+    if (text.trim()) {
+      parts.push({ type: "text", text: text.trim() });
+    }
+
+    for (const candidate of mediaCandidates) {
+      const part = await downloadCandidate(String(msg.chat.id), candidate);
+      if ((msg.caption ?? "").trim() && part.type === "media") {
+        parts.push({ ...part, caption: msg.caption?.trim() });
+      } else {
+        parts.push(part);
+      }
+    }
+
+    const textForPrompt = parts
+      .filter((part): part is { type: "text"; text: string } => part.type === "text")
+      .map((part) => part.text)
+      .join("\n")
+      .trim();
+    const preview = textForPrompt || `${parts.filter((part) => part.type === "media").length} media attachment(s)`;
+
     log.debug(
-      { chatId: msg.chat.id, chatType, isGroup, length: text.length, preview: text.slice(0, 120) },
+      { chatId: msg.chat.id, chatType, isGroup, length: textForPrompt.length, preview: preview.slice(0, 120) },
       "telegram message received",
     );
 
@@ -105,13 +317,87 @@ export function createTelegramAdapter(
         channel: "telegram",
         identityId: identity.id,
         peerId: String(msg.chat.id),
-        text,
+        text: textForPrompt,
+        parts,
         raw: msg,
       });
     } catch (error) {
       log.error({ error, peerId: msg.chat.id }, "telegram inbound handler failed");
     }
   });
+
+  const sendMessageInternal = async (
+    peerId: string,
+    message: { parts: OutboundMessagePart[] },
+  ): Promise<MessageDeliveryResult> => {
+    const chatId = parseTelegramPeerId(peerId);
+    if (chatId === null) {
+      throw invalidTelegramPeerIdError();
+    }
+
+    const partResults: MessageDeliveryResult["partResults"] = [];
+    let sentParts = 0;
+
+    for (let index = 0; index < message.parts.length; index += 1) {
+      const part = message.parts[index];
+      try {
+        if (part.type === "text") {
+          const chunks = chunkText(part.text, MAX_TEXT_LENGTH);
+          for (const chunk of chunks) {
+            await withDeliveryRetry("telegram.sendMessage", () => bot.api.sendMessage(chatId, chunk), {
+              logger: log,
+            });
+          }
+        } else if (part.type === "image") {
+          await withDeliveryRetry(
+            "telegram.sendPhoto",
+            () =>
+              bot.api.sendPhoto(chatId, new InputFile(part.filePath, part.filename), {
+                ...(truncateCaption(part.caption) ? { caption: truncateCaption(part.caption) } : {}),
+              }),
+            { logger: log },
+          );
+        } else if (part.type === "audio") {
+          await withDeliveryRetry(
+            "telegram.sendAudio",
+            () =>
+              bot.api.sendAudio(chatId, new InputFile(part.filePath, part.filename), {
+                ...(truncateCaption(part.caption) ? { caption: truncateCaption(part.caption) } : {}),
+              }),
+            { logger: log },
+          );
+        } else {
+          await withDeliveryRetry(
+            "telegram.sendDocument",
+            () =>
+              bot.api.sendDocument(chatId, new InputFile(part.filePath, part.filename), {
+                ...(truncateCaption(part.caption) ? { caption: truncateCaption(part.caption) } : {}),
+              }),
+            { logger: log },
+          );
+        }
+
+        sentParts += 1;
+        partResults.push({ index, type: part.type, sent: true });
+      } catch (error) {
+        const classified = classifyDeliveryError(error);
+        partResults.push({
+          index,
+          type: part.type,
+          sent: false,
+          error: classified.message,
+          code: classified.code,
+          retryable: classified.retryable,
+        });
+      }
+    }
+
+    return {
+      attemptedParts: message.parts.length,
+      sentParts,
+      partResults,
+    };
+  };
 
   return {
     name: "telegram",
@@ -126,16 +412,17 @@ export function createTelegramAdapter(
       bot.stop();
       log.info("telegram adapter stopped");
     },
+    async sendMessage(peerId: string, message: { parts: OutboundMessagePart[] }) {
+      return sendMessageInternal(peerId, message);
+    },
     async sendText(peerId: string, text: string) {
-      const chatId = parseTelegramPeerId(peerId);
-      if (chatId === null) {
-        const error = new Error(
-          "Telegram peerId must be a numeric chat_id. Usernames like @name are not valid direct targets.",
-        ) as Error & { status?: number };
-        error.status = 400;
-        throw error;
+      const result = await sendMessageInternal(peerId, {
+        parts: [{ type: "text", text }],
+      });
+      if (result.sentParts === 0) {
+        const firstError = result.partResults.find((part) => !part.sent)?.error;
+        throw new Error(firstError || "Failed to deliver Telegram text message");
       }
-      await bot.api.sendMessage(chatId, text);
     },
   };
 }

--- a/packages/opencode-router/test/health-send.test.js
+++ b/packages/opencode-router/test/health-send.test.js
@@ -223,6 +223,96 @@ test("health /send can deliver directly with peerId", async () => {
   store.close();
 });
 
+test("health /send can deliver file parts end-to-end", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencodeRouter-health-send-media-"));
+  const dbPath = path.join(dir, "opencode-router.db");
+  const store = new BridgeStore(dbPath);
+  const healthPort = await freePort();
+  const sourceFile = path.join(dir, "payload.txt");
+  fs.writeFileSync(sourceFile, "payload-from-test");
+
+  const deliveries = [];
+  const slackAdapter = {
+    key: "slack:default",
+    name: "slack",
+    identityId: "default",
+    maxTextLength: 39_000,
+    async start() {},
+    async stop() {},
+    async sendText(peerId, text) {
+      deliveries.push({ peerId, text });
+    },
+    async sendMessage(peerId, message) {
+      deliveries.push({ peerId, message });
+      const mediaPart = message.parts.find((part) => part.type === "file");
+      assert.ok(mediaPart);
+      assert.equal(path.isAbsolute(mediaPart.filePath), true);
+      assert.equal(fs.readFileSync(mediaPart.filePath, "utf8"), "payload-from-test");
+      return {
+        attemptedParts: message.parts.length,
+        sentParts: message.parts.length,
+        partResults: message.parts.map((part, index) => ({
+          index,
+          type: part.type,
+          sent: true,
+        })),
+      };
+    },
+  };
+
+  const bridge = await startBridge(
+    {
+      configPath: path.join(dir, "opencode-router.json"),
+      configFile: { version: 1 },
+      opencodeUrl: "http://127.0.0.1:4096",
+      opencodeDirectory: dir,
+      telegramBots: [],
+      slackApps: [],
+      dataDir: dir,
+      dbPath,
+      logFile: path.join(dir, "opencode-router.log"),
+      toolUpdatesEnabled: false,
+      groupsEnabled: false,
+      permissionMode: "allow",
+      toolOutputLimit: 1200,
+      healthPort,
+      logLevel: "silent",
+    },
+    createLoggerStub(),
+    undefined,
+    {
+      client: {
+        global: {
+          health: async () => ({ healthy: true, version: "test" }),
+        },
+      },
+      store,
+      adapters: new Map([["slack:default", slackAdapter]]),
+      disableEventStream: true,
+    },
+  );
+
+  const response = await fetch(`http://127.0.0.1:${healthPort}/send`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      channel: "slack",
+      peerId: "D999",
+      parts: [{ type: "file", filePath: "payload.txt" }],
+    }),
+  });
+  assert.equal(response.status, 200);
+  const json = await response.json();
+  assert.equal(json.ok, true);
+  assert.equal(json.sent, 1);
+  assert.equal(Array.isArray(json.targets), true);
+  assert.equal(json.targets[0].sentParts, 1);
+  assert.equal(deliveries.length, 1);
+
+  await bridge.stop();
+  store.close();
+});
+
 test("health /send rejects invalid telegram direct peerId", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencodeRouter-health-send-"));
   const dbPath = path.join(dir, "opencode-router.db");

--- a/packages/opencode-router/test/slack.test.js
+++ b/packages/opencode-router/test/slack.test.js
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
+import { MediaStore } from "../dist/media-store.js";
 import {
   createSlackAdapter,
   formatSlackPeerId,
@@ -51,6 +55,7 @@ test("createSlackAdapter routes DM + app mentions", async () => {
     constructor(token) {
       this.token = token;
       this.posts = [];
+      this.uploads = [];
       webInstance = this;
       this.auth = {
         test: async () => ({ ok: true, user_id: "UBOT" }),
@@ -58,6 +63,12 @@ test("createSlackAdapter routes DM + app mentions", async () => {
       this.chat = {
         postMessage: async (payload) => {
           this.posts.push(payload);
+          return { ok: true };
+        },
+      };
+      this.files = {
+        uploadV2: async (payload) => {
+          this.uploads.push(payload);
           return { ok: true };
         },
       };
@@ -142,10 +153,121 @@ test("createSlackAdapter routes DM + app mentions", async () => {
   await adapter.sendText("D123", "ok");
   await adapter.sendText("C123|1700000000.000100", "ok-thread");
 
+  const mediaFile = path.join(os.tmpdir(), `opencode-router-slack-${Date.now()}.txt`);
+  fs.writeFileSync(mediaFile, "hello from file");
+  const mediaResult = await adapter.sendMessage("D123", {
+    parts: [{ type: "file", filePath: mediaFile }],
+  });
+
   assert.equal(webInstance.posts.length, 2);
   assert.deepEqual(webInstance.posts[0], { channel: "D123", text: "ok" });
   assert.deepEqual(webInstance.posts[1], { channel: "C123", text: "ok-thread", thread_ts: "1700000000.000100" });
+  assert.equal(mediaResult.sentParts, 1);
+  assert.equal(webInstance.uploads.length, 1);
+  assert.equal(webInstance.uploads[0].channel_id, "D123");
+  assert.equal(Buffer.isBuffer(webInstance.uploads[0].file), true);
+  assert.equal(webInstance.uploads[0].filename, path.basename(mediaFile));
 
   await adapter.stop();
   assert.equal(socketInstance.started, false);
+});
+
+test("createSlackAdapter downloads inbound files into media store", async () => {
+  const logger = createLoggerStub();
+  const inbound = [];
+  let socketInstance;
+
+  class FakeWebClient {
+    constructor(token) {
+      this.token = token;
+      this.auth = {
+        test: async () => ({ ok: true, user_id: "UBOT" }),
+      };
+      this.chat = {
+        postMessage: async () => ({ ok: true }),
+      };
+      this.files = {
+        uploadV2: async () => ({ ok: true }),
+      };
+    }
+  }
+
+  class FakeSocketModeClient {
+    constructor() {
+      this.handlers = new Map();
+      socketInstance = this;
+    }
+    on(event, handler) {
+      this.handlers.set(event, handler);
+    }
+    async start() {}
+    async disconnect() {}
+    async emit(event, args) {
+      const handler = this.handlers.get(event);
+      if (handler) {
+        await handler(args);
+      }
+    }
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-router-slack-media-"));
+  const mediaStore = new MediaStore(path.join(tempDir, "media"));
+  await mediaStore.ensureReady();
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response("downloaded-slack-file", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+
+  try {
+    const adapter = createSlackAdapter(
+      {
+        id: "default",
+        botToken: "xoxb-test",
+        appToken: "xapp-test",
+        enabled: true,
+      },
+      { groupsEnabled: false },
+      logger,
+      async (msg) => inbound.push(msg),
+      { WebClient: FakeWebClient, SocketModeClient: FakeSocketModeClient },
+      mediaStore,
+    );
+
+    await adapter.start();
+
+    await socketInstance.emit("message", {
+      ack: async () => {},
+      event: {
+        type: "message",
+        subtype: "file_share",
+        channel: "D123",
+        user: "U1",
+        files: [
+          {
+            id: "F1",
+            url_private_download: "https://files.example.com/download/F1",
+            name: "report.txt",
+            mimetype: "text/plain",
+            size: 22,
+          },
+        ],
+      },
+    });
+
+    assert.equal(inbound.length, 1);
+    const mediaPart = inbound[0].parts.find((part) => part.type === "media");
+    assert.ok(mediaPart);
+    assert.equal(mediaPart.media.status, "ready");
+    const downloadedPath = mediaPart.media.filePath;
+    assert.ok(downloadedPath);
+    assert.equal(fs.existsSync(downloadedPath), true);
+    assert.equal(fs.readFileSync(downloadedPath, "utf8"), "downloaded-slack-file");
+
+    await adapter.stop();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/packages/opencode-router/test/telegram.test.js
+++ b/packages/opencode-router/test/telegram.test.js
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { MediaStore } from "../dist/media-store.js";
+import { createTelegramAdapter } from "../dist/telegram.js";
+
+function createLoggerStub() {
+  const base = {
+    child() {
+      return base;
+    },
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+  };
+  return base;
+}
+
+let lastFakeBot = null;
+
+class FakeBot {
+  constructor(token) {
+    this.token = token;
+    this.handlers = new Map();
+    this.me = { username: "routerbot" };
+    this.calls = {
+      sendMessage: [],
+      sendPhoto: [],
+      sendAudio: [],
+      sendDocument: [],
+      getFile: [],
+    };
+    this.api = {
+      sendMessage: async (chatId, text) => {
+        this.calls.sendMessage.push({ chatId, text });
+        return { ok: true };
+      },
+      sendPhoto: async (chatId, file, options) => {
+        this.calls.sendPhoto.push({ chatId, file, options });
+        return { ok: true };
+      },
+      sendAudio: async (chatId, file, options) => {
+        this.calls.sendAudio.push({ chatId, file, options });
+        return { ok: true };
+      },
+      sendDocument: async (chatId, file, options) => {
+        this.calls.sendDocument.push({ chatId, file, options });
+        return { ok: true };
+      },
+      getFile: async (fileId) => {
+        this.calls.getFile.push({ fileId });
+        return { file_path: `downloads/${fileId}.bin` };
+      },
+    };
+    lastFakeBot = this;
+  }
+
+  catch(handler) {
+    this.errorHandler = handler;
+  }
+
+  on(event, handler) {
+    this.handlers.set(event, handler);
+  }
+
+  async start() {
+    this.started = true;
+  }
+
+  stop() {
+    this.started = false;
+  }
+
+  async emitMessage(message) {
+    const handler = this.handlers.get("message");
+    if (handler) {
+      await handler({ message, me: this.me });
+    }
+  }
+}
+
+test("createTelegramAdapter sends text/images/audio/files", async () => {
+  const logger = createLoggerStub();
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-router-tg-send-"));
+  const imagePath = path.join(tempDir, "sample.jpg");
+  const audioPath = path.join(tempDir, "sample.ogg");
+  const filePath = path.join(tempDir, "sample.txt");
+  fs.writeFileSync(imagePath, "img");
+  fs.writeFileSync(audioPath, "aud");
+  fs.writeFileSync(filePath, "doc");
+
+  const adapter = createTelegramAdapter(
+    {
+      id: "default",
+      token: "tg-token",
+      enabled: true,
+    },
+    { groupsEnabled: false },
+    logger,
+    async () => {},
+    undefined,
+    { Bot: FakeBot },
+  );
+
+  const result = await adapter.sendMessage("12345", {
+    parts: [
+      { type: "text", text: "hello" },
+      { type: "image", filePath: imagePath, caption: "image caption" },
+      { type: "audio", filePath: audioPath },
+      { type: "file", filePath },
+    ],
+  });
+
+  assert.equal(result.attemptedParts, 4);
+  assert.equal(result.sentParts, 4);
+  assert.ok(lastFakeBot);
+  assert.equal(lastFakeBot.calls.sendMessage.length, 1);
+  assert.equal(lastFakeBot.calls.sendPhoto.length, 1);
+  assert.equal(lastFakeBot.calls.sendAudio.length, 1);
+  assert.equal(lastFakeBot.calls.sendDocument.length, 1);
+});
+
+test("createTelegramAdapter downloads inbound media to store", async () => {
+  const logger = createLoggerStub();
+  const inbound = [];
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "opencode-router-tg-inbound-"));
+  const mediaStore = new MediaStore(path.join(tempDir, "media"));
+  await mediaStore.ensureReady();
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response("telegram-media", {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+
+  try {
+    const adapter = createTelegramAdapter(
+      {
+        id: "default",
+        token: "tg-token",
+        enabled: true,
+      },
+      { groupsEnabled: false },
+      logger,
+      async (message) => inbound.push(message),
+      mediaStore,
+      { Bot: FakeBot },
+    );
+
+    await lastFakeBot.emitMessage({
+      chat: { id: 777, type: "private" },
+      caption: "here is photo",
+      photo: [{ file_id: "FILE123", file_unique_id: "UNIQ123", file_size: 13 }],
+    });
+
+    assert.equal(inbound.length, 1);
+    assert.equal(inbound[0].text, "here is photo");
+    const mediaPart = inbound[0].parts.find((part) => part.type === "media");
+    assert.ok(mediaPart);
+    assert.equal(mediaPart.media.status, "ready");
+    assert.ok(mediaPart.media.filePath);
+    assert.equal(fs.existsSync(mediaPart.media.filePath), true);
+    assert.equal(fs.readFileSync(mediaPart.media.filePath, "utf8"), "telegram-media");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- add a first-class media message model (`text`, `image`, `audio`, `file`) plus delivery error classification/retry and a workspace-scoped media store for inbound/outbound file handling
- extend Telegram and Slack adapters to receive/download media inbound and send media outbound, with structured per-part delivery results and partial-failure reporting
- extend router send surfaces (`/send` health endpoint and `opencode-router send`) to accept media parts, and update docs/tests to validate end-to-end file movement

## Testing
- `pnpm -C packages/opencode-router test:unit`
- `pnpm -C packages/opencode-router test:cli`
- `pnpm -C packages/opencode-router test:npx`
- `opencode serve --port 4106 --hostname 127.0.0.1 & OPENCODE_URL=http://127.0.0.1:4106 pnpm -C packages/opencode-router test:smoke`

## End-to-end file movement evidence
- added `test/health-send.test.js` case `health /send can deliver file parts end-to-end` to verify a file path is resolved, loaded, and delivered through router send flow
- added `test/slack.test.js` media tests to verify outbound file uploads and inbound file downloads into the media store
- added `test/telegram.test.js` media tests to verify outbound image/audio/file sends and inbound media download/storage flow