### PR TITLE
fix(vercel): include packages/app in deploy context

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -8,7 +8,6 @@ vendor
 **/dist
 **/.*.bun-build
 packages/agent-lab
-packages/app
 packages/desktop
 packages/headless
 packages/opencode-router


### PR DESCRIPTION
## Summary
- stop excluding `packages/app` in `.vercelignore` so Vercel includes the Vite app files in the build context
- fix the deployment failure where Vercel couldn't find `/packages/app/package.json` and built the wrong app path

## Testing
- not run (ignore-list config change)