### PR TITLE
feat(landing): wire enterprise contact flow to Loops

### DIFF
--- a/packages/landing/app/api/enterprise-contact/route.ts
+++ b/packages/landing/app/api/enterprise-contact/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from "next/server";
+
+type ContactPayload = {
+  fullName?: string;
+  companyEmail?: string;
+  message?: string;
+};
+
+const LOOPS_CONTACTS_API_URL = "https://app.loops.so/api/v1/contacts/update";
+const LOOPS_EVENTS_API_URL = "https://app.loops.so/api/v1/events/send";
+const ENTERPRISE_EVENT_NAME = "enterpriseContactSubmitted";
+const ENTERPRISE_SOURCE = "OpenWork Enterprise Contact Form";
+const ENTERPRISE_GROUP = "Enterprise Leads";
+
+function splitName(fullName: string) {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return { firstName: "", lastName: "" };
+  }
+
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" ")
+  };
+}
+
+function validatePayload(payload: ContactPayload) {
+  const fullName = payload.fullName?.trim() ?? "";
+  const companyEmail = payload.companyEmail?.trim() ?? "";
+  const message = payload.message?.trim() ?? "";
+
+  if (!fullName || !companyEmail || !message) {
+    return { error: "Please fill out all fields." };
+  }
+
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailPattern.test(companyEmail)) {
+    return { error: "Please enter a valid work email." };
+  }
+
+  return {
+    fullName,
+    companyEmail,
+    message
+  };
+}
+
+function deriveCompanyFromEmail(email: string) {
+  const domain = email.split("@")[1]?.toLowerCase() ?? "";
+  if (!domain) {
+    return "";
+  }
+
+  const parts = domain.split(".").filter(Boolean);
+  if (parts.length === 0) {
+    return "";
+  }
+
+  const compoundSuffixes = new Set([
+    "co.uk",
+    "com.au",
+    "co.jp",
+    "com.br",
+    "co.in",
+    "com.sg",
+    "com.mx",
+    "com.tr"
+  ]);
+
+  const suffix = parts.slice(-2).join(".");
+  const baseIndex =
+    parts.length >= 3 && compoundSuffixes.has(suffix)
+      ? parts.length - 3
+      : parts.length - 2;
+  const companySlug = parts[Math.max(baseIndex, 0)] ?? "";
+
+  return companySlug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export async function POST(request: Request) {
+  const apiKey = process.env.LOOPS_API_KEY?.trim();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "Loops is not configured on this deployment." },
+      { status: 500 }
+    );
+  }
+
+  let payload: ContactPayload;
+  try {
+    payload = (await request.json()) as ContactPayload;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request payload." },
+      { status: 400 }
+    );
+  }
+
+  const validated = validatePayload(payload);
+  if ("error" in validated) {
+    return NextResponse.json({ error: validated.error }, { status: 400 });
+  }
+
+  const { firstName, lastName } = splitName(validated.fullName);
+  const company = deriveCompanyFromEmail(validated.companyEmail);
+  const submittedAt = new Date().toISOString();
+
+  const contactResponse = await fetch(LOOPS_CONTACTS_API_URL, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      email: validated.companyEmail,
+      firstName,
+      lastName: lastName || undefined,
+      company: company || undefined,
+      notes: validated.message,
+      source: ENTERPRISE_SOURCE,
+      userGroup: ENTERPRISE_GROUP
+    }),
+    cache: "no-store"
+  });
+
+  if (!contactResponse.ok) {
+    let detail = "Failed to submit contact request.";
+
+    try {
+      const errorData = (await contactResponse.json()) as { message?: string };
+      if (errorData.message?.trim()) {
+        detail = errorData.message;
+      }
+    } catch {
+      // Ignore invalid error payloads from upstream and return a generic message.
+    }
+
+    return NextResponse.json({ error: detail }, { status: 502 });
+  }
+
+  const eventResponse = await fetch(LOOPS_EVENTS_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      email: validated.companyEmail,
+      eventName: ENTERPRISE_EVENT_NAME,
+      firstName,
+      lastName: lastName || undefined,
+      source: ENTERPRISE_SOURCE,
+      userGroup: ENTERPRISE_GROUP,
+      eventProperties: {
+        message: validated.message,
+        fullName: validated.fullName,
+        submittedAt,
+        page: "enterprise",
+        note: validated.message
+      }
+    }),
+    cache: "no-store"
+  });
+
+  if (!eventResponse.ok) {
+    let detail = "Failed to record contact event.";
+
+    try {
+      const errorData = (await eventResponse.json()) as { message?: string };
+      if (errorData.message?.trim()) {
+        detail = errorData.message;
+      }
+    } catch {
+      // Ignore invalid error payloads from upstream and return a generic message.
+    }
+
+    return NextResponse.json({ error: detail }, { status: 502 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/packages/landing/components/book-call-form.tsx
+++ b/packages/landing/components/book-call-form.tsx
@@ -1,153 +1,173 @@
 "use client";
 
-import { Cloud, LockKeyhole, ShieldCheck } from "lucide-react";
-import { useMemo, useState } from "react";
+import { Mail } from "lucide-react";
+import { useEffect, useState } from "react";
 
-type Props = {
-  calUrl: string;
+type FormState = "idle" | "loading" | "success" | "error";
+
+type FormFields = {
+  fullName: string;
+  companyEmail: string;
+  message: string;
 };
 
-const conversationTopics = [
-  {
-    title: "Secure hosting model",
-    icon: LockKeyhole
-  },
-  {
-    title: "Permission boundaries",
-    icon: ShieldCheck
-  },
-  {
-    title: "Hosted worker rollout",
-    icon: Cloud
-  }
-];
-
-const buildCalUrl = (baseUrl: string, params: Record<string, string>) => {
-  try {
-    const url = new URL(baseUrl);
-    for (const [key, value] of Object.entries(params)) {
-      if (!value) continue;
-      url.searchParams.set(key, value);
-    }
-    return url.toString();
-  } catch {
-    return baseUrl;
-  }
+const initialFields: FormFields = {
+  fullName: "",
+  companyEmail: "",
+  message: ""
 };
 
-export function BookCallForm(props: Props) {
-  const [email, setEmail] = useState("");
-  const [company, setCompany] = useState("");
+export function BookCallForm() {
+  const [fields, setFields] = useState<FormFields>(initialFields);
+  const [state, setState] = useState<FormState>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [hydrated, setHydrated] = useState(false);
 
-  const href = useMemo(
-    () => {
-      if (!props.calUrl) return "";
-      return buildCalUrl(props.calUrl, {
-        email,
-        company
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  const setField = (key: keyof FormFields, value: string) => {
+    setFields(current => ({ ...current, [key]: value }));
+  };
+
+  const reset = () => {
+    setFields(initialFields);
+    setState("idle");
+    setErrorMsg("");
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setState("loading");
+    setErrorMsg("");
+
+    try {
+      const response = await fetch("/api/enterprise-contact", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(fields)
       });
-    },
-    [props.calUrl, email, company]
-  );
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        setState("error");
+        setErrorMsg(
+          data?.error ?? "Something went wrong. Please try again."
+        );
+        return;
+      }
+
+      setState("success");
+      setFields(initialFields);
+    } catch (error) {
+      setState("error");
+      setErrorMsg(
+        error instanceof Error
+          ? error.message
+          : "Something went wrong. Please try again."
+      );
+    }
+  };
 
   return (
     <section id="book" className="landing-shell rounded-[2rem] p-6 md:p-8">
-      <div className="mb-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
-        Book a call
-      </div>
-      <h3 className="mb-3 text-2xl font-medium tracking-tight text-[#011627]">
-        Let us know how we can help.
-      </h3>
-      <p className="mb-6 max-w-2xl text-[15px] leading-relaxed text-slate-600">
-        Share your team context and we&apos;ll route you into the right rollout
-        path. You&apos;ll finish the details on the booking page.
-      </p>
-
-      <div className="mb-6 rounded-[1.5rem] border border-slate-200/70 bg-white/80 p-4 shadow-sm md:p-5">
-        <div className="text-[12px] font-semibold uppercase tracking-[0.2em] text-slate-400">
-          Typical conversations
+      <div className="rounded-[1.5rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm md:p-6">
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-slate-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+          <Mail size={12} />
+          Get in touch with us
         </div>
-        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {conversationTopics.map((topic) => {
-            const Icon = topic.icon;
+        <h3 className="mb-3 text-2xl font-medium tracking-tight text-[#011627]">
+          Tell us what you need.
+        </h3>
+        <p className="mb-6 max-w-2xl text-[15px] leading-relaxed text-slate-600">
+          Share your team context and we&apos;ll get back to you over email.
+        </p>
 
-            return (
-              <div
-                key={topic.title}
-                className="flex items-center gap-3 rounded-2xl border border-slate-200/70 bg-slate-50/80 px-4 py-3.5"
-              >
-                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-[#011627] shadow-inner">
-                  <Icon size={16} />
-                </div>
-                <div className="text-[13px] font-medium leading-snug text-slate-600 sm:text-[14px]">
-                  {topic.title}
-                </div>
+        {state === "success" ? (
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 text-[14px] leading-relaxed text-emerald-800">
+            Thanks. We&apos;ve got your note and will follow up soon.
+            <button
+              type="button"
+              onClick={reset}
+              className="mt-3 block text-[13px] font-medium text-emerald-700 transition hover:text-emerald-900"
+            >
+              Send another message
+            </button>
+          </div>
+        ) : (
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className="mb-2 block text-[12px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  Full name
+                </label>
+                <input
+                  value={fields.fullName}
+                  onChange={event => setField("fullName", event.target.value)}
+                  placeholder="Jeff Bezos"
+                  className="w-full rounded-2xl border border-slate-200 bg-white/90 px-4 py-3 text-[14px] text-[#011627] outline-none transition focus:border-slate-300 focus:bg-white"
+                  autoComplete="name"
+                  required
+                  type="text"
+                  disabled={state === "loading"}
+                />
               </div>
-            );
-          })}
-        </div>
-      </div>
-
-      <form
-        className="space-y-4"
-        onSubmit={event => {
-          event.preventDefault();
-          if (!href) return;
-          window.open(href, "_blank", "noopener,noreferrer");
-        }}
-      >
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.85fr)_auto_auto] lg:items-end">
-          <div>
-            <label className="mb-2 block text-[12px] font-semibold uppercase tracking-[0.16em] text-slate-500">
-              Company email
-            </label>
-            <input
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              placeholder="jeff@amazon.com"
-              className="w-full rounded-2xl border border-slate-200 bg-white/90 px-4 py-3 text-[14px] text-[#011627] outline-none transition focus:border-slate-300 focus:bg-white"
-              autoComplete="email"
-              type="email"
-            />
-          </div>
-          <div>
-            <label className="mb-2 block text-[12px] font-semibold uppercase tracking-[0.16em] text-slate-500">
-              Company
-            </label>
-            <input
-              value={company}
-              onChange={e => setCompany(e.target.value)}
-              placeholder="Amazon"
-              className="w-full rounded-2xl border border-slate-200 bg-white/90 px-4 py-3 text-[14px] text-[#011627] outline-none transition focus:border-slate-300 focus:bg-white"
-              autoComplete="organization"
-            />
-          </div>
-          {props.calUrl ? (
-            <>
-              <a
-                href={props.calUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex h-[52px] items-center justify-center whitespace-nowrap px-3 text-[13px] font-medium text-slate-400 transition hover:text-[#011627] lg:self-end"
-              >
-                Open booking link
-              </a>
-              <button
-                type="submit"
-                className="doc-button w-full lg:w-auto lg:self-end"
-              >
-                Book a call
-              </button>
-            </>
-          ) : (
-            <div className="lg:col-span-2">
-              <div className="rounded-2xl border border-slate-200/70 bg-slate-50/80 p-4 text-[13px] text-slate-500">
-                Cal link not set yet.
+              <div>
+                <label className="mb-2 block text-[12px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  Company email
+                </label>
+                <input
+                  value={fields.companyEmail}
+                  onChange={event =>
+                    setField("companyEmail", event.target.value)
+                  }
+                  placeholder="jeff@amazon.com"
+                  className="w-full rounded-2xl border border-slate-200 bg-white/90 px-4 py-3 text-[14px] text-[#011627] outline-none transition focus:border-slate-300 focus:bg-white"
+                  autoComplete="email"
+                  required
+                  type="email"
+                  disabled={state === "loading"}
+                />
               </div>
             </div>
-          )}
-        </div>
-      </form>
+
+            <div>
+              <label className="mb-2 block text-[12px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                How can we help?
+              </label>
+              <textarea
+                value={fields.message}
+                onChange={event => setField("message", event.target.value)}
+                placeholder="Share more about what you want to accomplish"
+                className="min-h-[160px] w-full rounded-2xl border border-slate-200 bg-white/90 px-4 py-3 text-[14px] text-[#011627] outline-none transition focus:border-slate-300 focus:bg-white"
+                required
+                disabled={state === "loading"}
+              />
+            </div>
+
+            {state === "error" ? (
+              <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-[13px] leading-relaxed text-red-700">
+                {errorMsg}
+              </div>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={!hydrated || state === "loading"}
+              className="doc-button w-full sm:w-auto disabled:opacity-60"
+            >
+              {!hydrated
+                ? "Loading..."
+                : state === "loading"
+                  ? "Sending..."
+                  : "Get in touch"}
+            </button>
+          </form>
+        )}
+      </div>
     </section>
   );
 }

--- a/packages/landing/components/landing-enterprise.tsx
+++ b/packages/landing/components/landing-enterprise.tsx
@@ -1,15 +1,11 @@
-import Link from "next/link";
 import {
-  ArrowRight,
-  Cloud,
-  LockKeyhole,
+  PlugZap,
   Rocket,
-  Sparkles,
-  Workflow
+  ShieldCheck,
+  Users
 } from "lucide-react";
 import { BookCallForm } from "./book-call-form";
 import { LandingBackground } from "./landing-background";
-import { OpenCodeLogo } from "./opencode-logo";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
 
@@ -21,29 +17,29 @@ type Props = {
 
 const deploymentModes = [
   {
-    title: "Desktop-hosted app/server",
+    title: "Easy for every team",
     description:
-      "Start local-first with approvals, existing skills, and the same control surface your operators already use.",
-    icon: LockKeyhole
+      "Give nontechnical users a desktop app they can install quickly and use without learning developer tools.",
+    icon: Users
   },
   {
-    title: "CLI-hosted server",
+    title: "Preconfigured environment",
     description:
-      "Run OpenWork server surfaces from a trusted machine without inventing a parallel control plane.",
-    icon: Workflow
+      "Start with your gateway, MCP servers, skills, and internal data sources already connected.",
+    icon: PlugZap
   },
   {
-    title: "Hosted OpenWork Cloud",
+    title: "Guardrails built in",
     description:
-      "Move the same workflows into hosted workers when a team needs always-on execution and managed isolation.",
-    icon: Cloud
+      "Set permissions, tool boundaries, and approved workflows so teams can use agentic workflows safely.",
+    icon: ShieldCheck
   }
 ];
 
 const rolloutSteps = [
-  "Map the workflows your team wants to automate first.",
-  "Set clear boundaries for workers, approvals, and access levels.",
-  "Pilot with one team, then expand into hosted workers or shared skills."
+  "Start with one workflow that has a clear owner.",
+  "Run it through your approved gateway with permissions in place.",
+  "Package what works into shared skills for broader rollout."
 ];
 
 export function LandingEnterprise(props: Props) {
@@ -68,116 +64,115 @@ export function LandingEnterprise(props: Props) {
             </div>
 
             <h1 className="mb-6 text-4xl font-medium leading-[1.05] tracking-tight md:text-5xl lg:text-6xl">
-              Safe, permissioned{" "}
-              <span className="font-pixel mx-1 inline-block align-middle text-[1.05em] font-normal">
-                AI
-              </span>
-              employees for real teams.
+              Secure, permissioned agentic workflows for enterprise teams.
             </h1>
 
             <p className="max-w-3xl text-lg leading-relaxed text-slate-600 md:text-xl">
-              OpenWork runs local-first and scales into hosted workers when you
-              need them. We help teams deploy the same agent workflows with
-              clear permissions, auditable behavior, and a rollout path that
-              non-technical coworkers can actually use.
+              Run agentic workflows through your existing gateway, with
+              approved tools, clear permissions, and a rollout path your
+              non-technical teams can actually use.
             </p>
 
             <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
-              <Link href="#book" className="doc-button">
-                Book a call
-              </Link>
-              <Link
-                href="/den"
-                className="secondary-button"
+              <a
+                href={props.calUrl || "#book"}
+                target={props.calUrl ? "_blank" : undefined}
+                rel={props.calUrl ? "noreferrer" : undefined}
+                className="doc-button"
               >
-                Explore Den
-              </Link>
-            </div>
+                Book a call
+              </a>
 
-            <div className="mt-8 flex flex-wrap items-center gap-3 text-[13px] text-slate-500">
-              <div className="landing-chip inline-flex items-center gap-2 rounded-full px-3 py-2">
-                <OpenCodeLogo className="h-3 w-auto" />
-                <span>Built on OpenCode primitives</span>
-              </div>
-              <div className="landing-chip inline-flex items-center gap-2 rounded-full px-3 py-2">
-                <Sparkles size={14} className="text-sky-600" />
-                <span>Local-first or hosted</span>
-              </div>
-              <div className="landing-chip inline-flex items-center gap-2 rounded-full px-3 py-2">
-                <LockKeyhole size={14} className="text-emerald-600" />
-                <span>Clear approvals and boundaries</span>
+              <div className="flex items-center gap-2 opacity-80 sm:ml-4">
+                <span className="text-[13px] font-medium text-gray-500">
+                  Backed by
+                </span>
+                <div className="flex items-center gap-1.5">
+                  <div className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] bg-[#ff6600] text-[11px] font-bold leading-none text-white">
+                    Y
+                  </div>
+                  <span className="text-[13px] font-semibold tracking-tight text-gray-600">
+                    Combinator
+                  </span>
+                </div>
               </div>
             </div>
           </section>
 
           <section className="space-y-6">
-              <div className="grid gap-6 md:grid-cols-3">
-                {deploymentModes.map(mode => {
-                  const Icon = mode.icon;
-
-                  return (
+            <div className="landing-shell rounded-[2rem] p-6 md:p-8">
+              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-700">
+                <Rocket size={12} />
+                Pilot and rollout
+              </div>
+              <div className="grid gap-4 md:grid-cols-[1.1fr_0.9fr]">
+                <div>
+                  <h3 className="mb-3 text-2xl font-medium tracking-tight text-[#011627]">
+                    Start with one workflow. Expand once it works.
+                  </h3>
+                  <p className="text-[15px] leading-relaxed text-slate-600">
+                    Most teams should begin with a focused use case, one
+                    approved path to data, and clear guardrails. Once the
+                    workflow works, it can be packaged and rolled out more
+                    broadly.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  {rolloutSteps.map((step, index) => (
                     <div
-                      key={mode.title}
-                      className="landing-shell rounded-[2rem] p-6"
+                      key={step}
+                      className="flex gap-3 rounded-2xl border border-slate-200/70 bg-white/85 px-4 py-4 shadow-sm"
                     >
-                      <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-100 text-[#011627] shadow-inner">
-                        <Icon size={18} />
-                      </div>
-                      <h3 className="mb-2 text-[17px] font-medium tracking-tight text-[#011627]">
-                        {mode.title}
-                      </h3>
+                      <div className="step-circle shrink-0">{index + 1}</div>
                       <p className="text-[14px] leading-relaxed text-slate-600">
-                        {mode.description}
+                        {step}
                       </p>
                     </div>
-                  );
-                })}
-              </div>
-
-              <div className="landing-shell rounded-[2rem] p-6 md:p-8">
-                <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-700">
-                  <Rocket size={12} />
-                  Rollout pattern
+                  ))}
                 </div>
-                <div className="grid gap-4 md:grid-cols-[1.1fr_0.9fr]">
-                  <div>
-                    <h3 className="mb-3 text-2xl font-medium tracking-tight text-[#011627]">
-                      Start with the workflows that already matter.
+              </div>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-3">
+              {deploymentModes.map(mode => {
+                const Icon = mode.icon;
+
+                return (
+                  <div
+                    key={mode.title}
+                    className="landing-shell rounded-[2rem] p-6"
+                  >
+                    <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-100 text-[#011627] shadow-inner">
+                      <Icon size={18} />
+                    </div>
+                    <h3 className="mb-2 text-[17px] font-medium tracking-tight text-[#011627]">
+                      {mode.title}
                     </h3>
-                    <p className="text-[15px] leading-relaxed text-slate-600">
-                      Most teams should begin with one approval-sensitive
-                      worker, one shared skill set, and one concrete business
-                      process. Once that path is safe and legible, the same
-                      model extends into OpenWork Cloud and Den.
+                    <p className="text-[14px] leading-relaxed text-slate-600">
+                      {mode.description}
                     </p>
                   </div>
-                  <div className="space-y-3">
-                    {rolloutSteps.map((step, index) => (
-                      <div
-                        key={step}
-                        className="flex gap-3 rounded-2xl border border-slate-200/70 bg-white/85 px-4 py-4 shadow-sm"
-                      >
-                        <div className="step-circle shrink-0">{index + 1}</div>
-                        <p className="text-[14px] leading-relaxed text-slate-600">
-                          {step}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                );
+              })}
+            </div>
 
-                <div className="mt-6 inline-flex items-center gap-2 text-[14px] font-medium text-slate-600">
-                  <Link
-                    href="/den"
-                    className="inline-flex items-center gap-2 transition-colors hover:text-[#011627]"
-                  >
-                    Hosted workers continue into Den
-                    <ArrowRight size={14} />
-                  </Link>
-                </div>
+            <div className="landing-shell rounded-[2rem] p-6 md:p-8">
+              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">
+                <ShieldCheck size={12} />
+                Information security
               </div>
+              <h3 className="mb-3 text-2xl font-medium tracking-tight text-[#011627]">
+                Compliance-ready agentic workflows
+              </h3>
+              <p className="max-w-3xl text-[15px] leading-relaxed text-slate-600">
+                OpenWork helps organizations run agentic workflows with a
+                local-first, permission-aware architecture built for privacy,
+                access control, and deployment flexibility across HIPAA, SOC 2
+                Type II, ISO 27001, CCPA, and GDPR-sensitive environments.
+              </p>
+            </div>
 
-            <BookCallForm calUrl={props.calUrl} />
+            <BookCallForm />
           </section>
 
           <SiteFooter />


### PR DESCRIPTION
## Summary
- replace the enterprise CTA booking stub with a real contact form flow
- add a landing API route that upserts Loops contacts and emits the  event
- prevent pre-hydration native form submits so the success state is shown reliably in dev

## Testing
-  (from )
- local  returned 
- verified a submitted test email appears in Loops Contacts and the event appears in Loops Events

## Notes
-  is derived from the company email domain so the form does not ask for another field
- Loops config is expected via  in  or deployment env