### PR TITLE
Add a skills launcher modal

### DIFF
--- a/packages/app/src/app/pages/skills.tsx
+++ b/packages/app/src/app/pages/skills.tsx
@@ -3,9 +3,13 @@ import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount }
 import type { HubSkillCard, SkillCard } from "../types";
 
 import Button from "../components/button";
-import { Copy, Edit2, FolderOpen, Link2, Loader2, Package, Plus, RefreshCw, Search, Share2, Sparkles, Trash2, Upload } from "lucide-solid";
+import { ArrowLeft, Copy, Edit2, FolderOpen, Link2, Loader2, Package, Plus, RefreshCw, Search, Share2, Sparkles, Trash2, Upload, X } from "lucide-solid";
 import { currentLocale, t } from "../../i18n";
-import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL, publishOpenworkBundleJson } from "../lib/publisher";
+import {
+  DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
+  publishOpenworkBundleJson,
+} from "../lib/publisher";
+import { isTauriRuntime } from "../utils";
 
 type InstallResult = { ok: boolean; message: string };
 
@@ -17,6 +21,9 @@ type SkillBundleV1 = {
   description?: string;
   trigger?: string;
 };
+
+type CreateSkillModalStep = "launcher" | "install-link";
+type InstallLinkSource = "launcher-external-editor" | "launcher-direct-link" | "toolbar-shortcut";
 
 const OPENWORK_DEFAULT_SKILL_NAMES = new Set([
   "workspace-guide",
@@ -73,6 +80,8 @@ export default function SkillsView(props: SkillsViewProps) {
   const [installLinkBusy, setInstallLinkBusy] = createSignal(false);
   const [installLinkError, setInstallLinkError] = createSignal<string | null>(null);
   const [installLinkBundle, setInstallLinkBundle] = createSignal<SkillBundleV1 | null>(null);
+  const [createSkillModalStep, setCreateSkillModalStep] = createSignal<CreateSkillModalStep | null>(null);
+  const [installLinkSource, setInstallLinkSource] = createSignal<InstallLinkSource>("toolbar-shortcut");
 
   const [selectedSkill, setSelectedSkill] = createSignal<SkillCard | null>(null);
   const [selectedContent, setSelectedContent] = createSignal("");
@@ -232,6 +241,13 @@ export default function SkillsView(props: SkillsViewProps) {
     props.setPrompt("/skill-creator");
   };
 
+  const resetInstallLinkState = () => {
+    setInstallLinkUrl("");
+    setInstallLinkBusy(false);
+    setInstallLinkError(null);
+    setInstallLinkBundle(null);
+  };
+
   const openShareLink = (skill: SkillCard) => {
     if (props.busy) return;
     setShareTarget(skill);
@@ -299,20 +315,59 @@ export default function SkillsView(props: SkillsViewProps) {
     }
   };
 
-  const openInstallFromLink = () => {
+  const openInstallFromLink = (source: InstallLinkSource = "toolbar-shortcut") => {
     if (props.busy) return;
+    setInstallLinkSource(source);
+    setCreateSkillModalStep("install-link");
     setInstallLinkOpen(true);
-    setInstallLinkUrl("");
-    setInstallLinkBusy(false);
-    setInstallLinkError(null);
-    setInstallLinkBundle(null);
+    resetInstallLinkState();
   };
 
   const closeInstallFromLink = () => {
+    setCreateSkillModalStep(null);
     setInstallLinkOpen(false);
-    setInstallLinkBusy(false);
-    setInstallLinkError(null);
-    setInstallLinkBundle(null);
+    resetInstallLinkState();
+  };
+
+  const openCreateSkillModal = () => {
+    if (props.busy) return;
+    setCreateSkillModalStep("launcher");
+    setInstallLinkOpen(false);
+    resetInstallLinkState();
+  };
+
+  const openCreateSkillInChat = async () => {
+    closeInstallFromLink();
+    await handleNewSkill();
+  };
+
+  const openExternalLink = async (url: string) => {
+    if (isTauriRuntime()) {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(url);
+      return;
+    }
+
+    if (typeof window !== "undefined") {
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  const openExternalSkillEditor = async () => {
+    if (props.busy) return;
+    try {
+      await openExternalLink(DEFAULT_OPENWORK_PUBLISHER_BASE_URL);
+      openInstallFromLink("launcher-external-editor");
+    } catch (e) {
+      setToast(maskError(e));
+    }
+  };
+
+  const backToCreateSkillLauncher = () => {
+    if (installLinkBusy()) return;
+    setCreateSkillModalStep("launcher");
+    setInstallLinkOpen(false);
+    resetInstallLinkState();
   };
 
   const previewInstallLink = async () => {
@@ -328,6 +383,9 @@ export default function SkillsView(props: SkillsViewProps) {
     setInstallLinkBundle(null);
     try {
       const url = new URL(raw);
+      if (!url.searchParams.has("format")) {
+        url.searchParams.set("format", "json");
+      }
       const controller = new AbortController();
       const timer = window.setTimeout(() => controller.abort(), 15_000);
       try {
@@ -466,17 +524,62 @@ export default function SkillsView(props: SkillsViewProps) {
     }
   };
 
-  const newSkillDisabled = createMemo(
-    () =>
-      props.busy ||
-      (!props.canInstallSkillCreator && !props.canUseDesktopTools)
-  );
-
   const workspaceLabel = createMemo(() => props.workspaceName.trim() || "Worker");
 
   const canCreateInChat = createMemo(
     () => !props.busy && (props.canInstallSkillCreator || props.canUseDesktopTools)
   );
+
+  const canOpenCreateSkillModal = createMemo(() => !props.busy);
+  const createSkillModalOpen = createMemo(() => createSkillModalStep() != null || installLinkOpen());
+  const installLinkShowsBack = createMemo(() => installLinkSource() !== "toolbar-shortcut");
+  const installLinkDescription = createMemo(() =>
+    installLinkSource() === "launcher-external-editor"
+      ? "Paste the share link from the editor to install it here."
+      : "Paste a skill bundle URL, preview it, then install."
+  );
+
+  const createSkillOptions = createMemo(() => [
+    {
+      id: "upload-local",
+      title: "Upload the skill",
+      description: "Import a local skill folder into this worker.",
+      icon: Upload,
+      disabled: props.busy || !props.canUseDesktopTools,
+      disabledReason: !props.canUseDesktopTools ? translate("skills.desktop_required") : null,
+      onClick: () => {
+        closeInstallFromLink();
+        props.importLocalSkill();
+      },
+    },
+    {
+      id: "external-editor",
+      title: "Create/edit in skill editor",
+      description: "Open the external editor, then paste the share link back here to install it.",
+      icon: Edit2,
+      disabled: props.busy,
+      disabledReason: null,
+      onClick: () => void openExternalSkillEditor(),
+    },
+    {
+      id: "install-link",
+      title: "Install from link",
+      description: "Paste a share link and install the skill bundle into this worker.",
+      icon: Link2,
+      disabled: props.busy,
+      disabledReason: null,
+      onClick: () => openInstallFromLink("launcher-direct-link"),
+    },
+    {
+      id: "create-in-chat",
+      title: "Create a skill in chat",
+      description: "Open a new thread with /skill-creator prefilled for the current worker.",
+      icon: Sparkles,
+      disabled: !canCreateInChat(),
+      disabledReason: props.busy ? null : props.accessHint ?? translate("skills.host_only_error"),
+      onClick: () => void openCreateSkillInChat(),
+    },
+  ]);
 
   const isOpenworkInjectedSkill = (skill: SkillCard) => {
     const normalizedName = skill.name.trim().toLowerCase();
@@ -505,15 +608,15 @@ export default function SkillsView(props: SkillsViewProps) {
             <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-dls-secondary">Worker profile</div>
             <div class="text-xl font-semibold text-dls-text truncate">{workspaceLabel()}</div>
             <p class="text-sm text-dls-secondary">
-              Skills are the core abilities of this worker. Add from Hub or create new ones directly in chat.
+              Skills are the core abilities of this worker. Add from Hub or create new ones from local files, share links, or chat.
             </p>
           </div>
           <button
             type="button"
-            onClick={handleNewSkill}
-            disabled={!canCreateInChat()}
+            onClick={openCreateSkillModal}
+            disabled={!canOpenCreateSkillModal()}
             class={`inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-xs font-medium transition-colors ${
-              canCreateInChat()
+              canOpenCreateSkillModal()
                 ? "bg-dls-text text-dls-surface hover:opacity-90"
                 : "bg-dls-active text-dls-secondary"
             }`}
@@ -573,10 +676,10 @@ export default function SkillsView(props: SkillsViewProps) {
         </div>
         <button
           type="button"
-          onClick={handleNewSkill}
-          disabled={newSkillDisabled()}
+          onClick={openCreateSkillModal}
+          disabled={!canOpenCreateSkillModal()}
           class={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
-            newSkillDisabled()
+            !canOpenCreateSkillModal()
               ? "bg-dls-active text-dls-secondary"
               : "bg-dls-text text-dls-surface hover:opacity-90"
           }`}
@@ -586,7 +689,7 @@ export default function SkillsView(props: SkillsViewProps) {
         </button>
         <button
           type="button"
-          onClick={openInstallFromLink}
+          onClick={() => openInstallFromLink()}
           disabled={props.busy}
           class={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors border ${
             props.busy
@@ -1043,102 +1146,181 @@ export default function SkillsView(props: SkillsViewProps) {
         </div>
       </Show>
 
-      <Show when={installLinkOpen()}>
+      <Show when={createSkillModalOpen()}>
         <div class="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm flex items-center justify-center p-4">
-          <div class="bg-dls-surface border border-dls-border w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden">
-            <div class="p-6 space-y-4">
-              <div>
-                <h3 class="text-lg font-semibold text-dls-text">Install from link</h3>
-                <p class="text-sm text-dls-secondary mt-1">Paste a skill bundle URL, preview it, then install.</p>
-              </div>
-
-              <div class="space-y-2">
-                <div class="text-xs font-semibold uppercase tracking-widest text-dls-secondary">Link</div>
-                <input
-                  type="url"
-                  value={installLinkUrl()}
-                  onInput={(e) => setInstallLinkUrl(e.currentTarget.value)}
-                  placeholder="https://share.openwork.software/b/..."
-                  class="w-full bg-dls-hover border border-dls-border rounded-lg px-3 py-2 text-xs font-mono text-dls-text focus:outline-none"
-                  spellcheck={false}
-                />
-              </div>
-
-              <Show when={installLinkError()}>
-                <div class="rounded-xl border border-red-7/20 bg-red-1/40 px-4 py-3 text-xs text-red-12">
-                  {installLinkError()}
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={createSkillModalStep() === "launcher" ? "Create a skill" : "Install from link"}
+            class="bg-dls-surface border border-dls-border w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden"
+          >
+            <div class="p-6 space-y-5">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <Show
+                    when={createSkillModalStep() === "launcher"}
+                    fallback={<h3 class="text-lg font-semibold text-dls-text">Install from link</h3>}
+                  >
+                    <h3 class="text-lg font-semibold text-dls-text">Create a skill</h3>
+                  </Show>
+                  <p class="text-sm text-dls-secondary mt-1">
+                    {createSkillModalStep() === "launcher"
+                      ? "Choose how you want to add or create a skill for this worker."
+                      : installLinkDescription()}
+                  </p>
                 </div>
-              </Show>
+                <button
+                  type="button"
+                  aria-label="Close create skill modal"
+                  class="rounded-full p-1 text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+                  onClick={closeInstallFromLink}
+                  disabled={installLinkBusy()}
+                >
+                  <X size={18} />
+                </button>
+              </div>
 
-              <Show when={installLinkBundle()}>
-                {(bundle) => {
-                  const taken = installedNames();
-                  const conflict = taken.has(bundle().name.trim());
-                  return (
-                    <div class="rounded-xl border border-dls-border bg-dls-hover p-4 space-y-2">
-                      <div class="text-xs font-semibold text-dls-text">Preview</div>
-                      <div class="text-xs text-dls-secondary">
-                        Skill: <span class="font-mono">{bundle().name}</span>
+              <Show
+                when={createSkillModalStep() === "launcher"}
+                fallback={
+                  <div class="space-y-4">
+                    <Show when={installLinkShowsBack()}>
+                      <button
+                        type="button"
+                        class="inline-flex items-center gap-1.5 text-xs font-medium text-dls-secondary transition-colors hover:text-dls-text"
+                        onClick={backToCreateSkillLauncher}
+                        disabled={installLinkBusy()}
+                      >
+                        <ArrowLeft size={14} />
+                        Back
+                      </button>
+                    </Show>
+
+                    <div class="space-y-2">
+                      <label class="text-xs font-semibold uppercase tracking-widest text-dls-secondary" for="skill-bundle-link">
+                        Link
+                      </label>
+                      <input
+                        id="skill-bundle-link"
+                        aria-label="Skill bundle link"
+                        type="url"
+                        value={installLinkUrl()}
+                        onInput={(e) => setInstallLinkUrl(e.currentTarget.value)}
+                        placeholder="https://share.openwork.software/b/..."
+                        class="w-full bg-dls-hover border border-dls-border rounded-lg px-3 py-2 text-xs font-mono text-dls-text focus:outline-none"
+                        spellcheck={false}
+                      />
+                    </div>
+
+                    <Show when={installLinkError()}>
+                      <div class="rounded-xl border border-red-7/20 bg-red-1/40 px-4 py-3 text-xs text-red-12">
+                        {installLinkError()}
                       </div>
-                      <Show when={bundle().description}>
-                        <div class="text-xs text-dls-secondary">{bundle().description}</div>
-                      </Show>
-                      <Show when={conflict}>
-                        <div class="text-xs text-amber-11">A skill with this name is already installed.</div>
+                    </Show>
+
+                    <Show when={installLinkBundle()}>
+                      {(bundle) => {
+                        const taken = installedNames();
+                        const conflict = taken.has(bundle().name.trim());
+                        return (
+                          <div class="rounded-xl border border-dls-border bg-dls-hover p-4 space-y-2">
+                            <div class="text-xs font-semibold text-dls-text">Preview</div>
+                            <div class="text-xs text-dls-secondary">
+                              Skill: <span class="font-mono">{bundle().name}</span>
+                            </div>
+                            <Show when={bundle().description}>
+                              <div class="text-xs text-dls-secondary">{bundle().description}</div>
+                            </Show>
+                            <Show when={conflict}>
+                              <div class="text-xs text-amber-11">A skill with this name is already installed.</div>
+                            </Show>
+                          </div>
+                        );
+                      }}
+                    </Show>
+
+                    <div class="flex flex-wrap justify-end gap-2">
+                      <Button variant="outline" onClick={closeInstallFromLink} disabled={installLinkBusy()}>
+                        {translate("common.cancel")}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => void previewInstallLink()}
+                        disabled={installLinkBusy() || !installLinkUrl().trim()}
+                      >
+                        {installLinkBusy() && !installLinkBundle() ? "Loading…" : "Preview"}
+                      </Button>
+                      <Show when={installLinkBundle()} keyed>
+                        {(bundle) => {
+                          const conflict = installedNames().has(bundle.name.trim());
+                          return (
+                            <Show
+                              when={conflict}
+                              fallback={
+                                <Button
+                                  variant="secondary"
+                                  onClick={() => void installFromPreview("overwrite")}
+                                  disabled={installLinkBusy()}
+                                >
+                                  {installLinkBusy() ? "Installing…" : "Install"}
+                                </Button>
+                              }
+                            >
+                              <div class="flex gap-2">
+                                <Button
+                                  variant="outline"
+                                  onClick={() => void installFromPreview("keep-both")}
+                                  disabled={installLinkBusy()}
+                                >
+                                  {installLinkBusy() ? "Installing…" : "Keep both"}
+                                </Button>
+                                <Button
+                                  variant="secondary"
+                                  onClick={() => void installFromPreview("overwrite")}
+                                  disabled={installLinkBusy()}
+                                >
+                                  {installLinkBusy() ? "Installing…" : "Overwrite"}
+                                </Button>
+                              </div>
+                            </Show>
+                          );
+                        }}
                       </Show>
                     </div>
-                  );
-                }}
-              </Show>
-
-              <div class="flex justify-end gap-2">
-                <Button variant="outline" onClick={closeInstallFromLink} disabled={installLinkBusy()}>
-                  {translate("common.cancel")}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => void previewInstallLink()}
-                  disabled={installLinkBusy() || !installLinkUrl().trim()}
-                >
-                  {installLinkBusy() && !installLinkBundle() ? "Loading…" : "Preview"}
-                </Button>
-                <Show when={installLinkBundle()} keyed>
-                  {(bundle) => {
-                    const conflict = installedNames().has(bundle.name.trim());
-                    return (
-                      <Show
-                        when={conflict}
-                        fallback={
-                          <Button
-                            variant="secondary"
-                            onClick={() => void installFromPreview("overwrite")}
-                            disabled={installLinkBusy()}
-                          >
-                            {installLinkBusy() ? "Installing…" : "Install"}
-                          </Button>
-                        }
+                  </div>
+                }
+              >
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <For each={createSkillOptions()}>
+                    {(item) => (
+                      <button
+                        type="button"
+                        class={`rounded-2xl border p-4 text-left transition-colors ${
+                          item.disabled
+                            ? "border-dls-border bg-dls-hover text-dls-secondary"
+                            : "border-dls-border bg-dls-surface hover:bg-dls-hover"
+                        }`}
+                        onClick={item.onClick}
+                        disabled={item.disabled}
+                        title={item.disabled ? item.disabledReason ?? item.title : item.title}
                       >
-                        <div class="flex gap-2">
-                          <Button
-                            variant="outline"
-                            onClick={() => void installFromPreview("keep-both")}
-                            disabled={installLinkBusy()}
-                          >
-                            {installLinkBusy() ? "Installing…" : "Keep both"}
-                          </Button>
-                          <Button
-                            variant="secondary"
-                            onClick={() => void installFromPreview("overwrite")}
-                            disabled={installLinkBusy()}
-                          >
-                            {installLinkBusy() ? "Installing…" : "Overwrite"}
-                          </Button>
+                        <div class="flex items-start gap-3">
+                          <div class="flex h-10 w-10 items-center justify-center rounded-xl border border-dls-border bg-dls-hover text-dls-secondary">
+                            <item.icon size={18} />
+                          </div>
+                          <div class="min-w-0">
+                            <div class="text-sm font-semibold text-dls-text">{item.title}</div>
+                            <p class="mt-1 text-xs text-dls-secondary">{item.description}</p>
+                            <Show when={item.disabled && item.disabledReason}>
+                              <div class="mt-2 text-[11px] text-dls-secondary">{item.disabledReason}</div>
+                            </Show>
+                          </div>
                         </div>
-                      </Show>
-                    );
-                  }}
-                </Show>
-              </div>
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </Show>
             </div>
           </div>
         </div>

--- a/packages/desktop/src-tauri/src/commands/skills.rs
+++ b/packages/desktop/src-tauri/src/commands/skills.rs
@@ -378,7 +378,9 @@ fn extract_description(raw: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::extract_description;
+    use super::{extract_description, write_local_skill};
+    use std::fs;
+    use uuid::Uuid;
 
     #[test]
     fn extract_description_truncates_multibyte_text_without_panicking() {
@@ -398,6 +400,33 @@ mod tests {
         let description = extract_description(raw).expect("description should be present");
 
         assert_eq!(description, "Short description");
+    }
+
+    #[test]
+    fn write_local_skill_creates_missing_project_skill() {
+        let project_dir = std::env::temp_dir().join(format!("openwork-skill-write-{}", Uuid::new_v4()));
+        fs::create_dir_all(&project_dir).expect("project dir");
+
+        let result = write_local_skill(
+            project_dir.to_string_lossy().to_string(),
+            "shared-skill".to_string(),
+            "# Shared skill".to_string(),
+        )
+        .expect("write should return exec result");
+
+        let skill_path = project_dir
+            .join(".opencode")
+            .join("skills")
+            .join("shared-skill")
+            .join("SKILL.md");
+
+        assert!(result.ok);
+        assert_eq!(
+            fs::read_to_string(&skill_path).expect("skill file"),
+            "# Shared skill\n"
+        );
+
+        fs::remove_dir_all(&project_dir).expect("cleanup temp project");
     }
 }
 
@@ -485,14 +514,17 @@ pub fn write_local_skill(
         }
     }
 
-    let Some(path) = target else {
-        return Ok(ExecResult {
-            ok: false,
-            status: 1,
-            stdout: String::new(),
-            stderr: "Skill not found".to_string(),
-        });
+    let path = match target {
+        Some(path) => path,
+        None => ensure_project_skill_root(project_dir)?
+            .join(&name)
+            .join("SKILL.md"),
     };
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+    }
 
     let next = if content.ends_with('\n') {
         content

--- a/packages/server/src/validators.test.ts
+++ b/packages/server/src/validators.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   sanitizeCommandName,
   validateCommandName,
+  validateDescription,
   validateMcpName,
   validateSkillName,
   validateMcpConfig,
@@ -92,6 +93,22 @@ describe("validateSkillName", () => {
 
   test("rejects names over 64 chars", () => {
     expect(() => validateSkillName("a".repeat(65))).toThrow();
+  });
+});
+
+describe("validateDescription", () => {
+  test("accepts missing descriptions", () => {
+    expect(() => validateDescription(undefined)).not.toThrow();
+    expect(() => validateDescription("")).not.toThrow();
+  });
+
+  test("accepts non-empty descriptions up to 1024 chars", () => {
+    expect(() => validateDescription("hello")).not.toThrow();
+    expect(() => validateDescription("a".repeat(1024))).not.toThrow();
+  });
+
+  test("rejects descriptions over 1024 chars", () => {
+    expect(() => validateDescription("a".repeat(1025))).toThrow();
   });
 });
 

--- a/packages/server/src/validators.ts
+++ b/packages/server/src/validators.ts
@@ -11,7 +11,10 @@ export function validateSkillName(name: string): void {
 }
 
 export function validateDescription(description: string | undefined): void {
-  if (!description || description.length < 1 || description.length > 1024) {
+  if (description == null || description.length === 0) {
+    return;
+  }
+  if (description.length > 1024) {
     throw new ApiError(422, "invalid_description", "Description must be 1-1024 characters");
   }
 }

--- a/services/openwork-share/app/b/[id]/data/route.ts
+++ b/services/openwork-share/app/b/[id]/data/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       searchParams: request.nextUrl.searchParams
     });
     const responseHeaders = new Headers({
+      "Access-Control-Allow-Origin": "*",
       Vary: "Accept",
       "Cache-Control": "public, max-age=3600",
       "Content-Type": blob.contentType || "application/json"

--- a/services/openwork-share/server/_lib/package-openwork-files.test.ts
+++ b/services/openwork-share/server/_lib/package-openwork-files.test.ts
@@ -30,6 +30,28 @@ Route fresh leads and qualify them.`,
   assert.equal(result.items[0]?.kind, "Skill");
 });
 
+test("packageOpenworkFiles rewrites shared skill frontmatter to the normalized bundle name", () => {
+  const result = packageOpenworkFiles({
+    files: [
+      {
+        path: ".opencode/skills/sales-inbound/SKILL.md",
+        content: `---
+name: Sales Inbound
+description: Handle inbound sales leads.
+---
+
+# Sales Inbound
+
+Route fresh leads and qualify them.`,
+      },
+    ],
+  });
+
+  assert.equal(result.bundleType, "skill");
+  assert.equal(result.bundle.name, "sales-inbound");
+  assert.match((result.bundle as { content: string }).content, /^---\nname: sales-inbound\n/m);
+});
+
 test("packageOpenworkFiles builds a workspace profile with agents and MCP config", () => {
   const result = packageOpenworkFiles({
     files: [

--- a/services/openwork-share/server/_lib/package-openwork-files.ts
+++ b/services/openwork-share/server/_lib/package-openwork-files.ts
@@ -1,4 +1,5 @@
 import { parse as parseJsonc } from "jsonc-parser";
+import { stringify as stringifyYaml } from "yaml";
 
 import type { PreviewItem } from "../../components/share-home-types.ts";
 import { humanizeType, maybeArray, maybeString, parseFrontmatter } from "./share-utils.ts";
@@ -149,11 +150,38 @@ interface SkillRecord {
   preview: PreviewItem;
 }
 
+function extractDescription(body: string): string {
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const cleaned = trimmed.replaceAll("`", "").trim();
+    if (!cleaned) continue;
+    const max = 180;
+    const truncated = Array.from(cleaned).slice(0, max).join("");
+    return truncated.length < cleaned.length ? `${truncated}...` : cleaned;
+  }
+
+  return "";
+}
+
+function buildSkillContent(frontmatter: Frontmatter, name: string, description: string): string {
+  const data: Record<string, unknown> = { ...frontmatter.data, name };
+  if (description) data.description = description;
+  else delete data.description;
+
+  const yaml = stringifyYaml(data).trimEnd();
+  const body = frontmatter.body.replace(/^\n/, "");
+  return `---\n${yaml}\n---\n${body}`;
+}
+
 function buildSkillRecord(file: NormalizedFile, warnings: string[], frontmatter: Frontmatter): SkillRecord | null {
   const { data } = frontmatter;
   const parentName = basename(dirname(file.path));
   const name = resolveName(data.name, parentName || stem(file.path));
-  const description = typeof data.description === "string" ? data.description.trim() : "";
+  const description =
+    typeof data.description === "string" && data.description.trim()
+      ? data.description.trim()
+      : extractDescription(frontmatter.body);
   const trigger = typeof data.trigger === "string" ? data.trigger.trim() : "";
   const version = typeof data.version === "string" ? data.version.trim() : "";
   if (!file.content.trim()) {
@@ -164,7 +192,7 @@ function buildSkillRecord(file: NormalizedFile, warnings: string[], frontmatter:
     name,
     description,
     trigger,
-    content: file.content,
+    content: buildSkillContent(frontmatter, name, description),
     preview: buildPreviewItem(name, "Skill", version ? `v${version}` : trigger ? `Trigger · ${trigger}` : "Skill", "skill"),
   };
 }


### PR DESCRIPTION
## Summary
- reapply the shared Skills launcher modal for both create-entry buttons
- keep the toolbar `Install from link` shortcut, but route both link-based flows through the same preview/install step
- fix share-link imports end to end:
  - plain share URLs now preview correctly
  - share JSON responses return browser-usable CORS headers
  - description-less skill bundles install correctly
  - packaged share bundles preserve a normalized skill name in `SKILL.md`
- use `DEFAULT_OPENWORK_PUBLISHER_BASE_URL` for the external editor handoff
- remove the OpenWork Playwright/harness additions from the earlier attempt so this branch does not change app package dependencies or build inputs

## Exact URL Repro
Public skill URL verified for this flow:
- [https://share.openwork.software/b/01KKMFFK2DVHWMPSVZN6Q523YG](https://share.openwork.software/b/01KKMFFK2DVHWMPSVZN6Q523YG)

## What Was Broken
1. Browser preview could fail when `GET /b/:id?format=json` did not send `Access-Control-Allow-Origin`.
2. Description-less skill bundles could fail on install with `422 invalid_description`.
3. Newly written local skills could preview but fail to create a missing project skill on install.
4. Shared skill bundles could keep a mismatched internal `SKILL.md` name.

## What This PR Changes
- `packages/app/src/app/pages/skills.tsx`
  - adds the launcher modal
  - shares the install-from-link flow
  - uses `DEFAULT_OPENWORK_PUBLISHER_BASE_URL` for the external editor handoff
- `services/openwork-share/app/b/[id]/data/route.ts`
  - returns `Access-Control-Allow-Origin: *` for JSON bundle responses
- `packages/server/src/validators.ts`
  - allows missing or empty descriptions
- `packages/desktop/src-tauri/src/commands/skills.rs`
  - creates missing project skills on local write
- `services/openwork-share/server/_lib/package-openwork-files.ts`
  - rewrites skill frontmatter to the normalized exported name

## Verification
### Ran
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter openwork-server test -- src/validators.test.ts`
- `pnpm --dir services/openwork-share test`
- `cargo test --manifest-path packages/desktop/src-tauri/Cargo.toml --lib commands::skills::tests`

### Result
- pass: all commands above exited 0

## Notes
- This branch intentionally does not add Playwright, `packages/app/playwright.config.ts`, harness files, or package/lockfile changes.
- This is the same functional fix set as PR #906, re-applied without the repo-level Playwright changes that affected builds.
