### PR TITLE
fix(app): stabilize remote messaging router health

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -3900,7 +3900,7 @@ export default function App() {
         const items = Array.isArray(response.items) ? response.items : [];
         const activeMatch = response.activeId ? items.find((item) => item.id === response.activeId) : null;
         const match = root ? items.find((item) => normalizeDirectoryPath(item.path) === root) : activeMatch ?? items[0];
-        setDevtoolsWorkspaceId(activeMatch?.id ?? match?.id ?? null);
+        setDevtoolsWorkspaceId(match?.id ?? activeMatch?.id ?? null);
       } catch {
         if (active) setDevtoolsWorkspaceId(null);
       }
@@ -4010,7 +4010,6 @@ export default function App() {
       (resolvedOpenworkCapabilities()?.config?.write ?? false),
   );
   const devtoolsCapabilities = createMemo(() => openworkServerCapabilities());
-  const resolvedDevtoolsWorkspaceId = createMemo(() => devtoolsWorkspaceId() ?? openworkServerWorkspaceId());
 
   function updateOpenworkServerSettings(next: OpenworkServerSettings) {
     const stored = writeOpenworkServerSettings(next);
@@ -7098,7 +7097,7 @@ export default function App() {
       openworkServerHostInfo: openworkServerHostInfo(),
       openworkServerCapabilities: devtoolsCapabilities(),
       openworkServerDiagnostics: openworkServerDiagnostics(),
-      openworkServerWorkspaceId: resolvedDevtoolsWorkspaceId(),
+      openworkServerWorkspaceId: openworkServerWorkspaceId(),
       activeWorkspaceType: workspaceStore.activeWorkspaceDisplay().workspaceType,
       openworkAuditEntries: openworkAuditEntries(),
       openworkAuditStatus: openworkAuditStatus(),

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1195,6 +1195,14 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     capabilities: () => requestJson<OpenworkServerCapabilities>(baseUrl, "/capabilities", { token, hostToken, timeoutMs: timeouts.capabilities }),
     opencodeRouterHealth: () =>
       requestJsonRaw<OpenworkOpenCodeRouterHealthSnapshot>(baseUrl, "/opencode-router/health", { token, hostToken, timeoutMs: timeouts.opencodeRouter }),
+    getOpenCodeRouterHealth: (workspaceId: string, options?: { healthPort?: number | null }) => {
+      const query = typeof options?.healthPort === "number" ? `?healthPort=${encodeURIComponent(String(options.healthPort))}` : "";
+      return requestJsonRaw<OpenworkOpenCodeRouterHealthSnapshot>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/opencode-router/health${query}`,
+        { token, hostToken, timeoutMs: timeouts.opencodeRouter },
+      );
+    },
     opencodeRouterBindings: (filters?: { channel?: string; identityId?: string }) => {
       const search = new URLSearchParams();
       if (filters?.channel?.trim()) search.set("channel", filters.channel.trim());

--- a/apps/app/src/app/pages/identities.tsx
+++ b/apps/app/src/app/pages/identities.tsx
@@ -431,7 +431,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
       }
 
       const [healthRes, tgRes, slackRes, telegramInfo] = await Promise.all([
-        client.opencodeRouterHealth(),
+        client.getOpenCodeRouterHealth(id),
         client.getOpenCodeRouterTelegramIdentities(id),
         client.getOpenCodeRouterSlackIdentities(id),
         client.getOpenCodeRouterTelegram(id).catch(() => null),

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -1046,6 +1046,7 @@ export default function SettingsView(props: SettingsViewProps) {
     },
     services: {
       engine: {
+        scope: props.startupPreference === "server" ? "local-desktop" : "local-host",
         status: engineStatusLabel(),
         baseUrl: props.engineInfo?.baseUrl ?? null,
         pid: props.engineInfo?.pid ?? null,
@@ -1053,12 +1054,14 @@ export default function SettingsView(props: SettingsViewProps) {
         stderr: engineStderr(),
       },
       orchestrator: {
+        scope: props.startupPreference === "server" ? "local-desktop" : "local-host",
         status: orchestratorStatusLabel(),
         dataDir: props.orchestratorStatus?.dataDir ?? null,
         activeWorkspace: props.orchestratorStatus?.activeId ?? null,
         sidecar: orchestratorSidecarSummary(),
       },
       openworkServer: {
+        scope: props.startupPreference === "server" ? "connected-worker" : "local-host",
         status: openworkStatusLabel(),
         baseUrl:
           (props.openworkServerHostInfo?.baseUrl ?? props.openworkServerUrl) ||
@@ -1068,6 +1071,11 @@ export default function SettingsView(props: SettingsViewProps) {
         stderr: openworkStderr(),
       },
       opencodeRouter: {
+        scope: props.startupPreference === "server" ? "local-desktop" : "local-host",
+        note:
+          props.startupPreference === "server"
+            ? "Local desktop router state. Remote worker router state is inferred through the connected OpenWork server."
+            : null,
         status: opencodeRouterStatusLabel(),
         healthPort: props.opencodeRouterInfo?.healthPort ?? null,
         pid: props.opencodeRouterInfo?.pid ?? null,

--- a/apps/orchestrator/scripts/router.mjs
+++ b/apps/orchestrator/scripts/router.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, realpath, rm } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -72,6 +72,14 @@ async function runCli(args, dataDir) {
   return trimmed ? JSON.parse(trimmed) : null;
 }
 
+async function canonicalPath(input) {
+  try {
+    return await realpath(input);
+  } catch {
+    return resolve(input);
+  }
+}
+
 const root = await mkdtemp(join(tmpdir(), "openwork-orchestrator-router-"));
 const dataDir = join(root, "data");
 const workspaceA = join(root, "ws-a");
@@ -121,8 +129,8 @@ try {
   const pathA = await runCli(["workspace", "path", idA, "--json"], dataDir);
   const pathB = await runCli(["workspace", "path", idB, "--json"], dataDir);
 
-  assert.equal(pathA.path.directory, workspaceA);
-  assert.equal(pathB.path.directory, workspaceB);
+  assert.equal(await canonicalPath(pathA.path.directory), await canonicalPath(workspaceA));
+  assert.equal(await canonicalPath(pathB.path.directory), await canonicalPath(workspaceB));
 
   const status2 = await runCli(["daemon", "status", "--json"], dataDir);
   const pid2 = status2.opencode.pid;
@@ -132,7 +140,7 @@ try {
   assert.equal(disposed.disposed, true);
 
   const pathA2 = await runCli(["workspace", "path", idA, "--json"], dataDir);
-  assert.equal(pathA2.path.directory, workspaceA);
+  assert.equal(await canonicalPath(pathA2.path.directory), await canonicalPath(workspaceA));
 
   await runCli(["daemon", "stop", "--json"], dataDir);
   await Promise.race([once(daemon, "exit"), new Promise((resolve) => setTimeout(resolve, 3000))]);

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -6933,10 +6933,10 @@ async function runStart(args: ParsedArgs) {
       opencodeDirectory: resolvedWorkspace,
       opencodeUsername,
       opencodePassword,
-      opencodeRouterHealthPort: opencodeRouterChild
+      opencodeRouterHealthPort: opencodeRouterEnabled
         ? opencodeRouterHealthPort
         : undefined,
-      opencodeRouterDataDir: opencodeRouterChild
+      opencodeRouterDataDir: opencodeRouterEnabled
         ? (opencodeRouterDataDir ?? undefined)
         : undefined,
       logger,
@@ -7854,10 +7854,10 @@ async function runStart(args: ParsedArgs) {
         opencodeDirectory: resolvedWorkspace,
         opencodeUsername,
         opencodePassword,
-        opencodeRouterHealthPort: opencodeRouterReady
+        opencodeRouterHealthPort: opencodeRouterEnabled
           ? opencodeRouterHealthPort
           : undefined,
-        opencodeRouterDataDir: opencodeRouterReady
+        opencodeRouterDataDir: opencodeRouterEnabled
           ? (opencodeRouterDataDir ?? undefined)
           : undefined,
         logger,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1584,6 +1584,38 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     return jsonResponse({ updatedAt: Date.now() });
   });
 
+  addRoute(routes, "GET", "/workspace/:id/opencode-router/health", "client", async (ctx) => {
+    requireClientScope(ctx, "collaborator");
+    await resolveWorkspace(config, ctx.params.id);
+
+    const healthPortParam = parseInteger(ctx.url.searchParams.get("healthPort") ?? undefined);
+    const port = healthPortParam ?? resolveOpenCodeRouterHealthPort();
+    const requestHost = ctx.url.hostname;
+    const apply = await tryFetchOpenCodeRouterHealth("GET", "/health", {
+      port,
+      requestHost,
+      timeoutMs: 2_000,
+    });
+
+    if (apply.applied && apply.body && typeof apply.body === "object") {
+      return jsonResponse(apply.body, apply.status ?? 200);
+    }
+
+    if (apply.applied) {
+      throw new ApiError(502, "opencodeRouter_invalid_health", "OpenCodeRouter returned an invalid health response", {
+        port,
+        host: apply.host ?? null,
+        hosts: apply.hosts,
+      });
+    }
+
+    throw new ApiError(apply.status ?? 503, "opencodeRouter_unreachable", apply.error ?? "OpenCodeRouter health unavailable", {
+      port,
+      host: apply.host ?? null,
+      hosts: apply.hosts,
+    });
+  });
+
   addRoute(routes, "POST", "/workspace/:id/opencode-router/telegram-token", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");


### PR DESCRIPTION
## Summary
- keep `openwork-server` and the orchestrator aligned on the router health port so remote workers stop reporting OpenCodeRouter as unconfigured during startup races
- fetch messaging health through a workspace-scoped route and stop devtools workspace state from overriding the active worker id in the Messaging UI
- normalize the orchestrator router integration test's temp paths so macOS `/var` and `/private/var` aliases do not fail the test

## Testing
- `pnpm --filter openwork-server build`
- `pnpm --filter openwork-orchestrator build`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-orchestrator test:router`
- `packaging/docker/dev-up.sh`
- Chrome MCP check of `http://localhost:<web-port>/dashboard/identities`
- `curl /capabilities`, `curl /workspace/<id>/opencode-router/health`, and `curl /opencode-router/health` against the Docker stack