### PR TITLE
Simplify composer controls for workspace users

### DIFF
--- a/apps/app/src/app/components/model-picker-modal.tsx
+++ b/apps/app/src/app/components/model-picker-modal.tsx
@@ -302,7 +302,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
               <Show when={enabledOptions().length > 0}>
                 <section class="space-y-2">
                   <div class="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-9">
-                    Enabled Providers
+                    Available now
                   </div>
                   <For each={enabledOptions()}>{({ opt, index }) => renderOption(opt, index)}</For>
                 </section>
@@ -311,7 +311,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
               <Show when={otherOptions().length > 0}>
                 <section class="space-y-2">
                   <div class="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-9">
-                    Other Providers
+                    Connect more models
                   </div>
                   <For each={otherOptions()}>
                     {(provider) => renderProviderLink(provider, provider.index)}

--- a/apps/app/src/app/components/session/composer.tsx
+++ b/apps/app/src/app/components/session/composer.tsx
@@ -210,13 +210,7 @@ const MOBILE_VIEW_MEDIA_QUERY = "(max-width: 767px)";
 const isMobileViewport = () =>
   typeof window !== "undefined" && window.matchMedia(MOBILE_VIEW_MEDIA_QUERY).matches;
 
-const MODEL_VARIANT_OPTIONS = [
-  { value: "none", label: "None" },
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-  { value: "xhigh", label: "X-High" },
-];
+const EXTENDED_THINKING_VARIANT = "high";
 
 const partsToText = (parts: ComposerPart[]) =>
   parts
@@ -450,7 +444,6 @@ export default function Composer(props: ComposerProps) {
   let editorRef: HTMLDivElement | undefined;
   let fileInputRef: HTMLInputElement | undefined;
   let inboxFileInputRef: HTMLInputElement | undefined;
-  let variantPickerRef: HTMLDivElement | undefined;
   let mentionSearchRun = 0;
   let suppressPromptSync = false;
   let pasteCounter = 0;
@@ -483,9 +476,9 @@ export default function Composer(props: ComposerProps) {
   const [historySnapshot, setHistorySnapshot] = createSignal<ComposerDraft | null>(null);
   const [historyIndex, setHistoryIndex] = createSignal({ prompt: -1, shell: -1 });
   const [history, setHistory] = createSignal({ prompt: [] as ComposerDraft[], shell: [] as ComposerDraft[] });
-  const [variantMenuOpen, setVariantMenuOpen] = createSignal(false);
   const [showInboxUploadAction, setShowInboxUploadAction] = createSignal(false);
   const activeVariant = createMemo(() => props.modelVariant ?? "none");
+  const extendedThinkingEnabled = createMemo(() => activeVariant() !== "none");
   const compactModelLabel = createMemo(() =>
     props.selectedModelLabel.length > 20 ? `${props.selectedModelLabel.slice(0, 20)}...` : props.selectedModelLabel,
   );
@@ -1548,20 +1541,6 @@ export default function Composer(props: ComposerProps) {
     setSlashOpen(false);
     setSlashQuery("");
   });
-
-
-
-  createEffect(() => {
-    if (!variantMenuOpen()) return;
-    const handler = (event: MouseEvent) => {
-      if (!variantPickerRef) return;
-      if (variantPickerRef.contains(event.target as Node)) return;
-      setVariantMenuOpen(false);
-    };
-    window.addEventListener("mousedown", handler);
-    onCleanup(() => window.removeEventListener("mousedown", handler));
-  });
-
   createEffect(() => {
     const handler = () => {
       editorRef?.focus();
@@ -1828,7 +1807,7 @@ export default function Composer(props: ComposerProps) {
                           title={
                             attachmentsDisabled()
                               ? props.attachmentsDisabledReason ?? "Attachments are unavailable."
-                              : "Attach files"
+                              : "Attach files to this conversation"
                           }
                         >
                           <Paperclip size={16} />
@@ -1841,7 +1820,7 @@ export default function Composer(props: ComposerProps) {
                             onClick={props.onToggleAgentPicker}
                             disabled={props.busy}
                             aria-expanded={props.agentPickerOpen}
-                            title="Agent"
+                            title="Assistant"
                           >
                             <AtSign size={14} />
                             <span class="max-w-[140px] truncate">{props.agentLabel}</span>
@@ -1851,7 +1830,7 @@ export default function Composer(props: ComposerProps) {
                           <Show when={props.agentPickerOpen}>
                             <div class="absolute left-0 bottom-full z-40 mb-2 w-64 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
                               <div class="border-b border-dls-border px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10">
-                                Agent
+                                Assistant
                               </div>
 
                               <div class="p-2 space-y-1 max-h-64 overflow-y-auto" onMouseDown={(event: MouseEvent) => event.preventDefault()}>
@@ -1873,7 +1852,7 @@ export default function Composer(props: ComposerProps) {
                                         props.onSelectAgent(null);
                                       }}
                                     >
-                                      <span>Default agent</span>
+                                      <span>General purpose</span>
                                       <Show when={!props.selectedAgent}>
                                         <Check size={14} class="text-gray-10" />
                                       </Show>
@@ -1894,7 +1873,7 @@ export default function Composer(props: ComposerProps) {
                                               props.onSelectAgent(agent.name);
                                             }}
                                           >
-                                            <span class="truncate">@{agent.name}</span>
+                                            <span class="truncate">{agent.name}</span>
                                             <Show when={active()}>
                                               <Check size={14} class="text-gray-10" />
                                             </Show>
@@ -1926,48 +1905,30 @@ export default function Composer(props: ComposerProps) {
                           <span class="hidden md:inline">{props.selectedModelLabel}</span>
                           <ChevronDown size={14} class="shrink-0" />
                         </button>
-                        <div class="relative hidden md:block" ref={(el) => (variantPickerRef = el)}>
-                          <button
-                            type="button"
-                            class="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] font-medium text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
-                            onClick={() => setVariantMenuOpen((open) => !open)}
-                            disabled={props.busy}
-                            aria-expanded={variantMenuOpen()}
-                          >
-                            <span>Thinking</span>
-                            <span class="font-mono text-gray-11">{props.modelVariantLabel}</span>
-                            <ChevronDown size={14} />
-                          </button>
-                          <Show when={variantMenuOpen()}>
-                            <div class="absolute left-0 bottom-full z-40 mb-2 w-48 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
-                              <div class="border-b border-dls-border px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10">
-                                Thinking effort
-                              </div>
-                              <div class="p-2 space-y-1">
-                                <For each={MODEL_VARIANT_OPTIONS}>
-                                  {(option) => (
-                                    <button
-                                      type="button"
-                                      class={`w-full flex items-center justify-between rounded-lg px-3 py-2 text-left text-xs transition-colors ${activeVariant() === option.value
-                                        ? "bg-gray-2 text-gray-12"
-                                        : "text-gray-11 hover:bg-gray-2/70"
-                                         }`}
-                                      onClick={() => {
-                                        props.onModelVariantChange(option.value);
-                                        setVariantMenuOpen(false);
-                                      }}
-                                    >
-                                      <span>{option.label}</span>
-                                      <Show when={activeVariant() === option.value}>
-                                        <span class="text-[10px] uppercase tracking-wider text-gray-10">Active</span>
-                                      </Show>
-                                    </button>
-                                  )}
-                                </For>
-                              </div>
-                            </div>
-                          </Show>
-                        </div>
+                        <button
+                          type="button"
+                          class={`hidden md:flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[13px] font-medium transition-colors ${
+                            extendedThinkingEnabled()
+                              ? "bg-gray-3 text-gray-12"
+                              : "text-gray-11 hover:bg-gray-3 hover:text-gray-12"
+                          }`}
+                          onClick={() =>
+                            props.onModelVariantChange(
+                              extendedThinkingEnabled()
+                                ? "none"
+                                : EXTENDED_THINKING_VARIANT,
+                            )
+                          }
+                          disabled={props.busy}
+                          title="Extended thinking"
+                          aria-pressed={extendedThinkingEnabled()}
+                        >
+                          <Zap size={14} />
+                          <span>Extended thinking</span>
+                          <span class="text-[11px] text-gray-10">
+                            {extendedThinkingEnabled() ? "On" : "Off"}
+                          </span>
+                        </button>
                       </div>
                       <div class="ml-auto flex shrink-0 items-center gap-3 text-gray-10">
                         <Show
@@ -1981,10 +1942,10 @@ export default function Composer(props: ComposerProps) {
                                 ? "bg-gray-4 text-gray-10"
                                 : "bg-dls-accent text-white hover:bg-[var(--dls-accent-hover)]"
                                 }`}
-                              title="Run task"
+                              title="Send"
                             >
                               <ArrowUp size={16} />
-                              <span>Run task</span>
+                              <span>Send</span>
                             </button>
                           }
                         >

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -455,7 +455,7 @@ export default function SessionView(props: SessionViewProps) {
   });
 
   const agentLabel = createMemo(
-    () => props.selectedSessionAgent ?? "Default agent",
+    () => props.selectedSessionAgent ?? "General purpose",
   );
   const workspaceLabel = (workspace: WorkspaceInfo) =>
     workspace.displayName?.trim() ||


### PR DESCRIPTION
## Summary
- rename the default assistant choice to `General purpose` and remove extra agent jargon from the composer
- simplify model browsing copy so configured choices feel safer to non-technical users
- replace the detailed thinking menu with a simple extended-thinking toggle and make the send action more obvious

## Testing
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`
- Not run: Docker + Chrome MCP end-to-end verification for this branch