### PR TITLE
fix(vercel): run the app build script correctly

### DIFF
--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "vite",
-  "buildCommand": "pnpm build:web",
+  "buildCommand": "pnpm run build:web",
   "outputDirectory": "dist",
   "rewrites": [
     {


### PR DESCRIPTION
## Summary
- fix the Vercel app build command so `packages/app` uses `pnpm run build:web`, which works for colon-named pnpm scripts
- keep the Vite output directory as `dist` for `packages/app` root-directory deployments
- unblock the desktop UI preview deploy that was failing with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`

## Testing
- not run (config-only change)