### PR TITLE
fix(den): hide mobile rename summary and repair docker startup

### DIFF
--- a/packages/web/components/cloud-control.tsx
+++ b/packages/web/components/cloud-control.tsx
@@ -3037,7 +3037,7 @@ export function CloudControlPanel() {
               </div>
             </div>
 
-            <div className="grid content-start gap-4 rounded-[30px] border border-[var(--dls-border)] bg-[var(--dls-hover)] p-5 md:p-6">
+            <div className="hidden content-start gap-4 rounded-[30px] border border-[var(--dls-border)] bg-[var(--dls-hover)] p-5 md:grid md:p-6">
               <div className="rounded-[24px] border border-white bg-white p-5 shadow-sm">
                 <div className="flex items-center gap-3">
                   <div className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-[#011627] text-[11px] font-semibold text-white">OW</div>

--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -23,4 +23,4 @@ RUN pnpm --dir /app/services/den run build
 
 EXPOSE 8788
 
-CMD ["sh", "-lc", "node dist/index.js"]
+CMD ["sh", "-lc", "node services/den/dist/index.js"]

--- a/packaging/docker/Dockerfile.den-worker-proxy
+++ b/packaging/docker/Dockerfile.den-worker-proxy
@@ -23,4 +23,4 @@ RUN pnpm --dir /app/services/den-worker-proxy run build
 
 EXPOSE 8789
 
-CMD ["sh", "-lc", "node dist/server.js"]
+CMD ["sh", "-lc", "node services/den-worker-proxy/dist/server.js"]


### PR DESCRIPTION
## Summary
- hide the secondary provisioning summary panel on the Den worker rename step below `md` so the mobile onboarding flow stays focused on the main form
- point the Den and worker-proxy Docker images at their built service entrypoints so the local Den stack can boot for onboarding verification

## Testing
- `packaging/docker/dev-up.sh`
- `packaging/docker/den-dev-up.sh`
- `DATABASE_URL=\"mysql://root:password@127.0.0.1:57153/openwork_den\" pnpm --dir services/den db:migrate:sql`
- Chrome DevTools mobile viewport (`390x844`) through Den signup to the `Name your worker` step; verified the secondary card is hidden on mobile and still visible on desktop

## Notes
- local verification screenshot saved at `/tmp/cleanup-den-onboarding-mobile.png`
- the Den stack still required the manual SQL migration above before signup worked end to end