### PR TITLE
fix(session): move actions into the selected row

### DIFF
--- a/packages/app/src/app/components/session/workspace-session-list.tsx
+++ b/packages/app/src/app/components/session/workspace-session-list.tsx
@@ -9,6 +9,7 @@ type Props = {
   workspaceSessionGroups: WorkspaceSessionGroup[];
   activeWorkspaceId: string;
   selectedSessionId: string | null;
+  showSessionActions?: boolean;
   sessionStatusById?: Record<string, string>;
   connectingWorkspaceId: string | null;
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
@@ -17,6 +18,8 @@ type Props = {
   onActivateWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string) => void;
+  onOpenRenameSession?: () => void;
+  onOpenDeleteSession?: () => void;
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;
   onRevealWorkspace: (workspaceId: string) => void;
@@ -66,8 +69,10 @@ export default function WorkspaceSessionList(props: Props) {
   const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = createSignal<Record<string, number>>({});
   const [workspaceMenuId, setWorkspaceMenuId] = createSignal<string | null>(null);
   const [addWorkspaceMenuOpen, setAddWorkspaceMenuOpen] = createSignal(false);
+  const [sessionMenuOpen, setSessionMenuOpen] = createSignal(false);
   let workspaceMenuRef: HTMLDivElement | undefined;
   let addWorkspaceMenuRef: HTMLDivElement | undefined;
+  let sessionMenuRef: HTMLDivElement | undefined;
 
   const isWorkspaceExpanded = (workspaceId: string) => expandedWorkspaceIds().has(workspaceId);
 
@@ -152,6 +157,124 @@ export default function WorkspaceSessionList(props: Props) {
     window.addEventListener("pointerdown", closeMenu);
     onCleanup(() => window.removeEventListener("pointerdown", closeMenu));
   });
+
+  createEffect(() => {
+    props.selectedSessionId;
+    setSessionMenuOpen(false);
+  });
+
+  createEffect(() => {
+    if (!sessionMenuOpen()) return;
+    const closeMenu = (event: PointerEvent) => {
+      if (!sessionMenuRef) return;
+      const target = event.target as Node | null;
+      if (target && sessionMenuRef.contains(target)) return;
+      setSessionMenuOpen(false);
+    };
+    window.addEventListener("pointerdown", closeMenu);
+    onCleanup(() => window.removeEventListener("pointerdown", closeMenu));
+  });
+
+  const renderSessionRow = (workspaceId: string, session: WorkspaceSessionGroup["sessions"][number]) => {
+    const isSelected = () => props.selectedSessionId === session.id;
+    const isSessionActive = () => (props.sessionStatusById?.[session.id] ?? "idle") !== "idle";
+    const canManageSession = () =>
+      Boolean(
+        props.showSessionActions &&
+          isSelected() &&
+          (props.onOpenRenameSession || props.onOpenDeleteSession),
+      );
+
+    const openSession = () => {
+      setSessionMenuOpen(false);
+      props.onOpenSession(workspaceId, session.id);
+    };
+
+    return (
+      <div class="relative">
+        <div
+          role="button"
+          tabIndex={0}
+          class={`group flex min-h-10 w-full items-center justify-between rounded-[15px] border px-3 py-2.5 transition-[background-color,border-color,box-shadow] ${
+            isSelected()
+              ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
+              : "border-transparent text-gray-11 hover:bg-gray-2/60"
+          }`}
+          onClick={openSession}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" && event.key !== " ") return;
+            if (event.isComposing || event.keyCode === 229) return;
+            event.preventDefault();
+            openSession();
+          }}
+        >
+          <div class="mr-2.5 flex min-w-0 items-center gap-2">
+            <Show when={isSessionActive()}>
+              <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" />
+            </Show>
+            <span class="truncate text-[13px] font-normal text-current">{session.title}</span>
+          </div>
+
+          <div class="ml-auto flex shrink-0 items-center gap-1">
+            <Show when={session.time?.updated}>
+              <span class="whitespace-nowrap text-[11px] text-gray-9 transition-colors group-hover:text-gray-10">
+                {formatRelativeTime(session.time?.updated ?? Date.now())}
+              </span>
+            </Show>
+
+            <Show when={canManageSession()}>
+              <button
+                type="button"
+                class="flex h-7 w-7 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
+                aria-label="Session actions"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setSessionMenuOpen((current) => !current);
+                }}
+              >
+                <MoreHorizontal size={14} />
+              </button>
+            </Show>
+          </div>
+        </div>
+
+        <Show when={canManageSession() && sessionMenuOpen()}>
+          <div
+            ref={(el) => (sessionMenuRef = el)}
+            class="absolute right-0 top-[calc(100%+6px)] z-20 w-48 rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Show when={props.onOpenRenameSession}>
+              <button
+                type="button"
+                class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                onClick={() => {
+                  setSessionMenuOpen(false);
+                  props.onOpenRenameSession?.();
+                }}
+              >
+                Rename session
+              </button>
+            </Show>
+
+            <Show when={props.onOpenDeleteSession}>
+              <button
+                type="button"
+                class="w-full rounded-xl px-3 py-2 text-left text-sm text-red-11 transition-colors hover:bg-red-1/40"
+                onClick={() => {
+                  setSessionMenuOpen(false);
+                  props.onOpenDeleteSession?.();
+                }}
+              >
+                Delete session
+              </button>
+            </Show>
+          </div>
+        </Show>
+      </div>
+    );
+  };
 
   return (
     <>
@@ -363,40 +486,7 @@ export default function WorkspaceSessionList(props: Props) {
                     fallback={
                       <Show when={group.sessions.length > 0}>
                         <For each={previewSessions(workspace().id, group.sessions)}>
-                          {(session) => {
-                            const isSelected = () => props.selectedSessionId === session.id;
-                            const isSessionActive = () => (props.sessionStatusById?.[session.id] ?? "idle") !== "idle";
-                            return (
-                              <div
-                                role="button"
-                                tabIndex={0}
-                                class={`group flex min-h-10 w-full items-center justify-between rounded-[15px] border px-3 py-2.5 transition-[background-color,border-color,box-shadow] ${
-                                  isSelected()
-                                    ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
-                                    : "border-transparent text-gray-11 hover:bg-gray-2/60"
-                                }`}
-                                onClick={() => props.onOpenSession(workspace().id, session.id)}
-                                onKeyDown={(event) => {
-                                  if (event.key !== "Enter" && event.key !== " ") return;
-                                  if (event.isComposing || event.keyCode === 229) return;
-                                  event.preventDefault();
-                                  props.onOpenSession(workspace().id, session.id);
-                                }}
-                              >
-                                <div class="mr-2.5 flex min-w-0 items-center gap-2">
-                                  <Show when={isSessionActive()}>
-                                    <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" />
-                                  </Show>
-                                  <span class="truncate text-[13px] font-normal text-current">{session.title}</span>
-                                </div>
-                                <Show when={session.time?.updated}>
-                                  <span class="whitespace-nowrap text-[11px] text-gray-9 transition-colors group-hover:text-gray-10">
-                                    {formatRelativeTime(session.time?.updated ?? Date.now())}
-                                  </span>
-                                </Show>
-                              </div>
-                            );
-                          }}
+                          {(session) => renderSessionRow(workspace().id, session)}
                         </For>
                       </Show>
                     }
@@ -422,40 +512,7 @@ export default function WorkspaceSessionList(props: Props) {
                           }
                         >
                           <For each={previewSessions(workspace().id, group.sessions)}>
-                            {(session) => {
-                              const isSelected = () => props.selectedSessionId === session.id;
-                              const isSessionActive = () => (props.sessionStatusById?.[session.id] ?? "idle") !== "idle";
-                              return (
-                                <div
-                                  role="button"
-                                  tabIndex={0}
-                                  class={`group flex min-h-10 w-full items-center justify-between rounded-[15px] border px-3 py-2.5 transition-[background-color,border-color,box-shadow] ${
-                                    isSelected()
-                                      ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
-                                      : "border-transparent text-gray-11 hover:bg-gray-2/60"
-                                  }`}
-                                  onClick={() => props.onOpenSession(workspace().id, session.id)}
-                                  onKeyDown={(event) => {
-                                    if (event.key !== "Enter" && event.key !== " ") return;
-                                    if (event.isComposing || event.keyCode === 229) return;
-                                    event.preventDefault();
-                                    props.onOpenSession(workspace().id, session.id);
-                                  }}
-                                >
-                                  <div class="mr-2.5 flex min-w-0 items-center gap-2">
-                                    <Show when={isSessionActive()}>
-                                      <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" />
-                                    </Show>
-                                    <span class="truncate text-[13px] font-normal text-current">{session.title}</span>
-                                  </div>
-                                  <Show when={session.time?.updated}>
-                                    <span class="whitespace-nowrap text-[11px] text-gray-9 transition-colors group-hover:text-gray-10">
-                                      {formatRelativeTime(session.time?.updated ?? Date.now())}
-                                    </span>
-                                  </Show>
-                                </div>
-                              );
-                            }}
+                            {(session) => renderSessionRow(workspace().id, session)}
                           </For>
 
                           <Show when={group.sessions.length === 0 && group.status === "ready"}>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -56,7 +56,6 @@ import {
   MessageCircle,
   Maximize2,
   Minimize2,
-  MoreHorizontal,
   Redo2,
   Search,
   Shield,
@@ -340,7 +339,6 @@ export default function SessionView(props: SessionViewProps) {
     | null = null;
   const [isChatContainerReady, setIsChatContainerReady] = createSignal(false);
   let agentPickerRef: HTMLDivElement | undefined;
-  let sessionMenuRef: HTMLDivElement | undefined;
   let searchInputEl: HTMLInputElement | undefined;
   let scrollFrame: number | undefined;
   let pendingScrollBehavior: ScrollBehavior = "auto";
@@ -355,11 +353,12 @@ export default function SessionView(props: SessionViewProps) {
   const [providerAuthActionBusy, setProviderAuthActionBusy] =
     createSignal(false);
   const [renameModalOpen, setRenameModalOpen] = createSignal(false);
+  const [renameSessionId, setRenameSessionId] = createSignal<string | null>(null);
   const [renameTitle, setRenameTitle] = createSignal("");
   const [renameBusy, setRenameBusy] = createSignal(false);
 
-  const [sessionMenuOpen, setSessionMenuOpen] = createSignal(false);
   const [deleteSessionOpen, setDeleteSessionOpen] = createSignal(false);
+  const [deleteSessionId, setDeleteSessionId] = createSignal<string | null>(null);
   const [deleteSessionBusy, setDeleteSessionBusy] = createSignal(false);
   const [agentPickerOpen, setAgentPickerOpen] = createSignal(false);
   const [agentPickerBusy, setAgentPickerBusy] = createSignal(false);
@@ -2791,14 +2790,18 @@ export default function SessionView(props: SessionViewProps) {
     return () => window.clearTimeout(id);
   });
 
-  const selectedSessionTitle = createMemo(() => {
-    const id = props.selectedSessionId;
+  function sessionTitleForId(id: string | null | undefined) {
     if (!id) return "";
     for (const group of props.workspaceSessionGroups) {
       const match = group.sessions.find((session) => session.id === id);
       if (match) return match.title ?? "";
     }
     return "";
+  }
+  const selectedSessionTitle = createMemo(() => {
+    const id = props.selectedSessionId;
+    if (!id) return "";
+    return sessionTitleForId(id);
   });
   const hasWorkspaceConfigured = createMemo(() => props.workspaces.length > 0);
   const showWorkspaceSetupEmptyState = createMemo(
@@ -2812,26 +2815,28 @@ export default function SessionView(props: SessionViewProps) {
     if (renameBusy()) return false;
     const next = renameTitle().trim();
     if (!next) return false;
-    return next !== selectedSessionTitle().trim();
+    return next !== sessionTitleForId(renameSessionId()).trim();
   });
 
   const openRenameModal = () => {
-    setSessionMenuOpen(false);
-    if (!props.selectedSessionId) {
+    const sessionId = props.selectedSessionId;
+    if (!sessionId) {
       setToastMessage("No session selected");
       return;
     }
-    setRenameTitle(selectedSessionTitle());
+    setRenameSessionId(sessionId);
+    setRenameTitle(sessionTitleForId(sessionId));
     setRenameModalOpen(true);
   };
 
   const closeRenameModal = () => {
     if (renameBusy()) return;
     setRenameModalOpen(false);
+    setRenameSessionId(null);
   };
 
   const submitRename = async () => {
-    const sessionId = props.selectedSessionId;
+    const sessionId = renameSessionId();
     if (!sessionId) return;
     const next = renameTitle().trim();
     if (!next || !renameCanSave()) return;
@@ -2839,6 +2844,7 @@ export default function SessionView(props: SessionViewProps) {
     try {
       await props.renameSession(sessionId, next);
       setRenameModalOpen(false);
+      setRenameSessionId(null);
     } catch (error) {
       const message =
         error instanceof Error ? error.message : props.safeStringify(error);
@@ -2849,27 +2855,30 @@ export default function SessionView(props: SessionViewProps) {
   };
 
   const openDeleteSessionModal = () => {
-    setSessionMenuOpen(false);
-    if (!props.selectedSessionId) {
+    const sessionId = props.selectedSessionId;
+    if (!sessionId) {
       setToastMessage("No session selected");
       return;
     }
+    setDeleteSessionId(sessionId);
     setDeleteSessionOpen(true);
   };
 
   const closeDeleteSessionModal = () => {
     if (deleteSessionBusy()) return;
     setDeleteSessionOpen(false);
+    setDeleteSessionId(null);
   };
 
   const confirmDeleteSession = async () => {
     if (deleteSessionBusy()) return;
-    const sessionId = props.selectedSessionId;
+    const sessionId = deleteSessionId();
     if (!sessionId) return;
     setDeleteSessionBusy(true);
     try {
       await props.deleteSession(sessionId);
       setDeleteSessionOpen(false);
+      setDeleteSessionId(null);
       setToastMessage("Session deleted");
       // Route away from the deleted session id.
       props.setView("session");
@@ -2914,17 +2923,6 @@ export default function SessionView(props: SessionViewProps) {
       if (!agentPickerRef) return;
       if (agentPickerRef.contains(event.target as Node)) return;
       setAgentPickerOpen(false);
-    };
-    window.addEventListener("mousedown", handler);
-    onCleanup(() => window.removeEventListener("mousedown", handler));
-  });
-
-  createEffect(() => {
-    if (!sessionMenuOpen()) return;
-    const handler = (event: MouseEvent) => {
-      if (!sessionMenuRef) return;
-      if (sessionMenuRef.contains(event.target as Node)) return;
-      setSessionMenuOpen(false);
     };
     window.addEventListener("mousedown", handler);
     onCleanup(() => window.removeEventListener("mousedown", handler));
@@ -3899,6 +3897,7 @@ export default function SessionView(props: SessionViewProps) {
               workspaceSessionGroups={props.workspaceSessionGroups}
               activeWorkspaceId={props.activeWorkspaceId}
               selectedSessionId={props.selectedSessionId}
+              showSessionActions
               sessionStatusById={props.sessionStatusById}
               connectingWorkspaceId={props.connectingWorkspaceId}
               workspaceConnectionStateById={props.workspaceConnectionStateById}
@@ -3907,6 +3906,8 @@ export default function SessionView(props: SessionViewProps) {
               onActivateWorkspace={props.activateWorkspace}
               onOpenSession={openSessionFromList}
               onCreateTaskInWorkspace={createTaskInWorkspace}
+              onOpenRenameSession={openRenameModal}
+              onOpenDeleteSession={openDeleteSessionModal}
               onOpenRenameWorkspace={props.openRenameWorkspace}
               onShareWorkspace={(workspaceId) =>
                 setShareWorkspaceId(workspaceId)
@@ -4085,65 +4086,6 @@ export default function SessionView(props: SessionViewProps) {
                   <Loader2 size={16} class="animate-spin" />
                 </Show>
               </button>
-              <div ref={(el) => (sessionMenuRef = el)} class="relative">
-                <button
-                  type="button"
-                  class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
-                  disabled={!props.selectedSessionId}
-                  title={
-                    props.selectedSessionId
-                      ? "Session actions"
-                      : "Select a session to manage it"
-                  }
-                  aria-label={
-                    props.selectedSessionId
-                      ? "Session actions"
-                      : "Select a session to manage it"
-                  }
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    setSessionMenuOpen((current) => !current);
-                  }}
-                >
-                  <MoreHorizontal size={18} />
-                </button>
-
-                <Show when={sessionMenuOpen() && props.selectedSessionId}>
-                  <div
-                    class="absolute right-0 top-[calc(100%+6px)] z-20 w-52 rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]"
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    <button
-                      type="button"
-                      class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2 disabled:opacity-60"
-                      onClick={() => {
-                        setSessionMenuOpen(false);
-                        void compactSessionHistory();
-                      }}
-                      disabled={
-                        !canCompactSession() || historyActionBusy() !== null
-                      }
-                    >
-                      Compact session context
-                    </button>
-                    <button
-                      type="button"
-                      class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
-                      onClick={openRenameModal}
-                    >
-                      Rename session
-                    </button>
-                    <button
-                      type="button"
-                      class="w-full rounded-xl px-3 py-2 text-left text-sm text-red-11 transition-colors hover:bg-red-1/40"
-                      onClick={openDeleteSessionModal}
-                    >
-                      Delete session
-                    </button>
-                  </div>
-                </Show>
-              </div>
             </div>
           </header>
 
@@ -4875,8 +4817,8 @@ export default function SessionView(props: SessionViewProps) {
         open={deleteSessionOpen()}
         title="Delete session?"
         message={
-          selectedSessionTitle().trim()
-            ? `This will permanently delete \"${selectedSessionTitle().trim()}\" and its messages.`
+          sessionTitleForId(deleteSessionId()).trim()
+            ? `This will permanently delete \"${sessionTitleForId(deleteSessionId()).trim()}\" and its messages.`
             : "This will permanently delete the selected session and its messages."
         }
         confirmLabel={deleteSessionBusy() ? "Deleting..." : "Delete"}


### PR DESCRIPTION
## Summary
- move session rename/delete actions from the session header into the selected sidebar row so controls live with the session they affect
- reuse the shared workspace session list to render the row-level `...` menu only in the session view, while leaving dashboard behavior unchanged
- keep rename/delete modals scoped to the selected session after the header menu removal

## Testing
- `pnpm typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
- fallback UI verification: `pnpm dev:headless-web -- --silent` + Chrome MCP
  - created a session in the running UI
  - confirmed the `...` button renders on the selected session row
  - opened the row menu and verified `Rename session` / `Delete session`
  - renamed the session from the row action flow and confirmed the sidebar + header title updated

## Blockers
- `packaging/docker/dev-up.sh` could not start because Docker failed with containerd I/O errors while pulling `node:22-bookworm-slim`
- fallback local verification passed, but the Docker gate should be re-run once the local Docker daemon is healthy