### PR TITLE
fix(app): wire auto compaction to OpenCode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,6 +85,33 @@ Tauri or other native shell behavior remains the fallback or shell boundary for:
 
 If an agent needs one of the server-owned behaviors above and only a Tauri path exists, treat that as an architecture gap to close rather than a parallel capability surface to preserve.
 
+## Reload-required flow
+
+OpenWork uses a single reload-required flow for changes that only take effect when OpenCode restarts.
+
+Key pieces:
+
+- `createSystemState()` owns the raw queued-reload state.
+- `reloadPending()` means a reload is currently queued for the active workspace.
+- `markReloadRequired(reason, trigger)` queues the reload and records the source that caused it.
+- `app.tsx` exposes `reloadRequired(...sources)` as a small helper for UI filtering. It is used to decide whether the shared reload popup should show for a given trigger type.
+
+Use this flow when a change mutates startup-loaded OpenCode inputs, for example:
+
+- `opencode.json`
+- `.opencode/skills/**`
+- `.opencode/agents/**`
+- `.opencode/commands/**`
+- MCP definitions or plugin lists that OpenCode only loads at startup
+
+Do not invent a separate reload banner per feature. New UI that needs restart semantics should:
+
+1. perform the config or filesystem mutation
+2. call `markReloadRequired(...)`
+3. rely on the shared reload popup to explain and execute the restart path
+
+Current examples that should use this shared flow include MCP changes, auto context compaction, default model changes, authorized folder updates, plugin changes, and other `opencode.json` writes.
+
 ## opencode primitives
 how to pick the right extension abstraction for 
 @opencode

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -7516,6 +7516,7 @@ export default function App() {
       setAutoCompactContextApplied(true);
       setAutoCompactContextDirty(false);
       setAutoCompactContextReady(false);
+      setAutoCompactContextSaving(false);
       return;
     }
 
@@ -7643,9 +7644,7 @@ export default function App() {
         const message = error instanceof Error ? error.message : safeStringify(error);
         setError(addOpencodeCacheHint(message));
       } finally {
-        if (!cancelled) {
-          setAutoCompactContextSaving(false);
-        }
+        setAutoCompactContextSaving(false);
       }
     };
 

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -58,7 +58,6 @@ import {
 import { clearPerfLogs, finishPerf, perfNow, recordPerfLog } from "./lib/perf-log";
 import { deepLinkBridgeEvent, drainPendingDeepLinks, type DeepLinkBridgeDetail } from "./lib/deep-link-bridge";
 import {
-  AUTO_COMPACT_CONTEXT_PREF_KEY,
   CHROME_DEVTOOLS_MCP_ID,
   DEFAULT_MODEL,
   HIDE_TITLEBAR_PREF_KEY,
@@ -1494,6 +1493,10 @@ export default function App() {
   const [workspaceDefaultModelReady, setWorkspaceDefaultModelReady] = createSignal(false);
   const [legacyDefaultModel, setLegacyDefaultModel] = createSignal<ModelRef>(DEFAULT_MODEL);
   const [defaultModelExplicit, setDefaultModelExplicit] = createSignal(false);
+  const [autoCompactContextReady, setAutoCompactContextReady] = createSignal(false);
+  const [autoCompactContextDirty, setAutoCompactContextDirty] = createSignal(false);
+  const [autoCompactContextApplied, setAutoCompactContextApplied] = createSignal(true);
+  const [autoCompactContextSaving, setAutoCompactContextSaving] = createSignal(false);
   type PromptFocusReturnTarget = "none" | "composer";
 
   const [sessionAgentById, setSessionAgentById] = createSignal<Record<string, string>>({});
@@ -1589,6 +1592,7 @@ export default function App() {
     sessionStatusById,
     selectedSession,
     selectedSessionStatus,
+    selectedSessionCompactionState,
     messages,
     messagesBySessionId,
     todos,
@@ -2050,34 +2054,6 @@ export default function App() {
       throw error;
     }
   }
-
-  const triggerAutoCompaction = async (sessionID: string) => {
-    if (!autoCompactContext()) return;
-    if (autoCompactingSessionId() === sessionID) return;
-
-    setAutoCompactingSessionId(sessionID);
-    try {
-      await compactCurrentSession(sessionID);
-    } catch {
-      // ignore auto-compaction failures; manual compact remains available
-    } finally {
-      setAutoCompactingSessionId((current) => (current === sessionID ? null : current));
-    }
-  };
-
-  const [lastSessionStatus, setLastSessionStatus] = createSignal<string | null>(null);
-  createEffect(() => {
-    const sessionID = selectedSessionId();
-    const status = sessionID ? sessionStatusById()[sessionID] ?? null : null;
-    const previous = lastSessionStatus();
-    setLastSessionStatus(status);
-
-    if (!sessionID) return;
-    if (!autoCompactContext()) return;
-    if (status !== "idle") return;
-    if (!previous || previous === "idle") return;
-    void triggerAutoCompaction(sessionID);
-  });
 
   const messageIdFromInfo = (message: MessageWithParts) => {
     const id = (message.info as { id?: string | number }).id;
@@ -3113,6 +3089,52 @@ export default function App() {
     return `${JSON.stringify(config, null, 2)}\n`;
   };
 
+  const parseAutoCompactContextFromConfig = (content: string | null) => {
+    if (!content) return null;
+    try {
+      const parsed = parse(content) as Record<string, unknown> | undefined;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return null;
+      }
+      const compaction = parsed.compaction;
+      if (!compaction || typeof compaction !== "object" || Array.isArray(compaction)) {
+        return null;
+      }
+      return typeof (compaction as Record<string, unknown>).auto === "boolean"
+        ? ((compaction as Record<string, unknown>).auto as boolean)
+        : null;
+    } catch {
+      return null;
+    }
+  };
+
+  const formatConfigWithAutoCompactContext = (content: string | null, enabled: boolean) => {
+    let config: Record<string, unknown> = {};
+    if (content?.trim()) {
+      try {
+        const parsed = parse(content) as Record<string, unknown> | undefined;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          config = { ...parsed };
+        }
+      } catch {
+        config = {};
+      }
+    }
+
+    if (!config["$schema"]) {
+      config["$schema"] = "https://opencode.ai/config.json";
+    }
+
+    const compaction =
+      typeof config.compaction === "object" && config.compaction && !Array.isArray(config.compaction)
+        ? { ...(config.compaction as Record<string, unknown>) }
+        : {};
+
+    compaction.auto = enabled;
+    config.compaction = compaction;
+    return `${JSON.stringify(config, null, 2)}\n`;
+  };
+
   const getConfigSnapshot = (content: string | null) => {
     if (!content?.trim()) return "";
     try {
@@ -3131,6 +3153,11 @@ export default function App() {
   const ensureRecord = (value: unknown): Record<string, unknown> => {
     if (!value || typeof value !== "object" || Array.isArray(value)) return {};
     return value as Record<string, unknown>;
+  };
+
+  const readAutoCompactContextFromRecord = (value: unknown) => {
+    const compaction = ensureRecord(ensureRecord(value).compaction);
+    return typeof compaction.auto === "boolean" ? compaction.auto : null;
   };
 
   const normalizeAuthorizedFolderPath = (input: string | null | undefined) => {
@@ -3206,8 +3233,8 @@ export default function App() {
     createSignal<PromptFocusReturnTarget>("none");
 
   const [showThinking, setShowThinking] = createSignal(false);
+  const [autoCompactContext, setAutoCompactContext] = createSignal(true);
   const [hideTitlebar, setHideTitlebar] = createSignal(false);
-  const [autoCompactContext, setAutoCompactContext] = createSignal(false);
   const [modelVariantMap, setModelVariantMap] = createSignal<Record<string, string>>({});
   const modelVariant = () => getVariantFor(selectedSessionModel());
   const getVariantFor = (ref: ModelRef) => modelVariantMap()[`${ref.providerID}/${ref.modelID}`] ?? null;
@@ -3221,7 +3248,11 @@ export default function App() {
     });
   };
   const setModelVariant = (value: string | null) => updateModelVariant(selectedSessionModel(), value);
-  const [autoCompactingSessionId, setAutoCompactingSessionId] = createSignal<string | null>(null);
+  const toggleAutoCompactContext = () => {
+    if (autoCompactContextSaving()) return;
+    setAutoCompactContext((value) => !value);
+    setAutoCompactContextDirty(true);
+  };
   const [authorizedFolders, setAuthorizedFolders] = createSignal<string[]>([]);
   const [authorizedFolderDraft, setAuthorizedFolderDraft] = createSignal("");
   const [, setAuthorizedFolderHiddenEntries] = createSignal<Record<string, unknown>>({});
@@ -7035,18 +7066,6 @@ export default function App() {
           }
         }
 
-        const storedAutoCompactContext = window.localStorage.getItem(AUTO_COMPACT_CONTEXT_PREF_KEY);
-        if (storedAutoCompactContext != null) {
-          try {
-            const parsed = JSON.parse(storedAutoCompactContext);
-            if (typeof parsed === "boolean") {
-              setAutoCompactContext(parsed);
-            }
-          } catch {
-            // ignore
-          }
-        }
-
         const storedVariant = window.localStorage.getItem(VARIANT_PREF_KEY);
         if (storedVariant && storedVariant.trim()) {
           try {
@@ -7491,6 +7510,153 @@ export default function App() {
   });
 
   createEffect(() => {
+    const workspaceId = workspaceStore.selectedWorkspaceId();
+    if (!workspaceId) {
+      setAutoCompactContext(true);
+      setAutoCompactContextApplied(true);
+      setAutoCompactContextDirty(false);
+      setAutoCompactContextReady(false);
+      return;
+    }
+
+    const workspace = workspaceStore.selectedWorkspaceDisplay();
+    const root = workspaceStore.selectedWorkspacePath().trim();
+    const activeClient = client();
+    const openworkClient = openworkServerClient();
+    const openworkWorkspaceId = runtimeWorkspaceId();
+    const openworkCapabilities = resolvedOpenworkCapabilities();
+    const canUseOpenworkServer =
+      openworkServerStatus() === "connected" &&
+      openworkClient &&
+      openworkWorkspaceId &&
+      openworkCapabilities?.config?.read;
+
+    let cancelled = false;
+    setAutoCompactContextReady(false);
+    setAutoCompactContextDirty(false);
+
+    const loadAutoCompactContext = async () => {
+      let nextValue = true;
+
+      if (canUseOpenworkServer) {
+        try {
+          const config = await openworkClient.getConfig(openworkWorkspaceId);
+          nextValue = readAutoCompactContextFromRecord(config.opencode) ?? true;
+        } catch {
+          // ignore
+        }
+      } else if (workspace.workspaceType === "local" && root && isTauriRuntime()) {
+        try {
+          const configFile = await readOpencodeConfig("project", root);
+          nextValue = parseAutoCompactContextFromConfig(configFile.content) ?? true;
+        } catch {
+          // ignore
+        }
+      } else if (activeClient) {
+        try {
+          const config = unwrap(await activeClient.config.get({ directory: root || undefined }));
+          nextValue = readAutoCompactContextFromRecord(config) ?? true;
+        } catch {
+          // ignore
+        }
+      }
+
+      if (cancelled) return;
+      setAutoCompactContext(nextValue);
+      setAutoCompactContextApplied(nextValue);
+      setAutoCompactContextReady(true);
+    };
+
+    void loadAutoCompactContext();
+
+    onCleanup(() => {
+      cancelled = true;
+    });
+  });
+
+  createEffect(() => {
+    if (!autoCompactContextReady()) return;
+    if (!autoCompactContextDirty()) return;
+
+    const nextValue = autoCompactContext();
+    const appliedValue = autoCompactContextApplied();
+    const workspace = workspaceStore.selectedWorkspaceDisplay();
+    const root = workspaceStore.selectedWorkspacePath().trim();
+    const openworkClient = openworkServerClient();
+    const openworkWorkspaceId = runtimeWorkspaceId();
+    const openworkCapabilities = resolvedOpenworkCapabilities();
+    const canUseOpenworkServer =
+      openworkServerStatus() === "connected" &&
+      openworkClient &&
+      openworkWorkspaceId &&
+      openworkCapabilities?.config?.write;
+
+    let cancelled = false;
+    setAutoCompactContextSaving(true);
+
+    const persistAutoCompactContext = async () => {
+      try {
+        if (canUseOpenworkServer) {
+          const config = await openworkClient.getConfig(openworkWorkspaceId);
+          const currentValue = readAutoCompactContextFromRecord(config.opencode) ?? true;
+          if (currentValue !== nextValue) {
+            await openworkClient.patchConfig(openworkWorkspaceId, {
+              opencode: {
+                compaction: {
+                  auto: nextValue,
+                },
+              },
+            });
+            markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+          }
+          if (cancelled) return;
+          setAutoCompactContextApplied(nextValue);
+          setAutoCompactContextDirty(false);
+          return;
+        }
+
+        if (workspace.workspaceType !== "local" || !root || !isTauriRuntime()) {
+          throw new Error(
+            "Auto context compaction can only be changed for a local workspace or a writable OpenWork server workspace.",
+          );
+        }
+
+        const configFile = await readOpencodeConfig("project", root);
+        const currentValue = parseAutoCompactContextFromConfig(configFile.content) ?? true;
+        if (currentValue !== nextValue) {
+          const content = formatConfigWithAutoCompactContext(configFile.content, nextValue);
+          const result = await writeOpencodeConfig("project", root, content);
+          if (!result.ok) {
+            throw new Error(result.stderr || result.stdout || "Failed to update opencode.json");
+          }
+          setLastKnownConfigSnapshot(getConfigSnapshot(content));
+          markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+        }
+
+        if (cancelled) return;
+        setAutoCompactContextApplied(nextValue);
+        setAutoCompactContextDirty(false);
+      } catch (error) {
+        if (cancelled) return;
+        setAutoCompactContext(appliedValue);
+        setAutoCompactContextDirty(false);
+        const message = error instanceof Error ? error.message : safeStringify(error);
+        setError(addOpencodeCacheHint(message));
+      } finally {
+        if (!cancelled) {
+          setAutoCompactContextSaving(false);
+        }
+      }
+    };
+
+    void persistAutoCompactContext();
+
+    onCleanup(() => {
+      cancelled = true;
+    });
+  });
+
+  createEffect(() => {
     if (!isTauriRuntime()) return;
     if (onboardingStep() !== "local") return;
     void workspaceStore.refreshEngineDoctor();
@@ -7633,15 +7799,6 @@ export default function App() {
       setWindowDecorations(!hide).catch(() => {
         // ignore errors (e.g., window not ready)
       });
-    }
-  });
-
-  createEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(AUTO_COMPACT_CONTEXT_PREF_KEY, JSON.stringify(autoCompactContext()));
-    } catch {
-      // ignore
     }
   });
 
@@ -8077,7 +8234,8 @@ export default function App() {
       showThinking: showThinking(),
       toggleShowThinking: () => setShowThinking((v) => !v),
       autoCompactContext: autoCompactContext(),
-      toggleAutoCompactContext: () => setAutoCompactContext((v) => !v),
+      toggleAutoCompactContext,
+      autoCompactContextBusy: autoCompactContextSaving(),
       hideTitlebar: hideTitlebar(),
       toggleHideTitlebar: () => setHideTitlebar((v) => !v),
       modelVariantLabel: getModelBehaviorCopy(defaultModel(), getVariantFor(defaultModel())).label,
@@ -8314,8 +8472,7 @@ export default function App() {
     busyLabel: busyLabel(),
     developerMode: developerMode(),
     showThinking: showThinking(),
-    autoCompactContext: autoCompactContext(),
-    toggleAutoCompactContext: () => setAutoCompactContext((v) => !v),
+    sessionCompactionState: selectedSessionCompactionState(),
     groupMessageParts,
     summarizeStep,
     expandedStepIds: expandedStepIds(),

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -38,6 +38,7 @@ import SharedBundleImportModal from "./components/shared-bundle-import-modal";
 import StartWithTemplateModal from "./components/start-with-template-modal";
 import RenameWorkspaceModal from "./components/rename-workspace-modal";
 import McpAuthModal from "./components/mcp-auth-modal";
+import ReloadWorkspaceToast from "./components/reload-workspace-toast";
 import StatusToast from "./components/status-toast";
 import OnboardingView from "./pages/onboarding";
 import DashboardView from "./pages/dashboard";
@@ -2760,6 +2761,7 @@ export default function App() {
           },
         });
         assertNoClientError(result);
+        markOpencodeConfigReloadRequired();
       } catch (error) {
         globalSync.set("config", "disabled_providers", disabledProviders);
         throw error;
@@ -5270,7 +5272,7 @@ export default function App() {
   });
 
   const {
-    reloadRequired,
+    reloadPending,
     reloadCopy,
     reloadTrigger,
     reloadBusy,
@@ -5416,10 +5418,25 @@ export default function App() {
     await reloadWorkspaceEngine();
   };
 
+  const isActiveSessionStatus = (status: string | null | undefined) =>
+    status === "running" || status === "retry";
+
+  const reloadRequired = (...sources: ReloadTrigger["type"][]) => {
+    if (!reloadPending()) return false;
+    const triggerType = reloadTrigger()?.type;
+    if (!triggerType) return false;
+    if (!sources.length) return true;
+    return sources.includes(triggerType);
+  };
+
+  const markOpencodeConfigReloadRequired = () => {
+    markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+  };
+
   const activeReloadBlockingSessions = createMemo(() => {
     const statuses = sessionStatusById();
     return sessions()
-      .filter((session) => statuses[session.id] === "running")
+      .filter((session) => isActiveSessionStatus(statuses[session.id]))
       .map((session) => ({
         id: session.id,
         title: session.title?.trim() || session.slug?.trim() || session.id,
@@ -6203,6 +6220,8 @@ export default function App() {
           throw new Error(result.stderr || result.stdout || "Failed to update opencode.json");
         }
       }
+
+      markReloadRequired("mcp", { type: "mcp", name: "notion", action: "added" });
 
       await refreshMcpServers();
       setNotionStatusDetail(t("mcp.connecting", currentLocale()));
@@ -7297,11 +7316,7 @@ export default function App() {
           "Authorized folders updated.",
         ),
       );
-      markReloadRequired("config", {
-        type: "config",
-        name: "opencode.json",
-        action: "updated",
-      });
+      markOpencodeConfigReloadRequired();
       return true;
     } catch (error) {
       const message = error instanceof Error ? error.message : safeStringify(error);
@@ -7480,7 +7495,7 @@ export default function App() {
           await openworkClient.patchConfig(openworkWorkspaceId, {
             opencode: { model: formatModelRef(nextModel) },
           });
-          markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+          markOpencodeConfigReloadRequired();
           return;
         }
 
@@ -7494,7 +7509,7 @@ export default function App() {
           throw new Error(result.stderr || result.stdout || "Failed to update opencode.json");
         }
         setLastKnownConfigSnapshot(getConfigSnapshot(content));
-        markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+        markOpencodeConfigReloadRequired();
       } catch (error) {
         if (cancelled) return;
         const message = error instanceof Error ? error.message : safeStringify(error);
@@ -7608,7 +7623,7 @@ export default function App() {
                 },
               },
             });
-            markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+            markOpencodeConfigReloadRequired();
           }
           if (cancelled) return;
           setAutoCompactContextApplied(nextValue);
@@ -7631,7 +7646,7 @@ export default function App() {
             throw new Error(result.stderr || result.stdout || "Failed to update opencode.json");
           }
           setLastKnownConfigSnapshot(getConfigSnapshot(content));
-          markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+          markOpencodeConfigReloadRequired();
         }
 
         if (cancelled) return;
@@ -8339,11 +8354,6 @@ export default function App() {
       logoutMcpAuth,
       removeMcp,
       refreshMcpServers,
-      showMcpReloadBanner:
-        reloadRequired() && (reloadTrigger()?.type === "mcp" || reloadTrigger()?.type === "config"),
-      mcpReloadBlocked: activeReloadBlockingSessions().length > 0,
-      reloadBlocked: activeReloadBlockingSessions().length > 0,
-      reloadMcpEngine: () => reloadWorkspaceEngineAndResume(),
       language: currentLocale(),
       setLanguage: setLocale,
     };
@@ -8438,17 +8448,6 @@ export default function App() {
     mcpStatus: mcpStatus(),
     skills: skills(),
     skillsStatus: skillsStatus(),
-    showSkillReloadBanner: reloadRequired() && reloadTrigger()?.type === "skill",
-    reloadBannerTitle: reloadCopy().title,
-    reloadBannerBody: reloadCopy().body,
-    reloadBannerBlocked: activeReloadBlockingSessions().length > 0,
-    reloadBannerActiveCount: activeReloadBlockingSessions().length,
-    canReloadWorkspace: canReloadWorkspace(),
-    reloadWorkspaceEngine: reloadWorkspaceEngineAndResume,
-    forceStopActiveConversations: forceStopActiveSessionsAndReload,
-    dismissReloadBanner: clearReloadRequired,
-    reloadBusy: reloadBusy(),
-    reloadError: reloadError(),
     createSessionAndOpen: createSessionAndOpen,
     sendPromptAsync: sendPrompt,
     abortSession: abortSession,
@@ -8982,6 +8981,27 @@ export default function App() {
       </Show>
 
       <div class="pointer-events-none fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-1.5rem))] max-w-full flex-col gap-3 sm:right-6 sm:top-6">
+        <div class="pointer-events-auto">
+          <ReloadWorkspaceToast
+            open={reloadRequired("config", "mcp", "plugin", "skill", "agent", "command")}
+            title={reloadCopy().title}
+            description={reloadCopy().body}
+            trigger={reloadTrigger()}
+            error={reloadError()}
+            reloadLabel={activeReloadBlockingSessions().length > 0 ? "Reload & Stop Tasks" : "Reload now"}
+            dismissLabel="Later"
+            busy={reloadBusy()}
+            canReload={canReloadWorkspace()}
+            hasActiveRuns={activeReloadBlockingSessions().length > 0}
+            onReload={() => {
+              void (activeReloadBlockingSessions().length > 0
+                ? forceStopActiveSessionsAndReload()
+                : reloadWorkspaceEngineAndResume());
+            }}
+            onDismiss={clearReloadRequired}
+          />
+        </div>
+
         <div class="pointer-events-auto">
           <StatusToast
             open={Boolean(sharedSkillSuccessToast())}

--- a/apps/app/src/app/components/reload-workspace-toast.tsx
+++ b/apps/app/src/app/components/reload-workspace-toast.tsx
@@ -76,7 +76,7 @@ export default function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
 
   return (
     <Show when={props.open}>
-      <div class="w-full max-w-[24rem] overflow-hidden rounded-[1.4rem] border border-white/70 bg-white/92 shadow-[0_24px_60px_-28px_rgba(15,23,42,0.28)] backdrop-blur-xl animate-in fade-in slide-in-from-top-4 duration-300">
+      <div class="w-full max-w-[24rem] overflow-hidden rounded-[1.4rem] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)] backdrop-blur-xl animate-in fade-in slide-in-from-top-4 duration-300">
         <div class="flex items-start gap-3 px-4 py-4">
           <div
             class={`flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border ${

--- a/apps/app/src/app/components/session/sidebar.tsx
+++ b/apps/app/src/app/components/session/sidebar.tsx
@@ -510,7 +510,7 @@ export default function SessionSidebar(props: SidebarProps) {
                                     >
                                       <span
                                         class={`shrink-0 text-[10px] px-1.5 py-0.5 rounded-full border flex items-center gap-1 ${
-                                          props.sessionStatusById[session.id] === "running"
+                                          props.sessionStatusById[session.id] === "running" || props.sessionStatusById[session.id] === "retry"
                                             ? "border-amber-7/50 text-amber-11 bg-amber-2/50"
                                             : "border-gray-7/50 text-gray-10 bg-gray-2/50"
                                         }`}
@@ -519,7 +519,9 @@ export default function SessionSidebar(props: SidebarProps) {
                                           class={`w-1 h-1 rounded-full ${
                                             props.sessionStatusById[session.id] === "running"
                                               ? "bg-amber-9 animate-pulse"
-                                              : "bg-gray-9"
+                                              : props.sessionStatusById[session.id] === "retry"
+                                                ? "bg-amber-9"
+                                                : "bg-gray-9"
                                           }`}
                                         />
                                       </span>

--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -6,7 +6,6 @@ export const THINKING_PREF_KEY = "openwork.showThinking";
 export const VARIANT_PREF_KEY = "openwork.modelVariant";
 export const LANGUAGE_PREF_KEY = "openwork.language";
 export const HIDE_TITLEBAR_PREF_KEY = "openwork.hideTitlebar";
-export const AUTO_COMPACT_CONTEXT_PREF_KEY = "openwork.autoCompactContext";
 
 export const DEFAULT_MODEL: ModelRef = {
   providerID: "opencode",

--- a/apps/app/src/app/context/extensions.ts
+++ b/apps/app/src/app/context/extensions.ts
@@ -719,6 +719,7 @@ export function createExtensionsStore(options: {
       try {
         setPluginStatus(null);
         await openworkClient.addPlugin(openworkWorkspaceId, pluginName);
+        options.markReloadRequired?.("plugins", { type: "plugin", name: triggerName, action: "added" });
         if (isManualInput) {
           setPluginInput("");
         }
@@ -816,6 +817,7 @@ export function createExtensionsStore(options: {
       try {
         setPluginStatus(null);
         await openworkClient.removePlugin(openworkWorkspaceId, name);
+        options.markReloadRequired?.("plugins", { type: "plugin", name: triggerName, action: "removed" });
         await refreshPlugins("project");
       } catch (e) {
         setPluginStatus(e instanceof Error ? e.message : "Failed to remove plugin.");

--- a/apps/app/src/app/context/session.ts
+++ b/apps/app/src/app/context/session.ts
@@ -14,6 +14,7 @@ import type {
   PlaceholderAssistantMessage,
   ReloadReason,
   ReloadTrigger,
+  SessionCompactionState,
   SessionErrorTurn,
   TodoItem,
 } from "../types";
@@ -49,6 +50,7 @@ type StoreState = {
   pendingPermissions: PendingPermission[];
   pendingQuestions: PendingQuestion[];
   events: OpencodeEvent[];
+  sessionCompaction: Record<string, SessionCompactionState>;
 };
 
 const sortById = <T extends { id: string }>(list: T[]) =>
@@ -198,6 +200,7 @@ export function createSessionStore(options: {
     pendingPermissions: [],
     pendingQuestions: [],
     events: [],
+    sessionCompaction: {},
   });
   const [permissionReplyBusy, setPermissionReplyBusy] = createSignal(false);
   const [messageLimitBySession, setMessageLimitBySession] = createSignal<Record<string, number>>({});
@@ -206,6 +209,7 @@ export function createSessionStore(options: {
   const [loadedScopeRoot, setLoadedScopeRoot] = createSignal("");
   const reloadDetectionSet = new Set<string>();
   const invalidToolDetectionSet = new Set<string>();
+  const pendingCompactionModeBySession = new Map<string, "auto" | "manual">();
   const syntheticContinueEventTimesBySession = new Map<string, number[]>();
   const syntheticTaskSummaryEventTimesBySession = new Map<string, number[]>();
   const syntheticContinueLoopLastWarnAtBySession = new Map<string, number>();
@@ -1183,6 +1187,68 @@ export function createSessionStore(options: {
     });
   };
 
+  const setSessionCompaction = (sessionID: string, next: SessionCompactionState) => {
+    setStore("sessionCompaction", sessionID, next);
+  };
+
+  const stopSessionCompaction = (sessionID: string) => {
+    const current = store.sessionCompaction[sessionID];
+    pendingCompactionModeBySession.delete(sessionID);
+    if (!current?.running) return;
+    setSessionCompaction(sessionID, {
+      ...current,
+      running: false,
+      messageID: null,
+    });
+  };
+
+  const startSessionCompaction = (sessionID: string, messageID: string) => {
+    const current = store.sessionCompaction[sessionID];
+    if (current?.running && current.messageID === messageID) return;
+    const startedAt = Date.now();
+    const mode = pendingCompactionModeBySession.get(sessionID) ?? current?.mode ?? null;
+    pendingCompactionModeBySession.delete(sessionID);
+    setSessionCompaction(sessionID, {
+      running: true,
+      startedAt,
+      finishedAt: null,
+      mode,
+      messageID,
+    });
+    if (options.developerMode()) {
+      appendDebugEvent({
+        type: "session.compaction.started",
+        properties: { sessionID, messageID, mode, startedAt },
+      });
+    }
+  };
+
+  const finishSessionCompaction = (sessionID: string) => {
+    const current = store.sessionCompaction[sessionID];
+    const finishedAt = Date.now();
+    pendingCompactionModeBySession.delete(sessionID);
+    setSessionCompaction(sessionID, {
+      running: false,
+      startedAt: current?.startedAt ?? null,
+      finishedAt,
+      mode: current?.mode ?? null,
+      messageID: null,
+    });
+    if (options.developerMode()) {
+      appendDebugEvent({
+        type: "session.compaction.finished",
+        properties: {
+          sessionID,
+          mode: current?.mode ?? null,
+          startedAt: current?.startedAt ?? null,
+          finishedAt,
+          durationMs:
+            typeof current?.startedAt === "number" ? Math.max(0, finishedAt - current.startedAt) : null,
+        },
+      });
+    }
+  };
+
   const compactDebugEvent = (event: OpencodeEvent) => {
     if (event.type === "message.part.updated") {
       const record = event.properties as Record<string, unknown> | undefined;
@@ -1281,9 +1347,11 @@ export function createSessionStore(options: {
           syntheticContinueLoopLastWarnAtBySession.delete(info.id);
           syntheticLoopLastAbortAtByKey.delete(`task-summary:${info.id}`);
           syntheticLoopLastAbortAtByKey.delete(`compaction-continue:${info.id}`);
+          pendingCompactionModeBySession.delete(info.id);
           setStore(
             produce((draft: StoreState) => {
               delete draft.sessionInfoById[info.id];
+              delete draft.sessionCompaction[info.id];
             }),
           );
           setStore("sessions", (current) => removeSession(current, info.id));
@@ -1303,6 +1371,9 @@ export function createSessionStore(options: {
         if (sessionID) {
           const normalized = normalizeSessionStatus(record.status);
           setStore("sessionStatus", sessionID, normalized);
+          if (normalized === "idle") {
+            stopSessionCompaction(sessionID);
+          }
           if (sessionID === options.selectedSessionId() && normalized !== "idle") {
             options.setError(null);
           }
@@ -1316,6 +1387,7 @@ export function createSessionStore(options: {
         const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
         if (sessionID) {
           setStore("sessionStatus", sessionID, "idle");
+          stopSessionCompaction(sessionID);
           const c = options.client();
           if (c) {
             try {
@@ -1340,6 +1412,7 @@ export function createSessionStore(options: {
         const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
         if (sessionID) {
           setStore("sessionStatus", sessionID, "idle");
+          stopSessionCompaction(sessionID);
         }
         const errorObj = record.error as Record<string, unknown> | undefined;
         if (errorObj) {
@@ -1374,6 +1447,7 @@ export function createSessionStore(options: {
         const record = event.properties as Record<string, unknown>;
         if (record.info && typeof record.info === "object") {
           const info = record.info as Message;
+          const messageRecord = info as Message & Record<string, unknown>;
           const model = modelFromUserMessage(info as MessageInfo);
           if (model) {
             options.setSessionModelState((current) => ({
@@ -1390,6 +1464,14 @@ export function createSessionStore(options: {
           }
 
           setStore("messages", info.sessionID, (current = []) => upsertMessageInfo(current, info));
+
+          if (
+            messageRecord.role === "assistant" &&
+            messageRecord.mode === "compaction" &&
+            messageRecord.summary === true
+          ) {
+            startSessionCompaction(info.sessionID, info.id);
+          }
         }
       }
     }
@@ -1413,6 +1495,13 @@ export function createSessionStore(options: {
           const part = record.part as Part;
           const delta = typeof record.delta === "string" ? record.delta : null;
           const partUpdatedStartedAt = perfNow();
+
+          if (part.type === "compaction") {
+            pendingCompactionModeBySession.set(
+              part.sessionID,
+              (part as Part & { auto?: unknown }).auto === true ? "auto" : "manual",
+            );
+          }
 
           setStore(
             produce((draft: StoreState) => {
@@ -1507,6 +1596,16 @@ export function createSessionStore(options: {
         const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
         if (sessionID && Array.isArray(record.todos)) {
           setStore("todos", sessionID, record.todos as TodoItem[]);
+        }
+      }
+    }
+
+    if (event.type === "session.compacted") {
+      if (event.properties && typeof event.properties === "object") {
+        const record = event.properties as Record<string, unknown>;
+        const sessionID = typeof record.sessionID === "string" ? record.sessionID : null;
+        if (sessionID) {
+          finishSessionCompaction(sessionID);
         }
       }
     }
@@ -1747,8 +1846,13 @@ export function createSessionStore(options: {
     sessionStatusById,
     selectedSession,
     selectedSessionStatus,
+    selectedSessionCompactionState: createMemo(() => {
+      const sessionID = options.selectedSessionId();
+      return sessionID ? store.sessionCompaction[sessionID] ?? null : null;
+    }),
     messages,
     messagesBySessionId,
+    sessionCompactionById: (sessionID: string | null) => (sessionID ? store.sessionCompaction[sessionID] ?? null : null),
     todos,
     pendingPermissions,
     permissionReplyBusy,

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -257,9 +257,6 @@ export type DashboardViewProps = {
   authorizeMcp: (entry: McpServerEntry) => void;
   logoutMcpAuth: (name: string) => Promise<void> | void;
   removeMcp: (name: string) => void;
-  showMcpReloadBanner: boolean;
-  mcpReloadBlocked: boolean;
-  reloadMcpEngine: () => void;
   createSessionAndOpen: () => void;
   setPrompt: (value: string) => void;
   selectSession: (sessionId: string) => Promise<void> | void;
@@ -1392,9 +1389,6 @@ export default function DashboardView(props: DashboardViewProps) {
                   authorizeMcp={props.authorizeMcp}
                   logoutMcpAuth={props.logoutMcpAuth}
                   removeMcp={props.removeMcp}
-                  showMcpReloadBanner={props.showMcpReloadBanner}
-                  reloadBlocked={props.mcpReloadBlocked}
-                  reloadMcpEngine={props.reloadMcpEngine}
                   canEditPlugins={props.canEditPlugins}
                   canUseGlobalScope={props.canUseGlobalPluginScope}
                   accessHint={props.pluginsAccessHint}
@@ -1631,14 +1625,11 @@ export default function DashboardView(props: DashboardViewProps) {
                   selectedMcp={props.selectedMcp}
                   setSelectedMcp={props.setSelectedMcp}
                   quickConnect={props.quickConnect}
-                  connectMcp={props.connectMcp}
-                  authorizeMcp={props.authorizeMcp}
-                  logoutMcpAuth={props.logoutMcpAuth}
-                  removeMcp={props.removeMcp}
-                  showMcpReloadBanner={props.showMcpReloadBanner}
-                  mcpReloadBlocked={props.mcpReloadBlocked}
-                  reloadMcpEngine={props.reloadMcpEngine}
-                  createSessionAndOpen={props.createSessionAndOpen}
+                   connectMcp={props.connectMcp}
+                   authorizeMcp={props.authorizeMcp}
+                   logoutMcpAuth={props.logoutMcpAuth}
+                   removeMcp={props.removeMcp}
+                   createSessionAndOpen={props.createSessionAndOpen}
                   setPrompt={props.setPrompt}
                   canReloadWorkspace={props.canReloadWorkspace}
                   reloadWorkspaceEngine={props.reloadWorkspaceEngine}

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -270,6 +270,7 @@ export type DashboardViewProps = {
   toggleShowThinking: () => void;
   autoCompactContext: boolean;
   toggleAutoCompactContext: () => void;
+  autoCompactContextBusy: boolean;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
   opencodeEnableExa: boolean;
@@ -1512,6 +1513,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   toggleShowThinking={props.toggleShowThinking}
                   autoCompactContext={props.autoCompactContext}
                   toggleAutoCompactContext={props.toggleAutoCompactContext}
+                  autoCompactContextBusy={props.autoCompactContextBusy}
                   hideTitlebar={props.hideTitlebar}
                   toggleHideTitlebar={props.toggleHideTitlebar}
                   modelVariantLabel={props.modelVariantLabel}

--- a/apps/app/src/app/pages/extensions.tsx
+++ b/apps/app/src/app/pages/extensions.tsx
@@ -144,9 +144,6 @@ export default function ExtensionsView(props: ExtensionsViewProps) {
             authorizeMcp={props.authorizeMcp}
             logoutMcpAuth={props.logoutMcpAuth}
             removeMcp={props.removeMcp}
-            showMcpReloadBanner={props.showMcpReloadBanner}
-            reloadBlocked={props.reloadBlocked}
-            reloadMcpEngine={props.reloadMcpEngine}
           />
         </div>
       </Show>

--- a/apps/app/src/app/pages/mcp.tsx
+++ b/apps/app/src/app/pages/mcp.tsx
@@ -30,7 +30,6 @@ import {
   MonitorSmartphone,
   Plug2,
   Plus,
-  RefreshCw,
   Settings,
   Settings2,
   Unplug,
@@ -56,9 +55,6 @@ export type McpViewProps = {
   authorizeMcp: (entry: McpServerEntry) => void;
   logoutMcpAuth: (name: string) => Promise<void> | void;
   removeMcp: (name: string) => void;
-  showMcpReloadBanner: boolean;
-  reloadBlocked: boolean;
-  reloadMcpEngine: () => void;
 };
 
 /* ── Status helpers ─────────────────────────────────── */
@@ -324,29 +320,6 @@ export default function McpView(props: McpViewProps) {
               </span>
             </div>
           </Show>
-        </div>
-      </Show>
-
-      {/* ── Reload banner ────────────────────────────── */}
-      <Show when={props.showMcpReloadBanner}>
-        <div class="bg-amber-2 border border-amber-6 rounded-xl px-5 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <div class="text-sm font-medium text-amber-11">{tr("mcp.finish_setup")}</div>
-            <div class="text-xs text-amber-11/70 mt-0.5">
-              {props.reloadBlocked
-                ? tr("mcp.reload_banner_description_blocked")
-                : tr("mcp.finish_setup_hint")}
-            </div>
-          </div>
-          <Button
-            variant="secondary"
-            onClick={() => props.reloadMcpEngine()}
-            disabled={props.reloadBlocked}
-            title={props.reloadBlocked ? tr("mcp.reload_banner_blocked_hint") : undefined}
-          >
-            <RefreshCw size={14} />
-            {tr("mcp.activate_button")}
-          </Button>
         </div>
       </Show>
 

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -19,6 +19,7 @@ import type {
   PendingPermission,
   PendingQuestion,
   ProviderListItem,
+  SessionCompactionState,
   SettingsTab,
   SkillCard,
   TodoItem,
@@ -191,6 +192,7 @@ export type SessionViewProps = {
   busyLabel: string | null;
   developerMode: boolean;
   showThinking: boolean;
+  sessionCompactionState: SessionCompactionState | null;
   groupMessageParts: (parts: Part[], messageId: string) => MessageGroup[];
   summarizeStep: (part: Part) => { title: string; detail?: string };
   expandedStepIds: Set<string>;
@@ -1914,6 +1916,37 @@ export default function SessionView(props: SessionViewProps) {
   });
 
   const showRunIndicator = createMemo(() => runPhase() !== "idle");
+  const showCompactionIndicator = createMemo(
+    () => props.sessionCompactionState?.running === true,
+  );
+  const compactionStatusDetail = createMemo(() => {
+    if (!showCompactionIndicator()) return "";
+    return props.sessionCompactionState?.mode === "auto"
+      ? "OpenCode is auto-compacting this session"
+      : "OpenCode is compacting this session";
+  });
+
+  createEffect(
+    on(
+      () => props.sessionCompactionState?.startedAt ?? null,
+      (startedAt, previous) => {
+        if (!startedAt || startedAt === previous) return;
+        if (props.sessionCompactionState?.mode === "manual") return;
+        setToastMessage("OpenCode started compacting the session context.");
+      },
+    ),
+  );
+
+  createEffect(
+    on(
+      () => props.sessionCompactionState?.finishedAt ?? null,
+      (finishedAt, previous) => {
+        if (!finishedAt || finishedAt === previous) return;
+        if (props.sessionCompactionState?.mode === "manual") return;
+        setToastMessage("OpenCode finished compacting the session context.");
+      },
+    ),
+  );
 
   const latestRunPart = createMemo<Part | null>(() => {
     if (!showRunIndicator()) return null;
@@ -4711,25 +4744,32 @@ export default function SessionView(props: SessionViewProps) {
             providerConnectedIds={props.providerConnectedIds}
             mcpStatuses={props.mcpStatuses}
             statusLabel={
-              showRunIndicator()
+              showCompactionIndicator()
+                ? "Compacting Context"
+                : showRunIndicator()
                 ? "Session Active"
                 : props.selectedSessionId
                   ? "Session Ready"
                   : "Ready"
             }
+            statusDetail={showCompactionIndicator() ? compactionStatusDetail() : undefined}
             statusDotClass={
-              showRunIndicator()
+              showCompactionIndicator()
+                ? "bg-blue-9"
+                : showRunIndicator()
                 ? "bg-green-9"
                 : props.selectedSessionId
                   ? "bg-green-9"
                   : "bg-gray-8"
             }
             statusPingClass={
-              showRunIndicator()
+              showCompactionIndicator()
+                ? "bg-blue-9/35 animate-ping"
+                : showRunIndicator()
                 ? "bg-green-9/45 animate-ping"
                 : "bg-green-9/35"
             }
-            statusPulse={showRunIndicator()}
+            statusPulse={showCompactionIndicator() || showRunIndicator()}
           />
         </main>
       </div>

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -46,7 +46,6 @@ import { getOpenWorkDeployment } from "../lib/openwork-deployment";
 import { createWorkspaceShellLayout } from "../lib/workspace-shell-layout";
 
 import {
-  AlertTriangle,
   Check,
   Circle,
   FolderOpen,
@@ -212,17 +211,6 @@ export type SessionViewProps = {
   mcpStatus: string | null;
   skills: SkillCard[];
   skillsStatus: string | null;
-  showSkillReloadBanner: boolean;
-  reloadBannerTitle: string;
-  reloadBannerBody: string;
-  reloadBannerBlocked: boolean;
-  reloadBannerActiveCount: number;
-  canReloadWorkspace: boolean;
-  reloadWorkspaceEngine: () => Promise<void>;
-  forceStopActiveConversations: () => Promise<void>;
-  dismissReloadBanner: () => void;
-  reloadBusy: boolean;
-  reloadError: string | null;
   busy: boolean;
   prompt: string;
   setPrompt: (value: string) => void;
@@ -4273,96 +4261,6 @@ export default function SessionView(props: SessionViewProps) {
                 >
                   <X size={14} />
                 </button>
-              </div>
-            </div>
-          </Show>
-
-          <Show when={props.showSkillReloadBanner}>
-            <div class="border-b border-dls-border/70 bg-dls-surface animate-in fade-in slide-in-from-top-3 duration-300">
-              <div class="flex min-h-[104px] items-start gap-3 px-4 py-5 sm:px-6 lg:px-10">
-                <div
-                  class={`flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border ${
-                    props.reloadBannerBlocked
-                      ? "border-amber-6/40 bg-amber-4/80 text-amber-11"
-                      : "border-sky-6/40 bg-sky-4/80 text-sky-11"
-                  }`.trim()}
-                >
-                  <RefreshCcw size={18} class={props.reloadBusy ? "animate-spin" : ""} />
-                </div>
-
-                <div class="min-w-0 flex-1">
-                  <div class="flex items-start justify-between gap-3">
-                    <div class="min-w-0">
-                      <div class="flex items-center gap-2">
-                        <span class="truncate text-sm font-semibold text-gray-12">{props.reloadBannerTitle}</span>
-                        <Show when={props.reloadBannerBlocked}>
-                          <span class="inline-flex items-center gap-1 rounded-full bg-amber-4 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-11">
-                            Active tasks
-                          </span>
-                        </Show>
-                      </div>
-
-                      <div class="mt-1 space-y-1 text-sm leading-relaxed text-gray-10">
-                        <div>
-                          <Show
-                            when={props.reloadBannerBlocked}
-                            fallback={
-                              <Show when={props.reloadError} fallback={props.reloadBannerBody}>
-                                <span class="font-medium text-red-11">{props.reloadError}</span>
-                              </Show>
-                            }
-                          >
-                            <span class="font-medium text-amber-11">Reloading will stop active tasks.</span>
-                          </Show>
-                        </div>
-
-                        <Show when={props.reloadBannerBlocked}>
-                          <div class="flex items-start gap-2 rounded-2xl border border-amber-6/40 bg-amber-3/70 px-3 py-2 text-xs text-amber-11">
-                            <AlertTriangle size={14} class="mt-0.5 shrink-0" />
-                            <span>
-                              {`Reloading stops ${props.reloadBannerActiveCount} active conversation${props.reloadBannerActiveCount === 1 ? "" : "s"}.`}
-                            </span>
-                          </div>
-                        </Show>
-                      </div>
-                    </div>
-
-                    <button
-                      type="button"
-                      onClick={props.dismissReloadBanner}
-                      class="rounded-full p-1 text-gray-9 transition hover:bg-gray-3 hover:text-gray-12"
-                      aria-label="Dismiss reload prompt"
-                    >
-                      <X size={16} />
-                    </button>
-                  </div>
-
-                  <div class="mt-3 flex flex-wrap items-center gap-2">
-                    <Button
-                      variant={props.reloadBannerBlocked ? "danger" : "primary"}
-                      class="rounded-full px-3 py-1.5 text-xs"
-                      disabled={!props.canReloadWorkspace || props.reloadBusy}
-                      onClick={() =>
-                        void (props.reloadBannerBlocked
-                          ? props.forceStopActiveConversations()
-                          : props.reloadWorkspaceEngine())
-                      }
-                    >
-                      {props.reloadBusy
-                        ? "Reloading..."
-                        : props.reloadBannerBlocked
-                          ? "Reload & Stop Tasks"
-                          : "Reload now"}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      class="rounded-full px-3 py-1.5 text-xs"
-                      onClick={props.dismissReloadBanner}
-                    >
-                      Later
-                    </Button>
-                  </div>
-                </div>
               </div>
             </div>
           </Show>

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -147,6 +147,7 @@ export type SettingsViewProps = {
   toggleShowThinking: () => void;
   autoCompactContext: boolean;
   toggleAutoCompactContext: () => void;
+  autoCompactContextBusy: boolean;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
   modelVariantLabel: string;
@@ -1888,25 +1889,6 @@ export default function SettingsView(props: SettingsViewProps) {
 
               <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                 <div class="min-w-0">
-                  <div class="text-sm text-gray-12">
-                    Auto context compaction
-                  </div>
-                  <div class="text-xs text-gray-7">
-                    Automatically compact after a run completes.
-                  </div>
-                </div>
-                <Button
-                  variant="outline"
-                  class="text-xs h-8 py-0 px-3 shrink-0"
-                  onClick={props.toggleAutoCompactContext}
-                  disabled={props.busy}
-                >
-                  {props.autoCompactContext ? "On" : "Off"}
-                </Button>
-              </div>
-
-              <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-                <div class="min-w-0">
                   <div class="text-sm text-gray-12">Model behavior</div>
                   <div class="text-xs text-gray-7 truncate">
                     Open the default model picker to choose reasoning profiles when they are available.
@@ -1922,6 +1904,23 @@ export default function SettingsView(props: SettingsViewProps) {
                   disabled={props.busy}
                 >
                   Configure
+                </Button>
+              </div>
+
+              <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+                <div class="min-w-0">
+                  <div class="text-sm text-gray-12">Auto context compaction</div>
+                  <div class="text-xs text-gray-7">
+                    Controls OpenCode <code>compaction.auto</code> for this workspace. Reload the engine after changing it.
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  class="text-xs h-8 py-0 px-3 shrink-0"
+                  onClick={props.toggleAutoCompactContext}
+                  disabled={props.busy || props.autoCompactContextBusy}
+                >
+                  {props.autoCompactContext ? "On" : "Off"}
                 </Button>
               </div>
             </div>

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -284,9 +284,6 @@ export type SettingsViewProps = {
   authorizeMcp: (entry: McpServerEntry) => void;
   logoutMcpAuth: (name: string) => Promise<void> | void;
   removeMcp: (name: string) => void;
-  showMcpReloadBanner: boolean;
-  mcpReloadBlocked: boolean;
-  reloadMcpEngine: () => void;
   createSessionAndOpen: () => void;
   setPrompt: (value: string) => void;
   connectRemoteWorkspace: (input: {
@@ -2180,9 +2177,6 @@ export default function SettingsView(props: SettingsViewProps) {
               authorizeMcp={props.authorizeMcp}
               logoutMcpAuth={props.logoutMcpAuth}
               removeMcp={props.removeMcp}
-              showMcpReloadBanner={props.showMcpReloadBanner}
-              reloadBlocked={props.mcpReloadBlocked}
-              reloadMcpEngine={props.reloadMcpEngine}
               canEditPlugins={props.canEditPlugins}
               canUseGlobalScope={props.canUseGlobalPluginScope}
               accessHint={props.pluginsAccessHint}

--- a/apps/app/src/app/system-state.ts
+++ b/apps/app/src/app/system-state.ts
@@ -73,7 +73,10 @@ export function createSystemState(options: {
   setError: (value: string | null) => void;
   notion?: NotionState;
 }) {
-  const [reloadRequired, setReloadRequired] = createSignal(false);
+  const isActiveSessionStatus = (status: string | null | undefined) =>
+    status === "running" || status === "retry";
+
+  const [reloadPending, setReloadPending] = createSignal(false);
   const [reloadReasons, setReloadReasons] = createSignal<ReloadReason[]>([]);
   const [reloadLastTriggeredAt, setReloadLastTriggeredAt] = createSignal<number | null>(null);
   const [reloadLastFinishedAt, setReloadLastFinishedAt] = createSignal<number | null>(null);
@@ -109,7 +112,7 @@ export function createSystemState(options: {
 
   const anyActiveRuns = createMemo(() => {
     const statuses = options.sessionStatusById();
-    return options.sessions().some((s) => statuses[s.id] === "running");
+    return options.sessions().some((s) => isActiveSessionStatus(statuses[s.id]));
   });
 
   function clearOpenworkLocalStorage(mode: ResetOpenworkMode) {
@@ -179,7 +182,7 @@ export function createSystemState(options: {
   }
 
   function markReloadRequired(reason: ReloadReason, trigger?: ReloadTrigger) {
-    setReloadRequired(true);
+    setReloadPending(true);
     setReloadLastTriggeredAt(Date.now());
     setReloadReasons((current) => (current.includes(reason) ? current : [...current, reason]));
     if (trigger) {
@@ -201,7 +204,7 @@ export function createSystemState(options: {
   }
 
   function clearReloadRequired() {
-    setReloadRequired(false);
+    setReloadPending(false);
     setReloadReasons([]);
     setReloadError(null);
     setReloadTrigger(null);
@@ -265,7 +268,7 @@ export function createSystemState(options: {
   });
 
   const canReloadEngine = createMemo(() => {
-    if (!reloadRequired()) return false;
+    if (!reloadPending()) return false;
     if (reloadBusy()) return false;
     const override = options.canReloadWorkspaceEngine?.();
     if (override === true) return true;
@@ -276,7 +279,7 @@ export function createSystemState(options: {
 
   // Keep this mounted so the reload banner UX remains in the app.
   createEffect(() => {
-    reloadRequired();
+    reloadPending();
   });
 
   async function reloadEngineInstance() {
@@ -607,7 +610,7 @@ export function createSystemState(options: {
   }
 
   return {
-    reloadRequired,
+    reloadPending,
     reloadReasons,
     reloadLastTriggeredAt,
     reloadLastFinishedAt,

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -142,6 +142,14 @@ export type OpencodeEvent = {
   properties?: unknown;
 };
 
+export type SessionCompactionState = {
+  running: boolean;
+  startedAt: number | null;
+  finishedAt: number | null;
+  mode: "auto" | "manual" | null;
+  messageID: string | null;
+};
+
 export type View = "onboarding" | "dashboard" | "session" | "proto";
 
 export type StartupPreference = "local" | "server";


### PR DESCRIPTION
## Summary
- wire the OpenWork auto context compaction toggle to OpenCode's `compaction.auto` workspace config instead of the old local post-run behavior
- remove the app-side auto-compact-after-run trigger and require the normal engine reload path when the config changes
- surface OpenCode compaction lifecycle in the session UI with visible status/debug events for start and finish

## Testing
- `git diff --check`
- `pnpm typecheck` *(fails in this worktree because `node_modules` is missing, so `vite/client` types are unavailable)*