### PR TITLE
fix(landing): route CTA to downloads

### DIFF
--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -48,11 +48,13 @@ export function LandingHome(props: Props) {
   const callLinkProps = externalLinkProps(props.callHref);
   const primaryCtaHref = props.isMobileVisitor
     ? "https://app.openworklabs.com"
-    : props.downloadHref;
+    : "/download";
   const primaryCtaLabel = props.isMobileVisitor
     ? "Open the app"
     : "Download for free";
-  const primaryCtaLinkProps = props.isMobileVisitor ? {} : downloadLinkProps;
+  const primaryCtaLinkProps = props.isMobileVisitor
+    ? {}
+    : externalLinkProps(primaryCtaHref);
 
   return (
     <div className="relative min-h-screen overflow-hidden text-[#011627]">


### PR DESCRIPTION
## Summary
- route the landing primary CTA to `/download` for desktop visitors
- keep the mobile CTA pointing to the app

## Testing
- not run (link change only)