### PR TITLE
fix(onboarding): delay startup escape actions

### DIFF
--- a/packages/app/src/app/pages/onboarding.tsx
+++ b/packages/app/src/app/pages/onboarding.tsx
@@ -80,7 +80,7 @@ export default function OnboardingView(props: OnboardingViewProps) {
       return;
     }
     setConnectingFallbackVisible(false);
-    const timer = window.setTimeout(() => setConnectingFallbackVisible(true), 4_000);
+    const timer = window.setTimeout(() => setConnectingFallbackVisible(true), 15_000);
     onCleanup(() => window.clearTimeout(timer));
   });
 


### PR DESCRIPTION
## Summary
- delay the onboarding connecting fallback so `Open Settings` and `Back` appear after 15 seconds instead of 4 seconds
- keep the existing escape hatch behavior unchanged once the timeout is reached

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
- `packaging/docker/dev-up.sh`
- Chrome MCP check against `http://localhost:59975/onboarding` (the web app immediately redirects to `/session`, so the desktop-only startup screen is not reachable in the Docker web stack)

## Notes
- I could not capture the changed startup screen via Docker + Chrome MCP because this onboarding startup path is desktop/Tauri-only and the Docker web app redirects `/onboarding` to `/session`.
- To finish the full end-to-end desktop gate locally, run the desktop app, force the onboarding connecting state, wait 15 seconds, and confirm the `Open Settings` and `Back` actions appear.