### PR TITLE
WIP: move workspace shell toward quiet operator layout

### DIFF
--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1543,7 +1543,6 @@ export default function Composer(props: ComposerProps) {
       style={{ contain: "layout style" }}
     >
       <div class="max-w-[800px] mx-auto">
-        <div class="mb-3 px-1 text-[13px] text-gray-9">Describe your task</div>
         <div
           class={`bg-dls-surface border border-dls-border rounded-[24px] overflow-visible transition-all relative group/input ${mentionOpen() || slashOpen() ? "rounded-t-[18px] border-t-transparent" : "shadow-[var(--dls-shell-shadow)]"
             }`}

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1539,12 +1539,13 @@ export default function Composer(props: ComposerProps) {
 
   return (
     <div
-      class={`sticky bottom-0 z-20 bg-gradient-to-t from-gray-1 via-gray-1 to-transparent px-8 ${props.compactTopSpacing ? "pt-0" : "pt-12"} pb-6`}
+      class={`sticky bottom-0 z-20 bg-gradient-to-t from-dls-surface via-dls-surface/95 to-transparent px-4 md:px-8 ${props.compactTopSpacing ? "pt-0" : "pt-10"} pb-5`}
       style={{ contain: "layout style" }}
     >
       <div class="max-w-[800px] mx-auto">
+        <div class="mb-3 px-1 text-[13px] text-gray-9">Describe your task</div>
         <div
-          class={`bg-gray-1 border border-gray-6/80 rounded-xl overflow-visible transition-all relative group/input ${mentionOpen() || slashOpen() ? "rounded-t-none border-t-transparent" : "shadow-[0_8px_30px_rgba(0,0,0,0.08)]"
+          class={`bg-dls-surface border border-dls-border rounded-[24px] overflow-visible transition-all relative group/input ${mentionOpen() || slashOpen() ? "rounded-t-[18px] border-t-transparent" : "shadow-[var(--dls-shell-shadow)]"
             }`}
           onDrop={handleDrop}
           onDragOver={(event: DragEvent) => {
@@ -1554,8 +1555,8 @@ export default function Composer(props: ComposerProps) {
         >
           <Show when={mentionOpen()}>
             <div class="absolute bottom-full left-[-1px] right-[-1px] z-30">
-              <div class="rounded-t-xl border border-gray-6 border-b-0 bg-gray-1 shadow-xl overflow-hidden">
-                <div class="p-2 bg-gray-1 max-h-64 overflow-y-auto" onMouseDown={(event: MouseEvent) => event.preventDefault()}>
+              <div class="overflow-hidden rounded-t-[20px] border border-dls-border border-b-0 bg-dls-surface shadow-[var(--dls-shell-shadow)]">
+                <div class="max-h-64 overflow-y-auto bg-dls-surface p-2" onMouseDown={(event: MouseEvent) => event.preventDefault()}>
                   <Show
                     when={mentionVisible().length}
                     fallback={<div class="px-3 py-2 text-xs text-gray-10">No matches found.</div>}
@@ -1567,7 +1568,7 @@ export default function Composer(props: ComposerProps) {
                         return (
                           <button
                             type="button"
-                            class={`w-full flex items-center gap-2 rounded-xl px-3 py-2 text-left transition-colors ${active() ? "bg-gray-3 text-gray-12" : "text-gray-11 hover:bg-gray-2"
+                            class={`w-full flex items-center gap-2 rounded-[16px] px-3 py-2.5 text-left transition-colors ${active() ? "bg-gray-2 text-gray-12" : "text-gray-11 hover:bg-gray-2/70"
                               }`}
                             onMouseDown={(event: MouseEvent) => {
                               event.preventDefault();
@@ -1615,8 +1616,8 @@ export default function Composer(props: ComposerProps) {
           {/* Slash command popup */}
           <Show when={slashOpen()}>
             <div class="absolute bottom-full left-[-1px] right-[-1px] z-30">
-              <div class="rounded-t-xl border border-gray-6 border-b-0 bg-gray-1 overflow-hidden">
-                <div class="p-2 bg-gray-1 max-h-64 overflow-y-auto" onMouseDown={(event: MouseEvent) => event.preventDefault()}>
+              <div class="overflow-hidden rounded-t-[20px] border border-dls-border border-b-0 bg-dls-surface shadow-[var(--dls-shell-shadow)]">
+                <div class="max-h-64 overflow-y-auto bg-dls-surface p-2" onMouseDown={(event: MouseEvent) => event.preventDefault()}>
                   <Show
                     when={slashFiltered().length}
                     fallback={
@@ -1631,7 +1632,7 @@ export default function Composer(props: ComposerProps) {
                         return (
                           <button
                             type="button"
-                            class={`w-full flex items-center justify-between gap-4 rounded-xl px-3 py-2 text-left transition-colors ${active() ? "bg-gray-3 text-gray-12" : "text-gray-11 hover:bg-gray-2"
+                            class={`w-full flex items-center justify-between gap-4 rounded-[16px] px-3 py-2.5 text-left transition-colors ${active() ? "bg-gray-2 text-gray-12" : "text-gray-11 hover:bg-gray-2/70"
                               }`}
                             onMouseDown={(event: MouseEvent) => {
                               event.preventDefault();
@@ -1661,7 +1662,7 @@ export default function Composer(props: ComposerProps) {
             </div>
           </Show>
 
-          <div class="p-3">
+          <div class="p-5 md:p-6">
             <Show when={props.showNotionBanner}>
               <button
                 type="button"
@@ -1736,10 +1737,10 @@ export default function Composer(props: ComposerProps) {
 
                   <div class="relative">
                     <Show when={!hasDraftContent()}>
-                      <div class="absolute left-0 top-0 text-gray-9 text-[15px] leading-relaxed pointer-events-none">
-                        Ask OpenWork...
-                      </div>
-                    </Show>
+                    <div class="absolute left-0 top-0 text-gray-9 text-[15px] leading-relaxed pointer-events-none">
+                        Describe your task...
+                    </div>
+                  </Show>
                     <div
                       ref={editorRef}
                       contentEditable={true}
@@ -1752,8 +1753,8 @@ export default function Composer(props: ComposerProps) {
                       class="bg-transparent border-none p-0 pb-8 pr-4 text-gray-12 focus:ring-0 text-[15px] leading-relaxed resize-none min-h-[24px] max-h-40 overflow-y-auto outline-none relative z-10"
                     />
 
-                    <div class="mt-3 flex items-center justify-between px-2 pb-2">
-                      <div class="flex items-center gap-2">
+                    <div class="mt-4 flex flex-col gap-4 px-1 pb-1 sm:flex-row sm:items-center sm:justify-between">
+                      <div class="flex flex-wrap items-center gap-2.5 text-gray-10">
                         <input
                           ref={inboxFileInputRef}
                           type="file"
@@ -1783,7 +1784,7 @@ export default function Composer(props: ComposerProps) {
                         />
                         <button
                           type="button"
-                          class={`p-1.5 hover:bg-gray-3 rounded-md text-gray-10 transition-colors ${attachmentsDisabled() ? "cursor-not-allowed" : ""
+                          class={`rounded-md p-1.5 text-gray-10 transition-colors hover:bg-gray-3 ${attachmentsDisabled() ? "cursor-not-allowed" : ""
                             }`}
                           onClick={() => {
                             if (attachmentsDisabled()) return;
@@ -1802,7 +1803,7 @@ export default function Composer(props: ComposerProps) {
                         <div class="relative" ref={(el) => props.setAgentPickerRef(el)}>
                           <button
                             type="button"
-                            class="flex items-center gap-1.5 px-2 py-1 hover:bg-gray-3 rounded-md text-[13px] font-medium text-gray-11 hover:text-gray-12"
+                            class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] font-medium text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
                             onClick={props.onToggleAgentPicker}
                             disabled={props.busy}
                             aria-expanded={props.agentPickerOpen}
@@ -1814,8 +1815,8 @@ export default function Composer(props: ComposerProps) {
                           </button>
 
                           <Show when={props.agentPickerOpen}>
-                            <div class="absolute left-0 bottom-full mb-2 w-64 rounded-xl border border-gray-6 bg-gray-1 shadow-xl backdrop-blur-md overflow-hidden z-40">
-                              <div class="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10 border-b border-gray-6">
+                            <div class="absolute left-0 bottom-full z-40 mb-2 w-64 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
+                              <div class="border-b border-dls-border px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10">
                                 Agent
                               </div>
 
@@ -1830,9 +1831,9 @@ export default function Composer(props: ComposerProps) {
                                     <button
                                       type="button"
                                       class={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-xs transition-colors ${!props.selectedAgent
-                                        ? "bg-gray-3 text-gray-12"
-                                        : "text-gray-11 hover:bg-gray-2"
-                                        }`}
+                                        ? "bg-gray-2 text-gray-12"
+                                        : "text-gray-11 hover:bg-gray-2/70"
+                                         }`}
                                       onMouseDown={(event: MouseEvent) => {
                                         event.preventDefault();
                                         props.onSelectAgent(null);
@@ -1851,9 +1852,9 @@ export default function Composer(props: ComposerProps) {
                                           <button
                                             type="button"
                                             class={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-xs transition-colors ${active()
-                                              ? "bg-gray-3 text-gray-12"
-                                              : "text-gray-11 hover:bg-gray-2"
-                                              }`}
+                                              ? "bg-gray-2 text-gray-12"
+                                              : "text-gray-11 hover:bg-gray-2/70"
+                                               }`}
                                             onMouseDown={(event: MouseEvent) => {
                                               event.preventDefault();
                                               props.onSelectAgent(agent.name);
@@ -1882,7 +1883,7 @@ export default function Composer(props: ComposerProps) {
 
                         <button
                           type="button"
-                          class="flex items-center gap-1.5 px-2 py-1 hover:bg-gray-3 rounded-md text-[13px] font-medium text-gray-11 hover:text-gray-12"
+                          class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] font-medium text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
                           onClick={props.onModelClick}
                           disabled={props.busy}
                         >
@@ -1892,7 +1893,7 @@ export default function Composer(props: ComposerProps) {
                         <div class="relative" ref={(el) => (variantPickerRef = el)}>
                           <button
                             type="button"
-                            class="flex items-center gap-1.5 px-2 py-1 hover:bg-gray-3 rounded-md text-[13px] font-medium text-gray-11 hover:text-gray-12"
+                            class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] font-medium text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
                             onClick={() => setVariantMenuOpen((open) => !open)}
                             disabled={props.busy}
                             aria-expanded={variantMenuOpen()}
@@ -1902,8 +1903,8 @@ export default function Composer(props: ComposerProps) {
                             <ChevronDown size={14} />
                           </button>
                           <Show when={variantMenuOpen()}>
-                            <div class="absolute left-0 bottom-full mb-2 w-48 rounded-xl border border-gray-6 bg-gray-1 shadow-xl backdrop-blur-md overflow-hidden z-40">
-                              <div class="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10 border-b border-gray-6">
+                            <div class="absolute left-0 bottom-full z-40 mb-2 w-48 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
+                              <div class="border-b border-dls-border px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10">
                                 Thinking effort
                               </div>
                               <div class="p-2 space-y-1">
@@ -1912,9 +1913,9 @@ export default function Composer(props: ComposerProps) {
                                     <button
                                       type="button"
                                       class={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-xs transition-colors ${activeVariant() === option.value
-                                        ? "bg-gray-3 text-gray-12"
-                                        : "text-gray-11 hover:bg-gray-2"
-                                        }`}
+                                        ? "bg-gray-2 text-gray-12"
+                                        : "text-gray-11 hover:bg-gray-2/70"
+                                         }`}
                                       onClick={() => {
                                         props.onModelVariantChange(option.value);
                                         setVariantMenuOpen(false);
@@ -1932,7 +1933,7 @@ export default function Composer(props: ComposerProps) {
                           </Show>
                         </div>
                       </div>
-                      <div class="flex items-center gap-3 text-gray-10">
+                      <div class="flex items-center gap-3 text-gray-10 sm:justify-end">
                         <Show
                           when={props.isStreaming}
                           fallback={
@@ -1940,23 +1941,25 @@ export default function Composer(props: ComposerProps) {
                               type="button"
                               disabled={!hasDraftContent()}
                               onClick={sendDraft}
-                              class={`p-1.5 rounded-full transition-colors ${!hasDraftContent()
+                              class={`inline-flex items-center gap-2 rounded-full px-4 py-2.5 text-[13px] font-medium transition-colors ${!hasDraftContent()
                                 ? "bg-gray-4 text-gray-10"
-                                : "bg-[#1B29FF] text-white hover:bg-blue-10"
+                                : "bg-dls-accent text-white hover:bg-[var(--dls-accent-hover)]"
                                 }`}
-                              title="Send"
+                              title="Run task"
                             >
-                              <ArrowUp size={18} />
+                              <ArrowUp size={16} />
+                              <span>Run task</span>
                             </button>
                           }
                         >
                           <button
                             type="button"
                             onClick={() => props.onStop()}
-                            class="p-1.5 rounded-full bg-gray-12 text-gray-1 hover:bg-gray-11 transition-colors"
+                            class="inline-flex items-center gap-2 rounded-full bg-gray-12 px-4 py-2.5 text-[13px] font-medium text-gray-1 transition-colors hover:bg-gray-11"
                             title="Stop"
                           >
-                            <Square size={14} fill="currentColor" />
+                            <Square size={13} fill="currentColor" />
+                            <span>Stop</span>
                           </button>
                         </Show>
                       </div>

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -932,8 +932,8 @@ export default function MessageList(props: MessageListProps) {
                 <div
                   class={`w-full relative ${
                     block.isUser
-                      ? "max-w-[80%] px-5 py-3 rounded-[24px] bg-gray-3 text-gray-12 text-[14px] leading-relaxed font-medium"
-                      : "max-w-[650px] text-[15px] leading-6 text-gray-12 group"
+                      ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
+                      : "max-w-[760px] text-[15px] leading-[1.7] text-dls-text group"
                   } ${searchOutlineClass}`}
                 >
                   <StepsContainer
@@ -989,20 +989,20 @@ export default function MessageList(props: MessageListProps) {
               <div
                 class={`w-full relative ${
                   block.isUser
-                    ? "max-w-[80%] px-5 py-3 rounded-[24px] bg-gray-3 text-gray-12 text-[14px] leading-relaxed font-medium"
-                    : "max-w-[650px] text-[15px] leading-[1.65] text-gray-12 antialiased group"
+                    ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
+                    : "max-w-[760px] text-[15px] leading-[1.72] text-dls-text antialiased group"
                 } ${searchOutlineClass}`}
               >
                 <Show when={attachmentsForMessage(block.message).length > 0}>
                   <div class={block.isUser ? "mb-3 flex flex-wrap gap-2" : "mb-4 flex flex-wrap gap-2"}>
                     <For each={attachmentsForMessage(block.message)}>
                       {(attachment) => (
-                        <div class="flex items-center gap-2 rounded-2xl border border-gray-6 bg-gray-1/70 px-3 py-2 text-xs text-gray-11">
+                        <div class="flex items-center gap-2 rounded-[18px] border border-dls-border bg-dls-surface px-3 py-2 text-xs text-gray-11 shadow-[var(--dls-card-shadow)]">
                           <Show
                             when={isImageAttachment(attachment.mime)}
                             fallback={<File size={14} class="text-gray-9" />}
                           >
-                            <div class="h-12 w-12 rounded-xl bg-gray-2 overflow-hidden border border-gray-6">
+                            <div class="h-12 w-12 overflow-hidden rounded-xl border border-dls-border bg-dls-sidebar">
                               <img
                                 src={attachment.url}
                                 alt={attachment.filename}

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -223,6 +223,99 @@ function getTaskStepInfo(part: Part): TaskStepInfo {
   return { isTask: true, agentType, sessionId };
 }
 
+function compactPathToken(value: string) {
+  const token = value
+    .trim()
+    .replace(/^[`'"([{]+|[`'"\])},.;:]+$/g, "");
+  const segments = token.split(/[\\/]/).filter(Boolean);
+  return segments.length > 0 ? segments[segments.length - 1] : token;
+}
+
+function compactText(value: string, max = 42) {
+  const singleLine = value.replace(/\s+/g, " ").trim();
+  if (!singleLine) return "";
+  return singleLine.length > max ? `${singleLine.slice(0, Math.max(0, max - 3))}...` : singleLine;
+}
+
+function isPathLike(value: string) {
+  return /^(?:[A-Za-z]:[\\/]|~[\\/]|\/[\w_\-~]|\.\.?[\\/])/.test(value) ||
+    /[\\/](?:\.opencode|Users|Library|workspaces)[\\/]/.test(value);
+}
+
+function toolHeadline(part: Part) {
+  if (part.type !== "tool") return "";
+
+  const record = part as any;
+  const state = record.state ?? {};
+  const input = state.input && typeof state.input === "object" ? (state.input as Record<string, unknown>) : {};
+  const tool = typeof record.tool === "string" ? record.tool.toLowerCase() : "";
+
+  const pick = (...keys: string[]) => {
+    for (const key of keys) {
+      const value = input[key];
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+    return "";
+  };
+
+  const target = (...keys: string[]) => {
+    const raw = pick(...keys);
+    if (!raw) return "";
+    return isPathLike(raw) ? compactPathToken(raw) : raw;
+  };
+
+  if (tool === "bash") {
+    const description = pick("description");
+    if (description) return compactText(description);
+    const command = pick("command", "cmd");
+    return command ? compactText(`Run ${command}`, 48) : "Run command";
+  }
+
+  if (tool === "read") {
+    const file = target("filePath", "path", "file");
+    return file ? `Read ${file}` : "Read file";
+  }
+
+  if (tool === "edit") {
+    const file = target("filePath", "path", "file");
+    return file ? `Edit ${file}` : "Edit file";
+  }
+
+  if (tool === "write" || tool === "apply_patch") {
+    const file = target("filePath", "path", "file");
+    return file ? `Update ${file}` : "Update file";
+  }
+
+  if (tool === "grep" || tool === "glob" || tool === "search") {
+    const pattern = pick("pattern", "query");
+    return pattern ? `Search ${compactText(pattern, 36)}` : "Search code";
+  }
+
+  if (tool === "list" || tool === "list_files") {
+    const path = target("path");
+    return path ? `List ${path}` : "List files";
+  }
+
+  if (tool === "task") {
+    const description = pick("description");
+    if (description) return compactText(description);
+    const agent = pick("subagent_type");
+    return agent ? `Delegate ${agent}` : "Delegate task";
+  }
+
+  if (tool === "webfetch") {
+    const url = pick("url");
+    return url ? `Fetch ${compactText(url, 36)}` : "Fetch web page";
+  }
+
+  if (tool === "skill") {
+    const name = pick("name");
+    return name ? `Load skill ${name}` : "Load skill";
+  }
+
+  return "";
+}
+
 export default function MessageList(props: MessageListProps) {
   const [copyingId, setCopyingId] = createSignal<string | null>(null);
   let previousMessagePartCountById = new Map<string, number>();
@@ -529,113 +622,48 @@ export default function MessageList(props: MessageListProps) {
     props.setScrollToMessageById?.(null);
   });
 
-  /** Compact single-line step row */
+  /** Quiet single-line timeline row */
   const StepRow = (rowProps: { part: Part; isUser: boolean; groupMode?: StepGroupMode }) => {
     const summary = createMemo(() => summarizeStep(rowProps.part));
-    const category = createMemo(() => summary().toolCategory ?? "tool");
-    const status = createMemo(() => summary().status);
-    const task = createMemo(() => getTaskStepInfo(rowProps.part));
+    const headline = createMemo(() => {
+      const fromTool = toolHeadline(rowProps.part);
+      if (fromTool) return fromTool;
+      const title = summary().title?.trim() ?? "";
+      const detail = summary().detail?.trim() ?? "";
+      if (title && detail && detail.toLowerCase() !== title.toLowerCase()) {
+        return `${title} - ${detail}`;
+      }
+      return detail || title || "Updates progress";
+    });
 
     if (rowProps.part.type === "reasoning") {
       return (
-        <div class="py-2">
-          <div
-            class={`rounded-2xl border border-gray-6/60 bg-gray-2/40 px-3 py-2.5 ${
-              rowProps.groupMode === "exploration" ? "opacity-85" : ""
-            }`}
-          >
-            <div class="text-[12px] font-medium text-gray-12">{summary().title}</div>
-            <Show when={summary().detail}>
-              {(detail) => (
-                <p class="mt-1 text-[12px] leading-relaxed text-gray-10 whitespace-pre-wrap break-words">
-                  {detail()}
-                </p>
-              )}
-            </Show>
+        <div class="flex items-start gap-3 text-[14px] text-gray-9">
+          <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
+          <div class="min-w-0 leading-relaxed">
+            <span class="mr-1">Execution timeline 1 step -</span>
+            <span>{headline()}</span>
           </div>
         </div>
       );
     }
 
     return (
-      <div class="flex items-center gap-2 py-1 min-h-[24px] leading-5 group/step">
-        {/* Status dot */}
-        <div class={`w-1.5 h-1.5 rounded-full shrink-0 ${statusDotClass(status())}`} />
-        {/* Tool icon */}
-        <div class={`shrink-0 ${
-          summary().isSkill 
-            ? "text-purple-10" 
-            : "text-gray-9"
-        }`}>
-          <ToolIcon category={category()} size={13} />
+      <div class="flex items-start gap-3 text-[14px] text-gray-9">
+        <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
+        <div class="min-w-0 leading-relaxed">
+          <span class="mr-1">Execution timeline 1 step -</span>
+          <span>{headline()}</span>
         </div>
-        {/* Title */}
-        <span class="text-[13px] leading-4 text-gray-12 font-medium truncate shrink-0 max-w-[200px]">
-          {summary().title}
-        </span>
-        {/* Skill badge */}
-        <Show when={summary().isSkill}>
-          <span class="text-[10px] leading-4 px-1.5 py-0.5 rounded-full bg-purple-3 text-purple-11 shrink-0">
-            skill
-          </span>
-        </Show>
-        <Show when={task().isTask}>
-          <span class="text-[10px] leading-4 px-1.5 py-0.5 rounded-full bg-blue-3 text-blue-11 shrink-0">
-            subagent
-          </span>
-        </Show>
-        {/* Detail - truncated to single line */}
-        <Show when={summary().detail}>
-          <span class="text-[12px] leading-4 text-gray-9 truncate min-w-0">
-            {summary().detail}
-          </span>
-        </Show>
-        <Show when={task().agentType && !summary().detail}>
-          {(agentType) => (
-            <span class="text-[12px] leading-4 text-gray-9 truncate min-w-0">
-              {agentType()} agent
-            </span>
-          )}
-        </Show>
-        <Show when={Boolean(task().sessionId && props.openSessionById)}>
-          <button
-            type="button"
-            class="ml-auto text-[11px] text-blue-11 hover:text-blue-10 underline underline-offset-2"
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              const sessionId = task().sessionId;
-              if (!sessionId) return;
-              props.openSessionById?.(sessionId);
-            }}
-          >
-            open
-          </button>
-        </Show>
       </div>
     );
   };
 
-  /** Compact steps list */
+  /** Quiet steps list */
   const StepsList = (listProps: { parts: Part[]; isUser: boolean; groupMode: StepGroupMode }) => (
-    <div class="divide-y divide-gray-6/40">
+    <div class="flex flex-col gap-4">
       <For each={listProps.parts}>
-        {(part) => (
-          <div>
-            <StepRow part={part} isUser={listProps.isUser} groupMode={listProps.groupMode} />
-            <Show when={props.developerMode && part.type !== "reasoning" && (part.type !== "tool" || props.showThinking)}>
-              <div class="pl-6 pb-2 text-xs text-gray-10">
-                <PartView
-                  part={part}
-                  developerMode={props.developerMode}
-                  showThinking={props.showThinking}
-                  workspaceRoot={props.workspaceRoot}
-                  tone={listProps.isUser ? "dark" : "light"}
-                />
-              </div>
-            </Show>
-          </div>
-        )}
+        {(part) => <StepRow part={part} isUser={listProps.isUser} groupMode={listProps.groupMode} />}
       </For>
     </div>
   );
@@ -648,265 +676,15 @@ export default function MessageList(props: MessageListProps) {
     isUser: boolean;
     isInline?: boolean;
   }) => {
-    const relatedIds = () =>
-      containerProps.relatedIds ?? containerProps.stepGroups.map((group) => group.id).filter((id) => id !== containerProps.id);
-    const expanded = () => isStepsExpanded(containerProps.id, relatedIds());
-    const latestStep = () => latestStepPart(containerProps.stepGroups);
-    const allStepParts = () => containerProps.stepGroups.flatMap((group) => group.parts);
-    const toolCallCount = () =>
-      containerProps.stepGroups.reduce(
-        (sum, group) => sum + group.parts.reduce((count, part) => (part.type === "tool" ? count + 1 : count), 0),
-        0,
-      );
-    const reasoningCount = () =>
-      containerProps.stepGroups.reduce(
-        (sum, group) => sum + group.parts.reduce((count, part) => (part.type === "reasoning" ? count + 1 : count), 0),
-        0,
-      );
-    const explorationGroups = () => containerProps.stepGroups.filter((group) => group.mode === "exploration");
-    const explorationOnly = () =>
-      explorationGroups().length > 0 && explorationGroups().length === containerProps.stepGroups.length;
-    const explorationSummary = () => summarizeExploration(explorationGroups().flatMap((group) => group.parts));
-    const explorationState = () => explorationStatus(explorationGroups().flatMap((group) => group.parts));
-
-    const executionSummary = () => {
-      const tools = toolCallCount();
-      const reasoning = reasoningCount();
-      if (tools > 0 && reasoning > 0) {
-        return `${tools} step${tools === 1 ? "" : "s"} with ${reasoning} thought update${reasoning === 1 ? "" : "s"}`;
-      }
-      if (tools > 0) {
-        return `${tools} step${tools === 1 ? "" : "s"}`;
-      }
-      if (reasoning > 0) {
-        return `${reasoning} thought update${reasoning === 1 ? "" : "s"}`;
-      }
-      return "updates";
-    };
-
-    const compactPathToken = (value: string) => {
-      const token = value
-        .trim()
-        .replace(/^[`'"([{]+|[`'"\])},.;:]+$/g, "");
-      const segments = token.split(/[\\/]/).filter(Boolean);
-      return segments.length > 0 ? segments[segments.length - 1] : token;
-    };
-
-    const compactText = (value: string, max = 42) => {
-      const singleLine = value.replace(/\s+/g, " ").trim();
-      if (!singleLine) return "";
-      return singleLine.length > max ? `${singleLine.slice(0, Math.max(0, max - 3))}...` : singleLine;
-    };
-
-    const isPathLike = (value: string) =>
-      /^(?:[A-Za-z]:[\\/]|~[\\/]|\/[\w_\-~]|\.\.?[\\/])/.test(value) ||
-      /[\\/](?:\.opencode|Users|Library|workspaces)[\\/]/.test(value);
-
-    const toolHeadline = (part: Part) => {
-      if (part.type !== "tool") return "";
-
-      const record = part as any;
-      const state = record.state ?? {};
-      const input = state.input && typeof state.input === "object" ? (state.input as Record<string, unknown>) : {};
-      const tool = typeof record.tool === "string" ? record.tool.toLowerCase() : "";
-
-      const pick = (...keys: string[]) => {
-        for (const key of keys) {
-          const value = input[key];
-          if (typeof value === "string" && value.trim()) return value.trim();
-        }
-        return "";
-      };
-
-      const target = (...keys: string[]) => {
-        const raw = pick(...keys);
-        if (!raw) return "";
-        return isPathLike(raw) ? compactPathToken(raw) : raw;
-      };
-
-      if (tool === "bash") {
-        const description = pick("description");
-        if (description) return compactText(description);
-        const command = pick("command", "cmd");
-        return command ? compactText(`Run ${command}`, 48) : "Run command";
-      }
-
-      if (tool === "read") {
-        const file = target("filePath", "path", "file");
-        return file ? `Read ${file}` : "Read file";
-      }
-
-      if (tool === "edit") {
-        const file = target("filePath", "path", "file");
-        return file ? `Edit ${file}` : "Edit file";
-      }
-
-      if (tool === "write" || tool === "apply_patch") {
-        const file = target("filePath", "path", "file");
-        return file ? `Update ${file}` : "Update file";
-      }
-
-      if (tool === "grep" || tool === "glob" || tool === "search") {
-        const pattern = pick("pattern", "query");
-        return pattern ? `Search ${compactText(pattern, 36)}` : "Search code";
-      }
-
-      if (tool === "list" || tool === "list_files") {
-        const path = target("path");
-        return path ? `List ${path}` : "List files";
-      }
-
-      if (tool === "task") {
-        const description = pick("description");
-        if (description) return compactText(description);
-        const agent = pick("subagent_type");
-        return agent ? `Delegate ${agent}` : "Delegate task";
-      }
-
-      if (tool === "webfetch") {
-        const url = pick("url");
-        return url ? `Fetch ${compactText(url, 36)}` : "Fetch web page";
-      }
-
-      if (tool === "skill") {
-        const name = pick("name");
-        return name ? `Load skill ${name}` : "Load skill";
-      }
-
-      return "";
-    };
-
-    const latestStepLabel = () => {
-      const step = latestStep();
-      if (!step) return "Last step";
-
-      const fromTool = toolHeadline(step);
-      if (fromTool) return compactText(fromTool);
-
-      if (step.type === "tool") {
-        const toolName = String((step as any).tool ?? "").trim();
-        if (toolName) {
-          const friendlyTool = toolName.replace(/[_-]+/g, " ");
-          return compactText(friendlyTool);
-        }
-      }
-
-      const summary = summarizeStep(step);
-      const title = compactText(summary.title);
-      const detail = compactText(summary.detail ?? "");
-      const generic = /^(application|tool|step|working|done|completed|success)$/i.test(title);
-
-      if (title && !generic) return title;
-      if (detail) return isPathLike(detail) ? compactPathToken(detail) : detail;
-      if (title) return title;
-      return "Last step";
-    };
-    const hasRunning = () =>
-      allStepParts().some((part) => {
-        if (part.type !== "tool") return false;
-        const state = (part as any).state ?? {};
-        return state.status === "running" || state.status === "pending";
-      });
-    const useInnerTimelineScroll = () => !(Boolean(props.isStreaming) && hasRunning());
-
-    const collapsedLabel = () => {
-      if (explorationOnly()) {
-        return explorationState() === "exploring" ? "Exploring" : "Explored";
-      }
-      return expanded() ? "Hide timeline" : "Execution timeline";
-    };
-
-    const collapsedSummary = () => {
-      if (explorationOnly()) {
-        return formatExplorationSummary(explorationSummary());
-      }
-      return executionSummary();
-    };
-
-    const collapsedDetail = () => {
-      if (explorationOnly()) return "";
-      if (expanded()) return executionSummary();
-      return `${executionSummary()} - ${latestStepLabel()}`;
-    };
-
-    const groupHeaderLabel = (group: StepTimelineGroup) => {
-      if (group.mode !== "exploration") return "";
-      return explorationStatus(group.parts) === "exploring" ? "Exploring" : "Explored";
-    };
-
-    const groupHeaderSummary = (group: StepTimelineGroup) => {
-      if (group.mode !== "exploration") return "";
-      return formatExplorationSummary(summarizeExploration(group.parts));
-    };
+    const useInnerTimelineScroll = () => !Boolean(props.isStreaming);
 
     return (
-      <div class={containerProps.isInline ? (containerProps.isUser ? "mt-2" : "mt-3 pt-3") : ""}>
-        {/* Toggle button - clean, compact */}
-        <button
-          class={`flex items-center gap-2 py-1 leading-5 text-[13px] transition-colors ${
-            containerProps.isUser
-              ? "text-gray-10 hover:text-gray-11"
-              : "text-gray-10 hover:text-gray-12"
-          }`}
-          onClick={() => toggleSteps(containerProps.id, relatedIds())}
-        >
-          <ChevronRight
-            size={14}
-            class={`transition-transform duration-200 ${expanded() ? "rotate-90" : ""}`}
-          />
-          <span class="font-medium inline-flex items-center gap-1.5 leading-4 text-xs sm:text-[13px] text-gray-11">
-            <Show when={hasRunning()}>
-              <span class="inline-flex h-1 w-1 rounded-full bg-blue-10/70 animate-pulse" />
-            </Show>
-            <span class="truncate max-w-[58ch]">{collapsedLabel()}</span>
-          </span>
-          <Show when={explorationOnly()}>
-            <span class="text-[11px] leading-4 text-gray-9 truncate max-w-[46ch]">{collapsedSummary()}</span>
-          </Show>
-          <Show when={!explorationOnly() && !expanded()}>
-            <span class="text-[11px] leading-4 text-gray-9 truncate max-w-[42ch]">{collapsedDetail()}</span>
-          </Show>
-          <Show when={!explorationOnly() && expanded()}>
-            <span class="text-[11px] leading-4 text-gray-9 truncate max-w-[42ch]">{collapsedSummary()}</span>
-          </Show>
-        </button>
-
-        {/* Expanded content */}
-        <Show when={expanded()}>
-          <div
-            class={`mt-1 ml-1 pl-3 border-l-2 ${useInnerTimelineScroll() ? "max-h-[480px] overflow-y-auto" : ""} ${
-              containerProps.isUser
-                ? "border-gray-6"
-                : "border-gray-6/60"
-            }`}
-          >
-            <For each={containerProps.stepGroups}>
-              {(group, index) => (
-                <div
-                  class={
-                    index() === 0
-                      ? ""
-                      : "mt-2 pt-2 border-t border-gray-6/40"
-                  }
-                >
-                  <Show when={group.mode === "exploration"}>
-                    <div class="mb-1 flex items-center gap-2 text-[11px] text-gray-9">
-                      <span
-                        class={`font-medium ${
-                          groupHeaderLabel(group) === "Exploring" ? "text-blue-11" : "text-gray-10"
-                        }`}
-                      >
-                        {groupHeaderLabel(group)}
-                      </span>
-                      <span class="truncate">{groupHeaderSummary(group)}</span>
-                    </div>
-                  </Show>
-                  <StepsList parts={group.parts} isUser={containerProps.isUser} groupMode={group.mode} />
-                </div>
-              )}
-            </For>
-          </div>
-        </Show>
+      <div class={containerProps.isInline ? (containerProps.isUser ? "mt-3" : "mt-4") : ""}>
+        <div class={`ml-4 flex flex-col gap-4 ${useInnerTimelineScroll() ? "max-h-[420px] overflow-y-auto pr-1" : ""}`}>
+          <For each={containerProps.stepGroups}>
+            {(group) => <StepsList parts={group.parts} isUser={containerProps.isUser} groupMode={group.mode} />}
+          </For>
+        </div>
       </div>
     );
   };
@@ -924,7 +702,7 @@ export default function MessageList(props: MessageListProps) {
           if (block.kind === "steps-cluster") {
             return (
               <div
-                class={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
+                class={`flex group ${block.isUser ? "justify-center" : "justify-start"}`.trim()}
                 data-message-role={block.isUser ? "user" : "assistant"}
                 data-message-id={block.messageIds[0] ?? ""}
                 style={blockPerfStyle(blockIndex)}
@@ -932,7 +710,7 @@ export default function MessageList(props: MessageListProps) {
                 <div
                   class={`w-full relative ${
                     block.isUser
-                      ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
+                      ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-center text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
                       : "max-w-[760px] text-[15px] leading-[1.7] text-dls-text group"
                   } ${searchOutlineClass}`}
                 >
@@ -981,7 +759,7 @@ export default function MessageList(props: MessageListProps) {
 
           return (
             <div
-              class={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
+              class={`flex group ${block.isUser ? "justify-center" : "justify-start"}`.trim()}
               data-message-role={block.isUser ? "user" : "assistant"}
               data-message-id={block.messageId}
               style={blockPerfStyle(blockIndex)}
@@ -989,7 +767,7 @@ export default function MessageList(props: MessageListProps) {
               <div
                 class={`w-full relative ${
                   block.isUser
-                    ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
+                    ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-center text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
                     : "max-w-[760px] text-[15px] leading-[1.72] text-dls-text antialiased group"
                 } ${searchOutlineClass}`}
               >

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -702,16 +702,16 @@ export default function MessageList(props: MessageListProps) {
           if (block.kind === "steps-cluster") {
             return (
               <div
-                class={`flex group ${block.isUser ? "justify-center" : "justify-start"}`.trim()}
+                class={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
                 data-message-role={block.isUser ? "user" : "assistant"}
                 data-message-id={block.messageIds[0] ?? ""}
                 style={blockPerfStyle(blockIndex)}
               >
                 <div
-                  class={`w-full relative ${
+                  class={`${
                     block.isUser
-                      ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-center text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
-                      : "max-w-[760px] text-[15px] leading-[1.7] text-dls-text group"
+                      ? "relative max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text"
+                      : "w-full relative max-w-[760px] text-[15px] leading-[1.7] text-dls-text group"
                   } ${searchOutlineClass}`}
                 >
                   <StepsContainer
@@ -759,16 +759,16 @@ export default function MessageList(props: MessageListProps) {
 
           return (
             <div
-              class={`flex group ${block.isUser ? "justify-center" : "justify-start"}`.trim()}
+              class={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
               data-message-role={block.isUser ? "user" : "assistant"}
               data-message-id={block.messageId}
               style={blockPerfStyle(blockIndex)}
             >
               <div
-                class={`w-full relative ${
+                class={`${
                   block.isUser
-                    ? "max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-center text-[15px] leading-relaxed text-dls-text shadow-[var(--dls-card-shadow)]"
-                    : "max-w-[760px] text-[15px] leading-[1.72] text-dls-text antialiased group"
+                    ? "relative max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text"
+                    : "w-full relative max-w-[760px] text-[15px] leading-[1.72] text-dls-text antialiased group"
                 } ${searchOutlineClass}`}
               >
                 <Show when={attachmentsForMessage(block.message).length > 0}>

--- a/packages/app/src/app/components/session/workspace-session-list.tsx
+++ b/packages/app/src/app/components/session/workspace-session-list.tsx
@@ -187,7 +187,7 @@ export default function WorkspaceSessionList(props: Props) {
                   <div
                     role="button"
                     tabIndex={0}
-                    class={`w-full flex items-center justify-between rounded-[20px] border px-4 py-3.5 text-left transition-[background-color,border-color,box-shadow] ${
+                    class={`w-full flex items-center justify-between rounded-[20px] border px-4 py-3 text-left transition-[background-color,border-color,box-shadow] ${
                       props.activeWorkspaceId === workspace().id
                         ? "border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]"
                         : "border-transparent text-gray-12 hover:bg-gray-2/70"
@@ -209,15 +209,15 @@ export default function WorkspaceSessionList(props: Props) {
                         class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
                         style={{ "background-color": workspaceSwatchColor(workspace().id || workspaceLabel(workspace())) }}
                       />
-                      <span class="truncate text-[16px] font-medium text-dls-text">{workspaceLabel(workspace())}</span>
+                      <div class="min-w-0">
+                        <div class="truncate text-[16px] font-medium text-dls-text">{workspaceLabel(workspace())}</div>
+                        <div class={`mt-0.5 truncate text-[13px] ${statusTone()}`}>{statusLabel()}</div>
+                      </div>
                     </div>
 
-                    <div class="ml-4 flex shrink-0 items-center gap-2">
+                    <div class="ml-4 flex shrink-0 items-center gap-1.5">
                       <Show when={group.status === "loading" || isConnecting()}>
                         <Loader2 size={14} class="animate-spin text-gray-9" />
-                      </Show>
-                      <Show when={!(group.status === "loading" || isConnecting())}>
-                        <span class={`text-[14px] ${statusTone()}`}>{statusLabel()}</span>
                       </Show>
 
                       <div class="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">

--- a/packages/app/src/app/components/session/workspace-session-list.tsx
+++ b/packages/app/src/app/components/session/workspace-session-list.tsx
@@ -48,6 +48,30 @@ const workspaceKindLabel = (workspace: WorkspaceInfo) =>
       : "Remote"
     : "Local";
 
+const WORKSPACE_SWATCHES = ["#2563eb", "#5a67d8", "#f97316", "#10b981"];
+
+const workspaceSwatchColor = (seed: string) => {
+  const value = seed.trim() || "worker";
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return WORKSPACE_SWATCHES[Math.abs(hash) % WORKSPACE_SWATCHES.length];
+};
+
+const workspaceSubtitle = (workspace: WorkspaceInfo) => {
+  if (workspace.workspaceType === "remote") {
+    return (
+      workspace.openworkWorkspaceName?.trim() ||
+      workspace.directory?.trim() ||
+      workspace.baseUrl?.trim() ||
+      `${workspaceKindLabel(workspace)} worker`
+    );
+  }
+  return "Local worker";
+};
+
 export default function WorkspaceSessionList(props: Props) {
   const revealLabel = isWindowsPlatform() ? "Reveal in Explorer" : "Reveal in Finder";
   const [expandedWorkspaceIds, setExpandedWorkspaceIds] = createSignal<Set<string>>(new Set());
@@ -143,7 +167,7 @@ export default function WorkspaceSessionList(props: Props) {
 
   return (
     <>
-      <div class="space-y-5 mb-3">
+      <div class="mb-4 space-y-4">
         <For each={props.workspaceSessionGroups}>
           {(group) => {
             const workspace = () => group.workspace;
@@ -156,14 +180,30 @@ export default function WorkspaceSessionList(props: Props) {
               workspace().workspaceType === "remote" && connectionState().status === "error";
             const isMenuOpen = () => workspaceMenuId() === workspace().id;
             const taskLoadError = () => getWorkspaceTaskLoadErrorDisplay(workspace(), group.error);
+            const statusLabel = () => {
+              if (group.status === "error") return taskLoadError().label;
+              if (isConnectionActionBusy()) return "Connecting";
+              if (props.activeWorkspaceId === workspace().id) return "Active";
+              return workspaceKindLabel(workspace());
+            };
+            const statusTone = () => {
+              if (group.status === "error") {
+                return taskLoadError().tone === "offline" ? "text-amber-11" : "text-red-11";
+              }
+              return "text-gray-9";
+            };
 
             return (
-              <div class="space-y-2">
+              <div class="space-y-2.5">
                 <div class="relative group">
                   <div
                     role="button"
                     tabIndex={0}
-                    class="w-full flex items-center justify-between min-h-11 px-3 rounded-xl text-left transition-colors text-gray-12 hover:bg-gray-3/70"
+                    class={`w-full flex items-center gap-3.5 rounded-[20px] border px-4 py-4 text-left transition-[background-color,border-color,box-shadow] ${
+                      props.activeWorkspaceId === workspace().id
+                        ? "border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]"
+                        : "border-transparent text-gray-12 hover:bg-gray-2/70"
+                    } ${isConnecting() ? "opacity-75" : ""}`}
                     onClick={() => {
                       expandWorkspace(workspace().id);
                       void Promise.resolve(props.onActivateWorkspace(workspace().id));
@@ -176,90 +216,81 @@ export default function WorkspaceSessionList(props: Props) {
                       void Promise.resolve(props.onActivateWorkspace(workspace().id));
                     }}
                   >
-                    <button
-                      type="button"
-                      class="mr-2 -ml-1 p-1 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-4/80"
-                      aria-label={isWorkspaceExpanded(workspace().id) ? "Collapse" : "Expand"}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        toggleWorkspaceExpanded(workspace().id);
-                      }}
-                    >
-                      <Show
-                        when={isWorkspaceExpanded(workspace().id)}
-                        fallback={<ChevronRight size={14} />}
-                      >
-                        <ChevronDown size={14} />
-                      </Show>
-                    </button>
+                    <div
+                      class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+                      style={{ "background-color": workspaceSwatchColor(workspace().id || workspaceLabel(workspace())) }}
+                    />
 
                     <div class="min-w-0 flex-1">
-                      <div class="text-[14px] font-medium truncate">{workspaceLabel(workspace())}</div>
-                      <div class="text-[11px] text-gray-10 flex items-center gap-1.5">
-                        <span>{workspaceKindLabel(workspace())}</span>
-                      </div>
+                      <div class="truncate text-[15px] font-medium text-dls-text">{workspaceLabel(workspace())}</div>
+                      <div class="mt-1 truncate text-[13px] text-dls-secondary">{workspaceSubtitle(workspace())}</div>
                     </div>
 
-                    <Show when={group.status === "loading"}>
-                      <Loader2 size={14} class="animate-spin text-gray-10 mr-1" />
-                    </Show>
+                    <div class="flex shrink-0 items-center gap-2.5">
+                      <Show when={group.status === "loading" || isConnecting()}>
+                        <Loader2 size={14} class="animate-spin text-gray-9" />
+                      </Show>
+                      <Show when={!(group.status === "loading" || isConnecting())}>
+                        <span class={`text-[12px] ${statusTone()}`}>{statusLabel()}</span>
+                      </Show>
 
-                    <Show when={group.status === "error"}>
-                      <span
-                        class={`text-[10px] px-2 py-0.5 rounded-full border ${
-                          taskLoadError().tone === "offline"
-                            ? "border-amber-7 text-amber-11 bg-amber-3"
-                            : "border-red-7 text-red-11 bg-red-3"
-                        }`}
-                        title={taskLoadError().title}
+                      <div class="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                        <button
+                          type="button"
+                          class="p-1.5 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-3/80"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            props.onCreateTaskInWorkspace(workspace().id);
+                          }}
+                          disabled={props.newTaskDisabled}
+                          aria-label="New task"
+                        >
+                          <Plus size={14} />
+                        </button>
+
+                        <button
+                          type="button"
+                          class="p-1.5 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-3/80"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setWorkspaceMenuId((current) =>
+                              current === workspace().id ? null : workspace().id,
+                            );
+                          }}
+                          aria-label="Worker options"
+                        >
+                          <MoreHorizontal size={14} />
+                        </button>
+                      </div>
+
+                      <button
+                        type="button"
+                        class="p-1.5 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-3/80"
+                        aria-label={isWorkspaceExpanded(workspace().id) ? "Collapse" : "Expand"}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          toggleWorkspaceExpanded(workspace().id);
+                        }}
                       >
-                        {taskLoadError().label}
-                      </span>
-                    </Show>
-
-                    <Show when={isConnecting()}>
-                      <Loader2 size={14} class="animate-spin text-gray-10" />
-                    </Show>
-                  </div>
-
-                  <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-                    <button
-                      type="button"
-                      class="p-1 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-4/80"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        props.onCreateTaskInWorkspace(workspace().id);
-                      }}
-                      disabled={props.newTaskDisabled}
-                      aria-label="New task"
-                    >
-                      <Plus size={14} />
-                    </button>
-
-                    <button
-                      type="button"
-                      class="p-1 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-4/80"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        setWorkspaceMenuId((current) =>
-                          current === workspace().id ? null : workspace().id,
-                        );
-                      }}
-                      aria-label="Worker options"
-                    >
-                      <MoreHorizontal size={14} />
-                    </button>
+                        <Show
+                          when={isWorkspaceExpanded(workspace().id)}
+                          fallback={<ChevronRight size={14} />}
+                        >
+                          <ChevronDown size={14} />
+                        </Show>
+                      </button>
+                    </div>
                   </div>
 
                   <Show when={isMenuOpen()}>
                     <div
                       ref={(el) => (workspaceMenuRef = el)}
-                      class="absolute right-2 top-[calc(100%+4px)] z-20 w-44 rounded-lg border border-gray-6 bg-gray-1 shadow-lg p-1"
+                      class="absolute right-0 top-[calc(100%+6px)] z-20 w-48 rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]"
                       onClick={(event) => event.stopPropagation()}
                     >
                       <button
                         type="button"
-                        class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3"
+                        class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                         onClick={() => {
                           props.onOpenRenameWorkspace(workspace().id);
                           setWorkspaceMenuId(null);
@@ -269,7 +300,7 @@ export default function WorkspaceSessionList(props: Props) {
                       </button>
                       <button
                         type="button"
-                        class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3"
+                        class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                         onClick={() => {
                           props.onShareWorkspace(workspace().id);
                           setWorkspaceMenuId(null);
@@ -280,7 +311,7 @@ export default function WorkspaceSessionList(props: Props) {
                       <Show when={workspace().workspaceType === "local"}>
                         <button
                           type="button"
-                          class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3"
+                          class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                           onClick={() => {
                             props.onRevealWorkspace(workspace().id);
                             setWorkspaceMenuId(null);
@@ -293,7 +324,7 @@ export default function WorkspaceSessionList(props: Props) {
                         <Show when={canRecover()}>
                           <button
                             type="button"
-                            class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3"
+                            class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                             onClick={() => {
                               void Promise.resolve(props.onRecoverWorkspace(workspace().id));
                               setWorkspaceMenuId(null);
@@ -305,7 +336,7 @@ export default function WorkspaceSessionList(props: Props) {
                         </Show>
                         <button
                           type="button"
-                          class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3"
+                          class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                           onClick={() => {
                             void Promise.resolve(props.onTestWorkspaceConnection(workspace().id));
                             setWorkspaceMenuId(null);
@@ -316,7 +347,7 @@ export default function WorkspaceSessionList(props: Props) {
                         </button>
                         <button
                           type="button"
-                          class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3"
+                          class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                           onClick={() => {
                             props.onEditWorkspaceConnection(workspace().id);
                             setWorkspaceMenuId(null);
@@ -328,7 +359,7 @@ export default function WorkspaceSessionList(props: Props) {
                       </Show>
                       <button
                         type="button"
-                        class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3 text-red-11"
+                        class="w-full rounded-xl px-3 py-2 text-left text-sm text-red-11 transition-colors hover:bg-red-1/40"
                         onClick={() => {
                           props.onForgetWorkspace(workspace().id);
                           setWorkspaceMenuId(null);
@@ -340,7 +371,7 @@ export default function WorkspaceSessionList(props: Props) {
                   </Show>
                 </div>
 
-                <div class="mt-0.5 space-y-0.5 border-l border-gray-6 ml-2">
+                <div class="ml-7 mt-1 space-y-1.5 border-l-2 border-dls-border pl-4">
                   <Show
                     when={isWorkspaceExpanded(workspace().id)}
                     fallback={
@@ -353,8 +384,10 @@ export default function WorkspaceSessionList(props: Props) {
                               <div
                                 role="button"
                                 tabIndex={0}
-                                class={`group flex items-center justify-between min-h-9 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
-                                  isSelected() ? "bg-gray-4/90 text-gray-12" : "hover:bg-gray-3/70"
+                                class={`group flex min-h-11 w-full items-center justify-between rounded-[16px] border px-3.5 py-3 transition-[background-color,border-color,box-shadow] ${
+                                  isSelected()
+                                    ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
+                                    : "border-transparent text-gray-11 hover:bg-gray-2/60"
                                 }`}
                                 onClick={() => props.onOpenSession(workspace().id, session.id)}
                                 onKeyDown={(event) => {
@@ -364,14 +397,14 @@ export default function WorkspaceSessionList(props: Props) {
                                   props.onOpenSession(workspace().id, session.id);
                                 }}
                               >
-                                <div class="flex min-w-0 items-center gap-1.5 mr-2">
+                                <div class="mr-3 flex min-w-0 items-center gap-2">
                                   <Show when={isSessionActive()}>
                                     <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" />
                                   </Show>
-                                  <span class="text-[13px] text-gray-11 truncate font-medium">{session.title}</span>
+                                  <span class="truncate text-[14px] font-medium text-current">{session.title}</span>
                                 </div>
                                 <Show when={session.time?.updated}>
-                                  <span class="text-[11px] text-gray-9 whitespace-nowrap group-hover:text-gray-10 transition-colors">
+                                  <span class="whitespace-nowrap text-[12px] text-gray-9 transition-colors group-hover:text-gray-10">
                                     {formatRelativeTime(session.time?.updated ?? Date.now())}
                                   </span>
                                 </Show>
@@ -390,10 +423,10 @@ export default function WorkspaceSessionList(props: Props) {
                           fallback={
                             <Show when={group.status === "error"}>
                               <div
-                                class={`w-full px-3 py-2 text-xs ml-2 text-left rounded-lg border ${
+                                class={`w-full rounded-[16px] border px-3.5 py-3 text-left text-xs ${
                                   taskLoadError().tone === "offline"
-                                    ? "text-amber-11 bg-amber-3 border-amber-7"
-                                    : "text-red-11 bg-red-3 border-red-7"
+                                    ? "border-amber-7/35 bg-amber-2/50 text-amber-11"
+                                    : "border-red-7/35 bg-red-1/40 text-red-11"
                                 }`}
                                 title={taskLoadError().title}
                               >
@@ -410,8 +443,10 @@ export default function WorkspaceSessionList(props: Props) {
                                 <div
                                   role="button"
                                   tabIndex={0}
-                                  class={`group flex items-center justify-between min-h-9 px-3 rounded-lg cursor-pointer relative overflow-hidden ml-2 w-[calc(100%-0.5rem)] ${
-                                    isSelected() ? "bg-gray-4/90 text-gray-12" : "hover:bg-gray-3/70"
+                                  class={`group flex min-h-11 w-full items-center justify-between rounded-[16px] border px-3.5 py-3 transition-[background-color,border-color,box-shadow] ${
+                                    isSelected()
+                                      ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
+                                      : "border-transparent text-gray-11 hover:bg-gray-2/60"
                                   }`}
                                   onClick={() => props.onOpenSession(workspace().id, session.id)}
                                   onKeyDown={(event) => {
@@ -421,14 +456,14 @@ export default function WorkspaceSessionList(props: Props) {
                                     props.onOpenSession(workspace().id, session.id);
                                   }}
                                 >
-                                  <div class="flex min-w-0 items-center gap-1.5 mr-2">
+                                  <div class="mr-3 flex min-w-0 items-center gap-2">
                                     <Show when={isSessionActive()}>
                                       <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" />
                                     </Show>
-                                    <span class="text-[13px] text-gray-11 truncate font-medium">{session.title}</span>
+                                    <span class="truncate text-[14px] font-medium text-current">{session.title}</span>
                                   </div>
                                   <Show when={session.time?.updated}>
-                                    <span class="text-[11px] text-gray-9 whitespace-nowrap group-hover:text-gray-10 transition-colors">
+                                    <span class="whitespace-nowrap text-[12px] text-gray-9 transition-colors group-hover:text-gray-10">
                                       {formatRelativeTime(session.time?.updated ?? Date.now())}
                                     </span>
                                   </Show>
@@ -440,7 +475,7 @@ export default function WorkspaceSessionList(props: Props) {
                           <Show when={group.sessions.length === 0 && group.status === "ready"}>
                             <button
                               type="button"
-                              class="group/empty w-full px-3 py-2 text-xs text-gray-10 ml-2 text-left rounded-lg hover:bg-gray-3/70 hover:text-gray-11 transition-colors"
+                              class="group/empty w-full rounded-[16px] border border-transparent px-3.5 py-3 text-left text-xs text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
                               onClick={() => props.onCreateTaskInWorkspace(workspace().id)}
                               disabled={props.newTaskDisabled}
                             >
@@ -452,7 +487,7 @@ export default function WorkspaceSessionList(props: Props) {
                           <Show when={group.sessions.length > previewCount(workspace().id)}>
                             <button
                               type="button"
-                              class="ml-2 w-[calc(100%-0.5rem)] px-3 py-2 text-xs text-gray-10 hover:text-gray-11 hover:bg-gray-3/70 rounded-lg transition-colors text-left"
+                              class="w-full rounded-[16px] border border-transparent px-3.5 py-3 text-left text-xs text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
                               onClick={() => showMoreSessions(workspace().id, group.sessions.length)}
                             >
                               {showMoreLabel(workspace().id, group.sessions.length)}
@@ -461,7 +496,7 @@ export default function WorkspaceSessionList(props: Props) {
                         </Show>
                       }
                     >
-                      <div class="w-full px-3 py-2 text-xs text-gray-10 ml-2 text-left rounded-lg">
+                      <div class="w-full rounded-[16px] px-3.5 py-3 text-left text-xs text-gray-10">
                         Loading tasks...
                       </div>
                     </Show>
@@ -476,7 +511,7 @@ export default function WorkspaceSessionList(props: Props) {
       <div class="relative" ref={(el) => (addWorkspaceMenuRef = el)}>
         <button
           type="button"
-          class="w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg text-[13px] font-medium text-gray-11 border border-gray-6 bg-gray-1 hover:bg-gray-2 shadow-sm transition-colors"
+          class="w-full flex items-center justify-center gap-2 rounded-[18px] border border-dls-border bg-dls-surface px-4 py-3 text-[13px] font-medium text-gray-11 shadow-[var(--dls-card-shadow)] transition-colors hover:bg-gray-2"
           onClick={() => setAddWorkspaceMenuOpen((prev) => !prev)}
         >
           <Plus size={14} />
@@ -484,10 +519,10 @@ export default function WorkspaceSessionList(props: Props) {
         </button>
 
         <Show when={addWorkspaceMenuOpen()}>
-          <div class="absolute left-0 right-0 top-full mt-2 rounded-lg border border-gray-6 bg-gray-1 shadow-xl overflow-hidden z-20">
+          <div class="absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]">
             <button
               type="button"
-              class="w-full flex items-center gap-2 px-3 py-2 text-xs text-gray-11 hover:text-gray-12 hover:bg-gray-3 transition-colors"
+              class="w-full flex items-center gap-2 rounded-xl px-3 py-2 text-xs text-gray-11 transition-colors hover:bg-gray-2 hover:text-gray-12"
               onClick={() => {
                 props.onOpenCreateWorkspace();
                 setAddWorkspaceMenuOpen(false);
@@ -498,7 +533,7 @@ export default function WorkspaceSessionList(props: Props) {
             </button>
             <button
               type="button"
-              class="w-full flex items-center gap-2 px-3 py-2 text-xs text-gray-11 hover:text-gray-12 hover:bg-gray-3 transition-colors"
+              class="w-full flex items-center gap-2 rounded-xl px-3 py-2 text-xs text-gray-11 transition-colors hover:bg-gray-2 hover:text-gray-12"
               onClick={() => {
                 props.onOpenCreateRemoteWorkspace();
                 setAddWorkspaceMenuOpen(false);
@@ -509,7 +544,7 @@ export default function WorkspaceSessionList(props: Props) {
             </button>
             <button
               type="button"
-              class="w-full flex items-center gap-2 px-3 py-2 text-xs text-gray-11 hover:text-gray-12 hover:bg-gray-3 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              class="w-full flex items-center gap-2 rounded-xl px-3 py-2 text-xs text-gray-11 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:cursor-not-allowed disabled:opacity-60"
               disabled={props.importingWorkspaceConfig}
               onClick={() => {
                 props.onImportWorkspaceConfig();

--- a/packages/app/src/app/components/session/workspace-session-list.tsx
+++ b/packages/app/src/app/components/session/workspace-session-list.tsx
@@ -60,18 +60,6 @@ const workspaceSwatchColor = (seed: string) => {
   return WORKSPACE_SWATCHES[Math.abs(hash) % WORKSPACE_SWATCHES.length];
 };
 
-const workspaceSubtitle = (workspace: WorkspaceInfo) => {
-  if (workspace.workspaceType === "remote") {
-    return (
-      workspace.openworkWorkspaceName?.trim() ||
-      workspace.directory?.trim() ||
-      workspace.baseUrl?.trim() ||
-      `${workspaceKindLabel(workspace)} worker`
-    );
-  }
-  return "Local worker";
-};
-
 export default function WorkspaceSessionList(props: Props) {
   const revealLabel = isWindowsPlatform() ? "Reveal in Explorer" : "Reveal in Finder";
   const [expandedWorkspaceIds, setExpandedWorkspaceIds] = createSignal<Set<string>>(new Set());
@@ -194,12 +182,12 @@ export default function WorkspaceSessionList(props: Props) {
             };
 
             return (
-              <div class="space-y-2.5">
+              <div class="space-y-2">
                 <div class="relative group">
                   <div
                     role="button"
                     tabIndex={0}
-                    class={`w-full flex items-center gap-3.5 rounded-[20px] border px-4 py-4 text-left transition-[background-color,border-color,box-shadow] ${
+                    class={`w-full flex items-center justify-between rounded-[20px] border px-4 py-3.5 text-left transition-[background-color,border-color,box-shadow] ${
                       props.activeWorkspaceId === workspace().id
                         ? "border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]"
                         : "border-transparent text-gray-12 hover:bg-gray-2/70"
@@ -216,28 +204,26 @@ export default function WorkspaceSessionList(props: Props) {
                       void Promise.resolve(props.onActivateWorkspace(workspace().id));
                     }}
                   >
-                    <div
-                      class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
-                      style={{ "background-color": workspaceSwatchColor(workspace().id || workspaceLabel(workspace())) }}
-                    />
-
-                    <div class="min-w-0 flex-1">
-                      <div class="truncate text-[15px] font-medium text-dls-text">{workspaceLabel(workspace())}</div>
-                      <div class="mt-1 truncate text-[13px] text-dls-secondary">{workspaceSubtitle(workspace())}</div>
+                    <div class="flex min-w-0 items-center gap-4">
+                      <div
+                        class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
+                        style={{ "background-color": workspaceSwatchColor(workspace().id || workspaceLabel(workspace())) }}
+                      />
+                      <span class="truncate text-[16px] font-medium text-dls-text">{workspaceLabel(workspace())}</span>
                     </div>
 
-                    <div class="flex shrink-0 items-center gap-2.5">
+                    <div class="ml-4 flex shrink-0 items-center gap-2">
                       <Show when={group.status === "loading" || isConnecting()}>
                         <Loader2 size={14} class="animate-spin text-gray-9" />
                       </Show>
                       <Show when={!(group.status === "loading" || isConnecting())}>
-                        <span class={`text-[12px] ${statusTone()}`}>{statusLabel()}</span>
+                        <span class={`text-[14px] ${statusTone()}`}>{statusLabel()}</span>
                       </Show>
 
                       <div class="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
                         <button
                           type="button"
-                          class="p-1.5 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-3/80"
+                          class="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
                           onClick={(event) => {
                             event.stopPropagation();
                             props.onCreateTaskInWorkspace(workspace().id);
@@ -250,7 +236,7 @@ export default function WorkspaceSessionList(props: Props) {
 
                         <button
                           type="button"
-                          class="p-1.5 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-3/80"
+                          class="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
                           onClick={(event) => {
                             event.stopPropagation();
                             setWorkspaceMenuId((current) =>
@@ -265,7 +251,7 @@ export default function WorkspaceSessionList(props: Props) {
 
                       <button
                         type="button"
-                        class="p-1.5 rounded-md text-gray-9 hover:text-gray-11 hover:bg-gray-3/80"
+                        class="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
                         aria-label={isWorkspaceExpanded(workspace().id) ? "Collapse" : "Expand"}
                         onClick={(event) => {
                           event.stopPropagation();

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -15,6 +15,11 @@ type StatusBarProps = {
   onOpenMcp: () => void;
   providerConnectedIds: string[];
   mcpStatuses: McpStatusMap;
+  statusLabel?: string;
+  statusDetail?: string;
+  statusDotClass?: string;
+  statusPingClass?: string;
+  statusPulse?: boolean;
 };
 
 export default function StatusBar(props: StatusBarProps) {
@@ -24,6 +29,16 @@ export default function StatusBar(props: StatusBarProps) {
   );
 
   const statusCopy = createMemo(() => {
+    if (props.statusLabel) {
+      return {
+        label: props.statusLabel,
+        detail: props.statusDetail ?? "",
+        dotClass: props.statusDotClass ?? "bg-green-9",
+        pingClass: props.statusPingClass ?? "bg-green-9/45 animate-ping",
+        pulse: props.statusPulse ?? true,
+      };
+    }
+
     const providers = providerConnectedCount();
     const mcp = mcpConnectedCount();
 

--- a/packages/app/src/app/components/status-bar.tsx
+++ b/packages/app/src/app/components/status-bar.tsx
@@ -1,12 +1,8 @@
-import { Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { Show, createMemo } from "solid-js";
 import { Settings } from "lucide-solid";
 
 import type { OpenworkServerStatus } from "../lib/openwork-server";
-import type { OpenCodeRouterStatus } from "../lib/tauri";
 import type { McpStatusMap } from "../types";
-import { getOpenCodeRouterStatus } from "../lib/tauri";
-
-import Button from "./button";
 
 type StatusBarProps = {
   clientConnected: boolean;
@@ -22,166 +18,83 @@ type StatusBarProps = {
 };
 
 export default function StatusBar(props: StatusBarProps) {
-  const [opencodeRouterStatus, setOpenCodeRouterStatus] = createSignal<OpenCodeRouterStatus | null>(null);
-  const [documentVisible, setDocumentVisible] = createSignal(true);
-
-  type ProTip = {
-    id: string;
-    label: string;
-    enabled: () => boolean;
-    action: () => void | Promise<void>;
-  };
-
   const providerConnectedCount = createMemo(() => props.providerConnectedIds?.length ?? 0);
-  const notionStatus = createMemo(() => props.mcpStatuses?.notion?.status ?? "disconnected");
+  const mcpConnectedCount = createMemo(
+    () => Object.values(props.mcpStatuses ?? {}).filter((status) => status?.status === "connected").length,
+  );
 
-  const runAction = (action?: () => void | Promise<void>) => {
-    if (!action) return;
-    const result = action();
-    if (result && typeof (result as Promise<void>).catch === "function") {
-      (result as Promise<void>).catch(() => undefined);
-    }
-  };
+  const statusCopy = createMemo(() => {
+    const providers = providerConnectedCount();
+    const mcp = mcpConnectedCount();
 
-  const proTips = createMemo<ProTip[]>(() => [
-    {
-      id: "slack",
-      label: "Connect Slack",
-      enabled: () => {
-        const status = opencodeRouterStatus();
-        return Boolean(status && (status.slack.items?.length ?? 0) === 0);
-      },
-      action: () => runAction(props.onOpenMessaging),
-    },
-    {
-      id: "telegram",
-      label: "Connect Telegram",
-      enabled: () => {
-        const status = opencodeRouterStatus();
-        return Boolean(status && (status.telegram.items?.length ?? 0) === 0);
-      },
-      action: () => runAction(props.onOpenMessaging),
-    },
-    {
-      id: "notion",
-      label: "Connect Notion MCP",
-      enabled: () => notionStatus() !== "connected",
-      action: () => runAction(props.onOpenMcp),
-    },
-    {
-      id: "providers",
-      label: "Use your own models (OpenRouter, Anthropic, OpenAI)",
-      enabled: () => props.clientConnected && providerConnectedCount() === 0,
-      action: () => runAction(props.onOpenProviders),
-    },
-  ]);
-
-  const availableTips = createMemo<ProTip[]>(() => proTips().filter((tip: ProTip) => tip.enabled()));
-  const [activeTip, setActiveTip] = createSignal<ProTip | null>(null);
-  const [tipVisible, setTipVisible] = createSignal(false);
-  const [tipCursor, setTipCursor] = createSignal(0);
-  let tipTimer: number | undefined;
-  let tipHideTimer: number | undefined;
-
-  const pickNextTip = () => {
-    const tips = availableTips();
-    if (!tips.length) return null;
-    const index = tipCursor() % tips.length;
-    const next = tips[index];
-    setTipCursor(index + 1);
-    setActiveTip(next);
-    return next;
-  };
-
-  const scheduleTips = (delayMs: number) => {
-    if (tipTimer) window.clearTimeout(tipTimer);
-    tipTimer = window.setTimeout(() => {
-      if (!availableTips().length) {
-        setTipVisible(false);
-        scheduleTips(20_000);
-        return;
+    if (props.clientConnected) {
+      const detailBits: string[] = [];
+      if (providers > 0) {
+        detailBits.push(`${providers} provider${providers === 1 ? "" : "s"} connected`);
       }
-      if (Math.random() < 0.55) {
-        pickNextTip();
-        setTipVisible(true);
-        if (tipHideTimer) window.clearTimeout(tipHideTimer);
-        tipHideTimer = window.setTimeout(() => setTipVisible(false), 9_000);
-      } else {
-        setTipVisible(false);
+      if (mcp > 0) {
+        detailBits.push(`${mcp} MCP connected`);
       }
-      scheduleTips(18_000 + Math.round(Math.random() * 10_000));
-    }, delayMs);
-  };
-
-  createEffect(() => {
-    const tips = availableTips();
-    const current = activeTip();
-    if (current && tips.some((tip: ProTip) => tip.id === current.id)) return;
-    if (!tips.length) {
-      setActiveTip(null);
-      setTipVisible(false);
-      return;
+      if (!detailBits.length) {
+        detailBits.push("Ready for new tasks");
+      }
+      if (props.developerMode) {
+        detailBits.push("Developer mode");
+      }
+      return {
+        label: "OpenWork Ready",
+        detail: detailBits.join(" · "),
+        dotClass: "bg-green-9",
+        pingClass: "bg-green-9/45 animate-ping",
+        pulse: true,
+      };
     }
-    setActiveTip(tips[0]);
-    setTipCursor(1);
-  });
 
-  const refreshOpenCodeRouter = async () => {
-    const next = await getOpenCodeRouterStatus();
-    setOpenCodeRouterStatus(next);
-  };
+    if (props.openworkServerStatus === "limited") {
+      return {
+        label: "Limited Mode",
+        detail:
+          mcp > 0
+            ? `${mcp} MCP connected · reconnect for full features`
+            : "Reconnect to restore full OpenWork features",
+        dotClass: "bg-amber-9",
+        pingClass: "bg-amber-9/35",
+        pulse: false,
+      };
+    }
 
-  createEffect(() => {
-    if (typeof document === "undefined") return;
-    const update = () => setDocumentVisible(document.visibilityState !== "hidden");
-    update();
-    document.addEventListener("visibilitychange", update);
-    onCleanup(() => document.removeEventListener("visibilitychange", update));
-  });
-
-  createEffect(() => {
-    if (!documentVisible()) return;
-    refreshOpenCodeRouter();
-    const interval = window.setInterval(refreshOpenCodeRouter, 15_000);
-    onCleanup(() => window.clearInterval(interval));
-  });
-
-  onMount(() => {
-    scheduleTips(6_000);
-    onCleanup(() => {
-      if (tipTimer) window.clearTimeout(tipTimer);
-      if (tipHideTimer) window.clearTimeout(tipHideTimer);
-    });
+    return {
+      label: "Disconnected",
+      detail: "Open settings to reconnect",
+      dotClass: "bg-red-9",
+      pingClass: "bg-red-9/35",
+      pulse: false,
+    };
   });
 
   return (
-    <div class="border-t border-gray-6 bg-gray-1/90 backdrop-blur-md">
-      <div class="flex min-h-11 items-center gap-2 px-4 py-2 text-xs">
-        <div class="flex min-w-0 flex-1 justify-end">
-          <Show when={tipVisible() && activeTip()}>
-            <button
-              type="button"
-              class="flex h-7 min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-full border border-gray-6/70 bg-gray-2/40 px-3 text-xs text-gray-10 transition-colors hover:bg-gray-2/60"
-              onClick={() => runAction(activeTip()?.action)}
-              title={activeTip()?.label}
-              aria-label={activeTip()?.label}
-            >
-              <span class="shrink-0 uppercase tracking-[0.2em] text-[10px] text-gray-8">Tip</span>
-              <span class="truncate text-gray-11 font-medium">{activeTip()?.label}</span>
-            </button>
-          </Show>
+    <div class="border-t border-dls-border bg-dls-surface">
+      <div class="flex h-12 items-center justify-between gap-3 px-4 md:px-6 text-[12px] text-dls-secondary">
+        <div class="flex min-w-0 items-center gap-2.5">
+          <span class="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
+            <Show when={statusCopy().pulse}>
+              <span class={`absolute inline-flex h-full w-full rounded-full ${statusCopy().pingClass}`} />
+            </Show>
+            <span class={`relative inline-flex h-2.5 w-2.5 rounded-full ${statusCopy().dotClass}`} />
+          </span>
+          <span class="shrink-0 font-medium text-dls-text">{statusCopy().label}</span>
+          <span class="truncate text-dls-secondary">{statusCopy().detail}</span>
         </div>
-        <Button
-          variant="ghost"
-          class={`h-7 shrink-0 py-0 text-xs ${props.developerMode ? "w-28 px-2.5" : "w-9 px-0"} ${props.settingsOpen ? "bg-gray-3 text-gray-12 hover:bg-gray-4" : ""}`}
+
+        <button
+          type="button"
+          class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
           onClick={props.onOpenSettings}
           title={props.settingsOpen ? "Back to previous screen" : "Settings"}
+          aria-label={props.settingsOpen ? "Back to previous screen" : "Settings"}
         >
-          <Settings class="h-4 w-4 shrink-0" />
-          <Show when={props.developerMode}>
-            <span class="truncate text-gray-11 font-medium">{props.settingsOpen ? "Back" : "Settings"}</span>
-          </Show>
-        </Button>
+          <Settings class="h-4 w-4" />
+        </button>
       </div>
     </div>
   );

--- a/packages/app/src/app/index.css
+++ b/packages/app/src/app/index.css
@@ -7,6 +7,7 @@
   color-scheme: light;
   --dls-surface: #ffffff;
   --dls-sidebar: #f9fafb;
+  --dls-app-bg: #ffffff;
   --dls-border: #f3f4f6;
   --dls-accent: #011627;
   --dls-accent-hover: #000000;
@@ -25,6 +26,7 @@
   color-scheme: dark;
   --dls-surface: #121212;
   --dls-sidebar: #1a1a1a;
+  --dls-app-bg: #161616;
   --dls-border: #262626;
   --dls-accent: #3b82f6;
   --dls-accent-hover: #2563eb;

--- a/packages/app/src/app/index.css
+++ b/packages/app/src/app/index.css
@@ -67,7 +67,7 @@ body {
   font-size: 0.875rem;
   line-height: 1.5;
   color: var(--dls-text-primary);
-  background-color: var(--dls-sidebar);
+  background-color: var(--dls-surface);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/app/src/app/index.css
+++ b/packages/app/src/app/index.css
@@ -7,16 +7,18 @@
   color-scheme: light;
   --dls-surface: #ffffff;
   --dls-sidebar: #f9fafb;
-  --dls-border: #e2e8f0;
-  --dls-accent: #1b29ff;
-  --dls-accent-hover: #1d4ed8;
-  --dls-accent-rgb: 27 41 255;
+  --dls-border: #f3f4f6;
+  --dls-accent: #011627;
+  --dls-accent-hover: #000000;
+  --dls-accent-rgb: 1 22 39;
   --dls-text-primary: #111827;
-  --dls-text-secondary: #64748b;
-  --dls-hover: #f8fafc;
-  --dls-active: #eaebef;
-  --dls-radius: 8px;
-  --dls-radius-lg: 16px;
+  --dls-text-secondary: #6b7280;
+  --dls-hover: #f3f4f6;
+  --dls-active: #eef2f7;
+  --dls-radius: 16px;
+  --dls-radius-lg: 24px;
+  --dls-shell-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  --dls-card-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
 }
 
 [data-theme="dark"] {
@@ -31,6 +33,8 @@
   --dls-text-secondary: #9ca3af;
   --dls-hover: #1f1f1f;
   --dls-active: #2d2d2d;
+  --dls-shell-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
+  --dls-card-shadow: 0 14px 36px rgba(0, 0, 0, 0.24);
 }
 
 html,
@@ -63,7 +67,7 @@ body {
   font-size: 0.875rem;
   line-height: 1.5;
   color: var(--dls-text-primary);
-  background-color: var(--dls-surface);
+  background-color: var(--dls-sidebar);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -60,6 +60,7 @@ import {
   Circle,
   History,
   Loader2,
+  Menu,
   MessageCircle,
   MoreHorizontal,
   Plus,
@@ -1029,7 +1030,7 @@ export default function DashboardView(props: DashboardViewProps) {
   };
 
   return (
-    <div class="h-screen w-full overflow-hidden bg-dls-sidebar p-3 md:p-4 text-dls-text font-sans">
+    <div class="h-screen w-full overflow-hidden bg-white p-3 md:p-4 text-dls-text font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
       <aside
         class="relative hidden md:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"
@@ -1143,7 +1144,29 @@ export default function DashboardView(props: DashboardViewProps) {
               <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.busyHint}</span>
             </Show>
           </div>
-          <div class="flex items-center gap-2" />
+          <div class="flex items-center gap-1.5 text-gray-10">
+            <button
+              type="button"
+              class="hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text sm:flex"
+              onClick={toggleRightSidebar}
+              title="Menu"
+              aria-label="Menu"
+            >
+              <Menu size={15} />
+              <span>Menu</span>
+              <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">⌘K</span>
+            </button>
+            <div class="hidden h-4 w-px bg-dls-border sm:block" />
+            <button
+              type="button"
+              class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
+              onClick={props.toggleSettings}
+              title="More"
+              aria-label="More"
+            >
+              <MoreHorizontal size={16} />
+            </button>
+          </div>
         </header>
 
         <div class="mx-auto w-full max-w-[1100px] space-y-10 p-6 md:p-10">

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -1030,7 +1030,7 @@ export default function DashboardView(props: DashboardViewProps) {
   };
 
   return (
-    <div class="h-screen w-full overflow-hidden bg-white p-3 md:p-4 text-dls-text font-sans">
+    <div class="h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-dls-text font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
       <aside
         class="relative hidden md:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -502,11 +502,15 @@ export default function DashboardView(props: DashboardViewProps) {
     return (
       <button
         type="button"
-        class={`w-full h-10 flex items-center rounded-lg text-sm font-medium transition-colors ${
+        class={`w-full border text-[13px] font-medium transition-[background-color,border-color,box-shadow,color] ${
           active()
-            ? "bg-dls-active text-dls-text"
-            : "text-dls-secondary hover:text-dls-text hover:bg-dls-hover"
-        } ${rightSidebarExpanded() ? "justify-start gap-3 px-3" : "justify-center px-0"}`}
+            ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
+            : "border-transparent text-dls-secondary hover:border-dls-border hover:bg-dls-surface hover:text-dls-text"
+        } ${
+          rightSidebarExpanded()
+            ? "flex min-h-11 items-center justify-start gap-2.5 rounded-[16px] px-3.5"
+            : "flex h-12 items-center justify-center rounded-[16px] px-0"
+        }`}
         onClick={() => props.setTab(t)}
         title={label}
         aria-label={label}
@@ -1025,9 +1029,10 @@ export default function DashboardView(props: DashboardViewProps) {
   };
 
   return (
-    <div class="flex h-screen w-full bg-dls-surface text-dls-text font-sans overflow-hidden">
+    <div class="h-screen w-full overflow-hidden bg-dls-sidebar p-3 md:p-4 text-dls-text font-sans">
+      <div class="flex h-full w-full gap-3 md:gap-4">
       <aside
-        class="relative hidden md:flex shrink-0 flex-col bg-dls-sidebar border-r border-dls-border p-4"
+        class="relative hidden md:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"
         style={{
           width: `${leftSidebarWidth()}px`,
           "min-width": `${leftSidebarWidth()}px`,
@@ -1085,7 +1090,7 @@ export default function DashboardView(props: DashboardViewProps) {
           />
         </div>
         <div
-          class="absolute right-0 top-0 hidden h-full w-2 translate-x-1/2 cursor-col-resize bg-transparent transition-colors hover:bg-gray-6/40 md:block"
+          class="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 md:block"
           onPointerDown={startLeftSidebarResize}
           title="Resize workspace column"
           aria-label="Resize workspace column"
@@ -1093,10 +1098,10 @@ export default function DashboardView(props: DashboardViewProps) {
 
       </aside>
 
-      <main class="flex-1 flex flex-col overflow-hidden bg-dls-surface">
+      <main class="min-w-0 flex-1 flex flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
         <div class="flex-1 overflow-y-auto">
-        <header class="h-14 flex items-center justify-between px-6 md:px-10 border-b border-dls-border sticky top-0 bg-dls-surface z-10">
-          <div class="flex items-center gap-3">
+        <header class="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6">
+          <div class="flex min-w-0 items-center gap-3">
             <Show when={showUpdatePill()}>
               <button
                 type="button"
@@ -1124,21 +1129,24 @@ export default function DashboardView(props: DashboardViewProps) {
                 </Show>
               </button>
             </Show>
-            <div class="px-3 py-1.5 rounded-xl bg-dls-hover text-xs text-dls-secondary font-medium">
+            <span class="shrink-0 rounded-md bg-dls-hover px-2 py-1 text-[11px] font-medium text-dls-secondary">
+              {props.activeWorkspaceDisplay.workspaceType === "remote" ? "Remote worker" : "Worker"}
+            </span>
+            <h1 class="truncate text-[15px] font-semibold text-dls-text">{title()}</h1>
+            <span class="hidden truncate text-[13px] text-dls-secondary lg:inline">
               {props.activeWorkspaceDisplay.name}
-            </div>
-            <h1 class="text-lg font-medium">{title()}</h1>
+            </span>
             <Show when={props.developerMode}>
-              <span class="text-xs text-dls-secondary">{props.headerStatus}</span>
+              <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.headerStatus}</span>
             </Show>
             <Show when={props.busyHint}>
-              <span class="text-xs text-dls-secondary">{props.busyHint}</span>
+              <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.busyHint}</span>
             </Show>
           </div>
           <div class="flex items-center gap-2" />
         </header>
 
-        <div class="p-6 md:p-10 max-w-5xl mx-auto space-y-10">
+        <div class="mx-auto w-full max-w-[1100px] space-y-10 p-6 md:p-10">
           <Switch>
             <Match when={props.tab === "scheduled"}>
               <ScheduledTasksView
@@ -1522,7 +1530,7 @@ export default function DashboardView(props: DashboardViewProps) {
       </main>
 
       <aside
-        class="flex shrink-0 flex-col overflow-hidden bg-dls-sidebar border-l border-dls-border p-3 transition-[width] duration-200"
+        class="flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 transition-[width] duration-200"
         style={{
           width: `${rightSidebarWidth()}px`,
           "min-width": `${rightSidebarWidth()}px`,
@@ -1531,7 +1539,7 @@ export default function DashboardView(props: DashboardViewProps) {
         <div class={`flex items-center pb-3 ${rightSidebarExpanded() ? "justify-end" : "justify-center"}`}>
           <button
             type="button"
-            class="flex h-9 w-9 items-center justify-center rounded-lg text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+            class="flex h-10 w-10 items-center justify-center rounded-[16px] text-dls-secondary transition-colors hover:bg-dls-surface hover:text-dls-text"
             onClick={toggleRightSidebar}
             title={rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
             aria-label={rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
@@ -1549,6 +1557,7 @@ export default function DashboardView(props: DashboardViewProps) {
           <Show when={props.developerMode}>{navItem("config", "Advanced", <SlidersHorizontal size={18} />)}</Show>
         </div>
       </aside>
+      </div>
 
     </div>
   );

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -3954,6 +3954,17 @@ export default function SessionView(props: SessionViewProps) {
           onOpenMcp={openMcp}
           providerConnectedIds={props.providerConnectedIds}
           mcpStatuses={props.mcpStatuses}
+          statusLabel={showRunIndicator() ? "Session Active" : props.selectedSessionId ? "Session Ready" : "Session Idle"}
+          statusDetail={
+            showRunIndicator()
+              ? `${props.activeWorkspaceDisplay.name} is running`
+              : props.selectedSessionId
+                ? `${selectedSessionTitle() || props.activeWorkspaceDisplay.name} is ready`
+                : "Choose a worker to begin"
+          }
+          statusDotClass={showRunIndicator() ? "bg-green-9" : props.selectedSessionId ? "bg-green-9" : "bg-gray-8"}
+          statusPingClass={showRunIndicator() ? "bg-green-9/45 animate-ping" : "bg-green-9/35"}
+          statusPulse={showRunIndicator()}
         />
       </main>
 

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -3321,7 +3321,7 @@ export default function SessionView(props: SessionViewProps) {
   );
 
   return (
-    <div class="h-screen w-full overflow-hidden bg-white p-3 md:p-4 text-gray-12 font-sans">
+    <div class="h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-gray-12 font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
       <aside
         class="relative hidden lg:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -41,6 +41,7 @@ import {
   History,
   ListTodo,
   Loader2,
+  Menu,
   MessageCircle,
   Maximize2,
   Minimize2,
@@ -3301,9 +3302,15 @@ export default function SessionView(props: SessionViewProps) {
   ) => (
     <button
       type="button"
-      class={`h-9 w-full rounded-lg text-[13px] font-medium transition-colors ${
-        active ? "bg-gray-4 text-gray-12" : "text-gray-11 hover:text-gray-12 hover:bg-gray-3"
-      } ${rightSidebarExpanded() ? "flex items-center gap-2.5 px-3 justify-start" : "flex items-center justify-center px-0"}`}
+      class={`w-full border text-[13px] font-medium transition-[background-color,border-color,box-shadow,color] ${
+        active
+          ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
+          : "border-transparent text-gray-10 hover:border-dls-border hover:bg-dls-surface hover:text-dls-text"
+      } ${
+        rightSidebarExpanded()
+          ? "flex min-h-11 items-center justify-start gap-2.5 rounded-[16px] px-3.5"
+          : "flex h-12 items-center justify-center rounded-[16px] px-0"
+      }`}
       onClick={onClick}
       title={label}
       aria-label={label}
@@ -3314,9 +3321,10 @@ export default function SessionView(props: SessionViewProps) {
   );
 
   return (
-    <div class="flex h-screen w-full bg-dls-sidebar text-gray-12 font-sans overflow-hidden">
+    <div class="h-screen w-full overflow-hidden bg-dls-sidebar p-3 md:p-4 text-gray-12 font-sans">
+      <div class="flex h-full w-full gap-3 md:gap-4">
       <aside
-        class="relative hidden lg:flex shrink-0 flex-col bg-dls-sidebar border-r border-gray-6/70 p-3 pt-5"
+        class="relative hidden lg:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"
         style={{
           width: `${leftSidebarWidth()}px`,
           "min-width": `${leftSidebarWidth()}px`,
@@ -3375,7 +3383,7 @@ export default function SessionView(props: SessionViewProps) {
           />
         </div>
         <div
-          class="absolute right-0 top-0 hidden h-full w-2 translate-x-1/2 cursor-col-resize bg-transparent transition-colors hover:bg-gray-6/40 lg:block"
+          class="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 lg:block"
           onPointerDown={startLeftSidebarResize}
           title="Resize workspace column"
           aria-label="Resize workspace column"
@@ -3383,9 +3391,9 @@ export default function SessionView(props: SessionViewProps) {
 
       </aside>
 
-      <main class="flex-1 flex flex-col overflow-hidden bg-gray-1">
-        <header class="h-14 border-b border-gray-5 flex items-center justify-between px-6 bg-gray-1 z-10 shrink-0">
-          <div class="flex items-center gap-3 min-w-0">
+      <main class="min-w-0 flex-1 flex flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
+        <header class="z-10 flex h-12 shrink-0 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6">
+          <div class="flex min-w-0 items-center gap-3">
             <Show when={showUpdatePill()}>
               <button
                 type="button"
@@ -3414,26 +3422,33 @@ export default function SessionView(props: SessionViewProps) {
               </button>
             </Show>
 
-            <h1 class="text-[13.5px] font-medium text-gray-11 truncate">
+            <span class="shrink-0 rounded-md bg-dls-hover px-2 py-1 text-[11px] font-medium text-dls-secondary">
+              {showWorkspaceSetupEmptyState()
+                ? "Worker"
+                : props.activeWorkspaceDisplay.workspaceType === "remote"
+                  ? "Remote worker"
+                  : "Worker"}
+            </span>
+            <h1 class="truncate text-[15px] font-semibold text-dls-text">
               {showWorkspaceSetupEmptyState()
                 ? "Create or connect a worker"
                 : (selectedSessionTitle() || "New session")}
             </h1>
             <Show when={props.developerMode}>
-              <span class="text-xs text-dls-secondary">{props.headerStatus}</span>
+              <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.headerStatus}</span>
             </Show>
             <Show when={props.busyHint}>
-              <span class="text-xs text-dls-secondary">· {props.busyHint}</span>
+              <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.busyHint}</span>
             </Show>
           </div>
 
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-1.5 text-gray-10">
             <button
               type="button"
-              class={`h-9 px-2.5 flex items-center justify-center rounded-lg text-[11px] font-mono transition-colors ${
+              class={`hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors sm:flex ${
                 commandPaletteOpen()
-                  ? "bg-gray-4 text-gray-12"
-                  : "text-gray-10 hover:text-gray-12 hover:bg-gray-3"
+                  ? "bg-gray-2 text-dls-text"
+                  : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
               }`}
               onClick={(event) => {
                 event.preventDefault();
@@ -3447,14 +3462,16 @@ export default function SessionView(props: SessionViewProps) {
               title="Quick actions (Ctrl/Cmd+K)"
               aria-label="Quick actions"
             >
-              Cmd+K
+              <Menu size={15} />
+              <span>Menu</span>
+              <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">Cmd+K</span>
             </button>
             <button
               type="button"
-              class={`h-9 w-9 flex items-center justify-center rounded-lg transition-colors ${
+              class={`flex h-9 w-9 items-center justify-center rounded-md transition-colors ${
                 searchOpen()
-                  ? "bg-gray-4 text-gray-12"
-                  : "text-gray-10 hover:text-gray-12 hover:bg-gray-3"
+                  ? "bg-gray-2 text-dls-text"
+                  : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
               }`}
               onClick={() => {
                 if (searchOpen()) {
@@ -3468,9 +3485,10 @@ export default function SessionView(props: SessionViewProps) {
             >
               <Search size={16} />
             </button>
+            <div class="hidden h-4 w-px bg-dls-border sm:block" />
             <button
               type="button"
-              class="h-9 w-9 flex items-center justify-center rounded-lg text-gray-10 hover:text-gray-12 hover:bg-gray-3 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
               onClick={undoLastMessage}
               disabled={!canUndoLastMessage() || historyActionBusy() !== null}
               title="Undo last message"
@@ -3479,10 +3497,11 @@ export default function SessionView(props: SessionViewProps) {
               <Show when={historyActionBusy() === "undo"} fallback={<Undo2 size={16} />}>
                 <Loader2 size={16} class="animate-spin" />
               </Show>
+              <span class="hidden lg:inline">Revert</span>
             </button>
             <button
               type="button"
-              class="h-9 w-9 flex items-center justify-center rounded-lg text-gray-10 hover:text-gray-12 hover:bg-gray-3 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
               onClick={redoLastMessage}
               disabled={!canRedoLastMessage() || historyActionBusy() !== null}
               title="Redo last reverted message"
@@ -3491,10 +3510,12 @@ export default function SessionView(props: SessionViewProps) {
               <Show when={historyActionBusy() === "redo"} fallback={<Redo2 size={16} />}>
                 <Loader2 size={16} class="animate-spin" />
               </Show>
+              <span class="hidden lg:inline">Redo</span>
             </button>
+            <div class="hidden h-4 w-px bg-dls-border sm:block" />
             <button
               type="button"
-              class="h-9 w-9 flex items-center justify-center rounded-lg text-gray-10 hover:text-gray-12 hover:bg-gray-3 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
               onClick={compactSessionHistory}
               disabled={!canCompactSession() || historyActionBusy() !== null}
               title="Compact session context"
@@ -3507,7 +3528,7 @@ export default function SessionView(props: SessionViewProps) {
             <div ref={(el) => (sessionMenuRef = el)} class="relative">
               <button
                 type="button"
-                class="h-9 w-9 flex items-center justify-center rounded-lg text-gray-10 hover:text-gray-12 hover:bg-gray-3 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
                 disabled={!props.selectedSessionId}
                 title={props.selectedSessionId ? "Session actions" : "Select a session to manage it"}
                 aria-label={props.selectedSessionId ? "Session actions" : "Select a session to manage it"}
@@ -3522,12 +3543,12 @@ export default function SessionView(props: SessionViewProps) {
 
               <Show when={sessionMenuOpen() && props.selectedSessionId}>
                 <div
-                  class="absolute right-0 top-[calc(100%+4px)] z-20 w-52 rounded-lg border border-gray-6 bg-gray-1 shadow-lg p-1"
+                  class="absolute right-0 top-[calc(100%+6px)] z-20 w-52 rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]"
                   onClick={(event) => event.stopPropagation()}
                 >
                   <button
                     type="button"
-                    class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3 disabled:opacity-60"
+                    class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2 disabled:opacity-60"
                     onClick={() => {
                       setSessionMenuOpen(false);
                       void compactSessionHistory();
@@ -3538,14 +3559,14 @@ export default function SessionView(props: SessionViewProps) {
                   </button>
                   <button
                     type="button"
-                    class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3"
+                    class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                     onClick={openRenameModal}
                   >
                     Rename session
                   </button>
                   <button
                     type="button"
-                    class="w-full text-left px-2 py-1.5 text-sm rounded-md hover:bg-gray-3 text-red-11"
+                    class="w-full rounded-xl px-3 py-2 text-left text-sm text-red-11 transition-colors hover:bg-red-1/40"
                     onClick={openDeleteSessionModal}
                   >
                     Delete session
@@ -3557,8 +3578,8 @@ export default function SessionView(props: SessionViewProps) {
         </header>
 
         <Show when={searchOpen()}>
-          <div class="border-b border-gray-5 bg-gray-2/70 px-6 py-2">
-            <div class="mx-auto flex w-full max-w-[800px] items-center gap-2 rounded-xl border border-gray-6 bg-gray-1 px-3 py-2">
+          <div class="border-b border-dls-border bg-dls-sidebar/70 px-4 py-2 md:px-6">
+            <div class="mx-auto flex w-full max-w-[800px] items-center gap-2 rounded-[16px] border border-dls-border bg-dls-surface px-3 py-2 shadow-[var(--dls-card-shadow)]">
               <Search size={14} class="text-gray-9" />
               <input
                 ref={(el) => (searchInputEl = el)}
@@ -3586,7 +3607,7 @@ export default function SessionView(props: SessionViewProps) {
               <span class="text-[11px] text-gray-10 tabular-nums">{activeSearchPositionLabel()}</span>
               <button
                 type="button"
-                class="rounded-md border border-gray-6 px-2 py-1 text-[11px] text-gray-10 hover:text-gray-12 hover:bg-gray-3 transition-colors disabled:opacity-60"
+                class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
                 disabled={searchHits().length === 0}
                 onClick={() => moveSearchHit(-1)}
                 aria-label="Previous match"
@@ -3595,7 +3616,7 @@ export default function SessionView(props: SessionViewProps) {
               </button>
               <button
                 type="button"
-                class="rounded-md border border-gray-6 px-2 py-1 text-[11px] text-gray-10 hover:text-gray-12 hover:bg-gray-3 transition-colors disabled:opacity-60"
+                class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
                 disabled={searchHits().length === 0}
                 onClick={() => moveSearchHit(1)}
                 aria-label="Next match"
@@ -3604,7 +3625,7 @@ export default function SessionView(props: SessionViewProps) {
               </button>
               <button
                 type="button"
-                class="h-7 w-7 flex items-center justify-center rounded-md text-gray-10 hover:text-gray-12 hover:bg-gray-3 transition-colors"
+                class="flex h-7 w-7 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12"
                 onClick={closeSearch}
                 aria-label="Close search"
               >
@@ -3662,19 +3683,19 @@ export default function SessionView(props: SessionViewProps) {
         </Show>
 
         <div class="flex-1 flex overflow-hidden">
-          <div class="flex-1 min-w-0 relative overflow-hidden bg-gray-1">
+          <div class="relative min-w-0 flex-1 overflow-hidden bg-dls-surface">
             <div
-              class={`h-full overflow-y-auto px-8 ${showWorkspaceSetupEmptyState() ? "pt-20 pb-20" : "pt-12 pb-56"} scroll-smooth bg-gray-1 ${initialAnchorPending() ? "invisible" : "visible"}`}
+              class={`h-full overflow-y-auto px-4 sm:px-6 lg:px-10 ${showWorkspaceSetupEmptyState() ? "pt-20 pb-20" : "pt-10 pb-60"} scroll-smooth bg-dls-surface ${initialAnchorPending() ? "invisible" : "visible"}`}
               style={{ contain: "layout paint style" }}
               ref={(el) => {
                 chatContainerEl = el;
                 setIsChatContainerReady(Boolean(el));
               }}
             >
-              <div class="max-w-[650px] mx-auto w-full">
+              <div class="mx-auto w-full max-w-[800px]">
             <Show when={showWorkspaceSetupEmptyState()}>
-              <div class="mx-auto max-w-xl rounded-3xl border border-gray-6 bg-gray-2/60 p-8 text-center shadow-sm">
-                <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-gray-6 bg-gray-1 text-gray-11">
+              <div class="mx-auto max-w-xl rounded-[24px] border border-dls-border bg-dls-sidebar p-8 text-center shadow-[var(--dls-card-shadow)]">
+                <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-surface text-gray-11">
                   <HardDrive size={24} />
                 </div>
                 <h3 class="text-2xl font-semibold text-gray-12">Set up your first worker</h3>
@@ -3684,14 +3705,14 @@ export default function SessionView(props: SessionViewProps) {
                 <div class="mt-6 grid gap-3 sm:grid-cols-2">
                   <button
                     type="button"
-                    class="rounded-2xl border border-gray-7 bg-gray-12 px-4 py-3 text-sm font-semibold text-gray-1 transition-colors hover:bg-gray-11"
+                    class="rounded-full border border-gray-7 bg-gray-12 px-5 py-3 text-sm font-semibold text-gray-1 transition-colors hover:bg-gray-11"
                     onClick={props.openCreateWorkspace}
                   >
                     Create local worker
                   </button>
                   <button
                     type="button"
-                    class="rounded-2xl border border-gray-7 bg-gray-1 px-4 py-3 text-sm font-semibold text-gray-12 transition-colors hover:bg-gray-3"
+                    class="rounded-full border border-dls-border bg-dls-surface px-5 py-3 text-sm font-semibold text-gray-12 transition-colors hover:bg-gray-2"
                     onClick={props.openCreateRemoteWorkspace}
                   >
                     Connect remote worker
@@ -3798,10 +3819,10 @@ export default function SessionView(props: SessionViewProps) {
 
             <Show when={props.messages.length > 0 && !nearBottom()}>
               <div class="absolute bottom-4 left-0 right-0 z-20 flex justify-center pointer-events-none">
-                <div class="pointer-events-auto flex items-center gap-2 rounded-full border border-gray-6 bg-gray-1/95 p-1 shadow-lg shadow-gray-12/5 backdrop-blur-md">
+                <div class="pointer-events-auto flex items-center gap-2 rounded-full border border-dls-border bg-dls-surface/95 p-1 shadow-[var(--dls-card-shadow)] backdrop-blur-md">
                   <button
                     type="button"
-                    class="rounded-full px-3 py-1.5 text-xs text-gray-11 hover:bg-gray-3 transition-colors"
+                    class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
                     onClick={() => jumpToLatest("smooth")}
                   >
                     Jump to latest
@@ -3814,11 +3835,11 @@ export default function SessionView(props: SessionViewProps) {
         </div>
 
       <Show when={todoCount() > 0}>
-        <div class="mx-auto w-full max-w-[68ch] px-4">
-          <div class="rounded-t-xl border border-b-0 border-gray-6/70 bg-gray-1/70 shadow-sm shadow-gray-12/5">
+        <div class="mx-auto w-full max-w-[800px] px-4">
+          <div class="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
             <button
               type="button"
-              class="w-full flex items-center justify-between px-4 py-2.5 text-xs text-gray-9 hover:bg-gray-2/50 transition-colors rounded-t-xl"
+              class="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
               onClick={() => setTodoExpanded((prev) => !prev)}
             >
               <div class="flex items-center gap-2">
@@ -3831,7 +3852,7 @@ export default function SessionView(props: SessionViewProps) {
               />
             </button>
             <Show when={todoExpanded()}>
-              <div class="px-4 pb-3 space-y-2.5 max-h-60 overflow-auto border-t border-gray-6/50">
+              <div class="max-h-60 overflow-auto border-t border-dls-border px-4 pb-3 space-y-2.5">
                 <For each={todoList()}>
                   {(todo, index) => {
                     const done = () => todo.status === "completed";
@@ -3937,7 +3958,7 @@ export default function SessionView(props: SessionViewProps) {
       </main>
 
       <aside
-        class="flex shrink-0 flex-col overflow-hidden bg-dls-sidebar border-l border-gray-6/70 p-3 transition-[width] duration-200"
+        class="flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 transition-[width] duration-200"
         style={{
           width: `${rightSidebarWidth()}px`,
           "min-width": `${rightSidebarWidth()}px`,
@@ -3946,7 +3967,7 @@ export default function SessionView(props: SessionViewProps) {
         <div class={`flex items-center pb-3 ${rightSidebarExpanded() ? "justify-end" : "justify-center"}`}>
           <button
             type="button"
-            class="flex h-9 w-9 items-center justify-center rounded-lg text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+            class="flex h-10 w-10 items-center justify-center rounded-[16px] text-gray-10 transition-colors hover:bg-dls-surface hover:text-dls-text"
             onClick={toggleRightSidebar}
             title={rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
             aria-label={rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
@@ -4005,24 +4026,29 @@ export default function SessionView(props: SessionViewProps) {
           </div>
 
           <Show when={rightSidebarExpanded()}>
-            <InboxPanel
-              id="sidebar-inbox"
-              client={props.openworkServerClient}
-              workspaceId={props.openworkServerWorkspaceId}
-              onToast={(message) => setToastMessage(message)}
-            />
+            <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
+              <InboxPanel
+                id="sidebar-inbox"
+                client={props.openworkServerClient}
+                workspaceId={props.openworkServerWorkspaceId}
+                onToast={(message) => setToastMessage(message)}
+              />
+            </div>
 
-            <ArtifactsPanel
-              id="sidebar-artifacts"
-              files={touchedFiles()}
-              workspaceRoot={props.activeWorkspaceRoot}
-              onRevealArtifact={revealArtifact}
-              onOpenInObsidian={openArtifactInObsidian}
-              obsidianAvailable={obsidianAvailable()}
-            />
+            <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
+              <ArtifactsPanel
+                id="sidebar-artifacts"
+                files={touchedFiles()}
+                workspaceRoot={props.activeWorkspaceRoot}
+                onRevealArtifact={revealArtifact}
+                onOpenInObsidian={openArtifactInObsidian}
+                obsidianAvailable={obsidianAvailable()}
+              />
+            </div>
           </Show>
         </div>
       </aside>
+      </div>
 
       <Show when={commandPaletteOpen()}>
         <div

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -3321,7 +3321,7 @@ export default function SessionView(props: SessionViewProps) {
   );
 
   return (
-    <div class="h-screen w-full overflow-hidden bg-dls-sidebar p-3 md:p-4 text-gray-12 font-sans">
+    <div class="h-screen w-full overflow-hidden bg-white p-3 md:p-4 text-gray-12 font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
       <aside
         class="relative hidden lg:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"
@@ -3464,7 +3464,7 @@ export default function SessionView(props: SessionViewProps) {
             >
               <Menu size={15} />
               <span>Menu</span>
-              <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">Cmd+K</span>
+              <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">⌘K</span>
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- refresh the app shell toward the quieter three-pane operator workspace reference
- restyle the session and dashboard chrome, side rails, composer, message surface, and status bar to get closer to the design direction
- leave this as a draft because the UI is still rough and not yet close enough to the reference

## Needs more love
- this is still broken / incomplete in spots and needs another pass
- it still needs more love to get materially closer to the design reference that was sent over
- @omar tagging you here because this one still needs refinement before it should be considered ready

## Validation
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm build`
- `pnpm test:health`
- `pnpm test:sessions`

## Verification gap
- `packaging/docker/dev-up.sh` aborted in this environment before I could finish the Docker + Chrome MCP UI check