### PR TITLE
Keep nuke reset loading state and clear app storage

### DIFF
--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -1350,6 +1350,22 @@ export default function SettingsView(props: SettingsViewProps) {
     setNukeConfigBusy(true);
     setNukeConfigStatus(null);
     try {
+      if (typeof window !== "undefined") {
+        try {
+          window.localStorage.clear();
+        } catch {
+          // ignore
+        }
+      }
+
+      await new Promise<void>((resolve) => {
+        if (typeof window === "undefined") {
+          resolve();
+          return;
+        }
+        window.requestAnimationFrame(() => resolve());
+      });
+
       await nukeOpenworkAndOpencodeConfigAndExit();
       setNukeConfigStatus(
         "Removed OpenWork and OpenCode state. OpenWork is closing...",


### PR DESCRIPTION
## Summary
- keep the settings reset button in its loading state long enough to render before the app exits
- clear the app's browser `localStorage` before invoking the desktop-side nuke command so local UI state is fully reset

## Testing
- `pnpm typecheck` *(fails: missing local dependencies / `node_modules` in this worktree, so `vite/client` types are unavailable)*