### PR TITLE
fix(docker): simplify local startup and sandbox diagnostics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.opencode
+_worktrees
+tmp
+vendor
+node_modules
+**/node_modules
+**/dist
+**/.next
+**/.turbo
+**/target
+**/.DS_Store
+*.log

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -1646,6 +1646,40 @@ export function createWorkspaceStore(options: {
               }
             }
 
+            if (stage === "docker.diagnostics") {
+              setSandboxStep("sandbox", { status: "active", detail: "Collecting Docker diagnostics" });
+              const diagnosticsPath = String(payload.payload?.diagnosticsPath ?? "").trim();
+              if (diagnosticsPath) {
+                pushSandboxCreateLog(`Docker diagnostics: ${diagnosticsPath}`);
+              }
+
+              const inspect = payload.payload?.dockerInspect as
+                | { status?: number; stdout?: string; stderr?: string }
+                | undefined;
+              if (inspect) {
+                if (typeof inspect.status === "number") {
+                  pushSandboxCreateLog(`docker inspect exit=${inspect.status}`);
+                }
+                const stdout = String(inspect.stdout ?? "").trim();
+                const stderr = String(inspect.stderr ?? "").trim();
+                if (stdout) pushSandboxCreateLog(`docker inspect: ${stdout}`);
+                if (stderr) pushSandboxCreateLog(`docker inspect stderr: ${stderr}`);
+              }
+
+              const logs = payload.payload?.dockerLogs as
+                | { status?: number; stdout?: string; stderr?: string }
+                | undefined;
+              if (logs) {
+                if (typeof logs.status === "number") {
+                  pushSandboxCreateLog(`docker logs exit=${logs.status}`);
+                }
+                const stdout = String(logs.stdout ?? "").trim();
+                const stderr = String(logs.stderr ?? "").trim();
+                if (stdout) pushSandboxCreateLog(`docker logs: ${stdout}`);
+                if (stderr) pushSandboxCreateLog(`docker logs stderr: ${stderr}`);
+              }
+            }
+
             if (stage === "openwork.waiting") {
               const elapsedMs = Number(payload.payload?.elapsedMs ?? 0);
               const seconds = elapsedMs > 0 ? Math.max(1, Math.floor(elapsedMs / 1000)) : 0;

--- a/packages/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/packages/desktop/src-tauri/src/commands/orchestrator.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use serde_json::json;
 use std::collections::HashSet;
 use std::env;
+use std::fs;
 use std::io::Read;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
@@ -593,6 +594,49 @@ fn docker_container_state(container_name: &str) -> Result<Option<String>, String
     ))
 }
 
+fn command_debug_from_error(error: String) -> SandboxDoctorCommandDebug {
+    SandboxDoctorCommandDebug {
+        status: -1,
+        stdout: String::new(),
+        stderr: truncate_for_report(&error),
+    }
+}
+
+fn docker_inspect_debug(container_name: &str) -> SandboxDoctorCommandDebug {
+    match run_docker_command_detailed(&["inspect", container_name], Duration::from_secs(4)) {
+        Ok(result) => to_command_debug(result),
+        Err(err) => command_debug_from_error(err),
+    }
+}
+
+fn docker_logs_debug(container_name: &str) -> SandboxDoctorCommandDebug {
+    match run_docker_command_detailed(
+        &["logs", "--tail", "200", container_name],
+        Duration::from_secs(4),
+    ) {
+        Ok(result) => to_command_debug(result),
+        Err(err) => command_debug_from_error(err),
+    }
+}
+
+fn command_debug_preview(command: &SandboxDoctorCommandDebug) -> serde_json::Value {
+    json!({
+        "status": command.status,
+        "stdout": truncate_for_debug(&command.stdout),
+        "stderr": truncate_for_debug(&command.stderr),
+    })
+}
+
+fn write_sandbox_timeout_diagnostics(run_id: &str, payload: &serde_json::Value) -> Option<String> {
+    let data_dir = PathBuf::from(resolve_orchestrator_data_dir());
+    let diagnostics_dir = data_dir.join("sandbox-debug");
+    fs::create_dir_all(&diagnostics_dir).ok()?;
+    let diagnostics_path = diagnostics_dir.join(format!("timeout-{run_id}.json"));
+    let body = serde_json::to_vec_pretty(payload).ok()?;
+    fs::write(&diagnostics_path, body).ok()?;
+    Some(diagnostics_path.to_string_lossy().to_string())
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct OrchestratorWorkspaceResponse {
@@ -714,23 +758,22 @@ fn format_sandbox_start_timeout_error(
     last_error: Option<&str>,
     container_state: Option<&str>,
     container_probe_error: Option<&str>,
+    diagnostics_path: Option<&str>,
 ) -> String {
     let mut details = vec![
         format!("stage=openwork.healthcheck"),
         format!("elapsed_ms={elapsed_ms}"),
         format!("url={openwork_url}"),
-        format!(
-            "last_error={}",
-            last_error.unwrap_or("none")
-        ),
-        format!(
-            "container_state={}",
-            container_state.unwrap_or("unknown")
-        ),
+        format!("last_error={}", last_error.unwrap_or("none")),
+        format!("container_state={}", container_state.unwrap_or("unknown")),
     ];
 
     if let Some(probe_error) = container_probe_error {
         details.push(format!("container_probe_error={probe_error}"));
+    }
+
+    if let Some(path) = diagnostics_path {
+        details.push(format!("diagnostics_path={path}"));
     }
 
     format!(
@@ -1014,12 +1057,46 @@ pub fn orchestrator_start_detached(
 
     if start.elapsed() >= Duration::from_millis(health_timeout_ms) {
         let elapsed_ms = start.elapsed().as_millis() as u64;
+        let mut diagnostics_path: Option<String> = None;
+        if wants_docker_sandbox {
+            if let Some(name) = sandbox_container_name.as_deref() {
+                let docker_inspect = docker_inspect_debug(name);
+                let docker_logs = docker_logs_debug(name);
+                let diagnostics_payload = json!({
+                    "runId": sandbox_run_id,
+                    "containerName": name,
+                    "openworkUrl": openwork_url,
+                    "elapsedMs": elapsed_ms,
+                    "lastError": last_error,
+                    "containerState": last_container_state,
+                    "containerProbeError": last_container_probe_error,
+                    "dockerInspect": docker_inspect,
+                    "dockerLogs": docker_logs,
+                });
+                diagnostics_path =
+                    write_sandbox_timeout_diagnostics(&sandbox_run_id, &diagnostics_payload);
+                emit_sandbox_progress(
+                    &app,
+                    &sandbox_run_id,
+                    "docker.diagnostics",
+                    "Collected Docker timeout diagnostics.",
+                    json!({
+                        "containerName": name,
+                        "elapsedMs": elapsed_ms,
+                        "diagnosticsPath": diagnostics_path,
+                        "dockerInspect": command_debug_preview(&docker_inspect),
+                        "dockerLogs": command_debug_preview(&docker_logs),
+                    }),
+                );
+            }
+        }
         let message = format_sandbox_start_timeout_error(
             elapsed_ms,
             &openwork_url,
             last_error.as_deref(),
             last_container_state.as_deref(),
             last_container_probe_error.as_deref(),
+            diagnostics_path.as_deref(),
         );
         emit_sandbox_progress(
             &app,
@@ -1032,6 +1109,7 @@ pub fn orchestrator_start_detached(
                 "openworkUrl": openwork_url,
                 "containerState": last_container_state,
                 "containerProbeError": last_container_probe_error,
+                "diagnosticsPath": diagnostics_path,
             }),
         );
         eprintln!(

--- a/packages/orchestrator/src/cli.ts
+++ b/packages/orchestrator/src/cli.ts
@@ -3134,6 +3134,7 @@ async function writeSandboxEntrypoint(options: {
 
   const script = [
     "set -eu",
+    "log() { printf '[openwork-sandbox] %s\\n' \"$1\"; }",
     `export HOME=${shQuote("/persist")}`,
     "export XDG_CONFIG_HOME=\"$HOME/.config\"",
     "export XDG_CACHE_HOME=\"$HOME/.cache\"",
@@ -3146,8 +3147,12 @@ async function writeSandboxEntrypoint(options: {
     `export OPENCODE_DIRECTORY=${shQuote(workspaceDir)}`,
     `export OPENCODE_CONFIG_DIR=${shQuote(opencodeConfigDir)}`,
     `mkdir -p ${shQuote(opencodeConfigDir)}`,
+    `log ${shQuote(`workspace ${workspaceDir}`)}`,
+    `log ${shQuote(`opencode config ${opencodeConfigDir}`)}`,
+    `if [ -d ${shQuote(hostOpencodeConfigDir)} ]; then log ${shQuote("importing host opencode config")}; fi`,
     `if [ -d ${shQuote(hostOpencodeConfigDir)} ]; then cp -R ${shQuote(`${hostOpencodeConfigDir}/.`)} ${shQuote(opencodeConfigDir)} 2>/dev/null || true; fi`,
     "mkdir -p \"$XDG_DATA_HOME/opencode\"",
+    `if [ -d ${shQuote(hostOpencodeDataDir)} ]; then log ${shQuote("importing host opencode auth/data")}; fi`,
     `if [ -d ${shQuote(hostOpencodeDataDir)} ]; then cp ${shQuote(`${hostOpencodeDataDir}/auth.json`)} \"$XDG_DATA_HOME/opencode/auth.json\" 2>/dev/null || true; cp ${shQuote(`${hostOpencodeDataDir}/mcp-auth.json`)} \"$XDG_DATA_HOME/opencode/mcp-auth.json\" 2>/dev/null || true; fi`,
     `export OPENCODE_URL=${shQuote(`http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`)}`,
     `export OPENCODE_CLIENT=openwork-orchestrator`,
@@ -3169,10 +3174,15 @@ async function writeSandboxEntrypoint(options: {
     "  if [ -n \"$opencode_pid\" ]; then kill \"$opencode_pid\" 2>/dev/null || true; fi",
     "}",
     "trap cleanup INT TERM",
+    `log ${shQuote(`starting opencode on 127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`)}`,
     `${shQuote(opencodeBin)} serve --hostname 127.0.0.1 --port ${shQuote(String(SANDBOX_INTERNAL_OPENCODE_PORT))} ${opencodeCors} &`,
     "opencode_pid=$!",
+    options.openwork.opencodeRouterEnabled
+      ? `log ${shQuote(`starting opencode-router with health port ${SANDBOX_INTERNAL_OPENCODE_ROUTER_HEALTH_PORT}`)}`
+      : "",
     options.openwork.opencodeRouterEnabled ? `${shQuote(opencodeRouterBin)} serve ${shQuote(workspaceDir)} &` : "",
     options.openwork.opencodeRouterEnabled ? "opencodeRouter_pid=$!" : "",
+    `log ${shQuote(`starting openwork-server on 0.0.0.0:${SANDBOX_INTERNAL_OPENWORK_PORT}`)}`,
     `exec ${shQuote(openworkBin)} --host 0.0.0.0 --port ${shQuote(String(SANDBOX_INTERNAL_OPENWORK_PORT))}` +
       ` --token ${shQuote(options.openwork.token)} --host-token ${shQuote(options.openwork.hostToken)}` +
       ` --workspace ${shQuote(workspaceDir)}` +

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-bookworm-slim
 
-ARG OPENWORK_ORCHESTRATOR_VERSION=0.11.22
+ARG OPENWORK_ORCHESTRATOR_VERSION=0.11.142
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -25,6 +25,9 @@ EXPOSE 8787
 
 # Optional: opencode-router health (only relevant if you enable the router).
 EXPOSE 3005
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=12 \
+  CMD curl -sf http://localhost:8787/health >/dev/null || exit 1
 
 VOLUME ["/workspace", "/data"]
 

--- a/packaging/docker/Dockerfile.dev
+++ b/packaging/docker/Dockerfile.dev
@@ -1,0 +1,32 @@
+FROM node:22-bookworm-slim
+
+ARG PNPM_VERSION=10.27.0
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV BUN_INSTALL=/root/.bun
+ENV PATH=/root/.bun/bin:$PATH
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://bun.sh/install | bash
+
+COPY . /app
+
+RUN corepack enable \
+  && corepack prepare "pnpm@${PNPM_VERSION}" --activate \
+  && pnpm install --frozen-lockfile --network-concurrency 1 --child-concurrency 1 \
+  && pnpm --filter openwork-server build:bin \
+  && pnpm --filter opencode-router build:bin
+
+RUN mkdir -p /runtime /workspace
+
+EXPOSE 8787 5173

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -2,7 +2,7 @@
 
 ## Dev testability stack (recommended for testing)
 
-One command, no custom Dockerfile. Uses `node:22-bookworm-slim` off the shelf.
+One command, one dev image, and a health-gated startup path.
 
 From the repo root:
 
@@ -13,14 +13,28 @@ From the repo root:
 Then open the printed Web UI URL (ports are randomized so you can run multiple stacks).
 
 What it does:
+- Builds a single Docker image from the current checkout before the stack starts
+- Installs dependencies and compiles Linux sidecars at image build time instead of every container boot
 - Starts **headless** (OpenCode + OpenWork server) on port 8787
 - Starts **web UI** (Vite dev server) on port 5173
-- Auto-generates and shares auth tokens between services
-- Web waits for headless health check before starting
-- Builds Linux binaries inside the container (no host binary conflicts)
+- Auto-generates and shares auth tokens between services through a mounted runtime env file
+- Waits for both `http://localhost:<openwork_port>/health` and the web UI before printing "ready"
 - Uses an isolated OpenCode dev state by default so the stack does not read your personal host config/auth/data
 
+This stack now favors reproducibility over live bind-mounted source edits. When you change code, rerun `./packaging/docker/dev-up.sh` so the image rebuild picks up the new checkout.
+
 If you want to seed the container from your host OpenCode state for debugging, run with `OPENWORK_DOCKER_DEV_MOUNT_HOST_OPENCODE=1`. This imports host config/auth into the isolated dev state instead of mounting live host state directly.
+
+For extra observability, run:
+
+```bash
+OPENWORK_DOCKER_DEBUG=1 ./packaging/docker/dev-up.sh
+```
+
+Debug mode:
+- Enables verbose orchestrator logs
+- Writes container status, logs, inspect output, and health snapshots under `tmp/docker-dev/<dev-id>/`
+- Prints the runtime metadata file that includes the exact `logs` and `down` commands for that stack
 
 Useful commands:
 - Logs: `docker compose -p <project> -f packaging/docker/docker-compose.dev.yml logs`
@@ -33,6 +47,8 @@ Optional env vars (via `.env` or `export`):
 - `OPENWORK_WORKSPACE` — host path to mount as workspace
 - `OPENWORK_PORT` — host port to map to container :8787
 - `WEB_PORT` — host port to map to container :5173
+- `OPENWORK_DOCKER_DEBUG=1` — capture extra runtime diagnostics under `tmp/docker-dev/<dev-id>/`
+- `OPENWORK_DOCKER_SKIP_BUILD=1` — reuse the last built dev image instead of rebuilding from the current checkout
 - `OPENWORK_DOCKER_DEV_MOUNT_HOST_OPENCODE=1` — import host OpenCode config/auth into the isolated dev state
 - `OPENWORK_OPENCODE_CONFIG_DIR` — override the host OpenCode config source used for that optional import
 - `OPENWORK_OPENCODE_DATA_DIR` — override the host OpenCode data source used for that optional import

--- a/packaging/docker/dev-up.sh
+++ b/packaging/docker/dev-up.sh
@@ -20,6 +20,8 @@ COMPOSE_FILE="$ROOT_DIR/packaging/docker/docker-compose.dev.yml"
 WORKSPACE_DIR="$ROOT_DIR/packaging/docker/workspace"
 DEV_RUNTIME_DIR="$ROOT_DIR/tmp/docker-dev"
 MOUNT_HOST_OPENCODE="${OPENWORK_DOCKER_DEV_MOUNT_HOST_OPENCODE:-0}"
+DOCKER_DEBUG="${OPENWORK_DOCKER_DEBUG:-0}"
+DOCKER_SKIP_BUILD="${OPENWORK_DOCKER_SKIP_BUILD:-0}"
 
 resolve_opencode_config_dir() {
   local override="${OPENWORK_OPENCODE_CONFIG_DIR:-}"
@@ -98,6 +100,29 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose is required" >&2
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "docker daemon is not reachable. Start Docker Desktop/OrbStack and retry." >&2
+  exit 1
+fi
+
+read_bool() {
+  local value="${1:-}"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    1|true|yes|on)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 pick_port() {
   node -e "
     const net = require('net');
@@ -112,12 +137,16 @@ pick_port() {
 
 DEV_ID="$(node -e "console.log(require('crypto').randomUUID().slice(0, 8))")"
 PROJECT="openwork-dev-$DEV_ID"
+RUN_DIR="$DEV_RUNTIME_DIR/$DEV_ID"
+TOKEN_FILE="$RUN_DIR/dev.env"
+STACK_INFO_FILE="$RUN_DIR/stack-info.txt"
 
 mkdir -p "$WORKSPACE_DIR"
 mkdir -p "$DEV_RUNTIME_DIR"
+mkdir -p "$RUN_DIR"
 
-OPENCODE_CONFIG_FALLBACK_DIR="$DEV_RUNTIME_DIR/host-opencode-config"
-OPENCODE_DATA_FALLBACK_DIR="$DEV_RUNTIME_DIR/host-opencode-data"
+OPENCODE_CONFIG_FALLBACK_DIR="$RUN_DIR/host-opencode-config"
+OPENCODE_DATA_FALLBACK_DIR="$RUN_DIR/host-opencode-data"
 mkdir -p "$OPENCODE_CONFIG_FALLBACK_DIR" "$OPENCODE_DATA_FALLBACK_DIR"
 
 HOST_OPENCODE_CONFIG_DIR="$OPENCODE_CONFIG_FALLBACK_DIR"
@@ -145,20 +174,139 @@ echo "Starting Docker Compose project: $PROJECT" >&2
 echo "- OPENWORK_PORT=$OPENWORK_PORT" >&2
 echo "- WEB_PORT=$WEB_PORT" >&2
 echo "- OPENWORK_DEV_MODE=1" >&2
+echo "- OPENWORK_RUNTIME_DIR=$RUN_DIR" >&2
+if read_bool "$DOCKER_SKIP_BUILD"; then
+  echo "- Docker image build: skipped" >&2
+else
+  echo "- Docker image build: enabled" >&2
+fi
+if read_bool "$DOCKER_DEBUG"; then
+  echo "- Docker debug mode: enabled" >&2
+else
+  echo "- Docker debug mode: disabled" >&2
+fi
 if [ "$MOUNT_HOST_OPENCODE" = "1" ]; then
   echo "- Host OpenCode import: enabled" >&2
 else
   echo "- Host OpenCode import: disabled (isolated dev state)" >&2
 fi
 
-start_stack() {
-  local config_dir="$1"
-  local data_dir="$2"
+OPENWORK_VERBOSE_VALUE="0"
+if read_bool "$DOCKER_DEBUG"; then
+  OPENWORK_VERBOSE_VALUE="1"
+fi
+
+compose() {
   OPENWORK_DEV_ID="$DEV_ID" OPENWORK_PORT="$OPENWORK_PORT" WEB_PORT="$WEB_PORT" \
     OPENWORK_DEV_MODE="1" \
-    OPENWORK_HOST_OPENCODE_CONFIG_DIR="$config_dir" \
-    OPENWORK_HOST_OPENCODE_DATA_DIR="$data_dir" \
-    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" up -d
+    OPENWORK_RUNTIME_DIR="$RUN_DIR" \
+    OPENWORK_DOCKER_DEBUG="$DOCKER_DEBUG" \
+    OPENWORK_LOG_FORMAT="${OPENWORK_LOG_FORMAT:-pretty}" \
+    OPENWORK_VERBOSE="$OPENWORK_VERBOSE_VALUE" \
+    OPENWORK_HOST_OPENCODE_CONFIG_DIR="$ACTIVE_OPENCODE_CONFIG_DIR" \
+    OPENWORK_HOST_OPENCODE_DATA_DIR="$ACTIVE_OPENCODE_DATA_DIR" \
+    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" "$@"
+}
+
+compose_build() {
+  local progress_mode="${1:-}"
+  if [ -n "$progress_mode" ]; then
+    OPENWORK_DEV_ID="$DEV_ID" OPENWORK_PORT="$OPENWORK_PORT" WEB_PORT="$WEB_PORT" \
+      OPENWORK_DEV_MODE="1" \
+      OPENWORK_RUNTIME_DIR="$RUN_DIR" \
+      OPENWORK_DOCKER_DEBUG="$DOCKER_DEBUG" \
+      OPENWORK_LOG_FORMAT="${OPENWORK_LOG_FORMAT:-pretty}" \
+      OPENWORK_VERBOSE="$OPENWORK_VERBOSE_VALUE" \
+      OPENWORK_HOST_OPENCODE_CONFIG_DIR="$ACTIVE_OPENCODE_CONFIG_DIR" \
+      OPENWORK_HOST_OPENCODE_DATA_DIR="$ACTIVE_OPENCODE_DATA_DIR" \
+      docker compose --progress "$progress_mode" -p "$PROJECT" -f "$COMPOSE_FILE" build
+    return
+  fi
+
+  OPENWORK_DEV_ID="$DEV_ID" OPENWORK_PORT="$OPENWORK_PORT" WEB_PORT="$WEB_PORT" \
+    OPENWORK_DEV_MODE="1" \
+    OPENWORK_RUNTIME_DIR="$RUN_DIR" \
+    OPENWORK_DOCKER_DEBUG="$DOCKER_DEBUG" \
+    OPENWORK_LOG_FORMAT="${OPENWORK_LOG_FORMAT:-pretty}" \
+    OPENWORK_VERBOSE="$OPENWORK_VERBOSE_VALUE" \
+    OPENWORK_HOST_OPENCODE_CONFIG_DIR="$ACTIVE_OPENCODE_CONFIG_DIR" \
+    OPENWORK_HOST_OPENCODE_DATA_DIR="$ACTIVE_OPENCODE_DATA_DIR" \
+    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" build
+}
+
+wait_for_http() {
+  local url="$1"
+  local label="$2"
+  local timeout_seconds="${3:-180}"
+  local started_at
+  started_at="$(date +%s)"
+
+  while true; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+
+    if [ $(( $(date +%s) - started_at )) -ge "$timeout_seconds" ]; then
+      echo "Timed out waiting for $label at $url" >&2
+      return 1
+    fi
+
+    sleep 2
+  done
+}
+
+collect_debug_snapshot() {
+  compose ps > "$RUN_DIR/compose-ps.txt" 2>&1 || true
+  compose logs --no-color > "$RUN_DIR/compose-logs.txt" 2>&1 || true
+
+  local orchestrator_id
+  local web_id
+  orchestrator_id="$(compose ps -q orchestrator 2>/dev/null || true)"
+  web_id="$(compose ps -q web 2>/dev/null || true)"
+
+  if [ -n "$orchestrator_id" ]; then
+    docker inspect "$orchestrator_id" > "$RUN_DIR/orchestrator.inspect.json" 2>/dev/null || true
+  fi
+  if [ -n "$web_id" ]; then
+    docker inspect "$web_id" > "$RUN_DIR/web.inspect.json" 2>/dev/null || true
+  fi
+
+  curl -fsS "http://localhost:$OPENWORK_PORT/health" > "$RUN_DIR/openwork-health.txt" 2>/dev/null || true
+  curl -fsS "http://localhost:$OPENWORK_PORT/status" > "$RUN_DIR/openwork-status.json" 2>/dev/null || true
+}
+
+write_stack_info() {
+  cat > "$STACK_INFO_FILE" <<EOF
+project=$PROJECT
+compose_file=$COMPOSE_FILE
+run_dir=$RUN_DIR
+openwork_url=http://localhost:$OPENWORK_PORT
+web_url=http://localhost:$WEB_PORT
+token_file=$TOKEN_FILE
+logs_command=docker compose -p $PROJECT -f $COMPOSE_FILE logs -f
+down_command=docker compose -p $PROJECT -f $COMPOSE_FILE down
+EOF
+}
+
+on_start_failure() {
+  echo "Docker stack failed to become ready." >&2
+  compose ps >&2 || true
+  compose logs --tail=200 >&2 || true
+  collect_debug_snapshot
+  echo "Debug artifacts: $RUN_DIR" >&2
+}
+
+start_stack() {
+  if ! read_bool "$DOCKER_SKIP_BUILD"; then
+    echo "Building Docker dev image from the current checkout..." >&2
+    if read_bool "$DOCKER_DEBUG"; then
+      compose_build plain || return 1
+    else
+      compose_build || return 1
+    fi
+  fi
+
+  compose up -d --remove-orphans || return 1
 }
 
 ACTIVE_OPENCODE_CONFIG_DIR="$HOST_OPENCODE_CONFIG_DIR"
@@ -170,21 +318,45 @@ echo "- OPENWORK_HOST_OPENCODE_DATA_DIR=$ACTIVE_OPENCODE_DATA_DIR" >&2
 if ! start_stack "$ACTIVE_OPENCODE_CONFIG_DIR" "$ACTIVE_OPENCODE_DATA_DIR"; then
   if [ "$ACTIVE_OPENCODE_CONFIG_DIR" != "$OPENCODE_CONFIG_FALLBACK_DIR" ] || [ "$ACTIVE_OPENCODE_DATA_DIR" != "$OPENCODE_DATA_FALLBACK_DIR" ]; then
     echo "Detected host OpenCode config mount failed; retrying with empty fallback dirs." >&2
-    docker compose -p "$PROJECT" -f "$COMPOSE_FILE" down >/dev/null 2>&1 || true
+    compose down >/dev/null 2>&1 || true
     ACTIVE_OPENCODE_CONFIG_DIR="$OPENCODE_CONFIG_FALLBACK_DIR"
     ACTIVE_OPENCODE_DATA_DIR="$OPENCODE_DATA_FALLBACK_DIR"
     echo "- OPENWORK_HOST_OPENCODE_CONFIG_DIR=$ACTIVE_OPENCODE_CONFIG_DIR" >&2
     echo "- OPENWORK_HOST_OPENCODE_DATA_DIR=$ACTIVE_OPENCODE_DATA_DIR" >&2
-    start_stack "$ACTIVE_OPENCODE_CONFIG_DIR" "$ACTIVE_OPENCODE_DATA_DIR"
+    if ! start_stack "$ACTIVE_OPENCODE_CONFIG_DIR" "$ACTIVE_OPENCODE_DATA_DIR"; then
+      on_start_failure
+      exit 1
+    fi
   else
+    on_start_failure
     exit 1
   fi
+fi
+
+write_stack_info
+
+if ! wait_for_http "http://localhost:$OPENWORK_PORT/health" "OpenWork health" 180; then
+  on_start_failure
+  exit 1
+fi
+
+if ! wait_for_http "http://localhost:$WEB_PORT/" "OpenWork web UI" 180; then
+  on_start_failure
+  exit 1
+fi
+
+if read_bool "$DOCKER_DEBUG"; then
+  collect_debug_snapshot
 fi
 
 echo "" >&2
 echo "OpenWork web UI:     http://localhost:$WEB_PORT" >&2
 echo "OpenWork server:     http://localhost:$OPENWORK_PORT" >&2
-echo "Token file:          $ROOT_DIR/tmp/.dev-env-$DEV_ID" >&2
+echo "Token file:          $TOKEN_FILE" >&2
+echo "Run metadata:        $STACK_INFO_FILE" >&2
+if read_bool "$DOCKER_DEBUG"; then
+  echo "Debug artifacts:     $RUN_DIR" >&2
+fi
 echo "" >&2
 echo "To stop this stack:" >&2
 echo "  docker compose -p $PROJECT -f $COMPOSE_FILE down" >&2

--- a/packaging/docker/dev/common.sh
+++ b/packaging/docker/dev/common.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPENWORK_RUNTIME_DIR="${OPENWORK_RUNTIME_DIR:-/runtime}"
+OPENWORK_RUNTIME_ENV_FILE="${OPENWORK_RUNTIME_ENV_FILE:-$OPENWORK_RUNTIME_DIR/dev.env}"
+OPENWORK_DOCKER_DEBUG="${OPENWORK_DOCKER_DEBUG:-0}"
+
+read_bool() {
+  local value="${1:-}"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    1|true|yes|on)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+docker_debug_enabled() {
+  read_bool "$OPENWORK_DOCKER_DEBUG"
+}
+
+log_line() {
+  local component="$1"
+  local message="$2"
+  printf '[openwork-docker:%s] %s\n' "$component" "$message"
+}
+
+ensure_runtime_dir() {
+  mkdir -p "$OPENWORK_RUNTIME_DIR"
+}
+
+print_debug_context() {
+  local component="$1"
+
+  if ! docker_debug_enabled; then
+    return 0
+  fi
+
+  log_line "$component" "debug mode enabled"
+  log_line "$component" "node $(node --version)"
+  log_line "$component" "bun $(bun --version)"
+  log_line "$component" "pnpm $(pnpm --version)"
+  log_line "$component" "runtime dir $OPENWORK_RUNTIME_DIR"
+  log_line "$component" "workspace ${OPENWORK_WORKSPACE:-/workspace}"
+}
+
+wait_for_file() {
+  local path="$1"
+  local timeout_seconds="$2"
+  local started_at
+  started_at="$(date +%s)"
+
+  while [ ! -f "$path" ]; do
+    if [ $(( $(date +%s) - started_at )) -ge "$timeout_seconds" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+
+  return 0
+}

--- a/packaging/docker/dev/orchestrator-entrypoint.sh
+++ b/packaging/docker/dev/orchestrator-entrypoint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=packaging/docker/dev/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+ensure_runtime_dir
+print_debug_context orchestrator
+
+mkdir -p /workspace
+touch /workspace/.keep 2>/dev/null || true
+
+OPENWORK_TOKEN="${OPENWORK_TOKEN:-$(cat /proc/sys/kernel/random/uuid)}"
+OPENWORK_HOST_TOKEN="${OPENWORK_HOST_TOKEN:-$(cat /proc/sys/kernel/random/uuid)}"
+OPENWORK_PORT="${OPENWORK_PORT:-8787}"
+WEB_PORT="${WEB_PORT:-5173}"
+OPENWORK_SERVER_BIN="${OPENWORK_SERVER_BIN:-/app/packages/server/dist/bin/openwork-server}"
+OPENCODE_ROUTER_BIN="${OPENCODE_ROUTER_BIN:-/app/packages/opencode-router/dist/bin/opencode-router}"
+
+cat > "$OPENWORK_RUNTIME_ENV_FILE" <<EOF
+OPENWORK_TOKEN=$OPENWORK_TOKEN
+OPENWORK_HOST_TOKEN=$OPENWORK_HOST_TOKEN
+OPENWORK_PORT=$OPENWORK_PORT
+WEB_PORT=$WEB_PORT
+OPENWORK_URL=http://localhost:$OPENWORK_PORT
+WEB_URL=http://localhost:$WEB_PORT
+EOF
+
+chmod 600 "$OPENWORK_RUNTIME_ENV_FILE"
+
+log_line orchestrator "server http://localhost:$OPENWORK_PORT"
+log_line orchestrator "health http://localhost:$OPENWORK_PORT/health"
+log_line orchestrator "runtime env $OPENWORK_RUNTIME_ENV_FILE"
+log_line orchestrator "token $OPENWORK_TOKEN"
+log_line orchestrator "host token $OPENWORK_HOST_TOKEN"
+
+command=(
+  pnpm
+  --filter
+  openwork-orchestrator
+  dev
+  --
+  start
+  --workspace
+  /workspace
+  --openwork-host
+  0.0.0.0
+  --openwork-port
+  8787
+  --openwork-token
+  "$OPENWORK_TOKEN"
+  --openwork-host-token
+  "$OPENWORK_HOST_TOKEN"
+  --openwork-server-bin
+  "$OPENWORK_SERVER_BIN"
+  --opencode-router-bin
+  "$OPENCODE_ROUTER_BIN"
+  --approval
+  auto
+  --allow-external
+  --no-opencode-auth
+  --cors
+  "*"
+)
+
+if docker_debug_enabled; then
+  command+=(--verbose --log-format "${OPENWORK_LOG_FORMAT:-pretty}")
+fi
+
+exec "${command[@]}"

--- a/packaging/docker/dev/web-entrypoint.sh
+++ b/packaging/docker/dev/web-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=packaging/docker/dev/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+ensure_runtime_dir
+print_debug_context web
+
+if ! wait_for_file "$OPENWORK_RUNTIME_ENV_FILE" 60; then
+  log_line web "timed out waiting for $OPENWORK_RUNTIME_ENV_FILE"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$OPENWORK_RUNTIME_ENV_FILE"
+
+export HOST="0.0.0.0"
+export PORT="5173"
+export VITE_ALLOWED_HOSTS="all"
+export VITE_OPENWORK_URL="http://localhost:${OPENWORK_PORT:-8787}"
+export VITE_OPENWORK_PORT="${OPENWORK_PORT:-8787}"
+export VITE_OPENWORK_TOKEN="$OPENWORK_TOKEN"
+
+log_line web "ui http://localhost:${WEB_PORT:-5173}"
+log_line web "token ${VITE_OPENWORK_TOKEN:-unset}"
+
+exec pnpm --filter @different-ai/openwork-ui exec vite \
+  --host 0.0.0.0 \
+  --port 5173 \
+  --strictPort

--- a/packaging/docker/docker-compose.dev.yml
+++ b/packaging/docker/docker-compose.dev.yml
@@ -1,204 +1,85 @@
-# docker-compose.dev.yml — Dev testability stack (no custom Dockerfile)
+# docker-compose.dev.yml — reproducible Docker dev stack
 #
 # Usage (from repo root):
-#   docker compose -f packaging/docker/docker-compose.dev.yml up
-#
-# Then open http://localhost:5173 — already wired to headless, no config needed.
+#   ./packaging/docker/dev-up.sh
 #
 # Env overrides (optional, via .env or export):
-#   OPENWORK_TOKEN        — shared client token (auto-generated if unset)
-#   OPENWORK_HOST_TOKEN   — host/admin token (auto-generated if unset)
+#   OPENWORK_TOKEN        — shared client token
+#   OPENWORK_HOST_TOKEN   — shared host/admin token
 #   OPENWORK_WORKSPACE    — host path to mount as workspace (default: ./workspace)
-#   OPENWORK_PORT         — host port to map to container :8787 (default: 8787)
-#   WEB_PORT              — host port to map to container :5173 (default: 5173)
-#   OPENWORK_DEV_ID       — unique ID for this stack (default: default)
-#   OPENWORK_DEV_MODE     — enables isolated OpenCode dev state (set by dev-up.sh)
-#   OPENWORK_DOCKER_DEV_MOUNT_HOST_OPENCODE=1 — import host OpenCode config/auth into the isolated dev state
-#   OPENWORK_OPENCODE_CONFIG_DIR      — host OpenCode config dir detection override (read by dev-up.sh)
-#   OPENWORK_OPENCODE_DATA_DIR        — host OpenCode data dir detection override (read by dev-up.sh)
-#   OPENWORK_HOST_OPENCODE_CONFIG_DIR — import source for OpenCode config (set by dev-up.sh)
-#   OPENWORK_HOST_OPENCODE_DATA_DIR   — import source for OpenCode auth/data (set by dev-up.sh)
+#   OPENWORK_PORT         — host port mapped to container :8787
+#   WEB_PORT              — host port mapped to container :5173
+#   OPENWORK_DEV_ID       — unique ID for this stack
+#   OPENWORK_RUNTIME_DIR  — host directory for runtime env + debug artifacts
+#   OPENWORK_DOCKER_DEBUG — enable verbose startup output and richer diagnostics
+#   OPENWORK_LOG_FORMAT   — pretty | json for orchestrator logs in debug mode
+#   OPENWORK_DOCKER_DEV_MOUNT_HOST_OPENCODE=1 — import host OpenCode config/auth into isolated dev state
+#   OPENWORK_OPENCODE_CONFIG_DIR      — host OpenCode config dir detection override
+#   OPENWORK_OPENCODE_DATA_DIR        — host OpenCode data dir detection override
+#   OPENWORK_HOST_OPENCODE_CONFIG_DIR — import source for OpenCode config
+#   OPENWORK_HOST_OPENCODE_DATA_DIR   — import source for OpenCode auth/data
 
-x-shared: &shared
-  image: node:22-bookworm-slim
+x-openwork-dev-image: &openwork-dev-image
+  image: ${OPENWORK_DEV_IMAGE:-openwork-dev:local}
+  build:
+    context: ../..
+    dockerfile: packaging/docker/Dockerfile.dev
+
+x-openwork-dev-env: &openwork-dev-env
+  CI: "true"
+  OPENWORK_PORT: ${OPENWORK_PORT:-8787}
+  WEB_PORT: ${WEB_PORT:-5173}
+  OPENWORK_DEV_ID: ${OPENWORK_DEV_ID:-default}
+  OPENWORK_DEV_MODE: ${OPENWORK_DEV_MODE:-1}
+  OPENWORK_DOCKER_DEBUG: ${OPENWORK_DOCKER_DEBUG:-0}
+  OPENWORK_LOG_FORMAT: ${OPENWORK_LOG_FORMAT:-pretty}
+  OPENWORK_RUNTIME_DIR: /runtime
+  OPENWORK_RUNTIME_ENV_FILE: /runtime/dev.env
+
+x-openwork-dev-service: &openwork-dev-service
+  <<: *openwork-dev-image
+  init: true
   working_dir: /app
   volumes:
-    # Mount the entire repo so both services share node_modules + source
-    - ../../:/app
-    - pnpm-store:/root/.local/share/pnpm/store
-    - bun-install:/root/.bun
     - ${OPENWORK_WORKSPACE:-./workspace}:/workspace
+    - ${OPENWORK_RUNTIME_DIR:-../../tmp/docker-dev/default}:/runtime
     - ${OPENWORK_HOST_OPENCODE_CONFIG_DIR:-./workspace/.openwork-host-opencode-config}:/persist/.config/opencode:ro
     - ${OPENWORK_HOST_OPENCODE_DATA_DIR:-./workspace/.openwork-host-opencode-data}:/persist/.openwork-host-opencode-data:ro
 
 services:
   orchestrator:
-    <<: *shared
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        set -e
-
-        # --- Ensure workspace dir is writable ---
-        mkdir -p /workspace && touch /workspace/.keep 2>/dev/null || true
-
-        # --- Install system deps ---
-        apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-          curl ca-certificates unzip git >/dev/null 2>&1
-
-        # --- Install bun (cached in named volume) ---
-        export BUN_INSTALL="/root/.bun"
-        export PATH="$$BUN_INSTALL/bin:$$PATH"
-        if ! command -v bun >/dev/null 2>&1; then
-          echo "[orchestrator] Installing bun..."
-          curl -fsSL https://bun.sh/install | bash
-        fi
-
-        # --- Enable pnpm via corepack ---
-        corepack enable && corepack prepare pnpm@10.27.0 --activate
-
-        # --- Install deps ---
-        echo "[orchestrator] Installing dependencies..."
-        pnpm install --no-frozen-lockfile --network-concurrency 1 --child-concurrency 1
-
-        # --- Build Linux binaries into container-local path ---
-        # Avoids overwriting macOS-native binaries on the host mount.
-        export OPENWORK_SERVER_BIN="/tmp/openwork-bins/openwork-server"
-        export OPENCODE_ROUTER_BIN="/tmp/openwork-bins/opencode-router"
-        mkdir -p /tmp/openwork-bins
-
-        # --- Compile sidecars for the container architecture ---
-        case "$(uname -m)" in
-          x86_64|amd64)
-            BUN_TARGET="bun-linux-x64"
-            ;;
-          aarch64|arm64)
-            BUN_TARGET="bun-linux-arm64"
-            ;;
-          *)
-            echo "Unsupported container architecture: $(uname -m)" >&2
-            exit 1
-            ;;
-        esac
-
-        echo "[orchestrator] Building openwork-server binary (linux)..."
-        cd /app/packages/server && bun build --compile --target "$$BUN_TARGET" src/cli.ts --outfile "$$OPENWORK_SERVER_BIN"
-
-        echo "[orchestrator] Building opencode-router binary (linux)..."
-        OPENCODE_ROUTER_VERSION=$$(node -p "require('/app/packages/opencode-router/package.json').version")
-        cd /app/packages/opencode-router && bun build --compile --target "$$BUN_TARGET" src/cli.ts \
-          --define "__OPENCODE_ROUTER_VERSION__=\"$${OPENCODE_ROUTER_VERSION}\"" --outfile "$$OPENCODE_ROUTER_BIN"
-
-        cd /app
-
-        # --- Resolve tokens ---
-        if [ -z "$$OPENWORK_TOKEN" ]; then
-          OPENWORK_TOKEN=$$(cat /proc/sys/kernel/random/uuid)
-          export OPENWORK_TOKEN
-        fi
-        if [ -z "$$OPENWORK_HOST_TOKEN" ]; then
-          OPENWORK_HOST_TOKEN=$$(cat /proc/sys/kernel/random/uuid)
-          export OPENWORK_HOST_TOKEN
-        fi
-
-        # Write tokens so the web service can source them
-        mkdir -p /app/tmp
-        printf 'OPENWORK_TOKEN=%s\nOPENWORK_HOST_TOKEN=%s\n' \
-          "$$OPENWORK_TOKEN" "$$OPENWORK_HOST_TOKEN" > "/app/tmp/.dev-env-${OPENWORK_DEV_ID:-default}"
-
-        echo ""
-        echo "============================================"
-        echo "  OpenWork orchestrator"
-        echo "  Server:     http://localhost:${OPENWORK_PORT:-8787}"
-        echo "  Health:     http://localhost:${OPENWORK_PORT:-8787}/health"
-        echo "  Token:      $$OPENWORK_TOKEN"
-        echo "  Host token: $$OPENWORK_HOST_TOKEN"
-        echo "============================================"
-        echo ""
-
-        exec pnpm --filter openwork-orchestrator dev -- start \
-          --workspace /workspace \
-          --openwork-host 0.0.0.0 \
-          --openwork-port 8787 \
-          --openwork-token "$$OPENWORK_TOKEN" \
-          --openwork-host-token "$$OPENWORK_HOST_TOKEN" \
-          --openwork-server-bin "$$OPENWORK_SERVER_BIN" \
-          --opencode-router-bin "$$OPENCODE_ROUTER_BIN" \
-          --approval auto \
-          --allow-external \
-          --no-opencode-auth \
-          --cors "*"
+    <<: *openwork-dev-service
+    entrypoint: ["bash", "/app/packaging/docker/dev/orchestrator-entrypoint.sh"]
     ports:
       - "${OPENWORK_PORT:-8787}:8787"
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8787/health || exit 1"]
-      interval: 5s
+      test: ["CMD-SHELL", "curl -sf http://localhost:8787/health >/dev/null || exit 1"]
+      interval: 3s
       timeout: 5s
-      retries: 30
-      start_period: 90s
+      retries: 40
+      start_period: 15s
     environment:
-      CI: "true"
+      <<: *openwork-dev-env
       OPENWORK_TOKEN: ${OPENWORK_TOKEN:-}
       OPENWORK_HOST_TOKEN: ${OPENWORK_HOST_TOKEN:-}
-      OPENWORK_DEV_ID: ${OPENWORK_DEV_ID:-default}
-      OPENWORK_DEV_MODE: ${OPENWORK_DEV_MODE:-1}
       OPENWORK_DEV_OPENCODE_IMPORT_CONFIG_DIR: /persist/.config/opencode
       OPENWORK_DEV_OPENCODE_IMPORT_DATA_DIR: /persist/.openwork-host-opencode-data
       OPENWORK_SIDECAR_SOURCE: external
- 
+      OPENWORK_VERBOSE: ${OPENWORK_VERBOSE:-0}
+
   web:
-    <<: *shared
+    <<: *openwork-dev-service
     depends_on:
       orchestrator:
         condition: service_healthy
-    entrypoint: ["/bin/sh", "-c"]
-    command:
-      - |
-        set -e
-
-        # --- Install system deps ---
-        apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-          curl ca-certificates >/dev/null 2>&1
-
-        # --- Bun + pnpm ---
-        export BUN_INSTALL="/root/.bun"
-        export PATH="$$BUN_INSTALL/bin:$$PATH"
-        if ! command -v bun >/dev/null 2>&1; then
-          curl -fsSL https://bun.sh/install | bash
-        fi
-        corepack enable && corepack prepare pnpm@10.27.0 --activate
-
-        # --- Read token written by orchestrator ---
-        if [ -f "/app/tmp/.dev-env-${OPENWORK_DEV_ID:-default}" ]; then
-          . "/app/tmp/.dev-env-${OPENWORK_DEV_ID:-default}"
-          export VITE_OPENWORK_TOKEN="$$OPENWORK_TOKEN"
-        fi
-
-        echo ""
-        echo "============================================"
-        echo "  OpenWork web UI"
-        echo "  URL:   http://localhost:${WEB_PORT:-5173}"
-        echo "  Token: $${VITE_OPENWORK_TOKEN:-<see orchestrator logs>}"
-        echo "============================================"
-        echo ""
-
-        export VITE_OPENWORK_URL="http://localhost:${OPENWORK_PORT:-8787}"
-        export VITE_OPENWORK_PORT="${OPENWORK_PORT:-8787}"
-        export VITE_ALLOWED_HOSTS="all"
-        export HOST="0.0.0.0"
-        export PORT="5173"
-
-        exec pnpm --filter @different-ai/openwork-ui exec vite \
-          --host 0.0.0.0 \
-          --port 5173 \
-          --strictPort
+    entrypoint: ["bash", "/app/packaging/docker/dev/web-entrypoint.sh"]
     ports:
       - "${WEB_PORT:-5173}:5173"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:5173/ >/dev/null || exit 1"]
+      interval: 3s
+      timeout: 5s
+      retries: 40
+      start_period: 10s
     environment:
-      OPENWORK_DEV_ID: ${OPENWORK_DEV_ID:-default}
-
-volumes:
-  pnpm-store:
-    name: openwork-dev-pnpm-store
-  bun-install:
-    name: openwork-dev-bun-install
+      <<: *openwork-dev-env

--- a/packaging/docker/docker-compose.yml
+++ b/packaging/docker/docker-compose.yml
@@ -5,7 +5,9 @@ services:
       dockerfile: Dockerfile
       args:
         # Keep this in sync with packages/orchestrator/package.json if you want a pinned release.
-        OPENWORK_ORCHESTRATOR_VERSION: 0.11.22
+        OPENWORK_ORCHESTRATOR_VERSION: 0.11.142
+    init: true
+    restart: unless-stopped
     ports:
       - "8787:8787"
     environment:


### PR DESCRIPTION
## Summary
- Replace the dev Docker stack's per-container bootstrap work with a single prebuilt `Dockerfile.dev`, lightweight entrypoint scripts, and runtime env sharing so startup is more predictable and easier to reason about.
- Add debug-mode readiness checks, metadata files, and artifact capture in `packaging/docker/dev-up.sh`, plus healthier defaults for the production compose path.
- Surface sandbox timeout diagnostics from the orchestrator and desktop app so Docker sandbox failures show inspect/log details instead of looking like a silent hang.

## Research Findings
- The old dev stack did too much work on every boot: `apt-get`, Bun install, `pnpm install`, Linux sidecar compilation, token handoff, and service startup all happened inline inside Compose commands.
- That design made container startup feel blocking and opaque, and it gave us very little state to inspect when Docker or sandbox startup went sideways.
- Sandboxes had a similar observability gap: the desktop flow could report container state, but not the inspect/log context needed to explain why a sandbox never became healthy.

## Testing
- `pnpm install --frozen-lockfile --network-concurrency 1 --child-concurrency 1`
- `pnpm --filter openwork-orchestrator typecheck`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml`
- `bash -n packaging/docker/dev-up.sh`
- `bash -n packaging/docker/dev/common.sh`
- `bash -n packaging/docker/dev/orchestrator-entrypoint.sh`
- `bash -n packaging/docker/dev/web-entrypoint.sh`
- `docker compose -f packaging/docker/docker-compose.dev.yml config`
- `docker compose -f packaging/docker/docker-compose.yml config`
- `OPENWORK_DOCKER_DEBUG=1 ./packaging/docker/dev-up.sh` *(fails in this environment with `write /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db: input/output error`; the script now exits cleanly and writes debug artifacts under `tmp/docker-dev/e34dbc2d/`)*

## Blockers
- I could not complete the end-to-end Docker + Chrome MCP validation flow because the local Docker daemon/BuildKit is unhealthy (`containerd` metadata DB I/O errors during `docker compose build`).
- I could not capture screenshots or a validation video for the same reason.

## Repro Once Docker Is Healthy
1. `OPENWORK_DOCKER_DEBUG=1 ./packaging/docker/dev-up.sh`
2. Open the printed UI URL, then create/connect a sandbox worker.
3. If startup regresses, inspect `tmp/docker-dev/<dev-id>/` and the desktop sandbox progress logs for the new `docker.diagnostics` output.