### PR TITLE
docs: add PR template and contributor PR hygiene baseline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## Summary
+-
+
+## Why
+-
+
+## Issue
+- Closes #
+
+## Scope
+-
+
+## Out of scope
+-
+
+## Testing
+### Ran
+- `...`
+
+### Result
+- pass/fail:
+- if fail, exact files/errors:
+
+## CI status
+- pass:
+- code-related failures:
+- external/env/auth blockers:
+
+## Manual verification
+1.
+2.
+3.
+
+## Evidence
+- video/screenshot link, or `N/A (docs-only)`
+
+## Risk
+-
+
+## Rollback
+-

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ WEBKIT_DISABLE_COMPOSITING_MODE=1 openwork
 - Review `AGENTS.md` plus `VISION.md`, `PRINCIPLES.md`, `PRODUCT.md`, and `ARCHITECTURE.md` to understand the product goals before making changes.
 - Ensure Node.js, `pnpm`, the Rust toolchain, and `opencode` are installed before working inside the repo.
 - Run `pnpm install` once per checkout, then verify your change with `pnpm typecheck` plus `pnpm test:e2e` (or the targeted subset of scripts) before opening a PR.
+- Use `.github/pull_request_template.md` when opening PRs and include exact commands, outcomes, manual verification steps, and evidence.
+- If CI fails, classify failures in the PR body as either code-related regressions or external/environment/auth blockers.
 - Add new PRDs to `packages/app/pr/<name>.md` following the `.opencode/skills/prd-conventions/SKILL.md` conventions described in `AGENTS.md`.
 
 ## For Teams & Businesses


### PR DESCRIPTION
## Summary
- Add a repository-level PR template at `.github/pull_request_template.md` with required sections for context, testing, CI classification, manual verification, evidence, risk, and rollback.
- Update the README Contributing section to require using the PR template and classifying CI failures as code vs external blockers.

## Target behavior (defined first)
- Every new PR starts from the same structure so reviewers get consistent context and test evidence.
- Contributors explicitly separate code regressions from environment/auth blockers to speed triage.

## Test pipeline
- Docs structure checks:
  - Verify `.github/pull_request_template.md` exists and includes all required headings.
  - Verify README Contributing section links to the PR template and CI classification guidance.
- Repo checks:
  - Confirm only docs/template files changed for this issue.

## Verification
- Confirmed template content and headings in `.github/pull_request_template.md`.
- Confirmed README guidance at `README.md` Contributing section.
- Verified change scope via git diff/status (docs-only delta).

## Issue
- Closes #707

## Notes
- This is docs-only; Docker stack + Chrome MCP flow are not applicable for this change.