### PR TITLE
Inline Den worker connect rows and add rename support

### DIFF
--- a/ee/apps/den-controller/src/http/workers.ts
+++ b/ee/apps/den-controller/src/http/workers.ts
@@ -791,6 +791,14 @@ workersRouter.patch("/:id", asyncRoute(async (req, res) => {
     return
   }
 
+  if (rows[0].created_by_user_id !== session.user.id) {
+    res.status(403).json({
+      error: "forbidden",
+      message: "Only the worker owner can rename this sandbox.",
+    })
+    return
+  }
+
   await db
     .update(WorkerTable)
     .set({ name: parsed.data.name })

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -101,6 +101,7 @@ type DenFlowContextValue = {
   workers: WorkerListItem[];
   filteredWorkers: WorkerListItem[];
   workersBusy: boolean;
+  workersLoadedOnce: boolean;
   workersError: string | null;
   workerQuery: string;
   setWorkerQuery: (value: string) => void;
@@ -117,6 +118,7 @@ type DenFlowContextValue = {
   actionBusy: "status" | "token" | null;
   deleteBusyWorkerId: string | null;
   redeployBusyWorkerId: string | null;
+  renameBusyWorkerId: string | null;
   runtimeSnapshot: WorkerRuntimeSnapshot | null;
   runtimeBusy: boolean;
   runtimeError: string | null;
@@ -134,6 +136,7 @@ type DenFlowContextValue = {
   launchWorker: (options?: { source?: "manual" | "signup_auto"; workerNameOverride?: string }) => Promise<LaunchWorkerResult>;
   checkWorkerStatus: (options?: { workerId?: string; quiet?: boolean; background?: boolean }) => Promise<void>;
   generateWorkerToken: () => Promise<void>;
+  renameWorker: (workerId: string, name: string) => Promise<boolean>;
   deleteWorker: (workerId: string) => Promise<void>;
   redeployWorker: (workerId: string) => Promise<void>;
   refreshRuntime: (workerId?: string, options?: { quiet?: boolean }) => Promise<WorkerRuntimeSnapshot | null>;
@@ -202,6 +205,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   const [workerLookupId, setWorkerLookupId] = useState("");
   const [workers, setWorkers] = useState<WorkerListItem[]>([]);
   const [workersBusy, setWorkersBusy] = useState(false);
+  const [workersLoadedOnce, setWorkersLoadedOnce] = useState(false);
   const [workersError, setWorkersError] = useState<string | null>(null);
   const [workerQuery, setWorkerQuery] = useState("");
   const [workerStatusFilter, setWorkerStatusFilter] = useState<WorkerStatusBucket | "all">("all");
@@ -214,6 +218,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   const [tokenFetchedForWorkerId, setTokenFetchedForWorkerId] = useState<string | null>(null);
   const [deleteBusyWorkerId, setDeleteBusyWorkerId] = useState<string | null>(null);
   const [redeployBusyWorkerId, setRedeployBusyWorkerId] = useState<string | null>(null);
+  const [renameBusyWorkerId, setRenameBusyWorkerId] = useState<string | null>(null);
   const [pendingRestoredWorkerId, setPendingRestoredWorkerId] = useState<string | null>(null);
   const [runtimeSnapshot, setRuntimeSnapshot] = useState<WorkerRuntimeSnapshot | null>(null);
   const [runtimeBusy, setRuntimeBusy] = useState(false);
@@ -563,15 +568,18 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     };
   }
 
-  async function refreshWorkers(options: { keepSelection?: boolean } = {}) {
+  async function refreshWorkers(options: { keepSelection?: boolean; quiet?: boolean } = {}) {
     if (!user) {
       setWorkers([]);
+      setWorkersLoadedOnce(false);
       setWorkersError(null);
       return;
     }
 
-    setWorkersBusy(true);
-    setWorkersError(null);
+    if (!options.quiet) {
+      setWorkersBusy(true);
+      setWorkersError(null);
+    }
 
     try {
       const { response, payload } = await requestJson("/v1/workers?limit=20", {
@@ -580,12 +588,16 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       });
 
       if (!response.ok) {
-        setWorkersError(getErrorMessage(payload, `Failed to load workers (${response.status}).`));
+        if (!options.quiet) {
+          setWorkersError(getErrorMessage(payload, `Failed to load workers (${response.status}).`));
+        }
+        setWorkersLoadedOnce(true);
         return;
       }
 
       const nextWorkers = getWorkersList(payload);
       setWorkers(nextWorkers);
+      setWorkersLoadedOnce(true);
 
       const restoredWorkerStillExists =
         pendingRestoredWorkerId && nextWorkers.some((item) => item.workerId === pendingRestoredWorkerId);
@@ -622,9 +634,14 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
         }
       }
     } catch (error) {
-      setWorkersError(error instanceof Error ? error.message : "Unknown network error");
+      if (!options.quiet) {
+        setWorkersError(error instanceof Error ? error.message : "Unknown network error");
+      }
+      setWorkersLoadedOnce(true);
     } finally {
-      setWorkersBusy(false);
+      if (!options.quiet) {
+        setWorkersBusy(false);
+      }
     }
   }
 
@@ -1554,6 +1571,50 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  async function renameWorker(workerId: string, name: string) {
+    if (!user) {
+      setLaunchError("Sign in before renaming a worker.");
+      return false;
+    }
+
+    const nextName = name.trim();
+    if (!nextName) {
+      setLaunchError("Enter a worker name.");
+      return false;
+    }
+
+    setRenameBusyWorkerId(workerId);
+    setLaunchError(null);
+
+    try {
+      const { response, payload } = await requestJson(`/v1/workers/${encodeURIComponent(workerId)}`, {
+        method: "PATCH",
+        headers: authToken ? { Authorization: `Bearer ${authToken}` } : undefined,
+        body: JSON.stringify({ name: nextName })
+      });
+
+      if (!response.ok) {
+        const message = getErrorMessage(payload, `Rename failed with ${response.status}.`);
+        setLaunchError(message);
+        appendEvent("error", "Rename failed", message);
+        return false;
+      }
+
+      setWorkers((current) => current.map((entry) => entry.workerId === workerId ? { ...entry, workerName: nextName } : entry));
+      setWorker((current) => current && current.workerId === workerId ? { ...current, workerName: nextName } : current);
+      setLaunchStatus(`Renamed worker to ${nextName}.`);
+      appendEvent("success", "Worker renamed", nextName);
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown network error";
+      setLaunchError(message);
+      appendEvent("error", "Rename failed", message);
+      return false;
+    } finally {
+      setRenameBusyWorkerId(null);
+    }
+  }
+
   async function deleteWorker(workerId: string) {
     if (!user) {
       setLaunchError("Sign in before deleting a worker.");
@@ -1739,6 +1800,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!user) {
       setWorkers([]);
+      setWorkersLoadedOnce(false);
       setWorkersError(null);
       return;
     }
@@ -1904,7 +1966,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      await refreshWorkers({ keepSelection: true });
+      await refreshWorkers({ keepSelection: true, quiet: true });
     };
 
     void poll();
@@ -2035,6 +2097,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     workers,
     filteredWorkers,
     workersBusy,
+    workersLoadedOnce,
     workersError,
     workerQuery,
     setWorkerQuery,
@@ -2051,6 +2114,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     actionBusy,
     deleteBusyWorkerId,
     redeployBusyWorkerId,
+    renameBusyWorkerId,
     runtimeSnapshot,
     runtimeBusy,
     runtimeError,
@@ -2068,6 +2132,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     launchWorker,
     checkWorkerStatus,
     generateWorkerToken,
+    renameWorker,
     deleteWorker,
     redeployWorker,
     refreshRuntime,

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/background-agents-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/background-agents-screen.tsx
@@ -69,12 +69,97 @@ function CredentialField({
   );
 }
 
+function RowConnectActions({
+  workerId,
+  openworkAppConnectUrl,
+  openworkDeepLink,
+  activeWorker,
+  copiedField,
+  copyToClipboard,
+  generateWorkerToken,
+  actionBusy,
+}: {
+  workerId: string;
+  openworkAppConnectUrl: string | null;
+  openworkDeepLink: string | null;
+  activeWorker: {
+    openworkUrl: string | null;
+    instanceUrl: string | null;
+    ownerToken: string | null;
+    clientToken: string | null;
+  };
+  copiedField: string | null;
+  copyToClipboard: (field: string, value: string | null) => Promise<void>;
+  generateWorkerToken: () => Promise<void>;
+  actionBusy: "status" | "token" | null;
+}) {
+  return (
+    <div className="mt-4 grid gap-4 border-t border-[var(--dls-border)] pt-4">
+      <div className="flex flex-wrap gap-3">
+        <a
+          href={openworkAppConnectUrl ?? "#"}
+          target="_blank"
+          rel="noreferrer"
+          className={`den-button-primary ${openworkAppConnectUrl ? "" : "pointer-events-none opacity-60"}`}
+        >
+          Open in web
+        </a>
+        <button
+          type="button"
+          className="den-button-secondary"
+          onClick={() => {
+            if (openworkDeepLink) {
+              window.location.href = openworkDeepLink;
+            }
+          }}
+          disabled={!openworkDeepLink}
+        >
+          Open in desktop
+        </button>
+        <button
+          type="button"
+          className="den-button-secondary"
+          onClick={() => void generateWorkerToken()}
+          disabled={actionBusy === "token"}
+        >
+          {actionBusy === "token" ? "Refreshing..." : "Refresh tokens"}
+        </button>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <CredentialField
+          label="Connection URL"
+          value={activeWorker.openworkUrl ?? activeWorker.instanceUrl}
+          copyKey={`background-connect-url-${workerId}`}
+          copiedField={copiedField}
+          onCopy={copyToClipboard}
+        />
+        <CredentialField
+          label="Owner token"
+          value={activeWorker.ownerToken}
+          copyKey={`background-owner-token-${workerId}`}
+          copiedField={copiedField}
+          onCopy={copyToClipboard}
+        />
+        <CredentialField
+          label="Collaborator token"
+          value={activeWorker.clientToken}
+          copyKey={`background-client-token-${workerId}`}
+          copiedField={copiedField}
+          onCopy={copyToClipboard}
+        />
+      </div>
+    </div>
+  );
+}
+
 export function BackgroundAgentsScreen() {
   const router = useRouter();
   const { orgSlug } = useOrgDashboard();
   const {
     workers,
     workersBusy,
+    workersLoadedOnce,
     workersError,
     launchBusy,
     launchWorker,
@@ -86,12 +171,12 @@ export function BackgroundAgentsScreen() {
     copiedField,
     copyToClipboard,
     generateWorkerToken,
+    renameWorker,
+    renameBusyWorkerId,
     actionBusy,
   } = useDenFlow();
 
   const selectedWorkerId = selectedWorker?.workerId ?? null;
-  const selectedMeta = selectedWorker ? getWorkerStatusMeta(selectedWorker.status) : null;
-  const showConnectPanel = Boolean(selectedWorkerId && selectedMeta?.bucket === "ready");
 
   async function handleAddSandbox() {
     const result = await launchWorker({ source: "manual" });
@@ -155,40 +240,72 @@ export function BackgroundAgentsScreen() {
           </h2>
         </div>
 
-        {workersBusy ? (
+        {!workersLoadedOnce || workersBusy ? (
           <div className="den-list-row text-sm text-[var(--dls-text-secondary)]">Loading sandboxes...</div>
         ) : workers.length > 0 ? (
           workers.map((worker) => {
             const meta = getWorkerStatusMeta(worker.status);
             const canConnect = meta.bucket === "ready";
             const isSelected = selectedWorkerId === worker.workerId;
+            const showInlineConnect = isSelected && canConnect && activeWorker?.workerId === worker.workerId;
             return (
-              <article key={worker.workerId} className="den-list-row">
-                <div className="grid gap-1">
-                  <h3 className="text-base font-semibold text-[var(--dls-text-primary)]">{worker.workerName}</h3>
-                  <p className="text-sm text-[var(--dls-text-secondary)]">
-                    Source: {worker.provider ? `${worker.provider} sandbox` : "Cloud sandbox"}
-                  </p>
+              <article key={worker.workerId} className="den-list-row flex-col items-stretch gap-4">
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="grid gap-1">
+                    <h3 className="text-base font-semibold text-[var(--dls-text-primary)]">{worker.workerName}</h3>
+                    <p className="text-sm text-[var(--dls-text-secondary)]">
+                      Source: {worker.provider ? `${worker.provider} sandbox` : "Cloud sandbox"}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {worker.isMine ? (
+                      <button
+                        type="button"
+                        className="den-button-secondary"
+                        onClick={() => {
+                          const nextName = window.prompt("Rename sandbox", worker.workerName)?.trim();
+                          if (!nextName || nextName === worker.workerName) {
+                            return;
+                          }
+                          void renameWorker(worker.workerId, nextName);
+                        }}
+                        disabled={renameBusyWorkerId === worker.workerId}
+                      >
+                        {renameBusyWorkerId === worker.workerId ? "Renaming..." : "Rename"}
+                      </button>
+                    ) : null}
+                    {canConnect ? (
+                      <button
+                        type="button"
+                        className="den-button-secondary"
+                        onClick={() => {
+                          selectWorker(worker);
+                          if (!isSelected) {
+                            window.setTimeout(() => {
+                              void generateWorkerToken();
+                            }, 0);
+                          }
+                        }}
+                      >
+                        Connect
+                      </button>
+                    ) : null}
+                    <span className={`den-status-pill ${statusClass(meta.bucket)}`}>{meta.label}</span>
+                  </div>
                 </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  {canConnect ? (
-                    <button
-                      type="button"
-                      className="den-button-secondary"
-                      onClick={() => {
-                        selectWorker(worker);
-                        if (!isSelected) {
-                          window.setTimeout(() => {
-                            void generateWorkerToken();
-                          }, 0);
-                        }
-                      }}
-                    >
-                      Connect
-                    </button>
-                  ) : null}
-                  <span className={`den-status-pill ${statusClass(meta.bucket)}`}>{meta.label}</span>
-                </div>
+
+                {showInlineConnect ? (
+                  <RowConnectActions
+                    workerId={worker.workerId}
+                    openworkAppConnectUrl={openworkAppConnectUrl}
+                    openworkDeepLink={openworkDeepLink}
+                    activeWorker={activeWorker}
+                    copiedField={copiedField}
+                    copyToClipboard={copyToClipboard}
+                    generateWorkerToken={generateWorkerToken}
+                    actionBusy={actionBusy}
+                  />
+                ) : null}
               </article>
             );
           })
@@ -205,74 +322,6 @@ export function BackgroundAgentsScreen() {
         )}
       </div>
 
-      {showConnectPanel && selectedWorker && activeWorker ? (
-        <div className="den-frame grid gap-5 p-6 md:p-8">
-          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-            <div>
-              <p className="den-eyebrow">Connect remote</p>
-              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{selectedWorker.workerName}</h2>
-              <p className="mt-2 text-sm leading-relaxed text-[var(--dls-text-secondary)]">
-                Open this worker in web or desktop, or copy the connection details below.
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-3">
-              <a
-                href={openworkAppConnectUrl ?? "#"}
-                target="_blank"
-                rel="noreferrer"
-                className={`den-button-primary ${openworkAppConnectUrl ? "" : "pointer-events-none opacity-60"}`}
-              >
-                Open in web
-              </a>
-              <button
-                type="button"
-                className="den-button-secondary"
-                onClick={() => {
-                  if (openworkDeepLink) {
-                    window.location.href = openworkDeepLink;
-                  }
-                }}
-                disabled={!openworkDeepLink}
-              >
-                Open in desktop
-              </button>
-              <button
-                type="button"
-                className="den-button-secondary"
-                onClick={() => void generateWorkerToken()}
-                disabled={actionBusy === "token"}
-              >
-                {actionBusy === "token" ? "Refreshing..." : "Refresh tokens"}
-              </button>
-            </div>
-          </div>
-
-          <div className="grid gap-4 lg:grid-cols-3">
-            <CredentialField
-              label="Connection URL"
-              value={activeWorker.openworkUrl ?? activeWorker.instanceUrl}
-              copyKey="background-connect-url"
-              copiedField={copiedField}
-              onCopy={copyToClipboard}
-            />
-            <CredentialField
-              label="Owner token"
-              value={activeWorker.ownerToken}
-              copyKey="background-owner-token"
-              copiedField={copiedField}
-              onCopy={copyToClipboard}
-            />
-            <CredentialField
-              label="Collaborator token"
-              value={activeWorker.clientToken}
-              copyKey="background-client-token"
-              copiedField={copiedField}
-              onCopy={copyToClipboard}
-            />
-          </div>
-        </div>
-      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- keep worker connect actions inline with each background-agent row instead of rendering a separate panel below the list
- add owner-only worker rename support in the Den controller and expose a simple rename action in the background agents UI
- prevent the worker list from flashing example rows or re-entering a visible loading state during background polling, while keeping a proper first-load loading state

## Verification
- `pnpm --filter @openwork-ee/den-controller build`
- `pnpm --filter @openwork-ee/den-web build`