### PR TITLE
ci: streamline desktop release packaging

### DIFF
--- a/.github/actions/run-tauri-release-build/action.yml
+++ b/.github/actions/run-tauri-release-build/action.yml
@@ -1,0 +1,161 @@
+name: Run Tauri release build
+description: Run optional Windows GitHub network diagnostics, then build and upload a Tauri desktop release.
+
+inputs:
+  os-type:
+    description: Target operating system family.
+    required: true
+  notarize:
+    description: Whether to run the notarized macOS path.
+    required: true
+  release-tag:
+    description: GitHub release tag.
+    required: true
+  release-name:
+    description: GitHub release title.
+    required: true
+  release-body:
+    description: GitHub release notes body.
+    required: true
+  release-draft:
+    description: Whether the release should remain a draft.
+    required: true
+  prerelease:
+    description: Whether the release is marked as a prerelease.
+    required: true
+  args:
+    description: CLI args for `tauri build`.
+    required: true
+  project-path:
+    description: Tauri project path.
+    required: false
+    default: packages/desktop
+  tauri-script:
+    description: Command used to invoke Tauri.
+    required: false
+    default: pnpm exec tauri
+  retry-attempts:
+    description: Upload retry attempts.
+    required: false
+    default: "3"
+  upload-updater-json:
+    description: Whether to upload updater JSON from tauri-action.
+    required: false
+    default: "false"
+  updater-json-prefer-nsis:
+    description: Whether updater JSON should prefer NSIS artifacts.
+    required: false
+    default: "true"
+  release-asset-name-pattern:
+    description: Release asset naming pattern.
+    required: false
+    default: openwork-desktop-[platform]-[arch][ext]
+
+runs:
+  using: composite
+  steps:
+    - name: Diagnose Windows GitHub connectivity
+      if: ${{ inputs.os-type == 'windows' }}
+      shell: pwsh
+      run: |
+        $hosts = @(
+          "github.com",
+          "api.github.com",
+          "uploads.github.com",
+          "objects.githubusercontent.com"
+        )
+
+        $failed = $false
+
+        foreach ($host in $hosts) {
+          Write-Host "==> Resolving $host"
+          try {
+            Resolve-DnsName $host -ErrorAction Stop |
+              Select-Object Name, Type, IPAddress |
+              Format-Table -AutoSize |
+              Out-String -Width 200 |
+              Write-Host
+          } catch {
+            Write-Host "::error::DNS lookup failed for $host - $($_.Exception.Message)"
+            $failed = $true
+            continue
+          }
+
+          Write-Host "==> Testing TCP 443 to $host"
+          try {
+            $result = Test-NetConnection $host -Port 443 -WarningAction SilentlyContinue
+            $result |
+              Select-Object ComputerName, RemoteAddress, RemotePort, TcpTestSucceeded |
+              Format-Table -AutoSize |
+              Out-String -Width 200 |
+              Write-Host
+
+            if (-not $result.TcpTestSucceeded) {
+              Write-Host "::error::TCP connection failed for $host:443"
+              $failed = $true
+            }
+          } catch {
+            Write-Host "::error::Connectivity test failed for $host - $($_.Exception.Message)"
+            $failed = $true
+          }
+        }
+
+        if ($failed) {
+          throw "Windows runner cannot resolve or reach required GitHub hosts."
+        }
+
+    - name: Build and upload (notarized)
+      if: ${{ inputs.os-type == 'macos' && inputs.notarize == 'true' }}
+      uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
+      env:
+        CI: true
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
+        TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+        APPLE_CERTIFICATE: ${{ env.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ env.APPLE_CERTIFICATE_PASSWORD }}
+        APPLE_API_KEY: ${{ env.APPLE_API_KEY }}
+        APPLE_API_ISSUER: ${{ env.APPLE_API_ISSUER }}
+        APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+      with:
+        tagName: ${{ inputs.release-tag }}
+        releaseName: ${{ inputs.release-name }}
+        releaseBody: ${{ inputs.release-body }}
+        releaseDraft: ${{ inputs.release-draft }}
+        prerelease: ${{ inputs.prerelease }}
+        projectPath: ${{ inputs.project-path }}
+        tauriScript: ${{ inputs.tauri-script }}
+        args: ${{ inputs.args }}
+        retryAttempts: ${{ inputs.retry-attempts }}
+        uploadUpdaterJson: ${{ inputs.upload-updater-json }}
+        updaterJsonPreferNsis: ${{ inputs.updater-json-prefer-nsis }}
+        releaseAssetNamePattern: ${{ inputs.release-asset-name-pattern }}
+
+    - name: Build and upload
+      if: ${{ inputs.os-type != 'macos' || inputs.notarize != 'true' }}
+      uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
+      env:
+        CI: true
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        TAURI_SIGNING_PRIVATE_KEY: ${{ env.TAURI_SIGNING_PRIVATE_KEY }}
+        TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+        APPLE_CERTIFICATE: ${{ env.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ env.APPLE_CERTIFICATE_PASSWORD }}
+        APPLE_API_KEY: ${{ env.APPLE_API_KEY }}
+        APPLE_API_ISSUER: ${{ env.APPLE_API_ISSUER }}
+        APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
+      with:
+        tagName: ${{ inputs.release-tag }}
+        releaseName: ${{ inputs.release-name }}
+        releaseBody: ${{ inputs.release-body }}
+        releaseDraft: ${{ inputs.release-draft }}
+        prerelease: ${{ inputs.prerelease }}
+        projectPath: ${{ inputs.project-path }}
+        tauriScript: ${{ inputs.tauri-script }}
+        args: ${{ inputs.args }}
+        retryAttempts: ${{ inputs.retry-attempts }}
+        uploadUpdaterJson: ${{ inputs.upload-updater-json }}
+        updaterJsonPreferNsis: ${{ inputs.updater-json-prefer-nsis }}
+        releaseAssetNamePattern: ${{ inputs.release-asset-name-pattern }}

--- a/.github/actions/setup-desktop-build-env/action.yml
+++ b/.github/actions/setup-desktop-build-env/action.yml
@@ -1,0 +1,93 @@
+name: Setup desktop build environment
+description: Prepare Node, pnpm, Bun, Rust, and target-specific system dependencies for desktop release builds.
+
+inputs:
+  os-type:
+    description: Target operating system family.
+    required: true
+  rust-target:
+    description: Rust target triple for the desktop build.
+    required: true
+  node-version:
+    description: Node.js version to install.
+    required: false
+    default: "20"
+  pnpm-version:
+    description: pnpm version to install.
+    required: false
+    default: "10.27.0"
+  bun-version:
+    description: Bun version to install.
+    required: false
+    default: "1.3.6"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: Get pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      uses: actions/cache@v4
+      continue-on-error: true
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v1
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile --prefer-offline
+
+    - name: Install OpenTUI x64 core (macOS x86_64)
+      if: ${{ inputs.rust-target == 'x86_64-apple-darwin' }}
+      shell: bash
+      run: pnpm add -w --ignore-workspace-root-check @opentui/core-darwin-x64@0.1.77
+
+    - name: Install Linux build dependencies
+      if: ${{ inputs.os-type == 'linux' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libgtk-3-dev \
+          libglib2.0-dev \
+          libayatana-appindicator3-dev \
+          libsoup-3.0-dev \
+          libwebkit2gtk-4.1-dev \
+          libssl-dev \
+          lld \
+          rpm \
+          libdbus-1-dev \
+          librsvg2-dev
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ inputs.rust-target }}
+
+    - name: Cache cargo
+      uses: Swatinem/rust-cache@v2
+      continue-on-error: true
+      with:
+        key: ${{ inputs.rust-target }}
+        workspaces: |
+          packages/desktop/src-tauri -> target

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -84,6 +84,7 @@ jobs:
       RELEASE_NAME: ${{ needs.prepare-release.outputs.release_name }}
       RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}
       MACOS_NOTARIZE: ${{ vars.MACOS_NOTARIZE || 'false' }}
+      RUSTFLAGS: ${{ matrix.os_type == 'linux' && '-C link-arg=-fuse-ld=lld' || '' }}
       OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
       OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
 
@@ -101,15 +102,15 @@ jobs:
             args: "--target x86_64-apple-darwin --bundles dmg,app"
           - os_type: linux
             target: x86_64-unknown-linux-gnu
-            runs_on: blacksmith-4vcpu-ubuntu-2404
+            runs_on: blacksmith-16vcpu-ubuntu-2404
             args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
           - os_type: linux
             target: aarch64-unknown-linux-gnu
-            runs_on: blacksmith-4vcpu-ubuntu-2404-arm
+            runs_on: blacksmith-16vcpu-ubuntu-2404-arm
             args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
           - os_type: windows
             target: x86_64-pc-windows-msvc
-            runs_on: blacksmith-4vcpu-windows-2025
+            runs_on: blacksmith-16vcpu-windows-2025
             args: "--target x86_64-pc-windows-msvc --bundles msi"
 
     steps:
@@ -127,187 +128,21 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup desktop build environment
+        uses: ./.github/actions/setup-desktop-build-env
         with:
-          node-version: 20
+          os-type: ${{ matrix.os_type }}
+          rust-target: ${{ matrix.target }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: "1.3.6"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install OpenTUI x64 core (macOS x86_64)
-        if: matrix.os_type == 'macos' && matrix.target == 'x86_64-apple-darwin'
-        run: pnpm add -w --ignore-workspace-root-check @opentui/core-darwin-x64@0.1.77
-
-      - name: Install Linux build dependencies
-        if: matrix.os_type == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libgtk-3-dev \
-            libglib2.0-dev \
-            libayatana-appindicator3-dev \
-            libsoup-3.0-dev \
-            libwebkit2gtk-4.1-dev \
-            libssl-dev \
-            rpm \
-            libdbus-1-dev \
-            librsvg2-dev
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Resolve OpenCode version
-        id: opencode-version
-        shell: bash
+      - name: Install OpenCode sidecar
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+          TARGET: ${{ matrix.target }}
+          OS_TYPE: ${{ matrix.os_type }}
         run: |
-          node <<'NODE' >> "$GITHUB_OUTPUT"
-          const fs = require('fs');
-          const repo = (process.env.OPENCODE_GITHUB_REPO || 'anomalyco/opencode').trim() || 'anomalyco/opencode';
-
-          async function resolveLatest() {
-            const token = (process.env.GITHUB_TOKEN || '').trim();
-            const headers = {
-              'Accept': 'application/vnd.github+json',
-              'X-GitHub-Api-Version': '2022-11-28',
-              'User-Agent': 'openwork-ci',
-            };
-            if (token) headers.Authorization = `Bearer ${token}`;
-
-            // Prefer API, but fall back to the web "latest" redirect if rate-limited (403) or otherwise blocked.
-            try {
-              const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
-              if (res.ok) {
-                const data = await res.json();
-                const tag = (typeof data.tag_name === 'string' ? data.tag_name : '').trim();
-                let v = tag.startsWith('v') ? tag.slice(1) : tag;
-                v = v.trim();
-                if (v) return v;
-              }
-              if (res.status !== 403) {
-                throw new Error(`Failed to resolve latest OpenCode version (HTTP ${res.status})`);
-              }
-            } catch {
-              // continue to fallback
-            }
-
-            const web = await fetch(`https://github.com/${repo}/releases/latest`, {
-              headers: { 'User-Agent': 'openwork-ci' },
-              redirect: 'follow',
-            });
-            const url = (web && web.url) ? String(web.url) : '';
-            const match = url.match(/\/tag\/v([^/?#]+)/);
-            if (!match) throw new Error('Failed to resolve latest OpenCode version (web redirect).');
-            return match[1];
-          }
-
-          async function main() {
-            const pkg = JSON.parse(fs.readFileSync('./packages/desktop/package.json', 'utf8'));
-            const configuredRaw = (process.env.OPENCODE_VERSION || pkg.opencodeVersion || '').toString().trim();
-            if (configuredRaw && configuredRaw.toLowerCase() !== 'latest') {
-              const normalized = configuredRaw.startsWith('v') ? configuredRaw.slice(1) : configuredRaw;
-              const resolved = normalized.trim();
-              if (process.env.GITHUB_ENV) {
-                fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${resolved}\n`);
-              }
-              console.log('version=' + resolved);
-              return;
-            }
-            const latest = await resolveLatest();
-            if (process.env.GITHUB_ENV) {
-              fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${latest}\n`);
-            }
-            console.log('version=' + latest);
-          }
-
-          main().catch((err) => {
-            console.error(err);
-            process.exit(1);
-          });
-          NODE
-
-      - name: Download OpenCode sidecar
-        shell: bash
-        env:
-          OPENCODE_VERSION: ${{ steps.opencode-version.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          case "${{ matrix.target }}" in
-            aarch64-apple-darwin)
-              opencode_asset="opencode-darwin-arm64.zip"
-              ;;
-            x86_64-apple-darwin)
-              opencode_asset="opencode-darwin-x64-baseline.zip"
-              ;;
-            x86_64-unknown-linux-gnu)
-              opencode_asset="opencode-linux-x64-baseline.tar.gz"
-              ;;
-            aarch64-unknown-linux-gnu)
-              opencode_asset="opencode-linux-arm64.tar.gz"
-              ;;
-            x86_64-pc-windows-msvc)
-              opencode_asset="opencode-windows-x64-baseline.zip"
-              ;;
-            *)
-              echo "Unsupported target: ${{ matrix.target }}"
-              exit 1
-              ;;
-          esac
-
-          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
-          url="https://github.com/${repo}/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
-          tmp_dir="$RUNNER_TEMP/opencode"
-          extract_dir="$tmp_dir/extracted"
-          rm -rf "$tmp_dir"
-          mkdir -p "$extract_dir"
-          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o "$tmp_dir/$opencode_asset" "$url"
-
-          if [[ "$opencode_asset" == *.tar.gz ]]; then
-            tar -xzf "$tmp_dir/$opencode_asset" -C "$extract_dir"
-          else
-            if command -v unzip >/dev/null 2>&1; then
-              unzip -q "$tmp_dir/$opencode_asset" -d "$extract_dir"
-            elif command -v 7z >/dev/null 2>&1; then
-              7z x "$tmp_dir/$opencode_asset" -o"$extract_dir" >/dev/null
-            else
-              echo "No unzip utility available"
-              exit 1
-            fi
-          fi
-
-          if [ -f "$extract_dir/opencode" ]; then
-            bin_path="$extract_dir/opencode"
-          elif [ -f "$extract_dir/opencode.exe" ]; then
-            bin_path="$extract_dir/opencode.exe"
-          else
-            echo "OpenCode binary not found in archive"
-            ls -la "$extract_dir"
-            exit 1
-          fi
-
-          target_name="opencode-${{ matrix.target }}"
-          if [ "${{ matrix.os_type }}" = "windows" ]; then
-            target_name="${target_name}.exe"
-          fi
-
-          mkdir -p packages/desktop/src-tauri/sidecars
-          cp "$bin_path" "packages/desktop/src-tauri/sidecars/${target_name}"
-          chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
+          node scripts/release/install-opencode-sidecar.mjs
 
       - name: Write notary API key
         if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
@@ -322,59 +157,24 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build + upload (notarized)
-        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
-        uses: tauri-apps/tauri-action@v0.5.17
+      - name: Build + upload desktop artifacts
+        uses: ./.github/actions/run-tauri-release-build
         env:
-          CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # Tauri updater signing
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-
-          # macOS signing
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
-
-          # macOS notarization (App Store Connect API key)
           APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
           APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
         with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: ${{ env.RELEASE_NAME }}
-          releaseBody: ${{ env.RELEASE_BODY }}
+          os-type: ${{ matrix.os_type }}
+          notarize: ${{ matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true' }}
+          release-tag: ${{ env.RELEASE_TAG }}
+          release-name: ${{ env.RELEASE_NAME }}
+          release-body: ${{ env.RELEASE_BODY }}
+          release-draft: false
           prerelease: true
-          releaseDraft: false
-          projectPath: packages/desktop
-          tauriScript: pnpm exec tauri -vvv
           args: ${{ matrix.args }}
-          retryAttempts: 3
-
-      - name: Build + upload
-        if: matrix.os_type != 'macos' || env.MACOS_NOTARIZE != 'true'
-        uses: tauri-apps/tauri-action@v0.5.17
-        env:
-          CI: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # Tauri updater signing
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-
-          # macOS signing
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
-        with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: ${{ env.RELEASE_NAME }}
-          releaseBody: ${{ env.RELEASE_BODY }}
-          prerelease: true
-          releaseDraft: false
-          projectPath: packages/desktop
-          tauriScript: pnpm exec tauri -vvv
-          args: ${{ matrix.args }}
-          retryAttempts: 3

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -238,6 +238,7 @@ jobs:
       RELEASE_DRAFT: ${{ needs.resolve-release.outputs.draft }}
       RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
       MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
+      RUSTFLAGS: ${{ matrix.os_type == 'linux' && '-C link-arg=-fuse-ld=lld' || '' }}
       # Ensure Tauri's beforeBuildCommand (prepare:sidecar) uses our fork.
       OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
       OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
@@ -256,15 +257,15 @@ jobs:
             args: "--target x86_64-apple-darwin --bundles dmg,app"
           - os_type: linux
             target: x86_64-unknown-linux-gnu
-            runs_on: blacksmith-4vcpu-ubuntu-2404
+            runs_on: blacksmith-16vcpu-ubuntu-2404
             args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
           - os_type: linux
             target: aarch64-unknown-linux-gnu
-            runs_on: blacksmith-4vcpu-ubuntu-2404-arm
+            runs_on: blacksmith-16vcpu-ubuntu-2404-arm
             args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
           - os_type: windows
             target: x86_64-pc-windows-msvc
-            runs_on: blacksmith-4vcpu-windows-2025
+            runs_on: blacksmith-16vcpu-windows-2025
             args: "--target x86_64-pc-windows-msvc --bundles msi"
 
     steps:
@@ -288,216 +289,20 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup desktop build environment
+        uses: ./.github/actions/setup-desktop-build-env
         with:
-          node-version: 20
+          os-type: ${{ matrix.os_type }}
+          rust-target: ${{ matrix.target }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: "1.3.6"
-
-      - name: Get pnpm store path
-        id: pnpm-store
-        shell: bash
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        continue-on-error: true
-        with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        continue-on-error: true
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/desktop/src-tauri/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('packages/desktop/src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
-
-      - name: Install OpenTUI x64 core (macOS x86_64)
-        if: matrix.os_type == 'macos' && matrix.target == 'x86_64-apple-darwin'
-        run: pnpm add -w --ignore-workspace-root-check @opentui/core-darwin-x64@0.1.77
-
-      - name: Install Linux build dependencies
-        if: matrix.os_type == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libgtk-3-dev \
-            libglib2.0-dev \
-            libayatana-appindicator3-dev \
-            libsoup-3.0-dev \
-            libwebkit2gtk-4.1-dev \
-            libssl-dev \
-            rpm \
-            libdbus-1-dev \
-            librsvg2-dev
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Resolve OpenCode version
-        id: opencode-version
-        shell: bash
+      - name: Install OpenCode sidecar
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
           OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
-        run: |
-          node <<'NODE' >> "$GITHUB_OUTPUT"
-          const fs = require('fs');
-          const repo = (process.env.OPENCODE_GITHUB_REPO || 'anomalyco/opencode').trim() || 'anomalyco/opencode';
-
-          async function resolveLatest() {
-            const token = (process.env.GITHUB_TOKEN || '').trim();
-            const headers = {
-              'Accept': 'application/vnd.github+json',
-              'X-GitHub-Api-Version': '2022-11-28',
-              'User-Agent': 'openwork-ci',
-            };
-            if (token) headers.Authorization = `Bearer ${token}`;
-
-            // Prefer API, but fall back to the web "latest" redirect if rate-limited (403) or otherwise blocked.
-            try {
-              const res = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, { headers });
-              if (res.ok) {
-                const data = await res.json();
-                const tag = (typeof data.tag_name === 'string' ? data.tag_name : '').trim();
-                let v = tag.startsWith('v') ? tag.slice(1) : tag;
-                v = v.trim();
-                if (v) return v;
-              }
-              if (res.status !== 403) {
-                throw new Error(`Failed to resolve latest OpenCode version (HTTP ${res.status})`);
-              }
-            } catch {
-              // continue to fallback
-            }
-
-            const web = await fetch(`https://github.com/${repo}/releases/latest`, {
-              headers: { 'User-Agent': 'openwork-ci' },
-              redirect: 'follow',
-            });
-            const url = (web && web.url) ? String(web.url) : '';
-            const match = url.match(/\/tag\/v([^/?#]+)/);
-            if (!match) throw new Error('Failed to resolve latest OpenCode version (web redirect).');
-            return match[1];
-          }
-
-          async function main() {
-            const pkg = JSON.parse(fs.readFileSync('./packages/desktop/package.json', 'utf8'));
-            const configuredRaw = (process.env.OPENCODE_VERSION || pkg.opencodeVersion || '').toString().trim();
-            if (configuredRaw && configuredRaw.toLowerCase() !== 'latest') {
-              const normalized = configuredRaw.startsWith('v') ? configuredRaw.slice(1) : configuredRaw;
-              const resolved = normalized.trim();
-              if (process.env.GITHUB_ENV) {
-                fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${resolved}\n`);
-              }
-              console.log('version=' + resolved);
-              return;
-            }
-            const latest = await resolveLatest();
-            if (process.env.GITHUB_ENV) {
-              fs.appendFileSync(process.env.GITHUB_ENV, `OPENCODE_VERSION=${latest}\n`);
-            }
-            console.log('version=' + latest);
-          }
-
-          main().catch((err) => {
-            console.error(err);
-            process.exit(1);
-          });
-          NODE
-
-      - name: Download OpenCode sidecar
-        shell: bash
-        env:
-          OPENCODE_VERSION: ${{ steps.opencode-version.outputs.version }}
-          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
-        run: |
-          set -euo pipefail
-
-          case "${{ matrix.target }}" in
-            aarch64-apple-darwin)
-              opencode_asset="opencode-darwin-arm64.zip"
-              ;;
-            x86_64-apple-darwin)
-              opencode_asset="opencode-darwin-x64-baseline.zip"
-              ;;
-            x86_64-unknown-linux-gnu)
-              opencode_asset="opencode-linux-x64-baseline.tar.gz"
-              ;;
-            aarch64-unknown-linux-gnu)
-              opencode_asset="opencode-linux-arm64.tar.gz"
-              ;;
-            x86_64-pc-windows-msvc)
-              opencode_asset="opencode-windows-x64-baseline.zip"
-              ;;
-            *)
-              echo "Unsupported target: ${{ matrix.target }}" >&2
-              exit 1
-              ;;
-          esac
-
-          repo="${OPENCODE_GITHUB_REPO:-anomalyco/opencode}"
-          url="https://github.com/${repo}/releases/download/v${OPENCODE_VERSION}/${opencode_asset}"
-          tmp_dir="$RUNNER_TEMP/opencode"
-          extract_dir="$tmp_dir/extracted"
-          rm -rf "$tmp_dir"
-          mkdir -p "$extract_dir"
-          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o "$tmp_dir/$opencode_asset" "$url"
-
-          if [[ "$opencode_asset" == *.tar.gz ]]; then
-            tar -xzf "$tmp_dir/$opencode_asset" -C "$extract_dir"
-          else
-            if command -v unzip >/dev/null 2>&1; then
-              unzip -q "$tmp_dir/$opencode_asset" -d "$extract_dir"
-            elif command -v 7z >/dev/null 2>&1; then
-              7z x "$tmp_dir/$opencode_asset" -o"$extract_dir" >/dev/null
-            else
-              echo "No unzip utility available" >&2
-              exit 1
-            fi
-          fi
-
-          if [ -f "$extract_dir/opencode" ]; then
-            bin_path="$extract_dir/opencode"
-          elif [ -f "$extract_dir/opencode.exe" ]; then
-            bin_path="$extract_dir/opencode.exe"
-          else
-            echo "OpenCode binary not found in archive" >&2
-            ls -la "$extract_dir"
-            exit 1
-          fi
-
-          target_name="opencode-${{ matrix.target }}"
-          if [ "${{ matrix.os_type }}" = "windows" ]; then
-            target_name="${target_name}.exe"
-          fi
-
-          mkdir -p packages/desktop/src-tauri/sidecars
-          cp "$bin_path" "packages/desktop/src-tauri/sidecars/${target_name}"
-          chmod 755 "packages/desktop/src-tauri/sidecars/${target_name}"
+          TARGET: ${{ matrix.target }}
+          OS_TYPE: ${{ matrix.os_type }}
+        run: node scripts/release/install-opencode-sidecar.mjs
 
       - name: Write notary API key
         if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
@@ -512,65 +317,27 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build + upload (notarized)
-        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
-        uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
+      - name: Build + upload desktop artifacts
+        uses: ./.github/actions/run-tauri-release-build
         env:
-          CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # Tauri updater signing
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-
-          # macOS signing
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
-
-          # macOS notarization (App Store Connect API key)
           APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
           APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
         with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: ${{ env.RELEASE_NAME }}
-          releaseBody: ${{ env.RELEASE_BODY }}
-          releaseDraft: ${{ env.RELEASE_DRAFT == 'true' }}
+          os-type: ${{ matrix.os_type }}
+          notarize: ${{ matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true' }}
+          release-tag: ${{ env.RELEASE_TAG }}
+          release-name: ${{ env.RELEASE_NAME }}
+          release-body: ${{ env.RELEASE_BODY }}
+          release-draft: ${{ env.RELEASE_DRAFT == 'true' }}
           prerelease: ${{ env.RELEASE_PRERELEASE == 'true' }}
-          projectPath: packages/desktop
-          tauriScript: pnpm exec tauri -vvv
           args: ${{ matrix.args }}
-          retryAttempts: 3
-          uploadUpdaterJson: false
-          updaterJsonPreferNsis: true
-          releaseAssetNamePattern: openwork-desktop-[platform]-[arch][ext]
-
-      - name: Build + upload
-        if: matrix.os_type != 'macos' || env.MACOS_NOTARIZE != 'true'
-        uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
-        env:
-          CI: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # Tauri updater signing
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-
-          # macOS signing
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
-        with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: ${{ env.RELEASE_NAME }}
-          releaseBody: ${{ env.RELEASE_BODY }}
-          releaseDraft: ${{ env.RELEASE_DRAFT == 'true' }}
-          prerelease: ${{ env.RELEASE_PRERELEASE == 'true' }}
-          projectPath: packages/desktop
-          tauriScript: pnpm exec tauri -vvv
-          args: ${{ matrix.args }}
-          retryAttempts: 3
           uploadUpdaterJson: false
           updaterJsonPreferNsis: true
           releaseAssetNamePattern: openwork-desktop-[platform]-[arch][ext]

--- a/scripts/release/install-opencode-sidecar.mjs
+++ b/scripts/release/install-opencode-sidecar.mjs
@@ -1,0 +1,177 @@
+import { copyFile, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const TARGET_ASSETS = {
+  "aarch64-apple-darwin": "opencode-darwin-arm64.zip",
+  "x86_64-apple-darwin": "opencode-darwin-x64-baseline.zip",
+  "x86_64-unknown-linux-gnu": "opencode-linux-x64-baseline.tar.gz",
+  "aarch64-unknown-linux-gnu": "opencode-linux-arm64.tar.gz",
+  "x86_64-pc-windows-msvc": "opencode-windows-x64-baseline.zip",
+};
+
+function appendGithubEnv(name, value) {
+  if (!process.env.GITHUB_ENV) return;
+  const line = `${name}=${value}\n`;
+  return writeFile(process.env.GITHUB_ENV, line, { flag: "a" });
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function resolveLatest(repo, token) {
+  const apiHeaders = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "openwork-ci",
+  };
+
+  if (token) {
+    apiHeaders.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const apiResponse = await fetch(`https://api.github.com/repos/${repo}/releases/latest`, {
+      headers: apiHeaders,
+    });
+
+    if (apiResponse.ok) {
+      const payload = await apiResponse.json();
+      const tag = typeof payload.tag_name === "string" ? payload.tag_name.trim() : "";
+      const version = tag.startsWith("v") ? tag.slice(1).trim() : tag;
+      if (version) return version;
+    }
+  } catch {
+    // Fall through to the redirect-based resolution below.
+  }
+
+  const webResponse = await fetch(`https://github.com/${repo}/releases/latest`, {
+    headers: { "User-Agent": "openwork-ci" },
+    redirect: "follow",
+  });
+  const match = String(webResponse.url || "").match(/\/tag\/v([^/?#]+)/);
+  if (!match) {
+    fail(`Failed to resolve latest OpenCode version for ${repo}.`);
+  }
+  return match[1];
+}
+
+async function resolveVersion(repoRoot) {
+  const pkgPath = path.join(repoRoot, "packages/desktop/package.json");
+  const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
+  const configuredRaw = String(process.env.OPENCODE_VERSION || pkg.opencodeVersion || "").trim();
+
+  if (configuredRaw && configuredRaw.toLowerCase() !== "latest") {
+    return configuredRaw.startsWith("v") ? configuredRaw.slice(1).trim() : configuredRaw;
+  }
+
+  const repo = (process.env.OPENCODE_GITHUB_REPO || "anomalyco/opencode").trim() || "anomalyco/opencode";
+  const token = (process.env.GITHUB_TOKEN || "").trim();
+  return resolveLatest(repo, token);
+}
+
+async function downloadFile(url, destination, token) {
+  const headers = { "User-Agent": "openwork-ci" };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(url, { headers, redirect: "follow" });
+  if (!response.ok) {
+    fail(`Failed to download ${url} (HTTP ${response.status}).`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  await writeFile(destination, buffer);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    fail(`Command failed: ${command} ${args.join(" ")}`);
+  }
+}
+
+function hasCommand(command) {
+  const probe = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(probe, [command], { stdio: "ignore" });
+  return result.status === 0;
+}
+
+function findBinary(dir) {
+  const candidates = [path.join(dir, "opencode"), path.join(dir, "opencode.exe")];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const repoRoot = process.cwd();
+  const target = (process.env.TARGET || "").trim();
+  const osType = (process.env.OS_TYPE || "").trim();
+  const repo = (process.env.OPENCODE_GITHUB_REPO || "anomalyco/opencode").trim() || "anomalyco/opencode";
+  const token = (process.env.GITHUB_TOKEN || "").trim();
+  const asset = TARGET_ASSETS[target];
+
+  if (!asset) {
+    fail(`Unsupported target: ${target}`);
+  }
+
+  const version = await resolveVersion(repoRoot);
+  await appendGithubEnv("OPENCODE_VERSION", version);
+
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openwork-opencode-"));
+  const extractDir = path.join(tmpDir, "extracted");
+  const archivePath = path.join(tmpDir, asset);
+  const url = `https://github.com/${repo}/releases/download/v${version}/${asset}`;
+
+  try {
+    await mkdir(extractDir, { recursive: true });
+    console.log(`Resolving OpenCode ${version} for ${target}`);
+    await downloadFile(url, archivePath, token);
+
+    if (asset.endsWith(".tar.gz")) {
+      run("tar", ["-xzf", archivePath, "-C", extractDir]);
+    } else if (hasCommand("unzip")) {
+      run("unzip", ["-q", archivePath, "-d", extractDir]);
+    } else if (hasCommand("7z")) {
+      run("7z", ["x", archivePath, `-o${extractDir}`]);
+    } else {
+      fail("No archive extractor available (expected unzip or 7z).");
+    }
+
+    const binaryPath = findBinary(extractDir);
+    if (!binaryPath) {
+      fail(`OpenCode binary not found after extracting ${asset}.`);
+    }
+
+    const targetName = osType === "windows" ? `opencode-${target}.exe` : `opencode-${target}`;
+    const sidecarsDir = path.join(repoRoot, "packages/desktop/src-tauri/sidecars");
+    const destination = path.join(sidecarsDir, targetName);
+
+    await mkdir(sidecarsDir, { recursive: true });
+    await copyFile(binaryPath, destination);
+    if (osType !== "windows") {
+      await chmod(destination, 0o755);
+    }
+
+    console.log(`Installed OpenCode sidecar at ${destination}`);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- move the repeated desktop release setup and Tauri upload logic into shared GitHub composite actions while keeping the release matrix in `release-macos-aarch64.yml`
- speed Linux release builds by using 16 vCPU Blacksmith runners, `lld`, `Swatinem/rust-cache`, and `RUSTFLAGS=-C link-arg=-fuse-ld=lld`
- add a shared OpenCode sidecar installer and fail-fast Windows DNS diagnostics for GitHub hosts before Tauri bundling

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos-aarch64.yml"); YAML.load_file(".github/workflows/prerelease.yml"); YAML.load_file(".github/actions/setup-desktop-build-env/action.yml"); YAML.load_file(".github/actions/run-tauri-release-build/action.yml"); puts "workflow yaml ok"'
- node --check scripts/release/install-opencode-sidecar.mjs