### PR TITLE
fix(domain): switch hosted URLs to openworklabs

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -637,7 +637,14 @@ function parseSharedBundleDeepLink(rawUrl: string): SharedBundleDeepLink | null 
       const host = url.hostname.toLowerCase();
       const path = url.pathname.replace(/^\/+/, "");
       const segments = path.split("/").filter(Boolean);
-      if ((host === "share.openwork.software" || host.endsWith(".openwork.software")) && segments[0] === "b" && segments[1]) {
+      if (
+        (host === "share.openworklabs.com"
+          || host.endsWith(".openworklabs.com")
+          || host === "share.openwork.software"
+          || host.endsWith(".openwork.software"))
+        && segments[0] === "b"
+        && segments[1]
+      ) {
         const intent = normalizeSharedBundleImportIntent(url.searchParams.get("ow_intent") ?? url.searchParams.get("intent"));
         const source = url.searchParams.get("ow_source")?.trim() ?? url.searchParams.get("source")?.trim() ?? "";
         const orgId = url.searchParams.get("ow_org")?.trim() ?? "";
@@ -786,7 +793,7 @@ function normalizeDebugDeepLinkInput(rawValue: string): string {
   const directMatch = trimmed.match(/(?:openwork-dev|openwork|https?):\/\/[^\s"'<>]+/i);
   if (directMatch) return directMatch[0];
 
-  const bareShareMatch = trimmed.match(/share\.openwork\.software\/b\/[^\s"'<>]+/i);
+  const bareShareMatch = trimmed.match(/share\.openwork(?:labs\.com|\.software)\/b\/[^\s"'<>]+/i);
   if (bareShareMatch) return `https://${bareShareMatch[0]}`;
 
   return trimmed;
@@ -836,12 +843,12 @@ function parseDebugDeepLinkInput(rawValue: string):
     }
   }
 
-  const shareIdMatch = normalized.match(/share\.openwork\.software\/b\/([^\s/?#"'<>]+)/i);
+  const shareIdMatch = normalized.match(/share\.openwork(?:labs\.com|\.software)\/b\/([^\s/?#"'<>]+)/i);
   if (shareIdMatch?.[1]) {
     return {
       kind: "bundle",
       link: {
-        bundleUrl: `https://share.openwork.software/b/${shareIdMatch[1]}`,
+        bundleUrl: `https://share.openworklabs.com/b/${shareIdMatch[1]}`,
         intent: "new_worker",
       },
     };

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -596,7 +596,7 @@ export function buildOpenworkWorkspaceBaseUrl(hostUrl: string, workspaceId?: str
   }
 }
 
-export const DEFAULT_OPENWORK_CONNECT_APP_URL = "https://app.openwork.software";
+export const DEFAULT_OPENWORK_CONNECT_APP_URL = "https://app.openworklabs.com";
 
 const OPENWORK_INVITE_PARAM_URL = "ow_url";
 const OPENWORK_INVITE_PARAM_TOKEN = "ow_token";

--- a/apps/app/src/app/lib/publisher.ts
+++ b/apps/app/src/app/lib/publisher.ts
@@ -7,7 +7,7 @@ export type PublishBundleResult = {
 const ENV_OPENWORK_PUBLISHER_BASE_URL = String(import.meta.env.VITE_OPENWORK_PUBLISHER_BASE_URL ?? "").trim();
 
 export const DEFAULT_OPENWORK_PUBLISHER_BASE_URL =
-  ENV_OPENWORK_PUBLISHER_BASE_URL || "https://share.openwork.software";
+  ENV_OPENWORK_PUBLISHER_BASE_URL || "https://share.openworklabs.com";
 
 function normalizeBaseUrl(input: string): string {
   const trimmed = String(input ?? "").trim();

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -2382,9 +2382,10 @@ export default function SettingsView(props: SettingsViewProps) {
                         </Button>
                         <div class="text-[11px] text-gray-8">
                           Accepts <span class="font-mono">openwork://</span>,{" "}
-                          <span class="font-mono">openwork-dev://</span>, or a raw supported{" "}
+                          <span class="font-mono">openwork-dev://</span>, or a
+                          raw supported{" "}
                           <span class="font-mono">
-                            https://share.openwork.software/b/...
+                            https://share.openworklabs.com/b/...
                           </span>{" "}
                           URL.
                         </div>

--- a/apps/app/src/app/pages/skills.tsx
+++ b/apps/app/src/app/pages/skills.tsx
@@ -1174,7 +1174,7 @@ export default function SkillsView(props: SkillsViewProps) {
                   type="url"
                   value={installLinkUrl()}
                   onInput={(e) => setInstallLinkUrl(e.currentTarget.value)}
-                  placeholder="https://share.openwork.software/b/..."
+                  placeholder="https://share.openworklabs.com/b/..."
                   class="w-full bg-dls-hover border border-dls-border rounded-lg px-3 py-2 text-xs font-mono text-dls-text focus:outline-none"
                   spellcheck={false}
                 />

--- a/apps/share/README.md
+++ b/apps/share/README.md
@@ -14,7 +14,7 @@ It keeps the existing bundle APIs, but the public share surface now runs as a si
 - `POST /v1/bundles`
   - Accepts JSON bundle payloads.
   - Stores bytes in Vercel Blob.
-  - Returns `{ "url": "https://share.openwork.software/b/<id>" }`.
+  - Returns `{ "url": "https://share.openworklabs.com/b/<id>" }`.
 
 - `POST /v1/package`
   - Accepts `{ files: [{ path, name?, content }], preview?: boolean }`.
@@ -63,7 +63,7 @@ The packager rejects files that appear to contain secrets in shareable config.
 ## Optional Environment Variables
 
 - `PUBLIC_BASE_URL`
-  - Default: `https://share.openwork.software`
+  - Default: `https://share.openworklabs.com`
   - Used to construct the returned share URL.
 
 - `MAX_BYTES`
@@ -75,7 +75,7 @@ The packager rejects files that appear to contain secrets in shareable config.
   - Defaults include the share origin, the hosted OpenWork app origin, and common local dev origins.
 
 - `PUBLIC_OPENWORK_APP_URL`
-  - Default: `https://app.openwork.software`
+  - Default: `https://app.openworklabs.com`
   - Target app URL for the Open in app action on bundle pages.
 
 - `LOCAL_BLOB_DIR`

--- a/apps/share/components/share-nav.tsx
+++ b/apps/share/components/share-nav.tsx
@@ -1,4 +1,4 @@
-const OPENWORK_DOWNLOAD_URL = "https://openwork.software/download";
+const OPENWORK_DOWNLOAD_URL = "https://openworklabs.com/download";
 
 function GitHubMark() {
   return (
@@ -23,13 +23,13 @@ export default function ShareNav({ stars = "" }: { stars?: string }) {
         <span style={{ fontWeight: "600", fontSize: "1.2rem" }}>openwork</span>
       </a>
       <div className="nav-links">
-        <a href="https://openwork.software/docs" target="_blank" rel="noreferrer">
+        <a href="https://openworklabs.com/docs" target="_blank" rel="noreferrer">
           Docs
         </a>
         <a href={OPENWORK_DOWNLOAD_URL} target="_blank" rel="noreferrer">
           Download
         </a>
-        <a href="https://openwork.software/enterprise" target="_blank" rel="noreferrer">
+        <a href="https://openworklabs.com/enterprise" target="_blank" rel="noreferrer">
           Enterprise
         </a>
       </div>

--- a/apps/share/e2e/bundle-share-page.spec.ts
+++ b/apps/share/e2e/bundle-share-page.spec.ts
@@ -174,7 +174,7 @@ test("publishes a share page with a valid OG preview card for link unfurls", asy
   expect(svg).toContain("Agent Creator");
   expect(svg).not.toContain("agent-creator.md");
   expect(svg).toContain("SKILL.md");
-  expect(svg).toContain("share.openwork.software");
+  expect(svg).toContain("share.openworklabs.com");
   expect(svg).not.toContain("Any markdown body is acceptable here.");
 
   const pastePreviewHtml = await page.content();

--- a/apps/share/server/_lib/publish-security.ts
+++ b/apps/share/server/_lib/publish-security.ts
@@ -6,6 +6,8 @@ type FixedWindowEntry = {
 };
 
 const defaultAllowedOrigins = [
+  "https://app.openworklabs.com",
+  "https://openworklabs.com",
   "https://app.openwork.software",
   "https://openwork.software",
   "http://localhost:5173",

--- a/apps/share/server/_lib/share-utils.test.ts
+++ b/apps/share/server/_lib/share-utils.test.ts
@@ -71,7 +71,7 @@ test("buildOgImageUrls returns typed platform variants", () => {
   const urls = buildOgImageUrls(
     {
       headers: {
-        host: "share.openwork.software",
+        host: "share.openworklabs.com",
         "x-forwarded-proto": "https",
       },
       query: {},
@@ -79,10 +79,10 @@ test("buildOgImageUrls returns typed platform variants", () => {
     "01TESTPREVIEW",
   );
 
-  assert.equal(urls.default, "https://share.openwork.software/og/01TESTPREVIEW");
-  assert.equal(urls.twitter, "https://share.openwork.software/og/01TESTPREVIEW?variant=twitter");
-  assert.equal(urls.byVariant.facebook, "https://share.openwork.software/og/01TESTPREVIEW");
-  assert.equal(urls.byVariant.linkedin, "https://share.openwork.software/og/01TESTPREVIEW?variant=linkedin");
-  assert.equal(urls.byVariant.slack, "https://share.openwork.software/og/01TESTPREVIEW?variant=slack");
-  assert.equal(urls.byVariant.whatsapp, "https://share.openwork.software/og/01TESTPREVIEW?variant=whatsapp");
+  assert.equal(urls.default, "https://share.openworklabs.com/og/01TESTPREVIEW");
+  assert.equal(urls.twitter, "https://share.openworklabs.com/og/01TESTPREVIEW?variant=twitter");
+  assert.equal(urls.byVariant.facebook, "https://share.openworklabs.com/og/01TESTPREVIEW");
+  assert.equal(urls.byVariant.linkedin, "https://share.openworklabs.com/og/01TESTPREVIEW?variant=linkedin");
+  assert.equal(urls.byVariant.slack, "https://share.openworklabs.com/og/01TESTPREVIEW?variant=slack");
+  assert.equal(urls.byVariant.whatsapp, "https://share.openworklabs.com/og/01TESTPREVIEW?variant=whatsapp");
 });

--- a/apps/share/server/_lib/share-utils.ts
+++ b/apps/share/server/_lib/share-utils.ts
@@ -21,10 +21,10 @@ import {
   type OgImageVariant,
 } from "./og-image-variants.ts";
 
-export const OPENWORK_SITE_URL = "https://openwork.software";
-export const OPENWORK_DOWNLOAD_URL = "https://openwork.software/download";
-export const DEFAULT_PUBLIC_BASE_URL = "https://share.openwork.software";
-export const DEFAULT_OPENWORK_APP_URL = "https://app.openwork.software";
+export const OPENWORK_SITE_URL = "https://openworklabs.com";
+export const OPENWORK_DOWNLOAD_URL = "https://openworklabs.com/download";
+export const DEFAULT_PUBLIC_BASE_URL = "https://share.openworklabs.com";
+export const DEFAULT_OPENWORK_APP_URL = "https://app.openworklabs.com";
 export const SHARE_EASE = "cubic-bezier(0.31, 0.325, 0, 0.92)";
 
 export function maybeString(value: unknown): string {
@@ -882,7 +882,7 @@ export function buildStatusMarkup({
   <style>
     @font-face {
       font-family: "FK Raster Roman Compact Smooth";
-      src: url("https://openwork.software/fonts/FKRasterRomanCompact-Smooth.woff2") format("woff2");
+      src: url("https://openworklabs.com/fonts/FKRasterRomanCompact-Smooth.woff2") format("woff2");
       font-weight: 400;
       font-style: normal;
       font-display: swap;

--- a/apps/share/server/b/render-bundle-page.test.ts
+++ b/apps/share/server/b/render-bundle-page.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { buildBundleUrls, renderBundlePage, wantsDownload } from "./render-bundle-page.ts";
 import type { RequestLike } from "../_lib/types.ts";
 
-function makeReq({ accept = "", query = {}, host = "share.openwork.software" }: { accept?: string; query?: Record<string, string>; host?: string } = {}): RequestLike {
+function makeReq({ accept = "", query = {}, host = "share.openworklabs.com" }: { accept?: string; query?: Record<string, string>; host?: string } = {}): RequestLike {
   return {
     query,
     headers: {
@@ -42,7 +42,7 @@ test("renderBundlePage includes machine-readable metadata and escaped json scrip
   const html = renderBundlePage({
     id: "01TEST",
     rawJson,
-    req: makeReq({ accept: "text/html", host: "share.openwork.software" }),
+    req: makeReq({ accept: "text/html", host: "share.openworklabs.com" }),
   });
 
   assert.match(html, /data-openwork-share="true"/);
@@ -50,7 +50,7 @@ test("renderBundlePage includes machine-readable metadata and escaped json scrip
   assert.match(html, /meta name="openwork:bundle-id" content="01TEST"/);
   assert.match(html, /\/b\/01TEST\/data/);
   assert.match(html, /openwork:\/\/import-bundle\?/);
-  assert.match(html, /ow_bundle=https%3A%2F%2Fshare\.openwork\.software%2Fb%2F01TEST/);
+  assert.match(html, /ow_bundle=https%3A%2F%2Fshare\.openworklabs\.com%2Fb%2F01TEST/);
   assert.match(html, /ow_intent=new_worker/);
   assert.match(html, /ow_source=share_service/);
   assert.match(html, /id="openwork-bundle-json" type="application\/json"/);
@@ -81,7 +81,7 @@ test("renderBundlePage shows workspace profile metadata", () => {
   const html = renderBundlePage({
     id: "01WORKSPACE",
     rawJson,
-    req: makeReq({ accept: "text/html", host: "share.openwork.software" }),
+    req: makeReq({ accept: "text/html", host: "share.openworklabs.com" }),
   });
 
   assert.match(html, /Open the bundle in OpenWork/);

--- a/apps/share/server/b/render-bundle-page.ts
+++ b/apps/share/server/b/render-bundle-page.ts
@@ -60,7 +60,7 @@ export function renderBundlePage({ id, rawJson, req }: { id: string; rawJson: st
   <style>
     @font-face {
       font-family: "FK Raster Roman Compact Smooth";
-      src: url("https://openwork.software/fonts/FKRasterRomanCompact-Smooth.woff2") format("woff2");
+      src: url("https://openworklabs.com/fonts/FKRasterRomanCompact-Smooth.woff2") format("woff2");
       font-weight: 400;
       font-style: normal;
       font-display: swap;
@@ -409,9 +409,9 @@ export function renderBundlePage({ id, rawJson, req }: { id: string; rawJson: st
         <span>openwork</span>
       </a>
       <div class="nav-links">
-        <a href="https://openwork.software/docs" target="_blank" rel="noreferrer">Docs</a>
+        <a href="https://openworklabs.com/docs" target="_blank" rel="noreferrer">Docs</a>
         <a href="${escapeHtml(OPENWORK_DOWNLOAD_URL)}" target="_blank" rel="noreferrer">Download</a>
-        <a href="https://openwork.software/enterprise" target="_blank" rel="noreferrer">Enterprise</a>
+        <a href="https://openworklabs.com/enterprise" target="_blank" rel="noreferrer">Enterprise</a>
       </div>
       <div class="nav-actions">
         <a class="button-secondary" href="https://github.com/different-ai/openwork" target="_blank" rel="noreferrer">

--- a/apps/share/styles/globals.css
+++ b/apps/share/styles/globals.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: "FK Raster Roman Compact Smooth";
-  src: url("https://openwork.software/fonts/FKRasterRomanCompact-Smooth.woff2") format("woff2");
+  src: url("https://openworklabs.com/fonts/FKRasterRomanCompact-Smooth.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;

--- a/ee/apps/den-controller/README.md
+++ b/ee/apps/den-controller/README.md
@@ -211,18 +211,18 @@ Optional GitHub Actions variable:
 
 - `DEN_RENDER_WORKER_PLAN` (defaults to `standard`)
 - `DEN_RENDER_WORKER_OPENWORK_VERSION` pins the `openwork-orchestrator` npm version installed in workers; the worker build bundles the matching `opencode` release asset into the Render image
-- `DEN_CORS_ORIGINS` (defaults to `https://app.openwork.software,https://api.openwork.software,<render-service-url>`)
+- `DEN_CORS_ORIGINS` (defaults to `https://app.openworklabs.com,https://api.openworklabs.com,<render-service-url>`)
 - `DEN_BETTER_AUTH_TRUSTED_ORIGINS` (defaults to `DEN_CORS_ORIGINS`)
 - `DEN_RENDER_WORKER_PUBLIC_DOMAIN_SUFFIX` (defaults to `openwork.studio`)
 - `DEN_RENDER_CUSTOM_DOMAIN_READY_TIMEOUT_MS` (defaults to `240000`)
-- `DEN_BETTER_AUTH_URL` (defaults to `https://app.openwork.software`)
+- `DEN_BETTER_AUTH_URL` (defaults to `https://app.openworklabs.com`)
 - `DEN_VERCEL_API_BASE` (defaults to `https://api.vercel.com`)
 - `DEN_VERCEL_TEAM_ID` (optional)
 - `DEN_VERCEL_TEAM_SLUG` (optional, defaults to `prologe`)
 - `DEN_VERCEL_DNS_DOMAIN` (defaults to `openwork.studio`)
 - `DEN_POLAR_FEATURE_GATE_ENABLED` (`true`/`false`, defaults to `false`)
 - `DEN_POLAR_API_BASE` (defaults to `https://api.polar.sh`)
-- `DEN_POLAR_SUCCESS_URL` (defaults to `https://app.openwork.software`)
+- `DEN_POLAR_SUCCESS_URL` (defaults to `https://app.openworklabs.com`)
 - `DEN_POLAR_RETURN_URL` (defaults to `DEN_POLAR_SUCCESS_URL`)
 
 Required additional secret when using vanity worker domains:

--- a/ee/apps/den-web/README.md
+++ b/ee/apps/den-web/README.md
@@ -1,14 +1,14 @@
 # OpenWork Cloud App (`ee/apps/den-web`)
 
-Frontend for `app.openwork.software`.
+Frontend for `app.openworklabs.com`.
 
 ## What it does
 
 - Signs up / signs in users against Den service auth.
 - Launches cloud workers via `POST /v1/workers`.
 - Handles paywall responses (`402 payment_required`) and shows Polar checkout links.
-- Uses a Next.js proxy route (`/api/den/*`) to reach `api.openwork.software` without browser CORS issues.
-- Uses a same-origin auth proxy (`/api/auth/*`) so GitHub OAuth callbacks can land on `app.openwork.software`.
+- Uses a Next.js proxy route (`/api/den/*`) to reach `api.openworklabs.com` without browser CORS issues.
+- Uses a same-origin auth proxy (`/api/auth/*`) so GitHub OAuth callbacks can land on `app.openworklabs.com`.
 
 ## Local development
 
@@ -22,16 +22,16 @@ Frontend for `app.openwork.software`.
 ### Optional env vars
 
 - `DEN_API_BASE` (server-only): upstream API base used by proxy route.
-  - default: `https://api.openwork.software`
+  - default: `https://api.openworklabs.com`
 - `DEN_AUTH_ORIGIN` (server-only): Origin header sent to Better Auth endpoints when the browser request does not include one.
-  - default: `https://app.openwork.software`
+  - default: `https://app.openworklabs.com`
 - `DEN_AUTH_FALLBACK_BASE` (server-only): fallback Den origin used if `DEN_API_BASE` serves an HTML/5xx error.
   - default: `https://den-control-plane-openwork.onrender.com`
 - `NEXT_PUBLIC_OPENWORK_APP_CONNECT_URL` (client): Base URL for "Open in App" links.
-  - Example: `https://openwork.software/app`
+  - Example: `https://openworklabs.com/app`
   - The web panel appends `/connect-remote` and injects worker URL/token params automatically.
 - `NEXT_PUBLIC_OPENWORK_AUTH_CALLBACK_URL` (client): Canonical URL used for GitHub auth callback redirects.
-  - default: `https://app.openwork.software`
+  - default: `https://app.openworklabs.com`
   - this host must serve `/api/auth/*`; the included proxy route does that
 - `NEXT_PUBLIC_POSTHOG_KEY` (client): PostHog project key used for Den analytics.
   - optional override; defaults to the same project key used by `ee/apps/landing`
@@ -51,4 +51,4 @@ Recommended project settings:
 
 Then assign custom domain:
 
-- `app.openwork.software`
+- `app.openworklabs.com`

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -239,7 +239,7 @@ export function deriveOnboardingWorkerName(user: AuthUser): string {
 
 export function getSocialCallbackUrl(): string {
   try {
-    const origin = typeof window !== "undefined" ? window.location.origin : OPENWORK_AUTH_CALLBACK_BASE_URL || "https://app.openwork.software";
+    const origin = typeof window !== "undefined" ? window.location.origin : OPENWORK_AUTH_CALLBACK_BASE_URL || "https://app.openworklabs.com";
     const callbackUrl = new URL("/", origin);
     if (typeof window !== "undefined") {
       const params = new URLSearchParams(window.location.search);
@@ -252,7 +252,7 @@ export function getSocialCallbackUrl(): string {
     }
     return callbackUrl.toString();
   } catch {
-    return "https://app.openwork.software/";
+    return "https://app.openworklabs.com/";
   }
 }
 

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 
-const DEFAULT_API_BASE = "https://api.openwork.software";
-const DEFAULT_AUTH_ORIGIN = "https://app.openwork.software";
+const DEFAULT_API_BASE = "https://api.openworklabs.com";
+const DEFAULT_AUTH_ORIGIN = "https://app.openworklabs.com";
 const DEFAULT_AUTH_FALLBACK_BASE = "https://den-control-plane-openwork.onrender.com";
 const NO_BODY_STATUS = new Set([204, 205, 304]);
 

--- a/ee/apps/den-web/app/layout.tsx
+++ b/ee/apps/den-web/app/layout.tsx
@@ -17,21 +17,21 @@ const ibmPlexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://app.openwork.software"),
+  metadataBase: new URL("https://app.openworklabs.com"),
   title: "Den Cloud Workers",
   description:
-    "Launch OpenWork cloud workers, manage Polar checkout flows, and run Den from app.openwork.software with the same positioning as the landing page.",
+    "Launch OpenWork cloud workers, manage Polar checkout flows, and run Den from app.openworklabs.com with the same positioning as the landing page.",
   openGraph: {
     title: "Den Cloud Workers",
     description:
-      "Always-on AI workers for you and your team, launched from app.openwork.software.",
+      "Always-on AI workers for you and your team, launched from app.openworklabs.com.",
     images: ["/opengraph-image"]
   },
   twitter: {
     card: "summary_large_image",
     title: "Den Cloud Workers",
     description:
-      "Launch OpenWork cloud workers, manage Polar checkout flows, and operate Den from app.openwork.software.",
+      "Launch OpenWork cloud workers, manage Polar checkout flows, and operate Den from app.openworklabs.com.",
     images: ["/opengraph-image"]
   },
   icons: {

--- a/ee/apps/den-web/app/opengraph-image.tsx
+++ b/ee/apps/den-web/app/opengraph-image.tsx
@@ -86,7 +86,7 @@ export default function OpenGraphImage() {
             </div>
 
             <div style={{ fontSize: 24, lineHeight: 1.45, color: "#475569", display: "flex", maxWidth: 520 }}>
-              Launch cloud workers, manage Polar checkout, and operate Den directly from app.openwork.software.
+              Launch cloud workers, manage Polar checkout, and operate Den directly from app.openworklabs.com.
             </div>
 
             <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>

--- a/ee/apps/landing/app/api/_lib/security.ts
+++ b/ee/apps/landing/app/api/_lib/security.ts
@@ -8,6 +8,8 @@ type FixedWindowEntry = {
 const minimumSubmissionAgeMs = 1500;
 const maximumSubmissionAgeMs = 1000 * 60 * 60;
 const defaultAllowedOrigins = [
+  "https://openworklabs.com",
+  "https://www.openworklabs.com",
   "https://openwork.software",
   "https://www.openwork.software",
   "http://localhost:3000",

--- a/ee/apps/landing/app/layout.tsx
+++ b/ee/apps/landing/app/layout.tsx
@@ -16,7 +16,7 @@ const jetbrains = JetBrains_Mono({
 });
 
 export const metadata = {
-  metadataBase: new URL("https://openwork.software"),
+  metadataBase: new URL("https://openworklabs.com"),
   title: "OpenWork — The open source Claude Cowork alternative",
   description:
     "Bring your own model and provider, wire in your tools and context, and ship reusable agent setups across your org — with guardrails built in.",

--- a/ee/apps/landing/components/den-value-section.tsx
+++ b/ee/apps/landing/components/den-value-section.tsx
@@ -14,7 +14,7 @@ export function DenValueSection(props: DenValueSectionProps) {
 I want to automate this {TASK} because {REASON}. I don't trust AI to do this because of the following {AI_CONCERN}. I'm willing to pay you {BUDGET} for {HOURS} of your time.
 
 Best`;
-  const hireHumanHref = `mailto:ben@openwork.software?subject=${encodeURIComponent(hireHumanSubject)}&body=${encodeURIComponent(hireHumanBody)}`;
+  const hireHumanHref = `mailto:ben@openworklabs.com?subject=${encodeURIComponent(hireHumanSubject)}&body=${encodeURIComponent(hireHumanBody)}`;
   const getStartedExternal = /^https?:\/\//.test(props.getStartedHref);
 
   return (

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -39,7 +39,7 @@ Optional env vars (via `.env` or `export`):
 - `OPENWORK_OPENCODE_CONFIG_DIR` — override the host OpenCode config source used for that optional import
 - `OPENWORK_OPENCODE_DATA_DIR` — override the host OpenCode data source used for that optional import
 
-The dev stack also starts the local share service automatically and points the OpenWork app at it, so share-link flows publish to a local service instead of `https://share.openwork.software`.
+The dev stack also starts the local share service automatically and points the OpenWork app at it, so share-link flows publish to a local service instead of `https://share.openworklabs.com`.
 
 ---
 


### PR DESCRIPTION
## Summary
- update hosted OpenWork landing, app, share, and Den references from `openwork.software` to `openworklabs.com`
- keep legacy deep-link and origin allowlist compatibility where existing `openwork.software` links may still arrive
- refresh docs and tests so share URLs, metadata, and examples point at the new domain

## Verification
- `pnpm --filter @openwork/share test`
- `pnpm --filter @openwork-ee/den-web build`
- `pnpm --filter @openwork/app typecheck` *(fails on a pre-existing `activeWorkspaceInfo` type error in `apps/app/src/app/app.tsx` unrelated to this change)*