### PR TITLE
fix(landing): improve mobile CTA flow

### DIFF
--- a/packages/landing/app/page.tsx
+++ b/packages/landing/app/page.tsx
@@ -1,15 +1,19 @@
 import { LandingHome } from "../components/landing-home";
 import { getGithubData } from "../lib/github";
+import { headers } from "next/headers";
 
 export default async function Home() {
   const github = await getGithubData();
   const cal = process.env.NEXT_PUBLIC_CAL_URL || "/enterprise#book";
+  const userAgent = headers().get("user-agent")?.toLowerCase() || "";
+  const isMobileVisitor = /android|iphone|ipad|ipod|mobile/.test(userAgent);
 
   return (
     <LandingHome
       stars={github.stars}
       downloadHref={github.downloads.macos}
       callHref={cal}
+      isMobileVisitor={isMobileVisitor}
     />
   );
 }

--- a/packages/landing/components/landing-home.tsx
+++ b/packages/landing/components/landing-home.tsx
@@ -253,7 +253,11 @@ export function LandingHome(props: Props) {
         <div className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-6 pb-24 md:gap-20 md:px-8 md:pb-28">
           <section className="max-w-3xl">
             <h1 className="mb-5 text-4xl font-medium leading-[1.1] tracking-tight md:text-5xl lg:text-6xl">
-              The open source alt to
+              The open source{" "}
+              <span className="font-pixel mx-1 inline-block align-middle text-[1.05em] font-normal">
+                alt
+              </span>{" "}
+              to
               <br />
               Claude Cowork
             </h1>

--- a/packages/landing/components/landing-home.tsx
+++ b/packages/landing/components/landing-home.tsx
@@ -8,6 +8,7 @@ import { LandingBackground } from "./landing-background";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
 import { ResponsiveGrain } from "./responsive-grain";
+import { WaitlistForm } from "./waitlist-form";
 
 type ChatMessage =
   | {
@@ -203,6 +204,7 @@ type Props = {
   stars: string;
   downloadHref: string;
   callHref: string;
+  isMobileVisitor: boolean;
 };
 
 const externalLinkProps = (href: string) =>
@@ -226,6 +228,11 @@ export function LandingHome(props: Props) {
 
   const downloadLinkProps = externalLinkProps(props.downloadHref);
   const callLinkProps = externalLinkProps(props.callHref);
+  const primaryCtaHref = props.isMobileVisitor ? "#mobile-signup" : props.downloadHref;
+  const primaryCtaLabel = props.isMobileVisitor
+    ? "Sign up for desktop access"
+    : "Download for free";
+  const primaryCtaLinkProps = props.isMobileVisitor ? {} : downloadLinkProps;
 
   return (
     <div className="relative min-h-screen overflow-hidden text-[#011627]">
@@ -237,6 +244,8 @@ export function LandingHome(props: Props) {
             stars={props.stars}
             downloadHref={props.downloadHref}
             callUrl={props.callHref}
+            mobilePrimaryHref="#mobile-signup"
+            mobilePrimaryLabel="Sign up"
             active="home"
           />
         </div>
@@ -256,11 +265,11 @@ export function LandingHome(props: Props) {
             <div className="mt-6 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
               <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
                 <a
-                  href={props.downloadHref}
+                  href={primaryCtaHref}
                   className="doc-button"
-                  {...downloadLinkProps}
+                  {...primaryCtaLinkProps}
                 >
-                  Download for free
+                  {primaryCtaLabel}
                 </a>
                 <a
                   href={props.callHref}
@@ -286,6 +295,28 @@ export function LandingHome(props: Props) {
               </div>
             </div>
           </section>
+
+          {props.isMobileVisitor ? (
+            <section
+              id="mobile-signup"
+              className="landing-shell-soft -mt-6 rounded-[2rem] p-6 md:hidden"
+            >
+              <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-400">
+                Mobile signup
+              </div>
+              <h2 className="mb-3 text-2xl font-medium leading-tight text-[#011627]">
+                Start on mobile. Continue on desktop.
+              </h2>
+              <p className="mb-5 text-[15px] leading-7 text-gray-600">
+                OpenWork is a desktop app. Sign up here from your phone and keep the
+                desktop install flow handy for when you switch to your computer.
+              </p>
+              <WaitlistForm />
+              <p className="mt-4 text-[13px] leading-6 text-gray-500">
+                Best path on mobile: landing, signup, then download on desktop.
+              </p>
+            </section>
+          ) : null}
 
           <section className="relative flex flex-col gap-6 overflow-hidden md:gap-8">
             <div className="landing-shell relative flex flex-col overflow-hidden rounded-2xl">
@@ -488,11 +519,12 @@ export function LandingHome(props: Props) {
               <div>
                 <h2 className="mb-3 text-2xl font-medium">OpenWork Desktop</h2>
                 <p className="mb-6 text-lg leading-relaxed text-gray-600">
-                  Start free on desktop with no signup, then automate email,
-                  Slack, and the work you do every day.
+                  {props.isMobileVisitor
+                    ? "Sign up from your phone now, then download OpenWork on desktop when you are back at your computer."
+                    : "Start free on desktop with no signup, then automate email, Slack, and the work you do every day."}
                 </p>
-                <a href={props.downloadHref} className="doc-button" {...downloadLinkProps}>
-                  Download for free
+                <a href={primaryCtaHref} className="doc-button" {...primaryCtaLinkProps}>
+                  {primaryCtaLabel}
                 </a>
               </div>
 

--- a/packages/landing/components/site-nav.tsx
+++ b/packages/landing/components/site-nav.tsx
@@ -9,6 +9,8 @@ type Props = {
   stars: string;
   callUrl?: string;
   downloadHref?: string;
+  mobilePrimaryHref?: string;
+  mobilePrimaryLabel?: string;
   active?: "home" | "download" | "enterprise" | "den";
 };
 
@@ -16,8 +18,11 @@ export function SiteNav(props: Props) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const callHref = props.callUrl || "/enterprise#book";
   const downloadHref = props.downloadHref || "/download";
+  const mobilePrimaryHref = props.mobilePrimaryHref || downloadHref;
+  const mobilePrimaryLabel = props.mobilePrimaryLabel || "Download for free";
   const callExternal = /^https?:\/\//.test(callHref);
   const downloadExternal = /^https?:\/\//.test(downloadHref);
+  const mobilePrimaryExternal = /^https?:\/\//.test(mobilePrimaryHref);
   const navItems = [
     { href: "/docs", label: "Docs", key: "docs" },
     { href: "/download", label: "Download", key: "download" },
@@ -60,7 +65,7 @@ export function SiteNav(props: Props) {
           <div className="flex items-center gap-4">
             <a
               href={downloadHref}
-              className="doc-button hidden px-6 text-sm md:inline-flex"
+              className="doc-button !hidden px-6 text-sm md:!inline-flex"
               rel={downloadExternal ? "noreferrer" : undefined}
               target={downloadExternal ? "_blank" : undefined}
             >
@@ -116,12 +121,12 @@ export function SiteNav(props: Props) {
 
             <div className="mt-4 flex flex-col gap-3">
               <a
-                href={downloadHref}
+                href={mobilePrimaryHref}
                 className="doc-button text-sm"
-                rel={downloadExternal ? "noreferrer" : undefined}
-                target={downloadExternal ? "_blank" : undefined}
+                rel={mobilePrimaryExternal ? "noreferrer" : undefined}
+                target={mobilePrimaryExternal ? "_blank" : undefined}
               >
-                Download for free
+                {mobilePrimaryLabel}
               </a>
               <a
                 href={callHref}

--- a/packages/landing/components/waitlist-form.tsx
+++ b/packages/landing/components/waitlist-form.tsx
@@ -104,7 +104,7 @@ export function WaitlistForm() {
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex flex-wrap items-center gap-3"
+      className="flex flex-wrap items-stretch gap-3"
     >
       <input
         ref={inputRef}
@@ -119,7 +119,7 @@ export function WaitlistForm() {
       <button
         type="submit"
         disabled={state === "loading"}
-        className="doc-button disabled:opacity-60"
+        className="doc-button w-full sm:w-auto disabled:opacity-60"
       >
         {state === "loading" ? "Please wait..." : "Keep me in the loop"}
         {state !== "loading" && (


### PR DESCRIPTION
## Summary
- make the landing CTA mobile-aware so phones go to signup first while desktop still goes straight to download
- fix the overlapping mobile header/button layout and keep the mobile signup form stacked cleanly
- restore the FK Raster accent treatment on the hero `alt` copy to match the design reference