### PR TITLE
fix(web): use dynamic viewport height for app shell

### DIFF
--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -1040,7 +1040,7 @@ export default function DashboardView(props: DashboardViewProps) {
   };
 
   return (
-    <div class="h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-dls-text font-sans">
+    <div class="h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-dls-text font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
       <aside
         class="relative hidden md:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -3853,7 +3853,7 @@ export default function SessionView(props: SessionViewProps) {
   );
 
   return (
-    <div class="h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-gray-12 font-sans">
+    <div class="h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-gray-12 font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
         <aside
           class="relative hidden lg:flex shrink-0 flex-col rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"


### PR DESCRIPTION
## Summary
- switch the web app shell container from `h-screen` to `h-[100dvh] min-h-screen` on session and dashboard pages
- ensure iOS Safari uses the visual viewport when the software keyboard opens so composer layout does not leave a large gap
- keep `min-h-screen` as a fallback for browsers that do not support `dvh`

## Testing
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build:web`

## Verification blocker
- could not run `packaging/docker/dev-up.sh` because Docker daemon is unavailable on this machine (`Cannot connect to the Docker daemon at unix:///Users/benjaminshafii/.colima/default/docker.sock`)
- once Docker is available, run `packaging/docker/dev-up.sh` and verify the iOS web keyboard flow in `/session`