### PR TITLE
fix(share): allow packaged desktop publish origin

### DIFF
--- a/apps/share/server/_lib/publish-security.ts
+++ b/apps/share/server/_lib/publish-security.ts
@@ -10,6 +10,8 @@ const defaultAllowedOrigins = [
   "https://openwork.software",
   "http://localhost:5173",
   "http://127.0.0.1:5173",
+  "tauri://localhost",
+  "http://tauri.localhost",
   "http://localhost:3000",
   "http://127.0.0.1:3000",
   "http://localhost:3006",


### PR DESCRIPTION
## Summary
- add `tauri://localhost` and `http://tauri.localhost` to the share publisher CORS allowlist
- let the packaged OpenWork desktop app publish bundles to `share.openwork.software` using its runtime origin
- keep existing localhost dev origins unchanged

## Verification
- attempted `pnpm build` in `apps/share`, but this fresh worktree does not have `node_modules`, so `next` was unavailable
- verified the change scope with `git diff -- apps/share/server/_lib/publish-security.ts`