### PR TITLE
feat(app): gate messaging behind explicit opt-in

### DIFF
--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -1303,6 +1303,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   openworkServerClient={props.openworkServerClient}
                   openworkReconnectBusy={props.openworkReconnectBusy}
                   reconnectOpenworkServer={props.reconnectOpenworkServer}
+                  restartLocalServer={props.restartLocalServer}
                   openworkServerWorkspaceId={props.openworkServerWorkspaceId}
                   activeWorkspaceRoot={props.activeWorkspaceRoot}
                   developerMode={props.developerMode}

--- a/apps/app/src/app/pages/identities.tsx
+++ b/apps/app/src/app/pages/identities.tsx
@@ -32,6 +32,7 @@ export type IdentitiesViewProps = {
   openworkServerClient: OpenworkServerClient | null;
   openworkReconnectBusy: boolean;
   reconnectOpenworkServer: () => Promise<boolean>;
+  restartLocalServer: () => Promise<boolean>;
   openworkServerWorkspaceId: string | null;
   activeWorkspaceRoot: string;
   developerMode: boolean;
@@ -84,6 +85,14 @@ function getTelegramUsernameFromResult(value: unknown): string | null {
   if (typeof username !== "string") return null;
   const normalized = username.trim().replace(/^@+/, "");
   return normalized || null;
+}
+
+function readMessagingEnabledFromOpenworkConfig(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const messaging = record.messaging;
+  if (!messaging || typeof messaging !== "object" || Array.isArray(messaging)) return false;
+  return (messaging as Record<string, unknown>).enabled === true;
 }
 
 /* ---- Brand channel icons ---- */
@@ -180,6 +189,16 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
 
   const [reconnectStatus, setReconnectStatus] = createSignal<string | null>(null);
   const [reconnectError, setReconnectError] = createSignal<string | null>(null);
+  const [messagingEnabled, setMessagingEnabled] = createSignal(false);
+  const [messagingSaving, setMessagingSaving] = createSignal(false);
+  const [messagingStatus, setMessagingStatus] = createSignal<string | null>(null);
+  const [messagingError, setMessagingError] = createSignal<string | null>(null);
+  const [messagingRiskOpen, setMessagingRiskOpen] = createSignal(false);
+  const [messagingRestartRequired, setMessagingRestartRequired] = createSignal(false);
+  const [messagingRestartPromptOpen, setMessagingRestartPromptOpen] = createSignal(false);
+  const [messagingRestartBusy, setMessagingRestartBusy] = createSignal(false);
+  const [messagingDisableConfirmOpen, setMessagingDisableConfirmOpen] = createSignal(false);
+  const [messagingRestartAction, setMessagingRestartAction] = createSignal<"enable" | "disable">("enable");
 
   const workspaceId = createMemo(() => {
     const explicitId = props.openworkServerWorkspaceId?.trim() ?? "";
@@ -415,6 +434,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
       setHealthError(null);
       setTelegramIdentitiesError(null);
       setSlackIdentitiesError(null);
+      setMessagingError(null);
 
       if (!id) {
         setHealth(null);
@@ -432,6 +452,26 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
         return;
       }
 
+      const config = await client.getConfig(id).catch(() => null);
+      const isModuleEnabled = readMessagingEnabledFromOpenworkConfig(config?.openwork);
+      setMessagingEnabled(isModuleEnabled);
+
+      if (!isModuleEnabled) {
+        setMessagingRestartRequired(false);
+        setHealth(null);
+        setHealthError(null);
+        setTelegramIdentities([]);
+        setTelegramIdentitiesError(null);
+        setTelegramBotUsername(null);
+        setTelegramPairingCode(null);
+        setSlackIdentities([]);
+        setSlackIdentitiesError(null);
+        if (!agentDirty() && !agentSaving()) {
+          void loadAgentFile();
+        }
+        return;
+      }
+
       const [healthRes, tgRes, slackRes, telegramInfo] = await Promise.all([
         client.getOpenCodeRouterHealth(id),
         client.getOpenCodeRouterTelegramIdentities(id),
@@ -443,6 +483,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
 
       if (isOpenCodeRouterSnapshot(healthRes.json)) {
         setHealth(healthRes.json);
+        setMessagingRestartRequired(false);
       } else {
         setHealth(null);
         if (!healthRes.ok) {
@@ -452,6 +493,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
               : `OpenCodeRouter health unavailable (${healthRes.status})`;
           setHealthError(message);
         }
+        setMessagingRestartRequired(true);
       }
 
       if (isOpenCodeRouterIdentities(tgRes)) {
@@ -484,6 +526,9 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
       setHealthError(message);
       setTelegramIdentitiesError(message);
       setSlackIdentitiesError(message);
+      if (messagingEnabled()) {
+        setMessagingRestartRequired(true);
+      }
     } finally {
       setRefreshing(false);
     }
@@ -503,6 +548,95 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
     setReconnectStatus("Reconnected. Refreshing worker state...");
     await refreshAll({ force: true });
     setReconnectStatus("Reconnected.");
+  };
+
+  const enableMessagingModule = async () => {
+    if (messagingSaving()) return;
+    if (!serverReady()) return;
+    const id = workspaceId();
+    if (!id) return;
+    const client = openworkServerClient();
+    if (!client) return;
+
+    setMessagingSaving(true);
+    setMessagingStatus(null);
+    setMessagingError(null);
+    try {
+      await client.patchConfig(id, {
+        openwork: {
+          messaging: {
+            enabled: true,
+          },
+        },
+      });
+      setMessagingEnabled(true);
+      setMessagingRestartRequired(true);
+      setMessagingRiskOpen(false);
+      setMessagingRestartAction("enable");
+      setMessagingRestartPromptOpen(true);
+      setMessagingStatus("Messaging enabled. Restart this worker to apply before configuring channels.");
+      await refreshAll({ force: true });
+    } catch (error) {
+      setMessagingError(formatRequestError(error));
+    } finally {
+      setMessagingSaving(false);
+    }
+  };
+
+  const disableMessagingModule = async () => {
+    if (messagingSaving()) return;
+    if (!serverReady()) return;
+    const id = workspaceId();
+    if (!id) return;
+    const client = openworkServerClient();
+    if (!client) return;
+
+    setMessagingSaving(true);
+    setMessagingStatus(null);
+    setMessagingError(null);
+    try {
+      await client.patchConfig(id, {
+        openwork: {
+          messaging: {
+            enabled: false,
+          },
+        },
+      });
+      setMessagingEnabled(false);
+      setMessagingDisableConfirmOpen(false);
+      setMessagingRestartRequired(true);
+      setMessagingRestartAction("disable");
+      setMessagingRestartPromptOpen(true);
+      setMessagingStatus("Messaging disabled. Restart this worker to stop the messaging sidecar.");
+      await refreshAll({ force: true });
+    } catch (error) {
+      setMessagingError(formatRequestError(error));
+    } finally {
+      setMessagingSaving(false);
+    }
+  };
+
+  const restartMessagingWorker = async () => {
+    if (messagingRestartBusy()) return;
+    setMessagingRestartBusy(true);
+    setMessagingError(null);
+    setMessagingStatus(null);
+    try {
+      const ok = await props.restartLocalServer();
+      if (!ok) {
+      setMessagingError("Restart failed. Please restart the worker from Settings and try again.");
+      return;
+    }
+      setMessagingRestartPromptOpen(false);
+      setMessagingRestartRequired(false);
+      setMessagingStatus("Worker restarted. Refreshing messaging status...");
+      await refreshAll({ force: true });
+      setMessagingStatus("Worker restarted.");
+    } catch (error) {
+      setMessagingError(formatRequestError(error));
+    } finally {
+      setMessagingRestartBusy(false);
+    }
   };
 
   const upsertTelegram = async (access: "public" | "private") => {
@@ -689,6 +823,16 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
     setSendResult(null);
     setReconnectStatus(null);
     setReconnectError(null);
+    setMessagingEnabled(false);
+    setMessagingSaving(false);
+    setMessagingStatus(null);
+    setMessagingError(null);
+    setMessagingRiskOpen(false);
+    setMessagingRestartRequired(false);
+    setMessagingRestartPromptOpen(false);
+    setMessagingRestartBusy(false);
+    setMessagingDisableConfirmOpen(false);
+    setMessagingRestartAction("enable");
     setActiveTab("general");
     setExpandedChannel("telegram");
   });
@@ -744,6 +888,12 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
         <Show when={reconnectError()}>
           {(value) => <div class="mt-1 text-[11px] text-red-12">{value()}</div>}
         </Show>
+        <Show when={messagingStatus()}>
+          {(value) => <div class="mt-1 text-[11px] text-gray-9">{value()}</div>}
+        </Show>
+        <Show when={messagingError()}>
+          {(value) => <div class="mt-1 text-[11px] text-red-12">{value()}</div>}
+        </Show>
       </div>
 
       {/* ---- Not connected to server ---- */}
@@ -763,30 +913,83 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
           </div>
         </Show>
 
-        <div class="flex items-center gap-2 rounded-xl border border-gray-4 bg-gray-1 p-1">
-          <button
-            class={`flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
-              activeTab() === "general"
-                ? "bg-gray-12 text-gray-1"
-                : "text-gray-10 hover:bg-gray-2"
-            }`}
-            onClick={() => setActiveTab("general")}
-          >
-            General
-          </button>
-          <button
-            class={`flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
-              activeTab() === "advanced"
-                ? "bg-gray-12 text-gray-1"
-                : "text-gray-10 hover:bg-gray-2"
-            }`}
-            onClick={() => setActiveTab("advanced")}
-          >
-            Advanced
-          </button>
-        </div>
+        <Show when={messagingEnabled()}>
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <div class="flex items-center gap-2 rounded-xl border border-gray-4 bg-gray-1 p-1 flex-1">
+              <button
+                class={`flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
+                  activeTab() === "general"
+                    ? "bg-gray-12 text-gray-1"
+                    : "text-gray-10 hover:bg-gray-2"
+                }`}
+                onClick={() => setActiveTab("general")}
+              >
+                General
+              </button>
+              <button
+                class={`flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
+                  activeTab() === "advanced"
+                    ? "bg-gray-12 text-gray-1"
+                    : "text-gray-10 hover:bg-gray-2"
+                }`}
+                onClick={() => setActiveTab("advanced")}
+              >
+                Advanced
+              </button>
+            </div>
+            <Button
+              variant="outline"
+              class="h-8 px-3 text-xs"
+              disabled={messagingSaving()}
+              onClick={() => setMessagingDisableConfirmOpen(true)}
+            >
+              Disable messaging
+            </Button>
+          </div>
+        </Show>
 
-        <Show when={activeTab() === "general"}>
+        <Show when={!messagingEnabled()}>
+          <div class="rounded-xl border border-gray-4 bg-gray-1 px-4 py-4 space-y-3">
+            <div class="text-sm font-semibold text-gray-12">Messaging is disabled by default</div>
+            <p class="text-xs text-gray-10 leading-relaxed">
+              Messaging bots can execute actions against your local worker. If exposed publicly, they may allow access
+              to files, credentials, and API keys available to this worker.
+            </p>
+            <p class="text-xs text-gray-10 leading-relaxed">
+              Enable messaging only if you understand the risk and plan to secure access (for example, private Telegram
+              pairing).
+            </p>
+            <div class="flex flex-wrap items-center gap-2">
+              <Button
+                variant="primary"
+                class="h-8 px-3 text-xs"
+                disabled={messagingSaving() || !workspaceId()}
+                onClick={() => setMessagingRiskOpen(true)}
+              >
+                {messagingSaving() ? "Enabling..." : "Enable messaging"}
+              </Button>
+            </div>
+          </div>
+        </Show>
+
+        <Show when={activeTab() === "general" && messagingEnabled()}>
+
+        <Show when={messagingRestartRequired()}>
+          <div class="rounded-xl border border-gray-4 bg-gray-1 px-4 py-3 text-xs text-gray-10 leading-relaxed">
+            Messaging is enabled in this workspace, but the messaging sidecar is not running yet. Restart this worker,
+            then return to Messaging settings to connect Telegram or Slack.
+            <div class="mt-3">
+              <Button
+                variant="primary"
+                class="h-8 px-3 text-xs"
+                disabled={messagingRestartBusy()}
+                onClick={() => void restartMessagingWorker()}
+              >
+                {messagingRestartBusy() ? "Restarting..." : "Restart worker"}
+              </Button>
+            </div>
+          </div>
+        </Show>
 
         {/* ---- Worker status card ---- */}
         <div class="rounded-xl border border-gray-4 bg-gray-1 p-4 space-y-3.5">
@@ -1291,7 +1494,7 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
 
         </Show>
 
-        <Show when={activeTab() === "advanced"}>
+        <Show when={activeTab() === "advanced" && messagingEnabled()}>
 
         {/* ---- Message routing ---- */}
         <div>
@@ -1511,6 +1714,56 @@ export default function IdentitiesView(props: IdentitiesViewProps) {
         </div>
 
         </Show>
+
+        <ConfirmModal
+          open={messagingRiskOpen()}
+          title="Enable messaging for this worker?"
+          message="Messaging can expose this worker to remote commands. If a bot is public or compromised, it can access files, credentials, and API keys available to this worker."
+          confirmLabel={messagingSaving() ? "Enabling..." : "Enable messaging"}
+          cancelLabel="Cancel"
+          variant="danger"
+          onCancel={() => {
+            if (messagingSaving()) return;
+            setMessagingRiskOpen(false);
+          }}
+          onConfirm={() => {
+            void enableMessagingModule();
+          }}
+        />
+
+        <ConfirmModal
+          open={messagingRestartPromptOpen()}
+          title="Restart worker now?"
+          message={
+            messagingRestartAction() === "enable"
+              ? "Messaging was enabled for this workspace. Restart the worker now to start the messaging sidecar and unlock Telegram and Slack setup."
+              : "Messaging was disabled for this workspace. Restart the worker now to stop the messaging sidecar."
+          }
+          confirmLabel={messagingRestartBusy() ? "Restarting..." : "Restart worker"}
+          cancelLabel="Later"
+          onCancel={() => {
+            if (messagingRestartBusy()) return;
+            setMessagingRestartPromptOpen(false);
+          }}
+          onConfirm={() => {
+            void restartMessagingWorker();
+          }}
+        />
+
+        <ConfirmModal
+          open={messagingDisableConfirmOpen()}
+          title="Disable messaging for this worker?"
+          message="This will turn off messaging for this workspace. Telegram and Slack setup will be hidden until messaging is enabled again, and you will need to restart the worker to fully stop the messaging sidecar."
+          confirmLabel={messagingSaving() ? "Disabling..." : "Disable messaging"}
+          cancelLabel="Cancel"
+          onCancel={() => {
+            if (messagingSaving()) return;
+            setMessagingDisableConfirmOpen(false);
+          }}
+          onConfirm={() => {
+            void disableMessagingModule();
+          }}
+        />
 
         <ConfirmModal
           open={publicTelegramWarningOpen()}

--- a/apps/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/apps/desktop/src-tauri/src/commands/orchestrator.rs
@@ -851,8 +851,6 @@ pub fn orchestrator_start_detached(
             "--approval".to_string(),
             "auto".to_string(),
             "--no-opencode-auth".to_string(),
-            "--opencode-router".to_string(),
-            "true".to_string(),
             "--detach".to_string(),
             "--openwork-host".to_string(),
             "0.0.0.0".to_string(),

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -438,6 +438,16 @@ function readBool(
   return fallback;
 }
 
+function readOptionalBool(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) return true;
+    if (["false", "0", "no", "off"].includes(normalized)) return false;
+  }
+  return undefined;
+}
+
 function readNumber(
   flags: Map<string, string | boolean>,
   key: string,
@@ -2618,6 +2628,148 @@ function resolveRouterDataDir(flags: Map<string, string | boolean>): string {
   return join(homedir(), ".openwork", "openwork-orchestrator");
 }
 
+function resolveWorkspaceOpenworkConfigPath(workspaceRoot: string): string {
+  return join(workspaceRoot, ".opencode", "openwork.json");
+}
+
+function resolveOpencodeRouterConfigPath(): string {
+  const override = process.env.OPENCODE_ROUTER_CONFIG_PATH?.trim();
+  if (override) return resolve(override.replace(/^~\//, `${homedir()}/`));
+  const dataDir =
+    process.env.OPENCODE_ROUTER_DATA_DIR?.trim() ||
+    join(homedir(), ".openwork", "opencode-router");
+  const expanded = dataDir.replace(/^~\//, `${homedir()}/`);
+  return join(resolve(expanded), "opencode-router.json");
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readMessagingEnabledFromOpenworkConfig(
+  openworkConfig: Record<string, unknown>,
+): boolean | undefined {
+  const messaging = asRecord(openworkConfig.messaging);
+  return readOptionalBool(messaging.enabled);
+}
+
+function hasConfiguredMessagingServices(routerConfig: Record<string, unknown>): boolean {
+  const channels = asRecord(routerConfig.channels);
+
+  const telegram = asRecord(channels.telegram);
+  const legacyTelegramToken =
+    typeof telegram.token === "string" ? telegram.token.trim() : "";
+  if (legacyTelegramToken) return true;
+  const telegramBots = Array.isArray(telegram.bots) ? telegram.bots : [];
+  if (
+    telegramBots.some((bot) => {
+      const record = asRecord(bot);
+      return (
+        typeof record.token === "string" && record.token.trim().length > 0
+      );
+    })
+  ) {
+    return true;
+  }
+
+  const slack = asRecord(channels.slack);
+  const legacySlackBotToken =
+    typeof slack.botToken === "string" ? slack.botToken.trim() : "";
+  const legacySlackAppToken =
+    typeof slack.appToken === "string" ? slack.appToken.trim() : "";
+  if (legacySlackBotToken && legacySlackAppToken) return true;
+  const slackApps = Array.isArray(slack.apps) ? slack.apps : [];
+  if (
+    slackApps.some((app) => {
+      const record = asRecord(app);
+      const botToken =
+        typeof record.botToken === "string" ? record.botToken.trim() : "";
+      const appToken =
+        typeof record.appToken === "string" ? record.appToken.trim() : "";
+      return Boolean(botToken && appToken);
+    })
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+async function resolveOpencodeRouterEnabled(
+  flags: Map<string, string | boolean>,
+  workspaceRoot: string,
+  logger: Logger,
+): Promise<{
+  enabled: boolean;
+  source: "flag" | "env" | "workspace-config" | "inferred";
+}> {
+  const flagValue = flags.get("opencode-router");
+  const parsedFlag = readOptionalBool(flagValue);
+  if (parsedFlag !== undefined) {
+    return { enabled: parsedFlag, source: "flag" };
+  }
+
+  const envValue = readOptionalBool(
+    process.env.OPENWORK_OPENCODE_ROUTER,
+  );
+  if (envValue !== undefined) {
+    return { enabled: envValue, source: "env" };
+  }
+
+  const openworkConfigPath = resolveWorkspaceOpenworkConfigPath(workspaceRoot);
+  let openworkConfig: Record<string, unknown> = {};
+  try {
+    const raw = await readFile(openworkConfigPath, "utf8");
+    openworkConfig = asRecord(JSON.parse(raw));
+  } catch {
+    openworkConfig = {};
+  }
+
+  const configured = readMessagingEnabledFromOpenworkConfig(openworkConfig);
+  if (configured !== undefined) {
+    return { enabled: configured, source: "workspace-config" };
+  }
+
+  let inferredEnabled = false;
+  const routerConfigPath = resolveOpencodeRouterConfigPath();
+  try {
+    const raw = await readFile(routerConfigPath, "utf8");
+    inferredEnabled = hasConfiguredMessagingServices(asRecord(JSON.parse(raw)));
+  } catch {
+    inferredEnabled = false;
+  }
+
+  const nextOpenworkConfig: Record<string, unknown> = {
+    ...openworkConfig,
+    messaging: {
+      ...asRecord(openworkConfig.messaging),
+      enabled: inferredEnabled,
+    },
+  };
+
+  try {
+    await mkdir(dirname(openworkConfigPath), { recursive: true });
+    await writeFile(
+      openworkConfigPath,
+      `${JSON.stringify(nextOpenworkConfig, null, 2)}\n`,
+      "utf8",
+    );
+  } catch (error) {
+    logger.warn(
+      "Failed to persist messaging enabled default",
+      {
+        path: openworkConfigPath,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "openwork-orchestrator",
+    );
+  }
+
+  return { enabled: inferredEnabled, source: "inferred" };
+}
+
 function resolveInternalDevMode(flags: Map<string, string | boolean>): boolean {
   return readBool(flags, "internal-dev-mode", false, "OPENWORK_DEV_MODE");
 }
@@ -3339,6 +3491,7 @@ function printHelp(): void {
     "  --openwork-server-bin <p> Path to openwork-server binary (requires --allow-external)",
     "  --opencode-router-bin <path>     Path to opencodeRouter binary (requires --allow-external)",
     "  --opencode-router-health-port <p> Health server port for opencodeRouter (default: random)",
+    "  --opencode-router                Enable opencodeRouter sidecar (default from workspace messaging config)",
     "  --no-opencode-router             Disable opencodeRouter sidecar",
     "  --opencode-router-required       Exit if opencodeRouter stops",
     "  --allow-external          Allow external sidecar binaries (dev only, required for custom bins)",
@@ -6677,12 +6830,20 @@ async function runStart(args: ParsedArgs) {
       }
     }
   }
-  const opencodeRouterEnabled = readBool(args.flags, "opencode-router", true);
+  const opencodeRouterMode = await resolveOpencodeRouterEnabled(
+    args.flags,
+    resolvedWorkspace,
+    logger,
+  );
+  const opencodeRouterEnabled = opencodeRouterMode.enabled;
   const opencodeRouterRequired = readBool(
     args.flags,
     "opencode-router-required",
     false,
     "OPENWORK_OPENCODE_ROUTER_REQUIRED",
+  );
+  logVerbose(
+    `opencodeRouter enabled: ${opencodeRouterEnabled ? "true" : "false"} (${opencodeRouterMode.source})`,
   );
   let openworkServerBinary = await resolveOpenworkServerBin({
     explicit: explicitOpenworkServerBin,


### PR DESCRIPTION
## Summary
- keep the messaging sidecar off by default unless a workspace explicitly enables it or already has Slack/Telegram configured
- persist a workspace-level `messaging.enabled` flag and infer `true` on first launch for existing configured users so current messaging setups keep working
- gate Messaging settings behind explicit risk acknowledgement, add restart prompts after enable/disable, and let users disable messaging again later

## Testing
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-orchestrator typecheck
- cargo check

## Notes
- I did not run Docker/Chrome MCP UI verification for this flow in this PR.