### PR TITLE
Polish session run indicator

### DIFF
--- a/packages/app/src/app/components/session/message-list.tsx
+++ b/packages/app/src/app/components/session/message-list.tsx
@@ -919,7 +919,6 @@ export default function MessageList(props: MessageListProps) {
         <div class="flex items-start gap-3 text-[14px] text-gray-9">
           <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
           <div class="min-w-0 leading-relaxed">
-            <span class="mr-1">Execution timeline 1 step -</span>
             <span>{headline()}</span>
           </div>
         </div>
@@ -930,7 +929,6 @@ export default function MessageList(props: MessageListProps) {
       <div class="flex items-start gap-3 text-[14px] text-gray-9">
         <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
         <div class="min-w-0 flex-1 leading-relaxed">
-          <span class="mr-1">Execution timeline 1 step -</span>
           <span>{headline()}</span>
           <Show when={task().isTask && task().sessionId}>
             <SubagentThread part={rowProps.part} />

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -4468,7 +4468,14 @@ export default function SessionView(props: SessionViewProps) {
                               role="status"
                               aria-live="polite"
                             >
-                              <span class="truncate">
+                              <span
+                                class={`truncate ${
+                                  runPhase() === "thinking" ||
+                                  runPhase() === "responding"
+                                    ? "animate-pulse"
+                                    : ""
+                                }`}
+                              >
                                 {thinkingStatus() || runLabel()}
                               </span>
                               <Show when={props.developerMode}>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -4464,17 +4464,10 @@ export default function SessionView(props: SessionViewProps) {
                         <div class="flex justify-start pl-2">
                           <div class="w-full max-w-[68ch]">
                             <div
-                              class={`flex items-center gap-2 text-xs py-1 ${runPhase() === "error" ? "text-red-11" : "text-gray-9"}`}
+                              class={`ml-3 mt-3 flex items-center gap-2 text-xs py-1 ${runPhase() === "error" ? "text-red-11" : "text-gray-9"}`}
                               role="status"
                               aria-live="polite"
                             >
-                              <span
-                                class={`h-1.5 w-1.5 rounded-full shrink-0 ${
-                                  runPhase() === "error"
-                                    ? "bg-red-9"
-                                    : "bg-gray-8 animate-pulse"
-                                }`}
-                              />
                               <span class="truncate">
                                 {thinkingStatus() || runLabel()}
                               </span>


### PR DESCRIPTION
## Summary
- remove the repeated execution timeline prefix in session message rows
- show run status text instead of the dot indicator
- animate the run status label while thinking/responding

## Testing
- pnpm -C packages/app test:health