### PR TITLE
feat(app): add env-driven deployment mode helper

### DIFF
--- a/packages/app/src/app/components/den-settings-panel.tsx
+++ b/packages/app/src/app/components/den-settings-panel.tsx
@@ -10,6 +10,7 @@ import {
   readDenSettings,
   writeDenSettings,
 } from "../lib/den";
+import { isDesktopDeployment } from "../lib/openwork-deployment";
 import { usePlatform } from "../context/platform";
 
 type DenSettingsPanelProps = {
@@ -128,8 +129,10 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
   const openBrowserAuth = (mode: "sign-in" | "sign-up") => {
     const target = new URL(normalizeDenBaseUrl(baseUrl()) ?? DEFAULT_DEN_BASE_URL);
     target.searchParams.set("mode", mode);
-    target.searchParams.set("desktopAuth", "1");
-    target.searchParams.set("desktopScheme", "openwork");
+    if (isDesktopDeployment()) {
+      target.searchParams.set("desktopAuth", "1");
+      target.searchParams.set("desktopScheme", "openwork");
+    }
     platform.openLink(target.toString());
     setStatusMessage(mode === "sign-up" ? "Finish account creation in your browser to connect OpenWork." : "Finish signing in in your browser to connect OpenWork.");
     setAuthError(null);

--- a/packages/app/src/app/context/server.tsx
+++ b/packages/app/src/app/context/server.tsx
@@ -2,6 +2,7 @@ import { createContext, createEffect, createMemo, createSignal, onCleanup, useCo
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 
+import { isWebDeployment } from "../lib/openwork-deployment";
 import { isTauriRuntime } from "../utils";
 
 export function normalizeServerUrl(input: string) {
@@ -59,11 +60,12 @@ export function ServerProvider(props: ParentProps & { defaultUrl: string }) {
 
     const fallback = normalizeServerUrl(props.defaultUrl) ?? "";
 
-    // In production web builds served by OpenWork (Docker "remote" mode), OpenCode
+    // In hosted web deployments served by OpenWork, OpenCode
     // traffic should go through the server proxy (usually same-origin `/opencode`).
     // Do not reuse any persisted localhost targets.
     const forceProxy =
       !isTauriRuntime() &&
+      isWebDeployment() &&
       (import.meta.env.PROD ||
         (typeof import.meta.env?.VITE_OPENWORK_URL === "string" &&
           import.meta.env.VITE_OPENWORK_URL.trim().length > 0));

--- a/packages/app/src/app/entry.tsx
+++ b/packages/app/src/app/entry.tsx
@@ -3,6 +3,7 @@ import { GlobalSDKProvider } from "./context/global-sdk";
 import { GlobalSyncProvider } from "./context/global-sync";
 import { LocalProvider } from "./context/local";
 import { ServerProvider } from "./context/server";
+import { isWebDeployment } from "./lib/openwork-deployment";
 import { isTauriRuntime } from "./utils";
 
 export default function AppEntry() {
@@ -20,9 +21,9 @@ export default function AppEntry() {
       return `${openworkUrl.replace(/\/+$/, "")}/opencode`;
     }
 
-    // When the UI is served by the OpenWork server (Docker "remote" mode),
+    // When the hosted web deployment is served by the OpenWork server,
     // OpenCode is proxied at same-origin `/opencode`.
-    if (import.meta.env.PROD && typeof window !== "undefined") {
+    if (isWebDeployment() && import.meta.env.PROD && typeof window !== "undefined") {
       return `${window.location.origin}/opencode`;
     }
 

--- a/packages/app/src/app/lib/openwork-deployment.ts
+++ b/packages/app/src/app/lib/openwork-deployment.ts
@@ -1,0 +1,25 @@
+export const OPENWORK_DEPLOYMENT_ENV_VAR = "VITE_OPENWORK_DEPLOYMENT";
+
+export type OpenWorkDeployment = "desktop" | "web";
+
+function normalizeDeployment(value: string | undefined): OpenWorkDeployment {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "web" ? "web" : "desktop";
+}
+
+export function getOpenWorkDeployment(): OpenWorkDeployment {
+  const envValue =
+    typeof import.meta !== "undefined" && typeof import.meta.env?.VITE_OPENWORK_DEPLOYMENT === "string"
+      ? import.meta.env.VITE_OPENWORK_DEPLOYMENT
+      : undefined;
+
+  return normalizeDeployment(envValue);
+}
+
+export function isWebDeployment(): boolean {
+  return getOpenWorkDeployment() === "web";
+}
+
+export function isDesktopDeployment(): boolean {
+  return getOpenWorkDeployment() === "desktop";
+}

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -6,6 +6,7 @@ import { bootstrapTheme } from "./app/theme";
 import "./app/index.css";
 import AppEntry from "./app/entry";
 import { PlatformProvider, type Platform } from "./app/context/platform";
+import { getOpenWorkDeployment } from "./app/lib/openwork-deployment";
 import { isTauriRuntime } from "./app/utils";
 import { initLocale } from "./i18n";
 
@@ -17,6 +18,8 @@ const root = document.getElementById("root");
 if (!root) {
   throw new Error("Root element not found");
 }
+
+root.dataset.openworkDeployment = getOpenWorkDeployment();
 
 const RouterComponent = isTauriRuntime() ? HashRouter : Router;
 


### PR DESCRIPTION
## Summary
- follow up on #977 by moving the deployment-mode helper into `packages/app`, where the primary OpenWork UI now lives
- add a shared `VITE_OPENWORK_DEPLOYMENT` utility and expose the resolved mode on the app root for hosted web builds
- use the helper to avoid desktop auth handoff params in hosted web deployments and keep server proxy selection explicit

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`

## Notes
- I did not run the Docker + Chrome MCP end-to-end flow for this follow-up move; this PR is validated with package-level typecheck and production build.