### PR TITLE
feat: add verify command as canonical PR validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,16 @@ If you cannot complete steps 4-8 (Docker, Chrome MCP, missing credentials, or en
 
 ## Pull Request Expectations (Fast Merge)
 
+Before opening a PR, run `pnpm verify` to ensure your changes pass all checks:
+
+```bash
+pnpm verify
+```
+
+This runs:
+1. **TypeCheck**: TypeScript type checking
+2. **E2E Tests**: End-to-end test suite
+
 If you open a PR, you must run tests and report what you ran (commands + result).
 
 To maximize merge speed, include evidence of the end-to-end flow:

--- a/README.md
+++ b/README.md
@@ -182,12 +182,13 @@ You can still edit `opencode.json` manually; OpenWork uses the same format as th
 ## Useful Commands
 
 ```bash
-pnpm dev
-pnpm dev:ui
-pnpm typecheck
-pnpm build
-pnpm build:ui
-pnpm test:e2e
+pnpm dev           # Start desktop app
+pnpm dev:ui        # Start web UI only
+pnpm verify        # Run all verification checks (typecheck + tests)
+pnpm typecheck     # TypeScript type checking
+pnpm build         # Build all packages
+pnpm build:ui      # Build web UI
+pnpm test:e2e      # Run e2e tests
 ```
 
 ## Troubleshooting
@@ -213,7 +214,7 @@ WEBKIT_DISABLE_COMPOSITING_MODE=1 openwork
 
 - Review `AGENTS.md` plus `VISION.md`, `PRINCIPLES.md`, `PRODUCT.md`, and `ARCHITECTURE.md` to understand the product goals before making changes.
 - Ensure Node.js, `pnpm`, the Rust toolchain, and `opencode` are installed before working inside the repo.
-- Run `pnpm install` once per checkout, then verify your change with `pnpm typecheck` plus `pnpm test:e2e` (or the targeted subset of scripts) before opening a PR.
+- Run `pnpm install` once per checkout, then verify your change with `pnpm verify` before opening a PR.
 - Use `.github/pull_request_template.md` when opening PRs and include exact commands, outcomes, manual verification steps, and evidence.
 - If CI fails, classify failures in the PR body as either code-related regressions or external/environment/auth blockers.
 - Add new PRDs to `packages/app/pr/<name>.md` following the `.opencode/skills/prd-conventions/SKILL.md` conventions described in `AGENTS.md`.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:ui": "pnpm --filter @different-ai/openwork-ui build",
     "build:web": "pnpm --filter @different-ai/openwork-ui build",
     "preview": "pnpm --filter @different-ai/openwork-ui preview",
+    "verify": "pnpm typecheck && pnpm test:e2e",
     "typecheck": "pnpm --filter @different-ai/openwork-ui typecheck",
     "test:health": "pnpm --filter @different-ai/openwork-ui test:health",
     "test:sessions": "pnpm --filter @different-ai/openwork-ui test:sessions",


### PR DESCRIPTION
## Summary

- Add `pnpm verify` command as the canonical pre-PR validation
- Update AGENTS.md with PR verification expectations
- Update README.md with verify command documentation

## Changes

| File | Type | Description |
|------|------|-------------|
| `package.json` | Modified | Add `verify` script |
| `AGENTS.md` | Modified | Add PR verification section |
| `README.md` | Modified | Document verify command |

## Features

- **Single command**: `pnpm verify` runs typecheck + e2e tests
- **Clear documentation**: AGENTS.md explains what to run before PRs
- **Contributor friendly**: One command instead of remembering multiple scripts

## Test Plan

```bash
# Run verify command
pnpm verify

# This runs:
# 1. pnpm typecheck
# 2. pnpm test:e2e
```

This is split from the original PR #788 as suggested by @OmarMcAdam.