### PR TITLE
fix: improve sandbox worker startup diagnostics

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@different-ai/openwork-ui",
   "private": true,
-  "version": "0.11.138",
+  "version": "0.11.139",
   "type": "module",
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 vite",

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -6082,6 +6082,7 @@ export default function App() {
       events: events(),
       workspaceDebugEvents: workspaceStore.workspaceDebugEvents(),
       sandboxCreateProgress: workspaceStore.sandboxCreateProgress(),
+      sandboxCreateProgressLast: workspaceStore.lastSandboxCreateProgress(),
       clearWorkspaceDebugEvents: workspaceStore.clearWorkspaceDebugEvents,
       safeStringify,
       repairOpencodeMigration: workspaceStore.repairOpencodeMigration,

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -249,7 +249,15 @@ export function createWorkspaceStore(options: {
   const [sandboxCreatePhase, setSandboxCreatePhase] = createSignal<SandboxCreatePhase>("idle");
 
   const [sandboxCreateProgress, setSandboxCreateProgress] = createSignal<SandboxCreateProgressState | null>(null);
-  const clearSandboxCreateProgress = () => setSandboxCreateProgress(null);
+  const [lastSandboxCreateProgress, setLastSandboxCreateProgress] =
+    createSignal<SandboxCreateProgressState | null>(null);
+  const clearSandboxCreateProgress = () => {
+    const snapshot = sandboxCreateProgress();
+    if (snapshot) {
+      setLastSandboxCreateProgress(snapshot);
+    }
+    setSandboxCreateProgress(null);
+  };
 
   const pushSandboxCreateLog = (line: string) => {
     const value = String(line ?? "").trim();
@@ -1581,6 +1589,10 @@ export function createWorkspaceStore(options: {
               const selected = String(payload.payload?.openworkDockerBin ?? "").trim();
               if (selected) {
                 pushSandboxCreateLog(`OPENWORK_DOCKER_BIN=${selected}`);
+              }
+              const resolved = String(payload.payload?.resolvedDockerBin ?? "").trim();
+              if (resolved) {
+                pushSandboxCreateLog(`Resolved docker: ${resolved}`);
               }
               const candidates = Array.isArray(payload.payload?.candidates)
                 ? payload.payload.candidates.filter((item: unknown) => String(item ?? "").trim())
@@ -3182,6 +3194,7 @@ export function createWorkspaceStore(options: {
     setEngineInstallLogs,
     refreshSandboxDoctor,
     sandboxCreateProgress,
+    lastSandboxCreateProgress,
     clearSandboxCreateProgress,
     workspaceDebugEvents,
     clearWorkspaceDebugEvents,

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -294,6 +294,7 @@ export type DashboardViewProps = {
   events: unknown;
   workspaceDebugEvents: unknown;
   sandboxCreateProgress: unknown;
+  sandboxCreateProgressLast: unknown;
   clearWorkspaceDebugEvents: () => void;
   safeStringify: (value: unknown) => string;
   repairOpencodeMigration: () => void;
@@ -1379,6 +1380,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   events={props.events}
                   workspaceDebugEvents={props.workspaceDebugEvents}
                   sandboxCreateProgress={props.sandboxCreateProgress}
+                  sandboxCreateProgressLast={props.sandboxCreateProgressLast}
                   clearWorkspaceDebugEvents={props.clearWorkspaceDebugEvents}
                   safeStringify={props.safeStringify}
                   repairOpencodeMigration={props.repairOpencodeMigration}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -114,6 +114,7 @@ export type SettingsViewProps = {
   events: unknown;
   workspaceDebugEvents: unknown;
   sandboxCreateProgress: unknown;
+  sandboxCreateProgressLast: unknown;
   clearWorkspaceDebugEvents: () => void;
   safeStringify: (value: unknown) => string;
   repairOpencodeMigration: () => void;
@@ -754,17 +755,18 @@ export default function SettingsView(props: SettingsViewProps) {
   const opencodeDevModeEnabled = createMemo(() => Boolean(buildInfo()?.openworkDevMode));
 
   const sandboxCreateSummary = createMemo(() => {
-    const raw = props.sandboxCreateProgress as
-      | { runId?: string; stage?: string; error?: string | null; logs?: string[] }
+    const raw = (props.sandboxCreateProgress ?? props.sandboxCreateProgressLast) as
+      | { runId?: string; stage?: string; error?: string | null; logs?: string[]; startedAt?: number }
       | null
       | undefined;
     if (!raw || typeof raw !== "object") {
-      return { runId: null, stage: null, error: null, logs: [] as string[] };
+      return { runId: null, stage: null, error: null, logs: [] as string[], startedAt: null };
     }
     return {
       runId: typeof raw.runId === "string" && raw.runId.trim() ? raw.runId : null,
       stage: typeof raw.stage === "string" && raw.stage.trim() ? raw.stage : null,
       error: typeof raw.error === "string" && raw.error.trim() ? raw.error : null,
+      startedAt: typeof raw.startedAt === "number" ? raw.startedAt : null,
       logs: Array.isArray(raw.logs)
         ? raw.logs.filter((line) => typeof line === "string" && line.trim()).slice(-400)
         : [],
@@ -828,7 +830,10 @@ export default function SettingsView(props: SettingsViewProps) {
     pendingPermissions: props.pendingPermissions,
     recentEvents: props.events,
     workspaceDebugEvents: props.workspaceDebugEvents,
-    sandboxCreateProgress: sandboxCreateSummary(),
+    sandboxCreateProgress: {
+      ...sandboxCreateSummary(),
+      lastRunAt: sandboxCreateSummary().startedAt ? new Date(sandboxCreateSummary().startedAt!).toISOString() : null,
+    },
     sandboxProbe: sandboxProbeResult(),
   }));
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@different-ai/openwork",
   "private": true,
-  "version": "0.11.138",
+  "version": "0.11.139",
   "opencodeVersion": "1.2.6",
-  "opencodeRouterVersion": "0.11.138",
+  "opencodeRouterVersion": "0.11.139",
   "type": "module",
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 OPENWORK_DATA_DIR=\"$HOME/.openwork/openwork-orchestrator-dev\" tauri dev --config src-tauri/tauri.dev.conf.json --config \"{\\\"build\\\":{\\\"devUrl\\\":\\\"http://localhost:${PORT:-5173}\\\"}}\"",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2774,7 +2774,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openwork"
-version = "0.11.138"
+version = "0.11.139"
 dependencies = [
  "gethostname",
  "json5",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwork"
-version = "0.11.138"
+version = "0.11.139"
 description = "OpenWork"
 authors = ["Different AI"]
 edition = "2021"

--- a/packages/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/packages/desktop/src-tauri/src/commands/orchestrator.rs
@@ -775,6 +775,7 @@ pub fn orchestrator_start_detached(
             .into_iter()
             .map(|p| p.to_string_lossy().to_string())
             .collect::<Vec<_>>();
+        let resolved = candidates.first().cloned();
         emit_sandbox_progress(
             &app,
             &sandbox_run_id,
@@ -782,6 +783,7 @@ pub fn orchestrator_start_detached(
             "Inspecting Docker configuration...",
             json!({
                 "candidates": candidates,
+                "resolvedDockerBin": resolved,
                 "openworkDockerBin": env::var("OPENWORK_DOCKER_BIN").ok(),
                 "openwrkDockerBin": env::var("OPENWRK_DOCKER_BIN").ok(),
                 "dockerBin": env::var("DOCKER_BIN").ok(),
@@ -789,9 +791,9 @@ pub fn orchestrator_start_detached(
         );
     }
 
-    let command = match app.shell().sidecar("openwork-orchestrator") {
-        Ok(command) => command,
-        Err(_) => app.shell().command("openwork"),
+    let (mut command, command_label) = match app.shell().sidecar("openwork-orchestrator") {
+        Ok(command) => (command, "sidecar:openwork-orchestrator".to_string()),
+        Err(_) => (app.shell().command("openwork"), "path:openwork".to_string()),
     };
 
     // Start a dedicated host stack for this workspace.
@@ -830,10 +832,36 @@ pub fn orchestrator_start_detached(
             str_args.push(arg.as_str());
         }
 
-        command
-            .args(str_args)
-            .spawn()
-            .map_err(|e| format!("Failed to start openwork orchestrator: {e}"))?;
+        emit_sandbox_progress(
+            &app,
+            &sandbox_run_id,
+            "spawn.config",
+            "Launching sandbox host...",
+            json!({
+                "command": command_label,
+                "args": args,
+                "env": {
+                    "PATH": env::var("PATH").ok(),
+                    "OPENWORK_DOCKER_BIN": env::var("OPENWORK_DOCKER_BIN").ok(),
+                    "OPENWRK_DOCKER_BIN": env::var("OPENWRK_DOCKER_BIN").ok(),
+                    "DOCKER_BIN": env::var("DOCKER_BIN").ok(),
+                }
+            }),
+        );
+
+        if let Err(err) = command.args(str_args).spawn() {
+            emit_sandbox_progress(
+                &app,
+                &sandbox_run_id,
+                "spawn.error",
+                "Failed to launch sandbox host.",
+                json!({
+                    "error": err.to_string(),
+                    "command": command_label,
+                }),
+            );
+            return Err(format!("Failed to start openwork orchestrator: {err}"));
+        }
         eprintln!(
             "[sandbox-create][at={}][runId={}][stage=spawn] launched openwork sidecar for detached sandbox host",
             now_ms(),

--- a/packages/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/packages/desktop/src-tauri/src/commands/orchestrator.rs
@@ -791,7 +791,7 @@ pub fn orchestrator_start_detached(
         );
     }
 
-    let (mut command, command_label) = match app.shell().sidecar("openwork-orchestrator") {
+    let (command, command_label) = match app.shell().sidecar("openwork-orchestrator") {
         Ok(command) => (command, "sidecar:openwork-orchestrator".to_string()),
         Err(_) => (app.shell().command("openwork"), "path:openwork".to_string()),
     };

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenWork",
-  "version": "0.11.138",
+  "version": "0.11.139",
   "identifier": "com.differentai.openwork",
   "build": {
     "beforeDevCommand": "node ./scripts/tauri-before-dev.mjs",

--- a/packages/opencode-router/package.json
+++ b/packages/opencode-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-router",
-  "version": "0.11.138",
+  "version": "0.11.139",
   "description": "opencode-router: Slack + Telegram bridge + directory routing for a running opencode server",
   "private": false,
   "type": "module",

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-orchestrator",
-  "version": "0.11.138",
+  "version": "0.11.139",
   "opencodeVersion": "1.2.6",
   "description": "OpenWork host orchestrator for opencode + OpenWork server + opencode-router",
   "private": true,
@@ -48,8 +48,8 @@
     "@opencode-ai/sdk": "^1.1.31",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "opencode-router": "0.11.138",
-    "openwork-server": "0.11.138",
+    "opencode-router": "0.11.139",
+    "openwork-server": "0.11.139",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/packages/orchestrator/src/cli.ts
+++ b/packages/orchestrator/src/cli.ts
@@ -5,7 +5,7 @@ import { chmod, copyFile, cp, mkdir, mkdtemp, readFile, readdir, rename, rm, sta
 import { createServer as createNetServer } from "node:net";
 import { createServer as createHttpServer } from "node:http";
 import { homedir, hostname, networkInterfaces, tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { basename, delimiter, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { access } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -830,6 +830,84 @@ async function isExecutable(path: string): Promise<boolean> {
   }
 }
 
+async function readPathHelperPaths(): Promise<string[]> {
+  if (process.platform !== "darwin") return [];
+  return await new Promise((resolve) => {
+    const child = spawnProcess("/usr/libexec/path_helper", ["-s"], { stdio: ["ignore", "pipe", "ignore"] });
+    let stdout = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.on("error", () => resolve([]));
+    child.on("exit", (code) => {
+      if (code !== 0) {
+        resolve([]);
+        return;
+      }
+      const match = stdout.match(/PATH="([^"]+)"/) ?? stdout.match(/PATH=([^;\n]+)/);
+      if (!match) {
+        resolve([]);
+        return;
+      }
+      resolve(match[1].split(":").filter(Boolean));
+    });
+  });
+}
+
+async function resolveDockerCandidates(): Promise<string[]> {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    out.push(trimmed);
+  };
+
+  for (const key of ["OPENWORK_DOCKER_BIN", "OPENWRK_DOCKER_BIN", "DOCKER_BIN"]) {
+    const value = process.env[key];
+    if (value) push(value);
+  }
+
+  const addFromPath = (value?: string | null) => {
+    if (!value) return;
+    for (const dir of value.split(delimiter)) {
+      if (!dir.trim()) continue;
+      push(join(dir, "docker"));
+    }
+  };
+
+  addFromPath(process.env.PATH ?? "");
+
+  if (process.platform === "darwin") {
+    const helperPaths = await readPathHelperPaths();
+    for (const dir of helperPaths) {
+      push(join(dir, "docker"));
+    }
+  }
+
+  for (const raw of [
+    "/opt/homebrew/bin/docker",
+    "/usr/local/bin/docker",
+    "/Applications/Docker.app/Contents/Resources/bin/docker",
+  ]) {
+    push(raw);
+  }
+
+  const valid: string[] = [];
+  for (const candidate of out) {
+    if (await isExecutable(candidate)) {
+      valid.push(candidate);
+    }
+  }
+  return valid;
+}
+
+async function resolveDockerCommand(): Promise<string> {
+  const candidates = await resolveDockerCandidates();
+  return candidates[0] ?? "docker";
+}
+
 async function ensureWorkspace(workspace: string): Promise<string> {
   const resolved = resolve(workspace);
   await mkdir(resolved, { recursive: true });
@@ -1100,7 +1178,8 @@ async function resolveSandboxMode(mode: SandboxMode): Promise<ResolvedSandboxMod
     if (containerOk) return "container";
   }
 
-  const dockerOk = await probeCommand("docker", ["version"]);
+  const dockerCommand = await resolveDockerCommand();
+  const dockerOk = await probeCommand(dockerCommand, ["version"]);
   if (dockerOk) return "docker";
 
   const containerOk = await probeCommand("container", ["--version"]);
@@ -2858,10 +2937,10 @@ async function opencodeRouterSupportsOpencodeUrl(bin: string): Promise<boolean> 
   });
 }
 
-async function stopDockerContainer(name: string): Promise<void> {
+async function stopDockerContainer(name: string, dockerCommand: string): Promise<void> {
   if (!name.trim()) return;
   await new Promise<void>((resolve) => {
-    const child = spawnProcess("docker", ["stop", name], { stdio: ["ignore", "ignore", "ignore"] });
+    const child = spawnProcess(dockerCommand, ["stop", name], { stdio: ["ignore", "ignore", "ignore"] });
     child.on("error", () => resolve());
     child.on("exit", () => resolve());
   });
@@ -3089,6 +3168,7 @@ async function writeSandboxEntrypoint(options: {
 
 async function startDockerSandbox(options: {
   image: string;
+  dockerCommand: string;
   containerName: string;
   workspace: string;
   persistDir: string;
@@ -3202,7 +3282,15 @@ async function startDockerSandbox(options: {
   const scriptInContainer = `${staged.rootInContainer}/entrypoint.sh`;
   args.push(options.image, "sh", scriptInContainer);
 
-  const child = spawnProcess("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
+  options.logger.debug("sandbox: docker run", {
+    dockerCommand: options.dockerCommand,
+    args,
+    containerName: options.containerName,
+    workspace: options.workspace,
+    persistDir: options.persistDir,
+  });
+
+  const child = spawnProcess(options.dockerCommand, args, { stdio: ["ignore", "pipe", "pipe"] });
   prefixStream(child.stdout, "sandbox", "stdout", options.logger, child.pid ?? undefined);
   prefixStream(child.stderr, "sandbox", "stderr", options.logger, child.pid ?? undefined);
 
@@ -5083,8 +5171,12 @@ async function runStart(args: ParsedArgs) {
       opencodeSource = explicitOpencodeBin ? "external" : "downloaded";
     }
   }
+  const dockerCommand = sandboxMode === "docker" ? await resolveDockerCommand() : null;
   logVerbose(`cli version: ${cliVersion}`);
   logVerbose(`sandbox: ${sandboxMode}`);
+  if (dockerCommand) {
+    logVerbose(`docker bin: ${dockerCommand}`);
+  }
   if (sandboxMode !== "none") {
     logVerbose(`sandbox image: ${sandboxImage}`);
     logVerbose(`sandbox persist dir: ${sandboxPersistDir}`);
@@ -5112,9 +5204,9 @@ async function runStart(args: ParsedArgs) {
 
   if (sandboxMode !== "none") {
     if (sandboxMode === "docker") {
-      if (!(await probeCommand("docker", ["version"]))) {
+      if (!(await probeCommand(dockerCommand ?? "docker", ["version"]))) {
         throw new Error(
-          "Docker is required for --sandbox docker. Install Docker Desktop and ensure 'docker' is on PATH.",
+          `Docker is required for --sandbox docker. Install Docker Desktop and ensure '${dockerCommand ?? "docker"}' is available.`,
         );
       }
     }
@@ -5447,51 +5539,96 @@ async function runStart(args: ParsedArgs) {
       const containerName = `openwork-orchestrator-${runId.replace(/[^a-zA-Z0-9_.-]+/g, "-").slice(0, 24)}`;
       sandboxContainerName = containerName;
 
-      sandboxStop = sandboxMode === "container" ? stopAppleContainer : stopDockerContainer;
+      sandboxStop =
+        sandboxMode === "container"
+          ? stopAppleContainer
+          : (name: string) => stopDockerContainer(name, dockerCommand ?? "docker");
       sandboxStopCommand = sandboxMode === "container" ? "container stop" : "docker stop";
       const opencodeInternalBaseUrl = `http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`;
 
-      const runner = sandboxMode === "container" ? startAppleContainerSandbox : startDockerSandbox;
-      const sandboxChild = await runner({
-        image: sandboxImage,
-        containerName,
-        workspace: resolvedWorkspace,
-        persistDir: sandboxPersistDir,
-        opencodeConfigDir,
-        extraMounts: sandboxExtraMounts,
-        sidecars: {
-          opencode: opencodeBinary.bin,
-          openworkServer: openworkServerBinary.bin,
-          opencodeRouter: opencodeRouterEnabled ? (opencodeRouterBinary?.bin ?? null) : null,
-        },
-        ports: {
-          openwork: openworkPort,
-          // In sandbox mode, opencodeRouter is only reachable via openwork-server
-          // proxy (/opencode-router/*). Do not publish a separate host port.
-          opencodeRouterHealth: null,
-        },
-        opencode: {
-          corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
-          username: opencodeUsername,
-          password: opencodePassword,
-          hotReload: opencodeHotReload,
-        },
-        openwork: {
-          token: openworkToken,
-          hostToken: openworkHostToken,
-          approvalMode: approvalMode === "auto" ? "auto" : "manual",
-          approvalTimeoutMs,
-          readOnly,
-          corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
-          opencodeUsername,
-          opencodePassword,
-          logFormat,
-        },
-        runId,
-        logFormat,
-        detach: detachRequested,
-        logger,
-      });
+      const sandboxChild =
+        sandboxMode === "container"
+          ? await startAppleContainerSandbox({
+              image: sandboxImage,
+              containerName,
+              workspace: resolvedWorkspace,
+              persistDir: sandboxPersistDir,
+              opencodeConfigDir,
+              extraMounts: sandboxExtraMounts,
+              sidecars: {
+                opencode: opencodeBinary.bin,
+                openworkServer: openworkServerBinary.bin,
+                opencodeRouter: opencodeRouterEnabled ? (opencodeRouterBinary?.bin ?? null) : null,
+              },
+              ports: {
+                openwork: openworkPort,
+                // In sandbox mode, opencodeRouter is only reachable via openwork-server
+                // proxy (/opencode-router/*). Do not publish a separate host port.
+                opencodeRouterHealth: null,
+              },
+              opencode: {
+                corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+                username: opencodeUsername,
+                password: opencodePassword,
+                hotReload: opencodeHotReload,
+              },
+              openwork: {
+                token: openworkToken,
+                hostToken: openworkHostToken,
+                approvalMode: approvalMode === "auto" ? "auto" : "manual",
+                approvalTimeoutMs,
+                readOnly,
+                corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+                opencodeUsername,
+                opencodePassword,
+                logFormat,
+              },
+              runId,
+              logFormat,
+              detach: detachRequested,
+              logger,
+            })
+          : await startDockerSandbox({
+              image: sandboxImage,
+              dockerCommand: dockerCommand ?? "docker",
+              containerName,
+              workspace: resolvedWorkspace,
+              persistDir: sandboxPersistDir,
+              opencodeConfigDir,
+              extraMounts: sandboxExtraMounts,
+              sidecars: {
+                opencode: opencodeBinary.bin,
+                openworkServer: openworkServerBinary.bin,
+                opencodeRouter: opencodeRouterEnabled ? (opencodeRouterBinary?.bin ?? null) : null,
+              },
+              ports: {
+                openwork: openworkPort,
+                // In sandbox mode, opencodeRouter is only reachable via openwork-server
+                // proxy (/opencode-router/*). Do not publish a separate host port.
+                opencodeRouterHealth: null,
+              },
+              opencode: {
+                corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+                username: opencodeUsername,
+                password: opencodePassword,
+                hotReload: opencodeHotReload,
+              },
+              openwork: {
+                token: openworkToken,
+                hostToken: openworkHostToken,
+                approvalMode: approvalMode === "auto" ? "auto" : "manual",
+                approvalTimeoutMs,
+                readOnly,
+                corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+                opencodeUsername,
+                opencodePassword,
+                logFormat,
+              },
+              runId,
+              logFormat,
+              detach: detachRequested,
+              logger,
+            });
 
       sandboxCleanup = sandboxChild.cleanup;
       tui?.updateService("opencode", { status: "running", port: SANDBOX_INTERNAL_OPENCODE_PORT });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.11.138",
+  "version": "0.11.139",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,10 +196,10 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       opencode-router:
-        specifier: 0.11.138
+        specifier: 0.11.139
         version: link:../opencode-router
       openwork-server:
-        specifier: 0.11.138
+        specifier: 0.11.139
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
## Summary
- unify Docker binary resolution in `openwork-orchestrator` so sandbox startup uses the same macOS discovery paths as the desktop doctor
- add richer sandbox startup diagnostics, including resolved Docker binary, spawn config, and persisted last-run sandbox logs in Runtime Debug exports
- bump OpenWork package versions to `0.11.139` for the hotfix release

## Testing
- `pnpm --filter openwork-orchestrator build` ✅
- `cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml --locked` ✅
- `pnpm typecheck` ⚠️ fails in existing `packages/app/src/app/components/model-picker-modal.tsx` type errors unrelated to this change