### PR TITLE
fix(desktop): forward warm deeplinks to the running app

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2791,6 +2791,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "ureq",
  "uuid",
@@ -4859,6 +4860,22 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ strip = true
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-process = "2.3.1"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-updater = "2.9.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -77,11 +77,18 @@ fn set_dev_app_name() {
 #[cfg(not(target_os = "macos"))]
 fn set_dev_app_name() {}
 
+fn issue_1022_h1_log(message: &str) {
+    println!("[issue-1022][h1] {message}");
+}
+
 fn show_main_window(app_handle: &AppHandle) {
+    issue_1022_h1_log("show_main_window called");
     if let Some(window) = app_handle.get_webview_window("main") {
         let _ = window.show();
         let _ = window.unminimize();
         let _ = window.set_focus();
+    } else {
+        issue_1022_h1_log("main window missing while trying to focus running app");
     }
 }
 
@@ -108,7 +115,10 @@ fn stop_managed_services(app_handle: &tauri::AppHandle) {
 
 pub fn run() {
     let builder = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
+            issue_1022_h1_log(&format!(
+                "single-instance callback fired cwd={cwd:?} args={args:?}"
+            ));
             show_main_window(app);
         }))
         .plugin(tauri_plugin_deep_link::init())
@@ -245,6 +255,9 @@ pub fn run() {
             has_visible_windows,
             ..
         } => {
+            issue_1022_h1_log(&format!(
+                "macOS reopen event received has_visible_windows={has_visible_windows}"
+            ));
             if !has_visible_windows {
                 show_main_window(&app_handle);
             }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -80,6 +80,7 @@ fn set_dev_app_name() {}
 fn show_main_window(app_handle: &AppHandle) {
     if let Some(window) = app_handle.get_webview_window("main") {
         let _ = window.show();
+        let _ = window.unminimize();
         let _ = window.set_focus();
     }
 }
@@ -107,6 +108,9 @@ fn stop_managed_services(app_handle: &tauri::AppHandle) {
 
 pub fn run() {
     let builder = tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            show_main_window(app);
+        }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())


### PR DESCRIPTION
## Summary
- add Tauri single-instance forwarding with deep-link support so a second launch can hand off the shared bundle URL to the already-running desktop app
- restore and focus the main window when the running instance receives the warm launch handoff
- add tagged `[issue-1022][h1]` native logs to verify whether the warm launch reached the running app

## Testing
- `pnpm --filter @different-ai/openwork exec cargo check --manifest-path src-tauri/Cargo.toml`
- launched `target/debug/OpenWork-Dev` twice, passing `openwork://import-bundle?ow_bundle=https%3A%2F%2Fshare.openwork.software%2Fb%2F01KKPSGYSGDRRWNTAACAMZY3PF&ow_intent=new_worker&ow_source=share_service&ow_label=workspace-guide&ow_nonce=2cbe54c3-3de3-49a6-a5ab-c2fa9536b11d` to the second launch; observed `[issue-1022][h1] single-instance callback fired ...` in `/tmp/openwork-issue-1022-h1.log`

## Notes
- I could verify the warm launch handoff reached the running dev process, but I could not fully automate the desktop modal assertion from this environment.