### PR TITLE
fix(den): restore worker dashboard access

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -140,6 +140,10 @@ export function getOrgDashboardRoute(orgSlug: string): string {
   return `/o/${encodeURIComponent(orgSlug)}/dashboard`;
 }
 
+export function getWorkersRoute(orgSlug: string): string {
+  return `${getOrgDashboardRoute(orgSlug)}/workers`;
+}
+
 export function getManageMembersRoute(orgSlug: string): string {
   return `${getOrgDashboardRoute(orgSlug)}/manage-members`;
 }

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -54,7 +54,7 @@ import {
 } from "../_lib/den-flow";
 import {
   PENDING_ORG_INVITATION_STORAGE_KEY,
-  getOrgDashboardRoute,
+  getWorkersRoute,
   parseOrgListPayload,
 } from "../_lib/den-org";
 
@@ -977,7 +977,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     const acceptedOrgSlug = await acceptPendingInvitationIfNeeded();
     const orgDirectory = await loadOrgDirectory();
     const activeOrgSlug = acceptedOrgSlug ?? orgDirectory.activeOrgSlug ?? orgDirectory.orgs[0]?.slug ?? null;
-    return activeOrgSlug ? getOrgDashboardRoute(activeOrgSlug) : null;
+    return activeOrgSlug ? getWorkersRoute(activeOrgSlug) : null;
   }
 
   async function completeDesktopAuthHandoff() {

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/dashboard-overview-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/dashboard-overview-screen.tsx
@@ -6,6 +6,7 @@ import {
   getCustomLlmProvidersRoute,
   getMembersRoute,
   getSharedSetupsRoute,
+  getWorkersRoute,
 } from "../../../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { OPENWORK_DOCS_URL, useOrgTemplates } from "./shared-setup-data";
@@ -30,6 +31,9 @@ export function DashboardOverviewScreen() {
           <div className="flex flex-wrap gap-3">
             <Link href={getMembersRoute(orgSlug)} className="den-button-secondary">
               Add member
+            </Link>
+            <Link href={getWorkersRoute(orgSlug)} className="den-button-secondary">
+              Open workers
             </Link>
             <a href={OPENWORK_DOCS_URL} target="_blank" rel="noreferrer" className="den-button-secondary">
               Learn how

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
@@ -11,6 +11,7 @@ import {
   getMembersRoute,
   getOrgDashboardRoute,
   getSharedSetupsRoute,
+  getWorkersRoute,
 } from "../../../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
@@ -62,6 +63,7 @@ export function OrgDashboardShell({ children }: { children: ReactNode }) {
 
   const navItems = [
     { href: activeOrg ? getOrgDashboardRoute(activeOrg.slug) : "#", label: "Dashboard" },
+    { href: activeOrg ? getWorkersRoute(activeOrg.slug) : "#", label: "Workers" },
     { href: activeOrg ? getSharedSetupsRoute(activeOrg.slug) : "#", label: "Shared setups" },
     { href: activeOrg ? getMembersRoute(activeOrg.slug) : "#", label: "Members" },
     { href: activeOrg ? getBackgroundAgentsRoute(activeOrg.slug) : "#", label: "Background agents", badge: "Alpha" },

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/workers/page.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/workers/page.tsx
@@ -1,0 +1,5 @@
+import { DashboardScreen } from "../../../../_components/dashboard-screen";
+
+export default function OrgWorkersPage() {
+  return <DashboardScreen showSidebar={false} />;
+}


### PR DESCRIPTION
## Summary
- restore a dedicated `Workers` route inside the org dashboard so the Den worker controls are reachable again
- route post-auth and onboarding landings back to the workers surface instead of the team overview
- add workers entry points in the dashboard nav and overview CTA

## Testing
- `pnpm --filter @openwork-ee/den-web build`

## Notes
- I did not run the full Docker + Chrome MCP flow in this pass.
- I also did not capture screenshots because the Den web stack was not started with the required auth/backend context.