### PR TITLE
fix: allow disconnecting providers from settings

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -2031,6 +2031,45 @@ export default function App() {
     }
   }
 
+  async function disconnectProvider(providerId: string) {
+    setProviderAuthError(null);
+    const c = client();
+    if (!c) {
+      throw new Error("Not connected to a server");
+    }
+
+    const resolved = providerId.trim();
+    if (!resolved) {
+      throw new Error("Provider ID is required");
+    }
+
+    const removeProviderAuth = async () => {
+      const rawClient = (c as unknown as { client?: { delete?: (options: { url: string }) => Promise<unknown> } })
+        .client;
+      if (rawClient?.delete) {
+        await rawClient.delete({ url: `/auth/${encodeURIComponent(resolved)}` });
+        return;
+      }
+      await c.auth.set({ providerID: resolved, auth: null as never });
+    };
+
+    try {
+      await removeProviderAuth();
+      try {
+        await c.global.dispose();
+      } catch {
+        // ignore
+      }
+      const updated = unwrap(await c.provider.list());
+      globalSync.set("provider", updated);
+      return `Disconnected ${resolved}`;
+    } catch (error) {
+      const message = describeProviderError(error, "Failed to disconnect provider");
+      setProviderAuthError(message);
+      throw error instanceof Error ? error : new Error(message);
+    }
+  }
+
   async function openProviderAuthModal() {
     setProviderAuthBusy(true);
     setProviderAuthError(null);
@@ -5717,6 +5756,7 @@ export default function App() {
       providerAuthError: providerAuthError(),
       providerAuthMethods: providerAuthMethods(),
       openProviderAuthModal,
+      disconnectProvider,
       closeProviderAuthModal,
       startProviderAuth,
       completeProviderAuthOAuth,

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -84,6 +84,7 @@ export type DashboardViewProps = {
   providerAuthError: string | null;
   providerAuthMethods: Record<string, { type: "oauth" | "api"; label: string }[]>;
   openProviderAuthModal: () => Promise<void>;
+  disconnectProvider: (providerId: string) => Promise<string | void>;
   closeProviderAuthModal: () => void;
   startProviderAuth: (providerId?: string) => Promise<ProviderOAuthStartResult>;
   completeProviderAuthOAuth: (providerId: string, methodIndex: number, code?: string) => Promise<string | void>;
@@ -1305,6 +1306,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   providerConnectedIds={props.providerConnectedIds}
                   providerAuthBusy={props.providerAuthBusy}
                   openProviderAuthModal={props.openProviderAuthModal}
+                  disconnectProvider={props.disconnectProvider}
                   openworkServerStatus={props.openworkServerStatus}
                   openworkServerUrl={props.openworkServerUrl}
                   openworkReconnectBusy={props.openworkReconnectBusy}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -44,6 +44,7 @@ export type SettingsViewProps = {
   providerConnectedIds: string[];
   providerAuthBusy: boolean;
   openProviderAuthModal: () => Promise<void>;
+  disconnectProvider: (providerId: string) => Promise<string | void>;
   openworkServerStatus: OpenworkServerStatus;
   openworkServerUrl: string;
   openworkReconnectBusy: boolean;
@@ -330,6 +331,9 @@ export default function SettingsView(props: SettingsViewProps) {
   };
 
   const [providerConnectError, setProviderConnectError] = createSignal<string | null>(null);
+  const [providerDisconnectStatus, setProviderDisconnectStatus] = createSignal<string | null>(null);
+  const [providerDisconnectError, setProviderDisconnectError] = createSignal<string | null>(null);
+  const [providerDisconnectingId, setProviderDisconnectingId] = createSignal<string | null>(null);
   const [openworkReconnectStatus, setOpenworkReconnectStatus] = createSignal<string | null>(null);
   const [openworkReconnectError, setOpenworkReconnectError] = createSignal<string | null>(null);
   const [openworkRestartBusy, setOpenworkRestartBusy] = createSignal(false);
@@ -337,20 +341,17 @@ export default function SettingsView(props: SettingsViewProps) {
   const [openworkRestartError, setOpenworkRestartError] = createSignal<string | null>(null);
   const providerConnectedCount = createMemo(() => (props.providerConnectedIds ?? []).length);
   const providerAvailableCount = createMemo(() => (props.providers ?? []).length);
-  const connectedProviderNames = createMemo(() => {
+  const connectedProviders = createMemo(() => {
     const connectedIds = props.providerConnectedIds ?? [];
-    if (!connectedIds.length) return [] as string[];
-
+    if (!connectedIds.length) return [] as { id: string; name: string }[];
     const providersById = new Map((props.providers ?? []).map((provider) => [provider.id, provider]));
-    const names = connectedIds
+    return connectedIds
       .map((id) => {
         const provider = providersById.get(id);
         const label = provider?.name?.trim() || provider?.id?.trim() || id.trim();
-        return label;
+        return { id, name: label || id };
       })
-      .filter((name) => name.length > 0);
-
-    return Array.from(new Set(names));
+      .filter((entry) => entry.id.trim());
   });
   const providerStatusLabel = createMemo(() => {
     if (!providerAvailableCount()) return "Unavailable";
@@ -373,11 +374,35 @@ export default function SettingsView(props: SettingsViewProps) {
   const handleOpenProviderAuth = async () => {
     if (props.busy || props.providerAuthBusy) return;
     setProviderConnectError(null);
+    setProviderDisconnectError(null);
+    setProviderDisconnectStatus(null);
     try {
       await props.openProviderAuthModal();
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to open providers";
       setProviderConnectError(message);
+    }
+  };
+
+  const handleDisconnectProvider = async (providerId: string) => {
+    const resolved = providerId.trim();
+    if (!resolved || props.busy || props.providerAuthBusy || providerDisconnectingId()) return;
+    const confirmed =
+      typeof window === "undefined"
+        ? true
+        : window.confirm(`Disconnect ${resolved}? This removes the stored credentials.`);
+    if (!confirmed) return;
+    setProviderDisconnectError(null);
+    setProviderDisconnectStatus(null);
+    setProviderDisconnectingId(resolved);
+    try {
+      const result = await props.disconnectProvider(resolved);
+      setProviderDisconnectStatus(result || `Disconnected ${resolved}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to disconnect provider";
+      setProviderDisconnectError(message);
+    } finally {
+      setProviderDisconnectingId(null);
     }
   };
 
@@ -997,13 +1022,26 @@ export default function SettingsView(props: SettingsViewProps) {
                 <div class="text-xs text-gray-10">{providerSummary()}</div>
               </div>
 
-              <Show when={connectedProviderNames().length > 0}>
-                <div class="flex flex-wrap items-center gap-2">
-                  <For each={connectedProviderNames()}>
-                    {(name) => (
-                      <span class="rounded-full border border-green-7/30 bg-green-3/40 px-2 py-1 text-[11px] font-medium text-green-12">
-                        {name}
-                      </span>
+              <Show when={connectedProviders().length > 0}>
+                <div class="space-y-2">
+                  <For each={connectedProviders()}>
+                    {(provider) => (
+                      <div class="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-gray-6/60 bg-gray-1/40 px-3 py-2">
+                        <div class="min-w-0">
+                          <div class="text-sm font-medium text-gray-12 truncate">{provider.name}</div>
+                          <div class="text-[11px] text-gray-8 font-mono truncate">{provider.id}</div>
+                        </div>
+                        <Button
+                          variant="outline"
+                          class="text-xs h-8 py-0 px-3"
+                          onClick={() => void handleDisconnectProvider(provider.id)}
+                          disabled={
+                            props.busy || props.providerAuthBusy || providerDisconnectingId() !== null
+                          }
+                        >
+                          {providerDisconnectingId() === provider.id ? "Disconnecting..." : "Disconnect"}
+                        </Button>
+                      </div>
                     )}
                   </For>
                 </div>
@@ -1012,6 +1050,16 @@ export default function SettingsView(props: SettingsViewProps) {
               <Show when={providerConnectError()}>
                 <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
                   {providerConnectError()}
+                </div>
+              </Show>
+              <Show when={providerDisconnectStatus()}>
+                <div class="rounded-xl border border-gray-6/60 bg-gray-1/40 px-3 py-2 text-xs text-gray-10">
+                  {providerDisconnectStatus()}
+                </div>
+              </Show>
+              <Show when={providerDisconnectError()}>
+                <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
+                  {providerDisconnectError()}
                 </div>
               </Show>
 


### PR DESCRIPTION
## Summary
- add Disconnect actions for connected providers in the settings Providers section
- remove provider auth with the same DELETE flow OpenCode uses, then dispose and refresh provider state so the list updates immediately
- show disconnect progress and success/error feedback in the settings UI

## Testing
- pnpm typecheck