### PR TITLE
fix(app): route new-session Claude CTA to Anthropic

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1375,6 +1375,7 @@ export default function App() {
   const [providerAuthBusy, setProviderAuthBusy] = createSignal(false);
   const [providerAuthError, setProviderAuthError] = createSignal<string | null>(null);
   const [providerAuthMethods, setProviderAuthMethods] = createSignal<Record<string, ProviderAuthMethod[]>>({});
+  const [providerAuthPreferredProviderId, setProviderAuthPreferredProviderId] = createSignal<string | null>(null);
   const [providerAuthReturnFocusTarget, setProviderAuthReturnFocusTarget] =
     createSignal<PromptFocusReturnTarget>("none");
 
@@ -2530,8 +2531,10 @@ export default function App() {
 
   async function openProviderAuthModal(options?: {
     returnFocusTarget?: PromptFocusReturnTarget;
+    preferredProviderId?: string;
   }) {
     setProviderAuthReturnFocusTarget(options?.returnFocusTarget ?? "none");
+    setProviderAuthPreferredProviderId(options?.preferredProviderId?.trim() || null);
     setProviderAuthBusy(true);
     setProviderAuthError(null);
     try {
@@ -2539,6 +2542,7 @@ export default function App() {
       setProviderAuthMethods(methods);
       setProviderAuthModalOpen(true);
     } catch (error) {
+      setProviderAuthPreferredProviderId(null);
       setProviderAuthReturnFocusTarget("none");
       const message = describeProviderError(error, "Failed to load providers");
       setProviderAuthError(message);
@@ -2554,6 +2558,7 @@ export default function App() {
       providerAuthReturnFocusTarget() === "composer";
     setProviderAuthModalOpen(false);
     setProviderAuthError(null);
+    setProviderAuthPreferredProviderId(null);
     setProviderAuthReturnFocusTarget("none");
     if (shouldFocusPrompt) {
       focusSessionPromptSoon();
@@ -6741,6 +6746,7 @@ export default function App() {
       providerAuthModalOpen: providerAuthModalOpen(),
       providerAuthError: providerAuthError(),
       providerAuthMethods: providerAuthMethods(),
+      providerAuthPreferredProviderId: providerAuthPreferredProviderId(),
       openProviderAuthModal,
       disconnectProvider,
       closeProviderAuthModal,
@@ -7101,6 +7107,7 @@ export default function App() {
     providerAuthBusy: providerAuthBusy(),
     providerAuthError: providerAuthError(),
     providerAuthMethods: providerAuthMethods(),
+    providerAuthPreferredProviderId: providerAuthPreferredProviderId(),
     providers: providers(),
     providerConnectedIds: providerConnectedIds(),
     listAgents: listAgents,

--- a/packages/app/src/app/components/provider-auth-modal.tsx
+++ b/packages/app/src/app/components/provider-auth-modal.tsx
@@ -44,6 +44,7 @@ export type ProviderAuthModalProps = {
   loading: boolean;
   submitting: boolean;
   error: string | null;
+  preferredProviderId?: string | null;
   providers: ProviderListItem[];
   connectedProviderIds: string[];
   authMethods: Record<string, ProviderAuthMethod[]>;
@@ -125,6 +126,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const [localError, setLocalError] = createSignal<string | null>(null);
   const [pollingBusy, setPollingBusy] = createSignal(false);
   const [oauthAutoBusy, setOauthAutoBusy] = createSignal(false);
+  const [autoOpenedPreferredProviderId, setAutoOpenedPreferredProviderId] = createSignal<string | null>(null);
   let searchInputEl: HTMLInputElement | undefined;
   let providerPoll: number | null = null;
   let oauthAutoPoll: number | null = null;
@@ -171,6 +173,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
   createEffect(() => {
     if (!props.open) {
+      setAutoOpenedPreferredProviderId(null);
       resetState();
     }
   });
@@ -189,6 +192,21 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     if (!props.open || resolvedView() !== "list") return;
     queueMicrotask(() => {
       searchInputEl?.focus();
+    });
+  });
+
+  createEffect(() => {
+    if (!props.open || props.loading || resolvedView() !== "list") return;
+
+    const preferredId = props.preferredProviderId?.trim().toLowerCase() ?? "";
+    if (!preferredId || autoOpenedPreferredProviderId() === preferredId) return;
+
+    const entry = entries().find((item) => item.id.trim().toLowerCase() === preferredId);
+    if (!entry) return;
+
+    setAutoOpenedPreferredProviderId(preferredId);
+    queueMicrotask(() => {
+      handleEntrySelect(entry);
     });
   });
 

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -91,8 +91,10 @@ export type DashboardViewProps = {
   providerAuthModalOpen: boolean;
   providerAuthError: string | null;
   providerAuthMethods: Record<string, ProviderAuthMethod[]>;
+  providerAuthPreferredProviderId: string | null;
   openProviderAuthModal: (options?: {
     returnFocusTarget?: "none" | "composer";
+    preferredProviderId?: string;
   }) => Promise<void>;
   disconnectProvider: (providerId: string) => Promise<string | void>;
   closeProviderAuthModal: (options?: { restorePromptFocus?: boolean }) => void;
@@ -1586,6 +1588,7 @@ export default function DashboardView(props: DashboardViewProps) {
           loading={props.providerAuthBusy}
           submitting={providerAuthActionBusy()}
           error={props.providerAuthError}
+          preferredProviderId={props.providerAuthPreferredProviderId}
           providers={props.providers}
           connectedProviderIds={props.providerConnectedIds}
           authMethods={props.providerAuthMethods}

--- a/packages/app/src/app/pages/session.tsx
+++ b/packages/app/src/app/pages/session.tsx
@@ -260,12 +260,14 @@ export type SessionViewProps = {
   refreshProviders: () => Promise<unknown>;
   openProviderAuthModal: (options?: {
     returnFocusTarget?: "none" | "composer";
+    preferredProviderId?: string;
   }) => Promise<void>;
   closeProviderAuthModal: (options?: { restorePromptFocus?: boolean }) => void;
   providerAuthModalOpen: boolean;
   providerAuthBusy: boolean;
   providerAuthError: string | null;
   providerAuthMethods: Record<string, ProviderAuthMethod[]>;
+  providerAuthPreferredProviderId: string | null;
   providers: ProviderListItem[];
   providerConnectedIds: string[];
   listAgents: () => Promise<Agent[]>;
@@ -3907,16 +3909,21 @@ export default function SessionView(props: SessionViewProps) {
     props.setView("dashboard");
   };
 
-  const openProviderAuth = () => {
-    void props.openProviderAuthModal().catch((error) => {
+  const openProviderAuth = (preferredProviderId?: string) => {
+    void props.openProviderAuthModal({ preferredProviderId }).catch((error) => {
       const message = error instanceof Error ? error.message : "Connect failed";
       setToastMessage(message);
     });
   };
 
-  const hasOpenAIProviderConnected = createMemo(() =>
-    (props.providerConnectedIds ?? []).some((id) => id.trim().toLowerCase() === "openai")
+  const openNewSessionProviderCta = () => {
+    openProviderAuth("anthropic");
+  };
+
+  const hasAnthropicProviderConnected = createMemo(() =>
+    (props.providerConnectedIds ?? []).some((id) => id.trim().toLowerCase() === "anthropic")
   );
+  const showNewSessionProviderCta = createMemo(() => !hasAnthropicProviderConnected());
   const rightSidebarNavButton = (
     label: string,
     icon: any,
@@ -4532,17 +4539,17 @@ export default function SessionView(props: SessionViewProps) {
                         </p>
                       </div>
                       <div class="grid gap-3 max-w-lg mx-auto text-left">
-                        <Show when={!hasOpenAIProviderConnected()}>
+                        <Show when={showNewSessionProviderCta()}>
                           <button
                             type="button"
                             class="rounded-2xl border border-dls-border bg-dls-hover p-4 transition-all hover:bg-dls-active hover:border-gray-7"
-                            onClick={openProviderAuth}
+                            onClick={openNewSessionProviderCta}
                           >
                             <div class="text-sm font-semibold text-dls-text">
-                              Connect ChatGPT
+                              Connect Claude
                             </div>
                             <div class="mt-1 text-xs text-dls-secondary leading-relaxed">
-                              Add your OpenAI provider so ChatGPT-style models are ready in new sessions.
+                              Add your Anthropic provider so Claude models are ready in new sessions.
                             </div>
                           </button>
                         </Show>
@@ -4967,6 +4974,7 @@ export default function SessionView(props: SessionViewProps) {
         loading={props.providerAuthBusy}
         submitting={providerAuthActionBusy()}
         error={props.providerAuthError}
+        preferredProviderId={props.providerAuthPreferredProviderId}
         providers={props.providers}
         connectedProviderIds={props.providerConnectedIds}
         authMethods={props.providerAuthMethods}

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -85,6 +85,7 @@ export type SettingsViewProps = {
   providerAuthBusy: boolean;
   openProviderAuthModal: (options?: {
     returnFocusTarget?: "none" | "composer";
+    preferredProviderId?: string;
   }) => Promise<void>;
   disconnectProvider: (providerId: string) => Promise<string | void>;
   openworkServerStatus: OpenworkServerStatus;


### PR DESCRIPTION
## Summary
- replace the empty-session ChatGPT/OpenAI prompt with a Claude/Anthropic CTA and hide it once Anthropic is already connected
- add preferred-provider support to the provider auth modal so entry points can open directly into the Anthropic connect flow
- thread the preferred provider state through the app, session, and dashboard surfaces that render the auth modal

## Testing
- pnpm install
- pnpm --filter @different-ai/openwork-ui typecheck
- pnpm --filter @different-ai/openwork-ui build
- bash packaging/docker/dev-up.sh
- Chrome MCP: opened `/session`, verified the `Connect Claude` CTA, clicked it, and confirmed the Anthropic auth options opened directly
- docker compose -p openwork-dev-3d2c3c94 -f packaging/docker/docker-compose.dev.yml down