### PR TITLE
fix(den): prefer client tokens for OpenWork links

### DIFF
--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -238,7 +238,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
         ? listItemToWorker(selectedWorker, worker)
         : worker;
   const openworkConnectUrl = activeWorker?.openworkUrl ?? activeWorker?.instanceUrl ?? null;
-  const preferredOpenworkToken = activeWorker?.ownerToken ?? activeWorker?.clientToken ?? null;
+  const preferredOpenworkToken = activeWorker?.clientToken ?? activeWorker?.ownerToken ?? null;
   const hasWorkspaceScopedUrl = Boolean(openworkConnectUrl && /\/w\/[^/?#]+/.test(openworkConnectUrl));
   const openworkDeepLink = buildOpenworkDeepLink(
     openworkConnectUrl,
@@ -537,7 +537,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       };
     }
 
-    const accessToken = candidate.ownerToken?.trim() ?? candidate.clientToken?.trim() ?? "";
+    const accessToken = candidate.clientToken?.trim() ?? candidate.ownerToken?.trim() ?? "";
     if (!accessToken) {
       const mountedWorkspaceId = parseWorkspaceIdFromUrl(instanceUrl);
       return {


### PR DESCRIPTION
## Summary
- prefer the worker client token over the owner token when building Den OpenWork connect links
- align the main connect flow with the background agent flow so first-run remote sessions use the bearer token OpenWork accepts
- keep the change scoped to the Den web launch path for remote sandbox workers

## Testing
- `pnpm --filter @openwork-ee/den-web lint` *(fails in this worktree: `next: command not found`, local `node_modules` missing)*