### PR TITLE
fix(app): improve skill sharing and hot-reload flows

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1189,6 +1189,11 @@ export default function App() {
     goToDashboard("settings");
   };
 
+  let markReloadRequiredHandler: ((reason: ReloadReason, trigger?: ReloadTrigger) => void) | undefined;
+  const markReloadRequired = (reason: ReloadReason, trigger?: ReloadTrigger) => {
+    markReloadRequiredHandler?.(reason, trigger);
+  };
+
   const sessionStore = createSessionStore({
     client,
     activeWorkspaceRoot: () => workspaceStore.activeWorkspaceRoot().trim(),
@@ -1211,6 +1216,7 @@ export default function App() {
     developerMode,
     setError,
     setSseConnected,
+    markReloadRequired,
     onHotReloadApplied: () => {
       void refreshSkills({ force: true });
       void refreshPlugins(pluginScope());
@@ -2366,6 +2372,7 @@ export default function App() {
     setBusyLabel,
     setBusyStartedAt,
     setError,
+    markReloadRequired,
     onNotionSkillInstalled: () => {
       setNotionSkillInstalled(true);
       try {
@@ -3744,9 +3751,13 @@ export default function App() {
   });
 
   const {
+    reloadRequired,
+    reloadCopy,
+    reloadTrigger,
     reloadBusy,
     reloadError,
     reloadWorkspaceEngine,
+    clearReloadRequired,
     cacheRepairBusy,
     cacheRepairResult,
     repairOpencodeCache,
@@ -3777,6 +3788,8 @@ export default function App() {
     confirmReset,
     anyActiveRuns,
   } = systemState;
+
+  markReloadRequiredHandler = systemState.markReloadRequired;
 
   const UPDATE_AUTO_CHECK_EVERY_MS = 12 * 60 * 60_000;
   const UPDATE_AUTO_CHECK_POLL_MS = 60_000;
@@ -3884,7 +3897,7 @@ export default function App() {
     await reloadWorkspaceEngine();
   };
 
-  const activeMcpBlockingSessions = createMemo(() => {
+  const activeReloadBlockingSessions = createMemo(() => {
     const statuses = sessionStatusById();
     return sessions()
       .filter((session) => statuses[session.id] === "running")
@@ -3894,11 +3907,16 @@ export default function App() {
       }));
   });
 
-  const markReloadRequired = (
-    _reason: ReloadReason,
-    _options?: { force?: boolean; trigger?: ReloadTrigger },
-  ) => {
-    return;
+  const forceStopActiveSessionsAndReload = async () => {
+    const activeSessions = activeReloadBlockingSessions();
+    for (const session of activeSessions) {
+      try {
+        await abortSession(session.id);
+      } catch {
+        // ignore and continue stopping the rest before reload
+      }
+    }
+    await reloadWorkspaceEngineAndResume();
   };
 
   onMount(() => {
@@ -5447,9 +5465,7 @@ export default function App() {
           await openworkClient.patchConfig(openworkWorkspaceId, {
             opencode: { model: formatModelRef(nextModel) },
           });
-          markReloadRequired("config", {
-            trigger: { type: "config", name: "opencode.json", action: "updated" },
-          });
+          markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
           return;
         }
 
@@ -5463,9 +5479,7 @@ export default function App() {
           throw new Error(result.stderr || result.stdout || "Failed to update opencode.json");
         }
         setLastKnownConfigSnapshot(getConfigSnapshot(content));
-        markReloadRequired("config", {
-          trigger: { type: "config", name: "opencode.json", action: "updated" },
-        });
+        markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
       } catch (error) {
         if (cancelled) return;
         const message = error instanceof Error ? error.message : safeStringify(error);
@@ -6193,6 +6207,17 @@ export default function App() {
     mcpStatus: mcpStatus(),
     skills: skills(),
     skillsStatus: skillsStatus(),
+    showSkillReloadBanner: reloadRequired() && reloadTrigger()?.type === "skill",
+    reloadBannerTitle: reloadCopy().title,
+    reloadBannerBody: reloadCopy().body,
+    reloadBannerBlocked: activeReloadBlockingSessions().length > 0,
+    reloadBannerActiveCount: activeReloadBlockingSessions().length,
+    canReloadWorkspace: canReloadWorkspace(),
+    reloadWorkspaceEngine: reloadWorkspaceEngineAndResume,
+    forceStopActiveConversations: forceStopActiveSessionsAndReload,
+    dismissReloadBanner: clearReloadRequired,
+    reloadBusy: reloadBusy(),
+    reloadError: reloadError(),
     createSessionAndOpen: createSessionAndOpen,
     sendPromptAsync: sendPrompt,
     abortSession: abortSession,
@@ -6446,8 +6471,8 @@ export default function App() {
         projectDir={workspaceProjectDir()}
         language={currentLocale()}
         reloadRequired={mcpAuthNeedsReload()}
-        reloadBlocked={activeMcpBlockingSessions().length > 0}
-        activeSessions={activeMcpBlockingSessions()}
+        reloadBlocked={activeReloadBlockingSessions().length > 0}
+        activeSessions={activeReloadBlockingSessions()}
         isRemoteWorkspace={activeWorkspaceDisplay().workspaceType === "remote"}
         onForceStopSession={(sessionID) => abortSession(sessionID)}
         onClose={() => {

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -510,7 +510,7 @@ export default function Composer(props: ComposerProps) {
   const [slashQuery, setSlashQuery] = createSignal("");
   const [slashIndex, setSlashIndex] = createSignal(0);
   const [slashCommands, setSlashCommands] = createSignal<SlashCommandOption[]>([]);
-  const [slashLoaded, setSlashLoaded] = createSignal(false);
+  const [slashLoading, setSlashLoading] = createSignal(false);
 
   onMount(() => {
     queueMicrotask(() => focusEditorEnd());
@@ -889,14 +889,16 @@ export default function Composer(props: ComposerProps) {
     setSlashIndex(0);
   });
 
-  // Fetch commands when slash popup opens for the first time
+  // Refresh commands each time the slash picker opens so hot-reloaded skills
+  // and commands become selectable without restarting the session view.
   createEffect(() => {
-    if (!slashOpen() || slashLoaded()) return;
+    if (!slashOpen()) return;
+    setSlashLoading(true);
     props
       .listCommands()
       .then((commands) => setSlashCommands(commands))
       .catch(() => setSlashCommands([]))
-      .finally(() => setSlashLoaded(true));
+      .finally(() => setSlashLoading(false));
   });
 
   // If the editor contains an exact /command (no spaces), auto-convert it into a styled chip.
@@ -1619,7 +1621,7 @@ export default function Composer(props: ComposerProps) {
                     when={slashFiltered().length}
                     fallback={
                       <div class="px-3 py-2 text-xs text-gray-10">
-                        {slashLoaded() ? "No commands found." : "Loading commands..."}
+                        {slashLoading() ? "Loading commands..." : "No commands found."}
                       </div>
                     }
                   >

--- a/packages/app/src/app/components/share-workspace-modal.tsx
+++ b/packages/app/src/app/components/share-workspace-modal.tsx
@@ -25,6 +25,7 @@ export default function ShareWorkspaceModal(props: {
   shareWorkspaceProfileError?: string | null;
   shareWorkspaceProfileDisabledReason?: string | null;
   onShareSkillsSet?: () => void;
+  onOpenSingleSkillShare?: () => void;
   shareSkillsSetBusy?: boolean;
   shareSkillsSetUrl?: string | null;
   shareSkillsSetError?: string | null;
@@ -306,13 +307,22 @@ export default function ShareWorkspaceModal(props: {
                   <Show 
                     when={props.shareSkillsSetUrl?.trim()} 
                     fallback={
-                      <button
-                        onClick={() => props.onShareSkillsSet?.()}
-                        disabled={Boolean(props.shareSkillsSetDisabledReason) || !props.onShareSkillsSet || props.shareSkillsSetBusy}
-                        class="w-full py-2.5 bg-gray-2 hover:bg-gray-3 text-gray-12 text-[13px] font-bold rounded-xl transition-all disabled:opacity-50"
-                      >
-                        {props.shareSkillsSetBusy ? "Publishing..." : "Create Skill Link"}
-                      </button>
+                      <div class="space-y-2">
+                        <button
+                          onClick={() => props.onShareSkillsSet?.()}
+                          disabled={Boolean(props.shareSkillsSetDisabledReason) || !props.onShareSkillsSet || props.shareSkillsSetBusy}
+                          class="w-full py-2.5 bg-gray-2 hover:bg-gray-3 text-gray-12 text-[13px] font-bold rounded-xl transition-all disabled:opacity-50"
+                        >
+                          {props.shareSkillsSetBusy ? "Publishing..." : "Create Skill Link"}
+                        </button>
+                        <button
+                          onClick={() => props.onOpenSingleSkillShare?.()}
+                          disabled={!props.onOpenSingleSkillShare}
+                          class="w-full py-2.5 bg-gray-1 border border-gray-6 hover:bg-gray-2 text-gray-11 hover:text-gray-12 text-[13px] font-bold rounded-xl transition-all disabled:opacity-50"
+                        >
+                          Share Single Skill
+                        </button>
+                      </div>
                     }
                   >
                     <div class="flex items-center gap-2 animate-in fade-in zoom-in-95 duration-200">

--- a/packages/app/src/app/data/skill-creator.md
+++ b/packages/app/src/app/data/skill-creator.md
@@ -11,6 +11,12 @@ This skill is a template + checklist for creating skills in a workspace.
 
 A skill is a folder under `.opencode/skills/<skill-name>/` or `.claude/skills/<skill-name>/` anchored by `SKILL.md`.
 
+## OpenWork behavior
+
+- In OpenWork, prefer creating the skill at `.opencode/skills/<skill-name>/SKILL.md`.
+- Use a file mutation tool (`write`, `edit`, or `apply_patch`) on the real skill path instead of pasting the whole skill into chat.
+- Writing the skill file lets OpenWork show the reload banner above the conversation so the user can activate the new skill immediately.
+
 ## Design goals
 
 - Portable: safe to copy between machines
@@ -69,3 +75,4 @@ description: |
 3. Include “Setup” steps if the skill needs local tooling.
 4. Add examples: at least 2 realistic user prompts.
 5. Keep it safe: avoid destructive defaults; ask for confirmation.
+6. In OpenWork, finish by writing the final `SKILL.md` file to `.opencode/skills/<skill-name>/SKILL.md` so the reload banner can appear.

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -1433,6 +1433,10 @@ export default function DashboardView(props: DashboardViewProps) {
           shareWorkspaceProfileError={shareWorkspaceProfileError()}
           shareWorkspaceProfileDisabledReason={shareServiceDisabledReason()}
           onShareSkillsSet={publishSkillsSetLink}
+          onOpenSingleSkillShare={() => {
+            setShareWorkspaceId(null);
+            props.setTab("skills");
+          }}
           shareSkillsSetBusy={shareSkillsSetBusy()}
           shareSkillsSetUrl={shareSkillsSetUrl()}
           shareSkillsSetError={shareSkillsSetError()}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -180,6 +180,17 @@ export type SessionViewProps = {
   mcpStatus: string | null;
   skills: SkillCard[];
   skillsStatus: string | null;
+  showSkillReloadBanner: boolean;
+  reloadBannerTitle: string;
+  reloadBannerBody: string;
+  reloadBannerBlocked: boolean;
+  reloadBannerActiveCount: number;
+  canReloadWorkspace: boolean;
+  reloadWorkspaceEngine: () => Promise<void>;
+  forceStopActiveConversations: () => Promise<void>;
+  dismissReloadBanner: () => void;
+  reloadBusy: boolean;
+  reloadError: string | null;
   busy: boolean;
   prompt: string;
   setPrompt: (value: string) => void;
@@ -3619,6 +3630,53 @@ export default function SessionView(props: SessionViewProps) {
               >
                 <X size={14} />
               </button>
+            </div>
+          </div>
+        </Show>
+
+        <Show when={props.showSkillReloadBanner}>
+          <div class="border-b border-amber-6/50 bg-amber-2/70 px-6 py-3">
+            <div class="mx-auto flex w-full max-w-[800px] flex-col gap-3 rounded-2xl border border-amber-6/60 bg-amber-1/80 px-4 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+              <div class="min-w-0">
+                <div class="text-sm font-medium text-amber-11">{props.reloadBannerTitle}</div>
+                <div class="mt-0.5 text-xs text-amber-11/80">
+                  {props.reloadBannerBody}
+                  <Show when={props.reloadBannerBlocked}>
+                    <span>
+                      {` Reloading stops ${props.reloadBannerActiveCount} active conversation${props.reloadBannerActiveCount === 1 ? "" : "s"}.`}
+                    </span>
+                  </Show>
+                </div>
+                <Show when={props.reloadError}>
+                  <div class="mt-1 text-xs text-red-11">{props.reloadError}</div>
+                </Show>
+              </div>
+
+              <div class="flex items-center gap-2 sm:shrink-0">
+                <button
+                  type="button"
+                  class="rounded-xl border border-amber-7 bg-amber-4 px-3 py-2 text-xs font-medium text-amber-12 transition-colors hover:bg-amber-5 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={!props.canReloadWorkspace || props.reloadBusy}
+                  onClick={() =>
+                    void (props.reloadBannerBlocked
+                      ? props.forceStopActiveConversations()
+                      : props.reloadWorkspaceEngine())
+                  }
+                >
+                  {props.reloadBusy
+                    ? "Reloading..."
+                    : props.reloadBannerBlocked
+                      ? "Reload & Stop Tasks"
+                      : "Reload"}
+                </button>
+                <button
+                  type="button"
+                  class="rounded-xl border border-amber-6/70 bg-transparent px-3 py-2 text-xs font-medium text-amber-11 transition-colors hover:bg-amber-3"
+                  onClick={props.dismissReloadBanner}
+                >
+                  Later
+                </button>
+              </div>
             </div>
           </div>
         </Show>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -4192,6 +4192,11 @@ export default function SessionView(props: SessionViewProps) {
         shareWorkspaceProfileError={shareWorkspaceProfileError()}
         shareWorkspaceProfileDisabledReason={shareServiceDisabledReason()}
         onShareSkillsSet={publishSkillsSetLink}
+        onOpenSingleSkillShare={() => {
+          setShareWorkspaceId(null);
+          props.setTab("skills");
+          props.setView("dashboard");
+        }}
         shareSkillsSetBusy={shareSkillsSetBusy()}
         shareSkillsSetUrl={shareSkillsSetUrl()}
         shareSkillsSetError={shareSkillsSetError()}

--- a/packages/app/src/app/pages/skills.tsx
+++ b/packages/app/src/app/pages/skills.tsx
@@ -3,7 +3,7 @@ import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount }
 import type { HubSkillCard, SkillCard } from "../types";
 
 import Button from "../components/button";
-import { Edit2, FolderOpen, Link2, Loader2, Package, Plus, RefreshCw, Search, Sparkles, Trash2, Upload } from "lucide-solid";
+import { Copy, Edit2, FolderOpen, Link2, Loader2, Package, Plus, RefreshCw, Search, Share2, Sparkles, Trash2, Upload } from "lucide-solid";
 import { currentLocale, t } from "../../i18n";
 import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL, publishOpenworkBundleJson } from "../lib/publisher";
 
@@ -285,6 +285,17 @@ export default function SkillsView(props: SkillsViewProps) {
       setShareError(maskError(e));
     } finally {
       setShareBusy(false);
+    }
+  };
+
+  const copyShareLink = async () => {
+    const url = shareUrl()?.trim();
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setToast("Link copied");
+    } catch {
+      setShareError("Failed to copy link");
     }
   };
 
@@ -663,9 +674,9 @@ export default function SkillsView(props: SkillsViewProps) {
                         openShareLink(skill);
                       }}
                       disabled={props.busy}
-                      title="Share link"
+                      title="Share"
                     >
-                      <Link2 size={14} />
+                      <Share2 size={14} />
                     </button>
                     <button
                       type="button"
@@ -1010,17 +1021,18 @@ export default function SkillsView(props: SkillsViewProps) {
                   </div>
                 }
               >
-                <div class="rounded-xl bg-dls-hover border border-dls-border p-3 text-xs text-dls-secondary font-mono break-all">
-                  {shareUrl()}
-                </div>
-                <div class="flex justify-end gap-2">
+                <div class="flex items-start gap-2 rounded-xl bg-dls-hover border border-dls-border p-3">
+                  <div class="min-w-0 flex-1 text-xs text-dls-secondary font-mono break-all">{shareUrl()}</div>
                   <Button
                     variant="outline"
-                    onClick={() => void navigator.clipboard.writeText(shareUrl() ?? "")}
+                    onClick={() => void copyShareLink()}
                     disabled={!shareUrl()}
                   >
+                    <Copy size={14} />
                     Copy link
                   </Button>
+                </div>
+                <div class="flex justify-end gap-2">
                   <Button variant="secondary" onClick={closeShareLink}>
                     Done
                   </Button>


### PR DESCRIPTION
## Summary
- surface a session-top reload banner when skills are created from chat, and update the skill creator guidance so new skills are written to the watched path
- refresh slash-command options on picker open so newly created skills become available in the same session after reload
- polish skill sharing by improving the Skills page share UX and adding a worker-share shortcut to jump directly to single-skill sharing

## Testing
- pnpm --dir packages/app typecheck
- pnpm --dir packages/app build

## Notes
- Docker and browser-based end-to-end verification were not run in this environment because Docker/Chrome MCP were unavailable during this session