### PR TITLE
fix(den): accept bearer auth on worker routes

### DIFF
--- a/services/den-v2/src/http/workers.ts
+++ b/services/den-v2/src/http/workers.ts
@@ -1,14 +1,13 @@
 import { randomBytes } from "crypto"
 import express from "express"
-import { fromNodeHeaders } from "better-auth/node"
 import { and, asc, desc, eq, isNull } from "../db/drizzle.js"
 import { z } from "zod"
-import { auth } from "../auth.js"
 import { getCloudWorkerBillingStatus, requireCloudWorkerAccess, setCloudWorkerSubscriptionCancellation } from "../billing/polar.js"
 import { db } from "../db/index.js"
 import { AuditEventTable, AuthUserTable, DaytonaSandboxTable, OrgMembershipTable, WorkerBundleTable, WorkerInstanceTable, WorkerTable, WorkerTokenTable } from "../db/schema.js"
 import { env } from "../env.js"
 import { asyncRoute, isTransientDbConnectionError } from "./errors.js"
+import { getRequestSession } from "./session.js"
 import { ensureDefaultOrg } from "../orgs.js"
 import { deprovisionWorker, provisionWorker } from "../workers/provisioner.js"
 import { customDomainForWorker } from "../workers/vanity-domain.js"
@@ -231,9 +230,7 @@ async function fetchWorkerRuntimeJson(input: {
 }
 
 async function requireSession(req: express.Request, res: express.Response) {
-  const session = await auth.api.getSession({
-    headers: fromNodeHeaders(req.headers),
-  })
+  const session = await getRequestSession(req)
   if (!session?.user?.id) {
     res.status(401).json({ error: "unauthorized" })
     return null

--- a/services/den/src/http/workers.ts
+++ b/services/den/src/http/workers.ts
@@ -1,9 +1,7 @@
 import { randomBytes } from "crypto"
 import express from "express"
-import { fromNodeHeaders } from "better-auth/node"
 import { and, asc, desc, eq, isNull } from "../db/drizzle.js"
 import { z } from "zod"
-import { auth } from "../auth.js"
 // Polar billing is temporarily disabled for the one-worker experiment in hosted mode.
 // Keep the old billing integration nearby so it can be restored quickly.
 // import { getCloudWorkerBillingStatus, setCloudWorkerSubscriptionCancellation } from "../billing/polar.js"
@@ -11,6 +9,7 @@ import { db } from "../db/index.js"
 import { AuditEventTable, AuthUserTable, DaytonaSandboxTable, OrgMembershipTable, WorkerBundleTable, WorkerInstanceTable, WorkerTable, WorkerTokenTable } from "../db/schema.js"
 import { env } from "../env.js"
 import { asyncRoute, isTransientDbConnectionError } from "./errors.js"
+import { getRequestSession } from "./session.js"
 import { ensureDefaultOrg } from "../orgs.js"
 import { deprovisionWorker, provisionWorker } from "../workers/provisioner.js"
 import { customDomainForWorker } from "../workers/vanity-domain.js"
@@ -233,9 +232,7 @@ async function fetchWorkerRuntimeJson(input: {
 }
 
 async function requireSession(req: express.Request, res: express.Response) {
-  const session = await auth.api.getSession({
-    headers: fromNodeHeaders(req.headers),
-  })
+  const session = await getRequestSession(req)
   if (!session?.user?.id) {
     res.status(401).json({ error: "unauthorized" })
     return null


### PR DESCRIPTION
## Summary
- switch Den worker route auth to use the shared request-session resolver instead of cookie-only Better Auth session lookup
- allow `/v1/workers` endpoints to authenticate desktop handoff sessions that arrive with bearer tokens
- apply the same fix in both `den` and `den-v2` so org loading and worker loading use the same auth behavior

## Why
Desktop sign-in had progressed far enough to load orgs, but worker requests still returned `unauthorized`. The worker routers were still using cookie-only session lookup, while the desktop flow stores and sends the Den session as a bearer token.

## Testing
- `pnpm install`
- `pnpm --dir services/den build`
- `pnpm --dir services/den-v2 build`

## Notes
- `pnpm install` emitted non-blocking warnings about missing generated bins in sibling packages before those packages are built, but the Den builds completed successfully afterward.