### PR TITLE
fix(app): stop over-deduping warm deeplinks

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -290,6 +290,14 @@ type SettingsReturnTarget = {
   sessionId: string | null;
 };
 
+function issue1022H4Log(message: string, details?: unknown) {
+  if (details === undefined) {
+    console.log(`[issue-1022][h4] ${message}`);
+    return;
+  }
+  console.log(`[issue-1022][h4] ${message}`, details);
+}
+
 function normalizeSharedBundleImportIntent(value: string | null | undefined): SharedBundleImportIntent {
   const normalized = (value ?? "").trim().toLowerCase();
   if (normalized === "new_worker" || normalized === "new-worker" || normalized === "newworker") {
@@ -6090,10 +6098,12 @@ export default function App() {
           source: "event" | "current" = "event",
         ) => {
           if (!Array.isArray(urls)) {
+            issue1022H4Log(`ignored non-array deep link payload from ${source}`, urls ?? null);
             return;
           }
 
           const normalized = urls.map((url) => url.trim()).filter(Boolean);
+          issue1022H4Log(`received deep links from ${source}`, { urls, normalized });
           if (normalized.length === 0) {
             return;
           }
@@ -6108,9 +6118,20 @@ export default function App() {
           for (const url of normalized) {
             const seenAt = recentDeepLinkEvents.get(url) ?? 0;
             if (now - seenAt < 1500) {
+              issue1022H4Log("skipped recently handled deep link", { source, url, ageMs: now - seenAt });
               continue;
             }
-            if (queueDenAuthDeepLink(url) || queueRemoteConnectDeepLink(url) || queueSharedBundleDeepLink(url)) {
+            const matchedDen = queueDenAuthDeepLink(url);
+            const matchedRemote = !matchedDen && queueRemoteConnectDeepLink(url);
+            const matchedBundle = !matchedDen && !matchedRemote && queueSharedBundleDeepLink(url);
+            issue1022H4Log("deep link dispatch result", {
+              source,
+              url,
+              matchedDen,
+              matchedRemote,
+              matchedBundle,
+            });
+            if (matchedDen || matchedRemote || matchedBundle) {
               recentDeepLinkEvents.set(url, now);
               break;
             }

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -6084,7 +6084,6 @@ export default function App() {
       try {
         const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
         const recentDeepLinkEvents = new Map<string, number>();
-        let lastObservedDeepLinkSignature: string | null = null;
 
         const consumeUrls = (
           urls: string[] | null | undefined,
@@ -6099,12 +6098,6 @@ export default function App() {
             return;
           }
 
-          const signature = normalized.join("\n");
-          if (source === "current" && signature === lastObservedDeepLinkSignature) {
-            return;
-          }
-          lastObservedDeepLinkSignature = signature;
-
           const now = Date.now();
           for (const [url, seenAt] of recentDeepLinkEvents) {
             if (now - seenAt > 1500) {
@@ -6117,8 +6110,8 @@ export default function App() {
             if (now - seenAt < 1500) {
               continue;
             }
-            recentDeepLinkEvents.set(url, now);
             if (queueDenAuthDeepLink(url) || queueRemoteConnectDeepLink(url) || queueSharedBundleDeepLink(url)) {
+              recentDeepLinkEvents.set(url, now);
               break;
             }
           }


### PR DESCRIPTION
## Summary
- remove the signature-based warm deep-link suppression path and only mark URLs as recently seen after a handler actually claims them
- keep recent-url dedupe, but avoid suppressing later warm deliveries based on an earlier no-op pass through `consumeUrls`
- add tagged `[issue-1022][h4]` console logs around warm deep-link receipt, dedupe skips, and dispatch outcomes

## Testing
- `pnpm typecheck`
- attempted a warm desktop repro by launching `target/debug/OpenWork-Dev` with `openwork://import-bundle?ow_bundle=https%3A%2F%2Fshare.openwork.software%2Fb%2F01KKPSGYSGDRRWNTAACAMZY3PF&ow_intent=new_worker&ow_source=share_service&ow_label=workspace-guide&ow_nonce=2cbe54c3-3de3-49a6-a5ab-c2fa9536b11d` while the app was already running

## Notes
- This branch intentionally isolates hypothesis 4 on top of `origin/dev`, so it does not include the h1 single-instance fix.
- Because of that, I could not fully validate the warm already-open desktop path from this environment; this PR is draft pending desktop validation with h1 either merged or cherry-picked locally.