### PR TITLE
Fix infinite auto compaction loop

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1723,6 +1723,7 @@ export default function App() {
       previousStatus: previous,
       status,
       messages: visibleMessages,
+      providers: providers(),
       lastAutoCompactedAt,
       now: Date.now(),
     });

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -49,6 +49,7 @@ import {
   shellInSession,
   listCommands as listCommandsTyped,
 } from "./lib/opencode-session";
+import { shouldAutoCompact } from "./lib/auto-compaction-policy";
 import { clearPerfLogs, finishPerf, perfNow, recordPerfLog } from "./lib/perf-log";
 import {
   AUTO_COMPACT_CONTEXT_PREF_KEY,
@@ -1691,6 +1692,7 @@ export default function App() {
     if (!autoCompactContext()) return;
     if (autoCompactingSessionId() === sessionID) return;
 
+    setLastAutoCompactedAtBySession((current) => ({ ...current, [sessionID]: Date.now() }));
     setAutoCompactingSessionId(sessionID);
     try {
       await compactCurrentSession(sessionID);
@@ -1701,17 +1703,30 @@ export default function App() {
     }
   };
 
-  const [lastSessionStatus, setLastSessionStatus] = createSignal<string | null>(null);
+  const [lastSessionStatus, setLastSessionStatus] = createSignal<{ sessionID: string | null; status: string | null }>({
+    sessionID: null,
+    status: null,
+  });
   createEffect(() => {
     const sessionID = selectedSessionId();
     const status = sessionID ? sessionStatusById()[sessionID] ?? null : null;
-    const previous = lastSessionStatus();
-    setLastSessionStatus(status);
+    const previousState = lastSessionStatus();
+    const previous = previousState.sessionID === sessionID ? previousState.status : null;
+    const visibleMessages = messages();
+    const lastAutoCompactedAt = sessionID ? lastAutoCompactedAtBySession()[sessionID] ?? null : null;
+    setLastSessionStatus({ sessionID: sessionID ?? null, status });
 
     if (!sessionID) return;
     if (!autoCompactContext()) return;
-    if (status !== "idle") return;
-    if (!previous || previous === "idle") return;
+    const decision = shouldAutoCompact({
+      sessionID,
+      previousStatus: previous,
+      status,
+      messages: visibleMessages,
+      lastAutoCompactedAt,
+      now: Date.now(),
+    });
+    if (!decision.shouldCompact) return;
     void triggerAutoCompaction(sessionID);
   });
 
@@ -2533,6 +2548,7 @@ export default function App() {
   const [autoCompactContext, setAutoCompactContext] = createSignal(false);
   const [modelVariant, setModelVariant] = createSignal<string | null>(null);
   const [autoCompactingSessionId, setAutoCompactingSessionId] = createSignal<string | null>(null);
+  const [lastAutoCompactedAtBySession, setLastAutoCompactedAtBySession] = createSignal<Record<string, number>>({});
 
   const MODEL_VARIANT_OPTIONS = [
     { value: "none", label: "None" },

--- a/packages/app/src/app/lib/auto-compaction-policy.custom.ts
+++ b/packages/app/src/app/lib/auto-compaction-policy.custom.ts
@@ -1,0 +1,10 @@
+import type { AutoCompactionPolicy } from "./auto-compaction-policy";
+
+export const customAutoCompactionPolicies: AutoCompactionPolicy[] = [];
+
+export function resolveCustomAutoCompactionPolicyId(_input: {
+  availablePolicies: AutoCompactionPolicy[];
+  defaultPolicyId: string;
+}): string | null {
+  return null;
+}

--- a/packages/app/src/app/lib/auto-compaction-policy.ts
+++ b/packages/app/src/app/lib/auto-compaction-policy.ts
@@ -1,18 +1,31 @@
-import type { MessageWithParts } from "../types";
+import type { MessageWithParts, ProviderListItem } from "../types";
 import { customAutoCompactionPolicies, resolveCustomAutoCompactionPolicyId } from "./auto-compaction-policy.custom";
+
+type AssistantMessageWithTokens = MessageWithParts["info"] & {
+  role: "assistant";
+  providerID: string;
+  modelID: string;
+  tokens: {
+    input: number;
+    output: number;
+    reasoning: number;
+    cache: { read: number; write: number };
+  };
+};
 
 export type AutoCompactionPolicyContext = {
   sessionID: string;
   previousStatus: string | null;
   status: string | null;
   messages: MessageWithParts[];
+  providers: ProviderListItem[];
   lastAutoCompactedAt: number | null;
   now: number;
 };
 
 export type AutoCompactionPolicyDecision = {
   shouldCompact: boolean;
-  estimatedTokens: number;
+  usagePercent: number | null;
 };
 
 export type AutoCompactionPolicy = {
@@ -20,8 +33,11 @@ export type AutoCompactionPolicy = {
   shouldCompact: (context: AutoCompactionPolicyContext) => AutoCompactionPolicyDecision;
 };
 
-const DEFAULT_POLICY_ID = "token-threshold";
-const DEFAULT_MIN_TOKENS = parsePositiveInt(import.meta.env?.VITE_OPENWORK_AUTO_COMPACTION_MIN_TOKENS, 100_000);
+const DEFAULT_POLICY_ID = "context-percent";
+const DEFAULT_MIN_CONTEXT_PERCENT = parsePositiveInt(
+  import.meta.env?.VITE_OPENWORK_AUTO_COMPACTION_MIN_CONTEXT_PERCENT,
+  50,
+);
 const DEFAULT_COOLDOWN_MS = parsePositiveInt(import.meta.env?.VITE_OPENWORK_AUTO_COMPACTION_COOLDOWN_MS, 60_000);
 
 function parsePositiveInt(value: unknown, fallback: number) {
@@ -29,13 +45,39 @@ function parsePositiveInt(value: unknown, fallback: number) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-export function estimateSessionTokens(messages: MessageWithParts[]): number {
-  return messages.reduce((sum, message) => {
-    if (!("tokens" in message.info)) return sum;
-    const tokens = message.info.tokens;
-    if (!tokens) return sum;
-    return sum + tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write;
-  }, 0);
+function lastAssistantWithTokens(messages: MessageWithParts[]) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const candidate = messages[index];
+    if (candidate.info.role !== "assistant") continue;
+    if (!("tokens" in candidate.info) || !("providerID" in candidate.info) || !("modelID" in candidate.info)) {
+      continue;
+    }
+    const info = candidate.info as AssistantMessageWithTokens;
+    const total =
+      info.tokens.input +
+      info.tokens.output +
+      info.tokens.reasoning +
+      info.tokens.cache.read +
+      info.tokens.cache.write;
+    if (total <= 0) continue;
+    return info;
+  }
+}
+
+function contextUsagePercent(context: AutoCompactionPolicyContext) {
+  const message = lastAssistantWithTokens(context.messages);
+  if (!message) return null;
+  const provider = context.providers.find((item) => item.id === message.providerID);
+  const model = provider?.models?.[message.modelID];
+  const limit = model?.limit?.context;
+  if (!limit || limit <= 0) return null;
+  const total =
+    message.tokens.input +
+    message.tokens.output +
+    message.tokens.reasoning +
+    message.tokens.cache.read +
+    message.tokens.cache.write;
+  return Math.round((total / limit) * 100);
 }
 
 function isIdleTransition(context: AutoCompactionPolicyContext) {
@@ -47,29 +89,29 @@ const idleAfterRunPolicy: AutoCompactionPolicy = {
   shouldCompact(context) {
     return {
       shouldCompact: isIdleTransition(context),
-      estimatedTokens: estimateSessionTokens(context.messages),
+      usagePercent: contextUsagePercent(context),
     };
   },
 };
 
-const tokenThresholdPolicy: AutoCompactionPolicy = {
-  id: DEFAULT_POLICY_ID,
+const contextPercentPolicy: AutoCompactionPolicy = {
+  id: "context-percent",
   shouldCompact(context) {
-    const estimatedTokens = estimateSessionTokens(context.messages);
+    const usagePercent = contextUsagePercent(context);
     if (!isIdleTransition(context)) {
-      return { shouldCompact: false, estimatedTokens };
+      return { shouldCompact: false, usagePercent };
     }
-    if (estimatedTokens < DEFAULT_MIN_TOKENS) {
-      return { shouldCompact: false, estimatedTokens };
+    if (usagePercent === null || usagePercent < DEFAULT_MIN_CONTEXT_PERCENT) {
+      return { shouldCompact: false, usagePercent };
     }
     if (context.lastAutoCompactedAt && context.now - context.lastAutoCompactedAt < DEFAULT_COOLDOWN_MS) {
-      return { shouldCompact: false, estimatedTokens };
+      return { shouldCompact: false, usagePercent };
     }
-    return { shouldCompact: true, estimatedTokens };
+    return { shouldCompact: true, usagePercent };
   },
 };
 
-const builtInPolicies: AutoCompactionPolicy[] = [tokenThresholdPolicy, idleAfterRunPolicy];
+const builtInPolicies: AutoCompactionPolicy[] = [contextPercentPolicy, idleAfterRunPolicy];
 
 function allPolicies() {
   return [...builtInPolicies, ...customAutoCompactionPolicies];
@@ -93,6 +135,6 @@ export function resolveAutoCompactionPolicyId() {
 }
 
 export function shouldAutoCompact(context: AutoCompactionPolicyContext): AutoCompactionPolicyDecision {
-  const policy = policyMap().get(resolveAutoCompactionPolicyId()) ?? tokenThresholdPolicy;
+  const policy = policyMap().get(resolveAutoCompactionPolicyId()) ?? contextPercentPolicy;
   return policy.shouldCompact(context);
 }

--- a/packages/app/src/app/lib/auto-compaction-policy.ts
+++ b/packages/app/src/app/lib/auto-compaction-policy.ts
@@ -1,0 +1,98 @@
+import type { MessageWithParts } from "../types";
+import { customAutoCompactionPolicies, resolveCustomAutoCompactionPolicyId } from "./auto-compaction-policy.custom";
+
+export type AutoCompactionPolicyContext = {
+  sessionID: string;
+  previousStatus: string | null;
+  status: string | null;
+  messages: MessageWithParts[];
+  lastAutoCompactedAt: number | null;
+  now: number;
+};
+
+export type AutoCompactionPolicyDecision = {
+  shouldCompact: boolean;
+  estimatedTokens: number;
+};
+
+export type AutoCompactionPolicy = {
+  id: string;
+  shouldCompact: (context: AutoCompactionPolicyContext) => AutoCompactionPolicyDecision;
+};
+
+const DEFAULT_POLICY_ID = "token-threshold";
+const DEFAULT_MIN_TOKENS = parsePositiveInt(import.meta.env?.VITE_OPENWORK_AUTO_COMPACTION_MIN_TOKENS, 100_000);
+const DEFAULT_COOLDOWN_MS = parsePositiveInt(import.meta.env?.VITE_OPENWORK_AUTO_COMPACTION_COOLDOWN_MS, 60_000);
+
+function parsePositiveInt(value: unknown, fallback: number) {
+  const parsed = Number.parseInt(typeof value === "string" ? value.trim() : "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function estimateSessionTokens(messages: MessageWithParts[]): number {
+  return messages.reduce((sum, message) => {
+    if (!("tokens" in message.info)) return sum;
+    const tokens = message.info.tokens;
+    if (!tokens) return sum;
+    return sum + tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write;
+  }, 0);
+}
+
+function isIdleTransition(context: AutoCompactionPolicyContext) {
+  return context.status === "idle" && !!context.previousStatus && context.previousStatus !== "idle";
+}
+
+const idleAfterRunPolicy: AutoCompactionPolicy = {
+  id: "idle-after-run",
+  shouldCompact(context) {
+    return {
+      shouldCompact: isIdleTransition(context),
+      estimatedTokens: estimateSessionTokens(context.messages),
+    };
+  },
+};
+
+const tokenThresholdPolicy: AutoCompactionPolicy = {
+  id: DEFAULT_POLICY_ID,
+  shouldCompact(context) {
+    const estimatedTokens = estimateSessionTokens(context.messages);
+    if (!isIdleTransition(context)) {
+      return { shouldCompact: false, estimatedTokens };
+    }
+    if (estimatedTokens < DEFAULT_MIN_TOKENS) {
+      return { shouldCompact: false, estimatedTokens };
+    }
+    if (context.lastAutoCompactedAt && context.now - context.lastAutoCompactedAt < DEFAULT_COOLDOWN_MS) {
+      return { shouldCompact: false, estimatedTokens };
+    }
+    return { shouldCompact: true, estimatedTokens };
+  },
+};
+
+const builtInPolicies: AutoCompactionPolicy[] = [tokenThresholdPolicy, idleAfterRunPolicy];
+
+function allPolicies() {
+  return [...builtInPolicies, ...customAutoCompactionPolicies];
+}
+
+function policyMap() {
+  return new Map(allPolicies().map((policy) => [policy.id, policy]));
+}
+
+export function resolveAutoCompactionPolicyId() {
+  const customPolicyId = resolveCustomAutoCompactionPolicyId({
+    availablePolicies: allPolicies(),
+    defaultPolicyId: DEFAULT_POLICY_ID,
+  });
+  const envPolicyId =
+    typeof import.meta.env?.VITE_OPENWORK_AUTO_COMPACTION_POLICY === "string"
+      ? import.meta.env.VITE_OPENWORK_AUTO_COMPACTION_POLICY.trim()
+      : "";
+  const desired = customPolicyId?.trim() || envPolicyId || DEFAULT_POLICY_ID;
+  return policyMap().has(desired) ? desired : DEFAULT_POLICY_ID;
+}
+
+export function shouldAutoCompact(context: AutoCompactionPolicyContext): AutoCompactionPolicyDecision {
+  const policy = policyMap().get(resolveAutoCompactionPolicyId()) ?? tokenThresholdPolicy;
+  return policy.shouldCompact(context);
+}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -1208,7 +1208,7 @@ export default function SettingsView(props: SettingsViewProps) {
               <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                 <div class="min-w-0">
                   <div class="text-sm text-gray-12">Auto context compaction</div>
-                  <div class="text-xs text-gray-7">Automatically compact after a run completes.</div>
+                  <div class="text-xs text-gray-7">Automatically compact once a session grows large enough after a run.</div>
                 </div>
                 <Button
                   variant="outline"


### PR DESCRIPTION
## Summary
- Replace idle-only auto-compaction with a policy-based implementation that compacts only when the active model's context usage crosses a threshold.
- Add a small policy seam so compaction behavior can be customized without patching the main app flow.
- Update the Settings copy to reflect that compaction is now context-pressure based instead of running after every completed turn.
- 
## Why
- The previous implementation compacted on every `non-idle -> idle` transition, which could retrigger on its own compaction run and leak continuation summaries into the chat repeatedly.
- OpenCode already exposes model context limits and per-message token usage, so OpenWork should use the same signal instead of a fixed heuristic.

## Issue
- Closes #

## Scope
- `packages/app/src/app/app.tsx`
- `packages/app/src/app/lib/auto-compaction-policy.ts`
- `packages/app/src/app/lib/auto-compaction-policy.custom.ts`
- `packages/app/src/app/pages/settings.tsx`

## Out of scope
- Worker/container packaging
- Kubernetes manifests
- Approval flow behavior
- Existing `Todo` typing issues outside the compaction path

## Testing

### Ran
- `pnpm --filter @different-ai/openwork-ui typecheck`

### Result
- pass/fail: fail
- if fail, exact files/errors:
  - `packages/app/src/app/app.tsx:2308` - `Type 'Todo[]' is not assignable to type 'TodoItem[]'`
  - `packages/app/src/app/context/session.ts:794` - `Argument of type 'Todo[]' is not assignable to parameter of type 'StoreSetter<TodoItem[] ...>'`

## CI status
- pass:
- code-related failures:
  - local typecheck is blocked by pre-existing `Todo` vs `TodoItem` type errors unrelated to this branch
- external/env/auth blockers:
  - none for this change set

## Manual verification
1. Enable `Auto context compaction` in Settings.
2. Run a session that approaches the selected model's context limit but stays below the threshold and confirm no compaction occurs on idle.
3. Continue the same session past the threshold, confirm compaction runs once on idle, and verify it does not loop or dump repeated handoff summaries into the transcript.

## Evidence
- N/A

## Risk
- Low to medium: compaction timing changes from a simple idle trigger to provider/model metadata-driven behavior, so sessions with missing model limit metadata may stop auto-compacting until a custom policy is added.
## Rollback
- Revert `4db87ab9` and `573e0898` from `fix/auto-compaction` to restore the prior idle-based compaction behavior