### PR TITLE
fix: improve HTTP 413 error handling with user-friendly message

### DIFF
--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -450,8 +450,8 @@ export function createSessionStore(options: {
 
   const inferHttpStatus = (value: string | null) => {
     if (!value) return null;
-    const match = value.match(/\b(?:status|code|http)\s*(?:=|:)?\s*(401|403|429)\b/i) ||
-      value.match(/\b(401|403|429)\b/);
+    const match = value.match(/\b(?:status|code|http)\s*(?:=|:)?\s*(401|403|413|429)\b/i) ||
+      value.match(/\b(401|403|413|429)\b/);
     if (!match) return null;
     const parsed = Number.parseInt(match[1], 10);
     if (!Number.isFinite(parsed)) return null;
@@ -520,10 +520,12 @@ export function createSessionStore(options: {
       if (errorName === "ProviderAuthError") return `Provider auth error${providerID ? ` (${providerID})` : ""}`;
       if (errorName === "APIError") {
         if (effectiveStatus === 401 || effectiveStatus === 403) return "Authentication failed";
+        if (effectiveStatus === 413) return "Context too large";
         if (effectiveStatus === 429) return "Rate limit exceeded";
         return `API error${effectiveStatus ? ` (${effectiveStatus})` : ""}`;
       }
       if (effectiveStatus === 401 || effectiveStatus === 403) return "Authentication failed";
+      if (effectiveStatus === 413) return "Context too large";
       if (effectiveStatus === 429) return "Rate limit exceeded";
       if (errorName === "MessageOutputLengthError") return "Output length limit exceeded";
       return errorName.replace(/([a-z])([A-Z])/g, "$1 $2");
@@ -531,6 +533,9 @@ export function createSessionStore(options: {
 
     const lines = [heading];
     if (rawMessage && rawMessage !== heading) lines.push(rawMessage);
+    if (effectiveStatus === 413) {
+      lines.push("Tip: Try compacting the session, or start a new session if the issue persists.");
+    }
     if (providerID && errorName !== "ProviderAuthError") lines.push(`Provider: ${providerID}`);
     if (effectiveStatus && errorName !== "APIError") lines.push(`Status: ${effectiveStatus}`);
     if (code) lines.push(`Code: ${code}`);


### PR DESCRIPTION
## Summary

- Add HTTP 413 status code detection in `inferHttpStatus` function
- Display "Context too large" as error title for 413 errors  
- Add tip message suggesting compact or starting a new session

## Problem

When session context becomes too large (usually due to accumulated base64 screenshot data), the API returns HTTP 413 "Request Entity Too Large". Previously, this error was not properly identified and displayed to users with a friendly message.

Note: The server-side compact feature may not be able to reduce image/base64 data. Hence the tip suggests both compact and starting a new session as fallback.

## Solution

This PR improves the error handling for HTTP 413 errors by:

1. **Status code detection**: Adding 413 to the regex patterns in `inferHttpStatus` function
2. **User-friendly error title**: Displaying "Context too large" instead of generic "API error (413)"
3. **Actionable tip**: Adding a tip message suggesting users to compact the session, or start a new session if the issue persists

## Example Output

```
Context too large
Request Entity Too Large
Tip: Try compacting the session, or start a new session if the issue persists.
```

## Test Plan

- [ ] Verify that HTTP 413 errors are correctly identified and display "Context too large" as the error title
- [ ] Verify that the tip message is displayed for 413 errors
- [ ] Verify that other HTTP errors (401, 403, 429) still work correctly

Fixes #798