### PR TITLE
feat(share): add existing-worker import flow for shared skills

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -33,6 +33,7 @@ import WorkspaceSwitchOverlay from "./components/workspace-switch-overlay";
 import CreateRemoteWorkspaceModal from "./components/create-remote-workspace-modal";
 import CreateWorkspaceModal from "./components/create-workspace-modal";
 import SharedSkillDestinationModal from "./components/shared-skill-destination-modal";
+import SharedBundleImportModal from "./components/shared-bundle-import-modal";
 import RenameWorkspaceModal from "./components/rename-workspace-modal";
 import McpAuthModal from "./components/mcp-auth-modal";
 import OnboardingView from "./pages/onboarding";
@@ -133,6 +134,7 @@ import {
 } from "./theme";
 import { createSystemState } from "./system-state";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { createSessionStore } from "./context/session";
 import { createExtensionsStore } from "./context/extensions";
 import { useGlobalSync } from "./context/global-sync";
@@ -253,6 +255,11 @@ type SharedBundleImportTarget = {
   directoryHint?: string | null;
 };
 
+type SharedBundleImportChoice = {
+  request: SharedBundleDeepLink;
+  bundle: SharedBundleV1;
+};
+
 type SettingsReturnTarget = {
   view: View;
   tab: DashboardTab;
@@ -265,6 +272,35 @@ function normalizeSharedBundleImportIntent(value: string | null | undefined): Sh
     return "new_worker";
   }
   return "import_current";
+}
+
+function describeSharedBundleImport(bundle: SharedBundleV1): { title: string; description: string; items: string[] } {
+  if (bundle.type === "skill") {
+    return {
+      title: "Import 1 skill",
+      description: bundle.description?.trim() || `Add \`${bundle.name}\` to an existing worker or create a new one for it.`,
+      items: [bundle.name],
+    };
+  }
+
+  if (bundle.type === "skills-set") {
+    const count = bundle.skills.length;
+    return {
+      title: `Import ${count} skill${count === 1 ? "" : "s"}`,
+      description:
+        bundle.description?.trim() ||
+        `${bundle.name || "Shared skills"} is ready to import into an existing worker or a new worker.`,
+      items: bundle.skills.map((skill) => skill.name),
+    };
+  }
+
+  return {
+    title: "Import workspace bundle",
+    description:
+      bundle.description?.trim() ||
+      `Create a new worker to import ${bundle.name || "this shared workspace bundle"}.`,
+    items: Array.isArray(bundle.workspace.skills) ? bundle.workspace.skills.map((skill) => skill.name) : [],
+  };
 }
 
 function readRecord(value: unknown): Record<string, unknown> | null {
@@ -368,15 +404,27 @@ async function fetchSharedBundle(bundleUrl: string): Promise<SharedBundleV1> {
   const timeout = window.setTimeout(() => controller.abort(), 15_000);
 
   try {
-    const response = await fetch(targetUrl.toString(), {
-      method: "GET",
-      headers: { Accept: "application/json" },
-      signal: controller.signal,
-    });
+    let response: Response;
+    try {
+      response = isTauriRuntime()
+        ? await tauriFetch(targetUrl.toString(), {
+            method: "GET",
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+          })
+        : await fetch(targetUrl.toString(), {
+            method: "GET",
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+          });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      throw new Error(`Failed to load shared bundle from ${targetUrl.toString()}: ${message}`);
+    }
     if (!response.ok) {
       const details = (await response.text()).trim();
       const suffix = details ? `: ${details}` : "";
-      throw new Error(`Failed to fetch bundle (${response.status})${suffix}`);
+      throw new Error(`Failed to fetch bundle from ${targetUrl.toString()} (${response.status})${suffix}`);
     }
     return parseSharedBundle(await response.json());
   } finally {
@@ -447,7 +495,7 @@ function parseSharedBundleDeepLink(rawUrl: string): SharedBundleDeepLink | null 
   }
 
   const protocol = url.protocol.toLowerCase();
-  if (protocol !== "openwork:" && protocol !== "https:" && protocol !== "http:") {
+  if (protocol !== "openwork:" && protocol !== "openwork-dev:" && protocol !== "https:" && protocol !== "http:") {
     return null;
   }
 
@@ -470,6 +518,25 @@ function parseSharedBundleDeepLink(rawUrl: string): SharedBundleDeepLink | null 
   }
 
   try {
+    if ((protocol === "https:" || protocol === "http:") && !rawBundleUrl.trim()) {
+      const host = url.hostname.toLowerCase();
+      const path = url.pathname.replace(/^\/+/, "");
+      const segments = path.split("/").filter(Boolean);
+      if ((host === "share.openwork.software" || host.endsWith(".openwork.software")) && segments[0] === "b" && segments[1]) {
+        const intent = normalizeSharedBundleImportIntent(url.searchParams.get("ow_intent") ?? url.searchParams.get("intent"));
+        const source = url.searchParams.get("ow_source")?.trim() ?? url.searchParams.get("source")?.trim() ?? "";
+        const orgId = url.searchParams.get("ow_org")?.trim() ?? "";
+        const label = url.searchParams.get("ow_label")?.trim() ?? url.searchParams.get("label")?.trim() ?? "";
+        return {
+          bundleUrl: url.toString(),
+          intent,
+          source: source || undefined,
+          orgId: orgId || undefined,
+          label: label || undefined,
+        };
+      }
+    }
+
     const parsedBundleUrl = new URL(rawBundleUrl.trim());
     if (parsedBundleUrl.protocol !== "https:" && parsedBundleUrl.protocol !== "http:") {
       return null;
@@ -523,7 +590,7 @@ function parseRemoteConnectDeepLink(rawUrl: string): RemoteWorkspaceDefaults | n
   }
 
   const protocol = url.protocol.toLowerCase();
-  if (protocol !== "openwork:" && protocol !== "https:" && protocol !== "http:") {
+  if (protocol !== "openwork:" && protocol !== "openwork-dev:" && protocol !== "https:" && protocol !== "http:") {
     return null;
   }
 
@@ -553,6 +620,71 @@ function parseRemoteConnectDeepLink(rawUrl: string): RemoteWorkspaceDefaults | n
     directory: null,
     displayName: displayName || null,
   };
+}
+
+function normalizeDebugShareLinkInput(rawValue: string): string {
+  const trimmed = rawValue.trim();
+  if (!trimmed) return "";
+
+  const directMatch = trimmed.match(/(?:openwork-dev|openwork|https?):\/\/[^\s"'<>]+/i);
+  if (directMatch) return directMatch[0];
+
+  const bareShareMatch = trimmed.match(/share\.openwork\.software\/b\/[^\s"'<>]+/i);
+  if (bareShareMatch) return `https://${bareShareMatch[0]}`;
+
+  return trimmed;
+}
+
+function parseDebugShareLinkInput(rawValue: string):
+  | { kind: "bundle"; link: SharedBundleDeepLink }
+  | { kind: "remote"; link: RemoteWorkspaceDefaults }
+  | null {
+  const normalized = normalizeDebugShareLinkInput(rawValue);
+  if (!normalized) return null;
+
+  const sharedBundleLink = parseSharedBundleDeepLink(normalized);
+  if (sharedBundleLink) {
+    return { kind: "bundle", link: sharedBundleLink };
+  }
+
+  const remoteConnectLink = parseRemoteConnectDeepLink(normalized);
+  if (remoteConnectLink) {
+    return { kind: "remote", link: remoteConnectLink };
+  }
+
+  const bundleMatch = normalized.match(/ow_bundle=([^&\s]+)/i);
+  if (bundleMatch?.[1]) {
+    try {
+      const bundleUrl = decodeURIComponent(bundleMatch[1]);
+      const intentMatch = normalized.match(/(?:ow_intent|intent)=([^&\s]+)/i);
+      const labelMatch = normalized.match(/ow_label=([^&\s]+)/i);
+      const sourceMatch = normalized.match(/(?:ow_source|source)=([^&\s]+)/i);
+      return {
+        kind: "bundle",
+        link: {
+          bundleUrl,
+          intent: normalizeSharedBundleImportIntent(intentMatch?.[1] ? decodeURIComponent(intentMatch[1]) : undefined),
+          label: labelMatch?.[1] ? decodeURIComponent(labelMatch[1]) : undefined,
+          source: sourceMatch?.[1] ? decodeURIComponent(sourceMatch[1]) : undefined,
+        },
+      };
+    } catch {
+      // ignore fallback parsing errors
+    }
+  }
+
+  const shareIdMatch = normalized.match(/share\.openwork\.software\/b\/([^\s/?#"'<>]+)/i);
+  if (shareIdMatch?.[1]) {
+    return {
+      kind: "bundle",
+      link: {
+        bundleUrl: `https://share.openwork.software/b/${shareIdMatch[1]}`,
+        intent: "new_worker",
+      },
+    };
+  }
+
+  return null;
 }
 
 function stripRemoteConnectQuery(rawUrl: string): string | null {
@@ -3263,6 +3395,11 @@ export default function App() {
     await refreshSkills({ force: true });
     await refreshHubSkills({ force: true });
     if (importedSkillsCount > 0) {
+      markReloadRequired("skills", {
+        type: "skill",
+        name: bundle.name?.trim() || undefined,
+        action: "added",
+      });
       console.log(`[openwork] imported ${importedSkillsCount} skills from share bundle`);
     }
   };
@@ -3342,6 +3479,70 @@ export default function App() {
     }
   };
 
+  const processSharedBundleInvite = async (request: SharedBundleDeepLink) => {
+    const bundle = await fetchSharedBundle(request.bundleUrl);
+
+    if (bundle.type === "skill") {
+      setView("dashboard");
+      setTab("scheduled");
+      setError(null);
+      setSharedSkillDestinationRequest({ request, bundle });
+      return { mode: "choice" as const, bundle };
+    }
+
+    if (bundle.type === "skills-set") {
+      setView("dashboard");
+      setTab("skills");
+      setError(null);
+      setSharedBundleImportChoice({ request, bundle });
+      return { mode: "choice" as const, bundle };
+    }
+
+    if (request.intent === "new_worker" && isTauriRuntime()) {
+      setView("dashboard");
+      setTab("scheduled");
+      setError(null);
+      setSharedBundleCreateWorkerRequest({
+        request,
+        bundle,
+        defaultPreset: "automation",
+      });
+      workspaceStore.setCreateWorkspaceOpen(true);
+      return { mode: "new_worker_modal" as const, bundle };
+    }
+
+    if (request.intent === "import_current") {
+      const client = openworkServerClient();
+      const connected = openworkServerStatus() === "connected";
+      const target = resolveActiveSharedBundleImportTarget();
+      const hasTargetHint = Boolean(target.workspaceId?.trim() || target.localRoot?.trim() || target.directoryHint?.trim());
+      if (!client || !connected || !hasTargetHint) {
+        if (!sharedBundleNoticeShown()) {
+          setSharedBundleNoticeShown(true);
+          setError("Share link detected. Connect to a writable OpenWork worker to import this bundle.");
+        }
+        return { mode: "blocked_import_current" as const, bundle };
+      }
+    } else {
+      const target = resolveSharedBundleWorkerTarget();
+      if (!target.hostUrl.trim() || !target.token.trim()) {
+        if (!sharedBundleNoticeShown()) {
+          setSharedBundleNoticeShown(true);
+          setError("Share link detected. Configure an OpenWork host and token to create a new worker.");
+        }
+        return { mode: "blocked_new_worker" as const, bundle };
+      }
+    }
+
+    if (request.intent === "new_worker") {
+      await createWorkerForSharedBundle(request, bundle);
+    }
+
+    await importSharedBundlePayload(bundle, resolveActiveSharedBundleImportTarget());
+    setError(null);
+    return { mode: "imported" as const, bundle };
+  };
+
   createEffect(() => {
     const request = pendingSharedBundleInvite();
     if (!request || booting()) {
@@ -3352,92 +3553,13 @@ export default function App() {
       return;
     }
 
-    if (request.intent === "new_worker" && isTauriRuntime()) {
-      let cancelled = false;
-      setSharedBundleImportBusy(true);
-
-      void (async () => {
-        try {
-          const bundle = await fetchSharedBundle(request.bundleUrl);
-          if (cancelled) return;
-
-          setView("dashboard");
-          setTab("scheduled");
-          setError(null);
-
-          if (bundle.type === "skill") {
-            setSharedSkillDestinationRequest({ request, bundle });
-          } else {
-            setSharedBundleCreateWorkerRequest({
-              request,
-              bundle,
-              defaultPreset: "automation",
-            });
-            workspaceStore.setCreateWorkspaceOpen(true);
-          }
-
-          setPendingSharedBundleInvite(null);
-          setSharedBundleNoticeShown(false);
-        } catch (error) {
-          if (!cancelled) {
-            const message = error instanceof Error ? error.message : safeStringify(error);
-            setError(addOpencodeCacheHint(message));
-            setPendingSharedBundleInvite(null);
-            setSharedBundleNoticeShown(false);
-          }
-        } finally {
-          if (!cancelled) {
-            setSharedBundleImportBusy(false);
-          }
-        }
-      })();
-
-      onCleanup(() => {
-        cancelled = true;
-      });
-      return;
-    }
-
-    if (request.intent === "import_current") {
-      const client = openworkServerClient();
-      const connected = openworkServerStatus() === "connected";
-      const target = resolveActiveSharedBundleImportTarget();
-      const hasTargetHint = Boolean(
-        target.workspaceId?.trim() || target.localRoot?.trim() || target.directoryHint?.trim(),
-      );
-      if (!client || !connected || !hasTargetHint) {
-        if (!sharedBundleNoticeShown()) {
-          setSharedBundleNoticeShown(true);
-          setError("Share link detected. Connect to a writable OpenWork worker to import this bundle.");
-        }
-        return;
-      }
-    } else {
-      const target = resolveSharedBundleWorkerTarget();
-      if (!target.hostUrl.trim() || !target.token.trim()) {
-        if (!sharedBundleNoticeShown()) {
-          setSharedBundleNoticeShown(true);
-          setError("Share link detected. Configure an OpenWork host and token to create a new worker.");
-        }
-        return;
-      }
-    }
-
     let cancelled = false;
     setSharedBundleImportBusy(true);
 
     void (async () => {
       try {
-        const bundle = await fetchSharedBundle(request.bundleUrl);
+        await processSharedBundleInvite(request);
         if (cancelled) return;
-
-        if (request.intent === "new_worker") {
-          await createWorkerForSharedBundle(request, bundle);
-          if (cancelled) return;
-        }
-
-        await importSharedBundlePayload(bundle, resolveActiveSharedBundleImportTarget());
-        setError(null);
       } catch (error) {
         if (!cancelled) {
           const message = error instanceof Error ? error.message : safeStringify(error);
@@ -3601,7 +3723,9 @@ export default function App() {
   const [sharedSkillDestinationRequest, setSharedSkillDestinationRequest] =
     createSignal<SharedSkillDestinationRequest | null>(null);
   const [sharedSkillDestinationBusyId, setSharedSkillDestinationBusyId] = createSignal<string | null>(null);
+  const [sharedBundleImportChoice, setSharedBundleImportChoice] = createSignal<SharedBundleImportChoice | null>(null);
   const [sharedBundleImportBusy, setSharedBundleImportBusy] = createSignal(false);
+  const [sharedBundleImportError, setSharedBundleImportError] = createSignal<string | null>(null);
   const [sharedBundleNoticeShown, setSharedBundleNoticeShown] = createSignal(false);
   const [renameWorkspaceOpen, setRenameWorkspaceOpen] = createSignal(false);
   const [renameWorkspaceId, setRenameWorkspaceId] = createSignal<string | null>(null);
@@ -3656,8 +3780,192 @@ export default function App() {
       return false;
     }
     setPendingSharedBundleInvite(parsed);
+    setSharedSkillDestinationRequest(null);
+    setSharedSkillDestinationBusyId(null);
+    setSharedBundleImportChoice(null);
+    setSharedBundleCreateWorkerRequest(null);
+    setSharedBundleImportError(null);
     setSharedBundleNoticeShown(false);
     return true;
+  };
+
+  const openDebugShareLink = async (rawUrl: string): Promise<{ ok: boolean; message: string }> => {
+    const parsed = parseDebugShareLinkInput(rawUrl);
+    if (!parsed) {
+      return { ok: false, message: "That link is not a recognized OpenWork deep link or share URL." };
+    }
+
+    setError(null);
+    setView("dashboard");
+    if (parsed.kind === "bundle") {
+      setPendingSharedBundleInvite(null);
+      setSharedBundleNoticeShown(false);
+      setSharedSkillDestinationRequest(null);
+      setSharedSkillDestinationBusyId(null);
+      setSharedBundleImportError(null);
+      setSharedBundleImportChoice(null);
+      setSharedBundleCreateWorkerRequest(null);
+
+      try {
+        setSharedBundleImportBusy(true);
+        const result = await processSharedBundleInvite(parsed.link);
+        switch (result.mode) {
+          case "choice":
+            return { ok: true, message: "Opened the share import chooser." };
+          case "new_worker_modal":
+            return { ok: true, message: "Opened the new worker import flow." };
+          case "blocked_import_current":
+          case "blocked_new_worker":
+            return { ok: false, message: error() || "The share link needs more worker setup before it can open." };
+          case "imported":
+            return { ok: true, message: "Imported the shared bundle into the current worker." };
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : safeStringify(error);
+        const friendly = addOpencodeCacheHint(message);
+        setError(friendly);
+        return { ok: false, message: friendly };
+      } finally {
+        setSharedBundleImportBusy(false);
+      }
+    }
+    setPendingRemoteConnectDeepLink(parsed.kind === "remote" ? parsed.link : null);
+    setTab("scheduled");
+    return { ok: true, message: "Queued remote worker link. OpenWork should move into the connect flow." };
+  };
+
+  const closeSharedBundleImportChoice = () => {
+    if (sharedBundleImportBusy()) return;
+    setSharedBundleImportChoice(null);
+    setSharedBundleImportError(null);
+  };
+
+  const sharedBundleImportCopy = createMemo(() => {
+    const choice = sharedBundleImportChoice();
+    if (!choice) return null;
+    return describeSharedBundleImport(choice.bundle);
+  });
+
+  const sharedBundleWorkerOptions = createMemo(() => {
+    const activeWorkspaceId = workspaceStore.activeWorkspaceId().trim();
+    const items = workspaceStore.workspaces().map((workspace) => {
+      let disabledReason: string | null = null;
+      if (!resolveSharedBundleImportTargetForWorkspace(workspace)) {
+        disabledReason =
+          workspace.workspaceType === "remote" && workspace.remoteType !== "openwork"
+            ? "Only OpenWork-connected workers support direct shared skill imports."
+            : "This worker is missing the info OpenWork needs to import the bundle.";
+      }
+
+      const label =
+        workspace.displayName?.trim() ||
+        workspace.openworkWorkspaceName?.trim() ||
+        workspace.name?.trim() ||
+        workspace.path?.trim() ||
+        "Worker";
+      const badge =
+        workspace.workspaceType === "remote"
+          ? workspace.sandboxBackend === "docker" ||
+            Boolean(workspace.sandboxRunId?.trim()) ||
+            Boolean(workspace.sandboxContainerName?.trim())
+            ? "Sandbox"
+            : "Remote"
+          : "Local";
+      const detail =
+        workspace.workspaceType === "local"
+          ? workspace.path?.trim() || "Local worker"
+          : workspace.directory?.trim() || workspace.baseUrl?.trim() || workspace.openworkHostUrl?.trim() || "Remote worker";
+
+      return {
+        id: workspace.id,
+        label,
+        detail,
+        badge,
+        current: workspace.id === activeWorkspaceId,
+        disabledReason,
+      };
+    });
+
+    return items.sort((a, b) => {
+      if (a.current !== b.current) return a.current ? -1 : 1;
+      return a.label.localeCompare(b.label);
+    });
+  });
+
+  const openSharedBundleCreateWorkerFlow = async () => {
+    const choice = sharedBundleImportChoice();
+    if (!choice || sharedBundleImportBusy()) return;
+
+    setSharedBundleImportError(null);
+    setError(null);
+
+    if (isTauriRuntime()) {
+      setView("dashboard");
+      setTab("scheduled");
+      setSharedBundleCreateWorkerRequest({
+        request: choice.request,
+        bundle: choice.bundle,
+        defaultPreset: "starter",
+      });
+      setSharedBundleImportChoice(null);
+      workspaceStore.setCreateWorkspaceOpen(true);
+      return;
+    }
+
+    setSharedBundleImportBusy(true);
+    try {
+      await createWorkerForSharedBundle(choice.request, choice.bundle);
+      await importSharedBundlePayload(choice.bundle, resolveActiveSharedBundleImportTarget());
+      setSharedBundleImportChoice(null);
+      setError(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      const friendly = addOpencodeCacheHint(message);
+      setSharedBundleImportError(friendly);
+      setError(friendly);
+    } finally {
+      setSharedBundleImportBusy(false);
+    }
+  };
+
+  const importSharedBundleIntoExistingWorkspace = async (workspaceId: string) => {
+    const choice = sharedBundleImportChoice();
+    if (!choice || sharedBundleImportBusy()) return;
+
+    const workspace = workspaceStore.workspaces().find((item) => item.id === workspaceId) ?? null;
+    if (!workspace) {
+      setSharedBundleImportError("The selected worker is no longer available.");
+      return;
+    }
+
+    const target = resolveSharedBundleImportTargetForWorkspace(workspace);
+    if (!target) {
+      setSharedBundleImportError("This worker cannot accept shared skill imports yet.");
+      return;
+    }
+
+    setSharedBundleImportBusy(true);
+    setSharedBundleImportError(null);
+    setError(null);
+
+    try {
+      setView("dashboard");
+      setTab("skills");
+      const ok = await workspaceStore.activateWorkspace(workspace.id);
+      if (!ok) {
+        throw new Error(error() || `Failed to switch to ${workspace.displayName?.trim() || workspace.name || "the selected worker"}.`);
+      }
+      await importSharedBundlePayload(choice.bundle, target);
+      setSharedBundleImportChoice(null);
+      setError(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      const friendly = addOpencodeCacheHint(message);
+      setSharedBundleImportError(friendly);
+      setError(friendly);
+    } finally {
+      setSharedBundleImportBusy(false);
+    }
   };
 
   createEffect(() => {
@@ -6268,6 +6576,7 @@ export default function App() {
       notionError: notionError(),
       notionBusy: notionBusy(),
       connectNotion,
+      openDebugShareLink,
       mcpServers: mcpServers(),
       mcpStatus: mcpStatus(),
       mcpLastUpdatedAt: mcpLastUpdatedAt(),
@@ -6640,6 +6949,23 @@ export default function App() {
           await refreshMcpServers();
         }}
         onReloadEngine={() => reloadWorkspaceEngineAndResume()}
+      />
+
+      <SharedBundleImportModal
+        open={Boolean(sharedBundleImportChoice())}
+        title={sharedBundleImportCopy()?.title ?? "Import shared bundle"}
+        description={sharedBundleImportCopy()?.description ?? "Choose how to import this shared bundle."}
+        items={sharedBundleImportCopy()?.items ?? []}
+        workers={sharedBundleWorkerOptions()}
+        busy={sharedBundleImportBusy()}
+        error={sharedBundleImportError()}
+        onClose={closeSharedBundleImportChoice}
+        onCreateNewWorker={() => {
+          void openSharedBundleCreateWorkerFlow();
+        }}
+        onSelectWorker={(workspaceId) => {
+          void importSharedBundleIntoExistingWorkspace(workspaceId);
+        }}
       />
 
       <CreateWorkspaceModal

--- a/packages/app/src/app/components/shared-bundle-import-modal.tsx
+++ b/packages/app/src/app/components/shared-bundle-import-modal.tsx
@@ -1,0 +1,182 @@
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
+
+import { Boxes, ChevronDown, ChevronRight, Plus, Sparkles, X } from "lucide-solid";
+
+type ExistingWorkerOption = {
+  id: string;
+  label: string;
+  detail: string;
+  badge: string;
+  current: boolean;
+  disabledReason?: string | null;
+};
+
+export default function SharedBundleImportModal(props: {
+  open: boolean;
+  title: string;
+  description: string;
+  items: string[];
+  workers: ExistingWorkerOption[];
+  busy?: boolean;
+  error?: string | null;
+  onClose: () => void;
+  onCreateNewWorker: () => void;
+  onSelectWorker: (workspaceId: string) => void;
+}) {
+  const [showWorkers, setShowWorkers] = createSignal(false);
+
+  createEffect(() => {
+    if (!props.open) return;
+    setShowWorkers(false);
+  });
+
+  createEffect(() => {
+    if (!props.open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      props.onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    onCleanup(() => window.removeEventListener("keydown", handleKeyDown));
+  });
+
+  const visibleItems = createMemo(() => props.items.filter(Boolean).slice(0, 4));
+  const hiddenItemCount = createMemo(() => Math.max(0, props.items.filter(Boolean).length - visibleItems().length));
+  const busy = () => Boolean(props.busy);
+
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-1/70 p-4 backdrop-blur-sm">
+        <div class="w-full max-w-xl overflow-hidden rounded-2xl border border-gray-6 bg-gray-2 shadow-2xl">
+          <div class="border-b border-gray-6 bg-gray-1 px-6 py-5">
+            <div class="flex items-start justify-between gap-4">
+              <div class="flex items-start gap-3">
+                <div class="flex h-11 w-11 items-center justify-center rounded-2xl bg-indigo-9/15 text-indigo-11">
+                  <Boxes size={20} />
+                </div>
+                <div>
+                  <h3 class="text-lg font-semibold text-gray-12">{props.title}</h3>
+                  <p class="mt-1 text-sm leading-relaxed text-gray-10">{props.description}</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={props.onClose}
+                disabled={busy()}
+                class="rounded-full p-1 text-gray-10 transition hover:bg-gray-4 hover:text-gray-12 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Close"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            <Show when={visibleItems().length > 0}>
+              <div class="mt-4 flex flex-wrap gap-2">
+                <For each={visibleItems()}>
+                  {(item) => (
+                    <span class="rounded-full border border-gray-6 bg-gray-3 px-3 py-1 text-xs font-medium text-gray-11">
+                      {item}
+                    </span>
+                  )}
+                </For>
+                <Show when={hiddenItemCount() > 0}>
+                  <span class="rounded-full border border-gray-6 bg-gray-3 px-3 py-1 text-xs font-medium text-gray-11">
+                    +{hiddenItemCount()} more
+                  </span>
+                </Show>
+              </div>
+            </Show>
+          </div>
+
+          <div class="space-y-4 p-6">
+            <Show when={props.error?.trim()}>
+              <div class="rounded-xl border border-red-6 bg-red-2 px-4 py-3 text-sm text-red-11">{props.error}</div>
+            </Show>
+
+            <button
+              type="button"
+              onClick={props.onCreateNewWorker}
+              disabled={busy()}
+              class="flex w-full items-center justify-between rounded-2xl border border-indigo-7/30 bg-indigo-9/10 px-4 py-4 text-left transition hover:border-indigo-7/50 hover:bg-indigo-9/15 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <div class="flex items-start gap-3">
+                <div class="mt-0.5 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-9/20 text-indigo-11">
+                  <Plus size={18} />
+                </div>
+                <div>
+                  <div class="text-sm font-semibold text-gray-12">Create New Worker</div>
+                  <div class="mt-1 text-sm text-gray-10">Open the existing new worker flow, then import this bundle into it.</div>
+                </div>
+              </div>
+              <Sparkles size={18} class="text-indigo-11" />
+            </button>
+
+            <div class="rounded-2xl border border-gray-6 bg-gray-1/70">
+              <button
+                type="button"
+                onClick={() => setShowWorkers((value) => !value)}
+                disabled={busy()}
+                class="flex w-full items-center justify-between gap-3 px-4 py-4 text-left transition hover:bg-gray-3/60 disabled:cursor-not-allowed disabled:opacity-60"
+                aria-expanded={showWorkers()}
+              >
+                <div>
+                  <div class="text-sm font-semibold text-gray-12">Add to existing worker</div>
+                  <div class="mt-1 text-sm text-gray-10">Pick an existing worker and import the shared skills there.</div>
+                </div>
+                <Show when={showWorkers()} fallback={<ChevronRight size={18} class="text-gray-10" />}>
+                  <ChevronDown size={18} class="text-gray-10" />
+                </Show>
+              </button>
+
+              <Show when={showWorkers()}>
+                <div class="space-y-3 border-t border-gray-6 px-4 py-4">
+                  <Show
+                    when={props.workers.length > 0}
+                    fallback={<div class="rounded-xl border border-dashed border-gray-6 px-4 py-5 text-sm text-gray-10">No configured workers are available yet. Create a new worker to import this bundle.</div>}
+                  >
+                    <For each={props.workers}>
+                      {(worker) => {
+                        const disabledReason = () => worker.disabledReason?.trim() ?? "";
+                        const disabled = () => Boolean(disabledReason()) || busy();
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => props.onSelectWorker(worker.id)}
+                            disabled={disabled()}
+                            class="w-full rounded-xl border border-gray-6 bg-gray-2 px-4 py-3 text-left transition hover:border-gray-7 hover:bg-gray-3 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            <div class="flex items-start justify-between gap-3">
+                              <div class="min-w-0 flex-1">
+                                <div class="flex flex-wrap items-center gap-2">
+                                  <span class="text-sm font-semibold text-gray-12">{worker.label}</span>
+                                  <span class="rounded-full border border-gray-6 bg-gray-3 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-gray-10">
+                                    {worker.badge}
+                                  </span>
+                                  <Show when={worker.current}>
+                                    <span class="rounded-full border border-emerald-7/40 bg-emerald-9/10 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-emerald-11">
+                                      Current
+                                    </span>
+                                  </Show>
+                                </div>
+                                <div class="mt-1 truncate text-sm text-gray-10">{worker.detail}</div>
+                                <Show when={disabledReason()}>
+                                  <div class="mt-2 text-xs text-amber-11">{disabledReason()}</div>
+                                </Show>
+                              </div>
+                              <ChevronRight size={18} class="mt-0.5 shrink-0 text-gray-10" />
+                            </div>
+                          </button>
+                        );
+                      }}
+                    </For>
+                  </Show>
+                </div>
+              </Show>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -304,6 +304,7 @@ export type DashboardViewProps = {
   notionError: string | null;
   notionBusy: boolean;
   connectNotion: () => void;
+  openDebugShareLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
 };
 
 type SharedSkillItem = {
@@ -1397,6 +1398,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   notionError={props.notionError}
                   notionBusy={props.notionBusy}
                   connectNotion={props.connectNotion}
+                  openDebugShareLink={props.openDebugShareLink}
                 />
 
             </Match>

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -136,6 +136,7 @@ export type SettingsViewProps = {
   notionBusy: boolean;
   connectNotion: () => void;
   engineDoctorVersion: string | null;
+  openDebugShareLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
 };
 
 // OpenCodeRouter Settings Component
@@ -787,6 +788,10 @@ export default function SettingsView(props: SettingsViewProps) {
   const [sandboxProbeResult, setSandboxProbeResult] = createSignal<SandboxDebugProbeResult | null>(null);
   const [nukeDevConfigBusy, setNukeDevConfigBusy] = createSignal(false);
   const [nukeDevConfigStatus, setNukeDevConfigStatus] = createSignal<string | null>(null);
+  const [debugShareLinkOpen, setDebugShareLinkOpen] = createSignal(false);
+  const [debugShareLinkInput, setDebugShareLinkInput] = createSignal("");
+  const [debugShareLinkBusy, setDebugShareLinkBusy] = createSignal(false);
+  const [debugShareLinkStatus, setDebugShareLinkStatus] = createSignal<string | null>(null);
   const opencodeDevModeEnabled = createMemo(() => Boolean(buildInfo()?.openworkDevMode));
 
   const sandboxCreateSummary = createMemo(() => {
@@ -981,6 +986,20 @@ export default function SettingsView(props: SettingsViewProps) {
       setSandboxProbeStatus(error instanceof Error ? error.message : "Sandbox probe failed.");
     } finally {
       setSandboxProbeBusy(false);
+    }
+  };
+
+  const submitDebugShareLink = async () => {
+    if (debugShareLinkBusy()) return;
+    setDebugShareLinkBusy(true);
+    setDebugShareLinkStatus(null);
+    try {
+      const result = await props.openDebugShareLink(debugShareLinkInput());
+      setDebugShareLinkStatus(result.message);
+    } catch (error) {
+      setDebugShareLinkStatus(error instanceof Error ? error.message : "Failed to open share link.");
+    } finally {
+      setDebugShareLinkBusy(false);
     }
   };
 
@@ -1320,6 +1339,59 @@ export default function SettingsView(props: SettingsViewProps) {
                 </div>
                 <Show when={nukeDevConfigStatus()}>
                   {(value) => <div class="text-xs text-red-11">{value()}</div>}
+                </Show>
+
+                <Show when={props.developerMode}>
+                  <div class="rounded-xl border border-gray-6/60 bg-gray-1/40 p-4 space-y-3">
+                    <div class="flex items-start justify-between gap-3">
+                      <div>
+                        <div class="text-sm font-medium text-gray-12">Open share link</div>
+                        <div class="text-xs text-gray-9">
+                          Paste an existing <span class="font-mono">openwork://</span> share link and route it through the dev app.
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        class={compactOutlineActionClass}
+                        onClick={() => {
+                          setDebugShareLinkOpen((value) => !value);
+                          setDebugShareLinkStatus(null);
+                        }}
+                        disabled={props.busy || debugShareLinkBusy()}
+                      >
+                        {debugShareLinkOpen() ? "Hide" : "Open share link"}
+                      </button>
+                    </div>
+
+                    <Show when={debugShareLinkOpen()}>
+                      <div class="space-y-3">
+                        <textarea
+                          value={debugShareLinkInput()}
+                          onInput={(event) => setDebugShareLinkInput(event.currentTarget.value)}
+                          rows={3}
+                          placeholder="openwork://import-bundle?ow_bundle=..."
+                          class="w-full rounded-xl border border-gray-6 bg-gray-1 px-3 py-2 text-xs font-mono text-gray-12 outline-none transition focus:border-blue-8"
+                        />
+                        <div class="flex flex-wrap items-center gap-2">
+                          <Button
+                            variant="secondary"
+                            class="text-xs h-8 py-0 px-3"
+                            onClick={() => void submitDebugShareLink()}
+                            disabled={props.busy || debugShareLinkBusy() || !debugShareLinkInput().trim()}
+                          >
+                            {debugShareLinkBusy() ? "Opening..." : "Open link"}
+                          </Button>
+                          <div class="text-[11px] text-gray-8">
+                            Accepts <span class="font-mono">openwork://</span>, <span class="font-mono">openwork-dev://</span>, or a raw <span class="font-mono">https://share.openwork.software/b/...</span> URL.
+                          </div>
+                        </div>
+                      </div>
+                    </Show>
+
+                    <Show when={debugShareLinkStatus()}>
+                      {(value) => <div class="text-xs text-gray-10">{value()}</div>}
+                    </Show>
+                  </div>
                 </Show>
               </Show>
             </div>

--- a/packages/desktop/src-tauri/Info.dev.plist
+++ b/packages/desktop/src-tauri/Info.dev.plist
@@ -2,9 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.differentai.openwork.dev</string>
   <key>CFBundleName</key>
   <string>OpenWork - Dev</string>
   <key>CFBundleDisplayName</key>
   <string>OpenWork - Dev</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>CFBundleURLName</key>
+      <string>com.differentai.openwork.dev openwork-dev</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>openwork-dev</string>
+      </array>
+    </dict>
+  </array>
 </dict>
 </plist>

--- a/packages/desktop/src-tauri/tauri.dev.conf.json
+++ b/packages/desktop/src-tauri/tauri.dev.conf.json
@@ -23,5 +23,14 @@
         "resizable": true
       }
     ]
+  },
+  "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": [
+          "openwork-dev"
+        ]
+      }
+    }
   }
 }

--- a/services/openwork-share/components/share-bundle-page.tsx
+++ b/services/openwork-share/components/share-bundle-page.tsx
@@ -252,11 +252,11 @@ export default function ShareBundlePage(props: BundlePageProps) {
                   </div>
                   <div className="step-row">
                     <span className="step-bullet">02</span>
-                    <span>OpenWork reads the bundle metadata, then prepares a new worker import flow.</span>
+                    <span>OpenWork reads the bundle metadata, then lets you choose an existing worker or a new one.</span>
                   </div>
                   <div className="step-row">
                     <span className="step-bullet">03</span>
-                    <span>Your teammate lands in a clean import path with the packaged skills, agents, and MCP setup attached.</span>
+                    <span>Your teammate lands in a clean import path with the packaged skills, agents, and MCP setup ready to apply.</span>
                   </div>
                 </div>
               </article>

--- a/services/openwork-share/server/_lib/share-utils.ts
+++ b/services/openwork-share/server/_lib/share-utils.ts
@@ -143,7 +143,8 @@ export function buildOpenInAppUrls(shareUrl: string, options: { label?: string }
   const label = String(options.label ?? "").trim();
   if (label) query.set("ow_label", label.slice(0, 120));
 
-  const openInAppDeepLink = `openwork://import-bundle?${query.toString()}`;
+  const appScheme = (getEnv("PUBLIC_OPENWORK_APP_SCHEME", "openwork") || "openwork").trim().toLowerCase();
+  const openInAppDeepLink = `${appScheme}://import-bundle?${query.toString()}`;
   const appUrl = normalizeAppUrl(getEnv("PUBLIC_OPENWORK_APP_URL", DEFAULT_OPENWORK_APP_URL)) || DEFAULT_OPENWORK_APP_URL;
 
   try {
@@ -580,10 +581,10 @@ export function prettyJson(rawJson: string): string {
 export function buildBundleNarrative(bundle: NormalizedBundle): string {
   const counts = getBundleCounts(bundle);
   if (bundle.type === "skill") {
-    return "One reusable skill, wrapped in a share link that opens directly into a new OpenWork worker.";
+    return "One reusable skill, wrapped in a share link that can be added to an existing worker or imported into a new one.";
   }
   if (bundle.type === "skills-set") {
-    return `${counts.skillCount} skills packaged together so a new worker can start with the full set in one import.`;
+    return `${counts.skillCount} skills packaged together so they can land in an existing worker or start a new worker with the full set in one import.`;
   }
 
   const parts: string[] = [];

--- a/services/openwork-share/server/b/get-bundle-page-props.ts
+++ b/services/openwork-share/server/b/get-bundle-page-props.ts
@@ -62,7 +62,7 @@ export async function getBundlePageProps({ id, requestLike }: { id: string; requ
       bundle.type === "skill"
         ? "Open in app to choose where to add this skill."
         : bundle.type === "skills-set"
-          ? "Open in app to create a new worker with this entire skills set already attached."
+          ? "Open in app to add this full skills set to an existing worker or create a new worker with it attached."
           : "Open in app to create a new worker with these skills, agents, MCPs, and config already bundled.";
 
     return {

--- a/services/openwork-share/server/b/render-bundle-page.ts
+++ b/services/openwork-share/server/b/render-bundle-page.ts
@@ -56,7 +56,7 @@ export function renderBundlePage({ id, rawJson, req }: { id: string; rawJson: st
     bundle.type === "skill"
       ? "Open in app to choose where to add this skill."
       : bundle.type === "skills-set"
-        ? "Open in app to create a new worker with this entire skills set already attached."
+        ? "Open in app to add this full skills set to an existing worker or create a new worker with it attached."
         : "Open in app to create a new worker with these skills, agents, MCPs, and config already bundled.";
   const metadataRows = [
     ["ID", id],


### PR DESCRIPTION
## Summary
- add a shared bundle import chooser so shared skills and skill sets can be added to an existing worker or used to create a new one
- reuse the existing skill import reload path after shared bundle imports, and update share page copy to reflect the new flow
- add a temporary dev-only Settings helper for pasting share links plus dev-scheme/testing support for desktop debugging

## Testing
- pnpm install
- pnpm --filter @different-ai/openwork-ui typecheck