### PR TITLE
feat: add auto context compaction after completed runs

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -51,6 +51,7 @@ import {
 } from "./lib/opencode-session";
 import { clearPerfLogs, finishPerf, perfNow, recordPerfLog } from "./lib/perf-log";
 import {
+  AUTO_COMPACT_CONTEXT_PREF_KEY,
   DEFAULT_MODEL,
   HIDE_TITLEBAR_PREF_KEY,
   MCP_QUICK_CONNECT,
@@ -1617,6 +1618,34 @@ export default function App() {
     }
   }
 
+  const triggerAutoCompaction = async (sessionID: string) => {
+    if (!autoCompactContext()) return;
+    if (autoCompactingSessionId() === sessionID) return;
+
+    setAutoCompactingSessionId(sessionID);
+    try {
+      await compactCurrentSession(sessionID);
+    } catch {
+      // ignore auto-compaction failures; manual compact remains available
+    } finally {
+      setAutoCompactingSessionId((current) => (current === sessionID ? null : current));
+    }
+  };
+
+  const [lastSessionStatus, setLastSessionStatus] = createSignal<string | null>(null);
+  createEffect(() => {
+    const sessionID = selectedSessionId();
+    const status = sessionID ? sessionStatusById()[sessionID] ?? null : null;
+    const previous = lastSessionStatus();
+    setLastSessionStatus(status);
+
+    if (!sessionID) return;
+    if (!autoCompactContext()) return;
+    if (status !== "idle") return;
+    if (!previous || previous === "idle") return;
+    void triggerAutoCompaction(sessionID);
+  });
+
   const messageIdFromInfo = (message: MessageWithParts) => {
     const id = (message.info as { id?: string | number }).id;
     if (typeof id === "string") return id;
@@ -2255,7 +2284,9 @@ export default function App() {
 
   const [showThinking, setShowThinking] = createSignal(false);
   const [hideTitlebar, setHideTitlebar] = createSignal(false);
+  const [autoCompactContext, setAutoCompactContext] = createSignal(false);
   const [modelVariant, setModelVariant] = createSignal<string | null>(null);
+  const [autoCompactingSessionId, setAutoCompactingSessionId] = createSignal<string | null>(null);
 
   const MODEL_VARIANT_OPTIONS = [
     { value: "none", label: "None" },
@@ -4862,6 +4893,18 @@ export default function App() {
           }
         }
 
+        const storedAutoCompactContext = window.localStorage.getItem(AUTO_COMPACT_CONTEXT_PREF_KEY);
+        if (storedAutoCompactContext != null) {
+          try {
+            const parsed = JSON.parse(storedAutoCompactContext);
+            if (typeof parsed === "boolean") {
+              setAutoCompactContext(parsed);
+            }
+          } catch {
+            // ignore
+          }
+        }
+
         const storedVariant = window.localStorage.getItem(VARIANT_PREF_KEY);
         if (storedVariant && storedVariant.trim()) {
           const normalized = normalizeModelVariant(storedVariant);
@@ -5300,6 +5343,15 @@ export default function App() {
   createEffect(() => {
     if (typeof window === "undefined") return;
     try {
+      window.localStorage.setItem(AUTO_COMPACT_CONTEXT_PREF_KEY, JSON.stringify(autoCompactContext()));
+    } catch {
+      // ignore
+    }
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
       const value = modelVariant();
       if (value) {
         window.localStorage.setItem(VARIANT_PREF_KEY, value);
@@ -5711,6 +5763,8 @@ export default function App() {
       openDefaultModelPicker,
       showThinking: showThinking(),
       toggleShowThinking: () => setShowThinking((v) => !v),
+      autoCompactContext: autoCompactContext(),
+      toggleAutoCompactContext: () => setAutoCompactContext((v) => !v),
       hideTitlebar: hideTitlebar(),
       toggleHideTitlebar: () => setHideTitlebar((v) => !v),
       modelVariantLabel: formatModelVariantLabel(modelVariant()),
@@ -5884,6 +5938,8 @@ export default function App() {
     busyLabel: busyLabel(),
     developerMode: developerMode(),
     showThinking: showThinking(),
+    autoCompactContext: autoCompactContext(),
+    toggleAutoCompactContext: () => setAutoCompactContext((v) => !v),
     groupMessageParts,
     summarizeStep,
     expandedStepIds: expandedStepIds(),

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -6,6 +6,7 @@ export const THINKING_PREF_KEY = "openwork.showThinking";
 export const VARIANT_PREF_KEY = "openwork.modelVariant";
 export const LANGUAGE_PREF_KEY = "openwork.language";
 export const HIDE_TITLEBAR_PREF_KEY = "openwork.hideTitlebar";
+export const AUTO_COMPACT_CONTEXT_PREF_KEY = "openwork.autoCompactContext";
 
 export const DEFAULT_MODEL: ModelRef = {
   providerID: "opencode",

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -237,6 +237,8 @@ export type DashboardViewProps = {
   openDefaultModelPicker: () => void;
   showThinking: boolean;
   toggleShowThinking: () => void;
+  autoCompactContext: boolean;
+  toggleAutoCompactContext: () => void;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
   modelVariantLabel: string;
@@ -1328,6 +1330,8 @@ export default function DashboardView(props: DashboardViewProps) {
                   openDefaultModelPicker={props.openDefaultModelPicker}
                   showThinking={props.showThinking}
                   toggleShowThinking={props.toggleShowThinking}
+                  autoCompactContext={props.autoCompactContext}
+                  toggleAutoCompactContext={props.toggleAutoCompactContext}
                   hideTitlebar={props.hideTitlebar}
                   toggleHideTitlebar={props.toggleHideTitlebar}
                   modelVariantLabel={props.modelVariantLabel}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -72,6 +72,8 @@ export type SettingsViewProps = {
   openDefaultModelPicker: () => void;
   showThinking: boolean;
   toggleShowThinking: () => void;
+  autoCompactContext: boolean;
+  toggleAutoCompactContext: () => void;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
   modelVariantLabel: string;
@@ -883,6 +885,21 @@ export default function SettingsView(props: SettingsViewProps) {
                   disabled={props.busy}
                 >
                   {props.showThinking ? "On" : "Off"}
+                </Button>
+              </div>
+
+              <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                <div class="min-w-0">
+                  <div class="text-sm text-gray-12">Auto context compaction</div>
+                  <div class="text-xs text-gray-7">Automatically compact after a run completes.</div>
+                </div>
+                <Button
+                  variant="outline"
+                  class="text-xs h-8 py-0 px-3 shrink-0"
+                  onClick={props.toggleAutoCompactContext}
+                  disabled={props.busy}
+                >
+                  {props.autoCompactContext ? "On" : "Off"}
                 </Button>
               </div>
 


### PR DESCRIPTION
## Summary
- fixes #691 by adding an **Auto context compaction** setting in Model settings.
- when enabled, OpenWork automatically triggers session compaction after the selected session transitions from running to idle.
- persists the setting in local storage (`openwork.autoCompactContext`) so it stays enabled across restarts.

## Expected behavior
- Users can enable/disable auto compaction from Settings -> Model.
- With auto compaction enabled, completed runs are compacted automatically to reduce context bloat and token spend.
- Manual compaction remains available; auto mode is best-effort and silently skips errors.

## Test pipeline
- `pnpm install`
- `pnpm --filter @different-ai/openwork-ui typecheck` *(fails on existing baseline `TS7016` in `packages/app/src/app/lib/local-file-path.ts`; unrelated to this patch)*