### PR TITLE
feat(settings): add persistent language preference in app settings

### DIFF
--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -70,6 +70,7 @@ import {
   SlidersHorizontal,
   Zap,
 } from "lucide-solid";
+import type { Language } from "../../i18n";
 
 export type DashboardViewProps = {
   tab: DashboardTab;
@@ -241,6 +242,8 @@ export type DashboardViewProps = {
   toggleHideTitlebar: () => void;
   modelVariantLabel: string;
   editModelVariant: () => void;
+  language: Language;
+  setLanguage: (value: Language) => void;
   updateAutoCheck: boolean;
   toggleUpdateAutoCheck: () => void;
   updateAutoDownload: boolean;
@@ -1332,6 +1335,8 @@ export default function DashboardView(props: DashboardViewProps) {
                   toggleHideTitlebar={props.toggleHideTitlebar}
                   modelVariantLabel={props.modelVariantLabel}
                   editModelVariant={props.editModelVariant}
+                  language={props.language}
+                  setLanguage={props.setLanguage}
                   updateAutoCheck={props.updateAutoCheck}
                   toggleUpdateAutoCheck={props.toggleUpdateAutoCheck}
                   updateAutoDownload={props.updateAutoDownload}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -28,7 +28,7 @@ import {
   openworkServerRestart,
   pickFile,
 } from "../lib/tauri";
-import { currentLocale, t } from "../../i18n";
+import { currentLocale, LANGUAGE_OPTIONS, t, type Language } from "../../i18n";
 
 export type SettingsViewProps = {
   startupPreference: StartupPreference | null;
@@ -76,6 +76,8 @@ export type SettingsViewProps = {
   toggleHideTitlebar: () => void;
   modelVariantLabel: string;
   editModelVariant: () => void;
+  language: Language;
+  setLanguage: (value: Language) => void;
   themeMode: "light" | "dark" | "system";
   setThemeMode: (value: "light" | "dark" | "system") => void;
   updateAutoCheck: boolean;
@@ -839,6 +841,25 @@ export default function SettingsView(props: SettingsViewProps) {
                 >
                   Dark
                 </Button>
+              </div>
+
+              <div class="space-y-2">
+                <div class="text-xs font-medium text-gray-11">{translate("settings.language")}</div>
+                <div class="text-xs text-gray-9">{translate("settings.language.description")}</div>
+                <div class="flex flex-wrap gap-2">
+                  <For each={LANGUAGE_OPTIONS}>
+                    {(option) => (
+                      <Button
+                        variant={props.language === option.value ? "secondary" : "outline"}
+                        class="text-xs h-8 py-0 px-3"
+                        onClick={() => props.setLanguage(option.value)}
+                        disabled={props.busy}
+                      >
+                        {option.nativeName}
+                      </Button>
+                    )}
+                  </For>
+                </div>
               </div>
 
               <div class="text-xs text-gray-8">

--- a/packages/app/src/i18n/index.ts
+++ b/packages/app/src/i18n/index.ts
@@ -59,6 +59,10 @@ export const setLocale = (newLocale: Language) => {
 
   setLocaleSignal(newLocale);
 
+  if (typeof document !== "undefined") {
+    document.documentElement.setAttribute("lang", newLocale);
+  }
+
   // Persist to localStorage
   if (typeof window !== "undefined") {
     try {
@@ -107,10 +111,17 @@ export const initLocale = (): Language => {
     const stored = window.localStorage.getItem(LANGUAGE_PREF_KEY);
     if (isLanguage(stored)) {
       setLocaleSignal(stored);
+      if (typeof document !== "undefined") {
+        document.documentElement.setAttribute("lang", stored);
+      }
       return stored;
     }
   } catch (e) {
     console.warn("Failed to read language preference:", e);
+  }
+
+  if (typeof document !== "undefined") {
+    document.documentElement.setAttribute("lang", "en");
   }
 
   return "en";

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -7,8 +7,10 @@ import "./app/index.css";
 import AppEntry from "./app/entry";
 import { PlatformProvider, type Platform } from "./app/context/platform";
 import { isTauriRuntime } from "./app/utils";
+import { initLocale } from "./i18n";
 
 bootstrapTheme();
+initLocale();
 
 const root = document.getElementById("root");
 


### PR DESCRIPTION
## Summary
- Wire language preference through Dashboard -> Settings props and expose language controls in Settings > General > Appearance.
- Initialize locale on app startup so stored preference is applied immediately.
- Update document `<html lang>` whenever locale changes for better browser/runtime semantics.

## Target behavior (defined first)
- Users can explicitly choose app language (English or Simplified Chinese) from Settings.
- Chosen language persists and is reloaded on next launch.
- Locale state is reflected in the document language attribute.

## Test pipeline
1. Build/runtime check:
   - `pnpm --filter @different-ai/openwork-ui build`
2. Type validation baseline:
   - `pnpm --filter @different-ai/openwork-ui typecheck`
3. Health script smoke check:
   - `pnpm --filter @different-ai/openwork-ui test:health`

## Verification
- `pnpm --filter @different-ai/openwork-ui build` ✅
- `pnpm --filter @different-ai/openwork-ui typecheck` ❌ (existing baseline TS7016 in `src/app/lib/local-file-path.ts` for `./local-file-path.impl.js`)
- `pnpm --filter @different-ai/openwork-ui test:health` ❌ (`Unauthorized` from local health script without matching auth/runtime context)

## Issue
- Closes #715

## Notes
- This PR focuses on language preference wiring and persistence in the app UI.
- Docker + Chrome MCP validation was not run for this non-flow backend-independent settings change.