### PR TITLE
fix(agent): guide users to install Control Chrome when browser access is unavailable

### DIFF
--- a/packages/desktop/src-tauri/src/workspace/files.rs
+++ b/packages/desktop/src-tauri/src/workspace/files.rs
@@ -170,6 +170,9 @@ Incremental adoption loop
 - If steps repeat, factor them into a skill.
 - If the work becomes ongoing, create/refine an agent role.
 - If it should run regularly, schedule it and store outputs in private memory.
+
+Specific User Requests
+- If a user asks you to do something with a broswer, like 'open a new tab', check if you have access to the chrome-devtools-mcp - if not, then ask the user to add the 'Control Chrome' extension using the sidebar or via the worker settings.
 "#;
 
     fs::write(&agent_path, doc)


### PR DESCRIPTION
## Summary
- add a specific instruction to the desktop workspace agent prompt for browser-related requests when Chrome MCP is unavailable
- direct the agent to ask users to install the `Control Chrome` extension via the sidebar or worker settings
- improve fallback guidance so browser actions fail with a clear next step instead of silent confusion