### PR TITLE
Stop committing PR proof files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 dist/
 packages/*/dist/
 tmp/
+artifacts/
 
 # Local git worktrees
 _worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ When the user asks to create a new feature, follow this exact procedure:
 3. Implement the feature.
 4. Start the OpenWork dev stack via Docker (from the OpenWork repo root): `packaging/docker/dev-up.sh`.
 5. Use Chrome MCP to fully test the feature: `.opencode/skills/openwork-docker-chrome-mcp/SKILL.md`.
-6. Take screenshots and put them in the repo.
-7. Refer to these screenshots in the PR (only if relevant in the UI).
+6. Capture screenshots/videos under `tmp/verification/` or another local temp path. Do not commit them into this repo.
+7. When working from OpenWork Factory / the enterprise superproject, publish PR evidence with the Factory Supabase workflow before referencing it in the PR. If that workflow is unavailable, say so explicitly instead of adding local proof files to git.
 8. Always test the flow you just implemented.
 
 If you cannot complete steps 4-8 (Docker, Chrome MCP, missing credentials, or environment limitations), you must say so explicitly and include:
@@ -64,6 +64,8 @@ To maximize merge speed, include evidence of the end-to-end flow:
 
 * Ideally: attach a short video/screen recording showing the flow running successfully.
 * Otherwise: screenshots are acceptable, but video is preferred.
+
+Local proof files under `artifacts/` or `tmp/verification/` are not acceptable PR evidence. Keep them temporary and publish canonical Supabase URLs through the Factory evidence workflow when that environment is available.
 
 If you cannot run tests or capture the video, say so explicitly and explain why, and include the exact commands/steps for the reviewer to reproduce.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:fs-engine": "pnpm --filter @different-ai/openwork-ui test:fs-engine",
     "test:e2e": "pnpm --filter @different-ai/openwork-ui test:e2e",
     "test:openwrk": "pnpm --filter openwrk test:router",
+    "check:pr-artifacts": "bash scripts/check-no-local-pr-artifacts.sh",
     "bump:patch": "pnpm --filter @different-ai/openwork-ui bump:patch",
     "bump:minor": "pnpm --filter @different-ai/openwork-ui bump:minor",
     "bump:major": "pnpm --filter @different-ai/openwork-ui bump:major",

--- a/scripts/check-no-local-pr-artifacts.sh
+++ b/scripts/check-no-local-pr-artifacts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+changed_files="$(
+  {
+    git diff --name-only --diff-filter=ACMR HEAD -- .
+    git ls-files --others --exclude-standard
+  } | awk 'NF' | sort -u
+)"
+
+offending_files="$(printf '%s\n' "$changed_files" | rg '^(artifacts/|tmp/verification/)' || true)"
+
+if [[ -n "$offending_files" ]]; then
+  cat >&2 <<EOF
+Local PR proof files are not allowed in git changes.
+Publish screenshots/videos via the Factory Supabase evidence workflow instead.
+
+Offending paths:
+$offending_files
+EOF
+  exit 1
+fi

--- a/scripts/check-no-local-pr-artifacts.test.mjs
+++ b/scripts/check-no-local-pr-artifacts.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const scriptPath = new URL('./check-no-local-pr-artifacts.sh', import.meta.url);
+
+async function initRepo() {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'openwork-pr-artifacts-guard-'));
+  await execFileAsync('git', ['init'], { cwd: repoDir });
+  await execFileAsync('git', ['config', 'user.email', 'codex@example.com'], { cwd: repoDir });
+  await execFileAsync('git', ['config', 'user.name', 'Codex'], { cwd: repoDir });
+  await writeFile(path.join(repoDir, 'README.md'), '# temp repo\n');
+  await execFileAsync('git', ['add', 'README.md'], { cwd: repoDir });
+  await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repoDir });
+  return repoDir;
+}
+
+test('guardrail fails when artifacts/ is introduced in the diff', async () => {
+  const repoDir = await initRepo();
+  await mkdir(path.join(repoDir, 'artifacts'), { recursive: true });
+  await writeFile(path.join(repoDir, 'artifacts', 'proof.png'), 'fake');
+
+  await assert.rejects(
+    () => execFileAsync('bash', [scriptPath.pathname], { cwd: repoDir }),
+    (error) => {
+      assert.match(error.stderr, /artifacts\/proof\.png/);
+      return true;
+    },
+  );
+});
+
+test('guardrail allows temporary files outside forbidden proof paths', async () => {
+  const repoDir = await initRepo();
+  await mkdir(path.join(repoDir, 'tmp', 'other'), { recursive: true });
+  await writeFile(path.join(repoDir, 'tmp', 'other', 'proof.png'), 'fake');
+
+  await execFileAsync('bash', [scriptPath.pathname], { cwd: repoDir });
+});


### PR DESCRIPTION
## Summary
- stop telling agents to commit screenshots into the repo
- redirect PR evidence to temporary local paths plus the Factory Supabase publish workflow
- add a guardrail that fails when new `artifacts/` or `tmp/verification/` proof files appear in git changes

## Problem
OpenWork still instructed agents to put screenshots in the repo. That led directly to proof commits like:
- `d9779bc0dd04b31ea6cba4f25b138a035e4e2458`
- `cb2365901e1b5f230bd416d26ac035fa4147d93d`

## Verification
- `node --test scripts/check-no-local-pr-artifacts.test.mjs`
- `bash scripts/check-no-local-pr-artifacts.sh`

## Notes
- This pairs with the Factory draft PR that enforces Supabase PR evidence publishing.
- Existing tracked proof history is left alone; this only blocks new occurrences.
