### PR TITLE
Fix/bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,15 +7,15 @@ body:
   - type: textarea
     id: summary
     attributes:
-      label: Describe the bug
-      description: A clear and concise description of what the bug is.
+      label: Summary
+      description: What's not working / wrong?
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
       label: To Reproduce
-      description: "Minimal Steps to reproduce the behavior:"
+      description: "Minimal Steps to reproduce the issue:"
       placeholder: |
         1. Go to '...'
         2. Click on '....'
@@ -27,7 +27,14 @@ body:
     id: expected
     attributes:
       label: Expected behavior
-      description: A clear and concise description of what you expected to happen.
+      description: A short description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Actual behavior
+      description: A short description of what actually happened.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,30 +7,52 @@ body:
   - type: textarea
     id: summary
     attributes:
-      label: Summary
-      description: What went wrong?
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
-      label: Steps to reproduce
-      description: Minimal steps to reproduce the issue.
+      label: To Reproduce
+      description: "Minimal Steps to reproduce the behavior:"
       placeholder: |
-        1. ...
-        2. ...
-        3. ...
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
     validations:
       required: true
   - type: textarea
-    id: actual
+    id: screenshots
     attributes:
-      label: Actual behavior
+      label: Screenshots
+      description: If applicable, add screenshots or a video to help explain your problem.
     validations:
-      required: true
+      required: false
+  - type: textarea
+    id: desktop_info
+    attributes:
+      label: OW version & Desktop info (optional) 
+      description: |
+        Include OS and OpenWork version if possible.
+        OpenWork version: Settings > General.
+      placeholder: |
+        - OpenWork version: [e.g. 0.1.166]
+        - OS: [e.g. macOS Tahoe 26.2]
+    validations:
+      required: false
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context (optional)
+      description: Add any other context about the problem here.
+    validations:
+      required: false


### PR DESCRIPTION
# Summary
Cleaned up the bug report template so people can file useful issues faster.
Added optional fields for OpenWork version/OS and extra context.

# Why
Better issue reports mean less back-and-forth and faster fixes.
Version + OS info helps us reproduce bugs right away.