### PR TITLE
ci: pin release runners per target

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -75,8 +75,8 @@ jobs:
   publish-tauri:
     name: Build + Publish (${{ matrix.target }})
     needs: prepare-release
-    # Set OPENWORK_LINUX_X64_RUNNER_LABEL to route Linux release builds to a larger runner.
-    runs-on: ${{ matrix.os_type == 'linux' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL != '' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL || matrix.platform }}
+    # Use explicit per-target runner labels so each release build can scale independently.
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 360
 
     env:
@@ -91,36 +91,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-14
-            os_type: macos
+          - os_type: macos
             target: aarch64-apple-darwin
+            runs_on: macos-latest
             args: "--target aarch64-apple-darwin --bundles dmg,app"
-          - platform: macos-14
-            os_type: macos
+          - os_type: macos
             target: x86_64-apple-darwin
+            runs_on: macos-26-intel
             args: "--target x86_64-apple-darwin --bundles dmg,app"
-          - platform: ubuntu-22.04
-            os_type: linux
+          - os_type: linux
             target: x86_64-unknown-linux-gnu
+            runs_on: blacksmith-4vcpu-ubuntu-2404
             args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
-          - platform: ubuntu-22.04-arm
-            os_type: linux
+          - os_type: linux
             target: aarch64-unknown-linux-gnu
+            runs_on: blacksmith-4vcpu-ubuntu-2404-arm
             args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
-          - platform: windows-2022
-            os_type: windows
+          - os_type: windows
             target: x86_64-pc-windows-msvc
+            runs_on: blacksmith-4vcpu-windows-2025
             args: "--target x86_64-pc-windows-msvc --bundles msi"
 
     steps:
       - name: Log runner selection
         shell: bash
         run: |
-          echo "Requested larger runner label: ${RUNNER_LABEL:-<unset>}"
-          echo "Effective runs-on: ${EFFECTIVE_RUNS_ON}"
+          echo "Configured runs-on: ${RUNS_ON}"
+          echo "Build target: ${TARGET}"
         env:
-          RUNNER_LABEL: ${{ vars.OPENWORK_LINUX_X64_RUNNER_LABEL }}
-          EFFECTIVE_RUNS_ON: ${{ matrix.os_type == 'linux' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL != '' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL || matrix.platform }}
+          RUNS_ON: ${{ matrix.runs_on }}
+          TARGET: ${{ matrix.target }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -228,8 +228,8 @@ jobs:
     name: Build + Publish (${{ matrix.target }})
     needs: [resolve-release, verify-release]
     if: needs.resolve-release.outputs.build_tauri == 'true'
-    # Set OPENWORK_LINUX_X64_RUNNER_LABEL to route Linux release builds to a larger runner.
-    runs-on: ${{ matrix.os_type == 'linux' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL != '' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL || matrix.platform }}
+    # Use explicit per-target runner labels so each release build can scale independently.
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 360
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -246,36 +246,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: macos-14
-            os_type: macos
+          - os_type: macos
             target: aarch64-apple-darwin
+            runs_on: macos-latest
             args: "--target aarch64-apple-darwin --bundles dmg,app"
-          - platform: macos-14
-            os_type: macos
+          - os_type: macos
             target: x86_64-apple-darwin
+            runs_on: macos-26-intel
             args: "--target x86_64-apple-darwin --bundles dmg,app"
-          - platform: ubuntu-22.04
-            os_type: linux
+          - os_type: linux
             target: x86_64-unknown-linux-gnu
+            runs_on: blacksmith-4vcpu-ubuntu-2404
             args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
-          - platform: ubuntu-22.04-arm
-            os_type: linux
+          - os_type: linux
             target: aarch64-unknown-linux-gnu
+            runs_on: blacksmith-4vcpu-ubuntu-2404-arm
             args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
-          - platform: windows-2022
-            os_type: windows
+          - os_type: windows
             target: x86_64-pc-windows-msvc
+            runs_on: blacksmith-4vcpu-windows-2025
             args: "--target x86_64-pc-windows-msvc --bundles msi"
 
     steps:
       - name: Log runner selection
         shell: bash
         run: |
-          echo "Requested larger runner label: ${RUNNER_LABEL:-<unset>}"
-          echo "Effective runs-on: ${EFFECTIVE_RUNS_ON}"
+          echo "Configured runs-on: ${RUNS_ON}"
+          echo "Build target: ${TARGET}"
         env:
-          RUNNER_LABEL: ${{ vars.OPENWORK_LINUX_X64_RUNNER_LABEL }}
-          EFFECTIVE_RUNS_ON: ${{ matrix.os_type == 'linux' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL != '' && vars.OPENWORK_LINUX_X64_RUNNER_LABEL || matrix.platform }}
+          RUNS_ON: ${{ matrix.runs_on }}
+          TARGET: ${{ matrix.target }}
 
       - name: Enable git long paths (Windows)
         if: matrix.os_type == 'windows'


### PR DESCRIPTION
## Summary
- replace the release and prerelease Linux-wide runner override with explicit per-target `runs_on` values in the matrix
- move mac release targets to the requested GitHub macOS labels (`macos-latest` for arm64 and `macos-26-intel` for x86_64) while keeping Linux and Windows on Blacksmith runners
- simplify runner logging so each matrix job reports its configured runner label and build target

## Testing
- ruby -e 'require "yaml"; [".github/workflows/release-macos-aarch64.yml", ".github/workflows/prerelease.yml"].each { |path| YAML.load_file(path); puts "OK #{path}" }'