### PR TITLE
fix(app): make Cloud settings self-serve

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1,5 +1,6 @@
 import {
   Match,
+  Show,
   Switch,
   createEffect,
   createMemo,
@@ -687,7 +688,7 @@ function parseDenAuthDeepLink(rawUrl: string): DenAuthDeepLink | null {
   return { grant, denBaseUrl };
 }
 
-function normalizeDebugShareLinkInput(rawValue: string): string {
+function normalizeDebugDeepLinkInput(rawValue: string): string {
   const trimmed = rawValue.trim();
   if (!trimmed) return "";
 
@@ -700,12 +701,18 @@ function normalizeDebugShareLinkInput(rawValue: string): string {
   return trimmed;
 }
 
-function parseDebugShareLinkInput(rawValue: string):
+function parseDebugDeepLinkInput(rawValue: string):
   | { kind: "bundle"; link: SharedBundleDeepLink }
   | { kind: "remote"; link: RemoteWorkspaceDefaults }
+  | { kind: "auth"; link: DenAuthDeepLink }
   | null {
-  const normalized = normalizeDebugShareLinkInput(rawValue);
+  const normalized = normalizeDebugDeepLinkInput(rawValue);
   if (!normalized) return null;
+
+  const denAuthLink = parseDenAuthDeepLink(normalized);
+  if (denAuthLink) {
+    return { kind: "auth", link: denAuthLink };
+  }
 
   const sharedBundleLink = parseSharedBundleDeepLink(normalized);
   if (sharedBundleLink) {
@@ -4057,8 +4064,8 @@ export default function App() {
     return true;
   };
 
-  const openDebugShareLink = async (rawUrl: string): Promise<{ ok: boolean; message: string }> => {
-    const parsed = parseDebugShareLinkInput(rawUrl);
+  const openDebugDeepLink = async (rawUrl: string): Promise<{ ok: boolean; message: string }> => {
+    const parsed = parseDebugDeepLinkInput(rawUrl);
     if (!parsed) {
       return { ok: false, message: "That link is not a recognized OpenWork deep link or share URL." };
     }
@@ -4097,6 +4104,11 @@ export default function App() {
         setSharedBundleImportBusy(false);
       }
     }
+    if (parsed.kind === "auth") {
+      setPendingDenAuthDeepLink(parsed.link);
+      return { ok: true, message: "Queued the Cloud auth deep link for OpenWork." };
+    }
+
     setPendingRemoteConnectDeepLink(parsed.kind === "remote" ? parsed.link : null);
     setTab("scheduled");
     return { ok: true, message: "Queued remote worker link. OpenWork should move into the connect flow." };
@@ -4245,7 +4257,7 @@ export default function App() {
     setProcessingDenAuthDeepLink(true);
     setPendingDenAuthDeepLink(null);
     setView("dashboard");
-    setSettingsTab(developerMode() ? "den" : "general");
+    setSettingsTab("den");
     goToDashboard("settings");
 
     void createDenClient({ baseUrl: pending.denBaseUrl })
@@ -6958,7 +6970,7 @@ export default function App() {
       notionError: notionError(),
       notionBusy: notionBusy(),
       connectNotion,
-      openDebugShareLink,
+      openDebugDeepLink,
       mcpServers: mcpServers(),
       mcpStatus: mcpStatus(),
       mcpLastUpdatedAt: mcpLastUpdatedAt(),

--- a/packages/app/src/app/components/den-settings-panel.tsx
+++ b/packages/app/src/app/components/den-settings-panel.tsx
@@ -3,6 +3,7 @@ import { ArrowUpRight, Cloud, CreditCard, LogOut, RefreshCcw, Server, Users } fr
 import Button from "./button";
 import TextInput from "./text-input";
 import {
+  clearDenSession,
   DEFAULT_DEN_BASE_URL,
   DenApiError,
   type DenBillingSummary,
@@ -230,6 +231,20 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     platform.openLink(normalized);
   };
 
+  const clearSignedInState = (message?: string | null) => {
+    clearDenSession({ includeBaseUrls: !props.developerMode });
+    if (!props.developerMode) {
+      setBaseUrl(DEFAULT_DEN_BASE_URL);
+      setBaseUrlDraft(DEFAULT_DEN_BASE_URL);
+    }
+    setAuthToken("");
+    setOpeningWorkerId(null);
+    clearSessionState();
+    setBaseUrlError(null);
+    setAuthError(null);
+    setStatusMessage(message ?? null);
+  };
+
   const applyBaseUrl = () => {
     const normalized = normalizeDenBaseUrl(baseUrlDraft());
     if (!normalized) {
@@ -247,10 +262,7 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
 
     setBaseUrl(resolved.baseUrl);
     setBaseUrlDraft(resolved.baseUrl);
-    setAuthToken("");
-    clearSessionState();
-    setAuthError(null);
-    setStatusMessage("Updated the Den control plane URL. Sign in again to continue.");
+    clearSignedInState("Updated the Den control plane URL. Sign in again to continue.");
   };
 
   const refreshOrgs = async (quiet = false) => {
@@ -398,9 +410,10 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
       })
       .catch((error) => {
         if (cancelled) return;
-        clearSessionState();
         if (error instanceof DenApiError && error.status === 401) {
-          setAuthToken("");
+          clearSignedInState();
+        } else {
+          clearSessionState();
         }
         setAuthError(error instanceof Error ? error.message : "No active Den session found.");
       })
@@ -461,19 +474,22 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
   });
 
   const signOut = async () => {
+    if (authBusy()) {
+      return;
+    }
+
     setAuthBusy(true);
     try {
-      await client().signOut();
+      if (authToken().trim()) {
+        await client().signOut();
+      }
     } catch {
       // Ignore remote sign-out failures and clear local state anyway.
     } finally {
       setAuthBusy(false);
     }
 
-    setAuthToken("");
-    clearSessionState();
-    setStatusMessage("Signed out of OpenWork Den.");
-    setAuthError(null);
+    clearSignedInState("Signed out and cleared your OpenWork Den session on this device.");
   };
 
   const handleOpenWorker = async (workerId: string, workerName: string) => {
@@ -607,11 +623,11 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
               <div class="flex items-start justify-between gap-4">
                 <div>
                   <div class="text-sm font-medium text-gray-12">Account</div>
-                  <div class="text-xs text-gray-9 mt-1">Desktop session hydrated from Den.</div>
+                  <div class="text-xs text-gray-9 mt-1">Desktop session hydrated from Den. Signing out clears saved Cloud auth on this device.</div>
                 </div>
-                <Button variant="outline" class="text-xs h-8 px-3" onClick={() => void signOut()} disabled={authBusy()}>
+                <Button variant="outline" class="text-xs h-8 px-3" onClick={() => void signOut()} disabled={authBusy() || sessionBusy()}>
                   <LogOut size={13} />
-                  Sign out
+                  {authBusy() ? "Signing out..." : "Sign out"}
                 </Button>
               </div>
               <div class="rounded-xl border border-gray-6/60 bg-gray-1/50 px-4 py-3">

--- a/packages/app/src/app/lib/den.ts
+++ b/packages/app/src/app/lib/den.ts
@@ -267,6 +267,20 @@ export function writeDenSettings(next: DenSettings) {
   }
 }
 
+export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (options?.includeBaseUrls) {
+    window.localStorage.removeItem(STORAGE_BASE_URL);
+    window.localStorage.removeItem(STORAGE_API_BASE_URL);
+  }
+
+  window.localStorage.removeItem(STORAGE_AUTH_TOKEN);
+  window.localStorage.removeItem(STORAGE_ACTIVE_ORG_ID);
+}
+
 function getErrorMessage(payload: unknown, fallback: string): string {
   if (typeof payload === "string" && payload.trim()) {
     return payload.trim();

--- a/packages/app/src/app/pages/dashboard.tsx
+++ b/packages/app/src/app/pages/dashboard.tsx
@@ -330,7 +330,7 @@ export type DashboardViewProps = {
   notionError: string | null;
   notionBusy: boolean;
   connectNotion: () => void;
-  openDebugShareLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
+  openDebugDeepLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
 };
 
 type SharedSkillItem = {
@@ -1542,7 +1542,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   notionError={props.notionError}
                   notionBusy={props.notionBusy}
                   connectNotion={props.connectNotion}
-                  openDebugShareLink={props.openDebugShareLink}
+                  openDebugDeepLink={props.openDebugDeepLink}
                   connectRemoteWorkspace={props.connectRemoteWorkspace}
                 />
 

--- a/packages/app/src/app/pages/settings.tsx
+++ b/packages/app/src/app/pages/settings.tsx
@@ -178,7 +178,7 @@ export type SettingsViewProps = {
   notionBusy: boolean;
   connectNotion: () => void;
   engineDoctorVersion: string | null;
-  openDebugShareLink: (
+  openDebugDeepLink: (
     rawUrl: string,
   ) => Promise<{ ok: boolean; message: string }>;
   connectRemoteWorkspace: (input: {
@@ -805,8 +805,7 @@ export default function SettingsView(props: SettingsViewProps) {
   };
 
   const availableTabs = createMemo<SettingsTab[]>(() => {
-    const tabs: SettingsTab[] = ["general", "model", "advanced"];
-    if (props.developerMode) tabs.splice(1, 0, "den");
+    const tabs: SettingsTab[] = ["general", "den", "model", "advanced"];
     if (props.developerMode) tabs.push("debug");
     return tabs;
   });
@@ -957,10 +956,10 @@ export default function SettingsView(props: SettingsViewProps) {
   const [nukeDevConfigStatus, setNukeDevConfigStatus] = createSignal<
     string | null
   >(null);
-  const [debugShareLinkOpen, setDebugShareLinkOpen] = createSignal(false);
-  const [debugShareLinkInput, setDebugShareLinkInput] = createSignal("");
-  const [debugShareLinkBusy, setDebugShareLinkBusy] = createSignal(false);
-  const [debugShareLinkStatus, setDebugShareLinkStatus] = createSignal<
+  const [debugDeepLinkOpen, setDebugDeepLinkOpen] = createSignal(false);
+  const [debugDeepLinkInput, setDebugDeepLinkInput] = createSignal("");
+  const [debugDeepLinkBusy, setDebugDeepLinkBusy] = createSignal(false);
+  const [debugDeepLinkStatus, setDebugDeepLinkStatus] = createSignal<
     string | null
   >(null);
   const opencodeDevModeEnabled = createMemo(() =>
@@ -1221,19 +1220,19 @@ export default function SettingsView(props: SettingsViewProps) {
     }
   };
 
-  const submitDebugShareLink = async () => {
-    if (debugShareLinkBusy()) return;
-    setDebugShareLinkBusy(true);
-    setDebugShareLinkStatus(null);
+  const submitDebugDeepLink = async () => {
+    if (debugDeepLinkBusy()) return;
+    setDebugDeepLinkBusy(true);
+    setDebugDeepLinkStatus(null);
     try {
-      const result = await props.openDebugShareLink(debugShareLinkInput());
-      setDebugShareLinkStatus(result.message);
+      const result = await props.openDebugDeepLink(debugDeepLinkInput());
+      setDebugDeepLinkStatus(result.message);
     } catch (error) {
-      setDebugShareLinkStatus(
-        error instanceof Error ? error.message : "Failed to open share link.",
+      setDebugDeepLinkStatus(
+        error instanceof Error ? error.message : "Failed to open deep link.",
       );
     } finally {
-      setDebugShareLinkBusy(false);
+      setDebugDeepLinkBusy(false);
     }
   };
 
@@ -1721,56 +1720,54 @@ export default function SettingsView(props: SettingsViewProps) {
                   <div class="rounded-xl border border-gray-6/60 bg-gray-1/40 p-4 space-y-3">
                     <div class="flex items-start justify-between gap-3">
                       <div>
-                        <div class="text-sm font-medium text-gray-12">
-                          Open share link
+                          <div class="text-sm font-medium text-gray-12">
+                          Open Deeplink
+                          </div>
+                          <div class="text-xs text-gray-9">
+                          Paste any supported <span class="font-mono">openwork://</span> deeplink and route it through the dev app.
+                          </div>
                         </div>
-                        <div class="text-xs text-gray-9">
-                          Paste an existing{" "}
-                          <span class="font-mono">openwork://</span> share link
-                          and route it through the dev app.
-                        </div>
-                      </div>
                       <button
                         type="button"
                         class={compactOutlineActionClass}
                         onClick={() => {
-                          setDebugShareLinkOpen((value) => !value);
-                          setDebugShareLinkStatus(null);
+                          setDebugDeepLinkOpen((value) => !value);
+                          setDebugDeepLinkStatus(null);
                         }}
-                        disabled={props.busy || debugShareLinkBusy()}
+                        disabled={props.busy || debugDeepLinkBusy()}
                       >
-                        {debugShareLinkOpen() ? "Hide" : "Open share link"}
+                        {debugDeepLinkOpen() ? "Hide" : "Open Deeplink"}
                       </button>
                     </div>
 
-                    <Show when={debugShareLinkOpen()}>
+                    <Show when={debugDeepLinkOpen()}>
                       <div class="space-y-3">
                         <textarea
-                          value={debugShareLinkInput()}
+                          value={debugDeepLinkInput()}
                           onInput={(event) =>
-                            setDebugShareLinkInput(event.currentTarget.value)
+                            setDebugDeepLinkInput(event.currentTarget.value)
                           }
                           rows={3}
-                          placeholder="openwork://import-bundle?ow_bundle=..."
+                          placeholder="openwork://..."
                           class="w-full rounded-xl border border-gray-6 bg-gray-1 px-3 py-2 text-xs font-mono text-gray-12 outline-none transition focus:border-blue-8"
                         />
                         <div class="flex flex-wrap items-center gap-2">
                           <Button
                             variant="secondary"
                             class="text-xs h-8 py-0 px-3"
-                            onClick={() => void submitDebugShareLink()}
+                            onClick={() => void submitDebugDeepLink()}
                             disabled={
                               props.busy ||
-                              debugShareLinkBusy() ||
-                              !debugShareLinkInput().trim()
+                              debugDeepLinkBusy() ||
+                              !debugDeepLinkInput().trim()
                             }
                           >
-                            {debugShareLinkBusy() ? "Opening..." : "Open link"}
+                            {debugDeepLinkBusy() ? "Opening..." : "Open deeplink"}
                           </Button>
                           <div class="text-[11px] text-gray-8">
                             Accepts <span class="font-mono">openwork://</span>,{" "}
                             <span class="font-mono">openwork-dev://</span>, or a
-                            raw{" "}
+                            raw supported{" "}
                             <span class="font-mono">
                               https://share.openwork.software/b/...
                             </span>{" "}
@@ -1780,7 +1777,7 @@ export default function SettingsView(props: SettingsViewProps) {
                       </div>
                     </Show>
 
-                    <Show when={debugShareLinkStatus()}>
+                    <Show when={debugDeepLinkStatus()}>
                       {(value) => (
                         <div class="text-xs text-gray-10">{value()}</div>
                       )}


### PR DESCRIPTION
## Summary
- always show the Cloud settings tab and route desktop Cloud auth deep links back to that tab
- add Cloud sign-out that clears saved Den auth, org selection, and related local session state on the device
- rename the developer helper to Open Deeplink and let it open Cloud auth, remote worker, and shared bundle deep links

## Testing
- pnpm typecheck