### PR TITLE
Add sandbox debug probe and exportable Docker diagnostics

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -5845,6 +5845,7 @@ export default function App() {
       pendingPermissions: pendingPermissions(),
       events: events(),
       workspaceDebugEvents: workspaceStore.workspaceDebugEvents(),
+      sandboxCreateProgress: workspaceStore.sandboxCreateProgress(),
       clearWorkspaceDebugEvents: workspaceStore.clearWorkspaceDebugEvents,
       safeStringify,
       repairOpencodeMigration: workspaceStore.repairOpencodeMigration,

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -1473,9 +1473,6 @@ export function createWorkspaceStore(options: {
     const doctor = await refreshSandboxDoctor();
     setSandboxPreflightBusy(false);
     setSandboxCreatePhase("provisioning");
-    options.setBusy(true);
-    options.setBusyLabel("status.creating_workspace");
-    options.setBusyStartedAt(startedAt);
     setSandboxCreateProgress({
       runId,
       startedAt,
@@ -1519,9 +1516,6 @@ export function createWorkspaceStore(options: {
       setSandboxStep("docker", { status: "error", detail });
       setSandboxError(detail);
       setSandboxStage("Docker not ready");
-      options.setBusy(false);
-      options.setBusyLabel(null);
-      options.setBusyStartedAt(null);
       setSandboxCreatePhase("idle");
       return false;
     }
@@ -1683,9 +1677,6 @@ export function createWorkspaceStore(options: {
     } finally {
       setSandboxPreflightBusy(false);
       setSandboxCreatePhase("idle");
-      options.setBusy(false);
-      options.setBusyLabel(null);
-      options.setBusyStartedAt(null);
     }
   }
 

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -461,6 +461,42 @@ export async function sandboxCleanupOpenworkContainers(): Promise<OpenworkDocker
   return invoke<OpenworkDockerCleanupResult>("sandbox_cleanup_openwork_containers");
 }
 
+export type SandboxDebugProbeResult = {
+  startedAt: number;
+  finishedAt: number;
+  runId: string;
+  workspacePath: string;
+  ready: boolean;
+  doctor: SandboxDoctorResult;
+  detachedHost?: OrchestratorDetachedHost | null;
+  dockerInspect?: {
+    status: number;
+    stdout: string;
+    stderr: string;
+  } | null;
+  dockerLogs?: {
+    status: number;
+    stdout: string;
+    stderr: string;
+  } | null;
+  cleanup: {
+    containerName?: string | null;
+    containerRemoved: boolean;
+    removeResult?: {
+      status: number;
+      stdout: string;
+      stderr: string;
+    } | null;
+    workspaceRemoved: boolean;
+    errors: string[];
+  };
+  error?: string | null;
+};
+
+export async function sandboxDebugProbe(): Promise<SandboxDebugProbeResult> {
+  return invoke<SandboxDebugProbeResult>("sandbox_debug_probe");
+}
+
 export async function openworkServerInfo(): Promise<OpenworkServerInfo> {
   return invoke<OpenworkServerInfo>("openwork_server_info");
 }

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -285,6 +285,7 @@ export type DashboardViewProps = {
   pendingPermissions: unknown;
   events: unknown;
   workspaceDebugEvents: unknown;
+  sandboxCreateProgress: unknown;
   clearWorkspaceDebugEvents: () => void;
   safeStringify: (value: unknown) => string;
   repairOpencodeMigration: () => void;
@@ -1362,6 +1363,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   pendingPermissions={props.pendingPermissions}
                   events={props.events}
                   workspaceDebugEvents={props.workspaceDebugEvents}
+                  sandboxCreateProgress={props.sandboxCreateProgress}
                   clearWorkspaceDebugEvents={props.clearWorkspaceDebugEvents}
                   safeStringify={props.safeStringify}
                   repairOpencodeMigration={props.repairOpencodeMigration}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -19,6 +19,7 @@ import type {
   OpenworkServerInfo,
   AppBuildInfo,
   OpenCodeRouterInfo,
+  SandboxDebugProbeResult,
 } from "../lib/tauri";
 import {
   appBuildInfo,
@@ -27,6 +28,7 @@ import {
   opencodeRouterStop,
   openworkServerRestart,
   pickFile,
+  sandboxDebugProbe,
 } from "../lib/tauri";
 import { currentLocale, LANGUAGE_OPTIONS, t, type Language } from "../../i18n";
 
@@ -109,6 +111,7 @@ export type SettingsViewProps = {
   pendingPermissions: unknown;
   events: unknown;
   workspaceDebugEvents: unknown;
+  sandboxCreateProgress: unknown;
   clearWorkspaceDebugEvents: () => void;
   safeStringify: (value: unknown) => string;
   repairOpencodeMigration: () => void;
@@ -717,6 +720,27 @@ export default function SettingsView(props: SettingsViewProps) {
   const [configActionStatus, setConfigActionStatus] = createSignal<string | null>(null);
   const [revealConfigBusy, setRevealConfigBusy] = createSignal(false);
   const [resetConfigBusy, setResetConfigBusy] = createSignal(false);
+  const [sandboxProbeBusy, setSandboxProbeBusy] = createSignal(false);
+  const [sandboxProbeStatus, setSandboxProbeStatus] = createSignal<string | null>(null);
+  const [sandboxProbeResult, setSandboxProbeResult] = createSignal<SandboxDebugProbeResult | null>(null);
+
+  const sandboxCreateSummary = createMemo(() => {
+    const raw = props.sandboxCreateProgress as
+      | { runId?: string; stage?: string; error?: string | null; logs?: string[] }
+      | null
+      | undefined;
+    if (!raw || typeof raw !== "object") {
+      return { runId: null, stage: null, error: null, logs: [] as string[] };
+    }
+    return {
+      runId: typeof raw.runId === "string" && raw.runId.trim() ? raw.runId : null,
+      stage: typeof raw.stage === "string" && raw.stage.trim() ? raw.stage : null,
+      error: typeof raw.error === "string" && raw.error.trim() ? raw.error : null,
+      logs: Array.isArray(raw.logs)
+        ? raw.logs.filter((line) => typeof line === "string" && line.trim()).slice(-400)
+        : [],
+    };
+  });
 
   const workspaceConfigPath = createMemo(() => {
     const root = props.activeWorkspaceRoot.trim();
@@ -775,6 +799,8 @@ export default function SettingsView(props: SettingsViewProps) {
     pendingPermissions: props.pendingPermissions,
     recentEvents: props.events,
     workspaceDebugEvents: props.workspaceDebugEvents,
+    sandboxCreateProgress: sandboxCreateSummary(),
+    sandboxProbe: sandboxProbeResult(),
   }));
 
   const runtimeDebugReportJson = createMemo(() => `${JSON.stringify(runtimeDebugReport(), null, 2)}\n`);
@@ -847,6 +873,25 @@ export default function SettingsView(props: SettingsViewProps) {
       setConfigActionStatus(error instanceof Error ? error.message : "Failed to reset app config.");
     } finally {
       setResetConfigBusy(false);
+    }
+  };
+
+  const runSandboxDebugProbe = async () => {
+    if (!isTauriRuntime() || sandboxProbeBusy()) return;
+    setSandboxProbeBusy(true);
+    setSandboxProbeStatus(null);
+    try {
+      const report = await sandboxDebugProbe();
+      setSandboxProbeResult(report);
+      if (report.ready) {
+        setSandboxProbeStatus("Sandbox probe succeeded. Export the debug report for support.");
+      } else {
+        setSandboxProbeStatus(report.error?.trim() || "Sandbox probe completed with errors.");
+      }
+    } catch (error) {
+      setSandboxProbeStatus(error instanceof Error ? error.message : "Sandbox probe failed.");
+    } finally {
+      setSandboxProbeBusy(false);
     }
   };
 
@@ -1411,6 +1456,49 @@ export default function SettingsView(props: SettingsViewProps) {
                   <Show when={debugReportStatus()}>
                     {(status) => <div class="text-xs text-gray-10">{status()}</div>}
                   </Show>
+                </div>
+
+                <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-3">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <div class="text-sm font-medium text-gray-12">Sandbox probe</div>
+                      <div class="text-xs text-gray-10">
+                        Runs a temporary Docker sandbox startup check and captures inspect/log output.
+                      </div>
+                    </div>
+                    <Button
+                      variant="secondary"
+                      class="text-xs h-8 py-0 px-3"
+                      onClick={runSandboxDebugProbe}
+                      disabled={!isTauriRuntime() || sandboxProbeBusy() || props.anyActiveRuns}
+                      title={
+                        !isTauriRuntime()
+                          ? "Sandbox probe requires desktop app"
+                          : props.anyActiveRuns
+                            ? "Stop active runs before probing"
+                            : ""
+                      }
+                    >
+                      {sandboxProbeBusy() ? "Running probe..." : "Run sandbox probe"}
+                    </Button>
+                  </div>
+                  <Show when={sandboxProbeResult()}>
+                    {(result) => (
+                      <div class="text-xs text-gray-11 space-y-1">
+                        <div>Run ID: <span class="font-mono">{result().runId}</span></div>
+                        <div>Result: {result().ready ? "ready" : "error"}</div>
+                        <Show when={result().error}>
+                          {(err) => <div class="text-red-11">{err()}</div>}
+                        </Show>
+                      </div>
+                    )}
+                  </Show>
+                  <Show when={sandboxProbeStatus()}>
+                    {(status) => <div class="text-xs text-gray-10">{status()}</div>}
+                  </Show>
+                  <div class="text-[11px] text-gray-7">
+                    Use <strong>Export</strong> in Runtime debug report above to save this probe output with logs.
+                  </div>
                 </div>
 
                 <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-3">

--- a/packages/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/packages/desktop/src-tauri/src/commands/orchestrator.rs
@@ -89,6 +89,38 @@ pub struct OpenworkDockerCleanupResult {
     pub errors: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxDebugProbeCleanup {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
+    pub container_removed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remove_result: Option<SandboxDoctorCommandDebug>,
+    pub workspace_removed: bool,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxDebugProbeResult {
+    pub started_at: u64,
+    pub finished_at: u64,
+    pub run_id: String,
+    pub workspace_path: String,
+    pub ready: bool,
+    pub doctor: SandboxDoctorResult,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detached_host: Option<OrchestratorDetachedHost>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_inspect: Option<SandboxDoctorCommandDebug>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docker_logs: Option<SandboxDoctorCommandDebug>,
+    pub cleanup: SandboxDebugProbeCleanup,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 fn run_local_command(program: &str, args: &[&str]) -> Result<(i32, String, String), String> {
     let mut command = Command::new(program);
     configure_hidden(&mut command);
@@ -364,6 +396,23 @@ fn truncate_for_debug(input: &str) -> String {
         return trimmed.to_string();
     }
     format!("{}...[truncated]", &trimmed[..MAX_LEN])
+}
+
+fn truncate_for_report(input: &str) -> String {
+    const MAX_LEN: usize = 48_000;
+    let trimmed = input.trim();
+    if trimmed.len() <= MAX_LEN {
+        return trimmed.to_string();
+    }
+    format!("{}...[truncated]", &trimmed[..MAX_LEN])
+}
+
+fn to_command_debug(result: DockerCommandResult) -> SandboxDoctorCommandDebug {
+    SandboxDoctorCommandDebug {
+        status: result.status,
+        stdout: truncate_for_report(&result.stdout),
+        stderr: truncate_for_report(&result.stderr),
+    }
 }
 
 fn derive_orchestrator_container_name(run_id: &str) -> String {
@@ -1148,6 +1197,159 @@ pub fn sandbox_cleanup_openwork_containers() -> Result<OpenworkDockerCleanupResu
         removed,
         errors,
     })
+}
+
+#[tauri::command]
+pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
+    let started_at = now_ms();
+    let run_id = format!("probe-{}", Uuid::new_v4());
+    let workspace_dir = env::temp_dir().join(format!("openwork-sandbox-probe-{}", Uuid::new_v4()));
+    let workspace_path = workspace_dir.to_string_lossy().to_string();
+
+    let mut cleanup_errors: Vec<String> = Vec::new();
+    let mut workspace_removed = false;
+
+    if let Err(err) = std::fs::create_dir_all(&workspace_dir) {
+        return SandboxDebugProbeResult {
+            started_at,
+            finished_at: now_ms(),
+            run_id,
+            workspace_path,
+            ready: false,
+            doctor: sandbox_doctor(),
+            detached_host: None,
+            docker_inspect: None,
+            docker_logs: None,
+            cleanup: SandboxDebugProbeCleanup {
+                container_name: None,
+                container_removed: false,
+                remove_result: None,
+                workspace_removed,
+                errors: vec![format!("Failed to create probe workspace: {err}")],
+            },
+            error: Some(format!("Failed to create sandbox probe workspace: {err}")),
+        };
+    }
+
+    let doctor = sandbox_doctor();
+    let mut detached_host: Option<OrchestratorDetachedHost> = None;
+    let mut docker_inspect: Option<SandboxDoctorCommandDebug> = None;
+    let mut docker_logs: Option<SandboxDoctorCommandDebug> = None;
+    let mut error: Option<String> = None;
+
+    if doctor.ready {
+        match orchestrator_start_detached(
+            app,
+            workspace_path.clone(),
+            Some("docker".to_string()),
+            Some(run_id.clone()),
+            None,
+            None,
+        ) {
+            Ok(host) => {
+                let container_name = host
+                    .sandbox_container_name
+                    .clone()
+                    .unwrap_or_else(|| derive_orchestrator_container_name(&run_id));
+
+                match run_docker_command_detailed(
+                    &["inspect", container_name.as_str()],
+                    Duration::from_secs(6),
+                ) {
+                    Ok(result) => {
+                        docker_inspect = Some(to_command_debug(result));
+                    }
+                    Err(err) => {
+                        cleanup_errors.push(format!("docker inspect failed: {err}"));
+                    }
+                }
+
+                match run_docker_command_detailed(
+                    &[
+                        "logs",
+                        "--timestamps",
+                        "--tail",
+                        "400",
+                        container_name.as_str(),
+                    ],
+                    Duration::from_secs(8),
+                ) {
+                    Ok(result) => {
+                        docker_logs = Some(to_command_debug(result));
+                    }
+                    Err(err) => {
+                        cleanup_errors.push(format!("docker logs failed: {err}"));
+                    }
+                }
+
+                detached_host = Some(host);
+            }
+            Err(err) => {
+                error = Some(format!("Sandbox probe failed to start: {err}"));
+            }
+        }
+    } else {
+        error = Some(
+            doctor
+                .error
+                .as_deref()
+                .unwrap_or("Docker is not ready for sandbox creation")
+                .to_string(),
+        );
+    }
+
+    let container_name = detached_host
+        .as_ref()
+        .and_then(|host| host.sandbox_container_name.clone())
+        .or_else(|| {
+            if doctor.ready {
+                Some(derive_orchestrator_container_name(&run_id))
+            } else {
+                None
+            }
+        });
+
+    let mut container_removed = false;
+    let mut remove_result: Option<SandboxDoctorCommandDebug> = None;
+
+    if let Some(name) = container_name.clone() {
+        match run_docker_command_detailed(&["rm", "-f", name.as_str()], Duration::from_secs(20)) {
+            Ok(result) => {
+                container_removed = result.status == 0;
+                remove_result = Some(to_command_debug(result));
+            }
+            Err(err) => {
+                cleanup_errors.push(format!("docker rm -f {name} failed: {err}"));
+            }
+        }
+    }
+
+    if let Err(err) = std::fs::remove_dir_all(&workspace_dir) {
+        cleanup_errors.push(format!("Failed to remove probe workspace: {err}"));
+    } else {
+        workspace_removed = true;
+    }
+
+    let ready = doctor.ready && error.is_none();
+    SandboxDebugProbeResult {
+        started_at,
+        finished_at: now_ms(),
+        run_id,
+        workspace_path,
+        ready,
+        doctor,
+        detached_host,
+        docker_inspect,
+        docker_logs,
+        cleanup: SandboxDebugProbeCleanup {
+            container_name,
+            container_removed,
+            remove_result,
+            workspace_removed,
+            errors: cleanup_errors,
+        },
+        error,
+    }
 }
 
 #[cfg(test)]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -36,8 +36,8 @@ use commands::openwork_server::{openwork_server_info, openwork_server_restart};
 use commands::opkg::{import_skill, opkg_install};
 use commands::orchestrator::{
     orchestrator_instance_dispose, orchestrator_start_detached, orchestrator_status,
-    orchestrator_workspace_activate, sandbox_cleanup_openwork_containers, sandbox_doctor,
-    sandbox_stop,
+    orchestrator_workspace_activate, sandbox_cleanup_openwork_containers, sandbox_debug_probe,
+    sandbox_doctor, sandbox_stop,
 };
 use commands::scheduler::{scheduler_delete_job, scheduler_list_jobs};
 use commands::skills::{
@@ -104,6 +104,7 @@ pub fn run() {
             orchestrator_instance_dispose,
             orchestrator_start_detached,
             sandbox_doctor,
+            sandbox_debug_probe,
             sandbox_stop,
             sandbox_cleanup_openwork_containers,
             openwork_server_info,


### PR DESCRIPTION
## Summary
- add a new desktop command `sandbox_debug_probe` that creates a temporary sandbox worker, runs docker preflight/startup checks, captures `docker inspect` + `docker logs`, and returns cleanup diagnostics for export
- extend Settings -> Debug with a **Sandbox probe** action (Developer Mode) and include probe output + recent sandbox creation logs in the Runtime Debug Report export JSON
- remove global `busy()` locking from sandbox creation flow so failed/slow Docker startup no longer blocks the full OpenWork UI while provisioning

## Why
Users were getting blocked during sandbox failures with too little diagnostic output to share. This adds a one-click action + export path for support triage and makes sandbox provisioning non-blocking for the rest of the UI.

## Validation
- `cargo check` in `packages/desktop/src-tauri` ✅
- `pnpm --filter @different-ai/openwork-ui build` ✅
- `pnpm --filter @different-ai/openwork-ui typecheck` ❌ (pre-existing repo issue: missing declaration for `src/app/lib/local-file-path.impl.js`)

## E2E / UI Evidence
- Not run in this environment: Docker dev stack + Chrome MCP + screenshots/video.
- Repro command for reviewer:
  - `packaging/docker/dev-up.sh`
  - open Settings -> Debug, click **Run sandbox probe**, then **Export** in Runtime debug report