### PR TITLE
chore: disable top landing paper grain

### DIFF
--- a/packages/landing/components/landing-background.tsx
+++ b/packages/landing/components/landing-background.tsx
@@ -1,23 +1,26 @@
 "use client";
 
-import { ResponsiveGrain } from "./responsive-grain";
-
 export function LandingBackground() {
   return (
     <>
       {/* <div className="pointer-events-none fixed inset-0 z-0 bg-[#f6f9fc]" /> */}
 
-      <div className="landing-background-fade pointer-events-none fixed inset-0 z-0">
-        <ResponsiveGrain
-          colors={["#f6f9fc", "#f6f9fc", "#1e293b", "#334155"]}
-          colorBack="#f6f9fc"
-          softness={1}
-          intensity={0.03}
-          noise={0.14}
-          shape="corners"
-          speed={0.2}
-        />
-      </div>
+      {/*
+        Top landing paper-grain background is intentionally disabled for now.
+        Keep this block for quick reactivation later.
+
+        <div className="landing-background-fade pointer-events-none fixed inset-0 z-0">
+          <ResponsiveGrain
+            colors={["#f6f9fc", "#f6f9fc", "#1e293b", "#334155"]}
+            colorBack="#f6f9fc"
+            softness={1}
+            intensity={0.03}
+            noise={0.14}
+            shape="corners"
+            speed={0.2}
+          />
+        </div>
+      */}
 
       <style jsx>{`
         .landing-background-fade {


### PR DESCRIPTION
## Summary
- Disable the top landing paper-grain background by commenting out the existing `ResponsiveGrain` block in `LandingBackground`.
- Keep the original JSX commented for quick reactivation later.
- Remove the now-unused `ResponsiveGrain` import from the component.

## Testing
- Ran: `pnpm --filter @different-ai/openwork-ui typecheck`
- Result: Fails due to existing unrelated workspace type errors (missing `@tauri-apps/plugin-deep-link`, missing `@tanstack/solid-virtual`, and existing type issues in `model-picker-modal.tsx` and `message-list.tsx`).