### PR TITLE
feat(app): virtualize session message rendering

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,6 +38,7 @@
     "@solid-primitives/event-bus": "^1.1.2",
     "@solid-primitives/storage": "^4.3.3",
     "@solidjs/router": "^0.15.4",
+    "@tanstack/solid-virtual": "^3.13.19",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-deep-link": "^2.4.7",
     "@tauri-apps/plugin-dialog": "~2.6.0",

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -1,7 +1,8 @@
-import { For, Show, createMemo, createSignal, onCleanup } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 import type { JSX } from "solid-js";
 import type { Part } from "@opencode-ai/sdk/v2/client";
 import { Check, ChevronDown, ChevronRight, Copy, Eye, File, FileEdit, FolderSearch, Pencil, Search, Sparkles, Terminal } from "lucide-solid";
+import { createVirtualizer } from "@tanstack/solid-virtual";
 
 import type { MessageGroup, MessageWithParts, StepGroupMode } from "../../types";
 import { groupMessageParts, isUserVisiblePart, summarizeStep } from "../../utils";
@@ -20,6 +21,8 @@ export type MessageListProps = {
   activeSearchMessageId?: string | null;
   searchHighlightQuery?: string;
   workspaceRoot?: string;
+  scrollElement?: () => HTMLElement | null | undefined;
+  virtualizationThreshold?: number;
   footer?: JSX.Element;
 };
 
@@ -427,6 +430,43 @@ export default function MessageList(props: MessageListProps) {
     };
   };
 
+  const blockContainsMessageId = (block: MessageBlockItem, messageId: string) => {
+    if (!messageId) return false;
+    if (block.kind === "steps-cluster") {
+      return block.messageIds.includes(messageId);
+    }
+    return block.messageId === messageId;
+  };
+
+  const virtualizationThreshold = () => props.virtualizationThreshold ?? 30;
+  const shouldVirtualize = createMemo(() => messageBlocks().length >= virtualizationThreshold());
+
+  const virtualizer = createVirtualizer<HTMLElement, HTMLDivElement>({
+    get count() {
+      return shouldVirtualize() ? messageBlocks().length : 0;
+    },
+    getScrollElement: () => props.scrollElement?.() ?? null,
+    estimateSize: () => 220,
+    overscan: 6,
+    getItemKey: (index) => {
+      const block = messageBlocks()[index];
+      if (!block) return `block-${index}`;
+      if (block.kind === "steps-cluster") {
+        return `steps-${block.messageIds.join(",")}`;
+      }
+      return `message-${block.messageId}`;
+    },
+  });
+
+  createEffect(() => {
+    if (!shouldVirtualize()) return;
+    const activeMessageId = props.activeSearchMessageId?.trim();
+    if (!activeMessageId) return;
+    const index = messageBlocks().findIndex((block) => blockContainsMessageId(block, activeMessageId));
+    if (index < 0) return;
+    virtualizer.scrollToIndex(index, { align: "center" });
+  });
+
   /** Compact single-line step row */
   const StepRow = (rowProps: { part: Part; isUser: boolean; groupMode?: StepGroupMode }) => {
     const summary = createMemo(() => summarizeStep(rowProps.part));
@@ -809,10 +849,7 @@ export default function MessageList(props: MessageListProps) {
     );
   };
 
-  return (
-    <div class="space-y-4 pb-24" style={{ contain: "layout paint style" }}>
-      <For each={messageBlocks()}>
-        {(block, blockIndex) => {
+  const renderBlock = (block: MessageBlockItem, blockIndex: number) => {
           const blockMessageIds = block.kind === "steps-cluster" ? block.messageIds : [block.messageId];
           const hasSearchMatch = blockMessageIds.some((id) => props.searchMatchMessageIds?.has(id));
           const hasActiveSearchMatch = blockMessageIds.some((id) => id === props.activeSearchMessageId);
@@ -828,7 +865,7 @@ export default function MessageList(props: MessageListProps) {
                 class={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
                 data-message-role={block.isUser ? "user" : "assistant"}
                 data-message-id={block.messageIds[0] ?? ""}
-                style={blockPerfStyle(blockIndex())}
+                style={blockPerfStyle(blockIndex)}
               >
                 <div
                   class={`w-full relative ${
@@ -854,7 +891,7 @@ export default function MessageList(props: MessageListProps) {
               class={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
               data-message-role={block.isUser ? "user" : "assistant"}
               data-message-id={block.messageId}
-              style={blockPerfStyle(blockIndex())}
+              style={blockPerfStyle(blockIndex)}
             >
               <div
                 class={`w-full relative ${
@@ -951,8 +988,40 @@ export default function MessageList(props: MessageListProps) {
               </div>
             </div>
           );
-        }}
-      </For>
+        };
+
+  return (
+    <div class="space-y-4 pb-24" style={{ contain: "layout paint style" }}>
+      <Show
+        when={shouldVirtualize()}
+        fallback={
+          <For each={messageBlocks()}>
+            {(block, index) => renderBlock(block, index())}
+          </For>
+        }
+      >
+        <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
+          <For each={virtualizer.getVirtualItems()}>
+            {(item) => {
+              const block = () => messageBlocks()[item.index];
+              return (
+                <div
+                  ref={(el) => virtualizer.measureElement(el)}
+                  style={{
+                    position: "absolute",
+                    top: "0",
+                    left: "0",
+                    width: "100%",
+                    transform: `translateY(${item.start}px)`,
+                  }}
+                >
+                  <Show when={block()}>{(value) => renderBlock(value(), item.index)}</Show>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
       <Show when={props.footer}>{props.footer}</Show>
     </div>
   );

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -3618,6 +3618,7 @@ export default function SessionView(props: SessionViewProps) {
             searchMatchMessageIds={searchMatchMessageIds()}
             activeSearchMessageId={activeSearchHit()?.messageId ?? null}
             searchHighlightQuery={searchQueryDebounced().trim()}
+            scrollElement={() => chatContainerEl}
             footer={
               showRunIndicator() ? (
                 <div class="flex justify-start pl-2">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@solidjs/router':
         specifier: ^0.15.4
         version: 0.15.4(patch_hash=1db11a7c28fe4da76187d42efaffc6b9a70ad370462fffb794ff90e67744d770)(solid-js@1.9.10)
+      '@tanstack/solid-virtual':
+        specifier: ^3.13.19
+        version: 3.13.19(solid-js@1.9.10)
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.9.1
@@ -1559,6 +1562,14 @@ packages:
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/solid-virtual@3.13.19':
+    resolution: {integrity: sha512-4uCuwY/nfQzoxuJCOroEGgRQkoDuzRE4wVdDq47InQ9WPQ+1dkBUyE7k7frcTPy+l1yjCCmLGdq9h9GQyofVHw==}
+    peerDependencies:
+      solid-js: ^1.3.0
+
+  '@tanstack/virtual-core@3.13.19':
+    resolution: {integrity: sha512-/BMP7kNhzKOd7wnDeB8NrIRNLwkf5AhCYCvtfZV2GXWbBieFm/el0n6LOAXlTi6ZwHICSNnQcIxRCWHrLzDY+g==}
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
@@ -4541,6 +4552,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 6.4.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@tanstack/solid-virtual@3.13.19(solid-js@1.9.10)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.19
+      solid-js: 1.9.10
+
+  '@tanstack/virtual-core@3.13.19': {}
 
   '@tauri-apps/api@2.10.1': {}
 


### PR DESCRIPTION
## Summary
- add `@tanstack/solid-virtual` and virtualize the session transcript rendering path in `MessageList`
- switch from rendering every message block to rendering only visible rows, with measured dynamic row heights and overscan
- keep existing step grouping/search highlighting behavior and wire search navigation to scroll to virtualized rows
- pass the chat scroll container into `MessageList` so virtual scrolling uses the existing conversation viewport

## Validation
- `pnpm --filter @different-ai/openwork-ui typecheck` ✅
- `pnpm --filter @different-ai/openwork-ui build` ✅
- `pnpm --filter @different-ai/openwork-ui test:session-switch` ⚠️ fails in this environment with `Timed out waiting for /global/health: Unauthorized`
- manual sanity check in dev server: opened conversation sessions and verified transcript still renders, steps expand/collapse, and composer/search controls remain available