### PR TITLE
ci: split desktop release packaging

### DIFF
--- a/.github/actions/run-tauri-release-build/action.yml
+++ b/.github/actions/run-tauri-release-build/action.yml
@@ -1,5 +1,5 @@
-name: Run Tauri release build
-description: Run optional Windows GitHub network diagnostics, then build and upload a Tauri desktop release.
+name: Build Tauri workflow artifacts
+description: Run optional Windows GitHub network diagnostics, then build Tauri desktop bundles as workflow artifacts.
 
 inputs:
   os-type:
@@ -7,21 +7,6 @@ inputs:
     required: true
   notarize:
     description: Whether to run the notarized macOS path.
-    required: true
-  release-tag:
-    description: GitHub release tag.
-    required: true
-  release-name:
-    description: GitHub release title.
-    required: true
-  release-body:
-    description: GitHub release notes body.
-    required: true
-  release-draft:
-    description: Whether the release should remain a draft.
-    required: true
-  prerelease:
-    description: Whether the release is marked as a prerelease.
     required: true
   args:
     description: CLI args for `tauri build`.
@@ -50,6 +35,10 @@ inputs:
     description: Release asset naming pattern.
     required: false
     default: openwork-desktop-[platform]-[arch][ext]
+  workflow-artifact-name-pattern:
+    description: Workflow artifact naming pattern.
+    required: false
+    default: desktop-release-[platform]-[arch]-[bundle]
 
 runs:
   using: composite
@@ -104,7 +93,7 @@ runs:
           throw "Windows runner cannot resolve or reach required GitHub hosts."
         }
 
-    - name: Build and upload (notarized)
+    - name: Build notarized workflow artifacts
       if: ${{ inputs.os-type == 'macos' && inputs.notarize == 'true' }}
       uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
       env:
@@ -119,20 +108,16 @@ runs:
         APPLE_API_ISSUER: ${{ env.APPLE_API_ISSUER }}
         APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
       with:
-        tagName: ${{ inputs.release-tag }}
-        releaseName: ${{ inputs.release-name }}
-        releaseBody: ${{ inputs.release-body }}
-        releaseDraft: ${{ inputs.release-draft }}
-        prerelease: ${{ inputs.prerelease }}
         projectPath: ${{ inputs.project-path }}
         tauriScript: ${{ inputs.tauri-script }}
         args: ${{ inputs.args }}
         retryAttempts: ${{ inputs.retry-attempts }}
         uploadUpdaterJson: ${{ inputs.upload-updater-json }}
         updaterJsonPreferNsis: ${{ inputs.updater-json-prefer-nsis }}
-        releaseAssetNamePattern: ${{ inputs.release-asset-name-pattern }}
+        uploadWorkflowArtifacts: true
+        workflowArtifactNamePattern: ${{ inputs.workflow-artifact-name-pattern }}
 
-    - name: Build and upload
+    - name: Build workflow artifacts
       if: ${{ inputs.os-type != 'macos' || inputs.notarize != 'true' }}
       uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
       env:
@@ -147,15 +132,11 @@ runs:
         APPLE_API_ISSUER: ${{ env.APPLE_API_ISSUER }}
         APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
       with:
-        tagName: ${{ inputs.release-tag }}
-        releaseName: ${{ inputs.release-name }}
-        releaseBody: ${{ inputs.release-body }}
-        releaseDraft: ${{ inputs.release-draft }}
-        prerelease: ${{ inputs.prerelease }}
         projectPath: ${{ inputs.project-path }}
         tauriScript: ${{ inputs.tauri-script }}
         args: ${{ inputs.args }}
         retryAttempts: ${{ inputs.retry-attempts }}
         uploadUpdaterJson: ${{ inputs.upload-updater-json }}
         updaterJsonPreferNsis: ${{ inputs.updater-json-prefer-nsis }}
-        releaseAssetNamePattern: ${{ inputs.release-asset-name-pattern }}
+        uploadWorkflowArtifacts: true
+        workflowArtifactNamePattern: ${{ inputs.workflow-artifact-name-pattern }}

--- a/.github/actions/setup-desktop-build-env/action.yml
+++ b/.github/actions/setup-desktop-build-env/action.yml
@@ -29,6 +29,15 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Configure build parallelism
+      shell: bash
+      run: |
+        jobs="$(node -e 'const os = require("node:os"); process.stdout.write(String(os.availableParallelism ? os.availableParallelism() : os.cpus().length));')"
+        {
+          echo "CARGO_BUILD_JOBS=${jobs}"
+          echo "CMAKE_BUILD_PARALLEL_LEVEL=${jobs}"
+        } >> "$GITHUB_ENV"
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,16 +73,13 @@ jobs:
             --prerelease
 
   publish-tauri:
-    name: Build + Publish (${{ matrix.target }})
+    name: Build + Package (${{ matrix.target }})
     needs: prepare-release
     # Use explicit per-target runner labels so each release build can scale independently.
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 360
 
     env:
-      RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
-      RELEASE_NAME: ${{ needs.prepare-release.outputs.release_name }}
-      RELEASE_BODY: ${{ needs.prepare-release.outputs.release_body }}
       MACOS_NOTARIZE: ${{ vars.MACOS_NOTARIZE || 'false' }}
       RUSTFLAGS: ${{ matrix.os_type == 'linux' && '-C link-arg=-fuse-ld=lld' || '' }}
       OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
@@ -104,10 +101,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             runs_on: blacksmith-16vcpu-ubuntu-2404
             args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
-          - os_type: linux
-            target: aarch64-unknown-linux-gnu
-            runs_on: blacksmith-16vcpu-ubuntu-2404-arm
-            args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
           - os_type: windows
             target: x86_64-pc-windows-msvc
             runs_on: blacksmith-16vcpu-windows-2025
@@ -157,7 +150,7 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build + upload desktop artifacts
+      - name: Build desktop workflow artifacts
         uses: ./.github/actions/run-tauri-release-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,12 +165,166 @@ jobs:
         with:
           os-type: ${{ matrix.os_type }}
           notarize: ${{ matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true' }}
-          release-tag: ${{ env.RELEASE_TAG }}
-          release-name: ${{ env.RELEASE_NAME }}
-          release-body: ${{ env.RELEASE_BODY }}
-          release-draft: false
-          prerelease: true
           args: ${{ matrix.args }}
           upload-updater-json: false
           updater-json-prefer-nsis: true
-          release-asset-name-pattern: openwork-desktop-[platform]-[arch][ext]
+          workflow-artifact-name-pattern: desktop-release-[platform]-[arch]-[bundle]
+
+      - name: Verify versions.json bundled (macOS)
+        if: success() && matrix.os_type == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_path="packages/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos/OpenWork.app"
+          manifest_path="$app_path/Contents/MacOS/versions.json"
+
+          if [ ! -f "$manifest_path" ]; then
+            echo "ERROR: versions.json missing from app bundle: $manifest_path" >&2
+            echo "Hint: ensure packages/desktop/src-tauri/tauri.conf.json bundles sidecars/versions.json" >&2
+            exit 1
+          fi
+
+          echo "Found bundled versions.json at $manifest_path"
+
+  build-tauri-linux-arm64:
+    name: Build ARM64 Linux binary
+    needs: prepare-release
+    runs-on: blacksmith-16vcpu-ubuntu-2404-arm
+    timeout-minutes: 360
+
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+      OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+
+    steps:
+      - name: Log runner selection
+        shell: bash
+        run: |
+          echo "Configured runs-on: blacksmith-16vcpu-ubuntu-2404-arm"
+          echo "Build target: aarch64-unknown-linux-gnu"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup desktop build environment
+        uses: ./.github/actions/setup-desktop-build-env
+        with:
+          os-type: linux
+          rust-target: aarch64-unknown-linux-gnu
+
+      - name: Install OpenCode sidecar
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+          TARGET: aarch64-unknown-linux-gnu
+          OS_TYPE: linux
+        run: node scripts/release/install-opencode-sidecar.mjs
+
+      - name: Build ARM64 binary without bundling
+        run: pnpm --dir packages/desktop exec tauri build --target aarch64-unknown-linux-gnu --no-bundle
+
+      - name: Upload ARM64 target directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-build-linux-arm64-target-dir
+          path: packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu
+          if-no-files-found: error
+
+  bundle-tauri-linux-arm64:
+    name: Bundle ARM64 Linux packages
+    needs: [prepare-release, build-tauri-linux-arm64]
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 360
+
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+      OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+
+    steps:
+      - name: Log runner selection
+        shell: bash
+        run: |
+          echo "Configured runs-on: blacksmith-16vcpu-ubuntu-2404"
+          echo "Bundle target: aarch64-unknown-linux-gnu"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup desktop build environment
+        uses: ./.github/actions/setup-desktop-build-env
+        with:
+          os-type: linux
+          rust-target: aarch64-unknown-linux-gnu
+
+      - name: Install OpenCode sidecar
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+          TARGET: aarch64-unknown-linux-gnu
+          OS_TYPE: linux
+        run: node scripts/release/install-opencode-sidecar.mjs
+
+      - name: Restore ARM64 target directory
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-build-linux-arm64-target-dir
+          path: packages/desktop/src-tauri/target
+
+      - name: Bundle ARM64 Linux packages on x86 runner
+        run: pnpm --dir packages/desktop exec tauri bundle --target aarch64-unknown-linux-gnu --bundles deb,rpm
+
+      - name: Upload ARM64 deb workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-release-linux-arm64-deb
+          path: |
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/deb/*.deb
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/deb/*.deb.sig
+          if-no-files-found: error
+
+      - name: Upload ARM64 rpm workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-release-linux-aarch64-rpm
+          path: |
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/rpm/*.rpm
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/rpm/*.rpm.sig
+          if-no-files-found: error
+
+  upload-tauri-release-assets:
+    name: Upload desktop release assets
+    needs: [prepare-release, publish-tauri, bundle-tauri-linux-arm64]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    env:
+      RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Download desktop workflow artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-release-*
+          path: ${{ runner.temp }}/desktop-release-artifacts
+
+      - name: Upload desktop assets to prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/release/upload-desktop-release-assets.mjs \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --artifacts-dir "$RUNNER_TEMP/desktop-release-artifacts"

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -225,18 +225,13 @@ jobs:
         run: node scripts/release/review.mjs --strict
 
   publish-tauri:
-    name: Build + Publish (${{ matrix.target }})
+    name: Build + Package (${{ matrix.target }})
     needs: [resolve-release, verify-release]
     if: needs.resolve-release.outputs.build_tauri == 'true'
     # Use explicit per-target runner labels so each release build can scale independently.
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 360
     env:
-      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
-      RELEASE_NAME: ${{ needs.resolve-release.outputs.release_name }}
-      RELEASE_BODY: ${{ needs.resolve-release.outputs.release_body }}
-      RELEASE_DRAFT: ${{ needs.resolve-release.outputs.draft }}
-      RELEASE_PRERELEASE: ${{ needs.resolve-release.outputs.prerelease }}
       MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
       RUSTFLAGS: ${{ matrix.os_type == 'linux' && '-C link-arg=-fuse-ld=lld' || '' }}
       # Ensure Tauri's beforeBuildCommand (prepare:sidecar) uses our fork.
@@ -259,10 +254,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             runs_on: blacksmith-16vcpu-ubuntu-2404
             args: "--target x86_64-unknown-linux-gnu --bundles deb,rpm"
-          - os_type: linux
-            target: aarch64-unknown-linux-gnu
-            runs_on: blacksmith-16vcpu-ubuntu-2404-arm
-            args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
           - os_type: windows
             target: x86_64-pc-windows-msvc
             runs_on: blacksmith-16vcpu-windows-2025
@@ -286,7 +277,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.resolve-release.outputs.release_tag }}
           fetch-depth: 0
 
       - name: Setup desktop build environment
@@ -317,7 +308,7 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build + upload desktop artifacts
+      - name: Build desktop workflow artifacts
         uses: ./.github/actions/run-tauri-release-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -332,49 +323,17 @@ jobs:
         with:
           os-type: ${{ matrix.os_type }}
           notarize: ${{ matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true' }}
-          release-tag: ${{ env.RELEASE_TAG }}
-          release-name: ${{ env.RELEASE_NAME }}
-          release-body: ${{ env.RELEASE_BODY }}
-          release-draft: ${{ env.RELEASE_DRAFT == 'true' }}
-          prerelease: ${{ env.RELEASE_PRERELEASE == 'true' }}
           args: ${{ matrix.args }}
           upload-updater-json: false
           updater-json-prefer-nsis: true
-          release-asset-name-pattern: openwork-desktop-[platform]-[arch][ext]
+          workflow-artifact-name-pattern: desktop-release-[platform]-[arch]-[bundle]
 
       - name: Verify versions.json bundled (macOS)
         if: success() && matrix.os_type == 'macos'
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          case "${{ matrix.target }}" in
-            aarch64-apple-darwin)
-              asset_arch="aarch64"
-              ;;
-            x86_64-apple-darwin)
-              asset_arch="x64"
-              ;;
-            *)
-              echo "Unexpected target for macOS verify: ${{ matrix.target }}" >&2
-              exit 1
-              ;;
-          esac
-
-          tmp_dir="$RUNNER_TEMP/openwork-bundle-verify"
-          rm -rf "$tmp_dir"
-          mkdir -p "$tmp_dir"
-
-          gh release download "${RELEASE_TAG}" \
-            --repo "$GITHUB_REPOSITORY" \
-            --pattern "openwork-desktop-darwin-${asset_arch}.app.tar.gz" \
-            --dir "$tmp_dir"
-
-          tar -xzf "$tmp_dir/openwork-desktop-darwin-${asset_arch}.app.tar.gz" -C "$tmp_dir"
-
-          app_path="$tmp_dir/OpenWork.app"
+          app_path="packages/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/macos/OpenWork.app"
           manifest_path="$app_path/Contents/MacOS/versions.json"
 
           if [ ! -f "$manifest_path" ]; then
@@ -385,9 +344,152 @@ jobs:
 
           echo "Found bundled versions.json at $manifest_path"
 
+  build-tauri-linux-arm64:
+    name: Build ARM64 Linux binary
+    needs: [resolve-release, verify-release]
+    if: needs.resolve-release.outputs.build_tauri == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404-arm
+    timeout-minutes: 360
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+      OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+    steps:
+      - name: Log runner selection
+        shell: bash
+        run: |
+          echo "Configured runs-on: blacksmith-16vcpu-ubuntu-2404-arm"
+          echo "Build target: aarch64-unknown-linux-gnu"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-release.outputs.release_tag }}
+          fetch-depth: 0
+
+      - name: Setup desktop build environment
+        uses: ./.github/actions/setup-desktop-build-env
+        with:
+          os-type: linux
+          rust-target: aarch64-unknown-linux-gnu
+
+      - name: Install OpenCode sidecar
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+          TARGET: aarch64-unknown-linux-gnu
+          OS_TYPE: linux
+        run: node scripts/release/install-opencode-sidecar.mjs
+
+      - name: Build ARM64 binary without bundling
+        run: pnpm --dir packages/desktop exec tauri build --target aarch64-unknown-linux-gnu --no-bundle
+
+      - name: Upload ARM64 target directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-build-linux-arm64-target-dir
+          path: packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu
+          if-no-files-found: error
+
+  bundle-tauri-linux-arm64:
+    name: Bundle ARM64 Linux packages
+    needs: [resolve-release, verify-release, build-tauri-linux-arm64]
+    if: needs.resolve-release.outputs.build_tauri == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 360
+    env:
+      RUSTFLAGS: -C link-arg=-fuse-ld=lld
+      OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+      OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+    steps:
+      - name: Log runner selection
+        shell: bash
+        run: |
+          echo "Configured runs-on: blacksmith-16vcpu-ubuntu-2404"
+          echo "Bundle target: aarch64-unknown-linux-gnu"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-release.outputs.release_tag }}
+          fetch-depth: 0
+
+      - name: Setup desktop build environment
+        uses: ./.github/actions/setup-desktop-build-env
+        with:
+          os-type: linux
+          rust-target: aarch64-unknown-linux-gnu
+
+      - name: Install OpenCode sidecar
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OPENCODE_GITHUB_REPO: ${{ vars.OPENCODE_GITHUB_REPO || 'anomalyco/opencode' }}
+          OPENCODE_VERSION: ${{ vars.OPENCODE_VERSION || '1.2.20' }}
+          TARGET: aarch64-unknown-linux-gnu
+          OS_TYPE: linux
+        run: node scripts/release/install-opencode-sidecar.mjs
+
+      - name: Restore ARM64 target directory
+        uses: actions/download-artifact@v4
+        with:
+          name: desktop-build-linux-arm64-target-dir
+          path: packages/desktop/src-tauri/target
+
+      - name: Bundle ARM64 Linux packages on x86 runner
+        run: pnpm --dir packages/desktop exec tauri bundle --target aarch64-unknown-linux-gnu --bundles deb,rpm
+
+      - name: Upload ARM64 deb workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-release-linux-arm64-deb
+          path: |
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/deb/*.deb
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/deb/*.deb.sig
+          if-no-files-found: error
+
+      - name: Upload ARM64 rpm workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-release-linux-aarch64-rpm
+          path: |
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/rpm/*.rpm
+            packages/desktop/src-tauri/target/aarch64-unknown-linux-gnu/release/bundle/rpm/*.rpm.sig
+          if-no-files-found: error
+
+  upload-tauri-release-assets:
+    name: Upload desktop release assets
+    needs: [resolve-release, verify-release, publish-tauri, bundle-tauri-linux-arm64]
+    if: needs.resolve-release.outputs.build_tauri == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Download desktop workflow artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-release-*
+          path: ${{ runner.temp }}/desktop-release-artifacts
+
+      - name: Upload desktop assets to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/release/upload-desktop-release-assets.mjs \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag "$RELEASE_TAG" \
+            --artifacts-dir "$RUNNER_TEMP/desktop-release-artifacts"
+
   publish-updater-json:
     name: Publish consolidated latest.json
-    needs: [resolve-release, verify-release, publish-tauri]
+    needs: [resolve-release, verify-release, upload-tauri-release-assets]
     if: needs.resolve-release.outputs.build_tauri == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ panic = "abort"
 codegen-units = 1
 lto = true
 opt-level = "s"
-strip = true
+strip = false
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-process = "2.3.1"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -24,6 +24,14 @@
   },
   "bundle": {
     "createUpdaterArtifacts": true,
+    "linux": {
+      "rpm": {
+        "compression": {
+          "type": "gzip",
+          "level": 1
+        }
+      }
+    },
     "macOS": {
       "entitlements": "./entitlements.plist"
     },

--- a/scripts/release/upload-desktop-release-assets.mjs
+++ b/scripts/release/upload-desktop-release-assets.mjs
@@ -1,0 +1,123 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const EXTENSIONS = {
+  app: ".app.tar.gz",
+  deb: ".deb",
+  dmg: ".dmg",
+  msi: ".msi",
+  rpm: ".rpm",
+};
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    ...options,
+  });
+
+  if (result.status !== 0) {
+    fail(`Command failed: ${command} ${args.join(" ")}`);
+  }
+}
+
+async function listFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function parseArgs(argv) {
+  const args = { repo: process.env.GITHUB_REPOSITORY || "", tag: "", artifactsDir: "" };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if (arg === "--repo") {
+      args.repo = next;
+      i += 1;
+    } else if (arg === "--tag") {
+      args.tag = next;
+      i += 1;
+    } else if (arg === "--artifacts-dir") {
+      args.artifactsDir = next;
+      i += 1;
+    }
+  }
+
+  if (!args.repo) fail("Missing --repo.");
+  if (!args.tag) fail("Missing --tag.");
+  if (!args.artifactsDir) fail("Missing --artifacts-dir.");
+
+  return args;
+}
+
+function parseArtifactName(name) {
+  const prefix = "desktop-release-";
+  if (!name.startsWith(prefix)) return null;
+
+  const parts = name.slice(prefix.length).split("-");
+  if (parts.length < 3) return null;
+
+  const bundle = parts.at(-1);
+  const platform = parts[0];
+  const arch = parts.slice(1, -1).join("-");
+
+  if (!platform || !arch || !(bundle in EXTENSIONS)) return null;
+
+  return { platform, arch, bundle };
+}
+
+async function main() {
+  const { repo, tag, artifactsDir } = parseArgs(process.argv.slice(2));
+  const artifactDirs = await readdir(artifactsDir, { withFileTypes: true });
+
+  for (const artifactDir of artifactDirs) {
+    if (!artifactDir.isDirectory()) continue;
+
+    const parsed = parseArtifactName(artifactDir.name);
+    if (!parsed) continue;
+
+    const bundleExt = EXTENSIONS[parsed.bundle];
+    if (!bundleExt) {
+      fail(`Unsupported bundle type in artifact name: ${artifactDir.name}`);
+    }
+
+    const fullDir = path.join(artifactsDir, artifactDir.name);
+    const files = await listFiles(fullDir);
+    const primaryFile = files.find((file) => file.endsWith(bundleExt));
+
+    if (!primaryFile) {
+      fail(`Missing ${bundleExt} file in ${artifactDir.name}`);
+    }
+
+    const signatureFile = files.find((file) => file === `${primaryFile}.sig` || file.endsWith(`${bundleExt}.sig`));
+    const releaseName = `openwork-desktop-${parsed.platform}-${parsed.arch}${bundleExt}`;
+
+    run("gh", ["release", "upload", tag, `${primaryFile}#${releaseName}`, "--repo", repo, "--clobber"]);
+
+    if (signatureFile) {
+      run("gh", ["release", "upload", tag, `${signatureFile}#${releaseName}.sig`, "--repo", repo, "--clobber"]);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- stop uploading desktop release assets from each platform runner and instead build workflow artifacts first, then upload them in a single downstream release job
- split Linux arm64 desktop packaging into an ARM build job plus an x86 Linux bundling job so the slow upload and packaging tail no longer blocks on the ARM runner
- fix the Tauri updater bundle warning by disabling release stripping, lower Linux RPM compression to gzip level 1, and make build parallelism explicit from available CPU count

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos-aarch64.yml"); YAML.load_file(".github/workflows/prerelease.yml"); YAML.load_file(".github/actions/run-tauri-release-build/action.yml"); YAML.load_file(".github/actions/setup-desktop-build-env/action.yml"); puts "workflow yaml ok"'
- node --check scripts/release/upload-desktop-release-assets.mjs

## Notes
- this has not been exercised end-to-end in GitHub Actions yet; the highest-risk path is restoring the ARM64 target directory on x86 Linux and running `tauri bundle` there