### PR TITLE
revert(app): restore original session trace

### DIFF
--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -9,26 +9,19 @@ import {
 import type { JSX } from "solid-js";
 import type { Part, Session } from "@opencode-ai/sdk/v2/client";
 import {
-  BookOpen,
   Check,
   ChevronDown,
   ChevronRight,
   CircleAlert,
   Copy,
+  Eye,
   File,
+  FileEdit,
   FolderSearch,
-  Globe,
-  List,
-  ListTodo,
-  MessageCircleQuestion,
-  PenLine,
+  Pencil,
   Search,
-  SquareCheck,
-  SquarePen,
+  Sparkles,
   Terminal,
-  Wrench,
-  Workflow,
-  Zap,
 } from "lucide-solid";
 import { createVirtualizer } from "@tanstack/solid-virtual";
 
@@ -37,13 +30,10 @@ import {
   type MessageGroup,
   type MessageWithParts,
   type StepGroupMode,
-  type TodoItem,
 } from "../../types";
 import {
-  formatToolLabel,
   groupMessageParts,
   isUserVisiblePart,
-  safeStringify,
   summarizeStep,
 } from "../../utils";
 import PartView from "../part-view";
@@ -204,43 +194,28 @@ function explorationStatus(parts: Part[]) {
   return pending ? "exploring" : "explored";
 }
 
-/** Icon for a given tool */
-function ToolIcon(props: { tool?: string; class?: string }) {
-  switch ((props.tool ?? "").toLowerCase()) {
-    case "bash":
-      return <Terminal class={props.class} />;
+/** Icon for a given tool category */
+function ToolIcon(props: { category: string; size?: number }) {
+  const s = () => props.size ?? 12;
+  switch (props.category) {
     case "read":
-      return <BookOpen class={props.class} />;
-    case "list":
-    case "list_files":
-      return <List class={props.class} />;
-    case "glob":
-      return <FolderSearch class={props.class} />;
-    case "grep":
-    case "search":
-      return <Search class={props.class} />;
-    case "task":
-      return <Workflow class={props.class} />;
-    case "todowrite":
-      return <SquareCheck class={props.class} />;
-    case "todoread":
-      return <ListTodo class={props.class} />;
+      return <Eye size={s()} />;
     case "edit":
-      return <SquarePen class={props.class} />;
+      return <Pencil size={s()} />;
     case "write":
-      return <PenLine class={props.class} />;
-    case "apply_patch":
-      return <Wrench class={props.class} />;
-    case "webfetch":
-      return <Globe class={props.class} />;
+      return <FileEdit size={s()} />;
+    case "search":
+      return <Search size={s()} />;
+    case "terminal":
+      return <Terminal size={s()} />;
+    case "glob":
+      return <FolderSearch size={s()} />;
+    case "task":
+      return <Sparkles size={s()} />;
     case "skill":
-      return <Zap class={props.class} />;
-    case "question":
-      return <MessageCircleQuestion class={props.class} />;
-    case "reasoning":
-      return <Zap class={props.class} />;
+      return <Sparkles size={s()} />;
     default:
-      return <Zap class={props.class} />;
+      return <File size={s()} />;
   }
 }
 
@@ -429,183 +404,6 @@ function toolHeadline(part: Part) {
   return "";
 }
 
-type StepBodyField = {
-  label: string;
-  value: string;
-};
-
-type StepBodyBlock = {
-  label?: string;
-  value: string;
-  tone?: "default" | "error";
-};
-
-type StepBody = {
-  fields: StepBodyField[];
-  blocks: StepBodyBlock[];
-  todos: TodoItem[];
-};
-
-function trimBodyText(value: unknown): string {
-  if (typeof value !== "string") return "";
-  return value.replace(/\r\n/g, "\n").trim();
-}
-
-function firstMeaningfulLine(value: string): string {
-  return value
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean) ?? "";
-}
-
-function getStepDisclosureId(part: Part): string {
-  const record = part as { id?: string | number; callID?: string | number; messageID?: string | number };
-  const raw = record.id ?? record.callID ?? record.messageID;
-  if (typeof raw === "string" && raw.trim()) return `step:${raw.trim()}`;
-  if (typeof raw === "number") return `step:${String(raw)}`;
-  return "";
-}
-
-function getStepBody(part: Part): StepBody {
-  if (part.type === "reasoning") {
-    const text = trimBodyText((part as { text?: string }).text);
-    if (!text) return { fields: [], blocks: [], todos: [] };
-    return { fields: [], blocks: [{ value: text }], todos: [] };
-  }
-
-  if (part.type !== "tool") {
-    return { fields: [], blocks: [], todos: [] };
-  }
-
-  const record = part as any;
-  const tool = typeof record.tool === "string" ? record.tool.toLowerCase() : "";
-  const state = record.state ?? {};
-  const input = state.input && typeof state.input === "object" ? (state.input as Record<string, unknown>) : {};
-  const fields: StepBodyField[] = [];
-  const blocks: StepBodyBlock[] = [];
-
-  const pick = (...keys: string[]) => {
-    for (const key of keys) {
-      const value = input[key];
-      if (typeof value === "string" && value.trim()) return value.trim();
-      if (typeof value === "number" || typeof value === "boolean") return String(value);
-    }
-    return "";
-  };
-
-  const pushField = (label: string, value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed) return;
-    fields.push({ label, value: trimmed });
-  };
-
-  const error = trimBodyText(state.error);
-  const output = trimBodyText(state.output);
-  const command = pick("command", "cmd");
-
-  if (tool === "todowrite" || tool === "todoread") {
-    const todos = Array.isArray(input.todos)
-      ? input.todos.filter((item): item is TodoItem => {
-          if (!item || typeof item !== "object") return false;
-          const content = (item as { content?: unknown }).content;
-          return typeof content === "string" && content.trim().length > 0;
-        })
-      : [];
-    return { fields: [], blocks: [], todos };
-  }
-
-  if (tool === "bash") {
-    if (command) {
-      const content = output ? `$ ${command}\n${output}` : `$ ${command}`;
-      blocks.push({ value: content });
-    } else if (output) {
-      blocks.push({ value: output });
-    }
-    if (error && error !== output) {
-      blocks.push({ label: "Error", value: error, tone: "error" });
-    }
-    return { fields, blocks, todos: [] };
-  }
-
-  if (tool === "grep" || tool === "search") {
-    pushField("pattern", pick("pattern", "query"));
-    pushField("path", pick("path"));
-    pushField("include", pick("include"));
-  } else if (tool === "glob") {
-    pushField("pattern", pick("pattern"));
-    pushField("path", pick("path"));
-  } else if (tool === "read") {
-    pushField("file", pick("filePath", "path", "file"));
-    pushField("offset", pick("offset"));
-    pushField("limit", pick("limit"));
-  } else if (tool === "list" || tool === "list_files") {
-    pushField("path", pick("path"));
-  } else if (tool === "webfetch") {
-    pushField("url", pick("url"));
-    pushField("format", pick("format"));
-  } else if (tool === "edit" || tool === "write") {
-    pushField("file", pick("filePath", "path", "file"));
-  } else if (tool === "apply_patch") {
-    const patch = trimBodyText(input.patchText);
-    if (patch) blocks.push({ value: patch });
-  }
-
-  if (output) {
-    blocks.push({ value: output });
-  }
-
-  if (error && error !== output) {
-    blocks.push({ label: "Error", value: error, tone: "error" });
-  }
-
-  if (!fields.length && !blocks.length && Object.keys(input).length > 0) {
-    blocks.push({ label: "Input", value: safeStringify(input) });
-  }
-
-  return { fields, blocks, todos: [] };
-}
-
-function hasExpandableStepBody(part: Part): boolean {
-  const body = getStepBody(part);
-  return body.fields.length > 0 || body.blocks.length > 0 || body.todos.length > 0;
-}
-
-function serializeStepBody(body: StepBody): string {
-  const sections: string[] = [];
-
-  if (body.todos.length > 0) {
-    sections.push(
-      body.todos
-        .map((todo) =>
-          todo.status && todo.status !== "pending"
-            ? `- ${todo.content} (${todo.status})`
-            : `- ${todo.content}`,
-        )
-        .join("\n"),
-    );
-  }
-
-  if (body.fields.length > 0) {
-    sections.push(body.fields.map((field) => `${field.label}: ${field.value}`).join("\n"));
-  }
-
-  if (body.blocks.length > 0) {
-    sections.push(
-      body.blocks
-        .map((block) => (block.label ? `${block.label}:\n${block.value}` : block.value))
-        .join("\n\n"),
-    );
-  }
-
-  return sections.join("\n\n").trim();
-}
-
-function isErrorStep(part: Part): boolean {
-  if (part.type !== "tool") return false;
-  const state = (part as any).state ?? {};
-  return state.status === "error" || trimBodyText(state.error).length > 0;
-}
-
 export default function MessageList(props: MessageListProps) {
   const [copyingId, setCopyingId] = createSignal<string | null>(null);
   let previousMessagePartCountById = new Map<string, number>();
@@ -655,22 +453,6 @@ export default function MessageList(props: MessageListProps) {
       // ignore
     }
   };
-
-  const CopyAction = (copyProps: { id: string; text: string; title: string }) => (
-    <button
-      class="text-dls-secondary hover:text-dls-text p-1 rounded hover:bg-dls-hover transition-colors"
-      title={copyProps.title}
-      aria-label={copyProps.title}
-      onClick={(event) => {
-        event.stopPropagation();
-        void handleCopy(copyProps.text, copyProps.id);
-      }}
-    >
-      <Show when={copyingId() === copyProps.id} fallback={<Copy size={12} />}>
-        <Check size={12} class="text-green-10" />
-      </Show>
-    </button>
-  );
 
   const partToText = (part: Part) => {
     if (part.type === "text") {
@@ -1120,168 +902,36 @@ export default function MessageList(props: MessageListProps) {
     groupMode?: StepGroupMode;
   }) => {
     const summary = createMemo(() => summarizeStep(rowProps.part));
-    const task = createMemo(() => getTaskStepInfo(rowProps.part));
-    const toolName = createMemo(() => {
-      if (rowProps.part.type !== "tool") return "reasoning";
-      return typeof (rowProps.part as any).tool === "string"
-        ? String((rowProps.part as any).tool)
-        : "tool";
-    });
-    const disclosureId = createMemo(() => getStepDisclosureId(rowProps.part));
-    const body = createMemo(() => getStepBody(rowProps.part));
-    const hasDisclosure = createMemo(() => {
-      if (task().isTask && task().sessionId) return true;
-      return hasExpandableStepBody(rowProps.part);
-    });
-    const open = createMemo(() => {
-      const id = disclosureId();
-      return Boolean(id) && hasDisclosure() && isStepsExpanded(id);
-    });
-    const label = createMemo(() => {
-      if (rowProps.part.type !== "tool") return summary().title?.trim() || "Thinking";
-      return formatToolLabel(toolName());
-    });
     const headline = createMemo(() => {
-      if (rowProps.part.type === "reasoning") {
-        return summary().detail?.trim() || summary().title?.trim() || "Thinking";
+      const fromTool = toolHeadline(rowProps.part);
+      if (fromTool) return fromTool;
+      const title = summary().title?.trim() ?? "";
+      const detail = summary().detail?.trim() ?? "";
+      if (title && detail && detail.toLowerCase() !== title.toLowerCase()) {
+        return `${title} - ${detail}`;
       }
-      return summary().detail?.trim() || toolHeadline(rowProps.part) || summary().title?.trim() || "Updates progress";
+      return detail || title || "Updates progress";
     });
-    const displayHeadline = createMemo(() => {
-      const base = headline();
-      if (!isErrorStep(rowProps.part)) return base;
-      return base.startsWith("ERROR:") ? base : `ERROR: ${base || firstMeaningfulLine(trimBodyText((rowProps.part as any)?.state?.error)) || "Tool failed"}`;
-    });
-    const summaryCopyText = createMemo(() => displayHeadline().trim());
-    const fullResponseCopyText = createMemo(() => serializeStepBody(body()));
-    const summaryCopyId = createMemo(() => `step-summary:${disclosureId() || toolName()}:${displayHeadline()}`);
-    const fullResponseCopyId = createMemo(() => `step-body:${disclosureId() || toolName()}`);
-    const toggleDisclosure = () => {
-      const id = disclosureId();
-      if (!id || !hasDisclosure()) return;
-      toggleSteps(id);
-    };
+    const task = createMemo(() => getTaskStepInfo(rowProps.part));
+
+    if (rowProps.part.type === "reasoning") {
+      return (
+        <div class="flex items-start gap-3 text-[14px] text-gray-9">
+          <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
+          <div class="min-w-0 leading-relaxed">
+            <span>{headline()}</span>
+          </div>
+        </div>
+      );
+    }
 
     return (
-      <div class="group/step flex items-start gap-3 text-[14px] text-gray-9">
+      <div class="flex items-start gap-3 text-[14px] text-gray-9">
+        <ChevronRight size={14} class="mt-[2px] shrink-0 text-gray-7" />
         <div class="min-w-0 flex-1 leading-relaxed">
-          <Show
-            when={hasDisclosure()}
-            fallback={
-              <div class="flex min-w-0 items-start gap-2.5 sm:items-center">
-                <div class="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-center sm:gap-2.5">
-                  <span
-                    class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11 sm:h-6 sm:w-6"
-                    title={label()}
-                    aria-label={label()}
-                  >
-                    <ToolIcon tool={toolName()} class="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-                  </span>
-                  <span class={`block min-w-0 break-words text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
-                    {displayHeadline()}
-                  </span>
-                </div>
-                <Show when={summaryCopyText()}>
-                  <div class="flex shrink-0 self-center opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/step:opacity-100 md:group-hover/step:pointer-events-auto md:group-focus-within/step:opacity-100 md:group-focus-within/step:pointer-events-auto transition-opacity select-none">
-                    <CopyAction id={summaryCopyId()} text={summaryCopyText()} title="Copy summary" />
-                  </div>
-                </Show>
-              </div>
-            }
-          >
-            <div class="flex min-w-0 items-start gap-2.5 sm:items-center">
-              <button
-                type="button"
-                class="group flex min-w-0 flex-1 items-start gap-2.5 text-left sm:items-center"
-                onClick={toggleDisclosure}
-                aria-expanded={open()}
-                aria-label={open() ? `Collapse ${label()} details` : `Expand ${label()} details`}
-              >
-                <div class="flex min-w-0 flex-col gap-1 sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-2.5 sm:gap-y-1">
-                  <span
-                    class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-gray-5/70 bg-gray-3 text-gray-11 sm:h-6 sm:w-6"
-                    title={label()}
-                    aria-label={label()}
-                  >
-                    <ToolIcon tool={toolName()} class="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-                  </span>
-                  <span class={`inline-flex min-w-0 items-center gap-1 leading-5 text-[13px] ${isErrorStep(rowProps.part) ? "font-medium text-red-11" : "text-gray-9"}`}>
-                    <span class="min-w-0 break-words [overflow-wrap:anywhere]">{displayHeadline()}</span>
-                    <span class="inline-flex shrink-0 self-center text-gray-7 transition-colors group-hover:text-gray-10" aria-hidden="true">
-                      <ChevronRight size={14} class={`transition-transform duration-200 ${open() ? "rotate-90" : ""}`} />
-                    </span>
-                  </span>
-                </div>
-              </button>
-              <Show when={summaryCopyText()}>
-                <div class="flex shrink-0 self-center opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/step:opacity-100 md:group-hover/step:pointer-events-auto md:group-focus-within/step:opacity-100 md:group-focus-within/step:pointer-events-auto transition-opacity select-none">
-                  <CopyAction id={summaryCopyId()} text={summaryCopyText()} title="Copy summary" />
-                </div>
-              </Show>
-            </div>
-          </Show>
-          <Show when={open() && (body().fields.length > 0 || body().blocks.length > 0 || body().todos.length > 0)}>
-            <div class="min-w-0 pt-2 sm:pl-[18px]">
-              <div class="grid min-w-0 w-full gap-2 overflow-hidden rounded-[18px] border border-gray-6/60 bg-gray-2/40 px-3 py-3">
-                <Show when={fullResponseCopyText()}>
-                  <div class="flex justify-end opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover/step:opacity-100 md:group-hover/step:pointer-events-auto md:group-focus-within/step:opacity-100 md:group-focus-within/step:pointer-events-auto transition-opacity select-none">
-                    <CopyAction id={fullResponseCopyId()} text={fullResponseCopyText()} title="Copy full response" />
-                  </div>
-                </Show>
-                <Show when={body().todos.length > 0}>
-                  <div class="grid gap-1.5 text-[12px] text-gray-10">
-                    <For each={body().todos}>
-                      {(todo) => (
-                        <div class="flex items-start gap-2">
-                          <span class="mt-[6px] h-1.5 w-1.5 shrink-0 rounded-full bg-gray-8" />
-                          <span class="leading-5">
-                            {todo.content}
-                            <Show when={todo.status && todo.status !== "pending"}>
-                              <span class="text-gray-8"> {`(${todo.status})`}</span>
-                            </Show>
-                          </span>
-                        </div>
-                      )}
-                    </For>
-                  </div>
-                </Show>
-                <Show when={body().fields.length > 0}>
-                  <div class="grid min-w-0 gap-1.5 text-[12px] text-gray-10">
-                    <For each={body().fields}>
-                      {(field) => (
-                        <div class="flex flex-wrap items-start gap-x-2 gap-y-1">
-                          <span class="font-medium text-gray-11">{field.label}:</span>
-                          <span class="font-mono text-[11px] text-gray-10 break-words [overflow-wrap:anywhere]">{field.value}</span>
-                        </div>
-                      )}
-                    </For>
-                  </div>
-                </Show>
-                <Show when={body().blocks.length > 0}>
-                  <div class="grid min-w-0 gap-2">
-                    <For each={body().blocks}>
-                      {(block) => (
-                        <div class="min-w-0">
-                          <Show when={block.label}>
-                            <div class="mb-1 text-[11px] font-medium text-gray-10">{block.label}</div>
-                          </Show>
-                          <pre
-                            class={`block max-h-80 min-w-0 w-full max-w-full overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] rounded-[14px] px-3 py-2 text-[11px] leading-4 sm:text-[12px] sm:leading-5 ${block.tone === "error" ? "bg-red-1/60 text-red-12" : "bg-gray-3 text-gray-11"}`}
-                          >
-                            {block.value}
-                          </pre>
-                        </div>
-                      )}
-                    </For>
-                  </div>
-                </Show>
-              </div>
-            </div>
-          </Show>
-          <Show when={task().isTask && task().sessionId && open()}>
-            <div class="pt-2 sm:pl-[18px]">
-              <SubagentThread part={rowProps.part} />
-            </div>
+          <span>{headline()}</span>
+          <Show when={task().isTask && task().sessionId}>
+            <SubagentThread part={rowProps.part} />
           </Show>
         </div>
       </div>

--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -620,39 +620,6 @@ export function classifyTool(toolName: string): "read" | "edit" | "write" | "sea
   return "tool";
 }
 
-export function formatToolLabel(toolName: string): string {
-  const lower = toolName.toLowerCase();
-  const labels: Record<string, string> = {
-    bash: "Shell",
-    read: "Read",
-    list: "List",
-    list_files: "List",
-    glob: "Glob",
-    grep: "Grep",
-    webfetch: "Fetch",
-    websearch: "Search",
-    codesearch: "Code Search",
-    task: "Task",
-    skill: "Skill",
-    edit: "Edit",
-    write: "Write",
-    apply_patch: "Patch",
-    todowrite: "Todos",
-    todoread: "Todos",
-    question: "Question",
-  };
-
-  if (labels[lower]) return labels[lower];
-
-  const fallback = normalizeStepText(toolName).replace(/[_-]+/g, " ");
-  if (!fallback) return "Tool";
-  return fallback
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
 /** Extract a clean filename from a file path */
 function extractFilename(filePath: string): string {
   const parts = filePath.replace(/\\/g, "/").split("/");
@@ -949,19 +916,16 @@ export function summarizeStep(part: Part): { title: string; detail?: string; isS
     const record = part as any;
     const toolName = record.tool ? String(record.tool) : "Tool";
     const state = record.state ?? {};
-    const title = formatToolLabel(toolName);
+    const title = buildToolTitle(state, toolName);
     const category = classifyTool(toolName);
     const status = state.status ? String(state.status) : undefined;
-    const heading = buildToolTitle(state, toolName);
-    const extra = buildToolDetail(state, toolName);
-    const normalizedHeading = normalizeStepText(heading).toLowerCase();
+    const detail = buildToolDetail(state, toolName);
     const normalizedTitle = normalizeStepText(title).toLowerCase();
-    const detail = normalizedHeading && normalizedHeading !== normalizedTitle ? heading : extra;
     const finalDetail = detail && normalizeStepText(detail).toLowerCase() !== normalizedTitle ? detail : undefined;
-
+    
     // Detect skill trigger
     if (category === "skill") {
-      const skillName = state.metadata?.name || heading.replace(/^(Loaded skill:\s*|Load skill\s+)/i, "");
+      const skillName = state.metadata?.name || title.replace(/^(Loaded skill:\s*|Load skill\s+)/i, "");
       return { title, isSkill: true, skillName, detail: finalDetail, toolCategory: category, status };
     }
     


### PR DESCRIPTION
## Summary
- revert the session trace redesign commits (`b05161e6`, `8166ce8e`, `e0cdda34`, `7dfcbc9d`) so `dev` returns to the original trace behavior
- restore the pre-trace StepRow implementation, including the existing reasoning/thinking behavior, while we rework a more surgical follow-up separately

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm typecheck` (in `apps/app`)
- `pnpm build` (in `apps/app`)