### PR TITLE
fix(desktop): harden router startup and add service restart controls

### DIFF
--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -361,6 +361,10 @@ export async function engineStop(): Promise<EngineInfo> {
   return invoke<EngineInfo>("engine_stop");
 }
 
+export async function engineRestart(): Promise<EngineInfo> {
+  return invoke<EngineInfo>("engine_restart");
+}
+
 export async function orchestratorStatus(): Promise<OrchestratorStatus> {
   return invoke<OrchestratorStatus>("orchestrator_status");
 }
@@ -459,6 +463,10 @@ export async function sandboxCleanupOpenworkContainers(): Promise<OpenworkDocker
 
 export async function openworkServerInfo(): Promise<OpenworkServerInfo> {
   return invoke<OpenworkServerInfo>("openwork_server_info");
+}
+
+export async function openworkServerRestart(): Promise<OpenworkServerInfo> {
+  return invoke<OpenworkServerInfo>("openwork_server_restart");
 }
 
 export async function engineInfo(): Promise<EngineInfo> {
@@ -765,6 +773,7 @@ export type OpenCodeRouterInfo = {
   version: string | null;
   workspacePath: string | null;
   opencodeUrl: string | null;
+  healthPort: number | null;
   pid: number | null;
   lastStdout: string | null;
   lastStderr: string | null;

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -22,8 +22,10 @@ import type {
 } from "../lib/tauri";
 import {
   appBuildInfo,
+  engineRestart,
   opencodeRouterRestart,
   opencodeRouterStop,
+  openworkServerRestart,
   pickFile,
 } from "../lib/tauri";
 import { currentLocale, t } from "../../i18n";
@@ -477,6 +479,10 @@ export default function SettingsView(props: SettingsViewProps) {
 
   const [opencodeRouterRestarting, setOpenCodeRouterRestarting] = createSignal(false);
   const [opencodeRouterRestartError, setOpenCodeRouterRestartError] = createSignal<string | null>(null);
+  const [openworkServerRestarting, setOpenworkServerRestarting] = createSignal(false);
+  const [openworkServerRestartError, setOpenworkServerRestartError] = createSignal<string | null>(null);
+  const [opencodeRestarting, setOpencodeRestarting] = createSignal(false);
+  const [opencodeRestartError, setOpencodeRestartError] = createSignal<string | null>(null);
 
   const handleOpenCodeRouterRestart = async () => {
     if (opencodeRouterRestarting()) return;
@@ -514,6 +520,34 @@ export default function SettingsView(props: SettingsViewProps) {
       setOpenCodeRouterRestartError(e instanceof Error ? e.message : String(e));
     } finally {
       setOpenCodeRouterRestarting(false);
+    }
+  };
+
+  const handleOpenworkServerRestart = async () => {
+    if (openworkServerRestarting() || !isTauriRuntime()) return;
+    setOpenworkServerRestarting(true);
+    setOpenworkServerRestartError(null);
+    try {
+      await openworkServerRestart();
+      await props.reconnectOpenworkServer();
+    } catch (e) {
+      setOpenworkServerRestartError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setOpenworkServerRestarting(false);
+    }
+  };
+
+  const handleOpenCodeRestart = async () => {
+    if (opencodeRestarting() || !isTauriRuntime()) return;
+    setOpencodeRestarting(true);
+    setOpencodeRestartError(null);
+    try {
+      await engineRestart();
+      await props.reconnectOpenworkServer();
+    } catch (e) {
+      setOpencodeRestartError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setOpencodeRestarting(false);
     }
   };
 
@@ -1411,6 +1445,59 @@ export default function SettingsView(props: SettingsViewProps) {
                     <div class="text-xs text-gray-10">Sidecar health, capabilities, and audit trail.</div>
                   </div>
 
+                  <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
+                    <div>
+                      <div class="text-sm font-medium text-gray-12">Service restarts</div>
+                      <div class="text-xs text-gray-10">Restart specific host services without leaving this screen.</div>
+                    </div>
+                    <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+                      <Button
+                        variant="secondary"
+                        onClick={handleRestartLocalServer}
+                        disabled={props.busy || openworkRestartBusy() || !isTauriRuntime()}
+                        class="text-xs px-3 py-1.5 justify-center"
+                      >
+                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${openworkRestartBusy() ? "animate-spin" : ""}`} />
+                        {openworkRestartBusy() ? "Restarting..." : "Restart orchestrator"}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={handleOpenCodeRestart}
+                        disabled={opencodeRestarting() || !isTauriRuntime()}
+                        class="text-xs px-3 py-1.5 justify-center"
+                      >
+                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${opencodeRestarting() ? "animate-spin" : ""}`} />
+                        {opencodeRestarting() ? "Restarting..." : "Restart OpenCode"}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={handleOpenworkServerRestart}
+                        disabled={openworkServerRestarting() || !isTauriRuntime()}
+                        class="text-xs px-3 py-1.5 justify-center"
+                      >
+                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${openworkServerRestarting() ? "animate-spin" : ""}`} />
+                        {openworkServerRestarting() ? "Restarting..." : "Restart OpenWork server"}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        onClick={handleOpenCodeRouterRestart}
+                        disabled={opencodeRouterRestarting() || !isTauriRuntime()}
+                        class="text-xs px-3 py-1.5 justify-center"
+                      >
+                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${opencodeRouterRestarting() ? "animate-spin" : ""}`} />
+                        {opencodeRouterRestarting() ? "Restarting..." : "Restart OpenCodeRouter"}
+                      </Button>
+                    </div>
+                    <Show when={openworkRestartStatus()}>
+                      <div class="text-xs text-green-11 bg-green-3/50 border border-green-6 rounded-lg p-2">{openworkRestartStatus()}</div>
+                    </Show>
+                    <Show when={openworkRestartError() || opencodeRestartError() || openworkServerRestartError() || opencodeRouterRestartError()}>
+                      <div class="text-xs text-red-11 bg-red-3/50 border border-red-6 rounded-lg p-2">
+                        {openworkRestartError() || opencodeRestartError() || openworkServerRestartError() || opencodeRouterRestartError()}
+                      </div>
+                    </Show>
+                  </div>
+
                   <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                     <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                       <div>
@@ -1612,6 +1699,9 @@ export default function SettingsView(props: SettingsViewProps) {
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
                           {props.opencodeRouterInfo?.workspacePath?.trim() || "No worker directory"}
+                        </div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          Health port: {props.opencodeRouterInfo?.healthPort ?? "—"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">PID: {props.opencodeRouterInfo?.pid ?? "—"}</div>
                       </div>

--- a/packages/desktop/src-tauri/src/commands/engine.rs
+++ b/packages/desktop/src-tauri/src/commands/engine.rs
@@ -146,6 +146,40 @@ pub fn engine_stop(
 }
 
 #[tauri::command]
+pub fn engine_restart(
+    app: AppHandle,
+    manager: State<EngineManager>,
+    orchestrator_manager: State<OrchestratorManager>,
+    openwork_manager: State<OpenworkServerManager>,
+    opencode_router_manager: State<OpenCodeRouterManager>,
+) -> Result<EngineInfo, String> {
+    let (project_dir, runtime) = {
+        let state = manager.inner.lock().expect("engine mutex poisoned");
+        (
+            state
+                .project_dir
+                .clone()
+                .ok_or_else(|| "OpenCode is not configured for a local workspace".to_string())?,
+            state.runtime.clone(),
+        )
+    };
+
+    let workspace_paths = vec![project_dir.clone()];
+    engine_start(
+        app,
+        manager,
+        orchestrator_manager,
+        openwork_manager,
+        opencode_router_manager,
+        project_dir,
+        None,
+        None,
+        Some(runtime),
+        Some(workspace_paths),
+    )
+}
+
+#[tauri::command]
 pub fn engine_doctor(
     app: AppHandle,
     prefer_sidecar: Option<bool>,

--- a/packages/desktop/src-tauri/src/commands/opencode_router.rs
+++ b/packages/desktop/src-tauri/src/commands/opencode_router.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use std::time::{Duration, Instant};
+
 use tauri::{AppHandle, State};
 use tauri_plugin_shell::process::CommandEvent;
 
@@ -21,6 +23,101 @@ fn check_health_endpoint(port: u16) -> Option<serde_json::Value> {
         response.into_json().ok()
     } else {
         None
+    }
+}
+
+const OPENCODE_ROUTER_STARTUP_WAIT_MS: u64 = 5_000;
+const OPENCODE_ROUTER_MAX_START_ATTEMPTS: usize = 5;
+
+fn append_output(slot: &mut Option<String>, line: &str) {
+    let existing = slot.as_deref().unwrap_or_default();
+    let next = format!("{existing}{line}");
+    *slot = Some(truncate_output(&next, 8000));
+}
+
+fn is_port_in_use_error(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("port is in use")
+        || lower.contains("eaddrinuse")
+        || lower.contains("address already in use")
+}
+
+fn format_startup_failure(
+    code: Option<i32>,
+    startup_stdout: &Option<String>,
+    startup_stderr: &Option<String>,
+) -> String {
+    let mut parts = Vec::new();
+    if let Some(stdout) = startup_stdout {
+        if !stdout.trim().is_empty() {
+            parts.push(format!("stdout:\n{}", stdout.trim()));
+        }
+    }
+    if let Some(stderr) = startup_stderr {
+        if !stderr.trim().is_empty() {
+            parts.push(format!("stderr:\n{}", stderr.trim()));
+        }
+    }
+
+    let suffix = if parts.is_empty() {
+        String::new()
+    } else {
+        format!("\n\n{}", parts.join("\n\n"))
+    };
+
+    format!(
+        "OpenCodeRouter exited during startup (code {}).{}",
+        code.unwrap_or(-1),
+        suffix
+    )
+}
+
+fn await_router_startup(
+    rx: &mut tauri::async_runtime::Receiver<CommandEvent>,
+    health_port: u16,
+    startup_stdout: &mut Option<String>,
+    startup_stderr: &mut Option<String>,
+) -> Result<(), String> {
+    if check_health_endpoint(health_port).is_some() {
+        return Ok(());
+    }
+
+    let deadline = Instant::now() + Duration::from_millis(OPENCODE_ROUTER_STARTUP_WAIT_MS);
+    loop {
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                CommandEvent::Stdout(line_bytes) => {
+                    let line = String::from_utf8_lossy(&line_bytes).to_string();
+                    append_output(startup_stdout, &line);
+                }
+                CommandEvent::Stderr(line_bytes) => {
+                    let line = String::from_utf8_lossy(&line_bytes).to_string();
+                    append_output(startup_stderr, &line);
+                }
+                CommandEvent::Terminated(payload) => {
+                    return Err(format_startup_failure(
+                        payload.code,
+                        startup_stdout,
+                        startup_stderr,
+                    ));
+                }
+                CommandEvent::Error(message) => {
+                    append_output(startup_stderr, &message);
+                    return Err(format!("OpenCodeRouter failed during startup: {message}"));
+                }
+                _ => {}
+            }
+        }
+
+        if check_health_endpoint(health_port).is_some() {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Ok(());
+        }
+
+        std::thread::sleep(Duration::from_millis(80));
     }
 }
 
@@ -107,71 +204,133 @@ pub fn opencodeRouter_start(
         .map_err(|_| "opencodeRouter mutex poisoned".to_string())?;
     OpenCodeRouterManager::stop_locked(&mut state);
 
-    let resolved_health_port = match health_port {
-        Some(port) => port,
-        None => resolve_opencode_router_health_port()?,
+    let max_attempts = if health_port.is_some() {
+        1
+    } else {
+        OPENCODE_ROUTER_MAX_START_ATTEMPTS
     };
-    let (mut rx, child) = spawn_opencode_router(
-        &app,
-        &workspace_path,
-        opencode_url.as_deref(),
-        opencode_username.as_deref(),
-        opencode_password.as_deref(),
-        resolved_health_port,
-    )?;
 
-    state.child = Some(child);
-    state.child_exited = false;
-    state.workspace_path = Some(workspace_path);
-    state.opencode_url = opencode_url;
-    state.health_port = Some(resolved_health_port);
-    state.last_stdout = None;
-    state.last_stderr = None;
+    let mut last_error: Option<String> = None;
 
-    let state_handle = manager.inner.clone();
+    for attempt in 0..max_attempts {
+        let resolved_health_port = if attempt == 0 {
+            match health_port {
+                Some(port) => port,
+                None => resolve_opencode_router_health_port()?,
+            }
+        } else {
+            resolve_opencode_router_health_port()?
+        };
 
-    tauri::async_runtime::spawn(async move {
-        while let Some(event) = rx.recv().await {
-            match event {
-                CommandEvent::Stdout(line_bytes) => {
-                    let line = String::from_utf8_lossy(&line_bytes).to_string();
-                    if let Ok(mut state) = state_handle.try_lock() {
-                        let next =
-                            state.last_stdout.as_deref().unwrap_or_default().to_string() + &line;
-                        state.last_stdout = Some(truncate_output(&next, 8000));
-                    }
-                }
-                CommandEvent::Stderr(line_bytes) => {
-                    let line = String::from_utf8_lossy(&line_bytes).to_string();
-                    if let Ok(mut state) = state_handle.try_lock() {
-                        let next =
-                            state.last_stderr.as_deref().unwrap_or_default().to_string() + &line;
-                        state.last_stderr = Some(truncate_output(&next, 8000));
-                    }
-                }
-                CommandEvent::Terminated(payload) => {
-                    if let Ok(mut state) = state_handle.try_lock() {
-                        state.child_exited = true;
-                        if let Some(code) = payload.code {
-                            let next = format!("OpenCodeRouter exited (code {code}).");
-                            state.last_stderr = Some(truncate_output(&next, 8000));
+        let (mut rx, child) = match spawn_opencode_router(
+            &app,
+            &workspace_path,
+            opencode_url.as_deref(),
+            opencode_username.as_deref(),
+            opencode_password.as_deref(),
+            resolved_health_port,
+        ) {
+            Ok(value) => value,
+            Err(error) => {
+                last_error = Some(error);
+                continue;
+            }
+        };
+
+        let mut startup_stdout: Option<String> = None;
+        let mut startup_stderr: Option<String> = None;
+
+        match await_router_startup(
+            &mut rx,
+            resolved_health_port,
+            &mut startup_stdout,
+            &mut startup_stderr,
+        ) {
+            Ok(()) => {
+                state.child = Some(child);
+                state.child_exited = false;
+                state.workspace_path = Some(workspace_path.clone());
+                state.opencode_url = opencode_url.clone();
+                state.health_port = Some(resolved_health_port);
+                state.last_stdout = startup_stdout;
+                state.last_stderr = startup_stderr;
+
+                let state_handle = manager.inner.clone();
+
+                tauri::async_runtime::spawn(async move {
+                    while let Some(event) = rx.recv().await {
+                        match event {
+                            CommandEvent::Stdout(line_bytes) => {
+                                let line = String::from_utf8_lossy(&line_bytes).to_string();
+                                if let Ok(mut state) = state_handle.try_lock() {
+                                    let next = state
+                                        .last_stdout
+                                        .as_deref()
+                                        .unwrap_or_default()
+                                        .to_string()
+                                        + &line;
+                                    state.last_stdout = Some(truncate_output(&next, 8000));
+                                }
+                            }
+                            CommandEvent::Stderr(line_bytes) => {
+                                let line = String::from_utf8_lossy(&line_bytes).to_string();
+                                if let Ok(mut state) = state_handle.try_lock() {
+                                    let next = state
+                                        .last_stderr
+                                        .as_deref()
+                                        .unwrap_or_default()
+                                        .to_string()
+                                        + &line;
+                                    state.last_stderr = Some(truncate_output(&next, 8000));
+                                }
+                            }
+                            CommandEvent::Terminated(payload) => {
+                                if let Ok(mut state) = state_handle.try_lock() {
+                                    state.child_exited = true;
+                                    if let Some(code) = payload.code {
+                                        let next = format!("OpenCodeRouter exited (code {code}).");
+                                        state.last_stderr = Some(truncate_output(&next, 8000));
+                                    }
+                                }
+                            }
+                            CommandEvent::Error(message) => {
+                                if let Ok(mut state) = state_handle.try_lock() {
+                                    state.child_exited = true;
+                                    let next = state
+                                        .last_stderr
+                                        .as_deref()
+                                        .unwrap_or_default()
+                                        .to_string()
+                                        + &message;
+                                    state.last_stderr = Some(truncate_output(&next, 8000));
+                                }
+                            }
+                            _ => {}
                         }
                     }
+                });
+
+                return Ok(OpenCodeRouterManager::snapshot_locked(&mut state));
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let retryable = health_port.is_none() && is_port_in_use_error(&error);
+                last_error = Some(error);
+                if !retryable {
+                    break;
                 }
-                CommandEvent::Error(message) => {
-                    if let Ok(mut state) = state_handle.try_lock() {
-                        state.child_exited = true;
-                        let next =
-                            state.last_stderr.as_deref().unwrap_or_default().to_string() + &message;
-                        state.last_stderr = Some(truncate_output(&next, 8000));
-                    }
-                }
-                _ => {}
             }
         }
-    });
+    }
 
-    Ok(OpenCodeRouterManager::snapshot_locked(&mut state))
+    let message = match last_error {
+        Some(error) if max_attempts > 1 => {
+            format!("Failed to start OpenCodeRouter after {max_attempts} attempts: {error}")
+        }
+        Some(error) => error,
+        None => "Failed to start OpenCodeRouter".to_string(),
+    };
+    Err(message)
 }
 
 #[tauri::command]

--- a/packages/desktop/src-tauri/src/commands/openwork_server.rs
+++ b/packages/desktop/src-tauri/src/commands/openwork_server.rs
@@ -1,6 +1,9 @@
-use tauri::State;
+use tauri::{AppHandle, State};
 
+use crate::engine::manager::EngineManager;
+use crate::opencode_router::manager::OpenCodeRouterManager;
 use crate::openwork_server::manager::OpenworkServerManager;
+use crate::openwork_server::start_openwork_server;
 use crate::types::OpenworkServerInfo;
 
 #[tauri::command]
@@ -12,4 +15,42 @@ pub fn openwork_server_info(manager: State<OpenworkServerManager>) -> OpenworkSe
     OpenworkServerManager::snapshot_locked(&mut state)
 }
 
-// start/stop are handled by engine lifecycle
+#[tauri::command]
+pub fn openwork_server_restart(
+    app: AppHandle,
+    manager: State<OpenworkServerManager>,
+    engine_manager: State<EngineManager>,
+    opencode_router_manager: State<OpenCodeRouterManager>,
+) -> Result<OpenworkServerInfo, String> {
+    let (workspace_path, opencode_url, opencode_username, opencode_password) = {
+        let engine = engine_manager
+            .inner
+            .lock()
+            .map_err(|_| "engine mutex poisoned".to_string())?;
+        (
+            engine
+                .project_dir
+                .clone()
+                .ok_or_else(|| "No active local workspace available".to_string())?,
+            engine.base_url.clone(),
+            engine.opencode_username.clone(),
+            engine.opencode_password.clone(),
+        )
+    };
+
+    let opencode_router_health_port = opencode_router_manager
+        .inner
+        .lock()
+        .ok()
+        .and_then(|state| state.health_port);
+
+    start_openwork_server(
+        &app,
+        &manager,
+        &[workspace_path],
+        opencode_url.as_deref(),
+        opencode_username.as_deref(),
+        opencode_password.as_deref(),
+        opencode_router_health_port,
+    )
+}

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -20,7 +20,9 @@ use commands::command_files::{
     opencode_command_delete, opencode_command_list, opencode_command_write,
 };
 use commands::config::{read_opencode_config, write_opencode_config};
-use commands::engine::{engine_doctor, engine_info, engine_install, engine_start, engine_stop};
+use commands::engine::{
+    engine_doctor, engine_info, engine_install, engine_restart, engine_start, engine_stop,
+};
 use commands::misc::{
     app_build_info, obsidian_is_available, open_in_obsidian, opencode_db_migrate,
     opencode_mcp_auth, read_obsidian_mirror_file, reset_opencode_cache, reset_openwork_state,
@@ -30,7 +32,7 @@ use commands::opencode_router::{
     opencodeRouter_config_set, opencodeRouter_info, opencodeRouter_start, opencodeRouter_status,
     opencodeRouter_stop,
 };
-use commands::openwork_server::openwork_server_info;
+use commands::openwork_server::{openwork_server_info, openwork_server_restart};
 use commands::opkg::{import_skill, opkg_install};
 use commands::orchestrator::{
     orchestrator_instance_dispose, orchestrator_start_detached, orchestrator_status,
@@ -96,6 +98,7 @@ pub fn run() {
             engine_info,
             engine_doctor,
             engine_install,
+            engine_restart,
             orchestrator_status,
             orchestrator_workspace_activate,
             orchestrator_instance_dispose,
@@ -104,6 +107,7 @@ pub fn run() {
             sandbox_stop,
             sandbox_cleanup_openwork_containers,
             openwork_server_info,
+            openwork_server_restart,
             opencodeRouter_info,
             opencodeRouter_start,
             opencodeRouter_stop,

--- a/packages/desktop/src-tauri/src/opencode_router/manager.rs
+++ b/packages/desktop/src-tauri/src/opencode_router/manager.rs
@@ -37,6 +37,7 @@ impl OpenCodeRouterManager {
             version: state.version.clone(),
             workspace_path: state.workspace_path.clone(),
             opencode_url: state.opencode_url.clone(),
+            health_port: state.health_port,
             pid,
             last_stdout: state.last_stdout.clone(),
             last_stderr: state.last_stderr.clone(),

--- a/packages/desktop/src-tauri/src/opencode_router/spawn.rs
+++ b/packages/desktop/src-tauri/src/opencode_router/spawn.rs
@@ -10,10 +10,9 @@ use tauri_plugin_shell::ShellExt;
 pub const DEFAULT_OPENCODE_ROUTER_HEALTH_PORT: u16 = 3005;
 
 pub fn resolve_opencode_router_health_port() -> Result<u16, String> {
-    if TcpListener::bind(("0.0.0.0", DEFAULT_OPENCODE_ROUTER_HEALTH_PORT)).is_ok() {
-        return Ok(DEFAULT_OPENCODE_ROUTER_HEALTH_PORT);
-    }
-    let listener = TcpListener::bind(("0.0.0.0", 0)).map_err(|e| e.to_string())?;
+    // Pick an ephemeral localhost port by default to avoid conflicts when
+    // multiple OpenWork desktop instances run on the same machine.
+    let listener = TcpListener::bind(("127.0.0.1", 0)).map_err(|e| e.to_string())?;
     let port = listener.local_addr().map_err(|e| e.to_string())?.port();
     Ok(port)
 }

--- a/packages/desktop/src-tauri/src/types.rs
+++ b/packages/desktop/src-tauri/src/types.rs
@@ -189,6 +189,7 @@ pub struct OpenCodeRouterInfo {
     pub version: Option<String>,
     pub workspace_path: Option<String>,
     pub opencode_url: Option<String>,
+    pub health_port: Option<u16>,
     pub pid: Option<u32>,
     pub last_stdout: Option<String>,
     pub last_stderr: Option<String>,


### PR DESCRIPTION
## Summary
- Prevent OpenCodeRouter health-port collisions by allocating ephemeral localhost ports and retrying startup when a race still returns \`port in use\`.
- Add desktop commands to restart OpenCode and OpenWork server from the debug surface, and expose OpenCodeRouter \`healthPort\` in the debug info payload.
- Add a new Debug > Devtools "Service restarts" section with one-click controls for orchestrator, OpenCode, OpenWork server, and OpenCodeRouter.

## Testing
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml`
- `pnpm install`
- `pnpm typecheck`

## Notes
- I did not run Docker/Chrome-MCP UI flow validation in this pass.