### PR TITLE
Composer focus fix

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1343,11 +1343,15 @@ export default function App() {
   const [workspaceDefaultModelReady, setWorkspaceDefaultModelReady] = createSignal(false);
   const [legacyDefaultModel, setLegacyDefaultModel] = createSignal<ModelRef>(DEFAULT_MODEL);
   const [defaultModelExplicit, setDefaultModelExplicit] = createSignal(false);
+  type PromptFocusReturnTarget = "none" | "composer";
+
   const [sessionAgentById, setSessionAgentById] = createSignal<Record<string, string>>({});
   const [providerAuthModalOpen, setProviderAuthModalOpen] = createSignal(false);
   const [providerAuthBusy, setProviderAuthBusy] = createSignal(false);
   const [providerAuthError, setProviderAuthError] = createSignal<string | null>(null);
   const [providerAuthMethods, setProviderAuthMethods] = createSignal<Record<string, ProviderAuthMethod[]>>({});
+  const [providerAuthReturnFocusTarget, setProviderAuthReturnFocusTarget] =
+    createSignal<PromptFocusReturnTarget>("none");
 
   createEffect(() => {
     const view = currentView();
@@ -2471,7 +2475,19 @@ export default function App() {
     }
   }
 
-  async function openProviderAuthModal() {
+  function focusSessionPromptSoon() {
+    if (typeof window === "undefined" || currentView() !== "session") return;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new CustomEvent("openwork:focusPrompt"));
+      });
+    });
+  }
+
+  async function openProviderAuthModal(options?: {
+    returnFocusTarget?: PromptFocusReturnTarget;
+  }) {
+    setProviderAuthReturnFocusTarget(options?.returnFocusTarget ?? "none");
     setProviderAuthBusy(true);
     setProviderAuthError(null);
     try {
@@ -2479,6 +2495,7 @@ export default function App() {
       setProviderAuthMethods(methods);
       setProviderAuthModalOpen(true);
     } catch (error) {
+      setProviderAuthReturnFocusTarget("none");
       const message = describeProviderError(error, "Failed to load providers");
       setProviderAuthError(message);
       throw error;
@@ -2487,9 +2504,16 @@ export default function App() {
     }
   }
 
-  function closeProviderAuthModal() {
+  function closeProviderAuthModal(options?: { restorePromptFocus?: boolean }) {
+    const shouldFocusPrompt =
+      options?.restorePromptFocus ??
+      providerAuthReturnFocusTarget() === "composer";
     setProviderAuthModalOpen(false);
     setProviderAuthError(null);
+    setProviderAuthReturnFocusTarget("none");
+    if (shouldFocusPrompt) {
+      focusSessionPromptSoon();
+    }
   }
 
   async function saveSessionExport(sessionID: string) {
@@ -2745,6 +2769,8 @@ export default function App() {
     "session" | "default"
   >("session");
   const [modelPickerQuery, setModelPickerQuery] = createSignal("");
+  const [modelPickerReturnFocusTarget, setModelPickerReturnFocusTarget] =
+    createSignal<PromptFocusReturnTarget>("none");
 
   const [showThinking, setShowThinking] = createSignal(false);
   const [hideTitlebar, setHideTitlebar] = createSignal(false);
@@ -4934,23 +4960,39 @@ export default function App() {
     });
   });
 
-  function openSessionModelPicker() {
+  function closeModelPicker(options?: { restorePromptFocus?: boolean }) {
+    const shouldFocusPrompt =
+      options?.restorePromptFocus ??
+      modelPickerReturnFocusTarget() === "composer";
+    setModelPickerOpen(false);
+    setModelPickerReturnFocusTarget("none");
+    if (shouldFocusPrompt) {
+      focusSessionPromptSoon();
+    }
+  }
+
+  function openSessionModelPicker(options?: {
+    returnFocusTarget?: PromptFocusReturnTarget;
+  }) {
     setModelPickerTarget("session");
     setModelPickerQuery("");
+    setModelPickerReturnFocusTarget(options?.returnFocusTarget ?? "composer");
     setModelPickerOpen(true);
   }
 
   function openDefaultModelPicker() {
     setModelPickerTarget("default");
     setModelPickerQuery("");
+    setModelPickerReturnFocusTarget("none");
     setModelPickerOpen(true);
   }
 
   function applyModelSelection(next: ModelRef) {
+    const restorePromptFocus = modelPickerTarget() === "session";
     if (modelPickerTarget() === "default") {
       setDefaultModelExplicit(true);
       setDefaultModel(next);
-      setModelPickerOpen(false);
+      closeModelPicker({ restorePromptFocus: false });
       return;
     }
 
@@ -4959,20 +5001,14 @@ export default function App() {
       setPendingSessionModel(next);
       setDefaultModelExplicit(true);
       setDefaultModel(next);
-      setModelPickerOpen(false);
+      closeModelPicker({ restorePromptFocus });
       return;
     }
 
     setSessionModelOverrideById((current) => ({ ...current, [id]: next }));
     setDefaultModelExplicit(true);
     setDefaultModel(next);
-    setModelPickerOpen(false);
-
-    if (typeof window !== "undefined" && currentView() === "session") {
-      requestAnimationFrame(() => {
-        window.dispatchEvent(new CustomEvent("openwork:focusPrompt"));
-      });
-    }
+    closeModelPicker({ restorePromptFocus });
   }
 
   function openSettingsFromModelPicker() {
@@ -7172,7 +7208,7 @@ export default function App() {
         current={modelPickerCurrent()}
         onSelect={applyModelSelection}
         onOpenSettings={openSettingsFromModelPicker}
-        onClose={() => setModelPickerOpen(false)}
+        onClose={closeModelPicker}
       />
 
       <ResetModal

--- a/packages/app/src/app/components/model-picker-modal.tsx
+++ b/packages/app/src/app/components/model-picker-modal.tsx
@@ -17,7 +17,7 @@ export type ModelPickerModalProps = {
   current: ModelRef;
   onSelect: (model: ModelRef) => void;
   onOpenSettings: () => void;
-  onClose: () => void;
+  onClose: (options?: { restorePromptFocus?: boolean }) => void;
 };
 
 export default function ModelPickerModal(props: ModelPickerModalProps) {
@@ -157,7 +157,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
         event.preventDefault();
         event.stopPropagation();
         if (item.kind === "provider") {
-          props.onClose();
+          props.onClose({ restorePromptFocus: false });
           props.onOpenSettings();
           return;
         }
@@ -238,7 +238,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
         setActiveIndex(index);
       }}
       onClick={() => {
-        props.onClose();
+        props.onClose({ restorePromptFocus: false });
         props.onOpenSettings();
       }}
     >
@@ -270,7 +270,11 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
                   {props.target === "default" ? translate("settings.model_description_default") : translate("settings.model_description_session")}
                 </p>
               </div>
-              <Button variant="ghost" class="!p-2 rounded-full" onClick={props.onClose}>
+              <Button
+                variant="ghost"
+                class="!p-2 rounded-full"
+                onClick={() => props.onClose()}
+              >
                 <X size={16} />
               </Button>
             </div>
@@ -323,7 +327,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
             </div>
 
             <div class="mt-5 flex justify-end shrink-0">
-              <Button variant="outline" onClick={props.onClose}>
+              <Button variant="outline" onClick={() => props.onClose()}>
                 {translate("settings.done")}
               </Button>
             </div>

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1541,27 +1541,7 @@ export default function Composer(props: ComposerProps) {
 
   createEffect(() => {
     const handler = () => {
-      const beforeFocus = document.activeElement;
-      console.debug("[focus-debug] composer received openwork:focusPrompt", {
-        activeElement:
-          beforeFocus instanceof HTMLElement ? beforeFocus.tagName : beforeFocus?.nodeName,
-        activeId: beforeFocus instanceof HTMLElement ? beforeFocus.id : undefined,
-        activeClass:
-          beforeFocus instanceof HTMLElement ? beforeFocus.className || undefined : undefined,
-        hasEditorRef: Boolean(editorRef),
-      });
       editorRef?.focus();
-      requestAnimationFrame(() => {
-        const afterFocus = document.activeElement;
-        console.debug("[focus-debug] composer focus applied", {
-          activeElement:
-            afterFocus instanceof HTMLElement ? afterFocus.tagName : afterFocus?.nodeName,
-          activeId: afterFocus instanceof HTMLElement ? afterFocus.id : undefined,
-          activeClass:
-            afterFocus instanceof HTMLElement ? afterFocus.className || undefined : undefined,
-          editorIsActive: afterFocus === editorRef,
-        });
-      });
     };
     window.addEventListener("openwork:focusPrompt", handler);
     onCleanup(() => window.removeEventListener("openwork:focusPrompt", handler));

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -1541,7 +1541,27 @@ export default function Composer(props: ComposerProps) {
 
   createEffect(() => {
     const handler = () => {
+      const beforeFocus = document.activeElement;
+      console.debug("[focus-debug] composer received openwork:focusPrompt", {
+        activeElement:
+          beforeFocus instanceof HTMLElement ? beforeFocus.tagName : beforeFocus?.nodeName,
+        activeId: beforeFocus instanceof HTMLElement ? beforeFocus.id : undefined,
+        activeClass:
+          beforeFocus instanceof HTMLElement ? beforeFocus.className || undefined : undefined,
+        hasEditorRef: Boolean(editorRef),
+      });
       editorRef?.focus();
+      requestAnimationFrame(() => {
+        const afterFocus = document.activeElement;
+        console.debug("[focus-debug] composer focus applied", {
+          activeElement:
+            afterFocus instanceof HTMLElement ? afterFocus.tagName : afterFocus?.nodeName,
+          activeId: afterFocus instanceof HTMLElement ? afterFocus.id : undefined,
+          activeClass:
+            afterFocus instanceof HTMLElement ? afterFocus.className || undefined : undefined,
+          editorIsActive: afterFocus === editorRef,
+        });
+      });
     };
     window.addEventListener("openwork:focusPrompt", handler);
     onCleanup(() => window.removeEventListener("openwork:focusPrompt", handler));

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -83,9 +83,11 @@ export type DashboardViewProps = {
   providerAuthModalOpen: boolean;
   providerAuthError: string | null;
   providerAuthMethods: Record<string, { type: "oauth" | "api"; label: string }[]>;
-  openProviderAuthModal: () => Promise<void>;
+  openProviderAuthModal: (options?: {
+    returnFocusTarget?: "none" | "composer";
+  }) => Promise<void>;
   disconnectProvider: (providerId: string) => Promise<string | void>;
-  closeProviderAuthModal: () => void;
+  closeProviderAuthModal: (options?: { restorePromptFocus?: boolean }) => void;
   startProviderAuth: (providerId?: string) => Promise<ProviderOAuthStartResult>;
   completeProviderAuthOAuth: (
     providerId: string,
@@ -1499,7 +1501,7 @@ export default function DashboardView(props: DashboardViewProps) {
           onSubmitApiKey={handleProviderAuthApiKey}
           onSubmitOAuth={handleProviderAuthOAuth}
           onRefreshProviders={props.refreshProviders}
-          onClose={props.closeProviderAuthModal}
+          onClose={() => props.closeProviderAuthModal()}
         />
 
         <ShareWorkspaceModal

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -218,7 +218,9 @@ export type SessionViewProps = {
   prompt: string;
   setPrompt: (value: string) => void;
   selectedSessionModelLabel: string;
-  openSessionModelPicker: () => void;
+  openSessionModelPicker: (options?: {
+    returnFocusTarget?: "none" | "composer";
+  }) => void;
   modelVariantLabel: string;
   modelVariant: string | null;
   setModelVariant: (value: string) => void;
@@ -252,8 +254,10 @@ export type SessionViewProps = {
     apiKey: string,
   ) => Promise<string | void>;
   refreshProviders: () => Promise<unknown>;
-  openProviderAuthModal: () => Promise<void>;
-  closeProviderAuthModal: () => void;
+  openProviderAuthModal: (options?: {
+    returnFocusTarget?: "none" | "composer";
+  }) => Promise<void>;
+  closeProviderAuthModal: (options?: { restorePromptFocus?: boolean }) => void;
   providerAuthModalOpen: boolean;
   providerAuthBusy: boolean;
   providerAuthError: string | null;
@@ -361,6 +365,8 @@ export default function SessionView(props: SessionViewProps) {
   const [renameSessionId, setRenameSessionId] = createSignal<string | null>(null);
   const [renameTitle, setRenameTitle] = createSignal("");
   const [renameBusy, setRenameBusy] = createSignal(false);
+  const [renameReturnFocusToComposer, setRenameReturnFocusToComposer] =
+    createSignal(false);
 
   const [deleteSessionOpen, setDeleteSessionOpen] = createSignal(false);
   const [deleteSessionId, setDeleteSessionId] = createSignal<string | null>(null);
@@ -2594,9 +2600,22 @@ export default function SessionView(props: SessionViewProps) {
     if (typeof window === "undefined") return;
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
+        const active = document.activeElement;
+        console.debug("[focus-debug] dispatch openwork:focusPrompt", {
+          source: "session.focusComposer",
+          activeElement: active instanceof HTMLElement ? active.tagName : active?.nodeName,
+          activeId: active instanceof HTMLElement ? active.id : undefined,
+          activeClass:
+            active instanceof HTMLElement ? active.className || undefined : undefined,
+        });
         window.dispatchEvent(new CustomEvent("openwork:focusPrompt"));
       });
     });
+  };
+
+  const closeCommandPaletteAndFocusComposer = () => {
+    closeCommandPalette();
+    focusComposer();
   };
 
   const openCommandPalette = (mode: CommandPaletteMode = "root") => {
@@ -2832,21 +2851,65 @@ export default function SessionView(props: SessionViewProps) {
     return next !== sessionTitleForId(renameSessionId()).trim();
   });
 
-  const openRenameModal = () => {
+  const finishRenameModal = (
+    restoreComposerFocus = renameReturnFocusToComposer(),
+  ) => {
+    const activeBeforeClose = document.activeElement;
+    console.debug("[focus-debug] finish rename modal", {
+      restoreComposerFocus,
+      activeElement:
+        activeBeforeClose instanceof HTMLElement
+          ? activeBeforeClose.tagName
+          : activeBeforeClose?.nodeName,
+      activeId:
+        activeBeforeClose instanceof HTMLElement ? activeBeforeClose.id : undefined,
+      activeClass:
+        activeBeforeClose instanceof HTMLElement
+          ? activeBeforeClose.className || undefined
+          : undefined,
+    });
+    setRenameModalOpen(false);
+    setRenameSessionId(null);
+    setRenameReturnFocusToComposer(false);
+    requestAnimationFrame(() => {
+      const activeAfterClose = document.activeElement;
+      console.debug("[focus-debug] rename modal closed", {
+        restoreComposerFocus,
+        activeElement:
+          activeAfterClose instanceof HTMLElement
+            ? activeAfterClose.tagName
+            : activeAfterClose?.nodeName,
+        activeId:
+          activeAfterClose instanceof HTMLElement ? activeAfterClose.id : undefined,
+        activeClass:
+          activeAfterClose instanceof HTMLElement
+            ? activeAfterClose.className || undefined
+            : undefined,
+      });
+    });
+    if (restoreComposerFocus) {
+      focusComposer();
+    }
+  };
+
+  const openRenameModal = (options?: { returnFocusToComposer?: boolean }) => {
     const sessionId = props.selectedSessionId;
     if (!sessionId) {
       setToastMessage("No session selected");
+      if (options?.returnFocusToComposer) {
+        focusComposer();
+      }
       return;
     }
     setRenameSessionId(sessionId);
     setRenameTitle(sessionTitleForId(sessionId));
+    setRenameReturnFocusToComposer(options?.returnFocusToComposer === true);
     setRenameModalOpen(true);
   };
 
   const closeRenameModal = () => {
     if (renameBusy()) return;
-    setRenameModalOpen(false);
-    setRenameSessionId(null);
+    finishRenameModal();
   };
 
   const submitRename = async () => {
@@ -2857,8 +2920,7 @@ export default function SessionView(props: SessionViewProps) {
     setRenameBusy(true);
     try {
       await props.renameSession(sessionId, next);
-      setRenameModalOpen(false);
-      setRenameSessionId(null);
+      finishRenameModal();
     } catch (error) {
       const message =
         error instanceof Error ? error.message : props.safeStringify(error);
@@ -3619,7 +3681,7 @@ export default function SessionView(props: SessionViewProps) {
         meta: "Rename",
         action: () => {
           closeCommandPalette();
-          openRenameModal();
+          openRenameModal({ returnFocusToComposer: true });
         },
       },
       {
@@ -3641,7 +3703,7 @@ export default function SessionView(props: SessionViewProps) {
         meta: "Open",
         action: () => {
           closeCommandPalette();
-          props.openSessionModelPicker();
+          props.openSessionModelPicker({ returnFocusTarget: "composer" });
         },
       },
       {
@@ -3651,13 +3713,16 @@ export default function SessionView(props: SessionViewProps) {
         meta: "Open",
         action: () => {
           closeCommandPalette();
-          void props.openProviderAuthModal().catch((error) => {
-            const message =
-              error instanceof Error
-                ? error.message
-                : "Failed to load providers";
-            setToastMessage(message);
-          });
+          void props
+            .openProviderAuthModal({ returnFocusTarget: "composer" })
+            .catch((error) => {
+              const message =
+                error instanceof Error
+                  ? error.message
+                  : "Failed to load providers";
+              setToastMessage(message);
+              focusComposer();
+            });
         },
       },
       {
@@ -3724,7 +3789,7 @@ export default function SessionView(props: SessionViewProps) {
       meta: activeVariant === option.value ? "Current" : undefined,
       action: () => {
         props.setModelVariant(option.value);
-        closeCommandPalette();
+        closeCommandPaletteAndFocusComposer();
         setToastMessage(`Thinking set to ${option.label}.`);
       },
     }));
@@ -4610,7 +4675,7 @@ export default function SessionView(props: SessionViewProps) {
               onStop={cancelRun}
               onDraftChange={handleDraftChange}
               selectedModelLabel={props.selectedSessionModelLabel || "Model"}
-              onModelClick={props.openSessionModelPicker}
+              onModelClick={() => props.openSessionModelPicker()}
               modelVariantLabel={props.modelVariantLabel}
               modelVariant={props.modelVariant}
               onModelVariantChange={props.setModelVariant}
@@ -4898,7 +4963,7 @@ export default function SessionView(props: SessionViewProps) {
         onSubmitApiKey={handleProviderAuthApiKey}
         onSubmitOAuth={handleProviderAuthOAuth}
         onRefreshProviders={props.refreshProviders}
-        onClose={props.closeProviderAuthModal}
+        onClose={() => props.closeProviderAuthModal()}
       />
 
       <RenameSessionModal

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -2600,14 +2600,6 @@ export default function SessionView(props: SessionViewProps) {
     if (typeof window === "undefined") return;
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        const active = document.activeElement;
-        console.debug("[focus-debug] dispatch openwork:focusPrompt", {
-          source: "session.focusComposer",
-          activeElement: active instanceof HTMLElement ? active.tagName : active?.nodeName,
-          activeId: active instanceof HTMLElement ? active.id : undefined,
-          activeClass:
-            active instanceof HTMLElement ? active.className || undefined : undefined,
-        });
         window.dispatchEvent(new CustomEvent("openwork:focusPrompt"));
       });
     });
@@ -2854,39 +2846,9 @@ export default function SessionView(props: SessionViewProps) {
   const finishRenameModal = (
     restoreComposerFocus = renameReturnFocusToComposer(),
   ) => {
-    const activeBeforeClose = document.activeElement;
-    console.debug("[focus-debug] finish rename modal", {
-      restoreComposerFocus,
-      activeElement:
-        activeBeforeClose instanceof HTMLElement
-          ? activeBeforeClose.tagName
-          : activeBeforeClose?.nodeName,
-      activeId:
-        activeBeforeClose instanceof HTMLElement ? activeBeforeClose.id : undefined,
-      activeClass:
-        activeBeforeClose instanceof HTMLElement
-          ? activeBeforeClose.className || undefined
-          : undefined,
-    });
     setRenameModalOpen(false);
     setRenameSessionId(null);
     setRenameReturnFocusToComposer(false);
-    requestAnimationFrame(() => {
-      const activeAfterClose = document.activeElement;
-      console.debug("[focus-debug] rename modal closed", {
-        restoreComposerFocus,
-        activeElement:
-          activeAfterClose instanceof HTMLElement
-            ? activeAfterClose.tagName
-            : activeAfterClose?.nodeName,
-        activeId:
-          activeAfterClose instanceof HTMLElement ? activeAfterClose.id : undefined,
-        activeClass:
-          activeAfterClose instanceof HTMLElement
-            ? activeAfterClose.className || undefined
-            : undefined,
-      });
-    });
     if (restoreComposerFocus) {
       focusComposer();
     }

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -63,7 +63,9 @@ export type SettingsViewProps = {
   providers: ProviderListItem[];
   providerConnectedIds: string[];
   providerAuthBusy: boolean;
-  openProviderAuthModal: () => Promise<void>;
+  openProviderAuthModal: (options?: {
+    returnFocusTarget?: "none" | "composer";
+  }) => Promise<void>;
   disconnectProvider: (providerId: string) => Promise<string | void>;
   openworkServerStatus: OpenworkServerStatus;
   openworkServerUrl: string;


### PR DESCRIPTION
## Summary
- Fixed composer to it focuses after action commands

Before:
- CMD+K + doing an action would take you out of focus

Now:
- CMD+K + doing an action takes you back to the focused spot in the componer

Minor bug // TODO later: We'd like to be able to track the position of the focus (which element in the textbox were we at) before the composer to be able to regain it afterwards. The reason this is try is that there's other textboxes in the modals that we could type into and hence, are currently overwriting said status.