### PR TITLE
fix(den): persist onboarding worker name updates

### DIFF
--- a/packages/web/components/cloud-control.tsx
+++ b/packages/web/components/cloud-control.tsx
@@ -159,6 +159,7 @@ const PENDING_SOCIAL_SIGNUP_STORAGE_KEY = "openwork:web:pending-social-signup";
 const AUTH_TOKEN_STORAGE_KEY = "openwork:web:auth-token";
 const WORKER_STATUS_POLL_MS = 5000;
 const DEFAULT_AUTH_NAME = "OpenWork User";
+const DEFAULT_WORKER_NAME = "My Worker";
 const OPENWORK_APP_CONNECT_BASE_URL = (process.env.NEXT_PUBLIC_OPENWORK_APP_CONNECT_URL ?? "").trim();
 const OPENWORK_AUTH_CALLBACK_BASE_URL = (process.env.NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL ?? "").trim();
 const OPENWORK_DOWNLOAD_URL = "https://openwork.software/download";
@@ -256,7 +257,7 @@ function getSocialProviderLabel(provider: SocialAuthProvider): string {
 
 function normalizeWorkerName(input: string): string {
   const normalized = input.trim().replace(/\s+/g, " ");
-  return normalized || "Founder Ops Pilot";
+  return normalized || DEFAULT_WORKER_NAME;
 }
 
 function isDesktopContext(): boolean {
@@ -1090,7 +1091,7 @@ export function CloudControlPanel() {
   });
   const [sessionHydrated, setSessionHydrated] = useState(false);
 
-  const [workerName, setWorkerName] = useState("Founder Ops Pilot");
+  const [workerName, setWorkerName] = useState(DEFAULT_WORKER_NAME);
   const [worker, setWorker] = useState<WorkerLaunch | null>(null);
   const [workerLookupId, setWorkerLookupId] = useState("");
   const [workers, setWorkers] = useState<WorkerListItem[]>([]);
@@ -2290,7 +2291,7 @@ export function CloudControlPanel() {
     setSignupOnboardingActive(false);
     setAutoLaunchPending(false);
     setNameStepBusy(false);
-    setWorkerName("Founder Ops Pilot");
+    setWorkerName(DEFAULT_WORKER_NAME);
     setWorkerQuery("");
     setWorkerStatusFilter("all");
     setShowLaunchForm(false);
@@ -2320,7 +2321,7 @@ export function CloudControlPanel() {
       return;
     }
 
-    const resolvedLaunchName = options.workerNameOverride?.trim() || workerName.trim() || "Cloud Worker";
+    const resolvedLaunchName = options.workerNameOverride?.trim() || workerName.trim() || DEFAULT_WORKER_NAME;
 
     setLaunchBusy(true);
     setLaunchError(null);
@@ -2775,7 +2776,7 @@ export function CloudControlPanel() {
     }
 
     const target = workers.find((entry) => entry.workerId === workerId) ?? null;
-    const workerLabel = target?.workerName?.trim() || "Cloud Worker";
+    const workerLabel = target?.workerName?.trim() || DEFAULT_WORKER_NAME;
 
     if (typeof window !== "undefined") {
       const confirmed = window.confirm(
@@ -3013,7 +3014,7 @@ export function CloudControlPanel() {
                   type="text"
                   value={workerName}
                   onChange={(event) => setWorkerName(event.target.value)}
-                  placeholder="Founder Ops Pilot"
+                  placeholder={DEFAULT_WORKER_NAME}
                   maxLength={64}
                 />
               </label>
@@ -3322,7 +3323,7 @@ export function CloudControlPanel() {
                             ? "Starting worker..."
                             : worker?.status === "provisioning"
                               ? "Worker is starting..."
-                              : `Launch "${workerName || "Cloud Worker"}"`}
+                              : `Launch "${workerName || DEFAULT_WORKER_NAME}"`}
                         </button>
 
                         {(launchStatus || launchError) && showLaunchForm ? (
@@ -3443,7 +3444,7 @@ export function CloudControlPanel() {
                           ? "Starting worker..."
                           : worker?.status === "provisioning"
                             ? "Worker is starting..."
-                            : `Launch "${workerName || "Cloud Worker"}"`}
+                            : `Launch "${workerName || DEFAULT_WORKER_NAME}"`}
                       </button>
 
                       {(launchStatus || launchError) && showLaunchForm ? (

--- a/services/den-v2/src/http/workers.ts
+++ b/services/den-v2/src/http/workers.ts
@@ -25,6 +25,10 @@ const createSchema = z.object({
   imageVersion: z.string().optional(),
 })
 
+const updateSchema = z.object({
+  name: z.string().trim().min(1).max(255),
+})
+
 const listSchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).default(20),
 })
@@ -640,6 +644,58 @@ workersRouter.get("/:id", asyncRoute(async (req, res) => {
   res.json({
     worker: toWorkerResponse(rows[0], session.user.id),
     instance: toInstanceResponse(instance),
+  })
+}))
+
+workersRouter.patch("/:id", asyncRoute(async (req, res) => {
+  const session = await requireSession(req, res)
+  if (!session) return
+
+  const orgId = await getOrgId(session.user.id)
+  if (!orgId) {
+    res.status(404).json({ error: "worker_not_found" })
+    return
+  }
+
+  const parsed = updateSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ error: "invalid_request", details: parsed.error.flatten() })
+    return
+  }
+
+  let workerId: WorkerId
+  try {
+    workerId = parseWorkerIdParam(req.params.id)
+  } catch {
+    res.status(404).json({ error: "worker_not_found" })
+    return
+  }
+
+  const rows = await db
+    .select()
+    .from(WorkerTable)
+    .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.org_id, orgId)))
+    .limit(1)
+
+  if (rows.length === 0) {
+    res.status(404).json({ error: "worker_not_found" })
+    return
+  }
+
+  await db
+    .update(WorkerTable)
+    .set({ name: parsed.data.name })
+    .where(eq(WorkerTable.id, workerId))
+
+  res.json({
+    worker: toWorkerResponse(
+      {
+        ...rows[0],
+        name: parsed.data.name,
+        updated_at: new Date(),
+      },
+      session.user.id,
+    ),
   })
 }))
 

--- a/services/den/src/http/workers.ts
+++ b/services/den/src/http/workers.ts
@@ -25,6 +25,10 @@ const createSchema = z.object({
   imageVersion: z.string().optional(),
 })
 
+const updateSchema = z.object({
+  name: z.string().trim().min(1).max(255),
+})
+
 const listSchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).default(20),
 })
@@ -640,6 +644,58 @@ workersRouter.get("/:id", asyncRoute(async (req, res) => {
   res.json({
     worker: toWorkerResponse(rows[0], session.user.id),
     instance: toInstanceResponse(instance),
+  })
+}))
+
+workersRouter.patch("/:id", asyncRoute(async (req, res) => {
+  const session = await requireSession(req, res)
+  if (!session) return
+
+  const orgId = await getOrgId(session.user.id)
+  if (!orgId) {
+    res.status(404).json({ error: "worker_not_found" })
+    return
+  }
+
+  const parsed = updateSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ error: "invalid_request", details: parsed.error.flatten() })
+    return
+  }
+
+  let workerId: WorkerId
+  try {
+    workerId = parseWorkerIdParam(req.params.id)
+  } catch {
+    res.status(404).json({ error: "worker_not_found" })
+    return
+  }
+
+  const rows = await db
+    .select()
+    .from(WorkerTable)
+    .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.org_id, orgId)))
+    .limit(1)
+
+  if (rows.length === 0) {
+    res.status(404).json({ error: "worker_not_found" })
+    return
+  }
+
+  await db
+    .update(WorkerTable)
+    .set({ name: parsed.data.name })
+    .where(eq(WorkerTable.id, workerId))
+
+  res.json({
+    worker: toWorkerResponse(
+      {
+        ...rows[0],
+        name: parsed.data.name,
+        updated_at: new Date(),
+      },
+      session.user.id,
+    ),
   })
 }))
 


### PR DESCRIPTION
## Summary
- add `PATCH /v1/workers/:id` in Den and Den v2 so onboarding worker name edits persist to the database
- keep rename authorization org-scoped by requiring the worker to belong to the caller's org before update
- change onboarding/default worker naming fallback in the Den web UI to `My Worker` and use a single constant across the flow

## Testing
- Attempted: `pnpm --filter @openwork/den build && pnpm --filter @openwork/den-v2 build && pnpm --filter @different-ai/openwork-web lint`
- Result: failed in this worktree due missing local dependencies / TS toolchain resolution (`node_modules` missing and `--moduleResolution` mismatch surfaced during dependency build)