### PR TITLE
Persist orchestrator remote tokens across restarts

### DIFF
--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "test:router": "pnpm build && node scripts/router.mjs",
     "test:files": "pnpm build && node scripts/files-session.mjs",
+    "test:token-persistence": "pnpm build && pnpm --dir ../server build:bin && pnpm --dir ../opencode-router build:bin && node scripts/token-persistence.mjs",
     "prepublishOnly": "node -e \"console.error('openwork-orchestrator is published via packages/orchestrator/scripts/publish-npm.mjs (meta + platform packages)'); process.exit(1);\""
   },
   "files": [

--- a/packages/orchestrator/scripts/token-persistence.mjs
+++ b/packages/orchestrator/scripts/token-persistence.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import { access } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(__dirname, "..", "dist", "cli.js");
+const serverBinPath = resolve(__dirname, "..", "..", "server", "dist", "bin", "openwork-server");
+const routerBinPath = resolve(__dirname, "..", "..", "opencode-router", "dist", "bin", "opencode-router");
+
+function workspaceIdForLocal(path) {
+  return `ws-${createHash("sha1").update(path).digest("hex").slice(0, 12)}`;
+}
+
+async function assertExecutable(path, label) {
+  try {
+    await access(path);
+  } catch {
+    throw new Error(`${label} not found at ${path}`);
+  }
+}
+
+async function resolveOpencodeBin() {
+  const configured = process.env.OPENCODE_BIN?.trim();
+  if (configured) return configured;
+  return "opencode";
+}
+
+function extractJsonPayload(raw) {
+  const start = raw.indexOf("{\n");
+  if (start === -1) {
+    throw new Error(`No JSON payload found in output:\n${raw}`);
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let index = start; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (char === "\\") {
+        escape = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return JSON.parse(raw.slice(start, index + 1));
+      }
+    }
+  }
+
+  throw new Error(`Incomplete JSON payload in output:\n${raw}`);
+}
+
+async function runStart({ workspace, dataDir, opencodeBin }) {
+  const child = spawn(
+    "node",
+    [
+      cliPath,
+      "start",
+      "--workspace",
+      workspace,
+      "--data-dir",
+      dataDir,
+      "--check",
+      "--json",
+      "--allow-external",
+      "--sidecar-source",
+      "external",
+      "--opencode-source",
+      "external",
+      "--openwork-server-bin",
+      serverBinPath,
+      "--opencode-router-bin",
+      routerBinPath,
+      "--opencode-bin",
+      opencodeBin,
+    ],
+    {
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const [code] = await once(child, "exit");
+  if (code !== 0) {
+    throw new Error(`openwork start failed with code ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+  }
+
+  return {
+    payload: extractJsonPayload(stdout),
+    stdout,
+    stderr,
+  };
+}
+
+const root = await mkdtemp(join(tmpdir(), "openwork-token-persistence-"));
+const dataDir = join(root, "data");
+const workspace = join(root, "workspace");
+const opencodeBin = await resolveOpencodeBin();
+
+await mkdir(workspace, { recursive: true });
+await assertExecutable(serverBinPath, "openwork-server binary");
+await assertExecutable(routerBinPath, "opencode-router binary");
+
+try {
+  const first = await runStart({ workspace, dataDir, opencodeBin });
+  const second = await runStart({ workspace, dataDir, opencodeBin });
+
+  assert.equal(second.payload.openwork.collaboratorToken, first.payload.openwork.collaboratorToken);
+  assert.equal(second.payload.openwork.ownerToken, first.payload.openwork.ownerToken);
+  assert.equal(second.payload.openwork.hostToken, first.payload.openwork.hostToken);
+  assert.equal(second.payload.openwork.port, first.payload.openwork.port);
+
+  const authPath = join(dataDir, "openwork-auth", `${workspaceIdForLocal(workspace)}.json`);
+  const authState = JSON.parse(await readFile(authPath, "utf8"));
+  assert.equal(authState.token, first.payload.openwork.collaboratorToken);
+  assert.equal(authState.ownerToken, first.payload.openwork.ownerToken);
+  assert.equal(authState.hostToken, first.payload.openwork.hostToken);
+  assert.equal(authState.port, first.payload.openwork.port);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        workspace,
+        authPath,
+        openwork: {
+          port: first.payload.openwork.port,
+          collaboratorToken: first.payload.openwork.collaboratorToken,
+          ownerToken: first.payload.openwork.ownerToken,
+          hostToken: first.payload.openwork.hostToken,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+} catch (error) {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exitCode = 1;
+} finally {
+  await rm(root, { recursive: true, force: true });
+}

--- a/packages/orchestrator/src/cli.ts
+++ b/packages/orchestrator/src/cli.ts
@@ -258,6 +258,17 @@ type RouterState = {
   workspaces: RouterWorkspace[];
 };
 
+type OpenworkServerAuthState = {
+  version: number;
+  workspaceId: string;
+  workspacePath: string;
+  token: string;
+  hostToken: string;
+  ownerToken?: string;
+  port: number;
+  updatedAt: number;
+};
+
 type OpencodeStateLayout = {
   devMode: boolean;
   rootDir: string;
@@ -2110,6 +2121,10 @@ function routerStatePath(dataDir: string): string {
   return join(dataDir, "openwork-orchestrator-state.json");
 }
 
+function openworkAuthStatePath(dataDir: string, workspaceId: string): string {
+  return join(dataDir, "openwork-auth", `${workspaceId}.json`);
+}
+
 function nowMs(): number {
   return Date.now();
 }
@@ -2137,6 +2152,38 @@ async function loadRouterState(path: string): Promise<RouterState> {
 }
 
 async function saveRouterState(path: string, state: RouterState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const payload = JSON.stringify(state, null, 2);
+  await writeFile(path, `${payload}\n`, "utf8");
+}
+
+async function loadOpenworkServerAuthState(path: string): Promise<OpenworkServerAuthState | null> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<OpenworkServerAuthState>;
+    const token = typeof parsed.token === "string" ? parsed.token.trim() : "";
+    const hostToken = typeof parsed.hostToken === "string" ? parsed.hostToken.trim() : "";
+    const ownerToken = typeof parsed.ownerToken === "string" ? parsed.ownerToken.trim() : "";
+    const port = typeof parsed.port === "number" && Number.isFinite(parsed.port) && parsed.port > 0
+      ? parsed.port
+      : 0;
+    if (!token || !hostToken || !port) return null;
+    return {
+      version: typeof parsed.version === "number" ? parsed.version : 1,
+      workspaceId: typeof parsed.workspaceId === "string" ? parsed.workspaceId : "",
+      workspacePath: typeof parsed.workspacePath === "string" ? parsed.workspacePath : "",
+      token,
+      hostToken,
+      ...(ownerToken ? { ownerToken } : {}),
+      port,
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function saveOpenworkServerAuthState(path: string, state: OpenworkServerAuthState): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const payload = JSON.stringify(state, null, 2);
   await writeFile(path, `${payload}\n`, "utf8");
@@ -3773,6 +3820,24 @@ async function issueOpenworkOwnerToken(baseUrl: string, hostToken: string, label
   return token;
 }
 
+async function readOpenworkOwnerToken(baseUrl: string, token: string): Promise<string | null> {
+  const trimmed = token.trim();
+  if (!trimmed) return null;
+  try {
+    const payload = await fetchJson(`${baseUrl.replace(/\/$/, "")}/tokens`, {
+      headers: {
+        Authorization: `Bearer ${trimmed}`,
+      },
+    });
+    if (Array.isArray(payload?.items)) {
+      return trimmed;
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
 function normalizeEvent(raw: unknown): { type: string } | null {
   if (!raw || typeof raw !== "object") return null;
   const record = raw as Record<string, unknown>;
@@ -5114,6 +5179,7 @@ async function runStart(args: ParsedArgs) {
 
   const workspace = readFlag(args.flags, "workspace") ?? process.env.OPENWORK_WORKSPACE ?? process.cwd();
   const resolvedWorkspace = await ensureWorkspace(workspace);
+  const workspaceId = workspaceIdForLocal(resolvedWorkspace);
   logger.info("Run starting", { workspace: resolvedWorkspace, logFormat, runId }, "openwork-orchestrator");
 
   const sandboxRequested = readSandboxMode(args.flags, "sandbox", "none", "OPENWORK_SANDBOX");
@@ -5123,6 +5189,8 @@ async function runStart(args: ParsedArgs) {
   const sandboxPersistOverride =
     readFlag(args.flags, "sandbox-persist-dir") ?? process.env.OPENWORK_SANDBOX_PERSIST_DIR;
   const dataDir = resolveRouterDataDir(args.flags);
+  const openworkAuthPath = openworkAuthStatePath(dataDir, workspaceId);
+  const persistedOpenworkAuth = await loadOpenworkServerAuthState(openworkAuthPath);
   const devMode = resolveInternalDevMode(args.flags);
   const opencodeStateLayout = resolveOpencodeStateLayout({
     dataDir,
@@ -5133,14 +5201,14 @@ async function runStart(args: ParsedArgs) {
   await ensureOpencodeStateLayout(opencodeStateLayout);
   await ensureOpencodeManagedTools(opencodeConfigDir);
   const opencodeRouterDataDir =
-    sandboxMode === "none" ? join(dataDir, "opencode-router", workspaceIdForLocal(resolvedWorkspace)) : null;
+    sandboxMode === "none" ? join(dataDir, "opencode-router", workspaceId) : null;
   if (opencodeRouterDataDir) {
     await mkdir(opencodeRouterDataDir, { recursive: true });
   }
   const sandboxPersistDir = resolve(
     sandboxPersistOverride?.trim()
       ? sandboxPersistOverride.trim()
-      : join(dataDir, "sandbox", workspaceIdForLocal(resolvedWorkspace)),
+      : join(dataDir, "sandbox", workspaceId),
   );
   if (sandboxMode !== "none") {
     await mkdir(sandboxPersistDir, { recursive: true });
@@ -5189,7 +5257,7 @@ async function runStart(args: ParsedArgs) {
 
   const openworkHost = readFlag(args.flags, "openwork-host") ?? process.env.OPENWORK_HOST ?? "0.0.0.0";
   const openworkPort = await resolvePort(
-    readNumber(args.flags, "openwork-port", undefined, "OPENWORK_PORT"),
+    readNumber(args.flags, "openwork-port", persistedOpenworkAuth?.port, "OPENWORK_PORT"),
     "127.0.0.1",
   );
   // Always choose a free opencodeRouter health port by default (avoid conflicts with
@@ -5198,8 +5266,24 @@ async function runStart(args: ParsedArgs) {
     readNumber(args.flags, "opencode-router-health-port", undefined, "OPENCODE_ROUTER_HEALTH_PORT"),
     "127.0.0.1",
   );
-  const openworkToken = readFlag(args.flags, "openwork-token") ?? process.env.OPENWORK_TOKEN ?? randomUUID();
-  const openworkHostToken = readFlag(args.flags, "openwork-host-token") ?? process.env.OPENWORK_HOST_TOKEN ?? randomUUID();
+  const openworkToken =
+    readFlag(args.flags, "openwork-token") ?? process.env.OPENWORK_TOKEN ?? persistedOpenworkAuth?.token ?? randomUUID();
+  const openworkHostToken =
+    readFlag(args.flags, "openwork-host-token") ?? process.env.OPENWORK_HOST_TOKEN ?? persistedOpenworkAuth?.hostToken ?? randomUUID();
+  let persistedOwnerToken = persistedOpenworkAuth?.ownerToken?.trim() || "";
+  const persistOpenworkAuth = async () => {
+    await saveOpenworkServerAuthState(openworkAuthPath, {
+      version: 1,
+      workspaceId,
+      workspacePath: resolvedWorkspace,
+      token: openworkToken,
+      hostToken: openworkHostToken,
+      ...(persistedOwnerToken ? { ownerToken: persistedOwnerToken } : {}),
+      port: openworkPort,
+      updatedAt: nowMs(),
+    });
+  };
+  await persistOpenworkAuth();
   const approvalMode =
     (readFlag(args.flags, "approval") as ApprovalMode | undefined) ??
     (process.env.OPENWORK_APPROVAL_MODE as ApprovalMode | undefined) ??
@@ -6057,7 +6141,11 @@ async function runStart(args: ParsedArgs) {
         // proved the server is running and proxying correctly.
         logger.warn("Sandbox server verification warning (non-fatal)", { error: String(verifyError) }, "openwork-server");
       }
-      openworkOwnerToken = await issueOpenworkOwnerToken(openworkBaseUrl, openworkHostToken, "OpenWork sandbox owner token");
+      openworkOwnerToken =
+        (await readOpenworkOwnerToken(openworkBaseUrl, persistedOwnerToken)) ??
+        (await issueOpenworkOwnerToken(openworkBaseUrl, openworkHostToken, "OpenWork sandbox owner token"));
+      persistedOwnerToken = openworkOwnerToken;
+      await persistOpenworkAuth();
       tui?.setConnectInfo({ ownerToken: openworkOwnerToken });
       logVerbose(`openwork-server version: ${openworkActualVersion ?? "unknown"}`);
     } else {
@@ -6222,7 +6310,11 @@ async function runStart(args: ParsedArgs) {
         expectedOpencodeUsername: opencodeUsername,
         expectedOpencodePassword: opencodePassword,
       });
-      openworkOwnerToken = await issueOpenworkOwnerToken(openworkBaseUrl, openworkHostToken, "OpenWork owner token");
+      openworkOwnerToken =
+        (await readOpenworkOwnerToken(openworkBaseUrl, persistedOwnerToken)) ??
+        (await issueOpenworkOwnerToken(openworkBaseUrl, openworkHostToken, "OpenWork owner token"));
+      persistedOwnerToken = openworkOwnerToken;
+      await persistOpenworkAuth();
       tui?.setConnectInfo({ ownerToken: openworkOwnerToken });
       logVerbose(`openwork-server version: ${openworkActualVersion ?? "unknown"}`);
 


### PR DESCRIPTION
## Summary
- persist the orchestrator OpenWork collaborator token, host token, owner token, and selected port per workspace in the CLI data dir
- reuse the saved owner token when it is still valid, and only mint a new one when the stored token no longer works
- add an orchestrator restart test that starts the built CLI twice and asserts the persisted credentials and port stay stable

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter openwork-orchestrator test:token-persistence`

## Notes
- no screenshots or video attached because this change is CLI-only