### PR TITLE
chore: disable enterprise landing paper grain

### DIFF
--- a/packages/landing/components/landing-home.tsx
+++ b/packages/landing/components/landing-home.tsx
@@ -15,7 +15,6 @@ import {
 import { LandingSharePackageCard } from "./landing-share-package-card";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
-import { ResponsiveGrain } from "./responsive-grain";
 import { WaitlistForm } from "./waitlist-form";
 
 type Props = {
@@ -356,17 +355,22 @@ export function LandingHome(props: Props) {
               <div className="landing-canvas relative flex min-h-[400px] w-full items-center justify-center overflow-hidden rounded-3xl p-6 lg:w-2/3 md:p-10">
                 {showEnterpriseGrain ? (
                   <>
-                    <ResponsiveGrain
-                      colors={["#f97316", "#a855f7", "#3b82f6", "#fcd34d"]}
-                      colorBack="#f97316"
-                      softness={0.6}
-                      intensity={0.8}
-                      noise={0.3}
-                      shape="corners"
-                      speed={0}
-                    />
-                    <div className="absolute left-8 top-8 h-28 w-28 rounded-[2rem] border border-white/60 bg-white/30" />
-                    <div className="absolute bottom-8 right-8 h-40 w-40 rounded-full border border-white/60 bg-white/24" />
+                    {/*
+                      Enterprise paper-grain background is intentionally disabled for now.
+                      Keep this block for quick reactivation later.
+
+                      <ResponsiveGrain
+                        colors={["#f97316", "#a855f7", "#3b82f6", "#fcd34d"]}
+                        colorBack="#f97316"
+                        softness={0.6}
+                        intensity={0.8}
+                        noise={0.3}
+                        shape="corners"
+                        speed={0}
+                      />
+                      <div className="absolute left-8 top-8 h-28 w-28 rounded-[2rem] border border-white/60 bg-white/30" />
+                      <div className="absolute bottom-8 right-8 h-40 w-40 rounded-full border border-white/60 bg-white/24" />
+                    */}
                   </>
                 ) : null}
 


### PR DESCRIPTION
## Summary
- Disable the enterprise showcase paper-grain visual on the landing page by commenting out the grain/background overlay block.
- Keep the original JSX in-place (commented) so the effect can be re-enabled quickly later.
- Remove the now-unused `ResponsiveGrain` import from `landing-home.tsx`.

## Testing
- Ran: `pnpm --filter @different-ai/openwork-ui typecheck`
- Result: Fails due to existing unrelated workspace type errors (e.g. missing `@tauri-apps/plugin-deep-link`, `@tanstack/solid-virtual`, and pre-existing type issues in `model-picker-modal.tsx`/`message-list.tsx`).