### PR TITLE
Simplify session chrome and settings exits

### DIFF
--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -72,8 +72,8 @@ import {
   Loader2,
   Menu,
   MessageCircle,
-  MoreHorizontal,
   Plus,
+  Settings2,
   SlidersHorizontal,
   X,
   Zap,
@@ -1301,22 +1301,23 @@ export default function DashboardView(props: DashboardViewProps) {
               type="button"
               class="hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text md:flex"
               onClick={toggleRightSidebar}
-              title="Menu"
-              aria-label="Menu"
+              title="Quick actions"
+              aria-label="Quick actions"
             >
               <Menu size={15} />
-              <span>Menu</span>
+              <span>Quick actions</span>
               <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">⌘K</span>
             </button>
             <div class="hidden h-4 w-px bg-dls-border md:block" />
             <button
               type="button"
-              class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
+              class="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
               onClick={props.toggleSettings}
-              title="More"
-              aria-label="More"
+              title="Settings"
+              aria-label="Settings"
             >
-              <MoreHorizontal size={16} />
+              <Settings2 size={15} />
+              <span class="hidden md:inline">Settings</span>
             </button>
           </div>
         </header>
@@ -1469,6 +1470,7 @@ export default function DashboardView(props: DashboardViewProps) {
 
             <Match when={props.tab === "settings"}>
               <SettingsView
+                  onClose={props.toggleSettings}
                   startupPreference={props.startupPreference}
                   baseUrl={props.baseUrl}
                   headerStatus={props.headerStatus}

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -4326,64 +4326,85 @@ export default function SessionView(props: SessionViewProps) {
                 aria-label="Quick actions"
               >
                 <Menu size={15} />
-                <span>Menu</span>
+                <span>Quick actions</span>
                 <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">
                   ⌘K
                 </span>
               </button>
-              <button
-                type="button"
-                class={`flex h-9 w-9 items-center justify-center rounded-md transition-colors ${
-                  searchOpen()
-                    ? "bg-gray-2 text-dls-text"
-                    : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
-                }`}
-                onClick={() => {
-                  if (searchOpen()) {
-                    closeSearch();
-                    return;
-                  }
-                  openSearch();
-                }}
-                title="Search conversation (Ctrl/Cmd+F)"
-                aria-label="Search conversation"
-              >
-                <Search size={16} />
-              </button>
-              <div class="hidden h-4 w-px bg-dls-border sm:block" />
-              <button
-                type="button"
-                class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
-                onClick={undoLastMessage}
-                disabled={!canUndoLastMessage() || historyActionBusy() !== null}
-                title="Undo last message"
-                aria-label="Undo last message"
-              >
-                <Show
-                  when={historyActionBusy() === "undo"}
-                  fallback={<Undo2 size={16} />}
+              <Show when={searchOpen() || props.messages.length > 0}>
+                <button
+                  type="button"
+                  class={`flex h-9 w-9 items-center justify-center rounded-md transition-colors ${
+                    searchOpen()
+                      ? "bg-gray-2 text-dls-text"
+                      : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
+                  }`}
+                  onClick={() => {
+                    if (searchOpen()) {
+                      closeSearch();
+                      return;
+                    }
+                    openSearch();
+                  }}
+                  title="Search conversation (Ctrl/Cmd+F)"
+                  aria-label="Search conversation"
                 >
-                  <Loader2 size={16} class="animate-spin" />
-                </Show>
-                <span class="hidden lg:inline">Revert</span>
-              </button>
-              <button
-                type="button"
-                class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
-                onClick={redoLastMessage}
-                disabled={!canRedoLastMessage() || historyActionBusy() !== null}
-                title="Redo last reverted message"
-                aria-label="Redo last reverted message"
+                  <Search size={16} />
+                </button>
+              </Show>
+              <Show
+                when={
+                  searchOpen() ||
+                  props.messages.length > 0 ||
+                  canUndoLastMessage() ||
+                  canRedoLastMessage() ||
+                  historyActionBusy() === "undo" ||
+                  historyActionBusy() === "redo" ||
+                  historyActionBusy() === "compact" ||
+                  canCompactSession()
+                }
               >
-                <Show
-                  when={historyActionBusy() === "redo"}
-                  fallback={<Redo2 size={16} />}
+                <div class="hidden h-4 w-px bg-dls-border sm:block" />
+              </Show>
+              <Show when={canUndoLastMessage() || historyActionBusy() === "undo"}>
+                <button
+                  type="button"
+                  class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={undoLastMessage}
+                  disabled={!canUndoLastMessage() || historyActionBusy() !== null}
+                  title="Undo last message"
+                  aria-label="Undo last message"
                 >
-                  <Loader2 size={16} class="animate-spin" />
-                </Show>
-                <span class="hidden lg:inline">Redo</span>
-              </button>
-              <div class="hidden h-4 w-px bg-dls-border sm:block" />
+                  <Show
+                    when={historyActionBusy() === "undo"}
+                    fallback={<Undo2 size={16} />}
+                  >
+                    <Loader2 size={16} class="animate-spin" />
+                  </Show>
+                  <span class="hidden lg:inline">Revert</span>
+                </button>
+              </Show>
+              <Show when={canRedoLastMessage() || historyActionBusy() === "redo"}>
+                <button
+                  type="button"
+                  class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={redoLastMessage}
+                  disabled={!canRedoLastMessage() || historyActionBusy() !== null}
+                  title="Redo last reverted message"
+                  aria-label="Redo last reverted message"
+                >
+                  <Show
+                    when={historyActionBusy() === "redo"}
+                    fallback={<Redo2 size={16} />}
+                  >
+                    <Loader2 size={16} class="animate-spin" />
+                  </Show>
+                  <span class="hidden lg:inline">Redo</span>
+                </button>
+              </Show>
+              <Show when={canCompactSession() || historyActionBusy() === "compact"}>
+                <div class="hidden h-4 w-px bg-dls-border sm:block" />
+              </Show>
               <button
                 type="button"
                 class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text md:hidden"
@@ -4393,21 +4414,23 @@ export default function SessionView(props: SessionViewProps) {
               >
                 <Menu size={16} />
               </button>
-              <button
-                type="button"
-                class="hidden h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60 md:flex"
-                onClick={compactSessionHistory}
-                disabled={!canCompactSession() || historyActionBusy() !== null}
-                title="Compact session context"
-                aria-label="Compact session context"
-              >
-                <Show
-                  when={historyActionBusy() === "compact"}
-                  fallback={<Maximize2 size={16} />}
+              <Show when={canCompactSession() || historyActionBusy() === "compact"}>
+                <button
+                  type="button"
+                  class="hidden h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60 md:flex"
+                  onClick={compactSessionHistory}
+                  disabled={!canCompactSession() || historyActionBusy() !== null}
+                  title="Compact session context"
+                  aria-label="Compact session context"
                 >
-                  <Loader2 size={16} class="animate-spin" />
-                </Show>
-              </button>
+                  <Show
+                    when={historyActionBusy() === "compact"}
+                    fallback={<Maximize2 size={16} />}
+                  >
+                    <Loader2 size={16} class="animate-spin" />
+                  </Show>
+                </button>
+              </Show>
             </div>
           </header>
 

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -81,6 +81,7 @@ export type SettingsViewProps = {
   clientConnected: boolean;
   settingsTab: SettingsTab;
   setSettingsTab: (tab: SettingsTab) => void;
+  onClose: () => void;
   providers: ProviderListItem[];
   providerConnectedIds: string[];
   providerAuthBusy: boolean;
@@ -1269,6 +1270,24 @@ export default function SettingsView(props: SettingsViewProps) {
 
   return (
     <section class="space-y-6">
+      <div class="flex items-start justify-between gap-4 rounded-2xl border border-gray-6/40 bg-gray-1/40 px-4 py-3">
+        <div>
+          <div class="text-lg font-semibold text-gray-12">Settings</div>
+          <div class="text-sm text-gray-10">
+            Manage app defaults, workspace access, and connection details.
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          class="!p-2 rounded-full"
+          onClick={props.onClose}
+          title="Close settings"
+          aria-label="Close settings"
+        >
+          <X size={16} />
+        </Button>
+      </div>
+
       <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between rounded-2xl border border-gray-6/40 bg-gray-1/40 px-3 py-2">
         <div class="flex flex-wrap gap-2">
           <For each={availableTabs()}>


### PR DESCRIPTION
## Summary
- remove misleading header actions in empty states and keep quick actions labeled consistently
- replace the vague dashboard ellipsis with an explicit settings affordance
- add a direct close path inside Settings so users can leave without jumping back into chat

## Testing
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`
- Not run: Docker + Chrome MCP end-to-end verification for this branch