### PR TITLE
fix(mcp): expose nvm-managed node tools to local spawns

### DIFF
--- a/apps/desktop/src-tauri/src/opkg.rs
+++ b/apps/desktop/src-tauri/src/opkg.rs
@@ -1,5 +1,6 @@
 use std::process::{Command, Stdio};
 
+use crate::paths::apply_augmented_path;
 use crate::platform::configure_hidden;
 use crate::types::ExecResult;
 
@@ -24,6 +25,7 @@ pub fn run_capture_optional(command: &mut Command) -> Result<Option<ExecResult>,
 
 pub fn opkg_install(project_dir: &str, package: &str) -> Result<ExecResult, String> {
     let mut opkg = Command::new("opkg");
+    apply_augmented_path(&mut opkg);
     configure_hidden(&mut opkg);
     opkg.arg("install")
         .arg(package)
@@ -37,6 +39,7 @@ pub fn opkg_install(project_dir: &str, package: &str) -> Result<ExecResult, Stri
     }
 
     let mut openpackage = Command::new("openpackage");
+    apply_augmented_path(&mut openpackage);
     configure_hidden(&mut openpackage);
     openpackage
         .arg("install")
@@ -51,6 +54,7 @@ pub fn opkg_install(project_dir: &str, package: &str) -> Result<ExecResult, Stri
     }
 
     let mut pnpm = Command::new("pnpm");
+    apply_augmented_path(&mut pnpm);
     configure_hidden(&mut pnpm);
     pnpm.arg("dlx")
         .arg("opkg")
@@ -66,6 +70,7 @@ pub fn opkg_install(project_dir: &str, package: &str) -> Result<ExecResult, Stri
     }
 
     let mut npx = Command::new("npx");
+    apply_augmented_path(&mut npx);
     configure_hidden(&mut npx);
     npx.arg("opkg")
         .arg("install")
@@ -80,9 +85,9 @@ pub fn opkg_install(project_dir: &str, package: &str) -> Result<ExecResult, Stri
     }
 
     Ok(ExecResult {
-    ok: false,
-    status: -1,
-    stdout: String::new(),
-    stderr: "OpenPackage CLI not found. Install with `npm install -g opkg` (or `openpackage`), or ensure pnpm/npx is available.".to_string(),
-  })
+        ok: false,
+        status: -1,
+        stdout: String::new(),
+        stderr: "OpenPackage CLI not found. Install with `npm install -g opkg` (or `openpackage`), or ensure pnpm/npx is available.".to_string(),
+    })
 }

--- a/apps/desktop/src-tauri/src/paths.rs
+++ b/apps/desktop/src-tauri/src/paths.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[cfg(target_os = "macos")]
 const MACOS_APP_SUPPORT_DIR: &str = "Library/Application Support";
@@ -130,6 +131,30 @@ pub fn sidecar_path_candidates(
 /// so tools installed via Homebrew, nvm, volta, etc. won't be found unless we
 /// explicitly include these common locations.
 fn common_tool_paths() -> Vec<PathBuf> {
+    common_tool_paths_for_home(home_dir().as_deref())
+}
+
+fn nvm_version_bin_paths(home: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let base = home.join(".nvm").join("versions").join("node");
+
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return paths;
+    };
+
+    for entry in entries.flatten() {
+        let candidate = entry.path().join("bin");
+        if candidate.is_dir() {
+            paths.push(candidate);
+        }
+    }
+
+    paths.sort();
+    paths.reverse();
+    paths
+}
+
+fn common_tool_paths_for_home(home: Option<&Path>) -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
     #[cfg(target_os = "macos")]
@@ -141,9 +166,10 @@ fn common_tool_paths() -> Vec<PathBuf> {
         paths.push(PathBuf::from("/usr/local/sbin"));
 
         // User-specific paths for common version managers
-        if let Some(home) = home_dir() {
+        if let Some(home) = home {
             // nvm, fnm (Node version managers)
             paths.push(home.join(".nvm/current/bin"));
+            paths.extend(nvm_version_bin_paths(home));
             paths.push(home.join(".fnm/current/bin"));
             // volta
             paths.push(home.join(".volta/bin"));
@@ -165,9 +191,10 @@ fn common_tool_paths() -> Vec<PathBuf> {
         paths.push(PathBuf::from("/usr/local/bin"));
         paths.push(PathBuf::from("/usr/local/sbin"));
 
-        if let Some(home) = home_dir() {
+        if let Some(home) = home {
             // nvm, fnm
             paths.push(home.join(".nvm/current/bin"));
+            paths.extend(nvm_version_bin_paths(home));
             paths.push(home.join(".fnm/current/bin"));
             // volta
             paths.push(home.join(".volta/bin"));
@@ -186,7 +213,7 @@ fn common_tool_paths() -> Vec<PathBuf> {
 
     #[cfg(windows)]
     {
-        if let Some(home) = home_dir() {
+        if let Some(home) = home {
             // volta
             paths.push(home.join(".volta/bin"));
             // pnpm
@@ -206,6 +233,16 @@ fn common_tool_paths() -> Vec<PathBuf> {
     }
 
     paths
+}
+
+pub fn augmented_path_env() -> Option<std::ffi::OsString> {
+    prepended_path_env(&[])
+}
+
+pub fn apply_augmented_path(command: &mut Command) {
+    if let Some(path_env) = augmented_path_env() {
+        command.env("PATH", path_env);
+    }
 }
 
 pub fn prepended_path_env(prefixes: &[PathBuf]) -> Option<std::ffi::OsString> {
@@ -237,4 +274,51 @@ pub fn prepended_path_env(prefixes: &[PathBuf]) -> Option<std::ffi::OsString> {
     }
 
     env::join_paths(entries).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{common_tool_paths_for_home, nvm_version_bin_paths};
+    use std::fs::create_dir_all;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_home() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("openwork-paths-{unique}"));
+        create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn nvm_version_bin_paths_include_installed_versions() {
+        let home = temp_home();
+        let v20 = home.join(".nvm/versions/node/v20.12.2/bin");
+        let v24 = home.join(".nvm/versions/node/v24.12.0/bin");
+        create_dir_all(&v20).unwrap();
+        create_dir_all(&v24).unwrap();
+
+        let paths = nvm_version_bin_paths(&home);
+        assert_eq!(paths, vec![v24, v20]);
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn common_tool_paths_include_nvm_current_and_versions() {
+        let home = temp_home();
+        let current = home.join(".nvm/current/bin");
+        let version = home.join(".nvm/versions/node/v24.12.0/bin");
+        create_dir_all(&current).unwrap();
+        create_dir_all(&version).unwrap();
+
+        let paths = common_tool_paths_for_home(Some(&home));
+        assert!(paths.contains(&current));
+        assert!(paths.contains(&version));
+
+        let _ = std::fs::remove_dir_all(home);
+    }
 }

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -19,6 +19,7 @@ import {
   writeFile,
   realpath,
 } from "node:fs/promises";
+import { readdirSync, statSync } from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import { createServer as createHttpServer } from "node:http";
 import { homedir, hostname, networkInterfaces, tmpdir } from "node:os";
@@ -143,6 +144,9 @@ const SANDBOX_OPENCODE_GLOBAL_CONFIG_CONTAINER_PATH =
   "/persist/.config/opencode";
 const SANDBOX_OPENCODE_GLOBAL_DATA_IMPORT_CONTAINER_PATH =
   "/persist/.openwork-host-opencode-data";
+const CLI_SOURCE_DIR = dirname(fileURLToPath(import.meta.url));
+const ORCHESTRATOR_ROOT_DIR = resolve(CLI_SOURCE_DIR, "..");
+const REPO_ROOT_DIR = resolve(ORCHESTRATOR_ROOT_DIR, "..", "..");
 
 type ParsedArgs = {
   positionals: string[];
@@ -1279,6 +1283,130 @@ const remoteManifestCache = new Map<
 >();
 
 let latestOpencodeVersionTask: Promise<string | undefined> | null = null;
+let cachedExtraPathEntries: string[] | null = null;
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function splitPathEntries(value?: string): string[] {
+  if (!value) return [];
+  return value.split(delimiter).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function pushPath(entries: string[], path?: string | null) {
+  if (!path) return;
+  const candidate = resolve(path.trim());
+  if (!isDirectory(candidate)) return;
+  if (!entries.includes(candidate)) entries.push(candidate);
+}
+
+function nvmVersionBinPaths(home: string): string[] {
+  const base = join(home, ".nvm", "versions", "node");
+  try {
+    return readdirSync(base, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(base, entry.name, "bin"))
+      .filter(isDirectory)
+      .sort()
+      .reverse();
+  } catch {
+    return [];
+  }
+}
+
+function resolveExtraPathEntries(): string[] {
+  if (cachedExtraPathEntries) return cachedExtraPathEntries;
+
+  const entries: string[] = [];
+  const sidecarOverride =
+    process.env.OPENWRK_SIDECAR_DIR ?? process.env.OPENWORK_SIDECAR_DIR;
+  const sidecarCandidates = [
+    sidecarOverride,
+    dirname(process.execPath),
+    join(dirname(process.execPath), "sidecars"),
+    join(ORCHESTRATOR_ROOT_DIR, "dist"),
+    resolve(REPO_ROOT_DIR, "apps", "desktop", "src-tauri", "sidecars"),
+  ];
+  for (const candidate of sidecarCandidates) {
+    pushPath(entries, candidate);
+  }
+
+  const home = homedir();
+  if (process.platform === "darwin") {
+    for (const candidate of [
+      "/opt/homebrew/bin",
+      "/opt/homebrew/sbin",
+      "/usr/local/bin",
+      "/usr/local/sbin",
+      join(home, ".nvm", "current", "bin"),
+      ...nvmVersionBinPaths(home),
+      join(home, ".fnm", "current", "bin"),
+      join(home, ".volta", "bin"),
+      join(home, "Library", "pnpm"),
+      join(home, ".bun", "bin"),
+      join(home, ".cargo", "bin"),
+      join(home, ".pyenv", "shims"),
+      join(home, ".local", "bin"),
+    ]) {
+      pushPath(entries, candidate);
+    }
+  }
+
+  if (process.platform === "linux") {
+    for (const candidate of [
+      "/usr/local/bin",
+      "/usr/local/sbin",
+      join(home, ".nvm", "current", "bin"),
+      ...nvmVersionBinPaths(home),
+      join(home, ".fnm", "current", "bin"),
+      join(home, ".volta", "bin"),
+      join(home, ".local", "share", "pnpm"),
+      join(home, ".bun", "bin"),
+      join(home, ".cargo", "bin"),
+      join(home, ".pyenv", "shims"),
+      join(home, ".local", "bin"),
+    ]) {
+      pushPath(entries, candidate);
+    }
+  }
+
+  if (process.platform === "win32") {
+    for (const candidate of [
+      join(home, ".volta", "bin"),
+      join(home, ".bun", "bin"),
+      join(home, ".cargo", "bin"),
+      process.env.APPDATA ? join(process.env.APPDATA, "npm") : null,
+      process.env.LOCALAPPDATA ? join(process.env.LOCALAPPDATA, "pnpm") : null,
+    ]) {
+      pushPath(entries, candidate);
+    }
+  }
+
+  cachedExtraPathEntries = entries;
+  return entries;
+}
+
+function buildSpawnEnv(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const base = env ?? process.env;
+  const pathKey =
+    Object.prototype.hasOwnProperty.call(base, "PATH") ||
+    !Object.prototype.hasOwnProperty.call(base, "Path")
+      ? "PATH"
+      : "Path";
+  const currentPath = pathKey === "PATH" ? base.PATH : base.Path;
+  const entries = [
+    ...resolveExtraPathEntries(),
+    ...splitPathEntries(currentPath),
+  ];
+  const deduped = entries.filter((entry, index) => entries.indexOf(entry) === index);
+  if (!deduped.length) return { ...base };
+  return { ...base, [pathKey]: deduped.join(delimiter) };
+}
 
 function resolveSidecarTarget(): SidecarTarget | null {
   if (process.platform === "darwin") {
@@ -1328,10 +1456,12 @@ function spawnProcess(
   args: string[],
   options: SpawnOptions = {},
 ) {
+  const env = buildSpawnEnv(options.env);
+  const resolvedOptions = { ...options, env };
   if (process.platform === "win32") {
-    return spawn(command, args, { ...options, windowsHide: true });
+    return spawn(command, args, { ...resolvedOptions, windowsHide: true });
   }
-  return spawn(command, args, options);
+  return spawn(command, args, resolvedOptions);
 }
 
 async function probeCommand(
@@ -3700,6 +3830,7 @@ async function writeSandboxEntrypoint(options: {
     'export XDG_CACHE_HOME="$HOME/.cache"',
     'export XDG_DATA_HOME="$HOME/.local/share"',
     'export XDG_STATE_HOME="$HOME/.local/state"',
+    `export PATH=${shQuote(`${options.rootInContainer}/sidecars`)}:"\${PATH:-}"`,
     'mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"',
     // Do not `cd` into the mounted workspace: bun-compiled sidecars read bunfig.toml
     // from cwd, and user workspaces may include preloads that break startup.


### PR DESCRIPTION
## Summary
- add desktop PATH augmentation that discovers versioned nvm installs and reuses it for `npx`, `pnpm`, and related local tool lookups
- apply the same PATH enrichment in the orchestrator so local MCP commands and worker spawns can find nvm-managed Node tools reliably
- prepend sandbox sidecars to `PATH` so bundled `chrome-devtools-mcp` resolves before shell-managed installs

## Testing
- `pnpm --filter openwork-orchestrator typecheck`
- `pnpm --filter openwork-orchestrator build`
- `pnpm --filter @openwork/desktop prepare:sidecar`
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml paths`