### PR TITLE
mini-fix(automations): pointing to the correct url

### DIFF
--- a/packages/app/src/app/pages/scheduled.tsx
+++ b/packages/app/src/app/pages/scheduled.tsx
@@ -538,7 +538,7 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
   const canCreateAutomation = createMemo(() => !!createPromptValue());
 
   const openSchedulerDocs = () => {
-    platform.openLink("https://github.com/anomalyco/opencode-scheduler");
+    platform.openLink("https://github.com/different-ai/opencode-scheduler");
   };
 
   const handleInstallScheduler = async () => {


### PR DESCRIPTION
## Summary                                                                                   
- Fix broken scheduler docs hyperlink
                                                                                             
## Why          
- The "Explore more" link in automations pointed to a non-existent repo

## Issue
- Broken hyperlink

## Scope
- Single URL change in `scheduled.tsx`

## Testing
### Ran
- Verified URL resolves to correct repo

### Result
- pass

## CI status
- pass:
- code-related failures: N/A
- external/env/auth blockers: N/A

## Manual verification
1. Click "Explore More" on the Automations page
2. Confirm it opens https://github.com/different-ai/opencode-scheduler

## Evidence
<img width="1969" height="1193" alt="CleanShot 2026-03-06 at 18 22 05" src="https://github.com/user-attachments/assets/ec365543-66e7-4bfa-8cfc-e27363074f47" />

## Risk
- None

## Rollback
- Revert commit