### PR TITLE
Move local workspace ownership into OpenWork server

### DIFF
--- a/packages/app/src/app/app.tsx
+++ b/packages/app/src/app/app.tsx
@@ -1630,6 +1630,8 @@ export default function App() {
     openworkServerSettings,
     updateOpenworkServerSettings,
     openworkServerClient,
+    openworkServerStatus,
+    openworkServerWorkspaceId,
     onEngineStable: () => {},
     engineRuntime,
     developerMode,
@@ -2040,7 +2042,7 @@ export default function App() {
           if (cancelled) return;
           const items = Array.isArray(response.items) ? response.items : [];
           const match = items.find((entry) => normalizeDirectoryPath(entry.path) === root);
-          setOpenworkServerWorkspaceId(match?.id ?? response.activeId ?? null);
+          setOpenworkServerWorkspaceId(match?.id ?? null);
         } catch {
           if (!cancelled) setOpenworkServerWorkspaceId(null);
         }
@@ -2484,8 +2486,6 @@ export default function App() {
 
   // Scheduler helpers - must be defined after workspaceStore
   const resolveOpenworkScheduler = () => {
-    const isRemoteWorkspace = workspaceStore.activeWorkspaceDisplay().workspaceType === "remote";
-    if (!isRemoteWorkspace) return null;
     const client = openworkServerClient();
     const workspaceId = openworkServerWorkspaceId();
     if (openworkServerStatus() !== "connected" || !client || !workspaceId) return null;
@@ -2493,7 +2493,7 @@ export default function App() {
   };
 
   const scheduledJobsSource = createMemo<"local" | "remote">(() => {
-    return workspaceStore.activeWorkspaceDisplay().workspaceType === "remote" ? "remote" : "local";
+    return resolveOpenworkScheduler() ? "remote" : "local";
   });
 
   const scheduledJobsSourceReady = createMemo(() => {
@@ -3055,6 +3055,25 @@ export default function App() {
       setMcpStatus(e instanceof Error ? e.message : "Failed to load MCP servers");
     }
   }
+
+  const readMcpConfigFile = async (scope: "project" | "global") => {
+    const projectDir = workspaceProjectDir().trim();
+    const openworkClient = openworkServerClient();
+    const openworkWorkspaceId = openworkServerWorkspaceId();
+    const canUseOpenworkServer =
+      openworkServerStatus() === "connected" &&
+      openworkClient &&
+      openworkWorkspaceId &&
+      resolvedOpenworkCapabilities()?.config?.read;
+
+    if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
+      return openworkClient.readOpencodeConfigFile(openworkWorkspaceId, scope);
+    }
+    if (!isTauriRuntime()) {
+      return null;
+    }
+    return readOpencodeConfig(scope, projectDir);
+  };
 
   async function connectMcp(entry: (typeof MCP_QUICK_CONNECT)[number]) {
     console.log("[connectMcp] called with entry:", entry);
@@ -4483,6 +4502,7 @@ export default function App() {
       mcpConnectingName: mcpConnectingName(),
       selectedMcp: selectedMcp(),
       setSelectedMcp,
+      readConfigFile: readMcpConfigFile,
       quickConnect: MCP_QUICK_CONNECT,
       connectMcp,
       logoutMcpAuth,

--- a/packages/app/src/app/context/workspace.ts
+++ b/packages/app/src/app/context/workspace.ts
@@ -28,6 +28,7 @@ import {
   OpenworkServerError,
   type OpenworkServerClient,
   type OpenworkServerSettings,
+  type OpenworkServerStatus,
   type OpenworkWorkspaceInfo,
 } from "../lib/openwork-server";
 import { downloadDir, homeDir } from "@tauri-apps/api/path";
@@ -136,6 +137,8 @@ export function createWorkspaceStore(options: {
   openworkServerSettings: () => OpenworkServerSettings;
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
   openworkServerClient?: () => OpenworkServerClient | null;
+  openworkServerStatus?: () => OpenworkServerStatus;
+  openworkServerWorkspaceId?: () => string | null;
   setOpencodeConnectStatus?: (status: OpencodeConnectStatus | null) => void;
   onEngineStable?: () => void;
   engineRuntime?: () => EngineRuntime;
@@ -234,6 +237,21 @@ export function createWorkspaceStore(options: {
 
   const syncActiveWorkspaceId = (id: string) => {
     setActiveWorkspaceId(id);
+  };
+
+  const applyServerLocalWorkspaces = (nextLocals: WorkspaceInfo[], nextActiveId: string | null | undefined) => {
+    const remotes = workspaces().filter((workspace) => workspace.workspaceType === "remote");
+    const merged = [...nextLocals, ...remotes];
+    setWorkspaces(merged);
+
+    const currentActiveId = activeWorkspaceId();
+    const fallbackActiveId = merged.some((workspace) => workspace.id === currentActiveId)
+      ? currentActiveId
+      : merged[0]?.id ?? "";
+    const resolvedActiveId = nextActiveId?.trim() || fallbackActiveId;
+    if (resolvedActiveId) {
+      syncActiveWorkspaceId(resolvedActiveId);
+    }
   };
 
   const [authorizedDirs, setAuthorizedDirs] = createSignal<string[]>([]);
@@ -457,18 +475,55 @@ export function createWorkspaceStore(options: {
     return resolved;
   };
 
-  const activateOpenworkHostWorkspace = async (workspacePath: string) => {
+  const resolveConnectedOpenworkServer = () => {
     const client = options.openworkServerClient?.();
-    if (!client) return;
+    if (!client) return null;
+    if (options.openworkServerStatus?.() !== "connected") return null;
+    return client;
+  };
+
+  const resolveActiveOpenworkWorkspace = () => {
+    const client = resolveConnectedOpenworkServer();
+    const workspaceId = options.openworkServerWorkspaceId?.()?.trim() ?? "";
+    if (!client || !workspaceId) return null;
+    return { client, workspaceId };
+  };
+
+  const findOpenworkWorkspaceByPath = async (workspacePath: string) => {
+    const client = resolveConnectedOpenworkServer();
     const targetPath = normalizeDirectoryPath(workspacePath);
-    if (!targetPath) return;
+    if (!client || !targetPath) return null;
+
+    const response = await client.listWorkspaces();
+    const items = Array.isArray(response.items) ? response.items : [];
+    const match = items.find((entry) => normalizeDirectoryPath(entry.path) === targetPath);
+    if (!match?.id) return null;
+    return { client, workspaceId: match.id, response };
+  };
+
+  const loadWorkspaceConfigFromOpenworkServer = async (workspacePath: string): Promise<WorkspaceOpenworkConfig | null> => {
+    const resolved = await findOpenworkWorkspaceByPath(workspacePath);
+    if (!resolved) return null;
+    if (resolved.response.activeId !== resolved.workspaceId) {
+      await resolved.client.activateWorkspace(resolved.workspaceId);
+    }
+    const config = await resolved.client.getConfig(resolved.workspaceId);
+    return (config.openwork as WorkspaceOpenworkConfig | null | undefined) ?? null;
+  };
+
+  const persistWorkspaceConfigToOpenworkServer = async (config: WorkspaceOpenworkConfig): Promise<boolean> => {
+    const active = resolveActiveOpenworkWorkspace();
+    if (!active) return false;
+    await active.client.patchConfig(active.workspaceId, { openwork: config as Record<string, unknown> });
+    return true;
+  };
+
+  const activateOpenworkHostWorkspace = async (workspacePath: string) => {
+    const resolved = await findOpenworkWorkspaceByPath(workspacePath);
+    if (!resolved) return;
     try {
-      const response = await client.listWorkspaces();
-      const items = Array.isArray(response.items) ? response.items : [];
-      const match = items.find((entry) => normalizeDirectoryPath(entry.path) === targetPath);
-      if (!match?.id) return;
-      if (response.activeId === match.id) return;
-      await client.activateWorkspace(match.id);
+      if (resolved.response.activeId === resolved.workspaceId) return;
+      await resolved.client.activateWorkspace(resolved.workspaceId);
     } catch {
       // ignore
     }
@@ -877,7 +932,8 @@ export function createWorkspaceStore(options: {
       } else {
         setWorkspaceConfigLoaded(false);
         try {
-          const cfg = await workspaceOpenworkRead({ workspacePath: next.path });
+          const cfg = await loadWorkspaceConfigFromOpenworkServer(next.path)
+            ?? await workspaceOpenworkRead({ workspacePath: next.path });
           setWorkspaceConfig(cfg);
           setWorkspaceConfigLoaded(true);
 
@@ -895,6 +951,9 @@ export function createWorkspaceStore(options: {
       }
 
       try {
+        if (!isRemote) {
+          await activateOpenworkHostWorkspace(next.path);
+        }
         await workspaceSetActive(id);
       } catch {
         // ignore
@@ -1302,9 +1361,20 @@ export function createWorkspaceStore(options: {
       }
 
       const name = resolvedFolder.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? "Worker";
-      const ws = await workspaceCreate({ folderPath: resolvedFolder, name, preset });
-      setWorkspaces(ws.workspaces);
-      syncActiveWorkspaceId(ws.activeId);
+      const openworkServer = resolveConnectedOpenworkServer();
+      const ws = openworkServer
+        ? await openworkServer.createLocalWorkspace({ folderPath: resolvedFolder, name, preset })
+        : await workspaceCreate({ folderPath: resolvedFolder, name, preset });
+
+      if (openworkServer && isTauriRuntime()) {
+        try {
+          await workspaceCreate({ folderPath: resolvedFolder, name, preset });
+        } catch {
+          // keep the server result as the source of truth for this run
+        }
+      }
+
+      applyServerLocalWorkspaces(ws.workspaces, ws.activeId);
       if (ws.activeId) {
         updateWorkspaceConnectionState(ws.activeId, { status: "connected", message: null });
       }
@@ -1391,18 +1461,39 @@ export function createWorkspaceStore(options: {
       pushSandboxCreateLog(`Worker: ${resolvedFolder}`);
 
       // Ensure the workspace folder has baseline OpenWork/OpenCode files.
-      const created = await workspaceCreate({ folderPath: resolvedFolder, name, preset });
-      setWorkspaces(created.workspaces);
-      syncActiveWorkspaceId(created.activeId);
+      const openworkServer = resolveConnectedOpenworkServer();
+      const created = openworkServer
+        ? await openworkServer.createLocalWorkspace({ folderPath: resolvedFolder, name, preset })
+        : await workspaceCreate({ folderPath: resolvedFolder, name, preset });
+      if (openworkServer && isTauriRuntime()) {
+        try {
+          await workspaceCreate({ folderPath: resolvedFolder, name, preset });
+        } catch {
+          // ignore desktop mirror failures here
+        }
+      }
+      applyServerLocalWorkspaces(created.workspaces, created.activeId);
       setSandboxStep("workspace", { status: "done", detail: null });
 
       // Remove the local workspace entry to avoid duplicate Local+Remote rows.
       const localId = created.activeId;
       if (localId) {
         pushSandboxCreateLog("Removing local worker row (will re-add as remote sandbox)...");
-        const forgotten = await workspaceForget(localId);
-        setWorkspaces(forgotten.workspaces);
-        syncActiveWorkspaceId(forgotten.activeId);
+        const activeLocalWorkspace = openworkServer ? await findOpenworkWorkspaceByPath(resolvedFolder) : null;
+        const forgotten = await (activeLocalWorkspace
+          ? (() => activeLocalWorkspace.client.deleteWorkspace(activeLocalWorkspace.workspaceId).then((response) => ({
+              activeId: response.activeId ?? "",
+              workspaces: response.workspaces ?? response.items,
+            })))()
+          : workspaceForget(localId));
+        if (activeLocalWorkspace && isTauriRuntime()) {
+          try {
+            await workspaceForget(localId);
+          } catch {
+            // ignore desktop mirror failures here
+          }
+        }
+        applyServerLocalWorkspaces(forgotten.workspaces, forgotten.activeId);
       }
 
       setSandboxStep("sandbox", { status: "active", detail: null });
@@ -1817,15 +1908,38 @@ export function createWorkspaceStore(options: {
 
     const id = workspaceId.trim();
     if (!id) return;
+    const workspace = workspaces().find((entry) => entry.id === id) ?? null;
 
     console.log("[workspace] forget", { id });
 
     try {
       const previousActive = activeWorkspaceId();
-      const ws = await workspaceForget(id);
-      setWorkspaces(ws.workspaces);
+      const openworkWorkspace = workspace?.workspaceType === "local" ? await findOpenworkWorkspaceByPath(workspace.path) : null;
+      const ws = openworkWorkspace
+        ? await openworkWorkspace.client.deleteWorkspace(openworkWorkspace.workspaceId).then((response) => ({
+            activeId: response.activeId ?? "",
+            workspaces: response.workspaces ?? response.items,
+          }))
+        : await workspaceForget(id);
+
+      if (openworkWorkspace && isTauriRuntime()) {
+        try {
+          await workspaceForget(id);
+        } catch {
+          // ignore desktop mirror failures here
+        }
+      }
+
+      if (openworkWorkspace) {
+        applyServerLocalWorkspaces(ws.workspaces, ws.activeId);
+      } else {
+        setWorkspaces(ws.workspaces);
+      }
       clearWorkspaceConnectionState(id);
-      syncActiveWorkspaceId(ws.activeId);
+
+      if (!openworkWorkspace) {
+        syncActiveWorkspaceId(ws.activeId);
+      }
 
       const active = ws.workspaces.find((w) => w.id === ws.activeId) ?? null;
       if (active) {
@@ -2130,6 +2244,32 @@ export function createWorkspaceStore(options: {
     const nextDisplayName = displayName?.trim() || null;
     options.setError(null);
 
+    const openworkWorkspace = workspace.workspaceType === "local"
+      ? await findOpenworkWorkspaceByPath(workspace.path)
+      : null;
+
+    if (openworkWorkspace) {
+      try {
+        const ws = await openworkWorkspace.client.updateWorkspaceDisplayName(openworkWorkspace.workspaceId, nextDisplayName);
+        if (isTauriRuntime()) {
+          try {
+            await workspaceUpdateDisplayName({ workspaceId: id, displayName: nextDisplayName });
+          } catch {
+            // ignore desktop mirror failures here
+          }
+        }
+        applyServerLocalWorkspaces(ws.workspaces, ws.activeId);
+        if (ws.activeId) {
+          updateWorkspaceConnectionState(ws.activeId, { status: "connected", message: null });
+        }
+        return true;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : safeStringify(e);
+        options.setError(addOpencodeCacheHint(message));
+        return false;
+      }
+    }
+
     if (isTauriRuntime()) {
       try {
         const ws = await workspaceUpdateDisplayName({ workspaceId: id, displayName: nextDisplayName });
@@ -2378,7 +2518,10 @@ export function createWorkspaceStore(options: {
       reload: existing?.reload ?? null,
     };
 
-    await workspaceOpenworkWrite({ workspacePath: root, config: cfg });
+    const persistedViaServer = await persistWorkspaceConfigToOpenworkServer(cfg).catch(() => false);
+    if (!persistedViaServer) {
+      await workspaceOpenworkWrite({ workspacePath: root, config: cfg });
+    }
     setWorkspaceConfig(cfg);
   }
 
@@ -2399,7 +2542,10 @@ export function createWorkspaceStore(options: {
       },
     };
 
-    await workspaceOpenworkWrite({ workspacePath: root, config: cfg });
+    const persistedViaServer = await persistWorkspaceConfigToOpenworkServer(cfg).catch(() => false);
+    if (!persistedViaServer) {
+      await workspaceOpenworkWrite({ workspacePath: root, config: cfg });
+    }
     setWorkspaceConfig(cfg);
   }
 

--- a/packages/app/src/app/lib/openwork-server.ts
+++ b/packages/app/src/app/lib/openwork-server.ts
@@ -1,6 +1,6 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { isTauriRuntime } from "../utils";
-import type { ScheduledJob } from "./tauri";
+import type { ExecResult, OpencodeConfigFile, ScheduledJob, WorkspaceInfo, WorkspaceList } from "./tauri";
 
 export type OpenworkServerCapabilities = {
   skills: { read: boolean; write: boolean; source: "openwork" | "opencode" };
@@ -56,13 +56,7 @@ export type OpenworkServerSettings = {
   token?: string;
 };
 
-export type OpenworkWorkspaceInfo = {
-  id: string;
-  name: string;
-  path: string;
-  workspaceType: "local" | "remote";
-  baseUrl?: string;
-  directory?: string;
+export type OpenworkWorkspaceInfo = WorkspaceInfo & {
   opencode?: {
     baseUrl?: string;
     directory?: string;
@@ -73,6 +67,7 @@ export type OpenworkWorkspaceInfo = {
 
 export type OpenworkWorkspaceList = {
   items: OpenworkWorkspaceInfo[];
+  workspaces?: WorkspaceInfo[];
   activeId?: string | null;
 };
 
@@ -830,6 +825,22 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     opencodeRouterSlackIdentities: () =>
       requestJsonRaw<OpenworkOpenCodeRouterSlackIdentitiesResult>(baseUrl, "/opencode-router/identities/slack", { token, hostToken, timeoutMs: timeouts.opencodeRouter }),
     listWorkspaces: () => requestJson<OpenworkWorkspaceList>(baseUrl, "/workspaces", { token, hostToken, timeoutMs: timeouts.listWorkspaces }),
+    createLocalWorkspace: (payload: { folderPath: string; name: string; preset: string }) =>
+      requestJson<WorkspaceList>(baseUrl, "/workspaces/local", {
+        token,
+        hostToken,
+        method: "POST",
+        body: payload,
+        timeoutMs: timeouts.activateWorkspace,
+      }),
+    updateWorkspaceDisplayName: (workspaceId: string, displayName: string | null) =>
+      requestJson<WorkspaceList>(baseUrl, `/workspaces/${encodeURIComponent(workspaceId)}/display-name`, {
+        token,
+        hostToken,
+        method: "PATCH",
+        body: { displayName },
+        timeoutMs: timeouts.activateWorkspace,
+      }),
     activateWorkspace: (workspaceId: string) =>
       requestJson<{ activeId: string; workspace: OpenworkWorkspaceInfo }>(
         baseUrl,
@@ -837,7 +848,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         { token, hostToken, method: "POST", timeoutMs: timeouts.activateWorkspace },
       ),
     deleteWorkspace: (workspaceId: string) =>
-      requestJson<{ ok: boolean; deleted: boolean; persisted: boolean; activeId: string | null; items: OpenworkWorkspaceInfo[] }>(
+      requestJson<{ ok: boolean; deleted: boolean; persisted: boolean; activeId: string | null; items: OpenworkWorkspaceInfo[]; workspaces?: WorkspaceInfo[] }>(
         baseUrl,
         `/workspaces/${encodeURIComponent(workspaceId)}`,
         { token, hostToken, method: "DELETE", timeoutMs: timeouts.deleteWorkspace },
@@ -1085,6 +1096,20 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         hostToken,
         method: "PATCH",
         body: payload,
+      }),
+    readOpencodeConfigFile: (workspaceId: string, scope: "project" | "global" = "project") => {
+      const query = `?scope=${scope}`;
+      return requestJson<OpencodeConfigFile>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/opencode-config${query}`, {
+        token,
+        hostToken,
+      });
+    },
+    writeOpencodeConfigFile: (workspaceId: string, scope: "project" | "global", content: string) =>
+      requestJson<ExecResult>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/opencode-config`, {
+        token,
+        hostToken,
+        method: "POST",
+        body: { scope, content },
       }),
     listReloadEvents: (workspaceId: string, options?: { since?: number }) => {
       const query = typeof options?.since === "number" ? `?since=${options.since}` : "";

--- a/packages/app/src/app/pages/mcp.tsx
+++ b/packages/app/src/app/pages/mcp.tsx
@@ -33,6 +33,7 @@ import { currentLocale, t, type Language } from "../../i18n";
 export type McpViewProps = {
   busy: boolean;
   activeWorkspaceRoot: string;
+  readConfigFile?: (scope: "project" | "global") => Promise<OpencodeConfigFile | null>;
   showHeader?: boolean;
   mcpServers: McpServerEntry[];
   mcpStatus: string | null;
@@ -157,8 +158,9 @@ export default function McpView(props: McpViewProps) {
   createEffect(() => {
     const root = props.activeWorkspaceRoot.trim();
     const nextId = (configRequestId += 1);
+    const readConfig = props.readConfigFile;
 
-    if (!isTauriRuntime()) {
+    if (!readConfig && !isTauriRuntime()) {
       setProjectConfig(null);
       setGlobalConfig(null);
       setConfigError(null);
@@ -169,8 +171,10 @@ export default function McpView(props: McpViewProps) {
       try {
         setConfigError(null);
         const [project, global] = await Promise.all([
-          root ? readOpencodeConfig("project", root) : Promise.resolve(null),
-          readOpencodeConfig("global", root),
+          root
+            ? (readConfig ? readConfig("project") : readOpencodeConfig("project", root))
+            : Promise.resolve(null),
+          readConfig ? readConfig("global") : readOpencodeConfig("global", root),
         ]);
         if (nextId !== configRequestId) return;
         setProjectConfig(project);
@@ -209,7 +213,12 @@ export default function McpView(props: McpViewProps) {
     setRevealBusy(true);
     setConfigError(null);
     try {
-      const resolved = await readOpencodeConfig(configScope(), root);
+      const resolved = props.readConfigFile
+        ? await props.readConfigFile(configScope())
+        : await readOpencodeConfig(configScope(), root);
+      if (!resolved) {
+        throw new Error(tr("mcp.config_load_failed"));
+      }
       const { openPath, revealItemInDir } = await import("@tauri-apps/plugin-opener");
       if (isWindowsPlatform()) {
         await openPath(resolved.path);

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -2750,6 +2750,7 @@ dependencies = [
  "notify",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ json5 = "0.4"
 notify = "6.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-http = "2.5.6"

--- a/packages/desktop/src-tauri/src/workspace/state.rs
+++ b/packages/desktop/src-tauri/src/workspace/state.rs
@@ -1,15 +1,15 @@
 use std::fs;
-use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
+use sha2::{Digest, Sha256};
 use tauri::Manager;
 
 use crate::types::{WorkspaceInfo, WorkspaceState, WorkspaceType, WORKSPACE_STATE_VERSION};
 
 pub fn stable_workspace_id(path: &str) -> String {
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    path.hash(&mut hasher);
-    format!("ws-{:x}", hasher.finish())
+    let digest = Sha256::digest(path.as_bytes());
+    let hex = format!("{:x}", digest);
+    format!("ws_{}", &hex[..12])
 }
 
 pub fn openwork_state_paths(app: &tauri::AppHandle) -> Result<(PathBuf, PathBuf), String> {
@@ -32,8 +32,45 @@ pub fn load_workspace_state(app: &tauri::AppHandle) -> Result<WorkspaceState, St
     let mut state: WorkspaceState = serde_json::from_str(&raw)
         .map_err(|e| format!("Failed to parse {}: {e}", path.display()))?;
 
+    let mut changed_ids = false;
+    let old_active_id = state.active_id.clone();
+    for workspace in state.workspaces.iter_mut() {
+        let next_id = match workspace.workspace_type {
+            WorkspaceType::Local => stable_workspace_id(&workspace.path),
+            WorkspaceType::Remote => {
+                if workspace.remote_type == Some(crate::types::RemoteType::Openwork) {
+                    stable_workspace_id_for_openwork(
+                        workspace.openwork_host_url.as_deref().unwrap_or(""),
+                        workspace.openwork_workspace_id.as_deref(),
+                    )
+                } else {
+                    stable_workspace_id_for_remote(
+                        workspace.base_url.as_deref().unwrap_or(""),
+                        workspace.directory.as_deref(),
+                    )
+                }
+            }
+        };
+
+        if workspace.id != next_id {
+            if old_active_id == workspace.id {
+                state.active_id = next_id.clone();
+            }
+            workspace.id = next_id;
+            changed_ids = true;
+        }
+    }
+
     if state.version < WORKSPACE_STATE_VERSION {
         state.version = WORKSPACE_STATE_VERSION;
+    }
+
+    if changed_ids && state.active_id.is_empty() {
+        state.active_id = state
+            .workspaces
+            .first()
+            .map(|workspace| workspace.id.clone())
+            .unwrap_or_default();
     }
 
     Ok(state)

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { readFile, writeFile, rm, readdir, rename, stat } from "node:fs/promises";
 import { homedir, hostname } from "node:os";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
@@ -13,10 +14,12 @@ import { ApiError, formatError } from "./errors.js";
 import { readJsoncFile, updateJsoncTopLevel, writeJsoncFile } from "./jsonc.js";
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
 import { ReloadEventStore } from "./events.js";
+import { startReloadWatchers } from "./reload-watcher.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { workspaceIdForPath } from "./workspaces.js";
+import { ensureWorkspaceFiles, readRawOpencodeConfig } from "./workspace-init.js";
 import { sanitizeCommandName, validateMcpName } from "./validators.js";
 import { TokenService } from "./tokens.js";
 import { TOY_UI_CSS, TOY_UI_HTML, TOY_UI_JS, cssResponse, htmlResponse, jsResponse } from "./toy-ui.js";
@@ -228,8 +231,13 @@ export function startServer(config: ServerConfig) {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
   const tokens = new TokenService(config);
-  const routes = createRoutes(config, approvals, tokens);
   const logger = createServerLogger(config);
+  let watcherHandle = startReloadWatchers({ config, reloadEvents, logger });
+  const restartReloadWatchers = () => {
+    watcherHandle.close();
+    watcherHandle = startReloadWatchers({ config, reloadEvents, logger });
+  };
+  const routes = createRoutes(config, approvals, tokens, restartReloadWatchers);
 
   const serverOptions: {
     hostname: string;
@@ -1000,10 +1008,7 @@ function emitReloadEvent(
   reason: ReloadReason,
   trigger?: ReloadTrigger,
 ) {
-  void reloadEvents;
-  void workspace;
-  void reason;
-  void trigger;
+  reloadEvents.recordDebounced(workspace.id, reason, trigger);
 }
 
 function buildConfigTrigger(path: string): ReloadTrigger {
@@ -1034,7 +1039,12 @@ function serializeWorkspace(workspace: ServerConfig["workspaces"][number]) {
   };
 }
 
-function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: TokenService): Route[] {
+function createRoutes(
+  config: ServerConfig,
+  approvals: ApprovalService,
+  tokens: TokenService,
+  onWorkspacesChanged: () => void,
+): Route[] {
   const routes: Route[] = [];
 
   addRoute(routes, "GET", "/health", "none", async () => {
@@ -1143,7 +1153,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
   addRoute(routes, "GET", "/workspaces", "client", async () => {
     const active = config.workspaces[0] ?? null;
     const items = config.workspaces.map(serializeWorkspace);
-    return jsonResponse({ items, activeId: active?.id ?? null });
+    return jsonResponse({ items, workspaces: items, activeId: active?.id ?? null });
   });
 
   addRoute(routes, "GET", "/tokens", "host", async () => {
@@ -1173,6 +1183,91 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     return jsonResponse({ ok: true });
   });
 
+  addRoute(routes, "POST", "/workspaces/local", "host", async (ctx) => {
+    ensureWritable(config);
+    const body = await readJsonBody(ctx.request);
+    const folderPath = typeof body.folderPath === "string" ? body.folderPath.trim() : "";
+    const name = typeof body.name === "string" && body.name.trim() ? body.name.trim() : basename(folderPath || "Workspace");
+    const preset = typeof body.preset === "string" && body.preset.trim() ? body.preset.trim() : "starter";
+
+    if (!folderPath) {
+      throw new ApiError(400, "invalid_payload", "folderPath is required");
+    }
+
+    const workspacePath = resolve(folderPath);
+    await ensureDir(workspacePath);
+    await ensureWorkspaceFiles(workspacePath, preset);
+
+    const workspace: WorkspaceInfo = {
+      id: workspaceIdForPath(workspacePath),
+      name,
+      path: workspacePath,
+      preset,
+      workspaceType: "local",
+    };
+
+    config.workspaces = [workspace, ...config.workspaces.filter((entry) => entry.id !== workspace.id)];
+    if (!config.authorizedRoots.some((root) => resolve(root) === workspacePath)) {
+      config.authorizedRoots = [...config.authorizedRoots, workspacePath];
+    }
+    const persisted = await persistServerWorkspaceState(config);
+    onWorkspacesChanged();
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "host" },
+      action: "workspace.create",
+      target: workspace.path,
+      summary: `Created workspace ${name}`,
+      timestamp: Date.now(),
+    });
+
+    return jsonResponse({
+      activeId: workspace.id,
+      workspaces: config.workspaces.map(serializeWorkspace),
+      persisted,
+    }, 201);
+  });
+
+  addRoute(routes, "PATCH", "/workspaces/:id/display-name", "host", async (ctx) => {
+    ensureWritable(config);
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const nextDisplayName = typeof body.displayName === "string" && body.displayName.trim()
+      ? body.displayName.trim()
+      : undefined;
+
+    config.workspaces = config.workspaces.map((entry) =>
+      entry.id === workspace.id
+        ? {
+            ...entry,
+            displayName: nextDisplayName,
+            name: nextDisplayName ?? entry.name,
+          }
+        : entry,
+    );
+
+    const persisted = await persistServerWorkspaceState(config);
+    onWorkspacesChanged();
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "host" },
+      action: "workspace.rename",
+      target: workspace.path,
+      summary: `Updated workspace display name${nextDisplayName ? ` to ${nextDisplayName}` : ""}`,
+      timestamp: Date.now(),
+    });
+
+    return jsonResponse({
+      activeId: config.workspaces[0]?.id ?? null,
+      workspaces: config.workspaces.map(serializeWorkspace),
+      persisted,
+    });
+  });
+
   addRoute(routes, "POST", "/workspaces/:id/activate", "host", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     config.workspaces = [
@@ -1188,19 +1283,13 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
       summary: "Switched active workspace",
       timestamp: Date.now(),
     });
-    return jsonResponse({ activeId: workspace.id, workspace: serializeWorkspace(workspace) });
+    return jsonResponse({ activeId: workspace.id, workspace: serializeWorkspace(workspace), persisted: false });
   });
 
   addRoute(routes, "DELETE", "/workspaces/:id", "host", async (ctx) => {
     ensureWritable(config);
 
     const workspace = await resolveWorkspace(config, ctx.params.id);
-
-    // Attempt to persist to server.json (when present) before mutating in-memory state.
-    const configPath = config.configPath?.trim() ?? "";
-    const persisted = configPath
-      ? await persistWorkspaceDeletion(configPath, workspace.id, workspace.path)
-      : false;
 
     const before = config.workspaces.length;
     config.workspaces = config.workspaces.filter((entry) => entry.id !== workspace.id);
@@ -1210,6 +1299,8 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
       // Only remove exact matches; authorizedRoots can contain broader entries.
       config.authorizedRoots = config.authorizedRoots.filter((root) => resolve(root) !== resolve(workspace.path));
     }
+    const persisted = await persistServerWorkspaceState(config);
+    onWorkspacesChanged();
 
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -1228,6 +1319,7 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
       persisted,
       activeId: active?.id ?? null,
       items: config.workspaces.map(serializeWorkspace),
+      workspaces: config.workspaces.map(serializeWorkspace),
     });
   });
 
@@ -1237,6 +1329,58 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
     const openwork = await readOpenworkConfig(workspace.path);
     const lastAudit = await readLastAudit(workspace.path, workspace.id);
     return jsonResponse({ opencode, openwork, updatedAt: lastAudit?.timestamp ?? null });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/opencode-config", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const scope = normalizeOpencodeScope(ctx.url.searchParams.get("scope"));
+    const configPath = resolveOpencodeConfigFilePath(scope, workspace.path);
+    const result = await readRawOpencodeConfig(configPath);
+    return jsonResponse({ path: configPath, exists: result.exists, content: result.content });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/opencode-config", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const scope = normalizeOpencodeScope(typeof body.scope === "string" ? body.scope : null);
+    const content = typeof body.content === "string" ? body.content : null;
+    if (content === null) {
+      throw new ApiError(400, "invalid_payload", "content must be a string");
+    }
+
+    const configPath = resolveOpencodeConfigFilePath(scope, workspace.path);
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: scope === "global" ? "config.global.write" : "config.write",
+      summary: `Write ${scope} OpenCode config`,
+      paths: [configPath],
+    });
+
+    await ensureDir(dirname(configPath));
+    await writeFile(configPath, content.endsWith("\n") ? content : `${content}\n`, "utf8");
+
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: scope === "global" ? "config.global.write" : "config.write",
+      target: configPath,
+      summary: `Updated ${scope} OpenCode config`,
+      timestamp: Date.now(),
+    });
+
+    if (scope === "project") {
+      emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(configPath));
+    }
+
+    return jsonResponse({
+      ok: true,
+      status: 0,
+      stdout: `Wrote ${configPath}`,
+      stderr: "",
+    });
   });
 
   addRoute(routes, "GET", "/workspace/:id/audit", "client", async (ctx) => {
@@ -2135,8 +2279,10 @@ function createRoutes(config: ServerConfig, approvals: ApprovalService, tokens: 
 
   addRoute(routes, "GET", "/workspace/:id/events", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    void ctx;
-    return jsonResponse({ items: [], cursor: 0, workspaceId: workspace.id, disabled: true });
+    const sinceRaw = ctx.url.searchParams.get("since");
+    const since = sinceRaw ? Number(sinceRaw) : undefined;
+    const items = ctx.reloadEvents.list(workspace.id, since);
+    return jsonResponse({ items, cursor: ctx.reloadEvents.cursor(), workspaceId: workspace.id, disabled: false });
   });
 
   addRoute(routes, "POST", "/workspace/:id/engine/reload", "client", async (ctx) => {
@@ -3143,62 +3289,55 @@ type OpenworkServerConfigFile = Record<string, unknown> & {
   authorizedRoots?: string[];
 };
 
-async function persistWorkspaceDeletion(configPath: string, workspaceId: string, workspacePath: string): Promise<boolean> {
-  if (!configPath.trim()) return false;
+async function readServerConfigFile(configPath: string): Promise<OpenworkServerConfigFile> {
   if (!(await exists(configPath))) {
-    // If the server was started from CLI args/env, avoid implicitly creating server.json
-    // because it can change token behavior on restart.
-    return false;
+    return {};
   }
 
-  let raw = "";
   try {
-    raw = await readFile(configPath, "utf8");
-  } catch (error) {
-    throw new ApiError(500, "server_config_read_failed", "Failed to read server config", {
-      path: configPath,
-      error: String(error),
-    });
-  }
-
-  let parsed: OpenworkServerConfigFile;
-  try {
-    parsed = ensurePlainObject(JSON.parse(raw)) as OpenworkServerConfigFile;
+    const raw = await readFile(configPath, "utf8");
+    return ensurePlainObject(JSON.parse(raw)) as OpenworkServerConfigFile;
   } catch (error) {
     throw new ApiError(422, "invalid_json", "Failed to parse server config", {
       path: configPath,
       error: String(error),
     });
   }
+}
 
-  const configDir = dirname(configPath);
-  const workspacesRaw = parsed.workspaces;
-  const workspaces = Array.isArray(workspacesRaw) ? workspacesRaw : [];
+function serializeWorkspaceConfigEntry(workspace: WorkspaceInfo): Record<string, unknown> {
+  return {
+    id: workspace.id,
+    path: workspace.path,
+    name: workspace.name,
+    preset: workspace.preset,
+    workspaceType: workspace.workspaceType,
+    ...(workspace.remoteType ? { remoteType: workspace.remoteType } : {}),
+    ...(workspace.baseUrl ? { baseUrl: workspace.baseUrl } : {}),
+    ...(workspace.directory ? { directory: workspace.directory } : {}),
+    ...(workspace.displayName ? { displayName: workspace.displayName } : {}),
+    ...(workspace.openworkHostUrl ? { openworkHostUrl: workspace.openworkHostUrl } : {}),
+    ...(workspace.openworkToken ? { openworkToken: workspace.openworkToken } : {}),
+    ...(workspace.openworkWorkspaceId ? { openworkWorkspaceId: workspace.openworkWorkspaceId } : {}),
+    ...(workspace.openworkWorkspaceName ? { openworkWorkspaceName: workspace.openworkWorkspaceName } : {}),
+    ...(workspace.sandboxBackend ? { sandboxBackend: workspace.sandboxBackend } : {}),
+    ...(workspace.sandboxRunId ? { sandboxRunId: workspace.sandboxRunId } : {}),
+    ...(workspace.sandboxContainerName ? { sandboxContainerName: workspace.sandboxContainerName } : {}),
+    ...(workspace.opencodeUsername ? { opencodeUsername: workspace.opencodeUsername } : {}),
+    ...(workspace.opencodePassword ? { opencodePassword: workspace.opencodePassword } : {}),
+  };
+}
 
-  const nextWorkspaces = workspaces.filter((entry) => {
-    const obj = ensurePlainObject(entry);
-    const path = typeof obj.path === "string" ? obj.path.trim() : "";
-    if (!path) return true;
-    const id = workspaceIdForPath(resolve(configDir, path));
-    return id !== workspaceId;
-  });
+async function persistServerWorkspaceState(config: ServerConfig): Promise<boolean> {
+  const configPath = config.configPath?.trim() ?? "";
+  if (!configPath) return false;
+  if (!(await exists(configPath))) return false;
 
-  const rootsRaw = parsed.authorizedRoots;
-  const roots = Array.isArray(rootsRaw) ? rootsRaw : [];
-  const nextRoots = roots.filter((root) => {
-    const value = typeof root === "string" ? root.trim() : "";
-    if (!value) return false;
-    return resolve(configDir, value) !== resolve(workspacePath);
-  });
-
-  const workspacesChanged = nextWorkspaces.length !== workspaces.length;
-  const rootsChanged = nextRoots.length !== roots.length;
-  if (!workspacesChanged && !rootsChanged) return false;
-
+  const parsed = await readServerConfigFile(configPath);
   const next: OpenworkServerConfigFile = {
     ...parsed,
-    ...(workspacesChanged ? { workspaces: nextWorkspaces } : {}),
-    ...(rootsChanged ? { authorizedRoots: nextRoots } : {}),
+    workspaces: config.workspaces.map(serializeWorkspaceConfigEntry),
+    authorizedRoots: Array.from(new Set(config.authorizedRoots.map((root) => resolve(root)))),
   };
 
   await ensureDir(dirname(configPath));
@@ -3214,6 +3353,22 @@ async function persistWorkspaceDeletion(configPath: string, workspaceId: string,
       // ignore
     }
   }
+}
+
+function normalizeOpencodeScope(value: string | null | undefined): "project" | "global" {
+  return value?.trim().toLowerCase() === "global" ? "global" : "project";
+}
+
+function resolveOpencodeConfigFilePath(scope: "project" | "global", workspaceRoot: string): string {
+  if (scope === "global") {
+    const base = join(homedir(), ".config", "opencode");
+    const jsoncPath = join(base, "opencode.jsonc");
+    const jsonPath = join(base, "opencode.json");
+    if (existsSync(jsoncPath)) return jsoncPath;
+    if (existsSync(jsonPath)) return jsonPath;
+    return jsoncPath;
+  }
+  return opencodeConfigPath(workspaceRoot);
 }
 
 function normalizeOpenCodeRouterIdentityId(value: unknown): string {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,5 +1,7 @@
 export type WorkspaceType = "local" | "remote";
 
+export type RemoteType = "opencode" | "openwork";
+
 export type ApprovalMode = "manual" | "auto";
 
 export type TokenScope = "owner" | "collaborator" | "viewer";
@@ -11,11 +13,22 @@ export type ProviderPlacement = "in-sandbox" | "host-machine" | "client-machine"
 export type LogFormat = "pretty" | "json";
 
 export interface WorkspaceConfig {
+  id?: string;
   path: string;
   name?: string;
+  preset?: string;
   workspaceType?: WorkspaceType;
+  remoteType?: RemoteType;
   baseUrl?: string;
   directory?: string;
+  displayName?: string;
+  openworkHostUrl?: string;
+  openworkToken?: string;
+  openworkWorkspaceId?: string;
+  openworkWorkspaceName?: string;
+  sandboxBackend?: string;
+  sandboxRunId?: string;
+  sandboxContainerName?: string;
   opencodeUsername?: string;
   opencodePassword?: string;
 }
@@ -24,9 +37,19 @@ export interface WorkspaceInfo {
   id: string;
   name: string;
   path: string;
+  preset: string;
   workspaceType: WorkspaceType;
+  remoteType?: RemoteType;
   baseUrl?: string;
   directory?: string;
+  displayName?: string;
+  openworkHostUrl?: string;
+  openworkToken?: string;
+  openworkWorkspaceId?: string;
+  openworkWorkspaceName?: string;
+  sandboxBackend?: string;
+  sandboxRunId?: string;
+  sandboxContainerName?: string;
   opencodeUsername?: string;
   opencodePassword?: string;
   opencode?: {
@@ -35,6 +58,12 @@ export interface WorkspaceInfo {
     username?: string;
     password?: string;
   };
+}
+
+export interface OpencodeConfigFile {
+  path: string;
+  exists: boolean;
+  content: string | null;
 }
 
 export interface ApprovalConfig {

--- a/packages/server/src/workspace-init.ts
+++ b/packages/server/src/workspace-init.ts
@@ -1,0 +1,283 @@
+import { basename, join } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+
+import { upsertSkill } from "./skills.js";
+import { upsertCommand } from "./commands.js";
+import { readJsoncFile, writeJsoncFile } from "./jsonc.js";
+import { ensureDir, exists } from "./utils.js";
+import { ApiError } from "./errors.js";
+import { openworkConfigPath, opencodeConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
+
+const WORKSPACE_GUIDE = `---
+name: workspace-guide
+description: Workspace guide to introduce OpenWork and onboard new users.
+---
+
+# Welcome to OpenWork
+
+Hi, I'm Ben and this is OpenWork. It's an open-source alternative to Claude's cowork. It helps you work on your files with AI and automate the mundane tasks so you don't have to.
+
+Before we start, use the question tool to ask:
+"Are you more technical or non-technical? I'll tailor the explanation."
+
+## If the person is non-technical
+OpenWork feels like a chat app, but it can safely work with the files you allow. Put files in this workspace and I can summarize them, create new ones, or help organize them.
+
+Try:
+- "Summarize the files in this workspace."
+- "Create a checklist for my week."
+- "Draft a short summary from this document."
+
+## Skills and plugins (simple)
+Skills add new capabilities. Plugins add advanced features like scheduling or browser automation. We can add them later when you're ready.
+
+## If the person is technical
+OpenWork is a GUI for OpenCode. Everything that works in OpenCode works here.
+
+Most reliable setup today:
+1) Install OpenCode from opencode.ai
+2) Configure providers there (models and API keys)
+3) Come back to OpenWork and start a session
+
+Skills:
+- Install from the Skills tab, or add them to this workspace.
+- Docs: https://opencode.ai/docs/skills
+
+Plugins:
+- Configure in opencode.json or use the Plugins tab.
+- Docs: https://opencode.ai/docs/plugins/
+
+MCP servers:
+- Add external tools via opencode.json.
+- Docs: https://opencode.ai/docs/mcp-servers/
+
+Config reference:
+- Docs: https://opencode.ai/docs/config/
+
+End with two friendly next actions to try in OpenWork.
+`;
+
+const GET_STARTED_SKILL = `---
+name: get-started
+description: Guide users through the get started setup and Chrome DevTools demo.
+---
+
+## When to use
+- Always load this skill when the user says "get started".
+
+## What to do
+- Reply with these four lines, exactly and in order:
+  1) hey there welcome this is openwork
+  2) we've pre-configured you with a couple tools
+  3) Get Started
+  4) write "hey go on google.com"
+
+## Then
+- If the user writes "go on google.com" (or "hey go on google.com"), use the chrome-devtools MCP to open the site.
+- After the navigation completes, reply: "I'm on <site>" where <site> is the final URL or page title they asked for.
+`;
+
+const OPENWORK_AGENT = `---
+description: OpenWork default agent (safe, mobile-first, self-referential)
+mode: primary
+temperature: 0.2
+---
+
+You are OpenWork.
+
+When the user refers to "you", they mean the OpenWork app and the current workspace.
+
+Your job:
+- Help the user work on files safely.
+- Automate repeatable work.
+- Keep behavior portable and reproducible.
+
+Memory (two kinds)
+1) Behavior memory (shareable, in git)
+- ".opencode/skills/**"
+- ".opencode/agents/**"
+- repo docs
+
+2) Private memory (never commit)
+- Tokens, IDs, credentials
+- Local DBs/logs/config files (gitignored)
+- Notion pages/databases (if configured via MCP)
+
+Hard rule: never copy private memory into repo files verbatim. Store only redacted summaries, schemas/templates, and stable pointers.
+
+Reconstruction-first
+- Do not assume env vars or prior setup.
+- If required state is missing, ask one targeted question.
+- After the user provides it, store it in private memory and continue.
+
+Verification-first
+- If you change code, run the smallest meaningful test or smoke check.
+- If you touch UI or remote behavior, validate end-to-end and capture logs on failure.
+
+Incremental adoption loop
+- Do the task once end-to-end.
+- If steps repeat, factor them into a skill.
+- If the work becomes ongoing, create/refine an agent role.
+- If it should run regularly, schedule it and store outputs in private memory.
+`;
+
+type WorkspaceOpenworkConfig = {
+  version: number;
+  workspace?: {
+    name?: string | null;
+    createdAt?: number | null;
+    preset?: string | null;
+  } | null;
+  authorizedRoots: string[];
+  reload?: {
+    auto?: boolean;
+    resume?: boolean;
+  } | null;
+};
+
+function normalizePreset(preset: string | null | undefined): string {
+  const trimmed = preset?.trim() ?? "";
+  if (!trimmed) return "starter";
+  return trimmed;
+}
+
+function mergePlugins(existing: string[], required: string[]): string[] {
+  const next = existing.slice();
+  for (const plugin of required) {
+    if (!next.includes(plugin)) {
+      next.push(plugin);
+    }
+  }
+  return next;
+}
+
+async function ensureOpenworkAgent(workspaceRoot: string): Promise<void> {
+  const agentsDir = join(workspaceRoot, ".opencode", "agents");
+  const agentPath = join(agentsDir, "openwork.md");
+  if (await exists(agentPath)) return;
+  await ensureDir(agentsDir);
+  await writeFile(agentPath, OPENWORK_AGENT.endsWith("\n") ? OPENWORK_AGENT : `${OPENWORK_AGENT}\n`, "utf8");
+}
+
+async function ensureStarterSkills(workspaceRoot: string, preset: string): Promise<void> {
+  await ensureDir(projectSkillsDir(workspaceRoot));
+  await upsertSkill(workspaceRoot, {
+    name: "workspace-guide",
+    description: "Workspace guide to introduce OpenWork and onboard new users.",
+    content: WORKSPACE_GUIDE,
+  });
+  if (preset === "starter") {
+    await upsertSkill(workspaceRoot, {
+      name: "get-started",
+      description: "Guide users through the get started setup and Chrome DevTools demo.",
+      content: GET_STARTED_SKILL,
+    });
+  }
+}
+
+async function ensureStarterCommands(workspaceRoot: string, preset: string): Promise<void> {
+  await ensureDir(projectCommandsDir(workspaceRoot));
+  await upsertCommand(workspaceRoot, {
+    name: "learn-files",
+    description: "Safe, practical file workflows",
+    template: "Show me how to interact with files in this workspace. Include safe examples for reading, summarizing, and editing.",
+  });
+  await upsertCommand(workspaceRoot, {
+    name: "learn-skills",
+    description: "How skills work and how to create your own",
+    template: "Explain what skills are, how to use them, and how to create a new skill for this workspace.",
+  });
+  await upsertCommand(workspaceRoot, {
+    name: "learn-plugins",
+    description: "What plugins are and how to install them",
+    template: "Explain what plugins are and how to install them in this workspace.",
+  });
+  if (preset === "starter") {
+    await upsertCommand(workspaceRoot, {
+      name: "get-started",
+      description: "Get started",
+      template: "get started",
+    });
+  }
+}
+
+async function ensureOpencodeConfig(workspaceRoot: string, preset: string): Promise<void> {
+  const path = opencodeConfigPath(workspaceRoot);
+  const { data } = await readJsoncFile<Record<string, unknown>>(path, {
+    $schema: "https://opencode.ai/config.json",
+  });
+  const next: Record<string, unknown> = data && typeof data === "object" && !Array.isArray(data)
+    ? { ...data }
+    : { $schema: "https://opencode.ai/config.json" };
+
+  if (typeof next.default_agent !== "string" || !next.default_agent.trim()) {
+    next.default_agent = "openwork";
+  }
+
+  const requiredPlugins = preset === "starter" || preset === "automation"
+    ? ["opencode-scheduler"]
+    : [];
+  if (requiredPlugins.length > 0) {
+    const currentPlugins = Array.isArray(next.plugin)
+      ? next.plugin.filter((value: unknown): value is string => typeof value === "string")
+      : typeof next.plugin === "string"
+        ? [next.plugin]
+        : [];
+    next.plugin = mergePlugins(currentPlugins, requiredPlugins);
+  }
+
+  if (preset === "starter") {
+    const currentMcp = next.mcp && typeof next.mcp === "object" && !Array.isArray(next.mcp)
+      ? { ...(next.mcp as Record<string, unknown>) }
+      : {};
+    if (!("control-chrome" in currentMcp)) {
+      currentMcp["control-chrome"] = {
+        type: "local",
+        command: ["chrome-devtools-mcp"],
+      };
+    }
+    next.mcp = currentMcp;
+  }
+
+  await writeJsoncFile(path, next);
+}
+
+async function ensureWorkspaceOpenworkConfig(workspaceRoot: string, preset: string): Promise<void> {
+  const path = openworkConfigPath(workspaceRoot);
+  if (await exists(path)) return;
+  const now = Date.now();
+  const config: WorkspaceOpenworkConfig = {
+    version: 1,
+    workspace: {
+      name: basename(workspaceRoot) || "Workspace",
+      createdAt: now,
+      preset,
+    },
+    authorizedRoots: [workspaceRoot],
+    reload: null,
+  };
+  await ensureDir(join(workspaceRoot, ".opencode"));
+  await writeFile(path, JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: string): Promise<void> {
+  const preset = normalizePreset(presetInput);
+  if (!workspaceRoot.trim()) {
+    throw new ApiError(400, "invalid_workspace_path", "workspace path is required");
+  }
+  await ensureDir(workspaceRoot);
+  await ensureStarterSkills(workspaceRoot, preset);
+  await ensureOpenworkAgent(workspaceRoot);
+  await ensureStarterCommands(workspaceRoot, preset);
+  await ensureOpencodeConfig(workspaceRoot, preset);
+  await ensureWorkspaceOpenworkConfig(workspaceRoot, preset);
+}
+
+export async function readRawOpencodeConfig(path: string): Promise<{ exists: boolean; content: string | null }> {
+  const hasFile = await exists(path);
+  if (!hasFile) {
+    return { exists: false, content: null };
+  }
+  const content = await readFile(path, "utf8");
+  return { exists: true, content };
+}

--- a/packages/server/src/workspaces.ts
+++ b/packages/server/src/workspaces.ts
@@ -2,9 +2,31 @@ import { createHash } from "node:crypto";
 import { basename, resolve } from "node:path";
 import type { WorkspaceConfig, WorkspaceInfo } from "./types.js";
 
-export function workspaceIdForPath(path: string): string {
-  const hash = createHash("sha256").update(path).digest("hex");
+function workspaceIdForKey(key: string): string {
+  const hash = createHash("sha256").update(key).digest("hex");
   return `ws_${hash.slice(0, 12)}`;
+}
+
+export function workspaceIdForPath(path: string): string {
+  return workspaceIdForKey(path);
+}
+
+export function workspaceIdForRemote(baseUrl: string, directory?: string | null): string {
+  const normalizedBaseUrl = baseUrl.trim();
+  const normalizedDirectory = directory?.trim() ?? "";
+  const key = normalizedDirectory
+    ? `remote::${normalizedBaseUrl}::${normalizedDirectory}`
+    : `remote::${normalizedBaseUrl}`;
+  return workspaceIdForKey(key);
+}
+
+export function workspaceIdForOpenwork(hostUrl: string, workspaceId?: string | null): string {
+  const normalizedHostUrl = hostUrl.trim();
+  const normalizedWorkspaceId = workspaceId?.trim() ?? "";
+  const key = normalizedWorkspaceId
+    ? `openwork::${normalizedHostUrl}::${normalizedWorkspaceId}`
+    : `openwork::${normalizedHostUrl}`;
+  return workspaceIdForKey(key);
 }
 
 export function buildWorkspaceInfos(
@@ -12,14 +34,37 @@ export function buildWorkspaceInfos(
   cwd: string,
 ): WorkspaceInfo[] {
   return workspaces.map((workspace) => {
-    const resolvedPath = resolve(cwd, workspace.path);
+    const rawPath = workspace.path?.trim() ?? "";
+    const workspaceType = workspace.workspaceType ?? "local";
+    const resolvedPath = rawPath ? resolve(cwd, rawPath) : "";
+    const remoteType = workspace.remoteType;
+    const id = workspace.id?.trim()
+      || (workspaceType === "remote"
+        ? remoteType === "openwork"
+          ? workspaceIdForOpenwork(workspace.openworkHostUrl ?? workspace.baseUrl ?? "", workspace.openworkWorkspaceId)
+          : workspaceIdForRemote(workspace.baseUrl ?? "", workspace.directory)
+        : workspaceIdForPath(resolvedPath));
+    const name = workspace.name?.trim()
+      || workspace.displayName?.trim()
+      || workspace.openworkWorkspaceName?.trim()
+      || basename(resolvedPath || workspace.directory?.trim() || workspace.baseUrl?.trim() || "Workspace");
     return {
-      id: workspaceIdForPath(resolvedPath),
-      name: workspace.name ?? basename(resolvedPath),
+      id,
+      name,
       path: resolvedPath,
-      workspaceType: workspace.workspaceType ?? "local",
+      preset: workspace.preset?.trim() || (workspaceType === "remote" ? "remote" : "starter"),
+      workspaceType,
+      remoteType,
       baseUrl: workspace.baseUrl,
       directory: workspace.directory,
+      displayName: workspace.displayName,
+      openworkHostUrl: workspace.openworkHostUrl,
+      openworkToken: workspace.openworkToken,
+      openworkWorkspaceId: workspace.openworkWorkspaceId,
+      openworkWorkspaceName: workspace.openworkWorkspaceName,
+      sandboxBackend: workspace.sandboxBackend,
+      sandboxRunId: workspace.sandboxRunId,
+      sandboxContainerName: workspace.sandboxContainerName,
       opencodeUsername: workspace.opencodeUsername,
       opencodePassword: workspace.opencodePassword,
     };


### PR DESCRIPTION
## Summary
- move local workspace creation, rename, raw OpenCode config access, and reload events into OpenWork server
- make the app prefer OpenWork server for local workspace lifecycle, scheduler, and MCP config reads while keeping Tauri as a desktop compatibility shim
- align desktop workspace IDs with server IDs and migrate persisted Tauri workspace state to avoid split-brain local workspace routing

## Checks
- `pnpm install --frozen-lockfile`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwork-server test`
- `pnpm --filter openwork-server build:bin`
- `pnpm --filter @different-ai/openwork-ui typecheck`
- `pnpm --filter @different-ai/openwork-ui build`
- `cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml` (run with temporary sidecar stubs for missing local packaging resources)
- smoke-tested the built `openwork-server` binary by creating, renaming, updating config for, and deleting a local workspace via HTTP routes

## Notes
- I did not run the Docker + Chrome MCP end-to-end flow because this change is centered on desktop host/server ownership and local Tauri/server integration rather than the browser-based remote flow.