### PR TITLE
feat(app): manage authorized folders from settings

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -166,6 +166,7 @@ import {
   openworkServerInfo,
   orchestratorStatus,
   opencodeRouterInfo,
+  pickDirectory,
   setWindowDecorations,
   type OrchestratorStatus,
   type OpenworkServerInfo,
@@ -2830,6 +2831,76 @@ export default function App() {
       return content;
     }
   };
+
+  const ensureRecord = (value: unknown): Record<string, unknown> => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+    return value as Record<string, unknown>;
+  };
+
+  const normalizeAuthorizedFolderPath = (input: string | null | undefined) => {
+    const trimmed = (input ?? "").trim();
+    if (!trimmed) return "";
+    const withoutWildcard = trimmed.replace(/[\\/]\*+$/, "");
+    return normalizeDirectoryQueryPath(withoutWildcard);
+  };
+
+  const authorizedFolderToExternalDirectoryKey = (folder: string) => {
+    const normalized = normalizeAuthorizedFolderPath(folder);
+    if (!normalized) return "";
+    return normalized === "/" ? "/*" : `${normalized}/*`;
+  };
+
+  const externalDirectoryKeyToAuthorizedFolder = (key: string, value: unknown) => {
+    if (value !== "allow") return null;
+    const trimmed = key.trim();
+    if (!trimmed) return null;
+    if (trimmed === "/*") return "/";
+    if (!trimmed.endsWith("/*")) return null;
+    return normalizeAuthorizedFolderPath(trimmed.slice(0, -2));
+  };
+
+  const readAuthorizedFoldersFromConfig = (opencodeConfig: Record<string, unknown>) => {
+    const permission = ensureRecord(opencodeConfig.permission);
+    const externalDirectory = ensureRecord(permission.external_directory);
+    const folders: string[] = [];
+    const hiddenEntries: Record<string, unknown> = {};
+    const seen = new Set<string>();
+
+    for (const [key, value] of Object.entries(externalDirectory)) {
+      const folder = externalDirectoryKeyToAuthorizedFolder(key, value);
+      if (!folder) {
+        hiddenEntries[key] = value;
+        continue;
+      }
+      if (seen.has(folder)) continue;
+      seen.add(folder);
+      folders.push(folder);
+    }
+
+    return { folders, hiddenEntries };
+  };
+
+  const buildAuthorizedFoldersStatus = (preservedCount: number, action?: string) => {
+    const preservedLabel =
+      preservedCount > 0
+        ? `Preserving ${preservedCount} non-folder permission ${preservedCount === 1 ? "entry" : "entries"}.`
+        : null;
+    if (action && preservedLabel) return `${action} ${preservedLabel}`;
+    return action ?? preservedLabel;
+  };
+
+  const mergeAuthorizedFoldersIntoExternalDirectory = (
+    folders: string[],
+    hiddenEntries: Record<string, unknown>,
+  ): Record<string, unknown> | undefined => {
+    const next: Record<string, unknown> = { ...hiddenEntries };
+    for (const folder of folders) {
+      const key = authorizedFolderToExternalDirectoryKey(folder);
+      if (!key) continue;
+      next[key] = "allow";
+    }
+    return Object.keys(next).length ? next : undefined;
+  };
   const [modelPickerOpen, setModelPickerOpen] = createSignal(false);
   const [modelPickerTarget, setModelPickerTarget] = createSignal<
     "session" | "default"
@@ -2843,6 +2914,13 @@ export default function App() {
   const [autoCompactContext, setAutoCompactContext] = createSignal(false);
   const [modelVariant, setModelVariant] = createSignal<string | null>(null);
   const [autoCompactingSessionId, setAutoCompactingSessionId] = createSignal<string | null>(null);
+  const [authorizedFolders, setAuthorizedFolders] = createSignal<string[]>([]);
+  const [authorizedFolderDraft, setAuthorizedFolderDraft] = createSignal("");
+  const [, setAuthorizedFolderHiddenEntries] = createSignal<Record<string, unknown>>({});
+  const [authorizedFoldersLoading, setAuthorizedFoldersLoading] = createSignal(false);
+  const [authorizedFoldersSaving, setAuthorizedFoldersSaving] = createSignal(false);
+  const [authorizedFoldersStatus, setAuthorizedFoldersStatus] = createSignal<string | null>(null);
+  const [authorizedFoldersError, setAuthorizedFoldersError] = createSignal<string | null>(null);
 
   const MODEL_VARIANT_OPTIONS = [
     { value: "none", label: "None" },
@@ -3911,6 +3989,18 @@ export default function App() {
       openworkServerReady() &&
       openworkServerWorkspaceReady() &&
       (resolvedOpenworkCapabilities()?.plugins?.write ?? false),
+  );
+  const openworkServerCanReadConfig = createMemo(
+    () =>
+      openworkServerReady() &&
+      openworkServerWorkspaceReady() &&
+      (resolvedOpenworkCapabilities()?.config?.read ?? false),
+  );
+  const openworkServerCanWriteConfig = createMemo(
+    () =>
+      openworkServerReady() &&
+      openworkServerWorkspaceReady() &&
+      (resolvedOpenworkCapabilities()?.config?.write ?? false),
   );
   const devtoolsCapabilities = createMemo(() => openworkServerCapabilities());
   const resolvedDevtoolsWorkspaceId = createMemo(() => devtoolsWorkspaceId() ?? openworkServerWorkspaceId());
@@ -6205,6 +6295,156 @@ export default function App() {
   });
 
   createEffect(() => {
+    const openworkClient = openworkServerClient();
+    const openworkWorkspaceId = openworkServerWorkspaceId();
+    const canReadConfig = openworkServerCanReadConfig();
+
+    if (!openworkClient || !openworkWorkspaceId || !canReadConfig) {
+      setAuthorizedFolders([]);
+      setAuthorizedFolderDraft("");
+      setAuthorizedFolderHiddenEntries({});
+      setAuthorizedFoldersLoading(false);
+      setAuthorizedFoldersStatus(null);
+      setAuthorizedFoldersError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setAuthorizedFolderDraft("");
+    setAuthorizedFoldersLoading(true);
+    setAuthorizedFoldersError(null);
+    setAuthorizedFoldersStatus(null);
+
+    const loadAuthorizedFolders = async () => {
+      try {
+        const config = await openworkClient.getConfig(openworkWorkspaceId);
+        if (cancelled) return;
+        const next = readAuthorizedFoldersFromConfig(ensureRecord(config.opencode));
+        setAuthorizedFolders(next.folders);
+        setAuthorizedFolderHiddenEntries(next.hiddenEntries);
+        setAuthorizedFoldersStatus(
+          buildAuthorizedFoldersStatus(Object.keys(next.hiddenEntries).length),
+        );
+      } catch (error) {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : safeStringify(error);
+        setAuthorizedFolders([]);
+        setAuthorizedFolderHiddenEntries({});
+        setAuthorizedFoldersError(message);
+      } finally {
+        if (!cancelled) {
+          setAuthorizedFoldersLoading(false);
+        }
+      }
+    };
+
+    void loadAuthorizedFolders();
+
+    onCleanup(() => {
+      cancelled = true;
+    });
+  });
+
+  const persistAuthorizedFolders = async (nextFolders: string[]) => {
+    const openworkClient = openworkServerClient();
+    const openworkWorkspaceId = openworkServerWorkspaceId();
+    if (!openworkClient || !openworkWorkspaceId || !openworkServerCanWriteConfig()) {
+      setAuthorizedFoldersError(
+        "A writable OpenWork server workspace is required to update authorized folders.",
+      );
+      return false;
+    }
+
+    setAuthorizedFoldersSaving(true);
+    setAuthorizedFoldersError(null);
+    setAuthorizedFoldersStatus("Saving authorized folders...");
+
+    try {
+      const currentConfig = await openworkClient.getConfig(openworkWorkspaceId);
+      const currentAuthorizedFolders = readAuthorizedFoldersFromConfig(
+        ensureRecord(currentConfig.opencode),
+      );
+      const nextExternalDirectory = mergeAuthorizedFoldersIntoExternalDirectory(
+        nextFolders,
+        currentAuthorizedFolders.hiddenEntries,
+      );
+
+      await openworkClient.patchConfig(openworkWorkspaceId, {
+        opencode: {
+          permission: {
+            external_directory: nextExternalDirectory,
+          },
+        },
+      });
+      setAuthorizedFolders(nextFolders);
+      setAuthorizedFolderHiddenEntries(currentAuthorizedFolders.hiddenEntries);
+      setAuthorizedFoldersStatus(
+        buildAuthorizedFoldersStatus(
+          Object.keys(currentAuthorizedFolders.hiddenEntries).length,
+          "Authorized folders updated.",
+        ),
+      );
+      markReloadRequired("config", {
+        type: "config",
+        name: "opencode.json",
+        action: "updated",
+      });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setAuthorizedFoldersError(message);
+      setAuthorizedFoldersStatus(null);
+      return false;
+    } finally {
+      setAuthorizedFoldersSaving(false);
+    }
+  };
+
+  const addAuthorizedFolder = async () => {
+    const normalized = normalizeAuthorizedFolderPath(authorizedFolderDraft());
+    if (!normalized) return;
+    if (authorizedFolders().includes(normalized)) {
+      setAuthorizedFolderDraft("");
+      setAuthorizedFoldersStatus("Folder is already authorized.");
+      setAuthorizedFoldersError(null);
+      return;
+    }
+
+    const ok = await persistAuthorizedFolders([...authorizedFolders(), normalized]);
+    if (ok) {
+      setAuthorizedFolderDraft("");
+    }
+  };
+
+  const removeAuthorizedFolder = async (folder: string) => {
+    const nextFolders = authorizedFolders().filter((entry) => entry !== folder);
+    await persistAuthorizedFolders(nextFolders);
+  };
+
+  const pickAuthorizedFolder = async () => {
+    if (!isTauriRuntime()) return;
+    try {
+      const selection = await pickDirectory({ title: t("onboarding.authorize_folder", currentLocale()) });
+      const folder = typeof selection === "string" ? selection : Array.isArray(selection) ? selection[0] : null;
+      const normalized = normalizeAuthorizedFolderPath(folder);
+      if (!normalized) return;
+      setAuthorizedFolderDraft(normalized);
+      if (authorizedFolders().includes(normalized)) {
+        setAuthorizedFoldersStatus("Folder is already authorized.");
+        setAuthorizedFoldersError(null);
+        return;
+      }
+      const ok = await persistAuthorizedFolders([...authorizedFolders(), normalized]);
+      if (ok) {
+        setAuthorizedFolderDraft("");
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setAuthorizedFoldersError(message);
+    }
+  };
+
+  createEffect(() => {
     if (typeof window === "undefined") return;
     const workspaceId = workspaceStore.activeWorkspaceId();
     if (!workspaceId) return;
@@ -6798,6 +7038,7 @@ export default function App() {
       openworkServerCapabilities: devtoolsCapabilities(),
       openworkServerDiagnostics: openworkServerDiagnostics(),
       openworkServerWorkspaceId: resolvedDevtoolsWorkspaceId(),
+      activeWorkspaceType: workspaceStore.activeWorkspaceDisplay().workspaceType,
       openworkAuditEntries: openworkAuditEntries(),
       openworkAuditStatus: openworkAuditStatus(),
       openworkAuditError: openworkAuditError(),
@@ -6964,6 +7205,27 @@ export default function App() {
       cleanupOpenworkDockerContainers,
       dockerCleanupBusy: dockerCleanupBusy(),
       dockerCleanupResult: dockerCleanupResult(),
+      authorizedFolders: authorizedFolders(),
+      authorizedFolderDraft: authorizedFolderDraft(),
+      setAuthorizedFolderDraft,
+      authorizedFoldersLoading: authorizedFoldersLoading(),
+      authorizedFoldersSaving: authorizedFoldersSaving(),
+      authorizedFoldersError: authorizedFoldersError(),
+      authorizedFoldersStatus: authorizedFoldersStatus(),
+      authorizedFoldersAvailable: openworkServerCanReadConfig(),
+      authorizedFoldersEditable: openworkServerCanWriteConfig(),
+      authorizedFoldersHint: !openworkServerReady()
+        ? "OpenWork server is disconnected."
+        : !openworkServerWorkspaceReady()
+          ? "No active server workspace is selected."
+          : !openworkServerCanReadConfig()
+            ? "OpenWork server config access is unavailable for this workspace."
+            : !openworkServerCanWriteConfig()
+              ? "OpenWork server is connected read-only for workspace config."
+              : null,
+      addAuthorizedFolder,
+      pickAuthorizedFolder,
+      removeAuthorizedFolder,
       resetAppConfigDefaults,
       notionStatus: notionStatus(),
       notionStatusDetail: notionStatusDetail(),

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -128,6 +128,7 @@ export type DashboardViewProps = {
   openworkServerCapabilities: OpenworkServerCapabilities | null;
   openworkServerDiagnostics: OpenworkServerDiagnostics | null;
   openworkServerWorkspaceId: string | null;
+  activeWorkspaceType: "local" | "remote";
   openworkAuditEntries: OpenworkAuditEntry[];
   openworkAuditStatus: "idle" | "loading" | "error";
   openworkAuditError: string | null;
@@ -324,6 +325,19 @@ export type DashboardViewProps = {
   cleanupOpenworkDockerContainers: () => void;
   dockerCleanupBusy: boolean;
   dockerCleanupResult: string | null;
+  authorizedFolders: string[];
+  authorizedFolderDraft: string;
+  setAuthorizedFolderDraft: (value: string) => void;
+  authorizedFoldersLoading: boolean;
+  authorizedFoldersSaving: boolean;
+  authorizedFoldersError: string | null;
+  authorizedFoldersStatus: string | null;
+  authorizedFoldersAvailable: boolean;
+  authorizedFoldersEditable: boolean;
+  authorizedFoldersHint: string | null;
+  addAuthorizedFolder: () => Promise<void>;
+  pickAuthorizedFolder: () => Promise<void>;
+  removeAuthorizedFolder: (folder: string) => Promise<void>;
   resetAppConfigDefaults: () => Promise<{ ok: boolean; message: string }>;
   notionStatus: "disconnected" | "connecting" | "connected" | "error";
   notionStatusDetail: string | null;
@@ -1448,7 +1462,7 @@ export default function DashboardView(props: DashboardViewProps) {
             </Match>
 
             <Match when={props.tab === "settings"}>
-                <SettingsView
+              <SettingsView
                   startupPreference={props.startupPreference}
                   baseUrl={props.baseUrl}
                   headerStatus={props.headerStatus}
@@ -1470,6 +1484,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   openworkServerDiagnostics={props.openworkServerDiagnostics}
                   openworkServerWorkspaceId={props.openworkServerWorkspaceId}
                   activeWorkspaceRoot={props.activeWorkspaceRoot}
+                  activeWorkspaceType={props.activeWorkspaceType}
                   openworkAuditEntries={props.openworkAuditEntries}
                   openworkAuditStatus={props.openworkAuditStatus}
                   openworkAuditError={props.openworkAuditError}
@@ -1536,6 +1551,19 @@ export default function DashboardView(props: DashboardViewProps) {
                   cleanupOpenworkDockerContainers={props.cleanupOpenworkDockerContainers}
                   dockerCleanupBusy={props.dockerCleanupBusy}
                   dockerCleanupResult={props.dockerCleanupResult}
+                  authorizedFolders={props.authorizedFolders}
+                  authorizedFolderDraft={props.authorizedFolderDraft}
+                  setAuthorizedFolderDraft={props.setAuthorizedFolderDraft}
+                  authorizedFoldersLoading={props.authorizedFoldersLoading}
+                  authorizedFoldersSaving={props.authorizedFoldersSaving}
+                  authorizedFoldersError={props.authorizedFoldersError}
+                  authorizedFoldersStatus={props.authorizedFoldersStatus}
+                  authorizedFoldersAvailable={props.authorizedFoldersAvailable}
+                  authorizedFoldersEditable={props.authorizedFoldersEditable}
+                  authorizedFoldersHint={props.authorizedFoldersHint}
+                  addAuthorizedFolder={props.addAuthorizedFolder}
+                  pickAuthorizedFolder={props.pickAuthorizedFolder}
+                  removeAuthorizedFolder={props.removeAuthorizedFolder}
                   resetAppConfigDefaults={props.resetAppConfigDefaults}
                   notionStatus={props.notionStatus}
                   notionStatusDetail={props.notionStatusDetail}
@@ -1544,7 +1572,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   connectNotion={props.connectNotion}
                   openDebugDeepLink={props.openDebugDeepLink}
                   connectRemoteWorkspace={props.connectRemoteWorkspace}
-                />
+              />
 
             </Match>
           </Switch>

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -18,6 +18,7 @@ import {
 
 import Button from "../components/button";
 import DenSettingsPanel from "../components/den-settings-panel";
+import TextInput from "../components/text-input";
 import { usePlatform } from "../context/platform";
 import { FEEDBACK_EMAIL_URL } from "../lib/feedback";
 import { getOpenWorkDeployment } from "../lib/openwork-deployment";
@@ -97,6 +98,7 @@ export type SettingsViewProps = {
   openworkServerDiagnostics: OpenworkServerDiagnostics | null;
   openworkServerWorkspaceId: string | null;
   activeWorkspaceRoot: string;
+  activeWorkspaceType: "local" | "remote";
   openworkAuditEntries: OpenworkAuditEntry[];
   openworkAuditStatus: "idle" | "loading" | "error";
   openworkAuditError: string | null;
@@ -171,6 +173,19 @@ export type SettingsViewProps = {
   cleanupOpenworkDockerContainers: () => void;
   dockerCleanupBusy: boolean;
   dockerCleanupResult: string | null;
+  authorizedFolders: string[];
+  authorizedFolderDraft: string;
+  setAuthorizedFolderDraft: (value: string) => void;
+  authorizedFoldersLoading: boolean;
+  authorizedFoldersSaving: boolean;
+  authorizedFoldersError: string | null;
+  authorizedFoldersStatus: string | null;
+  authorizedFoldersAvailable: boolean;
+  authorizedFoldersEditable: boolean;
+  authorizedFoldersHint: string | null;
+  addAuthorizedFolder: () => Promise<void>;
+  pickAuthorizedFolder: () => Promise<void>;
+  removeAuthorizedFolder: (folder: string) => Promise<void>;
   resetAppConfigDefaults: () => Promise<{ ok: boolean; message: string }>;
   notionStatus: "disconnected" | "connecting" | "connected" | "error";
   notionStatusDetail: string | null;
@@ -225,6 +240,9 @@ export default function SettingsView(props: SettingsViewProps) {
   const translate = (key: string) => t(key, currentLocale());
   const engineCustomBinPathLabel = () =>
     props.engineCustomBinPath.trim() || "No binary selected.";
+  const canPickAuthorizedFolder = createMemo(
+    () => isTauriRuntime() && props.authorizedFoldersEditable && props.activeWorkspaceType === "local",
+  );
 
   const openExternalLink = (url: string) => {
     const resolved = url.trim();
@@ -1385,9 +1403,9 @@ export default function SettingsView(props: SettingsViewProps) {
               </div>
             </div>
 
-            <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-4">
-              <div>
-                <div class="text-sm font-medium text-gray-12">Appearance</div>
+              <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-4">
+                <div>
+                  <div class="text-sm font-medium text-gray-12">Appearance</div>
                 <div class="text-xs text-gray-9">
                   Match the system or force light/dark mode.
                 </div>
@@ -1451,12 +1469,152 @@ export default function SettingsView(props: SettingsViewProps) {
                 </div>
               </div>
 
-              <div class="text-xs text-gray-8">
-                System mode follows your OS preference automatically.
+                <div class="text-xs text-gray-8">
+                  System mode follows your OS preference automatically.
+                </div>
               </div>
-            </div>
 
-            <div class="relative overflow-hidden rounded-2xl border border-blue-7/30 bg-gradient-to-br from-blue-3/35 via-gray-1/75 to-cyan-3/30 p-5">
+              <div class="bg-gray-2/30 border border-gray-7/60 rounded-2xl p-5 space-y-4">
+                <div>
+                  <div class="text-sm font-medium text-gray-12">
+                    Authorized folders
+                  </div>
+                  <div class="text-xs text-gray-9">
+                    Manage `permission.external_directory` for the active workspace through the OpenWork server.
+                  </div>
+                </div>
+
+                <Show
+                  when={props.authorizedFoldersAvailable}
+                  fallback={
+                    <div class="rounded-xl border border-gray-6/60 bg-gray-1/40 px-3 py-3 text-xs text-gray-10">
+                      {props.authorizedFoldersHint ??
+                        "Connect to a writable OpenWork server workspace to edit authorized folders."}
+                    </div>
+                  }
+                >
+                  <div class="space-y-4">
+                    <div class="text-[11px] text-gray-8">
+                      Enter a server-side folder path manually for remote-safe editing. Desktop folder picking is a convenience for local workspaces only.
+                    </div>
+                    <Show when={props.authorizedFoldersHint}>
+                      {(hint) => (
+                        <div class="rounded-xl border border-gray-6/60 bg-gray-1/40 px-3 py-2 text-xs text-gray-10">
+                          {hint()}
+                        </div>
+                      )}
+                    </Show>
+
+                    <form
+                      class="space-y-3"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        void props.addAuthorizedFolder();
+                      }}
+                    >
+                      <TextInput
+                        value={props.authorizedFolderDraft}
+                        onInput={(event) =>
+                          props.setAuthorizedFolderDraft(event.currentTarget.value)
+                        }
+                        placeholder={
+                          props.activeWorkspaceType === "remote"
+                            ? "/workspace/shared"
+                            : props.activeWorkspaceRoot || "/Users/example/shared"
+                        }
+                        disabled={
+                          props.authorizedFoldersLoading ||
+                          props.authorizedFoldersSaving ||
+                          !props.authorizedFoldersEditable
+                        }
+                        label="Folder path"
+                        hint="Saved as an allow rule in opencode.json/opencode.jsonc."
+                      />
+
+                      <div class="flex flex-wrap items-center gap-2">
+                        <Button
+                          type="submit"
+                          variant="secondary"
+                          class="text-xs h-8 py-0 px-3"
+                          disabled={
+                            props.authorizedFoldersLoading ||
+                            props.authorizedFoldersSaving ||
+                            !props.authorizedFoldersEditable ||
+                            !props.authorizedFolderDraft.trim()
+                          }
+                        >
+                          {props.authorizedFoldersSaving ? "Saving..." : "Add folder"}
+                        </Button>
+                        <Show when={canPickAuthorizedFolder()}>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            class="text-xs h-8 py-0 px-3"
+                            onClick={() => void props.pickAuthorizedFolder()}
+                            disabled={
+                              props.authorizedFoldersLoading ||
+                              props.authorizedFoldersSaving ||
+                              !props.authorizedFoldersEditable
+                            }
+                          >
+                            <FolderOpen size={13} class="mr-1.5" />
+                            Choose folder
+                          </Button>
+                        </Show>
+                      </div>
+                    </form>
+
+                    <Show when={props.authorizedFoldersStatus}>
+                      {(status) => (
+                        <div class="text-xs text-gray-10">{status()}</div>
+                      )}
+                    </Show>
+                    <Show when={props.authorizedFoldersError}>
+                      {(error) => (
+                        <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
+                          {error()}
+                        </div>
+                      )}
+                    </Show>
+
+                    <Show
+                      when={props.authorizedFolders.length > 0}
+                      fallback={
+                        <div class="rounded-xl border border-dashed border-gray-6/60 bg-gray-1/30 px-3 py-4 text-xs text-gray-9">
+                          No extra folders are authorized yet.
+                        </div>
+                      }
+                    >
+                      <div class="space-y-2">
+                        <For each={props.authorizedFolders}>
+                          {(folder) => (
+                            <div class="flex items-center justify-between gap-3 rounded-xl border border-gray-6/60 bg-gray-1/40 px-3 py-2">
+                              <div class="min-w-0 text-xs text-gray-12 font-mono break-all">
+                                {folder}
+                              </div>
+                              <Button
+                                variant="ghost"
+                                class="h-8 w-8 shrink-0 p-0 text-gray-9 hover:text-red-11"
+                                onClick={() => void props.removeAuthorizedFolder(folder)}
+                                disabled={
+                                  props.authorizedFoldersLoading ||
+                                  props.authorizedFoldersSaving ||
+                                  !props.authorizedFoldersEditable
+                                }
+                                aria-label={`Remove ${folder}`}
+                              >
+                                <X size={14} />
+                              </Button>
+                            </div>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
+                  </div>
+                </Show>
+              </div>
+
+              <div class="relative overflow-hidden rounded-2xl border border-blue-7/30 bg-gradient-to-br from-blue-3/35 via-gray-1/75 to-cyan-3/30 p-5">
               <div class="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-blue-6/20 blur-2xl" />
               <div class="pointer-events-none absolute -bottom-12 left-6 h-24 w-24 rounded-full bg-cyan-6/20 blur-2xl" />
 

--- a/apps/server/src/jsonc.test.ts
+++ b/apps/server/src/jsonc.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { updateJsoncPath } from "./jsonc.js";
+
+describe("updateJsoncPath", () => {
+  test("patches nested values without replacing sibling config", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openwork-jsonc-"));
+    const file = join(dir, "opencode.jsonc");
+    await writeFile(
+      file,
+      `{
+  // keep this permission comment
+  "permission": {
+    "clipboard": "ask",
+    "external_directory": {
+      "/old/*": "allow"
+    }
+  },
+  "model": "openai/gpt-5"
+}
+`,
+      "utf8",
+    );
+
+    await updateJsoncPath(file, ["permission", "external_directory"], {
+      "/next/*": "allow",
+    });
+
+    const next = await readFile(file, "utf8");
+    expect(next).toContain('"clipboard": "ask"');
+    expect(next).toContain('"model": "openai/gpt-5"');
+    expect(next).toContain('"/next/*": "allow"');
+    expect(next).not.toContain('"/old/*": "allow"');
+  });
+
+  test("removes parent object when nested property was the only entry", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openwork-jsonc-"));
+    const file = join(dir, "opencode.jsonc");
+    await writeFile(
+      file,
+      `{
+  "permission": {
+    "external_directory": {
+      "/old/*": "allow"
+    }
+  }
+}
+`,
+      "utf8",
+    );
+
+    await updateJsoncPath(file, ["permission"], undefined);
+
+    const next = await readFile(file, "utf8");
+    expect(next).not.toContain('"permission"');
+  });
+});

--- a/apps/server/src/jsonc.ts
+++ b/apps/server/src/jsonc.ts
@@ -45,6 +45,24 @@ export async function updateJsoncTopLevel(path: string, updates: Record<string, 
   await writeFile(path, content.endsWith("\n") ? content : content + "\n", "utf8");
 }
 
+export async function updateJsoncPath(path: string, jsonPath: (string | number)[], value: unknown): Promise<void> {
+  const formattingOptions = { insertSpaces: true, tabSize: 2, eol: "\n" };
+  const hasFile = await exists(path);
+  if (!hasFile) {
+    await ensureDir(dirname(path));
+    let content = "{}\n";
+    const edits = modify(content, jsonPath, value, { formattingOptions });
+    content = applyEdits(content, edits);
+    await writeFile(path, content.endsWith("\n") ? content : content + "\n", "utf8");
+    return;
+  }
+
+  let content = await readFile(path, "utf8");
+  const edits = modify(content, jsonPath, value, { formattingOptions });
+  content = applyEdits(content, edits);
+  await writeFile(path, content.endsWith("\n") ? content : content + "\n", "utf8");
+}
+
 export async function writeJsoncFile(path: string, value: unknown): Promise<void> {
   await ensureDir(dirname(path));
   const content = JSON.stringify(value, null, 2) + "\n";

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -11,7 +11,7 @@ import { installHubSkill, listHubSkills } from "./skill-hub.js";
 import { deleteCommand, listCommands, upsertCommand } from "./commands.js";
 import { deleteScheduledJob, listScheduledJobs, resolveScheduledJob } from "./scheduler.js";
 import { ApiError, formatError } from "./errors.js";
-import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
+import { readJsoncFile, updateJsoncPath, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
 import { ReloadEventStore } from "./events.js";
 import { parseFrontmatter } from "./frontmatter.js";
@@ -1537,7 +1537,31 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     });
 
     if (opencode) {
-      await updateJsoncTopLevel(opencodeConfigPath(workspace.path), opencode);
+      const configPath = opencodeConfigPath(workspace.path);
+      const nextOpencode = ensurePlainObject(opencode);
+      const { permission, ...topLevelUpdates } = nextOpencode;
+
+      if (Object.keys(topLevelUpdates).length) {
+        await updateJsoncTopLevel(configPath, topLevelUpdates);
+      }
+
+      const permissionUpdate = ensurePlainObject(permission);
+      if (Object.prototype.hasOwnProperty.call(permissionUpdate, "external_directory")) {
+        const existingOpencode = await readOpencodeConfig(workspace.path);
+        const existingPermission = ensurePlainObject(existingOpencode.permission);
+        const nextExternalDirectory = permissionUpdate.external_directory;
+        const existingPermissionKeys = Object.keys(existingPermission);
+        const removePermissionParent =
+          typeof nextExternalDirectory === "undefined" &&
+          (existingPermissionKeys.length === 0 ||
+            (existingPermissionKeys.length === 1 && Object.prototype.hasOwnProperty.call(existingPermission, "external_directory")));
+
+        if (removePermissionParent) {
+          await updateJsoncPath(configPath, ["permission"], undefined);
+        } else {
+          await updateJsoncPath(configPath, ["permission", "external_directory"], nextExternalDirectory);
+        }
+      }
     }
     if (openwork) {
       await writeOpenworkConfig(workspace.path, openwork, true);


### PR DESCRIPTION
## Summary
- add an Authorized folders section to General settings for the active workspace
- load and save folder authorization through the OpenWork server config API instead of local-only Tauri writes
- persist allowed folders into OpenCode config at `permission.external_directory` and add nested JSONC patch coverage so unrelated config survives targeted writes

## Verification
- `pnpm typecheck`
- `pnpm build:ui`
- `pnpm --filter openwork-server test`
- `pnpm --filter openwork-server build:bin`
- `git diff --check`

## Remaining E2E
- the full Docker + Chrome MCP settings flow was not completed in this pass
- reproduce with `packaging/docker/dev-up.sh`, then open Settings > General > Authorized folders and verify add/remove/save behavior against a running workspace