### PR TITLE
fix(share): add favicon and social metadata to share app

### DIFF
--- a/apps/share/app/layout.tsx
+++ b/apps/share/app/layout.tsx
@@ -24,7 +24,16 @@ export const metadata: Metadata = {
     default: "OpenWork Share",
     template: "%s - OpenWork Share"
   },
-  description: "Publish OpenWork worker packages and shareable import links."
+  description: "Publish OpenWork worker packages and shareable import links.",
+  icons: { icon: "/openwork-mark.svg" },
+  openGraph: {
+    type: "website",
+    siteName: "OpenWork Share",
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@getopenwork",
+  },
 };
 
 const defaultPosthogKey = "phc_4YnPTlDVYPjgwKvLuNxhbHjV5kadgvd7XLzVHWnCXAI";


### PR DESCRIPTION
## Summary
- Add favicon (`openwork-mark.svg`) to the share app — browser tabs now show the OpenWork icon, matching landing and den-web apps
- Add fallback OpenGraph metadata (`type`, `siteName`) to root layout so all routes have baseline social card support
- Add Twitter/X card defaults with `summary_large_image` and `@getopenwork` site attribution

## Why
When share links were posted on X, Slack, or messaging apps, the share app was the only app missing a favicon and had no fallback social metadata in the root layout. Routes without explicit OG tags (error pages, future routes) had zero social presence.

## Changes
Single file: `apps/share/app/layout.tsx` (+10, -1)

## Test plan
- [ ] Verify favicon appears in browser tab at share.openwork.software
- [ ] Inspect `<head>` for `og:site_name`, `twitter:card`, `twitter:site` meta tags
- [ ] Paste a share link into https://opengraph.xyz to preview social cards
- [ ] Confirm bundle pages still render their own dynamic OG images (metadata merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)