### PR TITLE
Add enterprise CTA to Den landing cards

### DIFF
--- a/packages/landing/components/landing-den.tsx
+++ b/packages/landing/components/landing-den.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 import { LandingBackground } from "./landing-background";
 import { DenCapabilityCarousel } from "./den-capability-carousel";
 import { DenHero } from "./den-hero";
@@ -25,18 +27,19 @@ const useCaseCards = [
     accent: "from-[#ffb570] via-[#ff9e43] to-[#f97316]",
   },
   {
-    label: "CODE",
-    title: "PR review, issue triage",
-    body: "Checks PRs against your style guide. Sorts issues by severity. Drafts first responses.",
-    detail: "Runs on every push",
-    accent: "from-[#6e87ff] via-[#4f6dff] to-[#1b29ff]",
-  },
-  {
-    label: "CONTENT",
+    label: "MARKETING",
     title: "Social drafts, follow-up emails",
     body: "Writes drafts from your changelog or CRM data. You approve before anything goes out.",
     detail: "You approve, it sends",
     accent: "from-[#67d9d1] via-[#3fcfc3] to-[#0f9f9a]",
+  },
+  {
+    label: "ENTERPRISE",
+    title: "Need this in your own infra?",
+    body: "Run OpenWork with your organization’s deployment, access controls, and rollout process.",
+    ctaLabel: "Explore enterprise",
+    ctaHref: "/enterprise",
+    accent: "from-[#6e87ff] via-[#4f6dff] to-[#1b29ff]",
   },
 ];
 
@@ -76,9 +79,20 @@ export function LandingDen(props: Props) {
                 <p className="flex-1 text-[15px] leading-7 text-gray-600">
                   {card.body}
                 </p>
-                <div className="mono mt-6 text-[13px] text-gray-500">
-                  {card.detail}
-                </div>
+                {card.ctaHref && card.ctaLabel ? (
+                  <div className="mt-6">
+                    <Link
+                      href={card.ctaHref}
+                      className="secondary-button inline-flex items-center justify-center px-4 py-2 text-sm font-semibold text-[#1f2937]"
+                    >
+                      {card.ctaLabel}
+                    </Link>
+                  </div>
+                ) : (
+                  <div className="mono mt-6 text-[13px] text-gray-500">
+                    {card.detail}
+                  </div>
+                )}
               </article>
             ))}
           </section>

--- a/packages/landing/components/landing-enterprise.tsx
+++ b/packages/landing/components/landing-enterprise.tsx
@@ -23,9 +23,9 @@ const deploymentModes = [
     icon: Users
   },
   {
-    title: "Self-hosted or managed",
+    title: "Preconfigured environment",
     description:
-      "Deploy inside your own environment or work with us on a managed rollout, with your gateway, MCP servers, skills, and internal data sources connected.",
+      "Start with your gateway, MCP servers, skills, and internal data sources already connected.",
     icon: PlugZap
   },
   {
@@ -157,20 +157,37 @@ export function LandingEnterprise(props: Props) {
               })}
             </div>
 
-            <div className="landing-shell rounded-[2rem] p-6 md:p-8">
-              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">
-                <ShieldCheck size={12} />
-                Information security
+            <div className="grid gap-6 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+              <div className="landing-shell rounded-[2rem] p-6 md:p-8">
+                <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">
+                  <ShieldCheck size={12} />
+                  Information security
+                </div>
+                <h3 className="mb-3 text-2xl font-medium tracking-tight text-[#011627]">
+                  Compliance-ready agentic workflows
+                </h3>
+                <p className="max-w-3xl text-[15px] leading-relaxed text-slate-600">
+                  OpenWork helps organizations run agentic workflows with a
+                  local-first, permission-aware architecture built for privacy,
+                  access control, and deployment flexibility across HIPAA, SOC 2
+                  Type II, ISO 27001, CCPA, and GDPR-sensitive environments.
+                </p>
               </div>
-              <h3 className="mb-3 text-2xl font-medium tracking-tight text-[#011627]">
-                Compliance-ready agentic workflows
-              </h3>
-              <p className="max-w-3xl text-[15px] leading-relaxed text-slate-600">
-                OpenWork helps organizations run agentic workflows with a
-                local-first, permission-aware architecture built for privacy,
-                access control, and deployment flexibility across HIPAA, SOC 2
-                Type II, ISO 27001, CCPA, and GDPR-sensitive environments.
-              </p>
+
+              <div className="landing-shell rounded-[2rem] p-6">
+                <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-blue-100 bg-blue-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-700">
+                  <PlugZap size={12} />
+                  Deployment
+                </div>
+                <h3 className="mb-3 text-[1.35rem] font-medium tracking-tight text-[#011627]">
+                  Self-hosted or managed
+                </h3>
+                <p className="text-[14px] leading-relaxed text-slate-600">
+                  Deploy inside your own environment or work with us on a
+                  managed rollout, with your gateway, MCP servers, skills, and
+                  internal data sources connected.
+                </p>
+              </div>
             </div>
 
             <BookCallForm />

--- a/packages/landing/components/landing-enterprise.tsx
+++ b/packages/landing/components/landing-enterprise.tsx
@@ -23,9 +23,9 @@ const deploymentModes = [
     icon: Users
   },
   {
-    title: "Preconfigured environment",
+    title: "Self-hosted or managed",
     description:
-      "Start with your gateway, MCP servers, skills, and internal data sources already connected.",
+      "Deploy inside your own environment or work with us on a managed rollout, with your gateway, MCP servers, skills, and internal data sources connected.",
     icon: PlugZap
   },
   {
@@ -70,7 +70,8 @@ export function LandingEnterprise(props: Props) {
             <p className="max-w-3xl text-lg leading-relaxed text-slate-600 md:text-xl">
               Run agentic workflows through your existing gateway, with
               approved tools, clear permissions, and a rollout path your
-              non-technical teams can actually use.
+              non-technical teams can actually use, whether you self-host in
+              your own infrastructure or deploy with OpenWork.
             </p>
 
             <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center">


### PR DESCRIPTION
## Summary
- move the existing content card into the middle slot as `MARKETING`
- replace the right-hand Den card with an enterprise CTA that routes to `/enterprise` in the same tab
- make self-hosting explicit on the enterprise landing page hero and deployment section

## Verification
- `pnpm --filter @different-ai/openwork-landing build`
- manual browser verification on `http://localhost:3010/den` and `http://localhost:3010/enterprise`
- before/after screenshots captured locally:
  - `/tmp/den-enterprise-cta/before-den.png`
  - `/tmp/den-enterprise-cta/after-den.png`
  - `/tmp/den-enterprise-cta/before-enterprise.png`
  - `/tmp/den-enterprise-cta/after-enterprise.png`

## Notes
- `next lint` for `packages/landing` opens the interactive Next.js ESLint setup prompt because the package does not have an ESLint config yet.

<img width="2880" height="6564" alt="image" src="https://github.com/user-attachments/assets/939914d9-7ecc-44f2-8371-8fd2eed28f2b" />
