### PR TITLE
fix: add type guards for RenderedItem union narrowing

### DIFF
--- a/packages/app/src/app/components/model-picker-modal.tsx
+++ b/packages/app/src/app/components/model-picker-modal.tsx
@@ -28,6 +28,16 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
     | { kind: "model"; opt: ModelOption }
     | { kind: "provider"; providerID: string; title: string; matchCount: number };
 
+  type RenderedItemWithIndex = { item: RenderedItem; index: number };
+
+  function isModelItem(entry: RenderedItemWithIndex): entry is { item: { kind: "model"; opt: ModelOption }; index: number } {
+    return entry.item.kind === "model";
+  }
+
+  function isProviderItem(entry: RenderedItemWithIndex): entry is { item: { kind: "provider"; providerID: string; title: string; matchCount: number }; index: number } {
+    return entry.item.kind === "provider";
+  }
+
   const [activeIndex, setActiveIndex] = createSignal(0);
   const optionRefs: HTMLButtonElement[] = [];
 
@@ -76,14 +86,14 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
   const enabledOptions = createMemo(() =>
     renderedItems()
       .map((item, index) => ({ item, index }))
-      .filter((entry) => entry.item.kind === "model")
+      .filter(isModelItem)
       .map((entry) => ({ opt: entry.item.opt, index: entry.index })),
   );
 
   const otherOptions = createMemo(() =>
     renderedItems()
       .map((item, index) => ({ item, index }))
-      .filter((entry) => entry.item.kind === "provider")
+      .filter(isProviderItem)
       .map((entry) => ({
         providerID: entry.item.providerID,
         title: entry.item.title,


### PR DESCRIPTION
## Problem

TypeScript compilation fails with the following errors in `model-picker-modal.tsx`:

```
src/app/components/model-picker-modal.tsx(80,42): error TS2339: Property 'opt' does not exist on type 'RenderedItem'.
src/app/components/model-picker-modal.tsx(88,32): error TS2339: Property 'providerID' does not exist on type 'RenderedItem'.
src/app/components/model-picker-modal.tsx(89,27): error TS2339: Property 'title' does not exist on type 'RenderedItem'.
src/app/components/model-picker-modal.tsx(90,32): error TS2339: Property 'matchCount' does not exist on type 'RenderedItem'.
```

## Root Cause Analysis

### Type Definition

```typescript
type RenderedItem =
  | { kind: "model"; opt: ModelOption }
  | { kind: "provider"; providerID: string; title: string; matchCount: number };
```

### Problematic Code Pattern

```typescript
const enabledOptions = createMemo(() =>
  renderedItems()
    .map((item, index) => ({ item, index }))
    .filter((entry) => entry.item.kind === "model")  // Filter happens here
    .map((entry) => ({ opt: entry.item.opt, index: entry.index })),  // Error: TypeScript doesn't narrow type
);
```

### Why TypeScript Fails

1. `renderedItems()` returns `RenderedItem[]` (a union type array)
2. `.map((item, index) => ({ item, index }))` creates `{ item: RenderedItem; index: number }[]`
3. `.filter((entry) => entry.item.kind === "model")` filters at **runtime**, but TypeScript does **not** automatically narrow the type after `filter()`
4. `.map((entry) => ({ opt: entry.item.opt, ... }))` - TypeScript still thinks `entry.item` is the full `RenderedItem` union type

**Key insight**: TypeScript's `Array.filter()` does not use the callback's condition to narrow element types. The filter callback is treated as a boolean predicate, not a type predicate.

### When Was This Introduced

This issue is **not introduced by any recent PR**. It appears to be a pre-existing issue in the codebase that may have been introduced during a refactor to:
- Optimize rendering with memoization
- Separate "enabled providers" from "other providers" display
- Support keyboard navigation with `activeIndex`

The code style suggests it was part of a feature enhancement rather than a bug fix.

## Solution

Added type guard functions that use TypeScript's type predicate syntax:

```typescript
type RenderedItemWithIndex = { item: RenderedItem; index: number };

function isModelItem(entry: RenderedItemWithIndex): entry is { item: { kind: "model"; opt: ModelOption }; index: number } {
  return entry.item.kind === "model";
}

function isProviderItem(entry: RenderedItemWithIndex): entry is { item: { kind: "provider"; providerID: string; title: string; matchCount: number }; index: number } {
  return entry.item.kind === "provider";
}
```

Then used these type guards in the filter:

```typescript
const enabledOptions = createMemo(() =>
  renderedItems()
    .map((item, index) => ({ item, index }))
    .filter(isModelItem)  // Type is properly narrowed
    .map((entry) => ({ opt: entry.item.opt, index: entry.index })),
);
```

## Alternative Solutions Considered

1. **Inline type predicate**: Works but less readable
   ```typescript
   .filter((entry): entry is { item: { kind: "model"; opt: ModelOption }; index: number } => entry.item.kind === "model")
   ```

2. **Type assertion**: Unsafe and defeats the purpose of type checking
   ```typescript
   .map((entry) => ({ opt: (entry.item as { kind: "model"; opt: ModelOption }).opt, ... }))
   ```

3. **flatMap pattern**: Works but changes the code structure more significantly

## Verification

```bash
cd packages/app && pnpm tsc --noEmit
# No errors
```

## Impact

- **Runtime**: Zero impact (type guards are just boolean functions at runtime)
- **Type safety**: Improved (proper type narrowing)
- **Code clarity**: Better (explicit type guards are self-documenting)