### PR TITLE
fix(app): collapse the session rail and rename shared folder

### DIFF
--- a/apps/app/src/app/components/session/composer.tsx
+++ b/apps/app/src/app/components/session/composer.tsx
@@ -1253,13 +1253,15 @@ export default function Composer(props: ComposerProps) {
           emitDraftChange();
           props.onToast(
             links.length === 1
-              ? `Uploaded ${links[0].name} to inbox and inserted a link.`
-              : `Uploaded ${links.length} files to inbox and inserted links.`,
+              ? `Uploaded ${links[0].name} to the shared folder and inserted a link.`
+              : `Uploaded ${links.length} files to the shared folder and inserted links.`,
           );
           return;
         }
       }
-      props.onToast("Couldn't upload to inbox. Inserted local links instead.");
+      props.onToast(
+        "Couldn't upload to the shared folder. Inserted local links instead.",
+      );
     }
 
     const text = formatLinks(fallbackLinks());
@@ -1305,8 +1307,8 @@ export default function Composer(props: ComposerProps) {
       const hasAbsoluteWindows = /(^|\s)[a-zA-Z]:\\/.test(trimmedForCheck);
       if (hasFileUrl || hasAbsolutePosix || hasAbsoluteWindows) {
         props.onToast(
-          "This is a remote worker. Sandboxes are remote too. To share files with it, upload them to the Inbox in the sidebar.",
-        );
+            "This is a remote worker. Sandboxes are remote too. To share files with it, upload them to the Shared folder in the sidebar.",
+          );
         setShowInboxUploadAction(Boolean(props.onUploadInboxFiles));
       }
     }
@@ -1756,7 +1758,7 @@ export default function Composer(props: ComposerProps) {
                         class="shrink-0 rounded-md border border-gray-6 bg-gray-2 px-2 py-1 text-[10px] text-gray-11 hover:bg-gray-3"
                         onClick={() => inboxFileInputRef?.click()}
                       >
-                        Upload to inbox
+                        Upload to shared folder
                       </button>
                     </Show>
                   </div>
@@ -1765,10 +1767,6 @@ export default function Composer(props: ComposerProps) {
 
               <div class="flex flex-col gap-2">
                 <div class="flex-1 min-w-0">
-                  <div class="mb-2 text-[10px] font-bold uppercase tracking-widest text-gray-9">
-                    {props.isRemoteWorkspace ? "Remote workspace" : "Local workspace"}
-                  </div>
-
                   <div class="relative">
                     <Show when={!hasDraftContent()}>
                     <div class="absolute left-0 top-0 text-gray-9 text-[15px] leading-relaxed pointer-events-none">

--- a/apps/app/src/app/components/session/inbox-panel.tsx
+++ b/apps/app/src/app/components/session/inbox-panel.tsx
@@ -48,7 +48,7 @@ export default function InboxPanel(props: InboxPanelProps) {
   });
 
   const connected = createMemo(() => Boolean(props.client && (props.workspaceId ?? "").trim()));
-  const helperText = "Share files with your remote worker.";
+  const helperText = "Share files with this worker from the app.";
 
   const visibleItems = createMemo(() => (items() ?? []).slice(0, maxPreview()));
   const hiddenCount = createMemo(() => Math.max(0, (items() ?? []).length - visibleItems().length));
@@ -71,7 +71,8 @@ export default function InboxPanel(props: InboxPanelProps) {
       const result = await client.listInbox(workspaceId);
       setItems(result.items ?? []);
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Failed to load inbox";
+      const message =
+        err instanceof Error ? err.message : "Failed to load shared folder";
       setError(message);
       setItems([]);
     } finally {
@@ -83,7 +84,7 @@ export default function InboxPanel(props: InboxPanelProps) {
     const client = props.client;
     const workspaceId = (props.workspaceId ?? "").trim();
     if (!client || !workspaceId) {
-      toast("Connect to a worker to upload inbox files.");
+      toast("Connect to a worker to upload files to the shared folder.");
       return;
     }
     if (!files.length) return;
@@ -96,10 +97,11 @@ export default function InboxPanel(props: InboxPanelProps) {
       for (const file of files) {
         await client.uploadInbox(workspaceId, file);
       }
-      toast("Uploaded to worker inbox.");
+      toast("Uploaded to the shared folder.");
       await refresh();
     } catch (err) {
-      const message = err instanceof Error ? err.message : "Inbox upload failed";
+      const message =
+        err instanceof Error ? err.message : "Shared folder upload failed";
       setError(message);
       toast(message);
     } finally {
@@ -121,12 +123,12 @@ export default function InboxPanel(props: InboxPanelProps) {
     const client = props.client;
     const workspaceId = (props.workspaceId ?? "").trim();
     if (!client || !workspaceId) {
-      toast("Connect to a worker to download inbox files.");
+      toast("Connect to a worker to download shared files.");
       return;
     }
     const id = String(item.id ?? "").trim();
     if (!id) {
-      toast("Missing inbox item id.");
+      toast("Missing shared file id.");
       return;
     }
 
@@ -158,7 +160,7 @@ export default function InboxPanel(props: InboxPanelProps) {
     <WebUnavailableSurface unavailable={webDeployment()} compact>
       <div id={props.id}>
         <div class="flex items-center justify-between px-2 mb-3">
-          <span class="text-[11px] font-semibold uppercase tracking-wider text-gray-10">Inbox</span>
+          <span class="text-[11px] font-semibold uppercase tracking-wider text-gray-10">Shared folder</span>
           <div class="flex items-center gap-2">
             <Show when={(items() ?? []).length > 0}>
               <span class="text-[11px] font-medium bg-gray-4/60 text-gray-10 px-1.5 rounded">
@@ -169,8 +171,8 @@ export default function InboxPanel(props: InboxPanelProps) {
               type="button"
               class="rounded-md p-1 text-gray-9 hover:text-gray-11 hover:bg-gray-3 transition-colors"
               onClick={() => void refresh()}
-              title="Refresh inbox"
-              aria-label="Refresh inbox"
+              title="Refresh shared folder"
+              aria-label="Refresh shared folder"
               disabled={!connected() || loading()}
             >
               <RefreshCw size={14} class={loading() ? "animate-spin" : ""} />
@@ -212,8 +214,8 @@ export default function InboxPanel(props: InboxPanelProps) {
             if (files.length) void uploadFiles(files);
           }}
           disabled={uploading()}
-          title={connected() ? "Drop files here to upload" : "Connect to a worker to upload"}
-        >
+             title={connected() ? "Drop files here to upload" : "Connect to a worker to upload"}
+          >
           <div class="flex flex-col items-center justify-center text-center">
             <UploadCloud size={18} class="text-gray-9 mb-2" />
             <span class="text-[13px] font-medium text-gray-11">
@@ -232,8 +234,8 @@ export default function InboxPanel(props: InboxPanelProps) {
             when={visibleItems().length > 0}
             fallback={
               <div class="text-xs text-gray-10 px-1 py-1">
-                <Show when={connected()} fallback={"Connect to see inbox files."}>
-                  No inbox files yet.
+                <Show when={connected()} fallback={"Connect to see shared files."}>
+                  No shared files yet.
                 </Show>
               </div>
             }
@@ -251,8 +253,8 @@ export default function InboxPanel(props: InboxPanelProps) {
                       type="button"
                       class="min-w-0 flex-1 text-left"
                       onClick={() => void copyPath(item)}
-                      title={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy inbox path"}
-                      aria-label={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy inbox path"}
+                      title={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy shared folder path"}
+                      aria-label={rel() ? `Copy ${INBOX_PREFIX}${rel()}` : "Copy shared folder path"}
                       disabled={!connected()}
                     >
                       <div class="truncate text-xs font-medium text-gray-11">{name()}</div>

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1645,7 +1645,11 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         } catch {
           // ignore
         }
-        throw new OpenworkServerError(result.status, "request_failed", message || "Inbox upload failed");
+        throw new OpenworkServerError(
+          result.status,
+          "request_failed",
+          message || "Shared folder upload failed",
+        );
       }
 
       const body = result.text.trim();

--- a/apps/app/src/app/lib/workspace-shell-layout.ts
+++ b/apps/app/src/app/lib/workspace-shell-layout.ts
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 const LEFT_SIDEBAR_WIDTH_KEY = "openwork.workspace-shell.left-width.v1";
-const RIGHT_SIDEBAR_EXPANDED_KEY = "openwork.workspace-shell.right-expanded.v2";
+const RIGHT_SIDEBAR_EXPANDED_KEY = "openwork.workspace-shell.right-expanded.v3";
 
 export const DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH = 260;
 export const MIN_WORKSPACE_LEFT_SIDEBAR_WIDTH = 220;
@@ -61,7 +61,7 @@ export function createWorkspaceShellLayout(options: WorkspaceShellLayoutOptions)
 
   const readRightSidebarExpanded = () => {
     const raw = readStorage(RIGHT_SIDEBAR_EXPANDED_KEY);
-    if (raw == null) return true;
+    if (raw == null) return false;
     return raw === "1";
   };
 

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -619,7 +619,7 @@ export default function DashboardView(props: DashboardViewProps) {
           </Show>
         </div>
 
-        <Show when={expanded}>
+        <Show when={expanded && props.activeWorkspaceDisplay.workspaceType === "remote"}>
           <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
             <InboxPanel
               id={mobile ? "dashboard-mobile-sidebar-inbox" : "dashboard-sidebar-inbox"}

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -594,7 +594,7 @@ export default function DashboardView(props: DashboardViewProps) {
   };
 
   const renderRightSidebar = (expanded: boolean, mobile = false) => (
-    <div class={`flex h-full flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 ${mobile ? "shadow-2xl" : "transition-[width] duration-200"}`}>
+    <div class={`flex h-full w-full flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 ${mobile ? "shadow-2xl" : "transition-[width] duration-200"}`}>
       <div class={`flex items-center pb-3 ${expanded ? "justify-end" : "justify-center"}`}>
         <button
           type="button"

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -3533,7 +3533,7 @@ export default function SessionView(props: SessionViewProps) {
     if (!client || !workspaceId) {
       if (notify) {
         setToastMessage(
-          "Connect to the OpenWork server to upload inbox files.",
+          "Connect to the OpenWork server to upload files to the shared folder.",
         );
       }
       return [];
@@ -3543,7 +3543,7 @@ export default function SessionView(props: SessionViewProps) {
     const label =
       files.length === 1 ? (files[0]?.name ?? "file") : `${files.length} files`;
     if (notify) {
-      setToastMessage(`Uploading ${label} to inbox...`);
+      setToastMessage(`Uploading ${label} to the shared folder...`);
     }
 
     try {
@@ -3559,14 +3559,18 @@ export default function SessionView(props: SessionViewProps) {
           .filter(Boolean)
           .join(", ");
         setToastMessage(
-          summary ? `Uploaded to inbox: ${summary}` : "Uploaded to inbox.",
+          summary
+            ? `Uploaded to the shared folder: ${summary}`
+            : "Uploaded to the shared folder.",
         );
       }
       return uploaded;
     } catch (error) {
       if (notify) {
         const message =
-          error instanceof Error ? error.message : "Inbox upload failed";
+          error instanceof Error
+            ? error.message
+            : "Shared folder upload failed";
         setToastMessage(message);
       }
       return [];
@@ -4038,7 +4042,7 @@ export default function SessionView(props: SessionViewProps) {
           </Show>
         </div>
 
-        <Show when={expanded}>
+        <Show when={expanded && props.activeWorkspaceDisplay.workspaceType === "remote"}>
           <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
             <InboxPanel
               id={mobile ? "mobile-sidebar-inbox" : "sidebar-inbox"}
@@ -4047,7 +4051,19 @@ export default function SessionView(props: SessionViewProps) {
               onToast={(message) => setToastMessage(message)}
             />
           </div>
+        </Show>
 
+        <Show when={expanded}>
+          <div class="rounded-[20px] border border-dls-border bg-dls-surface p-3 shadow-[var(--dls-card-shadow)]">
+            <ArtifactsPanel
+              id={mobile ? "mobile-sidebar-artifacts" : "sidebar-artifacts"}
+              files={touchedFiles()}
+              workspaceRoot={props.activeWorkspaceRoot}
+              onRevealArtifact={revealArtifact}
+              onOpenInObsidian={openArtifactInObsidian}
+              obsidianAvailable={obsidianAvailable()}
+            />
+          </div>
         </Show>
       </div>
     </div>

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -115,6 +115,7 @@ import type { SidebarSectionState } from "../components/session/sidebar";
 import FlyoutItem from "../components/flyout-item";
 import MobileSidebarDrawer from "../components/mobile-sidebar-drawer";
 import QuestionModal from "../components/question-modal";
+import ArtifactsPanel from "../components/session/artifacts-panel";
 import InboxPanel from "../components/session/inbox-panel";
 
 export type SessionViewProps = {
@@ -3975,7 +3976,7 @@ export default function SessionView(props: SessionViewProps) {
   };
 
   const renderRightSidebar = (expanded: boolean, mobile = false) => (
-    <div class={`flex h-full flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 ${mobile ? "shadow-2xl" : "transition-[width] duration-200"}`}>
+    <div class={`flex h-full w-full flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-3 ${mobile ? "shadow-2xl" : "transition-[width] duration-200"}`}>
       <div class={`flex items-center pb-3 ${expanded ? "justify-end" : "justify-center"}`}>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- default the right rail to collapsed and keep artifacts as the secondary panel
- rename Inbox to Shared folder across the rail, composer, and surfaced upload error copy
- hide the shared-folder panel for local workspaces and remove low-value local/remote chrome from the shell

## Verification
- `pnpm typecheck`
- `pnpm build:ui`
- `git diff --check`
- browser smoke against the built session shell confirmed the rail opens collapsed and local workspaces do not show the shared-folder panel

## Blockers
- `packaging/docker/dev-up.sh` did not complete cleanly in this workspace: the share container hit `ENOTEMPTY`/exit `137`, and orchestrator retries also failed
- because of that Docker stack failure, the full Chrome MCP remote shared-folder flow is still needed after the stack is stable