### PR TITLE
feat(app): unified status bar indicator with detail popover

### DIFF
--- a/packages/app/pr/unified-status-indicator.md
+++ b/packages/app/pr/unified-status-indicator.md
@@ -1,0 +1,47 @@
+# Unified Status Bar Indicator
+
+**Branch:** `dev`
+**Priority:** P2
+
+---
+
+## Goal
+
+Replace the two separate status indicators (OpenCode Engine + OpenWork Server) in the status bar with a single unified indicator that opens a detail popover on click.
+
+---
+
+## Problem
+
+The status bar shows two icons with individual colored dots, exposing internal architecture details users don't need at a glance. Users just want to know if everything is working.
+
+---
+
+## Implementation
+
+### Files changed
+- `packages/app/src/app/components/status-bar.tsx` — main changes
+- `packages/app/src/app/pages/dashboard.tsx` — pass `startupPreference` prop
+- `packages/app/src/app/pages/session.tsx` — pass `startupPreference` prop
+- `packages/app/src/app/app.tsx` — pass `startupPreference` to session props
+
+### Changes
+
+1. **Unified status signal** — combines `clientConnected` and `openworkServerStatus` into a single computed: green/"Ready" only when both are healthy, red/"Unavailable" otherwise.
+
+2. **Single clickable indicator** — replaces the two separate icon+dot pairs with one dot + text label.
+
+3. **Detail popover** — clicking the indicator opens a popover showing per-service status rows (OpenCode Engine, Local/Remote Server) with individual colored dots and labels. Closes on outside click.
+
+4. **Local vs Remote label** — uses `startupPreference` to show "Local Server" or "Remote Server" in the popover.
+
+---
+
+## Testing
+
+- [x] `pnpm --filter @different-ai/openwork-ui typecheck` passes
+- [ ] Manual: single indicator shows green "Ready" when both services healthy
+- [ ] Manual: shows red "Unavailable" when either service is down
+- [ ] Manual: click opens popover with per-service breakdown
+- [ ] Manual: popover closes on outside click
+- [ ] Manual: shows "Local Server" or "Remote Server" based on preference

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -5840,6 +5840,7 @@ export default function App() {
     exportWorkspaceBusy: workspaceStore.exportingWorkspaceConfig(),
     clientConnected: Boolean(client()),
     openworkServerStatus: openworkServerStatus(),
+    startupPreference: startupPreference(),
     openworkServerClient: openworkServerClient(),
     openworkServerSettings: openworkServerSettings(),
     openworkServerHostInfo: openworkServerHostInfo(),

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -34,6 +34,18 @@ export default function StatusBar(props: StatusBarProps) {
   const [documentVisible, setDocumentVisible] = createSignal(true);
   const [statusDetailOpen, setStatusDetailOpen] = createSignal(false);
   let statusPopoverRef: HTMLDivElement | undefined;
+  let statusAutoCloseTimer: number | undefined;
+
+  const openStatusDetail = () => {
+    setStatusDetailOpen(true);
+    if (statusAutoCloseTimer) window.clearTimeout(statusAutoCloseTimer);
+    statusAutoCloseTimer = window.setTimeout(() => setStatusDetailOpen(false), 5000);
+  };
+
+  const closeStatusDetail = () => {
+    setStatusDetailOpen(false);
+    if (statusAutoCloseTimer) window.clearTimeout(statusAutoCloseTimer);
+  };
 
   const opencodeStatusMeta = createMemo(() => ({
     dot: props.clientConnected ? "bg-green-9" : "bg-gray-6",
@@ -243,7 +255,7 @@ export default function StatusBar(props: StatusBarProps) {
             type="button"
             class="flex items-center gap-2 hover:opacity-80 transition-opacity"
             title={`Status: ${unifiedStatusMeta().label}`}
-            onClick={() => setStatusDetailOpen((v) => !v)}
+            onClick={() => (statusDetailOpen() ? closeStatusDetail() : openStatusDetail())}
           >
             <span class={`w-2 h-2 rounded-full ${unifiedStatusMeta().dot}`} />
             <span class={`font-medium ${unifiedStatusMeta().text}`}>
@@ -254,7 +266,7 @@ export default function StatusBar(props: StatusBarProps) {
           <Show when={statusDetailOpen()}>
             <div
               class="fixed inset-0 z-[999]"
-              onClick={() => setStatusDetailOpen(false)}
+              onClick={closeStatusDetail}
             />
             <div
               ref={statusPopoverRef}

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -10,7 +10,7 @@ import { Cpu, MessageCircle, Server, Settings } from "lucide-solid";
 
 import type { OpenworkServerStatus } from "../lib/openwork-server";
 import type { OpenCodeRouterStatus } from "../lib/tauri";
-import type { McpStatusMap } from "../types";
+import type { McpStatusMap, StartupPreference } from "../types";
 import { getOpenCodeRouterStatus } from "../lib/tauri";
 
 import Button from "./button";
@@ -18,6 +18,7 @@ import Button from "./button";
 type StatusBarProps = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
+  startupPreference: StartupPreference | null;
   developerMode: boolean;
   onOpenSettings: () => void;
   onOpenMessaging: () => void;
@@ -281,7 +282,7 @@ export default function StatusBar(props: StatusBarProps) {
                   />
                   <Server class="w-3.5 h-3.5 text-gray-11" />
                   <span class="text-xs text-gray-12 font-medium">
-                    OpenWork Server
+                    {props.startupPreference === "server" ? "Remote Server" : "Local Server"}
                   </span>
                   <span class={`ml-auto text-xs ${openworkStatusMeta().text}`}>
                     {openworkStatusMeta().label}

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -1,4 +1,11 @@
-import { Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import {
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+} from "solid-js";
 import { Cpu, MessageCircle, Server, Settings } from "lucide-solid";
 
 import type { OpenworkServerStatus } from "../lib/openwork-server";
@@ -21,7 +28,8 @@ type StatusBarProps = {
 };
 
 export default function StatusBar(props: StatusBarProps) {
-  const [opencodeRouterStatus, setOpenCodeRouterStatus] = createSignal<OpenCodeRouterStatus | null>(null);
+  const [opencodeRouterStatus, setOpenCodeRouterStatus] =
+    createSignal<OpenCodeRouterStatus | null>(null);
   const [documentVisible, setDocumentVisible] = createSignal(true);
   const [statusDetailOpen, setStatusDetailOpen] = createSignal(false);
   let statusPopoverRef: HTMLDivElement | undefined;
@@ -35,16 +43,21 @@ export default function StatusBar(props: StatusBarProps) {
   const openworkStatusMeta = createMemo(() => {
     switch (props.openworkServerStatus) {
       case "connected":
-        return { dot: "bg-green-9", text: "text-green-11", label: "Ready" };
+        return { dot: "bg-green-9", text: "text-green-11", label: "Connected" };
       case "limited":
-        return { dot: "bg-amber-9", text: "text-amber-11", label: "Limited access" };
+        return {
+          dot: "bg-amber-9",
+          text: "text-amber-11",
+          label: "Limited access",
+        };
       default:
         return { dot: "bg-gray-6", text: "text-gray-10", label: "Unavailable" };
     }
   });
 
   const unifiedStatusMeta = createMemo(() => {
-    const allGreen = props.clientConnected && props.openworkServerStatus === "connected";
+    const allGreen =
+      props.clientConnected && props.openworkServerStatus === "connected";
     return allGreen
       ? { dot: "bg-green-9", text: "text-green-11", label: "Ready" }
       : { dot: "bg-red-9", text: "text-red-11", label: "Unavailable" };
@@ -53,18 +66,36 @@ export default function StatusBar(props: StatusBarProps) {
   const messagingMeta = createMemo(() => {
     const status = opencodeRouterStatus();
     if (!status) {
-      return { dot: "bg-gray-6", text: "text-gray-10", label: "Messaging bridge unavailable" };
+      return {
+        dot: "bg-gray-6",
+        text: "text-gray-10",
+        label: "Messaging bridge unavailable",
+      };
     }
     const telegramConfigured = (status.telegram.items?.length ?? 0) > 0;
     const slackConfigured = (status.slack.items?.length ?? 0) > 0;
-    const configuredCount = [telegramConfigured, slackConfigured].filter(Boolean).length;
+    const configuredCount = [telegramConfigured, slackConfigured].filter(
+      Boolean,
+    ).length;
     if (status.running && configuredCount > 0) {
-      return { dot: "bg-green-9", text: "text-green-11", label: "Messaging bridge ready" };
+      return {
+        dot: "bg-green-9",
+        text: "text-green-11",
+        label: "Messaging bridge ready",
+      };
     }
     if (configuredCount > 0 || status.running) {
-      return { dot: "bg-amber-9", text: "text-amber-11", label: "Messaging bridge setup" };
+      return {
+        dot: "bg-amber-9",
+        text: "text-amber-11",
+        label: "Messaging bridge setup",
+      };
     }
-    return { dot: "bg-gray-6", text: "text-gray-10", label: "Messaging bridge offline" };
+    return {
+      dot: "bg-gray-6",
+      text: "text-gray-10",
+      label: "Messaging bridge offline",
+    };
   });
 
   type ProTip = {
@@ -74,8 +105,12 @@ export default function StatusBar(props: StatusBarProps) {
     action: () => void | Promise<void>;
   };
 
-  const providerConnectedCount = createMemo(() => props.providerConnectedIds?.length ?? 0);
-  const notionStatus = createMemo(() => props.mcpStatuses?.notion?.status ?? "disconnected");
+  const providerConnectedCount = createMemo(
+    () => props.providerConnectedIds?.length ?? 0,
+  );
+  const notionStatus = createMemo(
+    () => props.mcpStatuses?.notion?.status ?? "disconnected",
+  );
 
   const runAction = (action?: () => void | Promise<void>) => {
     if (!action) return;
@@ -118,7 +153,9 @@ export default function StatusBar(props: StatusBarProps) {
     },
   ]);
 
-  const availableTips = createMemo<ProTip[]>(() => proTips().filter((tip: ProTip) => tip.enabled()));
+  const availableTips = createMemo<ProTip[]>(() =>
+    proTips().filter((tip: ProTip) => tip.enabled()),
+  );
   const [activeTip, setActiveTip] = createSignal<ProTip | null>(null);
   const [tipVisible, setTipVisible] = createSignal(false);
   const [tipCursor, setTipCursor] = createSignal(0);
@@ -175,7 +212,8 @@ export default function StatusBar(props: StatusBarProps) {
 
   createEffect(() => {
     if (typeof document === "undefined") return;
-    const update = () => setDocumentVisible(document.visibilityState !== "hidden");
+    const update = () =>
+      setDocumentVisible(document.visibilityState !== "hidden");
     update();
     document.addEventListener("visibilitychange", update);
     onCleanup(() => document.removeEventListener("visibilitychange", update));
@@ -207,35 +245,48 @@ export default function StatusBar(props: StatusBarProps) {
             onClick={() => setStatusDetailOpen((v) => !v)}
           >
             <span class={`w-2 h-2 rounded-full ${unifiedStatusMeta().dot}`} />
-            <span class={`font-medium ${unifiedStatusMeta().text}`}>{unifiedStatusMeta().label}</span>
+            <span class={`font-medium ${unifiedStatusMeta().text}`}>
+              {unifiedStatusMeta().label}
+            </span>
           </button>
 
           <Show when={statusDetailOpen()}>
             <div
-              class="fixed inset-0 z-40"
+              class="fixed inset-0 z-[999]"
               onClick={() => setStatusDetailOpen(false)}
             />
             <div
               ref={statusPopoverRef}
-              class="absolute bottom-full left-0 mb-2 z-50 w-64 rounded-xl border border-gray-6 bg-gray-2 shadow-xl p-3 space-y-3"
+              class="absolute bottom-full left-0 mb-2 z-[1000] w-64 rounded-xl border border-gray-6 bg-gray-2 shadow-xl p-3 space-y-3"
             >
-              <div class="text-[11px] font-medium text-gray-11 uppercase tracking-wider">Service Status</div>
+              <div class="text-[11px] font-medium text-gray-11 uppercase tracking-wider">
+                Service Status
+              </div>
               <div class="space-y-2">
                 <div class="flex items-center gap-2">
-                  <span class={`w-2 h-2 rounded-full ${opencodeStatusMeta().dot}`} />
+                  <span
+                    class={`w-2 h-2 rounded-full ${opencodeStatusMeta().dot}`}
+                  />
                   <Cpu class="w-3.5 h-3.5 text-gray-11" />
-                  <span class="text-xs text-gray-12 font-medium">OpenCode Engine</span>
-                  <span class={`ml-auto text-xs ${opencodeStatusMeta().text}`}>{opencodeStatusMeta().label}</span>
+                  <span class="text-xs text-gray-12 font-medium">
+                    OpenCode Engine
+                  </span>
+                  <span class={`ml-auto text-xs ${opencodeStatusMeta().text}`}>
+                    {opencodeStatusMeta().label}
+                  </span>
                 </div>
                 <div class="flex items-center gap-2">
-                  <span class={`w-2 h-2 rounded-full ${openworkStatusMeta().dot}`} />
+                  <span
+                    class={`w-2 h-2 rounded-full ${openworkStatusMeta().dot}`}
+                  />
                   <Server class="w-3.5 h-3.5 text-gray-11" />
-                  <span class="text-xs text-gray-12 font-medium">OpenWork Server</span>
-                  <span class={`ml-auto text-xs ${openworkStatusMeta().text}`}>{openworkStatusMeta().label}</span>
+                  <span class="text-xs text-gray-12 font-medium">
+                    OpenWork Server
+                  </span>
+                  <span class={`ml-auto text-xs ${openworkStatusMeta().text}`}>
+                    {openworkStatusMeta().label}
+                  </span>
                 </div>
-              </div>
-              <div class="text-[10px] text-gray-9 border-t border-gray-6 pt-2">
-                Green means the service is connected and operational.
               </div>
             </div>
           </Show>
@@ -249,7 +300,9 @@ export default function StatusBar(props: StatusBarProps) {
               title={activeTip()?.label}
               aria-label={activeTip()?.label}
             >
-              <span class="uppercase tracking-[0.2em] text-[10px] text-gray-8">Tip</span>
+              <span class="uppercase tracking-[0.2em] text-[10px] text-gray-8">
+                Tip
+              </span>
               <span class="text-gray-11 font-medium">{activeTip()?.label}</span>
             </button>
           </Show>

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -47,6 +47,16 @@ export default function StatusBar(props: StatusBarProps) {
     if (statusAutoCloseTimer) window.clearTimeout(statusAutoCloseTimer);
   };
 
+  createEffect(() => {
+    if (!statusDetailOpen()) return;
+    const onClick = (e: MouseEvent) => {
+      if (statusPopoverRef?.contains(e.target as Node)) return;
+      closeStatusDetail();
+    };
+    window.addEventListener("click", onClick, true);
+    onCleanup(() => window.removeEventListener("click", onClick, true));
+  });
+
   const opencodeStatusMeta = createMemo(() => ({
     dot: props.clientConnected ? "bg-green-9" : "bg-gray-6",
     text: props.clientConnected ? "text-green-11" : "text-gray-10",
@@ -265,12 +275,8 @@ export default function StatusBar(props: StatusBarProps) {
 
           <Show when={statusDetailOpen()}>
             <div
-              class="fixed inset-0 z-[999]"
-              onClick={closeStatusDetail}
-            />
-            <div
               ref={statusPopoverRef}
-              class="absolute bottom-full left-0 mb-2 z-[1000] w-64 rounded-xl border border-gray-6 bg-gray-2 shadow-xl p-3 space-y-3"
+              class="absolute bottom-full left-0 mb-2 z-[200] w-64 rounded-xl border border-gray-6 bg-gray-2 shadow-xl p-3 space-y-3"
             >
               <div class="text-[11px] font-medium text-gray-11 uppercase tracking-wider">
                 Service Status

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -236,7 +236,7 @@ export default function StatusBar(props: StatusBarProps) {
   });
 
   return (
-    <div class="border-t border-gray-6 bg-gray-1/90 backdrop-blur-md">
+    <div class="border-t border-gray-6 bg-gray-1/90 backdrop-blur-md z-[100] relative">
       <div class="px-4 py-2 flex flex-wrap items-center gap-3 text-xs">
         <div class="relative">
           <button

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -23,6 +23,8 @@ type StatusBarProps = {
 export default function StatusBar(props: StatusBarProps) {
   const [opencodeRouterStatus, setOpenCodeRouterStatus] = createSignal<OpenCodeRouterStatus | null>(null);
   const [documentVisible, setDocumentVisible] = createSignal(true);
+  const [statusDetailOpen, setStatusDetailOpen] = createSignal(false);
+  let statusPopoverRef: HTMLDivElement | undefined;
 
   const opencodeStatusMeta = createMemo(() => ({
     dot: props.clientConnected ? "bg-green-9" : "bg-gray-6",
@@ -39,6 +41,13 @@ export default function StatusBar(props: StatusBarProps) {
       default:
         return { dot: "bg-gray-6", text: "text-gray-10", label: "Unavailable" };
     }
+  });
+
+  const unifiedStatusMeta = createMemo(() => {
+    const allGreen = props.clientConnected && props.openworkServerStatus === "connected";
+    return allGreen
+      ? { dot: "bg-green-9", text: "text-green-11", label: "Ready" }
+      : { dot: "bg-red-9", text: "text-red-11", label: "Unavailable" };
   });
 
   const messagingMeta = createMemo(() => {
@@ -190,27 +199,45 @@ export default function StatusBar(props: StatusBarProps) {
   return (
     <div class="border-t border-gray-6 bg-gray-1/90 backdrop-blur-md">
       <div class="px-4 py-2 flex flex-wrap items-center gap-3 text-xs">
-        <div
-          class="flex items-center gap-2"
-          title={`OpenCode Engine: ${opencodeStatusMeta().label}`}
-        >
-          <span class={`w-2 h-2 rounded-full ${opencodeStatusMeta().dot}`} />
-          <Cpu class="w-4 h-4 text-gray-11" />
-          <Show when={props.developerMode || !props.clientConnected}>
-            <span class="text-gray-11 font-medium">OpenCode</span>
-            <span class={opencodeStatusMeta().text}>{opencodeStatusMeta().label}</span>
-          </Show>
-        </div>
-        <div class="w-px h-4 bg-gray-6/70" />
-        <div
-          class="flex items-center gap-2"
-          title={`OpenWork Server: ${openworkStatusMeta().label}`}
-        >
-          <span class={`w-2 h-2 rounded-full ${openworkStatusMeta().dot}`} />
-          <Server class="w-4 h-4 text-gray-11" />
-          <Show when={props.developerMode || props.openworkServerStatus !== "connected"}>
-            <span class="text-gray-11 font-medium">OpenWork</span>
-            <span class={openworkStatusMeta().text}>{openworkStatusMeta().label}</span>
+        <div class="relative">
+          <button
+            type="button"
+            class="flex items-center gap-2 hover:opacity-80 transition-opacity"
+            title={`Status: ${unifiedStatusMeta().label}`}
+            onClick={() => setStatusDetailOpen((v) => !v)}
+          >
+            <span class={`w-2 h-2 rounded-full ${unifiedStatusMeta().dot}`} />
+            <span class={`font-medium ${unifiedStatusMeta().text}`}>{unifiedStatusMeta().label}</span>
+          </button>
+
+          <Show when={statusDetailOpen()}>
+            <div
+              class="fixed inset-0 z-40"
+              onClick={() => setStatusDetailOpen(false)}
+            />
+            <div
+              ref={statusPopoverRef}
+              class="absolute bottom-full left-0 mb-2 z-50 w-64 rounded-xl border border-gray-6 bg-gray-2 shadow-xl p-3 space-y-3"
+            >
+              <div class="text-[11px] font-medium text-gray-11 uppercase tracking-wider">Service Status</div>
+              <div class="space-y-2">
+                <div class="flex items-center gap-2">
+                  <span class={`w-2 h-2 rounded-full ${opencodeStatusMeta().dot}`} />
+                  <Cpu class="w-3.5 h-3.5 text-gray-11" />
+                  <span class="text-xs text-gray-12 font-medium">OpenCode Engine</span>
+                  <span class={`ml-auto text-xs ${opencodeStatusMeta().text}`}>{opencodeStatusMeta().label}</span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class={`w-2 h-2 rounded-full ${openworkStatusMeta().dot}`} />
+                  <Server class="w-3.5 h-3.5 text-gray-11" />
+                  <span class="text-xs text-gray-12 font-medium">OpenWork Server</span>
+                  <span class={`ml-auto text-xs ${openworkStatusMeta().text}`}>{openworkStatusMeta().label}</span>
+                </div>
+              </div>
+              <div class="text-[10px] text-gray-9 border-t border-gray-6 pt-2">
+                Green means the service is connected and operational.
+              </div>
+            </div>
           </Show>
         </div>
         <div class="ml-auto flex items-center gap-2">

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -1457,6 +1457,7 @@ export default function DashboardView(props: DashboardViewProps) {
         <StatusBar
           clientConnected={props.clientConnected}
           openworkServerStatus={props.openworkServerStatus}
+          startupPreference={props.startupPreference}
           developerMode={props.developerMode}
           onOpenSettings={() => openSettings("general")}
           onOpenMessaging={openConfig}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -18,6 +18,7 @@ import type {
   WorkspaceConnectionState,
   WorkspaceDisplay,
   WorkspaceSessionGroup,
+  StartupPreference,
 } from "../types";
 
 import {
@@ -124,6 +125,7 @@ export type SessionViewProps = {
   exportWorkspaceBusy: boolean;
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
+  startupPreference: StartupPreference | null;
   openworkServerClient: OpenworkServerClient | null;
   openworkServerSettings: OpenworkServerSettings;
   openworkServerHostInfo: OpenworkServerInfo | null;
@@ -3664,6 +3666,7 @@ export default function SessionView(props: SessionViewProps) {
         <StatusBar
           clientConnected={props.clientConnected}
           openworkServerStatus={props.openworkServerStatus}
+          startupPreference={props.startupPreference}
           developerMode={props.developerMode}
           onOpenSettings={() => openSettings("general")}
           onOpenMessaging={openConfig}


### PR DESCRIPTION
## Summary
- Instead of having two separate status indicators (OpenCode Engine + OpenWork Server), I'm replacing with a single "Ready"/"Unavailable" indicator giving us space to explain more when there are errors.
- Clicking it opens a popover showing per-service status breakdown with colored dots and labels
- Shows "Local Server" or "Remote Server" based if the server is local or not
- Status is red/unavailable if either service is not green

## Files changed
- `packages/app/src/app/components/status-bar.tsx` — main changes
- `packages/app/src/app/pages/dashboard.tsx` — pass `startupPreference` prop
- `packages/app/src/app/pages/session.tsx` — pass `startupPreference` prop
- `packages/app/src/app/app.tsx` — pass `startupPreference` to session props
- `packages/app/pr/unified-status-indicator.md` — PRD

<img width="370" height="162" alt="Screenshot 2026-03-02 at 12 45 00 PM" src="https://github.com/user-attachments/assets/e0ae1177-ab33-41c5-9078-fa0b1bf87127" />


## Test plan
- [x] `pnpm typecheck` passes
- [ ] Single indicator shows green "Ready" when both services healthy
- [ ] Shows red "Unavailable" when either service is down
- [ ] Click opens popover with per-service breakdown
- [ ] Popover closes on outside click
- [ ] Shows "Local Server" or "Remote Server" based on preference