### PR TITLE
fix(share): unify Next config for public routes

### DIFF
--- a/apps/share/next.config.mjs
+++ b/apps/share/next.config.mjs
@@ -1,8 +1,0 @@
-import { withBotId } from "botid/next/config";
-
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-};
-
-export default withBotId(nextConfig);

--- a/apps/share/next.config.ts
+++ b/apps/share/next.config.ts
@@ -1,11 +1,13 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
+import { withBotId } from "botid/next/config";
 
 const rootDir = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = resolve(rootDir, "../..");
 
 const nextConfig: NextConfig = {
+  reactStrictMode: true,
   turbopack: {
     root: workspaceRoot
   },
@@ -17,4 +19,4 @@ const nextConfig: NextConfig = {
   }
 };
 
-export default nextConfig;
+export default withBotId(nextConfig);


### PR DESCRIPTION
## Summary
- keep the share app on a single canonical Next config by moving the BotId wrapper into `apps/share/next.config.ts`
- remove the duplicate `apps/share/next.config.mjs` so `/v1/*` rewrites cannot drift away from the active config again
- preserve the public `/v1` route mapping to `/api/v1` so localhost app requests can reach the share API after the security hardening changes

## Verification
- `pnpm build` in `apps/share`