### PR TITLE
fix(sidebar): preserve Windows directory case for task loading

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -103,6 +103,7 @@ import {
   isVisibleTextPart,
   isTauriRuntime,
   modelEquals,
+  normalizeDirectoryQueryPath,
   normalizeDirectoryPath,
 } from "./utils";
 import { currentLocale, setLocale, t, type Language } from "../i18n";
@@ -2481,7 +2482,7 @@ export default function App() {
       if (!directory) {
         try {
           const pathInfo = unwrap(await c.path.get());
-          const discovered = normalizeDirectoryPath(pathInfo.directory ?? "");
+          const discovered = normalizeDirectoryQueryPath(pathInfo.directory ?? "");
           if (discovered) {
             directory = discovered;
             c = createClient(config.baseUrl, directory, config.auth);
@@ -2491,13 +2492,7 @@ export default function App() {
         }
       }
 
-      const queryDirectory = (() => {
-        const trimmed = (directory ?? "").trim();
-        if (!trimmed) return undefined;
-        const unified = trimmed.replace(/\\/g, "/");
-        const withoutTrailing = unified.replace(/\/+$/, "");
-        return withoutTrailing || "/";
-      })();
+      const queryDirectory = normalizeDirectoryQueryPath(directory) || undefined;
 
       // Fetch sessions scoped to the workspace directory to avoid loading the
       // full global session list for every workspace.
@@ -4310,7 +4305,7 @@ export default function App() {
     if (!resolvedProjectDir) {
       try {
         const pathInfo = unwrap(await activeClient.path.get());
-        const discoveredRaw = normalizeDirectoryPath(pathInfo.directory ?? "");
+        const discoveredRaw = normalizeDirectoryQueryPath(pathInfo.directory ?? "");
         const discovered = discoveredRaw.replace(/^\/private\/tmp(?=\/|$)/, "/tmp");
         if (discovered) {
           resolvedProjectDir = discovered;
@@ -4500,7 +4495,7 @@ export default function App() {
     if (!resolvedProjectDir) {
       try {
         const pathInfo = unwrap(await activeClient.path.get());
-        const discoveredRaw = normalizeDirectoryPath(pathInfo.directory ?? "");
+        const discoveredRaw = normalizeDirectoryQueryPath(pathInfo.directory ?? "");
         const discovered = discoveredRaw.replace(/^\/private\/tmp(?=\/|$)/, "/tmp");
         if (discovered) {
           resolvedProjectDir = discovered;

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -18,6 +18,7 @@ import type {
 } from "../types";
 import {
   addOpencodeCacheHint,
+  normalizeDirectoryQueryPath,
   modelFromUserMessage,
   normalizeDirectoryPath,
   normalizeEvent,
@@ -592,13 +593,7 @@ export function createSessionStore(options: {
     // Note: We intentionally normalize slashes + trailing separators but do NOT
     // lowercase on Windows for the query value because the server does strict
     // string equality against the stored session.directory.
-    const queryDirectory = (() => {
-      const trimmed = (scopeRoot ?? "").trim();
-      if (!trimmed) return undefined;
-      const unified = trimmed.replace(/\\/g, "/");
-      const withoutTrailing = unified.replace(/\/+$/, "");
-      return withoutTrailing || "/";
-    })();
+    const queryDirectory = normalizeDirectoryQueryPath(scopeRoot) || undefined;
 
     const start = Date.now();
     sessionDebug("sessions:load:start", { scopeRoot: scopeRoot ?? null, queryDirectory: queryDirectory ?? null });

--- a/packages/app/src/app/utils/index.ts
+++ b/packages/app/src/app/utils/index.ts
@@ -180,12 +180,17 @@ export function formatBytes(bytes: number) {
   return `${rounded} ${units[idx]}`;
 }
 
-export function normalizeDirectoryPath(input?: string | null) {
+export function normalizeDirectoryQueryPath(input?: string | null) {
   const trimmed = (input ?? "").trim();
   if (!trimmed) return "";
   const unified = trimmed.replace(/\\/g, "/");
   const withoutTrailing = unified.replace(/\/+$/, "");
-  const normalized = withoutTrailing || "/";
+  return withoutTrailing || "/";
+}
+
+export function normalizeDirectoryPath(input?: string | null) {
+  const normalized = normalizeDirectoryQueryPath(input);
+  if (!normalized) return "";
   return isWindowsPlatform() ? normalized.toLowerCase() : normalized;
 }
 


### PR DESCRIPTION
## Summary
- Add `normalizeDirectoryQueryPath` for query-safe path normalization (slashes + trailing separators only, no Windows lowercasing).
- Use query-safe normalization for sidebar session list queries and path discovery updates.
- Reuse the same helper in session store loading to keep query behavior consistent.

## Target behavior (defined first)
- On Windows, sidebar task loading should not fail because query directory casing differs from the server's stored `session.directory` value.
- Workers should stay in `ready` state after refresh/restart instead of switching to `Failed to load tasks` from strict path mismatch.

## Test pipeline
1. Build regression check:
   - `pnpm --filter @different-ai/openwork-ui build`
2. Typecheck baseline:
   - `pnpm --filter @different-ai/openwork-ui typecheck`
3. Filesystem flow script:
   - `pnpm --filter @different-ai/openwork-ui test:fs-engine`

## Verification
- `pnpm --filter @different-ai/openwork-ui build` ✅
- `pnpm --filter @different-ai/openwork-ui typecheck` ❌ (existing baseline TS7016 in `src/app/lib/local-file-path.ts`)
- `pnpm --filter @different-ai/openwork-ui test:fs-engine` ❌ (`Unauthorized` in local health check context)

## Issue
- Closes #717

## Notes
- This fix is intentionally scoped to directory query normalization and does not change client-side comparison normalization.
- Windows-specific runtime validation (desktop + refresh cycle) should be run by reviewers in a Windows environment.