### PR TITLE
docs: add community health docs and issue triage rubric

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,55 @@
+# Code of Conduct
+
+## Our commitment
+
+We are committed to making participation in the OpenWork community a harassment-free
+experience for everyone, regardless of age, body size, disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Taking responsibility and apologizing to those affected by our mistakes.
+- Focusing on what is best for the community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery and sexual attention or advances.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information without explicit permission.
+- Other conduct that could reasonably be considered inappropriate in a professional
+  setting.
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in response
+to behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, including GitHub issues,
+pull requests, discussions, and direct interactions in official OpenWork channels.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to
+`benjamin.shafii@gmail.com` with as much context as possible.
+
+All reports will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1.
+
+[homepage]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![Discord](https://img.shields.io/badge/discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/VEhNQXxYMB)
 
 # OpenWork
+
 > OpenWork helps you run your agents, skills, and MCP. It's an open-source alternative to Claude Cowork/Codex (desktop app).
 
-
-  
 ## Core Philosophy
+
 - Local-first, cloud-ready: OpenWork runs on your machine in one click. Send a message instantly.
 - Composable: desktop app, WhatsApp/Slack/Telegram connector, or server. Use what fits, no lock-in.
 - Ejectable: OpenWork is powered by OpenCode, so everything OpenCode can do works in OpenWork, even without a UI yet.
@@ -15,9 +15,7 @@
   <img src="./app-demo.gif" alt="OpenWork demo" width="800" />
 </p>
 
-
 OpenWork is designed around the idea that you can easily ship your agentic workflows as a repeatable, productized process.
-
 
 ## Alternate UIs
 
@@ -30,8 +28,8 @@ OpenWork is designed around the idea that you can easily ship your agentic workf
   - run: `openwork start --workspace /path/to/workspace --approval auto`
   - docs: [packages/orchestrator/README.md](./packages/orchestrator/README.md)
 
-
 ## Quick start
+
 Download the dmg here https://github.com/different-ai/openwork/releases (or install from source below)
 
 ## Why
@@ -39,12 +37,13 @@ Download the dmg here https://github.com/different-ai/openwork/releases (or inst
 Current CLI and GUIs for opencode are anchored around developers. That means a focus on file diffs, tool names, and hard to extend capabilities without relying on exposing some form of cli.
 
 OpenWork is designed to be:
+
 - **Extensible**: skill and opencode plugins are installable modules.
 - **Auditable**: show what happened, when, and why.
 - **Permissioned**: access to privileged flows.
 - **Local/Remote**: OpenWork works locally as well as can connect to remote servers.
 
-## What’s Included 
+## What’s Included
 
 - **Host mode**: runs opencode locally on your computer
 - **Client mode**: connect to an existing OpenCode server by URL.
@@ -57,15 +56,14 @@ OpenWork is designed to be:
   - list installed `.opencode/skills` folders
   - install from OpenPackage (`opkg install ...`)
   - import a local skill folder into `.opencode/skills/<skill-name>`
- 
 
-## Skill Manager    
+## Skill Manager
+
 <img width="1292" height="932" alt="image" src="https://github.com/user-attachments/assets/b500c1c6-a218-42ce-8a11-52787f5642b6" />
 
-
 ## Works on local computer or servers
-<img width="1292" height="932" alt="Screenshot 2026-01-13 at 7 05 16 PM" src="https://github.com/user-attachments/assets/9c864390-de69-48f2-82c1-93b328dd60c3" />
 
+<img width="1292" height="932" alt="Screenshot 2026-01-13 at 7 05 16 PM" src="https://github.com/user-attachments/assets/9c864390-de69-48f2-82c1-93b328dd60c3" />
 
 ## Quick Start
 
@@ -118,12 +116,11 @@ This lets you run agentic workflows, send prompts, and see progress entirely on 
   - subscribe to SSE events(Server-Sent Events are used to stream real-time updates from the server to the UI.)
   - read todos and permission requests
 
-
-
 ## Folder Picker
 
 The folder picker uses the Tauri dialog plugin.
 Capability permissions are defined in:
+
 - `packages/desktop/src-tauri/capabilities/default.json`
 
 ## OpenPackage Notes
@@ -187,6 +184,21 @@ WEBKIT_DISABLE_COMPOSITING_MODE=1 openwork
 - Ensure Node.js, `pnpm`, the Rust toolchain, and `opencode` are installed before working inside the repo.
 - Run `pnpm install` once per checkout, then verify your change with `pnpm typecheck` plus `pnpm test:e2e` (or the targeted subset of scripts) before opening a PR.
 - Add new PRDs to `packages/app/pr/<name>.md` following the `.opencode/skills/prd-conventions/SKILL.md` conventions described in `AGENTS.md`.
+
+Community docs:
+
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+- `TRIAGE.md`
+
+First contribution checklist:
+
+- [ ] Run `pnpm install` and baseline verification commands.
+- [ ] Confirm your change has a clear issue link and scope.
+- [ ] Add/update tests for behavioral changes.
+- [ ] Include commands run and outcomes in your PR.
+- [ ] Add screenshots/video for user-facing flow changes.
 
 ## For Teams & Businesses
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported versions
+
+OpenWork is under active development and we prioritize fixes on the latest release and
+the current `dev` branch.
+
+## Reporting a vulnerability
+
+Please do not open public GitHub issues for security vulnerabilities.
+
+Instead, report vulnerabilities privately to:
+
+- Email: `benjamin.shafii@gmail.com`
+- Subject: `[OpenWork security] <short summary>`
+
+Please include:
+
+- A clear description of the issue
+- Reproduction steps or proof of concept
+- Impact assessment
+- Suggested remediation (if known)
+
+## Response expectations
+
+- We will acknowledge receipt within 3 business days.
+- We will provide an initial triage status within 7 business days.
+- We will share remediation or mitigation guidance as soon as available.
+
+## Disclosure guidance
+
+Please keep details private until a fix or mitigation is available and maintainers
+confirm public disclosure timing.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# Support
+
+## Where to ask for help
+
+Use the right channel to get faster help:
+
+- **Questions / usage help**: open a GitHub issue and mark it as a question.
+- **Bug reports**: use the Bug issue template.
+- **Feature requests**: use the Feature issue template.
+- **Security reports**: follow `SECURITY.md` and report privately.
+
+## Before opening an issue
+
+- Search existing issues to avoid duplicates.
+- Include exact OpenWork/OpenCode versions, OS, and reproduction steps.
+- Add logs/screenshots when possible.
+
+## Maintainer triage
+
+Maintainers use the rubric in `TRIAGE.md` to label and route issues.

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -1,0 +1,35 @@
+# Issue Triage Rubric
+
+This document defines how maintainers triage issues consistently.
+
+## Core type labels
+
+- `bug`: behavior does not match expected behavior.
+- `enhancement`: improvement to existing behavior.
+- `question`: support or usage request.
+
+Apply exactly one core type label whenever possible.
+
+## Contribution-oriented labels
+
+- `good first issue`: small, well-scoped, low-risk, and has clear acceptance criteria.
+- `help wanted` or `help needed`: maintainers welcome external contributions.
+- `needs-info`: issue cannot be actioned until reporter provides missing details.
+
+## Suggested triage flow
+
+1. Confirm issue template fields are complete.
+2. Add a core type label (`bug`, `enhancement`, or `question`).
+3. Add scope/difficulty labels if helpful.
+4. Add `needs-info` when reproduction details are missing.
+5. Add `good first issue` or `help wanted/help needed` only when issue is ready to build.
+
+## Closing guidance
+
+Close as:
+
+- `duplicate`: issue already tracked elsewhere.
+- `invalid`: report is not actionable or not a product issue.
+- `wontfix`: acknowledged but not planned.
+
+When closing, include a short reason and a link to related issue/docs when available.


### PR DESCRIPTION
## Summary
- Add community health docs: `CODE_OF_CONDUCT.md`, `SECURITY.md`, and `SUPPORT.md`.
- Add `TRIAGE.md` with label usage, triage flow, and close guidance.
- Update README Contributing with links to community docs and a first-contribution checklist.

## Target behavior (defined first)
- Contributors can quickly find conduct, security reporting, support routing, and triage policy in-repo.
- Maintainers triage issues with consistent label semantics and close criteria.
- First-time contributors have a short checklist before opening PRs.

## Test pipeline
- Content checks:
  - Verify each new markdown doc exists at repo root and is discoverable from README.
  - Verify triage rubric includes `good first issue`, `help wanted/help needed`, `needs-info`, and close criteria (`invalid`, `duplicate`, `wontfix`).
- Formatting checks:
  - `pnpm exec prettier --check README.md CODE_OF_CONDUCT.md SECURITY.md SUPPORT.md TRIAGE.md`

## Verification
- Added and verified all requested docs.
- Verified README links and checklist visibility.
- Formatting check passed:
  - `pnpm exec prettier --check README.md CODE_OF_CONDUCT.md SECURITY.md SUPPORT.md TRIAGE.md`

## Issue
- Closes #709

## Notes
- Docs-only PR; Docker/Chrome MCP flow is not applicable.