### PR TITLE
ci: fix windows release diagnostics

### DIFF
--- a/.github/actions/run-tauri-release-build/action.yml
+++ b/.github/actions/run-tauri-release-build/action.yml
@@ -67,23 +67,23 @@ runs:
 
         $failed = $false
 
-        foreach ($host in $hosts) {
-          Write-Host "==> Resolving $host"
+        foreach ($githubHost in $hosts) {
+          Write-Host "==> Resolving $githubHost"
           try {
-            Resolve-DnsName $host -ErrorAction Stop |
+            Resolve-DnsName $githubHost -ErrorAction Stop |
               Select-Object Name, Type, IPAddress |
               Format-Table -AutoSize |
               Out-String -Width 200 |
               Write-Host
           } catch {
-            Write-Host "::error::DNS lookup failed for $host - $($_.Exception.Message)"
+            Write-Host "::error::DNS lookup failed for $githubHost - $($_.Exception.Message)"
             $failed = $true
             continue
           }
 
-          Write-Host "==> Testing TCP 443 to $host"
+          Write-Host "==> Testing TCP 443 to $githubHost"
           try {
-            $result = Test-NetConnection $host -Port 443 -WarningAction SilentlyContinue
+            $result = Test-NetConnection $githubHost -Port 443 -WarningAction SilentlyContinue
             $result |
               Select-Object ComputerName, RemoteAddress, RemotePort, TcpTestSucceeded |
               Format-Table -AutoSize |
@@ -91,11 +91,11 @@ runs:
               Write-Host
 
             if (-not $result.TcpTestSucceeded) {
-              Write-Host "::error::TCP connection failed for $host:443"
+              Write-Host "::error::TCP connection failed for $githubHost:443"
               $failed = $true
             }
           } catch {
-            Write-Host "::error::Connectivity test failed for $host - $($_.Exception.Message)"
+            Write-Host "::error::Connectivity test failed for $githubHost - $($_.Exception.Message)"
             $failed = $true
           }
         }

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -178,3 +178,6 @@ jobs:
           release-draft: false
           prerelease: true
           args: ${{ matrix.args }}
+          upload-updater-json: false
+          updater-json-prefer-nsis: true
+          release-asset-name-pattern: openwork-desktop-[platform]-[arch][ext]

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -338,9 +338,9 @@ jobs:
           release-draft: ${{ env.RELEASE_DRAFT == 'true' }}
           prerelease: ${{ env.RELEASE_PRERELEASE == 'true' }}
           args: ${{ matrix.args }}
-          uploadUpdaterJson: false
-          updaterJsonPreferNsis: true
-          releaseAssetNamePattern: openwork-desktop-[platform]-[arch][ext]
+          upload-updater-json: false
+          updater-json-prefer-nsis: true
+          release-asset-name-pattern: openwork-desktop-[platform]-[arch][ext]
 
       - name: Verify versions.json bundled (macOS)
         if: success() && matrix.os_type == 'macos'


### PR DESCRIPTION
## Summary
- fix the shared Tauri release composite action so the Windows DNS check no longer crashes on PowerShell's built-in `$Host` variable
- pass the release composite action's kebab-case inputs from both release workflows so the Windows and prerelease jobs use the intended asset upload settings
- keep the release and prerelease workflows aligned after the earlier release packaging cleanup

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos-aarch64.yml"); YAML.load_file(".github/workflows/prerelease.yml"); YAML.load_file(".github/actions/run-tauri-release-build/action.yml"); puts "workflow yaml ok"'