### PR TITLE
feat: add verify command and dependency preflight check

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -139,5 +139,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: TypeCheck
+        run: pnpm typecheck
+
       - name: Run e2e tests
-        run: pnpm --filter @different-ai/openwork-ui test:e2e
+        run: pnpm test:e2e

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,17 @@ If you cannot complete steps 4-8 (Docker, Chrome MCP, missing credentials, or en
 
 ## Pull Request Expectations (Fast Merge)
 
+Before opening a PR, run `pnpm verify` to ensure your changes pass all checks:
+
+```bash
+pnpm verify
+```
+
+This runs:
+1. **Preflight**: Validates your development environment (Node.js, pnpm, Bun, etc.)
+2. **TypeCheck**: TypeScript type checking
+3. **E2E Tests**: End-to-end test suite
+
 If you open a PR, you must run tests and report what you ran (commands + result).
 
 To maximize merge speed, include evidence of the end-to-end flow:

--- a/README.md
+++ b/README.md
@@ -174,12 +174,14 @@ You can still edit `opencode.json` manually; OpenWork uses the same format as th
 ## Useful Commands
 
 ```bash
-pnpm dev
-pnpm dev:ui
-pnpm typecheck
-pnpm build
-pnpm build:ui
-pnpm test:e2e
+pnpm dev           # Start desktop app
+pnpm dev:ui        # Start web UI only
+pnpm preflight     # Check development environment
+pnpm verify        # Run all verification checks (preflight + typecheck + tests)
+pnpm typecheck     # TypeScript type checking
+pnpm build         # Build all packages
+pnpm build:ui      # Build web UI only
+pnpm test:e2e      # Run end-to-end tests
 ```
 
 ## Troubleshooting
@@ -204,8 +206,8 @@ WEBKIT_DISABLE_COMPOSITING_MODE=1 openwork
 ## Contributing
 
 - Review `AGENTS.md` plus `VISION.md`, `PRINCIPLES.md`, `PRODUCT.md`, and `ARCHITECTURE.md` to understand the product goals before making changes.
-- Ensure Node.js, `pnpm`, the Rust toolchain, and `opencode` are installed before working inside the repo.
-- Run `pnpm install` once per checkout, then verify your change with `pnpm typecheck` plus `pnpm test:e2e` (or the targeted subset of scripts) before opening a PR.
+- Run `pnpm install` once per checkout.
+- Run `pnpm verify` to check your environment and run all verification checks before opening a PR.
 - Use `.github/pull_request_template.md` when opening PRs and include exact commands, outcomes, manual verification steps, and evidence.
 - If CI fails, classify failures in the PR body as either code-related regressions or external/environment/auth blockers.
 - Add new PRDs to `packages/app/pr/<name>.md` following the `.opencode/skills/prd-conventions/SKILL.md` conventions described in `AGENTS.md`.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build:ui": "pnpm --filter @different-ai/openwork-ui build",
     "build:web": "pnpm --filter @different-ai/openwork-ui build",
     "preview": "pnpm --filter @different-ai/openwork-ui preview",
+    "preflight": "node scripts/preflight.mjs",
+    "verify": "pnpm preflight && pnpm typecheck && pnpm test:e2e",
     "typecheck": "pnpm --filter @different-ai/openwork-ui typecheck",
     "test:health": "pnpm --filter @different-ai/openwork-ui test:health",
     "test:sessions": "pnpm --filter @different-ai/openwork-ui test:sessions",

--- a/packages/app/src/app/lib/local-file-path.impl.d.ts
+++ b/packages/app/src/app/lib/local-file-path.impl.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Type declarations for local-file-path.impl.js
+ */
+
+/**
+ * Normalizes a local file path or file URI to a standard filesystem path.
+ *
+ * @param value - The file path or file URI to normalize
+ * @returns The normalized filesystem path
+ *
+ * @example
+ * normalizeLocalFilePath("file:///Users/test/file.txt") // Returns "/Users/test/file.txt"
+ * normalizeLocalFilePath("/Users/test/file.txt") // Returns "/Users/test/file.txt"
+ */
+export function normalizeLocalFilePath(value: string): string;

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * Preflight check for OpenWork development environment
+ * Validates required tools and provides actionable guidance
+ *
+ * Usage: pnpm preflight
+ */
+
+import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
+
+// Support NO_COLOR and CI environments
+const shouldUseColor = process.stdout.isTTY && !process.env.NO_COLOR && !process.env.CI;
+
+const GREEN = shouldUseColor ? '\x1b[32m' : '';
+const RED = shouldUseColor ? '\x1b[31m' : '';
+const YELLOW = shouldUseColor ? '\x1b[33m' : '';
+const CYAN = shouldUseColor ? '\x1b[36m' : '';
+const RESET = shouldUseColor ? '\x1b[0m' : '';
+const BOLD = shouldUseColor ? '\x1b[1m' : '';
+
+/**
+ * Tool definitions
+ * - cmd: command to check if tool is available
+ * - min: minimum version (optional, for display purposes)
+ * - hint: guidance when tool is missing
+ * - installHint: installation instructions
+ */
+const REQUIRED_TOOLS = {
+  node: {
+    cmd: 'node --version',
+    min: '18',
+    hint: 'Node.js is required for running the build tools',
+    installHint: 'Install from https://nodejs.org or use nvm',
+  },
+  pnpm: {
+    cmd: 'pnpm --version',
+    min: '10.27.0',
+    hint: 'pnpm is the package manager for this project',
+    installHint: 'Run: npm install -g pnpm@10.27.0',
+  },
+  bun: {
+    cmd: 'bun --version',
+    min: '1.3.9',
+    hint: 'Bun is required for running server and scripts',
+    installHint: 'Run: curl -fsSL https://bun.sh/install | bash',
+  },
+};
+
+const OPTIONAL_TOOLS = {
+  cargo: {
+    cmd: 'cargo --version',
+    hint: 'Required for Tauri desktop development',
+    installHint: 'Install Rust from https://rustup.rs',
+  },
+  opencode: {
+    cmd: 'opencode --version',
+    hint: 'Required for running OpenCode integration',
+    installHint: 'See https://github.com/anomalyco/opencode for installation',
+  },
+  tauri: {
+    // Check if tauri CLI is available (either via global install or cargo)
+    cmd: 'tauri --version 2>/dev/null || cargo tauri --version 2>/dev/null',
+    useShell: true,
+    hint: 'Required for Tauri CLI (desktop development)',
+    installHint: 'Run: cargo install tauri-cli',
+  },
+};
+
+/**
+ * Execute a command and return the output or null if it fails
+ * @param {string} cmd - Command to execute
+ * @param {boolean} useShell - Whether to use shell for commands with pipes/operators
+ */
+function execCommand(cmd, useShell = false) {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+      shell: useShell,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse version string to comparable parts
+ * Handles formats: "v1.2.3", "1.2.3", "tool 1.2.3", "tool-cli 1.2.3"
+ */
+function parseVersion(output) {
+  if (!output) return null;
+  // Extract version number (first sequence of digits and dots)
+  const match = output.match(/(\d+(?:\.\d+)*)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Compare two semver-like versions
+ * @returns -1 if a < b, 0 if equal, 1 if a > b
+ */
+function compareVersions(a, b) {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+  const maxLen = Math.max(partsA.length, partsB.length);
+
+  for (let i = 0; i < maxLen; i++) {
+    const numA = partsA[i] || 0;
+    const numB = partsB[i] || 0;
+    if (numA < numB) return -1;
+    if (numA > numB) return 1;
+  }
+  return 0;
+}
+
+/**
+ * Check a single tool
+ */
+function checkTool(name, config, required = true) {
+  const useShell = config.useShell || false;
+  const output = execCommand(config.cmd, useShell);
+
+  if (output) {
+    // Extract version from output (usually first line)
+    const firstLine = output.split('\n')[0];
+    const version = parseVersion(firstLine);
+
+    // Check minimum version if specified
+    if (config.min && version) {
+      if (compareVersions(version, config.min) < 0) {
+        console.log(`  ${RED}✗${RESET} ${CYAN}${name}${RESET}: ${version} (requires ${config.min}+)`);
+        if (config.installHint) {
+          console.log(`    ${YELLOW}→${RESET} ${config.installHint}`);
+        }
+        return false;
+      }
+    }
+
+    console.log(`  ${GREEN}✓${RESET} ${CYAN}${name}${RESET}: ${firstLine}`);
+    return true;
+  } else {
+    if (required) {
+      console.log(`  ${RED}✗${RESET} ${CYAN}${name}${RESET}: not found`);
+      if (config.hint) {
+        console.log(`    ${YELLOW}→${RESET} ${config.hint}`);
+      }
+      if (config.installHint) {
+        console.log(`    ${YELLOW}→${RESET} ${config.installHint}`);
+      }
+      return false;
+    } else {
+      console.log(`  ${YELLOW}○${RESET} ${CYAN}${name}${RESET}: not found (optional)`);
+      if (config.hint) {
+        console.log(`    ${YELLOW}→${RESET} ${config.hint}`);
+      }
+      return true;
+    }
+  }
+}
+
+/**
+ * Main preflight check
+ */
+function main() {
+  console.log(`\n${BOLD}🔍 OpenWork Preflight Check${RESET}\n`);
+  console.log(`Platform: ${platform()}\n`);
+
+  let allPassed = true;
+
+  // Check required tools
+  console.log(`${BOLD}Required tools:${RESET}`);
+  for (const [name, config] of Object.entries(REQUIRED_TOOLS)) {
+    if (!checkTool(name, config, true)) {
+      allPassed = false;
+    }
+  }
+
+  // Check optional tools
+  console.log(`\n${BOLD}Optional tools:${RESET}`);
+  for (const [name, config] of Object.entries(OPTIONAL_TOOLS)) {
+    checkTool(name, config, false);
+  }
+
+  console.log('');
+
+  if (!allPassed) {
+    console.log(`${RED}${BOLD}✗ Preflight failed${RESET}`);
+    console.log('Please install missing required tools before continuing.\n');
+    process.exit(1);
+  }
+
+  console.log(`${GREEN}${BOLD}✓ Preflight passed${RESET}`);
+  console.log('Your environment is ready for development.\n');
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `pnpm preflight` to validate development environment (Node.js 18+, pnpm 10.27.0+, Bun 1.3.9+)
- Add `pnpm verify` as canonical pre-PR validation command
- Add typecheck step to CI workflow
- Fix TS7016 error (missing type declaration from #776)

## Why

Closes #708

During implementation, discovered that PR #776 introduced a TypeScript module without a corresponding type declaration, causing `pnpm typecheck` to fail. This PR includes the fix.

## Test Plan

- [x] `pnpm preflight` passes with all required tools
- [x] `pnpm typecheck` passes (TS7016 fixed)
- [x] `pnpm verify` runs complete validation pipeline
- [x] CI workflow includes typecheck step