### PR TITLE
fix(app): warn before creating public Telegram bots

### DIFF
--- a/apps/app/src/app/components/confirm-modal.tsx
+++ b/apps/app/src/app/components/confirm-modal.tsx
@@ -11,6 +11,8 @@ export type ConfirmModalProps = {
   confirmLabel: string;
   cancelLabel: string;
   variant?: "danger" | "warning";
+  confirmButtonVariant?: "primary" | "secondary" | "ghost" | "outline" | "danger";
+  cancelButtonVariant?: "primary" | "secondary" | "ghost" | "outline" | "danger";
   onConfirm: () => void;
   onCancel: () => void;
 };
@@ -40,11 +42,11 @@ export default function ConfirmModal(props: ConfirmModalProps) {
             </div>
 
             <div class="mt-6 flex justify-end gap-2">
-              <Button variant="outline" onClick={props.onCancel}>
+              <Button variant={props.cancelButtonVariant ?? "outline"} onClick={props.onCancel}>
                 {props.cancelLabel}
               </Button>
               <Button
-                variant={variant() === "danger" ? "danger" : "primary"}
+                variant={props.confirmButtonVariant ?? (variant() === "danger" ? "danger" : "primary")}
                 onClick={props.onConfirm}
               >
                 {props.confirmLabel}

--- a/apps/app/src/app/pages/identities.tsx
+++ b/apps/app/src/app/pages/identities.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-solid";
 
 import Button from "../components/button";
+import ConfirmModal from "../components/confirm-modal";
 import {
   buildOpenworkWorkspaceBaseUrl,
   OpenworkServerError,
@@ -146,6 +147,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
   const [telegramError, setTelegramError] = createSignal<string | null>(null);
   const [telegramBotUsername, setTelegramBotUsername] = createSignal<string | null>(null);
   const [telegramPairingCode, setTelegramPairingCode] = createSignal<string | null>(null);
+  const [publicTelegramWarningOpen, setPublicTelegramWarningOpen] = createSignal(false);
 
   const [slackBotToken, setSlackBotToken] = createSignal("");
   const [slackAppToken, setSlackAppToken] = createSignal("");
@@ -1009,7 +1011,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
 
                     <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
                       <button
-                        onClick={() => void upsertTelegram("public")}
+                        onClick={() => setPublicTelegramWarningOpen(true)}
                         disabled={telegramSaving() || !workspaceId() || !telegramToken().trim()}
                         class={`flex items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-semibold transition-colors ${
                           telegramSaving() || !workspaceId() || !telegramToken().trim()
@@ -1509,6 +1511,29 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
         </div>
 
         </Show>
+
+        <ConfirmModal
+          open={publicTelegramWarningOpen()}
+          title="Make this bot public?"
+          message={
+            <>
+              Your bot will be accessible to the public and anyone who gets access to your bot will be able to have
+              full access to your local worker including any files or API keys that you've given it. If you create a
+              private bot, you can limit who can access it by requiring a pairing token. Are you sure you want to make
+              your bot public?
+            </>
+          }
+          confirmLabel="Yes I understand the risk"
+          cancelLabel="Cancel"
+          variant="danger"
+          confirmButtonVariant="danger"
+          cancelButtonVariant="primary"
+          onCancel={() => setPublicTelegramWarningOpen(false)}
+          onConfirm={() => {
+            setPublicTelegramWarningOpen(false);
+            void upsertTelegram("public");
+          }}
+        />
 
       </Show>
     </div>


### PR DESCRIPTION
## Summary
- add a confirmation modal before creating a public Telegram bot from the identities page
- spell out that public bots expose the local worker and encourage private mode with pairing tokens
- let the shared confirm modal override confirm/cancel button variants so the warning uses red confirm and primary cancel

## Testing
- pnpm --filter @openwork/app typecheck