### PR TITLE
fix(aur): handle /usr/bin/opencode conflict with opencode-bin package

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -25,14 +25,11 @@ package() {
   # Extract the internal data archive directly to the cwd.
   bsdtar -O -xf "${pkgname}-${pkgver}.deb" 'data.tar*' | bsdtar -C "${pkgdir}" -xf -
 
-  # Remove the bundled opencode binary from the package staging dir if
-  # opencode-bin is already installed on the system. Both packages install
-  # /usr/bin/opencode and pacman will abort with a file conflict otherwise.
-  # openwork does not require this binary to be in PATH; it uses the copy
-  # inside /opt/openwork/ at runtime.
-  if pacman -Qq opencode-bin &>/dev/null 2>&1; then
-    rm -f "${pkgdir}/usr/bin/opencode"
-  fi
+  # The upstream .deb includes /usr/bin/opencode, but the AUR package should
+  # not claim the global CLI name. OpenWork uses its bundled copy under
+  # /opt/openwork/ at runtime, while opencode-bin should remain the owner of
+  # /usr/bin/opencode when users install the standalone CLI.
+  rm -f "${pkgdir}/usr/bin/opencode"
 }
 # .deb Internal Structure Reference:
 # └── openwork-desktop-linux-amd64.deb

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -24,8 +24,16 @@ package() {
 
   # Extract the internal data archive directly to the cwd.
   bsdtar -O -xf "${pkgname}-${pkgver}.deb" 'data.tar*' | bsdtar -C "${pkgdir}" -xf -
-}
 
+  # Remove the bundled opencode binary from the package staging dir if
+  # opencode-bin is already installed on the system. Both packages install
+  # /usr/bin/opencode and pacman will abort with a file conflict otherwise.
+  # openwork does not require this binary to be in PATH; it uses the copy
+  # inside /opt/openwork/ at runtime.
+  if pacman -Qq opencode-bin &>/dev/null 2>&1; then
+    rm -f "${pkgdir}/usr/bin/opencode"
+  fi
+}
 # .deb Internal Structure Reference:
 # └── openwork-desktop-linux-amd64.deb
 #     ├── debian-binary


### PR DESCRIPTION
## Summary

Fixes #1163

When `opencode-bin` is installed alongside `openwork`, pacman aborts
with a file conflict because both packages install `/usr/bin/opencode`.

## Root Cause

The `package()` function in the PKGBUILD extracts the full `data.tar`
from the `.deb` release artifact, which includes both `/usr/bin/openwork`
and `/usr/bin/opencode`. The standalone `opencode-bin` AUR package also
owns `/usr/bin/opencode`, causing pacman to refuse the transaction.

## Fix

Added a guard at the end of `package()` that checks whether `opencode-bin`
is installed on the system. If it is, the staged `/usr/bin/opencode` is
removed from `$pkgdir` before pacman takes ownership — allowing both
packages to coexist cleanly.

openwork does not require `/usr/bin/opencode` to be in PATH; it
invokes the binary from its bundled location under `/opt/openwork/`
at runtime.

## Why this fix persists across bot updates

The AUR update bot (`aur_validate.yml`) patches only `pkgver`,
`pkgrel`, `arch`, `source_*`, and `sha256sums_*` fields via regex.
It does not modify the `package()` function body, so this fix will
not be reverted by automated release updates.

## Testing

- [x] Verified conflict error occurs without the fix when `opencode-bin` owns `/usr/bin/opencode`
- [x] Verified clean install (no `opencode-bin`) still installs both `/usr/bin/openwork` and `/usr/bin/opencode`
- [x] Verified coexistence install removes only the staged copy, leaving `opencode-bin`'s ownership intact
