### PR TITLE
fix(den): stop pinning stale worker opencode builds

### DIFF
--- a/.github/workflows/deploy-den.yml
+++ b/.github/workflows/deploy-den.yml
@@ -255,7 +255,6 @@ jobs:
               {"key": "RENDER_WORKER_ROOT_DIR", "value": "services/den-worker-runtime"},
               {"key": "RENDER_WORKER_PLAN", "value": worker_plan},
               {"key": "RENDER_WORKER_REGION", "value": "oregon"},
-              {"key": "RENDER_WORKER_OPENWORK_VERSION", "value": openwork_version},
               {"key": "RENDER_WORKER_NAME_PREFIX", "value": "den-worker-openwork"},
               {"key": "RENDER_WORKER_PUBLIC_DOMAIN_SUFFIX", "value": worker_public_domain_suffix},
               {"key": "RENDER_CUSTOM_DOMAIN_READY_TIMEOUT_MS", "value": custom_domain_ready_timeout_ms},
@@ -275,6 +274,9 @@ jobs:
               {"key": "POLAR_SUCCESS_URL", "value": polar_success_url},
               {"key": "POLAR_RETURN_URL", "value": polar_return_url},
           ]
+
+          if openwork_version:
+              env_vars.append({"key": "RENDER_WORKER_OPENWORK_VERSION", "value": openwork_version})
 
           request("PUT", f"/services/{service_id}/env-vars", env_vars)
           _, deploy = request("POST", f"/services/{service_id}/deploys", {})

--- a/services/den-worker-runtime/scripts/install-opencode.mjs
+++ b/services/den-worker-runtime/scripts/install-opencode.mjs
@@ -58,10 +58,7 @@ function resolveOpencodeVersion() {
 
   const orchestratorPkg = readJson(resolveOrchestratorPackageJson());
   const version = String(orchestratorPkg.opencodeVersion ?? "").trim();
-  if (!version) {
-    throw new Error("openwork-orchestrator package is missing opencodeVersion");
-  }
-  return version;
+  return version || null;
 }
 
 function resolveAssetName() {
@@ -153,19 +150,22 @@ function findBinary(searchRoot) {
 }
 
 const version = resolveOpencodeVersion();
+const versionLabel = version ?? "latest";
 
 if (
   existsSync(outputPath) &&
   existsSync(versionStampPath) &&
-  readFileSync(versionStampPath, "utf8").trim() === version
+  readFileSync(versionStampPath, "utf8").trim() === versionLabel
 ) {
-  console.log(`[den-worker-runtime] opencode ${version} already bundled at ${outputPath}`);
+  console.log(`[den-worker-runtime] opencode ${versionLabel} already bundled at ${outputPath}`);
   process.exit(0);
 }
 
 const assetName = resolveAssetName();
 const downloadUrl = process.env.OPENWORK_OPENCODE_DOWNLOAD_URL?.trim()
-  || `https://github.com/anomalyco/opencode/releases/download/v${version}/${assetName}`;
+  || (version
+    ? `https://github.com/anomalyco/opencode/releases/download/v${version}/${assetName}`
+    : `https://github.com/anomalyco/opencode/releases/latest/download/${assetName}`);
 const tempDir = mkdtempSync(join(tmpdir(), "den-worker-opencode-"));
 const archivePath = join(tempDir, assetName);
 const extractDir = join(tempDir, "extract");
@@ -174,7 +174,7 @@ mkdirSync(extractDir, { recursive: true });
 mkdirSync(outputDir, { recursive: true });
 
 try {
-  console.log(`[den-worker-runtime] downloading opencode ${version} from ${downloadUrl}`);
+  console.log(`[den-worker-runtime] downloading opencode ${versionLabel} from ${downloadUrl}`);
   await downloadWithRetries(downloadUrl, archivePath);
   extractArchive(archivePath, extractDir);
   const extractedBinary = findBinary(extractDir);
@@ -182,8 +182,8 @@ try {
   if (process.platform !== "win32") {
     chmodSync(outputPath, 0o755);
   }
-  writeFileSync(versionStampPath, `${version}\n`, "utf8");
-  console.log(`[den-worker-runtime] bundled opencode ${version} at ${outputPath}`);
+  writeFileSync(versionStampPath, `${versionLabel}\n`, "utf8");
+  console.log(`[den-worker-runtime] bundled opencode ${versionLabel} at ${outputPath}`);
 } finally {
   rmSync(tempDir, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- stop sending `RENDER_WORKER_OPENWORK_VERSION` to the Den control plane unless the GitHub variable is explicitly set
- make the den worker runtime installer fall back to the latest `opencode` release when the published `openwork-orchestrator` package does not include `opencodeVersion`
- prevent newly provisioned workers from inheriting stale Render env pins or failing hard on missing package metadata

## Testing
- `node --check services/den-worker-runtime/scripts/install-opencode.mjs`