### PR TITLE
fix: send codex reasoning via reasoning_effort consistently

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1464,6 +1464,7 @@ export default function App() {
       const parts = buildPromptParts(resolvedDraft);
       const selectedVariant = modelVariant() ?? undefined;
       const reasoningEffort = resolveCodexReasoningEffort(model.modelID, selectedVariant ?? null);
+      const requestVariant = reasoningEffort ? undefined : selectedVariant;
       const promptOverrides = reasoningEffort
         ? ({ reasoning_effort: reasoningEffort } as const)
         : undefined;
@@ -1498,7 +1499,7 @@ export default function App() {
             arguments: command.arguments,
             agent: agent ?? undefined,
             model: modelString,
-            variant: selectedVariant,
+            variant: requestVariant,
             ...(promptOverrides ?? {}),
             parts: files.length ? files : undefined,
           }),
@@ -1509,7 +1510,7 @@ export default function App() {
           sessionID,
           model,
           agent: agent ?? undefined,
-          variant: selectedVariant,
+          variant: requestVariant,
           ...(promptOverrides ?? {}),
           parts,
         });


### PR DESCRIPTION
## Summary
- fixes #689 by preferring `reasoning_effort` for codex models and omitting `variant` when a codex reasoning level is resolved.
- keeps variant behavior unchanged for non-codex models.
- prevents mixed payloads (`variant` + `reasoning_effort`) from diverging and producing unexpected medium-level fallback behavior.

## Expected behavior
- For codex models, OpenWork sends a single normalized reasoning setting via `reasoning_effort` (with `xhigh` normalized to `high`).
- The selected thinking level is consistently respected across prompt and slash-command request paths.

## Test pipeline
- `pnpm install`
- `pnpm --filter @different-ai/openwork-ui typecheck` *(fails on existing baseline `TS7016` in `packages/app/src/app/lib/local-file-path.ts`; unrelated to this patch)*