### PR TITLE
fix(app): preserve worker names in narrow sidebars

### DIFF
--- a/apps/app/src/app/components/session/workspace-session-list.tsx
+++ b/apps/app/src/app/components/session/workspace-session-list.tsx
@@ -443,12 +443,12 @@ export default function WorkspaceSessionList(props: Props) {
                           ),
                         }}
                       />
-                      <div class="min-w-0 flex items-baseline gap-3">
+                      <div class="min-w-0 flex flex-1 flex-wrap items-baseline gap-x-3 gap-y-1">
                         <div class="min-w-0 flex-1 truncate text-[14px] font-normal text-dls-text">
                           {workspaceLabel(workspace())}
                         </div>
                         <div
-                          class={`shrink-0 whitespace-nowrap text-[12px] ${statusTone()}`}
+                          class={`ml-auto whitespace-nowrap text-[12px] ${statusTone()}`}
                         >
                           {statusLabel()}
                         </div>


### PR DESCRIPTION
Worker rows in the sidebar kept the Local/Remote status label on the same non-wrapping line as the worker name, so narrow widths would hide the worker name first. This updates the row layout so the status can wrap to its own line while the worker name keeps the primary truncation space.

Verified with 
> @different-ai/openwork-workspace@0.0.0 typecheck /Users/jan/Programming/the-cloud-factory/_repos/openwork/_worktrees/preserve-worker-name-sidebar
> pnpm --filter @openwork/app typecheck


> @openwork/app@0.11.173 typecheck /Users/jan/Programming/the-cloud-factory/_repos/openwork/_worktrees/preserve-worker-name-sidebar/apps/app
> tsc -p tsconfig.json --noEmit and 
> @different-ai/openwork-workspace@0.0.0 build:ui /Users/jan/Programming/the-cloud-factory/_repos/openwork/_worktrees/preserve-worker-name-sidebar
> pnpm --filter @openwork/app build


> @openwork/app@0.11.173 build /Users/jan/Programming/the-cloud-factory/_repos/openwork/_worktrees/preserve-worker-name-sidebar/apps/app
> vite build

vite v6.4.1 building for production...
transforming...
✓ 2091 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                     1.36 kB │ gzip:   0.61 kB
dist/assets/index-CogQJ8qF.css    204.74 kB │ gzip:  41.87 kB
dist/assets/index-BthJ-1Py.js       0.29 kB │ gzip:   0.18 kB
dist/assets/index-BTX6Bl_p.js       0.33 kB │ gzip:   0.22 kB
dist/assets/index-DnwC04Ee.js       0.52 kB │ gzip:   0.25 kB
dist/assets/index-BQqIPb1B.js   1,323.77 kB │ gzip: 358.22 kB
✓ built in 3.27s.