### PR TITLE
fix(session): reduce inline image churn in chat

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -138,6 +138,17 @@ import { createSystemState } from "./system-state";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { createSessionStore } from "./context/session";
+
+const fileToDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      resolve(result);
+    };
+    reader.readAsDataURL(file);
+  });
 import { createExtensionsStore } from "./context/extensions";
 import { useGlobalSync } from "./context/global-sync";
 import { createWorkspaceStore } from "./context/workspace";
@@ -1448,7 +1459,14 @@ export default function App() {
 
   type PartInput = TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput;
 
-  const buildPromptParts = (draft: ComposerDraft): PartInput[] => {
+  const attachmentToFilePart = async (attachment: ComposerAttachment): Promise<FilePartInput> => ({
+    type: "file",
+    url: await fileToDataUrl(attachment.file),
+    filename: attachment.name,
+    mime: attachment.mimeType,
+  });
+
+  const buildPromptParts = async (draft: ComposerDraft): Promise<PartInput[]> => {
     const parts: PartInput[] = [];
     const text = draft.resolvedText ?? draft.text;
     parts.push({ type: "text", text } as TextPartInput);
@@ -1488,19 +1506,12 @@ export default function App() {
       }
     }
 
-    for (const attachment of draft.attachments) {
-      parts.push({
-        type: "file",
-        url: attachment.dataUrl,
-        filename: attachment.name,
-        mime: attachment.mimeType,
-      } as FilePartInput);
-    }
+    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
 
     return parts;
   };
 
-  const buildCommandFileParts = (draft: ComposerDraft): FilePartInput[] => {
+  const buildCommandFileParts = async (draft: ComposerDraft): Promise<FilePartInput[]> => {
     const parts: FilePartInput[] = [];
     const root = workspaceProjectDir().trim();
 
@@ -1531,14 +1542,7 @@ export default function App() {
       } as FilePartInput);
     }
 
-    for (const attachment of draft.attachments) {
-      parts.push({
-        type: "file",
-        url: attachment.dataUrl,
-        filename: attachment.name,
-        mime: attachment.mimeType,
-      } as FilePartInput);
-    }
+    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
 
     return parts;
   };
@@ -1682,7 +1686,7 @@ export default function App() {
 
       const model = selectedSessionModel();
       const agent = selectedSessionAgent();
-      const parts = buildPromptParts(resolvedDraft);
+      const parts = await buildPromptParts(resolvedDraft);
       const selectedVariant = modelVariant() ?? undefined;
       const reasoningEffort = resolveCodexReasoningEffort(model.modelID, selectedVariant ?? null);
       const requestVariant = reasoningEffort ? undefined : selectedVariant;
@@ -1710,7 +1714,7 @@ export default function App() {
 
         // Slash command: route through session.command() API
         const modelString = `${model.providerID}/${model.modelID}`;
-        const files = buildCommandFileParts(resolvedDraft);
+        const files = await buildCommandFileParts(resolvedDraft);
 
         // session.command() expects `model` as a provider/model string and only supports file parts.
         unwrap(

--- a/packages/app/src/app/components/part-view.tsx
+++ b/packages/app/src/app/components/part-view.tsx
@@ -470,6 +470,8 @@ function createCustomRenderer(tone: "light" | "dark") {
         src="${safeHref}"
         alt="${escapeHtml(text || "")}"
         ${safeTitle ? `title="${safeTitle}"` : ""}
+        loading="lazy"
+        decoding="async"
         class="max-w-full h-auto rounded-lg my-4"
       />
     `;
@@ -1071,6 +1073,8 @@ export default function PartView(props: Props) {
                     <img
                       src={image.src}
                       alt={image.alt || ""}
+                      loading="lazy"
+                      decoding="async"
                       class="max-w-full h-auto rounded-lg border border-gray-6/50"
                     />
                   )}
@@ -1126,6 +1130,8 @@ export default function PartView(props: Props) {
         <img
           src={inlineImage()!}
           alt=""
+          loading="lazy"
+          decoding="async"
           class="max-w-full h-auto rounded-xl border border-gray-6/50"
         />
       </Match>

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -138,16 +138,12 @@ const formatLinks = (links: Array<{ name: string; target: string }>) =>
     .map((entry) => `[${escapeMarkdownLabel(entry.name || "file")}](${entry.target})`)
     .join("\n");
 
-const fileToDataUrl = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = () => reject(new Error("Failed to read attachment"));
-    reader.onload = () => {
-      const result = typeof reader.result === "string" ? reader.result : "";
-      resolve(result);
-    };
-    reader.readAsDataURL(file);
-  });
+const estimateInlineAttachmentBytes = (file: Blob) => {
+  const mimeType = file.type || "application/octet-stream";
+  const prefixBytes = `data:${mimeType};base64,`.length;
+  const base64Bytes = Math.ceil(file.size / 3) * 4;
+  return prefixBytes + base64Bytes + 512;
+};
 
 /**
  * Compress an image file to JPEG using OffscreenCanvas (off main thread when possible).
@@ -463,6 +459,11 @@ export default function Composer(props: ComposerProps) {
     objectUrls.add(url);
     return url;
   };
+  const releaseObjectUrl = (url?: string) => {
+    if (!url) return;
+    if (!objectUrls.delete(url)) return;
+    URL.revokeObjectURL(url);
+  };
   // Track IME composition state so we can combine it with keyCode === 229 to
   // reliably suppress Enter during CJK input across Chrome, Safari, and WebKit.
   let imeComposing = false;
@@ -490,6 +491,23 @@ export default function Composer(props: ComposerProps) {
     }
     objectUrls.clear();
   });
+
+  const clearSentAttachments = () => {
+    const current = attachments();
+    for (const attachment of current) {
+      releaseObjectUrl(attachment.previewUrl);
+    }
+    setAttachments([]);
+  };
+
+  const removeAttachment = (attachmentId: string) => {
+    setAttachments((current: ComposerAttachment[]) => {
+      const target = current.find((item) => item.id === attachmentId);
+      releaseObjectUrl(target?.previewUrl);
+      return current.filter((item) => item.id !== attachmentId);
+    });
+    emitDraftChange();
+  };
 
   const createPasteSpan = (part: Extract<ComposerPart, { type: "paste" }>) => {
     pasteTextById.set(part.id, part.text);
@@ -1047,7 +1065,7 @@ export default function Composer(props: ComposerProps) {
     props.onSend(draft);
     setSlashOpen(false);
     setSlashQuery("");
-    setAttachments([]);
+    clearSentAttachments();
     setEditorText("");
     emitDraftChange();
     queueMicrotask(() => focusEditorEnd());
@@ -1087,11 +1105,9 @@ export default function Composer(props: ComposerProps) {
         continue;
       }
       try {
-        // Compress images before encoding to data URL
+        // Compress images before keeping them in local draft state.
         const processed = isImageMime(file.type) ? await compressImageFile(file) : file;
-        const dataUrl = await fileToDataUrl(processed);
-        // Pre-check: data URL will be embedded in JSON body; reject if too large
-        const estimatedJsonBytes = dataUrl.length + 512; // data URL + JSON overhead
+        const estimatedJsonBytes = estimateInlineAttachmentBytes(processed);
         if (estimatedJsonBytes > MAX_ATTACHMENT_BYTES) {
           props.onToast(`${file.name} is too large after encoding. Try a smaller image.`);
           continue;
@@ -1102,7 +1118,8 @@ export default function Composer(props: ComposerProps) {
           mimeType: processed.type || "application/octet-stream",
           size: processed.size,
           kind: isImageMime(processed.type) ? "image" : "file",
-          dataUrl,
+          file: processed,
+          previewUrl: isImageMime(processed.type) ? createObjectUrl(processed) : undefined,
         });
       } catch (error) {
         props.onToast(error instanceof Error ? error.message : "Failed to read attachment");
@@ -1683,7 +1700,12 @@ export default function Composer(props: ComposerProps) {
                         fallback={<FileIcon size={14} class="text-gray-9" />}
                       >
                         <div class="h-10 w-10 rounded-xl bg-gray-1 overflow-hidden border border-gray-6">
-                          <img src={attachment.dataUrl} alt={attachment.name} class="h-full w-full object-cover" />
+                          <img
+                            src={attachment.previewUrl!}
+                            alt={attachment.name}
+                            decoding="async"
+                            class="h-full w-full object-cover"
+                          />
                         </div>
                       </Show>
                       <div class="max-w-[160px]">
@@ -1695,12 +1717,7 @@ export default function Composer(props: ComposerProps) {
                       <button
                         type="button"
                         class="ml-1 rounded-full p-1 text-gray-10 hover:text-gray-11 hover:bg-gray-4"
-                        onClick={() => {
-                          setAttachments((current: ComposerAttachment[]) =>
-                            current.filter((item) => item.id !== attachment.id)
-                          );
-                          emitDraftChange();
-                        }}
+                        onClick={() => removeAttachment(attachment.id)}
                       >
                         <X size={12} />
                       </button>

--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -76,6 +76,11 @@ type MessageBlock = {
   kind: "message";
   message: MessageWithParts;
   renderableParts: Part[];
+  attachments: Array<{
+    url: string;
+    filename: string;
+    mime: string;
+  }>;
   groups: MessageGroup[];
   isUser: boolean;
   messageId: string;
@@ -392,14 +397,16 @@ function toolHeadline(part: Part) {
 export default function MessageList(props: MessageListProps) {
   const [copyingId, setCopyingId] = createSignal<string | null>(null);
   let previousMessagePartCountById = new Map<string, number>();
+  let previousMessageBlockById = new Map<string, MessageBlock>();
+  let previousBlockRenderKey = "";
   let copyTimeout: number | undefined;
   const isAttachmentPart = (part: Part) => {
     if (part.type !== "file") return false;
     const url = (part as { url?: string }).url;
     return typeof url === "string" && !url.startsWith("file://");
   };
-  const attachmentsForMessage = (message: MessageWithParts) =>
-    message.parts
+  const attachmentsForParts = (parts: Part[]) =>
+    parts
       .filter(isAttachmentPart)
       .map((part) => {
         const record = part as {
@@ -505,8 +512,10 @@ export default function MessageList(props: MessageListProps) {
 
   const messageBlocks = createMemo<MessageBlockItem[]>(() => {
     const startedAt = perfNow();
+    const renderKey = `${props.developerMode ? 1 : 0}:${props.showThinking ? 1 : 0}`;
     const blocks: MessageBlockItem[] = [];
     const nextMessagePartCountById = new Map<string, number>();
+    const nextMessageBlockById = new Map<string, MessageBlock>();
     let changedMessageCount = 0;
     let addedMessageCount = 0;
     let toolPartCount = 0;
@@ -521,10 +530,34 @@ export default function MessageList(props: MessageListProps) {
       const totalParts = message.parts.length;
       nextMessagePartCountById.set(idKey, totalParts);
       const previousPartCount = previousMessagePartCountById.get(idKey);
+      const previousBlock = previousMessageBlockById.get(idKey);
       if (previousPartCount === undefined) {
         addedMessageCount += 1;
       } else if (previousPartCount !== totalParts) {
         changedMessageCount += 1;
+      }
+
+      const isUser = (message.info as any).role === "user";
+      const canReuseStableBlock =
+        previousBlockRenderKey === renderKey &&
+        index < props.messages.length - 1 &&
+        previousPartCount !== undefined &&
+        previousPartCount === totalParts &&
+        previousBlock?.kind === "message" &&
+        previousBlock.isUser === isUser;
+
+      if (canReuseStableBlock && previousBlock) {
+        toolPartCount += previousBlock.renderableParts.reduce(
+          (count, part) => (part.type === "tool" ? count + 1 : count),
+          0,
+        );
+        stepGroupCount += previousBlock.groups.reduce(
+          (count, group) => (group.kind === "steps" ? count + 1 : count),
+          0,
+        );
+        blocks.push(previousBlock);
+        nextMessageBlockById.set(idKey, previousBlock);
+        return;
       }
 
       toolPartCount += renderableParts.reduce(
@@ -532,8 +565,9 @@ export default function MessageList(props: MessageListProps) {
         0,
       );
       const groupId = String((message.info as any).id ?? "message");
-      const groups = groupMessageParts(renderableParts, groupId);
-      const isUser = (message.info as any).role === "user";
+      const attachments = attachmentsForParts(renderableParts);
+      const nonAttachmentParts = renderableParts.filter((part) => !isAttachmentPart(part));
+      const groups = groupMessageParts(nonAttachmentParts, groupId);
       const isStepsOnly =
         groups.length > 0 && groups.every((group) => group.kind === "steps");
       const stepGroups = isStepsOnly
@@ -565,14 +599,17 @@ export default function MessageList(props: MessageListProps) {
         return;
       }
 
-      blocks.push({
+      const block: MessageBlock = {
         kind: "message",
         message,
         renderableParts,
+        attachments,
         groups,
         isUser,
         messageId,
-      });
+      };
+      blocks.push(block);
+      nextMessageBlockById.set(idKey, block);
     });
 
     let removedMessageCount = 0;
@@ -582,6 +619,8 @@ export default function MessageList(props: MessageListProps) {
       }
     });
     previousMessagePartCountById = nextMessagePartCountById;
+    previousMessageBlockById = nextMessageBlockById;
+    previousBlockRenderKey = renderKey;
 
     const elapsedMs = Math.round((perfNow() - startedAt) * 100) / 100;
     if (
@@ -926,7 +965,7 @@ export default function MessageList(props: MessageListProps) {
               : "w-full relative max-w-[760px] text-[15px] leading-[1.72] text-dls-text antialiased group"
           } ${searchOutlineClass}`}
         >
-          <Show when={attachmentsForMessage(block.message).length > 0}>
+          <Show when={block.attachments.length > 0}>
             <div
               class={
                 block.isUser
@@ -934,7 +973,7 @@ export default function MessageList(props: MessageListProps) {
                   : "mb-4 flex flex-wrap gap-2"
               }
             >
-              <For each={attachmentsForMessage(block.message)}>
+              <For each={block.attachments}>
                 {(attachment) => (
                   <div class="flex items-center gap-2 rounded-[18px] border border-dls-border bg-dls-surface px-3 py-2 text-xs text-gray-11 shadow-[var(--dls-card-shadow)]">
                     <Show
@@ -945,6 +984,8 @@ export default function MessageList(props: MessageListProps) {
                         <img
                           src={attachment.url}
                           alt={attachment.filename}
+                          loading="lazy"
+                          decoding="async"
                           class="h-full w-full object-cover"
                         />
                       </div>

--- a/packages/app/src/app/types.ts
+++ b/packages/app/src/app/types.ts
@@ -96,7 +96,8 @@ export type ComposerAttachment = {
   mimeType: string;
   size: number;
   kind: "image" | "file";
-  dataUrl: string;
+  file: File;
+  previewUrl?: string;
 };
 
 export type SlashCommandOption = {


### PR DESCRIPTION
## Summary
- keep inline chat attachments as `File` objects with local blob previews in the composer, then convert to base64 only when sending the prompt
- remove duplicate post-send image rendering by keeping the attachment chip view and excluding the same attachment parts from the message body groups
- reuse stable message blocks for unchanged messages during streaming and lazy-load rendered images to cut flicker and reduce chat rerenders

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @different-ai/openwork-ui typecheck
- pnpm --filter @different-ai/openwork-ui build