### PR TITLE
fix den-v2 db env sync and org slug collisions

### DIFF
--- a/.github/workflows/deploy-den-v2.yml
+++ b/.github/workflows/deploy-den-v2.yml
@@ -33,10 +33,9 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_DEN_CONTROL_PLANE_SERVICE_ID: ${{ inputs.render_service_id || 'srv-d6sajsua2pns7383mis0' }}
           RENDER_OWNER_ID: ${{ secrets.RENDER_OWNER_ID }}
-          DEN_DATABASE_URL: ${{ secrets.DEN_DATABASE_URL || secrets.DATABASE_URL }}
-          DEN_DATABASE_HOST: ${{ secrets.DEN_DATABASE_HOST || secrets.DATABASE_HOST }}
-          DEN_DATABASE_USERNAME: ${{ secrets.DEN_DATABASE_USERNAME || secrets.DATABASE_USERNAME }}
-          DEN_DATABASE_PASSWORD: ${{ secrets.DEN_DATABASE_PASSWORD || secrets.DATABASE_PASSWORD }}
+          DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
           DEN_BETTER_AUTH_SECRET: ${{ secrets.DEN_BETTER_AUTH_SECRET }}
           DEN_GITHUB_CLIENT_ID: ${{ secrets.DEN_GITHUB_CLIENT_ID }}
           DEN_GITHUB_CLIENT_SECRET: ${{ secrets.DEN_GITHUB_CLIENT_SECRET }}
@@ -60,14 +59,12 @@ jobs:
             fi
           done
 
-          if [ -z "$DEN_DATABASE_URL" ]; then
-            for key in DEN_DATABASE_HOST DEN_DATABASE_USERNAME DEN_DATABASE_PASSWORD; do
-              if [ -z "${!key}" ]; then
-                echo "::error::Missing required database secret: $key (required when DEN_DATABASE_URL is not set)"
-                missing=1
-              fi
-            done
-          fi
+          for key in DATABASE_HOST DATABASE_USERNAME DATABASE_PASSWORD; do
+            if [ -z "${!key}" ]; then
+              echo "::error::Missing required database secret: $key"
+              missing=1
+            fi
+          done
 
           vanity_suffix="${DEN_RENDER_WORKER_PUBLIC_DOMAIN_SUFFIX:-openwork.studio}"
           if [ -n "$vanity_suffix" ] && [ -z "$VERCEL_TOKEN" ]; then
@@ -130,10 +127,9 @@ jobs:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_DEN_CONTROL_PLANE_SERVICE_ID: ${{ inputs.render_service_id || 'srv-d6sajsua2pns7383mis0' }}
           RENDER_OWNER_ID: ${{ secrets.RENDER_OWNER_ID }}
-          DEN_DATABASE_URL: ${{ secrets.DEN_DATABASE_URL || secrets.DATABASE_URL }}
-          DEN_DATABASE_HOST: ${{ secrets.DEN_DATABASE_HOST || secrets.DATABASE_HOST }}
-          DEN_DATABASE_USERNAME: ${{ secrets.DEN_DATABASE_USERNAME || secrets.DATABASE_USERNAME }}
-          DEN_DATABASE_PASSWORD: ${{ secrets.DEN_DATABASE_PASSWORD || secrets.DATABASE_PASSWORD }}
+          DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
           DEN_BETTER_AUTH_SECRET: ${{ secrets.DEN_BETTER_AUTH_SECRET }}
           DEN_GITHUB_CLIENT_ID: ${{ secrets.DEN_GITHUB_CLIENT_ID }}
           DEN_GITHUB_CLIENT_SECRET: ${{ secrets.DEN_GITHUB_CLIENT_SECRET }}
@@ -336,21 +332,18 @@ jobs:
               {"key": "POLAR_RETURN_URL", "value": polar_return_url},
           ]
 
-          database_url = os.environ.get("DEN_DATABASE_URL") or ""
-          database_host = os.environ.get("DEN_DATABASE_HOST") or ""
-          database_username = os.environ.get("DEN_DATABASE_USERNAME") or ""
-          database_password = os.environ.get("DEN_DATABASE_PASSWORD") or ""
+          database_host = os.environ.get("DATABASE_HOST") or ""
+          database_username = os.environ.get("DATABASE_USERNAME") or ""
+          database_password = os.environ.get("DATABASE_PASSWORD") or ""
 
-          if database_url:
-              env_vars.append({"key": "DATABASE_URL", "value": database_url})
-          else:
-              env_vars.extend(
-                  [
-                      {"key": "DATABASE_HOST", "value": database_host},
-                      {"key": "DATABASE_USERNAME", "value": database_username},
-                      {"key": "DATABASE_PASSWORD", "value": database_password},
-                  ]
-              )
+          env_vars.extend(
+              [
+                  {"key": "DATABASE_HOST", "value": database_host},
+                  {"key": "DATABASE_USERNAME", "value": database_username},
+                  {"key": "DATABASE_PASSWORD", "value": database_password},
+                  {"key": "DB_MODE", "value": "planetscale"},
+              ]
+          )
 
           if provisioner_mode == "daytona":
               env_vars.extend(

--- a/services/den-v2/src/orgs.ts
+++ b/services/den-v2/src/orgs.ts
@@ -6,6 +6,19 @@ import { createDenTypeId } from "./db/typeid.js"
 type UserId = typeof AuthUserTable.$inferSelect.id
 type OrgId = typeof OrgTable.$inferSelect.id
 
+function personalSlugFromOrgId(orgId: OrgId) {
+  return orgId
+}
+
+function isDuplicateSlugError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return message.includes("duplicate entry") && message.includes("org.org_slug")
+}
+
 export async function ensureDefaultOrg(userId: UserId, name: string): Promise<OrgId> {
   const existing = await db
     .select()
@@ -17,14 +30,33 @@ export async function ensureDefaultOrg(userId: UserId, name: string): Promise<Or
     return existing[0].org_id
   }
 
-  const orgId = createDenTypeId("org")
-  const slug = `personal-${orgId.slice(0, 8)}`
-  await db.insert(OrgTable).values({
-    id: orgId,
-    name,
-    slug,
-    owner_user_id: userId,
-  })
+  let orgId: OrgId | null = null
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidateOrgId = createDenTypeId("org")
+    const slug = personalSlugFromOrgId(candidateOrgId)
+
+    try {
+      await db.insert(OrgTable).values({
+        id: candidateOrgId,
+        name,
+        slug,
+        owner_user_id: userId,
+      })
+      orgId = candidateOrgId
+      break
+    } catch (error) {
+      if (isDuplicateSlugError(error) && attempt < 4) {
+        continue
+      }
+      throw error
+    }
+  }
+
+  if (!orgId) {
+    throw new Error("failed to create default org")
+  }
+
   await db.insert(OrgMembershipTable).values({
     id: createDenTypeId("orgMembership"),
     org_id: orgId,

--- a/services/den/src/orgs.ts
+++ b/services/den/src/orgs.ts
@@ -6,6 +6,19 @@ import { createDenTypeId } from "./db/typeid.js"
 type UserId = typeof AuthUserTable.$inferSelect.id
 type OrgId = typeof OrgTable.$inferSelect.id
 
+function personalSlugFromOrgId(orgId: OrgId) {
+  return orgId
+}
+
+function isDuplicateSlugError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return message.includes("duplicate entry") && message.includes("org.org_slug")
+}
+
 export async function ensureDefaultOrg(userId: UserId, name: string): Promise<OrgId> {
   const existing = await db
     .select()
@@ -17,14 +30,33 @@ export async function ensureDefaultOrg(userId: UserId, name: string): Promise<Or
     return existing[0].org_id
   }
 
-  const orgId = createDenTypeId("org")
-  const slug = `personal-${orgId.slice(0, 8)}`
-  await db.insert(OrgTable).values({
-    id: orgId,
-    name,
-    slug,
-    owner_user_id: userId,
-  })
+  let orgId: OrgId | null = null
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidateOrgId = createDenTypeId("org")
+    const slug = personalSlugFromOrgId(candidateOrgId)
+
+    try {
+      await db.insert(OrgTable).values({
+        id: candidateOrgId,
+        name,
+        slug,
+        owner_user_id: userId,
+      })
+      orgId = candidateOrgId
+      break
+    } catch (error) {
+      if (isDuplicateSlugError(error) && attempt < 4) {
+        continue
+      }
+      throw error
+    }
+  }
+
+  if (!orgId) {
+    throw new Error("failed to create default org")
+  }
+
   await db.insert(OrgMembershipTable).values({
     id: createDenTypeId("orgMembership"),
     org_id: orgId,


### PR DESCRIPTION
## Summary
- switch `deploy-den-v2.yml` to always sync PlanetScale credentials from unprefixed GitHub secrets (`DATABASE_HOST`, `DATABASE_USERNAME`, `DATABASE_PASSWORD`) and set `DB_MODE=planetscale`
- remove `DATABASE_URL` fallback logic from the v2 deploy workflow so den-v2 no longer gets flipped back to mysql mode by unrelated app secrets
- fix default org slug generation in both `services/den` and `services/den-v2` by using the full org typeid slug, plus retry on duplicate-slug insert races

## Validation
- `npm -v && node -v && pnpm -v`
- `npm run build` in `services/den-v2` (fails in this environment due to workspace dependency/toolchain setup)
- `npm run build` in `services/den` (fails in this environment due to workspace dependency/toolchain setup)