### PR TITLE
ci: add typecheck step to CI workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -139,5 +139,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: TypeCheck
+        run: pnpm typecheck
+
       - name: Run e2e tests
-        run: pnpm --filter @different-ai/openwork-ui test:e2e
+        run: pnpm test:e2e


### PR DESCRIPTION
## Summary

- Add TypeCheck step to CI workflow before e2e tests
- Use `pnpm test:e2e` instead of `--filter` for consistency

## Changes

| File | Type | Description |
|------|------|-------------|
| `.github/workflows/ci-tests.yml` | Modified | Add typecheck step |

## Benefits

- Catch TypeScript errors in CI before merging
- Consistent command usage with other scripts

## Test Plan

- CI will run typecheck automatically on this PR
- Verify the typecheck step passes

This is split from the original PR #788 as suggested by @OmarMcAdam.