### PR TITLE
fix(ci): authenticate Daytona snapshot publishing

### DIFF
--- a/scripts/create-daytona-openwork-snapshot.sh
+++ b/scripts/create-daytona-openwork-snapshot.sh
@@ -22,6 +22,11 @@ if [ -f "$DAYTONA_ENV_FILE" ]; then
   set +a
 fi
 
+if [ -n "${DAYTONA_API_KEY:-}" ]; then
+  echo "Authenticating Daytona CLI" >&2
+  daytona login --api-key "$DAYTONA_API_KEY" >/dev/null
+fi
+
 SNAPSHOT_NAME="${1:-${DAYTONA_SNAPSHOT_NAME:-openwork-runtime}}"
 SNAPSHOT_REGION="${DAYTONA_SNAPSHOT_REGION:-${DAYTONA_TARGET:-}}"
 SNAPSHOT_CPU="${DAYTONA_SNAPSHOT_CPU:-1}"


### PR DESCRIPTION
## Summary
- log the Daytona CLI in with `DAYTONA_API_KEY` before the release workflow publishes the snapshot
- teach `scripts/create-daytona-openwork-snapshot.sh` to auto-authenticate when the API key is present so CI and local env-driven runs share the same behavior
- fix the current release failure where `daytona snapshot push` aborts with `no profiles found. Run \`daytona login\` to authenticate`

## Validation
- `bash -n scripts/create-daytona-openwork-snapshot.sh`
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release-daytona-snapshot.yml\")'`