### PR TITLE
fix: route docs to /docs subpath consistently

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -20,7 +20,7 @@
           {
             "group": "Foundations",
             "pages": [
-              "index",
+              "introduction",
               "openwork",
               "orbita-layout-style",
               "opencode-router",
@@ -29,10 +29,7 @@
           },
           {
             "group": "Agent Playbooks",
-            "pages": [
-              "quickstart",
-              "create-openwork-instance"
-            ]
+            "pages": ["quickstart", "create-openwork-instance"]
           },
           {
             "group": "Tutorials",
@@ -45,9 +42,7 @@
           },
           {
             "group": "Contributing",
-            "pages": [
-              "development"
-            ]
+            "pages": ["development"]
           }
         ]
       }

--- a/packages/docs/introduction.mdx
+++ b/packages/docs/introduction.mdx
@@ -23,7 +23,8 @@ Use this docs set to deploy OpenWork quickly, onboard teammates, and keep work p
     Get from install to first worker in minutes.
   </Card>
   <Card title="CLI" icon="terminal" href="/cli">
-    Run OpenWork with `openwrk`, `openwork-server`, and `opencode-router`.
+    Run OpenWork with `openwork-orchestrator`, `openwork-server`, and
+    `opencode-router`.
   </Card>
   <Card title="OpenCode Router" icon="message-square" href="/opencode-router">
     Route Slack and Telegram messages to the right workspace directory.
@@ -31,7 +32,11 @@ Use this docs set to deploy OpenWork quickly, onboard teammates, and keep work p
   <Card title="Orbita UI Style" icon="layout" href="/orbita-layout-style">
     Session-surface layout, typography, and interaction baseline.
   </Card>
-  <Card title="Worker isolation" icon="shield" href="/tutorials/worker-isolation">
+  <Card
+    title="Worker isolation"
+    icon="shield"
+    href="/tutorials/worker-isolation"
+  >
     Avoid the shared-context chaos by separating workers by domain.
   </Card>
 </CardGroup>

--- a/packages/landing/next.config.js
+++ b/packages/landing/next.config.js
@@ -3,6 +3,60 @@ const mintlifyOrigin = "https://differentai.mintlify.app";
 
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/introduction",
+        destination: "/docs",
+        permanent: false,
+      },
+      {
+        source: "/get-started",
+        destination: "/docs/quickstart",
+        permanent: false,
+      },
+      {
+        source: "/quickstart",
+        destination: "/docs/quickstart",
+        permanent: false,
+      },
+      {
+        source: "/development",
+        destination: "/docs/development",
+        permanent: false,
+      },
+      {
+        source: "/openwork",
+        destination: "/docs/openwork",
+        permanent: false,
+      },
+      {
+        source: "/opencode-router",
+        destination: "/docs/opencode-router",
+        permanent: false,
+      },
+      {
+        source: "/cli",
+        destination: "/docs/cli",
+        permanent: false,
+      },
+      {
+        source: "/create-openwork-instance",
+        destination: "/docs/create-openwork-instance",
+        permanent: false,
+      },
+      {
+        source: "/tutorials/:path*",
+        destination: "/docs/tutorials/:path*",
+        permanent: false,
+      },
+      {
+        source: "/api-reference/:path*",
+        destination: "/docs/api-reference/:path*",
+        permanent: false,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {
@@ -15,73 +69,15 @@ const nextConfig = {
       },
       {
         source: "/docs",
-        destination: `${mintlifyOrigin}/`,
+        destination: `${mintlifyOrigin}/introduction`,
       },
       {
         source: "/docs/get-started",
         destination: `${mintlifyOrigin}/quickstart`,
       },
       {
-        source: "/docs/llms.txt",
-        destination: `${mintlifyOrigin}/llms.txt`,
-      },
-      {
-        source: "/docs/llms-full.txt",
-        destination: `${mintlifyOrigin}/llms-full.txt`,
-      },
-      {
-        source: "/docs/sitemap.xml",
-        destination: `${mintlifyOrigin}/sitemap.xml`,
-      },
-      {
-        source: "/docs/robots.txt",
-        destination: `${mintlifyOrigin}/robots.txt`,
-      },
-      {
-        source: "/docs/mcp",
-        destination: `${mintlifyOrigin}/mcp`,
-      },
-      {
         source: "/docs/:path*",
         destination: `${mintlifyOrigin}/:path*`,
-      },
-      // Mintlify emits root-based links (e.g. /cli) even when embedded under /docs.
-      // Mirror key docs routes at the root so in-doc navigation does not break.
-      {
-        source: "/get-started",
-        destination: `${mintlifyOrigin}/quickstart`,
-      },
-      {
-        source: "/quickstart",
-        destination: `${mintlifyOrigin}/quickstart`,
-      },
-      {
-        source: "/development",
-        destination: `${mintlifyOrigin}/development`,
-      },
-      {
-        source: "/openwork",
-        destination: `${mintlifyOrigin}/openwork`,
-      },
-      {
-        source: "/opencode-router",
-        destination: `${mintlifyOrigin}/opencode-router`,
-      },
-      {
-        source: "/cli",
-        destination: `${mintlifyOrigin}/cli`,
-      },
-      {
-        source: "/create-openwork-instance",
-        destination: `${mintlifyOrigin}/create-openwork-instance`,
-      },
-      {
-        source: "/tutorials/:path*",
-        destination: `${mintlifyOrigin}/tutorials/:path*`,
-      },
-      {
-        source: "/api-reference/:path*",
-        destination: `${mintlifyOrigin}/api-reference/:path*`,
       },
       {
         source: "/mintlify-assets/:path+",


### PR DESCRIPTION
## Summary
- fixes #719 by making `/docs` the canonical docs root and keeping doc links/references under `/docs/*` instead of mirroring docs pages at site root.
- updates Mintlify docs config and landing rewrites so legacy root-level doc paths (`/quickstart`, `/development`, etc.) 307-redirect to `/docs/*`.
- renames docs entry page from `index.mdx` to `introduction.mdx` so direct docs pages no longer resolve as root-page mirrors.

## Expected behavior
- Visiting `/docs` or `/docs/*` renders docs content.
- Legacy root docs URLs redirect to `/docs/*` and keep working.
- The marketing homepage (`/`) stays independent from docs entry content.

## Test pipeline
- `pnpm --filter @different-ai/openwork-landing build`
- Inspect generated `packages/landing/.next/routes-manifest.json` to verify root legacy redirects now target `/docs/*`.