### PR TITLE
Add desktop debug tooling and keep bundled OpenCode current

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -62,36 +62,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
-          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
         run: |
           set -euo pipefail
 
           repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
-          version="${OPENCODE_VERSION:-}"
-
-          if [ -z "$version" ]; then
-            version="$(node -p "require('./packages/desktop/package.json').opencodeVersion || ''" 2>/dev/null || true)"
-          fi
-
-          version="$(echo "$version" | tr -d '\r\n' | sed 's/^v//')"
-          if [ -z "$version" ] || [ "$version" = "latest" ]; then
-            latest=""
-            if [ -n "${GITHUB_TOKEN:-}" ]; then
-              latest=$(curl -fsSL \
-                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/${repo}/releases/latest" \
-                | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-            else
-              latest=$(curl -fsSL \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/${repo}/releases/latest" \
-                | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
-            fi
-            if [ -n "$latest" ]; then
-              version="$latest"
-            fi
-          fi
+          version="$(node ./packages/desktop/scripts/opencode-version.mjs resolve | tr -d '\r\n')"
 
           if [ -z "$version" ]; then
             echo "Unable to resolve OpenCode version (set OPENCODE_VERSION to pin)." >&2
@@ -130,6 +105,9 @@ jobs:
 
       - name: Prepare desktop sidecars
         run: pnpm -C packages/desktop prepare:sidecar
+
+      - name: Verify OpenCode version sync
+        run: pnpm -C packages/desktop check:opencode-version-sync
 
       - name: Run Rust tests (engine + sidecar resolution)
         run: cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml --locked

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -84,7 +84,6 @@ jobs:
       RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}
       MACOS_NOTARIZE: ${{ vars.MACOS_NOTARIZE || 'false' }}
       OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
-      OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
 
     strategy:
       fail-fast: false
@@ -165,70 +164,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          node <<'NODE' >> "$GITHUB_OUTPUT"
-          const fs = require('fs');
-          const repo = (process.env.OPENCODE_GITHUB_REPO || 'anomalyco/opencode').trim() || 'anomalyco/opencode';
-
-          async function resolveLatest() {
-            const token = (process.env.GITHUB_TOKEN || '').trim();
-            const headers = {
-              'Accept': 'application/vnd.github+json',
-              'X-GitHub-Api-Version': '2022-11-28',
-              'User-Agent': 'openwork-ci',
-            };
-            if (token) headers.Authorization = `Bearer ${token}`;
-
-            // Prefer API, but fall back to the web "latest" redirect if rate-limited (403) or otherwise blocked.
-            try {
-              const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
-              if (res.ok) {
-                const data = await res.json();
-                const tag = (typeof data.tag_name === 'string' ? data.tag_name : '').trim();
-                let v = tag.startsWith('v') ? tag.slice(1) : tag;
-                v = v.trim();
-                if (v) return v;
-              }
-              if (res.status !== 403) {
-                throw new Error(`Failed to resolve latest OpenCode version (HTTP ${res.status})`);
-              }
-            } catch {
-              // continue to fallback
-            }
-
-            const web = await fetch(`https://github.com/${repo}/releases/latest`, {
-              headers: { 'User-Agent': 'openwork-ci' },
-              redirect: 'follow',
-            });
-            const url = (web && web.url) ? String(web.url) : '';
-            const match = url.match(/\/tag\/v([^/?#]+)/);
-            if (!match) throw new Error('Failed to resolve latest OpenCode version (web redirect).');
-            return match[1];
-          }
-
-          async function main() {
-            const pkg = JSON.parse(fs.readFileSync('./packages/desktop/package.json', 'utf8'));
-            const configuredRaw = (process.env.OPENCODE_VERSION || pkg.opencodeVersion || '').toString().trim();
-            if (configuredRaw && configuredRaw.toLowerCase() !== 'latest') {
-              const normalized = configuredRaw.startsWith('v') ? configuredRaw.slice(1) : configuredRaw;
-              const resolved = normalized.trim();
-              if (process.env.GITHUB_ENV) {
-                fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${resolved}\n`);
-              }
-              console.log('version=' + resolved);
-              return;
-            }
-            const latest = await resolveLatest();
-            if (process.env.GITHUB_ENV) {
-              fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${latest}\n`);
-            }
-            console.log('version=' + latest);
-          }
-
-          main().catch((err) => {
-            console.error(err);
-            process.exit(1);
-          });
-          NODE
+          version="$(node ./packages/desktop/scripts/opencode-version.mjs resolve | tr -d '\r\n')"
+          echo "OPENCODE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Download OpenCode sidecar
         shell: bash
@@ -298,6 +236,12 @@ jobs:
           mkdir -p packages/desktop/src-tauri/sidecars
           cp "$bin_path" "packages/desktop/src-tauri/sidecars/${target_name}"
           chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
+
+      - name: Prepare desktop sidecars
+        run: pnpm -C packages/desktop prepare:sidecar
+
+      - name: Verify OpenCode version sync
+        run: pnpm -C packages/desktop check:opencode-version-sync
 
       - name: Write notary API key
         if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -352,72 +352,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
-          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
         run: |
-          node <<'NODE' >> "$GITHUB_OUTPUT"
-          const fs = require('fs');
-          const repo = (process.env.OPENCODE_GITHUB_REPO || 'anomalyco/opencode').trim() || 'anomalyco/opencode';
-
-          async function resolveLatest() {
-            const token = (process.env.GITHUB_TOKEN || '').trim();
-            const headers = {
-              'Accept': 'application/vnd.github+json',
-              'X-GitHub-Api-Version': '2022-11-28',
-              'User-Agent': 'openwork-ci',
-            };
-            if (token) headers.Authorization = `Bearer ${token}`;
-
-            // Prefer API, but fall back to the web "latest" redirect if rate-limited (403) or otherwise blocked.
-            try {
-              const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
-              if (res.ok) {
-                const data = await res.json();
-                const tag = (typeof data.tag_name === 'string' ? data.tag_name : '').trim();
-                let v = tag.startsWith('v') ? tag.slice(1) : tag;
-                v = v.trim();
-                if (v) return v;
-              }
-              if (res.status !== 403) {
-                throw new Error(`Failed to resolve latest OpenCode version (HTTP ${res.status})`);
-              }
-            } catch {
-              // continue to fallback
-            }
-
-            const web = await fetch(`https://github.com/${repo}/releases/latest`, {
-              headers: { 'User-Agent': 'openwork-ci' },
-              redirect: 'follow',
-            });
-            const url = (web && web.url) ? String(web.url) : '';
-            const match = url.match(/\/tag\/v([^/?#]+)/);
-            if (!match) throw new Error('Failed to resolve latest OpenCode version (web redirect).');
-            return match[1];
-          }
-
-          async function main() {
-            const pkg = JSON.parse(fs.readFileSync('./packages/desktop/package.json', 'utf8'));
-            const configuredRaw = (process.env.OPENCODE_VERSION || pkg.opencodeVersion || '').toString().trim();
-            if (configuredRaw && configuredRaw.toLowerCase() !== 'latest') {
-              const normalized = configuredRaw.startsWith('v') ? configuredRaw.slice(1) : configuredRaw;
-              const resolved = normalized.trim();
-              if (process.env.GITHUB_ENV) {
-                fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${resolved}\n`);
-              }
-              console.log('version=' + resolved);
-              return;
-            }
-            const latest = await resolveLatest();
-            if (process.env.GITHUB_ENV) {
-              fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${latest}\n`);
-            }
-            console.log('version=' + latest);
-          }
-
-          main().catch((err) => {
-            console.error(err);
-            process.exit(1);
-          });
-          NODE
+          version="$(node ./packages/desktop/scripts/opencode-version.mjs resolve | tr -d '\r\n')"
+          echo "OPENCODE_VERSION=$version" >> "$GITHUB_ENV"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Download OpenCode sidecar
         shell: bash
@@ -488,6 +426,12 @@ jobs:
           mkdir -p packages/desktop/src-tauri/sidecars
           cp "$bin_path" "packages/desktop/src-tauri/sidecars/${target_name}"
           chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
+
+      - name: Prepare desktop sidecars
+        run: pnpm -C packages/desktop prepare:sidecar
+
+      - name: Verify OpenCode version sync
+        run: pnpm -C packages/desktop check:opencode-version-sync
 
       - name: Write notary API key
         if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'

--- a/.github/workflows/update-opencode-version.yml
+++ b/.github/workflows/update-opencode-version.yml
@@ -1,0 +1,77 @@
+name: Update OpenCode Version
+
+on:
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-opencode:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.6
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve latest OpenCode version
+        id: resolve
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+        run: |
+          set -euo pipefail
+          current="$(node -p "require('./packages/desktop/package.json').opencodeVersion")"
+          latest="$(OPENCODE_VERSION=latest node ./packages/desktop/scripts/opencode-version.mjs resolve | tr -d '\r\n')"
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          if [ "$current" = "$latest" ]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update pinned OpenCode version
+        if: steps.resolve.outputs.up_to_date != 'true'
+        run: |
+          set -euo pipefail
+          node ./packages/desktop/scripts/opencode-version.mjs set --version "${{ steps.resolve.outputs.latest }}"
+          pnpm -C packages/desktop prepare:sidecar
+          pnpm -C packages/desktop check:opencode-version-sync
+
+      - name: Create pull request
+        if: steps.resolve.outputs.up_to_date != 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-opencode-${{ steps.resolve.outputs.latest }}
+          delete-branch: true
+          commit-message: "chore: bump bundled OpenCode to ${{ steps.resolve.outputs.latest }}"
+          title: "chore: bump bundled OpenCode to ${{ steps.resolve.outputs.latest }}"
+          body: |
+            Updates the bundled OpenCode version used by OpenWork desktop builds.
+
+            - bumps `packages/desktop/package.json`
+            - refreshes `packages/desktop/src-tauri/sidecars/versions.json`
+            - keeps bundled builds aligned with the latest OpenCode release
+          labels: dependencies

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,6 +21,7 @@
     "test:fs-engine": "node scripts/fs-engine.mjs",
     "test:local-file-path": "node scripts/local-file-path.mjs",
     "test:browser-entry": "node scripts/browser-entry.mjs",
+    "test:debug-redaction": "tsx scripts/debug-redaction.ts",
     "test:e2e": "pnpm test:local-file-path && node scripts/e2e.mjs && node scripts/session-switch.mjs && node scripts/fs-engine.mjs && node scripts/browser-entry.mjs",
     "bump:patch": "node scripts/bump-version.mjs patch",
     "bump:minor": "node scripts/bump-version.mjs minor",
@@ -55,6 +56,7 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
     "tailwindcss": "^4.1.18",
+    "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "vite": "^6.0.1",
     "vite-plugin-solid": "^2.11.0"

--- a/packages/app/scripts/debug-redaction.ts
+++ b/packages/app/scripts/debug-redaction.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+
+import { redactHeaders, redactRecord, sanitizePayload } from "../src/app/lib/debug-log";
+
+const redacted = redactRecord({
+  apiKey: "secret-123",
+  token: "abc",
+  nested: {
+    password: "p@ss",
+    safe: "ok",
+  },
+});
+
+assert.equal(typeof redacted.apiKey, "object");
+assert.equal((redacted.apiKey as { redacted?: boolean }).redacted, true);
+assert.equal((redacted.token as { redacted?: boolean }).redacted, true);
+assert.equal((redacted.nested as any).password.redacted, true);
+assert.equal((redacted.nested as any).safe, "ok");
+
+const headers = redactHeaders({
+  Authorization: "Bearer secret-token",
+  Cookie: "session=abc",
+  "X-Custom": "value",
+});
+
+assert.equal((headers?.Authorization as { redacted?: boolean }).redacted, true);
+assert.equal((headers?.Cookie as { redacted?: boolean }).redacted, true);
+assert.equal(headers?.["X-Custom"], "value");
+
+const payload = sanitizePayload({
+  prompt: "hello",
+  clientSecret: "super-secret",
+});
+assert.equal((payload?.clientSecret as { redacted?: boolean }).redacted, true);
+
+console.log(JSON.stringify({ ok: true }));

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -134,6 +134,9 @@ import { useGlobalSync } from "./context/global-sync";
 import { createWorkspaceStore } from "./context/workspace";
 import {
   updaterEnvironment,
+  debugSessionClearActive,
+  debugSessionStart,
+  debugSessionStop,
   readOpencodeConfig,
   writeOpencodeConfig,
   schedulerDeleteJob,
@@ -155,6 +158,12 @@ import {
   persistFontZoom,
   readStoredFontZoom,
 } from "./lib/font-zoom";
+import {
+  createDebugSessionId,
+  DEBUG_DEFAULT_RETENTION,
+  setDebugGate,
+  type DebugSessionManifest,
+} from "./lib/debug-log";
 import {
   parseOpenworkWorkspaceIdFromUrl,
   readOpenworkBundleInviteFromSearch,
@@ -1081,11 +1090,60 @@ export default function App() {
   const [lastKnownConfigSnapshot, setLastKnownConfigSnapshot] = createSignal("");
   const [developerMode, setDeveloperMode] = createSignal(false);
   const [documentVisible, setDocumentVisible] = createSignal(true);
+  const [debugSession, setDebugSession] = createSignal<DebugSessionManifest | null>(null);
+  const [debugSessionError, setDebugSessionError] = createSignal<string | null>(null);
+  const debugLoggingEnabled = createMemo(() => Boolean(debugSession()));
+
+  setDebugGate({ enabled: () => debugLoggingEnabled() });
+  onCleanup(() => setDebugGate(null));
 
   createEffect(() => {
     if (developerMode()) return;
     clearPerfLogs();
   });
+
+  const startDebugSession = async () => {
+    if (debugSession()) return debugSession();
+    if (!isTauriRuntime()) {
+      setDebugSessionError("Debug logging is only available in the desktop app.");
+      return null;
+    }
+    setDebugSessionError(null);
+
+    const now = new Date();
+    const envMode = typeof import.meta !== "undefined" ? (import.meta as any).env?.MODE : undefined;
+
+    try {
+      const result = await debugSessionStart({
+        sessionId: createDebugSessionId(),
+        startedAt: now.toISOString(),
+        startedTs: now.getTime(),
+        appVersion: appVersion() ?? undefined,
+        environment: typeof envMode === "string" ? envMode : undefined,
+        retention: DEBUG_DEFAULT_RETENTION,
+      });
+      setDebugSession(result.manifest);
+      return result.manifest;
+    } catch (error) {
+      setDebugSessionError(error instanceof Error ? error.message : safeStringify(error));
+      return null;
+    }
+  };
+
+  const stopDebugSession = async () => {
+    if (!debugSession()) return;
+    setDebugSessionError(null);
+    if (!isTauriRuntime()) {
+      setDebugSession(null);
+      return;
+    }
+    try {
+      await debugSessionStop();
+      setDebugSession(null);
+    } catch (error) {
+      setDebugSessionError(error instanceof Error ? error.message : safeStringify(error));
+    }
+  };
 
   const [selectedSessionId, setSelectedSessionId] = createSignal<string | null>(
     null
@@ -5149,6 +5207,12 @@ export default function App() {
     }
 
     if (isTauriRuntime()) {
+      try {
+        await debugSessionClearActive();
+      } catch {
+        // ignore
+      }
+
       try {
         setAppVersion(await getVersion());
       } catch {

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1735,6 +1735,13 @@ export default function App() {
       throw new Error("Select a session before compacting.");
     }
 
+    emitUiEvent({
+      surface: "session.actions",
+      action: "session.compact",
+      interaction: "click",
+      payload: { sessionId: sessionID },
+    });
+
     const visible = messages();
     if (!visible.length) {
       throw new Error("Nothing to compact yet.");
@@ -2019,6 +2026,12 @@ export default function App() {
 
   function setSessionAgent(sessionID: string, agent: string | null) {
     const trimmed = agent?.trim() ?? "";
+    emitUiEvent({
+      surface: "session.composer",
+      action: "session.agent.change",
+      interaction: "select",
+      payload: { sessionId: sessionID, agent: trimmed || null },
+    });
     setSessionAgentById((current) => {
       const next = { ...current };
       if (!trimmed) {
@@ -2343,6 +2356,31 @@ export default function App() {
     return fileName;
   }
 
+  const respondPermissionLogged = async (requestID: string, reply: "once" | "always" | "reject") => {
+    emitUiEvent({
+      surface: "session.permission",
+      action: "permission.respond",
+      interaction: "click",
+      payload: { requestId: requestID, reply },
+    });
+    await respondPermission(requestID, reply);
+  };
+
+  const respondQuestionLogged = async (requestID: string, answers: string[][]) => {
+    const totalParts = answers.reduce((sum, entry) => sum + entry.length, 0);
+    const totalChars = answers.reduce(
+      (sum, entry) => sum + entry.reduce((inner, value) => inner + value.length, 0),
+      0,
+    );
+    emitUiEvent({
+      surface: "session.question",
+      action: "question.respond",
+      interaction: "submit",
+      payload: { requestId: requestID, answersCount: answers.length, totalParts, totalChars },
+    });
+    await respondQuestion(requestID, answers);
+  };
+
 
   async function respondPermissionAndRemember(
     requestID: string,
@@ -2350,7 +2388,7 @@ export default function App() {
   ) {
     // Intentional no-op: permission prompts grant session-scoped access only.
     // Persistent workspace roots must be managed explicitly via workspace settings.
-    await respondPermission(requestID, reply);
+    await respondPermissionLogged(requestID, reply);
   }
 
   const [notionStatus, setNotionStatus] = createSignal<"disconnected" | "connecting" | "connected" | "error">(
@@ -6323,11 +6361,11 @@ export default function App() {
     setPrompt: setPrompt,
     activePermission: activePermissionMemo(),
     permissionReplyBusy: permissionReplyBusy(),
-    respondPermission: respondPermission,
+    respondPermission: respondPermissionLogged,
     respondPermissionAndRemember: respondPermissionAndRemember,
     activeQuestion: activeQuestion(),
     questionReplyBusy: questionReplyBusy(),
-    respondQuestion: respondQuestion,
+    respondQuestion: respondQuestionLogged,
     safeStringify: safeStringify,
     showTryNotionPrompt: tryNotionPromptVisible() && notionIsActive(),
     startProviderAuth: startProviderAuth,

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -159,12 +159,17 @@ import {
   readStoredFontZoom,
 } from "./lib/font-zoom";
 import {
+  buildDebugEventBase,
+  createDebugCorrelationId,
   createDebugSessionId,
   DEBUG_DEFAULT_RETENTION,
+  setActiveCorrelationId,
   setDebugGate,
   setDebugSessionProvider,
+  type DebugEventBase,
   type DebugSessionManifest,
 } from "./lib/debug-log";
+import { appendDebugEvent } from "./lib/debug-log-writer";
 import {
   parseOpenworkWorkspaceIdFromUrl,
   readOpenworkBundleInviteFromSearch,
@@ -623,6 +628,15 @@ export default function App() {
   };
 
   const setTab = (nextTab: DashboardTab) => {
+    const prevTab = tab();
+    if (prevTab !== nextTab) {
+      emitUiEvent({
+        surface: "app.dashboard",
+        action: "dashboard.tab.change",
+        interaction: "navigate",
+        payload: { from: prevTab, to: nextTab },
+      });
+    }
     if (currentView() === "dashboard") {
       goToDashboard(nextTab);
       return;
@@ -631,6 +645,15 @@ export default function App() {
   };
 
   const setView = (next: View, sessionId?: string) => {
+    const prevView = currentView();
+    if (prevView !== next) {
+      emitUiEvent({
+        surface: "app.shell",
+        action: "view.change",
+        interaction: "navigate",
+        payload: { from: prevView, to: next, sessionId: sessionId ?? null },
+      });
+    }
     if (next === "dashboard" && creatingSession()) {
       return;
     }
@@ -1146,6 +1169,73 @@ export default function App() {
     } catch (error) {
       setDebugSessionError(error instanceof Error ? error.message : safeStringify(error));
     }
+  };
+
+  const emitUiEvent = (input: {
+    action: string;
+    interaction: string;
+    surface?: string;
+    payload?: Record<string, unknown>;
+    entity?: DebugEventBase["entity"];
+    correlationId?: string;
+  }) => {
+    const session = debugSession();
+    if (!session) return;
+    const correlationId = input.correlationId ?? createDebugCorrelationId();
+    setActiveCorrelationId(correlationId);
+    const base = buildDebugEventBase({
+      kind: "ui",
+      debugSessionId: session.id,
+      correlationId,
+      surface: input.surface ?? "app.shell",
+      action: input.action,
+      entity: input.entity,
+      payload: input.payload,
+    });
+    void appendDebugEvent({
+      ...base,
+      kind: "ui",
+      interaction: input.interaction,
+    });
+  };
+
+  const [lastRoutePath, setLastRoutePath] = createSignal<string | null>(null);
+  createEffect(() => {
+    const path = location.pathname;
+    const prev = lastRoutePath();
+    if (prev === null) {
+      setLastRoutePath(path);
+      return;
+    }
+    if (prev === path) return;
+    emitUiEvent({
+      surface: "app.router",
+      action: "route.change",
+      interaction: "navigate",
+      payload: { from: prev, to: path, view: currentView() },
+    });
+    setLastRoutePath(path);
+  });
+
+  const trackDialog = (dialogId: string, isOpen: () => boolean, payload?: () => Record<string, unknown>) => {
+    let initialized = false;
+    let prev = isOpen();
+    createEffect(() => {
+      const next = isOpen();
+      if (!initialized) {
+        initialized = true;
+        prev = next;
+        return;
+      }
+      if (prev === next) return;
+      emitUiEvent({
+        surface: "app.modal",
+        action: next ? "dialog.open" : "dialog.close",
+        interaction: "toggle",
+        payload: { dialogId, state: next ? "open" : "closed", ...(payload ? payload() : {}) },
+      });
+      prev = next;
+    });
   };
 
   const [selectedSessionId, setSelectedSessionId] = createSignal<string | null>(
@@ -5747,6 +5837,15 @@ export default function App() {
     return "workspace.switching_status_preparing";
   });
 
+  trackDialog("model-picker", modelPickerOpen, () => ({ target: modelPickerTarget() }));
+  trackDialog("reset-openwork", resetModalOpen, () => ({ mode: resetModalMode() }));
+  trackDialog("mcp-auth", mcpAuthModalOpen, () => ({ provider: mcpAuthEntry()?.provider ?? null }));
+  trackDialog("provider-auth", providerAuthModalOpen);
+  trackDialog("workspace-create", () => workspaceStore.createWorkspaceOpen());
+  trackDialog("workspace-create-remote", () => workspaceStore.createRemoteWorkspaceOpen());
+  trackDialog("workspace-rename", renameWorkspaceOpen, () => ({ workspaceId: renameWorkspaceId() }));
+  trackDialog("workspace-switch", workspaceSwitchOpen, () => ({ workspaceId: workspaceStore.connectingWorkspaceId() }));
+
   const localHostLabel = createMemo(() => {
     const info = engine();
     if (info?.hostname && info?.port) {
@@ -5759,6 +5858,29 @@ export default function App() {
       return "localhost:4096";
     }
   });
+
+  const setSettingsTabLogged = (next: SettingsTab) => {
+    const prev = settingsTab();
+    if (prev !== next) {
+      emitUiEvent({
+        surface: "app.settings",
+        action: "settings.tab.change",
+        interaction: "navigate",
+        payload: { from: prev, to: next },
+      });
+    }
+    setSettingsTab(next);
+  };
+
+  const openSettingsFromUi = () => {
+    emitUiEvent({
+      surface: "app.settings",
+      action: "settings.open",
+      interaction: "click",
+    });
+    setTab("settings");
+    setView("dashboard");
+  };
 
   const onboardingProps = () => ({
     startupPreference: startupPreference(),
@@ -5828,10 +5950,7 @@ export default function App() {
         workspaceStore.engineDoctorResult()?.notes?.join("\n") ?? "";
       workspaceStore.setEngineInstallLogs(notes || null);
     },
-    onOpenSettings: () => {
-      setTab("settings");
-      setView("dashboard");
-    },
+    onOpenSettings: openSettingsFromUi,
     themeMode: themeMode(),
     setThemeMode,
   });
@@ -5871,7 +5990,7 @@ export default function App() {
       tab: tab(),
       setTab,
       settingsTab: settingsTab(),
-      setSettingsTab,
+      setSettingsTab: setSettingsTabLogged,
       providers: providers(),
       providerConnectedIds: providerConnectedIds(),
       providerAuthBusy: providerAuthBusy(),

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1149,6 +1149,17 @@ export default function App() {
         retention: DEBUG_DEFAULT_RETENTION,
       });
       setDebugSession(result.manifest);
+      const correlationId = createDebugCorrelationId();
+      setActiveCorrelationId(correlationId);
+      const base = buildDebugEventBase({
+        kind: "lifecycle",
+        debugSessionId: result.manifest.id,
+        correlationId,
+        surface: "app.support",
+        action: "debug.start",
+        payload: { startedAt: result.manifest.startedAt },
+      });
+      void appendDebugEvent({ ...base, kind: "lifecycle", phase: "start" });
       return result.manifest;
     } catch (error) {
       setDebugSessionError(error instanceof Error ? error.message : safeStringify(error));
@@ -1164,6 +1175,20 @@ export default function App() {
       return;
     }
     try {
+      const session = debugSession();
+      if (session) {
+        const correlationId = createDebugCorrelationId();
+        setActiveCorrelationId(correlationId);
+        const base = buildDebugEventBase({
+          kind: "lifecycle",
+          debugSessionId: session.id,
+          correlationId,
+          surface: "app.support",
+          action: "debug.stop",
+          payload: { stoppedAt: new Date().toISOString() },
+        });
+        void appendDebugEvent({ ...base, kind: "lifecycle", phase: "stop" });
+      }
       await debugSessionStop();
       setDebugSession(null);
     } catch (error) {
@@ -2070,6 +2095,14 @@ export default function App() {
 
   async function startProviderAuth(providerId?: string): Promise<ProviderOAuthStartResult> {
     setProviderAuthError(null);
+    if (providerId?.trim()) {
+      emitUiEvent({
+        surface: "app.settings",
+        action: "provider.oauth.start",
+        interaction: "click",
+        payload: { providerId: providerId.trim() },
+      });
+    }
     const c = client();
     if (!c) {
       throw new Error("Not connected to a server");
@@ -2154,6 +2187,12 @@ export default function App() {
 
   async function completeProviderAuthOAuth(providerId: string, methodIndex: number, code?: string) {
     setProviderAuthError(null);
+    emitUiEvent({
+      surface: "app.settings",
+      action: "provider.oauth.complete",
+      interaction: "submit",
+      payload: { providerId, methodIndex, hasCode: Boolean(code?.trim()) },
+    });
     const c = client();
     if (!c) {
       throw new Error("Not connected to a server");
@@ -2227,6 +2266,12 @@ export default function App() {
 
   async function submitProviderApiKey(providerId: string, apiKey: string) {
     setProviderAuthError(null);
+    emitUiEvent({
+      surface: "app.settings",
+      action: "provider.apiKey.submit",
+      interaction: "submit",
+      payload: { providerId, hasKey: Boolean(apiKey?.trim()) },
+    });
     const c = client();
     if (!c) {
       throw new Error("Not connected to a server");
@@ -2253,6 +2298,12 @@ export default function App() {
 
   async function disconnectProvider(providerId: string) {
     setProviderAuthError(null);
+    emitUiEvent({
+      surface: "app.settings",
+      action: "provider.disconnect",
+      interaction: "click",
+      payload: { providerId },
+    });
     const c = client();
     if (!c) {
       throw new Error("Not connected to a server");
@@ -3431,11 +3482,28 @@ export default function App() {
   const resolvedDevtoolsWorkspaceId = createMemo(() => devtoolsWorkspaceId() ?? openworkServerWorkspaceId());
 
   function updateOpenworkServerSettings(next: OpenworkServerSettings) {
+    const prev = openworkServerSettings();
+    emitUiEvent({
+      surface: "app.settings",
+      action: "openwork.settings.update",
+      interaction: "change",
+      payload: {
+        urlOverrideChanged: (prev.urlOverride ?? "") !== (next.urlOverride ?? ""),
+        portOverrideChanged: (prev.portOverride ?? null) !== (next.portOverride ?? null),
+        tokenChanged: (prev.token ?? "") !== (next.token ?? ""),
+        hasToken: Boolean((next.token ?? "").trim()),
+      },
+    });
     const stored = writeOpenworkServerSettings(next);
     setOpenworkServerSettings(stored);
   }
 
   const resetOpenworkServerSettings = () => {
+    emitUiEvent({
+      surface: "app.settings",
+      action: "openwork.settings.reset",
+      interaction: "click",
+    });
     clearOpenworkServerSettings();
     setOpenworkServerSettings({});
   };
@@ -3840,6 +3908,12 @@ export default function App() {
 
   const setWorkspaceAutoReloadEnabled = async (next: boolean) => {
     if (!workspaceAutoReloadAvailable()) return;
+    emitUiEvent({
+      surface: "app.settings",
+      action: "workspace.autoReload.toggle",
+      interaction: "toggle",
+      payload: { enabled: next },
+    });
     const cfg = workspaceStore.workspaceConfig();
     const resume = Boolean(cfg?.reload?.resume);
     await workspaceStore.persistReloadSettings({ auto: next, resume: next ? resume : false });
@@ -3847,6 +3921,12 @@ export default function App() {
 
   const setWorkspaceAutoReloadResumeEnabled = async (next: boolean) => {
     if (!workspaceAutoReloadAvailable()) return;
+    emitUiEvent({
+      surface: "app.settings",
+      action: "workspace.autoReload.resume.toggle",
+      interaction: "toggle",
+      payload: { enabled: next },
+    });
     const cfg = workspaceStore.workspaceConfig();
     const auto = Boolean(cfg?.reload?.auto);
     await workspaceStore.persistReloadSettings({ auto, resume: auto ? next : false });
@@ -4379,6 +4459,17 @@ export default function App() {
   }
 
   function applyModelSelection(next: ModelRef) {
+    const target = modelPickerTarget() === "default" ? "default" : "session";
+    emitUiEvent({
+      surface: "app.settings",
+      action: "model.select",
+      interaction: "select",
+      payload: {
+        target,
+        providerId: next.providerID,
+        modelId: next.modelID,
+      },
+    });
     if (modelPickerTarget() === "default") {
       setDefaultModelExplicit(true);
       setDefaultModel(next);
@@ -5920,6 +6011,37 @@ export default function App() {
     setView("dashboard");
   };
 
+  const setThemeModeLogged = (next: ThemeMode) => {
+    emitUiEvent({
+      surface: "app.settings",
+      action: "theme.change",
+      interaction: "select",
+      payload: { mode: next },
+    });
+    setThemeMode(next);
+  };
+
+  const setModelVariantLogged = (value: string) => {
+    emitUiEvent({
+      surface: "session.composer",
+      action: "model.variant.change",
+      interaction: "select",
+      payload: { value },
+    });
+    setModelVariant(value);
+  };
+
+  const toggleAutoCompactContextLogged = () => {
+    const next = !autoCompactContext();
+    emitUiEvent({
+      surface: "session.settings",
+      action: "session.autoCompact.toggle",
+      interaction: "toggle",
+      payload: { enabled: next },
+    });
+    setAutoCompactContext(next);
+  };
+
   const onboardingProps = () => ({
     startupPreference: startupPreference(),
     onboardingStep: onboardingStep(),
@@ -5968,7 +6090,7 @@ export default function App() {
     onRepairMigration: workspaceStore.onRepairOpencodeMigration,
     onCreateWorkspace: workspaceStore.createWorkspaceFlow,
     onPickWorkspaceFolder: workspaceStore.pickWorkspaceFolder,
-    onImportWorkspaceConfig: workspaceStore.importWorkspaceConfig,
+    onImportWorkspaceConfig: importWorkspaceConfigLogged,
     importingWorkspaceConfig: workspaceStore.importingWorkspaceConfig(),
     onAttachHost: workspaceStore.onAttachHost,
     onConnectClient: workspaceStore.onConnectClient,
@@ -5990,7 +6112,7 @@ export default function App() {
     },
     onOpenSettings: openSettingsFromUi,
     themeMode: themeMode(),
-    setThemeMode,
+    setThemeMode: setThemeModeLogged,
   });
 
   const dashboardProps = () => {
@@ -6093,9 +6215,9 @@ export default function App() {
       recoverWorkspace: workspaceStore.recoverWorkspace,
       openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
       openCreateRemoteWorkspace: () => workspaceStore.setCreateRemoteWorkspaceOpen(true),
-      importWorkspaceConfig: workspaceStore.importWorkspaceConfig,
+      importWorkspaceConfig: importWorkspaceConfigLogged,
       importingWorkspaceConfig: workspaceStore.importingWorkspaceConfig(),
-      exportWorkspaceConfig: workspaceStore.exportWorkspaceConfig,
+      exportWorkspaceConfig: exportWorkspaceConfigLogged,
       exportWorkspaceBusy: workspaceStore.exportingWorkspaceConfig(),
       createWorkspaceOpen: workspaceStore.createWorkspaceOpen(),
       setCreateWorkspaceOpen: workspaceStore.setCreateWorkspaceOpen,
@@ -6212,7 +6334,7 @@ export default function App() {
         setRememberStartupChoice(false);
       },
       themeMode: themeMode(),
-      setThemeMode,
+      setThemeMode: setThemeModeLogged,
       pendingPermissions: pendingPermissions(),
       events: events(),
       workspaceDebugEvents: workspaceStore.workspaceDebugEvents(),
@@ -6277,6 +6399,38 @@ export default function App() {
     }
   };
 
+  const importWorkspaceConfigLogged = () => {
+    emitUiEvent({
+      surface: "app.settings",
+      action: "workspace.import",
+      interaction: "click",
+      payload: { workspaceId: workspaceStore.activeWorkspaceId() },
+    });
+    return workspaceStore.importWorkspaceConfig();
+  };
+
+  const exportWorkspaceConfigLogged = (workspaceId?: string) => {
+    const id = workspaceId ?? workspaceStore.activeWorkspaceId();
+    emitUiEvent({
+      surface: "app.settings",
+      action: "workspace.export",
+      interaction: "click",
+      payload: { workspaceId: id },
+    });
+    return workspaceStore.exportWorkspaceConfig(id);
+  };
+
+  const saveSessionExportLogged = (sessionId?: string) => {
+    const id = sessionId ?? selectedSessionId() ?? null;
+    emitUiEvent({
+      surface: "session.export",
+      action: "session.export",
+      interaction: "click",
+      payload: { sessionId: id },
+    });
+    return saveSessionExport(sessionId);
+  };
+
   const sessionProps = () => ({
     selectedSessionId: activeSessionId(),
     setView,
@@ -6296,9 +6450,9 @@ export default function App() {
     forgetWorkspace: workspaceStore.forgetWorkspace,
     openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
     openCreateRemoteWorkspace: () => workspaceStore.setCreateRemoteWorkspaceOpen(true),
-    importWorkspaceConfig: workspaceStore.importWorkspaceConfig,
+    importWorkspaceConfig: importWorkspaceConfigLogged,
     importingWorkspaceConfig: workspaceStore.importingWorkspaceConfig(),
-    exportWorkspaceConfig: workspaceStore.exportWorkspaceConfig,
+    exportWorkspaceConfig: exportWorkspaceConfigLogged,
     exportWorkspaceBusy: workspaceStore.exportingWorkspaceConfig(),
     clientConnected: Boolean(client()),
     openworkServerStatus: openworkServerStatus(),
@@ -6318,7 +6472,7 @@ export default function App() {
     openSessionModelPicker: openSessionModelPicker,
     modelVariantLabel: formatModelVariantLabel(modelVariant()),
     modelVariant: modelVariant(),
-    setModelVariant: (value: string) => setModelVariant(value),
+    setModelVariant: setModelVariantLogged,
     activePlugins: sidebarPluginList(),
     activePluginStatus: sidebarPluginStatus(),
     mcpServers: mcpServers(),
@@ -6346,7 +6500,7 @@ export default function App() {
     developerMode: developerMode(),
     showThinking: showThinking(),
     autoCompactContext: autoCompactContext(),
-    toggleAutoCompactContext: () => setAutoCompactContext((v) => !v),
+    toggleAutoCompactContext: toggleAutoCompactContextLogged,
     groupMessageParts,
     summarizeStep,
     expandedStepIds: expandedStepIds(),
@@ -6384,7 +6538,7 @@ export default function App() {
     listCommands: listCommands,
     selectedSessionAgent: selectedSessionAgent(),
     setSessionAgent: setSessionAgent,
-    saveSession: saveSessionExport,
+    saveSession: saveSessionExportLogged,
     sessionStatusById: activeSessionStatusById(),
     hasEarlierMessages: selectedSessionHasEarlierMessages(),
     loadingEarlierMessages: selectedSessionLoadingEarlierMessages(),

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1115,7 +1115,12 @@ export default function App() {
   const [developerMode, setDeveloperMode] = createSignal(false);
   const [documentVisible, setDocumentVisible] = createSignal(true);
   const [debugSession, setDebugSession] = createSignal<DebugSessionManifest | null>(null);
+  const [lastDebugSession, setLastDebugSession] = createSignal<DebugSessionManifest | null>(null);
   const [debugSessionError, setDebugSessionError] = createSignal<string | null>(null);
+  const [debugSessionPending, setDebugSessionPending] = createSignal<"start" | "stop" | null>(null);
+  const [supportReportSubmitBusy, setSupportReportSubmitBusy] = createSignal(false);
+  const [supportReportSubmitStatus, setSupportReportSubmitStatus] = createSignal<string | null>(null);
+  const [supportReportSubmitError, setSupportReportSubmitError] = createSignal<string | null>(null);
   const debugLoggingEnabled = createMemo(() => Boolean(debugSession()));
 
   setDebugGate({ enabled: () => debugLoggingEnabled() });
@@ -1134,7 +1139,11 @@ export default function App() {
       setDebugSessionError("Debug logging is only available in the desktop app.");
       return null;
     }
+    setDebugSessionPending("start");
     setDebugSessionError(null);
+    setSupportReportSubmitStatus(null);
+    setSupportReportSubmitError(null);
+    setLastDebugSession(null);
 
     const now = new Date();
     const envMode = typeof import.meta !== "undefined" ? (import.meta as any).env?.MODE : undefined;
@@ -1164,18 +1173,24 @@ export default function App() {
     } catch (error) {
       setDebugSessionError(error instanceof Error ? error.message : safeStringify(error));
       return null;
+    } finally {
+      setDebugSessionPending(null);
     }
   };
 
   const stopDebugSession = async () => {
-    if (!debugSession()) return;
+    const active = debugSession();
+    if (!active) return lastDebugSession();
     setDebugSessionError(null);
+    setDebugSessionPending("stop");
     if (!isTauriRuntime()) {
+      setLastDebugSession(active);
       setDebugSession(null);
-      return;
+      setDebugSessionPending(null);
+      return active;
     }
     try {
-      const session = debugSession();
+      const session = active;
       if (session) {
         const correlationId = createDebugCorrelationId();
         setActiveCorrelationId(correlationId);
@@ -1190,9 +1205,50 @@ export default function App() {
         void appendDebugEvent({ ...base, kind: "lifecycle", phase: "stop" });
       }
       await debugSessionStop();
+      setLastDebugSession(session);
       setDebugSession(null);
+      return session;
     } catch (error) {
       setDebugSessionError(error instanceof Error ? error.message : safeStringify(error));
+      return null;
+    } finally {
+      setDebugSessionPending(null);
+    }
+  };
+
+  const submitSupportReport = async (input: { email: string; message: string }) => {
+    const email = input.email.trim();
+    const message = input.message.trim();
+    setSupportReportSubmitBusy(true);
+    setSupportReportSubmitStatus(null);
+    setSupportReportSubmitError(null);
+    try {
+      const session = debugSession() ? await stopDebugSession() : lastDebugSession();
+      if (!session) {
+        throw new Error("Start debug logging, reproduce the issue, then stop recording before sending a report.");
+      }
+      const correlationId = createDebugCorrelationId();
+      setActiveCorrelationId(correlationId);
+      const emailDomain = email.includes("@") ? email.split("@").pop() ?? null : null;
+      const base = buildDebugEventBase({
+        kind: "lifecycle",
+        debugSessionId: session.id,
+        correlationId,
+        surface: "app.support",
+        action: "debug.submit.requested",
+        payload: {
+          emailDomain,
+          messageLength: message.length,
+        },
+      });
+      await appendDebugEvent({ ...base, kind: "lifecycle", phase: "submit" });
+      throw new Error("Support report upload is not wired yet in this build.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setSupportReportSubmitError(message);
+      throw error;
+    } finally {
+      setSupportReportSubmitBusy(false);
     }
   };
 
@@ -5968,7 +6024,7 @@ export default function App() {
 
   trackDialog("model-picker", modelPickerOpen, () => ({ target: modelPickerTarget() }));
   trackDialog("reset-openwork", resetModalOpen, () => ({ mode: resetModalMode() }));
-  trackDialog("mcp-auth", mcpAuthModalOpen, () => ({ provider: mcpAuthEntry()?.provider ?? null }));
+  trackDialog("mcp-auth", mcpAuthModalOpen, () => ({ provider: mcpAuthEntry()?.name ?? null }));
   trackDialog("provider-auth", providerAuthModalOpen);
   trackDialog("workspace-create", () => workspaceStore.createWorkspaceOpen());
   trackDialog("workspace-create-remote", () => workspaceStore.createRemoteWorkspaceOpen());
@@ -6151,6 +6207,18 @@ export default function App() {
       setTab,
       settingsTab: settingsTab(),
       setSettingsTab: setSettingsTabLogged,
+      debugLoggingEnabled: debugLoggingEnabled(),
+      debugSession: debugSession(),
+      lastDebugSession: lastDebugSession(),
+      debugSessionError: debugSessionError(),
+      debugSessionStarting: debugSessionPending() === "start",
+      debugSessionStopping: debugSessionPending() === "stop",
+      supportSubmitBusy: supportReportSubmitBusy(),
+      supportSubmitStatus: supportReportSubmitStatus(),
+      supportSubmitError: supportReportSubmitError(),
+      startDebugLogging: startDebugSession,
+      stopDebugLogging: stopDebugSession,
+      submitSupportReport,
       providers: providers(),
       providerConnectedIds: providerConnectedIds(),
       providerAuthBusy: providerAuthBusy(),
@@ -6428,7 +6496,8 @@ export default function App() {
       interaction: "click",
       payload: { sessionId: id },
     });
-    return saveSessionExport(sessionId);
+    if (!id) return Promise.resolve("");
+    return saveSessionExport(id);
   };
 
   const sessionProps = () => ({

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -162,6 +162,7 @@ import {
   createDebugSessionId,
   DEBUG_DEFAULT_RETENTION,
   setDebugGate,
+  setDebugSessionProvider,
   type DebugSessionManifest,
 } from "./lib/debug-log";
 import {
@@ -1096,6 +1097,8 @@ export default function App() {
 
   setDebugGate({ enabled: () => debugLoggingEnabled() });
   onCleanup(() => setDebugGate(null));
+  setDebugSessionProvider({ get: () => debugSession() });
+  onCleanup(() => setDebugSessionProvider(null));
 
   createEffect(() => {
     if (developerMode()) return;

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -597,6 +597,7 @@ export default function App() {
       // ignore
     }
   };
+
   type ProviderAuthMethod = { type: "oauth" | "api"; label: string };
   type ProviderOAuthStartResult = {
     methodIndex: number;

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -12,7 +12,9 @@ type StatusBarProps = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
   developerMode: boolean;
+  debugLoggingEnabled: boolean;
   onOpenSettings: () => void;
+  onOpenSupport: () => void;
   onOpenMessaging: () => void;
   onOpenProviders: () => Promise<void> | void;
   onOpenMcp: () => void;
@@ -224,6 +226,18 @@ export default function StatusBar(props: StatusBarProps) {
             >
               <span class="uppercase tracking-[0.2em] text-[10px] text-gray-8">Tip</span>
               <span class="text-gray-11 font-medium">{activeTip()?.label}</span>
+            </button>
+          </Show>
+          <Show when={props.debugLoggingEnabled}>
+            <button
+              type="button"
+              class="flex h-7 items-center gap-2 rounded-full border border-red-7/45 bg-red-4/65 px-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-red-11 transition-colors hover:bg-red-4/85 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-7/35"
+              onClick={props.onOpenSupport}
+              title="Open debug logging support flow"
+              aria-label="Open debug logging support flow"
+            >
+              <span class="h-2 w-2 rounded-full bg-red-10" />
+              <span>Debug logging enabled</span>
             </button>
           </Show>
           <Button

--- a/packages/app/src/app/lib/debug-config.ts
+++ b/packages/app/src/app/lib/debug-config.ts
@@ -1,0 +1,165 @@
+import { parse } from "jsonc-parser";
+
+import { isTauriRuntime } from "../utils";
+import { readOpenworkServerSettings, type OpenworkServerSettings } from "./openwork-server";
+import { readOpencodeConfig, workspaceOpenworkRead, type WorkspaceOpenworkConfig } from "./tauri";
+import { redactRecord, redactUnknown, redactValue, type DebugRedactedValue } from "./debug-log";
+
+export type DebugConfigSnapshot = {
+  collectedAt: string;
+  app: {
+    openworkServerSettings: {
+      urlOverride?: string;
+      portOverride?: number;
+      token?: DebugRedactedValue | null;
+    };
+  };
+  workspace?: {
+    id?: string;
+    name?: string;
+    type?: string;
+    path?: string;
+  };
+  openworkConfig?: DebugConfigEntry;
+  opencodeConfig?: DebugConfigEntry;
+  notes: string[];
+};
+
+export type DebugConfigEntry = {
+  source: "tauri" | "server";
+  payload?: Record<string, unknown>;
+  error?: string;
+};
+
+type DebugConfigInput = {
+  workspaceId?: string | null;
+  workspaceName?: string | null;
+  workspaceType?: string | null;
+  workspacePath?: string | null;
+  openworkServerClient?: { getConfig: (workspaceId: string) => Promise<{ opencode: Record<string, unknown>; openwork: Record<string, unknown> }> } | null;
+  openworkServerWorkspaceId?: string | null;
+};
+
+const OPENCODE_CONFIG_ALLOWLIST = new Set([
+  "version",
+  "providers",
+  "models",
+  "mcp",
+  "plugins",
+  "skills",
+  "commands",
+  "agents",
+  "router",
+  "sandbox",
+  "policy",
+  "workspace",
+]);
+
+const OPENWORK_CONFIG_ALLOWLIST = new Set([
+  "version",
+  "workspace",
+  "authorizedRoots",
+  "reload",
+]);
+
+const pickAllowlist = (input: Record<string, unknown>, allowlist: Set<string>) => {
+  const next: Record<string, unknown> = {};
+  for (const key of Object.keys(input)) {
+    if (allowlist.has(key)) {
+      next[key] = redactUnknown(input[key]);
+    }
+  }
+  return next;
+};
+
+const readJsonc = (content: string) => {
+  try {
+    const parsed = parse(content) as Record<string, unknown> | null;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const sanitizeOpencodeConfig = (raw: Record<string, unknown>) => pickAllowlist(raw, OPENCODE_CONFIG_ALLOWLIST);
+const sanitizeOpenworkConfig = (raw: Record<string, unknown>) => pickAllowlist(raw, OPENWORK_CONFIG_ALLOWLIST);
+
+const redactOpenworkServerSettings = (settings: OpenworkServerSettings) => ({
+  urlOverride: settings.urlOverride,
+  portOverride: settings.portOverride,
+  token: settings.token ? redactValue("token") : null,
+});
+
+export async function collectDebugConfigSnapshots(input: DebugConfigInput): Promise<DebugConfigSnapshot> {
+  const notes: string[] = [];
+  const snapshot: DebugConfigSnapshot = {
+    collectedAt: new Date().toISOString(),
+    app: {
+      openworkServerSettings: redactOpenworkServerSettings(readOpenworkServerSettings()),
+    },
+    notes,
+  };
+
+  if (input.workspaceId || input.workspaceName || input.workspaceType || input.workspacePath) {
+    snapshot.workspace = {
+      id: input.workspaceId ?? undefined,
+      name: input.workspaceName ?? undefined,
+      type: input.workspaceType ?? undefined,
+      path: input.workspacePath ?? undefined,
+    };
+  }
+
+  if (input.openworkServerClient && input.openworkServerWorkspaceId) {
+    try {
+      const config = await input.openworkServerClient.getConfig(input.openworkServerWorkspaceId);
+      snapshot.opencodeConfig = {
+        source: "server",
+        payload: sanitizeOpencodeConfig(config.opencode ?? {}),
+      };
+      snapshot.openworkConfig = {
+        source: "server",
+        payload: sanitizeOpenworkConfig(config.openwork ?? {}),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to read OpenWork server config";
+      snapshot.opencodeConfig = { source: "server", error: message };
+      snapshot.openworkConfig = { source: "server", error: message };
+      notes.push(message);
+    }
+  }
+
+  if (isTauriRuntime() && input.workspacePath) {
+    try {
+      const opencode = await readOpencodeConfig("project", input.workspacePath);
+      const parsed = opencode.content ? readJsonc(opencode.content) : null;
+      if (parsed) {
+        snapshot.opencodeConfig = {
+          source: "tauri",
+          payload: sanitizeOpencodeConfig(parsed),
+        };
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to read opencode config";
+      snapshot.opencodeConfig = { source: "tauri", error: message };
+      notes.push(message);
+    }
+
+    try {
+      const openwork = await workspaceOpenworkRead({ workspacePath: input.workspacePath });
+      snapshot.openworkConfig = {
+        source: "tauri",
+        payload: sanitizeOpenworkConfig(redactRecord(openwork) as Record<string, unknown>),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to read openwork config";
+      snapshot.openworkConfig = { source: "tauri", error: message };
+      notes.push(message);
+    }
+  }
+
+  if (notes.length === 0) {
+    notes.push("Config snapshot collected with allowlisted keys and redaction.");
+  }
+
+  return snapshot;
+}

--- a/packages/app/src/app/lib/debug-log-writer.ts
+++ b/packages/app/src/app/lib/debug-log-writer.ts
@@ -1,0 +1,37 @@
+import { isTauriRuntime } from "../utils";
+import { debugSessionAppend } from "./tauri";
+import {
+  getActiveDebugSession,
+  isDebugLoggingEnabled,
+  sanitizePayload,
+  type DebugEvent,
+} from "./debug-log";
+
+export type DebugLogTarget = "timeline" | "system";
+
+export async function appendDebugEvent(
+  event: DebugEvent,
+  target: DebugLogTarget = "timeline",
+): Promise<boolean> {
+  if (!isDebugLoggingEnabled()) return false;
+  if (!isTauriRuntime()) return false;
+  const session = getActiveDebugSession();
+  if (!session) return false;
+
+  const sanitized = { ...event, payload: sanitizePayload(event.payload) };
+  const line = JSON.stringify(sanitized);
+  const maxBytes =
+    target === "system" ? session.retention.maxSystemBytes : session.retention.maxTimelineBytes;
+
+  try {
+    const result = await debugSessionAppend({
+      sessionId: session.id,
+      target,
+      line,
+      maxBytes,
+    });
+    return result.appended;
+  } catch {
+    return false;
+  }
+}

--- a/packages/app/src/app/lib/debug-log-writer.ts
+++ b/packages/app/src/app/lib/debug-log-writer.ts
@@ -1,13 +1,24 @@
 import { isTauriRuntime } from "../utils";
-import { debugSessionAppend } from "./tauri";
 import {
+  buildDebugEventBase,
+  createDebugCorrelationId,
   getActiveDebugSession,
+  getActiveCorrelationId,
   isDebugLoggingEnabled,
+  setActiveCorrelationId,
   sanitizePayload,
   type DebugEvent,
+  type DebugEventBase,
 } from "./debug-log";
 
 export type DebugLogTarget = "timeline" | "system";
+
+type DebugCallInput = {
+  operation: string;
+  surface: string;
+  args?: Record<string, unknown> | null;
+  entity?: DebugEventBase["entity"];
+};
 
 export async function appendDebugEvent(
   event: DebugEvent,
@@ -24,6 +35,7 @@ export async function appendDebugEvent(
     target === "system" ? session.retention.maxSystemBytes : session.retention.maxTimelineBytes;
 
   try {
+    const { debugSessionAppend } = await import("./tauri");
     const result = await debugSessionAppend({
       sessionId: session.id,
       target,
@@ -33,5 +45,89 @@ export async function appendDebugEvent(
     return result.appended;
   } catch {
     return false;
+  }
+}
+
+const normalizeError = (error: unknown) => {
+  if (error instanceof Error) {
+    const anyError = error as Error & { code?: string; status?: number; statusCode?: number };
+    return {
+      message: error.message,
+      kind: error.name,
+      code: typeof anyError.code === "string" ? anyError.code : undefined,
+      status: typeof anyError.status === "number" ? anyError.status : anyError.statusCode,
+    };
+  }
+  if (error && typeof error === "object") {
+    const record = error as Record<string, unknown>;
+    const message = typeof record.message === "string" ? record.message : undefined;
+    const code = typeof record.code === "string" ? record.code : undefined;
+    const kind = typeof record.name === "string" ? record.name : undefined;
+    const status = typeof record.status === "number"
+      ? record.status
+      : typeof record.statusCode === "number"
+        ? record.statusCode
+        : undefined;
+    return { message, code, kind, status };
+  }
+  return { message: undefined, code: undefined, kind: undefined, status: undefined };
+};
+
+export async function withDebugCall<T>(input: DebugCallInput, fn: () => Promise<T>): Promise<T> {
+  if (!isDebugLoggingEnabled() || !isTauriRuntime()) {
+    return fn();
+  }
+  const session = getActiveDebugSession();
+  if (!session) return fn();
+
+  const correlationId = getActiveCorrelationId() ?? createDebugCorrelationId();
+  setActiveCorrelationId(correlationId);
+  const startedAt = Date.now();
+
+  try {
+    const result = await fn();
+    const endedAt = Date.now();
+    const base = buildDebugEventBase({
+      kind: "call",
+      debugSessionId: session.id,
+      correlationId,
+      surface: input.surface,
+      action: input.operation,
+      entity: input.entity,
+      payload: input.args ? { args: input.args, startedAt, endedAt } : { startedAt, endedAt },
+    });
+    await appendDebugEvent({
+      ...base,
+      kind: "call",
+      operation: input.operation,
+      status: "ok",
+      durationMs: endedAt - startedAt,
+    });
+    return result;
+  } catch (error) {
+    const endedAt = Date.now();
+    const normalized = normalizeError(error);
+    const base = buildDebugEventBase({
+      kind: "call",
+      debugSessionId: session.id,
+      correlationId,
+      surface: input.surface,
+      action: input.operation,
+      entity: input.entity,
+      payload: input.args ? { args: input.args, startedAt, endedAt } : { startedAt, endedAt },
+    });
+    await appendDebugEvent({
+      ...base,
+      kind: "call",
+      operation: input.operation,
+      status: "error",
+      durationMs: endedAt - startedAt,
+      error: {
+        code: normalized.code || (normalized.status ? String(normalized.status) : undefined),
+        message: normalized.message,
+        kind: normalized.kind,
+      },
+    });
+    throw error;
   }
 }

--- a/packages/app/src/app/lib/debug-log.ts
+++ b/packages/app/src/app/lib/debug-log.ts
@@ -1,0 +1,265 @@
+export type DebugEventKind = "ui" | "call" | "system" | "lifecycle";
+
+export type DebugEventBase = {
+  kind: DebugEventKind;
+  id: string;
+  at: string;
+  ts: number;
+  debugSessionId: string;
+  correlationId?: string;
+  surface: string;
+  action: string;
+  entity?: {
+    workspaceId?: string;
+    sessionId?: string;
+    commandId?: string;
+    toolCallId?: string;
+    messageId?: string;
+  };
+  payload?: Record<string, unknown>;
+};
+
+export type DebugUiEvent = DebugEventBase & {
+  kind: "ui";
+  interaction: string;
+};
+
+export type DebugCallEvent = DebugEventBase & {
+  kind: "call";
+  operation: string;
+  status: "ok" | "error" | "cancelled";
+  durationMs?: number;
+  error?: {
+    code?: string;
+    message?: string;
+    kind?: string;
+  };
+};
+
+export type DebugSystemEvent = DebugEventBase & {
+  kind: "system";
+  command: string;
+  status: "ok" | "error";
+  exitCode?: number | null;
+  durationMs?: number;
+  stdoutExcerpt?: string;
+  stderrExcerpt?: string;
+};
+
+export type DebugLifecycleEvent = DebugEventBase & {
+  kind: "lifecycle";
+  phase: "start" | "stop" | "submit" | "reset";
+};
+
+export type DebugEvent = DebugUiEvent | DebugCallEvent | DebugSystemEvent | DebugLifecycleEvent;
+
+export type DebugSessionManifest = {
+  id: string;
+  startedAt: string;
+  startedTs: number;
+  appVersion?: string;
+  environment?: string;
+  fileLayout: DebugSessionFileLayout;
+  retention: DebugSessionRetention;
+};
+
+export type DebugSessionFileLayout = {
+  rootDir: string;
+  manifestFile: string;
+  summaryFile: string;
+  timelineFile: string;
+  systemFile: string;
+};
+
+export type DebugSessionRetention = {
+  maxTimelineBytes: number;
+  maxSystemBytes: number;
+};
+
+export const DEBUG_SESSION_FILES = {
+  manifest: "debug-session.json",
+  summary: "summary.json",
+  timeline: "timeline.jsonl",
+  system: "system.jsonl",
+} as const;
+
+export const DEBUG_DEFAULT_RETENTION: DebugSessionRetention = {
+  maxTimelineBytes: 2_000_000,
+  maxSystemBytes: 2_000_000,
+};
+
+export type DebugRedactionReason =
+  | "secret"
+  | "credential"
+  | "token"
+  | "cookie"
+  | "key"
+  | "payload"
+  | "privacy";
+
+export type DebugRedactedValue = {
+  redacted: true;
+  reason: DebugRedactionReason;
+  preview?: string;
+};
+
+export const DEBUG_REDACTED = "[redacted]";
+
+export function redactValue(reason: DebugRedactionReason, preview?: string): DebugRedactedValue {
+  const safePreview = preview && preview.length > 60 ? `${preview.slice(0, 57)}...` : preview;
+  return { redacted: true, reason, preview: safePreview };
+}
+
+const SECRET_KEY_PATTERN =
+  /(token|secret|api[_-]?key|password|cookie|authorization|auth|bearer|session|private|client[_-]?secret|access[_-]?key|refresh|mcp|credential)/i;
+
+const MAX_STRING_LENGTH = 1600;
+const MAX_OBJECT_DEPTH = 5;
+const MAX_OBJECT_KEYS = 60;
+
+const asString = (value: unknown) => (typeof value === "string" ? value : "");
+
+const truncate = (value: string, max = MAX_STRING_LENGTH) =>
+  value.length > max ? `${value.slice(0, Math.max(0, max - 3))}...` : value;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (!value || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+export function redactString(value: string, reason: DebugRedactionReason): DebugRedactedValue {
+  return redactValue(reason, truncate(value));
+}
+
+export function redactHeaders(headers?: Record<string, string>): Record<string, string | DebugRedactedValue> | undefined {
+  if (!headers) return undefined;
+  const entries = Object.entries(headers);
+  if (!entries.length) return undefined;
+  const next: Record<string, string | DebugRedactedValue> = {};
+  for (const [key, value] of entries) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      next[key] = redactValue("token");
+    } else if (typeof value === "string" && /bearer\s+/i.test(value)) {
+      next[key] = redactValue("token");
+    } else {
+      next[key] = truncate(String(value));
+    }
+  }
+  return next;
+}
+
+export function redactRecord(
+  input: Record<string, unknown>,
+  options: { depth?: number } = {},
+): Record<string, unknown> {
+  const depth = options.depth ?? 0;
+  if (depth > MAX_OBJECT_DEPTH) return { truncated: true };
+
+  const entries = Object.entries(input);
+  const next: Record<string, unknown> = {};
+  const limited = entries.slice(0, MAX_OBJECT_KEYS);
+  for (const [key, value] of limited) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      next[key] = redactValue("secret");
+      continue;
+    }
+    next[key] = redactUnknown(value, { depth: depth + 1 });
+  }
+
+  if (entries.length > MAX_OBJECT_KEYS) {
+    next.__truncated = entries.length - MAX_OBJECT_KEYS;
+  }
+
+  return next;
+}
+
+export function redactUnknown(
+  value: unknown,
+  options: { depth?: number } = {},
+): unknown {
+  const depth = options.depth ?? 0;
+  if (depth > MAX_OBJECT_DEPTH) return { truncated: true };
+
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") {
+    if (/bearer\s+/i.test(value)) return redactValue("token");
+    if (value.length > MAX_STRING_LENGTH) return truncate(value);
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_OBJECT_KEYS).map((item) => redactUnknown(item, { depth: depth + 1 }));
+  }
+  if (isPlainObject(value)) {
+    return redactRecord(value, { depth });
+  }
+  try {
+    return truncate(String(value));
+  } catch {
+    return redactValue("payload");
+  }
+}
+
+export function sanitizePayload(payload?: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!payload) return undefined;
+  return redactRecord(payload);
+}
+
+type DebugGate = {
+  enabled: () => boolean;
+};
+
+let debugGate: DebugGate | null = null;
+
+export function setDebugGate(gate: DebugGate | null) {
+  debugGate = gate;
+}
+
+export function isDebugLoggingEnabled(): boolean {
+  return debugGate?.enabled() ?? false;
+}
+
+function resolveCryptoId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const random = Math.random().toString(16).slice(2);
+  return `${Date.now().toString(16)}-${random}`;
+}
+
+export function createDebugSessionId() {
+  return `dbg_${resolveCryptoId()}`;
+}
+
+export function createDebugCorrelationId() {
+  return `corr_${resolveCryptoId()}`;
+}
+
+export function createDebugEventId() {
+  return `evt_${resolveCryptoId()}`;
+}
+
+export function buildDebugEventBase(input: {
+  kind: DebugEventKind;
+  debugSessionId: string;
+  correlationId?: string;
+  surface: string;
+  action: string;
+  entity?: DebugEventBase["entity"];
+  payload?: Record<string, unknown>;
+}) {
+  const now = new Date();
+  return {
+    kind: input.kind,
+    id: createDebugEventId(),
+    at: now.toISOString(),
+    ts: now.getTime(),
+    debugSessionId: input.debugSessionId,
+    correlationId: input.correlationId,
+    surface: input.surface,
+    action: input.action,
+    entity: input.entity,
+    payload: sanitizePayload(input.payload),
+  } satisfies DebugEventBase;
+}

--- a/packages/app/src/app/lib/debug-log.ts
+++ b/packages/app/src/app/lib/debug-log.ts
@@ -212,6 +212,7 @@ type DebugGate = {
 
 let debugGate: DebugGate | null = null;
 let debugSessionProvider: { get: () => DebugSessionManifest | null } | null = null;
+let activeCorrelationId: string | null = null;
 
 export function setDebugGate(gate: DebugGate | null) {
   debugGate = gate;
@@ -227,6 +228,14 @@ export function isDebugLoggingEnabled(): boolean {
 
 export function getActiveDebugSession(): DebugSessionManifest | null {
   return debugSessionProvider?.get() ?? null;
+}
+
+export function setActiveCorrelationId(value: string | null) {
+  activeCorrelationId = value;
+}
+
+export function getActiveCorrelationId(): string | null {
+  return activeCorrelationId;
 }
 
 function resolveCryptoId() {

--- a/packages/app/src/app/lib/debug-log.ts
+++ b/packages/app/src/app/lib/debug-log.ts
@@ -211,13 +211,22 @@ type DebugGate = {
 };
 
 let debugGate: DebugGate | null = null;
+let debugSessionProvider: { get: () => DebugSessionManifest | null } | null = null;
 
 export function setDebugGate(gate: DebugGate | null) {
   debugGate = gate;
 }
 
+export function setDebugSessionProvider(provider: { get: () => DebugSessionManifest | null } | null) {
+  debugSessionProvider = provider;
+}
+
 export function isDebugLoggingEnabled(): boolean {
   return debugGate?.enabled() ?? false;
+}
+
+export function getActiveDebugSession(): DebugSessionManifest | null {
+  return debugSessionProvider?.get() ?? null;
 }
 
 function resolveCryptoId() {

--- a/packages/app/src/app/lib/opencode.ts
+++ b/packages/app/src/app/lib/opencode.ts
@@ -2,6 +2,7 @@ import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 
 import { isTauriRuntime } from "../utils";
+import { withDebugCall } from "./debug-log-writer";
 
 type FieldsResult<T> =
   | ({ data: T; error?: undefined } & { request: Request; response: Response })
@@ -72,6 +73,52 @@ async function fetchWithTimeout(
   }
 }
 
+function summarizeRequestBody(body: RequestInit["body"]) {
+  if (!body) return { hasBody: false };
+  if (typeof body === "string") {
+    return { hasBody: true, bodyBytes: body.length, bodyType: "string" };
+  }
+  if (typeof Blob !== "undefined" && body instanceof Blob) {
+    return { hasBody: true, bodyBytes: body.size, bodyType: body.type || "blob" };
+  }
+  if (typeof FormData !== "undefined" && body instanceof FormData) {
+    return { hasBody: true, bodyType: "form-data" };
+  }
+  return { hasBody: true, bodyType: typeof body };
+}
+
+function extractRequestPath(input: RequestInfo | URL): string {
+  const url = getRequestUrl(input);
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+async function fetchWithDebug(
+  fetchImpl: typeof globalThis.fetch,
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  timeoutMs: number,
+) {
+  const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+  const path = extractRequestPath(input);
+  const bodySummary = summarizeRequestBody(init?.body);
+  return withDebugCall(
+    {
+      operation: `opencode.${method} ${path}`,
+      surface: "app.opencode",
+      args: {
+        path,
+        method,
+        ...bodySummary,
+      },
+    },
+    () => fetchWithTimeout(fetchImpl, input, init, timeoutMs),
+  );
+}
+
 const encodeBasicAuth = (auth?: OpencodeAuth) => {
   if (!auth?.username || !auth?.password) return null;
   const token = `${auth.username}:${auth.password}`;
@@ -101,7 +148,7 @@ const createTauriFetch = (auth?: OpencodeAuth) => {
       const headers = new Headers(input.headers);
       addAuth(headers);
       const request = new Request(input, { headers });
-      return fetchWithTimeout(
+      return fetchWithDebug(
         tauriFetch as unknown as typeof globalThis.fetch,
         request,
         undefined,
@@ -111,7 +158,7 @@ const createTauriFetch = (auth?: OpencodeAuth) => {
 
     const headers = new Headers(init?.headers);
     addAuth(headers);
-    return fetchWithTimeout(
+    return fetchWithDebug(
       tauriFetch as unknown as typeof globalThis.fetch,
       input,
       {
@@ -148,7 +195,7 @@ export function createClient(baseUrl: string, directory?: string, auth?: Opencod
   const fetchImpl = isTauriRuntime()
     ? createTauriFetch(auth)
     : (input: RequestInfo | URL, init?: RequestInit) =>
-        fetchWithTimeout(globalThis.fetch, input, init, DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS);
+        fetchWithDebug(globalThis.fetch, input, init, DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS);
   return createOpencodeClient({
     baseUrl,
     directory,

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -1,6 +1,7 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { isTauriRuntime } from "../utils";
 import type { ScheduledJob } from "./tauri";
+import { withDebugCall } from "./debug-log-writer";
 
 export type OpenworkServerCapabilities = {
   skills: { read: boolean; write: boolean; source: "openwork" | "opencode" };
@@ -1034,29 +1035,45 @@ async function requestJson<T>(
   path: string,
   options: { method?: string; token?: string; hostToken?: string; body?: unknown; timeoutMs?: number } = {},
 ): Promise<T> {
-  const url = `${baseUrl}${path}`;
-  const fetchImpl = resolveFetch();
-  const response = await fetchWithTimeout(
-    fetchImpl,
-    url,
+  const method = options.method ?? "GET";
+  return withDebugCall(
     {
-      method: options.method ?? "GET",
-      headers: buildHeaders(options.token, options.hostToken),
-      body: options.body ? JSON.stringify(options.body) : undefined,
+      operation: `openwork.${method} ${path}`,
+      surface: "app.openwork-server",
+      args: {
+        baseUrl,
+        path,
+        method,
+        hasBody: Boolean(options.body),
+        body: options.body ? (options.body as Record<string, unknown>) : undefined,
+      },
     },
-    options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+    async () => {
+      const url = `${baseUrl}${path}`;
+      const fetchImpl = resolveFetch();
+      const response = await fetchWithTimeout(
+        fetchImpl,
+        url,
+        {
+          method,
+          headers: buildHeaders(options.token, options.hostToken),
+          body: options.body ? JSON.stringify(options.body) : undefined,
+        },
+        options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+      );
+
+      const text = await response.text();
+      const json = text ? JSON.parse(text) : null;
+
+      if (!response.ok) {
+        const code = typeof json?.code === "string" ? json.code : "request_failed";
+        const message = typeof json?.message === "string" ? json.message : response.statusText;
+        throw new OpenworkServerError(response.status, code, message, json?.details);
+      }
+
+      return json as T;
+    },
   );
-
-  const text = await response.text();
-  const json = text ? JSON.parse(text) : null;
-
-  if (!response.ok) {
-    const code = typeof json?.code === "string" ? json.code : "request_failed";
-    const message = typeof json?.message === "string" ? json.message : response.statusText;
-    throw new OpenworkServerError(response.status, code, message, json?.details);
-  }
-
-  return json as T;
 }
 
 async function requestJsonRaw<T>(
@@ -1064,28 +1081,44 @@ async function requestJsonRaw<T>(
   path: string,
   options: { method?: string; token?: string; hostToken?: string; body?: unknown; timeoutMs?: number } = {},
 ): Promise<RawJsonResponse<T>> {
-  const url = `${baseUrl}${path}`;
-  const fetchImpl = resolveFetch();
-  const response = await fetchWithTimeout(
-    fetchImpl,
-    url,
+  const method = options.method ?? "GET";
+  return withDebugCall(
     {
-      method: options.method ?? "GET",
-      headers: buildHeaders(options.token, options.hostToken),
-      body: options.body ? JSON.stringify(options.body) : undefined,
+      operation: `openwork.${method} ${path}`,
+      surface: "app.openwork-server",
+      args: {
+        baseUrl,
+        path,
+        method,
+        hasBody: Boolean(options.body),
+        body: options.body ? (options.body as Record<string, unknown>) : undefined,
+      },
     },
-    options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+    async () => {
+      const url = `${baseUrl}${path}`;
+      const fetchImpl = resolveFetch();
+      const response = await fetchWithTimeout(
+        fetchImpl,
+        url,
+        {
+          method,
+          headers: buildHeaders(options.token, options.hostToken),
+          body: options.body ? JSON.stringify(options.body) : undefined,
+        },
+        options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+      );
+
+      const text = await response.text();
+      let json: T | null = null;
+      try {
+        json = text ? (JSON.parse(text) as T) : null;
+      } catch {
+        json = null;
+      }
+
+      return { ok: response.ok, status: response.status, json };
+    },
   );
-
-  const text = await response.text();
-  let json: T | null = null;
-  try {
-    json = text ? (JSON.parse(text) as T) : null;
-  } catch {
-    json = null;
-  }
-
-  return { ok: response.ok, status: response.status, json };
 }
 
 async function requestMultipartRaw(
@@ -1093,20 +1126,36 @@ async function requestMultipartRaw(
   path: string,
   options: { method?: string; token?: string; hostToken?: string; body?: FormData; timeoutMs?: number } = {},
 ): Promise<{ ok: boolean; status: number; text: string }>{
-  const url = `${baseUrl}${path}`;
-  const fetchImpl = resolveFetch();
-  const response = await fetchWithTimeout(
-    fetchImpl,
-    url,
+  const method = options.method ?? "POST";
+  return withDebugCall(
     {
-      method: options.method ?? "POST",
-      headers: buildAuthHeaders(options.token, options.hostToken),
-      body: options.body,
+      operation: `openwork.${method} ${path}`,
+      surface: "app.openwork-server",
+      args: {
+        baseUrl,
+        path,
+        method,
+        hasBody: Boolean(options.body),
+        bodyType: "form-data",
+      },
     },
-    options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+    async () => {
+      const url = `${baseUrl}${path}`;
+      const fetchImpl = resolveFetch();
+      const response = await fetchWithTimeout(
+        fetchImpl,
+        url,
+        {
+          method,
+          headers: buildAuthHeaders(options.token, options.hostToken),
+          body: options.body,
+        },
+        options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+      );
+      const text = await response.text();
+      return { ok: response.ok, status: response.status, text };
+    },
   );
-  const text = await response.text();
-  return { ok: response.ok, status: response.status, text };
 }
 
 async function requestBinary(
@@ -1114,38 +1163,52 @@ async function requestBinary(
   path: string,
   options: { method?: string; token?: string; hostToken?: string; timeoutMs?: number } = {},
 ): Promise<{ data: ArrayBuffer; contentType: string | null; filename: string | null }>{
-  const url = `${baseUrl}${path}`;
-  const fetchImpl = resolveFetch();
-  const response = await fetchWithTimeout(
-    fetchImpl,
-    url,
+  const method = options.method ?? "GET";
+  return withDebugCall(
     {
-      method: options.method ?? "GET",
-      headers: buildAuthHeaders(options.token, options.hostToken),
+      operation: `openwork.${method} ${path}`,
+      surface: "app.openwork-server",
+      args: {
+        baseUrl,
+        path,
+        method,
+      },
     },
-    options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+    async () => {
+      const url = `${baseUrl}${path}`;
+      const fetchImpl = resolveFetch();
+      const response = await fetchWithTimeout(
+        fetchImpl,
+        url,
+        {
+          method,
+          headers: buildAuthHeaders(options.token, options.hostToken),
+        },
+        options.timeoutMs ?? DEFAULT_OPENWORK_SERVER_TIMEOUT_MS,
+      );
+
+      if (!response.ok) {
+        const text = await response.text();
+        let json: any = null;
+        try {
+          json = text ? JSON.parse(text) : null;
+        } catch {
+          json = null;
+        }
+        const code = typeof json?.code === "string" ? json.code : "request_failed";
+        const message = typeof json?.message === "string" ? json.message : response.statusText;
+        throw new OpenworkServerError(response.status, code, message, json?.details);
+      }
+
+      const contentType = response.headers.get("content-type");
+      const disposition = response.headers.get("content-disposition") ?? "";
+      const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
+      const filenameRaw = filenameMatch?.[1] ?? filenameMatch?.[2] ?? null;
+      const filename = filenameRaw ? decodeURIComponent(filenameRaw) : null;
+      const data = await response.arrayBuffer();
+      return { data, contentType, filename };
+    },
   );
-
-  if (!response.ok) {
-    const text = await response.text();
-    let json: any = null;
-    try {
-      json = text ? JSON.parse(text) : null;
-    } catch {
-      json = null;
-    }
-    const code = typeof json?.code === "string" ? json.code : "request_failed";
-    const message = typeof json?.message === "string" ? json.message : response.statusText;
-    throw new OpenworkServerError(response.status, code, message, json?.details);
-  }
-
-  const contentType = response.headers.get("content-type");
-  const disposition = response.headers.get("content-disposition") ?? "";
-  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)|filename="?([^";]+)"?/i);
-  const filenameRaw = filenameMatch?.[1] ?? filenameMatch?.[2] ?? null;
-  const filename = filenameRaw ? decodeURIComponent(filenameRaw) : null;
-  const data = await response.arrayBuffer();
-  return { data, contentType, filename };
 }
 
 export function createOpenworkServerClient(options: { baseUrl: string; token?: string; hostToken?: string }) {

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -529,6 +529,10 @@ export async function debugSessionStart(input: DebugSessionStartInput): Promise<
   return invoke<DebugSessionStartResult>("debug_session_start", { input });
 }
 
+export async function debugSessionAppend(input: DebugSessionAppendInput): Promise<DebugSessionAppendResult> {
+  return invoke<DebugSessionAppendResult>("debug_session_append", { input });
+}
+
 export async function debugSessionStop(): Promise<void> {
   return invoke<void>("debug_session_stop");
 }
@@ -598,6 +602,20 @@ export type DebugSessionStartInput = {
 
 export type DebugSessionStartResult = {
   manifest: DebugSessionManifest;
+};
+
+export type DebugSessionAppendInput = {
+  sessionId: string;
+  target: "timeline" | "system";
+  line: string;
+  maxBytes: number;
+};
+
+export type DebugSessionAppendResult = {
+  ok: boolean;
+  appended: boolean;
+  truncated: boolean;
+  bytesWritten: number;
 };
 
 export type ScheduledJobRun = {

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -1,8 +1,23 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { isTauriRuntime } from "../utils";
 import { validateMcpServerName } from "../mcp";
 import type { DebugSessionManifest, DebugSessionRetention } from "./debug-log";
+import { withDebugCall } from "./debug-log-writer";
+
+const invoke = <T>(command: string, args?: Record<string, unknown>) => {
+  if (command.startsWith("debug_session_")) {
+    return tauriInvoke<T>(command, args);
+  }
+  return withDebugCall(
+    {
+      operation: `tauri.${command}`,
+      surface: "app.tauri",
+      args: args ?? undefined,
+    },
+    () => tauriInvoke<T>(command, args),
+  );
+};
 
 export type EngineInfo = {
   running: boolean;

--- a/packages/app/src/app/lib/tauri.ts
+++ b/packages/app/src/app/lib/tauri.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { isTauriRuntime } from "../utils";
 import { validateMcpServerName } from "../mcp";
+import type { DebugSessionManifest, DebugSessionRetention } from "./debug-log";
 
 export type EngineInfo = {
   running: boolean;
@@ -524,6 +525,18 @@ export async function engineDoctor(options?: {
   });
 }
 
+export async function debugSessionStart(input: DebugSessionStartInput): Promise<DebugSessionStartResult> {
+  return invoke<DebugSessionStartResult>("debug_session_start", { input });
+}
+
+export async function debugSessionStop(): Promise<void> {
+  return invoke<void>("debug_session_stop");
+}
+
+export async function debugSessionClearActive(): Promise<void> {
+  return invoke<void>("debug_session_clear_active");
+}
+
 export async function pickDirectory(options?: {
   title?: string;
   defaultPath?: string;
@@ -572,6 +585,19 @@ export type ExecResult = {
   status: number;
   stdout: string;
   stderr: string;
+};
+
+export type DebugSessionStartInput = {
+  sessionId: string;
+  startedAt: string;
+  startedTs: number;
+  appVersion?: string | null;
+  environment?: string | null;
+  retention: DebugSessionRetention;
+};
+
+export type DebugSessionStartResult = {
+  manifest: DebugSessionManifest;
 };
 
 export type ScheduledJobRun = {

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -1511,7 +1511,9 @@ export default function DashboardView(props: DashboardViewProps) {
           clientConnected={props.clientConnected}
           openworkServerStatus={props.openworkServerStatus}
           developerMode={props.developerMode}
+          debugLoggingEnabled={props.debugLoggingEnabled}
           onOpenSettings={() => openSettings("general")}
+          onOpenSupport={() => openSettings("support")}
           onOpenMessaging={openConfig}
           onOpenProviders={() => props.openProviderAuthModal()}
           onOpenMcp={() => props.setTab("mcp")}

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -71,12 +71,25 @@ import {
   Zap,
 } from "lucide-solid";
 import type { Language } from "../../i18n";
+import type { DebugSessionManifest } from "../lib/debug-log";
 
 export type DashboardViewProps = {
   tab: DashboardTab;
   setTab: (tab: DashboardTab) => void;
   settingsTab: SettingsTab;
   setSettingsTab: (tab: SettingsTab) => void;
+  debugLoggingEnabled: boolean;
+  debugSession: DebugSessionManifest | null;
+  lastDebugSession: DebugSessionManifest | null;
+  debugSessionError: string | null;
+  debugSessionStarting: boolean;
+  debugSessionStopping: boolean;
+  supportSubmitBusy: boolean;
+  supportSubmitStatus: string | null;
+  supportSubmitError: string | null;
+  startDebugLogging: () => Promise<DebugSessionManifest | null>;
+  stopDebugLogging: () => Promise<DebugSessionManifest | null>;
+  submitSupportReport: (input: { email: string; message: string }) => Promise<void>;
   providers: ProviderListItem[];
   providerConnectedIds: string[];
   providerAuthBusy: boolean;
@@ -1311,6 +1324,18 @@ export default function DashboardView(props: DashboardViewProps) {
                   busy={props.busy}
                   settingsTab={props.settingsTab}
                   setSettingsTab={props.setSettingsTab}
+                  debugLoggingEnabled={props.debugLoggingEnabled}
+                  debugSession={props.debugSession}
+                  lastDebugSession={props.lastDebugSession}
+                  debugSessionError={props.debugSessionError}
+                  debugSessionStarting={props.debugSessionStarting}
+                  debugSessionStopping={props.debugSessionStopping}
+                  supportSubmitBusy={props.supportSubmitBusy}
+                  supportSubmitStatus={props.supportSubmitStatus}
+                  supportSubmitError={props.supportSubmitError}
+                  startDebugLogging={props.startDebugLogging}
+                  stopDebugLogging={props.stopDebugLogging}
+                  submitSupportReport={props.submitSupportReport}
                   providers={props.providers}
                   providerConnectedIds={props.providerConnectedIds}
                   providerAuthBusy={props.providerAuthBusy}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -86,6 +86,14 @@ import {
 } from "../utils";
 import { finishPerf, perfNow, recordPerfLog } from "../lib/perf-log";
 import { normalizeLocalFilePath } from "../lib/local-file-path";
+import {
+  buildDebugEventBase,
+  createDebugCorrelationId,
+  getActiveDebugSession,
+  setActiveCorrelationId,
+  type DebugEventBase,
+} from "../lib/debug-log";
+import { appendDebugEvent } from "../lib/debug-log-writer";
 
 import browserSetupTemplate from "../data/commands/browser-setup.md?raw";
 import soulSetupTemplate from "../data/commands/give-me-a-soul.md?raw";
@@ -297,6 +305,36 @@ const COMMAND_PALETTE_THINKING_OPTIONS = [
 ] as const;
 
 export default function SessionView(props: SessionViewProps) {
+  const emitSessionUiEvent = (input: {
+    action: string;
+    interaction: string;
+    surface?: string;
+    payload?: Record<string, unknown>;
+    entity?: DebugEventBase["entity"];
+    correlationId?: string;
+  }) => {
+    const session = getActiveDebugSession();
+    if (!session) return;
+    const correlationId = input.correlationId ?? createDebugCorrelationId();
+    setActiveCorrelationId(correlationId);
+    const base = buildDebugEventBase({
+      kind: "ui",
+      debugSessionId: session.id,
+      correlationId,
+      surface: input.surface ?? "session.composer",
+      action: input.action,
+      entity: input.entity ?? {
+        workspaceId: props.activeWorkspaceId,
+        sessionId: props.selectedSessionId ?? undefined,
+      },
+      payload: input.payload,
+    });
+    void appendDebugEvent({
+      ...base,
+      kind: "ui",
+      interaction: input.interaction,
+    });
+  };
   let messagesEndEl: HTMLDivElement | undefined;
   let bottomVisibilityEl: HTMLDivElement | undefined;
   let chatContainerEl: HTMLDivElement | undefined;
@@ -368,6 +406,8 @@ export default function SessionView(props: SessionViewProps) {
       cancelled = true;
     });
   });
+
+  let lastAttachmentSnapshot = { count: 0, totalBytes: 0 };
 
   const agentLabel = createMemo(() => props.selectedSessionAgent ?? "Default agent");
   const workspaceLabel = (workspace: WorkspaceInfo) =>
@@ -2149,6 +2189,12 @@ export default function SessionView(props: SessionViewProps) {
       return;
     }
 
+    emitSessionUiEvent({
+      action: "composer.stop",
+      interaction: "click",
+      payload: { sessionId: props.selectedSessionId },
+    });
+
     setAbortBusy(true);
     setToastMessage("Stopping the run...");
     try {
@@ -2168,6 +2214,12 @@ export default function SessionView(props: SessionViewProps) {
       setToastMessage("Nothing to retry yet");
       return;
     }
+
+    emitSessionUiEvent({
+      action: "composer.retry",
+      interaction: "click",
+      payload: { sessionId: props.selectedSessionId, charCount: text.length },
+    });
 
     if (abortBusy()) return;
     setAbortBusy(true);
@@ -2940,6 +2992,18 @@ export default function SessionView(props: SessionViewProps) {
   });
 
   const handleSendPrompt = (draft: ComposerDraft) => {
+    const resolvedText = (draft.resolvedText ?? draft.text ?? "").trim();
+    emitSessionUiEvent({
+      action: "composer.submit",
+      interaction: "submit",
+      payload: {
+        mode: draft.mode,
+        command: draft.command?.name ?? null,
+        charCount: resolvedText.length,
+        partCount: draft.parts.length,
+        attachmentCount: draft.attachments.length,
+      },
+    });
     startRun();
     props.sendPromptAsync(draft).catch(() => undefined);
   };
@@ -3050,10 +3114,38 @@ export default function SessionView(props: SessionViewProps) {
 
   const handleDraftChange = (draft: ComposerDraft) => {
     props.setPrompt(draft.text);
+    const totalBytes = draft.attachments.reduce((sum, attachment) => sum + (attachment.size || 0), 0);
+    const types = Array.from(
+      new Set(draft.attachments.map((attachment) => attachment.mimeType).filter(Boolean)),
+    );
+    if (
+      draft.attachments.length !== lastAttachmentSnapshot.count ||
+      totalBytes !== lastAttachmentSnapshot.totalBytes
+    ) {
+      emitSessionUiEvent({
+        action: "composer.attachment.change",
+        interaction: "change",
+        payload: {
+          count: draft.attachments.length,
+          totalBytes,
+          types,
+        },
+      });
+      lastAttachmentSnapshot = {
+        count: draft.attachments.length,
+        totalBytes,
+      };
+    }
   };
 
   const openSessionFromList = (workspaceId: string, sessionId: string) => {
     if (!sessionId) return;
+    emitSessionUiEvent({
+      surface: "session.sidebar",
+      action: "session.select",
+      interaction: "select",
+      payload: { sessionId, workspaceId },
+    });
     // Route-driven selection: navigate first and let the route effect own selectSession.
     if (workspaceId === props.activeWorkspaceId) {
       props.setView("session", sessionId);
@@ -3069,6 +3161,12 @@ export default function SessionView(props: SessionViewProps) {
   const createTaskInWorkspace = (workspaceId: string) => {
     const id = workspaceId.trim();
     if (!id) return;
+    emitSessionUiEvent({
+      surface: "session.sidebar",
+      action: "session.create",
+      interaction: "click",
+      payload: { workspaceId: id },
+    });
     if (id === props.activeWorkspaceId) {
       props.createSessionAndOpen();
       return;

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -4023,7 +4023,9 @@ export default function SessionView(props: SessionViewProps) {
           clientConnected={props.clientConnected}
           openworkServerStatus={props.openworkServerStatus}
           developerMode={props.developerMode}
+          debugLoggingEnabled={false}
           onOpenSettings={() => openSettings("general")}
+          onOpenSupport={() => openSettings("support")}
           onOpenMessaging={openConfig}
           onOpenProviders={openProviderAuth}
           onOpenMcp={openMcp}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -32,6 +32,7 @@ import {
   sandboxDebugProbe,
 } from "../lib/tauri";
 import { currentLocale, LANGUAGE_OPTIONS, t, type Language } from "../../i18n";
+import type { DebugSessionManifest } from "../lib/debug-log";
 
 export type SettingsViewProps = {
   startupPreference: StartupPreference | null;
@@ -40,6 +41,18 @@ export type SettingsViewProps = {
   busy: boolean;
   settingsTab: SettingsTab;
   setSettingsTab: (tab: SettingsTab) => void;
+  debugLoggingEnabled: boolean;
+  debugSession: DebugSessionManifest | null;
+  lastDebugSession: DebugSessionManifest | null;
+  debugSessionError: string | null;
+  debugSessionStarting: boolean;
+  debugSessionStopping: boolean;
+  supportSubmitBusy: boolean;
+  supportSubmitStatus: string | null;
+  supportSubmitError: string | null;
+  startDebugLogging: () => Promise<DebugSessionManifest | null>;
+  stopDebugLogging: () => Promise<DebugSessionManifest | null>;
+  submitSupportReport: (input: { email: string; message: string }) => Promise<void>;
   providers: ProviderListItem[];
   providerConnectedIds: string[];
   providerAuthBusy: boolean;
@@ -622,6 +635,8 @@ export default function SettingsView(props: SettingsViewProps) {
 
   const tabLabel = (tab: SettingsTab) => {
     switch (tab) {
+      case "support":
+        return "Support";
       case "model":
         return "Model";
       case "advanced":
@@ -634,7 +649,7 @@ export default function SettingsView(props: SettingsViewProps) {
   };
 
   const availableTabs = createMemo<SettingsTab[]>(() => {
-    const tabs: SettingsTab[] = ["general", "model", "advanced"];
+    const tabs: SettingsTab[] = ["general", "support", "model", "advanced"];
     if (props.developerMode) tabs.push("debug");
     return tabs;
   });
@@ -751,7 +766,57 @@ export default function SettingsView(props: SettingsViewProps) {
   const [sandboxProbeResult, setSandboxProbeResult] = createSignal<SandboxDebugProbeResult | null>(null);
   const [nukeDevConfigBusy, setNukeDevConfigBusy] = createSignal(false);
   const [nukeDevConfigStatus, setNukeDevConfigStatus] = createSignal<string | null>(null);
+  const [supportEmail, setSupportEmail] = createSignal("");
+  const [supportMessage, setSupportMessage] = createSignal("");
+  const [supportValidationError, setSupportValidationError] = createSignal<string | null>(null);
   const opencodeDevModeEnabled = createMemo(() => Boolean(buildInfo()?.openworkDevMode));
+
+  const supportSession = createMemo(() => props.debugSession ?? props.lastDebugSession ?? null);
+  const supportSessionState = createMemo(() => {
+    if (props.debugLoggingEnabled) return "recording";
+    if (props.lastDebugSession) return "ready";
+    return "idle";
+  });
+  const supportCanSubmit = createMemo(
+    () => Boolean(props.lastDebugSession) && supportEmail().trim().length > 0 && supportMessage().trim().length > 0,
+  );
+
+  const handleStartDebugLogging = async () => {
+    setSupportValidationError(null);
+    try {
+      await props.startDebugLogging();
+    } catch {
+      // surfaced from parent state
+    }
+  };
+
+  const handleStopDebugLogging = async () => {
+    setSupportValidationError(null);
+    try {
+      await props.stopDebugLogging();
+    } catch {
+      // surfaced from parent state
+    }
+  };
+
+  const handleSubmitSupportReport = async () => {
+    const email = supportEmail().trim();
+    const message = supportMessage().trim();
+    if (!email || !message) {
+      setSupportValidationError("Email and a short description are required.");
+      return;
+    }
+    if (!props.lastDebugSession) {
+      setSupportValidationError("Stop recording after reproducing the issue before you send the report.");
+      return;
+    }
+    setSupportValidationError(null);
+    try {
+      await props.submitSupportReport({ email, message });
+    } catch {
+      // surfaced from parent state
+    }
+  };
 
   const sandboxCreateSummary = createMemo(() => {
     const raw = props.sandboxCreateProgress as
@@ -1069,6 +1134,45 @@ export default function SettingsView(props: SettingsViewProps) {
             </div>
 
             <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-4">
+              <div class="bg-red-2/55 border border-red-7/25 rounded-2xl p-5 space-y-4">
+                <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div class="space-y-1.5">
+                    <div class="text-sm font-medium text-red-12">Support and debug logging</div>
+                    <div class="text-xs text-red-11/80 max-w-xl">
+                      Record a private support session only when you are actively reproducing a problem. Nothing is captured until you start.
+                    </div>
+                  </div>
+                  <div
+                    class={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${
+                      supportSessionState() === "recording"
+                        ? "border-red-7/35 bg-red-4/55 text-red-11"
+                        : supportSessionState() === "ready"
+                          ? "border-amber-7/35 bg-amber-4/35 text-amber-11"
+                          : "border-gray-6/70 bg-gray-3/40 text-gray-11"
+                    }`}
+                  >
+                    {supportSessionState() === "recording"
+                      ? "Recording"
+                      : supportSessionState() === "ready"
+                        ? "Ready to send"
+                        : "Inactive"}
+                  </div>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-3">
+                  <Button
+                    variant="secondary"
+                    class="bg-red-10 text-white hover:bg-red-9"
+                    onClick={() => props.setSettingsTab("support")}
+                  >
+                    Open support flow
+                  </Button>
+                  <div class="text-xs text-red-11/80">
+                    Includes local debug logs, diagnostics, and redacted config snapshots when you choose to send a report.
+                  </div>
+                </div>
+              </div>
+
               <div>
                 <div class="text-sm font-medium text-gray-12">Appearance</div>
                 <div class="text-xs text-gray-9">Match the system or force light/dark mode.</div>
@@ -1122,6 +1226,166 @@ export default function SettingsView(props: SettingsViewProps) {
 
               <div class="text-xs text-gray-8">
                 System mode follows your OS preference automatically.
+              </div>
+            </div>
+          </div>
+        </Match>
+
+        <Match when={activeTab() === "support"}>
+          <div class="space-y-6">
+            <div class="bg-red-2/55 border border-red-7/25 rounded-2xl p-5 space-y-4">
+              <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                <div class="space-y-1.5">
+                  <div class="text-sm font-medium text-red-12">Debug logging for support</div>
+                  <div class="text-xs text-red-11/80 max-w-2xl">
+                    Use this only while reproducing a problem. OpenWork stores structured logs on this device while recording is active, then prepares them for a private support report.
+                  </div>
+                </div>
+                <div
+                  class={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${
+                    supportSessionState() === "recording"
+                      ? "border-red-7/35 bg-red-4/55 text-red-11"
+                      : supportSessionState() === "ready"
+                        ? "border-amber-7/35 bg-amber-4/35 text-amber-11"
+                        : "border-gray-6/70 bg-gray-3/40 text-gray-11"
+                  }`}
+                >
+                  {supportSessionState() === "recording"
+                    ? "Recording now"
+                    : supportSessionState() === "ready"
+                      ? "Capture ready"
+                      : "Not recording"}
+                </div>
+              </div>
+
+              <div class="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)]">
+                <div class="space-y-4 rounded-2xl border border-red-7/15 bg-red-1/40 p-4">
+                  <div class="space-y-2">
+                    <div class="text-sm font-medium text-gray-12">How this works</div>
+                    <div class="text-xs text-gray-10">
+                      1. Start recording. 2. Reproduce the issue. 3. Stop recording. 4. Add your email and a note for support.
+                    </div>
+                  </div>
+                  <div class="grid gap-2 text-xs text-gray-10 sm:grid-cols-2">
+                    <div class="rounded-xl border border-gray-6/60 bg-gray-1/50 px-3 py-2">
+                      <div class="font-medium text-gray-12">Included</div>
+                      <div class="mt-1">Timeline events, system logs, diagnostics, and redacted config snapshots.</div>
+                    </div>
+                    <div class="rounded-xl border border-gray-6/60 bg-gray-1/50 px-3 py-2">
+                      <div class="font-medium text-gray-12">Not always included</div>
+                      <div class="mt-1">Secrets, tokens, cookies, and raw provider credentials are masked before storage.</div>
+                    </div>
+                  </div>
+
+                  <Show when={supportSession()}>
+                    {(session) => (
+                      <div class="rounded-xl border border-gray-6/60 bg-gray-1/55 px-3 py-3 text-xs text-gray-10 space-y-1">
+                        <div class="font-medium text-gray-12">Current capture</div>
+                        <div><span class="text-gray-8">Session:</span> <span class="font-mono text-[11px]">{session().id}</span></div>
+                        <div><span class="text-gray-8">Started:</span> {formatRelativeTime(session().startedTs)}</div>
+                        <div><span class="text-gray-8">Version:</span> {session().appVersion || "Unknown"}</div>
+                      </div>
+                    )}
+                  </Show>
+
+                  <div class="flex flex-wrap items-center gap-3">
+                    <Show
+                      when={!props.debugLoggingEnabled}
+                      fallback={
+                        <Button
+                          variant="secondary"
+                          class="bg-red-10 text-white hover:bg-red-9"
+                          onClick={() => void handleStopDebugLogging()}
+                          disabled={props.debugSessionStopping}
+                        >
+                          {props.debugSessionStopping ? "Stopping recording..." : "Stop recording"}
+                        </Button>
+                      }
+                    >
+                      <Button
+                        variant="secondary"
+                        class="bg-red-10 text-white hover:bg-red-9"
+                        onClick={() => void handleStartDebugLogging()}
+                        disabled={props.debugSessionStarting || props.supportSubmitBusy}
+                      >
+                        {props.debugSessionStarting ? "Starting recording..." : props.lastDebugSession ? "Record another session" : "Start debug logging"}
+                      </Button>
+                    </Show>
+                    <div class="text-xs text-gray-10">
+                      {props.debugLoggingEnabled
+                        ? "Leave this on only while reproducing the issue."
+                        : props.lastDebugSession
+                          ? "Recording is stopped. Review and send the report when you are ready."
+                          : "Debug logging is off by default and stays off after restart."}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="space-y-4 rounded-2xl border border-gray-7/60 bg-gray-2/30 p-4">
+                  <div>
+                    <div class="text-sm font-medium text-gray-12">Send support report</div>
+                    <div class="text-xs text-gray-9 mt-1">
+                      We need your email and a short description so support can follow up and understand what to inspect.
+                    </div>
+                  </div>
+
+                  <label class="block space-y-1.5">
+                    <div class="text-xs font-medium text-gray-11">Email</div>
+                    <input
+                      type="email"
+                      value={supportEmail()}
+                      onInput={(event) => setSupportEmail(event.currentTarget.value)}
+                      placeholder="you@example.com"
+                      class="w-full rounded-xl border border-gray-6/70 bg-gray-1/70 px-3 py-2 text-sm text-gray-12 outline-none transition-colors focus:border-red-7/45"
+                      autocomplete="email"
+                    />
+                  </label>
+
+                  <label class="block space-y-1.5">
+                    <div class="text-xs font-medium text-gray-11">What went wrong?</div>
+                    <textarea
+                      value={supportMessage()}
+                      onInput={(event) => setSupportMessage(event.currentTarget.value)}
+                      placeholder="Tell support what you expected, what happened instead, and which workspace/session was involved."
+                      class="min-h-32 w-full rounded-xl border border-gray-6/70 bg-gray-1/70 px-3 py-2 text-sm text-gray-12 outline-none transition-colors focus:border-red-7/45"
+                    />
+                  </label>
+
+                  <div class="rounded-xl border border-gray-6/60 bg-gray-1/45 px-3 py-3 text-xs text-gray-10">
+                    <div class="font-medium text-gray-12">Before you send</div>
+                    <div class="mt-1">
+                      Support reports stay separate from public sharing. Do not include passwords, raw API keys, or anything you would not want in a support case note.
+                    </div>
+                  </div>
+
+                  <Show when={supportValidationError()}>
+                    {(value) => <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">{value()}</div>}
+                  </Show>
+                  <Show when={props.debugSessionError}>
+                    <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">{props.debugSessionError}</div>
+                  </Show>
+                  <Show when={props.supportSubmitError}>
+                    <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">{props.supportSubmitError}</div>
+                  </Show>
+                  <Show when={props.supportSubmitStatus}>
+                    <div class="rounded-xl border border-green-7/30 bg-green-1/40 px-3 py-2 text-xs text-green-11">{props.supportSubmitStatus}</div>
+                  </Show>
+
+                  <Button
+                    variant="secondary"
+                    class="w-full justify-center bg-red-10 text-white hover:bg-red-9 disabled:bg-gray-5 disabled:text-gray-9"
+                    onClick={() => void handleSubmitSupportReport()}
+                    disabled={!supportCanSubmit() || props.supportSubmitBusy || props.debugLoggingEnabled}
+                  >
+                    {props.supportSubmitBusy
+                      ? "Sending report..."
+                      : props.debugLoggingEnabled
+                        ? "Stop recording to send"
+                        : props.lastDebugSession
+                          ? "Send support report"
+                          : "Record an issue first"}
+                  </Button>
+                </div>
               </div>
             </div>
           </div>

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -145,7 +145,7 @@ export type DashboardTab =
   | "config"
   | "settings";
 
-export type SettingsTab = "general" | "model" | "advanced" | "debug";
+export type SettingsTab = "general" | "support" | "model" | "advanced" | "debug";
 
 export type WorkspacePreset = "starter" | "automation" | "minimal";
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -2,13 +2,16 @@
   "name": "@different-ai/openwork",
   "private": true,
   "version": "0.11.136",
-  "opencodeVersion": "1.2.6",
+  "opencodeVersion": "1.2.24",
   "opencodeRouterVersion": "0.11.136",
   "type": "module",
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 OPENWORK_DATA_DIR=\"$HOME/.openwork/openwork-orchestrator-dev\" tauri dev --config src-tauri/tauri.dev.conf.json --config \"{\\\"build\\\":{\\\"devUrl\\\":\\\"http://localhost:${PORT:-5173}\\\"}}\"",
     "build": "tauri build",
-    "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs"
+    "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
+    "resolve:opencode-version": "node ./scripts/opencode-version.mjs resolve",
+    "set:opencode-version": "node ./scripts/opencode-version.mjs set",
+    "check:opencode-version-sync": "node ./scripts/check-opencode-version-sync.mjs"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.0.0"

--- a/packages/desktop/scripts/check-opencode-version-sync.mjs
+++ b/packages/desktop/scripts/check-opencode-version-sync.mjs
@@ -1,0 +1,25 @@
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = resolve(__dirname, "..", "package.json");
+const versionsJsonPath = resolve(__dirname, "..", "src-tauri", "sidecars", "versions.json");
+
+const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+const versions = JSON.parse(readFileSync(versionsJsonPath, "utf8"));
+
+const expected = String(pkg.opencodeVersion ?? "").trim().replace(/^v/, "");
+const actual = String(versions?.opencode?.version ?? "").trim().replace(/^v/, "");
+
+if (!expected || !actual) {
+  console.error("Missing OpenCode version in package.json or sidecars/versions.json");
+  process.exit(1);
+}
+
+if (expected !== actual) {
+  console.error(`OpenCode version mismatch: package.json=${expected}, versions.json=${actual}`);
+  process.exit(1);
+}
+
+console.log(`OpenCode version sync OK: ${expected}`);

--- a/packages/desktop/scripts/opencode-version.mjs
+++ b/packages/desktop/scripts/opencode-version.mjs
@@ -1,0 +1,118 @@
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = resolve(__dirname, "..", "package.json");
+
+function normalizeVersion(value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  return raw.startsWith("v") ? raw.slice(1) : raw;
+}
+
+function readPackageJson() {
+  return JSON.parse(readFileSync(packageJsonPath, "utf8"));
+}
+
+function writePackageJson(pkg) {
+  writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+}
+
+async function fetchLatestVersion(repo, token) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "openwork-opencode-version",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
+    if (res.ok) {
+      const data = await res.json();
+      const tag = typeof data?.tag_name === "string" ? data.tag_name : "";
+      return normalizeVersion(tag);
+    }
+    if (res.status !== 403) {
+      throw new Error(`Failed to resolve latest OpenCode version (HTTP ${res.status})`);
+    }
+  } catch {
+    // Fall through to web redirect.
+  }
+
+  const web = await fetch(`https://github.com/${repo}/releases/latest`, {
+    headers: { "User-Agent": "openwork-opencode-version" },
+    redirect: "follow",
+  });
+  const match = String(web.url || "").match(/\/tag\/v([^/?#]+)/);
+  if (!match) {
+    throw new Error(`Failed to resolve latest OpenCode version for ${repo}`);
+  }
+  return normalizeVersion(match[1]);
+}
+
+function parseArgs(argv) {
+  const args = { command: "resolve", version: null, repo: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if ((arg === "resolve" || arg === "set") && i === 0) {
+      args.command = arg;
+      continue;
+    }
+    if (arg === "--version") {
+      args.version = argv[i + 1] ?? null;
+      i += 1;
+      continue;
+    }
+    if (arg === "--repo") {
+      args.repo = argv[i + 1] ?? null;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+async function resolveConfiguredVersion(repo) {
+  const pkg = readPackageJson();
+  const configuredRaw =
+    process.env.OPENCODE_VERSION?.trim() || String(pkg.opencodeVersion ?? "").trim();
+
+  if (configuredRaw && configuredRaw.toLowerCase() !== "latest") {
+    return normalizeVersion(configuredRaw);
+  }
+
+  return fetchLatestVersion(repo, process.env.GITHUB_TOKEN?.trim());
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const pkg = readPackageJson();
+  const repo =
+    args.repo?.trim() ||
+    process.env.OPENCODE_GITHUB_REPO?.trim() ||
+    process.env.OPENWORK_OPENCODE_GITHUB_REPO?.trim() ||
+    "anomalyco/opencode";
+
+  if (args.command === "set") {
+    const nextVersion = normalizeVersion(args.version);
+    if (!nextVersion) {
+      throw new Error("A version is required for 'set'");
+    }
+    pkg.opencodeVersion = nextVersion;
+    writePackageJson(pkg);
+    process.stdout.write(`${nextVersion}\n`);
+    return;
+  }
+
+  const resolved = await resolveConfiguredVersion(repo);
+  if (!resolved) {
+    throw new Error("Unable to resolve OpenCode version");
+  }
+  process.stdout.write(`${resolved}\n`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-http = "2.5.6"
 tauri-plugin-opener = "2.5.3"
 tauri-plugin-shell = "2"
+time = { version = "0.3", features = ["formatting"] }
 uuid = { version = "1", features = ["v4"] }
 ureq = { version = "2.10", features = ["json"] }
 gethostname = "0.4"

--- a/packages/desktop/src-tauri/src/commands/debug.rs
+++ b/packages/desktop/src-tauri/src/commands/debug.rs
@@ -1,0 +1,211 @@
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+use uuid::Uuid;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEBUG_ROOT_DIR: &str = "debug-logs";
+const DEBUG_SESSIONS_DIR: &str = "sessions";
+const DEBUG_ACTIVE_FILE: &str = "active-session.json";
+
+const DEBUG_MANIFEST_FILE: &str = "debug-session.json";
+const DEBUG_SUMMARY_FILE: &str = "summary.json";
+const DEBUG_TIMELINE_FILE: &str = "timeline.jsonl";
+const DEBUG_SYSTEM_FILE: &str = "system.jsonl";
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSessionRetention {
+    pub max_timeline_bytes: u64,
+    pub max_system_bytes: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSessionFileLayout {
+    pub root_dir: String,
+    pub manifest_file: String,
+    pub summary_file: String,
+    pub timeline_file: String,
+    pub system_file: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSessionManifest {
+    pub id: String,
+    pub started_at: String,
+    pub started_ts: i64,
+    pub app_version: Option<String>,
+    pub environment: Option<String>,
+    pub file_layout: DebugSessionFileLayout,
+    pub retention: DebugSessionRetention,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSessionStartInput {
+    pub session_id: String,
+    pub started_at: String,
+    pub started_ts: i64,
+    pub app_version: Option<String>,
+    pub environment: Option<String>,
+    pub retention: DebugSessionRetention,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSessionStartResult {
+    pub manifest: DebugSessionManifest,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSessionActiveMarker {
+    pub id: String,
+    pub root_dir: String,
+    pub started_at: String,
+    pub started_ts: i64,
+}
+
+fn resolve_debug_root(app: &AppHandle) -> Result<PathBuf, String> {
+    let data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
+    Ok(data_dir.join(DEBUG_ROOT_DIR))
+}
+
+fn sanitize_session_id(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::with_capacity(trimmed.len());
+    let mut last_dash = false;
+    for ch in trimmed.chars() {
+        let normalized = if ch.is_ascii_alphanumeric() || ch == '_' {
+            ch.to_ascii_lowercase()
+        } else {
+            '-'
+        };
+
+        if normalized == '-' {
+            if last_dash {
+                continue;
+            }
+            out.push('-');
+            last_dash = true;
+            continue;
+        }
+
+        out.push(normalized);
+        last_dash = false;
+    }
+
+    out.trim_matches('-').to_string()
+}
+
+fn ensure_parent(path: &Path) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    ensure_parent(path)?;
+    let payload = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("Failed to serialize {}: {e}", path.display()))?;
+    fs::write(path, payload).map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+fn touch_file(path: &Path) -> Result<(), String> {
+    ensure_parent(path)?;
+    fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn debug_session_start(
+    app: AppHandle,
+    input: DebugSessionStartInput,
+) -> Result<DebugSessionStartResult, String> {
+    let root = resolve_debug_root(&app)?;
+    let sessions_dir = root.join(DEBUG_SESSIONS_DIR);
+    let clean_id = sanitize_session_id(&input.session_id);
+    let session_id = if clean_id.is_empty() {
+        format!("dbg-{}", Uuid::new_v4())
+    } else {
+        clean_id
+    };
+
+    let session_dir = sessions_dir.join(&session_id);
+    fs::create_dir_all(&session_dir)
+        .map_err(|e| format!("Failed to create {}: {e}", session_dir.display()))?;
+
+    let manifest_path = session_dir.join(DEBUG_MANIFEST_FILE);
+    let summary_path = session_dir.join(DEBUG_SUMMARY_FILE);
+    let timeline_path = session_dir.join(DEBUG_TIMELINE_FILE);
+    let system_path = session_dir.join(DEBUG_SYSTEM_FILE);
+
+    let file_layout = DebugSessionFileLayout {
+        root_dir: session_dir.to_string_lossy().to_string(),
+        manifest_file: manifest_path.to_string_lossy().to_string(),
+        summary_file: summary_path.to_string_lossy().to_string(),
+        timeline_file: timeline_path.to_string_lossy().to_string(),
+        system_file: system_path.to_string_lossy().to_string(),
+    };
+
+    let manifest = DebugSessionManifest {
+        id: session_id.clone(),
+        started_at: input.started_at,
+        started_ts: input.started_ts,
+        app_version: input.app_version,
+        environment: input.environment,
+        file_layout: file_layout.clone(),
+        retention: input.retention,
+    };
+
+    write_json(&manifest_path, &manifest)?;
+    write_json(&summary_path, &serde_json::json!({}))?;
+    touch_file(&timeline_path)?;
+    touch_file(&system_path)?;
+
+    let active_marker = DebugSessionActiveMarker {
+        id: session_id,
+        root_dir: file_layout.root_dir.clone(),
+        started_at: manifest.started_at.clone(),
+        started_ts: manifest.started_ts,
+    };
+    let active_path = root.join(DEBUG_ACTIVE_FILE);
+    write_json(&active_path, &active_marker)?;
+
+    Ok(DebugSessionStartResult { manifest })
+}
+
+#[tauri::command]
+pub fn debug_session_stop(app: AppHandle) -> Result<(), String> {
+    debug_session_clear_active(app)
+}
+
+#[tauri::command]
+pub fn debug_session_clear_active(app: AppHandle) -> Result<(), String> {
+    let root = resolve_debug_root(&app)?;
+    let active_path = root.join(DEBUG_ACTIVE_FILE);
+    if active_path.exists() {
+        fs::remove_file(&active_path)
+            .map_err(|e| format!("Failed to remove {}: {e}", active_path.display()))?;
+    }
+    Ok(())
+}

--- a/packages/desktop/src-tauri/src/commands/debug.rs
+++ b/packages/desktop/src-tauri/src/commands/debug.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use uuid::Uuid;
 
 use std::fs;
@@ -87,12 +88,128 @@ pub struct DebugSessionActiveMarker {
     pub started_ts: i64,
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSystemEventInput {
+    pub surface: String,
+    pub action: String,
+    pub command: String,
+    pub status: String,
+    pub exit_code: Option<i32>,
+    pub duration_ms: Option<u64>,
+    pub stdout_excerpt: Option<String>,
+    pub stderr_excerpt: Option<String>,
+    pub payload: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DebugSystemEvent {
+    kind: String,
+    id: String,
+    at: String,
+    ts: i64,
+    debug_session_id: String,
+    correlation_id: Option<String>,
+    surface: String,
+    action: String,
+    command: String,
+    status: String,
+    exit_code: Option<i32>,
+    duration_ms: Option<u64>,
+    stdout_excerpt: Option<String>,
+    stderr_excerpt: Option<String>,
+    payload: Option<serde_json::Value>,
+}
+
 fn resolve_debug_root(app: &AppHandle) -> Result<PathBuf, String> {
     let data_dir = app
         .path()
         .app_data_dir()
         .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
     Ok(data_dir.join(DEBUG_ROOT_DIR))
+}
+
+fn now_iso() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "".to_string())
+}
+
+fn now_ms() -> i64 {
+    let now = std::time::SystemTime::now();
+    match now.duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => duration.as_millis() as i64,
+        Err(_) => 0,
+    }
+}
+
+fn read_active_marker(app: &AppHandle) -> Result<Option<DebugSessionActiveMarker>, String> {
+    let root = resolve_debug_root(app)?;
+    let active_path = root.join(DEBUG_ACTIVE_FILE);
+    if !active_path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&active_path)
+        .map_err(|e| format!("Failed to read {}: {e}", active_path.display()))?;
+    let marker = serde_json::from_str::<DebugSessionActiveMarker>(&raw)
+        .map_err(|e| format!("Failed to parse {}: {e}", active_path.display()))?;
+    Ok(Some(marker))
+}
+
+fn append_json_line(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    ensure_parent(path)?;
+    let payload = serde_json::to_string(value)
+        .map_err(|e| format!("Failed to serialize {}: {e}", path.display()))?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|e| format!("Failed to open {}: {e}", path.display()))?;
+    use std::io::Write;
+    file.write_all(payload.as_bytes())
+        .and_then(|_| file.write_all(b"\n"))
+        .map_err(|e| format!("Failed to append {}: {e}", path.display()))?;
+    Ok(())
+}
+
+fn truncate_excerpt(value: Option<String>) -> Option<String> {
+    value.map(|raw| {
+        let max = 2000usize;
+        if raw.len() <= max {
+            raw
+        } else {
+            format!("{}...", &raw[..max])
+        }
+    })
+}
+
+pub fn record_system_event(app: &AppHandle, input: DebugSystemEventInput) -> Result<(), String> {
+    let marker = match read_active_marker(app)? {
+        Some(marker) => marker,
+        None => return Ok(()),
+    };
+
+    let system_path = PathBuf::from(&marker.root_dir).join(DEBUG_SYSTEM_FILE);
+    let event = DebugSystemEvent {
+        kind: "system".to_string(),
+        id: format!("evt_{}", Uuid::new_v4()),
+        at: now_iso(),
+        ts: now_ms(),
+        debug_session_id: marker.id,
+        correlation_id: None,
+        surface: input.surface,
+        action: input.action,
+        command: input.command,
+        status: input.status,
+        exit_code: input.exit_code,
+        duration_ms: input.duration_ms,
+        stdout_excerpt: truncate_excerpt(input.stdout_excerpt),
+        stderr_excerpt: truncate_excerpt(input.stderr_excerpt),
+        payload: input.payload,
+    };
+
+    append_json_line(&system_path, &event)
 }
 
 fn sanitize_session_id(value: &str) -> String {

--- a/packages/desktop/src-tauri/src/commands/debug.rs
+++ b/packages/desktop/src-tauri/src/commands/debug.rs
@@ -62,6 +62,24 @@ pub struct DebugSessionStartResult {
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct DebugSessionAppendInput {
+    pub session_id: String,
+    pub target: String,
+    pub line: String,
+    pub max_bytes: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DebugSessionAppendResult {
+    pub ok: bool,
+    pub appended: bool,
+    pub truncated: bool,
+    pub bytes_written: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DebugSessionActiveMarker {
     pub id: String,
     pub root_dir: String,
@@ -136,6 +154,21 @@ fn touch_file(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+fn resolve_session_file(root: &Path, session_id: &str, target: &str) -> Result<PathBuf, String> {
+    let sessions_dir = root.join(DEBUG_SESSIONS_DIR);
+    let clean_id = sanitize_session_id(session_id);
+    if clean_id.is_empty() {
+        return Err("session_id is required".to_string());
+    }
+    let session_dir = sessions_dir.join(clean_id);
+    let file_name = match target {
+        "timeline" => DEBUG_TIMELINE_FILE,
+        "system" => DEBUG_SYSTEM_FILE,
+        _ => return Err("target must be 'timeline' or 'system'".to_string()),
+    };
+    Ok(session_dir.join(file_name))
+}
+
 #[tauri::command]
 pub fn debug_session_start(
     app: AppHandle,
@@ -208,4 +241,54 @@ pub fn debug_session_clear_active(app: AppHandle) -> Result<(), String> {
             .map_err(|e| format!("Failed to remove {}: {e}", active_path.display()))?;
     }
     Ok(())
+}
+
+#[tauri::command]
+pub fn debug_session_append(
+    app: AppHandle,
+    input: DebugSessionAppendInput,
+) -> Result<DebugSessionAppendResult, String> {
+    let root = resolve_debug_root(&app)?;
+    let target = input.target.trim();
+    let line = input.line;
+    if line.is_empty() {
+        return Ok(DebugSessionAppendResult {
+            ok: true,
+            appended: false,
+            truncated: false,
+            bytes_written: 0,
+        });
+    }
+
+    let file_path = resolve_session_file(&root, &input.session_id, target)?;
+    ensure_parent(&file_path)?;
+
+    let current_size = fs::metadata(&file_path).map(|meta| meta.len()).unwrap_or(0);
+    let line_bytes = line.as_bytes().len() as u64 + 1;
+    if input.max_bytes > 0 && current_size.saturating_add(line_bytes) > input.max_bytes {
+        return Ok(DebugSessionAppendResult {
+            ok: true,
+            appended: false,
+            truncated: true,
+            bytes_written: 0,
+        });
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&file_path)
+        .map_err(|e| format!("Failed to open {}: {e}", file_path.display()))?;
+
+    use std::io::Write;
+    file.write_all(line.as_bytes())
+        .and_then(|_| file.write_all(b"\n"))
+        .map_err(|e| format!("Failed to append {}: {e}", file_path.display()))?;
+
+    Ok(DebugSessionAppendResult {
+        ok: true,
+        appended: true,
+        truncated: false,
+        bytes_written: line_bytes,
+    })
 }

--- a/packages/desktop/src-tauri/src/commands/mod.rs
+++ b/packages/desktop/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod command_files;
 pub mod config;
+pub mod debug;
 pub mod engine;
 pub mod misc;
 pub mod opencode_router;

--- a/packages/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/packages/desktop/src-tauri/src/commands/orchestrator.rs
@@ -456,7 +456,7 @@ fn truncate_for_report(input: &str) -> String {
     format!("{}...[truncated]", &trimmed[..MAX_LEN])
 }
 
-fn to_command_debug(result: DockerCommandResult) -> SandboxDoctorCommandDebug {
+fn to_command_debug(result: &DockerCommandResult) -> SandboxDoctorCommandDebug {
     SandboxDoctorCommandDebug {
         status: result.status,
         stdout: truncate_for_report(&result.stdout),
@@ -1329,7 +1329,7 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
 
     if doctor.ready {
         match orchestrator_start_detached(
-            app,
+            app.clone(),
             workspace_path.clone(),
             Some("docker".to_string()),
             Some(run_id.clone()),
@@ -1348,7 +1348,7 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
                     Duration::from_secs(6),
                 ) {
                     Ok(result) => {
-                        docker_inspect = Some(to_command_debug(result));
+                        docker_inspect = Some(to_command_debug(&result));
                         let _ = record_system_event(
                             &app,
                             DebugSystemEventInput {
@@ -1399,7 +1399,7 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
                     Duration::from_secs(8),
                 ) {
                     Ok(result) => {
-                        docker_logs = Some(to_command_debug(result));
+                        docker_logs = Some(to_command_debug(&result));
                         let _ = record_system_event(
                             &app,
                             DebugSystemEventInput {
@@ -1485,7 +1485,7 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
         match run_docker_command_detailed(&["rm", "-f", name.as_str()], Duration::from_secs(20)) {
             Ok(result) => {
                 container_removed = result.status == 0;
-                remove_result = Some(to_command_debug(result));
+                remove_result = Some(to_command_debug(&result));
                 let _ = record_system_event(
                     &app,
                     DebugSystemEventInput {

--- a/packages/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/packages/desktop/src-tauri/src/commands/orchestrator.rs
@@ -16,6 +16,7 @@ use tauri::State;
 use tauri_plugin_shell::ShellExt;
 use uuid::Uuid;
 
+use crate::commands::debug::{record_system_event, DebugSystemEventInput};
 use crate::orchestrator::manager::OrchestratorManager;
 use crate::orchestrator::{resolve_orchestrator_data_dir, resolve_orchestrator_status};
 use crate::platform::configure_hidden;
@@ -830,10 +831,51 @@ pub fn orchestrator_start_detached(
             str_args.push(arg.as_str());
         }
 
-        command
-            .args(str_args)
-            .spawn()
-            .map_err(|e| format!("Failed to start openwork orchestrator: {e}"))?;
+        let spawn_started = now_ms();
+        let spawn_result = command.args(str_args).spawn();
+        match spawn_result {
+            Ok(_) => {
+                let _ = record_system_event(
+                    &app,
+                    DebugSystemEventInput {
+                        surface: "desktop.orchestrator".to_string(),
+                        action: "orchestrator.spawn".to_string(),
+                        command: "openwork start".to_string(),
+                        status: "ok".to_string(),
+                        exit_code: None,
+                        duration_ms: Some(now_ms().saturating_sub(spawn_started)),
+                        stdout_excerpt: None,
+                        stderr_excerpt: None,
+                        payload: Some(json!({
+                            "workspacePath": workspace_path.clone(),
+                            "sandboxBackend": if wants_docker_sandbox { "docker" } else { "none" },
+                            "runId": sandbox_run_id.clone(),
+                        })),
+                    },
+                );
+            }
+            Err(err) => {
+                let _ = record_system_event(
+                    &app,
+                    DebugSystemEventInput {
+                        surface: "desktop.orchestrator".to_string(),
+                        action: "orchestrator.spawn".to_string(),
+                        command: "openwork start".to_string(),
+                        status: "error".to_string(),
+                        exit_code: None,
+                        duration_ms: Some(now_ms().saturating_sub(spawn_started)),
+                        stdout_excerpt: None,
+                        stderr_excerpt: Some(err.to_string()),
+                        payload: Some(json!({
+                            "workspacePath": workspace_path.clone(),
+                            "sandboxBackend": if wants_docker_sandbox { "docker" } else { "none" },
+                            "runId": sandbox_run_id.clone(),
+                        })),
+                    },
+                );
+                return Err(format!("Failed to start openwork orchestrator: {err}"));
+            }
+        }
         eprintln!(
             "[sandbox-create][at={}][runId={}][stage=spawn] launched openwork sidecar for detached sandbox host",
             now_ms(),
@@ -1300,18 +1342,52 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
                     .clone()
                     .unwrap_or_else(|| derive_orchestrator_container_name(&run_id));
 
+                let inspect_started = now_ms();
                 match run_docker_command_detailed(
                     &["inspect", container_name.as_str()],
                     Duration::from_secs(6),
                 ) {
                     Ok(result) => {
                         docker_inspect = Some(to_command_debug(result));
+                        let _ = record_system_event(
+                            &app,
+                            DebugSystemEventInput {
+                                surface: "desktop.sandbox".to_string(),
+                                action: "docker.inspect".to_string(),
+                                command: "docker inspect".to_string(),
+                                status: "ok".to_string(),
+                                exit_code: Some(result.status),
+                                duration_ms: Some(now_ms().saturating_sub(inspect_started)),
+                                stdout_excerpt: Some(result.stdout.clone()),
+                                stderr_excerpt: Some(result.stderr.clone()),
+                                payload: Some(
+                                    json!({ "args": ["inspect", container_name.as_str()] }),
+                                ),
+                            },
+                        );
                     }
                     Err(err) => {
                         cleanup_errors.push(format!("docker inspect failed: {err}"));
+                        let _ = record_system_event(
+                            &app,
+                            DebugSystemEventInput {
+                                surface: "desktop.sandbox".to_string(),
+                                action: "docker.inspect".to_string(),
+                                command: "docker inspect".to_string(),
+                                status: "error".to_string(),
+                                exit_code: None,
+                                duration_ms: Some(now_ms().saturating_sub(inspect_started)),
+                                stdout_excerpt: None,
+                                stderr_excerpt: Some(err.clone()),
+                                payload: Some(
+                                    json!({ "args": ["inspect", container_name.as_str()] }),
+                                ),
+                            },
+                        );
                     }
                 }
 
+                let logs_started = now_ms();
                 match run_docker_command_detailed(
                     &[
                         "logs",
@@ -1324,9 +1400,53 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
                 ) {
                     Ok(result) => {
                         docker_logs = Some(to_command_debug(result));
+                        let _ = record_system_event(
+                            &app,
+                            DebugSystemEventInput {
+                                surface: "desktop.sandbox".to_string(),
+                                action: "docker.logs".to_string(),
+                                command: "docker logs".to_string(),
+                                status: "ok".to_string(),
+                                exit_code: Some(result.status),
+                                duration_ms: Some(now_ms().saturating_sub(logs_started)),
+                                stdout_excerpt: Some(result.stdout.clone()),
+                                stderr_excerpt: Some(result.stderr.clone()),
+                                payload: Some(json!({
+                                    "args": [
+                                        "logs",
+                                        "--timestamps",
+                                        "--tail",
+                                        "400",
+                                        container_name.as_str(),
+                                    ]
+                                })),
+                            },
+                        );
                     }
                     Err(err) => {
                         cleanup_errors.push(format!("docker logs failed: {err}"));
+                        let _ = record_system_event(
+                            &app,
+                            DebugSystemEventInput {
+                                surface: "desktop.sandbox".to_string(),
+                                action: "docker.logs".to_string(),
+                                command: "docker logs".to_string(),
+                                status: "error".to_string(),
+                                exit_code: None,
+                                duration_ms: Some(now_ms().saturating_sub(logs_started)),
+                                stdout_excerpt: None,
+                                stderr_excerpt: Some(err.clone()),
+                                payload: Some(json!({
+                                    "args": [
+                                        "logs",
+                                        "--timestamps",
+                                        "--tail",
+                                        "400",
+                                        container_name.as_str(),
+                                    ]
+                                })),
+                            },
+                        );
                     }
                 }
 
@@ -1361,13 +1481,42 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
     let mut remove_result: Option<SandboxDoctorCommandDebug> = None;
 
     if let Some(name) = container_name.clone() {
+        let remove_started = now_ms();
         match run_docker_command_detailed(&["rm", "-f", name.as_str()], Duration::from_secs(20)) {
             Ok(result) => {
                 container_removed = result.status == 0;
                 remove_result = Some(to_command_debug(result));
+                let _ = record_system_event(
+                    &app,
+                    DebugSystemEventInput {
+                        surface: "desktop.sandbox".to_string(),
+                        action: "docker.rm".to_string(),
+                        command: "docker rm".to_string(),
+                        status: "ok".to_string(),
+                        exit_code: Some(result.status),
+                        duration_ms: Some(now_ms().saturating_sub(remove_started)),
+                        stdout_excerpt: Some(result.stdout.clone()),
+                        stderr_excerpt: Some(result.stderr.clone()),
+                        payload: Some(json!({ "args": ["rm", "-f", name.as_str()] })),
+                    },
+                );
             }
             Err(err) => {
                 cleanup_errors.push(format!("docker rm -f {name} failed: {err}"));
+                let _ = record_system_event(
+                    &app,
+                    DebugSystemEventInput {
+                        surface: "desktop.sandbox".to_string(),
+                        action: "docker.rm".to_string(),
+                        command: "docker rm".to_string(),
+                        status: "error".to_string(),
+                        exit_code: None,
+                        duration_ms: Some(now_ms().saturating_sub(remove_started)),
+                        stdout_excerpt: None,
+                        stderr_excerpt: Some(err.clone()),
+                        payload: Some(json!({ "args": ["rm", "-f", name.as_str()] })),
+                    },
+                );
             }
         }
     }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -20,7 +20,9 @@ use commands::command_files::{
     opencode_command_delete, opencode_command_list, opencode_command_write,
 };
 use commands::config::{read_opencode_config, write_opencode_config};
-use commands::debug::{debug_session_clear_active, debug_session_start, debug_session_stop};
+use commands::debug::{
+    debug_session_append, debug_session_clear_active, debug_session_start, debug_session_stop,
+};
 use commands::engine::{
     engine_doctor, engine_info, engine_install, engine_restart, engine_start, engine_stop,
 };
@@ -101,6 +103,7 @@ pub fn run() {
             engine_install,
             engine_restart,
             debug_session_start,
+            debug_session_append,
             debug_session_stop,
             debug_session_clear_active,
             orchestrator_status,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ use commands::command_files::{
     opencode_command_delete, opencode_command_list, opencode_command_write,
 };
 use commands::config::{read_opencode_config, write_opencode_config};
+use commands::debug::{debug_session_clear_active, debug_session_start, debug_session_stop};
 use commands::engine::{
     engine_doctor, engine_info, engine_install, engine_restart, engine_start, engine_stop,
 };
@@ -99,6 +100,9 @@ pub fn run() {
             engine_doctor,
             engine_install,
             engine_restart,
+            debug_session_start,
+            debug_session_stop,
+            debug_session_clear_active,
             orchestrator_status,
             orchestrator_workspace_activate,
             orchestrator_instance_dispose,


### PR DESCRIPTION
## Summary
- add desktop and app debug logging surfaces, support-report helpers, and sandbox/orchestrator diagnostics to make issue investigation easier
- fix the sandbox debug probe ownership errors in the Tauri orchestrator command path
- keep bundled OpenCode aligned with desktop builds by pinning `packages/desktop/package.json`, sharing version resolution across CI/release workflows, and adding a scheduled updater PR workflow

## Testing
- `pnpm -C packages/desktop prepare:sidecar`
- `pnpm -C packages/desktop check:opencode-version-sync`
- `cargo check -p openwork`