### PR TITLE
fix(app): abort session on synthetic continue loop detection

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1154,6 +1154,11 @@ export default function App() {
       void refreshPlugins(pluginScope());
       void refreshMcpServers();
     },
+    abortSession: async (sessionID: string) => {
+      const c = client();
+      if (!c) return;
+      await abortSessionTyped(c, sessionID);
+    },
   });
 
   const {

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -128,6 +128,7 @@ export function createSessionStore(options: {
   setSseConnected: (connected: boolean) => void;
   markReloadRequired?: (reason: ReloadReason, trigger?: ReloadTrigger) => void;
   onHotReloadApplied?: () => void;
+  abortSession?: (sessionID: string) => Promise<void>;
 }) {
 
   const sessionDebugEnabled = () => options.developerMode();
@@ -177,6 +178,7 @@ export function createSessionStore(options: {
   const invalidToolDetectionSet = new Set<string>();
   const syntheticContinueEventTimesBySession = new Map<string, number[]>();
   const syntheticContinueLoopLastWarnAtBySession = new Map<string, number>();
+  const syntheticContinueAutoAbortedSessions = new Set<string>();
 
   const skillPathPattern = /[\\/]\.opencode[\\/](skill|skills)[\\/]/i;
   const skillNamePattern = /[\\/]\.opencode[\\/](?:skill|skills)[\\/]+([^\\/]+)/i;
@@ -432,6 +434,14 @@ export function createSessionStore(options: {
       threshold: COMPACTION_LOOP_WARN_THRESHOLD,
       windowMs: COMPACTION_DIAGNOSTIC_WINDOW_MS,
     });
+
+    // Abort the session to break the infinite loop (issue #777).
+    // Only abort once per session to avoid abort spam.
+    if (!syntheticContinueAutoAbortedSessions.has(sessionID) && options.abortSession) {
+      syntheticContinueAutoAbortedSessions.add(sessionID);
+      sessionWarn("compaction:synthetic-continue-loop:aborting", { sessionID });
+      void options.abortSession(sessionID);
+    }
   };
 
   const addError = (error: unknown, fallback = "Unknown error") => {


### PR DESCRIPTION
## Summary
- When the synthetic continue loop is detected, actually abort the session instead of just logging a warning.

## Why
- Users are seeing infinite work summaries after a command finishes. The LLM ends its response with "Suggested next steps for continuation," and OpenCode interprets that as wanting to continue, sends a synthetic continue prompt, gets another summary, and it just keeps going. The detection for this was already in place but it only logged a warning and never stopped the loop.

## Issue
- Closes #777

## Scope
- `session.ts`: added `abortSession` callback to store options, call it when loop threshold (3+ synthetic continues in 60s) is hit, track per-session to only abort once
- `app.tsx`: wire the existing abort function into the session store

## Out of scope
- Auto-compaction cooldown (defaults to off, not related to this bug)
- Server-side changes to how synthetic continues are generated

## Testing
### Ran
- `pnpm typecheck`
- `node packages/app/scripts/health.mjs`
- `node packages/app/scripts/sessions.mjs`

### Result
- pass: all three
- if fail, exact files/errors: N/A

### Bug verification
- Wrote a local reproduction test that simulates rapid synthetic continue events hitting the detection logic
- Confirmed the old code detects the loop but never aborts (bug reproduced)
- Confirmed the new code detects the loop and aborts the session exactly once (fix verified)
- Also verified edge cases: independent sessions get independent aborts, below-threshold events don't false-positive, missing callback doesn't crash

## CI status
- pass: awaiting CI
- code-related failures: N/A
- external/env/auth blockers: N/A

## Manual verification
1. Trigger a session where the LLM produces a work summary ending with "Suggested next steps for continuation"
2. Observe that the session aborts after 3 synthetic continues within 60 seconds instead of looping forever
3. Start a new session and confirm it works normally (abort tracking is per-session)

## Evidence
- N/A (no UI changes, behavior-only fix)

## Risk
- Low. The abort callback is optional and only fires once per session. Worst case a session that would have looped gets stopped early, which is what we want.

## Rollback
- Revert the commit. The old behavior (warn-only) is restored.