### PR TITLE
chore: add Infisical project config

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "e9f4542a-8714-46c3-a8fd-99d8cb370aeb",
+    "defaultEnvironment": "",
+    "gitBranchToEnvironmentMapping": null
+}


### PR DESCRIPTION
## Summary
- add `.infisical.json` generated by `infisical init` to link this repo to the configured Infisical project
- keep the project setup reproducible for contributors using the Infisical CLI in this workspace

## Testing
- `pnpm test`