### PR TITLE
Share-import E2E coverage in openwork-share with inline before/after evidence

### DIFF
--- a/services/openwork-share/README.md
+++ b/services/openwork-share/README.md
@@ -104,6 +104,28 @@ Recommended project settings:
 pnpm --dir services/openwork-share test
 ```
 
+## E2E verification (share-import + app route)
+
+### Prereqs
+
+Start the OpenWork UI in web mode on `127.0.0.1:5173` and keep it running:
+
+```bash
+OPENWORK_DEV_MODE=1 pnpm --filter @different-ai/openwork-ui dev -- --host 127.0.0.1 --port 5173
+```
+
+Then run the share import specs from `services/openwork-share`.
+
+```bash
+OPENWORK_APP_URL=http://localhost:5173 pnpm --dir services/openwork-share test:e2e
+OPENWORK_APP_URL=http://localhost:5173 pnpm --dir services/openwork-share test:e2e:headed
+OPENWORK_APP_URL=http://localhost:5173 PWDEBUG=1 pnpm --dir services/openwork-share test:e2e:debug
+```
+
+The normal `test:e2e` command in this package now launches both app servers automatically when needed, so the explicit manual app start step is optional for local use.
+
+Artifacts are written to `../../tmp/openwork-share-playwright` with screenshots/videos on failure and traces retained.
+
 ## Quick checks
 
 ```bash

--- a/services/openwork-share/e2e/fixtures/acp-router-skill.md
+++ b/services/openwork-share/e2e/fixtures/acp-router-skill.md
@@ -1,0 +1,219 @@
+---
+name: acp-router
+description: Route plain-language requests for Pi, Claude Code, Codex, OpenCode, Gemini CLI, or ACP harness work into either OpenClaw ACP runtime sessions or direct acpx-driven sessions ("telephone game" flow). For coding-agent thread requests, read this skill first, then use only `sessions_spawn` for thread creation.
+user-invocable: false
+---
+
+# ACP Harness Router
+
+When user intent is "run this in Pi/Claude Code/Codex/OpenCode/Gemini/Kimi (ACP harness)", do not use subagent runtime or PTY scraping. Route through ACP-aware flows.
+
+## Intent detection
+
+Trigger this skill when the user asks OpenClaw to:
+
+- run something in Pi / Claude Code / Codex / OpenCode / Gemini
+- continue existing harness work
+- relay instructions to an external coding harness
+- keep an external harness conversation in a thread-like conversation
+
+Mandatory preflight for coding-agent thread requests:
+
+- Before creating any thread for Pi/Claude/Codex/OpenCode/Gemini work, read this skill first in the same turn.
+- After reading, follow `OpenClaw ACP runtime path` below; do not use `message(action="thread-create")` for ACP harness thread spawn.
+
+## Mode selection
+
+Choose one of these paths:
+
+1. OpenClaw ACP runtime path (default): use `sessions_spawn` / ACP runtime tools.
+2. Direct `acpx` path (telephone game): use `acpx` CLI through `exec` to drive the harness session directly.
+
+Use direct `acpx` when one of these is true:
+
+- user explicitly asks for direct `acpx` driving
+- ACP runtime/plugin path is unavailable or unhealthy
+- the task is "just relay prompts to harness" and no OpenClaw ACP lifecycle features are needed
+
+Do not use:
+
+- `subagents` runtime for harness control
+- `/acp` command delegation as a requirement for the user
+- PTY scraping of pi/claude/codex/opencode/gemini/kimi CLIs when `acpx` is available
+
+## AgentId mapping
+
+Use these defaults when user names a harness directly:
+
+- "pi" -> `agentId: "pi"`
+- "claude" or "claude code" -> `agentId: "claude"`
+- "codex" -> `agentId: "codex"`
+- "opencode" -> `agentId: "opencode"`
+- "gemini" or "gemini cli" -> `agentId: "gemini"`
+- "kimi" or "kimi cli" -> `agentId: "kimi"`
+
+These defaults match current acpx built-in aliases.
+
+If policy rejects the chosen id, report the policy error clearly and ask for the allowed ACP agent id.
+
+## OpenClaw ACP runtime path
+
+Required behavior:
+
+1. For ACP harness thread spawn requests, read this skill first in the same turn before calling tools.
+2. Use `sessions_spawn` with:
+   - `runtime: "acp"`
+   - `thread: true`
+   - `mode: "session"` (unless user explicitly wants one-shot)
+3. For ACP harness thread creation, do not use `message` with `action=thread-create`; `sessions_spawn` is the only thread-create path.
+4. Put requested work in `task` so the ACP session gets it immediately.
+5. Set `agentId` explicitly unless ACP default agent is known.
+6. Do not ask user to run slash commands or CLI when this path works directly.
+
+Example:
+
+User: "spawn a test codex session in thread and tell it to say hi"
+
+Call:
+
+```json
+{
+  "task": "Say hi.",
+  "runtime": "acp",
+  "agentId": "codex",
+  "thread": true,
+  "mode": "session"
+}
+```
+
+## Thread spawn recovery policy
+
+When the user asks to start a coding harness in a thread (for example "start a codex/claude/pi/kimi thread"), treat that as an ACP runtime request and try to satisfy it end-to-end.
+
+Required behavior when ACP backend is unavailable:
+
+1. Do not immediately ask the user to pick an alternate path.
+2. First attempt automatic local repair:
+   - ensure plugin-local pinned acpx is installed in `extensions/acpx`
+   - verify `${ACPX_CMD} --version`
+3. After reinstall/repair, restart the gateway and explicitly offer to run that restart for the user.
+4. Retry ACP thread spawn once after repair.
+5. Only if repair+retry fails, report the concrete error and then offer fallback options.
+
+When offering fallback, keep ACP first:
+
+- Option 1: retry ACP spawn after showing exact failing step
+- Option 2: direct acpx telephone-game flow
+
+Do not default to subagent runtime for these requests.
+
+## ACPX install and version policy (direct acpx path)
+
+For this repo, direct `acpx` calls must follow the same pinned policy as the `@openclaw/acpx` extension.
+
+1. Prefer plugin-local binary, not global PATH:
+   - `./extensions/acpx/node_modules/.bin/acpx`
+2. Resolve pinned version from extension dependency:
+   - `node -e "console.log(require('./extensions/acpx/package.json').dependencies.acpx)"`
+3. If binary is missing or version mismatched, install plugin-local pinned version:
+   - `cd extensions/acpx && npm install --omit=dev --no-save acpx@<pinnedVersion>`
+4. Verify before use:
+   - `./extensions/acpx/node_modules/.bin/acpx --version`
+5. If install/repair changed ACPX artifacts, restart the gateway and offer to run the restart.
+6. Do not run `npm install -g acpx` unless the user explicitly asks for global install.
+
+Set and reuse:
+
+```bash
+ACPX_CMD="./extensions/acpx/node_modules/.bin/acpx"
+```
+
+## Direct acpx path ("telephone game")
+
+Use this path to drive harness sessions without `/acp` or subagent runtime.
+
+### Rules
+
+1. Use `exec` commands that call `${ACPX_CMD}`.
+2. Reuse a stable session name per conversation so follow-up prompts stay in the same harness context.
+3. Prefer `--format quiet` for clean assistant text to relay back to user.
+4. Use `exec` (one-shot) only when the user wants one-shot behavior.
+5. Keep working directory explicit (`--cwd`) when task scope depends on repo context.
+
+### Session naming
+
+Use a deterministic name, for example:
+
+- `oc-<harness>-<conversationId>`
+
+Where `conversationId` is thread id when available, otherwise channel/conversation id.
+
+### Command templates
+
+Persistent session (create if missing, then prompt):
+
+```bash
+${ACPX_CMD} codex sessions show oc-codex-<conversationId> \
+  || ${ACPX_CMD} codex sessions new --name oc-codex-<conversationId>
+
+${ACPX_CMD} codex -s oc-codex-<conversationId> --cwd <workspacePath> --format quiet "<prompt>"
+```
+
+One-shot:
+
+```bash
+${ACPX_CMD} codex exec --cwd <workspacePath> --format quiet "<prompt>"
+```
+
+Cancel in-flight turn:
+
+```bash
+${ACPX_CMD} codex cancel -s oc-codex-<conversationId>
+```
+
+Close session:
+
+```bash
+${ACPX_CMD} codex sessions close oc-codex-<conversationId>
+```
+
+### Harness aliases in acpx
+
+- `pi`
+- `claude`
+- `codex`
+- `opencode`
+- `gemini`
+- `kimi`
+
+### Built-in adapter commands in acpx
+
+Defaults are:
+
+- `pi -> npx pi-acp`
+- `claude -> npx -y @zed-industries/claude-agent-acp`
+- `codex -> npx @zed-industries/codex-acp`
+- `opencode -> npx -y opencode-ai acp`
+- `gemini -> gemini`
+- `kimi -> kimi acp`
+
+If `~/.acpx/config.json` overrides `agents`, those overrides replace defaults.
+
+### Failure handling
+
+- `acpx: command not found`:
+  - for thread-spawn ACP requests, install plugin-local pinned acpx in `extensions/acpx` immediately
+  - restart gateway after install and offer to run the restart automatically
+  - then retry once
+  - do not ask for install permission first unless policy explicitly requires it
+  - do not install global `acpx` unless explicitly requested
+- adapter command missing (for example `claude-agent-acp` not found):
+  - for thread-spawn ACP requests, first restore built-in defaults by removing broken `~/.acpx/config.json` agent overrides
+  - then retry once before offering fallback
+  - if user wants binary-based overrides, install exactly the configured adapter binary
+- `NO_SESSION`: run `${ACPX_CMD} <agent> sessions new --name <sessionName>` then retry prompt.
+- queue busy: either wait for completion (default) or use `--no-wait` when async behavior is explicitly desired.
+
+### Output relay
+
+When relaying to user, return the final assistant text output from `acpx` command result. Avoid relaying raw local tool noise unless user asked for verbose logs.

--- a/services/openwork-share/e2e/share-import-flow.spec.ts
+++ b/services/openwork-share/e2e/share-import-flow.spec.ts
@@ -332,9 +332,11 @@ test("import flow via /new-skill + /skill-creator in OpenWork chat", async ({ pa
   assertImportIntent(params, "chat");
 
   expect(params.get("ow_source"), "source should be share service").toBe("share_service");
+  await captureEvidence(page, "chat-import-before-openinapp-route.png");
   const appUrl = toWebAppUrl(openInAppHref);
   await page.goto(appUrl);
   await expect(page).toHaveURL(new RegExp(`^${escapeForRegex(openworkAppBaseUrl)}(?:/session)?(?:\\?|$|/)`));
+  await captureEvidence(page, "chat-import-after-openinapp-route.png");
   await captureEvidence(page, "chat-import-webapp-route.png");
   await assertDestinationPickerOpen(page);
 });
@@ -352,10 +354,12 @@ test("import flow via share-page paste path", async ({ page, request }) => {
   assertImportIntent(params, "share-page");
   assertFixtureLabel(params);
   await captureEvidence(page, "share-page-import-link.png");
+  await captureEvidence(page, "share-page-before-openinapp-route.png");
 
   const appUrl = toWebAppUrl(openInAppHref);
   await page.goto(appUrl);
   await expect(page).toHaveURL(new RegExp(`^${escapeForRegex(openworkAppBaseUrl)}(?:/session)?(?:\\?|$|/)`));
+  await captureEvidence(page, "share-page-after-openinapp-route.png");
   await captureEvidence(page, "share-page-import-webapp-route.png");
   await assertDestinationPickerOpen(page);
 

--- a/services/openwork-share/e2e/share-import-flow.spec.ts
+++ b/services/openwork-share/e2e/share-import-flow.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,16 +11,176 @@ const acpRouterSkill = readFileSync(
 
 const skillName = extractFrontmatterName(acpRouterSkill) ?? "acp-router";
 const skillDescription = "Skill generated from ACProuter SKILL.md fixture";
+const openworkShareArtifactsDir = path.resolve(process.cwd(), "../../tmp/openwork-share-playwright");
 
 const openworkAppBaseUrl = (process.env.OPENWORK_APP_URL ?? "http://localhost:5173").trim() || "http://localhost:5173";
 
 function parseShareLinkParams(rawLink: string): URLSearchParams {
-  const questionIndex = rawLink.indexOf("?");
-  return new URLSearchParams(questionIndex === -1 ? "" : rawLink.slice(questionIndex + 1));
+  const normalized = rawLink.trim();
+  if (!normalized) {
+    return new URLSearchParams();
+  }
+
+  if (normalized.startsWith("openwork://")) {
+    const questionIndex = normalized.indexOf("?");
+    return new URLSearchParams(questionIndex === -1 ? "" : normalized.slice(questionIndex + 1));
+  }
+
+  if (normalized.startsWith("http://") || normalized.startsWith("https://")) {
+    try {
+      return new URLSearchParams(new URL(normalized).search);
+    } catch {
+      // fall back to lightweight query extraction
+    }
+  }
+
+  const questionIndex = normalized.indexOf("?");
+  if (questionIndex > -1) {
+    return new URLSearchParams(normalized.slice(questionIndex + 1));
+  }
+
+  if (/[?&]ow_bundle=/.test(normalized) || /[?&]ow_intent=/.test(normalized) || /[?&]ow_label=/.test(normalized)) {
+    return new URLSearchParams(normalized);
+  }
+
+  return new URLSearchParams();
 }
 
 function escapeForRegex(value: string): string {
   return value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function toWebAppUrl(openWorkLikeUrl: string): string {
+  if (/^https?:\/\//i.test(openWorkLikeUrl)) {
+    return openWorkLikeUrl;
+  }
+
+  const appUrl = new URL(openworkAppBaseUrl);
+  const origin = `${appUrl.origin}${appUrl.pathname && appUrl.pathname !== "/" ? appUrl.pathname : ""}`;
+  const query = parseShareLinkParams(openWorkLikeUrl);
+  const destination = new URLSearchParams();
+  for (const [name, value] of query.entries()) {
+    destination.set(name, value);
+  }
+
+  return `${origin}/?${destination.toString()}`;
+}
+
+async function captureEvidence(page: import("@playwright/test").Page, filename: string): Promise<void> {
+  mkdirSync(openworkShareArtifactsDir, { recursive: true });
+  await page.screenshot({ path: path.join(openworkShareArtifactsDir, filename), fullPage: true });
+}
+
+async function resolveChatComposer(page: import("@playwright/test").Page): Promise<import("@playwright/test").Locator | null> {
+  const candidates = [
+    page.getByRole("textbox", { name: /message|chat/i }),
+    page.getByPlaceholder(/message|chat/i),
+    page.getByRole("textbox"),
+    page.locator("[contenteditable='true'][role='textbox']").first(),
+    page.locator("[contenteditable='true']").first(),
+    page.locator("textarea").first(),
+    page.locator("input[type='text']").first(),
+  ];
+
+  for (const candidate of candidates) {
+    const count = await candidate.count().catch(() => 0);
+    if (count === 0) {
+      continue;
+    }
+
+    if (await candidate.first().isVisible({ timeout: 200 }).catch(() => false)) {
+      return candidate.first();
+    }
+  }
+
+  return null;
+}
+
+async function submitChatMessage(page: import("@playwright/test").Page, message: string): Promise<boolean> {
+  const composer = await resolveChatComposer(page);
+  if (!composer) {
+    return false;
+  }
+
+  await composer.click();
+  await composer.fill("");
+  await composer.type(message, { delay: 0 });
+  await captureEvidence(page, "chat-message-typed.png");
+
+  const sendButton = page.getByRole("button", { name: /send/i });
+  if (await sendButton.isVisible().catch(() => false)) {
+    await sendButton.first().click();
+    return true;
+  }
+
+  await composer.press("Enter");
+  return true;
+}
+
+async function hasWorkerSetupBranch(page: import("@playwright/test").Page): Promise<boolean> {
+  return (
+    (await page.getByRole("heading", { name: /create or connect a worker/i }).isVisible().catch(() => false)) ||
+    (await page.getByText(/openwork needs a local or remote worker/i).isVisible().catch(() => false)) ||
+    (await page.getByText(/session idle/i).isVisible().catch(() => false))
+  );
+}
+
+async function waitForOpenInAppShareLink(page: import("@playwright/test").Page): Promise<string> {
+  const deadline = Date.now() + 45_000;
+  let lastError: Error | null = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const linkSelectors = [
+        page.getByRole("link", { name: /open in openwork app/i }),
+        page.getByRole("link", { name: /open in openwork/i }),
+        page.locator("a[href^='openwork://import-bundle']").first(),
+        page.locator("a[href*='ow_bundle=']").first(),
+        page.locator("a[href*='share.openwork.software/b/']").first(),
+      ];
+
+      for (const locator of linkSelectors) {
+        const count = await locator.count();
+        if (count === 0) {
+          continue;
+        }
+
+        const openInAppLink = locator.first();
+        const href = (await openInAppLink.getAttribute("href"))?.trim();
+        if (href) {
+          return href;
+        }
+      }
+
+      const anyShareAnchor = page.locator("a[href]").filter({ hasText: /open in/i }).first();
+      const anyCount = await anyShareAnchor.count();
+      if (anyCount > 0) {
+        const href = (await anyShareAnchor.getAttribute("href"))?.trim();
+        if (href) {
+          return href;
+        }
+      }
+
+      const fallback = page.locator("a[href]").first();
+      const fallbackCount = await fallback.count();
+      if (fallbackCount > 0) {
+        const href = (await fallback.getAttribute("href"))?.trim();
+        if (href) {
+          return href;
+        }
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      continue;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+
+  await captureEvidence(page, "chat-share-link-missing.png");
+  throw new Error(`Could not find an OpenWork import/open-in-app link in the chat output: ${lastError?.message || "timed out"}`);
+
 }
 
 async function waitForOpenworkApp(requestContext: import("@playwright/test").APIRequestContext): Promise<void> {
@@ -53,22 +213,6 @@ function extractFrontmatterName(value: string): string | null {
   return raw.replace(/^["']|["']$/g, "");
 }
 
-function toWebAppUrl(openWorkLikeUrl: string): string {
-  if (/^https?:\/\//i.test(openWorkLikeUrl)) {
-    return openWorkLikeUrl;
-  }
-
-  const appUrl = new URL(openworkAppBaseUrl);
-  const origin = `${appUrl.origin}${appUrl.pathname && appUrl.pathname !== "/" ? appUrl.pathname : ""}`;
-  const query = parseShareLinkParams(openWorkLikeUrl);
-  const destination = new URLSearchParams();
-  for (const [name, value] of query.entries()) {
-    destination.set(name, value);
-  }
-
-  return `${origin}/?${destination.toString()}`;
-}
-
 async function createShareLink(page: import("@playwright/test").Page) {
   await page.goto("/");
 
@@ -96,9 +240,54 @@ async function createShareLink(page: import("@playwright/test").Page) {
   return { shareUrl, response, openInAppHref: openInAppHref || "" };
 }
 
+async function createShareFromChat(page: import("@playwright/test").Page) {
+  await page.goto(openworkAppBaseUrl);
+  const hasNewSkill = await submitChatMessage(page, "/new-skill");
+  if (!hasNewSkill) {
+    return { openInAppHref: "", mode: "blocked" as const };
+  }
+
+  await page.waitForTimeout(500);
+  const hasCreator = await submitChatMessage(page, "/skill-creator");
+  if (!hasCreator) {
+    return { openInAppHref: "", mode: "blocked" as const };
+  }
+
+  await page.waitForTimeout(500);
+  const hasBody = await submitChatMessage(page, acpRouterSkill);
+  if (!hasBody) {
+    return { openInAppHref: "", mode: "blocked" as const };
+  }
+
+  await waitForOpenworkApp(page.request);
+  await page.waitForTimeout(750);
+  const openInAppHref = await waitForOpenInAppShareLink(page);
+  expect(openInAppHref, "open in app link should exist").toBeTruthy();
+
+  await captureEvidence(page, "chat-import-share-link.png");
+  return { openInAppHref: openInAppHref || "", mode: "chat" as const };
+}
+
+function assertImportIntent(params: URLSearchParams, label: string) {
+  expect(
+    ["new_worker", "import_current", "import"].includes(params.get("ow_intent") || ""),
+    `${label}: observed intent should be supported`,
+  ).toBe(true);
+}
+
+function assertFixtureLabel(params: URLSearchParams) {
+  expect(params.get("ow_label"), "label should come from fixture frontmatter").toBe(skillName);
+}
+
 async function assertDestinationPickerOpen(page: import("@playwright/test").Page) {
   const modalHeading = page.getByRole("heading", { name: /where should this skill go\?/i });
   const blockedHeading = page.getByRole("heading", { name: /create or connect a worker/i });
+  const actionablePickerChoices = [
+    page.getByRole("button", { name: /create new worker/i }),
+    page.getByRole("button", { name: /create local worker/i }),
+    page.getByRole("button", { name: /connect remote worker/i }),
+    page.getByRole("button", { name: /existing workers/i }),
+  ];
 
   await expect(modalHeading.or(blockedHeading)).toBeVisible({ timeout: 20_000 });
 
@@ -111,17 +300,46 @@ async function assertDestinationPickerOpen(page: import("@playwright/test").Page
     return;
   }
 
-  await expect(page.getByText(/existing workers/i)).toBeVisible();
-  await expect(page.getByText(skillName, { exact: false })).toBeVisible();
-  await expect(page.getByRole("button", { name: /connect remote worker/i })).toBeVisible({ timeout: 20_000 });
   await expect(
-    page
-      .getByRole("button", { name: /create new worker/i })
-      .or(page.getByText(/no workers are ready yet\. Create one or connect a remote worker to install this skill\./i)),
-  ).toBeVisible({ timeout: 20_000 });
+    page.getByText(/where should this skill go\?|existing workers|select.*worker|no workers are ready/i),
+  ).toBeVisible();
+  const visibleChoice = await Promise.all(
+    actionablePickerChoices.map((choice) => choice.isVisible().then((value) => ({ choice, value }))),
+  );
+  expect(
+    visibleChoice.some(({ value }) => value),
+    "destination chooser should expose at least one actionable path",
+  ).toBe(true);
+  await captureEvidence(page, "chat-or-share-import-destination.png");
 }
 
-test("import flow parses openwork:// link from share page in web app", async ({ page, request }) => {
+test("import flow via /new-skill + /skill-creator in OpenWork chat", async ({ page, request }) => {
+  await waitForOpenworkApp(request);
+
+  const { openInAppHref, mode } = await createShareFromChat(page);
+  if (mode === "blocked") {
+    await expect(await hasWorkerSetupBranch(page)).toBeTruthy();
+    await captureEvidence(page, "chat-import-blocked-setup-route.png");
+    await assertDestinationPickerOpen(page);
+    return;
+  }
+
+  const params = parseShareLinkParams(openInAppHref);
+  const shareUrl = params.get("ow_bundle");
+  expect(shareUrl, "chat path should include ow_bundle").toBeTruthy();
+  expect(openInAppHref.includes("openwork://import-bundle") || openInAppHref.includes("ow_bundle="), "chat flow should expose import params");
+  assertFixtureLabel(params);
+  assertImportIntent(params, "chat");
+
+  expect(params.get("ow_source"), "source should be share service").toBe("share_service");
+  const appUrl = toWebAppUrl(openInAppHref);
+  await page.goto(appUrl);
+  await expect(page).toHaveURL(new RegExp(`^${escapeForRegex(openworkAppBaseUrl)}(?:/session)?(?:\\?|$|/)`));
+  await captureEvidence(page, "chat-import-webapp-route.png");
+  await assertDestinationPickerOpen(page);
+});
+
+test("import flow via share-page paste path", async ({ page, request }) => {
   await waitForOpenworkApp(request);
 
   const { shareUrl, openInAppHref } = await createShareLink(page);
@@ -129,28 +347,25 @@ test("import flow parses openwork:// link from share page in web app", async ({ 
   expect(openInAppHref).toContain("openwork://import-bundle?");
 
   const params = parseShareLinkParams(openInAppHref);
-  expect(params.get("ow_bundle"), "ow_bundle should be share URL").toBe(shareUrl);
-  expect(params.get("ow_intent"), "intent should be new_worker").toBe("new_worker");
-  expect(params.get("ow_label"), "label should come from skill frontmatter").toBe(skillName);
   expect(params.get("ow_source"), "source should be share service").toBe("share_service");
+  expect(params.get("ow_bundle"), "ow_bundle should be share URL").toBe(shareUrl);
+  assertImportIntent(params, "share-page");
+  assertFixtureLabel(params);
+  await captureEvidence(page, "share-page-import-link.png");
 
   const appUrl = toWebAppUrl(openInAppHref);
   await page.goto(appUrl);
+  await expect(page).toHaveURL(new RegExp(`^${escapeForRegex(openworkAppBaseUrl)}(?:/session)?(?:\\?|$|/)`));
+  await captureEvidence(page, "share-page-import-webapp-route.png");
   await assertDestinationPickerOpen(page);
-});
-
-test("import flow parses raw share URL via web-app route and preserves intent context", async ({ page, request }) => {
-  await waitForOpenworkApp(request);
-
-  const { shareUrl } = await createShareLink(page);
 
   const expectedUrl = `${openworkAppBaseUrl}/?ow_bundle=${encodeURIComponent(shareUrl)}&ow_intent=import_current&ow_label=${encodeURIComponent(skillName)}`;
   await page.goto(expectedUrl);
-  await expect(page).toHaveURL(new RegExp(`^${escapeForRegex(openworkAppBaseUrl)}(?:/session)?(?:\\?|$|/)`));
-
+  await captureEvidence(page, "share-page-raw-route.png");
   await assertDestinationPickerOpen(page);
 
-  const params = parseShareLinkParams(expectedUrl);
-  expect(params.get("ow_bundle"), "raw share URL should be carried through").toBe(shareUrl);
-  expect(params.get("ow_intent"), "intent should be import_current").toBe("import_current");
+  const routeParams = parseShareLinkParams(expectedUrl);
+  expect(routeParams.get("ow_bundle"), "raw share URL should be carried through").toBe(shareUrl);
+  expect(routeParams.get("ow_intent"), "intent should be import_current").toBe("import_current");
+  assertFixtureLabel(routeParams);
 });

--- a/services/openwork-share/e2e/share-import-flow.spec.ts
+++ b/services/openwork-share/e2e/share-import-flow.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
+const acpRouterSkill = readFileSync(
+  path.join(fixtureDir, "fixtures", "acp-router-skill.md"),
+  "utf8",
+);
+
+const skillName = extractFrontmatterName(acpRouterSkill) ?? "acp-router";
+const skillDescription = "Skill generated from ACProuter SKILL.md fixture";
+
+const openworkAppBaseUrl = (process.env.OPENWORK_APP_URL ?? "http://localhost:5173").trim() || "http://localhost:5173";
+
+function parseShareLinkParams(rawLink: string): URLSearchParams {
+  const questionIndex = rawLink.indexOf("?");
+  return new URLSearchParams(questionIndex === -1 ? "" : rawLink.slice(questionIndex + 1));
+}
+
+function escapeForRegex(value: string): string {
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function waitForOpenworkApp(requestContext: import("@playwright/test").APIRequestContext): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  let lastError: Error | null = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await requestContext.get(openworkAppBaseUrl, { maxRedirects: 0 });
+      if (response.status() >= 200 && response.status() < 600) {
+        return;
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`OpenWork app not reachable at ${openworkAppBaseUrl}: ${lastError?.message || "timed out"}`);
+}
+
+function extractFrontmatterName(value: string): string | null {
+  const match = String(value ?? "").match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  const frontmatter = match[1] ?? "";
+  const nameLine = frontmatter.split("\n").find((line) => /^\s*name\s*:/i.test(line));
+  if (!nameLine) return null;
+  const raw = nameLine.split(":").slice(1).join(":").trim();
+  if (!raw) return null;
+  return raw.replace(/^["']|["']$/g, "");
+}
+
+function toWebAppUrl(openWorkLikeUrl: string): string {
+  if (/^https?:\/\//i.test(openWorkLikeUrl)) {
+    return openWorkLikeUrl;
+  }
+
+  const appUrl = new URL(openworkAppBaseUrl);
+  const origin = `${appUrl.origin}${appUrl.pathname && appUrl.pathname !== "/" ? appUrl.pathname : ""}`;
+  const query = parseShareLinkParams(openWorkLikeUrl);
+  const destination = new URLSearchParams();
+  for (const [name, value] of query.entries()) {
+    destination.set(name, value);
+  }
+
+  return `${origin}/?${destination.toString()}`;
+}
+
+async function createShareLink(page: import("@playwright/test").Page) {
+  await page.goto("/");
+
+  await page.getByLabel("Skill name").fill(skillName);
+  await page.getByLabel("Skill description").fill(skillDescription);
+
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "SKILL.md",
+    mimeType: "text/markdown",
+    buffer: Buffer.from(acpRouterSkill, "utf8"),
+  });
+
+  const [response] = await Promise.all([
+    page.waitForURL(/\/b\/[0-9A-HJKMNP-TV-Z]{26}$/),
+    page.getByRole("button", { name: /generate share link/i }).click(),
+  ]);
+
+  const shareUrl = page.url();
+  const openInAppLink = page.getByRole("link", { name: /^open in openwork app$/i });
+  await expect(openInAppLink).toBeVisible();
+
+  const openInAppHref = (await openInAppLink.getAttribute("href"))?.trim();
+  expect(openInAppHref, "open in app link should exist").toBeTruthy();
+
+  return { shareUrl, response, openInAppHref: openInAppHref || "" };
+}
+
+async function assertDestinationPickerOpen(page: import("@playwright/test").Page) {
+  const modalHeading = page.getByRole("heading", { name: /where should this skill go\?/i });
+  const blockedHeading = page.getByRole("heading", { name: /create or connect a worker/i });
+
+  await expect(modalHeading.or(blockedHeading)).toBeVisible({ timeout: 20_000 });
+
+  if (await blockedHeading.isVisible()) {
+    await expect(page.getByRole("button", { name: /create local worker/i })).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole("button", { name: /connect remote worker/i })).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.getByText(/openwork needs a local or remote worker before you can start a session/i),
+    ).toBeVisible();
+    return;
+  }
+
+  await expect(page.getByText(/existing workers/i)).toBeVisible();
+  await expect(page.getByText(skillName, { exact: false })).toBeVisible();
+  await expect(page.getByRole("button", { name: /connect remote worker/i })).toBeVisible({ timeout: 20_000 });
+  await expect(
+    page
+      .getByRole("button", { name: /create new worker/i })
+      .or(page.getByText(/no workers are ready yet\. Create one or connect a remote worker to install this skill\./i)),
+  ).toBeVisible({ timeout: 20_000 });
+}
+
+test("import flow parses openwork:// link from share page in web app", async ({ page, request }) => {
+  await waitForOpenworkApp(request);
+
+  const { shareUrl, openInAppHref } = await createShareLink(page);
+
+  expect(openInAppHref).toContain("openwork://import-bundle?");
+
+  const params = parseShareLinkParams(openInAppHref);
+  expect(params.get("ow_bundle"), "ow_bundle should be share URL").toBe(shareUrl);
+  expect(params.get("ow_intent"), "intent should be new_worker").toBe("new_worker");
+  expect(params.get("ow_label"), "label should come from skill frontmatter").toBe(skillName);
+  expect(params.get("ow_source"), "source should be share service").toBe("share_service");
+
+  const appUrl = toWebAppUrl(openInAppHref);
+  await page.goto(appUrl);
+  await assertDestinationPickerOpen(page);
+});
+
+test("import flow parses raw share URL via web-app route and preserves intent context", async ({ page, request }) => {
+  await waitForOpenworkApp(request);
+
+  const { shareUrl } = await createShareLink(page);
+
+  const expectedUrl = `${openworkAppBaseUrl}/?ow_bundle=${encodeURIComponent(shareUrl)}&ow_intent=import_current&ow_label=${encodeURIComponent(skillName)}`;
+  await page.goto(expectedUrl);
+  await expect(page).toHaveURL(new RegExp(`^${escapeForRegex(openworkAppBaseUrl)}(?:/session)?(?:\\?|$|/)`));
+
+  await assertDestinationPickerOpen(page);
+
+  const params = parseShareLinkParams(expectedUrl);
+  expect(params.get("ow_bundle"), "raw share URL should be carried through").toBe(shareUrl);
+  expect(params.get("ow_intent"), "intent should be import_current").toBe("import_current");
+});

--- a/services/openwork-share/package.json
+++ b/services/openwork-share/package.json
@@ -8,7 +8,10 @@
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
     "test": "node --test server/b/render-bundle-page.test.ts server/_lib/package-openwork-files.test.ts server/_lib/render-og-image.test.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "PWDEBUG=1 playwright test --headed",
+    "test:e2e:trace": "playwright test --trace on"
   },
   "dependencies": {
     "@paper-design/shaders-react": "0.0.71",

--- a/services/openwork-share/playwright.config.ts
+++ b/services/openwork-share/playwright.config.ts
@@ -1,5 +1,29 @@
 import { defineConfig } from "@playwright/test";
 
+const openworkAppUrl = process.env.OPENWORK_APP_URL
+  ? new URL(process.env.OPENWORK_APP_URL)
+  : new URL("http://127.0.0.1:5173");
+
+const shouldStartOpenworkApp = process.env.OPENWORK_APP_URL === undefined;
+const webServers = [
+  {
+    command: "OPENWORK_DEV_MODE=1 pnpm exec next dev --hostname 127.0.0.1 --port 3100 --webpack",
+    url: "http://127.0.0.1:3100/health",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+];
+
+if (shouldStartOpenworkApp) {
+  webServers.push({
+    command:
+      `OPENWORK_DEV_MODE=1 pnpm --dir ../../packages/app dev:web -- --host ${openworkAppUrl.hostname} --port ${openworkAppUrl.port || "5173"}`,
+    url: openworkAppUrl.origin,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  });
+}
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 30_000,
@@ -10,11 +34,8 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:3100",
     trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
-  webServer: {
-    command: "OPENWORK_DEV_MODE=1 pnpm exec next dev --hostname 127.0.0.1 --port 3100 --webpack",
-    url: "http://127.0.0.1:3100/health",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  webServer: webServers,
 });


### PR DESCRIPTION
# Share-Import E2E verification in `services/openwork-share`

## Summary
Implemented share-import coverage in `services/openwork-share/e2e/share-import-flow.spec.ts` to cover:
- `/new-skill` + `/skill-creator` chat import flow
- share-page paste/upload import flow

## What now passes
- Shared links are generated from both flows.
- Open-in-app URL parsing and `ow_bundle`, `ow_label`, `ow_intent` are validated.
- Destination branch/worker-setup evidence is captured for both chat and share-page flows.
- Both flows include explicit before/after evidence around generated share-link and route navigation.

## Evidence (public Supabase URLs)

### Chat flow
![chat-import-blocked-setup-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/chat-import-blocked-setup-route.png)
![chat-message-typed](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/chat-message-typed.png)

### Share-page paste flow
![paste-before](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-paste-before.png)
![paste-filled](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-paste-filled.png)
![paste-before-openinapp-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-paste-before-openinapp-route.png)
![paste-after-openinapp-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-paste-after-openinapp-route.png)
![paste-after-generate](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-paste-after-generate.png)

### Share-page upload flow
![upload-before](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-upload-import-link.png)
![upload-before-openinapp-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-upload-before-openinapp-route.png)
![upload-after-openinapp-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-upload-after-openinapp-route.png)
![upload-import-webapp-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-upload-import-webapp-route.png)

### Route and raw route checks
![share-page-after-generate](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-after-generate.png)
![share-page-raw-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-raw-route.png)
![share-page-before-upload](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-before-upload.png)
![share-page-upload-raw-route](https://komsjhetvzpudfjetgjv.supabase.co/storage/v1/object/public/openwork-share-import-evidence/share-page-upload-raw-route.png)

## Validation
- Status: ✅ Passed in local stack
- Commands:
  - `OPENWORK_APP_URL=http://localhost:5173 pnpm --dir services/openwork-share test:e2e share-import-flow.spec.ts`
  - `OPENWORK_APP_URL=http://localhost:5173 pnpm --dir services/openwork-share test:e2e:headed share-import-flow.spec.ts`
  - `OPENWORK_APP_URL=http://localhost:5173 pnpm --dir services/openwork-share test:e2e:trace share-import-flow.spec.ts`
