### PR TITLE
Adjust share CTA sizing and disabled state

### DIFF
--- a/services/openwork-share/styles/globals.css
+++ b/services/openwork-share/styles/globals.css
@@ -969,7 +969,7 @@ a {
 }
 
 .share-upload-row-actions {
-  grid-template-columns: minmax(180px, 220px) auto;
+  grid-template-columns: 1fr 1fr;
 }
 
 .share-upload-actions {
@@ -1022,7 +1022,24 @@ a {
 
 .share-home-generate-button {
   width: 100%;
-  min-width: 240px;
+  min-width: 0;
+}
+
+.share-home-generate-button:disabled {
+  cursor: not-allowed;
+  pointer-events: none;
+  transform: none;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: var(--ow-muted);
+  opacity: 1;
+  box-shadow: none;
+}
+
+.share-home-generate-button:disabled:hover {
+  background: #ffffff;
+  transform: none;
+  box-shadow: none;
 }
 
 .share-upload-supporting-row {
@@ -1819,11 +1836,10 @@ button.included-item {
   }
 
   .share-upload-row-actions {
-    grid-template-columns: minmax(180px, 220px) 1fr;
+    grid-template-columns: 1fr 1fr;
   }
 
   .share-home-generate-button {
-    grid-column: 1 / -1;
     width: 100%;
   }
 


### PR DESCRIPTION
## Problem
The share home CTA layout keeps the upload zone and generate button at uneven proportions, and the disabled generate state still looked like an active link.

## Change
- Changed the upload/action row to a 50/50 split (`share-upload-row-actions` now uses `1fr 1fr` at desktop and small-breakpoint row layout).
- Made the disabled Generate button visually explicit:
  - white background and muted border/text,
  - no box-shadow/hover shift,
  - pointer disabled and not clickable (`not-allowed`).

## Validation
- Did not rerun automated tests in this task worktree because dependencies were not installed (`jsonc-parser` / `yaml` resolution error in `pnpm --dir services/openwork-share test`).
