### PR TITLE
feat(web): tailor app UI for hosted web deployment

### DIFF
--- a/packages/app/src/app/components/desktop-only-badge.tsx
+++ b/packages/app/src/app/components/desktop-only-badge.tsx
@@ -1,0 +1,9 @@
+type DesktopOnlyBadgeProps = {
+  class?: string;
+};
+
+const BASE_CLASS = "rounded-full bg-gray-3 px-2 py-0.5 text-[8px] tracking-[0.18em] text-gray-11";
+
+export default function DesktopOnlyBadge(props: DesktopOnlyBadgeProps) {
+  return <span class={props.class ? `${BASE_CLASS} ${props.class}` : BASE_CLASS}>Desktop Only</span>;
+}

--- a/packages/app/src/app/components/mobile-sidebar-drawer.tsx
+++ b/packages/app/src/app/components/mobile-sidebar-drawer.tsx
@@ -1,0 +1,46 @@
+import { Show, createEffect, onCleanup } from "solid-js";
+import type { JSX } from "solid-js";
+
+type MobileSidebarDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  children: JSX.Element;
+};
+
+export default function MobileSidebarDrawer(props: MobileSidebarDrawerProps) {
+  createEffect(() => {
+    if (!props.open || typeof window === "undefined" || typeof document === "undefined") return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        props.onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    onCleanup(() => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    });
+  });
+
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-[45] md:hidden">
+        <button
+          type="button"
+          class="absolute inset-0 bg-gray-1/60 backdrop-blur-sm"
+          onClick={props.onClose}
+          aria-label="Close sidebar"
+        />
+        <div class="absolute inset-y-0 right-0 w-[min(360px,calc(100vw-20px))] max-w-full border-l border-dls-border bg-dls-sidebar p-3 shadow-2xl">
+          {props.children}
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/app/src/app/components/session/composer.tsx
+++ b/packages/app/src/app/components/session/composer.tsx
@@ -205,6 +205,10 @@ const readEditorText = (editor: HTMLElement | undefined) => normalizeText(editor
 const RECENT_EMIT_TTL_MS = 30_000;
 const MAX_RECENT_EMITS = 400;
 const DRAFT_FLUSH_DEBOUNCE_MS = 140;
+const MOBILE_VIEW_MEDIA_QUERY = "(max-width: 767px)";
+
+const isMobileViewport = () =>
+  typeof window !== "undefined" && window.matchMedia(MOBILE_VIEW_MEDIA_QUERY).matches;
 
 const MODEL_VARIANT_OPTIONS = [
   { value: "none", label: "None" },
@@ -1068,7 +1072,21 @@ export default function Composer(props: ComposerProps) {
     clearSentAttachments();
     setEditorText("");
     emitDraftChange();
-    queueMicrotask(() => focusEditorEnd());
+    queueMicrotask(() => {
+      if (isMobileViewport()) {
+        const activeElement = document.activeElement;
+        if (
+          activeElement instanceof HTMLElement &&
+          editorRef &&
+          (activeElement === editorRef || editorRef.contains(activeElement))
+        ) {
+          window.getSelection()?.removeAllRanges();
+          activeElement.blur();
+        }
+        return;
+      }
+      focusEditorEnd();
+    });
   };
 
   const recordHistory = (draft: ComposerDraft) => {

--- a/packages/app/src/app/components/session/inbox-panel.tsx
+++ b/packages/app/src/app/components/session/inbox-panel.tsx
@@ -1,7 +1,9 @@
 import { For, Show, createEffect, createMemo, createSignal } from "solid-js";
 import { Download, RefreshCw, UploadCloud } from "lucide-solid";
 
+import { getOpenWorkDeployment } from "../../lib/openwork-deployment";
 import type { OpenworkInboxItem, OpenworkServerClient } from "../../lib/openwork-server";
+import WebUnavailableSurface from "../web-unavailable-surface";
 import { formatBytes, formatRelativeTime } from "../../utils";
 
 export type InboxPanelProps = {
@@ -35,6 +37,7 @@ export default function InboxPanel(props: InboxPanelProps) {
   const [uploading, setUploading] = createSignal(false);
   const [dragOver, setDragOver] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
+  const webDeployment = createMemo(() => getOpenWorkDeployment() === "web");
 
   let fileInputRef: HTMLInputElement | undefined;
 
@@ -152,139 +155,141 @@ export default function InboxPanel(props: InboxPanelProps) {
   });
 
   return (
-    <div id={props.id}>
-      <div class="flex items-center justify-between px-2 mb-3">
-        <span class="text-[11px] font-semibold uppercase tracking-wider text-gray-10">Inbox</span>
-        <div class="flex items-center gap-2">
-          <Show when={(items() ?? []).length > 0}>
-            <span class="text-[11px] font-medium bg-gray-4/60 text-gray-10 px-1.5 rounded">
-              {(items() ?? []).length}
-            </span>
-          </Show>
-          <button
-            type="button"
-            class="rounded-md p-1 text-gray-9 hover:text-gray-11 hover:bg-gray-3 transition-colors"
-            onClick={() => void refresh()}
-            title="Refresh inbox"
-            aria-label="Refresh inbox"
-            disabled={!connected() || loading()}
-          >
-            <RefreshCw size={14} class={loading() ? "animate-spin" : ""} />
-          </button>
+    <WebUnavailableSurface unavailable={webDeployment()} compact>
+      <div id={props.id}>
+        <div class="flex items-center justify-between px-2 mb-3">
+          <span class="text-[11px] font-semibold uppercase tracking-wider text-gray-10">Inbox</span>
+          <div class="flex items-center gap-2">
+            <Show when={(items() ?? []).length > 0}>
+              <span class="text-[11px] font-medium bg-gray-4/60 text-gray-10 px-1.5 rounded">
+                {(items() ?? []).length}
+              </span>
+            </Show>
+            <button
+              type="button"
+              class="rounded-md p-1 text-gray-9 hover:text-gray-11 hover:bg-gray-3 transition-colors"
+              onClick={() => void refresh()}
+              title="Refresh inbox"
+              aria-label="Refresh inbox"
+              disabled={!connected() || loading()}
+            >
+              <RefreshCw size={14} class={loading() ? "animate-spin" : ""} />
+            </button>
+          </div>
         </div>
-      </div>
 
-      <input
-        ref={fileInputRef}
-        type="file"
-        multiple
-        class="hidden"
-        onChange={(event: Event) => {
-          const target = event.currentTarget as HTMLInputElement;
-          const files = Array.from(target.files ?? []);
-          if (files.length) void uploadFiles(files);
-          target.value = "";
-        }}
-      />
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          class="hidden"
+          onChange={(event: Event) => {
+            const target = event.currentTarget as HTMLInputElement;
+            const files = Array.from(target.files ?? []);
+            if (files.length) void uploadFiles(files);
+            target.value = "";
+          }}
+        />
 
-      <button
-        type="button"
-        class={`w-full border border-dashed border-gray-7 rounded-xl px-4 py-4 text-left transition-colors ${
-          dragOver() ? "bg-gray-3" : "bg-gray-2/60 hover:bg-gray-2"
-        } ${!connected() ? "opacity-70" : ""}`}
-        onClick={() => fileInputRef?.click()}
-        onDragOver={(event: DragEvent) => {
-          event.preventDefault();
-          setDragOver(true);
-        }}
-        onDragLeave={(event: DragEvent) => {
-          event.preventDefault();
-          setDragOver(false);
-        }}
-        onDrop={(event: DragEvent) => {
-          event.preventDefault();
-          setDragOver(false);
-          const files = Array.from(event.dataTransfer?.files ?? []);
-          if (files.length) void uploadFiles(files);
-        }}
-        disabled={uploading()}
-        title={connected() ? "Drop files here to upload" : "Connect to a worker to upload"}
-      >
-        <div class="flex flex-col items-center justify-center text-center">
-          <UploadCloud size={18} class="text-gray-9 mb-2" />
-          <span class="text-[13px] font-medium text-gray-11">
-            {uploading() ? "Uploading..." : "Drop files or click to upload"}
-          </span>
-          <span class="mt-0.5 text-[11px] text-gray-9">{helperText}</span>
-        </div>
-      </button>
-
-      <div class="mt-2 space-y-1">
-        <Show when={error()}>
-          <div class="text-xs text-red-11 px-1 py-1">{error()}</div>
-        </Show>
-
-        <Show
-          when={visibleItems().length > 0}
-          fallback={
-            <div class="text-xs text-gray-10 px-1 py-1">
-              <Show when={connected()} fallback={"Connect to see inbox files."}>
-                No inbox files yet.
-              </Show>
-            </div>
-          }
+        <button
+          type="button"
+          class={`w-full border border-dashed border-gray-7 rounded-xl px-4 py-4 text-left transition-colors ${
+            dragOver() ? "bg-gray-3" : "bg-gray-2/60 hover:bg-gray-2"
+          } ${!connected() ? "opacity-70" : ""}`}
+          onClick={() => fileInputRef?.click()}
+          onDragOver={(event: DragEvent) => {
+            event.preventDefault();
+            setDragOver(true);
+          }}
+          onDragLeave={(event: DragEvent) => {
+            event.preventDefault();
+            setDragOver(false);
+          }}
+          onDrop={(event: DragEvent) => {
+            event.preventDefault();
+            setDragOver(false);
+            const files = Array.from(event.dataTransfer?.files ?? []);
+            if (files.length) void uploadFiles(files);
+          }}
+          disabled={uploading()}
+          title={connected() ? "Drop files here to upload" : "Connect to a worker to upload"}
         >
-          <For each={visibleItems()}>
-            {(item) => {
-              const name = () => safeName(item);
-              const rel = () => safeRelPath(item);
-              const bytes = () => (typeof item.size === "number" ? item.size : null);
-              const updatedAt = () => (typeof item.updatedAt === "number" ? item.updatedAt : null);
+          <div class="flex flex-col items-center justify-center text-center">
+            <UploadCloud size={18} class="text-gray-9 mb-2" />
+            <span class="text-[13px] font-medium text-gray-11">
+              {uploading() ? "Uploading..." : "Drop files or click to upload"}
+            </span>
+            <span class="mt-0.5 text-[11px] text-gray-9">{helperText}</span>
+          </div>
+        </button>
 
-              return (
-                <div class="group flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-2 transition-colors border border-transparent hover:border-gray-6/80">
-                  <button
-                    type="button"
-                    class="min-w-0 flex-1 text-left"
-                    onClick={() => void copyPath(item)}
-                    title={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy inbox path"}
-                    aria-label={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy inbox path"}
-                    disabled={!connected()}
-                  >
-                    <div class="truncate text-xs font-medium text-gray-11">{name()}</div>
-                    <div class="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-gray-9">
-                      <Show when={bytes() != null}>
-                        <span class="font-mono">{formatBytes(bytes() as number)}</span>
-                      </Show>
-                      <Show when={updatedAt() != null}>
-                        <span>{formatRelativeTime(updatedAt() as number)}</span>
-                      </Show>
-                      <Show when={rel()}>
-                        <span class="min-w-0 truncate font-mono">{rel()}</span>
-                      </Show>
-                    </div>
-                  </button>
+        <div class="mt-2 space-y-1">
+          <Show when={error()}>
+            <div class="text-xs text-red-11 px-1 py-1">{error()}</div>
+          </Show>
 
-                  <button
-                    type="button"
-                    class="shrink-0 rounded-md p-1 text-gray-9 opacity-0 group-hover:opacity-100 hover:text-gray-11 hover:bg-gray-3"
-                    onClick={() => void downloadItem(item)}
-                    title="Download"
-                    aria-label="Download"
-                    disabled={!connected()}
-                  >
-                    <Download size={14} />
-                  </button>
-                </div>
-              );
-            }}
-          </For>
-        </Show>
+          <Show
+            when={visibleItems().length > 0}
+            fallback={
+              <div class="text-xs text-gray-10 px-1 py-1">
+                <Show when={connected()} fallback={"Connect to see inbox files."}>
+                  No inbox files yet.
+                </Show>
+              </div>
+            }
+          >
+            <For each={visibleItems()}>
+              {(item) => {
+                const name = () => safeName(item);
+                const rel = () => safeRelPath(item);
+                const bytes = () => (typeof item.size === "number" ? item.size : null);
+                const updatedAt = () => (typeof item.updatedAt === "number" ? item.updatedAt : null);
 
-        <Show when={hiddenCount() > 0}>
-          <div class="text-[11px] text-gray-10 px-1 py-1">Showing first {maxPreview()}.</div>
-        </Show>
+                return (
+                  <div class="group flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-2 transition-colors border border-transparent hover:border-gray-6/80">
+                    <button
+                      type="button"
+                      class="min-w-0 flex-1 text-left"
+                      onClick={() => void copyPath(item)}
+                      title={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy inbox path"}
+                      aria-label={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy inbox path"}
+                      disabled={!connected()}
+                    >
+                      <div class="truncate text-xs font-medium text-gray-11">{name()}</div>
+                      <div class="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-gray-9">
+                        <Show when={bytes() != null}>
+                          <span class="font-mono">{formatBytes(bytes() as number)}</span>
+                        </Show>
+                        <Show when={updatedAt() != null}>
+                          <span>{formatRelativeTime(updatedAt() as number)}</span>
+                        </Show>
+                        <Show when={rel()}>
+                          <span class="min-w-0 truncate font-mono">{rel()}</span>
+                        </Show>
+                      </div>
+                    </button>
+
+                    <button
+                      type="button"
+                      class="shrink-0 rounded-md p-1 text-gray-9 opacity-0 group-hover:opacity-100 hover:text-gray-11 hover:bg-gray-3"
+                      onClick={() => void downloadItem(item)}
+                      title="Download"
+                      aria-label="Download"
+                      disabled={!connected()}
+                    >
+                      <Download size={14} />
+                    </button>
+                  </div>
+                );
+              }}
+            </For>
+          </Show>
+
+          <Show when={hiddenCount() > 0}>
+            <div class="text-[11px] text-gray-10 px-1 py-1">Showing first {maxPreview()}.</div>
+          </Show>
+        </div>
       </div>
-    </div>
+    </WebUnavailableSurface>
   );
 }

--- a/packages/app/src/app/components/session/workspace-session-list.tsx
+++ b/packages/app/src/app/components/session/workspace-session-list.tsx
@@ -1,9 +1,31 @@
-import { For, Show, createEffect, createSignal, onCleanup, onMount } from "solid-js";
-import { ChevronDown, ChevronRight, Loader2, MoreHorizontal, Plus } from "lucide-solid";
+import {
+  For,
+  Show,
+  createEffect,
+  createSignal,
+  onCleanup,
+  onMount,
+} from "solid-js";
+import {
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  MoreHorizontal,
+  Plus,
+} from "lucide-solid";
 
+import DesktopOnlyBadge from "../desktop-only-badge";
+import { getOpenWorkDeployment } from "../../lib/openwork-deployment";
 import type { WorkspaceInfo } from "../../lib/tauri";
-import type { WorkspaceConnectionState, WorkspaceSessionGroup } from "../../types";
-import { formatRelativeTime, getWorkspaceTaskLoadErrorDisplay, isWindowsPlatform } from "../../utils";
+import type {
+  WorkspaceConnectionState,
+  WorkspaceSessionGroup,
+} from "../../types";
+import {
+  formatRelativeTime,
+  getWorkspaceTaskLoadErrorDisplay,
+  isWindowsPlatform,
+} from "../../utils";
 
 type Props = {
   workspaceSessionGroups: WorkspaceSessionGroup[];
@@ -15,7 +37,9 @@ type Props = {
   workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
   newTaskDisabled: boolean;
   importingWorkspaceConfig: boolean;
-  onActivateWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onActivateWorkspace: (
+    workspaceId: string,
+  ) => Promise<boolean> | boolean | void;
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string) => void;
   onOpenRenameSession?: () => void;
@@ -23,8 +47,12 @@ type Props = {
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;
   onRevealWorkspace: (workspaceId: string) => void;
-  onRecoverWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
-  onTestWorkspaceConnection: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onRecoverWorkspace: (
+    workspaceId: string,
+  ) => Promise<boolean> | boolean | void;
+  onTestWorkspaceConnection: (
+    workspaceId: string,
+  ) => Promise<boolean> | boolean | void;
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
@@ -51,7 +79,10 @@ const getRootSessions = (sessions: WorkspaceSessionGroup["sessions"]) => {
   });
 };
 
-const flattenSessionRows = (sessions: WorkspaceSessionGroup["sessions"], rootLimit: number) => {
+const flattenSessionRows = (
+  sessions: WorkspaceSessionGroup["sessions"],
+  rootLimit: number,
+) => {
   const childrenByParent = new Map<string, SessionListItem[]>();
   sessions.forEach((session) => {
     const parentID = normalizeSessionParentID(session);
@@ -106,17 +137,26 @@ const workspaceSwatchColor = (seed: string) => {
 };
 
 export default function WorkspaceSessionList(props: Props) {
-  const revealLabel = isWindowsPlatform() ? "Reveal in Explorer" : "Reveal in Finder";
-  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = createSignal<Set<string>>(new Set());
-  const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = createSignal<Record<string, number>>({});
-  const [workspaceMenuId, setWorkspaceMenuId] = createSignal<string | null>(null);
+  const revealLabel = isWindowsPlatform()
+    ? "Reveal in Explorer"
+    : "Reveal in Finder";
+  const newWorkerDesktopOnly = getOpenWorkDeployment() === "web";
+  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = createSignal<
+    Set<string>
+  >(new Set());
+  const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] =
+    createSignal<Record<string, number>>({});
+  const [workspaceMenuId, setWorkspaceMenuId] = createSignal<string | null>(
+    null,
+  );
   const [addWorkspaceMenuOpen, setAddWorkspaceMenuOpen] = createSignal(false);
   const [sessionMenuOpen, setSessionMenuOpen] = createSignal(false);
   let workspaceMenuRef: HTMLDivElement | undefined;
   let addWorkspaceMenuRef: HTMLDivElement | undefined;
   let sessionMenuRef: HTMLDivElement | undefined;
 
-  const isWorkspaceExpanded = (workspaceId: string) => expandedWorkspaceIds().has(workspaceId);
+  const isWorkspaceExpanded = (workspaceId: string) =>
+    expandedWorkspaceIds().has(workspaceId);
 
   const expandWorkspace = (workspaceId: string) => {
     const id = workspaceId.trim();
@@ -152,14 +192,17 @@ export default function WorkspaceSessionList(props: Props) {
   });
 
   const previewCount = (workspaceId: string) => {
-    const base = previewCountByWorkspaceId()[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+    const base =
+      previewCountByWorkspaceId()[workspaceId] ?? MAX_SESSIONS_PREVIEW;
     return isWorkspaceExpanded(workspaceId)
       ? base
       : Math.min(COLLAPSED_SESSIONS_PREVIEW, base);
   };
 
-  const previewSessions = (workspaceId: string, sessions: WorkspaceSessionGroup["sessions"]) =>
-    flattenSessionRows(sessions, previewCount(workspaceId));
+  const previewSessions = (
+    workspaceId: string,
+    sessions: WorkspaceSessionGroup["sessions"],
+  ) => flattenSessionRows(sessions, previewCount(workspaceId));
 
   const showMoreSessions = (workspaceId: string, totalRoots: number) => {
     expandWorkspace(workspaceId);
@@ -193,7 +236,8 @@ export default function WorkspaceSessionList(props: Props) {
     if (!addWorkspaceMenuOpen()) return;
     const closeMenu = (event: PointerEvent) => {
       const target = event.target as Node | null;
-      if (addWorkspaceMenuRef && target && addWorkspaceMenuRef.contains(target)) return;
+      if (addWorkspaceMenuRef && target && addWorkspaceMenuRef.contains(target))
+        return;
       setAddWorkspaceMenuOpen(false);
     };
     window.addEventListener("pointerdown", closeMenu);
@@ -221,12 +265,13 @@ export default function WorkspaceSessionList(props: Props) {
     const session = () => row.session;
     const depth = () => row.depth;
     const isSelected = () => props.selectedSessionId === session().id;
-    const isSessionActive = () => (props.sessionStatusById?.[session().id] ?? "idle") !== "idle";
+    const isSessionActive = () =>
+      (props.sessionStatusById?.[session().id] ?? "idle") !== "idle";
     const canManageSession = () =>
       Boolean(
         props.showSessionActions &&
-          isSelected() &&
-          (props.onOpenRenameSession || props.onOpenDeleteSession),
+        isSelected() &&
+        (props.onOpenRenameSession || props.onOpenDeleteSession),
       );
 
     const openSession = () => {
@@ -260,7 +305,9 @@ export default function WorkspaceSessionList(props: Props) {
             <Show when={isSessionActive()}>
               <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" />
             </Show>
-            <span class="truncate text-[13px] font-normal text-current">{session().title}</span>
+            <span class="truncate text-[13px] font-normal text-current">
+              {session().title}
+            </span>
           </div>
 
           <div class="ml-auto flex shrink-0 items-center gap-1">
@@ -330,15 +377,21 @@ export default function WorkspaceSessionList(props: Props) {
         <For each={props.workspaceSessionGroups}>
           {(group) => {
             const workspace = () => group.workspace;
-            const isConnecting = () => props.connectingWorkspaceId === workspace().id;
+            const isConnecting = () =>
+              props.connectingWorkspaceId === workspace().id;
             const connectionState = () =>
-              props.workspaceConnectionStateById[workspace().id] ?? { status: "idle", message: null };
+              props.workspaceConnectionStateById[workspace().id] ?? {
+                status: "idle",
+                message: null,
+              };
             const isConnectionActionBusy = () =>
               isConnecting() || connectionState().status === "connecting";
             const canRecover = () =>
-              workspace().workspaceType === "remote" && connectionState().status === "error";
+              workspace().workspaceType === "remote" &&
+              connectionState().status === "error";
             const isMenuOpen = () => workspaceMenuId() === workspace().id;
-            const taskLoadError = () => getWorkspaceTaskLoadErrorDisplay(workspace(), group.error);
+            const taskLoadError = () =>
+              getWorkspaceTaskLoadErrorDisplay(workspace(), group.error);
             const statusLabel = () => {
               if (group.status === "error") return taskLoadError().label;
               if (isConnectionActionBusy()) return "Connecting";
@@ -347,7 +400,9 @@ export default function WorkspaceSessionList(props: Props) {
             };
             const statusTone = () => {
               if (group.status === "error") {
-                return taskLoadError().tone === "offline" ? "text-amber-11" : "text-red-11";
+                return taskLoadError().tone === "offline"
+                  ? "text-amber-11"
+                  : "text-red-11";
               }
               return "text-gray-9";
             };
@@ -365,24 +420,38 @@ export default function WorkspaceSessionList(props: Props) {
                     } ${isConnecting() ? "opacity-75" : ""}`}
                     onClick={() => {
                       expandWorkspace(workspace().id);
-                      void Promise.resolve(props.onActivateWorkspace(workspace().id));
+                      void Promise.resolve(
+                        props.onActivateWorkspace(workspace().id),
+                      );
                     }}
                     onKeyDown={(event) => {
                       if (event.key !== "Enter" && event.key !== " ") return;
                       if (event.isComposing || event.keyCode === 229) return;
                       event.preventDefault();
                       expandWorkspace(workspace().id);
-                      void Promise.resolve(props.onActivateWorkspace(workspace().id));
+                      void Promise.resolve(
+                        props.onActivateWorkspace(workspace().id),
+                      );
                     }}
                   >
                     <div class="flex min-w-0 items-center gap-3.5">
                       <div
                         class="flex h-6.5 w-6.5 shrink-0 items-center justify-center rounded-full"
-                        style={{ "background-color": workspaceSwatchColor(workspace().id || workspaceLabel(workspace())) }}
+                        style={{
+                          "background-color": workspaceSwatchColor(
+                            workspace().id || workspaceLabel(workspace()),
+                          ),
+                        }}
                       />
                       <div class="min-w-0 flex items-baseline gap-3">
-                        <div class="min-w-0 flex-1 truncate text-[14px] font-normal text-dls-text">{workspaceLabel(workspace())}</div>
-                        <div class={`shrink-0 whitespace-nowrap text-[12px] ${statusTone()}`}>{statusLabel()}</div>
+                        <div class="min-w-0 flex-1 truncate text-[14px] font-normal text-dls-text">
+                          {workspaceLabel(workspace())}
+                        </div>
+                        <div
+                          class={`shrink-0 whitespace-nowrap text-[12px] ${statusTone()}`}
+                        >
+                          {statusLabel()}
+                        </div>
                       </div>
                     </div>
 
@@ -411,7 +480,9 @@ export default function WorkspaceSessionList(props: Props) {
                           onClick={(event) => {
                             event.stopPropagation();
                             setWorkspaceMenuId((current) =>
-                              current === workspace().id ? null : workspace().id,
+                              current === workspace().id
+                                ? null
+                                : workspace().id,
                             );
                           }}
                           aria-label="Worker options"
@@ -423,7 +494,11 @@ export default function WorkspaceSessionList(props: Props) {
                       <button
                         type="button"
                         class="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
-                        aria-label={isWorkspaceExpanded(workspace().id) ? "Collapse" : "Expand"}
+                        aria-label={
+                          isWorkspaceExpanded(workspace().id)
+                            ? "Collapse"
+                            : "Expand"
+                        }
                         onClick={(event) => {
                           event.stopPropagation();
                           toggleWorkspaceExpanded(workspace().id);
@@ -483,7 +558,9 @@ export default function WorkspaceSessionList(props: Props) {
                             type="button"
                             class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                             onClick={() => {
-                              void Promise.resolve(props.onRecoverWorkspace(workspace().id));
+                              void Promise.resolve(
+                                props.onRecoverWorkspace(workspace().id),
+                              );
                               setWorkspaceMenuId(null);
                             }}
                             disabled={isConnectionActionBusy()}
@@ -495,7 +572,9 @@ export default function WorkspaceSessionList(props: Props) {
                           type="button"
                           class="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
                           onClick={() => {
-                            void Promise.resolve(props.onTestWorkspaceConnection(workspace().id));
+                            void Promise.resolve(
+                              props.onTestWorkspaceConnection(workspace().id),
+                            );
                             setWorkspaceMenuId(null);
                           }}
                           disabled={isConnectionActionBusy()}
@@ -533,14 +612,19 @@ export default function WorkspaceSessionList(props: Props) {
                     when={isWorkspaceExpanded(workspace().id)}
                     fallback={
                       <Show when={group.sessions.length > 0}>
-                        <For each={previewSessions(workspace().id, group.sessions)}>
+                        <For
+                          each={previewSessions(workspace().id, group.sessions)}
+                        >
                           {(row) => renderSessionRow(workspace().id, row)}
                         </For>
                       </Show>
                     }
                   >
                     <Show
-                      when={group.status === "loading" && group.sessions.length === 0}
+                      when={
+                        group.status === "loading" &&
+                        group.sessions.length === 0
+                      }
                       fallback={
                         <Show
                           when={group.sessions.length > 0}
@@ -559,29 +643,58 @@ export default function WorkspaceSessionList(props: Props) {
                             </Show>
                           }
                         >
-                          <For each={previewSessions(workspace().id, group.sessions)}>
+                          <For
+                            each={previewSessions(
+                              workspace().id,
+                              group.sessions,
+                            )}
+                          >
                             {(row) => renderSessionRow(workspace().id, row)}
                           </For>
 
-                          <Show when={group.sessions.length === 0 && group.status === "ready"}>
+                          <Show
+                            when={
+                              group.sessions.length === 0 &&
+                              group.status === "ready"
+                            }
+                          >
                             <button
                               type="button"
                               class="group/empty w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
-                              onClick={() => props.onCreateTaskInWorkspace(workspace().id)}
+                              onClick={() =>
+                                props.onCreateTaskInWorkspace(workspace().id)
+                              }
                               disabled={props.newTaskDisabled}
                             >
-                              <span class="group-hover/empty:hidden">No tasks yet.</span>
-                              <span class="hidden group-hover/empty:inline font-medium">+ New task</span>
+                              <span class="group-hover/empty:hidden">
+                                No tasks yet.
+                              </span>
+                              <span class="hidden group-hover/empty:inline font-medium">
+                                + New task
+                              </span>
                             </button>
                           </Show>
 
-                          <Show when={getRootSessions(group.sessions).length > previewCount(workspace().id)}>
+                          <Show
+                            when={
+                              getRootSessions(group.sessions).length >
+                              previewCount(workspace().id)
+                            }
+                          >
                             <button
                               type="button"
                               class="w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
-                              onClick={() => showMoreSessions(workspace().id, getRootSessions(group.sessions).length)}
+                              onClick={() =>
+                                showMoreSessions(
+                                  workspace().id,
+                                  getRootSessions(group.sessions).length,
+                                )
+                              }
                             >
-                              {showMoreLabel(workspace().id, getRootSessions(group.sessions).length)}
+                              {showMoreLabel(
+                                workspace().id,
+                                getRootSessions(group.sessions).length,
+                              )}
                             </button>
                           </Show>
                         </Show>
@@ -613,14 +726,27 @@ export default function WorkspaceSessionList(props: Props) {
           <div class="absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]">
             <button
               type="button"
-              class="w-full flex items-center gap-2 rounded-xl px-3 py-2 text-xs text-gray-11 transition-colors hover:bg-gray-2 hover:text-gray-12"
+              class={`w-full flex items-center gap-2 rounded-xl px-3 py-2 text-xs transition-colors ${
+                newWorkerDesktopOnly
+                  ? "cursor-not-allowed text-gray-9 opacity-70"
+                  : "text-gray-11 hover:bg-gray-2 hover:text-gray-12"
+              }`}
+              disabled={newWorkerDesktopOnly}
+              title={
+                newWorkerDesktopOnly
+                  ? "Create local workers in the desktop app."
+                  : undefined
+              }
               onClick={() => {
                 props.onOpenCreateWorkspace();
                 setAddWorkspaceMenuOpen(false);
               }}
             >
               <Plus size={12} />
-              New worker
+              <span class="flex-1 text-left">New worker</span>
+              <Show when={newWorkerDesktopOnly}>
+                <DesktopOnlyBadge />
+              </Show>
             </button>
             <button
               type="button"

--- a/packages/app/src/app/components/web-unavailable-surface.tsx
+++ b/packages/app/src/app/components/web-unavailable-surface.tsx
@@ -1,0 +1,63 @@
+import { Show, createEffect } from "solid-js";
+import { ArrowUpRight } from "lucide-solid";
+import type { JSX } from "solid-js";
+
+type WebUnavailableSurfaceProps = {
+  unavailable: boolean;
+  children: JSX.Element;
+  compact?: boolean;
+  class?: string;
+  contentClass?: string;
+};
+
+const MESSAGE =
+  "This feature is currently unavailable in OpenWork Web, check OpenWork Desktop for full functionality.";
+
+export default function WebUnavailableSurface(props: WebUnavailableSurfaceProps) {
+  let contentRef: HTMLDivElement | undefined;
+
+  createEffect(() => {
+    if (!contentRef) return;
+    if (props.unavailable) {
+      contentRef.setAttribute("inert", "");
+      contentRef.setAttribute("aria-disabled", "true");
+      return;
+    }
+    contentRef.removeAttribute("inert");
+    contentRef.removeAttribute("aria-disabled");
+  });
+
+  return (
+    <div class={props.class}>
+      <Show when={props.unavailable}>
+        <div
+          class={props.compact
+            ? "mb-3 rounded-xl border border-amber-7/30 bg-amber-2/45 px-3 py-2 text-[11px] text-amber-12"
+            : "mb-4 rounded-2xl border border-amber-7/30 bg-amber-2/45 px-4 py-3 text-[13px] text-amber-12"}
+        >
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span>{MESSAGE}</span>
+            <a
+              href="https://openworklabs.com"
+              target="_blank"
+              rel="noreferrer"
+              class="inline-flex items-center gap-1 underline underline-offset-2 hover:no-underline"
+            >
+              <span>Download OpenWork Desktop</span>
+              <ArrowUpRight size={props.compact ? 12 : 14} />
+            </a>
+          </div>
+        </div>
+      </Show>
+
+      <div class={`relative ${props.contentClass ?? ""}`}>
+        <div ref={contentRef} classList={{ "opacity-55": props.unavailable }}>
+          {props.children}
+        </div>
+        <Show when={props.unavailable}>
+          <div class="absolute inset-0 z-10 cursor-not-allowed" aria-hidden="true" />
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/app/lib/workspace-shell-layout.ts
+++ b/packages/app/src/app/lib/workspace-shell-layout.ts
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 const LEFT_SIDEBAR_WIDTH_KEY = "openwork.workspace-shell.left-width.v1";
-const RIGHT_SIDEBAR_EXPANDED_KEY = "openwork.workspace-shell.right-expanded.v1";
+const RIGHT_SIDEBAR_EXPANDED_KEY = "openwork.workspace-shell.right-expanded.v2";
 
 export const DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH = 260;
 export const MIN_WORKSPACE_LEFT_SIDEBAR_WIDTH = 220;
@@ -59,7 +59,11 @@ export function createWorkspaceShellLayout(options: WorkspaceShellLayoutOptions)
     return clampNumber(parsed, minLeftWidth, maxLeftWidth);
   };
 
-  const readRightSidebarExpanded = () => readStorage(RIGHT_SIDEBAR_EXPANDED_KEY) === "1";
+  const readRightSidebarExpanded = () => {
+    const raw = readStorage(RIGHT_SIDEBAR_EXPANDED_KEY);
+    if (raw == null) return true;
+    return raw === "1";
+  };
 
   const [leftSidebarWidth, setLeftSidebarWidth] = createSignal(readLeftSidebarWidth());
   const [rightSidebarExpanded, setRightSidebarExpanded] = createSignal(readRightSidebarExpanded());

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -1,4 +1,4 @@
-import { For, Match, Show, Switch, createEffect, createMemo, createSignal, on, onCleanup } from "solid-js";
+import { For, Match, Show, Switch, createEffect, createMemo, createSignal, on, onCleanup, type JSX } from "solid-js";
 import type {
   DashboardTab,
   McpServerEntry,
@@ -26,6 +26,7 @@ import {
 } from "../utils";
 import { usePlatform } from "../context/platform";
 import { FEEDBACK_EMAIL_URL } from "../lib/feedback";
+import { getOpenWorkDeployment } from "../lib/openwork-deployment";
 import { createWorkspaceShellLayout } from "../lib/workspace-shell-layout";
 import {
   buildOpenworkConnectInviteUrl,
@@ -56,6 +57,9 @@ import StatusBar from "../components/status-bar";
 import ProviderAuthModal, { type ProviderOAuthStartResult } from "../components/provider-auth-modal";
 import ShareWorkspaceModal from "../components/share-workspace-modal";
 import WorkspaceSessionList from "../components/session/workspace-session-list";
+import InboxPanel from "../components/session/inbox-panel";
+import MobileSidebarDrawer from "../components/mobile-sidebar-drawer";
+import WebUnavailableSurface from "../components/web-unavailable-surface";
 import {
   Box,
   ChevronLeft,
@@ -68,6 +72,7 @@ import {
   MoreHorizontal,
   Plus,
   SlidersHorizontal,
+  X,
   Zap,
 } from "lucide-solid";
 import type { Language } from "../../i18n";
@@ -352,6 +357,8 @@ type SkillsSetBundleV1 = {
 
 export default function DashboardView(props: DashboardViewProps) {
   const platform = usePlatform();
+  const webDeployment = createMemo(() => getOpenWorkDeployment() === "web");
+  const [mobileRightSidebarOpen, setMobileRightSidebarOpen] = createSignal(false);
   const title = createMemo(() => {
     switch (props.tab) {
       case "scheduled":
@@ -522,26 +529,49 @@ export default function DashboardView(props: DashboardViewProps) {
     });
   });
 
-  const navItem = (t: DashboardTab, label: string, icon: any) => {
+  const navItem = (
+    t: DashboardTab,
+    label: string,
+    icon: any,
+    options?: {
+      disabled?: boolean;
+      badge?: JSX.Element;
+      disabledTitle?: string;
+      expanded?: boolean;
+      onSelect?: () => void;
+    },
+  ) => {
+    const expanded = options?.expanded ?? rightSidebarExpanded();
     const active = () => props.tab === t || (t === "mcp" && props.tab === "plugins");
     return (
       <button
         type="button"
+        disabled={options?.disabled}
         class={`w-full border text-[13px] font-medium transition-[background-color,border-color,box-shadow,color] ${
-          active()
-            ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
-            : "border-transparent text-dls-secondary hover:border-dls-border hover:bg-dls-surface hover:text-dls-text"
+          options?.disabled
+            ? "cursor-not-allowed border-transparent text-gray-8 opacity-70"
+            : active()
+              ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
+              : "border-transparent text-dls-secondary hover:border-dls-border hover:bg-dls-surface hover:text-dls-text"
         } ${
-          rightSidebarExpanded()
+          expanded
             ? "flex min-h-11 items-center justify-start gap-2.5 rounded-[16px] px-3.5"
             : "flex h-12 items-center justify-center rounded-[16px] px-0"
         }`}
-        onClick={() => props.setTab(t)}
-        title={label}
-        aria-label={label}
+        onClick={() => {
+          props.setTab(t);
+          options?.onSelect?.();
+        }}
+        title={options?.disabled ? options.disabledTitle ?? label : label}
+        aria-label={options?.disabled ? `${label}. ${options.disabledTitle ?? "Desktop only."}` : label}
       >
         {icon}
-        <Show when={rightSidebarExpanded()}>{label}</Show>
+        <Show when={expanded}>
+          <span class="flex min-w-0 flex-1 items-center gap-2">
+            <span class="truncate">{label}</span>
+            {options?.badge}
+          </span>
+        </Show>
       </button>
     );
   };
@@ -554,6 +584,45 @@ export default function DashboardView(props: DashboardViewProps) {
   const openConfig = () => {
     props.setTab(props.developerMode ? "config" : "identities");
   };
+
+  const renderRightSidebar = (expanded: boolean, mobile = false) => (
+    <div class={`flex h-full flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 ${mobile ? "shadow-2xl" : "transition-[width] duration-200"}`}>
+      <div class={`flex items-center pb-3 ${expanded ? "justify-end" : "justify-center"}`}>
+        <button
+          type="button"
+          class="flex h-10 w-10 items-center justify-center rounded-[16px] text-dls-secondary transition-colors hover:bg-dls-surface hover:text-dls-text"
+          onClick={mobile ? () => setMobileRightSidebarOpen(false) : toggleRightSidebar}
+          title={mobile ? "Close sidebar" : rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
+          aria-label={mobile ? "Close sidebar" : rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
+        >
+          <Show when={mobile} fallback={<Show when={expanded} fallback={<ChevronLeft size={18} />}><ChevronRight size={18} /></Show>}>
+            <X size={18} />
+          </Show>
+        </button>
+      </div>
+      <div class={`pt-1 ${expanded ? "space-y-5" : "space-y-3"}`}>
+        <div class="space-y-1">
+          {navItem("scheduled", "Automations", <History size={18} />, { expanded, onSelect: mobile ? () => setMobileRightSidebarOpen(false) : undefined })}
+          {navItem("skills", "Skills", <Zap size={18} />, { expanded, onSelect: mobile ? () => setMobileRightSidebarOpen(false) : undefined })}
+          {navItem("mcp", "Extensions", <Box size={18} />, { expanded, onSelect: mobile ? () => setMobileRightSidebarOpen(false) : undefined })}
+          {navItem("identities", "Messaging", <MessageCircle size={18} />, { expanded, onSelect: mobile ? () => setMobileRightSidebarOpen(false) : undefined })}
+          <Show when={props.developerMode}>
+            {navItem("config", "Advanced", <SlidersHorizontal size={18} />, { expanded, onSelect: mobile ? () => setMobileRightSidebarOpen(false) : undefined })}
+          </Show>
+        </div>
+
+        <Show when={expanded}>
+          <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
+            <InboxPanel
+              id={mobile ? "dashboard-mobile-sidebar-inbox" : "dashboard-sidebar-inbox"}
+              client={props.openworkServerClient}
+              workspaceId={props.openworkServerWorkspaceId}
+            />
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
 
   const revealWorkspaceInFinder = async (workspaceId: string) => {
     const workspace = props.workspaces.find((entry) => entry.id === workspaceId) ?? null;
@@ -1193,7 +1262,16 @@ export default function DashboardView(props: DashboardViewProps) {
           <div class="flex items-center gap-1.5 text-gray-10">
             <button
               type="button"
-              class="hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text sm:flex"
+              class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text md:hidden"
+              onClick={() => setMobileRightSidebarOpen(true)}
+              title="Open sidebar"
+              aria-label="Open sidebar"
+            >
+              <Menu size={16} />
+            </button>
+            <button
+              type="button"
+              class="hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text md:flex"
               onClick={toggleRightSidebar}
               title="Menu"
               aria-label="Menu"
@@ -1202,7 +1280,7 @@ export default function DashboardView(props: DashboardViewProps) {
               <span>Menu</span>
               <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">⌘K</span>
             </button>
-            <div class="hidden h-4 w-px bg-dls-border sm:block" />
+            <div class="hidden h-4 w-px bg-dls-border md:block" />
             <button
               type="button"
               class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
@@ -1218,113 +1296,121 @@ export default function DashboardView(props: DashboardViewProps) {
         <div class="mx-auto w-full max-w-[1100px] space-y-10 p-6 md:p-10">
           <Switch>
             <Match when={props.tab === "scheduled"}>
-              <ScheduledTasksView
-                jobs={props.scheduledJobs}
-                source={props.scheduledJobsSource}
-                sourceReady={props.scheduledJobsSourceReady}
-                status={props.scheduledJobsStatus}
-                busy={props.scheduledJobsBusy}
-                lastUpdatedAt={props.scheduledJobsUpdatedAt}
-                refreshJobs={props.refreshScheduledJobs}
-                deleteJob={props.deleteScheduledJob}
-                isWindows={props.isWindows}
-                activeWorkspaceRoot={props.activeWorkspaceRoot}
-                createSessionAndOpen={props.createSessionAndOpen}
-                setPrompt={props.setPrompt}
-                newTaskDisabled={props.newTaskDisabled}
-                schedulerInstalled={props.schedulerPluginInstalled}
-                canEditPlugins={props.canEditPlugins}
-                addPlugin={props.addPlugin}
-                reloadWorkspaceEngine={props.reloadWorkspaceEngine}
-                reloadBusy={props.reloadBusy}
-                canReloadWorkspace={props.canReloadWorkspace}
-              />
+              <WebUnavailableSurface unavailable={webDeployment()}>
+                <ScheduledTasksView
+                  jobs={props.scheduledJobs}
+                  source={props.scheduledJobsSource}
+                  sourceReady={props.scheduledJobsSourceReady}
+                  status={props.scheduledJobsStatus}
+                  busy={props.scheduledJobsBusy}
+                  lastUpdatedAt={props.scheduledJobsUpdatedAt}
+                  refreshJobs={props.refreshScheduledJobs}
+                  deleteJob={props.deleteScheduledJob}
+                  isWindows={props.isWindows}
+                  activeWorkspaceRoot={props.activeWorkspaceRoot}
+                  createSessionAndOpen={props.createSessionAndOpen}
+                  setPrompt={props.setPrompt}
+                  newTaskDisabled={props.newTaskDisabled}
+                  schedulerInstalled={props.schedulerPluginInstalled}
+                  canEditPlugins={props.canEditPlugins}
+                  addPlugin={props.addPlugin}
+                  reloadWorkspaceEngine={props.reloadWorkspaceEngine}
+                  reloadBusy={props.reloadBusy}
+                  canReloadWorkspace={props.canReloadWorkspace}
+                />
+              </WebUnavailableSurface>
             </Match>
             <Match when={props.tab === "skills"}>
-              <SkillsView
-                workspaceName={props.activeWorkspaceDisplay.name}
-                busy={props.busy}
-                canInstallSkillCreator={props.canInstallSkillCreator}
-                canUseDesktopTools={props.canUseDesktopTools}
-                accessHint={props.skillsAccessHint}
-                refreshSkills={props.refreshSkills}
-                refreshHubSkills={props.refreshHubSkills}
-                skills={props.skills}
-                skillsStatus={props.skillsStatus}
-                hubSkills={props.hubSkills}
-                hubSkillsStatus={props.hubSkillsStatus}
-                hubRepo={props.hubRepo}
-                hubRepos={props.hubRepos}
-                importLocalSkill={props.importLocalSkill}
-                installSkillCreator={props.installSkillCreator}
-                installHubSkill={props.installHubSkill}
-                setHubRepo={props.setHubRepo}
-                addHubRepo={props.addHubRepo}
-                removeHubRepo={props.removeHubRepo}
-                revealSkillsFolder={props.revealSkillsFolder}
-                uninstallSkill={props.uninstallSkill}
-                readSkill={props.readSkill}
-                saveSkill={props.saveSkill}
-                createSessionAndOpen={props.createSessionAndOpen}
-                setPrompt={props.setPrompt}
-              />
+              <WebUnavailableSurface unavailable={webDeployment()}>
+                <SkillsView
+                  workspaceName={props.activeWorkspaceDisplay.name}
+                  busy={props.busy}
+                  canInstallSkillCreator={props.canInstallSkillCreator}
+                  canUseDesktopTools={props.canUseDesktopTools}
+                  accessHint={props.skillsAccessHint}
+                  refreshSkills={props.refreshSkills}
+                  refreshHubSkills={props.refreshHubSkills}
+                  skills={props.skills}
+                  skillsStatus={props.skillsStatus}
+                  hubSkills={props.hubSkills}
+                  hubSkillsStatus={props.hubSkillsStatus}
+                  hubRepo={props.hubRepo}
+                  hubRepos={props.hubRepos}
+                  importLocalSkill={props.importLocalSkill}
+                  installSkillCreator={props.installSkillCreator}
+                  installHubSkill={props.installHubSkill}
+                  setHubRepo={props.setHubRepo}
+                  addHubRepo={props.addHubRepo}
+                  removeHubRepo={props.removeHubRepo}
+                  revealSkillsFolder={props.revealSkillsFolder}
+                  uninstallSkill={props.uninstallSkill}
+                  readSkill={props.readSkill}
+                  saveSkill={props.saveSkill}
+                  createSessionAndOpen={props.createSessionAndOpen}
+                  setPrompt={props.setPrompt}
+                />
+              </WebUnavailableSurface>
             </Match>
 
             <Match when={props.tab === "plugins" || props.tab === "mcp"}>
-              <ExtensionsView
-                initialSection={props.tab === "plugins" ? "plugins" : "mcp"}
-                setDashboardTab={props.setTab}
-                busy={props.busy}
-                activeWorkspaceRoot={props.activeWorkspaceRoot}
-                isRemoteWorkspace={props.isRemoteWorkspace}
-                refreshMcpServers={props.refreshMcpServers}
-                mcpServers={props.mcpServers}
-                mcpStatus={props.mcpStatus}
-                mcpLastUpdatedAt={props.mcpLastUpdatedAt}
-                mcpStatuses={props.mcpStatuses}
-                mcpConnectingName={props.mcpConnectingName}
-                selectedMcp={props.selectedMcp}
-                setSelectedMcp={props.setSelectedMcp}
-                quickConnect={props.quickConnect}
-                connectMcp={props.connectMcp}
-                authorizeMcp={props.authorizeMcp}
-                logoutMcpAuth={props.logoutMcpAuth}
-                removeMcp={props.removeMcp}
-                showMcpReloadBanner={props.showMcpReloadBanner}
-                reloadBlocked={props.mcpReloadBlocked}
-                reloadMcpEngine={props.reloadMcpEngine}
-                canEditPlugins={props.canEditPlugins}
-                canUseGlobalScope={props.canUseGlobalPluginScope}
-                accessHint={props.pluginsAccessHint}
-                pluginScope={props.pluginScope}
-                setPluginScope={props.setPluginScope}
-                pluginConfigPath={props.pluginConfigPath}
-                pluginList={props.pluginList}
-                pluginInput={props.pluginInput}
-                setPluginInput={props.setPluginInput}
-                pluginStatus={props.pluginStatus}
-                activePluginGuide={props.activePluginGuide}
-                setActivePluginGuide={props.setActivePluginGuide}
-                isPluginInstalled={props.isPluginInstalled}
-                suggestedPlugins={props.suggestedPlugins}
-                refreshPlugins={props.refreshPlugins}
-                addPlugin={props.addPlugin}
-                removePlugin={props.removePlugin}
-              />
+              <WebUnavailableSurface unavailable={webDeployment()}>
+                <ExtensionsView
+                  initialSection={props.tab === "plugins" ? "plugins" : "mcp"}
+                  setDashboardTab={props.setTab}
+                  busy={props.busy}
+                  activeWorkspaceRoot={props.activeWorkspaceRoot}
+                  isRemoteWorkspace={props.isRemoteWorkspace}
+                  refreshMcpServers={props.refreshMcpServers}
+                  mcpServers={props.mcpServers}
+                  mcpStatus={props.mcpStatus}
+                  mcpLastUpdatedAt={props.mcpLastUpdatedAt}
+                  mcpStatuses={props.mcpStatuses}
+                  mcpConnectingName={props.mcpConnectingName}
+                  selectedMcp={props.selectedMcp}
+                  setSelectedMcp={props.setSelectedMcp}
+                  quickConnect={props.quickConnect}
+                  connectMcp={props.connectMcp}
+                  authorizeMcp={props.authorizeMcp}
+                  logoutMcpAuth={props.logoutMcpAuth}
+                  removeMcp={props.removeMcp}
+                  showMcpReloadBanner={props.showMcpReloadBanner}
+                  reloadBlocked={props.mcpReloadBlocked}
+                  reloadMcpEngine={props.reloadMcpEngine}
+                  canEditPlugins={props.canEditPlugins}
+                  canUseGlobalScope={props.canUseGlobalPluginScope}
+                  accessHint={props.pluginsAccessHint}
+                  pluginScope={props.pluginScope}
+                  setPluginScope={props.setPluginScope}
+                  pluginConfigPath={props.pluginConfigPath}
+                  pluginList={props.pluginList}
+                  pluginInput={props.pluginInput}
+                  setPluginInput={props.setPluginInput}
+                  pluginStatus={props.pluginStatus}
+                  activePluginGuide={props.activePluginGuide}
+                  setActivePluginGuide={props.setActivePluginGuide}
+                  isPluginInstalled={props.isPluginInstalled}
+                  suggestedPlugins={props.suggestedPlugins}
+                  refreshPlugins={props.refreshPlugins}
+                  addPlugin={props.addPlugin}
+                  removePlugin={props.removePlugin}
+                />
+              </WebUnavailableSurface>
             </Match>
 
             <Match when={props.tab === "identities"}>
-              <IdentitiesView
-                busy={props.busy}
-                openworkServerStatus={props.openworkServerStatus}
-                openworkServerUrl={props.openworkServerUrl}
-                openworkServerClient={props.openworkServerClient}
-                openworkReconnectBusy={props.openworkReconnectBusy}
-                reconnectOpenworkServer={props.reconnectOpenworkServer}
-                openworkServerWorkspaceId={props.openworkServerWorkspaceId}
-                activeWorkspaceRoot={props.activeWorkspaceRoot}
-                developerMode={props.developerMode}
-              />
+              <WebUnavailableSurface unavailable={webDeployment()}>
+                <IdentitiesView
+                  busy={props.busy}
+                  openworkServerStatus={props.openworkServerStatus}
+                  openworkServerUrl={props.openworkServerUrl}
+                  openworkServerClient={props.openworkServerClient}
+                  openworkReconnectBusy={props.openworkReconnectBusy}
+                  reconnectOpenworkServer={props.reconnectOpenworkServer}
+                  openworkServerWorkspaceId={props.openworkServerWorkspaceId}
+                  activeWorkspaceRoot={props.activeWorkspaceRoot}
+                  developerMode={props.developerMode}
+                />
+              </WebUnavailableSurface>
             </Match>
 
             <Match when={props.tab === "config" && props.developerMode}>
@@ -1607,33 +1693,21 @@ export default function DashboardView(props: DashboardViewProps) {
       </main>
 
       <aside
-        class="flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 transition-[width] duration-200"
+        class="hidden shrink-0 md:flex"
         style={{
           width: `${rightSidebarWidth()}px`,
           "min-width": `${rightSidebarWidth()}px`,
         }}
       >
-        <div class={`flex items-center pb-3 ${rightSidebarExpanded() ? "justify-end" : "justify-center"}`}>
-          <button
-            type="button"
-            class="flex h-10 w-10 items-center justify-center rounded-[16px] text-dls-secondary transition-colors hover:bg-dls-surface hover:text-dls-text"
-            onClick={toggleRightSidebar}
-            title={rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
-            aria-label={rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
-          >
-            <Show when={rightSidebarExpanded()} fallback={<ChevronLeft size={18} />}>
-              <ChevronRight size={18} />
-            </Show>
-          </button>
-        </div>
-        <div class="space-y-1 pt-1">
-          {navItem("scheduled", "Automations", <History size={18} />)}
-          {navItem("skills", "Skills", <Zap size={18} />)}
-          {navItem("mcp", "Extensions", <Box size={18} />)}
-          {navItem("identities", "Messaging", <MessageCircle size={18} />)}
-          <Show when={props.developerMode}>{navItem("config", "Advanced", <SlidersHorizontal size={18} />)}</Show>
-        </div>
+        {renderRightSidebar(rightSidebarExpanded())}
       </aside>
+
+      <MobileSidebarDrawer
+        open={mobileRightSidebarOpen()}
+        onClose={() => setMobileRightSidebarOpen(false)}
+      >
+        {renderRightSidebar(true, true)}
+      </MobileSidebarDrawer>
       </div>
 
     </div>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -7,6 +7,7 @@ import {
   on,
   onCleanup,
   onMount,
+  type JSX,
 } from "solid-js";
 import type { Agent, Part, Session } from "@opencode-ai/sdk/v2/client";
 import type {
@@ -111,6 +112,7 @@ import Composer from "../components/session/composer";
 import WorkspaceSessionList from "../components/session/workspace-session-list";
 import type { SidebarSectionState } from "../components/session/sidebar";
 import FlyoutItem from "../components/flyout-item";
+import MobileSidebarDrawer from "../components/mobile-sidebar-drawer";
 import QuestionModal from "../components/question-modal";
 import InboxPanel from "../components/session/inbox-panel";
 
@@ -402,6 +404,7 @@ export default function SessionView(props: SessionViewProps) {
   const [initialAnchorPending, setInitialAnchorPending] = createSignal(false);
 
   const [obsidianAvailable, setObsidianAvailable] = createSignal(false);
+  const [mobileRightSidebarOpen, setMobileRightSidebarOpen] = createSignal(false);
 
   // In Session view the right sidebar is navigation-only; never pre-highlight a
   // dashboard tab here so first-run feels chat-first rather than Automations-first.
@@ -3914,31 +3917,144 @@ export default function SessionView(props: SessionViewProps) {
   const hasOpenAIProviderConnected = createMemo(() =>
     (props.providerConnectedIds ?? []).some((id) => id.trim().toLowerCase() === "openai")
   );
-
   const rightSidebarNavButton = (
     label: string,
     icon: any,
     active: boolean,
     onClick: () => void,
-  ) => (
-    <button
-      type="button"
-      class={`w-full border text-[13px] font-medium transition-[background-color,border-color,box-shadow,color] ${
-        active
-          ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
-          : "border-transparent text-gray-10 hover:border-dls-border hover:bg-dls-surface hover:text-dls-text"
-      } ${
-        rightSidebarExpanded()
-          ? "flex min-h-11 items-center justify-start gap-2.5 rounded-[16px] px-3.5"
-          : "flex h-12 items-center justify-center rounded-[16px] px-0"
-      }`}
-      onClick={onClick}
-      title={label}
-      aria-label={label}
-    >
-      {icon}
-      <Show when={rightSidebarExpanded()}>{label}</Show>
-    </button>
+    options?: {
+      disabled?: boolean;
+      badge?: JSX.Element;
+      disabledTitle?: string;
+      expanded?: boolean;
+      onSelect?: () => void;
+    },
+  ) => {
+    const expanded = options?.expanded ?? rightSidebarExpanded();
+    return (
+      <button
+        type="button"
+        disabled={options?.disabled}
+        class={`w-full border text-[13px] font-medium transition-[background-color,border-color,box-shadow,color] ${
+          options?.disabled
+            ? "cursor-not-allowed border-transparent text-gray-8 opacity-70"
+            : active
+              ? "border-dls-border bg-dls-surface text-dls-text shadow-[var(--dls-card-shadow)]"
+              : "border-transparent text-gray-10 hover:border-dls-border hover:bg-dls-surface hover:text-dls-text"
+        } ${
+          expanded
+            ? "flex min-h-11 items-center justify-start gap-2.5 rounded-[16px] px-3.5"
+            : "flex h-12 items-center justify-center rounded-[16px] px-0"
+        }`}
+        onClick={() => {
+          onClick();
+          options?.onSelect?.();
+        }}
+        title={options?.disabled ? options.disabledTitle ?? label : label}
+        aria-label={options?.disabled ? `${label}. ${options.disabledTitle ?? "Desktop only."}` : label}
+      >
+        {icon}
+        <Show when={expanded}>
+          <span class="flex min-w-0 flex-1 items-center gap-2">
+            <span class="truncate">{label}</span>
+            {options?.badge}
+          </span>
+        </Show>
+      </button>
+    );
+  };
+
+  const renderRightSidebar = (expanded: boolean, mobile = false) => (
+    <div class={`flex h-full flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 ${mobile ? "shadow-2xl" : "transition-[width] duration-200"}`}>
+      <div class={`flex items-center pb-3 ${expanded ? "justify-end" : "justify-center"}`}>
+        <button
+          type="button"
+          class="flex h-10 w-10 items-center justify-center rounded-[16px] text-gray-10 transition-colors hover:bg-dls-surface hover:text-dls-text"
+          onClick={mobile ? () => setMobileRightSidebarOpen(false) : toggleRightSidebar}
+          title={mobile ? "Close sidebar" : rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
+          aria-label={mobile ? "Close sidebar" : rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"}
+        >
+          <Show when={mobile} fallback={<Show when={expanded} fallback={<ChevronLeft size={18} />}><ChevronRight size={18} /></Show>}>
+            <X size={18} />
+          </Show>
+        </button>
+      </div>
+      <div class={`flex-1 overflow-y-auto ${expanded ? "space-y-5 pt-1" : "space-y-3 pt-1"}`}>
+        <div class="space-y-1 mb-2">
+          {rightSidebarNavButton(
+            "Automations",
+            <History size={18} />,
+            showRightSidebarSelection() && props.tab === "scheduled",
+            () => {
+              props.setTab("scheduled");
+              props.setView("dashboard");
+            },
+            mobile ? { expanded, onSelect: () => setMobileRightSidebarOpen(false) } : { expanded },
+          )}
+          {rightSidebarNavButton(
+            "Skills",
+            <Zap size={18} />,
+            showRightSidebarSelection() && props.tab === "skills",
+            () => {
+              props.setTab("skills");
+              props.setView("dashboard");
+            },
+            mobile ? { expanded, onSelect: () => setMobileRightSidebarOpen(false) } : { expanded },
+          )}
+          {rightSidebarNavButton(
+            "Extensions",
+            <Box size={18} />,
+            showRightSidebarSelection() && (props.tab === "mcp" || props.tab === "plugins"),
+            () => {
+              props.setTab("mcp");
+              props.setView("dashboard");
+            },
+            mobile ? { expanded, onSelect: () => setMobileRightSidebarOpen(false) } : { expanded },
+          )}
+          {rightSidebarNavButton(
+            "Messaging",
+            <MessageCircle size={18} />,
+            showRightSidebarSelection() && props.tab === "identities",
+            () => {
+              props.setTab("identities");
+              props.setView("dashboard");
+            },
+            mobile ? { expanded, onSelect: () => setMobileRightSidebarOpen(false) } : { expanded },
+          )}
+          <Show when={props.developerMode}>
+            {rightSidebarNavButton(
+              "Advanced",
+              <SlidersHorizontal size={18} />,
+              showRightSidebarSelection() && props.tab === "config",
+              openConfig,
+              mobile ? { expanded, onSelect: () => setMobileRightSidebarOpen(false) } : { expanded },
+            )}
+          </Show>
+        </div>
+
+        <Show when={expanded}>
+          <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
+            <InboxPanel
+              id={mobile ? "mobile-sidebar-inbox" : "sidebar-inbox"}
+              client={props.openworkServerClient}
+              workspaceId={props.openworkServerWorkspaceId}
+              onToast={(message) => setToastMessage(message)}
+            />
+          </div>
+
+          <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
+            <ArtifactsPanel
+              id={mobile ? "mobile-sidebar-artifacts" : "sidebar-artifacts"}
+              files={touchedFiles()}
+              workspaceRoot={props.activeWorkspaceRoot}
+              onRevealArtifact={revealArtifact}
+              onOpenInObsidian={openArtifactInObsidian}
+              obsidianAvailable={obsidianAvailable()}
+            />
+          </div>
+        </Show>
+      </div>
+    </div>
   );
 
   return (
@@ -4166,7 +4282,16 @@ export default function SessionView(props: SessionViewProps) {
               <div class="hidden h-4 w-px bg-dls-border sm:block" />
               <button
                 type="button"
-                class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
+                class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text md:hidden"
+                onClick={() => setMobileRightSidebarOpen(true)}
+                title="Open sidebar"
+                aria-label="Open sidebar"
+              >
+                <Menu size={16} />
+              </button>
+              <button
+                type="button"
+                class="hidden h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60 md:flex"
                 onClick={compactSessionHistory}
                 disabled={!canCompactSession() || historyActionBusy() !== null}
                 title="Compact session context"
@@ -4716,97 +4841,21 @@ export default function SessionView(props: SessionViewProps) {
         </main>
 
         <aside
-          class="flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 transition-[width] duration-200"
+          class="hidden shrink-0 md:flex"
           style={{
             width: `${rightSidebarWidth()}px`,
             "min-width": `${rightSidebarWidth()}px`,
           }}
         >
-          <div
-            class={`flex items-center pb-3 ${rightSidebarExpanded() ? "justify-end" : "justify-center"}`}
-          >
-            <button
-              type="button"
-              class="flex h-10 w-10 items-center justify-center rounded-[16px] text-gray-10 transition-colors hover:bg-dls-surface hover:text-dls-text"
-              onClick={toggleRightSidebar}
-              title={
-                rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"
-              }
-              aria-label={
-                rightSidebarExpanded() ? "Collapse sidebar" : "Expand sidebar"
-              }
-            >
-              <Show
-                when={rightSidebarExpanded()}
-                fallback={<ChevronLeft size={18} />}
-              >
-                <ChevronRight size={18} />
-              </Show>
-            </button>
-          </div>
-          <div
-            class={`flex-1 overflow-y-auto ${rightSidebarExpanded() ? "space-y-5 pt-1" : "space-y-3 pt-1"}`}
-          >
-            <div class="space-y-1 mb-2">
-              {rightSidebarNavButton(
-                "Automations",
-                <History size={18} />,
-                showRightSidebarSelection() && props.tab === "scheduled",
-                () => {
-                  props.setTab("scheduled");
-                  props.setView("dashboard");
-                },
-              )}
-              {rightSidebarNavButton(
-                "Skills",
-                <Zap size={18} />,
-                showRightSidebarSelection() && props.tab === "skills",
-                () => {
-                  props.setTab("skills");
-                  props.setView("dashboard");
-                },
-              )}
-              {rightSidebarNavButton(
-                "Extensions",
-                <Box size={18} />,
-                showRightSidebarSelection() &&
-                  (props.tab === "mcp" || props.tab === "plugins"),
-                () => {
-                  props.setTab("mcp");
-                  props.setView("dashboard");
-                },
-              )}
-              {rightSidebarNavButton(
-                "Messaging",
-                <MessageCircle size={18} />,
-                showRightSidebarSelection() && props.tab === "identities",
-                () => {
-                  props.setTab("identities");
-                  props.setView("dashboard");
-                },
-              )}
-              <Show when={props.developerMode}>
-                {rightSidebarNavButton(
-                  "Advanced",
-                  <SlidersHorizontal size={18} />,
-                  showRightSidebarSelection() && props.tab === "config",
-                  openConfig,
-                )}
-              </Show>
-            </div>
-
-            <Show when={rightSidebarExpanded()}>
-              <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
-                <InboxPanel
-                  id="sidebar-inbox"
-                  client={props.openworkServerClient}
-                  workspaceId={props.openworkServerWorkspaceId}
-                  onToast={(message) => setToastMessage(message)}
-                />
-              </div>
-            </Show>
-          </div>
+          {renderRightSidebar(rightSidebarExpanded())}
         </aside>
+
+        <MobileSidebarDrawer
+          open={mobileRightSidebarOpen()}
+          onClose={() => setMobileRightSidebarOpen(false)}
+        >
+          {renderRightSidebar(true, true)}
+        </MobileSidebarDrawer>
       </div>
 
       <Show when={commandPaletteOpen()}>

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -111,6 +111,7 @@ import MessageList from "../components/session/message-list";
 import Composer from "../components/session/composer";
 import WorkspaceSessionList from "../components/session/workspace-session-list";
 import type { SidebarSectionState } from "../components/session/sidebar";
+import ArtifactsPanel from "../components/session/artifacts-panel";
 import FlyoutItem from "../components/flyout-item";
 import MobileSidebarDrawer from "../components/mobile-sidebar-drawer";
 import QuestionModal from "../components/question-modal";

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -1,11 +1,26 @@
-import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onMount } from "solid-js";
+import {
+  For,
+  Match,
+  Show,
+  Switch,
+  createEffect,
+  createMemo,
+  createSignal,
+  onMount,
+} from "solid-js";
 
-import { formatBytes, formatRelativeTime, isTauriRuntime, isWindowsPlatform } from "../utils";
+import {
+  formatBytes,
+  formatRelativeTime,
+  isTauriRuntime,
+  isWindowsPlatform,
+} from "../utils";
 
 import Button from "../components/button";
 import DenSettingsPanel from "../components/den-settings-panel";
 import { usePlatform } from "../context/platform";
 import { FEEDBACK_EMAIL_URL } from "../lib/feedback";
+import { getOpenWorkDeployment } from "../lib/openwork-deployment";
 import {
   ArrowUpRight,
   CircleAlert,
@@ -23,7 +38,12 @@ import {
   X,
   Zap,
 } from "lucide-solid";
-import type { OpencodeConnectStatus, ProviderListItem, SettingsTab, StartupPreference } from "../types";
+import type {
+  OpencodeConnectStatus,
+  ProviderListItem,
+  SettingsTab,
+  StartupPreference,
+} from "../types";
 import type {
   OpenworkAuditEntry,
   OpenworkServerCapabilities,
@@ -157,7 +177,9 @@ export type SettingsViewProps = {
   notionBusy: boolean;
   connectNotion: () => void;
   engineDoctorVersion: string | null;
-  openDebugShareLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
+  openDebugShareLink: (
+    rawUrl: string,
+  ) => Promise<{ ok: boolean; message: string }>;
   connectRemoteWorkspace: (input: {
     openworkHostUrl?: string | null;
     openworkToken?: string | null;
@@ -167,7 +189,8 @@ export type SettingsViewProps = {
 };
 
 const DISCORD_INVITE_URL = "https://discord.gg/VEhNQXxYMB";
-const BUG_REPORT_URL = "https://github.com/different-ai/openwork/issues/new?template=bug.yml";
+const BUG_REPORT_URL =
+  "https://github.com/different-ai/openwork/issues/new?template=bug.yml";
 
 // OpenCodeRouter Settings Component
 //
@@ -188,17 +211,19 @@ export function OpenCodeRouterSettings(_props: {
         <div class="text-sm font-medium text-gray-12">Messaging</div>
       </div>
       <div class="text-xs text-gray-10">
-        Manage Telegram/Slack identities and bindings in the <span class="font-medium text-gray-12">Identities</span> tab.
+        Manage Telegram/Slack identities and bindings in the{" "}
+        <span class="font-medium text-gray-12">Identities</span> tab.
       </div>
     </div>
   );
 }
 
-
 export default function SettingsView(props: SettingsViewProps) {
   const platform = usePlatform();
+  const webDeployment = createMemo(() => getOpenWorkDeployment() === "web");
   const translate = (key: string) => t(key, currentLocale());
-  const engineCustomBinPathLabel = () => props.engineCustomBinPath.trim() || "No binary selected.";
+  const engineCustomBinPathLabel = () =>
+    props.engineCustomBinPath.trim() || "No binary selected.";
 
   const openExternalLink = (url: string) => {
     const resolved = url.trim();
@@ -225,7 +250,8 @@ export default function SettingsView(props: SettingsViewProps) {
   const updateVersion = () => props.updateStatus?.version ?? null;
   const updateDate = () => props.updateStatus?.date ?? null;
   const updateLastCheckedAt = () => props.updateStatus?.lastCheckedAt ?? null;
-  const updateDownloadedBytes = () => props.updateStatus?.downloadedBytes ?? null;
+  const updateDownloadedBytes = () =>
+    props.updateStatus?.downloadedBytes ?? null;
   const updateTotalBytes = () => props.updateStatus?.totalBytes ?? null;
   const updateErrorMessage = () => props.updateStatus?.message ?? null;
 
@@ -246,7 +272,8 @@ export default function SettingsView(props: SettingsViewProps) {
         : typeof navigator.platform === "string"
           ? navigator.platform
           : "";
-    const ua = typeof navigator.userAgent === "string" ? navigator.userAgent : "";
+    const ua =
+      typeof navigator.userAgent === "string" ? navigator.userAgent : "";
     return /mac/i.test(platform) || /mac/i.test(ua);
   });
 
@@ -272,7 +299,9 @@ export default function SettingsView(props: SettingsViewProps) {
     }
   });
 
-  const updateToolbarSpinning = createMemo(() => updateState() === "checking" || updateState() === "downloading");
+  const updateToolbarSpinning = createMemo(
+    () => updateState() === "checking" || updateState() === "downloading",
+  );
 
   const updateToolbarLabel = createMemo(() => {
     const state = updateState();
@@ -370,25 +399,48 @@ export default function SettingsView(props: SettingsViewProps) {
     return "bg-gray-4/60 text-gray-11 border-gray-7/50";
   };
 
-  const [providerConnectError, setProviderConnectError] = createSignal<string | null>(null);
-  const [providerDisconnectStatus, setProviderDisconnectStatus] = createSignal<string | null>(null);
-  const [providerDisconnectError, setProviderDisconnectError] = createSignal<string | null>(null);
-  const [providerDisconnectingId, setProviderDisconnectingId] = createSignal<string | null>(null);
-  const [openworkReconnectStatus, setOpenworkReconnectStatus] = createSignal<string | null>(null);
-  const [openworkReconnectError, setOpenworkReconnectError] = createSignal<string | null>(null);
+  const [providerConnectError, setProviderConnectError] = createSignal<
+    string | null
+  >(null);
+  const [providerDisconnectStatus, setProviderDisconnectStatus] = createSignal<
+    string | null
+  >(null);
+  const [providerDisconnectError, setProviderDisconnectError] = createSignal<
+    string | null
+  >(null);
+  const [providerDisconnectingId, setProviderDisconnectingId] = createSignal<
+    string | null
+  >(null);
+  const [openworkReconnectStatus, setOpenworkReconnectStatus] = createSignal<
+    string | null
+  >(null);
+  const [openworkReconnectError, setOpenworkReconnectError] = createSignal<
+    string | null
+  >(null);
   const [openworkRestartBusy, setOpenworkRestartBusy] = createSignal(false);
-  const [openworkRestartStatus, setOpenworkRestartStatus] = createSignal<string | null>(null);
-  const [openworkRestartError, setOpenworkRestartError] = createSignal<string | null>(null);
-  const providerConnectedCount = createMemo(() => (props.providerConnectedIds ?? []).length);
-  const providerAvailableCount = createMemo(() => (props.providers ?? []).length);
+  const [openworkRestartStatus, setOpenworkRestartStatus] = createSignal<
+    string | null
+  >(null);
+  const [openworkRestartError, setOpenworkRestartError] = createSignal<
+    string | null
+  >(null);
+  const providerConnectedCount = createMemo(
+    () => (props.providerConnectedIds ?? []).length,
+  );
+  const providerAvailableCount = createMemo(
+    () => (props.providers ?? []).length,
+  );
   const connectedProviders = createMemo(() => {
     const connectedIds = props.providerConnectedIds ?? [];
     if (!connectedIds.length) return [] as { id: string; name: string }[];
-    const providersById = new Map((props.providers ?? []).map((provider) => [provider.id, provider]));
+    const providersById = new Map(
+      (props.providers ?? []).map((provider) => [provider.id, provider]),
+    );
     return connectedIds
       .map((id) => {
         const provider = providersById.get(id);
-        const label = provider?.name?.trim() || provider?.id?.trim() || id.trim();
+        const label =
+          provider?.name?.trim() || provider?.id?.trim() || id.trim();
         return { id, name: label || id };
       })
       .filter((entry) => entry.id.trim());
@@ -399,12 +451,15 @@ export default function SettingsView(props: SettingsViewProps) {
     return `${providerConnectedCount()} connected`;
   });
   const providerStatusStyle = createMemo(() => {
-    if (!providerAvailableCount()) return "bg-gray-4/60 text-gray-11 border-gray-7/50";
-    if (!providerConnectedCount()) return "bg-amber-7/10 text-amber-11 border-amber-7/20";
+    if (!providerAvailableCount())
+      return "bg-gray-4/60 text-gray-11 border-gray-7/50";
+    if (!providerConnectedCount())
+      return "bg-amber-7/10 text-amber-11 border-amber-7/20";
     return "bg-green-7/10 text-green-11 border-green-7/20";
   });
   const providerSummary = createMemo(() => {
-    if (!providerAvailableCount()) return "Connect to OpenCode to load providers.";
+    if (!providerAvailableCount())
+      return "Connect to OpenCode to load providers.";
     const connected = providerConnectedCount();
     const available = providerAvailableCount();
     if (!connected) return `${available} available`;
@@ -419,18 +474,27 @@ export default function SettingsView(props: SettingsViewProps) {
     try {
       await props.openProviderAuthModal();
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to open providers";
+      const message =
+        error instanceof Error ? error.message : "Failed to open providers";
       setProviderConnectError(message);
     }
   };
 
   const handleDisconnectProvider = async (providerId: string) => {
     const resolved = providerId.trim();
-    if (!resolved || props.busy || props.providerAuthBusy || providerDisconnectingId()) return;
+    if (
+      !resolved ||
+      props.busy ||
+      props.providerAuthBusy ||
+      providerDisconnectingId()
+    )
+      return;
     const confirmed =
       typeof window === "undefined"
         ? true
-        : window.confirm(`Disconnect ${resolved}? This removes stored API keys or OAuth credentials for this provider.`);
+        : window.confirm(
+            `Disconnect ${resolved}? This removes stored API keys or OAuth credentials for this provider.`,
+          );
     if (!confirmed) return;
     setProviderDisconnectError(null);
     setProviderDisconnectStatus(null);
@@ -439,7 +503,10 @@ export default function SettingsView(props: SettingsViewProps) {
       const result = await props.disconnectProvider(resolved);
       setProviderDisconnectStatus(result || `Disconnected ${resolved}.`);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to disconnect provider";
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to disconnect provider";
       setProviderDisconnectError(message);
     } finally {
       setProviderDisconnectingId(null);
@@ -454,13 +521,17 @@ export default function SettingsView(props: SettingsViewProps) {
     try {
       const ok = await props.reconnectOpenworkServer();
       if (!ok) {
-        setOpenworkReconnectError("Reconnect failed. Check server URL/token and try again.");
+        setOpenworkReconnectError(
+          "Reconnect failed. Check server URL/token and try again.",
+        );
         return;
       }
       setOpenworkReconnectStatus("Reconnected to OpenWork server.");
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      setOpenworkReconnectError(message || "Failed to reconnect OpenWork server.");
+      setOpenworkReconnectError(
+        message || "Failed to reconnect OpenWork server.",
+      );
     }
   };
 
@@ -526,7 +597,8 @@ export default function SettingsView(props: SettingsViewProps) {
 
   const clientStatusStyle = createMemo(() => {
     const status = props.opencodeConnectStatus?.status;
-    if (status === "connecting") return "bg-amber-7/10 text-amber-11 border-amber-7/20";
+    if (status === "connecting")
+      return "bg-amber-7/10 text-amber-11 border-amber-7/20";
     if (status === "error") return "bg-red-7/10 text-red-11 border-red-7/20";
     return props.clientConnected
       ? "bg-green-7/10 text-green-11 border-green-7/20"
@@ -563,8 +635,10 @@ export default function SettingsView(props: SettingsViewProps) {
   const opencodeConnectStatusStyle = createMemo(() => {
     const status = props.opencodeConnectStatus?.status;
     if (!status) return "bg-gray-4/60 text-gray-11 border-gray-7/50";
-    if (status === "connected") return "bg-green-7/10 text-green-11 border-green-7/20";
-    if (status === "connecting") return "bg-amber-7/10 text-amber-11 border-amber-7/20";
+    if (status === "connected")
+      return "bg-green-7/10 text-green-11 border-green-7/20";
+    if (status === "connecting")
+      return "bg-amber-7/10 text-amber-11 border-amber-7/20";
     return "bg-red-7/10 text-red-11 border-red-7/20";
   });
 
@@ -586,19 +660,31 @@ export default function SettingsView(props: SettingsViewProps) {
       : "bg-gray-4/60 text-gray-11 border-gray-7/50";
   });
 
-  const [opencodeRouterRestarting, setOpenCodeRouterRestarting] = createSignal(false);
-  const [opencodeRouterRestartError, setOpenCodeRouterRestartError] = createSignal<string | null>(null);
-  const [openworkServerRestarting, setOpenworkServerRestarting] = createSignal(false);
-  const [openworkServerRestartError, setOpenworkServerRestartError] = createSignal<string | null>(null);
+  const [opencodeRouterRestarting, setOpenCodeRouterRestarting] =
+    createSignal(false);
+  const [opencodeRouterRestartError, setOpenCodeRouterRestartError] =
+    createSignal<string | null>(null);
+  const [openworkServerRestarting, setOpenworkServerRestarting] =
+    createSignal(false);
+  const [openworkServerRestartError, setOpenworkServerRestartError] =
+    createSignal<string | null>(null);
   const [opencodeRestarting, setOpencodeRestarting] = createSignal(false);
-  const [opencodeRestartError, setOpencodeRestartError] = createSignal<string | null>(null);
+  const [opencodeRestartError, setOpencodeRestartError] = createSignal<
+    string | null
+  >(null);
 
   const handleOpenCodeRouterRestart = async () => {
     if (opencodeRouterRestarting()) return;
-    const workspacePath = props.opencodeRouterInfo?.workspacePath?.trim() || props.engineInfo?.projectDir?.trim();
-    const opencodeUrl = props.opencodeRouterInfo?.opencodeUrl?.trim() || props.engineInfo?.baseUrl?.trim();
-    const opencodeUsername = props.engineInfo?.opencodeUsername?.trim() || undefined;
-    const opencodePassword = props.engineInfo?.opencodePassword?.trim() || undefined;
+    const workspacePath =
+      props.opencodeRouterInfo?.workspacePath?.trim() ||
+      props.engineInfo?.projectDir?.trim();
+    const opencodeUrl =
+      props.opencodeRouterInfo?.opencodeUrl?.trim() ||
+      props.engineInfo?.baseUrl?.trim();
+    const opencodeUsername =
+      props.engineInfo?.opencodeUsername?.trim() || undefined;
+    const opencodePassword =
+      props.engineInfo?.opencodePassword?.trim() || undefined;
     if (!workspacePath) {
       setOpenCodeRouterRestartError("No worker path available");
       return;
@@ -666,7 +752,8 @@ export default function SettingsView(props: SettingsViewProps) {
   });
 
   const orchestratorStatusStyle = createMemo(() => {
-    if (!props.orchestratorStatus) return "bg-gray-4/60 text-gray-11 border-gray-7/50";
+    if (!props.orchestratorStatus)
+      return "bg-gray-4/60 text-gray-11 border-gray-7/50";
     return props.orchestratorStatus.running
       ? "bg-green-7/10 text-green-11 border-green-7/20"
       : "bg-gray-4/60 text-gray-11 border-gray-7/50";
@@ -680,14 +767,21 @@ export default function SettingsView(props: SettingsViewProps) {
   });
 
   const openworkAuditStatusStyle = createMemo(() => {
-    if (!props.openworkServerWorkspaceId) return "bg-gray-4/60 text-gray-11 border-gray-7/50";
-    if (props.openworkAuditStatus === "loading") return "bg-amber-7/10 text-amber-11 border-amber-7/20";
-    if (props.openworkAuditStatus === "error") return "bg-red-7/10 text-red-11 border-red-7/20";
+    if (!props.openworkServerWorkspaceId)
+      return "bg-gray-4/60 text-gray-11 border-gray-7/50";
+    if (props.openworkAuditStatus === "loading")
+      return "bg-amber-7/10 text-amber-11 border-amber-7/20";
+    if (props.openworkAuditStatus === "error")
+      return "bg-red-7/10 text-red-11 border-red-7/20";
     return "bg-green-7/10 text-green-11 border-green-7/20";
   });
 
-  const isLocalEngineRunning = createMemo(() => Boolean(props.engineInfo?.running));
-  const isLocalPreference = createMemo(() => props.startupPreference === "local");
+  const isLocalEngineRunning = createMemo(() =>
+    Boolean(props.engineInfo?.running),
+  );
+  const isLocalPreference = createMemo(
+    () => props.startupPreference === "local",
+  );
   const startupLabel = createMemo(() => {
     if (props.startupPreference === "local") return "Start local server";
     if (props.startupPreference === "server") return "Connect to server";
@@ -737,9 +831,15 @@ export default function SettingsView(props: SettingsViewProps) {
     return "unknown";
   };
 
-  const formatCapability = (cap?: { read?: boolean; write?: boolean; source?: string }) => {
+  const formatCapability = (cap?: {
+    read?: boolean;
+    write?: boolean;
+    source?: string;
+  }) => {
     if (!cap) return "Unavailable";
-    const parts = [cap.read ? "read" : null, cap.write ? "write" : null].filter(Boolean).join(" / ");
+    const parts = [cap.read ? "read" : null, cap.write ? "write" : null]
+      .filter(Boolean)
+      .join(" / ");
     const label = parts || "no access";
     return cap.source ? `${label} · ${cap.source}` : label;
   };
@@ -756,22 +856,32 @@ export default function SettingsView(props: SettingsViewProps) {
 
   const openworkStdout = () => {
     if (!props.openworkServerHostInfo) return "Logs are available on the host.";
-    return props.openworkServerHostInfo.lastStdout?.trim() || "No stdout captured yet.";
+    return (
+      props.openworkServerHostInfo.lastStdout?.trim() ||
+      "No stdout captured yet."
+    );
   };
 
   const openworkStderr = () => {
     if (!props.openworkServerHostInfo) return "Logs are available on the host.";
-    return props.openworkServerHostInfo.lastStderr?.trim() || "No stderr captured yet.";
+    return (
+      props.openworkServerHostInfo.lastStderr?.trim() ||
+      "No stderr captured yet."
+    );
   };
 
   const opencodeRouterStdout = () => {
     if (!isTauriRuntime()) return "Available in the desktop app.";
-    return props.opencodeRouterInfo?.lastStdout?.trim() || "No stdout captured yet.";
+    return (
+      props.opencodeRouterInfo?.lastStdout?.trim() || "No stdout captured yet."
+    );
   };
 
   const opencodeRouterStderr = () => {
     if (!isTauriRuntime()) return "Available in the desktop app.";
-    return props.opencodeRouterInfo?.lastStderr?.trim() || "No stderr captured yet.";
+    return (
+      props.opencodeRouterInfo?.lastStderr?.trim() || "No stderr captured yet."
+    );
   };
 
   const formatOrchestratorBinary = (binary?: OrchestratorBinaryInfo | null) => {
@@ -780,12 +890,15 @@ export default function SettingsView(props: SettingsViewProps) {
     return `${binary.source} · ${version}`;
   };
 
-  const formatOrchestratorBinaryVersion = (binary?: OrchestratorBinaryInfo | null) => {
+  const formatOrchestratorBinaryVersion = (
+    binary?: OrchestratorBinaryInfo | null,
+  ) => {
     if (!binary) return "—";
     return binary.actualVersion || binary.expectedVersion || "—";
   };
 
-  const orchestratorBinaryPath = () => props.orchestratorStatus?.binaries?.opencode?.path ?? "—";
+  const orchestratorBinaryPath = () =>
+    props.orchestratorStatus?.binaries?.opencode?.path ?? "—";
   const orchestratorSidecarSummary = () => {
     const info = props.orchestratorStatus?.sidecar;
     if (!info) return "Sidecar config unavailable";
@@ -794,7 +907,8 @@ export default function SettingsView(props: SettingsViewProps) {
     return `${source} · ${target}`;
   };
 
-  const appVersionLabel = () => (props.appVersion ? `v${props.appVersion}` : "—");
+  const appVersionLabel = () =>
+    props.appVersion ? `v${props.appVersion}` : "—";
   const appCommitLabel = () => {
     const sha = buildInfo()?.gitSha?.trim();
     if (!sha) return "—";
@@ -805,13 +919,18 @@ export default function SettingsView(props: SettingsViewProps) {
     if (binary) return formatOrchestratorBinary(binary);
     return props.engineDoctorVersion ?? "—";
   };
-  const openworkServerVersionLabel = () => props.openworkServerDiagnostics?.version ?? "—";
-  const opencodeRouterVersionLabel = () => props.opencodeRouterInfo?.version ?? "—";
-  const orchestratorVersionLabel = () => props.orchestratorStatus?.cliVersion ?? "—";
+  const openworkServerVersionLabel = () =>
+    props.openworkServerDiagnostics?.version ?? "—";
+  const opencodeRouterVersionLabel = () =>
+    props.opencodeRouterInfo?.version ?? "—";
+  const orchestratorVersionLabel = () =>
+    props.orchestratorStatus?.cliVersion ?? "—";
 
   onMount(() => {
     if (!isTauriRuntime()) return;
-    void appBuildInfo().then((info) => setBuildInfo(info)).catch(() => setBuildInfo(null));
+    void appBuildInfo()
+      .then((info) => setBuildInfo(info))
+      .catch(() => setBuildInfo(null));
   });
 
   const formatUptime = (uptimeMs?: number | null) => {
@@ -819,36 +938,67 @@ export default function SettingsView(props: SettingsViewProps) {
     return formatRelativeTime(Date.now() - uptimeMs);
   };
 
-  const [debugReportStatus, setDebugReportStatus] = createSignal<string | null>(null);
-  const [configActionStatus, setConfigActionStatus] = createSignal<string | null>(null);
+  const [debugReportStatus, setDebugReportStatus] = createSignal<string | null>(
+    null,
+  );
+  const [configActionStatus, setConfigActionStatus] = createSignal<
+    string | null
+  >(null);
   const [revealConfigBusy, setRevealConfigBusy] = createSignal(false);
   const [resetConfigBusy, setResetConfigBusy] = createSignal(false);
   const [sandboxProbeBusy, setSandboxProbeBusy] = createSignal(false);
-  const [sandboxProbeStatus, setSandboxProbeStatus] = createSignal<string | null>(null);
-  const [sandboxProbeResult, setSandboxProbeResult] = createSignal<SandboxDebugProbeResult | null>(null);
+  const [sandboxProbeStatus, setSandboxProbeStatus] = createSignal<
+    string | null
+  >(null);
+  const [sandboxProbeResult, setSandboxProbeResult] =
+    createSignal<SandboxDebugProbeResult | null>(null);
   const [nukeDevConfigBusy, setNukeDevConfigBusy] = createSignal(false);
-  const [nukeDevConfigStatus, setNukeDevConfigStatus] = createSignal<string | null>(null);
+  const [nukeDevConfigStatus, setNukeDevConfigStatus] = createSignal<
+    string | null
+  >(null);
   const [debugShareLinkOpen, setDebugShareLinkOpen] = createSignal(false);
   const [debugShareLinkInput, setDebugShareLinkInput] = createSignal("");
   const [debugShareLinkBusy, setDebugShareLinkBusy] = createSignal(false);
-  const [debugShareLinkStatus, setDebugShareLinkStatus] = createSignal<string | null>(null);
-  const opencodeDevModeEnabled = createMemo(() => Boolean(buildInfo()?.openworkDevMode));
+  const [debugShareLinkStatus, setDebugShareLinkStatus] = createSignal<
+    string | null
+  >(null);
+  const opencodeDevModeEnabled = createMemo(() =>
+    Boolean(buildInfo()?.openworkDevMode),
+  );
 
   const sandboxCreateSummary = createMemo(() => {
-    const raw = (props.sandboxCreateProgress ?? props.sandboxCreateProgressLast) as
-      | { runId?: string; stage?: string; error?: string | null; logs?: string[]; startedAt?: number }
+    const raw = (props.sandboxCreateProgress ??
+      props.sandboxCreateProgressLast) as
+      | {
+          runId?: string;
+          stage?: string;
+          error?: string | null;
+          logs?: string[];
+          startedAt?: number;
+        }
       | null
       | undefined;
     if (!raw || typeof raw !== "object") {
-      return { runId: null, stage: null, error: null, logs: [] as string[], startedAt: null };
+      return {
+        runId: null,
+        stage: null,
+        error: null,
+        logs: [] as string[],
+        startedAt: null,
+      };
     }
     return {
-      runId: typeof raw.runId === "string" && raw.runId.trim() ? raw.runId : null,
-      stage: typeof raw.stage === "string" && raw.stage.trim() ? raw.stage : null,
-      error: typeof raw.error === "string" && raw.error.trim() ? raw.error : null,
+      runId:
+        typeof raw.runId === "string" && raw.runId.trim() ? raw.runId : null,
+      stage:
+        typeof raw.stage === "string" && raw.stage.trim() ? raw.stage : null,
+      error:
+        typeof raw.error === "string" && raw.error.trim() ? raw.error : null,
       startedAt: typeof raw.startedAt === "number" ? raw.startedAt : null,
       logs: Array.isArray(raw.logs)
-        ? raw.logs.filter((line) => typeof line === "string" && line.trim()).slice(-400)
+        ? raw.logs
+            .filter((line) => typeof line === "string" && line.trim())
+            .slice(-400)
         : [],
     };
   });
@@ -892,7 +1042,9 @@ export default function SettingsView(props: SettingsViewProps) {
       },
       openworkServer: {
         status: openworkStatusLabel(),
-        baseUrl: (props.openworkServerHostInfo?.baseUrl ?? props.openworkServerUrl) || null,
+        baseUrl:
+          (props.openworkServerHostInfo?.baseUrl ?? props.openworkServerUrl) ||
+          null,
         pid: props.openworkServerHostInfo?.pid ?? null,
         stdout: openworkStdout(),
         stderr: openworkStderr(),
@@ -912,12 +1064,16 @@ export default function SettingsView(props: SettingsViewProps) {
     workspaceDebugEvents: props.workspaceDebugEvents,
     sandboxCreateProgress: {
       ...sandboxCreateSummary(),
-      lastRunAt: sandboxCreateSummary().startedAt ? new Date(sandboxCreateSummary().startedAt!).toISOString() : null,
+      lastRunAt: sandboxCreateSummary().startedAt
+        ? new Date(sandboxCreateSummary().startedAt!).toISOString()
+        : null,
     },
     sandboxProbe: sandboxProbeResult(),
   }));
 
-  const runtimeDebugReportJson = createMemo(() => `${JSON.stringify(runtimeDebugReport(), null, 2)}\n`);
+  const runtimeDebugReportJson = createMemo(
+    () => `${JSON.stringify(runtimeDebugReport(), null, 2)}\n`,
+  );
 
   const copyRuntimeDebugReport = async () => {
     if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
@@ -928,7 +1084,11 @@ export default function SettingsView(props: SettingsViewProps) {
       await navigator.clipboard.writeText(runtimeDebugReportJson());
       setDebugReportStatus("Copied runtime report JSON.");
     } catch (error) {
-      setDebugReportStatus(error instanceof Error ? error.message : "Failed to copy runtime report.");
+      setDebugReportStatus(
+        error instanceof Error
+          ? error.message
+          : "Failed to copy runtime report.",
+      );
     }
   };
 
@@ -938,8 +1098,13 @@ export default function SettingsView(props: SettingsViewProps) {
       return;
     }
     try {
-      const stamp = new Date().toISOString().replace(/[:]/g, "-").replace(/\..+$/, "");
-      const blob = new Blob([runtimeDebugReportJson()], { type: "application/json" });
+      const stamp = new Date()
+        .toISOString()
+        .replace(/[:]/g, "-")
+        .replace(/\..+$/, "");
+      const blob = new Blob([runtimeDebugReportJson()], {
+        type: "application/json",
+      });
       const url = window.URL.createObjectURL(blob);
       const anchor = document.createElement("a");
       anchor.href = url;
@@ -948,7 +1113,11 @@ export default function SettingsView(props: SettingsViewProps) {
       window.URL.revokeObjectURL(url);
       setDebugReportStatus("Exported runtime report JSON.");
     } catch (error) {
-      setDebugReportStatus(error instanceof Error ? error.message : "Failed to export runtime report.");
+      setDebugReportStatus(
+        error instanceof Error
+          ? error.message
+          : "Failed to export runtime report.",
+      );
     }
   };
 
@@ -956,13 +1125,16 @@ export default function SettingsView(props: SettingsViewProps) {
     if (!isTauriRuntime() || revealConfigBusy()) return;
     const path = workspaceConfigPath();
     if (!path) {
-      setConfigActionStatus("Select a local workspace before revealing config.");
+      setConfigActionStatus(
+        "Select a local workspace before revealing config.",
+      );
       return;
     }
     setRevealConfigBusy(true);
     setConfigActionStatus(null);
     try {
-      const { openPath, revealItemInDir } = await import("@tauri-apps/plugin-opener");
+      const { openPath, revealItemInDir } =
+        await import("@tauri-apps/plugin-opener");
       if (isWindowsPlatform()) {
         await openPath(path);
       } else {
@@ -970,7 +1142,11 @@ export default function SettingsView(props: SettingsViewProps) {
       }
       setConfigActionStatus("Revealed workspace config.");
     } catch (error) {
-      setConfigActionStatus(error instanceof Error ? error.message : "Failed to reveal workspace config.");
+      setConfigActionStatus(
+        error instanceof Error
+          ? error.message
+          : "Failed to reveal workspace config.",
+      );
     } finally {
       setRevealConfigBusy(false);
     }
@@ -984,28 +1160,37 @@ export default function SettingsView(props: SettingsViewProps) {
       const result = await props.resetAppConfigDefaults();
       setConfigActionStatus(result.message);
     } catch (error) {
-      setConfigActionStatus(error instanceof Error ? error.message : "Failed to reset app config.");
+      setConfigActionStatus(
+        error instanceof Error ? error.message : "Failed to reset app config.",
+      );
     } finally {
       setResetConfigBusy(false);
     }
   };
 
   const handleNukeOpencodeDevConfig = async () => {
-    if (!isTauriRuntime() || !opencodeDevModeEnabled() || nukeDevConfigBusy()) return;
+    if (!isTauriRuntime() || !opencodeDevModeEnabled() || nukeDevConfigBusy())
+      return;
     const confirmed =
       typeof window === "undefined"
         ? true
         : window.confirm(
-            "Delete the isolated OpenCode dev config and auth/data state, then quit OpenWork? This only affects dev-mode state."
+            "Delete the isolated OpenCode dev config and auth/data state, then quit OpenWork? This only affects dev-mode state.",
           );
     if (!confirmed) return;
     setNukeDevConfigBusy(true);
     setNukeDevConfigStatus(null);
     try {
       await nukeOpencodeDevConfigAndExit();
-      setNukeDevConfigStatus("Removed OpenCode dev state. OpenWork is closing...");
+      setNukeDevConfigStatus(
+        "Removed OpenCode dev state. OpenWork is closing...",
+      );
     } catch (error) {
-      setNukeDevConfigStatus(error instanceof Error ? error.message : "Failed to nuke OpenCode dev config.");
+      setNukeDevConfigStatus(
+        error instanceof Error
+          ? error.message
+          : "Failed to nuke OpenCode dev config.",
+      );
       setNukeDevConfigBusy(false);
     }
   };
@@ -1018,12 +1203,18 @@ export default function SettingsView(props: SettingsViewProps) {
       const report = await sandboxDebugProbe();
       setSandboxProbeResult(report);
       if (report.ready) {
-        setSandboxProbeStatus("Sandbox probe succeeded. Export the debug report for support.");
+        setSandboxProbeStatus(
+          "Sandbox probe succeeded. Export the debug report for support.",
+        );
       } else {
-        setSandboxProbeStatus(report.error?.trim() || "Sandbox probe completed with errors.");
+        setSandboxProbeStatus(
+          report.error?.trim() || "Sandbox probe completed with errors.",
+        );
       }
     } catch (error) {
-      setSandboxProbeStatus(error instanceof Error ? error.message : "Sandbox probe failed.");
+      setSandboxProbeStatus(
+        error instanceof Error ? error.message : "Sandbox probe failed.",
+      );
     } finally {
       setSandboxProbeBusy(false);
     }
@@ -1037,7 +1228,9 @@ export default function SettingsView(props: SettingsViewProps) {
       const result = await props.openDebugShareLink(debugShareLinkInput());
       setDebugShareLinkStatus(result.message);
     } catch (error) {
-      setDebugShareLinkStatus(error instanceof Error ? error.message : "Failed to open share link.");
+      setDebugShareLinkStatus(
+        error instanceof Error ? error.message : "Failed to open share link.",
+      );
     } finally {
       setDebugShareLinkBusy(false);
     }
@@ -1076,7 +1269,9 @@ export default function SettingsView(props: SettingsViewProps) {
               <Show when={updateToolbarSpinning()}>
                 <RefreshCcw size={12} class="animate-spin" />
               </Show>
-              <span class="tabular-nums whitespace-nowrap">{updateToolbarLabel()}</span>
+              <span class="tabular-nums whitespace-nowrap">
+                {updateToolbarLabel()}
+              </span>
             </div>
             <Show when={updateToolbarActionLabel()}>
               <Button
@@ -1084,7 +1279,11 @@ export default function SettingsView(props: SettingsViewProps) {
                 class="text-xs h-8 py-0 px-3 rounded-full border-gray-6/60 bg-gray-1/70 hover:bg-gray-2/70"
                 onClick={handleUpdateToolbarAction}
                 disabled={updateToolbarDisabled()}
-                title={updateState() === "ready" && props.anyActiveRuns ? "Stop active runs to update" : ""}
+                title={
+                  updateState() === "ready" && props.anyActiveRuns
+                    ? "Stop active runs to update"
+                    : ""
+                }
               >
                 {updateToolbarActionLabel()}
               </Button>
@@ -1101,11 +1300,17 @@ export default function SettingsView(props: SettingsViewProps) {
                 <div>
                   <div class="flex items-center gap-2">
                     <PlugZap size={16} class="text-gray-11" />
-                    <div class="text-sm font-medium text-gray-12">Providers</div>
+                    <div class="text-sm font-medium text-gray-12">
+                      Providers
+                    </div>
                   </div>
-                  <div class="text-xs text-gray-9 mt-1">Connect services for models and tools.</div>
+                  <div class="text-xs text-gray-9 mt-1">
+                    Connect services for models and tools.
+                  </div>
                 </div>
-                <div class={`text-xs px-2 py-1 rounded-full border ${providerStatusStyle()}`}>
+                <div
+                  class={`text-xs px-2 py-1 rounded-full border ${providerStatusStyle()}`}
+                >
                   {providerStatusLabel()}
                 </div>
               </div>
@@ -1116,7 +1321,9 @@ export default function SettingsView(props: SettingsViewProps) {
                   onClick={handleOpenProviderAuth}
                   disabled={props.busy || props.providerAuthBusy}
                 >
-                  {props.providerAuthBusy ? "Loading providers..." : "Connect provider"}
+                  {props.providerAuthBusy
+                    ? "Loading providers..."
+                    : "Connect provider"}
                 </Button>
                 <div class="text-xs text-gray-10">{providerSummary()}</div>
               </div>
@@ -1127,18 +1334,28 @@ export default function SettingsView(props: SettingsViewProps) {
                     {(provider) => (
                       <div class="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-gray-6/60 bg-gray-1/40 px-3 py-2">
                         <div class="min-w-0">
-                          <div class="text-sm font-medium text-gray-12 truncate">{provider.name}</div>
-                          <div class="text-[11px] text-gray-8 font-mono truncate">{provider.id}</div>
+                          <div class="text-sm font-medium text-gray-12 truncate">
+                            {provider.name}
+                          </div>
+                          <div class="text-[11px] text-gray-8 font-mono truncate">
+                            {provider.id}
+                          </div>
                         </div>
                         <Button
                           variant="outline"
                           class="text-xs h-8 py-0 px-3"
-                          onClick={() => void handleDisconnectProvider(provider.id)}
+                          onClick={() =>
+                            void handleDisconnectProvider(provider.id)
+                          }
                           disabled={
-                            props.busy || props.providerAuthBusy || providerDisconnectingId() !== null
+                            props.busy ||
+                            props.providerAuthBusy ||
+                            providerDisconnectingId() !== null
                           }
                         >
-                          {providerDisconnectingId() === provider.id ? "Disconnecting..." : "Disconnect"}
+                          {providerDisconnectingId() === provider.id
+                            ? "Disconnecting..."
+                            : "Disconnect"}
                         </Button>
                       </div>
                     )}
@@ -1163,19 +1380,24 @@ export default function SettingsView(props: SettingsViewProps) {
               </Show>
 
               <div class="text-[11px] text-gray-9">
-                API keys are stored locally by OpenCode. Set your default model in the <span class="font-medium">Model</span> tab.
+                API keys are stored locally by OpenCode. Set your default model
+                in the <span class="font-medium">Model</span> tab.
               </div>
             </div>
 
             <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-4">
               <div>
                 <div class="text-sm font-medium text-gray-12">Appearance</div>
-                <div class="text-xs text-gray-9">Match the system or force light/dark mode.</div>
+                <div class="text-xs text-gray-9">
+                  Match the system or force light/dark mode.
+                </div>
               </div>
 
               <div class="flex flex-wrap gap-2">
                 <Button
-                  variant={props.themeMode === "system" ? "secondary" : "outline"}
+                  variant={
+                    props.themeMode === "system" ? "secondary" : "outline"
+                  }
                   class="text-xs h-8 py-0 px-3"
                   onClick={() => props.setThemeMode("system")}
                   disabled={props.busy}
@@ -1183,7 +1405,9 @@ export default function SettingsView(props: SettingsViewProps) {
                   System
                 </Button>
                 <Button
-                  variant={props.themeMode === "light" ? "secondary" : "outline"}
+                  variant={
+                    props.themeMode === "light" ? "secondary" : "outline"
+                  }
                   class="text-xs h-8 py-0 px-3"
                   onClick={() => props.setThemeMode("light")}
                   disabled={props.busy}
@@ -1201,13 +1425,21 @@ export default function SettingsView(props: SettingsViewProps) {
               </div>
 
               <div class="space-y-2">
-                <div class="text-xs font-medium text-gray-11">{translate("settings.language")}</div>
-                <div class="text-xs text-gray-9">{translate("settings.language.description")}</div>
+                <div class="text-xs font-medium text-gray-11">
+                  {translate("settings.language")}
+                </div>
+                <div class="text-xs text-gray-9">
+                  {translate("settings.language.description")}
+                </div>
                 <div class="flex flex-wrap gap-2">
                   <For each={LANGUAGE_OPTIONS}>
                     {(option) => (
                       <Button
-                        variant={props.language === option.value ? "secondary" : "outline"}
+                        variant={
+                          props.language === option.value
+                            ? "secondary"
+                            : "outline"
+                        }
                         class="text-xs h-8 py-0 px-3"
                         onClick={() => props.setLanguage(option.value)}
                         disabled={props.busy}
@@ -1234,10 +1466,13 @@ export default function SettingsView(props: SettingsViewProps) {
                     <LifeBuoy size={12} />
                     We read every message
                   </div>
-                  <div class="text-sm font-semibold text-gray-12">Help shape OpenWork</div>
+                  <div class="text-sm font-semibold text-gray-12">
+                    Help shape OpenWork
+                  </div>
                   <div class="max-w-[58ch] text-xs text-gray-10">
-                    Tell us what feels great and what feels rough. Feedback goes straight to the team and helps
-                    us prioritize what ships next.
+                    Tell us what feels great and what feels rough. Feedback goes
+                    straight to the team and helps us prioritize what ships
+                    next.
                   </div>
                 </div>
 
@@ -1287,13 +1522,19 @@ export default function SettingsView(props: SettingsViewProps) {
             <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
               <div>
                 <div class="text-sm font-medium text-gray-12">Model</div>
-                <div class="text-xs text-gray-10">Defaults + thinking controls for runs.</div>
+                <div class="text-xs text-gray-10">
+                  Defaults + thinking controls for runs.
+                </div>
               </div>
 
               <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                 <div class="min-w-0">
-                  <div class="text-sm text-gray-12 truncate">{props.defaultModelLabel}</div>
-                  <div class="text-xs text-gray-7 font-mono truncate">{props.defaultModelRef}</div>
+                  <div class="text-sm text-gray-12 truncate">
+                    {props.defaultModelLabel}
+                  </div>
+                  <div class="text-xs text-gray-7 font-mono truncate">
+                    {props.defaultModelRef}
+                  </div>
                 </div>
                 <Button
                   variant="outline"
@@ -1308,7 +1549,9 @@ export default function SettingsView(props: SettingsViewProps) {
               <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                 <div class="min-w-0">
                   <div class="text-sm text-gray-12">Thinking</div>
-                  <div class="text-xs text-gray-7">Show thinking parts (Developer mode only).</div>
+                  <div class="text-xs text-gray-7">
+                    Show thinking parts (Developer mode only).
+                  </div>
                 </div>
                 <Button
                   variant="outline"
@@ -1322,8 +1565,12 @@ export default function SettingsView(props: SettingsViewProps) {
 
               <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                 <div class="min-w-0">
-                  <div class="text-sm text-gray-12">Auto context compaction</div>
-                  <div class="text-xs text-gray-7">Automatically compact after a run completes.</div>
+                  <div class="text-sm text-gray-12">
+                    Auto context compaction
+                  </div>
+                  <div class="text-xs text-gray-7">
+                    Automatically compact after a run completes.
+                  </div>
                 </div>
                 <Button
                   variant="outline"
@@ -1338,7 +1585,9 @@ export default function SettingsView(props: SettingsViewProps) {
               <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                 <div class="min-w-0">
                   <div class="text-sm text-gray-12">Model variant</div>
-                  <div class="text-xs text-gray-7 font-mono truncate">{props.modelVariantLabel}</div>
+                  <div class="text-xs text-gray-7 font-mono truncate">
+                    {props.modelVariantLabel}
+                  </div>
                 </div>
                 <Button
                   variant="outline"
@@ -1358,7 +1607,9 @@ export default function SettingsView(props: SettingsViewProps) {
             <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-4">
               <div>
                 <div class="text-sm font-medium text-gray-12">Runtime</div>
-                <div class="text-xs text-gray-9">Status for your local engine and OpenWork server.</div>
+                <div class="text-xs text-gray-9">
+                  Status for your local engine and OpenWork server.
+                </div>
               </div>
 
               <div class="grid gap-3 sm:grid-cols-2">
@@ -1368,11 +1619,17 @@ export default function SettingsView(props: SettingsViewProps) {
                       <Cpu size={18} />
                     </div>
                     <div>
-                      <div class="text-sm font-medium text-gray-12">OpenCode engine</div>
-                      <div class="text-xs text-gray-9">Local runtime for agents, tools, and model providers.</div>
+                      <div class="text-sm font-medium text-gray-12">
+                        OpenCode engine
+                      </div>
+                      <div class="text-xs text-gray-9">
+                        Local runtime for agents, tools, and model providers.
+                      </div>
                     </div>
                   </div>
-                  <div class={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium ${clientStatusStyle()}`}>
+                  <div
+                    class={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium ${clientStatusStyle()}`}
+                  >
                     <span class={`h-2 w-2 rounded-full ${clientStatusDot()}`} />
                     {clientStatusLabel()}
                   </div>
@@ -1384,12 +1641,21 @@ export default function SettingsView(props: SettingsViewProps) {
                       <Server size={18} />
                     </div>
                     <div>
-                      <div class="text-sm font-medium text-gray-12">OpenWork server</div>
-                      <div class="text-xs text-gray-9">Session control plane for app sync, workers, and remote access.</div>
+                      <div class="text-sm font-medium text-gray-12">
+                        OpenWork server
+                      </div>
+                      <div class="text-xs text-gray-9">
+                        Session control plane for app sync, workers, and remote
+                        access.
+                      </div>
                     </div>
                   </div>
-                  <div class={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium ${openworkStatusStyle()}`}>
-                    <span class={`h-2 w-2 rounded-full ${openworkStatusDot()}`} />
+                  <div
+                    class={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium ${openworkStatusStyle()}`}
+                  >
+                    <span
+                      class={`h-2 w-2 rounded-full ${openworkStatusDot()}`}
+                    />
                     {openworkStatusLabel()}
                   </div>
                 </div>
@@ -1411,11 +1677,22 @@ export default function SettingsView(props: SettingsViewProps) {
                   }`}
                   onClick={props.toggleDeveloperMode}
                 >
-                  <Zap size={14} class={props.developerMode ? "text-blue-10" : "text-dls-secondary"} />
-                  {props.developerMode ? "Disable Developer Mode" : "Enable Developer Mode"}
+                  <Zap
+                    size={14}
+                    class={
+                      props.developerMode
+                        ? "text-blue-10"
+                        : "text-dls-secondary"
+                    }
+                  />
+                  {props.developerMode
+                    ? "Disable Developer Mode"
+                    : "Enable Developer Mode"}
                 </button>
                 <div class="text-xs text-gray-10">
-                  {props.developerMode ? "Developer panel enabled." : "Enable this to access the Developer panel."}
+                  {props.developerMode
+                    ? "Developer panel enabled."
+                    : "Enable this to access the Developer panel."}
                 </div>
               </div>
               <Show when={isTauriRuntime() && opencodeDevModeEnabled()}>
@@ -1427,7 +1704,9 @@ export default function SettingsView(props: SettingsViewProps) {
                     disabled={props.busy || nukeDevConfigBusy()}
                   >
                     <CircleAlert size={14} />
-                    {nukeDevConfigBusy() ? "Nuking OpenCode Dev Config..." : "Nuke Opencode Dev Config"}
+                    {nukeDevConfigBusy()
+                      ? "Nuking OpenCode Dev Config..."
+                      : "Nuke Opencode Dev Config"}
                   </button>
                   <div class="text-xs text-gray-10">
                     Deletes isolated OpenCode dev state and then quits OpenWork.
@@ -1441,9 +1720,13 @@ export default function SettingsView(props: SettingsViewProps) {
                   <div class="rounded-xl border border-gray-6/60 bg-gray-1/40 p-4 space-y-3">
                     <div class="flex items-start justify-between gap-3">
                       <div>
-                        <div class="text-sm font-medium text-gray-12">Open share link</div>
+                        <div class="text-sm font-medium text-gray-12">
+                          Open share link
+                        </div>
                         <div class="text-xs text-gray-9">
-                          Paste an existing <span class="font-mono">openwork://</span> share link and route it through the dev app.
+                          Paste an existing{" "}
+                          <span class="font-mono">openwork://</span> share link
+                          and route it through the dev app.
                         </div>
                       </div>
                       <button
@@ -1463,7 +1746,9 @@ export default function SettingsView(props: SettingsViewProps) {
                       <div class="space-y-3">
                         <textarea
                           value={debugShareLinkInput()}
-                          onInput={(event) => setDebugShareLinkInput(event.currentTarget.value)}
+                          onInput={(event) =>
+                            setDebugShareLinkInput(event.currentTarget.value)
+                          }
                           rows={3}
                           placeholder="openwork://import-bundle?ow_bundle=..."
                           class="w-full rounded-xl border border-gray-6 bg-gray-1 px-3 py-2 text-xs font-mono text-gray-12 outline-none transition focus:border-blue-8"
@@ -1473,19 +1758,31 @@ export default function SettingsView(props: SettingsViewProps) {
                             variant="secondary"
                             class="text-xs h-8 py-0 px-3"
                             onClick={() => void submitDebugShareLink()}
-                            disabled={props.busy || debugShareLinkBusy() || !debugShareLinkInput().trim()}
+                            disabled={
+                              props.busy ||
+                              debugShareLinkBusy() ||
+                              !debugShareLinkInput().trim()
+                            }
                           >
                             {debugShareLinkBusy() ? "Opening..." : "Open link"}
                           </Button>
                           <div class="text-[11px] text-gray-8">
-                            Accepts <span class="font-mono">openwork://</span>, <span class="font-mono">openwork-dev://</span>, or a raw <span class="font-mono">https://share.openwork.software/b/...</span> URL.
+                            Accepts <span class="font-mono">openwork://</span>,{" "}
+                            <span class="font-mono">openwork-dev://</span>, or a
+                            raw{" "}
+                            <span class="font-mono">
+                              https://share.openwork.software/b/...
+                            </span>{" "}
+                            URL.
                           </div>
                         </div>
                       </div>
                     </Show>
 
                     <Show when={debugShareLinkStatus()}>
-                      {(value) => <div class="text-xs text-gray-10">{value()}</div>}
+                      {(value) => (
+                        <div class="text-xs text-gray-10">{value()}</div>
+                      )}
                     </Show>
                   </div>
                 </Show>
@@ -1495,16 +1792,27 @@ export default function SettingsView(props: SettingsViewProps) {
             <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-3">
               <div class="text-sm font-medium text-gray-12">Connection</div>
               <div class="text-xs text-gray-9">{props.headerStatus}</div>
-              <div class="text-xs text-gray-8 font-mono break-all">{props.baseUrl}</div>
+              <div class="text-xs text-gray-8 font-mono break-all">
+                {props.baseUrl}
+              </div>
               <div class="pt-2 flex flex-wrap gap-2">
                 <button
                   type="button"
                   class={compactOutlineActionClass}
                   onClick={handleReconnectOpenworkServer}
-                  disabled={props.busy || props.openworkReconnectBusy || !props.openworkServerUrl.trim()}
+                  disabled={
+                    props.busy ||
+                    props.openworkReconnectBusy ||
+                    !props.openworkServerUrl.trim()
+                  }
                 >
-                  <RefreshCcw size={14} class={`text-dls-secondary ${props.openworkReconnectBusy ? "animate-spin" : ""}`} />
-                  {props.openworkReconnectBusy ? "Reconnecting..." : "Reconnect server"}
+                  <RefreshCcw
+                    size={14}
+                    class={`text-dls-secondary ${props.openworkReconnectBusy ? "animate-spin" : ""}`}
+                  />
+                  {props.openworkReconnectBusy
+                    ? "Reconnecting..."
+                    : "Reconnect server"}
                 </button>
                 <Show when={isLocalEngineRunning()}>
                   <button
@@ -1513,8 +1821,13 @@ export default function SettingsView(props: SettingsViewProps) {
                     onClick={handleRestartLocalServer}
                     disabled={props.busy || openworkRestartBusy()}
                   >
-                    <RefreshCcw size={14} class={`text-dls-secondary ${openworkRestartBusy() ? "animate-spin" : ""}`} />
-                    {openworkRestartBusy() ? "Restarting..." : "Restart local server"}
+                    <RefreshCcw
+                      size={14}
+                      class={`text-dls-secondary ${openworkRestartBusy() ? "animate-spin" : ""}`}
+                    />
+                    {openworkRestartBusy()
+                      ? "Restarting..."
+                      : "Restart local server"}
                   </button>
                 </Show>
                 <Show when={isLocalEngineRunning()}>
@@ -1528,7 +1841,12 @@ export default function SettingsView(props: SettingsViewProps) {
                     Stop local server
                   </button>
                 </Show>
-                <Show when={!isLocalEngineRunning() && props.openworkServerStatus === "connected"}>
+                <Show
+                  when={
+                    !isLocalEngineRunning() &&
+                    props.openworkServerStatus === "connected"
+                  }
+                >
                   <button
                     type="button"
                     class={compactOutlineActionClass}
@@ -1555,27 +1873,45 @@ export default function SettingsView(props: SettingsViewProps) {
 
             <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-4">
               <div>
-                <div class="text-sm font-medium text-gray-12">{translate("settings.migration_recovery_label")}</div>
-                <div class="text-xs text-gray-9">{translate("settings.migration_recovery_hint")}</div>
+                <div class="text-sm font-medium text-gray-12">
+                  {translate("settings.migration_recovery_label")}
+                </div>
+                <div class="text-xs text-gray-9">
+                  {translate("settings.migration_recovery_hint")}
+                </div>
               </div>
               <div class="flex flex-wrap items-center gap-2">
                 <Button
                   variant="secondary"
                   class="text-xs h-8 py-0 px-3"
                   onClick={props.repairOpencodeMigration}
-                  disabled={props.busy || props.migrationRepairBusy || !props.migrationRepairAvailable}
-                  title={props.migrationRepairUnavailableReason ?? ""}
+                  disabled={
+                    webDeployment() ||
+                    props.busy ||
+                    props.migrationRepairBusy ||
+                    !props.migrationRepairAvailable
+                  }
+                  title={
+                    webDeployment()
+                      ? "Migration repair requires the desktop app."
+                      : (props.migrationRepairUnavailableReason ?? "")
+                  }
                 >
                   {props.migrationRepairBusy
                     ? translate("settings.fixing_migration")
                     : translate("settings.fix_migration")}
                 </Button>
               </div>
+
               <Show when={props.migrationRepairUnavailableReason}>
-                {(reason) => <div class="text-xs text-amber-11">{reason()}</div>}
+                {(reason) => (
+                  <div class="text-xs text-amber-11">{reason()}</div>
+                )}
               </Show>
               <Show when={props.migrationRepairBusy}>
-                <div class="text-xs text-gray-10">{translate("status.repairing_migration")}</div>
+                <div class="text-xs text-gray-10">
+                  {translate("status.repairing_migration")}
+                </div>
               </Show>
               <Show when={props.migrationRepairResult}>
                 {(result) => (
@@ -1596,22 +1932,33 @@ export default function SettingsView(props: SettingsViewProps) {
               <div class="flex items-start justify-between gap-4">
                 <div>
                   <div class="text-sm font-medium text-gray-12">Updates</div>
-                  <div class="text-xs text-gray-10">Keep OpenWork up to date.</div>
+                  <div class="text-xs text-gray-10">
+                    Keep OpenWork up to date.
+                  </div>
                 </div>
-                <div class="text-xs text-gray-7 font-mono">{props.appVersion ? `v${props.appVersion}` : ""}</div>
+                <div class="text-xs text-gray-7 font-mono">
+                  {props.appVersion ? `v${props.appVersion}` : ""}
+                </div>
               </div>
 
               <Show
-                when={!isTauriRuntime()}
+                when={webDeployment()}
                 fallback={
                   <Show
-                    when={props.updateEnv && props.updateEnv.supported === false}
+                    when={
+                      props.updateEnv && props.updateEnv.supported === false
+                    }
                     fallback={
                       <>
                         <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6">
                           <div class="space-y-0.5">
-                            <div class="text-sm text-gray-12">Background checks</div>
-                            <div class="text-xs text-gray-7">OpenWork always checks on launch. Also checks once per day (quiet).</div>
+                            <div class="text-sm text-gray-12">
+                              Background checks
+                            </div>
+                            <div class="text-xs text-gray-7">
+                              OpenWork always checks on launch. Also checks once
+                              per day (quiet).
+                            </div>
                           </div>
                           <button
                             class={`min-w-[70px] px-4 py-1.5 rounded-full text-xs font-medium border shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition-colors ${
@@ -1628,7 +1975,10 @@ export default function SettingsView(props: SettingsViewProps) {
                         <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6">
                           <div class="space-y-0.5">
                             <div class="text-sm text-gray-12">Auto-update</div>
-                            <div class="text-xs text-gray-7">Download updates automatically (prompts to restart)</div>
+                            <div class="text-xs text-gray-7">
+                              Download updates automatically (prompts to
+                              restart)
+                            </div>
                           </div>
                           <button
                             class={`min-w-[70px] px-4 py-1.5 rounded-full text-xs font-medium border shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition-colors ${
@@ -1646,32 +1996,60 @@ export default function SettingsView(props: SettingsViewProps) {
                           <div class="space-y-0.5">
                             <div class="text-sm text-gray-12">
                               <Switch>
-                                <Match when={updateState() === "checking"}>Checking...</Match>
-                                <Match when={updateState() === "available"}>Update available: v{updateVersion()}</Match>
-                                <Match when={updateState() === "downloading"}>Downloading...</Match>
-                                <Match when={updateState() === "ready"}>Ready to install: v{updateVersion()}</Match>
-                                <Match when={updateState() === "error"}>Update check failed</Match>
+                                <Match when={updateState() === "checking"}>
+                                  Checking...
+                                </Match>
+                                <Match when={updateState() === "available"}>
+                                  Update available: v{updateVersion()}
+                                </Match>
+                                <Match when={updateState() === "downloading"}>
+                                  Downloading...
+                                </Match>
+                                <Match when={updateState() === "ready"}>
+                                  Ready to install: v{updateVersion()}
+                                </Match>
+                                <Match when={updateState() === "error"}>
+                                  Update check failed
+                                </Match>
                                 <Match when={true}>Up to date</Match>
                               </Switch>
                             </div>
-                            <Show when={updateState() === "idle" && updateLastCheckedAt()}>
+                            <Show
+                              when={
+                                updateState() === "idle" &&
+                                updateLastCheckedAt()
+                              }
+                            >
                               <div class="text-xs text-gray-7">
-                                Last checked {formatRelativeTime(updateLastCheckedAt() as number)}
+                                Last checked{" "}
+                                {formatRelativeTime(
+                                  updateLastCheckedAt() as number,
+                                )}
                               </div>
                             </Show>
-                            <Show when={updateState() === "available" && updateDate()}>
-                              <div class="text-xs text-gray-7">Published {updateDate()}</div>
+                            <Show
+                              when={
+                                updateState() === "available" && updateDate()
+                              }
+                            >
+                              <div class="text-xs text-gray-7">
+                                Published {updateDate()}
+                              </div>
                             </Show>
                             <Show when={updateState() === "downloading"}>
                               <div class="text-xs text-gray-7">
-                                {formatBytes((updateDownloadedBytes() as number) ?? 0)}
+                                {formatBytes(
+                                  (updateDownloadedBytes() as number) ?? 0,
+                                )}
                                 <Show when={updateTotalBytes() != null}>
                                   {` / ${formatBytes(updateTotalBytes() as number)}`}
                                 </Show>
                               </div>
                             </Show>
                             <Show when={updateState() === "error"}>
-                              <div class="text-xs text-red-11">{updateErrorMessage()}</div>
+                              <div class="text-xs text-red-11">
+                                {updateErrorMessage()}
+                              </div>
                             </Show>
                           </div>
 
@@ -1680,7 +2058,11 @@ export default function SettingsView(props: SettingsViewProps) {
                               variant="outline"
                               class="text-xs h-9 py-0 px-4 rounded-full border-gray-6/60 bg-gray-1/70 hover:bg-gray-2/70"
                               onClick={props.checkForUpdates}
-                              disabled={props.busy || updateState() === "checking" || updateState() === "downloading"}
+                              disabled={
+                                props.busy ||
+                                updateState() === "checking" ||
+                                updateState() === "downloading"
+                              }
                             >
                               Check
                             </Button>
@@ -1690,7 +2072,9 @@ export default function SettingsView(props: SettingsViewProps) {
                                 variant="secondary"
                                 class="text-xs h-9 py-0 px-4 rounded-full"
                                 onClick={props.downloadUpdate}
-                                disabled={props.busy || updateState() === "downloading"}
+                                disabled={
+                                  props.busy || updateState() === "downloading"
+                                }
                               >
                                 Download
                               </Button>
@@ -1702,7 +2086,11 @@ export default function SettingsView(props: SettingsViewProps) {
                                 class="text-xs h-9 py-0 px-4 rounded-full"
                                 onClick={props.installUpdateAndRestart}
                                 disabled={props.busy || props.anyActiveRuns}
-                                title={props.anyActiveRuns ? "Stop active runs to update" : ""}
+                                title={
+                                  props.anyActiveRuns
+                                    ? "Stop active runs to update"
+                                    : ""
+                                }
                               >
                                 Install & Restart
                               </Button>
@@ -1710,7 +2098,9 @@ export default function SettingsView(props: SettingsViewProps) {
                           </div>
                         </div>
 
-                        <Show when={updateState() === "available" && updateNotes()}>
+                        <Show
+                          when={updateState() === "available" && updateNotes()}
+                        >
                           <div class="rounded-xl bg-gray-1/20 border border-gray-6 p-3 text-xs text-gray-11 whitespace-pre-wrap max-h-40 overflow-auto">
                             {updateNotes()}
                           </div>
@@ -1719,7 +2109,8 @@ export default function SettingsView(props: SettingsViewProps) {
                     }
                   >
                     <div class="rounded-xl bg-gray-1/20 border border-gray-6 p-3 text-sm text-gray-11">
-                      {props.updateEnv?.reason ?? "Updates are not supported in this environment."}
+                      {props.updateEnv?.reason ??
+                        "Updates are not supported in this environment."}
                     </div>
                   </Show>
                 }
@@ -1734,14 +2125,17 @@ export default function SettingsView(props: SettingsViewProps) {
               <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-3">
                 <div>
                   <div class="text-sm font-medium text-gray-12">Appearance</div>
-                  <div class="text-xs text-gray-10">Customize window appearance.</div>
+                  <div class="text-xs text-gray-10">
+                    Customize window appearance.
+                  </div>
                 </div>
 
                 <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                   <div class="min-w-0">
                     <div class="text-sm text-gray-12">Hide titlebar</div>
                     <div class="text-xs text-gray-7">
-                      Hide the window titlebar. Useful for tiling window managers on Linux (Hyprland, i3, sway).
+                      Hide the window titlebar. Useful for tiling window
+                      managers on Linux (Hyprland, i3, sway).
                     </div>
                   </div>
                   <Button
@@ -1755,28 +2149,41 @@ export default function SettingsView(props: SettingsViewProps) {
                 </div>
               </div>
             </Show>
-
           </div>
         </Match>
 
         <Match when={activeTab() === "debug"}>
           <Show when={props.developerMode}>
             <section>
-              <h3 class="text-sm font-medium text-gray-11 uppercase tracking-wider mb-4">Developer</h3>
+              <h3 class="text-sm font-medium text-gray-11 uppercase tracking-wider mb-4">
+                Developer
+              </h3>
 
               <div class="space-y-4">
                 <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-3">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <div class="text-sm font-medium text-gray-12">Runtime debug report</div>
-                      <div class="text-xs text-gray-10">Readable diagnostics snapshot with one-click export.</div>
+                      <div class="text-sm font-medium text-gray-12">
+                        Runtime debug report
+                      </div>
+                      <div class="text-xs text-gray-10">
+                        Readable diagnostics snapshot with one-click export.
+                      </div>
                     </div>
                     <div class="flex items-center gap-2 shrink-0">
-                      <Button variant="outline" class="text-xs h-8 py-0 px-3" onClick={copyRuntimeDebugReport}>
+                      <Button
+                        variant="outline"
+                        class="text-xs h-8 py-0 px-3"
+                        onClick={copyRuntimeDebugReport}
+                      >
                         <Copy size={13} class="mr-1.5" />
                         Copy JSON
                       </Button>
-                      <Button variant="secondary" class="text-xs h-8 py-0 px-3" onClick={exportRuntimeDebugReport}>
+                      <Button
+                        variant="secondary"
+                        class="text-xs h-8 py-0 px-3"
+                        onClick={exportRuntimeDebugReport}
+                      >
                         <Download size={13} class="mr-1.5" />
                         Export
                       </Button>
@@ -1794,23 +2201,32 @@ export default function SettingsView(props: SettingsViewProps) {
                     {runtimeDebugReportJson()}
                   </pre>
                   <Show when={debugReportStatus()}>
-                    {(status) => <div class="text-xs text-gray-10">{status()}</div>}
+                    {(status) => (
+                      <div class="text-xs text-gray-10">{status()}</div>
+                    )}
                   </Show>
                 </div>
 
                 <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-3">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <div class="text-sm font-medium text-gray-12">Sandbox probe</div>
+                      <div class="text-sm font-medium text-gray-12">
+                        Sandbox probe
+                      </div>
                       <div class="text-xs text-gray-10">
-                        Runs a temporary Docker sandbox startup check and captures inspect/log output.
+                        Runs a temporary Docker sandbox startup check and
+                        captures inspect/log output.
                       </div>
                     </div>
                     <Button
                       variant="secondary"
                       class="text-xs h-8 py-0 px-3"
                       onClick={runSandboxDebugProbe}
-                      disabled={!isTauriRuntime() || sandboxProbeBusy() || props.anyActiveRuns}
+                      disabled={
+                        !isTauriRuntime() ||
+                        sandboxProbeBusy() ||
+                        props.anyActiveRuns
+                      }
                       title={
                         !isTauriRuntime()
                           ? "Sandbox probe requires desktop app"
@@ -1819,13 +2235,18 @@ export default function SettingsView(props: SettingsViewProps) {
                             : ""
                       }
                     >
-                      {sandboxProbeBusy() ? "Running probe..." : "Run sandbox probe"}
+                      {sandboxProbeBusy()
+                        ? "Running probe..."
+                        : "Run sandbox probe"}
                     </Button>
                   </div>
                   <Show when={sandboxProbeResult()}>
                     {(result) => (
                       <div class="text-xs text-gray-11 space-y-1">
-                        <div>Run ID: <span class="font-mono">{result().runId}</span></div>
+                        <div>
+                          Run ID:{" "}
+                          <span class="font-mono">{result().runId}</span>
+                        </div>
                         <div>Result: {result().ready ? "ready" : "error"}</div>
                         <Show when={result().error}>
                           {(err) => <div class="text-red-11">{err()}</div>}
@@ -1834,24 +2255,42 @@ export default function SettingsView(props: SettingsViewProps) {
                     )}
                   </Show>
                   <Show when={sandboxProbeStatus()}>
-                    {(status) => <div class="text-xs text-gray-10">{status()}</div>}
+                    {(status) => (
+                      <div class="text-xs text-gray-10">{status()}</div>
+                    )}
                   </Show>
                   <div class="text-[11px] text-gray-7">
-                    Use <strong>Export</strong> in Runtime debug report above to save this probe output with logs.
+                    Use <strong>Export</strong> in Runtime debug report above to
+                    save this probe output with logs.
                   </div>
                 </div>
 
                 <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-3">
-                  <div class="text-sm font-medium text-gray-12">Workspace config</div>
-                  <div class="text-xs text-gray-10">Reveal or reset `.opencode/openwork.json` defaults for this app workspace.</div>
-                  <div class="text-[11px] text-gray-7 font-mono break-all">{workspaceConfigPath() || "No active local workspace."}</div>
+                  <div class="text-sm font-medium text-gray-12">
+                    Workspace config
+                  </div>
+                  <div class="text-xs text-gray-10">
+                    Reveal or reset `.opencode/openwork.json` defaults for this
+                    app workspace.
+                  </div>
+                  <div class="text-[11px] text-gray-7 font-mono break-all">
+                    {workspaceConfigPath() || "No active local workspace."}
+                  </div>
                   <div class="flex flex-wrap items-center gap-2">
                     <Button
                       variant="outline"
                       class="text-xs h-8 py-0 px-3"
                       onClick={revealWorkspaceConfig}
-                      disabled={!isTauriRuntime() || revealConfigBusy() || !workspaceConfigPath()}
-                      title={!isTauriRuntime() ? "Reveal config requires the desktop app" : ""}
+                      disabled={
+                        !isTauriRuntime() ||
+                        revealConfigBusy() ||
+                        !workspaceConfigPath()
+                      }
+                      title={
+                        !isTauriRuntime()
+                          ? "Reveal config requires the desktop app"
+                          : ""
+                      }
                     >
                       <FolderOpen size={13} class="mr-1.5" />
                       {revealConfigBusy() ? "Opening..." : "Reveal config"}
@@ -1861,13 +2300,21 @@ export default function SettingsView(props: SettingsViewProps) {
                       class="text-xs h-8 py-0 px-3"
                       onClick={resetAppConfigDefaults}
                       disabled={resetConfigBusy() || props.anyActiveRuns}
-                      title={props.anyActiveRuns ? "Stop active runs before resetting config" : ""}
+                      title={
+                        props.anyActiveRuns
+                          ? "Stop active runs before resetting config"
+                          : ""
+                      }
                     >
-                      {resetConfigBusy() ? "Resetting..." : "Reset config defaults"}
+                      {resetConfigBusy()
+                        ? "Resetting..."
+                        : "Reset config defaults"}
                     </Button>
                   </div>
                   <Show when={configActionStatus()}>
-                    {(status) => <div class="text-xs text-gray-10">{status()}</div>}
+                    {(status) => (
+                      <div class="text-xs text-gray-10">{status()}</div>
+                    )}
                   </Show>
                 </div>
 
@@ -1878,7 +2325,9 @@ export default function SettingsView(props: SettingsViewProps) {
                       Repairs cached data used to start the engine. Safe to run.
                     </div>
                     <Show when={props.cacheRepairResult}>
-                      <div class="text-xs text-gray-11 mt-2">{props.cacheRepairResult}</div>
+                      <div class="text-xs text-gray-11 mt-2">
+                        {props.cacheRepairResult}
+                      </div>
                     </Show>
                   </div>
                   <Button
@@ -1886,7 +2335,11 @@ export default function SettingsView(props: SettingsViewProps) {
                     class="text-xs h-8 py-0 px-3 shrink-0"
                     onClick={props.repairOpencodeCache}
                     disabled={props.cacheRepairBusy || !isTauriRuntime()}
-                    title={isTauriRuntime() ? "" : "Cache repair requires the desktop app"}
+                    title={
+                      isTauriRuntime()
+                        ? ""
+                        : "Cache repair requires the desktop app"
+                    }
                   >
                     {props.cacheRepairBusy ? "Repairing cache" : "Repair cache"}
                   </Button>
@@ -1894,19 +2347,28 @@ export default function SettingsView(props: SettingsViewProps) {
 
                 <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
                   <div class="min-w-0">
-                    <div class="text-sm text-gray-12">OpenWork Docker containers</div>
+                    <div class="text-sm text-gray-12">
+                      OpenWork Docker containers
+                    </div>
                     <div class="text-xs text-gray-7">
-                      Force-remove Docker containers launched by OpenWork (sandbox + local dev stacks).
+                      Force-remove Docker containers launched by OpenWork
+                      (sandbox + local dev stacks).
                     </div>
                     <Show when={props.dockerCleanupResult}>
-                      <div class="text-xs text-gray-11 mt-2">{props.dockerCleanupResult}</div>
+                      <div class="text-xs text-gray-11 mt-2">
+                        {props.dockerCleanupResult}
+                      </div>
                     </Show>
                   </div>
                   <Button
                     variant="danger"
                     class="text-xs h-8 py-0 px-3 shrink-0"
                     onClick={props.cleanupOpenworkDockerContainers}
-                    disabled={props.dockerCleanupBusy || props.anyActiveRuns || !isTauriRuntime()}
+                    disabled={
+                      props.dockerCleanupBusy ||
+                      props.anyActiveRuns ||
+                      !isTauriRuntime()
+                    }
                     title={
                       !isTauriRuntime()
                         ? "Docker cleanup requires the desktop app"
@@ -1915,7 +2377,9 @@ export default function SettingsView(props: SettingsViewProps) {
                           : ""
                     }
                   >
-                    {props.dockerCleanupBusy ? "Removing containers..." : "Delete containers"}
+                    {props.dockerCleanupBusy
+                      ? "Removing containers..."
+                      : "Delete containers"}
                   </Button>
                 </div>
 
@@ -1926,14 +2390,21 @@ export default function SettingsView(props: SettingsViewProps) {
                     <div class="flex items-center gap-3">
                       <div
                         class={`p-2 rounded-lg ${
-                          isLocalPreference() ? "bg-indigo-7/10 text-indigo-11" : "bg-green-7/10 text-green-11"
+                          isLocalPreference()
+                            ? "bg-indigo-7/10 text-indigo-11"
+                            : "bg-green-7/10 text-green-11"
                         }`}
                       >
-                        <Show when={isLocalPreference()} fallback={<Smartphone size={18} />}>
+                        <Show
+                          when={isLocalPreference()}
+                          fallback={<Smartphone size={18} />}
+                        >
                           <HardDrive size={18} />
                         </Show>
                       </div>
-                      <span class="text-sm font-medium text-gray-12">{startupLabel()}</span>
+                      <span class="text-sm font-medium text-gray-12">
+                        {startupLabel()}
+                      </span>
                     </div>
                     <Button
                       variant="outline"
@@ -1951,40 +2422,65 @@ export default function SettingsView(props: SettingsViewProps) {
                     onClick={props.onResetStartupPreference}
                   >
                     <span>Reset startup preference</span>
-                    <RefreshCcw size={14} class="opacity-80 group-hover:rotate-180 transition-transform" />
+                    <RefreshCcw
+                      size={14}
+                      class="opacity-80 group-hover:rotate-180 transition-transform"
+                    />
                   </Button>
 
                   <p class="text-xs text-gray-7">
-                    This clears your saved preference and shows the connection choice on next launch.
+                    This clears your saved preference and shows the connection
+                    choice on next launch.
                   </p>
                 </div>
 
-                <Show when={isTauriRuntime() && (isLocalPreference() || props.developerMode)}>
+                <Show
+                  when={
+                    isTauriRuntime() &&
+                    (isLocalPreference() || props.developerMode)
+                  }
+                >
                   <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
                     <div>
                       <div class="text-sm font-medium text-gray-12">Engine</div>
-                      <div class="text-xs text-gray-10">Choose how OpenCode runs locally.</div>
+                      <div class="text-xs text-gray-10">
+                        Choose how OpenCode runs locally.
+                      </div>
                     </div>
 
                     <Show when={!isLocalPreference()}>
                       <div class="text-[11px] text-amber-11 bg-amber-3/40 border border-amber-7/40 rounded-lg px-3 py-2">
-                        Startup preference is currently remote. Engine settings are saved now and apply the next time you
-                        run locally.
+                        Startup preference is currently remote. Engine settings
+                        are saved now and apply the next time you run locally.
                       </div>
                     </Show>
 
                     <div class="space-y-3">
                       <div class="text-xs text-gray-10">Engine source</div>
-                      <div class={props.developerMode ? "grid grid-cols-3 gap-2" : "grid grid-cols-2 gap-2"}>
+                      <div
+                        class={
+                          props.developerMode
+                            ? "grid grid-cols-3 gap-2"
+                            : "grid grid-cols-2 gap-2"
+                        }
+                      >
                         <Button
-                          variant={props.engineSource === "sidecar" ? "secondary" : "outline"}
+                          variant={
+                            props.engineSource === "sidecar"
+                              ? "secondary"
+                              : "outline"
+                          }
                           onClick={() => props.setEngineSource("sidecar")}
                           disabled={props.busy}
                         >
                           Bundled (recommended)
                         </Button>
                         <Button
-                          variant={props.engineSource === "path" ? "secondary" : "outline"}
+                          variant={
+                            props.engineSource === "path"
+                              ? "secondary"
+                              : "outline"
+                          }
                           onClick={() => props.setEngineSource("path")}
                           disabled={props.busy}
                         >
@@ -1992,7 +2488,11 @@ export default function SettingsView(props: SettingsViewProps) {
                         </Button>
                         <Show when={props.developerMode}>
                           <Button
-                            variant={props.engineSource === "custom" ? "secondary" : "outline"}
+                            variant={
+                              props.engineSource === "custom"
+                                ? "secondary"
+                                : "outline"
+                            }
                             onClick={() => props.setEngineSource("custom")}
                             disabled={props.busy}
                           >
@@ -2001,13 +2501,20 @@ export default function SettingsView(props: SettingsViewProps) {
                         </Show>
                       </div>
                       <div class="text-[11px] text-gray-7">
-                        Bundled engine is the most reliable option. Use System install only if you manage OpenCode yourself.
+                        Bundled engine is the most reliable option. Use System
+                        install only if you manage OpenCode yourself.
                       </div>
                     </div>
 
-                    <Show when={props.developerMode && props.engineSource === "custom"}>
+                    <Show
+                      when={
+                        props.developerMode && props.engineSource === "custom"
+                      }
+                    >
                       <div class="space-y-2">
-                        <div class="text-xs text-gray-10">Custom OpenCode binary</div>
+                        <div class="text-xs text-gray-10">
+                          Custom OpenCode binary
+                        </div>
                         <div class="flex items-center gap-2">
                           <div
                             class="flex-1 min-w-0 text-[11px] text-gray-7 font-mono truncate bg-gray-1 p-3 rounded-xl border border-gray-6"
@@ -2027,14 +2534,22 @@ export default function SettingsView(props: SettingsViewProps) {
                             variant="outline"
                             class="text-xs h-10 px-3 shrink-0"
                             onClick={() => props.setEngineCustomBinPath("")}
-                            disabled={props.busy || !props.engineCustomBinPath.trim()}
-                            title={!props.engineCustomBinPath.trim() ? "No custom path set" : "Clear"}
+                            disabled={
+                              props.busy || !props.engineCustomBinPath.trim()
+                            }
+                            title={
+                              !props.engineCustomBinPath.trim()
+                                ? "No custom path set"
+                                : "Clear"
+                            }
                           >
                             Clear
                           </Button>
                         </div>
                         <div class="text-[11px] text-gray-7">
-                          Use this to point OpenWork at a local OpenCode build (e.g. your fork). Applies next time the engine starts or reloads.
+                          Use this to point OpenWork at a local OpenCode build
+                          (e.g. your fork). Applies next time the engine starts
+                          or reloads.
                         </div>
                       </div>
                     </Show>
@@ -2044,21 +2559,33 @@ export default function SettingsView(props: SettingsViewProps) {
                         <div class="text-xs text-gray-10">Engine runtime</div>
                         <div class="grid grid-cols-2 gap-2">
                           <Button
-                            variant={props.engineRuntime === "direct" ? "secondary" : "outline"}
+                            variant={
+                              props.engineRuntime === "direct"
+                                ? "secondary"
+                                : "outline"
+                            }
                             onClick={() => props.setEngineRuntime("direct")}
                             disabled={props.busy}
                           >
                             Direct (OpenCode)
                           </Button>
                           <Button
-                            variant={props.engineRuntime === "openwork-orchestrator" ? "secondary" : "outline"}
-                            onClick={() => props.setEngineRuntime("openwork-orchestrator")}
+                            variant={
+                              props.engineRuntime === "openwork-orchestrator"
+                                ? "secondary"
+                                : "outline"
+                            }
+                            onClick={() =>
+                              props.setEngineRuntime("openwork-orchestrator")
+                            }
                             disabled={props.busy}
                           >
                             OpenWork Orchestrator
                           </Button>
                         </div>
-                        <div class="text-[11px] text-gray-7">Applies the next time the engine starts or reloads.</div>
+                        <div class="text-[11px] text-gray-7">
+                          Applies the next time the engine starts or reloads.
+                        </div>
                       </div>
                     </Show>
                   </div>
@@ -2066,21 +2593,33 @@ export default function SettingsView(props: SettingsViewProps) {
 
                 <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
                   <div>
-                    <div class="text-sm font-medium text-gray-12">Reset & Recovery</div>
-                    <div class="text-xs text-gray-10">Clear data or restart the setup flow.</div>
+                    <div class="text-sm font-medium text-gray-12">
+                      Reset & Recovery
+                    </div>
+                    <div class="text-xs text-gray-10">
+                      Clear data or restart the setup flow.
+                    </div>
                   </div>
 
                   <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                     <div class="min-w-0">
                       <div class="text-sm text-gray-12">Reset onboarding</div>
-                      <div class="text-xs text-gray-7">Clears OpenWork preferences and restarts the app.</div>
+                      <div class="text-xs text-gray-7">
+                        Clears OpenWork preferences and restarts the app.
+                      </div>
                     </div>
                     <Button
                       variant="outline"
                       class="text-xs h-8 py-0 px-3 shrink-0"
                       onClick={() => props.openResetModal("onboarding")}
-                      disabled={props.busy || props.resetModalBusy || props.anyActiveRuns}
-                      title={props.anyActiveRuns ? "Stop active runs to reset" : ""}
+                      disabled={
+                        props.busy ||
+                        props.resetModalBusy ||
+                        props.anyActiveRuns
+                      }
+                      title={
+                        props.anyActiveRuns ? "Stop active runs to reset" : ""
+                      }
                     >
                       Reset
                     </Button>
@@ -2089,44 +2628,69 @@ export default function SettingsView(props: SettingsViewProps) {
                   <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                     <div class="min-w-0">
                       <div class="text-sm text-gray-12">Reset app data</div>
-                      <div class="text-xs text-gray-7">More aggressive. Clears OpenWork cache + app data.</div>
+                      <div class="text-xs text-gray-7">
+                        More aggressive. Clears OpenWork cache + app data.
+                      </div>
                     </div>
                     <Button
                       variant="danger"
                       class="text-xs h-8 py-0 px-3 shrink-0"
                       onClick={() => props.openResetModal("all")}
-                      disabled={props.busy || props.resetModalBusy || props.anyActiveRuns}
-                      title={props.anyActiveRuns ? "Stop active runs to reset" : ""}
+                      disabled={
+                        props.busy ||
+                        props.resetModalBusy ||
+                        props.anyActiveRuns
+                      }
+                      title={
+                        props.anyActiveRuns ? "Stop active runs to reset" : ""
+                      }
                     >
                       Reset
                     </Button>
                   </div>
 
                   <div class="text-xs text-gray-7">
-                    Requires typing <span class="font-mono text-gray-11">RESET</span> and will restart the app.
+                    Requires typing{" "}
+                    <span class="font-mono text-gray-11">RESET</span> and will
+                    restart the app.
                   </div>
                 </div>
 
                 <div class="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-4">
                   <div>
                     <div class="text-sm font-medium text-gray-12">Devtools</div>
-                    <div class="text-xs text-gray-10">Sidecar health, capabilities, and audit trail.</div>
+                    <div class="text-xs text-gray-10">
+                      Sidecar health, capabilities, and audit trail.
+                    </div>
                   </div>
 
                   <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                     <div>
-                      <div class="text-sm font-medium text-gray-12">Service restarts</div>
-                      <div class="text-xs text-gray-10">Restart specific host services without leaving this screen.</div>
+                      <div class="text-sm font-medium text-gray-12">
+                        Service restarts
+                      </div>
+                      <div class="text-xs text-gray-10">
+                        Restart specific host services without leaving this
+                        screen.
+                      </div>
                     </div>
                     <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
                       <Button
                         variant="secondary"
                         onClick={handleRestartLocalServer}
-                        disabled={props.busy || openworkRestartBusy() || !isTauriRuntime()}
+                        disabled={
+                          props.busy ||
+                          openworkRestartBusy() ||
+                          !isTauriRuntime()
+                        }
                         class="text-xs px-3 py-1.5 justify-center"
                       >
-                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${openworkRestartBusy() ? "animate-spin" : ""}`} />
-                        {openworkRestartBusy() ? "Restarting..." : "Restart orchestrator"}
+                        <RefreshCcw
+                          class={`w-3.5 h-3.5 mr-1.5 ${openworkRestartBusy() ? "animate-spin" : ""}`}
+                        />
+                        {openworkRestartBusy()
+                          ? "Restarting..."
+                          : "Restart orchestrator"}
                       </Button>
                       <Button
                         variant="secondary"
@@ -2134,34 +2698,62 @@ export default function SettingsView(props: SettingsViewProps) {
                         disabled={opencodeRestarting() || !isTauriRuntime()}
                         class="text-xs px-3 py-1.5 justify-center"
                       >
-                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${opencodeRestarting() ? "animate-spin" : ""}`} />
-                        {opencodeRestarting() ? "Restarting..." : "Restart OpenCode"}
+                        <RefreshCcw
+                          class={`w-3.5 h-3.5 mr-1.5 ${opencodeRestarting() ? "animate-spin" : ""}`}
+                        />
+                        {opencodeRestarting()
+                          ? "Restarting..."
+                          : "Restart OpenCode"}
                       </Button>
                       <Button
                         variant="secondary"
                         onClick={handleOpenworkServerRestart}
-                        disabled={openworkServerRestarting() || !isTauriRuntime()}
+                        disabled={
+                          openworkServerRestarting() || !isTauriRuntime()
+                        }
                         class="text-xs px-3 py-1.5 justify-center"
                       >
-                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${openworkServerRestarting() ? "animate-spin" : ""}`} />
-                        {openworkServerRestarting() ? "Restarting..." : "Restart OpenWork server"}
+                        <RefreshCcw
+                          class={`w-3.5 h-3.5 mr-1.5 ${openworkServerRestarting() ? "animate-spin" : ""}`}
+                        />
+                        {openworkServerRestarting()
+                          ? "Restarting..."
+                          : "Restart OpenWork server"}
                       </Button>
                       <Button
                         variant="secondary"
                         onClick={handleOpenCodeRouterRestart}
-                        disabled={opencodeRouterRestarting() || !isTauriRuntime()}
+                        disabled={
+                          opencodeRouterRestarting() || !isTauriRuntime()
+                        }
                         class="text-xs px-3 py-1.5 justify-center"
                       >
-                        <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${opencodeRouterRestarting() ? "animate-spin" : ""}`} />
-                        {opencodeRouterRestarting() ? "Restarting..." : "Restart OpenCodeRouter"}
+                        <RefreshCcw
+                          class={`w-3.5 h-3.5 mr-1.5 ${opencodeRouterRestarting() ? "animate-spin" : ""}`}
+                        />
+                        {opencodeRouterRestarting()
+                          ? "Restarting..."
+                          : "Restart OpenCodeRouter"}
                       </Button>
                     </div>
                     <Show when={openworkRestartStatus()}>
-                      <div class="text-xs text-green-11 bg-green-3/50 border border-green-6 rounded-lg p-2">{openworkRestartStatus()}</div>
+                      <div class="text-xs text-green-11 bg-green-3/50 border border-green-6 rounded-lg p-2">
+                        {openworkRestartStatus()}
+                      </div>
                     </Show>
-                    <Show when={openworkRestartError() || opencodeRestartError() || openworkServerRestartError() || opencodeRouterRestartError()}>
+                    <Show
+                      when={
+                        openworkRestartError() ||
+                        opencodeRestartError() ||
+                        openworkServerRestartError() ||
+                        opencodeRouterRestartError()
+                      }
+                    >
                       <div class="text-xs text-red-11 bg-red-3/50 border border-red-6 rounded-lg p-2">
-                        {openworkRestartError() || opencodeRestartError() || openworkServerRestartError() || opencodeRouterRestartError()}
+                        {openworkRestartError() ||
+                          opencodeRestartError() ||
+                          openworkServerRestartError() ||
+                          opencodeRouterRestartError()}
                       </div>
                     </Show>
                   </div>
@@ -2169,28 +2761,48 @@ export default function SettingsView(props: SettingsViewProps) {
                   <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                     <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                       <div>
-                        <div class="text-sm font-medium text-gray-12">Versions</div>
-                        <div class="text-xs text-gray-10">Sidecar + desktop build info.</div>
-                      </div>
-                        <div class="space-y-1">
-                          <div class="text-[11px] text-gray-7 font-mono truncate">Desktop app: {appVersionLabel()}</div>
-                          <div class="text-[11px] text-gray-7 font-mono truncate">Commit: {appCommitLabel()}</div>
-                          <div class="text-[11px] text-gray-7 font-mono truncate">Orchestrator: {orchestratorVersionLabel()}</div>
-                          <div class="text-[11px] text-gray-7 font-mono truncate">OpenCode: {opencodeVersionLabel()}</div>
-                          <div class="text-[11px] text-gray-7 font-mono truncate">
-                            OpenWork server: {openworkServerVersionLabel()}
-                          </div>
-                          <div class="text-[11px] text-gray-7 font-mono truncate">OpenCodeRouter: {opencodeRouterVersionLabel()}</div>
+                        <div class="text-sm font-medium text-gray-12">
+                          Versions
                         </div>
+                        <div class="text-xs text-gray-10">
+                          Sidecar + desktop build info.
+                        </div>
+                      </div>
+                      <div class="space-y-1">
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          Desktop app: {appVersionLabel()}
+                        </div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          Commit: {appCommitLabel()}
+                        </div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          Orchestrator: {orchestratorVersionLabel()}
+                        </div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          OpenCode: {opencodeVersionLabel()}
+                        </div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          OpenWork server: {openworkServerVersionLabel()}
+                        </div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          OpenCodeRouter: {opencodeRouterVersionLabel()}
+                        </div>
+                      </div>
                     </div>
 
                     <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                       <div class="flex items-center justify-between gap-3">
                         <div>
-                          <div class="text-sm font-medium text-gray-12">OpenCode engine</div>
-                          <div class="text-xs text-gray-10">Local execution sidecar.</div>
+                          <div class="text-sm font-medium text-gray-12">
+                            OpenCode engine
+                          </div>
+                          <div class="text-xs text-gray-10">
+                            Local execution sidecar.
+                          </div>
                         </div>
-                        <div class={`text-xs px-2 py-1 rounded-full border ${engineStatusStyle()}`}>
+                        <div
+                          class={`text-xs px-2 py-1 rounded-full border ${engineStatusStyle()}`}
+                        >
                           {engineStatusLabel()}
                         </div>
                       </div>
@@ -2199,19 +2811,26 @@ export default function SettingsView(props: SettingsViewProps) {
                           {props.engineInfo?.baseUrl ?? "Base URL unavailable"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          {props.engineInfo?.projectDir ?? "No project directory"}
+                          {props.engineInfo?.projectDir ??
+                            "No project directory"}
                         </div>
-                        <div class="text-[11px] text-gray-7 font-mono truncate">PID: {props.engineInfo?.pid ?? "—"}</div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          PID: {props.engineInfo?.pid ?? "—"}
+                        </div>
                       </div>
                       <div class="grid gap-2">
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last stdout</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last stdout
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {engineStdout()}
                           </pre>
                         </div>
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last stderr</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last stderr
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {engineStderr()}
                           </pre>
@@ -2222,22 +2841,31 @@ export default function SettingsView(props: SettingsViewProps) {
                     <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                       <div class="flex items-center justify-between gap-3">
                         <div>
-                          <div class="text-sm font-medium text-gray-12">Orchestrator daemon</div>
-                          <div class="text-xs text-gray-10">Workspace orchestration layer.</div>
+                          <div class="text-sm font-medium text-gray-12">
+                            Orchestrator daemon
+                          </div>
+                          <div class="text-xs text-gray-10">
+                            Workspace orchestration layer.
+                          </div>
                         </div>
-                        <div class={`text-xs px-2 py-1 rounded-full border ${orchestratorStatusStyle()}`}>
+                        <div
+                          class={`text-xs px-2 py-1 rounded-full border ${orchestratorStatusStyle()}`}
+                        >
                           {orchestratorStatusLabel()}
                         </div>
                       </div>
                       <div class="space-y-1">
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          {props.orchestratorStatus?.dataDir ?? "Data directory unavailable"}
+                          {props.orchestratorStatus?.dataDir ??
+                            "Data directory unavailable"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          Daemon: {props.orchestratorStatus?.daemon?.baseUrl ?? "—"}
+                          Daemon:{" "}
+                          {props.orchestratorStatus?.daemon?.baseUrl ?? "—"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          OpenCode: {props.orchestratorStatus?.opencode?.baseUrl ?? "—"}
+                          OpenCode:{" "}
+                          {props.orchestratorStatus?.opencode?.baseUrl ?? "—"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
                           Version: {props.orchestratorStatus?.cliVersion ?? "—"}
@@ -2245,16 +2873,26 @@ export default function SettingsView(props: SettingsViewProps) {
                         <div class="text-[11px] text-gray-7 font-mono truncate">
                           Sidecar: {orchestratorSidecarSummary()}
                         </div>
-                        <div class="text-[11px] text-gray-7 font-mono truncate" title={orchestratorBinaryPath()}>
-                          Opencode binary: {formatOrchestratorBinary(props.orchestratorStatus?.binaries?.opencode ?? null)}
+                        <div
+                          class="text-[11px] text-gray-7 font-mono truncate"
+                          title={orchestratorBinaryPath()}
+                        >
+                          Opencode binary:{" "}
+                          {formatOrchestratorBinary(
+                            props.orchestratorStatus?.binaries?.opencode ??
+                              null,
+                          )}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          Active workspace: {props.orchestratorStatus?.activeId ?? "—"}
+                          Active workspace:{" "}
+                          {props.orchestratorStatus?.activeId ?? "—"}
                         </div>
                       </div>
                       <Show when={props.orchestratorStatus?.lastError}>
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last error</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last error
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {props.orchestratorStatus?.lastError}
                           </pre>
@@ -2265,45 +2903,77 @@ export default function SettingsView(props: SettingsViewProps) {
                     <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                       <div class="flex items-center justify-between gap-3">
                         <div>
-                          <div class="text-sm font-medium text-gray-12">OpenCode SDK</div>
-                          <div class="text-xs text-gray-10">UI connection diagnostics.</div>
+                          <div class="text-sm font-medium text-gray-12">
+                            OpenCode SDK
+                          </div>
+                          <div class="text-xs text-gray-10">
+                            UI connection diagnostics.
+                          </div>
                         </div>
-                        <div class={`text-xs px-2 py-1 rounded-full border ${opencodeConnectStatusStyle()}`}>
+                        <div
+                          class={`text-xs px-2 py-1 rounded-full border ${opencodeConnectStatusStyle()}`}
+                        >
                           {opencodeConnectStatusLabel()}
                         </div>
                       </div>
                       <div class="space-y-1">
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          {props.opencodeConnectStatus?.baseUrl ?? "Base URL unavailable"}
+                          {props.opencodeConnectStatus?.baseUrl ??
+                            "Base URL unavailable"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          {props.opencodeConnectStatus?.directory ?? "No project directory"}
+                          {props.opencodeConnectStatus?.directory ??
+                            "No project directory"}
                         </div>
                         <div class="text-[11px] text-gray-7">
                           Last attempt: {opencodeConnectTimestamp() ?? "—"}
                         </div>
                         <Show when={props.opencodeConnectStatus?.reason}>
-                          <div class="text-[11px] text-gray-7">Reason: {props.opencodeConnectStatus?.reason}</div>
+                          <div class="text-[11px] text-gray-7">
+                            Reason: {props.opencodeConnectStatus?.reason}
+                          </div>
                         </Show>
                         <Show when={props.opencodeConnectStatus?.metrics}>
                           {(metrics) => (
                             <div class="pt-1 space-y-1 text-[11px] text-gray-7">
                               <Show when={metrics().healthyMs != null}>
-                                <div>Healthy: {Math.round(metrics().healthyMs as number)}ms</div>
+                                <div>
+                                  Healthy:{" "}
+                                  {Math.round(metrics().healthyMs as number)}ms
+                                </div>
                               </Show>
                               <Show when={metrics().loadSessionsMs != null}>
-                                <div>Load sessions: {Math.round(metrics().loadSessionsMs as number)}ms</div>
-                              </Show>
-                              <Show when={metrics().pendingPermissionsMs != null}>
                                 <div>
-                                  Pending permissions: {Math.round(metrics().pendingPermissionsMs as number)}ms
+                                  Load sessions:{" "}
+                                  {Math.round(
+                                    metrics().loadSessionsMs as number,
+                                  )}
+                                  ms
+                                </div>
+                              </Show>
+                              <Show
+                                when={metrics().pendingPermissionsMs != null}
+                              >
+                                <div>
+                                  Pending permissions:{" "}
+                                  {Math.round(
+                                    metrics().pendingPermissionsMs as number,
+                                  )}
+                                  ms
                                 </div>
                               </Show>
                               <Show when={metrics().providersMs != null}>
-                                <div>Providers: {Math.round(metrics().providersMs as number)}ms</div>
+                                <div>
+                                  Providers:{" "}
+                                  {Math.round(metrics().providersMs as number)}
+                                  ms
+                                </div>
                               </Show>
                               <Show when={metrics().totalMs != null}>
-                                <div>Total: {Math.round(metrics().totalMs as number)}ms</div>
+                                <div>
+                                  Total:{" "}
+                                  {Math.round(metrics().totalMs as number)}ms
+                                </div>
                               </Show>
                             </div>
                           )}
@@ -2311,7 +2981,9 @@ export default function SettingsView(props: SettingsViewProps) {
                       </div>
                       <Show when={props.opencodeConnectStatus?.error}>
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last error</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last error
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {props.opencodeConnectStatus?.error}
                           </pre>
@@ -2322,28 +2994,42 @@ export default function SettingsView(props: SettingsViewProps) {
                     <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                       <div class="flex items-center justify-between gap-3">
                         <div>
-                          <div class="text-sm font-medium text-gray-12">OpenWork server</div>
-                          <div class="text-xs text-gray-10">Config and approvals sidecar.</div>
+                          <div class="text-sm font-medium text-gray-12">
+                            OpenWork server
+                          </div>
+                          <div class="text-xs text-gray-10">
+                            Config and approvals sidecar.
+                          </div>
                         </div>
-                        <div class={`text-xs px-2 py-1 rounded-full border ${openworkStatusStyle()}`}>
+                        <div
+                          class={`text-xs px-2 py-1 rounded-full border ${openworkStatusStyle()}`}
+                        >
                           {openworkStatusLabel()}
                         </div>
                       </div>
                       <div class="space-y-1">
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          {(props.openworkServerHostInfo?.baseUrl ?? props.openworkServerUrl) || "Base URL unavailable"}
+                          {(props.openworkServerHostInfo?.baseUrl ??
+                            props.openworkServerUrl) ||
+                            "Base URL unavailable"}
                         </div>
-                        <div class="text-[11px] text-gray-7 font-mono truncate">PID: {props.openworkServerHostInfo?.pid ?? "—"}</div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          PID: {props.openworkServerHostInfo?.pid ?? "—"}
+                        </div>
                       </div>
                       <div class="grid gap-2">
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last stdout</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last stdout
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {openworkStdout()}
                           </pre>
                         </div>
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last stderr</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last stderr
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {openworkStderr()}
                           </pre>
@@ -2354,34 +3040,51 @@ export default function SettingsView(props: SettingsViewProps) {
                     <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                       <div class="flex items-center justify-between gap-3">
                         <div>
-                          <div class="text-sm font-medium text-gray-12">OpenCodeRouter sidecar</div>
-                          <div class="text-xs text-gray-10">Messaging bridge service.</div>
+                          <div class="text-sm font-medium text-gray-12">
+                            OpenCodeRouter sidecar
+                          </div>
+                          <div class="text-xs text-gray-10">
+                            Messaging bridge service.
+                          </div>
                         </div>
-                        <div class={`text-xs px-2 py-1 rounded-full border ${opencodeRouterStatusStyle()}`}>
+                        <div
+                          class={`text-xs px-2 py-1 rounded-full border ${opencodeRouterStatusStyle()}`}
+                        >
                           {opencodeRouterStatusLabel()}
                         </div>
                       </div>
                       <div class="space-y-1">
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          {props.opencodeRouterInfo?.opencodeUrl?.trim() || "OpenCode URL unavailable"}
+                          {props.opencodeRouterInfo?.opencodeUrl?.trim() ||
+                            "OpenCode URL unavailable"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          {props.opencodeRouterInfo?.workspacePath?.trim() || "No worker directory"}
+                          {props.opencodeRouterInfo?.workspacePath?.trim() ||
+                            "No worker directory"}
                         </div>
                         <div class="text-[11px] text-gray-7 font-mono truncate">
-                          Health port: {props.opencodeRouterInfo?.healthPort ?? "—"}
+                          Health port:{" "}
+                          {props.opencodeRouterInfo?.healthPort ?? "—"}
                         </div>
-                        <div class="text-[11px] text-gray-7 font-mono truncate">PID: {props.opencodeRouterInfo?.pid ?? "—"}</div>
+                        <div class="text-[11px] text-gray-7 font-mono truncate">
+                          PID: {props.opencodeRouterInfo?.pid ?? "—"}
+                        </div>
                       </div>
                       <div class="flex items-center gap-2">
                         <Button
                           variant="secondary"
                           onClick={handleOpenCodeRouterRestart}
-                          disabled={opencodeRouterRestarting() || !isTauriRuntime()}
+                          disabled={
+                            opencodeRouterRestarting() || !isTauriRuntime()
+                          }
                           class="text-xs px-3 py-1.5"
                         >
-                          <RefreshCcw class={`w-3.5 h-3.5 mr-1.5 ${opencodeRouterRestarting() ? "animate-spin" : ""}`} />
-                          {opencodeRouterRestarting() ? "Restarting..." : "Restart"}
+                          <RefreshCcw
+                            class={`w-3.5 h-3.5 mr-1.5 ${opencodeRouterRestarting() ? "animate-spin" : ""}`}
+                          />
+                          {opencodeRouterRestarting()
+                            ? "Restarting..."
+                            : "Restart"}
                         </Button>
                         <Show when={props.opencodeRouterInfo?.running}>
                           <Button
@@ -2401,13 +3104,17 @@ export default function SettingsView(props: SettingsViewProps) {
                       </Show>
                       <div class="grid gap-2">
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last stdout</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last stdout
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {opencodeRouterStdout()}
                           </pre>
                         </div>
                         <div>
-                          <div class="text-[11px] text-gray-9 mb-1">Last stderr</div>
+                          <div class="text-[11px] text-gray-9 mb-1">
+                            Last stderr
+                          </div>
                           <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-24 overflow-auto bg-gray-2/50 border border-gray-6 rounded-lg p-2">
                             {opencodeRouterStderr()}
                           </pre>
@@ -2418,27 +3125,42 @@ export default function SettingsView(props: SettingsViewProps) {
 
                   <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                     <div class="flex items-center justify-between gap-3">
-                      <div class="text-sm font-medium text-gray-12">OpenWork server diagnostics</div>
+                      <div class="text-sm font-medium text-gray-12">
+                        OpenWork server diagnostics
+                      </div>
                       <div class="text-[11px] text-gray-8 font-mono truncate">
                         {props.openworkServerDiagnostics?.version ?? "—"}
                       </div>
                     </div>
                     <Show
                       when={props.openworkServerDiagnostics}
-                      fallback={<div class="text-xs text-gray-9">Diagnostics unavailable.</div>}
+                      fallback={
+                        <div class="text-xs text-gray-9">
+                          Diagnostics unavailable.
+                        </div>
+                      }
                     >
                       {(diag) => (
                         <div class="grid md:grid-cols-2 gap-2 text-xs text-gray-11">
                           <div>Started: {formatUptime(diag().uptimeMs)}</div>
-                          <div>Read-only: {diag().readOnly ? "true" : "false"}</div>
                           <div>
-                            Approval: {diag().approval.mode} ({diag().approval.timeoutMs}ms)
+                            Read-only: {diag().readOnly ? "true" : "false"}
+                          </div>
+                          <div>
+                            Approval: {diag().approval.mode} (
+                            {diag().approval.timeoutMs}ms)
                           </div>
                           <div>Workspaces: {diag().workspaceCount}</div>
-                          <div>Active workspace: {diag().activeWorkspaceId ?? "—"}</div>
-                          <div>Config path: {diag().server.configPath ?? "default"}</div>
+                          <div>
+                            Active workspace: {diag().activeWorkspaceId ?? "—"}
+                          </div>
+                          <div>
+                            Config path: {diag().server.configPath ?? "default"}
+                          </div>
                           <div>Token source: {diag().tokenSource.client}</div>
-                          <div>Host token source: {diag().tokenSource.host}</div>
+                          <div>
+                            Host token source: {diag().tokenSource.host}
+                          </div>
                         </div>
                       )}
                     </Show>
@@ -2446,40 +3168,61 @@ export default function SettingsView(props: SettingsViewProps) {
 
                   <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                     <div class="flex items-center justify-between gap-3">
-                      <div class="text-sm font-medium text-gray-12">OpenWork server capabilities</div>
+                      <div class="text-sm font-medium text-gray-12">
+                        OpenWork server capabilities
+                      </div>
                       <div class="text-[11px] text-gray-8 font-mono truncate">
-                        {props.openworkServerWorkspaceId ? `Worker ${props.openworkServerWorkspaceId}` : "Worker unresolved"}
+                        {props.openworkServerWorkspaceId
+                          ? `Worker ${props.openworkServerWorkspaceId}`
+                          : "Worker unresolved"}
                       </div>
                     </div>
                     <Show
                       when={props.openworkServerCapabilities}
-                      fallback={<div class="text-xs text-gray-9">Capabilities unavailable. Connect with a client token.</div>}
+                      fallback={
+                        <div class="text-xs text-gray-9">
+                          Capabilities unavailable. Connect with a client token.
+                        </div>
+                      }
                     >
                       {(caps) => (
                         <div class="grid md:grid-cols-2 gap-2 text-xs text-gray-11">
                           <div>Skills: {formatCapability(caps().skills)}</div>
                           <div>Plugins: {formatCapability(caps().plugins)}</div>
                           <div>MCP: {formatCapability(caps().mcp)}</div>
-                          <div>Commands: {formatCapability(caps().commands)}</div>
-                          <div>Config: {formatCapability(caps().config)}</div>
-                          <div>Proxy (OpenCodeRouter): {caps().proxy?.opencodeRouter ? "enabled" : "disabled"}</div>
                           <div>
-                            Browser tools: {(() => {
+                            Commands: {formatCapability(caps().commands)}
+                          </div>
+                          <div>Config: {formatCapability(caps().config)}</div>
+                          <div>
+                            Proxy (OpenCodeRouter):{" "}
+                            {caps().proxy?.opencodeRouter
+                              ? "enabled"
+                              : "disabled"}
+                          </div>
+                          <div>
+                            Browser tools:{" "}
+                            {(() => {
                               const browser = caps().toolProviders?.browser;
                               if (!browser?.enabled) return "disabled";
                               return `${browser.mode} · ${browser.placement}`;
                             })()}
                           </div>
                           <div>
-                            File tools: {(() => {
+                            File tools:{" "}
+                            {(() => {
                               const files = caps().toolProviders?.files;
                               if (!files) return "Unavailable";
-                              const parts = [files.injection ? "inbox on" : "inbox off", files.outbox ? "outbox on" : "outbox off"];
+                              const parts = [
+                                files.injection ? "inbox on" : "inbox off",
+                                files.outbox ? "outbox on" : "outbox off",
+                              ];
                               return parts.join(" · ");
                             })()}
                           </div>
                           <div>
-                            Sandbox: {(() => {
+                            Sandbox:{" "}
+                            {(() => {
                               const sandbox = caps().sandbox;
                               return sandbox
                                 ? `${sandbox.backend} (${sandbox.enabled ? "on" : "off"})`
@@ -2493,7 +3236,9 @@ export default function SettingsView(props: SettingsViewProps) {
 
                   <div class="grid md:grid-cols-2 gap-4">
                     <div class="bg-gray-1 border border-gray-6 rounded-xl p-4">
-                      <div class="text-xs text-gray-10 mb-2">Pending permissions</div>
+                      <div class="text-xs text-gray-10 mb-2">
+                        Pending permissions
+                      </div>
                       <pre class="text-xs text-gray-12 whitespace-pre-wrap break-words max-h-64 overflow-auto">
                         {props.safeStringify(props.pendingPermissions)}
                       </pre>
@@ -2508,7 +3253,9 @@ export default function SettingsView(props: SettingsViewProps) {
 
                   <div class="bg-gray-1 border border-gray-6 rounded-xl p-4">
                     <div class="flex items-center justify-between gap-3 mb-2">
-                      <div class="text-xs text-gray-10">Workspace debug events</div>
+                      <div class="text-xs text-gray-10">
+                        Workspace debug events
+                      </div>
                       <Button
                         variant="outline"
                         class="text-xs h-7 py-0 px-2 shrink-0"
@@ -2525,30 +3272,45 @@ export default function SettingsView(props: SettingsViewProps) {
 
                   <div class="bg-gray-1 p-4 rounded-xl border border-gray-6 space-y-3">
                     <div class="flex items-center justify-between gap-3">
-                      <div class="text-sm font-medium text-gray-12">Audit log</div>
-                      <div class={`text-xs px-2 py-1 rounded-full border ${openworkAuditStatusStyle()}`}>
+                      <div class="text-sm font-medium text-gray-12">
+                        Audit log
+                      </div>
+                      <div
+                        class={`text-xs px-2 py-1 rounded-full border ${openworkAuditStatusStyle()}`}
+                      >
                         {openworkAuditStatusLabel()}
                       </div>
                     </div>
                     <Show when={props.openworkAuditError}>
-                      <div class="text-xs text-red-11">{props.openworkAuditError}</div>
+                      <div class="text-xs text-red-11">
+                        {props.openworkAuditError}
+                      </div>
                     </Show>
                     <Show
                       when={props.openworkAuditEntries.length > 0}
-                      fallback={<div class="text-xs text-gray-9">No audit entries yet.</div>}
+                      fallback={
+                        <div class="text-xs text-gray-9">
+                          No audit entries yet.
+                        </div>
+                      }
                     >
                       <div class="divide-y divide-gray-6/50">
                         <For each={props.openworkAuditEntries}>
                           {(entry) => (
                             <div class="flex items-start justify-between gap-4 py-2">
                               <div class="min-w-0">
-                                <div class="text-sm text-gray-12 truncate">{entry.summary}</div>
+                                <div class="text-sm text-gray-12 truncate">
+                                  {entry.summary}
+                                </div>
                                 <div class="text-[11px] text-gray-9 truncate">
-                                  {entry.action} · {entry.target} · {formatActor(entry)}
+                                  {entry.action} · {entry.target} ·{" "}
+                                  {formatActor(entry)}
                                 </div>
                               </div>
                               <div class="text-[11px] text-gray-9 whitespace-nowrap">
-                                {entry.timestamp ? formatRelativeTime(entry.timestamp) : "—"}
+                                {entry.timestamp
+                                  ? formatRelativeTime(entry.timestamp)
+                                  : "—"}
                               </div>
                             </div>
                           )}


### PR DESCRIPTION
## Summary
- add an app-side `getOpenWorkDeployment()` helper and use it to gate desktop-only worker creation and advanced settings affordances in hosted web
- keep the dashboard and session right sidebars aligned, default them open, and switch mobile to a hamburger-driven drawer with the same expanded sidebar content
- keep Automations, Skills, Extensions, Messaging, and Inbox navigable on web while showing an unavailable banner, disabling page actions, and dismissing the mobile keyboard after send

## Testing
- `pnpm typecheck`

## Verification Notes
- Docker/Chrome MCP UI verification was not run in this session