### PR TITLE
Fix shared bundle Open in OpenWork blueprint flow

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -92,6 +92,7 @@ import type {
   UpdateHandle,
   OpencodeConnectStatus,
   ScheduledJob,
+  WorkspacePreset,
 } from "./types";
 import {
   clearStartupPreference,
@@ -3022,6 +3023,30 @@ export default function App() {
     throw new Error("OpenWork worker is not ready yet.");
   };
 
+  const importSharedBundlePayload = async (bundle: SharedBundleV1) => {
+    const { client, workspaceId } = await waitForSharedBundleImportTarget();
+    const { payload, importedSkillsCount } = buildImportPayloadFromBundle(bundle);
+    await client.importWorkspace(workspaceId, payload);
+    await refreshSkills({ force: true });
+    await refreshHubSkills({ force: true });
+    if (importedSkillsCount > 0) {
+      console.log(`[openwork] imported ${importedSkillsCount} skills from share bundle`);
+    }
+  };
+
+  const importSharedBundleIntoActiveWorker = async (request: SharedBundleDeepLink) => {
+    try {
+      const bundle = await fetchSharedBundle(request.bundleUrl);
+      await importSharedBundlePayload(bundle);
+      setError(null);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setError(addOpencodeCacheHint(message));
+      return false;
+    }
+  };
+
   const createWorkerForSharedBundle = async (request: SharedBundleDeepLink, bundle: SharedBundleV1) => {
     const target = resolveSharedBundleWorkerTarget();
     const hostUrl = target.hostUrl.trim();
@@ -3052,6 +3077,17 @@ export default function App() {
     }
 
     if (sharedBundleImportBusy()) {
+      return;
+    }
+
+    if (request.intent === "new_worker" && isTauriRuntime()) {
+      setView("dashboard");
+      setTab("scheduled");
+      setError(null);
+      setSharedBundleCreateWorkerRequest(request);
+      workspaceStore.setCreateWorkspaceOpen(true);
+      setPendingSharedBundleInvite(null);
+      setSharedBundleNoticeShown(false);
       return;
     }
 
@@ -3090,17 +3126,8 @@ export default function App() {
           if (cancelled) return;
         }
 
-        const { client, workspaceId } = await waitForSharedBundleImportTarget();
-        if (cancelled) return;
-
-        const { payload, importedSkillsCount } = buildImportPayloadFromBundle(bundle);
-        await client.importWorkspace(workspaceId, payload);
-        await refreshSkills({ force: true });
-        await refreshHubSkills({ force: true });
+        await importSharedBundlePayload(bundle);
         setError(null);
-        if (importedSkillsCount > 0) {
-          console.log(`[openwork] imported ${importedSkillsCount} skills from share bundle`);
-        }
       } catch (error) {
         if (!cancelled) {
           const message = error instanceof Error ? error.message : safeStringify(error);
@@ -3259,12 +3286,17 @@ export default function App() {
   const [deepLinkRemoteWorkspaceDefaults, setDeepLinkRemoteWorkspaceDefaults] = createSignal<RemoteWorkspaceDefaults | null>(null);
   const [pendingRemoteConnectDeepLink, setPendingRemoteConnectDeepLink] = createSignal<RemoteWorkspaceDefaults | null>(null);
   const [pendingSharedBundleInvite, setPendingSharedBundleInvite] = createSignal<SharedBundleDeepLink | null>(null);
+  const [sharedBundleCreateWorkerRequest, setSharedBundleCreateWorkerRequest] = createSignal<SharedBundleDeepLink | null>(null);
   const [sharedBundleImportBusy, setSharedBundleImportBusy] = createSignal(false);
   const [sharedBundleNoticeShown, setSharedBundleNoticeShown] = createSignal(false);
   const [renameWorkspaceOpen, setRenameWorkspaceOpen] = createSignal(false);
   const [renameWorkspaceId, setRenameWorkspaceId] = createSignal<string | null>(null);
   const [renameWorkspaceName, setRenameWorkspaceName] = createSignal("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = createSignal(false);
+
+  const createWorkspaceDefaultPreset = createMemo<WorkspacePreset>(() =>
+    sharedBundleCreateWorkerRequest() ? "automation" : "starter"
+  );
 
   const queueRemoteConnectDeepLink = (rawUrl: string): boolean => {
     const parsed = parseRemoteConnectDeepLink(rawUrl);
@@ -6438,20 +6470,31 @@ export default function App() {
         onClose={() => {
           workspaceStore.setCreateWorkspaceOpen(false);
           workspaceStore.clearSandboxCreateProgress?.();
+          setSharedBundleCreateWorkerRequest(null);
         }}
         onPickFolder={workspaceStore.pickWorkspaceFolder}
-        onConfirm={(preset, folder) =>
-          workspaceStore.createWorkspaceFlow(preset, folder)
-        }
+        defaultPreset={createWorkspaceDefaultPreset()}
+        onConfirm={async (preset, folder) => {
+          const request = sharedBundleCreateWorkerRequest();
+          const ok = await workspaceStore.createWorkspaceFlow(preset, folder);
+          if (!ok || !request) return;
+          await importSharedBundleIntoActiveWorker(request);
+          setSharedBundleCreateWorkerRequest(null);
+        }}
         onConfirmWorker={
           isTauriRuntime()
             ? async (preset, folder) => {
+                const request = sharedBundleCreateWorkerRequest();
                 const ok = await workspaceStore.createSandboxFlow(preset, folder, {
                   onReady: async () => {
+                    if (request) {
+                      await importSharedBundleIntoActiveWorker(request);
+                    }
                     await createSessionAndOpen();
                   },
                 });
                 if (!ok) return;
+                setSharedBundleCreateWorkerRequest(null);
               }
             : undefined
         }

--- a/packages/app/src/app/components/create-workspace-modal.tsx
+++ b/packages/app/src/app/components/create-workspace-modal.tsx
@@ -2,18 +2,20 @@ import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "so
 
 import { CheckCircle2, FolderPlus, Loader2, X, XCircle } from "lucide-solid";
 import { t, currentLocale } from "../../i18n";
+import type { WorkspacePreset } from "../types";
 
 import Button from "./button";
 
 export default function CreateWorkspaceModal(props: {
   open: boolean;
   onClose: () => void;
-  onConfirm: (preset: "starter" | "automation" | "minimal", folder: string | null) => void;
-  onConfirmWorker?: (preset: "starter" | "automation" | "minimal", folder: string | null) => void;
+  onConfirm: (preset: WorkspacePreset, folder: string | null) => void;
+  onConfirmWorker?: (preset: WorkspacePreset, folder: string | null) => void;
   onPickFolder: () => Promise<string | null>;
   submitting?: boolean;
   inline?: boolean;
   showClose?: boolean;
+  defaultPreset?: WorkspacePreset;
   title?: string;
   subtitle?: string;
   confirmLabel?: string;
@@ -40,12 +42,13 @@ export default function CreateWorkspaceModal(props: {
   let pickFolderRef: HTMLButtonElement | undefined;
   const translate = (key: string) => t(key, currentLocale());
 
-  const [preset, setPreset] = createSignal<"starter" | "automation" | "minimal">("starter");
+  const [preset, setPreset] = createSignal<WorkspacePreset>("starter");
   const [selectedFolder, setSelectedFolder] = createSignal<string | null>(null);
   const [pickingFolder, setPickingFolder] = createSignal(false);
 
   createEffect(() => {
     if (props.open) {
+      setPreset(props.defaultPreset ?? "starter");
       requestAnimationFrame(() => pickFolderRef?.focus());
     }
   });
@@ -60,6 +63,11 @@ export default function CreateWorkspaceModal(props: {
       id: "minimal" as const,
       name: translate("dashboard.empty_workspace"),
       desc: translate("dashboard.empty_workspace_desc"),
+    },
+    {
+      id: "automation" as const,
+      name: translate("dashboard.blueprints_workspace"),
+      desc: translate("dashboard.blueprints_workspace_desc"),
     },
   ];
 

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -1395,15 +1395,15 @@ export function createWorkspaceStore(options: {
     }
   }
 
-  async function createWorkspaceFlow(preset: WorkspacePreset, folder: string | null) {
+  async function createWorkspaceFlow(preset: WorkspacePreset, folder: string | null): Promise<boolean> {
     if (!isTauriRuntime()) {
       options.setError(t("app.error.tauri_required", currentLocale()));
-      return;
+      return false;
     }
 
     if (!folder) {
       options.setError(t("app.error.choose_folder", currentLocale()));
-      return;
+      return false;
     }
 
     options.setBusy(true);
@@ -1417,7 +1417,7 @@ export function createWorkspaceStore(options: {
       const resolvedFolder = await resolveWorkspacePath(folder);
       if (!resolvedFolder) {
         options.setError(t("app.error.choose_folder", currentLocale()));
-        return;
+        return false;
       }
 
       const name = resolvedFolder.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? "Worker";
@@ -1438,9 +1438,11 @@ export function createWorkspaceStore(options: {
       options.setTab("scheduled");
       options.setView("dashboard");
       markOnboardingComplete();
+      return true;
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
       options.setError(addOpencodeCacheHint(message));
+      return false;
     } finally {
       options.setBusy(false);
       options.setBusyLabel(null);

--- a/packages/app/src/i18n/locales/en.ts
+++ b/packages/app/src/i18n/locales/en.ts
@@ -93,6 +93,8 @@ export default {
   "dashboard.starter_workspace_desc": "Preconfigured to show you how to use plugins, commands, and skills.",
   "dashboard.empty_workspace": "Empty worker",
   "dashboard.empty_workspace_desc": "Start with a blank folder and add what you need.",
+  "dashboard.blueprints_workspace": "Blueprints",
+  "dashboard.blueprints_workspace_desc": "Start with an automation-ready worker for reusable skills, commands, and shared flows.",
 
   // ==================== Workspace ====================
   "workspace.rename_title": "Edit worker name",

--- a/packages/app/src/i18n/locales/zh.ts
+++ b/packages/app/src/i18n/locales/zh.ts
@@ -93,6 +93,8 @@ export default {
   "dashboard.starter_workspace_desc": "预配置以展示如何使用插件、命令和技能。",
   "dashboard.empty_workspace": "空白工作区",
   "dashboard.empty_workspace_desc": "从空白文件夹开始，添加您需要的内容。",
+  "dashboard.blueprints_workspace": "蓝图工作区",
+  "dashboard.blueprints_workspace_desc": "从适合复用技能、命令和共享流程的自动化工作区开始。",
 
   // ==================== Workspace ====================
   "workspace.rename_title": "编辑工作区名称",


### PR DESCRIPTION
## Summary
- route share-service `new_worker` bundle deeplinks into the create-worker modal instead of auto-creating a worker
- add a third preset option labeled `Blueprints` and preselect it for shared bundle opens
- import the shared workspace or skill bundle after the new local or sandbox worker is created

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm typecheck` *(fails on pre-existing errors in `packages/app/src/app/components/model-picker-modal.tsx`)*
- `pnpm --filter @different-ai/openwork-ui build`

## Notes
- I did not run the full Docker + Chrome MCP + Tauri deep-link validation because this flow is handled by the desktop deep-link runtime rather than the browser app.