### PR TITLE
Isolate managed OpenCode state and reset paths

### DIFF
--- a/apps/app/src/app/lib/tauri.ts
+++ b/apps/app/src/app/lib/tauri.ts
@@ -431,8 +431,8 @@ export async function appBuildInfo(): Promise<AppBuildInfo> {
   return invoke<AppBuildInfo>("app_build_info");
 }
 
-export async function nukeOpencodeDevConfigAndExit(): Promise<void> {
-  return invoke<void>("nuke_opencode_dev_config_and_exit");
+export async function nukeOpenworkAndOpencodeConfigAndExit(): Promise<void> {
+  return invoke<void>("nuke_openwork_and_opencode_config_and_exit");
 }
 
 export type OrchestratorDetachedHost = {

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -83,7 +83,7 @@ import type {
 import {
   appBuildInfo,
   engineRestart,
-  nukeOpencodeDevConfigAndExit,
+  nukeOpenworkAndOpencodeConfigAndExit,
   opencodeRouterRestart,
   opencodeRouterStop,
   openworkServerRestart,
@@ -1106,8 +1106,8 @@ export default function SettingsView(props: SettingsViewProps) {
   >(null);
   const [sandboxProbeResult, setSandboxProbeResult] =
     createSignal<SandboxDebugProbeResult | null>(null);
-  const [nukeDevConfigBusy, setNukeDevConfigBusy] = createSignal(false);
-  const [nukeDevConfigStatus, setNukeDevConfigStatus] = createSignal<
+  const [nukeConfigBusy, setNukeConfigBusy] = createSignal(false);
+  const [nukeConfigStatus, setNukeConfigStatus] = createSignal<
     string | null
   >(null);
   const [debugDeepLinkOpen, setDebugDeepLinkOpen] = createSignal(false);
@@ -1330,30 +1330,32 @@ export default function SettingsView(props: SettingsViewProps) {
     }
   };
 
-  const handleNukeOpencodeDevConfig = async () => {
-    if (!isTauriRuntime() || !opencodeDevModeEnabled() || nukeDevConfigBusy())
-      return;
+  const handleNukeOpenworkAndOpencodeConfig = async () => {
+    if (!isTauriRuntime() || nukeConfigBusy()) return;
+    const devMode = opencodeDevModeEnabled();
     const confirmed =
       typeof window === "undefined"
         ? true
         : window.confirm(
-            "Delete the isolated OpenCode dev config and auth/data state, then quit OpenWork? This only affects dev-mode state.",
+            devMode
+              ? "This is irreversible. It WILL delete all OpenWork data for this dev build and all isolated OpenCode dev config, auth, cache, data, and state, then quit OpenWork. Continue?"
+              : "This is irreversible. It WILL delete all OpenWork data for this production build and all standard OpenCode config, auth, cache, data, and state, then quit OpenWork. Continue?",
           );
     if (!confirmed) return;
-    setNukeDevConfigBusy(true);
-    setNukeDevConfigStatus(null);
+    setNukeConfigBusy(true);
+    setNukeConfigStatus(null);
     try {
-      await nukeOpencodeDevConfigAndExit();
-      setNukeDevConfigStatus(
-        "Removed OpenCode dev state. OpenWork is closing...",
+      await nukeOpenworkAndOpencodeConfigAndExit();
+      setNukeConfigStatus(
+        "Removed OpenWork and OpenCode state. OpenWork is closing...",
       );
     } catch (error) {
-      setNukeDevConfigStatus(
+      setNukeConfigStatus(
         error instanceof Error
           ? error.message
-          : "Failed to nuke OpenCode dev config.",
+          : "Failed to remove OpenWork and OpenCode state.",
       );
-      setNukeDevConfigBusy(false);
+      setNukeConfigBusy(false);
     }
   };
 
@@ -2322,95 +2324,72 @@ export default function SettingsView(props: SettingsViewProps) {
                     : "Enable this to access the Developer panel."}
                 </div>
               </div>
-              <Show when={isTauriRuntime() && opencodeDevModeEnabled()}>
-                <div class="pt-1 flex flex-wrap items-center gap-3">
-                  <button
-                    type="button"
-                    class={compactDangerActionClass}
-                    onClick={() => void handleNukeOpencodeDevConfig()}
-                    disabled={props.busy || nukeDevConfigBusy()}
-                  >
-                    <CircleAlert size={14} />
-                    {nukeDevConfigBusy()
-                      ? "Nuking OpenCode Dev Config..."
-                      : "Nuke Opencode Dev Config"}
-                  </button>
-                  <div class="text-xs text-gray-10">
-                    Deletes isolated OpenCode dev state and then quits OpenWork.
-                  </div>
-                </div>
-                <Show when={nukeDevConfigStatus()}>
-                  {(value) => <div class="text-xs text-red-11">{value()}</div>}
-                </Show>
-
-                <Show when={props.developerMode}>
-                  <div class={`${settingsPanelSoftClass} p-4 space-y-3`}>
-                    <div class="flex items-start justify-between gap-3">
-                      <div>
-                          <div class="text-sm font-medium text-gray-12">
-                          Open Deeplink
-                          </div>
-                          <div class="text-xs text-gray-9">
-                          Paste any supported <span class="font-mono">openwork://</span> deeplink and route it through the dev app.
-                          </div>
-                        </div>
-                      <button
-                        type="button"
-                        class={compactOutlineActionClass}
-                        onClick={() => {
-                          setDebugDeepLinkOpen((value) => !value);
-                          setDebugDeepLinkStatus(null);
-                        }}
-                        disabled={props.busy || debugDeepLinkBusy()}
-                      >
-                        {debugDeepLinkOpen() ? "Hide" : "Open Deeplink"}
-                      </button>
+              <Show when={isTauriRuntime() && opencodeDevModeEnabled() && props.developerMode}>
+                <div class={`${settingsPanelSoftClass} p-4 space-y-3`}>
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <div class="text-sm font-medium text-gray-12">
+                        Open Deeplink
+                      </div>
+                      <div class="text-xs text-gray-9">
+                        Paste any supported <span class="font-mono">openwork://</span> deeplink and route it through the dev app.
+                      </div>
                     </div>
+                    <button
+                      type="button"
+                      class={compactOutlineActionClass}
+                      onClick={() => {
+                        setDebugDeepLinkOpen((value) => !value);
+                        setDebugDeepLinkStatus(null);
+                      }}
+                      disabled={props.busy || debugDeepLinkBusy()}
+                    >
+                      {debugDeepLinkOpen() ? "Hide" : "Open Deeplink"}
+                    </button>
+                  </div>
 
-                    <Show when={debugDeepLinkOpen()}>
-                      <div class="space-y-3">
-                        <textarea
-                          value={debugDeepLinkInput()}
-                          onInput={(event) =>
-                            setDebugDeepLinkInput(event.currentTarget.value)
+                  <Show when={debugDeepLinkOpen()}>
+                    <div class="space-y-3">
+                      <textarea
+                        value={debugDeepLinkInput()}
+                        onInput={(event) =>
+                          setDebugDeepLinkInput(event.currentTarget.value)
+                        }
+                        rows={3}
+                        placeholder="openwork://..."
+                        class="w-full rounded-xl border border-gray-6 bg-gray-1 px-3 py-2 text-xs font-mono text-gray-12 outline-none transition focus:border-blue-8"
+                      />
+                      <div class="flex flex-wrap items-center gap-2">
+                        <Button
+                          variant="secondary"
+                          class="text-xs h-8 py-0 px-3"
+                          onClick={() => void submitDebugDeepLink()}
+                          disabled={
+                            props.busy ||
+                            debugDeepLinkBusy() ||
+                            !debugDeepLinkInput().trim()
                           }
-                          rows={3}
-                          placeholder="openwork://..."
-                          class="w-full rounded-xl border border-gray-6 bg-gray-1 px-3 py-2 text-xs font-mono text-gray-12 outline-none transition focus:border-blue-8"
-                        />
-                        <div class="flex flex-wrap items-center gap-2">
-                          <Button
-                            variant="secondary"
-                            class="text-xs h-8 py-0 px-3"
-                            onClick={() => void submitDebugDeepLink()}
-                            disabled={
-                              props.busy ||
-                              debugDeepLinkBusy() ||
-                              !debugDeepLinkInput().trim()
-                            }
-                          >
-                            {debugDeepLinkBusy() ? "Opening..." : "Open deeplink"}
-                          </Button>
-                          <div class="text-[11px] text-gray-8">
-                            Accepts <span class="font-mono">openwork://</span>,{" "}
-                            <span class="font-mono">openwork-dev://</span>, or a
-                            raw supported{" "}
-                            <span class="font-mono">
-                              https://share.openwork.software/b/...
-                            </span>{" "}
-                            URL.
-                          </div>
+                        >
+                          {debugDeepLinkBusy() ? "Opening..." : "Open deeplink"}
+                        </Button>
+                        <div class="text-[11px] text-gray-8">
+                          Accepts <span class="font-mono">openwork://</span>,{" "}
+                          <span class="font-mono">openwork-dev://</span>, or a raw supported{" "}
+                          <span class="font-mono">
+                            https://share.openwork.software/b/...
+                          </span>{" "}
+                          URL.
                         </div>
                       </div>
-                    </Show>
+                    </div>
+                  </Show>
 
-                    <Show when={debugDeepLinkStatus()}>
-                      {(value) => (
-                        <div class="text-xs text-gray-10">{value()}</div>
-                      )}
-                    </Show>
-                  </div>
-                </Show>
+                  <Show when={debugDeepLinkStatus()}>
+                    {(value) => (
+                      <div class="text-xs text-gray-10">{value()}</div>
+                    )}
+                  </Show>
+                </div>
               </Show>
             </div>
 
@@ -3928,6 +3907,61 @@ export default function SettingsView(props: SettingsViewProps) {
                       </div>
                     </Show>
                   </div>
+
+                  <Show when={isTauriRuntime()}>
+                    <div class="rounded-2xl border border-red-7/30 bg-red-3/10 p-5 space-y-4">
+                      <div class="flex items-start justify-between gap-3">
+                        <div>
+                          <div class="text-sm font-medium text-gray-12">
+                            Reset OpenWork + OpenCode state
+                          </div>
+                          <div class="text-xs text-gray-10">
+                            This is irreversible and deletes all local OpenWork data for the current app mode. {opencodeDevModeEnabled()
+                              ? "With dev mode active, it only clears the isolated OpenCode dev state inside openwork-dev-data."
+                              : "With production mode active, it only clears the standard OpenCode config, auth, cache, data, and state paths."}
+                          </div>
+                        </div>
+                        <div
+                          class={`shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium ${opencodeDevModeEnabled()
+                            ? "border-blue-7/35 bg-blue-3/25 text-blue-11"
+                            : "border-gray-6 bg-gray-2 text-gray-10"}`}
+                        >
+                          {opencodeDevModeEnabled()
+                            ? "Dev mode"
+                            : "Production mode"}
+                        </div>
+                      </div>
+
+                      <div class="text-[11px] text-gray-8">
+                        OpenWork quits immediately after cleanup so the next launch starts from a blank local state for this mode.
+                      </div>
+
+                      <div class="flex flex-wrap items-center gap-3">
+                        <button
+                          type="button"
+                          class={compactDangerActionClass}
+                          onClick={() =>
+                            void handleNukeOpenworkAndOpencodeConfig()
+                          }
+                          disabled={props.busy || nukeConfigBusy()}
+                        >
+                          <CircleAlert size={14} />
+                          {nukeConfigBusy()
+                            ? "Removing local state..."
+                            : "Delete local config and quit"}
+                        </button>
+                        <div class="text-xs text-gray-10">
+                          Use this only when you want to fully reset the desktop app and its OpenCode runtime state.
+                        </div>
+                      </div>
+
+                      <Show when={nukeConfigStatus()}>
+                        {(value) => (
+                          <div class="text-xs text-red-11">{value()}</div>
+                        )}
+                      </Show>
+                    </div>
+                  </Show>
                 </div>
               </div>
             </section>

--- a/apps/desktop/src-tauri/src/commands/misc.rs
+++ b/apps/desktop/src-tauri/src/commands/misc.rs
@@ -9,7 +9,7 @@ use crate::opencode_router::manager::OpenCodeRouterManager;
 use crate::openwork_server::manager::OpenworkServerManager;
 use crate::orchestrator;
 use crate::orchestrator::manager::OrchestratorManager;
-use crate::paths::home_dir;
+use crate::paths::{candidate_xdg_config_dirs, candidate_xdg_data_dirs, home_dir};
 use crate::platform::command_for_program;
 use crate::types::{ExecResult, WorkspaceOpenworkConfig};
 use crate::workspace::state::load_workspace_state;
@@ -98,6 +98,71 @@ fn opencode_cache_candidates() -> Vec<PathBuf> {
         .into_iter()
         .filter(|path| seen.insert(path.to_string_lossy().to_string()))
         .collect()
+}
+
+fn push_opencode_env_path(candidates: &mut Vec<PathBuf>, key: &str) {
+    let Ok(value) = std::env::var(key) else {
+        return;
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    candidates.push(PathBuf::from(trimmed).join("opencode"));
+}
+
+fn opencode_standard_state_paths() -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    push_opencode_env_path(&mut candidates, "XDG_CONFIG_HOME");
+    push_opencode_env_path(&mut candidates, "XDG_DATA_HOME");
+    push_opencode_env_path(&mut candidates, "XDG_STATE_HOME");
+    candidates.extend(opencode_cache_candidates());
+
+    for dir in candidate_xdg_config_dirs() {
+        candidates.push(dir.join("opencode"));
+    }
+
+    for dir in candidate_xdg_data_dirs() {
+        candidates.push(dir.join("opencode"));
+    }
+
+    if let Some(home) = home_dir() {
+        candidates.push(home.join(".local").join("state").join("opencode"));
+
+        #[cfg(target_os = "macos")]
+        {
+            candidates.push(
+                home.join("Library")
+                    .join("Application Support")
+                    .join("opencode"),
+            );
+        }
+    }
+
+    let mut seen = HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|path| seen.insert(path.to_string_lossy().to_string()))
+        .collect()
+}
+
+fn current_openwork_state_paths(app: &AppHandle) -> Result<Vec<PathBuf>, String> {
+    Ok(vec![
+        app.path()
+            .app_cache_dir()
+            .map_err(|e| format!("Failed to resolve app cache dir: {e}"))?,
+        app.path()
+            .app_config_dir()
+            .map_err(|e| format!("Failed to resolve app config dir: {e}"))?,
+        app.path()
+            .app_local_data_dir()
+            .map_err(|e| format!("Failed to resolve app local data dir: {e}"))?,
+        app.path()
+            .app_data_dir()
+            .map_err(|e| format!("Failed to resolve app data dir: {e}"))?,
+        PathBuf::from(orchestrator::resolve_orchestrator_data_dir()),
+    ])
 }
 
 fn stop_host_services(
@@ -362,54 +427,36 @@ pub fn app_build_info(app: AppHandle) -> AppBuildInfo {
 }
 
 #[tauri::command]
-pub fn nuke_opencode_dev_config_and_exit(
+pub fn nuke_openwork_and_opencode_config_and_exit(
     app: AppHandle,
     engine_manager: State<EngineManager>,
     orchestrator_manager: State<OrchestratorManager>,
     openwork_manager: State<OpenworkServerManager>,
     opencode_router_manager: State<OpenCodeRouterManager>,
 ) -> Result<(), String> {
-    if !env_truthy("OPENWORK_DEV_MODE") {
-        return Err("OpenCode dev mode is not enabled.".to_string());
+    stop_host_services(
+        &engine_manager,
+        &orchestrator_manager,
+        &openwork_manager,
+        &opencode_router_manager,
+    );
+
+    let dev_mode = env_truthy("OPENWORK_DEV_MODE");
+    let mut paths = current_openwork_state_paths(&app)?;
+    if dev_mode {
+        // In dev mode, the current app + orchestrator directories are already isolated
+        // by the dev app identity and OPENWORK_DATA_DIR, so only clear those dev paths.
+    } else {
+        // In production, clear the normal app/orchestrator paths plus the standard
+        // user OpenCode config/data/cache/state locations.
+        paths.extend(opencode_standard_state_paths());
     }
 
-    if let Ok(mut engine) = engine_manager.inner.lock() {
-        EngineManager::stop_locked(&mut engine);
-    }
-    if let Ok(mut orchestrator_state) = orchestrator_manager.inner.lock() {
-        OrchestratorManager::stop_locked(&mut orchestrator_state);
-    }
-    if let Ok(mut openwork_state) = openwork_manager.inner.lock() {
-        OpenworkServerManager::stop_locked(&mut openwork_state);
-    }
-    if let Ok(mut opencode_router_state) = opencode_router_manager.inner.lock() {
-        OpenCodeRouterManager::stop_locked(&mut opencode_router_state);
-    }
-
-    let app_data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
-    let desktop_dev_dir = app_data_dir.join("opencode-dev");
-    if desktop_dev_dir.exists() {
-        fs::remove_dir_all(&desktop_dev_dir)
-            .map_err(|e| format!("Failed to remove {}: {e}", desktop_dev_dir.display()))?;
-    }
-
-    let orchestrator_data_dir = PathBuf::from(orchestrator::resolve_orchestrator_data_dir());
-    let orchestrator_dev_dir = orchestrator_data_dir.join("opencode-dev");
-    if orchestrator_dev_dir.exists() {
-        fs::remove_dir_all(&orchestrator_dev_dir)
-            .map_err(|e| format!("Failed to remove {}: {e}", orchestrator_dev_dir.display()))?;
-    }
-
-    for path in [
-        orchestrator_data_dir.join("openwork-orchestrator-state.json"),
-        orchestrator_data_dir.join("openwork-orchestrator-auth.json"),
-    ] {
-        if path.exists() {
-            fs::remove_file(&path)
-                .map_err(|e| format!("Failed to remove {}: {e}", path.display()))?;
+    let mut seen = HashSet::new();
+    for path in paths {
+        let key = path.to_string_lossy().to_string();
+        if seen.insert(key) {
+            remove_path_if_exists(&path)?;
         }
     }
 

--- a/apps/desktop/src-tauri/src/engine/spawn.rs
+++ b/apps/desktop/src-tauri/src/engine/spawn.rs
@@ -18,6 +18,8 @@ struct DevModePaths {
     opencode_config_dir: PathBuf,
 }
 
+const OPENWORK_DEV_DATA_DIR: &str = "openwork-dev-data";
+
 fn workspace_dev_slug(project_dir: &str) -> String {
     let mut hash: u64 = 0xcbf29ce484222325;
     for byte in project_dir.as_bytes() {
@@ -33,7 +35,7 @@ fn resolve_dev_mode_paths(app: &AppHandle, project_dir: &str) -> Result<DevModeP
         .app_data_dir()
         .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
     let root_dir = app_data_dir
-        .join("opencode-dev")
+        .join(OPENWORK_DEV_DATA_DIR)
         .join(workspace_dev_slug(project_dir));
 
     let paths = DevModePaths {
@@ -106,6 +108,7 @@ pub fn spawn_engine(
     if dev_mode {
         let dev_paths = resolve_dev_mode_paths(app, project_dir)?;
         command = command.env("OPENWORK_DEV_MODE", "1");
+        command = command.env("OPENCODE_TEST_HOME", &dev_paths.home_dir);
         command = command.env("HOME", dev_paths.home_dir);
         command = command.env("XDG_CONFIG_HOME", dev_paths.xdg_config_home);
         command = command.env("XDG_DATA_HOME", dev_paths.xdg_data_home);

--- a/apps/desktop/src-tauri/src/engine/spawn.rs
+++ b/apps/desktop/src-tauri/src/engine/spawn.rs
@@ -20,23 +20,12 @@ struct DevModePaths {
 
 const OPENWORK_DEV_DATA_DIR: &str = "openwork-dev-data";
 
-fn workspace_dev_slug(project_dir: &str) -> String {
-    let mut hash: u64 = 0xcbf29ce484222325;
-    for byte in project_dir.as_bytes() {
-        hash ^= u64::from(*byte);
-        hash = hash.wrapping_mul(0x100000001b3);
-    }
-    format!("ws-{hash:016x}")
-}
-
-fn resolve_dev_mode_paths(app: &AppHandle, project_dir: &str) -> Result<DevModePaths, String> {
+fn resolve_dev_mode_paths(app: &AppHandle) -> Result<DevModePaths, String> {
     let app_data_dir = app
         .path()
         .app_data_dir()
         .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
-    let root_dir = app_data_dir
-        .join(OPENWORK_DEV_DATA_DIR)
-        .join(workspace_dev_slug(project_dir));
+    let root_dir = app_data_dir.join(OPENWORK_DEV_DATA_DIR);
 
     let paths = DevModePaths {
         home_dir: root_dir.join("home"),
@@ -106,7 +95,7 @@ pub fn spawn_engine(
     let mut command = command.args(args).current_dir(project_dir);
 
     if dev_mode {
-        let dev_paths = resolve_dev_mode_paths(app, project_dir)?;
+        let dev_paths = resolve_dev_mode_paths(app)?;
         command = command.env("OPENWORK_DEV_MODE", "1");
         command = command.env("OPENCODE_TEST_HOME", &dev_paths.home_dir);
         command = command.env("HOME", dev_paths.home_dir);

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -24,9 +24,9 @@ use commands::engine::{
     engine_doctor, engine_info, engine_install, engine_restart, engine_start, engine_stop,
 };
 use commands::misc::{
-    app_build_info, nuke_opencode_dev_config_and_exit, obsidian_is_available, open_in_obsidian,
-    opencode_db_migrate, opencode_mcp_auth, read_obsidian_mirror_file, reset_opencode_cache,
-    reset_openwork_state, write_obsidian_mirror_file,
+    app_build_info, nuke_openwork_and_opencode_config_and_exit, obsidian_is_available,
+    open_in_obsidian, opencode_db_migrate, opencode_mcp_auth, read_obsidian_mirror_file,
+    reset_opencode_cache, reset_openwork_state, write_obsidian_mirror_file,
 };
 use commands::opencode_router::{
     opencodeRouter_config_set, opencodeRouter_info, opencodeRouter_start, opencodeRouter_status,
@@ -215,7 +215,7 @@ pub fn run() {
             write_opencode_config,
             updater_environment,
             app_build_info,
-            nuke_opencode_dev_config_and_exit,
+            nuke_openwork_and_opencode_config_and_exit,
             obsidian_is_available,
             open_in_obsidian,
             write_obsidian_mirror_file,

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -2910,17 +2910,16 @@ function resolveOpencodeStateLayout(options: {
   workspace: string;
   devMode: boolean;
 }): OpencodeStateLayout {
-  const workspaceId = workspaceIdForLocal(options.workspace);
   if (!options.devMode) {
     return {
       devMode: false,
-      rootDir: join(options.dataDir, "opencode-config", workspaceId),
-      configDir: join(options.dataDir, "opencode-config", workspaceId),
+      rootDir: join(options.dataDir, "opencode-config"),
+      configDir: join(options.dataDir, "opencode-config"),
       env: {},
     };
   }
 
-  const rootDir = join(options.dataDir, OPENWORK_DEV_DATA_DIR, workspaceId);
+  const rootDir = join(options.dataDir, OPENWORK_DEV_DATA_DIR);
   const homeDir = join(rootDir, "home");
   const xdgConfigHome = join(rootDir, "xdg", "config");
   const xdgDataHome = join(rootDir, "xdg", "data");

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -144,6 +144,7 @@ const SANDBOX_INTERNAL_OPENWORK_PORT = DEFAULT_OPENWORK_PORT;
 // mode we keep the *internal* port stable and only vary the published host
 // port to avoid collisions.
 const SANDBOX_INTERNAL_OPENCODE_ROUTER_HEALTH_PORT = 3005;
+const OPENWORK_DEV_DATA_DIR = "openwork-dev-data";
 
 const SANDBOX_OPENCODE_GLOBAL_CONFIG_CONTAINER_PATH =
   "/persist/.config/opencode";
@@ -2919,7 +2920,7 @@ function resolveOpencodeStateLayout(options: {
     };
   }
 
-  const rootDir = join(options.dataDir, "opencode-dev", workspaceId);
+  const rootDir = join(options.dataDir, OPENWORK_DEV_DATA_DIR, workspaceId);
   const homeDir = join(rootDir, "home");
   const xdgConfigHome = join(rootDir, "xdg", "config");
   const xdgDataHome = join(rootDir, "xdg", "data");
@@ -2937,6 +2938,7 @@ function resolveOpencodeStateLayout(options: {
       process.env.OPENWORK_DEV_OPENCODE_IMPORT_DATA_DIR?.trim() || undefined,
     env: {
       OPENWORK_DEV_MODE: "1",
+      OPENCODE_TEST_HOME: homeDir,
       HOME: homeDir,
       XDG_CONFIG_HOME: xdgConfigHome,
       XDG_DATA_HOME: xdgDataHome,
@@ -4215,16 +4217,18 @@ async function writeSandboxEntrypoint(options: {
     ? `export OPENCODE_ROUTER_HEALTH_PORT=${shQuote(String(SANDBOX_INTERNAL_OPENCODE_ROUTER_HEALTH_PORT))}`
     : "";
   const openworkDevMode = (process.env.OPENWORK_DEV_MODE ?? "").trim() === "1";
+  const sandboxHomeDir = openworkDevMode ? "/persist/openwork-dev-data/home" : "/persist";
 
   const script = [
     "set -eu",
-    `export HOME=${shQuote("/persist")}`,
+    `export HOME=${shQuote(sandboxHomeDir)}`,
+    `export OPENCODE_TEST_HOME=${shQuote(sandboxHomeDir)}`,
     'export XDG_CONFIG_HOME="$HOME/.config"',
     'export XDG_CACHE_HOME="$HOME/.cache"',
     'export XDG_DATA_HOME="$HOME/.local/share"',
     'export XDG_STATE_HOME="$HOME/.local/state"',
     `export PATH=${shQuote(`${options.rootInContainer}/sidecars`)}:"\${PATH:-}"`,
-    'mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"',
+    'mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"',
     // Do not `cd` into the mounted workspace: bun-compiled sidecars read bunfig.toml
     // from cwd, and user workspaces may include preloads that break startup.
     `cd ${shQuote("/persist")}`,

--- a/apps/server/src/opencode-db.test.ts
+++ b/apps/server/src/opencode-db.test.ts
@@ -134,7 +134,7 @@ describe("resolveOpencodeDbPath", () => {
 
   test("finds orchestrator-managed OpenCode dbs under OPENWORK_DATA_DIR", async () => {
     const root = await mkdtemp(join(tmpdir(), "openwork-orchestrator-data-"));
-    const dir = join(root, "openwork-dev-data", "ws-test", "xdg", "data", "opencode");
+    const dir = join(root, "openwork-dev-data", "xdg", "data", "opencode");
     const file = join(dir, "opencode.db");
     await mkdir(dir, { recursive: true });
     await writeFile(file, "", "utf8");

--- a/apps/server/src/opencode-db.test.ts
+++ b/apps/server/src/opencode-db.test.ts
@@ -134,6 +134,36 @@ describe("resolveOpencodeDbPath", () => {
 
   test("finds orchestrator-managed OpenCode dbs under OPENWORK_DATA_DIR", async () => {
     const root = await mkdtemp(join(tmpdir(), "openwork-orchestrator-data-"));
+    const dir = join(root, "openwork-dev-data", "ws-test", "xdg", "data", "opencode");
+    const file = join(dir, "opencode.db");
+    await mkdir(dir, { recursive: true });
+    await writeFile(file, "", "utf8");
+
+    const previousDataDir = process.env.OPENWORK_DATA_DIR;
+    const previousXdg = process.env.XDG_DATA_HOME;
+    const previousChannel = process.env.OPENCODE_CHANNEL;
+    const previousDb = process.env.OPENCODE_DB;
+    try {
+      process.env.OPENWORK_DATA_DIR = root;
+      delete process.env.XDG_DATA_HOME;
+      process.env.OPENCODE_CHANNEL = "local";
+      delete process.env.OPENCODE_DB;
+
+      expect(resolveOpencodeDbPath()).toBe(file);
+    } finally {
+      if (previousDataDir === undefined) delete process.env.OPENWORK_DATA_DIR;
+      else process.env.OPENWORK_DATA_DIR = previousDataDir;
+      if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = previousXdg;
+      if (previousChannel === undefined) delete process.env.OPENCODE_CHANNEL;
+      else process.env.OPENCODE_CHANNEL = previousChannel;
+      if (previousDb === undefined) delete process.env.OPENCODE_DB;
+      else process.env.OPENCODE_DB = previousDb;
+    }
+  });
+
+  test("finds legacy orchestrator-managed OpenCode dbs under OPENWORK_DATA_DIR", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-orchestrator-data-"));
     const dir = join(root, "opencode-dev", "ws-test", "xdg", "data", "opencode");
     const file = join(dir, "opencode.db");
     await mkdir(dir, { recursive: true });

--- a/apps/server/src/opencode-db.ts
+++ b/apps/server/src/opencode-db.ts
@@ -13,6 +13,7 @@ type SeedMessage = {
 const DEFAULT_AGENT = "openwork";
 const DEFAULT_PROVIDER = "openai";
 const DEFAULT_MODEL = "gpt-5.4";
+const OPENWORK_DEV_DATA_DIRS = ["openwork-dev-data", "opencode-dev"];
 
 function truthy(value: string | undefined): boolean {
   if (!value) return false;
@@ -24,18 +25,20 @@ function opencodeOrchestratorDataDirs(): string[] {
   const root = process.env.OPENWORK_DATA_DIR?.trim();
   if (!root) return [];
 
-  const base = join(root, "opencode-dev");
   const dirs: string[] = [];
   const pushIfExists = (dir: string) => {
     if (existsSync(dir)) dirs.push(dir);
   };
 
-  pushIfExists(join(base, "xdg", "data", "opencode"));
-  if (!existsSync(base)) return dirs;
+  for (const name of OPENWORK_DEV_DATA_DIRS) {
+    const base = join(root, name);
+    pushIfExists(join(base, "xdg", "data", "opencode"));
+    if (!existsSync(base)) continue;
 
-  for (const entry of readdirSync(base, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    pushIfExists(join(base, entry.name, "xdg", "data", "opencode"));
+    for (const entry of readdirSync(base, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      pushIfExists(join(base, entry.name, "xdg", "data", "opencode"));
+    }
   }
 
   return dirs;


### PR DESCRIPTION
## Summary
- route dev-mode OpenCode state into a dedicated `openwork-dev-data` home and move the destructive reset into the Debug page with an irreversible, mode-aware warning
- make the reset clear only the current mode's OpenWork and OpenCode state, and keep orchestrator-managed OpenCode state on one shared path per mode instead of per-workspace directories
- preserve non-dev OpenCode data/auth locations while updating the server-side DB lookup to recognize the new dev path layout

## Testing
- pnpm --filter openwork-server test -- opencode-db.test.ts
- pnpm --filter openwork-orchestrator typecheck
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app build
- cargo check

## Notes
- I did not run the full Docker + Chrome MCP desktop flow in this task; verification here is targeted compile/test coverage.