### PR TITLE
feat: Do not lock scroll position while text is streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ vendor/opencode/
 .vercel
 .env*.local
 .claude/*
-.gstack/

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ vendor/opencode/
 .vercel
 .env*.local
 .claude/*
+.gstack/

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -351,6 +351,7 @@ export default function SessionView(props: SessionViewProps) {
   let pendingScrollBehavior: ScrollBehavior = "auto";
   let lastAutoScrollAt = 0;
   let lastKnownScrollTop = 0;
+  let userScrolledAwayAt = 0;
   let streamRenderBatchTimer: number | undefined;
   let streamRenderBatchQueuedAt = 0;
   let streamRenderBatchReschedules = 0;
@@ -2292,6 +2293,9 @@ export default function SessionView(props: SessionViewProps) {
     runProgressSignature();
     if (initialAnchorPending()) return;
     if (!isViewingLatest()) return;
+    // Suppress auto-scroll for 800ms after user scrolled away to prevent fighting manual scroll
+    const timeSinceUserScroll = Date.now() - userScrolledAwayAt;
+    if (timeSinceUserScroll < 800) return;
     scheduleScrollToLatest("auto");
   });
 
@@ -4224,10 +4228,14 @@ export default function SessionView(props: SessionViewProps) {
                   const bottomGap =
                     container.scrollHeight -
                     (container.scrollTop + container.clientHeight);
-                  if (bottomGap <= 96) {
+                  // Use a small threshold (24px) to only pin when truly at bottom
+                  // This prevents auto-scroll from fighting manual scroll during streaming
+                  if (bottomGap <= 24) {
                     setIsViewingLatest(true);
                   } else if (container.scrollTop < lastKnownScrollTop - 1) {
+                    // User scrolled up - respect their intent
                     setIsViewingLatest(false);
+                    userScrolledAwayAt = Date.now();
                   }
                   lastKnownScrollTop = container.scrollTop;
                   refreshTopClippedMessage();


### PR DESCRIPTION
## Summary
1. Added userScrolledAwayAt tracking variable 
    - Tracks when user last scrolled away from bottom
  2. Reduced auto-scroll threshold from 96px to 24px
    - Only pins to "viewing latest" when truly at the bottom
    - Prevents auto-scroll from activating when user is just reading near the bottom
  3. Added scroll-away timestamp tracking
    - Records userScrolledAwayAt = Date.now() when user scrolls up
  4. Added 800ms cooldown after manual scroll 
    - Suppresses auto-scroll for 800ms after user scrolls away
    - Prevents the view from fighting manual scroll position during streaming

## Issue
- Closes #1092 