### PR TITLE
Hide OpenWork to tray on close

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ json5 = "0.4"
 notify = "6.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-http = "2.5.6"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -236,6 +236,15 @@ pub fn run() {
             api.prevent_close();
             hide_main_window(&app_handle);
         }
+        #[cfg(target_os = "macos")]
+        RunEvent::Reopen {
+            has_visible_windows,
+            ..
+        } => {
+            if !has_visible_windows {
+                show_main_window(&app_handle);
+            }
+        }
         _ => {}
     });
 }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -56,7 +56,7 @@ use opencode_router::manager::OpenCodeRouterManager;
 use openwork_server::manager::OpenworkServerManager;
 use orchestrator::manager::OrchestratorManager;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
-use tauri::tray::TrayIconBuilder;
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Manager, RunEvent, WindowEvent};
 use workspace::watch::WorkspaceWatchState;
 
@@ -129,10 +129,21 @@ pub fn run() {
             let mut tray = TrayIconBuilder::with_id("main-tray")
                 .menu(&menu)
                 .tooltip("OpenWork")
+                .show_menu_on_left_click(false)
                 .on_menu_event(|app, event| match event.id.as_ref() {
                     "tray-show" => show_main_window(app),
                     "tray-quit" => app.exit(0),
                     _ => {}
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if let TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    } = event
+                    {
+                        show_main_window(tray.app_handle());
+                    }
                 });
 
             if let Some(icon) = app.default_window_icon().cloned() {

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -55,7 +55,9 @@ use engine::manager::EngineManager;
 use opencode_router::manager::OpenCodeRouterManager;
 use openwork_server::manager::OpenworkServerManager;
 use orchestrator::manager::OrchestratorManager;
-use tauri::Manager;
+use tauri::menu::{MenuBuilder, MenuItemBuilder};
+use tauri::tray::TrayIconBuilder;
+use tauri::{AppHandle, Manager, RunEvent, WindowEvent};
 use workspace::watch::WorkspaceWatchState;
 
 #[cfg(target_os = "macos")]
@@ -74,6 +76,19 @@ fn set_dev_app_name() {
 
 #[cfg(not(target_os = "macos"))]
 fn set_dev_app_name() {}
+
+fn show_main_window(app_handle: &AppHandle) {
+    if let Some(window) = app_handle.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+fn hide_main_window(app_handle: &AppHandle) {
+    if let Some(window) = app_handle.get_webview_window("main") {
+        let _ = window.hide();
+    }
+}
 
 fn stop_managed_services(app_handle: &tauri::AppHandle) {
     if let Ok(mut engine) = app_handle.state::<EngineManager>().inner.lock() {
@@ -104,8 +119,28 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build());
 
     let app = builder
-        .setup(|_| {
+        .setup(|app| {
             set_dev_app_name();
+
+            let show_item = MenuItemBuilder::with_id("tray-show", "Show OpenWork").build(app)?;
+            let quit_item = MenuItemBuilder::with_id("tray-quit", "Quit OpenWork").build(app)?;
+            let menu = MenuBuilder::new(app).items(&[&show_item, &quit_item]).build()?;
+
+            let mut tray = TrayIconBuilder::with_id("main-tray")
+                .menu(&menu)
+                .tooltip("OpenWork")
+                .on_menu_event(|app, event| match event.id.as_ref() {
+                    "tray-show" => show_main_window(app),
+                    "tray-quit" => app.exit(0),
+                    _ => {}
+                });
+
+            if let Some(icon) = app.default_window_icon().cloned() {
+                tray = tray.icon(icon);
+            }
+
+            let tray = tray.build(app)?;
+            app.manage(tray);
             Ok(())
         })
         .manage(EngineManager::default())
@@ -181,14 +216,14 @@ pub fn run() {
     // running after the UI quits (especially during dev), leading to multiple
     // orchestrator/opencode/openwork-server processes and stale ports.
     app.run(|app_handle, event| match event {
-        tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
-            stop_managed_services(&app_handle);
-        }
-        tauri::RunEvent::WindowEvent {
-            event: tauri::WindowEvent::CloseRequested { .. },
+        RunEvent::ExitRequested { .. } | RunEvent::Exit => stop_managed_services(&app_handle),
+        RunEvent::WindowEvent {
+            label,
+            event: WindowEvent::CloseRequested { api, .. },
             ..
-        } => {
-            stop_managed_services(&app_handle);
+        } if label == "main" => {
+            api.prevent_close();
+            hide_main_window(&app_handle);
         }
         _ => {}
     });


### PR DESCRIPTION
## Summary
- keep the desktop app alive when the main window is closed by preventing the close request and hiding the window instead
- add a tray icon with `Show OpenWork` and `Quit OpenWork` actions so the hidden app can be restored or exited explicitly
- keep the existing sidecar cleanup on real app exit, and enable Tauri's `tray-icon` feature to support the new tray behavior

## Testing
- `cargo check` in `packages/desktop/src-tauri`
- local dev run via `pnpm dev`
- temporary local-only instrumentation (removed before commit) verified the close path kept the process alive while the window count dropped to 0, and the show helper restored the window count to 1

## Notes
- I could not attach before/after screenshots because this environment does not have macOS Screen Recording permission (`CGPreflightScreenCaptureAccess()` was false and `screencapture` failed with `could not create image from display`)
- I attempted native capture before and after the change, but the OS permission blocker prevented artifact generation
- reviewer reproduction: run `pnpm dev`, close the window, then use the tray icon menu to choose `Show OpenWork` or `Quit OpenWork`