### PR TITLE
Follow up inline session error UX

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -63,12 +63,10 @@ import {
 } from "./constants";
 import { parseMcpServersFromContent, removeMcpFromConfig, validateMcpServerName } from "./mcp";
 import { mapConfigProvidersToList } from "./utils/providers";
-import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "./types";
 import type {
   Client,
   DashboardTab,
   MessageWithParts,
-  PlaceholderAssistantMessage,
   StartupPreference,
   EngineRuntime,
   ModelOption,
@@ -91,7 +89,6 @@ import type {
   ComposerDraft,
   ComposerPart,
   ProviderListItem,
-  SessionErrorTurn,
   UpdateHandle,
   OpencodeConnectStatus,
   ScheduledJob,
@@ -1665,65 +1662,6 @@ export default function App() {
     return "";
   };
 
-  const createSyntheticSessionErrorMessage = (
-    sessionID: string,
-    errorTurn: SessionErrorTurn,
-  ): MessageWithParts => {
-    const info: PlaceholderAssistantMessage = {
-      id: errorTurn.id,
-      sessionID,
-      role: "assistant",
-      time: { created: errorTurn.time, completed: errorTurn.time },
-      parentID: errorTurn.afterMessageID ?? "",
-      modelID: "",
-      providerID: "",
-      mode: "",
-      agent: "",
-      path: { cwd: "", root: "" },
-      cost: 0,
-      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-    };
-
-    return {
-      info,
-      parts: [
-        {
-          id: `${errorTurn.id}:text`,
-          sessionID,
-          messageID: errorTurn.id,
-          type: "text",
-          text: errorTurn.text,
-        } as Part,
-      ],
-    };
-  };
-
-  const insertSyntheticSessionErrors = (
-    list: MessageWithParts[],
-    sessionID: string | null,
-    errorTurns: SessionErrorTurn[],
-  ) => {
-    if (!sessionID || errorTurns.length === 0) return list;
-
-    const next = list.slice();
-    errorTurns.forEach((errorTurn) => {
-      if (next.some((message) => messageIdFromInfo(message) === errorTurn.id)) return;
-      const syntheticMessage = createSyntheticSessionErrorMessage(sessionID, errorTurn);
-      const anchorIndex = errorTurn.afterMessageID
-        ? next.findIndex((message) => messageIdFromInfo(message) === errorTurn.afterMessageID)
-        : -1;
-
-      if (anchorIndex === -1) {
-        next.push(syntheticMessage);
-        return;
-      }
-
-      next.splice(anchorIndex + 1, 0, syntheticMessage);
-    });
-
-    return next;
-  };
-
   const upsertLocalSession = (next: Session | null | undefined) => {
     const id = (next as { id?: string } | null)?.id ?? "";
     if (!id) return;
@@ -1739,23 +1677,7 @@ export default function App() {
     setSessions(copy);
   };
 
-  // OpenCode keeps reverted messages in the log and uses `session.revert.messageID`
-  // as the visibility boundary. OpenWork mirrors that behavior by filtering the
-  // displayed transcript.
-  const visibleMessages = createMemo(() => {
-    const sessionID = selectedSessionId();
-    const errorTurns = sessionStore.selectedSessionErrorTurns();
-    const list = messages().filter((message) => {
-      const id = messageIdFromInfo(message);
-      return !id.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX);
-    });
-    const revert = selectedSession()?.revert?.messageID ?? null;
-    const visible = !revert ? list : list.filter((message) => {
-      const id = messageIdFromInfo(message);
-      return Boolean(id) && id < revert;
-    });
-    return insertSyntheticSessionErrors(visible, sessionID, errorTurns);
-  });
+  const visibleMessages = createMemo(() => sessionStore.displayMessages());
 
   const restorePromptFromUserMessage = (message: MessageWithParts) => {
     const text = message.parts

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -954,10 +954,17 @@ export default function MessageList(props: MessageListProps) {
           if (isSyntheticSessionError) {
             const messageText = block.renderableParts
               .map((part) => partToText(part))
-              .join(" ")
-              .replace(/\s*\n+\s*/g, " ")
-              .replace(/\s{2,}/g, " ")
+              .join("\n")
               .trim();
+            const syntheticInfo = block.message.info as {
+              syntheticErrorSummary?: string;
+              syntheticErrorFullText?: string;
+            };
+            const summaryText =
+              syntheticInfo.syntheticErrorSummary?.trim() ||
+              messageText.split(/\r?\n/, 1)[0] ||
+              "Request failed";
+            const fullText = syntheticInfo.syntheticErrorFullText?.trim() || messageText;
 
             return (
               <div
@@ -967,13 +974,21 @@ export default function MessageList(props: MessageListProps) {
                 style={blockPerfStyle(blockIndex)}
               >
                 <div class={`w-full relative max-w-[650px] ${searchOutlineClass}`}>
-                  <div
-                    class="inline-flex max-w-full items-start gap-2 rounded-[18px] border border-red-7/20 bg-red-1/35 px-3 py-2 text-[13px] leading-5 text-red-12 shadow-sm"
-                    role="alert"
-                  >
-                    <CircleAlert size={14} class="mt-0.5 shrink-0" />
-                    <div class="min-w-0 break-words">{messageText}</div>
-                  </div>
+                  <details class="max-w-full rounded-[18px] border border-red-7/20 bg-red-1/35 text-red-12 shadow-sm [&_summary::-webkit-details-marker]:hidden">
+                    <summary
+                      class="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-[13px] leading-5"
+                      role="alert"
+                    >
+                      <CircleAlert size={14} class="mt-0.5 shrink-0" />
+                      <div class="min-w-0 flex-1 truncate">{summaryText}</div>
+                      <ChevronDown size={14} class="shrink-0 opacity-70 transition-transform group-open:rotate-180" />
+                    </summary>
+                    <div class="border-t border-red-7/15 px-3 pb-3 pt-2">
+                      <pre class="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-red-12/95">
+                        {fullText}
+                      </pre>
+                    </div>
+                  </details>
                 </div>
               </div>
             );

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -225,6 +225,7 @@ function getTaskStepInfo(part: Part): TaskStepInfo {
 
 export default function MessageList(props: MessageListProps) {
   const [copyingId, setCopyingId] = createSignal<string | null>(null);
+  const [expandedSyntheticErrorIds, setExpandedSyntheticErrorIds] = createSignal<Set<string>>(new Set());
   let previousMessagePartCountById = new Map<string, number>();
   let copyTimeout: number | undefined;
   const isAttachmentPart = (part: Part) => {
@@ -250,6 +251,15 @@ export default function MessageList(props: MessageListProps) {
       window.clearTimeout(copyTimeout);
     }
   });
+
+  const toggleSyntheticErrorExpanded = (messageId: string) => {
+    setExpandedSyntheticErrorIds((current) => {
+      const next = new Set(current);
+      if (next.has(messageId)) next.delete(messageId);
+      else next.add(messageId);
+      return next;
+    });
+  };
 
   const handleCopy = async (text: string, id: string) => {
     try {
@@ -965,6 +975,7 @@ export default function MessageList(props: MessageListProps) {
               messageText.split(/\r?\n/, 1)[0] ||
               "Request failed";
             const fullText = syntheticInfo.syntheticErrorFullText?.trim() || messageText;
+            const expanded = () => expandedSyntheticErrorIds().has(block.messageId);
 
             return (
               <div
@@ -974,21 +985,28 @@ export default function MessageList(props: MessageListProps) {
                 style={blockPerfStyle(blockIndex)}
               >
                 <div class={`w-full relative max-w-[650px] ${searchOutlineClass}`}>
-                  <details class="max-w-full rounded-[18px] border border-red-7/20 bg-red-1/35 text-red-12 shadow-sm [&_summary::-webkit-details-marker]:hidden">
-                    <summary
-                      class="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-[13px] leading-5"
+                  <div class="max-w-full rounded-[18px] border border-red-7/20 bg-red-1/35 text-red-12 shadow-sm">
+                    <button
+                      type="button"
+                      class="flex w-full items-center gap-2 px-3 py-2 text-left text-[13px] leading-5"
+                      aria-expanded={expanded()}
+                      onClick={() => toggleSyntheticErrorExpanded(block.messageId)}
                       role="alert"
                     >
                       <CircleAlert size={14} class="mt-0.5 shrink-0" />
                       <div class="min-w-0 flex-1 truncate">{summaryText}</div>
-                      <ChevronDown size={14} class="shrink-0 opacity-70 transition-transform group-open:rotate-180" />
-                    </summary>
-                    <div class="border-t border-red-7/15 px-3 pb-3 pt-2">
-                      <pre class="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-red-12/95">
-                        {fullText}
-                      </pre>
-                    </div>
-                  </details>
+                      <Show when={expanded()} fallback={<ChevronRight size={14} class="shrink-0 opacity-70" />}>
+                        <ChevronDown size={14} class="shrink-0 opacity-70" />
+                      </Show>
+                    </button>
+                    <Show when={expanded()}>
+                      <div class="border-t border-red-7/15 px-3 pb-3 pt-2">
+                        <pre class="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-red-12/95">
+                          {fullText}
+                        </pre>
+                      </div>
+                    </Show>
+                  </div>
                 </div>
               </div>
             );

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -50,7 +50,8 @@ type StoreState = {
 
 type SessionErrorTurn = {
   id: string;
-  text: string;
+  summary: string;
+  fullText: string;
   afterMessageID: string | null;
   time: number;
 };
@@ -107,9 +108,14 @@ const createSyntheticSessionErrorMessage = (
     providerID: "",
     mode: "",
     agent: "",
+    syntheticErrorSummary: errorTurn.summary,
+    syntheticErrorFullText: errorTurn.fullText,
     path: { cwd: "", root: "" },
     cost: 0,
     tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  } as PlaceholderAssistantMessage & {
+    syntheticErrorSummary: string;
+    syntheticErrorFullText: string;
   },
   parts: [
     {
@@ -117,7 +123,7 @@ const createSyntheticSessionErrorMessage = (
       sessionID,
       messageID: errorTurn.id,
       type: "text",
-      text: errorTurn.text,
+      text: errorTurn.fullText,
     } as Part,
   ],
 });
@@ -522,28 +528,19 @@ export function createSessionStore(options: {
       .join(" ");
   };
 
-  const combineErrorDetail = (primary: string | null, secondary: string | null) => {
-    if (primary && secondary) {
-      if (primary === secondary) return primary;
-      if (secondary.startsWith(primary)) return secondary;
-      return `${primary}: ${secondary}`;
-    }
-    return primary ?? secondary ?? null;
-  };
-
-  const formatInlineSessionError = (errorObj: Record<string, unknown>) => {
+  const summarizeInlineSessionError = (errorObj: Record<string, unknown>) => {
     const records = getNestedRecords(errorObj);
     const errorName = typeof errorObj.name === "string" ? errorObj.name : "UnknownError";
-    const rawMessage = firstStringField(records, ["message", "detail", "reason"]);
-    const responseBody = firstStringField(records, ["responseBody", "body", "response"]);
     const providerID = firstStringField(records, ["providerID", "providerId", "provider"]);
     const statusCode = firstNumberField(records, ["statusCode", "status"]);
+    const rawMessage = firstStringField(records, ["message", "detail", "reason"]);
+    const responseBody = firstStringField(records, ["responseBody", "body", "response"]);
     const inferred = inferHttpStatus(rawMessage) ?? inferHttpStatus(responseBody);
     const effectiveStatus = statusCode ?? inferred;
     const providerLabel = formatProviderLabel(providerID);
     const authFailure = errorName === "ProviderAuthError" || effectiveStatus === 401 || effectiveStatus === 403;
 
-    const heading = (() => {
+    return (() => {
       if (authFailure) return `${providerLabel ?? "Provider"} authentication failed`;
       if (effectiveStatus === 413) return "Context too large";
       if (effectiveStatus === 429) return providerLabel ? `${providerLabel} rate limit exceeded` : "Rate limit exceeded";
@@ -551,26 +548,15 @@ export function createSessionStore(options: {
       if (providerLabel && errorName === "APIError") return `${providerLabel} request failed`;
       return formatSessionError(errorObj).split(/\r?\n/)[0] ?? "Unknown error";
     })();
-
-    const detail = combineErrorDetail(rawMessage, responseBody);
-    return [heading, detail].filter((line, index, list) => line && list.indexOf(line) === index).join("\n");
   };
 
-  const sanitizeInlineSessionError = (message: string) =>
-    message
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .filter((line) => !/^retryable\s*:/i.test(line))
-      .map((line) =>
-        line
-          .replace(/\b(Bearer\s+)[A-Za-z0-9._~-]+/gi, "$1[redacted]")
-          .replace(/\b((?:api[_-]?key|token|authorization|secret)\s*[:=]\s*)\S+/gi, "$1[redacted]"))
-      .join("\n");
-
-  const appendSessionErrorTurn = (sessionID: string, message: string | null) => {
-    const text = message ? sanitizeInlineSessionError(message) : "";
-    if (!sessionID || !text) return;
+  const appendSessionErrorTurn = (
+    sessionID: string,
+    error: { summary?: string | null; fullText?: string | null } | string | null,
+  ) => {
+    const fullText = typeof error === "string" ? error.trim() : error?.fullText?.trim() ?? "";
+    const summary = typeof error === "string" ? error.trim().split(/\r?\n/, 1)[0] ?? "" : error?.summary?.trim() ?? "";
+    if (!sessionID || !fullText) return;
 
     const list = store.messages[sessionID] ?? [];
     const lastMessage = list.length > 0 ? list[list.length - 1] : null;
@@ -579,13 +565,19 @@ export function createSessionStore(options: {
     setStore("sessionErrorTurns", sessionID, (current) => {
       const existing = current ?? [];
       const previous = existing[existing.length - 1];
-      if (previous && previous.text === text && previous.afterMessageID === afterMessageID) {
+      if (
+        previous &&
+        previous.summary === summary &&
+        previous.fullText === fullText &&
+        previous.afterMessageID === afterMessageID
+      ) {
         return existing;
       }
 
       return existing.concat({
         id: `${SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX}${sessionID}:${Date.now()}:${existing.length}`,
-        text,
+        summary: summary || (fullText.split(/\r?\n/, 1)[0] ?? "Request failed"),
+        fullText,
         afterMessageID,
         time: Date.now(),
       });
@@ -1243,7 +1235,10 @@ export function createSessionStore(options: {
             return;
           }
           if (sessionID) {
-            appendSessionErrorTurn(sessionID, addOpencodeCacheHint(formatInlineSessionError(errorObj)));
+            appendSessionErrorTurn(sessionID, {
+              summary: summarizeInlineSessionError(errorObj),
+              fullText: addOpencodeCacheHint(formatSessionError(errorObj)),
+            });
           } else {
             options.setError(addOpencodeCacheHint(formatSessionError(errorObj)));
           }

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -535,12 +535,16 @@ export function createSessionStore(options: {
     const statusCode = firstNumberField(records, ["statusCode", "status"]);
     const rawMessage = firstStringField(records, ["message", "detail", "reason"]);
     const responseBody = firstStringField(records, ["responseBody", "body", "response"]);
+    const detailLine = (rawMessage ?? responseBody ?? "")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? null;
     const inferred = inferHttpStatus(rawMessage) ?? inferHttpStatus(responseBody);
     const effectiveStatus = statusCode ?? inferred;
     const providerLabel = formatProviderLabel(providerID);
     const authFailure = errorName === "ProviderAuthError" || effectiveStatus === 401 || effectiveStatus === 403;
 
-    return (() => {
+    const heading = (() => {
       if (authFailure) return `${providerLabel ?? "Provider"} authentication failed`;
       if (effectiveStatus === 413) return "Context too large";
       if (effectiveStatus === 429) return providerLabel ? `${providerLabel} rate limit exceeded` : "Rate limit exceeded";
@@ -548,6 +552,15 @@ export function createSessionStore(options: {
       if (providerLabel && errorName === "APIError") return `${providerLabel} request failed`;
       return formatSessionError(errorObj).split(/\r?\n/)[0] ?? "Unknown error";
     })();
+
+    const isGenericHeading =
+      !heading ||
+      /^unknown error$/i.test(heading) ||
+      /^api error(?:\s*\(\d+\))?$/i.test(heading) ||
+      /^provider request failed$/i.test(heading);
+
+    if (isGenericHeading && detailLine) return detailLine;
+    return heading;
   };
 
   const appendSessionErrorTurn = (

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -14,7 +14,6 @@ import type {
   PlaceholderAssistantMessage,
   ReloadReason,
   ReloadTrigger,
-  SessionErrorTurn,
   TodoItem,
 } from "../types";
 import {
@@ -47,6 +46,13 @@ type StoreState = {
   pendingPermissions: PendingPermission[];
   pendingQuestions: PendingQuestion[];
   events: OpencodeEvent[];
+};
+
+type SessionErrorTurn = {
+  id: string;
+  text: string;
+  afterMessageID: string | null;
+  time: number;
 };
 
 const sortById = <T extends { id: string }>(list: T[]) =>
@@ -86,6 +92,68 @@ const createPlaceholderMessage = (part: Part): PlaceholderAssistantMessage => ({
   cost: 0,
   tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
 });
+
+const createSyntheticSessionErrorMessage = (
+  sessionID: string,
+  errorTurn: SessionErrorTurn,
+): MessageWithParts => ({
+  info: {
+    id: errorTurn.id,
+    sessionID,
+    role: "assistant",
+    time: { created: errorTurn.time, completed: errorTurn.time },
+    parentID: errorTurn.afterMessageID ?? "",
+    modelID: "",
+    providerID: "",
+    mode: "",
+    agent: "",
+    path: { cwd: "", root: "" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  },
+  parts: [
+    {
+      id: `${errorTurn.id}:text`,
+      sessionID,
+      messageID: errorTurn.id,
+      type: "text",
+      text: errorTurn.text,
+    } as Part,
+  ],
+});
+
+const messageIdFromInfo = (message: MessageWithParts) => {
+  const id = (message.info as { id?: string | number }).id;
+  if (typeof id === "string") return id;
+  if (typeof id === "number") return String(id);
+  return "";
+};
+
+const insertSyntheticSessionErrors = (
+  list: MessageWithParts[],
+  sessionID: string | null,
+  errorTurns: SessionErrorTurn[],
+) => {
+  if (!sessionID || errorTurns.length === 0) return list;
+
+  const next = list.slice();
+  errorTurns.forEach((errorTurn) => {
+    if (next.some((message) => messageIdFromInfo(message) === errorTurn.id)) return;
+    const syntheticMessage = createSyntheticSessionErrorMessage(sessionID, errorTurn);
+    const anchorIndex = errorTurn.afterMessageID
+      ? next.findIndex((message) => messageIdFromInfo(message) === errorTurn.afterMessageID)
+      : -1;
+
+    if (anchorIndex === -1) {
+      next.push(syntheticMessage);
+      return;
+    }
+
+    next.splice(anchorIndex + 1, 0, syntheticMessage);
+  });
+
+  return next;
+};
 
 const upsertSession = (list: Session[], next: Session) => {
   const index = list.findIndex((session) => session.id === next.id);
@@ -444,8 +512,20 @@ export function createSessionStore(options: {
     options.setError(addOpencodeCacheHint(message));
   };
 
+  const sanitizeInlineSessionError = (message: string) =>
+    message
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((line) => !/^response\s*:/i.test(line))
+      .map((line) =>
+        line
+          .replace(/\b(Bearer\s+)[A-Za-z0-9._~-]+/gi, "$1[redacted]")
+          .replace(/\b((?:api[_-]?key|token|authorization|secret)\s*[:=]\s*)\S+/gi, "$1[redacted]"))
+      .join("\n");
+
   const appendSessionErrorTurn = (sessionID: string, message: string | null) => {
-    const text = message?.trim() ?? "";
+    const text = message ? sanitizeInlineSessionError(message) : "";
     if (!sessionID || !text) return;
 
     const list = store.messages[sessionID] ?? [];
@@ -613,6 +693,17 @@ export function createSessionStore(options: {
     if (!id) return [];
     const list = store.messages[id] ?? [];
     return list.map((info) => ({ info, parts: store.parts[info.id] ?? [] }));
+  });
+
+  const displayMessages = createMemo<MessageWithParts[]>(() => {
+    const sessionID = options.selectedSessionId();
+    if (!sessionID) return [];
+    const revert = selectedSession()?.revert?.messageID ?? null;
+    const visible = !revert ? messages() : messages().filter((message) => {
+      const id = messageIdFromInfo(message);
+      return Boolean(id) && id < revert;
+    });
+    return insertSyntheticSessionErrors(visible, sessionID, store.sessionErrorTurns[sessionID] ?? []);
   });
 
   const todos = createMemo<TodoItem[]>(() => {
@@ -1465,15 +1556,11 @@ export function createSessionStore(options: {
 
   return {
     sessions,
-    sessionErrorTurnsById: (sessionID: string | null) => (sessionID ? store.sessionErrorTurns[sessionID] ?? [] : []),
-    selectedSessionErrorTurns: createMemo(() => {
-      const sessionID = options.selectedSessionId();
-      return sessionID ? store.sessionErrorTurns[sessionID] ?? [] : [];
-    }),
     sessionStatusById,
     selectedSession,
     selectedSessionStatus,
     messages,
+    displayMessages,
     todos,
     pendingPermissions,
     permissionReplyBusy,

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -512,12 +512,56 @@ export function createSessionStore(options: {
     options.setError(addOpencodeCacheHint(message));
   };
 
+  const formatProviderLabel = (providerID: string | null) => {
+    const value = providerID?.trim();
+    if (!value) return null;
+    return value
+      .split(/[^a-z0-9]+/i)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  };
+
+  const combineErrorDetail = (primary: string | null, secondary: string | null) => {
+    if (primary && secondary) {
+      if (primary === secondary) return primary;
+      if (secondary.startsWith(primary)) return secondary;
+      return `${primary}: ${secondary}`;
+    }
+    return primary ?? secondary ?? null;
+  };
+
+  const formatInlineSessionError = (errorObj: Record<string, unknown>) => {
+    const records = getNestedRecords(errorObj);
+    const errorName = typeof errorObj.name === "string" ? errorObj.name : "UnknownError";
+    const rawMessage = firstStringField(records, ["message", "detail", "reason"]);
+    const responseBody = firstStringField(records, ["responseBody", "body", "response"]);
+    const providerID = firstStringField(records, ["providerID", "providerId", "provider"]);
+    const statusCode = firstNumberField(records, ["statusCode", "status"]);
+    const inferred = inferHttpStatus(rawMessage) ?? inferHttpStatus(responseBody);
+    const effectiveStatus = statusCode ?? inferred;
+    const providerLabel = formatProviderLabel(providerID);
+    const authFailure = errorName === "ProviderAuthError" || effectiveStatus === 401 || effectiveStatus === 403;
+
+    const heading = (() => {
+      if (authFailure) return `${providerLabel ?? "Provider"} authentication failed`;
+      if (effectiveStatus === 413) return "Context too large";
+      if (effectiveStatus === 429) return providerLabel ? `${providerLabel} rate limit exceeded` : "Rate limit exceeded";
+      if (errorName === "MessageOutputLengthError") return "Output length limit exceeded";
+      if (providerLabel && errorName === "APIError") return `${providerLabel} request failed`;
+      return formatSessionError(errorObj).split(/\r?\n/)[0] ?? "Unknown error";
+    })();
+
+    const detail = combineErrorDetail(rawMessage, responseBody);
+    return [heading, detail].filter((line, index, list) => line && list.indexOf(line) === index).join("\n");
+  };
+
   const sanitizeInlineSessionError = (message: string) =>
     message
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter(Boolean)
-      .filter((line) => !/^response\s*:/i.test(line))
+      .filter((line) => !/^retryable\s*:/i.test(line))
       .map((line) =>
         line
           .replace(/\b(Bearer\s+)[A-Za-z0-9._~-]+/gi, "$1[redacted]")
@@ -1199,7 +1243,7 @@ export function createSessionStore(options: {
             return;
           }
           if (sessionID) {
-            appendSessionErrorTurn(sessionID, addOpencodeCacheHint(formatSessionError(errorObj)));
+            appendSessionErrorTurn(sessionID, addOpencodeCacheHint(formatInlineSessionError(errorObj)));
           } else {
             options.setError(addOpencodeCacheHint(formatSessionError(errorObj)));
           }

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -67,13 +67,6 @@ export type MessageWithParts = {
   parts: Part[];
 };
 
-export type SessionErrorTurn = {
-  id: string;
-  text: string;
-  afterMessageID: string | null;
-  time: number;
-};
-
 export const SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX = "session-error:";
 
 export type StepGroupMode = "exploration" | "standalone";


### PR DESCRIPTION
## Summary
- carry forward the post-merge follow-up changes from #845 onto a fresh branch from latest `dev`
- simplify inline session error handling so transcript display is owned by the session store
- show provider-aware inline error summaries with expandable full error details in monospace
- fix the disclosure chevron so it points right when collapsed and down when expanded

## Screenshots
Before (#845 merged state)

![Before](https://files.catbox.moe/1ifans.png)

After (#849 follow-up)

![After](https://files.catbox.moe/v8uy3p.png)

## Verification
- `pnpm install`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
