### PR TITLE
Fix blueprint seeded session materialization

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -2127,9 +2127,17 @@ export default function App() {
     };
   };
 
+  const [blueprintSeedMessagesBySessionId, setBlueprintSeedMessagesBySessionId] =
+    createSignal<Record<string, Array<{ role?: "assistant" | "user" | null; text?: string | null }>>>({});
+
   const blueprintSeedMessagesForSelectedSession = createMemo(() => {
     const sessionID = selectedSessionId();
     if (!sessionID) return [];
+
+    const fallback = blueprintSeedMessagesBySessionId()[sessionID];
+    if (Array.isArray(fallback) && fallback.length > 0) {
+      return fallback;
+    }
 
     const materialized = blueprintMaterializedSessions(resolvedActiveWorkspaceConfig());
     const match = materialized.find((item) => item.sessionId?.trim() === sessionID);
@@ -2150,6 +2158,7 @@ export default function App() {
     seeds: Array<{ role?: "assistant" | "user" | null; text?: string | null }>,
   ) => {
     if (!sessionID || seeds.length === 0) return list;
+    if (list.length > 0) return list;
     const existingIds = new Set(list.map((message) => messageIdFromInfo(message)));
     const synthetic = seeds
       .map((seed, index) => createSyntheticBlueprintSeedMessage(sessionID, index, seed))
@@ -5531,6 +5540,11 @@ export default function App() {
     const templates = blueprintSessions(config);
     const materialized = blueprintMaterializedSessions(config);
     const currentSessions = sessions();
+    const normalizedRoot = normalizeDirectoryPath(root);
+    const hasWorkspaceSessions = currentSessions.some((session) => {
+      const directory = typeof session.directory === "string" ? session.directory : "";
+      return normalizeDirectoryPath(directory) === normalizedRoot;
+    });
 
     if (!workspaceId || !client || !connected) return;
     if (!root) return;
@@ -5539,7 +5553,7 @@ export default function App() {
     if (selectedSessionId()) return;
     if (!templates.length) return;
     if (materialized.length > 0) return;
-    if (currentSessions.length > 0) return;
+    if (hasWorkspaceSessions) return;
     if (blueprintSessionMaterializeBusyByWorkspaceId()[workspaceId]) return;
     if (blueprintSessionMaterializeAttemptedByWorkspaceId()[workspaceId]) return;
 
@@ -5551,6 +5565,21 @@ export default function App() {
     void (async () => {
       try {
         const result = await client.materializeBlueprintSessions(workspaceId);
+        const templateMessages = new Map(
+          templates.map((template) => [template.id?.trim(), (template.messages ?? []).filter((entry) => entry?.text?.trim())] as const),
+        );
+        if (result.created.length > 0) {
+          setBlueprintSeedMessagesBySessionId((current) => {
+            const next = { ...current };
+            result.created.forEach((entry) => {
+              const messages = templateMessages.get(entry.templateId?.trim());
+              if (messages && messages.length > 0) {
+                next[entry.sessionId] = messages;
+              }
+            });
+            return next;
+          });
+        }
         setBlueprintSessionMaterializeAttemptedByWorkspaceId((current) => ({
           ...current,
           [workspaceId]: true,
@@ -5558,6 +5587,7 @@ export default function App() {
         await refreshActiveWorkspaceServerConfig(workspaceId);
         await loadSessionsWithReady(root || undefined);
         if (result.openSessionId) {
+          setView("session");
           await selectSession(result.openSessionId);
         }
       } catch (error) {

--- a/apps/app/src/app/lib/workspace-blueprints.ts
+++ b/apps/app/src/app/lib/workspace-blueprints.ts
@@ -24,7 +24,7 @@ const DEFAULT_WELCOME_BLUEPRINT_MESSAGES: WorkspaceBlueprintSessionMessage[] = [
   {
     role: "assistant",
     text:
-      "Hi welcome to OpenWork!\n\nPeople use us to write .csv files on their computer, connect to their chrome and automate repetitive tasks, sync contacts to notion.\n\nBut the only limit is your imagniation.\n\nWhat would you want to do?",
+      "Hi welcome to OpenWork!\n\nPeople use us to write .csv files on their computer, connect to Chrome and automate repetitive tasks, and sync contacts to Notion.\n\nBut the only limit is your imagination.\n\nWhat would you want to do?",
   },
 ];
 
@@ -35,6 +35,21 @@ export function defaultBlueprintSessionsForPreset(_preset: string): WorkspaceBlu
       title: "Welcome to OpenWork",
       messages: DEFAULT_WELCOME_BLUEPRINT_MESSAGES,
       openOnFirstLoad: true,
+    },
+    {
+      id: "csv-playbook",
+      title: "CSV workflow ideas",
+      messages: [
+        {
+          role: "assistant",
+          text: "I can help you generate, clean, merge, and summarize CSV files. What kind of CSV work do you want to automate?",
+        },
+        {
+          role: "user",
+          text: "I want to combine exports from multiple tools into one clean CSV.",
+        },
+      ],
+      openOnFirstLoad: false,
     },
   ];
 }
@@ -141,6 +156,13 @@ export function defaultBlueprintStartersForPreset(preset: string): WorkspaceBlue
     default:
       return [
         {
+          id: "csv-help",
+          kind: "prompt",
+          title: "Work on a CSV",
+          description: "Clean up or generate spreadsheet data.",
+          prompt: "Help me create or edit CSV files on this computer.",
+        },
+        {
           id: "starter-connect-openai",
           kind: "action",
           title: "Connect ChatGPT",
@@ -148,11 +170,11 @@ export function defaultBlueprintStartersForPreset(preset: string): WorkspaceBlue
           action: "connect-openai",
         },
         {
-          id: "starter-browser",
+          id: "browser-automation",
           kind: "session",
-          title: "Automate your browser",
-          description: "Set up browser actions and run reliable web tasks from OpenWork.",
-          prompt: BROWSER_AUTOMATION_QUICKSTART_PROMPT,
+          title: "Automate Chrome",
+          description: "Start a browser automation conversation right away.",
+          prompt: "Help me connect to Chrome and automate a repetitive task.",
         },
       ];
   }

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -36,6 +36,8 @@ interface FileConfig {
   corsOrigins?: string[];
   authorizedRoots?: string[];
   readOnly?: boolean;
+  opencodeBaseUrl?: string;
+  opencodeDirectory?: string;
   opencodeUsername?: string;
   opencodePassword?: string;
   logFormat?: LogFormat;
@@ -222,8 +224,8 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
   const envOpencodeDirectory = process.env.OPENWORK_OPENCODE_DIRECTORY;
   const envOpencodeUsername = process.env.OPENWORK_OPENCODE_USERNAME;
   const envOpencodePassword = process.env.OPENWORK_OPENCODE_PASSWORD;
-  const opencodeBaseUrl = cli.opencodeBaseUrl ?? envOpencodeBaseUrl;
-  const opencodeDirectory = cli.opencodeDirectory ?? envOpencodeDirectory;
+  const opencodeBaseUrl = cli.opencodeBaseUrl ?? envOpencodeBaseUrl ?? fileConfig.opencodeBaseUrl;
+  const opencodeDirectory = cli.opencodeDirectory ?? envOpencodeDirectory ?? fileConfig.opencodeDirectory;
   const opencodeUsername = cli.opencodeUsername ?? envOpencodeUsername ?? fileConfig.opencodeUsername;
   const opencodePassword = cli.opencodePassword ?? envOpencodePassword ?? fileConfig.opencodePassword;
 
@@ -317,6 +319,10 @@ export async function resolveServerConfig(cli: CliArgs): Promise<ServerConfig> {
     token,
     hostToken,
     configPath,
+    opencodeBaseUrl,
+    opencodeDirectory,
+    opencodeUsername,
+    opencodePassword,
     approval,
     corsOrigins,
     workspaces,

--- a/apps/server/src/opencode-connection.test.ts
+++ b/apps/server/src/opencode-connection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { inheritWorkspaceOpencodeConnection, resolveWorkspaceOpencodeConnection } from "./opencode-connection.js";
+
+describe("resolveWorkspaceOpencodeConnection", () => {
+  test("falls back to server-level OpenCode settings when a workspace entry is missing them", () => {
+    const connection = resolveWorkspaceOpencodeConnection(
+      {
+        opencodeBaseUrl: "http://127.0.0.1:54235",
+        opencodeUsername: "user",
+        opencodePassword: "pass",
+      },
+      {
+        id: "ws_test",
+        name: "Test",
+        path: "/tmp/test",
+        preset: "starter",
+        workspaceType: "local",
+      },
+    );
+
+    expect(connection.baseUrl).toBe("http://127.0.0.1:54235");
+    expect(connection.authHeader).toBe(`Basic ${Buffer.from("user:pass").toString("base64")}`);
+  });
+
+  test("prefers workspace-specific settings when present", () => {
+    const connection = resolveWorkspaceOpencodeConnection(
+      {
+        opencodeBaseUrl: "http://127.0.0.1:54235",
+        opencodeUsername: "user",
+        opencodePassword: "pass",
+      },
+      {
+        id: "ws_test",
+        name: "Test",
+        path: "/tmp/test",
+        preset: "starter",
+        workspaceType: "local",
+        baseUrl: "http://127.0.0.1:6000",
+        opencodeUsername: "local-user",
+        opencodePassword: "local-pass",
+      },
+    );
+
+    expect(connection.baseUrl).toBe("http://127.0.0.1:6000");
+    expect(connection.authHeader).toBe(`Basic ${Buffer.from("local-user:local-pass").toString("base64")}`);
+  });
+});
+
+describe("inheritWorkspaceOpencodeConnection", () => {
+  test("copies server-level OpenCode connection into new local workspaces", () => {
+    expect(
+      inheritWorkspaceOpencodeConnection({
+        opencodeBaseUrl: "http://127.0.0.1:54235",
+        opencodeUsername: "user",
+        opencodePassword: "pass",
+      }),
+    ).toEqual({
+      baseUrl: "http://127.0.0.1:54235",
+      opencodeUsername: "user",
+      opencodePassword: "pass",
+    });
+  });
+});

--- a/apps/server/src/opencode-connection.ts
+++ b/apps/server/src/opencode-connection.ts
@@ -1,0 +1,42 @@
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+type OpencodeConnection = {
+  baseUrl?: string;
+  authHeader?: string;
+};
+
+function trim(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+export function resolveWorkspaceOpencodeConnection(
+  config: Pick<ServerConfig, "opencodeBaseUrl" | "opencodeUsername" | "opencodePassword">,
+  workspace: WorkspaceInfo,
+): OpencodeConnection {
+  const baseUrl = trim(workspace.baseUrl) || trim(config.opencodeBaseUrl) || undefined;
+  const username = trim(workspace.opencodeUsername) || trim(config.opencodeUsername);
+  const password = trim(workspace.opencodePassword) || trim(config.opencodePassword);
+
+  return {
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(username && password
+      ? {
+          authHeader: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+        }
+      : {}),
+  };
+}
+
+export function inheritWorkspaceOpencodeConnection(
+  config: Pick<ServerConfig, "opencodeBaseUrl" | "opencodeUsername" | "opencodePassword">,
+): Pick<WorkspaceInfo, "baseUrl" | "opencodeUsername" | "opencodePassword"> {
+  const baseUrl = trim(config.opencodeBaseUrl);
+  const username = trim(config.opencodeUsername);
+  const password = trim(config.opencodePassword);
+
+  return {
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(username ? { opencodeUsername: username } : {}),
+    ...(password ? { opencodePassword: password } : {}),
+  };
+}

--- a/apps/server/src/opencode-db.test.ts
+++ b/apps/server/src/opencode-db.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, mkdir } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Database } from "bun:sqlite";
 
-import { seedOpencodeSessionMessages } from "./opencode-db.js";
+import { resolveOpencodeDbPath, seedOpencodeSessionMessages } from "./opencode-db.js";
 
 async function createDb(): Promise<{ path: string; dispose: () => void }> {
   const dir = await mkdtemp(join(tmpdir(), "openwork-opencode-db-"));
@@ -71,10 +71,17 @@ describe("seedOpencodeSessionMessages", () => {
     const decoded = rows.map((row) => JSON.parse(row.data) as Record<string, unknown>);
     expect(decoded[0]?.role).toBe("assistant");
     expect(decoded[0]?.parentID).toBe(rows[0]?.id);
+    expect(decoded[0]?.modelID).toBe("gpt-5.4");
+    expect(decoded[0]?.providerID).toBe("openai");
     expect(decoded[1]?.role).toBe("user");
+    expect(decoded[1]?.summary).toEqual({ diffs: [] });
     expect(decoded[2]?.role).toBe("assistant");
     expect(decoded[2]?.parentID).toBe(rows[1]?.id);
-    expect(parts.map((row) => JSON.parse(row.data).text)).toEqual(["Welcome", "Help me start", "Sure"]);
+    expect(parts.map((row) => JSON.parse(row.data))).toEqual([
+      { type: "text", text: "Welcome" },
+      { type: "text", text: "Help me start" },
+      { type: "text", text: "Sure" },
+    ]);
     expect(session.time_updated).toBe(1700000000003);
   });
 
@@ -95,5 +102,63 @@ describe("seedOpencodeSessionMessages", () => {
 
     expect(first.skipped).toBe(false);
     expect(second).toEqual({ inserted: 0, skipped: true });
+  });
+});
+
+describe("resolveOpencodeDbPath", () => {
+  test("prefers an existing XDG opencode.db when present", async () => {
+    const xdg = await mkdtemp(join(tmpdir(), "openwork-opencode-xdg-"));
+    const dir = join(xdg, "opencode");
+    const file = join(dir, "opencode.db");
+    await mkdir(dir, { recursive: true });
+    await writeFile(file, "", "utf8");
+
+    const previousXdg = process.env.XDG_DATA_HOME;
+    const previousChannel = process.env.OPENCODE_CHANNEL;
+    const previousDb = process.env.OPENCODE_DB;
+    try {
+      process.env.XDG_DATA_HOME = xdg;
+      process.env.OPENCODE_CHANNEL = "local";
+      delete process.env.OPENCODE_DB;
+
+      expect(resolveOpencodeDbPath()).toBe(file);
+    } finally {
+      if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = previousXdg;
+      if (previousChannel === undefined) delete process.env.OPENCODE_CHANNEL;
+      else process.env.OPENCODE_CHANNEL = previousChannel;
+      if (previousDb === undefined) delete process.env.OPENCODE_DB;
+      else process.env.OPENCODE_DB = previousDb;
+    }
+  });
+
+  test("finds orchestrator-managed OpenCode dbs under OPENWORK_DATA_DIR", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-orchestrator-data-"));
+    const dir = join(root, "opencode-dev", "ws-test", "xdg", "data", "opencode");
+    const file = join(dir, "opencode.db");
+    await mkdir(dir, { recursive: true });
+    await writeFile(file, "", "utf8");
+
+    const previousDataDir = process.env.OPENWORK_DATA_DIR;
+    const previousXdg = process.env.XDG_DATA_HOME;
+    const previousChannel = process.env.OPENCODE_CHANNEL;
+    const previousDb = process.env.OPENCODE_DB;
+    try {
+      process.env.OPENWORK_DATA_DIR = root;
+      delete process.env.XDG_DATA_HOME;
+      process.env.OPENCODE_CHANNEL = "local";
+      delete process.env.OPENCODE_DB;
+
+      expect(resolveOpencodeDbPath()).toBe(file);
+    } finally {
+      if (previousDataDir === undefined) delete process.env.OPENWORK_DATA_DIR;
+      else process.env.OPENWORK_DATA_DIR = previousDataDir;
+      if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = previousXdg;
+      if (previousChannel === undefined) delete process.env.OPENCODE_CHANNEL;
+      else process.env.OPENCODE_CHANNEL = previousChannel;
+      if (previousDb === undefined) delete process.env.OPENCODE_DB;
+      else process.env.OPENCODE_DB = previousDb;
+    }
   });
 });

--- a/apps/server/src/opencode-db.test.ts
+++ b/apps/server/src/opencode-db.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Database } from "bun:sqlite";
+
+import { seedOpencodeSessionMessages } from "./opencode-db.js";
+
+async function createDb(): Promise<{ path: string; dispose: () => void }> {
+  const dir = await mkdtemp(join(tmpdir(), "openwork-opencode-db-"));
+  await mkdir(dir, { recursive: true });
+  const dbPath = join(dir, "opencode-test.db");
+  const db = new Database(dbPath);
+  db.exec(`
+    create table session (
+      id text primary key,
+      time_updated integer
+    );
+    create table message (
+      id text primary key,
+      session_id text not null,
+      time_created integer,
+      time_updated integer,
+      data text not null
+    );
+    create table part (
+      id text primary key,
+      message_id text not null,
+      session_id text not null,
+      time_created integer,
+      time_updated integer,
+      data text not null
+    );
+    insert into session (id, time_updated) values ('ses_test123', 1);
+  `);
+  db.close();
+  return {
+    path: dbPath,
+    dispose: () => new Database(dbPath).close(),
+  };
+}
+
+describe("seedOpencodeSessionMessages", () => {
+  test("writes seeded transcript messages into the OpenCode db", async () => {
+    const fixture = await createDb();
+    const result = seedOpencodeSessionMessages({
+      dbPath: fixture.path,
+      sessionId: "ses_test123",
+      workspaceRoot: "/tmp/workspace",
+      now: 1700000000000,
+      messages: [
+        { role: "assistant", text: "Welcome" },
+        { role: "user", text: "Help me start" },
+        { role: "assistant", text: "Sure" },
+      ],
+    });
+
+    expect(result).toEqual({ inserted: 3, skipped: false });
+
+    const db = new Database(fixture.path, { readonly: true });
+    const rows = db.query("select id, session_id, data from message order by time_created asc").all() as Array<{
+      id: string;
+      session_id: string;
+      data: string;
+    }>;
+    const parts = db.query("select data from part order by time_created asc").all() as Array<{ data: string }>;
+    const session = db.query("select time_updated from session where id = 'ses_test123'").get() as { time_updated: number };
+    db.close();
+
+    const decoded = rows.map((row) => JSON.parse(row.data) as Record<string, unknown>);
+    expect(decoded[0]?.role).toBe("assistant");
+    expect(decoded[0]?.parentID).toBe(rows[0]?.id);
+    expect(decoded[1]?.role).toBe("user");
+    expect(decoded[2]?.role).toBe("assistant");
+    expect(decoded[2]?.parentID).toBe(rows[1]?.id);
+    expect(parts.map((row) => JSON.parse(row.data).text)).toEqual(["Welcome", "Help me start", "Sure"]);
+    expect(session.time_updated).toBe(1700000000003);
+  });
+
+  test("does not seed a session twice", async () => {
+    const fixture = await createDb();
+    const first = seedOpencodeSessionMessages({
+      dbPath: fixture.path,
+      sessionId: "ses_test123",
+      workspaceRoot: "/tmp/workspace",
+      messages: [{ role: "assistant", text: "Welcome" }],
+    });
+    const second = seedOpencodeSessionMessages({
+      dbPath: fixture.path,
+      sessionId: "ses_test123",
+      workspaceRoot: "/tmp/workspace",
+      messages: [{ role: "assistant", text: "Welcome again" }],
+    });
+
+    expect(first.skipped).toBe(false);
+    expect(second).toEqual({ inserted: 0, skipped: true });
+  });
+});

--- a/apps/server/src/opencode-db.ts
+++ b/apps/server/src/opencode-db.ts
@@ -1,0 +1,161 @@
+import { randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import { Database } from "bun:sqlite";
+
+type SeedMessage = {
+  role: "assistant" | "user";
+  text: string;
+};
+
+function truthy(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function opencodeDataDir(): string {
+  const xdg = process.env.XDG_DATA_HOME?.trim();
+  if (xdg) return join(xdg, "opencode");
+  if (process.platform === "darwin") return join(homedir(), "Library", "Application Support", "opencode");
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA?.trim();
+    if (appData) return join(appData, "opencode");
+  }
+  return join(homedir(), ".local", "share", "opencode");
+}
+
+export function resolveOpencodeDbPath(): string {
+  const override = process.env.OPENCODE_DB?.trim();
+  if (override) return isAbsolute(override) ? override : join(opencodeDataDir(), override);
+
+  const channel = process.env.OPENCODE_CHANNEL?.trim() || "local";
+  if (channel === "latest" || channel === "beta" || truthy(process.env.OPENCODE_DISABLE_CHANNEL_DB)) {
+    return join(opencodeDataDir(), "opencode.db");
+  }
+
+  return join(opencodeDataDir(), `opencode-${channel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`);
+}
+
+function randomBase62(length: number): string {
+  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  const bytes = randomBytes(length);
+  let output = "";
+  for (let index = 0; index < length; index += 1) {
+    output += chars[bytes[index]! % 62];
+  }
+  return output;
+}
+
+function ascendingId(prefix: "msg" | "prt", timestamp: number, counter: number): string {
+  const now = BigInt(timestamp) * 0x1000n + BigInt(counter);
+  const bytes = Buffer.alloc(6);
+  for (let index = 0; index < 6; index += 1) {
+    bytes[index] = Number((now >> BigInt(40 - 8 * index)) & 0xffn);
+  }
+  return `${prefix}_${bytes.toString("hex")}${randomBase62(14)}`;
+}
+
+export function seedOpencodeSessionMessages(input: {
+  sessionId: string;
+  workspaceRoot: string;
+  messages: SeedMessage[];
+  dbPath?: string;
+  now?: number;
+}): { inserted: number; skipped: boolean } {
+  const sessionId = input.sessionId.trim();
+  if (!sessionId) {
+    throw new Error("sessionId is required");
+  }
+
+  const messages = input.messages.filter((item) => item.text.trim());
+  if (!messages.length) {
+    return { inserted: 0, skipped: true };
+  }
+
+  const dbPath = input.dbPath?.trim() || resolveOpencodeDbPath();
+  if (!existsSync(dbPath)) {
+    throw new Error(`OpenCode database not found at ${dbPath}`);
+  }
+
+  const db = new Database(dbPath);
+  db.exec("PRAGMA foreign_keys = ON");
+
+  try {
+    const run = db.transaction(() => {
+      const session = db.query("select id from session where id = ?1").get(sessionId);
+      if (!session) {
+        throw new Error(`OpenCode session not found: ${sessionId}`);
+      }
+
+      const existing = db.query("select count(1) as count from message where session_id = ?1").get(sessionId) as { count?: number } | null;
+      if ((existing?.count ?? 0) > 0) {
+        return { inserted: 0, skipped: true };
+      }
+
+      const insertMessage = db.prepare(
+        "insert into message (id, session_id, time_created, time_updated, data) values (?1, ?2, ?3, ?4, ?5)",
+      );
+      const insertPart = db.prepare(
+        "insert into part (id, message_id, session_id, time_created, time_updated, data) values (?1, ?2, ?3, ?4, ?5, ?6)",
+      );
+      const updateSession = db.prepare("update session set time_updated = ?2 where id = ?1");
+
+      const startedAt = input.now ?? Date.now();
+      let counter = 0;
+      let lastUserId: string | null = null;
+
+      messages.forEach((item, index) => {
+        const createdAt = startedAt + index;
+        counter += 1;
+        const messageId = ascendingId("msg", createdAt, counter);
+        counter += 1;
+        const partId = ascendingId("prt", createdAt, counter);
+
+        const messageData =
+          item.role === "user"
+            ? {
+                role: "user",
+                time: { created: createdAt },
+                agent: "",
+                model: { providerID: "", modelID: "" },
+              }
+            : {
+                role: "assistant",
+                time: { created: createdAt, completed: createdAt },
+                parentID: lastUserId ?? messageId,
+                modelID: "",
+                providerID: "",
+                mode: "",
+                agent: "",
+                path: { cwd: input.workspaceRoot, root: input.workspaceRoot },
+                cost: 0,
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              };
+
+        insertMessage.run(messageId, sessionId, createdAt, createdAt, JSON.stringify(messageData));
+        insertPart.run(
+          partId,
+          messageId,
+          sessionId,
+          createdAt,
+          createdAt,
+          JSON.stringify({ type: "text", text: item.text.trim(), synthetic: true, time: { start: createdAt, end: createdAt } }),
+        );
+
+        if (item.role === "user") {
+          lastUserId = messageId;
+        }
+      });
+
+      updateSession.run(sessionId, startedAt + messages.length);
+      return { inserted: messages.length, skipped: false };
+    });
+
+    return run();
+  } finally {
+    db.close();
+  }
+}

--- a/apps/server/src/opencode-db.ts
+++ b/apps/server/src/opencode-db.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
@@ -10,33 +10,101 @@ type SeedMessage = {
   text: string;
 };
 
+const DEFAULT_AGENT = "openwork";
+const DEFAULT_PROVIDER = "openai";
+const DEFAULT_MODEL = "gpt-5.4";
+
 function truthy(value: string | undefined): boolean {
   if (!value) return false;
   const normalized = value.trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-function opencodeDataDir(): string {
+function opencodeOrchestratorDataDirs(): string[] {
+  const root = process.env.OPENWORK_DATA_DIR?.trim();
+  if (!root) return [];
+
+  const base = join(root, "opencode-dev");
+  const dirs: string[] = [];
+  const pushIfExists = (dir: string) => {
+    if (existsSync(dir)) dirs.push(dir);
+  };
+
+  pushIfExists(join(base, "xdg", "data", "opencode"));
+  if (!existsSync(base)) return dirs;
+
+  for (const entry of readdirSync(base, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    pushIfExists(join(base, entry.name, "xdg", "data", "opencode"));
+  }
+
+  return dirs;
+}
+
+function opencodeDataDirs(): string[] {
+  const dirs: string[] = [];
+  dirs.push(...opencodeOrchestratorDataDirs());
   const xdg = process.env.XDG_DATA_HOME?.trim();
-  if (xdg) return join(xdg, "opencode");
-  if (process.platform === "darwin") return join(homedir(), "Library", "Application Support", "opencode");
+  if (xdg) dirs.push(join(xdg, "opencode"));
+  dirs.push(join(homedir(), ".local", "share", "opencode"));
+  if (process.platform === "darwin") dirs.push(join(homedir(), "Library", "Application Support", "opencode"));
   if (process.platform === "win32") {
     const appData = process.env.APPDATA?.trim();
-    if (appData) return join(appData, "opencode");
+    if (appData) dirs.push(join(appData, "opencode"));
   }
-  return join(homedir(), ".local", "share", "opencode");
+  return Array.from(new Set(dirs));
+}
+
+function preferredDbNames(): string[] {
+  const channel = process.env.OPENCODE_CHANNEL?.trim() || "local";
+  return channel === "latest" || channel === "beta" || truthy(process.env.OPENCODE_DISABLE_CHANNEL_DB)
+    ? ["opencode.db"]
+    : [`opencode-${channel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`, "opencode.db"];
+}
+
+function candidateOpencodeDbPaths(): string[] {
+  const override = process.env.OPENCODE_DB?.trim();
+  if (override) {
+    if (isAbsolute(override)) return [override];
+    const candidates: string[] = [];
+    for (const dir of opencodeDataDirs()) {
+      candidates.push(join(dir, override));
+    }
+    candidates.push(join(opencodeDataDirs()[0] ?? join(homedir(), ".local", "share", "opencode"), override));
+    return Array.from(new Set(candidates));
+  }
+
+  const candidates: string[] = [];
+  for (const dir of opencodeDataDirs()) {
+    for (const name of preferredDbNames()) {
+      candidates.push(join(dir, name));
+    }
+  }
+
+  return Array.from(new Set(candidates));
 }
 
 export function resolveOpencodeDbPath(): string {
-  const override = process.env.OPENCODE_DB?.trim();
-  if (override) return isAbsolute(override) ? override : join(opencodeDataDir(), override);
+  const candidates = candidateOpencodeDbPaths();
+  const existing = candidates.find((candidate) => existsSync(candidate));
+  if (existing) return existing;
+  return candidates[0] ?? join(homedir(), ".local", "share", "opencode", preferredDbNames()[0] ?? "opencode.db");
+}
 
-  const channel = process.env.OPENCODE_CHANNEL?.trim() || "local";
-  if (channel === "latest" || channel === "beta" || truthy(process.env.OPENCODE_DISABLE_CHANNEL_DB)) {
-    return join(opencodeDataDir(), "opencode.db");
+function findOpencodeSessionDbPath(sessionId: string, inputPath?: string): string | null {
+  const candidates = (inputPath ? [inputPath] : candidateOpencodeDbPaths()).filter((candidate) => existsSync(candidate));
+  for (const dbPath of candidates) {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const session = db.query("select id from session where id = ?1").get(sessionId);
+      if (session) return dbPath;
+    } catch {
+      // ignore non-matching dbs
+    } finally {
+      db.close();
+    }
   }
-
-  return join(opencodeDataDir(), `opencode-${channel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`);
+  return null;
 }
 
 function randomBase62(length: number): string {
@@ -75,7 +143,8 @@ export function seedOpencodeSessionMessages(input: {
     return { inserted: 0, skipped: true };
   }
 
-  const dbPath = input.dbPath?.trim() || resolveOpencodeDbPath();
+  const explicitDbPath = input.dbPath?.trim() || undefined;
+  const dbPath = findOpencodeSessionDbPath(sessionId, explicitDbPath) || explicitDbPath || resolveOpencodeDbPath();
   if (!existsSync(dbPath)) {
     throw new Error(`OpenCode database not found at ${dbPath}`);
   }
@@ -119,17 +188,18 @@ export function seedOpencodeSessionMessages(input: {
             ? {
                 role: "user",
                 time: { created: createdAt },
-                agent: "",
-                model: { providerID: "", modelID: "" },
+                summary: { diffs: [] },
+                agent: DEFAULT_AGENT,
+                model: { providerID: DEFAULT_PROVIDER, modelID: DEFAULT_MODEL },
               }
             : {
                 role: "assistant",
                 time: { created: createdAt, completed: createdAt },
                 parentID: lastUserId ?? messageId,
-                modelID: "",
-                providerID: "",
-                mode: "",
-                agent: "",
+                modelID: DEFAULT_MODEL,
+                providerID: DEFAULT_PROVIDER,
+                mode: DEFAULT_AGENT,
+                agent: DEFAULT_AGENT,
                 path: { cwd: input.workspaceRoot, root: input.workspaceRoot },
                 cost: 0,
                 tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
@@ -142,7 +212,7 @@ export function seedOpencodeSessionMessages(input: {
           sessionId,
           createdAt,
           createdAt,
-          JSON.stringify({ type: "text", text: item.text.trim(), synthetic: true, time: { start: createdAt, end: createdAt } }),
+          JSON.stringify({ type: "text", text: item.text.trim() }),
         );
 
         if (item.role === "user") {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -33,6 +33,7 @@ import {
   sanitizeOpenworkTemplateConfig,
 } from "./blueprint-sessions.js";
 import { fetchSharedBundle, publishSharedBundle } from "./share-bundles.js";
+import { seedOpencodeSessionMessages } from "./opencode-db.js";
 import { listTemplateFiles, planTemplateFiles, writeTemplateFiles } from "./template-files.js";
 import pkg from "../package.json" with { type: "json" };
 
@@ -5275,6 +5276,11 @@ async function materializeBlueprintSessions(workspace: WorkspaceInfo): Promise<{
     if (!sessionId) {
       throw new ApiError(502, "opencode_failed", "OpenCode session did not return an id");
     }
+    seedOpencodeSessionMessages({
+      sessionId,
+      workspaceRoot: resolveOpencodeDirectory(workspace) ?? workspace.path,
+      messages: template.messages,
+    });
     created.push({ templateId: template.id, sessionId, title: template.title });
   }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -32,6 +32,7 @@ import {
   readMaterializedBlueprintSessions,
   sanitizeOpenworkTemplateConfig,
 } from "./blueprint-sessions.js";
+import { inheritWorkspaceOpencodeConnection, resolveWorkspaceOpencodeConnection } from "./opencode-connection.js";
 import { fetchSharedBundle, publishSharedBundle } from "./share-bundles.js";
 import { seedOpencodeSessionMessages } from "./opencode-db.js";
 import { listTemplateFiles, planTemplateFiles, writeTemplateFiles } from "./template-files.js";
@@ -304,7 +305,7 @@ export function startServer(config: ServerConfig) {
           const workspace = await resolveWorkspace(config, mount.workspaceId);
           proxyService = "opencode";
           proxyBaseUrl = workspace.baseUrl?.trim() || undefined;
-          const response = await proxyOpencodeRequest({ request, url, workspace, proxyPath: mount.restPath });
+          const response = await proxyOpencodeRequest({ config, request, url, workspace, proxyPath: mount.restPath });
           return finalize(response);
         } catch (error) {
           const apiError = error instanceof ApiError
@@ -367,7 +368,7 @@ export function startServer(config: ServerConfig) {
           const actor = await requireClient(request, config, tokens);
           assertOpencodeProxyAllowed(actor, request.method, url.pathname);
           proxyService = "opencode";
-          const response = await proxyOpencodeRequest({ request, url, workspace: config.workspaces[0] });
+          const response = await proxyOpencodeRequest({ config, request, url, workspace: config.workspaces[0] });
           return finalize(response);
         } catch (error) {
           const apiError = error instanceof ApiError
@@ -486,8 +487,9 @@ function buildOpencodeProxyUrl(baseUrl: string, path: string, search: string) {
   return target.toString();
 }
 
-async function fetchOpencodeJson(workspace: WorkspaceInfo, path: string, init: { method: string; body?: unknown }) {
-  const baseUrl = workspace.baseUrl?.trim() ?? "";
+async function fetchOpencodeJson(config: ServerConfig, workspace: WorkspaceInfo, path: string, init: { method: string; body?: unknown }) {
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  const baseUrl = connection.baseUrl?.trim() ?? "";
   if (!baseUrl) {
     throw new ApiError(400, "opencode_unconfigured", "OpenCode base URL is missing for this workspace");
   }
@@ -504,7 +506,7 @@ async function fetchOpencodeJson(workspace: WorkspaceInfo, path: string, init: {
     headers.set("x-opencode-directory", directory);
   }
 
-  const auth = buildOpencodeAuthHeader(workspace);
+  const auth = connection.authHeader ?? null;
   if (auth) {
     headers.set("Authorization", auth);
   }
@@ -542,13 +544,14 @@ function buildOpenCodeRouterProxyUrl(baseUrl: string, path: string, search: stri
 }
 
 async function proxyOpencodeRequest(input: {
+  config: ServerConfig;
   request: Request;
   url: URL;
   workspace?: WorkspaceInfo;
   proxyPath?: string;
 }) {
   const workspace = input.workspace;
-  const baseUrl = workspace?.baseUrl?.trim() ?? "";
+  const baseUrl = workspace ? resolveWorkspaceOpencodeConnection(input.config, workspace).baseUrl?.trim() ?? "" : "";
   if (!baseUrl) {
     throw new ApiError(400, "opencode_unconfigured", "OpenCode base URL is missing for this workspace");
   }
@@ -567,7 +570,7 @@ async function proxyOpencodeRequest(input: {
     headers.set("x-opencode-directory", directory);
   }
 
-  const auth = workspace ? buildOpencodeAuthHeader(workspace) : null;
+  const auth = workspace ? resolveWorkspaceOpencodeConnection(input.config, workspace).authHeader ?? null : null;
   if (auth) {
     headers.set("Authorization", auth);
   }
@@ -1465,6 +1468,7 @@ function createRoutes(
       path: workspacePath,
       preset,
       workspaceType: "local",
+      ...inheritWorkspaceOpencodeConnection(config),
     };
 
     config.workspaces = [workspace, ...config.workspaces.filter((entry) => entry.id !== workspace.id)];
@@ -1664,7 +1668,7 @@ function createRoutes(
     }
 
     // OpenCode session deletion via the upstream API.
-    await fetchOpencodeJson(workspace, `/session/${encodeURIComponent(sessionId)}`, {
+        await fetchOpencodeJson(config, workspace, `/session/${encodeURIComponent(sessionId)}`, {
       method: "DELETE",
     });
 
@@ -2656,7 +2660,7 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     requireClientScope(ctx, "collaborator");
 
-    await reloadOpencodeEngine(workspace);
+      await reloadOpencodeEngine(config, workspace);
 
     await recordAudit(workspace.path, {
       id: shortId(),
@@ -3562,13 +3566,13 @@ function createRoutes(
 
     // Best-effort disconnect so any active connection is torn down.
     try {
-      await fetchOpencodeJson(workspace, `/mcp/${encodeURIComponent(name)}/disconnect`, { method: "POST" });
+      await fetchOpencodeJson(config, workspace, `/mcp/${encodeURIComponent(name)}/disconnect`, { method: "POST" });
     } catch {
       // ignore
     }
 
     try {
-      await fetchOpencodeJson(workspace, `/mcp/${encodeURIComponent(name)}/auth`, { method: "DELETE" });
+      await fetchOpencodeJson(config, workspace, `/mcp/${encodeURIComponent(name)}/auth`, { method: "DELETE" });
     } catch (error) {
       // Treat missing credentials as a successful logout (idempotent).
       if (
@@ -3798,7 +3802,7 @@ function createRoutes(
     }
 
     const now = Date.now();
-    const created = await fetchOpencodeJson(workspace, "/session", {
+    const created = await fetchOpencodeJson(config, workspace, "/session", {
       method: "POST",
       body: { title: `Automation: ${automation.name}` },
     });
@@ -3807,7 +3811,7 @@ function createRoutes(
       throw new ApiError(502, "opencode_failed", "OpenCode session did not return an id");
     }
 
-    await fetchOpencodeJson(workspace, `/session/${encodeURIComponent(sessionId)}/prompt_async`, {
+    await fetchOpencodeJson(config, workspace, `/session/${encodeURIComponent(sessionId)}/prompt_async`, {
       method: "POST",
       body: {
         parts: [{ type: "text", text: automation.prompt }],
@@ -3941,7 +3945,7 @@ function createRoutes(
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    const result = await materializeBlueprintSessions(workspace);
+    const result = await materializeBlueprintSessions(config, workspace);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
@@ -5078,13 +5082,6 @@ function buildOpencodeReloadUrl(baseUrl: string, directory?: string | null): str
   }
 }
 
-function buildOpencodeAuthHeader(workspace: WorkspaceInfo): string | null {
-  const username = workspace.opencodeUsername?.trim() ?? "";
-  const password = workspace.opencodePassword?.trim() ?? "";
-  if (!username || !password) return null;
-  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
-}
-
 function parseOpencodeErrorBody(input: string): unknown {
   const trimmed = input.trim();
   if (!trimmed) return null;
@@ -5095,8 +5092,9 @@ function parseOpencodeErrorBody(input: string): unknown {
   }
 }
 
-async function reloadOpencodeEngine(workspace: WorkspaceInfo): Promise<void> {
-  const baseUrl = workspace.baseUrl?.trim() ?? "";
+async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceInfo): Promise<void> {
+  const connection = resolveWorkspaceOpencodeConnection(config, workspace);
+  const baseUrl = connection.baseUrl?.trim() ?? "";
   if (!baseUrl) {
     throw new ApiError(400, "opencode_unconfigured", "OpenCode base URL is missing for this workspace");
   }
@@ -5104,7 +5102,7 @@ async function reloadOpencodeEngine(workspace: WorkspaceInfo): Promise<void> {
   const directory = resolveOpencodeDirectory(workspace);
   const targetUrl = buildOpencodeReloadUrl(baseUrl, directory);
   const headers: Record<string, string> = {};
-  const auth = buildOpencodeAuthHeader(workspace);
+  const auth = connection.authHeader ?? null;
   if (auth) headers.Authorization = auth;
 
   const response = await fetch(targetUrl, { method: "POST", headers });
@@ -5245,7 +5243,7 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
   }
 }
 
-async function materializeBlueprintSessions(workspace: WorkspaceInfo): Promise<{
+async function materializeBlueprintSessions(config: ServerConfig, workspace: WorkspaceInfo): Promise<{
   ok: boolean;
   created: Array<{ templateId: string; sessionId: string; title: string }>;
   existing: Array<{ templateId: string; sessionId: string }>;
@@ -5268,7 +5266,7 @@ async function materializeBlueprintSessions(workspace: WorkspaceInfo): Promise<{
 
   const created: Array<{ templateId: string; sessionId: string; title: string }> = [];
   for (const template of templates) {
-    const result = await fetchOpencodeJson(workspace, "/session", {
+    const result = await fetchOpencodeJson(config, workspace, "/session", {
       method: "POST",
       body: template.title ? { title: template.title } : undefined,
     });

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -77,6 +77,10 @@ export interface ServerConfig {
   token: string;
   hostToken: string;
   configPath?: string;
+  opencodeBaseUrl?: string;
+  opencodeDirectory?: string;
+  opencodeUsername?: string;
+  opencodePassword?: string;
   approval: ApprovalConfig;
   corsOrigins: string[];
   workspaces: WorkspaceInfo[];

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -143,6 +143,13 @@ function buildDefaultWorkspaceBlueprint(_preset: string): Record<string, unknown
       body: "Pick a starting point or just type below.",
       starters: [
         {
+          id: "csv-help",
+          kind: "prompt",
+          title: "Work on a CSV",
+          description: "Clean up or generate spreadsheet data.",
+          prompt: "Help me create or edit CSV files on this computer.",
+        },
+        {
           id: "starter-connect-openai",
           kind: "action",
           title: "Connect ChatGPT",
@@ -150,11 +157,11 @@ function buildDefaultWorkspaceBlueprint(_preset: string): Record<string, unknown
           action: "connect-openai",
         },
         {
-          id: "starter-browser",
+          id: "browser-automation",
           kind: "session",
-          title: "Automate your browser",
-          description: "Set up browser actions and run reliable web tasks from OpenWork.",
-          prompt: "Set up browser actions and show me how to automate repetitive work in OpenWork.",
+          title: "Automate Chrome",
+          description: "Start a browser automation conversation right away.",
+          prompt: "Help me connect to Chrome and automate a repetitive task.",
         },
       ],
     },
@@ -167,7 +174,21 @@ function buildDefaultWorkspaceBlueprint(_preset: string): Record<string, unknown
           {
             role: "assistant",
             text:
-              "Hi welcome to OpenWork!\n\nPeople use us to write .csv files on their computer, connect to their chrome and automate repetitive tasks, sync contacts to notion.\n\nBut the only limit is your imagniation.\n\nWhat would you want to do?",
+              "Hi welcome to OpenWork!\n\nPeople use us to write .csv files on their computer, connect to Chrome and automate repetitive tasks, and sync contacts to Notion.\n\nBut the only limit is your imagination.\n\nWhat would you want to do?",
+          },
+        ],
+      },
+      {
+        id: "csv-playbook",
+        title: "CSV workflow ideas",
+        messages: [
+          {
+            role: "assistant",
+            text: "I can help you generate, clean, merge, and summarize CSV files. What kind of CSV work do you want to automate?",
+          },
+          {
+            role: "user",
+            text: "I want to combine exports from multiple tools into one clean CSV.",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- persist blueprint welcome/session seed messages into the OpenCode session database during OpenWork server materialization instead of relying only on UI-only synthetic messages
- make the app materialization flow more resilient by switching into the session view, ignoring stale sessions from other workspace roots, and keeping a local fallback map for newly materialized seed messages
- add focused regression coverage for seeded OpenCode DB writes so welcome sessions are idempotent and survive reloads

## Testing
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server test -- src/blueprint-sessions.test.ts src/opencode-db.test.ts src/template-files.test.ts src/share-bundles.test.ts src/portable-opencode.test.ts`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwork-server build:bin`

## Notes
- I did not run the full Docker + Chrome MCP flow here, so this still needs an end-to-end desktop pass to confirm the seeded welcome message appears in a freshly created workspace.