### PR TITLE
Fix share OG PNG rendering on Vercel

### DIFF
--- a/services/openwork-share/app/og/[id]/route.ts
+++ b/services/openwork-share/app/og/[id]/route.ts
@@ -1,6 +1,6 @@
-import sharp from "sharp";
 import { fetchBundleJsonById } from "../../../server/_lib/blob-store.ts";
-import { renderBundleOgImage, renderRootOgImage } from "../../../server/_lib/render-og-image.ts";
+import { buildBundleOgImageModel, buildRootOgImageModel, renderBundleOgImage, renderRootOgImage } from "../../../server/_lib/render-og-image.ts";
+import { renderOgPngResponse } from "../../../server/_lib/render-og-image-response.tsx";
 
 export const runtime = "nodejs";
 
@@ -10,12 +10,6 @@ function getCorsHeaders(): Record<string, string> {
     "Access-Control-Allow-Methods": "GET,OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type,Accept"
   };
-}
-
-async function renderOgBody(svg: string, format: "svg" | "png") {
-  if (format === "svg") return svg;
-  const buffer = await sharp(Buffer.from(svg)).png().toBuffer();
-  return new Uint8Array(buffer);
 }
 
 export function OPTIONS() {
@@ -29,36 +23,64 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   const routeParams = await params;
   const id = String(routeParams?.id ?? "root").trim() || "root";
   const format = new URL(request.url).searchParams.get("format") === "svg" ? "svg" : "png";
-  const responseHeaders = new Headers({
-    ...getCorsHeaders(),
-    "Content-Type": format === "svg" ? "image/svg+xml; charset=utf-8" : "image/png",
-    "Cache-Control":
-      id === "root"
-        ? "public, max-age=3600"
-        : "public, max-age=3600, stale-while-revalidate=86400"
-  });
+  const cacheControl =
+    id === "root"
+      ? "public, max-age=3600"
+      : "public, max-age=3600, stale-while-revalidate=86400";
 
   if (id === "root") {
-    const svg = renderRootOgImage();
-    return new Response(await renderOgBody(svg, format), {
-      status: 200,
-      headers: responseHeaders
+    if (format === "svg") {
+      return new Response(renderRootOgImage(), {
+        status: 200,
+        headers: {
+          ...getCorsHeaders(),
+          "Content-Type": "image/svg+xml; charset=utf-8",
+          "Cache-Control": cacheControl
+        }
+      });
+    }
+
+    return renderOgPngResponse(buildRootOgImageModel(), {
+      ...getCorsHeaders(),
+      "Cache-Control": cacheControl
     });
   }
 
   try {
     const { rawJson } = await fetchBundleJsonById(id);
-    const svg = renderBundleOgImage({ id, rawJson });
-    return new Response(await renderOgBody(svg, format), {
-      status: 200,
-      headers: responseHeaders
+    if (format === "svg") {
+      return new Response(renderBundleOgImage({ id, rawJson }), {
+        status: 200,
+        headers: {
+          ...getCorsHeaders(),
+          "Content-Type": "image/svg+xml; charset=utf-8",
+          "Cache-Control": cacheControl
+        }
+      });
+    }
+
+    return renderOgPngResponse(buildBundleOgImageModel({ id, rawJson }), {
+      ...getCorsHeaders(),
+      "Cache-Control": cacheControl
     });
   } catch {
-    responseHeaders.set("Cache-Control", "public, max-age=300, stale-while-revalidate=3600");
-    const svg = renderRootOgImage();
-    return new Response(await renderOgBody(svg, format), {
-      status: 200,
-      headers: responseHeaders
+    console.error(`[share-og] failed to render bundle ${id}`);
+    const fallbackCacheControl = "public, max-age=300, stale-while-revalidate=3600";
+
+    if (format === "svg") {
+      return new Response(renderRootOgImage(), {
+        status: 200,
+        headers: {
+          ...getCorsHeaders(),
+          "Content-Type": "image/svg+xml; charset=utf-8",
+          "Cache-Control": fallbackCacheControl
+        }
+      });
+    }
+
+    return renderOgPngResponse(buildRootOgImageModel(), {
+      ...getCorsHeaders(),
+      "Cache-Control": fallbackCacheControl
     });
   }
 }

--- a/services/openwork-share/server/_lib/render-og-image-response.tsx
+++ b/services/openwork-share/server/_lib/render-og-image-response.tsx
@@ -1,0 +1,209 @@
+import { ImageResponse } from "next/og";
+import type { CSSProperties, ReactElement } from "react";
+
+import type { OgImageModel, OgTokenClass } from "./render-og-image.ts";
+
+const canvasStyle: CSSProperties = {
+  width: "1200px",
+  height: "630px",
+  position: "relative",
+  display: "flex",
+  background: "#f6f9fc",
+  overflow: "hidden",
+};
+
+const monoStyle: CSSProperties = {
+  fontFamily: "monospace",
+  fontSize: "15px",
+  lineHeight: "22px",
+  color: "#475569",
+};
+
+const sansStyle: CSSProperties = {
+  fontFamily: "sans-serif",
+  color: "#0f172a",
+};
+
+function circleStyle(options: {
+  left?: number;
+  right?: number;
+  top: number;
+  size: number;
+  background: string;
+  opacity?: number;
+}): CSSProperties {
+  const style: CSSProperties = {
+    position: "absolute",
+    top: `${options.top}px`,
+    width: `${options.size}px`,
+    height: `${options.size}px`,
+    borderRadius: "999px",
+    background: options.background,
+    opacity: options.opacity ?? 1,
+  };
+
+  if (options.left != null) style.left = `${options.left}px`;
+  if (options.right != null) style.right = `${options.right}px`;
+
+  return style;
+}
+
+function segmentStyle(className: OgTokenClass): CSSProperties {
+  switch (className) {
+    case "hl-frontmatter":
+      return { color: "#94a3b8" };
+    case "hl-key":
+      return { color: "#475569" };
+    case "hl-url":
+      return { color: "#2563eb" };
+    case "hl-string":
+      return { color: "#0f766e" };
+    case "hl-bracket":
+      return { color: "#94a3b8" };
+    case "hl-punctuation":
+      return { color: "#94a3b8" };
+    case "hl-number":
+      return { color: "#f97316" };
+    case "hl-keyword":
+      return { color: "#be123c" };
+    case "hl-comment":
+      return { color: "#94a3b8", fontStyle: "italic" };
+    case "hl-heading":
+      return { color: "#0f172a", fontWeight: 700 };
+    case "hl-field":
+      return { color: "#be123c" };
+    case "hl-inline-code":
+      return { color: "#7c3aed" };
+    case "hl-bold":
+      return { color: "#0f172a", fontWeight: 700 };
+    case "hl-type":
+      return { color: "#0ea5e9", fontStyle: "italic" };
+    case "hl-cta":
+      return { color: "#0f172a" };
+    case "hl-cta-skill":
+      return { color: "#0f172a", fontWeight: 700 };
+    case "hl-cta-url":
+      return { color: "#0f172a", fontWeight: 700, textDecoration: "underline" };
+    case "hl-codeblock":
+      return {
+        color: "#F99D16",
+        background: "#f8fafc",
+        border: "1px solid #cbd5e1",
+        borderRadius: "5px",
+        paddingRight: "6px",
+      };
+    default:
+      return { color: "#475569" };
+  }
+}
+
+function OgImage({ model }: { model: OgImageModel }): ReactElement {
+  return (
+    <div style={canvasStyle}>
+      <div style={circleStyle({ left: -42, top: -90, size: 420, background: "#F99D16", opacity: 0.22 })} />
+      <div style={circleStyle({ right: -46, top: -92, size: 400, background: "#111827", opacity: 0.09 })} />
+      <div
+        style={{
+          position: "absolute",
+          left: "48px",
+          top: "44px",
+          width: "1104px",
+          height: "542px",
+          borderRadius: "42px",
+          background: "rgba(255,255,255,0.72)",
+          border: "1px solid rgba(255,255,255,0.9)",
+          boxShadow: "0 36px 56px rgba(15, 23, 42, 0.14)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          left: "18px",
+          top: "12px",
+          width: "1164px",
+          height: "606px",
+          borderRadius: "38px",
+          background: "rgba(255,255,255,0.96)",
+          border: "1px solid rgba(148,163,184,0.16)",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            height: "66px",
+            borderBottom: "1px solid rgba(226,232,240,0.92)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "0 34px",
+          }}
+        >
+          <div style={{ ...sansStyle, fontSize: "28px", fontWeight: 800, letterSpacing: "-1.2px" }}>SKILL.md</div>
+          <div style={{ display: "flex", alignItems: "center", gap: "13px" }}>
+            <div
+              style={{
+                width: "14px",
+                height: "14px",
+                borderRadius: "999px",
+                background: "linear-gradient(135deg, #f97316 0%, #facc15 100%)",
+              }}
+            />
+            <div style={{ ...monoStyle, fontSize: "16px", color: "#94a3b8" }}>{model.filename}</div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            padding: "50px 34px 0 34px",
+            gap: "0px",
+            ...monoStyle,
+          }}
+        >
+          {model.lines.map((line, index) => (
+            <div key={index} style={{ display: "flex", minHeight: "22px", alignItems: "baseline" }}>
+              <div
+                style={{
+                  width: "44px",
+                  color: "#cbd5e1",
+                  fontSize: "13px",
+                  fontWeight: 600,
+                  lineHeight: "22px",
+                }}
+              >
+                {line.lineNumber == null ? "" : String(line.lineNumber).padStart(2, "0")}
+              </div>
+              <div style={{ display: "flex", whiteSpace: "pre", flexWrap: "nowrap" }}>
+                {line.segments.length ? (
+                  line.segments.map((segment, segmentIndex) => (
+                    <span key={segmentIndex} style={segmentStyle(segment.className)}>
+                      {segment.text}
+                    </span>
+                  ))
+                ) : (
+                  <span>{" "}</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function renderOgPngResponse(model: OgImageModel, headers: Record<string, string> = {}): ImageResponse {
+  const response = new ImageResponse(<OgImage model={model} />, {
+    width: 1200,
+    height: 630,
+  });
+
+  for (const [name, value] of Object.entries(headers)) {
+    response.headers.set(name, value);
+  }
+
+  return response;
+}

--- a/services/openwork-share/server/_lib/render-og-image.ts
+++ b/services/openwork-share/server/_lib/render-og-image.ts
@@ -1,5 +1,5 @@
 import { highlightSyntax } from "../../components/share-preview-syntax.ts";
-import { buildBundlePreview, maybeString, parseBundle, parseFrontmatter } from "./share-utils.ts";
+import { DEFAULT_PUBLIC_BASE_URL, buildBundlePreview, maybeString, parseBundle, parseFrontmatter } from "./share-utils.ts";
 
 type TokenClass =
   | "plain"
@@ -30,6 +30,21 @@ type TokenSegment = {
 type WrappedLine = {
   lineNumber: number | null;
   segments: TokenSegment[];
+};
+
+export type OgTokenClass = TokenClass;
+export type OgTokenSegment = TokenSegment;
+export type OgWrappedLine = WrappedLine;
+export type OgImageModel = {
+  filename: string;
+  lines: WrappedLine[];
+};
+
+type SkillCardInput = {
+  title: string;
+  filename: string;
+  text: string;
+  shareUrl: string;
 };
 
 const FONT_SIZE = 15;
@@ -261,6 +276,13 @@ function buildWrappedLines(text: string, shareUrl: string): WrappedLine[] {
   return wrapped;
 }
 
+function buildSkillCardModel(input: SkillCardInput): OgImageModel {
+  return {
+    filename: input.filename,
+    lines: buildWrappedLines(input.text, input.shareUrl),
+  };
+}
+
 function classStyle(className: TokenClass): { fill: string; weight?: string; style?: string } {
   switch (className) {
     case "hl-frontmatter":
@@ -325,7 +347,7 @@ function renderLine(line: WrappedLine, y: number): string {
 }
 
 function renderPreviewSurface(input: { title: string; filename: string; text: string; shareUrl: string }): string {
-  const wrappedLines = buildWrappedLines(input.text, input.shareUrl);
+  const model = buildSkillCardModel(input);
 
   return `
     <g transform="translate(18 12)">
@@ -334,7 +356,7 @@ function renderPreviewSurface(input: { title: string; filename: string; text: st
       <text x="34" y="42" fill="#0f172a" font-family="${OG_SANS_FONT}" font-size="28" font-weight="800" letter-spacing="-1.2">SKILL.md</text>
       <circle cx="930" cy="33" r="7" fill="url(#skillGradient)" />
       <text x="950" y="40" fill="#94a3b8" font-family="${OG_MONO_FONT}" font-size="16">${escapeSvgText(input.filename)}</text>
-      ${wrappedLines.map((line, index) => renderLine(line, BODY_Y + index * LINE_HEIGHT)).join("")}
+      ${model.lines.map((line, index) => renderLine(line, BODY_Y + index * LINE_HEIGHT)).join("")}
     </g>`;
 }
 
@@ -367,11 +389,11 @@ function renderSkillCard(input: { title: string; filename: string; text: string;
 </svg>`;
 }
 
-export function renderRootOgImage(): string {
-  return renderSkillCard({
+function buildRootOgInput(): SkillCardInput {
+  return {
     title: "Meeting Reminder",
     filename: "meeting-reminder.md",
-    shareUrl: "http://127.0.0.1:3002/b/01KKPSGYSGDRRWNTAACAMZY3PF",
+    shareUrl: `${DEFAULT_PUBLIC_BASE_URL}/b/root`,
     text: `# Welcome to OpenWork
 
 Hi, I'm Ben and this is OpenWork. It's an open-source alternative to Claude's cowork. It helps you work on your files with AI and automate the mundane tasks so you don't have to.
@@ -414,19 +436,35 @@ Config reference:
 - Docs: https://opencode.ai/docs/config/
 
 End with two friendly next actions to try in OpenWork.`,
-  });
+  };
 }
 
-export function renderBundleOgImage({ id, rawJson }: { id: string; rawJson: string }): string {
+function buildBundleOgInput({ id, rawJson }: { id: string; rawJson: string }): SkillCardInput {
   const bundle = parseBundle(rawJson);
   const preview = buildBundlePreview(bundle);
   const { data } = parseFrontmatter(bundle.content);
   const skillName = maybeString(data.name).trim() || bundle.name || "shared-skill";
 
-  return renderSkillCard({
+  return {
     title: humanizeSkillName(skillName),
     filename: preview.filename || `${skillName}.md`,
-    shareUrl: `http://127.0.0.1:3002/b/${id}`,
+    shareUrl: `${DEFAULT_PUBLIC_BASE_URL}/b/${id}`,
     text: bundle.content || preview.text || "",
-  });
+  };
+}
+
+export function buildRootOgImageModel(): OgImageModel {
+  return buildSkillCardModel(buildRootOgInput());
+}
+
+export function buildBundleOgImageModel({ id, rawJson }: { id: string; rawJson: string }): OgImageModel {
+  return buildSkillCardModel(buildBundleOgInput({ id, rawJson }));
+}
+
+export function renderRootOgImage(): string {
+  return renderSkillCard(buildRootOgInput());
+}
+
+export function renderBundleOgImage({ id, rawJson }: { id: string; rawJson: string }): string {
+  return renderSkillCard(buildBundleOgInput({ id, rawJson }));
 }


### PR DESCRIPTION
## Summary
- stop generating public OG PNGs via `sharp` rasterization of SVG
- serve `/og/:id` PNGs with `ImageResponse` instead so Vercel renders readable text for social crawlers
- keep `?format=svg` as a debug fallback and fix the OG continuation URL to use the public share domain

## Root cause
The live page metadata was correct and `/og/:id` was returning a valid `image/png`, but the PNG itself was already broken before WhatsApp saw it. The raw SVG output from the same route was correct. That isolated the failure to the `SVG -> sharp/librsvg -> PNG` rasterization path on Vercel.

## Verification
- `cd services/openwork-share && pnpm build`
- `LOCAL_BLOB_DIR=/tmp/openwork-share-blobs PORT=3002 pnpm start`
- published a local skill with `POST /api/v1/package`
- loaded the share page and extracted `og:image` from the page HTML
- fetched that `og:image` URL directly and verified:
  - `200 OK`
  - `content-type: image/png`
  - `PNG image data, 1200 x 630`

## Evidence
Broken production PNG rendered from the previous pipeline:

![Broken production PNG](https://files.catbox.moe/tvtm0l.png)

Fixed local PNG fetched from the share page's `og:image` meta tag after this change:

![Fixed local PNG](https://files.catbox.moe/m1jdc4.png)
