### PR TITLE
Remove legacy share-ready status messaging

### DIFF
--- a/services/openwork-share/components/share-home-client.tsx
+++ b/services/openwork-share/components/share-home-client.tsx
@@ -156,7 +156,7 @@ export default function ShareHomeClient() {
     packageStatus.severity === "warn" ||
     packageStatus.severity === "info" ||
     packageStatus.items.length > 0 ||
-    (statusMessage !== DEFAULT_STATUS && statusMessage !== "Skill body ready to validate.");
+    statusMessage !== DEFAULT_STATUS;
 
   const requestPackage = async (previewOnly: boolean): Promise<PackageResponse> => {
     const files = await Promise.all(effectiveEntries.map(fileToPayload));
@@ -272,7 +272,7 @@ export default function ShareHomeClient() {
       setSkillDescription(parsed.hasFrontmatter ? parsed.description : (current) => current || DEFAULT_SKILL_DESCRIPTION);
       setBodyValue(parsed.body);
       setErrorMessage("");
-      setStatusMessage(`Loaded ${entries[0].name}.`);
+      setStatusMessage(DEFAULT_STATUS);
     } catch {
       setBodyValue("");
       setErrorMessage("Could not read the uploaded file.");
@@ -423,7 +423,7 @@ export default function ShareHomeClient() {
                 </ul>
               ) : null}
 
-              {statusMessage !== DEFAULT_STATUS && statusMessage !== "Skill body ready to validate." ? (
+              {statusMessage !== DEFAULT_STATUS ? (
                 <p className="share-inline-status">{statusMessage}</p>
               ) : null}
             </div>
@@ -445,7 +445,7 @@ export default function ShareHomeClient() {
             setBodyValue(value);
             setPreview(null);
             setWarnings([]);
-            setStatusMessage(value.trim() ? "Skill body ready to validate." : DEFAULT_STATUS);
+            setStatusMessage(DEFAULT_STATUS);
           }}
         />
       </div>

--- a/services/openwork-share/components/share-home-state.ts
+++ b/services/openwork-share/components/share-home-state.ts
@@ -41,8 +41,8 @@ export function getPackageStatus({ errorMessage, warnings, effectiveEntryCount }
   }
 
   return {
-    severity: "success",
-    label: "Ready to share this skill.",
+    severity: "neutral",
+    label: "",
     items: [],
   };
 }


### PR DESCRIPTION
## Problem
The share home flow still showed legacy status messaging in the publish flow, including a "ready" step state and file-specific loading copy, which no longer matches the simplified skill upload behavior.

## Change
- Removed the legacy "Ready to share this skill." package status from share home state.
- Removed upload/validate chatter from the home preview path (`Loaded ...` and `Skill body ready to validate.`), so generation moves directly to publish without extra blocking copy.
- Kept status feedback to default/clear states only while preserving existing error/validation behavior.

## Validation
- `pnpm --dir services/openwork-share test`
