### PR TITLE
fix(share): simplify shared skill pages and enrich workspace previews

### DIFF
--- a/services/openwork-share/components/share-bundle-page.tsx
+++ b/services/openwork-share/components/share-bundle-page.tsx
@@ -7,6 +7,69 @@ import ShareNav from "./share-nav";
 import SkillEditorSurface from "./skill-editor-surface";
 import { parseSkillMarkdown } from "./skill-markdown";
 
+type BundleSelection = NonNullable<BundlePageProps["previewSelections"]>[number];
+
+const SPECIAL_TOKENS: Record<string, string> = {
+  api: "API",
+  json: "JSON",
+  jsonc: "JSONC",
+  mcp: "MCP",
+  md: "MD",
+  mdx: "MDX",
+  opencode: "OpenCode",
+  openwork: "OpenWork",
+  yaml: "YAML",
+  yml: "YAML",
+};
+
+function humanizeLabel(value: string | null | undefined): string {
+  const normalized = String(value ?? "")
+    .trim()
+    .replace(/\.[a-z0-9]+$/i, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
+
+  if (!normalized) return "OpenWork Bundle";
+
+  return normalized
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (SPECIAL_TOKENS[lower]) return SPECIAL_TOKENS[lower];
+      return `${part.slice(0, 1).toUpperCase()}${part.slice(1).toLowerCase()}`;
+    })
+    .join(" ");
+}
+
+function formatSurfaceEyebrow(selection: BundleSelection | undefined, parsedName: string, fallbackTitle: string | undefined): string {
+  if (selection?.tone === "skill") {
+    return humanizeLabel(parsedName || selection.name || fallbackTitle || "Skill");
+  }
+
+  if (selection?.tone === "command") {
+    return humanizeLabel(selection.name || "Command");
+  }
+
+  if (selection?.tone === "agent") {
+    const label = humanizeLabel(selection.name || "Agent");
+    return /agent$/i.test(label) ? label : `${label} Agent`;
+  }
+
+  if (selection?.tone === "mcp") {
+    const label = humanizeLabel(selection.name || "MCP");
+    return /mcp$/i.test(label) ? label : `${label} MCP`;
+  }
+
+  const filename = selection?.filename || selection?.name || fallbackTitle || "config";
+  if (/^openwork\.json$/i.test(filename)) return "OpenWork Config";
+  if (/^opencode\.jsonc?$/i.test(filename)) return "OpenCode Config";
+
+  const label = humanizeLabel(filename);
+  return /config$/i.test(label) ? label : `${label} Config`;
+}
+
 function toneClass(item: { tone?: string } | null | undefined): string {
   if (item?.tone === "agent") return "dot-agent";
   if (item?.tone === "mcp") return "dot-mcp";
@@ -35,8 +98,10 @@ export default function ShareBundlePage(props: BundlePageProps & { stars?: strin
       ];
   const activeSelection = previewSelections.find((selection) => selection.id === activeSelectionId) ?? previewSelections[0];
   const parsedPreview = useMemo(() => parseSkillMarkdown(activeSelection?.text || ""), [activeSelection?.text]);
-  const previewName = parsedPreview.name || activeSelection?.name || props.title || "OpenWork bundle";
-  const showBundleSidebar = previewSelections.length > 1;
+  const surfaceEyebrow = formatSurfaceEyebrow(activeSelection, parsedPreview.name, props.title);
+  const previewFilename = activeSelection?.filename || props.previewFilename || "bundle.json";
+  const showBundleSidebar = previewSelections.length > 1 || Boolean(props.metadataRows?.length);
+  const isSingleSkill = props.bundleType === "skill" && previewSelections.length === 1;
 
   const copyPreview = async () => {
     if (!activeSelection?.text) return;
@@ -68,6 +133,17 @@ export default function ShareBundlePage(props: BundlePageProps & { stars?: strin
     }
   };
 
+  const actionButtons = (
+    <>
+      <button className="button-primary" type="button" onClick={() => void copyPreview()}>
+        {previewCopied ? "Copied to clipboard" : "Copy to clipboard"}
+      </button>
+      <a className="button-secondary" href={openInAppUrl} onClick={openInOpenWork}>
+        Open in OpenWork
+      </a>
+    </>
+  );
+
   return (
     <main className="shell">
       <ShareNav stars={props.stars} />
@@ -87,55 +163,117 @@ export default function ShareBundlePage(props: BundlePageProps & { stars?: strin
         </section>
       ) : (
         <>
-          <section className="hero-layout hero-layout-share">
-            <div className="hero-copy">
-              <span className="eyebrow">{props.typeLabel}</span>
-              <h1>Skill share</h1>
-              <div className="button-row share-bundle-actions">
-                <button className="button-primary" type="button" onClick={() => void copyPreview()}>
-                  {previewCopied ? "Copied to clipboard" : "Copy to clipboard"}
-                </button>
-                <a className="button-secondary" href={openInAppUrl} onClick={openInOpenWork}>
-                  Open in OpenWork
-                </a>
-              </div>
-            </div>
-          </section>
+          {isSingleSkill ? (
+            <>
+              <section className="share-bundle-toolbar surface-shell">
+                <div className="button-row share-bundle-actions">{actionButtons}</div>
+              </section>
 
-          <section className={`share-bundle-stack${showBundleSidebar ? " has-sidebar" : ""}`}>
-            {showBundleSidebar ? (
-              <article className="bundle-compact-strip surface-soft">
-                <div className="bundle-strip-header">Skills:</div>
-                <div className="bundle-strip-list" aria-label="Skills">
-                  {previewSelections.map((selection) => {
-                    const isActive = selection.id === activeSelection?.id;
-                    return (
-                      <button
-                        key={selection.id}
-                        type="button"
-                        className={`bundle-strip-chip${isActive ? " is-active" : ""}`}
-                        onClick={() => setActiveSelectionId(selection.id)}
-                        disabled={isActive}
-                      >
-                        <span className={`preview-filename-dot ${toneClass(selection)}`} />
-                        {selection.name}
-                      </button>
-                    );
-                  })}
+              <section className="share-bundle-simple-stack">
+                <SkillEditorSurface
+                  className="share-bundle-editor share-bundle-editor-simple"
+                  toneClassName={toneClass(activeSelection)}
+                  eyebrow={surfaceEyebrow}
+                  filename={previewFilename}
+                  documentValue={activeSelection?.text || ""}
+                  readOnly={true}
+                  copied={previewCopied}
+                  onCopy={() => void copyPreview()}
+                />
+              </section>
+            </>
+          ) : (
+            <>
+              <section className="share-bundle-hero-card surface-shell">
+                <div className="share-bundle-hero-copy">
+                  <span className="eyebrow">{props.typeLabel}</span>
+                  <h1>{props.title}</h1>
+                  {props.description ? <p className="hero-body">{props.description}</p> : null}
+                  {props.installHint ? <p className="preview-note">{props.installHint}</p> : null}
+                  <div className="button-row share-bundle-actions">{actionButtons}</div>
                 </div>
-              </article>
-            ) : null}
 
-            <SkillEditorSurface
-              className="share-bundle-editor"
-              toneClassName={toneClass(activeSelection)}
-              filename={previewName}
-              documentValue={activeSelection?.text || ""}
-              readOnly={true}
-              copied={previewCopied}
-              onCopy={() => void copyPreview()}
-            />
-          </section>
+                <aside className="share-bundle-summary surface-soft">
+                  <div className="bundle-strip-header">Bundle summary</div>
+                  <div className="summary-grid">
+                    <div className="summary-stat">
+                      <span className="summary-stat-value">{previewSelections.length}</span>
+                      <span className="summary-stat-label">Previewable items</span>
+                    </div>
+                    <div className="summary-stat">
+                      <span className="summary-stat-value">{props.typeLabel || "Bundle"}</span>
+                      <span className="summary-stat-label">Share type</span>
+                    </div>
+                    <div className="summary-stat">
+                      <span className="summary-stat-value">{props.schemaVersion || "unknown"}</span>
+                      <span className="summary-stat-label">Schema version</span>
+                    </div>
+                    <div className="summary-stat">
+                      <span className="summary-stat-value">{surfaceEyebrow}</span>
+                      <span className="summary-stat-label">Open now</span>
+                    </div>
+                  </div>
+                </aside>
+              </section>
+
+              <section className={`share-bundle-stack${showBundleSidebar ? " has-sidebar" : ""}`}>
+                {showBundleSidebar ? (
+                  <div className="share-bundle-sidebar">
+                    <article className="bundle-compact-strip surface-soft">
+                      <div className="bundle-strip-header">Included</div>
+                      <div className="bundle-strip-list" aria-label="Included bundle items">
+                        {previewSelections.map((selection) => {
+                          const isActive = selection.id === activeSelection?.id;
+                          return (
+                            <button
+                              key={selection.id}
+                              type="button"
+                              className={`included-item${isActive ? " is-active" : ""}`}
+                              onClick={() => setActiveSelectionId(selection.id)}
+                              disabled={isActive}
+                            >
+                              <span className="item-left">
+                                <span className={`item-dot ${toneClass(selection)}`} />
+                                <span className="item-text">
+                                  <span className="item-title">{formatSurfaceEyebrow(selection, selection.name, selection.name)}</span>
+                                  <span className="item-meta">{selection.label || selection.filename}</span>
+                                </span>
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </article>
+
+                    {props.metadataRows?.length ? (
+                      <article className="share-bundle-meta-card surface-soft">
+                        <div className="bundle-strip-header">Bundle info</div>
+                        <dl className="metadata-list share-bundle-metadata-list">
+                          {props.metadataRows.map((row) => (
+                            <div className="metadata-row" key={row.label}>
+                              <dt>{row.label}</dt>
+                              <dd>{row.value}</dd>
+                            </div>
+                          ))}
+                        </dl>
+                      </article>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                <SkillEditorSurface
+                  className="share-bundle-editor"
+                  toneClassName={toneClass(activeSelection)}
+                  eyebrow={surfaceEyebrow}
+                  filename={previewFilename}
+                  documentValue={activeSelection?.text || ""}
+                  readOnly={true}
+                  copied={previewCopied}
+                  onCopy={() => void copyPreview()}
+                />
+              </section>
+            </>
+          )}
         </>
       )}
     </main>

--- a/services/openwork-share/components/skill-editor-surface.tsx
+++ b/services/openwork-share/components/skill-editor-surface.tsx
@@ -30,6 +30,7 @@ function countLabel(text: string | undefined): string {
 export default function SkillEditorSurface({
   className,
   toneClassName,
+  eyebrow,
   filename,
   documentValue,
   documentPlaceholderPreview = "",
@@ -41,6 +42,7 @@ export default function SkillEditorSurface({
 }: {
   className?: string;
   toneClassName?: string;
+  eyebrow?: string;
   filename?: string;
   documentValue: string;
   documentPlaceholderPreview?: string;
@@ -58,7 +60,7 @@ export default function SkillEditorSurface({
     <aside className={rootClassName}>
       <div className="preview-surface">
         <div className="preview-header">
-          <span className="preview-eyebrow">Preview</span>
+          <span className="preview-eyebrow">{eyebrow || "Preview"}</span>
           <div className="preview-header-actions">
             {headerActions}
             <span className="preview-filename">

--- a/services/openwork-share/e2e/bundle-share-page.spec.ts
+++ b/services/openwork-share/e2e/bundle-share-page.spec.ts
@@ -1,15 +1,17 @@
 import { expect, test } from "@playwright/test";
 
-const initialBody = `# Agent Creator
+const initialBody = `---
+name: agent-creator
+description: Create new OpenCode agents with a gpt-5.2-codex default.
+---
+
+# Agent Creator
 
 Any markdown body is acceptable here.
 `;
 
 test("shows a read-only shared skill page with OpenWork import actions", async ({ page }) => {
   await page.goto("/");
-
-  await page.getByLabel("Skill name").fill("agent-creator");
-  await page.getByLabel("Skill description").fill("Create new OpenCode agents with a gpt-5.2-codex default.");
 
   await page.locator('input[type="file"]').setInputFiles({
     name: "AGENTS.md",
@@ -31,17 +33,16 @@ test("shows a read-only shared skill page with OpenWork import actions", async (
   await expect(page.getByLabel("Skill description")).toHaveCount(0);
   await expect(page.getByRole("link", { name: /open in web app/i })).toHaveCount(0);
   await expect(page.getByRole("button", { name: /copy share link/i })).toHaveCount(0);
-  await expect(page.getByText("Skills:")).toBeVisible();
-  await expect(page.locator(".preview-filename")).toContainText("skill.md");
+  await expect(page.getByText("Preview", { exact: true })).toHaveCount(0);
+  await expect(page.locator(".preview-eyebrow")).toContainText("Agent Creator");
+  await expect(page.locator(".preview-filename")).toContainText("agent-creator.md");
   await expect(page.locator(".preview-highlight")).toContainText("Any markdown body is acceptable here.");
 
-  const openInAppHref = await page.getByRole("link", { name: /^open in openwork app$/i }).getAttribute("href");
+  const openInAppHref = await page.getByRole("link", { name: /^open in openwork$/i }).getAttribute("href");
   expect(openInAppHref).toBeTruthy();
   expect(openInAppHref ?? "").toContain("openwork://import-bundle?");
 
   const deepLinkQuery = new URL((openInAppHref ?? "").replace("openwork://import-bundle?", "https://example.test/?"));
   expect(deepLinkQuery.searchParams.get("ow_bundle")).toBe(shareUrl);
   expect(deepLinkQuery.searchParams.get("ow_label")).toBe("agent-creator");
-
-  await expect(page.getByRole("link", { name: /open in an openwork den/i })).toHaveAttribute("href", "https://openworklabs.com/den");
 });

--- a/services/openwork-share/package.json
+++ b/services/openwork-share/package.json
@@ -7,7 +7,7 @@
     "dev": "OPENWORK_DEV_MODE=1 next dev --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
-    "test": "node --test server/b/render-bundle-page.test.ts server/_lib/package-openwork-files.test.ts server/_lib/render-og-image.test.ts",
+    "test": "node --test server/b/render-bundle-page.test.ts server/_lib/package-openwork-files.test.ts server/_lib/render-og-image.test.ts server/_lib/share-utils.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/services/openwork-share/server/_lib/share-utils.test.ts
+++ b/services/openwork-share/server/_lib/share-utils.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildBundlePreviewSelections } from "./share-utils.ts";
+import type { NormalizedBundle } from "./types.ts";
+
+test("buildBundlePreviewSelections slugifies shared skill filenames", () => {
+  const selections = buildBundlePreviewSelections({
+    schemaVersion: 1,
+    type: "skill",
+    name: "agent-creator",
+    description: "",
+    trigger: "",
+    content: "# Agent Creator",
+    workspace: null,
+    skills: [],
+    commands: [],
+  });
+
+  assert.equal(selections[0]?.filename, "agent-creator.md");
+  assert.equal(selections[0]?.label, "Skill");
+});
+
+test("buildBundlePreviewSelections exposes workspace configs alongside skills", () => {
+  const bundle: NormalizedBundle = {
+    schemaVersion: 1,
+    type: "workspace-profile",
+    name: "Team Workspace",
+    description: "",
+    trigger: "",
+    content: "",
+    workspace: {
+      skills: [{ name: "workspace-guide", description: "", trigger: "", content: "# Guide" }],
+      commands: [{ name: "daily-sync", description: "", template: "# Daily Sync", content: "", agent: "planner", model: "", subtask: false }],
+      openwork: { reload: { auto: true } },
+      opencode: {
+        agent: { concierge: { model: "openai/gpt-5.4" } },
+        mcp: { github: { type: "remote" } },
+        model: "openai/gpt-5.4",
+      },
+      config: {
+        "team-rules.json": { strict: true },
+      },
+    },
+    skills: [],
+    commands: [],
+  };
+
+  const selections = buildBundlePreviewSelections(bundle);
+
+  assert.deepEqual(
+    selections.map((selection) => selection.filename),
+    ["workspace-guide.md", "daily-sync.md", "concierge.json", "github.json", "opencode.json", "openwork.json", "team-rules.json"],
+  );
+  assert.equal(selections[4]?.label, "OpenCode settings");
+  assert.equal(selections[5]?.label, "Workspace settings");
+});

--- a/services/openwork-share/server/_lib/share-utils.ts
+++ b/services/openwork-share/server/_lib/share-utils.ts
@@ -581,10 +581,10 @@ export function buildBundlePreviewSelections(bundle: NormalizedBundle): {
       {
         id: "skill-0",
         name: bundle.name || "Untitled skill",
-        filename: "skill.md",
+        filename: slugifyPreviewFilename(bundle.name || "skill", "skill", "md"),
         text: buildTextPreview(bundle.content, `# ${bundle.name || "OpenWork skill"}`),
         tone: "skill",
-        label: bundle.trigger ? `Trigger: ${bundle.trigger}` : "Skill preview",
+        label: bundle.trigger ? `Trigger · ${bundle.trigger}` : "Skill",
       },
     ];
   }
@@ -593,24 +593,125 @@ export function buildBundlePreviewSelections(bundle: NormalizedBundle): {
     return bundle.skills.map((skill, index) => ({
       id: `skill-${index}`,
       name: skill.name || `Skill ${index + 1}`,
-      filename: "skill.md",
+      filename: slugifyPreviewFilename(skill.name || `skill-${index + 1}`, "skill", "md"),
       text: buildTextPreview(skill.content, `# ${skill.name || `Skill ${index + 1}`}`),
       tone: "skill",
-      label: bundle.skills.length > 1 ? `Skill ${index + 1} of ${bundle.skills.length}` : "Skill preview",
+      label: skill.trigger ? `Trigger · ${skill.trigger}` : "Skill",
     }));
   }
 
   const workspaceSkills = maybeArray(bundle.workspace?.skills).map(normalizeSkillItem).filter((skill): skill is NormalizedSkillItem => skill !== null);
+  const selections: {
+    id: string;
+    name: string;
+    filename: string;
+    text: string;
+    tone: PreviewItem["tone"];
+    label: string;
+  }[] = [];
+
   if (workspaceSkills.length) {
-    return workspaceSkills.map((skill, index) => ({
+    selections.push(...workspaceSkills.map((skill, index) => ({
       id: `workspace-skill-${index}`,
       name: skill.name || `Skill ${index + 1}`,
-      filename: "skill.md",
+      filename: slugifyPreviewFilename(skill.name || `skill-${index + 1}`, "skill", "md"),
       text: buildTextPreview(skill.content, `# ${skill.name || `Skill ${index + 1}`}`),
-      tone: "skill",
-      label: workspaceSkills.length > 1 ? `Skill ${index + 1} of ${workspaceSkills.length}` : "Skill preview",
+      tone: "skill" as const,
+      label: skill.trigger ? `Trigger · ${skill.trigger}` : "Skill",
+    })));
+  }
+
+  const commands = maybeArray(bundle.workspace?.commands).map(normalizeCommandItem).filter((command): command is NormalizedCommandItem => command !== null);
+  if (commands.length) {
+    selections.push(...commands.map((command, index) => ({
+      id: `workspace-command-${index}`,
+      name: command.name || `Command ${index + 1}`,
+      filename: slugifyPreviewFilename(command.name || `command-${index + 1}`, "command", "md"),
+      text: buildTextPreview(command.template || command.content, `# ${command.name || `Command ${index + 1}`}`),
+      tone: "command" as const,
+      label: command.agent ? `Agent · ${command.agent}` : "Command",
+    })));
+  }
+
+  const opencode = maybeObject(bundle.workspace?.opencode);
+  const agentEntries = Object.entries(maybeObject(opencode?.agent) ?? {});
+  if (agentEntries.length) {
+    selections.push(...agentEntries.map(([name, config], index) => {
+      const entry = maybeObject(config) ?? {};
+      const version = maybeString(entry.version).trim();
+      const model = maybeString(entry.model).trim();
+
+      return {
+        id: `workspace-agent-${index}`,
+        name,
+        filename: slugifyPreviewFilename(name, "agent", "json"),
+        text: buildJsonPreview({ agent: { [name]: config } }, '{\n  "agent": {}\n}'),
+        tone: "agent" as const,
+        label: version ? `v${version}` : model ? model : "Agent config",
+      };
     }));
   }
+
+  const mcpEntries = Object.entries(maybeObject(opencode?.mcp) ?? {});
+  if (mcpEntries.length) {
+    selections.push(...mcpEntries.map(([name, config], index) => {
+      const entry = maybeObject(config) ?? {};
+      const type = maybeString(entry.type).trim();
+      const url = maybeString(entry.url).trim();
+
+      return {
+        id: `workspace-mcp-${index}`,
+        name,
+        filename: slugifyPreviewFilename(name, "mcp", "json"),
+        text: buildJsonPreview({ mcp: { [name]: config } }, '{\n  "mcp": {}\n}'),
+        tone: "mcp" as const,
+        label: type ? `${humanizeType(type)} MCP` : url ? "Remote MCP" : "MCP config",
+      };
+    }));
+  }
+
+  const opencodeConfigKeys = Object.keys(opencode ?? {}).filter((key) => !["agent", "mcp"].includes(key));
+  if (opencodeConfigKeys.length) {
+    selections.push({
+      id: "workspace-opencode-config",
+      name: "OpenCode config",
+      filename: "opencode.json",
+      text: buildJsonPreview(opencode, '{\n  "opencode": {}\n}'),
+      tone: "config" as const,
+      label: "OpenCode settings",
+    });
+  }
+
+  if (maybeObject(bundle.workspace?.openwork)) {
+    selections.push({
+      id: "workspace-openwork-config",
+      name: "OpenWork config",
+      filename: "openwork.json",
+      text: buildJsonPreview(bundle.workspace?.openwork, '{\n  "openwork": {}\n}'),
+      tone: "config" as const,
+      label: "Workspace settings",
+    });
+  }
+
+  const configEntries = Object.entries(maybeObject(bundle.workspace?.config) ?? {});
+  if (configEntries.length) {
+    selections.push(...configEntries.map(([name, value], index) => {
+      const extension = name.includes(".") ? name.split(".").pop() || "json" : "json";
+
+      return {
+        id: `workspace-config-${index}`,
+        name,
+        filename: name,
+        text: buildJsonPreview(value, `{
+  "${name}": {}
+}`),
+        tone: "config" as const,
+        label: `Config file · ${extension}`,
+      };
+    }));
+  }
+
+  if (selections.length) return selections;
 
   const preview = buildBundlePreview(bundle);
   return [

--- a/services/openwork-share/styles/globals.css
+++ b/services/openwork-share/styles/globals.css
@@ -392,9 +392,58 @@ a {
   margin-top: 26px;
 }
 
+.share-bundle-simple-stack {
+  margin-top: 22px;
+}
+
 .share-bundle-stack.has-sidebar {
-  grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   align-items: start;
+}
+
+.share-bundle-toolbar {
+  margin-top: 4px;
+  padding: 18px 20px;
+}
+
+.share-bundle-hero-card {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+  align-items: start;
+  padding: 22px;
+}
+
+.share-bundle-hero-copy {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.share-bundle-summary,
+.share-bundle-meta-card {
+  padding: 18px;
+}
+
+.share-bundle-sidebar {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.share-bundle-metadata-list {
+  gap: 12px;
+}
+
+.share-bundle-actions .button-primary,
+.share-bundle-actions .button-secondary {
+  min-height: 64px;
+  padding: 0 30px;
+  font-size: 1.05rem;
+}
+
+.share-bundle-editor-simple {
+  min-height: 660px;
 }
 
 .share-bundle-grid {
@@ -500,14 +549,14 @@ a {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 22px;
+  padding: 18px 22px;
   border-bottom: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .preview-eyebrow {
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 700;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--ow-muted);
 }
@@ -1427,7 +1476,7 @@ a {
 
 .bundle-compact-strip {
   align-self: start;
-  padding: 8px 12px;
+  padding: 16px;
   border-radius: 24px;
 }
 
@@ -1851,6 +1900,10 @@ button.included-item {
     grid-template-columns: 1fr;
   }
 
+  .share-bundle-hero-card {
+    grid-template-columns: 1fr;
+  }
+
   .share-bundle-stack.has-sidebar {
     grid-template-columns: 1fr;
   }
@@ -1867,6 +1920,10 @@ button.included-item {
   .share-skill-drop-zone-compact {
     justify-content: center;
     text-align: center;
+  }
+
+  .summary-grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify single-skill share pages so the live view keeps the nav, foregrounds the primary actions, and uses a capitalized skill name instead of a generic preview label
- give workspace-profile shares a richer layout with bundle summary cards, an included-items rail, and human-readable config names for OpenWork/OpenCode/config files
- add preview-selection coverage and refresh the share e2e spec to match the upload-only share flow

## Verification
- `npm test`
- `npm run build`
- Chrome MCP: uploaded a sample skill, generated a live share link, and confirmed the simplified single-skill layout rendered correctly
- Chrome MCP: published a sample workspace-profile bundle and confirmed the richer config preview flow rendered correctly
- `./packaging/docker/dev-up.sh` started the stack, but the `share` container exited with code `137` during the Turbopack build; verified the share flow instead with a local webpack build/start on port `53595`
- `npm run test:e2e -- bundle-share-page.spec.ts` *(fails locally until Playwright browsers are installed; run `npx playwright install` first)*

## Evidence
### Before publish
![Before publish](https://files.catbox.moe/69jn0q.png)

### Live single skill
![Live single skill](https://files.catbox.moe/7m2ntr.png)

### Live workspace config
![Live workspace config](https://files.catbox.moe/a1trzp.png)