### PR TITLE
fix(desktop): include stage diagnostics in sandbox probe timeout errors

### DIFF
--- a/packages/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/packages/desktop/src-tauri/src/commands/orchestrator.rs
@@ -708,6 +708,37 @@ pub fn orchestrator_instance_dispose(
     Ok(result.disposed)
 }
 
+fn format_sandbox_start_timeout_error(
+    elapsed_ms: u64,
+    openwork_url: &str,
+    last_error: Option<&str>,
+    container_state: Option<&str>,
+    container_probe_error: Option<&str>,
+) -> String {
+    let mut details = vec![
+        format!("stage=openwork.healthcheck"),
+        format!("elapsed_ms={elapsed_ms}"),
+        format!("url={openwork_url}"),
+        format!(
+            "last_error={}",
+            last_error.unwrap_or("none")
+        ),
+        format!(
+            "container_state={}",
+            container_state.unwrap_or("unknown")
+        ),
+    ];
+
+    if let Some(probe_error) = container_probe_error {
+        details.push(format!("container_probe_error={probe_error}"));
+    }
+
+    format!(
+        "Timed out waiting for OpenWork server ({})",
+        details.join(", ")
+    )
+}
+
 #[tauri::command]
 pub fn orchestrator_start_detached(
     app: AppHandle,
@@ -954,8 +985,14 @@ pub fn orchestrator_start_detached(
     }
 
     if start.elapsed() >= Duration::from_millis(health_timeout_ms) {
-        let message =
-            last_error.unwrap_or_else(|| "Timed out waiting for OpenWork server".to_string());
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        let message = format_sandbox_start_timeout_error(
+            elapsed_ms,
+            &openwork_url,
+            last_error.as_deref(),
+            last_container_state.as_deref(),
+            last_container_probe_error.as_deref(),
+        );
         emit_sandbox_progress(
             &app,
             &sandbox_run_id,
@@ -963,7 +1000,7 @@ pub fn orchestrator_start_detached(
             "Sandbox failed to start.",
             json!({
                 "error": message,
-                "elapsedMs": start.elapsed().as_millis() as u64,
+                "elapsedMs": elapsed_ms,
                 "openworkUrl": openwork_url,
                 "containerState": last_container_state,
                 "containerProbeError": last_container_probe_error,
@@ -973,7 +1010,7 @@ pub fn orchestrator_start_detached(
             "[sandbox-create][at={}][runId={}][stage=timeout] health wait timed out after {}ms error={}",
             now_ms(),
             sandbox_run_id,
-            start.elapsed().as_millis(),
+            elapsed_ms,
             message
         );
         return Err(message);
@@ -1531,6 +1568,24 @@ exit 0
                 .status();
         }
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sandbox_start_timeout_error_includes_stage_diagnostics() {
+        let message = format_sandbox_start_timeout_error(
+            90_000,
+            "http://127.0.0.1:43210",
+            Some("Connection refused (os error 61)"),
+            Some("created"),
+            Some("No such container"),
+        );
+
+        assert!(message.contains("stage=openwork.healthcheck"));
+        assert!(message.contains("elapsed_ms=90000"));
+        assert!(message.contains("url=http://127.0.0.1:43210"));
+        assert!(message.contains("last_error=Connection refused (os error 61)"));
+        assert!(message.contains("container_state=created"));
+        assert!(message.contains("container_probe_error=No such container"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `format_sandbox_start_timeout_error(...)` to produce deterministic timeout diagnostics for detached sandbox startup
- include probe stage context directly in timeout failures (`stage`, elapsed ms, target url, last health error, container state, optional container inspect error)
- cover the formatter with a focused unit test so the diagnostic contract stays stable

## Why
- issue #762 reports docker preflight success followed by opaque `Sandbox probe failed to start: ... connection refused`
- operators need a clear stage-level reason from the final failure payload to distinguish health-check timeout vs container startup/inspect failures

## Issue
- Closes #762

## Scope
- `packages/desktop/src-tauri/src/commands/orchestrator.rs`
- timeout-message formatting only; no behavior change to startup sequence or timeout thresholds

## Out of scope
- changing sandbox startup timing/retry policy
- adding cross-process log capture plumbing to the detached host launcher

## Testing
### Ran
- `git diff --check HEAD~1..HEAD`

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: not run locally
- code-related failures: N/A
- external/env/auth blockers: rust toolchain unavailable in this environment (`cargo: command not found`), so Rust unit tests could not be executed locally

## Manual verification
1. trigger sandbox probe with Docker preflight healthy but OpenWork health endpoint unreachable
2. inspect returned error string from `sandbox_debug_probe`
3. confirm timeout error now includes `stage=openwork.healthcheck` plus elapsed/url/last_error/container diagnostics

## Evidence
- N/A (runtime diagnostics change)

## Risk
- low: string formatting/path for timeout errors only

## Rollback
- revert commit `e0a59c57` from this branch
