### PR TITLE
fix(app): defer headless OpenAI auth polling

### DIFF
--- a/apps/app/src/app/components/provider-auth-modal.tsx
+++ b/apps/app/src/app/components/provider-auth-modal.tsx
@@ -170,6 +170,13 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     if (!session) return false;
     return session.providerId === "openai" && session.methodLabel.toLowerCase().includes("headless");
   });
+  const shouldStartOauthAutoPolling = createMemo(() => {
+    if (!props.open || resolvedView() !== "oauth-auto" || !oauthSession()) {
+      return false;
+    }
+    if (!isOpenAiHeadlessSession()) return true;
+    return oauthBrowserOpened();
+  });
 
   const oauthDisplayCode = createMemo(() => {
     const instructions = oauthInstructions();
@@ -320,7 +327,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   });
 
   createEffect(() => {
-    if (!props.open || resolvedView() !== "oauth-auto" || !oauthSession()) {
+    if (!shouldStartOauthAutoPolling()) {
       stopOauthAutoPolling();
       return;
     }
@@ -862,7 +869,6 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                           const url = oauthSession()?.authorization.url ?? "";
                           void openOauthUrl(url);
                         }}
-                        disabled={actionDisabled()}
                       >
                         Open browser again
                       </Button>
@@ -914,10 +920,19 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                         </Button>
                       </div>
                     </Show>
-                    <div class="flex items-center gap-2 text-xs text-gray-9">
-                      <Loader2 size={14} class={props.submitting || pollingBusy() || oauthAutoBusy() ? "animate-spin" : ""} />
-                      <span>Checking connection status automatically...</span>
-                    </div>
+                    <Show
+                      when={isOpenAiHeadlessSession() && !oauthBrowserOpened()}
+                      fallback={
+                        <div class="flex items-center gap-2 text-xs text-gray-9">
+                          <Loader2 size={14} class={props.submitting || pollingBusy() || oauthAutoBusy() ? "animate-spin" : ""} />
+                          <span>Checking connection status automatically...</span>
+                        </div>
+                      }
+                    >
+                      <div class="flex items-center gap-2 text-xs text-gray-9">
+                        <span>Authorization checks will start after you click Open Browser.</span>
+                      </div>
+                    </Show>
                     <div class="flex items-center justify-between gap-3">
                       <Button
                         variant="outline"
@@ -925,7 +940,6 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                           const url = oauthSession()?.authorization.url ?? "";
                           void openOauthUrl(url);
                         }}
-                        disabled={actionDisabled()}
                       >
                         {isOpenAiHeadlessSession()
                           ? oauthBrowserOpened()

--- a/apps/app/src/i18n/index.ts
+++ b/apps/app/src/i18n/index.ts
@@ -92,7 +92,6 @@ export const setLocale = (newLocale: Language) => {
  */
 export const t = (key: string, localeOverride?: Language): string => {
   const loc = localeOverride ?? locale();
-1
 
   // Try target language first
   if (TRANSLATIONS[loc]?.[key]) {


### PR DESCRIPTION
## Summary
- defer remote OpenAI headless auth polling until the user actually clicks `Open Browser`
- keep the browser launch action enabled during the headless flow and clarify the pre-click status copy
- remove a stray `1` in the i18n helper that was blocking parsing in this worktree

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm typecheck` *(fails on an existing unrelated error at `apps/app/src/app/app.tsx:3063` because `workspaceStore.activeWorkspaceInfo()` does not exist on the current store type)*