### PR TITLE
feat: Add UI to configure custom model providers (#829)

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -14,6 +14,8 @@ import { useLocation, useNavigate } from "@solidjs/router";
 
 import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
+import CustomProviderModal from "./components/custom-provider-modal";
+import { addCustomProviderToConfig, type CustomProviderConfig } from "./provider-config";
 import ModelPickerModal from "./components/model-picker-modal";
 import ConfirmModal from "./components/confirm-modal";
 import ResetModal from "./components/reset-modal";
@@ -381,6 +383,9 @@ export default function App() {
     null
   );
   const [sseConnected, setSseConnected] = createSignal(false);
+
+  const [customProviderModalOpen, setCustomProviderModalOpen] = createSignal(false);
+  const [customProviderBusy, setCustomProviderBusy] = createSignal(false);
 
   const [busy, setBusy] = createSignal(false);
   const [busyLabel, setBusyLabel] = createSignal<string | null>(null);
@@ -925,6 +930,28 @@ export default function App() {
     markOpencodeConfigReloadRequired: () => markOpencodeConfigReloadRequired(),
     focusPromptSoon: focusSessionPromptSoon,
   });
+
+  async function openCustomProviderModal() {
+    setCustomProviderModalOpen(true);
+  }
+
+  function closeCustomProviderModal() {
+    setCustomProviderModalOpen(false);
+  }
+
+  async function submitCustomProvider(
+    providerId: string,
+    config: CustomProviderConfig,
+  ): Promise<void> {
+    setCustomProviderBusy(true);
+    try {
+      await addCustomProviderToConfig(workspaceStore.selectedWorkspaceRoot(), providerId, config);
+      await refreshProviders();
+      setCustomProviderModalOpen(false);
+    } finally {
+      setCustomProviderBusy(false);
+    }
+  }
 
   const runtimeWorkspaceId = createMemo(() => workspaceStore.runtimeWorkspaceId());
   const activeWorkspaceServerConfig = createMemo(() => workspaceStore.runtimeWorkspaceConfig());
@@ -2059,6 +2086,11 @@ export default function App() {
       refreshProviders,
       submitProviderApiKey,
       connectCloudProvider,
+      customProviderModalOpen: customProviderModalOpen(),
+      customProviderBusy: customProviderBusy(),
+      openCustomProviderModal,
+      closeCustomProviderModal,
+      submitCustomProvider,
       setView,
       toggleSettings: () => toggleSettingsView("general"),
       startupPreference: startupPreference(),
@@ -2525,6 +2557,14 @@ export default function App() {
         onConfirm={(folder) => {
           void bundlesStore.startWorkspaceFromBundle(folder);
         }}
+      />
+
+      <CustomProviderModal
+        open={customProviderModalOpen()}
+        projectDir={workspaceStore.selectedWorkspaceRoot()}
+        existingProviderIds={providers().map((p) => p.id)}
+        onSubmit={submitCustomProvider}
+        onClose={closeCustomProviderModal}
       />
 
       <CreateWorkspaceModal

--- a/apps/app/src/app/components/custom-provider-modal.tsx
+++ b/apps/app/src/app/components/custom-provider-modal.tsx
@@ -1,0 +1,412 @@
+import { CheckCircle2, Plus, Trash2, X, AlertTriangle } from "lucide-solid";
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js";
+import { t, currentLocale } from "../../i18n";
+
+import Button from "./button";
+import TextInput from "./text-input";
+import {
+  type CustomProviderConfig,
+  type ProviderPresetKey,
+  validateProviderId,
+  validateBaseUrl,
+  PROVIDER_PRESETS,
+} from "../provider-config";
+
+const translate = (key: string) => t(key, currentLocale());
+
+type ModelEntry = {
+  id: string;
+  name: string;
+};
+
+export type CustomProviderModalProps = {
+  open: boolean;
+  projectDir: string;
+  existingProviderIds: string[];
+  onSubmit: (providerId: string, config: CustomProviderConfig) => Promise<void>;
+  onClose: () => void;
+};
+
+type ViewStep = "form" | "submitting" | "success" | "error";
+
+const NPM_OPTIONS = [
+  { value: "@ai-sdk/openai-compatible", label: "OpenAI Compatible" },
+  { value: "@ai-sdk/ollama", label: "Ollama" },
+];
+
+export default function CustomProviderModal(props: CustomProviderModalProps) {
+  const [view, setView] = createSignal<ViewStep>("form");
+  const [error, setError] = createSignal<string | null>(null);
+
+  // Form fields
+  const [providerId, setProviderId] = createSignal("");
+  const [providerName, setProviderName] = createSignal("");
+  const [selectedPreset, setSelectedPreset] = createSignal<ProviderPresetKey | "custom">("openaiCompatible");
+  const [npmPackage, setNpmPackage] = createSignal("@ai-sdk/openai-compatible");
+  const [baseUrl, setBaseUrl] = createSignal("");
+  const [models, setModels] = createSignal<ModelEntry[]>([{ id: "", name: "" }]);
+  const [apiKey, setApiKey] = createSignal("");
+
+  // Validation
+  const providerIdError = createMemo(() => {
+    const id = providerId().trim();
+    if (!id) return null;
+    try {
+      validateProviderId(id);
+      if (props.existingProviderIds.includes(id.toLowerCase())) {
+        return "Provider ID already exists";
+      }
+      return null;
+    } catch (e) {
+      return e instanceof Error ? e.message : "Invalid provider ID";
+    }
+  });
+
+  const baseUrlError = createMemo(() => {
+    const url = baseUrl().trim();
+    if (!url) return null;
+    try {
+      validateBaseUrl(url);
+      return null;
+    } catch (e) {
+      return e instanceof Error ? e.message : "Invalid URL";
+    }
+  });
+
+  const hasValidModel = createMemo(() => {
+    return models().some((m) => m.id.trim() && m.name.trim());
+  });
+
+  const canSubmit = createMemo(() => {
+    return (
+      providerId().trim() &&
+      !providerIdError() &&
+      providerName().trim() &&
+      baseUrl().trim() &&
+      !baseUrlError() &&
+      hasValidModel() &&
+      view() === "form"
+    );
+  });
+
+  // Reset form when modal opens
+  createEffect(() => {
+    if (props.open) {
+      setView("form");
+      setError(null);
+      setProviderId("");
+      setProviderName("");
+      setSelectedPreset("openaiCompatible");
+      setNpmPackage("@ai-sdk/openai-compatible");
+      setBaseUrl("");
+      setModels([{ id: "", name: "" }]);
+      setApiKey("");
+    }
+  });
+
+  // Update form when preset changes
+  createEffect(() => {
+    const preset = selectedPreset();
+    if (preset === "custom") return;
+
+    const presetConfig = PROVIDER_PRESETS[preset];
+    setProviderName(presetConfig.name);
+    setNpmPackage(presetConfig.npm);
+    setBaseUrl(presetConfig.defaultBaseURL);
+  });
+
+  const addModel = () => {
+    setModels([...models(), { id: "", name: "" }]);
+  };
+
+  const removeModel = (index: number) => {
+    const current = models();
+    if (current.length > 1) {
+      setModels([...current.slice(0, index), ...current.slice(index + 1)]);
+    }
+  };
+
+  const updateModel = (index: number, field: "id" | "name", value: string) => {
+    const current = models();
+    current[index] = { ...current[index], [field]: value };
+    setModels([...current]);
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit()) return;
+
+    setView("submitting");
+    setError(null);
+
+    try {
+      const validatedId = validateProviderId(providerId());
+      const validatedUrl = validateBaseUrl(baseUrl());
+
+      // Build model config
+      const modelConfig: CustomProviderConfig["models"] = {};
+      for (const model of models()) {
+        const trimmedId = model.id.trim();
+        const trimmedName = model.name.trim();
+        if (trimmedId && trimmedName) {
+          modelConfig[trimmedId] = { name: trimmedName };
+        }
+      }
+
+      const config: CustomProviderConfig = {
+        npm: npmPackage(),
+        name: providerName().trim(),
+        options: {
+          baseURL: validatedUrl,
+          ...(apiKey().trim() ? { apiKey: apiKey().trim() } : {}),
+        },
+        models: modelConfig,
+      };
+
+      await props.onSubmit(validatedId, config);
+      setView("success");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add provider");
+      setView("error");
+    }
+  };
+
+  const handleClose = () => {
+    props.onClose();
+  };
+
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 bg-gray-1/60 backdrop-blur-sm flex items-start justify-center p-4 overflow-y-auto">
+        <div class="bg-gray-2 border border-gray-6/70 w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden max-h-[calc(100vh-2rem)] flex flex-col">
+          {/* Header */}
+          <div class="px-6 pt-6 pb-4 border-b border-gray-6/50 flex items-start justify-between gap-4">
+            <div>
+              <h3 class="text-lg font-semibold text-gray-12">Add custom provider</h3>
+              <p class="text-sm text-gray-11 mt-1">Configure your own model API provider.</p>
+            </div>
+            <Button variant="ghost" class="!p-2 rounded-full" onClick={handleClose}>
+              <X size={16} />
+            </Button>
+          </div>
+
+          {/* Content */}
+          <div class="px-6 py-4 flex flex-col gap-4 min-h-0 overflow-y-auto">
+            {/* Error message */}
+            <Show when={error()}>
+              <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
+                {error()}
+              </div>
+            </Show>
+
+            {/* Success message */}
+            <Show when={view() === "success"}>
+              <div class="rounded-xl border border-green-7/30 bg-green-1/40 px-4 py-3 flex items-center gap-2">
+                <CheckCircle2 size={16} class="text-green-11" />
+                <span class="text-sm text-green-12">Provider added successfully!</span>
+              </div>
+              <div class="text-xs text-gray-10">
+                The provider has been added to your configuration. You may need to reload the workspace for changes to take effect.
+              </div>
+            </Show>
+
+            {/* Form */}
+            <Show when={view() === "form" || view() === "submitting"}>
+              {/* Preset selector */}
+              <div class="space-y-2">
+                <label class="text-xs font-medium text-gray-11">Preset</label>
+                <div class="flex flex-wrap gap-2">
+                  <For each={Object.entries(PROVIDER_PRESETS)}>
+                    {([key, preset]) => (
+                      <button
+                        type="button"
+                        class={`px-3 py-1.5 text-xs rounded-lg border transition-colors ${
+                          selectedPreset() === key
+                            ? "border-dls-accent bg-dls-accent/10 text-dls-accent"
+                            : "border-gray-6 bg-gray-1 text-gray-11 hover:bg-gray-3"
+                        }`}
+                        onClick={() => setSelectedPreset(key as ProviderPresetKey)}
+                      >
+                        {preset.name}
+                      </button>
+                    )}
+                  </For>
+                  <button
+                    type="button"
+                    class={`px-3 py-1.5 text-xs rounded-lg border transition-colors ${
+                      selectedPreset() === "custom"
+                        ? "border-dls-accent bg-dls-accent/10 text-dls-accent"
+                        : "border-gray-6 bg-gray-1 text-gray-11 hover:bg-gray-3"
+                    }`}
+                    onClick={() => setSelectedPreset("custom")}
+                  >
+                    Custom
+                  </button>
+                </div>
+              </div>
+
+              {/* Provider ID */}
+              <div class="space-y-1">
+                <TextInput
+                  label="Provider ID"
+                  type="text"
+                  placeholder="my-custom-provider"
+                  value={providerId()}
+                  onInput={(e) => setProviderId(e.currentTarget.value)}
+                  autocomplete="off"
+                  autocapitalize="off"
+                  spellcheck={false}
+                  disabled={view() === "submitting"}
+                />
+                <Show when={providerIdError()}>
+                  <div class="text-xs text-red-11">{providerIdError()}</div>
+                </Show>
+                <div class="text-[11px] text-gray-9">
+                  Unique identifier (alphanumeric, -, _)
+                </div>
+              </div>
+
+              {/* Provider Name */}
+              <TextInput
+                label="Display name"
+                type="text"
+                placeholder="My Custom Provider"
+                value={providerName()}
+                onInput={(e) => setProviderName(e.currentTarget.value)}
+                autocomplete="off"
+                disabled={view() === "submitting"}
+              />
+
+              {/* NPM Package */}
+              <div class="space-y-2">
+                <label class="text-xs font-medium text-gray-11">SDK Package</label>
+                <select
+                  class="w-full bg-dls-surface border border-dls-border rounded-xl py-2.5 px-3 text-sm text-dls-text focus:outline-none focus:ring-1 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] focus:border-dls-accent"
+                  value={npmPackage()}
+                  onChange={(e) => setNpmPackage(e.currentTarget.value)}
+                  disabled={view() === "submitting"}
+                >
+                  <For each={NPM_OPTIONS}>
+                    {(opt) => <option value={opt.value}>{opt.label}</option>}
+                  </For>
+                </select>
+              </div>
+
+              {/* Base URL */}
+              <div class="space-y-1">
+                <TextInput
+                  label="Base URL"
+                  type="text"
+                  placeholder="https://api.example.com/v1"
+                  value={baseUrl()}
+                  onInput={(e) => setBaseUrl(e.currentTarget.value)}
+                  autocomplete="off"
+                  autocapitalize="off"
+                  spellcheck={false}
+                  disabled={view() === "submitting"}
+                />
+                <Show when={baseUrlError()}>
+                  <div class="text-xs text-red-11">{baseUrlError()}</div>
+                </Show>
+                <div class="text-[11px] text-gray-9">
+                  The API endpoint URL (e.g., http://localhost:11434 for Ollama)
+                </div>
+              </div>
+
+              {/* Models */}
+              <div class="space-y-2">
+                <div class="flex items-center justify-between">
+                  <label class="text-xs font-medium text-gray-11">Models</label>
+                  <Button
+                    variant="ghost"
+                    class="!p-1 !text-xs"
+                    onClick={addModel}
+                    disabled={view() === "submitting"}
+                  >
+                    <Plus size={14} class="mr-1" /> Add model
+                  </Button>
+                </div>
+                <For each={models()}>
+                  {(model, index) => (
+                    <div class="flex items-start gap-2">
+                      <div class="flex-1 space-y-2">
+                        <input
+                          type="text"
+                          placeholder="model-id"
+                          value={model.id}
+                          onInput={(e) => updateModel(index(), "id", e.currentTarget.value)}
+                          class="w-full bg-dls-surface border border-dls-border rounded-lg py-2 px-3 text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none focus:ring-1 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] focus:border-dls-accent"
+                          disabled={view() === "submitting"}
+                        />
+                        <input
+                          type="text"
+                          placeholder="Display name"
+                          value={model.name}
+                          onInput={(e) => updateModel(index(), "name", e.currentTarget.value)}
+                          class="w-full bg-dls-surface border border-dls-border rounded-lg py-2 px-3 text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none focus:ring-1 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] focus:border-dls-accent"
+                          disabled={view() === "submitting"}
+                        />
+                      </div>
+                      <Show when={models().length > 1}>
+                        <Button
+                          variant="ghost"
+                          class="!p-2 text-gray-10 hover:text-red-11"
+                          onClick={() => removeModel(index())}
+                          disabled={view() === "submitting"}
+                        >
+                          <Trash2 size={16} />
+                        </Button>
+                      </Show>
+                    </div>
+                  )}
+                </For>
+                <Show when={!hasValidModel()}>
+                  <div class="text-xs text-amber-11">At least one model with ID and name is required</div>
+                </Show>
+              </div>
+
+              {/* API Key (optional) */}
+              <div class="space-y-2">
+                <TextInput
+                  label="API Key (optional)"
+                  type="password"
+                  placeholder="sk-..."
+                  value={apiKey()}
+                  onInput={(e) => setApiKey(e.currentTarget.value)}
+                  autocomplete="off"
+                  disabled={view() === "submitting"}
+                />
+                <div class="flex items-start gap-2 text-[11px] text-amber-11 bg-amber-1/40 border border-amber-7/30 rounded-lg px-3 py-2">
+                  <AlertTriangle size={14} class="shrink-0 mt-0.5" />
+                  <span>API keys are stored in plaintext in opencode.json. Consider using environment variables instead.</span>
+                </div>
+              </div>
+            </Show>
+          </div>
+
+          {/* Footer */}
+          <div class="px-6 pt-4 pb-6 border-t border-gray-6/50 flex flex-col gap-3">
+            <div class="flex items-center justify-end gap-3">
+              <Show when={view() === "success"}>
+                <Button variant="outline" onClick={handleClose}>
+                  Close
+                </Button>
+              </Show>
+              <Show when={view() === "form" || view() === "submitting" || view() === "error"}>
+                <Button variant="outline" onClick={handleClose} disabled={view() === "submitting"}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={handleSubmit}
+                  disabled={!canSubmit()}
+                >
+                  {view() === "submitting" ? "Adding..." : "Add provider"}
+                </Button>
+              </Show>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -101,6 +101,8 @@ export type SettingsViewProps = {
     preferredProviderId?: string;
   }) => Promise<void>;
   disconnectProvider: (providerId: string) => Promise<string | void>;
+  openCustomProviderModal: () => Promise<void>;
+  customProviderBusy: boolean;
   openworkServerStatus: OpenworkServerStatus;
   openworkServerUrl: string;
   openworkServerClient: OpenworkServerClient | null;
@@ -1509,6 +1511,13 @@ export default function SettingsView(props: SettingsViewProps) {
                   {props.providerAuthBusy
                     ? translate("settings.loading_providers")
                     : translate("settings.connect_provider")}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={props.openCustomProviderModal}
+                  disabled={props.busy || props.customProviderBusy}
+                >
+                  Add custom provider
                 </Button>
                 <div class="text-xs text-gray-10">{providerSummary()}</div>
               </div>

--- a/apps/app/src/app/provider-config.ts
+++ b/apps/app/src/app/provider-config.ts
@@ -1,0 +1,369 @@
+import { parse } from "jsonc-parser";
+import { readOpencodeConfig, writeOpencodeConfig } from "./lib/tauri";
+
+/**
+ * Provider configuration structure matching the opencode.json schema.
+ */
+export type CustomProviderConfig = {
+  /** NPM package for the provider (e.g., "@ai-sdk/openai-compatible") */
+  npm?: string;
+  /** Display name for the provider */
+  name?: string;
+  /** API type identifier */
+  api?: string;
+  /** Environment variable names for credentials */
+  env?: string[];
+  /** Provider-specific options */
+  options?: {
+    /** API base URL */
+    baseURL?: string;
+    /** API key (stored in plaintext - warn users) */
+    apiKey?: string;
+    /** Request timeout in milliseconds */
+    timeout?: number | false;
+    /** Additional provider-specific options */
+    [key: string]: unknown;
+  };
+  /** Model configurations */
+  models?: {
+    [modelId: string]: {
+      /** Display name for the model */
+      name?: string;
+      /** Model family */
+      family?: string;
+      /** Cost configuration */
+      cost?: {
+        input: number;
+        output: number;
+        cache_read?: number;
+        cache_write?: number;
+      };
+      /** Context limits */
+      limit?: {
+        context: number;
+        input?: number;
+        output: number;
+      };
+      /** Additional model-specific options */
+      [key: string]: unknown;
+    };
+  };
+  /** Allowed model IDs (whitelist) */
+  whitelist?: string[];
+  /** Blocked model IDs (blacklist) */
+  blacklist?: string[];
+};
+
+/**
+ * Custom provider entry with ID and config.
+ */
+export type CustomProviderEntry = {
+  id: string;
+  config: CustomProviderConfig;
+};
+
+type ProviderConfigValue = Record<string, unknown> | null | undefined;
+
+/**
+ * Validates a provider ID string.
+ * Must be alphanumeric with '-' or '_', and not start with '-'.
+ *
+ * @param id - The provider ID to validate
+ * @returns The trimmed and validated provider ID
+ * @throws Error if the ID is invalid
+ */
+export function validateProviderId(id: string): string {
+  const trimmed = id.trim();
+  if (!trimmed) {
+    throw new Error("Provider ID is required");
+  }
+  if (trimmed.startsWith("-")) {
+    throw new Error("Provider ID must not start with '-'");
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(trimmed)) {
+    throw new Error("Provider ID must be alphanumeric with '-' or '_'");
+  }
+  if (trimmed.length > 64) {
+    throw new Error("Provider ID must be 64 characters or less");
+  }
+  return trimmed;
+}
+
+/**
+ * Validates a URL string.
+ * Must be a valid HTTP or HTTPS URL.
+ *
+ * @param url - The URL to validate
+ * @returns The trimmed URL or empty string if not provided
+ * @throws Error if the URL is invalid
+ */
+export function validateBaseUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return "";
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("URL must use http or https protocol");
+    }
+    return trimmed;
+  } catch {
+    throw new Error("Invalid URL format");
+  }
+}
+
+/**
+ * Adds a custom provider to the opencode.json configuration file.
+ *
+ * @param projectDir - The project directory path
+ * @param providerId - The unique provider identifier
+ * @param config - The provider configuration
+ * @throws Error if the provider ID is invalid or already exists, or if writing fails
+ */
+export async function addCustomProviderToConfig(
+  projectDir: string,
+  providerId: string,
+  config: CustomProviderConfig,
+): Promise<void> {
+  const validatedId = validateProviderId(providerId);
+
+  const configFile = await readOpencodeConfig("project", projectDir);
+  let existingConfig: Record<string, unknown> = {};
+
+  if (configFile.exists && configFile.content?.trim()) {
+    try {
+      existingConfig = parse(configFile.content) ?? {};
+    } catch {
+      existingConfig = {};
+    }
+  }
+
+  // Get or create the provider section
+  const providerSection = (existingConfig["provider"] as ProviderConfigValue) ?? {};
+
+  // Check if provider already exists
+  if (providerSection && validatedId in providerSection) {
+    throw new Error(`Provider "${validatedId}" already exists. Use a different ID or delete the existing provider first.`);
+  }
+
+  // Add the new provider
+  existingConfig = {
+    ...existingConfig,
+    provider: {
+      ...providerSection,
+      [validatedId]: config,
+    },
+  };
+
+  const writeResult = await writeOpencodeConfig(
+    "project",
+    projectDir,
+    `${JSON.stringify(existingConfig, null, 2)}\n`,
+  );
+
+  if (!writeResult.ok) {
+    throw new Error(writeResult.stderr || writeResult.stdout || "Failed to write opencode.json");
+  }
+}
+
+/**
+ * Updates an existing custom provider in the opencode.json configuration file.
+ *
+ * @param projectDir - The project directory path
+ * @param providerId - The unique provider identifier
+ * @param config - The updated provider configuration
+ * @throws Error if the provider ID is invalid or doesn't exist, or if writing fails
+ */
+export async function updateCustomProviderInConfig(
+  projectDir: string,
+  providerId: string,
+  config: CustomProviderConfig,
+): Promise<void> {
+  const validatedId = validateProviderId(providerId);
+
+  const configFile = await readOpencodeConfig("project", projectDir);
+  let existingConfig: Record<string, unknown> = {};
+
+  if (configFile.exists && configFile.content?.trim()) {
+    try {
+      existingConfig = parse(configFile.content) ?? {};
+    } catch {
+      existingConfig = {};
+    }
+  }
+
+  const providerSection = existingConfig["provider"] as ProviderConfigValue;
+
+  if (!providerSection || !(validatedId in providerSection)) {
+    throw new Error(`Provider "${validatedId}" does not exist`);
+  }
+
+  // Update the provider
+  existingConfig = {
+    ...existingConfig,
+    provider: {
+      ...providerSection,
+      [validatedId]: config,
+    },
+  };
+
+  const writeResult = await writeOpencodeConfig(
+    "project",
+    projectDir,
+    `${JSON.stringify(existingConfig, null, 2)}\n`,
+  );
+
+  if (!writeResult.ok) {
+    throw new Error(writeResult.stderr || writeResult.stdout || "Failed to write opencode.json");
+  }
+}
+
+/**
+ * Removes a custom provider from the opencode.json configuration file.
+ *
+ * @param projectDir - The project directory path
+ * @param providerId - The unique provider identifier
+ * @throws Error if the provider ID is invalid or if writing fails
+ */
+export async function removeCustomProviderFromConfig(
+  projectDir: string,
+  providerId: string,
+): Promise<void> {
+  const validatedId = validateProviderId(providerId);
+
+  const configFile = await readOpencodeConfig("project", projectDir);
+  let existingConfig: Record<string, unknown> = {};
+
+  if (configFile.exists && configFile.content?.trim()) {
+    try {
+      existingConfig = parse(configFile.content) ?? {};
+    } catch {
+      existingConfig = {};
+    }
+  }
+
+  const providerSection = existingConfig["provider"] as ProviderConfigValue;
+  if (!providerSection || !(validatedId in providerSection)) {
+    return; // Provider doesn't exist, nothing to do
+  }
+
+  delete providerSection[validatedId];
+
+  const writeResult = await writeOpencodeConfig(
+    "project",
+    projectDir,
+    `${JSON.stringify(existingConfig, null, 2)}\n`,
+  );
+
+  if (!writeResult.ok) {
+    throw new Error(writeResult.stderr || writeResult.stdout || "Failed to write opencode.json");
+  }
+}
+
+/**
+ * Parses custom providers from opencode.json content.
+ * Only returns providers that have npm or api fields (indicating custom providers).
+ *
+ * @param content - The opencode.json file content
+ * @returns A map of provider IDs to their configurations
+ */
+export function parseCustomProvidersFromContent(content: string): CustomProviderEntry[] {
+  if (!content.trim()) return [];
+
+  try {
+    const parsed = parse(content) as Record<string, unknown> | undefined;
+    const provider = parsed?.provider as ProviderConfigValue;
+
+    if (!provider || typeof provider !== "object") {
+      return [];
+    }
+
+    // Filter to only custom providers (those with npm or api fields)
+    return Object.entries(provider)
+      .filter(([, config]) => {
+        if (!config || typeof config !== "object") {
+          return false;
+        }
+        const pc = config as CustomProviderConfig;
+        // Custom providers have npm or api field
+        return !!(pc.npm || pc.api);
+      })
+      .map(([id, config]) => ({
+        id,
+        config: config as CustomProviderConfig,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Checks if a provider ID already exists in the configuration.
+ *
+ * @param projectDir - The project directory path
+ * @param providerId - The provider ID to check
+ * @returns True if the provider exists, false otherwise
+ */
+export async function providerExists(
+  projectDir: string,
+  providerId: string,
+): Promise<boolean> {
+  const validatedId = validateProviderId(providerId);
+
+  const configFile = await readOpencodeConfig("project", projectDir);
+  if (!configFile.exists || !configFile.content?.trim()) {
+    return false;
+  }
+
+  try {
+    const parsed = parse(configFile.content) as Record<string, unknown> | undefined;
+    const provider = parsed?.provider as ProviderConfigValue;
+    return !!(provider && validatedId in provider);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets all custom providers from the opencode.json configuration file.
+ *
+ * @param projectDir - The project directory path
+ * @returns Array of custom provider entries
+ */
+export async function getCustomProviders(
+  projectDir: string,
+): Promise<CustomProviderEntry[]> {
+  const configFile = await readOpencodeConfig("project", projectDir);
+  if (!configFile.exists || !configFile.content?.trim()) {
+    return [];
+  }
+
+  return parseCustomProvidersFromContent(configFile.content);
+}
+
+/**
+ * Preset templates for common custom providers.
+ */
+export const PROVIDER_PRESETS = {
+  ollama: {
+    name: "Ollama",
+    npm: "@ai-sdk/ollama",
+    defaultBaseURL: "http://localhost:11434",
+    description: "Local LLM server (Ollama)",
+  },
+  vllm: {
+    name: "vLLM",
+    npm: "@ai-sdk/openai-compatible",
+    defaultBaseURL: "http://localhost:8000/v1",
+    description: "vLLM inference server",
+  },
+  openaiCompatible: {
+    name: "OpenAI Compatible",
+    npm: "@ai-sdk/openai-compatible",
+    defaultBaseURL: "",
+    description: "Any OpenAI-compatible API",
+  },
+} as const;
+
+export type ProviderPresetKey = keyof typeof PROVIDER_PRESETS;

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -53,6 +53,7 @@ import { ProviderAuthModal,
   type ProviderAuthMethod,
   type ProviderOAuthStartResult,
 } from "../context/providers";
+import CustomProviderModal from "../components/custom-provider-modal";
 import WorkspaceSessionList from "../components/session/workspace-session-list";
 import { ShareWorkspaceModal } from "../workspace";
 import {
@@ -96,6 +97,11 @@ export type SettingsShellProps = {
   submitProviderApiKey: (providerId: string, apiKey: string) => Promise<string | void>;
   connectCloudProvider: (cloudProviderId: string) => Promise<string | void>;
   refreshProviders: () => Promise<unknown>;
+  customProviderModalOpen: boolean;
+  customProviderBusy: boolean;
+  openCustomProviderModal: () => Promise<void>;
+  closeCustomProviderModal: () => void;
+  submitCustomProvider: (providerId: string, config: import("../provider-config").CustomProviderConfig) => Promise<void>;
   setView: (view: View, sessionId?: string) => void;
   toggleSettings: () => void;
   startupPreference: StartupPreference | null;
@@ -1151,6 +1157,8 @@ export default function SettingsShell(props: SettingsShellProps) {
                   providerAuthBusy={props.providerAuthBusy}
                   openProviderAuthModal={props.openProviderAuthModal}
                   disconnectProvider={props.disconnectProvider}
+                  openCustomProviderModal={props.openCustomProviderModal}
+                  customProviderBusy={props.customProviderBusy}
                   openworkServerStatus={props.openworkServerStatus}
                   openworkServerUrl={props.openworkServerUrl}
                   openworkServerClient={props.openworkServerClient}
@@ -1292,6 +1300,14 @@ export default function SettingsShell(props: SettingsShellProps) {
           onSubmitOAuth={handleProviderAuthOAuth}
           onRefreshProviders={props.refreshProviders}
           onClose={() => props.closeProviderAuthModal()}
+        />
+
+        <CustomProviderModal
+          open={props.customProviderModalOpen}
+          projectDir={props.selectedWorkspaceRoot}
+          existingProviderIds={props.providers.map((p) => p.id.toLowerCase())}
+          onSubmit={props.submitCustomProvider}
+          onClose={props.closeCustomProviderModal}
         />
 
         <ShareWorkspaceModal


### PR DESCRIPTION
## Summary

- Add a modal dialog in Settings to configure custom model providers (e.g., Ollama, vLLM, OpenAI-compatible APIs) through the GUI
- Users can now add custom providers without manually editing `opencode.json`
- Includes preset templates for Ollama, vLLM, and generic OpenAI-compatible APIs

## Changes

| File | Type | Description |
|------|------|-------------|
| `packages/app/src/app/provider-config.ts` | New | Provider config utilities with validation |
| `packages/app/src/app/components/custom-provider-modal.tsx` | New | Modal component for adding custom providers |
| `packages/app/src/app/pages/settings.tsx` | Modified | Add "Add custom provider" button |
| `packages/app/src/app/pages/dashboard.tsx` | Modified | Integrate modal rendering |
| `packages/app/src/app/app.tsx` | Modified | Add modal state and handlers |

## Features

- **Preset Templates**: Quick setup for Ollama (`localhost:11434`), vLLM (`localhost:8000/v1`), or custom APIs
- **Form Validation**: Provider ID format validation, URL validation, duplicate detection
- **Dynamic Model List**: Add/remove multiple models for each provider
- **Security Warning**: API keys stored in plaintext with visible warning
- **Success/Error States**: Clear feedback on save operations

## Test Plan

1. Open Settings → General
2. Click "Add custom provider"
3. Select Ollama preset and fill in model details
4. Save and verify provider appears in list
5. Check `opencode.json` contains new provider entry
6. Test selecting custom provider model in chat

Closes #829