### PR TITLE
fix(den): prevent billing internal_error when Polar subscription sort changes

### DIFF
--- a/services/den/src/billing/polar.ts
+++ b/services/den/src/billing/polar.ts
@@ -414,15 +414,28 @@ async function listSubscriptionsByExternalCustomer(
     params.set("product_id", env.polar.productId)
   }
   params.set("limit", String(options.limit ?? 1))
-  params.set("sorting", "-created_at")
+  params.set("sorting", "-started_at")
 
   if (options.activeOnly === true) {
     params.set("active", "true")
   }
 
-  const { response, payload, text } = await polarFetchJson<PolarListResource<PolarSubscription>>(`/v1/subscriptions/?${params.toString()}`, {
+  const lookup = await polarFetchJson<PolarListResource<PolarSubscription>>(`/v1/subscriptions/?${params.toString()}`, {
     method: "GET",
   })
+  let response = lookup.response
+  let payload = lookup.payload
+  let text = lookup.text
+
+  if (response.status === 422 && params.has("sorting")) {
+    params.delete("sorting")
+    const fallbackLookup = await polarFetchJson<PolarListResource<PolarSubscription>>(`/v1/subscriptions/?${params.toString()}`, {
+      method: "GET",
+    })
+    response = fallbackLookup.response
+    payload = fallbackLookup.payload
+    text = fallbackLookup.text
+  }
 
   if (!response.ok) {
     throw new Error(`Polar subscriptions lookup failed (${response.status}): ${text.slice(0, 400)}`)
@@ -652,7 +665,7 @@ export async function getCloudWorkerBillingStatus(
   let invoices: CloudWorkerBillingInvoice[] = []
 
   const [subscriptionResult, priceResult, portalResult, invoicesResult] = await Promise.all([
-    getPrimarySubscriptionForCustomer(input.userId),
+    getPrimarySubscriptionForCustomer(input.userId).catch(() => null),
     env.polar.productId ? getProductBillingPrice(env.polar.productId).catch(() => null) : Promise.resolve<CloudWorkerBillingPrice | null>(null),
     includePortalUrl ? createCustomerPortalUrl(input.userId).catch(() => null) : Promise.resolve<string | null>(null),
     includeInvoices ? listBillingInvoices(input.userId).catch(() => []) : Promise.resolve<CloudWorkerBillingInvoice[]>([]),


### PR DESCRIPTION
## Summary
- Fix the Den billing regression where `/v1/workers/billing` returned `internal_error` after Polar rejected `sorting=-created_at` for subscriptions.
- Switch subscription sorting to `-started_at` (supported by current Polar API) and add a 422 fallback that retries without a sorting parameter.
- Make billing status resilient by treating subscription lookup as optional so non-critical Polar failures do not 500 the entire Billing page.

## Root cause
- Render logs for `den-control-plane-openwork` showed: `Polar subscriptions lookup failed (422)` with `sorting=-created_at` no longer accepted by Polar.
- The billing endpoint awaited subscription lookup without a catch, so this error propagated to Express and surfaced as `internal_error` in the web UI.

## Verification
- `pnpm install`
- `pnpm --filter @openwork/den build`
- Render API probe: `/logs?ownerId=...&resource=srv-d6ctuuogjchc73e4990g` confirms the failing 422 shape.
- Polar API probe with production token confirmed `-created_at -> 422` and `-started_at -> 200` on `/v1/subscriptions`.

## Notes
- Vercel API token currently configured on Render returns `invalidToken: true`; this does not cause the billing failure but should be rotated for DNS automation reliability.