### PR TITLE
fix(streaming): restore live session updates and scroll pinning

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -1015,7 +1015,7 @@ export default function MessageList(props: MessageListProps) {
                       props.isStreaming &&
                       block.messageId === latestAssistantMessageId();
                     const markdownThrottleMs = isStreamingLatestAssistant
-                      ? 550
+                      ? 120
                       : 100;
                     return (
                       <PartView

--- a/packages/app/src/app/context/session.ts
+++ b/packages/app/src/app/context/session.ts
@@ -118,6 +118,25 @@ const upsertPartInfo = (list: Part[], next: Part) => {
 
 const removePartInfo = (list: Part[], partID: string) => list.filter((part) => part.id !== partID);
 
+const appendPartDelta = (list: Part[], partID: string, field: string, delta: string) => {
+  if (!delta) return list;
+  const index = list.findIndex((part) => part.id === partID);
+  if (index === -1) return list;
+
+  const existing = list[index] as Part & Record<string, unknown>;
+  const current = existing[field];
+  if (current !== undefined && typeof current !== "string") {
+    return list;
+  }
+
+  const nextValue = `${typeof current === "string" ? current : ""}${delta}`;
+  if (nextValue === current) return list;
+
+  const copy = list.slice();
+  copy[index] = { ...existing, [field]: nextValue } as Part;
+  return copy;
+};
+
 export function createSessionStore(options: {
   client: () => Client | null;
   activeWorkspaceRoot: () => string;
@@ -985,6 +1004,21 @@ export function createSessionStore(options: {
       };
     }
 
+    if (event.type === "message.part.delta") {
+      const record = event.properties as Record<string, unknown> | undefined;
+      const delta = typeof record?.delta === "string" ? record.delta : "";
+      return {
+        type: event.type,
+        properties: {
+          sessionID: typeof record?.sessionID === "string" ? record.sessionID : null,
+          messageID: typeof record?.messageID === "string" ? record.messageID : null,
+          partID: typeof record?.partID === "string" ? record.partID : null,
+          field: typeof record?.field === "string" ? record.field : null,
+          deltaLength: delta.length,
+        },
+      };
+    }
+
     return {
       type: event.type,
       properties: event.properties,
@@ -998,7 +1032,7 @@ export function createSessionStore(options: {
 
     if (options.developerMode()) {
       const compact = compactDebugEvent(event);
-      if (event.type === "message.part.updated") {
+      if (event.type === "message.part.updated" || event.type === "message.part.delta") {
         const now = Date.now();
         if (now - lastPartDebugEventAt < 250) {
           suppressedPartDebugEvents += 1;
@@ -1016,7 +1050,7 @@ export function createSessionStore(options: {
       } else {
         if (suppressedPartDebugEvents > 0) {
           appendDebugEvent({
-            type: "message.part.updated.sample",
+            type: "message.part.stream.sample",
             properties: { suppressed: suppressedPartDebugEvents },
           });
           suppressedPartDebugEvents = 0;
@@ -1218,6 +1252,31 @@ export function createSessionStore(options: {
       }
     }
 
+    if (event.type === "message.part.delta") {
+      if (event.properties && typeof event.properties === "object") {
+        const record = event.properties as Record<string, unknown>;
+        const messageID = typeof record.messageID === "string" ? record.messageID : null;
+        const partID = typeof record.partID === "string" ? record.partID : null;
+        const field = typeof record.field === "string" ? record.field : null;
+        const delta = typeof record.delta === "string" ? record.delta : null;
+        const partDeltaStartedAt = perfNow();
+
+        if (messageID && partID && field && delta) {
+          setStore("parts", messageID, (current = []) => appendPartDelta(current, partID, field, delta));
+          const partDeltaMs = Math.round((perfNow() - partDeltaStartedAt) * 100) / 100;
+          if (sessionDebugEnabled() && (partDeltaMs >= 8 || delta.length >= 120)) {
+            recordPerfLog(true, "session.event", "message.part.delta", {
+              messageID,
+              partID,
+              field,
+              deltaLength: delta.length,
+              ms: partDeltaMs,
+            });
+          }
+        }
+      }
+    }
+
     if (event.type === "message.part.removed") {
       if (event.properties && typeof event.properties === "object") {
         const record = event.properties as Record<string, unknown>;
@@ -1323,7 +1382,7 @@ export function createSessionStore(options: {
       batch(() => {
         for (const event of eventsToApply) {
           if (!event) continue;
-          if (event.type === "message.part.updated") partUpdates += 1;
+          if (event.type === "message.part.updated" || event.type === "message.part.delta") partUpdates += 1;
           if (event.type === "message.updated") messageUpdates += 1;
           applied += 1;
           void applyEvent(event);
@@ -1398,7 +1457,7 @@ export function createSessionStore(options: {
           if (queue.length === 0) {
             queueStartedAt = Date.now();
           }
-          if (event.type === "message.part.updated") {
+          if (event.type === "message.part.updated" || event.type === "message.part.delta") {
             queueHasPartUpdates = true;
           }
           queue.push(event);

--- a/packages/app/src/app/lib/perf-log.ts
+++ b/packages/app/src/app/lib/perf-log.ts
@@ -19,6 +19,7 @@ const HOT_EVENT_MIN_INTERVAL_MS = 750;
 const HOT_EVENT_KEYS = new Set([
   "session.sse:flush",
   "session.sse:arrival-gap",
+  "session.event:message.part.delta",
   "session.event:message.part.updated",
   "session.compaction:synthetic-continue",
   "session.input:draft-flush",

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -316,8 +316,7 @@ const MESSAGE_WINDOW_LOAD_CHUNK = 120;
 const MAX_SEARCH_MESSAGE_CHARS = 4_000;
 const MAX_SEARCH_HITS = 2_000;
 const STREAM_SCROLL_MIN_INTERVAL_MS = 90;
-const LATEST_MESSAGE_TOP_OFFSET_PX = 200;
-const STREAM_RENDER_BATCH_MS = 220;
+const STREAM_RENDER_BATCH_MS = 48;
 const MAIN_THREAD_LAG_INTERVAL_MS = 200;
 const MAIN_THREAD_LAG_WARN_MS = 180;
 
@@ -370,6 +369,8 @@ export default function SessionView(props: SessionViewProps) {
   );
   const [agentOptions, setAgentOptions] = createSignal<Agent[]>([]);
   const [isViewingLatest, setIsViewingLatest] = createSignal(true);
+  const [topClippedMessageId, setTopClippedMessageId] = createSignal<string | null>(null);
+  const [jumpControlsSuppressed, setJumpControlsSuppressed] = createSignal(false);
   const [searchOpen, setSearchOpen] = createSignal(false);
   const [searchQuery, setSearchQuery] = createSignal("");
   const [searchQueryDebounced, setSearchQueryDebounced] = createSignal("");
@@ -1648,6 +1649,7 @@ export default function SessionView(props: SessionViewProps) {
   let initialAnchorRafA: number | undefined;
   let initialAnchorRafB: number | undefined;
   let initialAnchorGuardTimer: ReturnType<typeof setTimeout> | undefined;
+  let jumpControlsSuppressTimer: ReturnType<typeof setTimeout> | undefined;
   const attachmentsEnabled = createMemo(() => {
     if (props.activeWorkspaceDisplay.workspaceType !== "remote") return true;
     return props.openworkServerStatus === "connected";
@@ -1664,25 +1666,41 @@ export default function SessionView(props: SessionViewProps) {
     messagesEndEl?.scrollIntoView({ behavior, block: "end" });
   };
 
-  const scrollToLatestMessageAnchor = (behavior: ScrollBehavior = "auto") => {
+  const refreshTopClippedMessage = () => {
     const container = chatContainerEl;
-    if (!container) return false;
-    const messageEls = container.querySelectorAll("[data-message-id]");
-    const latestMessageEl = messageEls[messageEls.length - 1] as
-      | HTMLElement
-      | undefined;
-    if (!latestMessageEl) return false;
+    if (!container) {
+      setTopClippedMessageId(null);
+      return;
+    }
 
     const containerRect = container.getBoundingClientRect();
-    const targetRect = latestMessageEl.getBoundingClientRect();
-    const desiredTop =
-      container.scrollTop +
-      (targetRect.top - containerRect.top) -
-      LATEST_MESSAGE_TOP_OFFSET_PX;
-    const maxTop = Math.max(0, container.scrollHeight - container.clientHeight);
-    const nextTop = Math.max(0, Math.min(desiredTop, maxTop));
-    container.scrollTo({ top: nextTop, behavior });
-    return true;
+    const messageEls = container.querySelectorAll("[data-message-id]");
+    const latestMessageEl = messageEls[messageEls.length - 1] as HTMLElement | undefined;
+    const latestMessageId = latestMessageEl?.getAttribute("data-message-id")?.trim() ?? "";
+    let nextId: string | null = null;
+
+    for (const node of messageEls) {
+      const el = node as HTMLElement;
+      const rect = el.getBoundingClientRect();
+      if (rect.bottom <= containerRect.top + 1) continue;
+      if (rect.top >= containerRect.bottom - 1) break;
+
+      if (
+        rect.top < containerRect.top - 1
+      ) {
+        const id = el.getAttribute("data-message-id")?.trim() ?? "";
+        if (id) {
+          const isLatestMessage = id === latestMessageId;
+          const fillsViewportTail = rect.bottom >= containerRect.bottom - 1;
+          if (isLatestMessage || fillsViewportTail) {
+            nextId = id;
+          }
+        }
+      }
+      break;
+    }
+
+    setTopClippedMessageId(nextId);
   };
 
   const pinToLatestNow = () => {
@@ -1690,10 +1708,19 @@ export default function SessionView(props: SessionViewProps) {
     messagesEndEl?.scrollIntoView({ behavior: "auto", block: "end" });
   };
 
-  const shouldUseLatestMessageAnchor = () => {
-    const latestMessage = props.messages[props.messages.length - 1];
-    const info = latestMessage?.info as { role?: string } | undefined;
-    return info?.role === "assistant";
+  const pinToLatestAfterLayout = () => {
+    setIsViewingLatest(true);
+    setTopClippedMessageId(null);
+    messagesEndEl?.scrollIntoView({ behavior: "auto", block: "end" });
+    queueMicrotask(() => {
+      messagesEndEl?.scrollIntoView({ behavior: "auto", block: "end" });
+    });
+    window.requestAnimationFrame(() => {
+      messagesEndEl?.scrollIntoView({ behavior: "auto", block: "end" });
+      window.requestAnimationFrame(() => {
+        pinToLatestNow();
+      });
+    });
   };
 
   const scheduleScrollToLatest = (behavior: ScrollBehavior = "auto") => {
@@ -1709,17 +1736,12 @@ export default function SessionView(props: SessionViewProps) {
       if (
         nextBehavior === "auto" &&
         now - lastAutoScrollAt < STREAM_SCROLL_MIN_INTERVAL_MS
-      ) {
-        return;
-      }
-      lastAutoScrollAt = now;
-      if (
-        shouldUseLatestMessageAnchor() &&
-        scrollToLatestMessageAnchor(nextBehavior)
-      )
-        return;
-      scrollToLatest(nextBehavior);
-    });
+        ) {
+          return;
+        }
+        lastAutoScrollAt = now;
+        scrollToLatest(nextBehavior);
+      });
   };
 
   const cancelInitialAnchorFrames = () => {
@@ -1734,6 +1756,10 @@ export default function SessionView(props: SessionViewProps) {
     if (initialAnchorGuardTimer) {
       clearTimeout(initialAnchorGuardTimer);
       initialAnchorGuardTimer = undefined;
+    }
+    if (jumpControlsSuppressTimer !== undefined) {
+      clearTimeout(jumpControlsSuppressTimer);
+      jumpControlsSuppressTimer = undefined;
     }
   };
 
@@ -2126,6 +2152,32 @@ export default function SessionView(props: SessionViewProps) {
     scheduleScrollToLatest(behavior);
   };
 
+  const jumpToStartOfMessage = (behavior: ScrollBehavior = "smooth") => {
+    const messageId = topClippedMessageId();
+    const container = chatContainerEl;
+    if (!messageId || !container) return;
+
+    const escapedId = messageId.replace(/"/g, '\\"');
+    const target = container.querySelector(
+      `[data-message-id="${escapedId}"]`,
+    ) as HTMLElement | null;
+    if (!target) return;
+
+    setIsViewingLatest(false);
+    target.scrollIntoView({ behavior, block: "start" });
+  };
+
+  const suppressJumpControlsTemporarily = () => {
+    if (jumpControlsSuppressTimer !== undefined) {
+      clearTimeout(jumpControlsSuppressTimer);
+    }
+    setJumpControlsSuppressed(true);
+    jumpControlsSuppressTimer = setTimeout(() => {
+      jumpControlsSuppressTimer = undefined;
+      setJumpControlsSuppressed(false);
+    }, 1000);
+  };
+
   onMount(() => {
     const container = chatContainerEl;
     const sentinel = bottomVisibilityEl;
@@ -2138,6 +2190,7 @@ export default function SessionView(props: SessionViewProps) {
         if (atBottom) {
           setIsViewingLatest(true);
         }
+        refreshTopClippedMessage();
       },
       {
         root: container,
@@ -2164,6 +2217,7 @@ export default function SessionView(props: SessionViewProps) {
 
         if (!sessionId) return;
         setIsViewingLatest(true);
+        setTopClippedMessageId(null);
         const firstVisit = !topInitializedSessionIds.has(sessionId);
         topInitializedSessionIds.add(sessionId);
         setInitialAnchorPending(true);
@@ -2338,6 +2392,9 @@ export default function SessionView(props: SessionViewProps) {
     if (status === "running" || status === "retry") {
       startRun();
       setRunHasBegun(true);
+      if (isViewingLatest()) {
+        pinToLatestAfterLayout();
+      }
     }
   });
 
@@ -2369,8 +2426,13 @@ export default function SessionView(props: SessionViewProps) {
     runProgressSignature();
     if (initialAnchorPending()) return;
     if (!isViewingLatest()) return;
-    if (!shouldUseLatestMessageAnchor()) return;
     scheduleScrollToLatest("auto");
+  });
+
+  createEffect(() => {
+    batchedRenderedMessages();
+    initialAnchorPending();
+    queueMicrotask(refreshTopClippedMessage);
   });
 
   createEffect(
@@ -3374,6 +3436,8 @@ export default function SessionView(props: SessionViewProps) {
   });
 
   const handleSendPrompt = (draft: ComposerDraft) => {
+    suppressJumpControlsTemporarily();
+    pinToLatestAfterLayout();
     startRun();
     props.sendPromptAsync(draft).catch(() => undefined);
   };
@@ -4210,11 +4274,13 @@ export default function SessionView(props: SessionViewProps) {
                     setIsViewingLatest(false);
                   }
                   lastKnownScrollTop = container.scrollTop;
+                  refreshTopClippedMessage();
                 }}
                 ref={(el) => {
                   chatContainerEl = el;
                   setIsChatContainerReady(Boolean(el));
                   lastKnownScrollTop = el?.scrollTop ?? 0;
+                  queueMicrotask(refreshTopClippedMessage);
                 }}
               >
                 <div class="mx-auto w-full max-w-[800px]">
@@ -4381,16 +4447,33 @@ export default function SessionView(props: SessionViewProps) {
                 </div>
               </div>
 
-              <Show when={props.messages.length > 0 && !isViewingLatest()}>
+              <Show when={props.messages.length > 0 && !jumpControlsSuppressed() && (!isViewingLatest() || Boolean(topClippedMessageId()))}>
                 <div class="absolute bottom-4 left-0 right-0 z-20 flex justify-center pointer-events-none">
                   <div class="pointer-events-auto flex items-center gap-2 rounded-full border border-dls-border bg-dls-surface/95 p-1 shadow-[var(--dls-card-shadow)] backdrop-blur-md">
-                    <button
-                      type="button"
-                      class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
-                      onClick={() => jumpToLatest("smooth")}
-                    >
-                      Jump to latest
-                    </button>
+                    <Show when={Boolean(topClippedMessageId())}>
+                      <button
+                        type="button"
+                        class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
+                        onClick={() => {
+                          suppressJumpControlsTemporarily();
+                          jumpToStartOfMessage("smooth");
+                        }}
+                      >
+                        Jump to start of message
+                      </button>
+                    </Show>
+                    <Show when={!isViewingLatest()}>
+                      <button
+                        type="button"
+                        class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
+                        onClick={() => {
+                          suppressJumpControlsTemporarily();
+                          jumpToLatest("smooth");
+                        }}
+                      >
+                        Jump to latest
+                      </button>
+                    </Show>
                   </div>
                 </div>
               </Show>

--- a/packages/web/app/api/_lib/upstream-proxy.ts
+++ b/packages/web/app/api/_lib/upstream-proxy.ts
@@ -168,7 +168,7 @@ async function fetchUpstream(
   targetUrl: string,
   contentType: string | null,
   body: Uint8Array | null,
-): Promise<{ response: Response; body: ArrayBuffer }> {
+): Promise<Response> {
   const init: RequestInit = {
     method: request.method,
     headers: buildHeaders(request, contentType),
@@ -179,9 +179,33 @@ async function fetchUpstream(
     init.body = body;
   }
 
-  const response = await fetch(targetUrl, init);
-  const responseBody = await response.arrayBuffer();
-  return { response, body: responseBody };
+  return fetch(targetUrl, init);
+}
+
+async function readUpstreamBody(response: Response): Promise<ArrayBuffer> {
+  return response.arrayBuffer();
+}
+
+function isEventStreamRequest(request: NextRequest): boolean {
+  const accept = request.headers.get("accept")?.toLowerCase() ?? "";
+  return accept.includes("text/event-stream");
+}
+
+function isEventStreamResponse(response: Response): boolean {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  return contentType.includes("text/event-stream");
+}
+
+function shouldFallbackToAuthBaseForStream(response: Response, targetPath: string): boolean {
+  if (response.status === 502 || response.status === 503 || response.status === 504) {
+    return true;
+  }
+
+  if (response.status === 404 && isAdminTargetPath(targetPath)) {
+    return true;
+  }
+
+  return false;
 }
 
 function rewriteLocationHeader(location: string, request: NextRequest): string {
@@ -210,53 +234,12 @@ function rewriteLocationHeader(location: string, request: NextRequest): string {
   return `${requestOrigin}${parsedLocation.pathname}${parsedLocation.search}${parsedLocation.hash}`;
 }
 
-export async function proxyUpstream(
+function buildProxyResponse(
   request: NextRequest,
-  segments: string[] = [],
+  upstream: Response,
   options: ProxyOptions,
-): Promise<Response> {
-  const targetPath = getTargetPath(request, segments, options.routePrefix);
-  const primaryTargetUrl = buildTargetUrl(apiBase, request, targetPath, options.upstreamPathPrefix);
-  const fallbackTargetUrl = buildTargetUrl(authFallbackBase, request, targetPath, options.upstreamPathPrefix);
-  const contentType = request.headers.get("content-type");
-  const requestBody = request.method !== "GET" && request.method !== "HEAD"
-    ? new Uint8Array(await request.arrayBuffer())
-    : null;
-
-  let upstream: Response | null = null;
-  let body: ArrayBuffer | null = null;
-
-  try {
-    const primary = await fetchUpstream(request, primaryTargetUrl, contentType, requestBody);
-    upstream = primary.response;
-    body = primary.body;
-  } catch {
-    if (apiBase !== authFallbackBase) {
-      try {
-        const fallback = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
-        upstream = fallback.response;
-        body = fallback.body;
-      } catch {}
-    }
-  }
-
-  if (!upstream || !body) {
-    return buildUpstreamErrorResponse(502, "Upstream request failed.");
-  }
-
-  if (apiBase !== authFallbackBase && shouldFallbackToAuthBase(upstream, body, targetPath)) {
-    try {
-      const fallback = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
-      upstream = fallback.response;
-      body = fallback.body;
-    } catch {}
-  }
-
-  const responseContentType = upstream.headers.get("content-type")?.toLowerCase() ?? "";
-  if (upstream.status >= 500 && (responseContentType.includes("text/html") || isLikelyHtmlBody(body))) {
-    return buildUpstreamErrorResponse(upstream.status, "Upstream service unavailable.");
-  }
-
+  body?: BodyInit | null,
+): Response {
   const responseHeaders = new Headers();
   const passThroughHeaders = ["content-type", "location", "cache-control"];
 
@@ -278,8 +261,63 @@ export async function proxyUpstream(
 
   const shouldDropBody = request.method === "HEAD" || NO_BODY_STATUS.has(upstream.status);
 
-  return new Response(shouldDropBody ? null : body, {
+  return new Response(shouldDropBody ? null : (body ?? upstream.body), {
     status: upstream.status,
     headers: responseHeaders,
   });
+}
+
+export async function proxyUpstream(
+  request: NextRequest,
+  segments: string[] = [],
+  options: ProxyOptions,
+): Promise<Response> {
+  const targetPath = getTargetPath(request, segments, options.routePrefix);
+  const primaryTargetUrl = buildTargetUrl(apiBase, request, targetPath, options.upstreamPathPrefix);
+  const fallbackTargetUrl = buildTargetUrl(authFallbackBase, request, targetPath, options.upstreamPathPrefix);
+  const contentType = request.headers.get("content-type");
+  const requestBody = request.method !== "GET" && request.method !== "HEAD"
+    ? new Uint8Array(await request.arrayBuffer())
+    : null;
+
+  let upstream: Response | null = null;
+
+  try {
+    upstream = await fetchUpstream(request, primaryTargetUrl, contentType, requestBody);
+  } catch {
+    if (apiBase !== authFallbackBase) {
+      try {
+        upstream = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
+      } catch {}
+    }
+  }
+
+  if (!upstream) {
+    return buildUpstreamErrorResponse(502, "Upstream request failed.");
+  }
+
+  if (isEventStreamRequest(request) || isEventStreamResponse(upstream)) {
+    if (apiBase !== authFallbackBase && shouldFallbackToAuthBaseForStream(upstream, targetPath)) {
+      try {
+        upstream = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
+      } catch {}
+    }
+    return buildProxyResponse(request, upstream, options);
+  }
+
+  let body = await readUpstreamBody(upstream);
+
+  if (apiBase !== authFallbackBase && shouldFallbackToAuthBase(upstream, body, targetPath)) {
+    try {
+      upstream = await fetchUpstream(request, fallbackTargetUrl, contentType, requestBody);
+      body = await readUpstreamBody(upstream);
+    } catch {}
+  }
+
+  const responseContentType = upstream.headers.get("content-type")?.toLowerCase() ?? "";
+  if (upstream.status >= 500 && (responseContentType.includes("text/html") || isLikelyHtmlBody(body))) {
+    return buildUpstreamErrorResponse(upstream.status, "Upstream service unavailable.");
+  }
+
+  return buildProxyResponse(request, upstream, options, body);
 }


### PR DESCRIPTION
## Summary
- restore live assistant response streaming in OpenWork by handling `message.part.delta` events and preserving SSE passthrough in the web upstream proxy
- keep session views pinned to the true bottom while sending and thinking, and reduce render throttling so streaming content and status updates stay visible
- fix the latest/jump controls so `Jump to latest` only shows when needed and `Jump to start of message` targets the clipped active/latest message without flicker

## Testing
- pnpm --filter @different-ai/openwork-ui typecheck
- pnpm --filter @different-ai/openwork-ui build
- pnpm --filter @different-ai/openwork-web build