### PR TITLE
fix: add explicit styling for markdown strong and em elements

### DIFF
--- a/packages/app/src/app/components/part-view.tsx
+++ b/packages/app/src/app/components/part-view.tsx
@@ -907,6 +907,8 @@ export default function PartView(props: Props) {
                 textContainerEl = el;
               }}
               class={`markdown-content max-w-none ${textClass()}
+                [&_strong]:font-semibold
+                [&_em]:italic
                 [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:my-4
                 [&_h2]:text-xl [&_h2]:font-bold [&_h2]:my-3
                 [&_h3]:text-lg [&_h3]:font-bold [&_h3]:my-2


### PR DESCRIPTION
## Summary

Adds explicit Tailwind CSS utility classes for `<strong>` and `<em>` elements in markdown content rendering.

## Problem

Markdown bold syntax (`**text**`) was not visually rendered as bold in AI assistant chat messages. The `<strong>` tags were correctly generated by the marked library, but Tailwind CSS v4 sets `font-weight: bolder` by default, which is a relative value that may not produce visible bold effect depending on the parent element's font weight.

## Solution

Added explicit styling in `part-view.tsx`:
- `[&_strong]:font-semibold` - ensures bold text renders with `font-weight: 600`
- `[&_em]:italic` - ensures italic text renders correctly

## Testing

1. Ask AI to respond with bold text: `请回复：这是 **加粗文字** 测试`
2. Verify that the bold text is now visually distinct

Fixes #802