### PR TITLE
fix(app): close competing modals for shared deeplinks

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4054,6 +4054,9 @@ export default function App() {
     if (!parsed) {
       return false;
     }
+    workspaceStore.setCreateWorkspaceOpen(false);
+    workspaceStore.setCreateRemoteWorkspaceOpen(false);
+    setDeepLinkRemoteWorkspaceDefaults(null);
     setPendingSharedBundleInvite(parsed);
     setSharedSkillDestinationRequest(null);
     setSharedSkillDestinationBusyId(null);

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -290,6 +290,14 @@ type SettingsReturnTarget = {
   sessionId: string | null;
 };
 
+function issue1022H5Log(message: string, details?: unknown) {
+  if (details === undefined) {
+    console.log(`[issue-1022][h5] ${message}`);
+    return;
+  }
+  console.log(`[issue-1022][h5] ${message}`, details);
+}
+
 function normalizeSharedBundleImportIntent(value: string | null | undefined): SharedBundleImportIntent {
   const normalized = (value ?? "").trim().toLowerCase();
   if (normalized === "new_worker" || normalized === "new-worker" || normalized === "newworker") {
@@ -3777,6 +3785,20 @@ export default function App() {
   });
 
   createEffect(() => {
+    const request = sharedSkillDestinationRequest();
+    if (!request) {
+      return;
+    }
+
+    issue1022H5Log("shared skill modal state updated", {
+      bundleName: request.bundle.name,
+      createWorkspaceOpen: workspaceStore.createWorkspaceOpen(),
+      createRemoteWorkspaceOpen: workspaceStore.createRemoteWorkspaceOpen(),
+      modalVisible: !workspaceStore.createWorkspaceOpen() && !workspaceStore.createRemoteWorkspaceOpen(),
+    });
+  });
+
+  createEffect(() => {
     if (!developerMode()) {
       setDevtoolsWorkspaceId(null);
       return;
@@ -4054,6 +4076,12 @@ export default function App() {
     if (!parsed) {
       return false;
     }
+    issue1022H5Log("queueSharedBundleDeepLink closing competing modals", {
+      rawUrl,
+      parsed,
+      createWorkspaceOpen: workspaceStore.createWorkspaceOpen(),
+      createRemoteWorkspaceOpen: workspaceStore.createRemoteWorkspaceOpen(),
+    });
     workspaceStore.setCreateWorkspaceOpen(false);
     workspaceStore.setCreateRemoteWorkspaceOpen(false);
     setDeepLinkRemoteWorkspaceDefaults(null);


### PR DESCRIPTION
## Summary
- close competing create-worker / connect-remote modal state before queuing a shared bundle deep link so the shared-skill import modal can surface immediately
- clear stale deep-link remote defaults when a shared bundle takes over the current flow
- add tagged `[issue-1022][h5]` console logs for modal visibility and competing-modal closure

## Testing
- `pnpm typecheck`

## Notes
- I could not fully automate a desktop repro where a competing modal is already open and then a shared bundle deep link arrives.
- This PR stays draft until that already-open modal interaction is exercised in the desktop app.