### PR TITLE
Fix PKGBUILD - Remove opencode binary if present

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -23,7 +23,7 @@ package() {
 
   # Extract the internal data archive directly to the cwd.
   bsdtar -O -xf "${pkgname}-${pkgver}.deb" 'data.tar*' | bsdtar -C "${pkgdir}" -xf -
-    if [ -f /usr/bin/opencode ]; then rm -f "${pkgdir}/usr/bin/opencode"; fi;
+  rm -f "${pkgdir}/usr/bin/opencode"
 }
 
 # .deb Internal Structure Reference:

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -23,6 +23,7 @@ package() {
 
   # Extract the internal data archive directly to the cwd.
   bsdtar -O -xf "${pkgname}-${pkgver}.deb" 'data.tar*' | bsdtar -C "${pkgdir}" -xf -
+    if [ -f /usr/bin/opencode ]; then rm -f "${pkgdir}/usr/bin/opencode"; fi;
 }
 
 # .deb Internal Structure Reference:


### PR DESCRIPTION
Remove opencode binary if it is already installed during package installation to avoid pacman conflicts.

## Summary
- Fixes PKGBUILD conflicts when Opencode is already installed.
- Matches current AUR version.

## Why
- When Opencode binary is installed via pacman, it becomes 'owned' by a package which breaks installation due to Openwork shipping with the Opencode binary.

## Issue
- Closes #288 

## Scope
- Fix PKGBUILD

## Out of scope
- Update checksums and .SRCINFO,  I'm gonna leave that to upstream this time.

## Testing
### Ran
- This is the same as the AUR PKGBUILD, it's been tested via:
```bash
yay -S
```

## Manual verification
1. Run either 
```bash
makepkg -si
```
or
```bash
yay -S openwork
```

## Evidence
<img width="983" height="536" alt="image" src="https://github.com/user-attachments/assets/7b5f8a3a-aa8a-4b7b-a48e-e200caeacd8a" />

## Risk
- N/A

## Rollback
- N/A
