### PR TITLE
Fix local workspace bootstrap initialization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,7 @@ Guidelines:
 - Local Tauri filesystem commands are a host-mode fallback, not the primary product surface.
 - If a feature cannot yet write through the OpenWork server, treat that as an architecture gap and close it before depending on direct local writes.
 - Reads can fall back locally when necessary, but writes should be designed around the OpenWork server path.
+- Local workspace bootstrap follows the same rule: starter and newly created local workspaces should be initialized through the OpenWork server contract, with Tauri only responsible for remembering/selecting the folder.
 
 ## Agent authority map
 

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -742,6 +742,16 @@ export function createWorkspaceStore(options: {
     return client;
   };
 
+  const waitForConnectedOpenworkServer = async (timeoutMs = 5000, pollMs = 100) => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const client = resolveConnectedOpenworkServer();
+      if (client) return client;
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+    return null;
+  };
+
   const resolveActiveOpenworkWorkspace = () => {
     const client = resolveConnectedOpenworkServer();
     const workspaceId = options.runtimeWorkspaceId?.()?.trim() ?? "";
@@ -1727,7 +1737,6 @@ export function createWorkspaceStore(options: {
 
   const activateFreshLocalWorkspace = async (workspaceId: string | null, workspacePath: string) => {
     if (!workspaceId) {
-      await openEmptySession(workspacePath);
       return true;
     }
 
@@ -1740,7 +1749,6 @@ export function createWorkspaceStore(options: {
       return false;
     }
 
-    await openEmptySession(selectedWorkspaceRoot().trim() || workspacePath);
     return true;
   };
 
@@ -1796,6 +1804,31 @@ export function createWorkspaceStore(options: {
       if (!opened) {
         return false;
       }
+
+      if (!openworkServer) {
+        const connectedOpenworkServer = await waitForConnectedOpenworkServer();
+        if (!connectedOpenworkServer) {
+          throw new Error("OpenWork server did not become ready after starting the local worker.");
+        }
+
+        const synced = await connectedOpenworkServer.createLocalWorkspace({
+          folderPath: resolvedFolder,
+          name,
+          preset,
+        });
+        const syncedSelectedId = pickSelectedWorkspaceId(
+          synced.workspaces,
+          [nextSelectedId, resolveWorkspaceListSelectedId(synced)],
+          synced,
+        );
+        applyServerLocalWorkspaces(synced.workspaces, syncedSelectedId);
+        if (syncedSelectedId) {
+          syncSelectedWorkspaceId(syncedSelectedId);
+          updateWorkspaceConnectionState(syncedSelectedId, { status: "connected", message: null });
+        }
+      }
+
+      await openEmptySession(selectedWorkspaceRoot().trim() || resolvedFolder);
 
       markOnboardingComplete();
 

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -6,7 +6,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::types::{
     ExecResult, RemoteType, WorkspaceInfo, WorkspaceList, WorkspaceOpenworkConfig, WorkspaceType,
 };
-use crate::workspace::files::ensure_workspace_files;
 use crate::workspace::state::{
     load_workspace_state, normalize_local_workspace_path, save_workspace_state,
     stable_workspace_id, stable_workspace_id_for_openwork, stable_workspace_id_for_remote,
@@ -248,8 +247,6 @@ pub fn workspace_create(
     folder = normalize_local_workspace_path(&folder);
 
     let id = stable_workspace_id(&folder);
-
-    ensure_workspace_files(&folder, &preset)?;
 
     let mut state = load_workspace_state(&app)?;
 

--- a/apps/desktop/src-tauri/src/workspace/mod.rs
+++ b/apps/desktop/src-tauri/src/workspace/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+#[allow(dead_code)]
 pub mod files;
 pub mod state;
 pub mod watch;

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -136,6 +136,12 @@ type WorkspaceOpenworkConfig = {
   } | null;
 };
 
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 function buildDefaultWorkspaceBlueprint(_preset: string): Record<string, unknown> {
   return {
     emptyState: {
@@ -303,20 +309,44 @@ async function ensureOpencodeConfig(workspaceRoot: string, preset: string): Prom
   await writeJsoncFile(path, next);
 }
 
+async function readWorkspaceOpenworkConfig(workspaceRoot: string): Promise<Record<string, unknown>> {
+  const path = openworkConfigPath(workspaceRoot);
+  if (!(await exists(path))) return {};
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+  } catch {
+    throw new ApiError(422, "invalid_json", "Failed to parse openwork.json");
+  }
+}
+
 async function ensureWorkspaceOpenworkConfig(workspaceRoot: string, preset: string): Promise<void> {
   const path = openworkConfigPath(workspaceRoot);
-  if (await exists(path)) return;
   const now = Date.now();
+  const existing = await readWorkspaceOpenworkConfig(workspaceRoot);
+  const existingWorkspace = readRecord(existing.workspace);
+  const existingBlueprint = readRecord(existing.blueprint);
   const config: WorkspaceOpenworkConfig = {
-    version: 1,
+    ...(existing as WorkspaceOpenworkConfig),
+    version: typeof existing.version === "number" && Number.isFinite(existing.version) ? existing.version : 1,
     workspace: {
-      name: basename(workspaceRoot) || "Workspace",
-      createdAt: now,
-      preset,
+      name:
+        typeof existingWorkspace?.name === "string" && existingWorkspace.name.trim()
+          ? existingWorkspace.name
+          : basename(workspaceRoot) || "Workspace",
+      createdAt:
+        typeof existingWorkspace?.createdAt === "number"
+          ? existingWorkspace.createdAt
+          : now,
+      preset:
+        typeof existingWorkspace?.preset === "string" && existingWorkspace.preset.trim()
+          ? existingWorkspace.preset
+          : preset,
     },
-    authorizedRoots: [workspaceRoot],
-    blueprint: buildDefaultWorkspaceBlueprint(preset),
-    reload: null,
+    authorizedRoots: Array.isArray(existing.authorizedRoots) && existing.authorizedRoots.length > 0
+      ? existing.authorizedRoots
+      : [workspaceRoot],
+    blueprint: existingBlueprint ?? buildDefaultWorkspaceBlueprint(preset),
+    reload: existing.reload ?? null,
   };
   await ensureDir(join(workspaceRoot, ".opencode"));
   await writeFile(path, JSON.stringify(config, null, 2) + "\n", "utf8");


### PR DESCRIPTION
## Summary
- route first-run local workspace bootstrap back through the OpenWork server so starter and fallback-created local workspaces get the same server-owned filesystem initialization
- merge blueprint defaults into existing `.opencode/openwork.json` files instead of skipping initialization when the file already exists for other reasons
- stop the desktop workspace create command from pre-seeding files so Tauri only records the folder while the server owns the bootstrap contract

## Before
- fresh installs could fall back to the desktop `workspaceCreate` path before a local OpenWork server existed
- that path wrote local workspace files directly, but it did not write the server blueprint session contract
- when the workspace later connected, the starter worker could show stale/empty state instead of materializing `Welcome to OpenWork` and `CSV workflow ideas`

## Expected
- starter bootstrap should create the starter folder, connect the local worker, then let the OpenWork server initialize the workspace contents
- creating any new local workspace should follow the same contract and materialize the onboarding sessions inside that workspace

## Current behavior after this patch
- the app waits for the local OpenWork server after fallback host start, then calls `POST /workspaces/local` to let the server initialize the selected folder
- the server now backfills missing workspace metadata, authorized roots, and blueprint sessions even when `.opencode/openwork.json` already exists
- local starter and newly created workspaces both materialize the two onboarding sessions through the same server-owned flow

## Validation
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server build`
- `pnpm --filter openwork-server build:bin`
- `OPENWORK_SIDECAR_FORCE_BUILD=1 pnpm --filter @openwork/desktop run prepare:sidecar`
- `pnpm --filter @openwork/desktop build`
- source runtime smoke: started `bun apps/orchestrator/src/cli.ts serve ... --openwork-server-bin apps/server/dist/bin/openwork-server` and verified both `starter` and `minimal` workspace creation returned the blueprint session templates and materialized 2 sessions each
- built runtime smoke: started `apps/desktop/src-tauri/sidecars/openwork-orchestrator-bun-darwin-arm64 serve ... --openwork-server-bin apps/desktop/src-tauri/sidecars/openwork-server-bun-darwin-arm64` and verified the same materialization behavior in the built runtime path

## Screenshots
- I attempted desktop screenshots, but this environment kept unrelated windows in front of the OpenWork window, so I do not have a clean artifact worth attaching.