### PR TITLE
fix(web): auto-connect Den workers from open-in-web links

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -206,6 +206,7 @@ type RemoteWorkspaceDefaults = {
   openworkToken?: string | null;
   directory?: string | null;
   displayName?: string | null;
+  autoConnect?: boolean;
 };
 
 type SharedSkillItem = {
@@ -635,12 +636,19 @@ function parseRemoteConnectDeepLink(rawUrl: string): RemoteWorkspaceDefaults | n
   const workerName = url.searchParams.get("workerName")?.trim() ?? "";
   const workerId = url.searchParams.get("workerId")?.trim() ?? "";
   const displayName = workerName || (workerId ? `Worker ${workerId.slice(0, 8)}` : "");
+  const autoConnectRaw =
+    url.searchParams.get("autoConnect") ??
+    url.searchParams.get("bypassModal") ??
+    url.searchParams.get("bypassAddWorkerModal") ??
+    "";
+  const autoConnect = ["1", "true", "yes", "on"].includes(autoConnectRaw.trim().toLowerCase());
 
   return {
     openworkHostUrl: normalizedHostUrl,
     openworkToken: token,
     directory: null,
     displayName: displayName || null,
+    autoConnect,
   };
 }
 
@@ -760,6 +768,9 @@ function stripRemoteConnectQuery(rawUrl: string): string | null {
     "accessToken",
     "workerId",
     "workerName",
+    "autoConnect",
+    "bypassModal",
+    "bypassAddWorkerModal",
     "source",
   ]) {
     if (url.searchParams.has(key)) {
@@ -983,6 +994,16 @@ export default function App() {
         label: bundleInvite.label,
       });
       setSharedBundleNoticeShown(false);
+    }
+
+    if (invite?.autoConnect) {
+      setPendingRemoteConnectDeepLink({
+        openworkHostUrl: invite.url,
+        openworkToken: invite.token ?? null,
+        directory: null,
+        displayName: null,
+        autoConnect: true,
+      });
     }
 
     const cleanedConnect = stripOpenworkConnectInviteFromUrl(window.location.href);
@@ -3953,6 +3974,31 @@ export default function App() {
     return true;
   };
 
+  const completeRemoteConnectDeepLink = async (pending: RemoteWorkspaceDefaults) => {
+    const input = {
+      openworkHostUrl: pending.openworkHostUrl,
+      openworkToken: pending.openworkToken,
+      directory: pending.directory,
+      displayName: pending.displayName,
+    };
+
+    if (!pending.autoConnect) {
+      setDeepLinkRemoteWorkspaceDefaults(input);
+      workspaceStore.setCreateRemoteWorkspaceOpen(true);
+      return;
+    }
+
+    setError(null);
+    const ok = await workspaceStore.createRemoteWorkspaceFlow(input);
+    if (ok) {
+      setDeepLinkRemoteWorkspaceDefaults(null);
+      return;
+    }
+
+    setDeepLinkRemoteWorkspaceDefaults(input);
+    workspaceStore.setCreateRemoteWorkspaceOpen(true);
+  };
+
   const queueDenAuthDeepLink = (rawUrl: string): boolean => {
     const parsed = parseDenAuthDeepLink(rawUrl);
     if (!parsed) {
@@ -4213,9 +4259,8 @@ export default function App() {
 
     setView("dashboard");
     setTab("scheduled");
-    setDeepLinkRemoteWorkspaceDefaults(pending);
-    workspaceStore.setCreateRemoteWorkspaceOpen(true);
     setPendingRemoteConnectDeepLink(null);
+    void completeRemoteConnectDeepLink(pending);
   });
 
   createEffect(() => {

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -593,6 +593,7 @@ export const DEFAULT_OPENWORK_CONNECT_APP_URL = "https://app.openwork.software";
 const OPENWORK_INVITE_PARAM_URL = "ow_url";
 const OPENWORK_INVITE_PARAM_TOKEN = "ow_token";
 const OPENWORK_INVITE_PARAM_STARTUP = "ow_startup";
+const OPENWORK_INVITE_PARAM_AUTO_CONNECT = "ow_auto_connect";
 const OPENWORK_INVITE_PARAM_BUNDLE = "ow_bundle";
 const OPENWORK_INVITE_PARAM_BUNDLE_INTENT = "ow_intent";
 const OPENWORK_INVITE_PARAM_BUNDLE_SOURCE = "ow_source";
@@ -603,6 +604,7 @@ export type OpenworkConnectInvite = {
   url: string;
   token?: string;
   startup?: "server";
+  autoConnect?: boolean;
 };
 
 export type OpenworkBundleInviteIntent = "new_worker" | "import_current";
@@ -628,6 +630,7 @@ export function buildOpenworkConnectInviteUrl(input: {
   token?: string | null;
   appUrl?: string | null;
   startup?: "server";
+  autoConnect?: boolean;
 }) {
   const workspaceUrl = normalizeOpenworkServerUrl(input.workspaceUrl ?? "") ?? "";
   if (!workspaceUrl) return "";
@@ -646,6 +649,9 @@ export function buildOpenworkConnectInviteUrl(input: {
 
     const startup = input.startup ?? "server";
     search.set(OPENWORK_INVITE_PARAM_STARTUP, startup);
+    if (input.autoConnect) {
+      search.set(OPENWORK_INVITE_PARAM_AUTO_CONNECT, "1");
+    }
 
     url.search = search.toString();
     return url.toString();
@@ -657,6 +663,9 @@ export function buildOpenworkConnectInviteUrl(input: {
       search.set(OPENWORK_INVITE_PARAM_TOKEN, token);
     }
     search.set(OPENWORK_INVITE_PARAM_STARTUP, input.startup ?? "server");
+    if (input.autoConnect) {
+      search.set(OPENWORK_INVITE_PARAM_AUTO_CONNECT, "1");
+    }
     return `${DEFAULT_OPENWORK_CONNECT_APP_URL}?${search.toString()}`;
   }
 }
@@ -674,11 +683,13 @@ export function readOpenworkConnectInviteFromSearch(input: string | URLSearchPar
   const token = search.get(OPENWORK_INVITE_PARAM_TOKEN)?.trim() ?? "";
   const startupRaw = search.get(OPENWORK_INVITE_PARAM_STARTUP)?.trim() ?? "";
   const startup = startupRaw === "server" ? "server" : undefined;
+  const autoConnect = search.get(OPENWORK_INVITE_PARAM_AUTO_CONNECT)?.trim() === "1";
 
   return {
     url,
     token: token || undefined,
     startup,
+    autoConnect: autoConnect || undefined,
   } satisfies OpenworkConnectInvite;
 }
 
@@ -791,6 +802,7 @@ export function stripOpenworkConnectInviteFromUrl(input: string) {
     url.searchParams.delete(OPENWORK_INVITE_PARAM_URL);
     url.searchParams.delete(OPENWORK_INVITE_PARAM_TOKEN);
     url.searchParams.delete(OPENWORK_INVITE_PARAM_STARTUP);
+    url.searchParams.delete(OPENWORK_INVITE_PARAM_AUTO_CONNECT);
     return url.toString();
   } catch {
     return input;

--- a/packages/web/components/cloud-control.tsx
+++ b/packages/web/components/cloud-control.tsx
@@ -848,6 +848,7 @@ function buildOpenworkAppConnectUrl(
   accessToken: string | null,
   workerId: string | null,
   workerName: string | null,
+  options?: { autoConnect?: boolean },
 ): string | null {
   if (!appConnectBaseUrl || !openworkUrl || !accessToken) {
     return null;
@@ -872,6 +873,9 @@ function buildOpenworkAppConnectUrl(
 
   connectUrl.searchParams.set("openworkHostUrl", openworkUrl);
   connectUrl.searchParams.set("openworkToken", accessToken);
+  if (options?.autoConnect) {
+    connectUrl.searchParams.set("autoConnect", "1");
+  }
   connectUrl.searchParams.set("source", "openwork-web");
 
   if (workerId) {
@@ -1168,6 +1172,7 @@ export function CloudControlPanel() {
     preferredOpenworkToken,
     activeWorker?.workerId ?? null,
     activeWorker?.workerName ?? null,
+    { autoConnect: true },
   );
 
   const filteredWorkers = workers.filter((item) => {


### PR DESCRIPTION
## Summary
- add an auto-connect flag to OpenWork remote-connect links so web handoffs can skip the add-worker confirmation modal
- send that flag from the Den web `Open in Web` action and route flagged links straight into remote worker creation
- fall back to the existing prefilled modal if automatic connection fails so users still have a recovery path

## Testing
- `git diff --check`
- `pnpm --filter @different-ai/openwork-ui typecheck` *(fails: worktree is missing dependencies / `node_modules`)*
- `pnpm --filter @different-ai/openwork-web build` *(fails: worktree is missing dependencies / `next` not installed)*