### PR TITLE
fix(app): open update notification in general settings

### DIFF
--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -1176,7 +1176,7 @@ export default function DashboardView(props: DashboardViewProps) {
       props.installUpdateAndRestart();
       return;
     }
-    openSettings("advanced");
+    openSettings("general");
   };
 
   return (

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -3846,7 +3846,7 @@ export default function SessionView(props: SessionViewProps) {
       props.installUpdateAndRestart();
       return;
     }
-    openSettings("advanced");
+    openSettings("general");
   };
 
   const openMcp = () => {


### PR DESCRIPTION
## Summary
- route the desktop update notification in the workspace list to `Settings > General` instead of `Settings > Advanced`
- keep the existing install-and-restart shortcut behavior unchanged when an update is ready and no runs are active

## Testing
- attempted `pnpm --filter @openwork/app typecheck` *(fails in this worktree because `apps/app/node_modules` is not installed and TypeScript cannot resolve `vite/client`)*
- verified the affected handlers in `apps/app/src/app/pages/dashboard.tsx` and `apps/app/src/app/pages/session.tsx` now call `openSettings(\"general\")`