### PR TITLE
Proxy Den PostHog requests through /ow

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -35,8 +35,9 @@ Frontend for `app.openwork.software`.
   - this host must serve `/api/auth/*`; the included proxy route does that
 - `NEXT_PUBLIC_POSTHOG_KEY` (client): PostHog project key used for Den analytics.
   - optional override; defaults to the same project key used by `packages/landing`
-- `NEXT_PUBLIC_POSTHOG_HOST` (client): PostHog host URL.
-  - default: `https://us.i.posthog.com`
+- `NEXT_PUBLIC_POSTHOG_HOST` (client): PostHog ingest host or same-origin proxy path.
+  - default: `/ow`
+  - set it to `https://us.i.posthog.com` to bypass the local proxy
 - `LOOPS_API_KEY` (server-only): Loops API key for signup contact capture.
 
 ## Deploy on Vercel

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -23,11 +23,12 @@ export const metadata: Metadata = {
 };
 
 const defaultPosthogKey = "phc_4YnPTlDVYPjgwKvLuNxhbHjV5kadgvd7XLzVHWnCXAI";
+const defaultPosthogProxyPath = "/ow";
 const posthogKey =
   process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim() ||
   process.env.NEXT_PUBLIC_POSTHOG_API_KEY?.trim() ||
   defaultPosthogKey;
-const posthogHost = (process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com").trim();
+const posthogHost = (process.env.NEXT_PUBLIC_POSTHOG_HOST ?? defaultPosthogProxyPath).trim();
 
 const posthogBootstrap = posthogKey
   ? `!function(t,e){var o,n,p,r;e.__SV||(window.posthog&&window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture identify alias reset register unregister setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])})}(document,window.posthog||[]);

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const POSTHOG_PROXY_PATH = "/ow";
+const POSTHOG_API_HOST = "us.i.posthog.com";
+const POSTHOG_ASSETS_HOST = "us-assets.i.posthog.com";
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl.clone();
+  const { pathname } = url;
+
+  if (!pathname.startsWith(POSTHOG_PROXY_PATH)) {
+    return NextResponse.next();
+  }
+
+  const hostname = pathname.startsWith(`${POSTHOG_PROXY_PATH}/static/`)
+    ? POSTHOG_ASSETS_HOST
+    : POSTHOG_API_HOST;
+  const requestHeaders = new Headers(request.headers);
+
+  requestHeaders.set("host", hostname);
+  requestHeaders.delete("cookie");
+
+  url.protocol = "https";
+  url.hostname = hostname;
+  url.port = "443";
+  url.pathname = pathname.replace(/^\/ow/, "") || "/";
+
+  return NextResponse.rewrite(url, {
+    request: {
+      headers: requestHeaders
+    }
+  });
+}
+
+export const config = {
+  matcher: "/ow/:path*"
+};

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  skipTrailingSlashRedirect: true
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add a same-origin Next.js middleware proxy at `/ow` for Den PostHog traffic so ingest and asset requests stay on the app domain
- switch the Den web bootstrap to use `/ow` by default while still allowing `NEXT_PUBLIC_POSTHOG_HOST` to override the target
- enable `skipTrailingSlashRedirect` and document the proxy-based PostHog setup in the Den web README

## Verification
- `pnpm install`
- `pnpm --filter @different-ai/openwork-web build` ✅
- `pnpm --filter @different-ai/openwork-web lint` ⚠️ `next lint` prompts for first-time ESLint setup in this package, so it could not run non-interactively

## Notes
- I previously opened this against the wrong repo by mistake, then closed that PR and reimplemented the change in `_repos/openwork`.