### PR TITLE
Preserve detached worker share credentials across restarts

### DIFF
--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -1866,6 +1866,8 @@ export function createWorkspaceStore(options: {
         const ok = await createRemoteWorkspaceFlow({
           openworkHostUrl: host.openworkUrl,
           openworkToken: host.ownerToken?.trim() || host.token,
+          openworkClientToken: host.token,
+          openworkHostToken: host.hostToken,
           directory: resolvedFolder,
           displayName: name,
           sandboxBackend: host.sandboxBackend ?? "docker",
@@ -1913,6 +1915,8 @@ export function createWorkspaceStore(options: {
   async function createRemoteWorkspaceFlow(input: {
     openworkHostUrl?: string | null;
     openworkToken?: string | null;
+    openworkClientToken?: string | null;
+    openworkHostToken?: string | null;
     directory?: string | null;
     displayName?: string | null;
     manageBusy?: boolean;
@@ -2048,6 +2052,10 @@ export function createWorkspaceStore(options: {
           remoteType,
           openworkHostUrl: remoteType === "openwork" ? resolvedHostUrl : null,
           openworkToken: remoteType === "openwork" ? (token || null) : null,
+          openworkClientToken:
+            remoteType === "openwork" ? (input.openworkClientToken?.trim() || null) : null,
+          openworkHostToken:
+            remoteType === "openwork" ? (input.openworkHostToken?.trim() || null) : null,
           openworkWorkspaceId: remoteType === "openwork" ? openworkWorkspace?.id ?? null : null,
           openworkWorkspaceName: remoteType === "openwork" ? openworkWorkspace?.name ?? null : null,
           sandboxBackend: input.sandboxBackend ?? null,
@@ -2071,6 +2079,10 @@ export function createWorkspaceStore(options: {
           displayName,
           openworkHostUrl: remoteType === "openwork" ? resolvedHostUrl : null,
           openworkToken: remoteType === "openwork" ? (token || null) : null,
+          openworkClientToken:
+            remoteType === "openwork" ? (input.openworkClientToken?.trim() || null) : null,
+          openworkHostToken:
+            remoteType === "openwork" ? (input.openworkHostToken?.trim() || null) : null,
           openworkWorkspaceId: remoteType === "openwork" ? openworkWorkspace?.id ?? null : null,
           openworkWorkspaceName: remoteType === "openwork" ? openworkWorkspace?.name ?? null : null,
           sandboxBackend: input.sandboxBackend ?? null,
@@ -2132,6 +2144,8 @@ export function createWorkspaceStore(options: {
     input: {
       openworkHostUrl?: string | null;
       openworkToken?: string | null;
+      openworkClientToken?: string | null;
+      openworkHostToken?: string | null;
       directory?: string | null;
       displayName?: string | null;
     },
@@ -2241,6 +2255,10 @@ export function createWorkspaceStore(options: {
           displayName,
           openworkHostUrl: resolvedHostUrl,
           openworkToken: token ? token : null,
+          openworkClientToken:
+            input.openworkClientToken?.trim() || workspace.openworkClientToken?.trim() || null,
+          openworkHostToken:
+            input.openworkHostToken?.trim() || workspace.openworkHostToken?.trim() || null,
           openworkWorkspaceId: openworkWorkspace?.id ?? workspace.openworkWorkspaceId ?? null,
           openworkWorkspaceName: openworkWorkspace?.name ?? workspace.openworkWorkspaceName ?? null,
         });
@@ -2261,6 +2279,10 @@ export function createWorkspaceStore(options: {
                 displayName,
                 openworkHostUrl: resolvedHostUrl,
                 openworkToken: token ? token : null,
+                openworkClientToken:
+                  input.openworkClientToken?.trim() || item.openworkClientToken?.trim() || null,
+                openworkHostToken:
+                  input.openworkHostToken?.trim() || item.openworkHostToken?.trim() || null,
                 openworkWorkspaceId: openworkWorkspace?.id ?? item.openworkWorkspaceId ?? null,
                 openworkWorkspaceName: openworkWorkspace?.name ?? item.openworkWorkspaceName ?? null,
               }
@@ -2397,7 +2419,11 @@ export function createWorkspaceStore(options: {
         sandboxBackend: "docker",
         runId: workspace.sandboxRunId?.trim() || null,
         openworkToken:
-          workspace.openworkToken?.trim() || options.openworkServerSettings().token?.trim() || null,
+          workspace.openworkClientToken?.trim() ||
+          workspace.openworkToken?.trim() ||
+          options.openworkServerSettings().token?.trim() ||
+          null,
+        openworkHostToken: workspace.openworkHostToken?.trim() || null,
       });
 
       const resolved = await resolveOpenworkHost({
@@ -2417,6 +2443,8 @@ export function createWorkspaceStore(options: {
         directory: resolved.directory || workspacePath,
         openworkHostUrl: resolved.hostUrl,
         openworkToken: host.ownerToken?.trim() || host.token,
+        openworkClientToken: host.token,
+        openworkHostToken: host.hostToken,
         openworkWorkspaceId: resolved.workspace.id,
         openworkWorkspaceName: resolved.workspace.name ?? workspace.openworkWorkspaceName ?? null,
         sandboxBackend: host.sandboxBackend ?? "docker",

--- a/apps/app/src/app/lib/tauri.ts
+++ b/apps/app/src/app/lib/tauri.ts
@@ -118,6 +118,8 @@ export type WorkspaceInfo = {
   displayName?: string | null;
   openworkHostUrl?: string | null;
   openworkToken?: string | null;
+  openworkClientToken?: string | null;
+  openworkHostToken?: string | null;
   openworkWorkspaceId?: string | null;
   openworkWorkspaceName?: string | null;
 
@@ -187,6 +189,8 @@ export async function workspaceCreateRemote(input: {
   remoteType?: "openwork" | "opencode" | null;
   openworkHostUrl?: string | null;
   openworkToken?: string | null;
+  openworkClientToken?: string | null;
+  openworkHostToken?: string | null;
   openworkWorkspaceId?: string | null;
   openworkWorkspaceName?: string | null;
 
@@ -202,6 +206,8 @@ export async function workspaceCreateRemote(input: {
     remoteType: input.remoteType ?? null,
     openworkHostUrl: input.openworkHostUrl ?? null,
     openworkToken: input.openworkToken ?? null,
+    openworkClientToken: input.openworkClientToken ?? null,
+    openworkHostToken: input.openworkHostToken ?? null,
     openworkWorkspaceId: input.openworkWorkspaceId ?? null,
     openworkWorkspaceName: input.openworkWorkspaceName ?? null,
     sandboxBackend: input.sandboxBackend ?? null,
@@ -218,6 +224,8 @@ export async function workspaceUpdateRemote(input: {
   remoteType?: "openwork" | "opencode" | null;
   openworkHostUrl?: string | null;
   openworkToken?: string | null;
+  openworkClientToken?: string | null;
+  openworkHostToken?: string | null;
   openworkWorkspaceId?: string | null;
   openworkWorkspaceName?: string | null;
 
@@ -234,6 +242,8 @@ export async function workspaceUpdateRemote(input: {
     remoteType: input.remoteType ?? null,
     openworkHostUrl: input.openworkHostUrl ?? null,
     openworkToken: input.openworkToken ?? null,
+    openworkClientToken: input.openworkClientToken ?? null,
+    openworkHostToken: input.openworkHostToken ?? null,
     openworkWorkspaceId: input.openworkWorkspaceId ?? null,
     openworkWorkspaceName: input.openworkWorkspaceName ?? null,
     sandboxBackend: input.sandboxBackend ?? null,

--- a/apps/desktop/src-tauri/src/commands/engine.rs
+++ b/apps/desktop/src-tauri/src/commands/engine.rs
@@ -9,9 +9,7 @@ use crate::engine::manager::EngineManager;
 use crate::engine::spawn::{find_free_port, spawn_engine};
 use crate::opencode_router::manager::OpenCodeRouterManager;
 use crate::opencode_router::spawn::resolve_opencode_router_health_port;
-use crate::openwork_server::{
-    manager::OpenworkServerManager, start_openwork_server,
-};
+use crate::openwork_server::{manager::OpenworkServerManager, start_openwork_server};
 use crate::orchestrator::manager::OrchestratorManager;
 use crate::orchestrator::{self, OrchestratorSpawnOptions};
 use crate::types::{EngineDoctorResult, EngineInfo, EngineRuntime, ExecResult};
@@ -66,7 +64,10 @@ fn openwork_dev_mode_enabled() -> bool {
 }
 
 fn pinned_opencode_version() -> String {
-    let constants = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../constants.json"));
+    let constants = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../constants.json"
+    ));
     let parsed: serde_json::Value =
         serde_json::from_str(constants).expect("constants.json must be valid JSON");
     parsed["opencodeVersion"]
@@ -396,8 +397,8 @@ pub fn engine_start(
         let notes_text = notes.join("\n");
         let install_command = pinned_opencode_install_command();
         return Err(format!(
-      "OpenCode CLI not found.\n\nInstall with:\n- {install_command}\n\nNotes:\n{notes_text}"
-    ));
+            "OpenCode CLI not found.\n\nInstall with:\n- {install_command}\n\nNotes:\n{notes_text}"
+        ));
     };
 
     let (sidecar_candidate, _sidecar_notes) = resolve_sidecar_candidate(
@@ -713,8 +714,7 @@ pub fn engine_start(
     state.opencode_username = opencode_username.clone();
     state.opencode_password = opencode_password.clone();
 
-    let opencode_connect_url =
-        format!("http://{client_host}:{port}");
+    let opencode_connect_url = format!("http://{client_host}:{port}");
     let opencode_router_health_port = match resolve_opencode_router_health_port() {
         Ok(port) => Some(port),
         Err(error) => {

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -200,6 +200,8 @@ pub fn workspace_create(
         display_name: None,
         openwork_host_url: None,
         openwork_token: None,
+        openwork_client_token: None,
+        openwork_host_token: None,
         openwork_workspace_id: None,
         openwork_workspace_name: None,
         sandbox_backend: None,
@@ -228,6 +230,8 @@ pub fn workspace_create_remote(
     remote_type: Option<RemoteType>,
     openwork_host_url: Option<String>,
     openwork_token: Option<String>,
+    openwork_client_token: Option<String>,
+    openwork_host_token: Option<String>,
     openwork_workspace_id: Option<String>,
     openwork_workspace_name: Option<String>,
     sandbox_backend: Option<String>,
@@ -257,6 +261,14 @@ pub fn workspace_create_remote(
         .filter(|value| !value.is_empty());
 
     let openwork_token = openwork_token
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    let openwork_client_token = openwork_client_token
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    let openwork_host_token = openwork_host_token
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
@@ -307,6 +319,8 @@ pub fn workspace_create_remote(
         display_name,
         openwork_host_url,
         openwork_token,
+        openwork_client_token,
+        openwork_host_token,
         openwork_workspace_id,
         openwork_workspace_name,
         sandbox_backend: sandbox_backend
@@ -341,6 +355,8 @@ pub fn workspace_update_remote(
     remote_type: Option<RemoteType>,
     openwork_host_url: Option<String>,
     openwork_token: Option<String>,
+    openwork_client_token: Option<String>,
+    openwork_host_token: Option<String>,
     openwork_workspace_id: Option<String>,
     openwork_workspace_name: Option<String>,
     sandbox_backend: Option<String>,
@@ -406,6 +422,18 @@ pub fn workspace_update_remote(
 
     if openwork_token.is_some() {
         entry.openwork_token = openwork_token
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+
+    if openwork_client_token.is_some() {
+        entry.openwork_client_token = openwork_client_token
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+
+    if openwork_host_token.is_some() {
+        entry.openwork_host_token = openwork_host_token
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
     }
@@ -899,6 +927,8 @@ pub fn workspace_import_config(
         display_name: None,
         openwork_host_url: None,
         openwork_token: None,
+        openwork_client_token: None,
+        openwork_host_token: None,
         openwork_workspace_id: None,
         openwork_workspace_name: None,
         sandbox_backend: None,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -244,7 +244,10 @@ pub fn run() {
         }
         #[cfg(target_os = "macos")]
         RunEvent::Opened { urls } => {
-            let urls = urls.into_iter().map(|url| url.to_string()).collect::<Vec<_>>();
+            let urls = urls
+                .into_iter()
+                .map(|url| url.to_string())
+                .collect::<Vec<_>>();
             show_main_window(&app_handle);
             emit_native_deep_links(&app_handle, urls);
         }

--- a/apps/desktop/src-tauri/src/openwork_server/mod.rs
+++ b/apps/desktop/src-tauri/src/openwork_server/mod.rs
@@ -78,11 +78,8 @@ fn save_openwork_server_token_store(
         fs::create_dir_all(parent)
             .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
     }
-    fs::write(
-        path,
-        serde_json::to_string_pretty(store).map_err(|e| e.to_string())?,
-    )
-    .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+    let payload = serde_json::to_string_pretty(store).map_err(|e| e.to_string())?;
+    fs::write(path, payload).map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
     Ok(())
 }
 
@@ -98,13 +95,11 @@ fn load_or_create_workspace_tokens_at_path(
     path: &Path,
     workspace_key: &str,
 ) -> Result<PersistedOpenworkServerTokens, String> {
-    let mut store = load_openwork_server_token_store(&path)?;
+    let mut store = load_openwork_server_token_store(path)?;
     if let Some(tokens) = store.workspaces.get(workspace_key) {
         return Ok(tokens.clone());
     }
 
-    // Keep the desktop-hosted share codes stable for the same workspace across
-    // full app restarts so reconnecting clients do not need a fresh invite.
     let tokens = PersistedOpenworkServerTokens {
         client_token: generate_token(),
         host_token: generate_token(),
@@ -114,7 +109,7 @@ fn load_or_create_workspace_tokens_at_path(
     store
         .workspaces
         .insert(workspace_key.to_string(), tokens.clone());
-    save_openwork_server_token_store(&path, &store)?;
+    save_openwork_server_token_store(path, &store)?;
     Ok(tokens)
 }
 
@@ -132,13 +127,13 @@ fn persist_workspace_owner_token_at_path(
     workspace_key: &str,
     owner_token: &str,
 ) -> Result<(), String> {
-    let mut store = load_openwork_server_token_store(&path)?;
+    let mut store = load_openwork_server_token_store(path)?;
     let Some(tokens) = store.workspaces.get_mut(workspace_key) else {
         return Ok(());
     };
     tokens.owner_token = Some(owner_token.to_string());
     tokens.updated_at = now_ms();
-    save_openwork_server_token_store(&path, &store)
+    save_openwork_server_token_store(path, &store)
 }
 
 fn wait_for_openwork_health(base_url: &str, timeout: Duration) -> Result<(), String> {
@@ -192,7 +187,6 @@ fn build_urls(port: u16) -> (Option<String>, Option<String>, Option<String>) {
     };
 
     let lan_url = local_ip().ok().map(|ip| format!("http://{ip}:{port}"));
-
     let connect_url = lan_url.clone().or(mdns_url.clone());
 
     (connect_url, mdns_url, lan_url)
@@ -322,4 +316,33 @@ pub fn start_openwork_server(
     });
 
     Ok(OpenworkServerManager::snapshot_locked(&mut state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_path(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("openwork-server-{name}-{nonce}.json"))
+    }
+
+    #[test]
+    fn reuses_tokens_for_the_same_workspace_after_restart() {
+        let path = unique_temp_path("reuse");
+        let first = load_or_create_workspace_tokens_at_path(&path, "/tmp/workspace")
+            .expect("create first token set");
+        let second = load_or_create_workspace_tokens_at_path(&path, "/tmp/workspace")
+            .expect("load existing token set");
+
+        assert_eq!(first.client_token, second.client_token);
+        assert_eq!(first.host_token, second.host_token);
+        assert_eq!(first.owner_token, second.owner_token);
+
+        let _ = fs::remove_file(path);
+    }
 }

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -327,6 +327,10 @@ pub struct WorkspaceInfo {
     #[serde(default)]
     pub openwork_token: Option<String>,
     #[serde(default)]
+    pub openwork_client_token: Option<String>,
+    #[serde(default)]
+    pub openwork_host_token: Option<String>,
+    #[serde(default)]
     pub openwork_workspace_id: Option<String>,
     #[serde(default)]
     pub openwork_workspace_name: Option<String>,


### PR DESCRIPTION
## Summary
- persist the detached local worker's client and host tokens in workspace metadata instead of only keeping the owner access token
- reuse those stored tokens when restarting a local sandbox worker so shared access keeps working across desktop restarts
- keep the desktop-hosted token persistence coverage in place with a focused Rust regression test

## Testing
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml openwork_server`
- `pnpm --filter @openwork/app exec tsc -p tsconfig.json --noEmit` *(currently fails on a pre-existing `activeWorkspaceInfo` type error in `apps/app/src/app/app.tsx:3063`)*