### PR TITLE
fix(app): prevent raw markdown flash during streaming responses

### DIFF
--- a/packages/app/src/app/components/part-view.tsx
+++ b/packages/app/src/app/components/part-view.tsx
@@ -334,11 +334,15 @@ const applyTextHighlights = (root: HTMLElement, query: string) => {
 function useThrottledValue<T>(value: () => T, delayMs: number | (() => number) = 80) {
   const [state, setState] = createSignal<T>(value());
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let hasEmitted = false;
 
   createEffect(() => {
     const next = value();
     const delay = typeof delayMs === "function" ? delayMs() : delayMs;
-    if (!delay) {
+    // Always apply the first non-empty value synchronously so the initial
+    // render never falls through to the raw-text fallback.
+    if (!delay || !hasEmitted) {
+      hasEmitted = true;
       setState(() => next);
       return;
     }
@@ -602,6 +606,11 @@ export default function PartView(props: Props) {
       }
 
       const html = typeof result === "string" ? result : "";
+      // If marked returned empty HTML for non-empty source, treat as a parse
+      // failure so the fallback renders plain text instead of blank space.
+      if (!html && text.trim()) {
+        return null;
+      }
       writeMarkdownCache(cacheKey, html);
       return html;
     } catch (error) {
@@ -889,23 +898,18 @@ export default function PartView(props: Props) {
             </div>
           }
         >
-          <Show
-            when={renderedMarkdown()}
-            fallback={
-              <div
-                ref={(el) => {
-                  textContainerEl = el;
-                }}
-                class={`whitespace-pre-wrap break-words ${textClass()}`.trim()}
-              >
-                {renderTextWithLinks()}
-              </div>
-            }
-          >
+          {/* null = parse error → plain text; "" = empty/pending → nothing; string = rendered HTML */}
+          <Show when={renderedMarkdown() === null}>
             <div
-              ref={(el) => {
-                textContainerEl = el;
-              }}
+              ref={(el) => { textContainerEl = el; }}
+              class={`whitespace-pre-wrap break-words ${textClass()}`.trim()}
+            >
+              {renderTextWithLinks()}
+            </div>
+          </Show>
+          <Show when={typeof renderedMarkdown() === "string" && renderedMarkdown()}>
+            <div
+              ref={(el) => { textContainerEl = el; }}
               class={`markdown-content max-w-none ${textClass()}
                 [&_strong]:font-semibold
                 [&_em]:italic


### PR DESCRIPTION
## Summary

Fixes intermittent raw markdown syntax (e.g. `**bold**`, `` `code` ``, `# headings`) flashing in assistant responses instead of properly rendered formatted text.

## Root Cause

The markdown rendering pipeline in `part-view.tsx` had a race condition:

1. **Throttle delay**: `useThrottledValue` delays markdown source updates by 80–550ms during streaming
2. **Falsy fallback**: During the delay, `renderedMarkdown()` returns `""` (empty string = falsy), causing `<Show when={renderedMarkdown()}>` to fall through to the **raw text fallback**
3. **Raw text displayed**: The fallback renders `renderTextWithLinks()` which shows unformatted markdown syntax like `**Local**:`, `**Remote**:`, triple backticks, etc.

## Fixes (3 changes in `part-view.tsx`)

### 1. `useThrottledValue`: Synchronous first emission
The first value is now always applied synchronously (no delay), so the component never starts in the raw-text fallback state.

### 2. Rendering fallback: Show nothing instead of raw text
Replaced the nested `<Show when={renderedMarkdown()} fallback={rawText}>` with explicit state handling:
- `null` → markdown parse **failed** → fall back to plain text (graceful degradation)
- `""` → source is empty or throttle delay in progress → render **nothing** (no flash)
- non-empty string → rendered HTML → display formatted markdown

### 3. Edge case: Empty HTML from `marked.parse`
If `marked.parse` returns an empty string for non-empty source text, treat it as a parse failure (`null`) so the fallback renders plain text instead of blank space.

## Testing

- `vite build` passes successfully
- No TypeScript errors
- SolidJS reactivity preserved (uses `<Show>` components, not IIFEs)