### PR TITLE
fix(desktop,app): preserve shared skill modal on warm deeplinks

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -290,6 +290,14 @@ type SettingsReturnTarget = {
   sessionId: string | null;
 };
 
+function issue1022H4Log(message: string, details?: unknown) {
+  if (details === undefined) {
+    console.log(`[issue-1022][h4] ${message}`);
+    return;
+  }
+  console.log(`[issue-1022][h4] ${message}`, details);
+}
+
 function normalizeSharedBundleImportIntent(value: string | null | undefined): SharedBundleImportIntent {
   const normalized = (value ?? "").trim().toLowerCase();
   if (normalized === "new_worker" || normalized === "new-worker" || normalized === "newworker") {
@@ -6090,10 +6098,12 @@ export default function App() {
           source: "event" | "current" = "event",
         ) => {
           if (!Array.isArray(urls)) {
+            issue1022H4Log(`ignored non-array deep link payload from ${source}`, urls ?? null);
             return;
           }
 
           const normalized = urls.map((url) => url.trim()).filter(Boolean);
+          issue1022H4Log(`received deep links from ${source}`, { urls, normalized });
           if (normalized.length === 0) {
             return;
           }
@@ -6108,9 +6118,20 @@ export default function App() {
           for (const url of normalized) {
             const seenAt = recentDeepLinkEvents.get(url) ?? 0;
             if (now - seenAt < 1500) {
+              issue1022H4Log("skipped recently handled deep link", { source, url, ageMs: now - seenAt });
               continue;
             }
-            if (queueDenAuthDeepLink(url) || queueRemoteConnectDeepLink(url) || queueSharedBundleDeepLink(url)) {
+            const matchedDen = queueDenAuthDeepLink(url);
+            const matchedRemote = !matchedDen && queueRemoteConnectDeepLink(url);
+            const matchedBundle = !matchedDen && !matchedRemote && queueSharedBundleDeepLink(url);
+            issue1022H4Log("deep link dispatch result", {
+              source,
+              url,
+              matchedDen,
+              matchedRemote,
+              matchedBundle,
+            });
+            if (matchedDen || matchedRemote || matchedBundle) {
               recentDeepLinkEvents.set(url, now);
               break;
             }

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -4062,6 +4062,9 @@ export default function App() {
     if (!parsed) {
       return false;
     }
+    workspaceStore.setCreateWorkspaceOpen(false);
+    workspaceStore.setCreateRemoteWorkspaceOpen(false);
+    setDeepLinkRemoteWorkspaceDefaults(null);
     setPendingSharedBundleInvite(parsed);
     setSharedSkillDestinationRequest(null);
     setSharedSkillDestinationBusyId(null);

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -298,6 +298,14 @@ function issue1022H4Log(message: string, details?: unknown) {
   console.log(`[issue-1022][h4] ${message}`, details);
 }
 
+function issue1022H5Log(message: string, details?: unknown) {
+  if (details === undefined) {
+    console.log(`[issue-1022][h5] ${message}`);
+    return;
+  }
+  console.log(`[issue-1022][h5] ${message}`, details);
+}
+
 function normalizeSharedBundleImportIntent(value: string | null | undefined): SharedBundleImportIntent {
   const normalized = (value ?? "").trim().toLowerCase();
   if (normalized === "new_worker" || normalized === "new-worker" || normalized === "newworker") {
@@ -3785,6 +3793,20 @@ export default function App() {
   });
 
   createEffect(() => {
+    const request = sharedSkillDestinationRequest();
+    if (!request) {
+      return;
+    }
+
+    issue1022H5Log("shared skill modal state updated", {
+      bundleName: request.bundle.name,
+      createWorkspaceOpen: workspaceStore.createWorkspaceOpen(),
+      createRemoteWorkspaceOpen: workspaceStore.createRemoteWorkspaceOpen(),
+      modalVisible: !workspaceStore.createWorkspaceOpen() && !workspaceStore.createRemoteWorkspaceOpen(),
+    });
+  });
+
+  createEffect(() => {
     if (!developerMode()) {
       setDevtoolsWorkspaceId(null);
       return;
@@ -4062,6 +4084,12 @@ export default function App() {
     if (!parsed) {
       return false;
     }
+    issue1022H5Log("queueSharedBundleDeepLink closing competing modals", {
+      rawUrl,
+      parsed,
+      createWorkspaceOpen: workspaceStore.createWorkspaceOpen(),
+      createRemoteWorkspaceOpen: workspaceStore.createRemoteWorkspaceOpen(),
+    });
     workspaceStore.setCreateWorkspaceOpen(false);
     workspaceStore.setCreateRemoteWorkspaceOpen(false);
     setDeepLinkRemoteWorkspaceDefaults(null);

--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -6084,7 +6084,6 @@ export default function App() {
       try {
         const { getCurrent, onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
         const recentDeepLinkEvents = new Map<string, number>();
-        let lastObservedDeepLinkSignature: string | null = null;
 
         const consumeUrls = (
           urls: string[] | null | undefined,
@@ -6099,12 +6098,6 @@ export default function App() {
             return;
           }
 
-          const signature = normalized.join("\n");
-          if (source === "current" && signature === lastObservedDeepLinkSignature) {
-            return;
-          }
-          lastObservedDeepLinkSignature = signature;
-
           const now = Date.now();
           for (const [url, seenAt] of recentDeepLinkEvents) {
             if (now - seenAt > 1500) {
@@ -6117,8 +6110,8 @@ export default function App() {
             if (now - seenAt < 1500) {
               continue;
             }
-            recentDeepLinkEvents.set(url, now);
             if (queueDenAuthDeepLink(url) || queueRemoteConnectDeepLink(url) || queueSharedBundleDeepLink(url)) {
+              recentDeepLinkEvents.set(url, now);
               break;
             }
           }

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2791,6 +2791,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "ureq",
  "uuid",
@@ -4859,6 +4860,22 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ strip = true
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-process = "2.3.1"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-updater = "2.9.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -77,11 +77,18 @@ fn set_dev_app_name() {
 #[cfg(not(target_os = "macos"))]
 fn set_dev_app_name() {}
 
+fn issue_1022_h1_log(message: &str) {
+    println!("[issue-1022][h1] {message}");
+}
+
 fn show_main_window(app_handle: &AppHandle) {
+    issue_1022_h1_log("show_main_window called");
     if let Some(window) = app_handle.get_webview_window("main") {
         let _ = window.show();
         let _ = window.unminimize();
         let _ = window.set_focus();
+    } else {
+        issue_1022_h1_log("main window missing while trying to focus running app");
     }
 }
 
@@ -108,7 +115,10 @@ fn stop_managed_services(app_handle: &tauri::AppHandle) {
 
 pub fn run() {
     let builder = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
+            issue_1022_h1_log(&format!(
+                "single-instance callback fired cwd={cwd:?} args={args:?}"
+            ));
             show_main_window(app);
         }))
         .plugin(tauri_plugin_deep_link::init())
@@ -245,6 +255,9 @@ pub fn run() {
             has_visible_windows,
             ..
         } => {
+            issue_1022_h1_log(&format!(
+                "macOS reopen event received has_visible_windows={has_visible_windows}"
+            ));
             if !has_visible_windows {
                 show_main_window(&app_handle);
             }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -80,6 +80,7 @@ fn set_dev_app_name() {}
 fn show_main_window(app_handle: &AppHandle) {
     if let Some(window) = app_handle.get_webview_window("main") {
         let _ = window.show();
+        let _ = window.unminimize();
         let _ = window.set_focus();
     }
 }
@@ -107,6 +108,9 @@ fn stop_managed_services(app_handle: &tauri::AppHandle) {
 
 pub fn run() {
     let builder = tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            show_main_window(app);
+        }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_http::init())


### PR DESCRIPTION
## Summary
- combine the h1 desktop single-instance handoff fix, the h4 warm-deeplink dedupe fix, and the h5 modal-state cleanup for shared bundle imports
- forward second launches into the already-running desktop app and stop dropping follow-up warm deeplinks before dispatch
- close competing create-worker and connect-remote modal state before opening the shared-skill flow so the shared skill modal can surface immediately
- keep `[issue-1022][h1]`, `[issue-1022][h4]`, and `[issue-1022][h5]` logs to inspect the full handoff, dispatch, and modal-visibility chain

## Testing
- `pnpm --filter @different-ai/openwork exec cargo check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`

## Notes
- This branch is the fullest combination of the current hypotheses. I have not yet validated the desktop already-open modal behavior end-to-end in this exact combined branch from this environment.