### PR TITLE
fix(ci): build Daytona snapshot image from source orchestrator

### DIFF
--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -1,3 +1,18 @@
+FROM node:22-bookworm-slim AS openwork-builder
+
+WORKDIR /src
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl git unzip \
+  && npm install -g bun \
+  && corepack enable \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN pnpm install --frozen-lockfile --filter openwork-orchestrator... \
+  && pnpm --filter openwork-orchestrator build:bin
+
 FROM node:22-bookworm-slim
 
 ARG OPENWORK_ORCHESTRATOR_VERSION=0.11.151
@@ -8,7 +23,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl tar unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g "openwork-orchestrator@${OPENWORK_ORCHESTRATOR_VERSION}"
+COPY --from=openwork-builder /src/apps/orchestrator/dist/bin/openwork /usr/local/bin/openwork
+COPY --from=openwork-builder /src/constants.json /usr/local/constants.json
 
 RUN set -eux; \
   test -n "$OPENCODE_VERSION"; \
@@ -30,6 +46,7 @@ RUN set -eux; \
   install -m 0755 "$binary" /usr/local/bin/opencode; \
   rm -rf "$tmpdir"
 
-RUN openwork --version && opencode --version
+RUN test "$(openwork --version)" = "$OPENWORK_ORCHESTRATOR_VERSION" \
+  && opencode --version
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary
- replace the broken Linux `npm install -g openwork-orchestrator` step in the Daytona snapshot image with a source-built `openwork` binary
- copy the built orchestrator and `constants.json` into the runtime image so the pinned OpenCode version still resolves correctly
- keep the existing OpenCode install flow and add a version assertion for `openwork` during the image build

## Testing
- `docker run --rm -v "$PWD":/src -w /src node:22-bookworm-slim sh -lc 'apt-get update >/dev/null && apt-get install -y --no-install-recommends ca-certificates curl git unzip >/dev/null && npm install -g bun >/dev/null && corepack enable && pnpm install --frozen-lockfile --filter openwork-orchestrator... && pnpm --filter openwork-orchestrator build:bin && ./apps/orchestrator/dist/bin/openwork --version'`
- `docker buildx build --platform linux/amd64 -f ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot --build-arg OPENWORK_ORCHESTRATOR_VERSION=0.11.176 --build-arg OPENCODE_VERSION=1.2.27 --load -t openwork-daytona-snapshot:test .`