### PR TITLE
Restyle Den dashboard toward Story-book shell

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
@@ -99,61 +99,61 @@ function CredentialRow({
 }) {
   return (
     <label className="grid gap-2">
-      <span className="px-0.5 text-[0.67rem] font-bold uppercase tracking-[0.11em] text-slate-500">{label}</span>
-      <div className={`flex items-center gap-2 rounded-xl border border-slate-200 bg-white p-1.5 ${muted ? "opacity-75" : ""}`}>
+      <span className="px-0.5 text-[0.67rem] font-bold uppercase tracking-[0.11em] text-[var(--dls-text-secondary)]">{label}</span>
+      <div className={`flex items-center gap-2 rounded-xl border border-[var(--dls-border)] bg-[var(--dls-surface)] p-1.5 ${muted ? "opacity-75" : ""}`}>
         <input
           readOnly
           value={value ?? placeholder}
-          className="min-w-0 flex-1 border-none bg-transparent px-2 py-1.5 font-mono text-xs text-slate-700 outline-none"
+          className="min-w-0 flex-1 border-none bg-transparent px-2 py-1.5 font-mono text-xs text-[var(--dls-text-primary)] outline-none"
           onClick={(event) => event.currentTarget.select()}
         />
         <button
           type="button"
-          className="rounded-lg border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-lg border border-[var(--dls-border)] bg-[var(--dls-surface)] px-2.5 py-1 text-xs font-medium text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
           disabled={!canCopy}
           onClick={onCopy}
         >
           {copied ? "Copied" : canCopy ? "Copy" : "N/A"}
         </button>
       </div>
-      {hint ? <span className="px-0.5 text-[0.7rem] text-slate-500">{hint}</span> : null}
+      {hint ? <span className="px-0.5 text-[0.7rem] text-[var(--dls-text-secondary)]">{hint}</span> : null}
     </label>
   );
 }
 
 function SkeletonBar({ widthClass }: { widthClass: string }) {
-  return <div className={`h-11 rounded-xl bg-slate-200/70 ${widthClass}`} aria-hidden="true" />;
+  return <div className={`h-11 rounded-xl bg-[var(--dls-hover)] ${widthClass}`} aria-hidden="true" />;
 }
 
 function ProvisioningGraphic({ ready }: { ready: boolean }) {
   return (
-    <div className="relative overflow-hidden rounded-[22px] border border-gray-100 bg-gray-50/80 p-6">
+    <div className="relative overflow-hidden rounded-[22px] border border-[var(--dls-border)] bg-[var(--dls-sidebar)] p-6">
       <div className="pointer-events-none absolute -right-8 -top-8 text-slate-900/5" aria-hidden="true">
         <CubeIcon className="h-44 w-44" />
       </div>
 
       <div className="relative z-10 flex flex-col items-center justify-center gap-6">
         <div className="flex items-center gap-6">
-          <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-gray-200 bg-white shadow-sm">
-            <CubeIcon className="h-6 w-6 text-slate-400" />
+          <div className="flex h-14 w-14 items-center justify-center rounded-xl border border-[var(--dls-border)] bg-[var(--dls-surface)]">
+            <CubeIcon className="h-6 w-6 text-[var(--dls-text-secondary)]" />
           </div>
 
           <div className="flex w-32 flex-col gap-2">
-            <div className="h-1.5 overflow-hidden rounded-full bg-gray-200">
+            <div className="h-1.5 overflow-hidden rounded-full bg-[var(--dls-border)]">
               <div className={`h-full w-1/2 rounded-full ${ready ? "bg-emerald-400" : "animate-[pulse_1.5s_ease-in-out_infinite] bg-amber-400"}`} />
             </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-gray-200">
+            <div className="h-1.5 overflow-hidden rounded-full bg-[var(--dls-border)]">
               <div className={`h-full w-2/3 rounded-full ${ready ? "bg-emerald-300" : "animate-[pulse_1.5s_ease-in-out_0.4s_infinite] bg-amber-300"}`} />
             </div>
           </div>
 
-          <div className="relative flex h-14 w-14 items-center justify-center rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="relative flex h-14 w-14 items-center justify-center rounded-xl border border-[var(--dls-border)] bg-[var(--dls-surface)]">
             <MonitorIcon className={ready ? "h-6 w-6 text-emerald-500" : "h-6 w-6 text-amber-500"} />
             <span className={`absolute -right-1 -top-1 h-3 w-3 rounded-full border-2 border-white ${ready ? "bg-emerald-500" : "animate-pulse bg-amber-500"}`} />
           </div>
         </div>
 
-        <div className="flex items-center gap-2 text-sm font-medium text-gray-500">
+        <div className="flex items-center gap-2 text-sm font-medium text-[var(--dls-text-secondary)]">
           <RefreshIcon className={ready ? "h-4 w-4 text-emerald-500" : "h-4 w-4 animate-spin text-amber-500"} />
           <span>{ready ? "Connection details are ready to use." : "Allocating resources and configuring your worker..."}</span>
         </div>
@@ -174,12 +174,12 @@ function SectionBadge({
   dimmed?: boolean;
 }) {
   return (
-    <div className={`rounded-[28px] border border-gray-200 p-8 shadow-sm ${dimmed ? "bg-gray-50/60 grayscale-[0.25] opacity-70" : "bg-white"}`}>
+    <div className={`rounded-[28px] border border-[var(--dls-border)] p-8 ${dimmed ? "bg-[var(--dls-sidebar)] grayscale-[0.25] opacity-70" : "bg-[var(--dls-surface)]"}`}>
       <div className="mb-4 flex items-center gap-3">
-        <div className="rounded-xl border border-gray-200 bg-white p-2.5 text-slate-500 shadow-sm">{icon}</div>
-        <h3 className="text-xl font-semibold tracking-tight text-slate-900">{title}</h3>
+        <div className="rounded-xl border border-[var(--dls-border)] bg-[var(--dls-sidebar)] p-2.5 text-[var(--dls-text-secondary)]">{icon}</div>
+        <h3 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{title}</h3>
       </div>
-      <p className="text-[15px] leading-relaxed text-gray-500">{body}</p>
+      <p className="text-[15px] leading-relaxed text-[var(--dls-text-secondary)]">{body}</p>
     </div>
   );
 }
@@ -249,8 +249,8 @@ export function DashboardScreen() {
 
   if (!sessionHydrated || !user || onboardingDecisionBusy) {
     return (
-      <section className="mx-auto grid w-full max-w-[52rem] gap-4 rounded-[32px] border border-white/70 bg-white/92 p-6 shadow-[0_28px_80px_-44px_rgba(15,23,42,0.35)]">
-        <p className="text-sm text-slate-500">Preparing your dashboard...</p>
+      <section className="mx-auto grid w-full max-w-[52rem] gap-4 rounded-[32px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-6">
+        <p className="text-sm text-[var(--dls-text-secondary)]">Preparing your dashboard...</p>
       </section>
     );
   }
@@ -263,20 +263,20 @@ export function DashboardScreen() {
   const showConnectionHint = !openworkDeepLink || !hasWorkspaceScopedUrl;
 
   return (
-    <section className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[32px] border border-white/70 bg-[#f3f4f6]/95 shadow-[0_28px_80px_-44px_rgba(15,23,42,0.2)] md:min-h-[calc(100vh-8.5rem)] md:flex-row">
-      <aside className="order-2 w-full shrink-0 border-t border-gray-200 bg-[#f9fafb] md:order-1 md:w-[280px] md:border-r md:border-t-0">
+    <section className="flex min-h-0 w-full flex-1 flex-col overflow-hidden rounded-[32px] border border-[var(--dls-border)] bg-[var(--dls-surface)] md:min-h-[calc(100vh-8.5rem)] md:flex-row">
+      <aside className="order-2 w-full shrink-0 border-t border-[var(--dls-border)] bg-[var(--dls-sidebar)] md:order-1 md:w-[296px] md:border-r md:border-t-0">
         <div className="flex h-full flex-col justify-between gap-4 p-4 md:gap-6 md:p-6">
           <div className="flex flex-col gap-4 md:gap-6">
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
-                <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#011627] text-white">
+                <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--dls-border)] bg-[var(--dls-surface)] text-[var(--dls-text-primary)]">
                   <CubeIcon className="h-4 w-4" />
                 </div>
-                <span className="text-lg font-semibold tracking-tight text-[#011627]">OpenWork</span>
+                <span className="text-lg font-semibold tracking-tight text-[var(--dls-text-primary)]">OpenWork</span>
               </div>
               <button
                 type="button"
-                className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-gray-50"
+                className="rounded-full border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-1.5 text-sm font-medium text-[var(--dls-text-secondary)] transition-colors hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)]"
                 onClick={() => void signOut()}
               >
                 Log out
@@ -285,8 +285,8 @@ export function DashboardScreen() {
 
             <div className="flex flex-col gap-3 md:gap-4">
               <div>
-                <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.16em] text-gray-400">Dashboard</div>
-                <span className="text-lg font-medium text-[#011627] md:text-xl">Workers</span>
+                <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.16em] text-[var(--dls-text-secondary)]">Dashboard</div>
+                <span className="text-lg font-medium text-[var(--dls-text-primary)] md:text-xl">Workers</span>
               </div>
 
               <nav className="flex flex-col gap-1.5 md:gap-2">
@@ -300,18 +300,18 @@ export function DashboardScreen() {
                       onClick={() => selectWorker(item)}
                       className={`flex items-center justify-between rounded-2xl border px-3.5 py-3 text-left transition-colors md:px-4 ${
                         selected
-                          ? "border-blue-100 bg-blue-50"
-                          : "border-transparent bg-transparent hover:border-gray-200 hover:bg-white"
-                      }`}
+                            ? "border-[var(--dls-border)] bg-[var(--dls-active)]"
+                            : "border-transparent bg-transparent hover:border-[var(--dls-border)] hover:bg-[var(--dls-surface)]"
+                        }`}
                     >
                       <span className="flex min-w-0 flex-col">
-                        <span className={`truncate text-sm font-semibold ${selected ? "text-blue-950" : "text-slate-800"}`}>{item.workerName}</span>
-                        <span className={`text-xs ${selected ? "text-blue-600" : "text-gray-500"}`}>{meta.label}</span>
+                        <span className="truncate text-sm font-semibold text-[var(--dls-text-primary)]">{item.workerName}</span>
+                        <span className="text-xs text-[var(--dls-text-secondary)]">{meta.label}</span>
                       </span>
                       {item.isMine ? (
-                        <span className={`shrink-0 rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${selected ? "bg-blue-100 text-blue-500" : "bg-slate-100 text-slate-500"}`}>
-                          Yours
-                        </span>
+                          <span className={`shrink-0 rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${selected ? "bg-[var(--dls-surface)] text-[var(--dls-text-primary)]" : "bg-[var(--dls-hover)] text-[var(--dls-text-secondary)]"}`}>
+                            Yours
+                          </span>
                       ) : null}
                     </button>
                   );
@@ -319,21 +319,21 @@ export function DashboardScreen() {
 
                 <Link
                   href="/checkout"
-                  className="rounded-2xl px-4 py-3 text-left text-sm font-medium text-gray-600 transition-colors hover:bg-white hover:text-[#011627]"
+                  className="rounded-2xl px-4 py-3 text-left text-sm font-medium text-[var(--dls-text-secondary)] transition-colors hover:bg-[var(--dls-surface)] hover:text-[var(--dls-text-primary)]"
                 >
                   Billing
                 </Link>
               </nav>
             </div>
 
-            {workersBusy ? <p className="text-xs text-slate-500">Loading workers...</p> : null}
+            {workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">Loading workers...</p> : null}
             {workersError ? <p className="text-xs font-medium text-rose-600">{workersError}</p> : null}
-            {workers.length === 0 && !workersBusy ? <p className="text-xs text-slate-500">No workers yet. Create one to get started.</p> : null}
+            {workers.length === 0 && !workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">No workers yet. Create one to get started.</p> : null}
           </div>
 
-            <div className="text-xs text-gray-500 md:text-sm">
-              Signed in as <span className="font-medium text-[#011627]">{user.email}</span>
-              <div className="mt-2 text-xs text-slate-400">
+            <div className="text-xs text-[var(--dls-text-secondary)] md:text-sm">
+              Signed in as <span className="font-medium text-[var(--dls-text-primary)]">{user.email}</span>
+              <div className="mt-2 text-xs text-[var(--dls-text-secondary)]">
                 {billingSummary?.featureGateEnabled && !billingSummary.hasActivePlan
                   ? "Billing required before the next launch."
                   : `${ownedWorkerCount} worker${ownedWorkerCount === 1 ? "" : "s"} in your account.`}
@@ -342,18 +342,18 @@ export function DashboardScreen() {
         </div>
       </aside>
 
-      <main className="order-1 min-h-0 flex-1 overflow-y-auto bg-[#f3f4f6] md:order-2">
+      <main className="order-1 min-h-0 flex-1 overflow-y-auto bg-[var(--dls-sidebar)] md:order-2">
         <div className="mx-auto flex max-w-5xl flex-col gap-5 p-4 md:gap-6 md:p-12">
           {selectedWorker ? (
             <>
               <div className="flex items-center justify-between gap-4">
                 <div>
-                  <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.16em] text-gray-400">Overview</div>
-                  <h1 className="text-2xl font-semibold tracking-tight text-[#011627] md:text-3xl">{currentWorker?.workerName ?? selectedWorker.workerName}</h1>
+                  <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.16em] text-[var(--dls-text-secondary)]">Overview</div>
+                  <h1 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)] md:text-3xl">{currentWorker?.workerName ?? selectedWorker.workerName}</h1>
                 </div>
               </div>
 
-              <div className="relative overflow-hidden rounded-[28px] border border-gray-200 bg-white p-6 shadow-sm md:rounded-[32px] md:p-10">
+              <div className="relative overflow-hidden rounded-[28px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-6 md:rounded-[32px] md:p-10">
                 <div className="pointer-events-none absolute -right-10 -top-10 text-slate-900/[0.03]" aria-hidden="true">
                   <CubeIcon className="h-[15rem] w-[15rem]" />
                 </div>
@@ -365,12 +365,12 @@ export function DashboardScreen() {
                         <span className={`absolute inline-flex h-full w-full rounded-full ${isReady ? "bg-emerald-400/60" : "animate-ping bg-amber-400/70"}`} />
                         <span className={`relative inline-flex h-3 w-3 rounded-full ${isReady ? "bg-emerald-500" : "bg-amber-500"}`} />
                       </div>
-                      <h2 className="text-xl font-semibold tracking-tight text-[#011627] md:text-2xl">
+                      <h2 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)] md:text-2xl">
                         {isReady ? "Your worker is ready." : isStarting ? "Provisioning in the background" : currentWorker ? getWorkerStatusCopy(currentWorker.status) : "Preparing worker"}
                       </h2>
                     </div>
 
-                    <p className="text-[16px] leading-relaxed text-gray-600 md:text-[17px]">
+                    <p className="text-[16px] leading-relaxed text-[var(--dls-text-secondary)] md:text-[17px]">
                       {isReady
                         ? "Open the worker in web or desktop, or copy the live credentials below."
                         : "We are allocating resources and preparing the OpenWork connection before unlocking the rest of the controls."}
@@ -385,8 +385,8 @@ export function DashboardScreen() {
                         href={openworkAppConnectUrl}
                         target="_blank"
                         rel="noreferrer"
-                        className={`flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-base font-medium shadow-md transition-all md:min-h-[52px] md:text-sm ${
-                          webDisabled ? "pointer-events-none border border-gray-200 bg-white text-gray-400 shadow-sm" : "bg-[#011627] text-white hover:bg-black"
+                        className={`flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-base font-medium transition-all md:min-h-[52px] md:text-sm ${
+                          webDisabled ? "pointer-events-none border border-[var(--dls-border)] bg-[var(--dls-surface)] text-[var(--dls-text-secondary)]" : "bg-[#011627] text-white hover:bg-black"
                         }`}
                         aria-disabled={webDisabled}
                       >
@@ -397,7 +397,7 @@ export function DashboardScreen() {
                       <button
                         type="button"
                         disabled
-                        className="flex w-full items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-6 py-3.5 font-medium text-gray-400 shadow-sm"
+                        className="flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--dls-border)] bg-[var(--dls-surface)] px-6 py-3.5 font-medium text-[var(--dls-text-secondary)]"
                       >
                         <GlobeIcon className="h-[18px] w-[18px]" />
                         Preparing web access
@@ -408,7 +408,7 @@ export function DashboardScreen() {
                       <button
                         type="button"
                         className={`flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium transition-all ${
-                          desktopDisabled ? "border border-gray-200 bg-white text-gray-400 shadow-sm" : "border border-gray-200 bg-white text-gray-600 shadow-sm hover:bg-gray-50 hover:text-[#011627]"
+                          desktopDisabled ? "border border-[var(--dls-border)] bg-[var(--dls-surface)] text-[var(--dls-text-secondary)]" : "border border-[var(--dls-border)] bg-[var(--dls-surface)] text-[var(--dls-text-secondary)] hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)]"
                         }`}
                         onClick={() => {
                           if (!desktopDisabled && openworkDeepLink) {
@@ -420,28 +420,28 @@ export function DashboardScreen() {
                         <MonitorIcon className="h-4 w-4" />
                         {desktopDisabled ? "Preparing desktop launch" : "Open in Desktop"}
                       </button>
-                      <span className="mt-2 text-[11px] font-medium text-gray-400">requires the OpenWork desktop app</span>
+                      <span className="mt-2 text-[11px] font-medium text-[var(--dls-text-secondary)]">requires the OpenWork desktop app</span>
                     </div>
                   </div>
                 </div>
               </div>
 
               <div className="grid gap-6 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
-                <div className={`rounded-[28px] border border-gray-200 shadow-sm transition-all ${isReady ? "bg-white" : "bg-gray-50/60 opacity-80"}`}>
+                <div className={`rounded-[28px] border border-[var(--dls-border)] transition-all ${isReady ? "bg-[var(--dls-surface)]" : "bg-[var(--dls-sidebar)] opacity-80"}`}>
                   <details className="group" open>
                     <summary className="flex cursor-pointer list-none items-center justify-between p-8 outline-none [&::-webkit-details-marker]:hidden">
                       <div>
-                        <div className="mb-4 flex items-center gap-3">
-                          <div className="rounded-xl border border-gray-200 bg-white p-2.5 text-slate-500 shadow-sm">
-                            <LockIcon className="h-[18px] w-[18px]" />
+                          <div className="mb-4 flex items-center gap-3">
+                            <div className="rounded-xl border border-[var(--dls-border)] bg-[var(--dls-sidebar)] p-2.5 text-[var(--dls-text-secondary)]">
+                              <LockIcon className="h-[18px] w-[18px]" />
+                            </div>
+                            <h3 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)]">Connection details</h3>
                           </div>
-                          <h3 className="text-xl font-semibold tracking-tight text-slate-900">Connection details</h3>
-                        </div>
-                        <p className="text-[15px] leading-relaxed text-gray-500">
+                          <p className="text-[15px] leading-relaxed text-[var(--dls-text-secondary)]">
                           Connect now or copy manual credentials for another client.
                         </p>
                       </div>
-                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-400 transition-transform group-open:rotate-180">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--dls-hover)] text-[var(--dls-text-secondary)] transition-transform group-open:rotate-180">
                         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m2 4 4 4 4-4"/></svg>
                       </div>
                     </summary>
@@ -450,7 +450,7 @@ export function DashboardScreen() {
                       <div className="flex flex-wrap gap-2">
                         <button
                           type="button"
-                          className="rounded-[16px] bg-[#011627] px-5 py-3 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(15,23,42,0.14)] transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-[16px] bg-[#011627] px-5 py-3 text-sm font-semibold text-white transition hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
                           onClick={() => {
                             if (openworkDeepLink) {
                               window.location.href = openworkDeepLink;
@@ -462,7 +462,7 @@ export function DashboardScreen() {
                         </button>
                         <button
                           type="button"
-                          className="rounded-[16px] border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          className="rounded-[16px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-4 py-3 text-sm font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)] disabled:cursor-not-allowed disabled:opacity-60"
                           onClick={() => void generateWorkerToken()}
                           disabled={actionBusy !== null}
                         >
@@ -509,21 +509,21 @@ export function DashboardScreen() {
                 </div>
 
                 <div className="flex flex-col gap-6">
-                  <div className={`rounded-[28px] border border-gray-200 shadow-sm transition-all ${isReady ? "bg-white" : "bg-gray-50/60 opacity-80"}`}>
+                  <div className={`rounded-[28px] border border-[var(--dls-border)] transition-all ${isReady ? "bg-[var(--dls-surface)]" : "bg-[var(--dls-sidebar)] opacity-80"}`}>
                     <details className="group">
                       <summary className="flex cursor-pointer list-none items-center justify-between p-8 outline-none [&::-webkit-details-marker]:hidden">
                         <div>
                           <div className="mb-4 flex items-center gap-3">
-                            <div className="rounded-xl border border-gray-200 bg-white p-2.5 text-slate-500 shadow-sm">
+                            <div className="rounded-xl border border-[var(--dls-border)] bg-[var(--dls-sidebar)] p-2.5 text-[var(--dls-text-secondary)]">
                               <ActivityIcon className="h-[18px] w-[18px]" />
                             </div>
-                            <h3 className="text-xl font-semibold tracking-tight text-slate-900">Worker actions</h3>
+                            <h3 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)]">Worker actions</h3>
                           </div>
-                          <p className="text-[15px] leading-relaxed text-gray-500">
+                          <p className="text-[15px] leading-relaxed text-[var(--dls-text-secondary)]">
                             Refresh state, recover tokens, or replace the worker. Controls unlock as the worker becomes reachable.
                           </p>
                         </div>
-                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-400 transition-transform group-open:rotate-180">
+                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--dls-hover)] text-[var(--dls-text-secondary)] transition-transform group-open:rotate-180">
                           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m2 4 4 4 4-4"/></svg>
                         </div>
                       </summary>
@@ -532,7 +532,7 @@ export function DashboardScreen() {
                         <div className="flex flex-wrap gap-2">
                           <button
                             type="button"
-                            className="rounded-[12px] border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
                             onClick={() => void refreshWorkers({ keepSelection: true })}
                             disabled={workersBusy || actionBusy !== null}
                           >
@@ -540,7 +540,7 @@ export function DashboardScreen() {
                           </button>
                           <button
                             type="button"
-                            className="rounded-[12px] border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
                             onClick={() => void checkWorkerStatus({ workerId: selectedWorker.workerId })}
                             disabled={actionBusy !== null}
                           >
@@ -548,7 +548,7 @@ export function DashboardScreen() {
                           </button>
                           <button
                             type="button"
-                            className="rounded-[12px] border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
                             onClick={() => void generateWorkerToken()}
                             disabled={actionBusy !== null}
                           >
@@ -556,7 +556,7 @@ export function DashboardScreen() {
                           </button>
                           <button
                             type="button"
-                            className="rounded-[12px] border border-slate-200 bg-slate-900/5 px-3 py-2 text-xs font-semibold text-slate-900 transition hover:bg-slate-900/10 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-hover)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-primary)] transition hover:bg-[var(--dls-active)] disabled:cursor-not-allowed disabled:opacity-50"
                             onClick={() => void redeployWorker(selectedWorker.workerId)}
                             disabled={!isSelectedWorkerFailed || redeployBusyWorkerId !== null || deleteBusyWorkerId !== null || actionBusy !== null || launchBusy}
                           >
@@ -575,21 +575,21 @@ export function DashboardScreen() {
                     </details>
                   </div>
 
-                  <div className={`rounded-[28px] border border-gray-200 shadow-sm transition-all ${isReady ? "bg-white" : "bg-gray-50/60 opacity-80"}`}>
+                  <div className={`rounded-[28px] border border-[var(--dls-border)] transition-all ${isReady ? "bg-[var(--dls-surface)]" : "bg-[var(--dls-sidebar)] opacity-80"}`}>
                     <details className="group">
                       <summary className="flex cursor-pointer list-none items-center justify-between p-8 outline-none [&::-webkit-details-marker]:hidden">
                         <div>
                           <div className="mb-4 flex items-center gap-3">
-                            <div className="rounded-xl border border-gray-200 bg-white p-2.5 text-slate-500 shadow-sm">
+                            <div className="rounded-xl border border-[var(--dls-border)] bg-[var(--dls-sidebar)] p-2.5 text-[var(--dls-text-secondary)]">
                               <TerminalIcon className="h-[18px] w-[18px]" />
                             </div>
-                            <h3 className="text-xl font-semibold tracking-tight text-slate-900">Worker runtime</h3>
+                            <h3 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)]">Worker runtime</h3>
                           </div>
-                          <p className="text-[15px] leading-relaxed text-gray-500">
+                          <p className="text-[15px] leading-relaxed text-[var(--dls-text-secondary)]">
                             Compare installed runtime versions with the versions this worker should be running.
                           </p>
                         </div>
-                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-400 transition-transform group-open:rotate-180">
+                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--dls-hover)] text-[var(--dls-text-secondary)] transition-transform group-open:rotate-180">
                           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m2 4 4 4 4-4"/></svg>
                         </div>
                       </summary>
@@ -598,7 +598,7 @@ export function DashboardScreen() {
                         <div className="mb-4 flex flex-wrap gap-2">
                           <button
                             type="button"
-                            className="rounded-[12px] border border-slate-200 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                            className="rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)] disabled:cursor-not-allowed disabled:opacity-50"
                             onClick={() => void refreshRuntime(selectedWorker.workerId)}
                             disabled={runtimeBusy || runtimeUpgradeBusy}
                           >
@@ -618,11 +618,11 @@ export function DashboardScreen() {
 
                         <div className="space-y-3">
                           {(runtimeSnapshot?.services ?? []).map((service) => (
-                            <div key={service.name} className="rounded-[18px] border border-slate-200 bg-white px-4 py-3">
+                            <div key={service.name} className="rounded-[18px] border border-[var(--dls-border)] bg-[var(--dls-sidebar)] px-4 py-3">
                               <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                                 <div>
-                                  <p className="text-sm font-semibold text-slate-900">{getRuntimeServiceLabel(service.name)}</p>
-                                  <p className="text-xs text-slate-500">
+                                  <p className="text-sm font-semibold text-[var(--dls-text-primary)]">{getRuntimeServiceLabel(service.name)}</p>
+                                  <p className="text-xs text-[var(--dls-text-secondary)]">
                                     Installed {service.actualVersion ?? "unknown"} · Target {service.targetVersion ?? "unknown"}
                                   </p>
                                 </div>
@@ -642,7 +642,7 @@ export function DashboardScreen() {
                             <div className="space-y-3">
                               <SkeletonBar widthClass="w-full" />
                               <SkeletonBar widthClass="w-4/5" />
-                              <p className="text-sm text-slate-500">Runtime details appear after the worker is reachable.</p>
+                              <p className="text-sm text-[var(--dls-text-secondary)]">Runtime details appear after the worker is reachable.</p>
                             </div>
                           ) : null}
                         </div>
@@ -657,14 +657,14 @@ export function DashboardScreen() {
                     dimmed={false}
                   />
 
-                  <div className="rounded-[28px] border border-gray-200 bg-white p-8 shadow-sm">
+                  <div className="rounded-[28px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-8">
                     <div className="mb-4 flex items-center gap-3">
-                      <div className="rounded-xl border border-gray-200 bg-white p-2.5 text-slate-500 shadow-sm">
+                      <div className="rounded-xl border border-[var(--dls-border)] bg-[var(--dls-sidebar)] p-2.5 text-[var(--dls-text-secondary)]">
                         <GlobeIcon className="h-[18px] w-[18px]" />
                       </div>
-                      <h3 className="text-xl font-semibold tracking-tight text-slate-900">Billing snapshot</h3>
+                      <h3 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)]">Billing snapshot</h3>
                     </div>
-                    <p className="text-[15px] leading-relaxed text-gray-500">
+                    <p className="text-[15px] leading-relaxed text-[var(--dls-text-secondary)]">
                       {billingSummary?.featureGateEnabled
                         ? billingSummary.hasActivePlan
                           ? "Your account has an active Den Cloud plan."
@@ -673,7 +673,7 @@ export function DashboardScreen() {
                     </p>
                     <Link
                       href="/checkout"
-                      className="mt-4 inline-flex rounded-[12px] border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                      className="mt-4 inline-flex rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)]"
                     >
                       Open billing
                     </Link>
@@ -682,10 +682,10 @@ export function DashboardScreen() {
               </div>
             </>
           ) : (
-            <div className="rounded-[24px] border border-slate-200 bg-white p-8 shadow-sm">
+            <div className="rounded-[24px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-8">
               <div className="mx-auto max-w-[30rem] text-center">
-                <h2 className="text-2xl font-semibold tracking-tight text-slate-900">No workers yet</h2>
-                <p className="mt-3 text-sm leading-6 text-slate-600">Create your first worker to unlock connection details and runtime controls.</p>
+                <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">No workers yet</h2>
+                <p className="mt-3 text-sm leading-6 text-[var(--dls-text-secondary)]">Create your first worker to unlock connection details and runtime controls.</p>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- restyle the Den dashboard shell, sidebar, and cards to use the flatter Story-book/DLS surface language
- update worker list, connection details, runtime rows, and action controls to match the stronger neutral borders and hover states
- keep the existing dashboard behavior intact while reducing the old shadow-heavy, glassy treatment

## Verification
- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit`
- `pnpm --filter @openwork/story-book typecheck`