### PR TITLE
feat(den): hand off desktop auth through the web

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -43,6 +43,7 @@ import SessionView from "./pages/session";
 import ProtoWorkspacesView from "./pages/proto-workspaces";
 import ProtoV1UxView from "./pages/proto-v1-ux";
 import { createClient, unwrap, waitForHealthy, type OpencodeAuth } from "./lib/opencode";
+import { createDenClient, normalizeDenBaseUrl, writeDenSettings, DEFAULT_DEN_BASE_URL } from "./lib/den";
 import {
   abortSession as abortSessionTyped,
   abortSessionSafe,
@@ -641,6 +642,41 @@ function parseRemoteConnectDeepLink(rawUrl: string): RemoteWorkspaceDefaults | n
     directory: null,
     displayName: displayName || null,
   };
+}
+
+type DenAuthDeepLink = {
+  grant: string;
+  denBaseUrl: string;
+};
+
+function parseDenAuthDeepLink(rawUrl: string): DenAuthDeepLink | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== "openwork:" && protocol !== "openwork-dev:" && protocol !== "https:" && protocol !== "http:") {
+    return null;
+  }
+
+  const routeHost = url.hostname.toLowerCase();
+  const routePath = url.pathname.replace(/^\/+/, "").toLowerCase();
+  const routeSegments = routePath.split("/").filter(Boolean);
+  const routeTail = routeSegments[routeSegments.length - 1] ?? "";
+  if (routeHost !== "den-auth" && routePath !== "den-auth" && routeTail !== "den-auth") {
+    return null;
+  }
+
+  const grant = url.searchParams.get("grant")?.trim() ?? "";
+  const denBaseUrl = normalizeDenBaseUrl(url.searchParams.get("denBaseUrl")?.trim() ?? "") ?? DEFAULT_DEN_BASE_URL;
+  if (!grant) {
+    return null;
+  }
+
+  return { grant, denBaseUrl };
 }
 
 function normalizeDebugShareLinkInput(rawValue: string): string {
@@ -3796,6 +3832,8 @@ export default function App() {
   const [editRemoteWorkspaceError, setEditRemoteWorkspaceError] = createSignal<string | null>(null);
   const [deepLinkRemoteWorkspaceDefaults, setDeepLinkRemoteWorkspaceDefaults] = createSignal<RemoteWorkspaceDefaults | null>(null);
   const [pendingRemoteConnectDeepLink, setPendingRemoteConnectDeepLink] = createSignal<RemoteWorkspaceDefaults | null>(null);
+  const [pendingDenAuthDeepLink, setPendingDenAuthDeepLink] = createSignal<DenAuthDeepLink | null>(null);
+  const [processingDenAuthDeepLink, setProcessingDenAuthDeepLink] = createSignal(false);
   const [pendingSharedBundleInvite, setPendingSharedBundleInvite] = createSignal<SharedBundleDeepLink | null>(null);
   const [sharedBundleCreateWorkerRequest, setSharedBundleCreateWorkerRequest] =
     createSignal<SharedBundleCreateWorkerRequest | null>(null);
@@ -3886,6 +3924,15 @@ export default function App() {
       return false;
     }
     setPendingRemoteConnectDeepLink(parsed);
+    return true;
+  };
+
+  const queueDenAuthDeepLink = (rawUrl: string): boolean => {
+    const parsed = parseDenAuthDeepLink(rawUrl);
+    if (!parsed) {
+      return false;
+    }
+    setPendingDenAuthDeepLink(parsed);
     return true;
   };
 
@@ -4082,6 +4129,55 @@ export default function App() {
       setSharedBundleImportBusy(false);
     }
   };
+
+  createEffect(() => {
+    const pending = pendingDenAuthDeepLink();
+    if (!pending || booting() || processingDenAuthDeepLink()) {
+      return;
+    }
+
+    setProcessingDenAuthDeepLink(true);
+    setPendingDenAuthDeepLink(null);
+    setView("dashboard");
+    setSettingsTab("den");
+    goToDashboard("settings");
+
+    void createDenClient({ baseUrl: pending.denBaseUrl })
+      .exchangeDesktopHandoff(pending.grant)
+      .then((result) => {
+        if (!result.token) {
+          throw new Error("Desktop sign-in completed, but Den did not return a session token.");
+        }
+
+        writeDenSettings({
+          baseUrl: pending.denBaseUrl,
+          authToken: result.token,
+          activeOrgId: null,
+        });
+
+        window.dispatchEvent(
+          new CustomEvent("openwork-den-session-updated", {
+            detail: {
+              status: "success",
+              email: result.user?.email ?? null,
+            },
+          }),
+        );
+      })
+      .catch((error) => {
+        window.dispatchEvent(
+          new CustomEvent("openwork-den-session-updated", {
+            detail: {
+              status: "error",
+              message: error instanceof Error ? error.message : "Failed to complete OpenWork Den sign-in.",
+            },
+          }),
+        );
+      })
+      .finally(() => {
+        setProcessingDenAuthDeepLink(false);
+      });
+  });
 
   createEffect(() => {
     const pending = pendingRemoteConnectDeepLink();
@@ -5891,7 +5987,7 @@ export default function App() {
               continue;
             }
             recentDeepLinkEvents.set(url, now);
-            if (queueRemoteConnectDeepLink(url) || queueSharedBundleDeepLink(url)) {
+            if (queueDenAuthDeepLink(url) || queueRemoteConnectDeepLink(url) || queueSharedBundleDeepLink(url)) {
               break;
             }
           }
@@ -5925,10 +6021,11 @@ export default function App() {
     }
 
     if (!isTauriRuntime()) {
-      const currentUrl = typeof window === "undefined" ? "" : window.location.href;
-      if (currentUrl) {
-        queueRemoteConnectDeepLink(currentUrl);
-        queueSharedBundleDeepLink(currentUrl);
+        const currentUrl = typeof window === "undefined" ? "" : window.location.href;
+        if (currentUrl) {
+        queueDenAuthDeepLink(currentUrl);
+          queueRemoteConnectDeepLink(currentUrl);
+          queueSharedBundleDeepLink(currentUrl);
         const remoteStripped = stripRemoteConnectQuery(currentUrl) ?? currentUrl;
         const bundleStripped = stripSharedBundleQuery(remoteStripped) ?? remoteStripped;
         if (bundleStripped !== currentUrl) {

--- a/packages/app/src/app/components/den-settings-panel.tsx
+++ b/packages/app/src/app/components/den-settings-panel.tsx
@@ -1,5 +1,5 @@
 import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
-import { ArrowUpRight, Cloud, LogIn, LogOut, RefreshCcw, Server, Users } from "lucide-solid";
+import { ArrowUpRight, Cloud, LogOut, RefreshCcw, Server, Users } from "lucide-solid";
 import Button from "./button";
 import TextInput from "./text-input";
 import {
@@ -21,8 +21,6 @@ type DenSettingsPanelProps = {
     displayName?: string | null;
   }) => Promise<boolean>;
 };
-
-type AuthMode = "sign-in" | "sign-up";
 
 function statusBadgeClass(kind: "ready" | "warning" | "neutral" | "error") {
   switch (kind) {
@@ -67,9 +65,6 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
   const [baseUrlError, setBaseUrlError] = createSignal<string | null>(null);
   const [authToken, setAuthToken] = createSignal(initial.authToken?.trim() || "");
   const [activeOrgId, setActiveOrgId] = createSignal(initial.activeOrgId?.trim() || "");
-  const [authMode, setAuthMode] = createSignal<AuthMode>("sign-in");
-  const [email, setEmail] = createSignal("");
-  const [password, setPassword] = createSignal("");
   const [authBusy, setAuthBusy] = createSignal(false);
   const [sessionBusy, setSessionBusy] = createSignal(false);
   const [orgsBusy, setOrgsBusy] = createSignal(false);
@@ -128,6 +123,16 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
   const openControlPlane = () => {
     const target = normalizeDenBaseUrl(baseUrl()) ?? DEFAULT_DEN_BASE_URL;
     platform.openLink(target);
+  };
+
+  const openBrowserAuth = (mode: "sign-in" | "sign-up") => {
+    const target = new URL(normalizeDenBaseUrl(baseUrl()) ?? DEFAULT_DEN_BASE_URL);
+    target.searchParams.set("mode", mode);
+    target.searchParams.set("desktopAuth", "1");
+    target.searchParams.set("desktopScheme", import.meta.env.DEV ? "openwork-dev" : "openwork");
+    platform.openLink(target.toString());
+    setStatusMessage(mode === "sign-up" ? "Finish account creation in your browser to connect OpenWork." : "Finish signing in in your browser to connect OpenWork.");
+    setAuthError(null);
   };
 
   const clearSessionState = () => {
@@ -275,38 +280,29 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     void refreshWorkers(true);
   });
 
-  const submitAuth = async () => {
-    const trimmedEmail = email().trim();
-    const currentPassword = password();
-    if (!trimmedEmail || !currentPassword) {
-      setAuthError("Email and password are required.");
-      return;
-    }
-
-    setAuthBusy(true);
-    setAuthError(null);
-    setStatusMessage(null);
-
-    try {
-      const result =
-        authMode() === "sign-up"
-          ? await client().signUpEmail(trimmedEmail, currentPassword)
-          : await client().signInEmail(trimmedEmail, currentPassword);
-
-      if (!result.token) {
-        throw new Error("Den did not return a desktop access token.");
+  createEffect(() => {
+    const handler = (event: Event) => {
+      const customEvent = event as CustomEvent<{ status?: string; email?: string | null; message?: string | null }>;
+      const nextSettings = readDenSettings();
+      setBaseUrl(nextSettings.baseUrl || DEFAULT_DEN_BASE_URL);
+      setBaseUrlDraft(nextSettings.baseUrl || DEFAULT_DEN_BASE_URL);
+      setAuthToken(nextSettings.authToken?.trim() || "");
+      setActiveOrgId(nextSettings.activeOrgId?.trim() || "");
+      if (customEvent.detail?.status === "success") {
+        setAuthError(null);
+        setStatusMessage(
+          customEvent.detail.email?.trim()
+            ? `Connected OpenWork Den as ${customEvent.detail.email.trim()}.`
+            : "Connected OpenWork Den.",
+        );
+      } else if (customEvent.detail?.status === "error") {
+        setAuthError(customEvent.detail.message?.trim() || "Failed to finish OpenWork Den sign-in.");
       }
+    };
 
-      setAuthToken(result.token);
-      setUser(result.user);
-      setPassword("");
-      setStatusMessage(authMode() === "sign-up" ? "Account created. Loading orgs..." : "Signed in. Loading orgs...");
-    } catch (error) {
-      setAuthError(error instanceof Error ? error.message : "Sign-in failed.");
-    } finally {
-      setAuthBusy(false);
-    }
-  };
+    window.addEventListener("openwork-den-session-updated", handler as EventListener);
+    return () => window.removeEventListener("openwork-den-session-updated", handler as EventListener);
+  });
 
   const signOut = async () => {
     setAuthBusy(true);
@@ -319,10 +315,8 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     }
 
     setAuthToken("");
-    setPassword("");
-    setEmail("");
     clearSessionState();
-    setStatusMessage("Signed out of OpenWork Cloud.");
+    setStatusMessage("Signed out of OpenWork Den.");
     setAuthError(null);
   };
 
@@ -372,13 +366,11 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
             <div class="space-y-2">
               <div class="inline-flex items-center gap-2 rounded-full border border-sky-7/25 bg-sky-3/20 px-2.5 py-1 text-[11px] font-medium text-sky-11">
                 <Cloud size={12} />
-                OpenWork Cloud
+                OpenWork Den
               </div>
               <div>
                 <div class="text-sm font-semibold text-gray-12">Sign in, pick an org, and open Den workers from Settings.</div>
-                <div class="mt-1 max-w-[60ch] text-xs text-gray-10">
-                  This is the foundation for desktop OpenWork Cloud access. It stores your Den URL, session token, and active org locally on this device.
-                </div>
+                <div class="mt-1 max-w-[60ch] text-xs text-gray-10">Sign in to OpenWork Den to keep your tasks alive even when your computer sleeps.</div>
               </div>
             </div>
             <div class={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium ${statusBadgeClass(summaryTone())}`}>
@@ -389,18 +381,7 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
 
           <Show
             when={props.developerMode}
-            fallback={
-              <div class="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-gray-6/60 bg-gray-1/60 px-3 py-3 text-xs text-gray-10">
-                <div>
-                  <div class="font-medium text-gray-12">Hosted control plane</div>
-                  <div>{DEFAULT_DEN_BASE_URL}</div>
-                </div>
-                <Button variant="outline" class="h-9 px-3 text-xs" onClick={openControlPlane}>
-                  Open in browser
-                  <ArrowUpRight size={13} />
-                </Button>
-              </div>
-            }
+            fallback={<></>}
           >
             <>
               <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
@@ -438,75 +419,27 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
       </div>
 
       <Show when={!isSignedIn()}>
-        <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_260px]">
-          <div class="rounded-2xl border border-gray-7/60 bg-gray-2/30 p-5 space-y-4">
-            <div class="flex items-start justify-between gap-4">
-              <div>
-                <div class="text-sm font-medium text-gray-12">Sign in to OpenWork Cloud</div>
-                <div class="text-xs text-gray-9 mt-1">
-                  Email/password auth works directly in the app. Social sign-in can stay in Den web for now.
-                </div>
-              </div>
-              <div class="flex rounded-xl border border-gray-6/60 bg-gray-1/60 p-1">
-                <button
-                  class={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${authMode() === "sign-in" ? "bg-gray-12/10 text-gray-12" : "text-gray-9 hover:text-gray-12"}`}
-                  onClick={() => setAuthMode("sign-in")}
-                  disabled={authBusy()}
-                >
-                  Sign in
-                </button>
-                <button
-                  class={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${authMode() === "sign-up" ? "bg-gray-12/10 text-gray-12" : "text-gray-9 hover:text-gray-12"}`}
-                  onClick={() => setAuthMode("sign-up")}
-                  disabled={authBusy()}
-                >
-                  Sign up
-                </button>
-              </div>
-            </div>
-
-            <div class="grid gap-4 sm:grid-cols-2">
-              <TextInput
-                label="Email"
-                type="email"
-                value={email()}
-                onInput={(event) => setEmail(event.currentTarget.value)}
-                placeholder="you@example.com"
-                disabled={authBusy()}
-              />
-              <TextInput
-                label="Password"
-                type="password"
-                value={password()}
-                onInput={(event) => setPassword(event.currentTarget.value)}
-                placeholder={authMode() === "sign-up" ? "Create a password" : "Enter your password"}
-                disabled={authBusy()}
-              />
-            </div>
-
-            <div class="flex flex-wrap items-center gap-2">
-              <Button variant="secondary" onClick={() => void submitAuth()} disabled={authBusy() || sessionBusy()}>
-                <LogIn size={14} />
-                {authBusy() ? (authMode() === "sign-up" ? "Creating account..." : "Signing in...") : authMode() === "sign-up" ? "Create account" : "Sign in"}
-              </Button>
-              <Button variant="outline" class="text-xs h-9 px-3" onClick={openControlPlane}>
-                Continue in browser
-                <ArrowUpRight size={13} />
-              </Button>
-            </div>
-
-            <Show when={authError()}>
-              {(value) => <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">{value()}</div>}
-            </Show>
+        <div class="rounded-2xl border border-gray-7/60 bg-gray-2/30 p-5 space-y-4">
+          <div class="space-y-2">
+            <div class="text-sm font-medium text-gray-12">Sign in to OpenWork Den</div>
+            <div class="max-w-[54ch] text-sm text-gray-10">Sign in to OpenWork Den to keep your tasks alive even when your computer sleeps.</div>
           </div>
 
-          <div class="rounded-2xl border border-gray-7/60 bg-gray-2/20 p-5 space-y-3">
-            <div class="text-sm font-medium text-gray-12">What this unlocks</div>
-            <div class="space-y-2 text-xs text-gray-10">
-              <div class="rounded-xl border border-gray-6/50 bg-gray-1/50 px-3 py-2">List the workers visible to your org.</div>
-              <div class="rounded-xl border border-gray-6/50 bg-gray-1/50 px-3 py-2">Click <span class="font-medium text-gray-12">Open</span> to jump into a Den worker in OpenWork.</div>
-              <div class="rounded-xl border border-gray-6/50 bg-gray-1/50 px-3 py-2">Prepare the app for org marketplace access in the next PR.</div>
-            </div>
+          <div class="flex flex-wrap items-center gap-2">
+            <Button variant="secondary" onClick={() => openBrowserAuth("sign-in")}>
+              Sign in
+              <ArrowUpRight size={13} />
+            </Button>
+            <Button variant="outline" class="text-xs h-9 px-3" onClick={() => openBrowserAuth("sign-up")}>
+              Create account
+              <ArrowUpRight size={13} />
+            </Button>
+          </div>
+
+          <Show when={authError()}>
+            {(value) => <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">{value()}</div>}</Show>
+          <div class="rounded-2xl border border-gray-6/60 bg-gray-1/40 p-4 text-sm text-gray-10">
+            Finish auth in your browser and OpenWork will reconnect here automatically.
           </div>
         </div>
       </Show>

--- a/packages/app/src/app/lib/den.ts
+++ b/packages/app/src/app/lib/den.ts
@@ -54,6 +54,11 @@ type DenAuthResult = {
   token: string | null;
 };
 
+export type DenDesktopHandoffExchange = {
+  user: DenUser | null;
+  token: string | null;
+};
+
 type RawJsonResponse<T> = {
   ok: boolean;
   status: number;
@@ -370,6 +375,14 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         throw new DenApiError(500, "invalid_session_payload", "Session response did not include a user.");
       }
       return user;
+    },
+
+    async exchangeDesktopHandoff(grant: string): Promise<DenDesktopHandoffExchange> {
+      const payload = await requestJson<unknown>(baseUrl, "/v1/auth/desktop-handoff/exchange", {
+        method: "POST",
+        body: { grant },
+      });
+      return { user: getUser(payload), token: getToken(payload) };
     },
 
     async listOrgs(): Promise<{ orgs: DenOrgSummary[]; defaultOrgId: string | null }> {

--- a/packages/web/components/cloud-control.tsx
+++ b/packages/web/components/cloud-control.tsx
@@ -231,13 +231,23 @@ async function trackDenSignupInLoops(payload: DenSignupTrackPayload) {
 
 function getSocialCallbackUrl(): string {
   try {
-    const origin = typeof window !== "undefined"
-      ? window.location.origin
-      : OPENWORK_AUTH_CALLBACK_BASE_URL || "https://app.openwork.software";
-    return new URL("/", origin).toString();
+    const origin = typeof window !== "undefined" ? window.location.origin : OPENWORK_AUTH_CALLBACK_BASE_URL || "https://app.openwork.software";
+    const callbackUrl = new URL("/", origin);
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      for (const key of ["mode", "desktopAuth", "desktopScheme"]) {
+        const value = params.get(key)?.trim() ?? "";
+        if (value) callbackUrl.searchParams.set(key, value);
+      }
+    }
+    return callbackUrl.toString();
   } catch {
     return "https://app.openwork.software/";
   }
+}
+
+function normalizeAuthModeParam(value: string | null | undefined): AuthMode | null {
+  return value === "sign-in" || value === "sign-up" ? value : null;
 }
 
 function getSocialProviderLabel(provider: SocialAuthProvider): string {
@@ -1101,6 +1111,11 @@ export function CloudControlPanel() {
   const [signupOnboardingActive, setSignupOnboardingActive] = useState(false);
   const [autoLaunchPending, setAutoLaunchPending] = useState(false);
   const [desktopContext, setDesktopContext] = useState(false);
+  const [desktopAuthRequested, setDesktopAuthRequested] = useState(false);
+  const [desktopAuthScheme, setDesktopAuthScheme] = useState("openwork");
+  const [desktopRedirectBusy, setDesktopRedirectBusy] = useState(false);
+  const [desktopRedirectUrl, setDesktopRedirectUrl] = useState<string | null>(null);
+  const [desktopRedirectAttempted, setDesktopRedirectAttempted] = useState(false);
   const [nameStepBusy, setNameStepBusy] = useState(false);
 
   const selectedWorker = workers.find((item) => item.workerId === workerLookupId) ?? null;
@@ -1737,12 +1752,39 @@ export function CloudControlPanel() {
       userId: user.id,
       authMethod: pendingSocialSignup
     });
+    if (desktopAuthRequested) {
+      setSignupOnboardingActive(false);
+      setStep("auth");
+      setAuthInfo("Signed in. Returning to OpenWork...");
+      return;
+    }
+
     setSignupOnboardingActive(true);
     setAutoLaunchPending(true);
     setLaunchError(null);
     setLaunchStatus("Creating your first worker now. First runs usually take around 1-2 minutes.");
     setStep("name");
-  }, [user?.id]);
+  }, [desktopAuthRequested, user?.id]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const requestedMode = normalizeAuthModeParam(params.get("mode"));
+    if (requestedMode) {
+      setAuthMode(requestedMode);
+      setAuthInfo(getAuthInfoForMode(requestedMode));
+      setAuthError(null);
+    }
+
+    setDesktopAuthRequested(params.get("desktopAuth") === "1");
+    const requestedScheme = params.get("desktopScheme")?.trim() ?? "";
+    if (/^[a-z][a-z0-9+.-]*$/i.test(requestedScheme)) {
+      setDesktopAuthScheme(requestedScheme);
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -1841,6 +1883,9 @@ export function CloudControlPanel() {
 
   useEffect(() => {
     if (user || checkoutUrl) {
+      if (desktopAuthRequested) {
+        return;
+      }
       if (step === "auth" && !signupOnboardingActive) {
         setStep("workspace");
       }
@@ -1854,7 +1899,7 @@ export function CloudControlPanel() {
     setStep("auth");
     setSignupOnboardingActive(false);
     setAutoLaunchPending(false);
-  }, [checkoutUrl, sessionHydrated, signupOnboardingActive, step, user]);
+  }, [checkoutUrl, desktopAuthRequested, sessionHydrated, signupOnboardingActive, step, user]);
 
   useEffect(() => {
     if (step !== "workspace") {
@@ -1942,6 +1987,55 @@ export function CloudControlPanel() {
     };
   }, [actionBusy, authToken, launchBusy, pendingRestoredWorkerId, user?.id, worker?.workerId, worker?.status]);
 
+  useEffect(() => {
+    if (!desktopAuthRequested || !user || desktopRedirectUrl || desktopRedirectBusy || desktopRedirectAttempted) {
+      return;
+    }
+
+    void completeDesktopAuthHandoff();
+  }, [desktopAuthRequested, user?.id, authToken, desktopRedirectUrl, desktopRedirectBusy, desktopRedirectAttempted, desktopAuthScheme]);
+
+  async function completeDesktopAuthHandoff() {
+    if (!desktopAuthRequested || desktopRedirectBusy) {
+      return;
+    }
+
+    setDesktopRedirectBusy(true);
+    setDesktopRedirectAttempted(true);
+    setAuthError(null);
+
+    try {
+      const headers = new Headers();
+      if (authToken) {
+        headers.set("Authorization", `Bearer ${authToken}`);
+      }
+
+      const { response, payload } = await requestJson("/v1/auth/desktop-handoff", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ desktopScheme: desktopAuthScheme }),
+      });
+
+      if (!response.ok) {
+        setAuthError(getErrorMessage(payload, `Desktop handoff failed with ${response.status}.`));
+        return;
+      }
+
+      const openworkUrl = isRecord(payload) && typeof payload.openworkUrl === "string" ? payload.openworkUrl.trim() : "";
+      if (!openworkUrl) {
+        setAuthError("Desktop handoff succeeded, but no OpenWork redirect URL was returned.");
+        return;
+      }
+
+      setDesktopRedirectUrl(openworkUrl);
+      window.location.assign(openworkUrl);
+    } catch (error) {
+      setAuthError(error instanceof Error ? error.message : "Failed to open OpenWork.");
+    } finally {
+      setDesktopRedirectBusy(false);
+    }
+  }
+
   async function handleAuthSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -2026,7 +2120,11 @@ export function CloudControlPanel() {
         }
       }
 
-      if (authMode === "sign-up") {
+      if (desktopAuthRequested) {
+        setSignupOnboardingActive(false);
+        setStep("auth");
+        setAuthInfo("Signed in. Returning to OpenWork...");
+      } else if (authMode === "sign-up") {
         setSignupOnboardingActive(true);
         setAutoLaunchPending(true);
         setLaunchError(null);
@@ -2764,14 +2862,29 @@ export function CloudControlPanel() {
               <div className="grid gap-6 rounded-[32px] border border-white/70 bg-white/92 p-5 shadow-[0_28px_80px_-44px_rgba(15,23,42,0.35)] backdrop-blur md:p-6">
                 <div className="grid gap-3 text-center">
                   <h1 className="text-[2rem] font-semibold leading-[1.02] tracking-[-0.045em] text-[var(--dls-text-primary)] md:text-[2.5rem]">
-                    {authMode === "sign-up" ? "Create your account." : "Sign in to Den."}
+                    {authMode === "sign-up" ? "Create your OpenWork Den account." : "Sign in to OpenWork Den."}
                   </h1>
                   <p className="mx-auto max-w-[24rem] text-[15px] leading-7 text-[var(--dls-text-secondary)]">
-                    {authMode === "sign-up"
-                      ? "Sign up to launch your first worker and connect it in minutes."
-                      : "Sign in to launch and connect your worker."}
+                    Keep your tasks alive even when your computer sleeps.
                   </p>
                 </div>
+
+                {desktopAuthRequested ? (
+                  <div className="rounded-[24px] border border-sky-200 bg-sky-50/80 px-4 py-3 text-sm text-sky-900">
+                    Finish auth here and we&apos;ll bounce you back into the OpenWork desktop app automatically.
+                    {desktopRedirectUrl ? (
+                      <div className="mt-3">
+                        <button
+                          type="button"
+                          className="inline-flex items-center justify-center gap-2 rounded-xl border border-sky-200 bg-white px-3 py-2 text-xs font-medium text-sky-900 transition hover:border-sky-300 hover:bg-sky-50"
+                          onClick={() => window.location.assign(desktopRedirectUrl)}
+                        >
+                          Open OpenWork
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
 
                 <form className="grid gap-3 rounded-[28px] border border-[var(--dls-border)] bg-white p-5 shadow-[var(--dls-card-shadow)] md:p-6" onSubmit={handleAuthSubmit}>
                   <button

--- a/services/den/drizzle/0004_desktop_handoff_grants.sql
+++ b/services/den/drizzle/0004_desktop_handoff_grants.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `desktop_handoff_grant` (
+	`id` varchar(64) NOT NULL,
+	`user_id` varchar(64) NOT NULL,
+	`session_token` text NOT NULL,
+	`expires_at` timestamp(3) NOT NULL,
+	`consumed_at` timestamp(3),
+	`created_at` timestamp(3) NOT NULL DEFAULT (now(3)),
+	CONSTRAINT `desktop_handoff_grant_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE INDEX `desktop_handoff_grant_user_id` ON `desktop_handoff_grant` (`user_id`);
+--> statement-breakpoint
+CREATE INDEX `desktop_handoff_grant_expires_at` ON `desktop_handoff_grant` (`expires_at`);

--- a/services/den/drizzle/meta/_journal.json
+++ b/services/den/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1773353100000,
       "tag": "0003_admin_allowlist",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1773705000000,
+      "tag": "0004_desktop_handoff_grants",
+      "breakpoints": true
     }
   ]
 }

--- a/services/den/src/db/schema.ts
+++ b/services/den/src/db/schema.ts
@@ -103,6 +103,19 @@ export const session = AuthSessionTable
 export const account = AuthAccountTable
 export const verification = AuthVerificationTable
 
+export const DesktopHandoffGrantTable = mysqlTable(
+  "desktop_handoff_grant",
+  {
+    id: id().primaryKey(),
+    user_id: varchar("user_id", { length: 64 }).notNull(),
+    session_token: text("session_token").notNull(),
+    expires_at: timestamp("expires_at", { fsp: 3 }).notNull(),
+    consumed_at: timestamp("consumed_at", { fsp: 3 }),
+    created_at: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
+  },
+  (table) => [index("desktop_handoff_grant_user_id").on(table.user_id), index("desktop_handoff_grant_expires_at").on(table.expires_at)],
+)
+
 export const OrgTable = mysqlTable(
   "org",
   {

--- a/services/den/src/http/desktop-auth.ts
+++ b/services/den/src/http/desktop-auth.ts
@@ -1,0 +1,116 @@
+import { randomBytes } from "crypto"
+import express from "express"
+import { and, eq, gt, isNull } from "drizzle-orm"
+import { z } from "zod"
+import { db } from "../db/index.js"
+import { AuthSessionTable, DesktopHandoffGrantTable, AuthUserTable } from "../db/schema.js"
+import { asyncRoute } from "./errors.js"
+import { getRequestSession } from "./session.js"
+
+const desktopAuthRouter = express.Router()
+
+const createGrantSchema = z.object({
+  next: z.string().trim().max(128).optional(),
+  desktopScheme: z.string().trim().max(32).optional(),
+})
+
+const exchangeGrantSchema = z.object({
+  grant: z.string().trim().min(12).max(128),
+})
+
+function buildOpenworkDeepLink(input: { scheme?: string | null; grant: string; denBaseUrl: string }) {
+  const requestedScheme = input.scheme?.trim() || "openwork"
+  const scheme = /^[a-z][a-z0-9+.-]*$/i.test(requestedScheme) ? requestedScheme : "openwork"
+  const url = new URL(`${scheme}://den-auth`)
+  url.searchParams.set("grant", input.grant)
+  url.searchParams.set("denBaseUrl", input.denBaseUrl)
+  return url.toString()
+}
+
+desktopAuthRouter.post("/desktop-handoff", asyncRoute(async (req, res) => {
+  const session = await getRequestSession(req)
+  if (!session?.user?.id || !session.session?.token) {
+    res.status(401).json({ error: "unauthorized" })
+    return
+  }
+
+  const parsed = createGrantSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ error: "invalid_request", details: parsed.error.flatten() })
+    return
+  }
+
+  const grant = randomBytes(24).toString("base64url")
+  const expiresAt = new Date(Date.now() + 5 * 60 * 1000)
+  await db.insert(DesktopHandoffGrantTable).values({
+    id: grant,
+    user_id: session.user.id,
+    session_token: session.session.token,
+    expires_at: expiresAt,
+    consumed_at: null,
+  })
+
+  const forwardedProto = typeof req.headers["x-forwarded-proto"] === "string" ? req.headers["x-forwarded-proto"] : null
+  const host = typeof req.headers.host === "string" ? req.headers.host : null
+  const protocol = forwardedProto ?? req.protocol ?? "https"
+  const denBaseUrl = host ? `${protocol}://${host}` : "https://app.openworklabs.com"
+  res.json({
+    grant,
+    expiresAt: expiresAt.toISOString(),
+    openworkUrl: buildOpenworkDeepLink({
+      scheme: parsed.data.desktopScheme || "openwork",
+      grant,
+      denBaseUrl,
+    }),
+  })
+}))
+
+desktopAuthRouter.post("/desktop-handoff/exchange", asyncRoute(async (req, res) => {
+  const parsed = exchangeGrantSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ error: "invalid_request", details: parsed.error.flatten() })
+    return
+  }
+
+  const now = new Date()
+  const rows = await db
+    .select({
+      grant: DesktopHandoffGrantTable,
+      session: AuthSessionTable,
+      user: AuthUserTable,
+    })
+    .from(DesktopHandoffGrantTable)
+    .innerJoin(AuthSessionTable, eq(DesktopHandoffGrantTable.session_token, AuthSessionTable.token))
+    .innerJoin(AuthUserTable, eq(DesktopHandoffGrantTable.user_id, AuthUserTable.id))
+    .where(
+      and(
+        eq(DesktopHandoffGrantTable.id, parsed.data.grant),
+        isNull(DesktopHandoffGrantTable.consumed_at),
+        gt(DesktopHandoffGrantTable.expires_at, now),
+        gt(AuthSessionTable.expiresAt, now),
+      ),
+    )
+    .limit(1)
+
+  const row = rows[0]
+  if (!row) {
+    res.status(404).json({ error: "grant_not_found", message: "This desktop sign-in link is missing, expired, or already used." })
+    return
+  }
+
+  await db
+    .update(DesktopHandoffGrantTable)
+    .set({ consumed_at: now })
+    .where(and(eq(DesktopHandoffGrantTable.id, parsed.data.grant), isNull(DesktopHandoffGrantTable.consumed_at)))
+
+  res.json({
+    token: row.session.token,
+    user: {
+      id: row.user.id,
+      email: row.user.email,
+      name: row.user.name,
+    },
+  })
+}))
+
+export { desktopAuthRouter }

--- a/services/den/src/index.ts
+++ b/services/den/src/index.ts
@@ -7,6 +7,7 @@ import { toNodeHandler } from "better-auth/node"
 import { auth } from "./auth.js"
 import { env } from "./env.js"
 import { adminRouter } from "./http/admin.js"
+import { desktopAuthRouter } from "./http/desktop-auth.js"
 import { asyncRoute, errorMiddleware } from "./http/errors.js"
 import { getRequestSession } from "./http/session.js"
 import { workersRouter } from "./http/workers.js"
@@ -58,6 +59,7 @@ app.get("/v1/me/orgs", asyncRoute(async (req, res) => {
 }))
 
 app.use("/v1/admin", adminRouter)
+app.use("/v1/auth", desktopAuthRouter)
 app.use("/v1/workers", workersRouter)
 app.use(errorMiddleware)
 


### PR DESCRIPTION
## Summary
- replace the Cloud tab's direct email/password flow with browser-based OpenWork Den sign-in and create-account actions
- add a Den desktop handoff grant flow so web auth can bounce back into `openwork://den-auth` and hydrate the desktop session token locally
- update Den web auth to preserve desktop intent across email and social login, then redirect back into OpenWork after auth completes

## Testing
- `pnpm install --force`
- `pnpm --filter @openwork/den build`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
- `pnpm --filter @different-ai/openwork-web build`
- `DATABASE_URL=\"mysql://root:password@127.0.0.1:33308/openwork_den_handoff\" BETTER_AUTH_SECRET=\"dev-den-handoff-secret-1234567890\" BETTER_AUTH_URL=\"http://localhost:63980\" CORS_ORIGINS=\"http://localhost:63981,http://127.0.0.1:63981,tauri://localhost,http://tauri.localhost,https://tauri.localhost\" DEN_BETTER_AUTH_TRUSTED_ORIGINS=\"http://localhost:63981,http://127.0.0.1:63981,tauri://localhost,http://tauri.localhost,https://tauri.localhost\" PORT=\"63980\" PROVISIONER_MODE=\"stub\" WORKER_URL_TEMPLATE=\"http://localhost:9999\" pnpm --filter @openwork/den db:migrate`
- `DATABASE_URL=\"mysql://root:password@127.0.0.1:33308/openwork_den_handoff\" BETTER_AUTH_SECRET=\"dev-den-handoff-secret-1234567890\" BETTER_AUTH_URL=\"http://localhost:63980\" CORS_ORIGINS=\"http://localhost:63981,http://127.0.0.1:63981,tauri://localhost,http://tauri.localhost,https://tauri.localhost\" DEN_BETTER_AUTH_TRUSTED_ORIGINS=\"http://localhost:63981,http://127.0.0.1:63981,tauri://localhost,http://tauri.localhost,https://tauri.localhost\" PORT=\"63980\" PROVISIONER_MODE=\"stub\" WORKER_URL_TEMPLATE=\"http://localhost:9999\" pnpm --filter @openwork/den dev`
- local verification script: sign up over `/api/auth/sign-up/email`, create `/v1/auth/desktop-handoff`, exchange it via `/v1/auth/desktop-handoff/exchange`, confirm `/v1/me` succeeds with the returned bearer token, and confirm a second exchange on the same grant fails with `grant_not_found`

## Notes
- I attempted `packaging/docker/dev-up.sh` for a fresh app-side UI validation pass, but the local `share` container exited with code `137`, which blocked a clean Docker UI run in this session.
- Because of that blocker, the handoff itself was validated directly against the live Den HTTP endpoints plus app/web production builds rather than a full desktop Chrome flow.