### PR TITLE
fix(desktop): forward deep links to the running app

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2791,6 +2791,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "ureq",
  "uuid",
@@ -4859,6 +4860,22 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-http = "2.5.6"
 tauri-plugin-opener = "2.5.3"
 tauri-plugin-shell = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 uuid = { version = "1", features = ["v4"] }
 ureq = { version = "2.10", features = ["json"] }
 gethostname = "0.4"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -92,6 +92,15 @@ fn stop_managed_services(app_handle: &tauri::AppHandle) {
 
 pub fn run() {
     let builder = tauri::Builder::default()
+        // Keep a single desktop instance alive so protocol links can be forwarded
+        // into the running app instead of being dropped by a short-lived second one.
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())


### PR DESCRIPTION
## Summary
- add Tauri's single-instance plugin alongside the existing deep-link plugin so `openwork://` launches are forwarded into the already-running desktop app
- refocus the main window when a second launch is attempted so the warmed app can handle the share import flow instead of leaving the handoff to a short-lived duplicate process
- document the single-instance guard inline in the desktop bootstrap code

## Testing
- `cargo check` in `packages/desktop/src-tauri`

## Notes
- I did not run the full Docker + Chrome MCP end-to-end flow in this pass; you said you'll verify the share-link behavior manually on another machine.
- This PR is intended to address issue #1022.