### PR TITLE
fix: keep long-running loops from pausing on doom-loop prompts

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4657,6 +4657,13 @@ export default function App() {
         mark("session:create:start");
         rawResult = await c.session.create({
           directory: workspaceStore.activeWorkspaceRoot().trim(),
+          permission: [
+            {
+              permission: "doom_loop",
+              pattern: "*",
+              action: "allow",
+            },
+          ],
         });
         mark("session:create:ok");
       } catch (createErr) {


### PR DESCRIPTION
## Summary
- fixes #723 by creating new sessions with an explicit `doom_loop` permission rule set to `allow`.
- this prevents repetitive-loop guard prompts from blocking autonomous runs that intentionally continue until stopped by the user.
- keeps existing per-tool permission prompts unchanged; this only targets the `doom_loop` guard.

## Expected behavior
- Prompts like "count until I say stop" continue running without being interrupted by a doom-loop permission modal.
- Other permission gates (file edits, shell, network, etc.) still require explicit user approval under existing rules.

## Test pipeline
- `pnpm install`
- `pnpm --filter @different-ai/openwork-ui typecheck` *(fails on existing baseline `TS7016` in `packages/app/src/app/lib/local-file-path.ts`; unrelated to this patch)*