### PR TITLE
fix(app): add type declaration for local-file-path.impl.js

### DIFF
--- a/packages/app/src/app/lib/local-file-path.impl.d.ts
+++ b/packages/app/src/app/lib/local-file-path.impl.d.ts
@@ -1,0 +1,1 @@
+export function normalizeLocalFilePath(value: unknown): string;


### PR DESCRIPTION
## Summary

- Add `local-file-path.impl.d.ts` type declaration file to resolve TS7016 error
- The error was caused by importing a `.js` file without type declarations

## Problem

TypeScript compilation failed with:
```
src/app/lib/local-file-path.ts(1,70): error TS7016: Could not find a declaration file for module './local-file-path.impl.js'.
```

## Solution

Added a minimal `.d.ts` file declaring the function signature instead of modifying tsconfig.json `allowJs` setting. This is the least invasive approach.

## Test plan

- [x] `pnpm typecheck` passes with no errors