### PR TITLE
fix provider oauth polling flow

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -62,6 +62,7 @@ import {
   VARIANT_PREF_KEY,
 } from "./constants";
 import { parseMcpServersFromContent, removeMcpFromConfig, validateMcpServerName } from "./mcp";
+import { mapConfigProvidersToList } from "./utils/providers";
 import type {
   Client,
   DashboardTab,
@@ -1946,6 +1947,47 @@ export default function App() {
     }
   }
 
+  async function refreshProviders(options?: { dispose?: boolean }) {
+    const c = client();
+    if (!c) return null;
+
+    if (options?.dispose) {
+      try {
+        unwrap(await c.instance.dispose());
+      } catch {
+        // ignore dispose failures and try reading current state anyway
+      }
+
+      try {
+        await waitForHealthy(client() ?? c, { timeoutMs: 8_000, pollMs: 250 });
+      } catch {
+        // ignore health wait failures and still attempt provider reads
+      }
+    }
+
+    const activeClient = client() ?? c;
+    try {
+      const updated = unwrap(await activeClient.provider.list());
+      globalSync.set("provider", updated);
+      return updated;
+    } catch {
+      try {
+        const fallback = unwrap(await activeClient.config.providers());
+        const mapped = mapConfigProvidersToList(fallback.providers);
+        const previousConnected = providerConnectedIds();
+        const next = {
+          all: mapped,
+          connected: previousConnected.filter((id) => mapped.some((provider) => provider.id === id)),
+          default: fallback.default,
+        };
+        globalSync.set("provider", next);
+        return next;
+      } catch {
+        return null;
+      }
+    }
+  }
+
   async function completeProviderAuthOAuth(providerId: string, methodIndex: number, code?: string) {
     setProviderAuthError(null);
     const c = client();
@@ -1962,13 +2004,12 @@ export default function App() {
       throw new Error("OAuth method is required");
     }
 
-    const waitForProviderConnection = async (timeoutMs = 15_000, pollMs = 1_000) => {
+    const waitForProviderConnection = async (timeoutMs = 15_000, pollMs = 2_000) => {
       const startedAt = Date.now();
       while (Date.now() - startedAt < timeoutMs) {
         try {
-          const updated = unwrap(await c.provider.list()) as { connected?: string[] };
-          if (Array.isArray(updated.connected) && updated.connected.includes(resolved)) {
-            globalSync.set("provider", updated);
+          const updated = await refreshProviders({ dispose: true });
+          if (Array.isArray(updated?.connected) && updated.connected.includes(resolved)) {
             return true;
           }
         } catch {
@@ -1979,6 +2020,11 @@ export default function App() {
       return false;
     };
 
+    const isPendingOauthError = (error: unknown) => {
+      const text = error instanceof Error ? error.message : String(error ?? "");
+      return /request timed out/i.test(text) || /ProviderAuthOauthMissing/i.test(text);
+    };
+
     try {
       const trimmedCode = code?.trim();
       const result = await c.provider.oauth.callback({
@@ -1987,16 +2033,27 @@ export default function App() {
         code: trimmedCode || undefined,
       });
       assertNoClientError(result);
-      const updated = unwrap(await c.provider.list());
-      globalSync.set("provider", updated);
-      return `Connected ${resolved}`;
+      const updated = await refreshProviders({ dispose: true });
+      const connectedNow = Array.isArray(updated?.connected) && updated.connected.includes(resolved);
+      if (connectedNow) {
+        return { connected: true, message: `Connected ${resolved}` };
+      }
+      const connected = await waitForProviderConnection();
+      if (connected) {
+        return { connected: true, message: `Connected ${resolved}` };
+      }
+      return { connected: false, pending: true };
     } catch (error) {
-      const messageText = error instanceof Error ? error.message : String(error ?? "");
-      if (/request timed out/i.test(messageText)) {
+      if (isPendingOauthError(error)) {
+        const updated = await refreshProviders({ dispose: true });
+        if (Array.isArray(updated?.connected) && updated.connected.includes(resolved)) {
+          return { connected: true, message: `Connected ${resolved}` };
+        }
         const connected = await waitForProviderConnection();
         if (connected) {
-          return `Connected ${resolved}`;
+          return { connected: true, message: `Connected ${resolved}` };
         }
+        return { connected: false, pending: true };
       }
       const message = describeProviderError(error, "Failed to complete OAuth");
       setProviderAuthError(message);
@@ -2021,8 +2078,7 @@ export default function App() {
         providerID: providerId,
         auth: { type: "api", key: trimmed },
       });
-      const updated = unwrap(await c.provider.list());
-      globalSync.set("provider", updated);
+      await refreshProviders({ dispose: true });
       return `Connected ${providerId}`;
     } catch (error) {
       const message = describeProviderError(error, "Failed to save API key");
@@ -5760,6 +5816,7 @@ export default function App() {
       closeProviderAuthModal,
       startProviderAuth,
       completeProviderAuthOAuth,
+      refreshProviders,
       submitProviderApiKey,
       view: currentView(),
       setView,
@@ -6089,6 +6146,7 @@ export default function App() {
     showTryNotionPrompt: tryNotionPromptVisible() && notionIsActive(),
     startProviderAuth: startProviderAuth,
     completeProviderAuthOAuth: completeProviderAuthOAuth,
+    refreshProviders: refreshProviders,
     submitProviderApiKey: submitProviderApiKey,
     openProviderAuthModal: openProviderAuthModal,
     closeProviderAuthModal: closeProviderAuthModal,

--- a/packages/app/src/app/components/provider-auth-modal.tsx
+++ b/packages/app/src/app/components/provider-auth-modal.tsx
@@ -1,7 +1,7 @@
 import type { ProviderAuthAuthorization } from "@opencode-ai/sdk/v2/client";
 import { CheckCircle2, Loader2, X } from "lucide-solid";
 import type { ProviderListItem } from "../types";
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
 import { isTauriRuntime } from "../utils";
 
 import Button from "./button";
@@ -43,7 +43,12 @@ export type ProviderAuthModalProps = {
   authMethods: Record<string, ProviderAuthMethod[]>;
   onSelect: (providerId: string) => Promise<ProviderOAuthStartResult>;
   onSubmitApiKey: (providerId: string, apiKey: string) => Promise<string | void>;
-  onSubmitOAuth: (providerId: string, methodIndex: number, code?: string) => Promise<string | void>;
+  onSubmitOAuth: (
+    providerId: string,
+    methodIndex: number,
+    code?: string
+  ) => Promise<{ connected: boolean; pending?: boolean; message?: string }>;
+  onRefreshProviders?: () => Promise<unknown>;
   onClose: () => void;
 };
 
@@ -109,7 +114,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const [searchQuery, setSearchQuery] = createSignal("");
   const [activeEntryIndex, setActiveEntryIndex] = createSignal(0);
   const [localError, setLocalError] = createSignal<string | null>(null);
+  const [pollingBusy, setPollingBusy] = createSignal(false);
+  const [oauthAutoBusy, setOauthAutoBusy] = createSignal(false);
   let searchInputEl: HTMLInputElement | undefined;
+  let providerPoll: number | null = null;
+  let oauthAutoPoll: number | null = null;
 
   const selectedEntry = createMemo(() =>
     entries().find((entry) => entry.id === selectedProviderId()) ?? null,
@@ -178,9 +187,89 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     !!entry?.methods?.some((method) => method.type === type);
 
   const handleClose = () => {
+    void props.onRefreshProviders?.();
+    if (oauthAutoPoll !== null) {
+      window.clearInterval(oauthAutoPoll);
+      oauthAutoPoll = null;
+    }
+    if (providerPoll !== null) {
+      window.clearInterval(providerPoll);
+      providerPoll = null;
+    }
     resetState();
     props.onClose();
   };
+
+  onCleanup(() => {
+    if (oauthAutoPoll !== null) {
+      window.clearInterval(oauthAutoPoll);
+      oauthAutoPoll = null;
+    }
+    if (providerPoll !== null) {
+      window.clearInterval(providerPoll);
+      providerPoll = null;
+    }
+  });
+
+  const isOauthView = () => resolvedView() === "oauth-code" || resolvedView() === "oauth-auto";
+  const activeProviderId = () => oauthSession()?.providerId ?? selectedProviderId();
+
+  const isActiveProviderConnected = () => {
+    const id = activeProviderId();
+    if (!id) return false;
+    return (props.connectedProviderIds ?? []).includes(id);
+  };
+
+  const pollProviders = async () => {
+    const id = activeProviderId();
+    if (!id) return;
+    if (pollingBusy()) return;
+    setPollingBusy(true);
+    try {
+      await props.onRefreshProviders?.();
+    } finally {
+      setPollingBusy(false);
+    }
+    if (isActiveProviderConnected()) {
+      handleClose();
+    }
+  };
+
+  const startProviderPolling = () => {
+    if (typeof window === "undefined") return;
+    if (providerPoll !== null) return;
+    void pollProviders();
+    providerPoll = window.setInterval(() => {
+      void pollProviders();
+    }, 2000);
+  };
+
+  const stopProviderPolling = () => {
+    if (providerPoll !== null) {
+      window.clearInterval(providerPoll);
+      providerPoll = null;
+    }
+  };
+
+  createEffect(() => {
+    if (!props.open || !isOauthView()) {
+      stopProviderPolling();
+      return;
+    }
+    if (isActiveProviderConnected()) {
+      handleClose();
+      return;
+    }
+    startProviderPolling();
+  });
+
+  createEffect(() => {
+    if (!props.open || resolvedView() !== "oauth-auto" || !oauthSession()) {
+      stopOauthAutoPolling();
+      return;
+    }
+    startOauthAutoPolling();
+  });
 
   const openOauthUrl = async (url: string) => {
     if (!url) return;
@@ -196,12 +285,42 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     const trimmedCode = code?.trim();
     setLocalError(null);
     try {
-      await props.onSubmitOAuth(providerId, methodIndex, trimmedCode || undefined);
+      return await props.onSubmitOAuth(providerId, methodIndex, trimmedCode || undefined);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to complete OAuth";
       setLocalError(message);
       throw error instanceof Error ? error : new Error(message);
     }
+  };
+
+  const stopOauthAutoPolling = () => {
+    if (oauthAutoPoll !== null) {
+      window.clearInterval(oauthAutoPoll);
+      oauthAutoPoll = null;
+    }
+  };
+
+  const attemptOauthAutoCompletion = async () => {
+    const session = oauthSession();
+    if (!session || oauthAutoBusy()) return;
+    setOauthAutoBusy(true);
+    try {
+      const result = await submitOauth(session.providerId, session.methodIndex);
+      if (result?.connected) {
+        stopOauthAutoPolling();
+      }
+    } finally {
+      setOauthAutoBusy(false);
+    }
+  };
+
+  const startOauthAutoPolling = () => {
+    if (typeof window === "undefined") return;
+    if (oauthAutoPoll !== null) return;
+    void attemptOauthAutoCompletion();
+    oauthAutoPoll = window.setInterval(() => {
+      void attemptOauthAutoCompletion();
+    }, 2000);
   };
 
   const startOauth = async (entry: ProviderAuthEntry) => {
@@ -225,7 +344,6 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       }
 
       setView("oauth-auto");
-      await submitOauth(entry.id, started.methodIndex);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start OAuth";
       setLocalError(message);
@@ -302,13 +420,6 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     }
 
     await submitOauth(entry.id, session.methodIndex, trimmed);
-  };
-
-  const handleOauthAutoRetry = async () => {
-    const entry = selectedEntry();
-    const session = oauthSession();
-    if (!entry || !session || actionDisabled()) return;
-    await submitOauth(entry.id, session.methodIndex);
   };
 
   const handleBack = () => {
@@ -656,8 +767,8 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       <TextInput label="Confirmation code" value={oauthDisplayCode()} readOnly class="font-mono" />
                     </Show>
                     <div class="flex items-center gap-2 text-xs text-gray-9">
-                      <Loader2 size={14} class={props.submitting ? "animate-spin" : ""} />
-                      <span>{props.submitting ? "Waiting for confirmation..." : "Ready to retry completion."}</span>
+                      <Loader2 size={14} class={props.submitting || pollingBusy() || oauthAutoBusy() ? "animate-spin" : ""} />
+                      <span>Checking connection status automatically...</span>
                     </div>
                     <div class="flex items-center justify-between gap-3">
                       <Button
@@ -670,9 +781,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       >
                         Open browser again
                       </Button>
-                      <Button variant="secondary" onClick={() => void handleOauthAutoRetry()} disabled={actionDisabled()}>
-                        {props.submitting ? "Waiting..." : "Retry completion"}
-                      </Button>
+                      <div class="text-[11px] text-gray-9 text-right">This window will close once the provider is connected.</div>
                     </div>
                   </div>
                 </Show>

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -87,8 +87,13 @@ export type DashboardViewProps = {
   disconnectProvider: (providerId: string) => Promise<string | void>;
   closeProviderAuthModal: () => void;
   startProviderAuth: (providerId?: string) => Promise<ProviderOAuthStartResult>;
-  completeProviderAuthOAuth: (providerId: string, methodIndex: number, code?: string) => Promise<string | void>;
+  completeProviderAuthOAuth: (
+    providerId: string,
+    methodIndex: number,
+    code?: string
+  ) => Promise<{ connected: boolean; pending?: boolean; message?: string }>;
   submitProviderApiKey: (providerId: string, apiKey: string) => Promise<string | void>;
+  refreshProviders: () => Promise<unknown>;
   view: View;
   setView: (view: View, sessionId?: string) => void;
   startupPreference: StartupPreference | null;
@@ -420,13 +425,17 @@ export default function DashboardView(props: DashboardViewProps) {
   };
 
   const handleProviderAuthOAuth = async (providerId: string, methodIndex: number, code?: string) => {
-    if (providerAuthActionBusy()) return;
+    if (providerAuthActionBusy()) return { connected: false, pending: true };
     setProviderAuthActionBusy(true);
     try {
-      await props.completeProviderAuthOAuth(providerId, methodIndex, code);
-      props.closeProviderAuthModal();
+      const result = await props.completeProviderAuthOAuth(providerId, methodIndex, code);
+      if (result.connected) {
+        props.closeProviderAuthModal();
+      }
+      return result;
     } catch {
       // Errors are surfaced in the modal.
+      return { connected: false };
     } finally {
       setProviderAuthActionBusy(false);
     }
@@ -1437,6 +1446,7 @@ export default function DashboardView(props: DashboardViewProps) {
           onSelect={handleProviderAuthSelect}
           onSubmitApiKey={handleProviderAuthApiKey}
           onSubmitOAuth={handleProviderAuthOAuth}
+          onRefreshProviders={props.refreshProviders}
           onClose={props.closeProviderAuthModal}
         />
 

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -204,8 +204,13 @@ export type SessionViewProps = {
   sessionStatus: string;
   renameSession: (sessionId: string, title: string) => Promise<void>;
   startProviderAuth: (providerId?: string) => Promise<ProviderOAuthStartResult>;
-  completeProviderAuthOAuth: (providerId: string, methodIndex: number, code?: string) => Promise<string | void>;
+  completeProviderAuthOAuth: (
+    providerId: string,
+    methodIndex: number,
+    code?: string
+  ) => Promise<{ connected: boolean; pending?: boolean; message?: string }>;
   submitProviderApiKey: (providerId: string, apiKey: string) => Promise<string | void>;
+  refreshProviders: () => Promise<unknown>;
   openProviderAuthModal: () => Promise<void>;
   closeProviderAuthModal: () => void;
   providerAuthModalOpen: boolean;
@@ -2519,15 +2524,19 @@ export default function SessionView(props: SessionViewProps) {
   };
 
   const handleProviderAuthOAuth = async (providerId: string, methodIndex: number, code?: string) => {
-    if (providerAuthActionBusy()) return;
+    if (providerAuthActionBusy()) return { connected: false, pending: true };
     setProviderAuthActionBusy(true);
     try {
-      const message = await props.completeProviderAuthOAuth(providerId, methodIndex, code);
-      setToastMessage(message || "Provider connected");
-      props.closeProviderAuthModal();
+      const result = await props.completeProviderAuthOAuth(providerId, methodIndex, code);
+      if (result.connected) {
+        setToastMessage(result.message || "Provider connected");
+        props.closeProviderAuthModal();
+      }
+      return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : "OAuth failed";
       setToastMessage(message);
+      return { connected: false };
     } finally {
       setProviderAuthActionBusy(false);
     }
@@ -4139,6 +4148,7 @@ export default function SessionView(props: SessionViewProps) {
         onSelect={handleProviderAuthSelect}
         onSubmitApiKey={handleProviderAuthApiKey}
         onSubmitOAuth={handleProviderAuthOAuth}
+        onRefreshProviders={props.refreshProviders}
         onClose={props.closeProviderAuthModal}
       />
 


### PR DESCRIPTION
## Summary
- keep provider OAuth auto flows retrying in the background instead of showing a manual retry button
- treat pending OAuth callback states as waiting conditions while refreshing provider state from a disposed client
- refresh and close the provider modal automatically once the provider connection is detected

## Testing
- `pnpm typecheck`