### PR TITLE
fix(landing): open Docs links in new tab

### DIFF
--- a/ee/apps/landing/components/site-footer.tsx
+++ b/ee/apps/landing/components/site-footer.tsx
@@ -19,7 +19,7 @@ export function SiteFooter() {
         </div>
 
         <div className="flex flex-wrap items-center gap-4 md:gap-8">
-          <Link href="/docs" className="transition-colors hover:text-gray-800">
+          <Link href="/docs" target="_blank" className="transition-colors hover:text-gray-800">
             Docs
           </Link>
           <Link href="/download" className="transition-colors hover:text-gray-800">

--- a/ee/apps/landing/components/site-nav.tsx
+++ b/ee/apps/landing/components/site-nav.tsx
@@ -55,6 +55,7 @@ export function SiteNav(props: Props) {
               <Link
                 key={item.key}
                 href={item.href}
+                {...(item.key === "docs" ? { target: "_blank" } : {})}
                 className={navLink(props.active === item.key)}
               >
                 {item.label}
@@ -109,6 +110,7 @@ export function SiteNav(props: Props) {
                 <Link
                   key={item.key}
                   href={item.href}
+                  {...(item.key === "docs" ? { target: "_blank" } : {})}
                   className={`rounded-2xl px-4 py-3 ${navLink(
                     props.active === item.key
                   )}`}


### PR DESCRIPTION
## Summary
- Docs nav links (`/docs`) are served via a Mintlify rewrite in `next.config.js`
- Next.js `<Link>` client-side navigation intercepted the click and broke the page
- Added `target="_blank"` to Docs links in desktop nav, mobile nav, and footer so they open in a new tab

## Test plan
- [ ] Click "Docs" in the desktop nav → opens in new tab
- [ ] Click "Docs" in the mobile nav → opens in new tab
- [ ] Click "Docs" in the footer → opens in new tab
- [ ] All other nav links still work normally (same-tab navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)