### PR TITLE
Prototype callback bridge for loopback auth flows

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -198,8 +198,11 @@ import {
   type OpenworkServerStatus,
   type OpenworkServerSettings,
   type OpenworkWorkspaceExport,
+  type OpenworkCallbackBridgeRegisterResult,
   OpenworkServerError,
 } from "./lib/openwork-server";
+import { openExternalUrl } from "./lib/open-external-url";
+import { generateWorkerLinkUrl } from "./lib/worker-link-url";
 
 type RemoteWorkspaceDefaults = {
   openworkHostUrl?: string | null;
@@ -2212,6 +2215,48 @@ export default function App() {
       next[sessionID] = trimmed;
       return next;
     });
+  }
+
+  async function generateWorkerAuthLinkUrl(inputUrl: string): Promise<string> {
+    const raw = inputUrl.trim();
+    if (!raw) return inputUrl;
+
+    const workspace = workspaceStore.activeWorkspaceDisplay();
+    const callbackBaseUrl = (
+      workspace.openworkHostUrl?.trim() ||
+      workspace.baseUrl?.trim() ||
+      openworkServerBaseUrl().trim() ||
+      ""
+    ).replace(/\/+$/, "");
+    if (!callbackBaseUrl) return inputUrl;
+
+    const workspaceId =
+      openworkServerWorkspaceId()?.trim() ||
+      workspace.openworkWorkspaceId?.trim() ||
+      workspace.id?.trim() ||
+      parseOpenworkWorkspaceIdFromUrl(workspace.openworkHostUrl ?? "") ||
+      parseOpenworkWorkspaceIdFromUrl(workspace.baseUrl ?? "") ||
+      "";
+    if (!workspaceId) return inputUrl;
+
+    const owClient = openworkServerClient();
+    if (!owClient) return inputUrl;
+
+    return generateWorkerLinkUrl(raw, async (targetUrl) => {
+      const registered: OpenworkCallbackBridgeRegisterResult = await owClient.registerCallbackBridge(workspaceId, {
+        targetUrl,
+        methods: ["GET"],
+        singleUse: true,
+        ttlMs: 5 * 60_000,
+      });
+      const callbackPath = registered.path.startsWith("/") ? registered.path : `/${registered.path}`;
+      return `${callbackBaseUrl}${callbackPath}`;
+    });
+  }
+
+  async function openExternalBrowserUrl(inputUrl: string): Promise<string> {
+    const rewrittenUrl = await generateWorkerAuthLinkUrl(inputUrl);
+    return openExternalUrl(rewrittenUrl);
   }
 
   const buildProviderAuthMethods = (
@@ -6676,6 +6721,7 @@ export default function App() {
       openProviderAuthModal,
       disconnectProvider,
       closeProviderAuthModal,
+      openExternalUrl: openExternalBrowserUrl,
       startProviderAuth,
       completeProviderAuthOAuth,
       refreshProviders,
@@ -7029,6 +7075,7 @@ export default function App() {
     submitProviderApiKey: submitProviderApiKey,
     openProviderAuthModal: openProviderAuthModal,
     closeProviderAuthModal: closeProviderAuthModal,
+    openExternalUrl: openExternalBrowserUrl,
     providerAuthModalOpen: providerAuthModalOpen(),
     providerAuthBusy: providerAuthBusy(),
     providerAuthError: providerAuthError(),
@@ -7238,6 +7285,7 @@ export default function App() {
         reloadBlocked={activeReloadBlockingSessions().length > 0}
         activeSessions={activeReloadBlockingSessions()}
         isRemoteWorkspace={activeWorkspaceDisplay().workspaceType === "remote"}
+        openExternalUrl={openExternalBrowserUrl}
         onForceStopSession={(sessionID) => abortSession(sessionID)}
         onClose={() => {
           setMcpAuthModalOpen(false);
@@ -7355,12 +7403,7 @@ export default function App() {
         workerCtaDescription={t("dashboard.sandbox_get_ready_desc", currentLocale())}
         onWorkerCta={async () => {
           const url = "https://www.docker.com/products/docker-desktop/";
-          if (isTauriRuntime()) {
-            const { openUrl } = await import("@tauri-apps/plugin-opener");
-            await openUrl(url);
-          } else {
-            window.open(url, "_blank", "noopener,noreferrer");
-          }
+          await openExternalBrowserUrl(url);
         }}
         workerRetryLabel={t("common.retry", currentLocale())}
         workerDebugLines={(() => {

--- a/packages/app/src/app/components/mcp-auth-modal.tsx
+++ b/packages/app/src/app/components/mcp-auth-modal.tsx
@@ -4,6 +4,7 @@ import Button from "./button";
 import TextInput from "./text-input";
 import type { Client } from "../types";
 import type { McpDirectoryInfo } from "../constants";
+import { openExternalUrl as openExternalUrlDirect } from "../lib/open-external-url";
 import { unwrap } from "../lib/opencode";
 import { opencodeMcpAuth } from "../lib/tauri";
 import { validateMcpServerName } from "../mcp";
@@ -28,6 +29,7 @@ export type McpAuthModalProps = {
   projectDir: string;
   language: Language;
   onForceStopSession?: (sessionID: string) => void | Promise<void>;
+  openExternalUrl?: (url: string) => Promise<string>;
 };
 
 export default function McpAuthModal(props: McpAuthModalProps) {
@@ -86,15 +88,7 @@ export default function McpAuthModal(props: McpAuthModalProps) {
   });
 
   const openAuthorizationUrl = async (url: string) => {
-    if (isTauriRuntime()) {
-      const { openUrl } = await import("@tauri-apps/plugin-opener");
-      await openUrl(url);
-      return;
-    }
-
-    if (typeof window !== "undefined") {
-      window.open(url, "_blank", "noopener,noreferrer");
-    }
+    return (props.openExternalUrl ?? openExternalUrlDirect)(url);
   };
 
   const handleCopyAuthorizationUrl = async () => {
@@ -273,8 +267,9 @@ export default function McpAuthModal(props: McpAuthModalProps) {
         return;
       }
 
-      setAuthorizationUrl(auth.authorizationUrl);
-      await openAuthorizationUrl(auth.authorizationUrl);
+      const launchUrl = await openAuthorizationUrl(auth.authorizationUrl);
+
+      setAuthorizationUrl(launchUrl || auth.authorizationUrl);
       startStatusPolling(slug);
     } catch (err) {
       const message = err instanceof Error ? err.message : translate("mcp.auth.failed_to_start_oauth");

--- a/packages/app/src/app/components/provider-auth-modal.tsx
+++ b/packages/app/src/app/components/provider-auth-modal.tsx
@@ -2,7 +2,7 @@ import type { ProviderAuthAuthorization } from "@opencode-ai/sdk/v2/client";
 import { CheckCircle2, Loader2, X } from "lucide-solid";
 import type { ProviderListItem } from "../types";
 import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js";
-import { isTauriRuntime } from "../utils";
+import { openExternalUrl as openExternalUrlDirect } from "../lib/open-external-url";
 import { compareProviders } from "../utils/providers";
 
 import Button from "./button";
@@ -50,6 +50,7 @@ export type ProviderAuthModalProps = {
     code?: string
   ) => Promise<{ connected: boolean; pending?: boolean; message?: string }>;
   onRefreshProviders?: () => Promise<unknown>;
+  openExternalUrl?: (url: string) => Promise<string>;
   onClose: () => void;
 };
 
@@ -269,12 +270,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
   const openOauthUrl = async (url: string) => {
     if (!url) return;
-    if (isTauriRuntime()) {
-      const { openUrl } = await import("@tauri-apps/plugin-opener");
-      await openUrl(url);
-      return;
-    }
-    window.open(url, "_blank", "noopener,noreferrer");
+    return (props.openExternalUrl ?? openExternalUrlDirect)(url);
   };
 
   const submitOauth = async (providerId: string, methodIndex: number, code?: string) => {
@@ -331,8 +327,15 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
         methodIndex: started.methodIndex,
         authorization: started.authorization,
       };
-      setOauthSession(nextSession);
-      await openOauthUrl(started.authorization.url);
+      const openedUrl = await openOauthUrl(started.authorization.url);
+      setOauthSession(
+        openedUrl && openedUrl !== started.authorization.url
+          ? {
+              ...nextSession,
+              authorization: { ...started.authorization, url: openedUrl },
+            }
+          : nextSession,
+      );
 
       if (started.authorization.method === "code") {
         setView("oauth-code");

--- a/packages/app/src/app/lib/open-external-url.ts
+++ b/packages/app/src/app/lib/open-external-url.ts
@@ -1,0 +1,18 @@
+import { isTauriRuntime } from "../utils";
+
+export async function openExternalUrl(url: string): Promise<string> {
+  const nextUrl = url.trim();
+  if (!nextUrl) return url;
+
+  if (isTauriRuntime()) {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(nextUrl);
+    return nextUrl;
+  }
+
+  if (typeof window !== "undefined") {
+    window.open(nextUrl, "_blank", "noopener,noreferrer");
+  }
+
+  return nextUrl;
+}

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -108,6 +108,25 @@ export type OpenworkWorkspaceList = {
   activeId?: string | null;
 };
 
+export type OpenworkCallbackBridgeRegisterInput = {
+  targetUrl: string;
+  ttlMs?: number;
+  methods?: string[];
+  singleUse?: boolean;
+};
+
+export type OpenworkCallbackBridgeRegisterResult = {
+  ok: boolean;
+  token: string;
+  path: string;
+  workspaceId: string;
+  targetUrl: string;
+  methods: string[];
+  ttlMs: number;
+  expiresAt: number;
+  singleUse: boolean;
+};
+
 export type OpenworkPluginItem = {
   spec: string;
   source: "config" | "dir.project" | "dir.global";
@@ -1167,6 +1186,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     status: 6_000,
     config: 10_000,
     opencodeRouter: 10_000,
+    callbackBridge: 10_000,
     workspaceExport: 30_000,
     workspaceImport: 30_000,
     binary: 60_000,
@@ -1213,6 +1233,18 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         baseUrl,
         `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
         { token, hostToken, method: "DELETE", timeoutMs: timeouts.deleteSession },
+      ),
+    registerCallbackBridge: (workspaceId: string, input: OpenworkCallbackBridgeRegisterInput) =>
+      requestJson<OpenworkCallbackBridgeRegisterResult>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/callback-bridge/register`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: input,
+          timeoutMs: timeouts.callbackBridge,
+        },
       ),
     exportWorkspace: (workspaceId: string) =>
       requestJson<OpenworkWorkspaceExport>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/export`, {

--- a/packages/app/src/app/lib/worker-link-url.ts
+++ b/packages/app/src/app/lib/worker-link-url.ts
@@ -1,0 +1,58 @@
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function maybeParseUrl(value: string): URL | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    return new URL(trimmed);
+  } catch {
+    // Some values come as localhost:1455/path with no scheme.
+    if (/^(localhost|127\.0\.0\.1|\[?::1\]?)(:\d+)?(\/|$)/i.test(trimmed)) {
+      try {
+        return new URL(`http://${trimmed}`);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+export function isLoopbackUrl(url: URL): boolean {
+  return LOOPBACK_HOSTS.has(url.hostname.toLowerCase());
+}
+
+export async function generateWorkerLinkUrl(
+  inputUrl: string,
+  registerLoopbackTarget: (targetUrl: string) => Promise<string>,
+): Promise<string> {
+  const parsed = maybeParseUrl(inputUrl);
+  if (!parsed) return inputUrl;
+
+  if (isLoopbackUrl(parsed)) {
+    return registerLoopbackTarget(parsed.toString());
+  }
+
+  let replacedAny = false;
+  const nextParams: Array<[string, string]> = [];
+
+  for (const [key, value] of parsed.searchParams.entries()) {
+    const nested = maybeParseUrl(value);
+    if (!nested || !isLoopbackUrl(nested)) {
+      nextParams.push([key, value]);
+      continue;
+    }
+    nextParams.push([key, await registerLoopbackTarget(nested.toString())]);
+    replacedAny = true;
+  }
+
+  if (!replacedAny) return parsed.toString();
+
+  parsed.search = "";
+  for (const [key, value] of nextParams) {
+    parsed.searchParams.append(key, value);
+  }
+
+  return parsed.toString();
+}

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -87,6 +87,8 @@ export type DashboardViewProps = {
     returnFocusTarget?: "none" | "composer";
   }) => Promise<void>;
   disconnectProvider: (providerId: string) => Promise<string | void>;
+<<<<<<< HEAD
+  openExternalUrl: (url: string) => Promise<string>;
   closeProviderAuthModal: (options?: { restorePromptFocus?: boolean }) => void;
   startProviderAuth: (providerId?: string) => Promise<ProviderOAuthStartResult>;
   completeProviderAuthOAuth: (
@@ -1501,6 +1503,7 @@ export default function DashboardView(props: DashboardViewProps) {
           onSubmitApiKey={handleProviderAuthApiKey}
           onSubmitOAuth={handleProviderAuthOAuth}
           onRefreshProviders={props.refreshProviders}
+          openExternalUrl={props.openExternalUrl}
           onClose={() => props.closeProviderAuthModal()}
         />
 

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -87,7 +87,6 @@ export type DashboardViewProps = {
     returnFocusTarget?: "none" | "composer";
   }) => Promise<void>;
   disconnectProvider: (providerId: string) => Promise<string | void>;
-<<<<<<< HEAD
   openExternalUrl: (url: string) => Promise<string>;
   closeProviderAuthModal: (options?: { restorePromptFocus?: boolean }) => void;
   startProviderAuth: (providerId?: string) => Promise<ProviderOAuthStartResult>;

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -258,6 +258,7 @@ export type SessionViewProps = {
     returnFocusTarget?: "none" | "composer";
   }) => Promise<void>;
   closeProviderAuthModal: (options?: { restorePromptFocus?: boolean }) => void;
+  openExternalUrl: (url: string) => Promise<string>;
   providerAuthModalOpen: boolean;
   providerAuthBusy: boolean;
   providerAuthError: string | null;
@@ -4925,6 +4926,7 @@ export default function SessionView(props: SessionViewProps) {
         onSubmitApiKey={handleProviderAuthApiKey}
         onSubmitOAuth={handleProviderAuthOAuth}
         onRefreshProviders={props.refreshProviders}
+        openExternalUrl={props.openExternalUrl}
         onClose={() => props.closeProviderAuthModal()}
       />
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, rm, readdir, rename, stat } from "node:fs/promises";
-import { createHash, randomInt } from "node:crypto";
+import { createHash, randomBytes, randomInt } from "node:crypto";
 import { homedir, hostname } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger, TokenScope } from "./types.js";
@@ -33,6 +33,19 @@ const FILE_SESSION_MAX_BATCH_ITEMS = 64;
 const FILE_SESSION_MAX_FILE_BYTES = 5_000_000;
 const FILE_SESSION_CATALOG_DEFAULT_LIMIT = 2000;
 const FILE_SESSION_CATALOG_MAX_LIMIT = 10000;
+const CALLBACK_BRIDGE_DEFAULT_TTL_MS = 5 * 60 * 1000;
+const CALLBACK_BRIDGE_MIN_TTL_MS = 30 * 1000;
+const CALLBACK_BRIDGE_MAX_TTL_MS = 10 * 60 * 1000;
+
+type CallbackBridgeEntry = {
+  token: string;
+  workspaceId: string;
+  targetUrl: string;
+  methods: string[];
+  singleUse: boolean;
+  createdAt: number;
+  expiresAt: number;
+};
 
 type LogLevel = "info" | "warn" | "error";
 
@@ -339,6 +352,10 @@ export function startServer(config: ServerConfig) {
           errorMessage = "not_found";
           return finalize(jsonResponse({ code: "not_found", message: "Not found" }, 404));
         }
+        url.pathname = mount.restPath;
+      }
+
+      if (mount && mount.restPath.startsWith("/callback-bridge/")) {
         url.pathname = mount.restPath;
       }
 
@@ -1221,6 +1238,7 @@ function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
 function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: TokenService): Route[] {
   const routes: Route[] = [];
   const fileSessions = new FileSessionStore();
+  const callbackBridge = new Map<string, CallbackBridgeEntry>();
 
   const serializeFileSession = (session: {
     id: string;
@@ -1258,6 +1276,63 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
   const recordWorkspaceFileEvent = (workspaceId: string, input: { type: "write" | "delete" | "rename" | "mkdir"; path: string; toPath?: string; revision?: string }) => {
     return fileSessions.recordWorkspaceEvent({ workspaceId, ...input });
   };
+
+  const cleanupExpiredCallbackBridge = () => {
+    const now = Date.now();
+    for (const [token, entry] of callbackBridge.entries()) {
+      if (entry.expiresAt <= now) {
+        callbackBridge.delete(token);
+      }
+    }
+  };
+
+  const handleCallbackBridgeRequest = async (ctx: RequestContext) => {
+    cleanupExpiredCallbackBridge();
+    const token = (ctx.params.token ?? "").trim();
+    if (!token) {
+      throw new ApiError(404, "not_found", "Not found");
+    }
+
+    const entry = callbackBridge.get(token);
+    if (!entry || entry.expiresAt <= Date.now()) {
+      callbackBridge.delete(token);
+      throw new ApiError(404, "callback_bridge_not_found", "Callback bridge not found or expired");
+    }
+
+    const method = ctx.request.method.toUpperCase();
+    if (!entry.methods.includes(method)) {
+      throw new ApiError(405, "method_not_allowed", "Method not allowed for callback bridge", {
+        methods: entry.methods,
+      });
+    }
+
+    if (entry.singleUse) {
+      callbackBridge.delete(token);
+    }
+
+    await resolveWorkspace(config, entry.workspaceId);
+
+    const incomingUrl = new URL(ctx.request.url);
+    const targetUrl = buildCallbackBridgeTargetUrl(entry.targetUrl, incomingUrl);
+    const headers = new Headers(ctx.request.headers);
+    headers.delete("host");
+    headers.delete("origin");
+    headers.delete("authorization");
+    headers.delete("x-openwork-host-token");
+    headers.delete("x-openwork-client-id");
+
+    const body = method === "GET" || method === "HEAD" ? undefined : ctx.request.body;
+    const upstream = await fetch(targetUrl, {
+      method,
+      headers,
+      body,
+      redirect: "manual",
+    });
+    return upstream;
+  };
+
+  addRoute(routes, "GET", "/callback-bridge/:token", "none", handleCallbackBridgeRequest);
+  addRoute(routes, "POST", "/callback-bridge/:token", "none", handleCallbackBridgeRequest);
 
   addRoute(routes, "GET", "/health", "none", async () => {
     return jsonResponse({ ok: true, version: SERVER_VERSION, uptimeMs: Date.now() - config.startedAt });
@@ -1650,6 +1725,43 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     });
 
     return jsonResponse(result);
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/callback-bridge/register", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+
+    const targetUrl = normalizeCallbackBridgeTargetUrl(body.targetUrl);
+    const methods = normalizeCallbackBridgeMethods(body.methods);
+    const ttlMs = normalizeCallbackBridgeTtlMs(body.ttlMs);
+    const singleUse = body.singleUse !== false;
+    const now = Date.now();
+    const token = createCallbackBridgeToken();
+    const expiresAt = now + ttlMs;
+
+    callbackBridge.set(token, {
+      token,
+      workspaceId: workspace.id,
+      targetUrl,
+      methods,
+      singleUse,
+      createdAt: now,
+      expiresAt,
+    });
+    cleanupExpiredCallbackBridge();
+
+    return jsonResponse({
+      ok: true,
+      token,
+      path: `/callback-bridge/${encodeURIComponent(token)}`,
+      workspaceId: workspace.id,
+      targetUrl,
+      methods,
+      ttlMs,
+      expiresAt,
+      singleUse,
+    });
   });
 
   addRoute(routes, "GET", "/workspace/:id/opencode-router/telegram", "client", async (ctx) => {
@@ -3795,6 +3907,72 @@ function parseInteger(value: string | undefined): number | null {
   if (!value) return null;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeCallbackBridgeTtlMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return CALLBACK_BRIDGE_DEFAULT_TTL_MS;
+  }
+  const rounded = Math.trunc(value);
+  if (rounded < CALLBACK_BRIDGE_MIN_TTL_MS) return CALLBACK_BRIDGE_MIN_TTL_MS;
+  if (rounded > CALLBACK_BRIDGE_MAX_TTL_MS) return CALLBACK_BRIDGE_MAX_TTL_MS;
+  return rounded;
+}
+
+function normalizeCallbackBridgeMethods(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return ["GET"];
+  }
+  const methods = value
+    .map((item) => (typeof item === "string" ? item.trim().toUpperCase() : ""))
+    .filter((item) => item === "GET" || item === "POST");
+  return methods.length ? Array.from(new Set(methods)) : ["GET"];
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1" || normalized === "[::1]";
+}
+
+function normalizeCallbackBridgeTargetUrl(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new ApiError(400, "invalid_payload", "targetUrl is required");
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new ApiError(400, "invalid_payload", "targetUrl is required");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new ApiError(400, "invalid_payload", "targetUrl must be a valid URL");
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new ApiError(400, "invalid_payload", "targetUrl must use http or https");
+  }
+  if (!isLoopbackHostname(url.hostname)) {
+    throw new ApiError(400, "invalid_payload", "targetUrl must point to localhost");
+  }
+  if (url.username || url.password) {
+    throw new ApiError(400, "invalid_payload", "targetUrl credentials are not allowed");
+  }
+
+  return url.toString();
+}
+
+function createCallbackBridgeToken(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+function buildCallbackBridgeTargetUrl(targetUrl: string, incoming: URL): string {
+  const target = new URL(targetUrl);
+  for (const [key, value] of incoming.searchParams.entries()) {
+    target.searchParams.append(key, value);
+  }
+  return target.toString();
 }
 
 function expandHome(value: string): string {


### PR DESCRIPTION
## Summary
- add an OpenWork callback-bridge registration/consume flow plus app-side URL rewriting for loopback auth targets opened from provider and MCP auth flows
- route browser launches through a shared app opener so desktop and web use the same interception point before opening external auth URLs
- document the current blocker discovered in testing: OpenAI rejects rewritten `redirect_uri` values, so this branch is exploratory and not yet a shippable fix

## Testing
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `packaging/docker/dev-up.sh`
- Chrome MCP validation of provider auth launch and callback-bridge registration against the Docker stack

## Current blocker
- OpenAI's OAuth client appears bound to the original loopback redirect (`http://localhost:1455/auth/callback`)
- rewriting the provider-facing `redirect_uri` to OpenWork's callback bridge causes OpenAI to fail with `unknown_error`
- local callback-bridge registration now resolves the correct OpenWork workspace id, but the overall redirect rewrite approach still needs a different architecture for strict OAuth clients