### PR TITLE
fix(app): prevent blank transcript in virtualized sessions

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -22,6 +22,7 @@ export type MessageListProps = {
   searchHighlightQuery?: string;
   workspaceRoot?: string;
   scrollElement?: () => HTMLElement | null | undefined;
+  scrollReady?: boolean;
   virtualizationThreshold?: number;
   footer?: JSX.Element;
 };
@@ -439,7 +440,9 @@ export default function MessageList(props: MessageListProps) {
   };
 
   const virtualizationThreshold = () => props.virtualizationThreshold ?? 30;
-  const shouldVirtualize = createMemo(() => messageBlocks().length >= virtualizationThreshold());
+  const shouldVirtualize = createMemo(
+    () => Boolean(props.scrollReady) && messageBlocks().length >= virtualizationThreshold(),
+  );
 
   const virtualizer = createVirtualizer<HTMLElement, HTMLDivElement>({
     get count() {
@@ -466,6 +469,15 @@ export default function MessageList(props: MessageListProps) {
     if (index < 0) return;
     virtualizer.scrollToIndex(index, { align: "center" });
   });
+
+  createEffect(() => {
+    if (!shouldVirtualize()) return;
+    queueMicrotask(() => {
+      virtualizer.measure();
+    });
+  });
+
+  const virtualItems = createMemo(() => virtualizer.getVirtualItems());
 
   /** Compact single-line step row */
   const StepRow = (rowProps: { part: Part; isUser: boolean; groupMode?: StepGroupMode }) => {
@@ -1000,27 +1012,36 @@ export default function MessageList(props: MessageListProps) {
           </For>
         }
       >
-        <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
-          <For each={virtualizer.getVirtualItems()}>
-            {(item) => {
-              const block = () => messageBlocks()[item.index];
-              return (
-                <div
-                  ref={(el) => virtualizer.measureElement(el)}
-                  style={{
-                    position: "absolute",
-                    top: "0",
-                    left: "0",
-                    width: "100%",
-                    transform: `translateY(${item.start}px)`,
-                  }}
-                >
-                  <Show when={block()}>{(value) => renderBlock(value(), item.index)}</Show>
-                </div>
-              );
-            }}
-          </For>
-        </div>
+        <Show
+          when={virtualItems().length > 0}
+          fallback={
+            <For each={messageBlocks()}>
+              {(block, index) => renderBlock(block, index())}
+            </For>
+          }
+        >
+          <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
+            <For each={virtualItems()}>
+              {(item) => {
+                const block = () => messageBlocks()[item.index];
+                return (
+                  <div
+                    ref={(el) => virtualizer.measureElement(el)}
+                    style={{
+                      position: "absolute",
+                      top: "0",
+                      left: "0",
+                      width: "100%",
+                      transform: `translateY(${item.start}px)`,
+                    }}
+                  >
+                    <Show when={block()}>{(value) => renderBlock(value(), item.index)}</Show>
+                  </div>
+                );
+              }}
+            </For>
+          </div>
+        </Show>
       </Show>
       <Show when={props.footer}>{props.footer}</Show>
     </div>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -294,6 +294,7 @@ export default function SessionView(props: SessionViewProps) {
   let messagesEndEl: HTMLDivElement | undefined;
   let bottomVisibilityEl: HTMLDivElement | undefined;
   let chatContainerEl: HTMLDivElement | undefined;
+  const [isChatContainerReady, setIsChatContainerReady] = createSignal(false);
   let agentPickerRef: HTMLDivElement | undefined;
   let sessionMenuRef: HTMLDivElement | undefined;
   let searchInputEl: HTMLInputElement | undefined;
@@ -3548,7 +3549,10 @@ export default function SessionView(props: SessionViewProps) {
             <div
               class="h-full overflow-y-auto px-8 pt-12 pb-56 scroll-smooth bg-gray-1"
               style={{ contain: "layout paint style" }}
-              ref={(el) => (chatContainerEl = el)}
+              ref={(el) => {
+                chatContainerEl = el;
+                setIsChatContainerReady(Boolean(el));
+              }}
             >
               <div class="max-w-[650px] mx-auto w-full">
            <Show when={props.messages.length === 0}>
@@ -3619,6 +3623,7 @@ export default function SessionView(props: SessionViewProps) {
             activeSearchMessageId={activeSearchHit()?.messageId ?? null}
             searchHighlightQuery={searchQueryDebounced().trim()}
             scrollElement={() => chatContainerEl}
+            scrollReady={isChatContainerReady()}
             footer={
               showRunIndicator() ? (
                 <div class="flex justify-start pl-2">


### PR DESCRIPTION
## Summary
- gate session virtualization on scroll-container readiness so long sessions do not enter virtual mode before the viewport is mounted
- add a defensive fallback: if virtual mode is active but no virtual rows are produced, render the standard message list instead of showing a blank transcript
- trigger virtualizer measurement after activation to stabilize row measurement on mount and session switches

## Validation
- `pnpm --filter @different-ai/openwork-ui build` ✅
- `pnpm --filter @different-ai/openwork-ui typecheck` ⚠️ fails on existing repo issue: `src/app/lib/local-file-path.ts(1,70): Could not find a declaration file for module './local-file-path.impl.js'`
- Manual Chrome MCP verification ✅
  - `ses_348e6379bffewp4yT3FIMjt5le` (USDC fees thread, long session) now renders transcript content
  - `ses_3492f7816ffeR17b2SvoaRzWMT` (scheduling thread) still renders as expected