### PR TITLE
Fix cmd+k session flow focus and add rename action

### DIFF
--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -2589,6 +2589,15 @@ export default function SessionView(props: SessionViewProps) {
     });
   };
 
+  const focusComposer = () => {
+    if (typeof window === "undefined") return;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new CustomEvent("openwork:focusPrompt"));
+      });
+    });
+  };
+
   const openCommandPalette = (mode: CommandPaletteMode = "root") => {
     setCommandPaletteMode(mode);
     setCommandPaletteQuery("");
@@ -3517,17 +3526,28 @@ export default function SessionView(props: SessionViewProps) {
     props.setPrompt(draft.text);
   };
 
-  const openSessionFromList = (workspaceId: string, sessionId: string) => {
+  const openSessionFromList = (
+    workspaceId: string,
+    sessionId: string,
+    options?: { focusComposer?: boolean },
+  ) => {
     if (!sessionId) return;
+    const shouldFocusComposer = options?.focusComposer === true;
     // Route-driven selection: navigate first and let the route effect own selectSession.
     if (workspaceId === props.activeWorkspaceId) {
       props.setView("session", sessionId);
+      if (shouldFocusComposer) {
+        focusComposer();
+      }
       return;
     }
     // For different workspace, activate workspace first
     void (async () => {
       await Promise.resolve(props.activateWorkspace(workspaceId));
       props.setView("session", sessionId);
+      if (shouldFocusComposer) {
+        focusComposer();
+      }
     })();
   };
 
@@ -3553,13 +3573,30 @@ export default function SessionView(props: SessionViewProps) {
         meta: "Create",
         action: () => {
           closeCommandPalette();
-          void Promise.resolve(props.createSessionAndOpen()).catch((error) => {
-            const message =
-              error instanceof Error
-                ? error.message
-                : "Failed to create session";
-            setToastMessage(message);
-          });
+          void Promise.resolve(props.createSessionAndOpen())
+            .then((sessionId) => {
+              if (!sessionId) return;
+              focusComposer();
+            })
+            .catch((error) => {
+              const message =
+                error instanceof Error
+                  ? error.message
+                  : "Failed to create session";
+              setToastMessage(message);
+            });
+        },
+      },
+      {
+        id: "rename-session",
+        title: "Rename current session",
+        detail:
+          selectedSessionTitle().trim() ||
+          "Give your selected session a clearer name",
+        meta: "Rename",
+        action: () => {
+          closeCommandPalette();
+          openRenameModal();
         },
       },
       {
@@ -3639,7 +3676,9 @@ export default function SessionView(props: SessionViewProps) {
           : "Switch",
       action: () => {
         closeCommandPalette();
-        openSessionFromList(item.workspaceId, item.sessionId);
+        openSessionFromList(item.workspaceId, item.sessionId, {
+          focusComposer: true,
+        });
       },
     }));
   });


### PR DESCRIPTION
## Summary
- Keep focus in the composer after `Cmd+K` session actions that navigate/create a session by dispatching the existing `openwork:focusPrompt` event after navigation settles.
- Add a new `Rename current session` quick action to the command palette root menu so session renaming is accessible from `Cmd+K`.
- Update session jump behavior in command palette to restore composer focus after switching sessions.

## Testing
- `pnpm --filter @different-ai/openwork-ui typecheck` ✅
- `./packaging/docker/dev-up.sh` ❌ blocked: Docker failed with `all predefined address pools have been fully subnetted` while creating the compose network.

## Verification Notes
- Could not run the Chrome MCP UI verification gate because the Docker dev stack failed to start.
- Once Docker networking is fixed, run `./packaging/docker/dev-up.sh` and verify:
  1. Open `Cmd+K` and select **Create new session**; composer should be focused in the new session.
  2. Open `Cmd+K` -> **Search sessions** and jump to another session; composer should be focused.
  3. Open `Cmd+K` and run **Rename current session**; rename modal should open for the selected session.