### PR TITLE
fix: poll automations while the page is open

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -5445,13 +5445,29 @@ export default function App() {
 
   const schedulerPluginInstalled = createMemo(() => isPluginInstalledByName("opencode-scheduler"));
 
-  const refreshScheduledJobs = async (options?: { force?: boolean }) => {
-    if (scheduledJobsBusy() && !options?.force) return;
+  const scheduledJobsContextKey = createMemo(() => {
+    const workspaceId = workspaceStore.selectedWorkspaceId().trim();
+    const root = normalizeDirectoryPath(workspaceStore.selectedWorkspaceRoot().trim());
+    return `${scheduledJobsSource()}:${workspaceId}:${root}`;
+  });
+
+  const scheduledJobsPollingAvailable = createMemo(() => {
+    if (scheduledJobsSource() === "remote") return scheduledJobsSourceReady();
+    return isTauriRuntime() && !isWindowsPlatform() && schedulerPluginInstalled();
+  });
+
+  const refreshScheduledJobs = async (
+    options?: { force?: boolean },
+  ): Promise<"success" | "error" | "unavailable" | "skipped"> => {
+    void options;
+    if (scheduledJobsBusy()) return "skipped";
+
+    const requestContextKey = scheduledJobsContextKey();
 
     if (scheduledJobsSource() === "remote") {
       const scheduler = resolveOpenworkScheduler();
       if (!scheduler) {
-        setScheduledJobs([]);
+        if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
         const status =
           openworkServerStatus() === "disconnected"
             ? "OpenWork server unavailable. Connect to sync scheduled tasks."
@@ -5459,7 +5475,7 @@ export default function App() {
               ? "OpenWork server needs a token to load scheduled tasks."
               : "OpenWork server not ready.";
         setScheduledJobsStatus(status);
-        return;
+        return "unavailable";
       }
 
       setScheduledJobsBusy(true);
@@ -5467,35 +5483,37 @@ export default function App() {
 
       try {
         const response = await scheduler.client.listScheduledJobs(scheduler.workspaceId);
+        if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
         const jobs = Array.isArray(response.items) ? response.items : [];
         setScheduledJobs(jobs);
         setScheduledJobsUpdatedAt(Date.now());
+        return "success";
       } catch (error) {
+        if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
         const message = error instanceof Error ? error.message : String(error);
-        setScheduledJobs([]);
         setScheduledJobsStatus(message || "Failed to load scheduled tasks.");
+        return "error";
       } finally {
         setScheduledJobsBusy(false);
       }
-      return;
     }
 
     if (!isTauriRuntime()) {
-      setScheduledJobs([]);
+      if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
       setScheduledJobsStatus(null);
-      return;
+      return "unavailable";
     }
 
     if (isWindowsPlatform()) {
-      setScheduledJobs([]);
+      if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
       setScheduledJobsStatus(null);
-      return;
+      return "unavailable";
     }
 
     if (!schedulerPluginInstalled()) {
-      setScheduledJobs([]);
+      if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
       setScheduledJobsStatus(null);
-      return;
+      return "unavailable";
     }
 
     setScheduledJobsBusy(true);
@@ -5504,16 +5522,87 @@ export default function App() {
     try {
       const root = workspaceStore.selectedWorkspaceRoot().trim();
       const jobs = await schedulerListJobs(root || undefined);
+      if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
       setScheduledJobs(jobs);
       setScheduledJobsUpdatedAt(Date.now());
+      return "success";
     } catch (error) {
+      if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
       const message = error instanceof Error ? error.message : String(error);
-      setScheduledJobs([]);
       setScheduledJobsStatus(message || "Failed to load scheduled tasks.");
+      return "error";
     } finally {
       setScheduledJobsBusy(false);
     }
   };
+
+  createEffect(() => {
+    scheduledJobsContextKey();
+    setScheduledJobs([]);
+    setScheduledJobsStatus(null);
+    setScheduledJobsUpdatedAt(null);
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    if (currentView() !== "dashboard") return;
+    if (tab() !== "scheduled") return;
+    if (!documentVisible()) return;
+
+    const pollingAvailable = scheduledJobsPollingAvailable();
+    const startedAt = Date.now();
+    let active = true;
+    let failureCount = 0;
+    let timeoutId: number | undefined;
+
+    const clearTimer = () => {
+      if (timeoutId == null) return;
+      window.clearTimeout(timeoutId);
+      timeoutId = undefined;
+    };
+
+    const nextDelayMs = () => {
+      const baseDelay = Date.now() - startedAt < 60_000 ? 5_000 : 15_000;
+      if (failureCount <= 0) return baseDelay;
+      return Math.min(baseDelay * 2 ** failureCount, 60_000);
+    };
+
+    const scheduleNext = () => {
+      clearTimer();
+      if (!active || !pollingAvailable) return;
+      timeoutId = window.setTimeout(() => {
+        void run("poll");
+      }, nextDelayMs());
+    };
+
+    const run = async (_reason: "initial" | "focus" | "poll") => {
+      if (!active) return;
+      const result = await refreshScheduledJobs();
+      if (!active) return;
+
+      if (result === "error") {
+        failureCount += 1;
+      } else if (result === "success" || result === "unavailable") {
+        failureCount = 0;
+      }
+
+      scheduleNext();
+    };
+
+    const handleFocus = () => {
+      clearTimer();
+      void run("focus");
+    };
+
+    void run("initial");
+    window.addEventListener("focus", handleFocus);
+
+    onCleanup(() => {
+      active = false;
+      clearTimer();
+      window.removeEventListener("focus", handleFocus);
+    });
+  });
 
   const deleteScheduledJob = async (name: string) => {
     if (scheduledJobsSource() === "remote") {

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -537,9 +537,6 @@ export default function DashboardView(props: DashboardViewProps) {
         if ((currentTab === "plugins" || currentTab === "mcp") && !cancelled) {
           await Promise.all([props.refreshPlugins(), props.refreshMcpServers()]);
         }
-        if (currentTab === "scheduled" && !cancelled) {
-          await props.refreshScheduledJobs();
-        }
       } catch {
         // Ignore errors during navigation
       } finally {

--- a/apps/app/src/app/pages/scheduled.tsx
+++ b/apps/app/src/app/pages/scheduled.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo, createSignal } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 import type { ScheduledJob } from "../types";
 import { usePlatform } from "../context/platform";
@@ -484,8 +484,16 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
       ? "This removes the schedule and deletes the job definition from the connected OpenWork server."
       : "This removes the schedule and deletes the job definition from your machine."
   );
+  const [lastUpdatedNow, setLastUpdatedNow] = createSignal(Date.now());
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    const interval = window.setInterval(() => setLastUpdatedNow(Date.now()), 1_000);
+    onCleanup(() => window.clearInterval(interval));
+  });
 
   const lastUpdatedLabel = createMemo(() => {
+    lastUpdatedNow();
     if (!props.lastUpdatedAt) return "Not synced yet";
     return formatRelativeTime(props.lastUpdatedAt);
   });
@@ -687,6 +695,19 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
           </div>
         </Show>
         <p class={`text-sm text-gray-9 ${props.showHeader !== false ? "mt-2" : ""}`}>{sourceDescription()}</p>
+        <div class="mt-4 flex flex-wrap items-center justify-center gap-2 text-[11px] text-gray-9">
+          <span class="rounded-full border border-gray-4 bg-gray-1 px-2.5 py-1">
+            {sourceLabel()}
+          </span>
+          <span class="rounded-full border border-gray-4 bg-gray-1 px-2.5 py-1">
+            Last updated {lastUpdatedLabel()}
+          </span>
+          <Show when={props.busy}>
+            <span class="rounded-full border border-blue-7/30 bg-blue-3/50 px-2.5 py-1 text-blue-11">
+              Refreshing in background
+            </span>
+          </Show>
+        </div>
       </div>
 
       <Show when={schedulerGateActive()}>


### PR DESCRIPTION
## Summary
- poll scheduled jobs while the Automations page is visible, with an immediate fetch plus focus-triggered refreshes
- keep the current job list rendered during refreshes and avoid clearing stale data on transient scheduler errors
- reset scheduled job state when the selected workspace context changes and surface a live last-updated badge in the UI

## Testing
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm --filter @openwork/app build

## Notes
- I created this PR from a clean branch off `origin/dev` and cherry-picked only the Automations polling changes, excluding unrelated story-book work
- I did not run Docker or Chrome MCP for end-to-end UI verification in this pass