### PR TITLE
fix: expand session trace rows only when details exist

### DIFF
--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -30,10 +30,13 @@ import {
   type MessageGroup,
   type MessageWithParts,
   type StepGroupMode,
+  type TodoItem,
 } from "../../types";
 import {
+  formatToolLabel,
   groupMessageParts,
   isUserVisiblePart,
+  safeStringify,
   summarizeStep,
 } from "../../utils";
 import PartView from "../part-view";
@@ -402,6 +405,153 @@ function toolHeadline(part: Part) {
   }
 
   return "";
+}
+
+type StepBodyField = {
+  label: string;
+  value: string;
+};
+
+type StepBodyBlock = {
+  label?: string;
+  value: string;
+  tone?: "default" | "error";
+};
+
+type StepBody = {
+  fields: StepBodyField[];
+  blocks: StepBodyBlock[];
+  todos: TodoItem[];
+};
+
+function trimBodyText(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.replace(/\r\n/g, "\n").trim();
+}
+
+function firstMeaningfulLine(value: string): string {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) ?? "";
+}
+
+function getStepDisclosureId(part: Part): string {
+  const record = part as { id?: string | number; callID?: string | number; messageID?: string | number };
+  const raw = record.id ?? record.callID ?? record.messageID;
+  if (typeof raw === "string" && raw.trim()) return `step:${raw.trim()}`;
+  if (typeof raw === "number") return `step:${String(raw)}`;
+  return "";
+}
+
+function getStepBody(part: Part): StepBody {
+  if (part.type === "reasoning") {
+    const text = trimBodyText((part as { text?: string }).text);
+    if (!text) return { fields: [], blocks: [], todos: [] };
+    return { fields: [], blocks: [{ value: text }], todos: [] };
+  }
+
+  if (part.type !== "tool") {
+    return { fields: [], blocks: [], todos: [] };
+  }
+
+  const record = part as any;
+  const tool = typeof record.tool === "string" ? record.tool.toLowerCase() : "";
+  const state = record.state ?? {};
+  const input = state.input && typeof state.input === "object" ? (state.input as Record<string, unknown>) : {};
+  const fields: StepBodyField[] = [];
+  const blocks: StepBodyBlock[] = [];
+
+  const pick = (...keys: string[]) => {
+    for (const key of keys) {
+      const value = input[key];
+      if (typeof value === "string" && value.trim()) return value.trim();
+      if (typeof value === "number" || typeof value === "boolean") return String(value);
+    }
+    return "";
+  };
+
+  const pushField = (label: string, value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    fields.push({ label, value: trimmed });
+  };
+
+  const error = trimBodyText(state.error);
+  const output = trimBodyText(state.output);
+  const command = pick("command", "cmd");
+
+  if (tool === "todowrite" || tool === "todoread") {
+    const todos = Array.isArray(input.todos)
+      ? input.todos.filter((item): item is TodoItem => {
+          if (!item || typeof item !== "object") return false;
+          const content = (item as { content?: unknown }).content;
+          return typeof content === "string" && content.trim().length > 0;
+        })
+      : [];
+    return { fields: [], blocks: [], todos };
+  }
+
+  if (tool === "bash") {
+    if (command) {
+      const content = output ? `$ ${command}\n${output}` : `$ ${command}`;
+      blocks.push({ value: content });
+    } else if (output) {
+      blocks.push({ value: output });
+    }
+    if (error && error !== output) {
+      blocks.push({ label: "Error", value: error, tone: "error" });
+    }
+    return { fields, blocks, todos: [] };
+  }
+
+  if (tool === "grep" || tool === "search") {
+    pushField("pattern", pick("pattern", "query"));
+    pushField("path", pick("path"));
+    pushField("include", pick("include"));
+  } else if (tool === "glob") {
+    pushField("pattern", pick("pattern"));
+    pushField("path", pick("path"));
+  } else if (tool === "read") {
+    pushField("file", pick("filePath", "path", "file"));
+    pushField("offset", pick("offset"));
+    pushField("limit", pick("limit"));
+  } else if (tool === "list" || tool === "list_files") {
+    pushField("path", pick("path"));
+  } else if (tool === "webfetch") {
+    pushField("url", pick("url"));
+    pushField("format", pick("format"));
+  } else if (tool === "edit" || tool === "write") {
+    pushField("file", pick("filePath", "path", "file"));
+  } else if (tool === "apply_patch") {
+    const patch = trimBodyText(input.patchText);
+    if (patch) blocks.push({ value: patch });
+  }
+
+  if (output) {
+    blocks.push({ value: output });
+  }
+
+  if (error && error !== output) {
+    blocks.push({ label: "Error", value: error, tone: "error" });
+  }
+
+  if (!fields.length && !blocks.length && Object.keys(input).length > 0) {
+    blocks.push({ label: "Input", value: safeStringify(input) });
+  }
+
+  return { fields, blocks, todos: [] };
+}
+
+function hasExpandableStepBody(part: Part): boolean {
+  const body = getStepBody(part);
+  return body.fields.length > 0 || body.blocks.length > 0 || body.todos.length > 0;
+}
+
+function isErrorStep(part: Part): boolean {
+  if (part.type !== "tool") return false;
+  const state = (part as any).state ?? {};
+  return state.status === "error" || trimBodyText(state.error).length > 0;
 }
 
 export default function MessageList(props: MessageListProps) {
@@ -902,36 +1052,133 @@ export default function MessageList(props: MessageListProps) {
     groupMode?: StepGroupMode;
   }) => {
     const summary = createMemo(() => summarizeStep(rowProps.part));
-    const headline = createMemo(() => {
-      const fromTool = toolHeadline(rowProps.part);
-      if (fromTool) return fromTool;
-      const title = summary().title?.trim() ?? "";
-      const detail = summary().detail?.trim() ?? "";
-      if (title && detail && detail.toLowerCase() !== title.toLowerCase()) {
-        return `${title} - ${detail}`;
-      }
-      return detail || title || "Updates progress";
-    });
     const task = createMemo(() => getTaskStepInfo(rowProps.part));
-
-    if (rowProps.part.type === "reasoning") {
-      return (
-        <div class="flex items-start gap-3 text-[14px] text-gray-9">
-          <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
-          <div class="min-w-0 leading-relaxed">
-            <span>{headline()}</span>
-          </div>
-        </div>
-      );
-    }
+    const disclosureId = createMemo(() => getStepDisclosureId(rowProps.part));
+    const body = createMemo(() => getStepBody(rowProps.part));
+    const hasDisclosure = createMemo(() => {
+      if (task().isTask && task().sessionId) return true;
+      return hasExpandableStepBody(rowProps.part);
+    });
+    const open = createMemo(() => {
+      const id = disclosureId();
+      return Boolean(id) && hasDisclosure() && isStepsExpanded(id);
+    });
+    const label = createMemo(() => {
+      if (rowProps.part.type !== "tool") return summary().title?.trim() || "Thinking";
+      const toolName =
+        typeof (rowProps.part as any).tool === "string"
+          ? String((rowProps.part as any).tool)
+          : "tool";
+      return formatToolLabel(toolName);
+    });
+    const headline = createMemo(() => {
+      if (rowProps.part.type === "reasoning") {
+        return summary().detail?.trim() || summary().title?.trim() || "Thinking";
+      }
+      return summary().detail?.trim() || toolHeadline(rowProps.part) || summary().title?.trim() || "Updates progress";
+    });
+    const displayHeadline = createMemo(() => {
+      const base = headline();
+      if (!isErrorStep(rowProps.part)) return base;
+      return base.startsWith("ERROR:") ? base : `ERROR: ${base || firstMeaningfulLine(trimBodyText((rowProps.part as any)?.state?.error)) || "Tool failed"}`;
+    });
+    const toggleDisclosure = () => {
+      const id = disclosureId();
+      if (!id || !hasDisclosure()) return;
+      toggleSteps(id);
+    };
 
     return (
       <div class="flex items-start gap-3 text-[14px] text-gray-9">
-        <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
         <div class="min-w-0 flex-1 leading-relaxed">
-          <span>{headline()}</span>
-          <Show when={task().isTask && task().sessionId}>
-            <SubagentThread part={rowProps.part} />
+          <div class="flex min-w-0 items-start gap-2.5">
+            <span class="mt-0.5 inline-flex shrink-0 items-center rounded-md border border-gray-5/70 bg-gray-3 px-1.5 py-0.5 font-mono text-[11px] leading-none text-gray-11">
+              {label()}
+            </span>
+            <Show
+              when={hasDisclosure()}
+              fallback={<span class="mt-[2px] h-[14px] w-[14px] shrink-0" aria-hidden="true" />}
+            >
+              <button
+                type="button"
+                class="mt-[1px] shrink-0 rounded-sm p-0.5 text-gray-7 transition-colors hover:bg-gray-3 hover:text-gray-10"
+                onClick={toggleDisclosure}
+                aria-expanded={open()}
+                aria-label={open() ? `Collapse ${label()} details` : `Expand ${label()} details`}
+              >
+                <ChevronRight size={14} class={`transition-transform duration-200 ${open() ? "rotate-90" : ""}`} />
+              </button>
+            </Show>
+            <button
+              type="button"
+              class={`min-w-0 flex-1 text-left ${hasDisclosure() ? "cursor-pointer" : "cursor-default"}`}
+              onClick={() => {
+                if (hasDisclosure()) toggleDisclosure();
+              }}
+              aria-expanded={hasDisclosure() ? open() : undefined}
+            >
+              <span class={`block min-w-0 truncate text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
+                {displayHeadline()}
+              </span>
+            </button>
+          </div>
+          <Show when={open() && (body().fields.length > 0 || body().blocks.length > 0 || body().todos.length > 0)}>
+            <div class="pt-2 pl-[34px]">
+              <div class="grid gap-2 rounded-[18px] border border-gray-6/60 bg-gray-2/40 px-3 py-3">
+                <Show when={body().todos.length > 0}>
+                  <div class="grid gap-1.5 text-[12px] text-gray-10">
+                    <For each={body().todos}>
+                      {(todo) => (
+                        <div class="flex items-start gap-2">
+                          <span class="mt-[6px] h-1.5 w-1.5 shrink-0 rounded-full bg-gray-8" />
+                          <span class="leading-5">
+                            {todo.content}
+                            <Show when={todo.status && todo.status !== "pending"}>
+                              <span class="text-gray-8"> {`(${todo.status})`}</span>
+                            </Show>
+                          </span>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                </Show>
+                <Show when={body().fields.length > 0}>
+                  <div class="grid gap-1.5 text-[12px] text-gray-10">
+                    <For each={body().fields}>
+                      {(field) => (
+                        <div class="flex flex-wrap items-start gap-x-2 gap-y-1">
+                          <span class="font-medium text-gray-11">{field.label}:</span>
+                          <span class="font-mono text-[11px] text-gray-10 break-all">{field.value}</span>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                </Show>
+                <Show when={body().blocks.length > 0}>
+                  <div class="grid gap-2">
+                    <For each={body().blocks}>
+                      {(block) => (
+                        <div>
+                          <Show when={block.label}>
+                            <div class="mb-1 text-[11px] font-medium text-gray-10">{block.label}</div>
+                          </Show>
+                          <pre
+                            class={`max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-[14px] px-3 py-2 text-[12px] leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
+                          >
+                            {block.value}
+                          </pre>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                </Show>
+              </div>
+            </div>
+          </Show>
+          <Show when={task().isTask && task().sessionId && open()}>
+            <div class="pt-2 pl-[34px]">
+              <SubagentThread part={rowProps.part} />
+            </div>
           </Show>
         </div>
       </div>

--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -1113,22 +1113,22 @@ export default function MessageList(props: MessageListProps) {
               aria-expanded={open()}
               aria-label={open() ? `Collapse ${label()} details` : `Expand ${label()} details`}
             >
-              <div class="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-start sm:gap-2.5">
+              <div class="flex min-w-0 flex-col gap-1 sm:flex-row sm:flex-wrap sm:items-start sm:gap-x-2.5 sm:gap-y-1">
                 <span class="mt-0.5 inline-flex w-fit shrink-0 items-center rounded-md border border-gray-5/70 bg-gray-3 px-1.5 py-0.5 font-mono text-[11px] leading-none text-gray-11">
                   {label()}
                 </span>
-                <span class={`block min-w-0 break-words text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
-                  {displayHeadline()}
+                <span class={`block min-w-0 text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
+                  <span class="break-words [overflow-wrap:anywhere]">{displayHeadline()}</span>
+                  <span class="ml-1 inline-flex align-text-top text-gray-7 transition-colors group-hover:text-gray-10" aria-hidden="true">
+                    <ChevronRight size={14} class={`transition-transform duration-200 ${open() ? "rotate-90" : ""}`} />
+                  </span>
                 </span>
               </div>
-              <span class="mt-[1px] shrink-0 rounded-sm p-0.5 text-gray-7 transition-colors group-hover:text-gray-10" aria-hidden="true">
-                <ChevronRight size={14} class={`transition-transform duration-200 ${open() ? "rotate-90" : ""}`} />
-              </span>
             </button>
           </Show>
           <Show when={open() && (body().fields.length > 0 || body().blocks.length > 0 || body().todos.length > 0)}>
-            <div class="pt-2 sm:pl-[18px]">
-              <div class="grid gap-2 rounded-[18px] border border-gray-6/60 bg-gray-2/40 px-3 py-3">
+            <div class="min-w-0 pt-2 sm:pl-[18px]">
+              <div class="grid min-w-0 w-full gap-2 overflow-hidden rounded-[18px] border border-gray-6/60 bg-gray-2/40 px-3 py-3">
                 <Show when={body().todos.length > 0}>
                   <div class="grid gap-1.5 text-[12px] text-gray-10">
                     <For each={body().todos}>
@@ -1147,7 +1147,7 @@ export default function MessageList(props: MessageListProps) {
                   </div>
                 </Show>
                 <Show when={body().fields.length > 0}>
-                  <div class="grid gap-1.5 text-[12px] text-gray-10">
+                  <div class="grid min-w-0 gap-1.5 text-[12px] text-gray-10">
                     <For each={body().fields}>
                       {(field) => (
                         <div class="flex flex-wrap items-start gap-x-2 gap-y-1">
@@ -1159,15 +1159,15 @@ export default function MessageList(props: MessageListProps) {
                   </div>
                 </Show>
                 <Show when={body().blocks.length > 0}>
-                  <div class="grid gap-2">
+                  <div class="grid min-w-0 gap-2">
                     <For each={body().blocks}>
                       {(block) => (
-                        <div>
+                        <div class="min-w-0">
                           <Show when={block.label}>
                             <div class="mb-1 text-[11px] font-medium text-gray-10">{block.label}</div>
                           </Show>
                           <pre
-                            class={`max-h-80 max-w-full overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] rounded-[14px] px-3 py-2 text-[12px] leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
+                            class={`block max-h-80 min-w-0 w-full max-w-full overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] rounded-[14px] px-3 py-2 text-[11px] leading-4 sm:text-[12px] sm:leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
                           >
                             {block.value}
                           </pre>

--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -1152,7 +1152,7 @@ export default function MessageList(props: MessageListProps) {
                       {(field) => (
                         <div class="flex flex-wrap items-start gap-x-2 gap-y-1">
                           <span class="font-medium text-gray-11">{field.label}:</span>
-                          <span class="font-mono text-[11px] text-gray-10 break-all">{field.value}</span>
+                          <span class="font-mono text-[11px] text-gray-10 break-words [overflow-wrap:anywhere]">{field.value}</span>
                         </div>
                       )}
                     </For>
@@ -1167,7 +1167,7 @@ export default function MessageList(props: MessageListProps) {
                             <div class="mb-1 text-[11px] font-medium text-gray-10">{block.label}</div>
                           </Show>
                           <pre
-                            class={`max-h-80 max-w-full overflow-auto whitespace-pre-wrap break-all rounded-[14px] px-3 py-2 text-[12px] leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
+                            class={`max-h-80 max-w-full overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] rounded-[14px] px-3 py-2 text-[12px] leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
                           >
                             {block.value}
                           </pre>

--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -9,19 +9,26 @@ import {
 import type { JSX } from "solid-js";
 import type { Part, Session } from "@opencode-ai/sdk/v2/client";
 import {
+  BookOpen,
   Check,
   ChevronDown,
   ChevronRight,
   CircleAlert,
   Copy,
-  Eye,
   File,
-  FileEdit,
   FolderSearch,
-  Pencil,
+  Globe,
+  List,
+  ListTodo,
+  MessageCircleQuestion,
+  PenLine,
   Search,
-  Sparkles,
+  SquareCheck,
+  SquarePen,
   Terminal,
+  Wrench,
+  Workflow,
+  Zap,
 } from "lucide-solid";
 import { createVirtualizer } from "@tanstack/solid-virtual";
 
@@ -197,28 +204,44 @@ function explorationStatus(parts: Part[]) {
   return pending ? "exploring" : "explored";
 }
 
-/** Icon for a given tool category */
-function ToolIcon(props: { category: string; size?: number }) {
+/** Icon for a given tool */
+function ToolIcon(props: { tool?: string; size?: number }) {
   const s = () => props.size ?? 12;
-  switch (props.category) {
-    case "read":
-      return <Eye size={s()} />;
-    case "edit":
-      return <Pencil size={s()} />;
-    case "write":
-      return <FileEdit size={s()} />;
-    case "search":
-      return <Search size={s()} />;
-    case "terminal":
+  switch ((props.tool ?? "").toLowerCase()) {
+    case "bash":
       return <Terminal size={s()} />;
+    case "read":
+      return <BookOpen size={s()} />;
+    case "list":
+    case "list_files":
+      return <List size={s()} />;
     case "glob":
       return <FolderSearch size={s()} />;
+    case "grep":
+    case "search":
+      return <Search size={s()} />;
     case "task":
-      return <Sparkles size={s()} />;
+      return <Workflow size={s()} />;
+    case "todowrite":
+      return <SquareCheck size={s()} />;
+    case "todoread":
+      return <ListTodo size={s()} />;
+    case "edit":
+      return <SquarePen size={s()} />;
+    case "write":
+      return <PenLine size={s()} />;
+    case "apply_patch":
+      return <Wrench size={s()} />;
+    case "webfetch":
+      return <Globe size={s()} />;
     case "skill":
-      return <Sparkles size={s()} />;
+      return <Zap size={s()} />;
+    case "question":
+      return <MessageCircleQuestion size={s()} />;
+    case "reasoning":
+      return <Zap size={s()} />;
     default:
-      return <File size={s()} />;
+      return <Zap size={s()} />;
   }
 }
 
@@ -1053,6 +1076,12 @@ export default function MessageList(props: MessageListProps) {
   }) => {
     const summary = createMemo(() => summarizeStep(rowProps.part));
     const task = createMemo(() => getTaskStepInfo(rowProps.part));
+    const toolName = createMemo(() => {
+      if (rowProps.part.type !== "tool") return "reasoning";
+      return typeof (rowProps.part as any).tool === "string"
+        ? String((rowProps.part as any).tool)
+        : "tool";
+    });
     const disclosureId = createMemo(() => getStepDisclosureId(rowProps.part));
     const body = createMemo(() => getStepBody(rowProps.part));
     const hasDisclosure = createMemo(() => {
@@ -1065,11 +1094,7 @@ export default function MessageList(props: MessageListProps) {
     });
     const label = createMemo(() => {
       if (rowProps.part.type !== "tool") return summary().title?.trim() || "Thinking";
-      const toolName =
-        typeof (rowProps.part as any).tool === "string"
-          ? String((rowProps.part as any).tool)
-          : "tool";
-      return formatToolLabel(toolName);
+      return formatToolLabel(toolName());
     });
     const headline = createMemo(() => {
       if (rowProps.part.type === "reasoning") {
@@ -1096,8 +1121,12 @@ export default function MessageList(props: MessageListProps) {
             fallback={
               <div class="flex min-w-0 items-start gap-2.5">
                 <div class="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-start sm:gap-2.5">
-                  <span class="mt-0.5 inline-flex w-fit shrink-0 items-center rounded-md border border-gray-5/70 bg-gray-3 px-1.5 py-0.5 font-mono text-[11px] leading-none text-gray-11">
-                    {label()}
+                  <span
+                    class="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11"
+                    title={label()}
+                    aria-label={label()}
+                  >
+                    <ToolIcon tool={toolName()} size={13} />
                   </span>
                   <span class={`block min-w-0 break-words text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
                     {displayHeadline()}
@@ -1114,8 +1143,12 @@ export default function MessageList(props: MessageListProps) {
               aria-label={open() ? `Collapse ${label()} details` : `Expand ${label()} details`}
             >
               <div class="flex min-w-0 flex-col gap-1 sm:flex-row sm:flex-wrap sm:items-start sm:gap-x-2.5 sm:gap-y-1">
-                <span class="mt-0.5 inline-flex w-fit shrink-0 items-center rounded-md border border-gray-5/70 bg-gray-3 px-1.5 py-0.5 font-mono text-[11px] leading-none text-gray-11">
-                  {label()}
+                <span
+                  class="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11"
+                  title={label()}
+                  aria-label={label()}
+                >
+                  <ToolIcon tool={toolName()} size={13} />
                 </span>
                 <span class={`block min-w-0 text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
                   <span class="break-words [overflow-wrap:anywhere]">{displayHeadline()}</span>

--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -205,43 +205,42 @@ function explorationStatus(parts: Part[]) {
 }
 
 /** Icon for a given tool */
-function ToolIcon(props: { tool?: string; size?: number }) {
-  const s = () => props.size ?? 12;
+function ToolIcon(props: { tool?: string; class?: string }) {
   switch ((props.tool ?? "").toLowerCase()) {
     case "bash":
-      return <Terminal size={s()} />;
+      return <Terminal class={props.class} />;
     case "read":
-      return <BookOpen size={s()} />;
+      return <BookOpen class={props.class} />;
     case "list":
     case "list_files":
-      return <List size={s()} />;
+      return <List class={props.class} />;
     case "glob":
-      return <FolderSearch size={s()} />;
+      return <FolderSearch class={props.class} />;
     case "grep":
     case "search":
-      return <Search size={s()} />;
+      return <Search class={props.class} />;
     case "task":
-      return <Workflow size={s()} />;
+      return <Workflow class={props.class} />;
     case "todowrite":
-      return <SquareCheck size={s()} />;
+      return <SquareCheck class={props.class} />;
     case "todoread":
-      return <ListTodo size={s()} />;
+      return <ListTodo class={props.class} />;
     case "edit":
-      return <SquarePen size={s()} />;
+      return <SquarePen class={props.class} />;
     case "write":
-      return <PenLine size={s()} />;
+      return <PenLine class={props.class} />;
     case "apply_patch":
-      return <Wrench size={s()} />;
+      return <Wrench class={props.class} />;
     case "webfetch":
-      return <Globe size={s()} />;
+      return <Globe class={props.class} />;
     case "skill":
-      return <Zap size={s()} />;
+      return <Zap class={props.class} />;
     case "question":
-      return <MessageCircleQuestion size={s()} />;
+      return <MessageCircleQuestion class={props.class} />;
     case "reasoning":
-      return <Zap size={s()} />;
+      return <Zap class={props.class} />;
     default:
-      return <Zap size={s()} />;
+      return <Zap class={props.class} />;
   }
 }
 
@@ -1122,11 +1121,11 @@ export default function MessageList(props: MessageListProps) {
               <div class="flex min-w-0 items-start gap-2.5">
                 <div class="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-start sm:gap-2.5">
                   <span
-                    class="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11"
+                    class="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11 sm:h-6 sm:w-6"
                     title={label()}
                     aria-label={label()}
                   >
-                    <ToolIcon tool={toolName()} size={13} />
+                    <ToolIcon tool={toolName()} class="h-2.5 w-2.5 sm:h-3 sm:w-3" />
                   </span>
                   <span class={`block min-w-0 break-words text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
                     {displayHeadline()}
@@ -1144,11 +1143,11 @@ export default function MessageList(props: MessageListProps) {
             >
               <div class="flex min-w-0 flex-col gap-1 sm:flex-row sm:flex-wrap sm:items-start sm:gap-x-2.5 sm:gap-y-1">
                 <span
-                  class="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11"
+                  class="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11 sm:h-6 sm:w-6"
                   title={label()}
                   aria-label={label()}
                 >
-                  <ToolIcon tool={toolName()} size={13} />
+                  <ToolIcon tool={toolName()} class="h-2.5 w-2.5 sm:h-3 sm:w-3" />
                 </span>
                 <span class={`block min-w-0 text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
                   <span class="break-words [overflow-wrap:anywhere]">{displayHeadline()}</span>

--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -1091,39 +1091,43 @@ export default function MessageList(props: MessageListProps) {
     return (
       <div class="flex items-start gap-3 text-[14px] text-gray-9">
         <div class="min-w-0 flex-1 leading-relaxed">
-          <div class="flex min-w-0 items-start gap-2.5">
-            <span class="mt-0.5 inline-flex shrink-0 items-center rounded-md border border-gray-5/70 bg-gray-3 px-1.5 py-0.5 font-mono text-[11px] leading-none text-gray-11">
-              {label()}
-            </span>
-            <Show
-              when={hasDisclosure()}
-              fallback={<span class="mt-[2px] h-[14px] w-[14px] shrink-0" aria-hidden="true" />}
-            >
-              <button
-                type="button"
-                class="mt-[1px] shrink-0 rounded-sm p-0.5 text-gray-7 transition-colors hover:bg-gray-3 hover:text-gray-10"
-                onClick={toggleDisclosure}
-                aria-expanded={open()}
-                aria-label={open() ? `Collapse ${label()} details` : `Expand ${label()} details`}
-              >
-                <ChevronRight size={14} class={`transition-transform duration-200 ${open() ? "rotate-90" : ""}`} />
-              </button>
-            </Show>
+          <Show
+            when={hasDisclosure()}
+            fallback={
+              <div class="flex min-w-0 items-start gap-2.5">
+                <div class="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-start sm:gap-2.5">
+                  <span class="mt-0.5 inline-flex w-fit shrink-0 items-center rounded-md border border-gray-5/70 bg-gray-3 px-1.5 py-0.5 font-mono text-[11px] leading-none text-gray-11">
+                    {label()}
+                  </span>
+                  <span class={`block min-w-0 break-words text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
+                    {displayHeadline()}
+                  </span>
+                </div>
+              </div>
+            }
+          >
             <button
               type="button"
-              class={`min-w-0 flex-1 text-left ${hasDisclosure() ? "cursor-pointer" : "cursor-default"}`}
-              onClick={() => {
-                if (hasDisclosure()) toggleDisclosure();
-              }}
-              aria-expanded={hasDisclosure() ? open() : undefined}
+              class="group flex w-full min-w-0 items-start gap-2.5 text-left"
+              onClick={toggleDisclosure}
+              aria-expanded={open()}
+              aria-label={open() ? `Collapse ${label()} details` : `Expand ${label()} details`}
             >
-              <span class={`block min-w-0 truncate text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
-                {displayHeadline()}
+              <div class="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-start sm:gap-2.5">
+                <span class="mt-0.5 inline-flex w-fit shrink-0 items-center rounded-md border border-gray-5/70 bg-gray-3 px-1.5 py-0.5 font-mono text-[11px] leading-none text-gray-11">
+                  {label()}
+                </span>
+                <span class={`block min-w-0 break-words text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
+                  {displayHeadline()}
+                </span>
+              </div>
+              <span class="mt-[1px] shrink-0 rounded-sm p-0.5 text-gray-7 transition-colors group-hover:text-gray-10" aria-hidden="true">
+                <ChevronRight size={14} class={`transition-transform duration-200 ${open() ? "rotate-90" : ""}`} />
               </span>
             </button>
-          </div>
+          </Show>
           <Show when={open() && (body().fields.length > 0 || body().blocks.length > 0 || body().todos.length > 0)}>
-            <div class="pt-2 pl-[34px]">
+            <div class="pt-2 sm:pl-[18px]">
               <div class="grid gap-2 rounded-[18px] border border-gray-6/60 bg-gray-2/40 px-3 py-3">
                 <Show when={body().todos.length > 0}>
                   <div class="grid gap-1.5 text-[12px] text-gray-10">
@@ -1163,7 +1167,7 @@ export default function MessageList(props: MessageListProps) {
                             <div class="mb-1 text-[11px] font-medium text-gray-10">{block.label}</div>
                           </Show>
                           <pre
-                            class={`max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-[14px] px-3 py-2 text-[12px] leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
+                            class={`max-h-80 max-w-full overflow-auto whitespace-pre-wrap break-all rounded-[14px] px-3 py-2 text-[12px] leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
                           >
                             {block.value}
                           </pre>
@@ -1176,7 +1180,7 @@ export default function MessageList(props: MessageListProps) {
             </div>
           </Show>
           <Show when={task().isTask && task().sessionId && open()}>
-            <div class="pt-2 pl-[34px]">
+            <div class="pt-2 sm:pl-[18px]">
               <SubagentThread part={rowProps.part} />
             </div>
           </Show>

--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -620,6 +620,39 @@ export function classifyTool(toolName: string): "read" | "edit" | "write" | "sea
   return "tool";
 }
 
+export function formatToolLabel(toolName: string): string {
+  const lower = toolName.toLowerCase();
+  const labels: Record<string, string> = {
+    bash: "Shell",
+    read: "Read",
+    list: "List",
+    list_files: "List",
+    glob: "Glob",
+    grep: "Grep",
+    webfetch: "Fetch",
+    websearch: "Search",
+    codesearch: "Code Search",
+    task: "Task",
+    skill: "Skill",
+    edit: "Edit",
+    write: "Write",
+    apply_patch: "Patch",
+    todowrite: "Todos",
+    todoread: "Todos",
+    question: "Question",
+  };
+
+  if (labels[lower]) return labels[lower];
+
+  const fallback = normalizeStepText(toolName).replace(/[_-]+/g, " ");
+  if (!fallback) return "Tool";
+  return fallback
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
 /** Extract a clean filename from a file path */
 function extractFilename(filePath: string): string {
   const parts = filePath.replace(/\\/g, "/").split("/");
@@ -916,16 +949,19 @@ export function summarizeStep(part: Part): { title: string; detail?: string; isS
     const record = part as any;
     const toolName = record.tool ? String(record.tool) : "Tool";
     const state = record.state ?? {};
-    const title = buildToolTitle(state, toolName);
+    const title = formatToolLabel(toolName);
     const category = classifyTool(toolName);
     const status = state.status ? String(state.status) : undefined;
-    const detail = buildToolDetail(state, toolName);
+    const heading = buildToolTitle(state, toolName);
+    const extra = buildToolDetail(state, toolName);
+    const normalizedHeading = normalizeStepText(heading).toLowerCase();
     const normalizedTitle = normalizeStepText(title).toLowerCase();
+    const detail = normalizedHeading && normalizedHeading !== normalizedTitle ? heading : extra;
     const finalDetail = detail && normalizeStepText(detail).toLowerCase() !== normalizedTitle ? detail : undefined;
-    
+
     // Detect skill trigger
     if (category === "skill") {
-      const skillName = state.metadata?.name || title.replace(/^(Loaded skill:\s*|Load skill\s+)/i, "");
+      const skillName = state.metadata?.name || heading.replace(/^(Loaded skill:\s*|Load skill\s+)/i, "");
       return { title, isSkill: true, skillName, detail: finalDetail, toolCategory: category, status };
     }
     


### PR DESCRIPTION
## Summary
- add explicit tool labels to compact session trace rows and only show the chevron when a step actually has expandable content
- render inline step bodies for reasoning, todos, shell commands, search tools, and generic tool output so users can inspect full details without losing the compact timeline
- surface tool failures in the collapsed row with an `ERROR:` prefix and an expanded red error block

## Testing
- `pnpm typecheck` (in `apps/app`)
- `pnpm build` (in `apps/app`)
- attempted a live dev-server smoke run via `pnpm dev --host 127.0.0.1 --port 4177`, but the app stopped at the first-worker onboarding state so I could not exercise a real trace row without a seeded worker/session