### PR TITLE
fix(web): keep open-in-web auto-connect on session

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4285,8 +4285,12 @@ export default function App() {
       return;
     }
 
-    setView("dashboard");
-    setTab("scheduled");
+    if (pending.autoConnect) {
+      setView("session");
+    } else {
+      setView("dashboard");
+      setTab("scheduled");
+    }
     setPendingRemoteConnectDeepLink(null);
     void completeRemoteConnectDeepLink(pending);
   });


### PR DESCRIPTION
## Summary
- keep Den open-in-web auto-connect flows on the session surface instead of forcing the Automations dashboard first
- preserve the existing dashboard + scheduled-tab routing for non-auto-connect remote invite links
- align the bypassed add-worker flow with the existing empty session state so the worker connects in the background without a visible dashboard flash