### PR TITLE
fix: use theme-aware colors for automation modal and telegram language picker

### DIFF
--- a/packages/app/src/app/pages/identities.tsx
+++ b/packages/app/src/app/pages/identities.tsx
@@ -1054,7 +1054,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
                       {(code) => (
                         <div class="rounded-xl border border-sky-7/25 bg-sky-1/40 px-3.5 py-3 space-y-2">
                           <div class="text-[12px] font-semibold text-sky-11">Private pairing code</div>
-                          <div class="rounded-md border border-sky-7/20 bg-white/80 px-3 py-2 font-mono text-[13px] tracking-[0.08em] text-sky-12">
+                          <div class="rounded-md border border-sky-7/20 bg-sky-2/80 px-3 py-2 font-mono text-[13px] tracking-[0.08em] text-sky-12">
                             {code()}
                           </div>
                           <div class="text-[11px] text-sky-11/90 leading-relaxed">

--- a/packages/app/src/app/pages/scheduled.tsx
+++ b/packages/app/src/app/pages/scheduled.tsx
@@ -798,7 +798,7 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
 
       <Show when={deleteTarget()}>
         <div class="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm flex items-center justify-center p-4">
-          <div class="bg-white border border-gray-6 w-full max-w-md rounded-2xl shadow-2xl overflow-hidden">
+          <div class="bg-gray-1 border border-gray-6 w-full max-w-md rounded-2xl shadow-2xl overflow-hidden">
             <div class="p-6 space-y-4">
               <div class="flex items-start justify-between gap-4">
                 <div>
@@ -824,7 +824,7 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
 
       <Show when={createModalOpen()}>
         <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-[2px] p-4">
-          <div class="w-full max-w-2xl rounded-3xl bg-white shadow-2xl overflow-hidden border border-gray-6">
+          <div class="w-full max-w-2xl rounded-3xl bg-gray-1 shadow-2xl overflow-hidden border border-gray-6">
             <div class="p-8 space-y-6">
               <div class="flex items-start justify-between gap-4">
                 <div>


### PR DESCRIPTION
## Summary
- Replace hardcoded `bg-white` with theme-aware Radix color variables in modals

## Why
- Modals on the Scheduled and Identities pages render with white backgrounds in dark mode, breaking the theme

## Scope
- `packages/app/src/app/pages/scheduled.tsx`: delete modal and create automation modal (`bg-white` → `bg-gray-1`)
- `packages/app/src/app/pages/identities.tsx`: Telegram pairing code box (`bg-white/80` → `bg-sky-2/80`)

## Out of scope
  - Language picker modal (uses hardcoded zinc palette but I assume it is intentionally dark-styled, works in both modes)
  - `text-white` on solid-color buttons (also assume it is intentional white text on accent backgrounds is correct in both themes)

## Testing
### Ran
- `pnpm run dev` with the changes and no additional issues.

### Result
- pass
- if fail, exact files/errors:

## Manual verification
1. Open app → Scheduled page → click "New automation" → verify modal background adapts to dark mode
2. Open app → Scheduled page → click "Delete" on a job → verify delete confirmation modal adapts to dark mode
3. Open app → Messaging tab → Telegram identity → verify pairing code box blends with dark theme
4. Toggle back to light mode → verify all three still look correct

## Evidence

### Before
- <img width="1276" height="1310" alt="CleanShot 2026-03-06 at 18 47 39" src="https://github.com/user-attachments/assets/1c677879-8dd6-4cd2-89dc-3717029ba643" />
- <img width="1275" height="1312" alt="CleanShot 2026-03-06 at 18 50 32" src="https://github.com/user-attachments/assets/3197eaf5-907b-4b9a-88b5-3c3760bcdc22" />

### After
- <img width="1280" height="1310" alt="CleanShot 2026-03-06 at 18 47 46" src="https://github.com/user-attachments/assets/e2c972a0-88c7-4cf5-b8b6-d77bdb600bb4" />
- <img width="1269" height="1313" alt="CleanShot 2026-03-06 at 18 50 39" src="https://github.com/user-attachments/assets/f4431b69-8a4b-4553-b12a-fd10e342ebe2" />

## Risk
- Minimal: CSS class swaps only, no logic changes

## Rollback
- Revert the three class name changes