### PR TITLE
fix(mcp): seed Control Chrome as chrome-devtools

### DIFF
--- a/.opencode/skills/browser-setup-devtools/SKILL.md
+++ b/.opencode/skills/browser-setup-devtools/SKILL.md
@@ -24,7 +24,7 @@ description: Guide users through browser automation setup using Chrome DevTools 
 4. If DevTools MCP calls fail:
    - Ask the user to open Chrome and keep it running.
    - Retry `chrome-devtools_list_pages`.
-   - If it still fails, ensure `opencode.jsonc` includes `mcp.control-chrome` with command `['chrome-devtools-mcp']` and ask the user to restart OpenWork/OpenCode.
+   - If it still fails, ensure `opencode.jsonc` includes `mcp["chrome-devtools"]` with command `['npx', '-y', 'chrome-devtools-mcp@latest']` and ask the user to restart OpenWork/OpenCode.
    - Retry the DevTools MCP check.
 5. If DevTools MCP is ready:
    - Offer a first task ("Let's try opening a webpage").

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4566,7 +4566,7 @@ export default function App() {
       return;
     }
 
-    const slug = entry.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    const slug = entry.id ?? entry.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 
     try {
       setMcpStatus(null);

--- a/packages/app/src/app/constants.ts
+++ b/packages/app/src/app/constants.ts
@@ -24,6 +24,7 @@ export const SUGGESTED_PLUGINS: SuggestedPlugin[] = [
 ];
 
 export type McpDirectoryInfo = {
+  id?: string;
   name: string;
   description: string;
   url?: string;
@@ -69,10 +70,11 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     oauth: false,
   },
   {
+    id: "chrome-devtools",
     name: "Control Chrome",
     description: "Drive Chrome tabs with browser automation.",
     type: "local",
-    command: ["chrome-devtools-mcp"],
+    command: ["npx", "-y", "chrome-devtools-mcp@latest"],
     oauth: false,
   },
 ];

--- a/packages/desktop/scripts/chrome-devtools-mcp-shim.ts
+++ b/packages/desktop/scripts/chrome-devtools-mcp-shim.ts
@@ -21,7 +21,7 @@ child.on("error", (error) => {
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes("ENOENT")) {
     console.error(
-      "Control Chrome requires npm (Node.js). Install Node.js or configure mcp.control-chrome.command to a local chrome-devtools-mcp binary."
+      "Control Chrome requires npm (Node.js). Install Node.js or configure mcp.chrome-devtools.command to a local chrome-devtools-mcp binary."
     );
   } else {
     console.error(`Failed to start chrome-devtools-mcp via npm exec: ${message}`);

--- a/packages/desktop/src-tauri/src/workspace/files.rs
+++ b/packages/desktop/src-tauri/src/workspace/files.rs
@@ -511,12 +511,12 @@ pub fn ensure_workspace_files(workspace_path: &str, preset: &str) -> Result<(), 
                 _ => serde_json::Map::new(),
             };
 
-            if !mcp_obj.contains_key("control-chrome") {
+            if !mcp_obj.contains_key("chrome-devtools") {
                 mcp_obj.insert(
-                    "control-chrome".to_string(),
+                    "chrome-devtools".to_string(),
                     serde_json::json!({
                       "type": "local",
-                      "command": ["chrome-devtools-mcp"]
+                      "command": ["npx", "-y", "chrome-devtools-mcp@latest"]
                     }),
                 );
                 config_changed = true;


### PR DESCRIPTION
## Summary
- switch the Control Chrome quick-connect entry to write the canonical \
  `chrome-devtools` MCP key with the local `npx -y chrome-devtools-mcp@latest` command
- keep the UI label as Control Chrome while ensuring seeded workspace config and docs match the actual MCP name
- update the desktop fallback messaging to point at `mcp.chrome-devtools.command`

## Verification
- `pnpm install`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml`
- served the web app locally and confirmed `http://localhost:5173` returned `HTTP/1.1 200 OK`

## Notes
- full Chrome MCP UI verification was blocked in this environment because the browser broker socket and Google Chrome stable were unavailable