### PR TITLE
feat(web): add env-driven deployment mode utility

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -19,6 +19,17 @@ Frontend for `app.openwork.software`.
 3. Open:
    `http://localhost:3005`
 
+## Deployment mode utility
+
+- Shared helper path: `packages/web/lib/openwork-deployment.ts`
+- Main API: `getOpenWorkDeployment()`
+- Convenience APIs: `isWebDeployment()` and `isDesktopDeployment()`
+- Runtime values: `desktop` (default) or `web`
+- Environment resolution order:
+  - `NEXT_PUBLIC_OPENWORK_DEPLOYMENT` (client + server)
+  - `OPENWORK_DEPLOYMENT` (server-only fallback)
+  - `desktop` (final fallback)
+
 ### Optional env vars
 
 - `DEN_API_BASE` (server-only): upstream API base used by proxy route.
@@ -33,6 +44,13 @@ Frontend for `app.openwork.software`.
 - `NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL` (client): Canonical URL used for GitHub auth callback redirects.
   - default: `https://app.openwork.software`
   - this host must serve `/api/auth/*`; the included proxy route does that
+- `NEXT_PUBLIC_OPENWORK_DEPLOYMENT` (client + server): Deployment mode used by shared helpers.
+  - allowed values: `desktop` | `web`
+  - default: `desktop`
+  - set to `web` in Vercel to indicate hosted web deployment
+- `OPENWORK_DEPLOYMENT` (server-only): Optional server override when `NEXT_PUBLIC_OPENWORK_DEPLOYMENT` is unset.
+  - allowed values: `desktop` | `web`
+  - default: `desktop`
 - `NEXT_PUBLIC_POSTHOG_KEY` (client): PostHog project key used for Den analytics.
   - optional override; defaults to the same project key used by `packages/landing`
 - `NEXT_PUBLIC_POSTHOG_HOST` (client): PostHog ingest host or same-origin proxy path.

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,9 +1,15 @@
 import Image from "next/image";
 import { CloudControlPanel } from "../components/cloud-control";
+import { getOpenWorkDeployment } from "../lib/openwork-deployment";
 
 export default function HomePage() {
+  const deployment = getOpenWorkDeployment();
+
   return (
-    <main className="relative min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] text-[var(--dls-text-primary)]">
+    <main
+      className="relative min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] text-[var(--dls-text-primary)]"
+      data-openwork-deployment={deployment}
+    >
       <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden>
         <span className="absolute -left-24 top-[-8rem] h-[24rem] w-[24rem] rounded-full bg-[#e2e8f0]/90 blur-[120px]" />
         <span className="absolute right-[-6rem] top-20 h-[20rem] w-[20rem] rounded-full bg-[#c7d2fe]/50 blur-[120px]" />

--- a/packages/web/components/cloud-control.tsx
+++ b/packages/web/components/cloud-control.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
+import { isDesktopDeployment } from "../lib/openwork-deployment";
 
 type Step = "auth" | "name" | "initializing" | "connect" | "workspace";
 type AuthMode = "sign-in" | "sign-up";
@@ -260,6 +261,10 @@ function normalizeWorkerName(input: string): string {
 }
 
 function isDesktopContext(): boolean {
+  if (!isDesktopDeployment()) {
+    return false;
+  }
+
   if (typeof window === "undefined") {
     return false;
   }

--- a/packages/web/lib/openwork-deployment.ts
+++ b/packages/web/lib/openwork-deployment.ts
@@ -1,0 +1,36 @@
+export const OPENWORK_DEPLOYMENT_ENV_VAR = "NEXT_PUBLIC_OPENWORK_DEPLOYMENT";
+
+export type OpenWorkDeployment = "desktop" | "web";
+
+/**
+ * Normalizes deployment values from environment variables.
+ * Any unknown or empty value falls back to desktop.
+ */
+function normalizeDeployment(value: string | undefined): OpenWorkDeployment {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "web" ? "web" : "desktop";
+}
+
+/**
+ * Returns the runtime deployment mode for the web app.
+ *
+ * Resolution order:
+ * 1) NEXT_PUBLIC_OPENWORK_DEPLOYMENT (client + server)
+ * 2) OPENWORK_DEPLOYMENT (server-only override)
+ * 3) "desktop" default
+ */
+export function getOpenWorkDeployment(): OpenWorkDeployment {
+  return normalizeDeployment(
+    process.env.NEXT_PUBLIC_OPENWORK_DEPLOYMENT ?? process.env.OPENWORK_DEPLOYMENT
+  );
+}
+
+/** True when deployment mode is explicitly set to "web". */
+export function isWebDeployment(): boolean {
+  return getOpenWorkDeployment() === "web";
+}
+
+/** True when deployment mode resolves to "desktop" (including fallback). */
+export function isDesktopDeployment(): boolean {
+  return getOpenWorkDeployment() === "desktop";
+}


### PR DESCRIPTION
## Summary
- add a shared `packages/web/lib/openwork-deployment.ts` utility that resolves deployment mode from env vars with a safe default (`desktop`)
- use the utility from both server and client code paths (`app/page.tsx` and `components/cloud-control.tsx`) so behavior can be toggled via environment
- document the helper and env configuration in `packages/web/README.md`, including Vercel guidance for `NEXT_PUBLIC_OPENWORK_DEPLOYMENT=web`

## Verification
- `pnpm install`
- `pnpm --filter @different-ai/openwork-web build`
- `pnpm --filter @different-ai/openwork-web lint` *(blocked: Next.js interactive ESLint setup prompt in this package)*