### PR TITLE
fix(provider): fully clear disconnected credentials

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -2395,24 +2395,38 @@ export default function App() {
     }
 
     const removeProviderAuth = async () => {
+      const authClient = c.auth as unknown as {
+        remove?: (options: { providerID: string }) => Promise<unknown>;
+        set?: (options: { providerID: string; auth: unknown }) => Promise<unknown>;
+      };
+      if (typeof authClient.remove === "function") {
+        const result = await authClient.remove({ providerID: resolved });
+        assertNoClientError(result);
+        return;
+      }
+
       const rawClient = (c as unknown as { client?: { delete?: (options: { url: string }) => Promise<unknown> } })
         .client;
       if (rawClient?.delete) {
         await rawClient.delete({ url: `/auth/${encodeURIComponent(resolved)}` });
         return;
       }
-      await c.auth.set({ providerID: resolved, auth: null as never });
+
+      if (typeof authClient.set === "function") {
+        const result = await authClient.set({ providerID: resolved, auth: null });
+        assertNoClientError(result);
+        return;
+      }
+
+      throw new Error("Provider auth removal is not supported by this client.");
     };
 
     try {
       await removeProviderAuth();
-      try {
-        await c.global.dispose();
-      } catch {
-        // ignore
+      const updated = await refreshProviders({ dispose: true });
+      if (Array.isArray(updated?.connected) && updated.connected.includes(resolved)) {
+        return `Removed stored credentials for ${resolved}, but the worker still reports it as connected. Clear any remaining API key or OAuth credentials and restart the worker to fully disconnect.`;
       }
-      const updated = unwrap(await c.provider.list());
-      globalSync.set("provider", updated);
       return `Disconnected ${resolved}`;
     } catch (error) {
       const message = describeProviderError(error, "Failed to disconnect provider");

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -428,7 +428,7 @@ export default function SettingsView(props: SettingsViewProps) {
     const confirmed =
       typeof window === "undefined"
         ? true
-        : window.confirm(`Disconnect ${resolved}? This removes the stored credentials.`);
+        : window.confirm(`Disconnect ${resolved}? This removes stored API keys or OAuth credentials for this provider.`);
     if (!confirmed) return;
     setProviderDisconnectError(null);
     setProviderDisconnectStatus(null);


### PR DESCRIPTION
## Summary
- use the provider auth remove path when disconnecting so OpenWork clears stored API-key and OAuth credentials through the same auth store
- refresh provider state through the standard dispose-and-reload flow and surface a restart hint if the worker still reports the provider as connected
- clarify the settings confirmation copy so users know disconnect removes both API keys and OAuth credentials

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @different-ai/openwork-ui typecheck
- pnpm --filter @different-ai/openwork-ui build

## Notes
- I did not run the full Docker + Chrome MCP provider flow in this environment because no safe real provider credentials/auth state were available to exercise both OAuth and API-key removal end to end.