### PR TITLE
fix(den): refresh onboarding flow on next 15

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { Dithering, MeshGradient } from "@paper-design/shaders-react";
+import { ArrowRight, CheckCircle2 } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { isSamePathname } from "../_lib/client-route";
 import { useDenFlow } from "../_providers/den-flow-provider";
 
 function getDesktopGrant(url: string | null) {
@@ -37,8 +40,56 @@ function GoogleLogo() {
   );
 }
 
+function FeatureCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5">
+      <p className="mb-2 text-[14px] font-medium text-gray-900">{title}</p>
+      <p className="text-[13px] leading-[1.6] text-gray-500">{body}</p>
+    </div>
+  );
+}
+
+function SocialButton({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}
+
+function LoadingPanel({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.22)] md:p-7">
+      <div className="grid gap-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+          OpenWork Cloud
+        </p>
+        <h2 className="text-[28px] font-semibold tracking-[-0.04em] text-gray-900">{title}</h2>
+        <p className="text-[14px] leading-relaxed text-gray-500">{body}</p>
+      </div>
+      <div className="mt-6 h-2 overflow-hidden rounded-full bg-gray-100">
+        <div className="h-full w-1/3 animate-pulse rounded-full bg-gray-900/80" />
+      </div>
+    </div>
+  );
+}
+
 export function AuthScreen() {
   const router = useRouter();
+  const pathname = usePathname();
   const routingRef = useRef(false);
   const [copiedDesktopField, setCopiedDesktopField] = useState<"link" | "code" | null>(null);
   const {
@@ -65,9 +116,10 @@ export function AuthScreen() {
     resendVerificationCode,
     cancelVerification,
     beginSocialAuth,
-    resolveUserLandingRoute
+    resolveUserLandingRoute,
   } = useDenFlow();
   const desktopGrant = getDesktopGrant(desktopRedirectUrl);
+  const hasResolvedSession = sessionHydrated && Boolean(user) && !desktopAuthRequested;
 
   const copyDesktopValue = async (field: "link" | "code", value: string | null) => {
     if (!value) return;
@@ -79,18 +131,21 @@ export function AuthScreen() {
   };
 
   useEffect(() => {
-    if (!sessionHydrated || !user || desktopAuthRequested || routingRef.current) {
+    if (!hasResolvedSession || routingRef.current) {
       return;
     }
 
     routingRef.current = true;
-    void resolveUserLandingRoute().then((target) => {
-      if (target) {
-        router.replace(target);
-      }
-      routingRef.current = false;
-    });
-  }, [desktopAuthRequested, resolveUserLandingRoute, router, sessionHydrated, user]);
+    void resolveUserLandingRoute()
+      .then((target) => {
+        if (target && !isSamePathname(pathname, target)) {
+          router.replace(target);
+        }
+      })
+      .finally(() => {
+        routingRef.current = false;
+      });
+  }, [hasResolvedSession, pathname, resolveUserLandingRoute, router]);
 
   const panelTitle = verificationRequired
     ? "Verify your email."
@@ -104,61 +159,111 @@ export function AuthScreen() {
       ? "Start with email, GitHub, or Google."
       : "Welcome back. Keep your team setup in sync across Cloud and desktop.";
 
+  if (!sessionHydrated) {
+    return (
+      <section className="den-page flex w-full items-center py-4 lg:min-h-[calc(100vh-2.5rem)]">
+        <LoadingPanel title="Checking your session." body="Loading your Cloud account state..." />
+      </section>
+    );
+  }
+
   return (
     <section className="den-page flex w-full items-center py-4 lg:min-h-[calc(100vh-2.5rem)]">
-      {sessionHydrated ? (
-        <div className="grid w-full gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)]">
-          <div className="den-frame-soft flex flex-col justify-between gap-10 p-7 md:p-10 lg:p-12">
-            <div className="grid gap-6">
-              <span className="den-kicker w-fit">OpenWork Cloud</span>
-              <div className="grid gap-4">
-                <h1 className="den-title-xl max-w-[12ch]">Share your OpenWork setup with your team.</h1>
-                <p className="den-copy max-w-[40rem]">
-                  Provision shared setups, invite your org, and keep background agents available when you need them.
-                </p>
-              </div>
+      <div className="grid w-full gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)]">
+        <div className="flex flex-col gap-6">
+          <div className="relative min-h-[300px] overflow-hidden rounded-[32px] border border-gray-100 px-7 py-8 md:px-10 md:py-10">
+            <div className="absolute inset-0 z-0">
+              <Dithering
+                speed={0}
+                shape="warp"
+                type="4x4"
+                size={2.5}
+                scale={1}
+                frame={30214.2}
+                colorBack="#00000000"
+                colorFront="#FEFEFE"
+                style={{ backgroundColor: "#142033", width: "100%", height: "100%" }}
+              >
+                <MeshGradient
+                  speed={0.7}
+                  distortion={0.8}
+                  swirl={0.1}
+                  grainMixer={0}
+                  grainOverlay={0}
+                  frame={176868.9}
+                  colors={["#E0FCFF", "#3B82F6", "#7C3AED", "#50F7D4"]}
+                  style={{ width: "100%", height: "100%" }}
+                />
+              </Dithering>
             </div>
 
-            <div className="grid gap-6 md:grid-cols-3 lg:grid-cols-1">
-              <div className="grid gap-1 border-t border-gray-200 pt-4">
-                <p className="text-base font-medium text-[var(--dls-text-primary)]">Share setup across your team and org</p>
-                <p className="den-copy text-sm">Package skills, MCPs, plugins, and config once.</p>
+            <div className="relative z-10 flex h-full flex-col justify-between gap-10">
+              <div className="flex items-center gap-3">
+                <img src="/openwork-mark.svg" alt="OpenWork" className="h-9 w-auto" />
+                <span className="text-[13px] font-medium text-white/80">OpenWork Cloud</span>
               </div>
-              <div className="grid gap-1 border-t border-gray-200 pt-4">
-                <p className="text-base font-medium text-[var(--dls-text-primary)]">Background agents</p>
-                <p className="den-copy text-sm">Keep selected workflows running in the cloud. Alpha.</p>
-              </div>
-              <div className="grid gap-1 border-t border-gray-200 pt-4">
-                <p className="text-base font-medium text-[var(--dls-text-primary)]">Custom LLM providers</p>
-                <p className="den-copy text-sm">Standardize provider access for your team. Coming soon.</p>
+
+              <div className="grid gap-4">
+                <span className="inline-flex w-fit rounded-full border border-white/20 bg-white/15 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-white backdrop-blur-md">
+                  Shared setups
+                </span>
+                <h1 className="max-w-[12ch] text-[2.25rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white md:text-[3rem]">
+                  Share your OpenWork setup with your team.
+                </h1>
+                <p className="max-w-[34rem] text-[15px] leading-7 text-white/80">
+                  Provision shared setups, invite your org, and keep background workspaces available across Cloud and desktop.
+                </p>
               </div>
             </div>
           </div>
 
-          <div className="den-frame grid h-fit gap-5 p-6 md:p-7 lg:mt-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            <FeatureCard
+              title="Team sharing"
+              body="Package skills, MCPs, plugins, and config once so the whole org can use the same setup."
+            />
+            <FeatureCard
+              title="Shared workspaces"
+              body="Keep selected workflows running in the cloud without asking each teammate to run them locally."
+            />
+            <FeatureCard
+              title="Provider control"
+              body="Roll into standardized model access and billing controls as your team grows into Cloud."
+            />
+          </div>
+        </div>
+
+        {hasResolvedSession ? (
+          <LoadingPanel
+            title="Redirecting to your workspace."
+            body="We found your account and are sending you to the right Cloud destination now."
+          />
+        ) : (
+          <div className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.22)] md:p-7">
             <div className="grid gap-2">
-              <p className="den-eyebrow">Account</p>
-              <h2 className="den-title-lg">{panelTitle}</h2>
-              <p className="den-copy text-sm">{panelCopy}</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                Account
+              </p>
+              <h2 className="text-[28px] font-semibold tracking-[-0.04em] text-gray-900">{panelTitle}</h2>
+              <p className="text-[14px] leading-relaxed text-gray-500">{panelCopy}</p>
             </div>
 
             {desktopAuthRequested ? (
-              <div className="den-notice is-info">
-                Finish auth here and we&apos;ll send you back into the OpenWork
-                desktop app.
+              <div className="mt-5 rounded-2xl border border-sky-100 bg-sky-50 p-4 text-[13px] text-sky-900">
+                Finish auth here and we&apos;ll send you back into the OpenWork desktop app.
                 {desktopRedirectUrl ? (
                   <div className="mt-4 grid gap-2">
                     <div className="flex flex-wrap gap-2">
                       <button
                         type="button"
-                        className="den-button-secondary text-xs"
+                        className="rounded-full border border-sky-200 bg-white px-4 py-2 text-xs font-medium text-sky-900 transition-colors hover:bg-sky-100"
                         onClick={() => window.location.assign(desktopRedirectUrl)}
                       >
                         Open OpenWork
                       </button>
                       <button
                         type="button"
-                        className="den-button-secondary text-xs"
+                        className="rounded-full border border-sky-200 bg-white px-4 py-2 text-xs font-medium text-sky-900 transition-colors hover:bg-sky-100"
                         onClick={() => void copyDesktopValue("link", desktopRedirectUrl)}
                       >
                         {copiedDesktopField === "link" ? "Copied link" : "Copy sign-in link"}
@@ -166,16 +271,15 @@ export function AuthScreen() {
                       {desktopGrant ? (
                         <button
                           type="button"
-                          className="den-button-secondary text-xs"
+                          className="rounded-full border border-sky-200 bg-white px-4 py-2 text-xs font-medium text-sky-900 transition-colors hover:bg-sky-100"
                           onClick={() => void copyDesktopValue("code", desktopGrant)}
                         >
                           {copiedDesktopField === "code" ? "Copied code" : "Copy one-time code"}
                         </button>
                       ) : null}
                     </div>
-                    <p className="text-xs leading-5 opacity-80">
-                      If OpenWork does not open automatically, copy the sign-in
-                      link or one-time code and paste it into the OpenWork desktop app.
+                    <p className="text-xs leading-5 text-sky-800/80">
+                      If OpenWork does not open automatically, copy the sign-in link or one-time code and paste it into the OpenWork desktop app.
                     </p>
                   </div>
                 ) : null}
@@ -183,53 +287,56 @@ export function AuthScreen() {
             ) : null}
 
             <form
-              className="grid gap-3"
+              className="mt-5 grid gap-3"
               onSubmit={async (event) => {
-                const next = verificationRequired ? await submitVerificationCode(event) : await submitAuth(event);
+                const next = verificationRequired
+                  ? await submitVerificationCode(event)
+                  : await submitAuth(event);
                 if (next === "dashboard") {
                   const target = await resolveUserLandingRoute();
-                  if (target) {
+                  if (target && !isSamePathname(pathname, target)) {
                     router.replace(target);
                   }
-                } else if (next === "checkout") {
+                } else if (next === "checkout" && !isSamePathname(pathname, "/checkout")) {
                   router.replace("/checkout");
                 }
               }}
             >
               {!verificationRequired ? (
                 <>
-                  <button
-                    type="button"
-                    className="den-button-secondary w-full gap-3"
+                  <SocialButton
                     onClick={() => void beginSocialAuth("github")}
                     disabled={authBusy || desktopRedirectBusy}
                   >
                     <GitHubLogo />
                     <span>Continue with GitHub</span>
-                  </button>
+                  </SocialButton>
 
-                  <button
-                    type="button"
-                    className="den-button-secondary w-full gap-3"
+                  <SocialButton
                     onClick={() => void beginSocialAuth("google")}
                     disabled={authBusy || desktopRedirectBusy}
                   >
                     <GoogleLogo />
                     <span>Continue with Google</span>
-                  </button>
+                  </SocialButton>
 
-                  <div className="flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400" aria-hidden="true">
-                    <span className="h-px flex-1 bg-slate-200" />
+                  <div
+                    className="flex items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400"
+                    aria-hidden="true"
+                  >
+                    <span className="h-px flex-1 bg-gray-200" />
                     <span>or</span>
-                    <span className="h-px flex-1 bg-slate-200" />
+                    <span className="h-px flex-1 bg-gray-200" />
                   </div>
                 </>
               ) : null}
 
               <label className="grid gap-2">
-                <span className="den-label">Email</span>
+                <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                  Email
+                </span>
                 <input
-                  className="den-input"
+                  className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-[14px] text-gray-900 outline-none transition focus:border-gray-300 focus:ring-4 focus:ring-gray-900/5"
                   type="email"
                   value={email}
                   onChange={(event) => setEmail(event.target.value)}
@@ -240,9 +347,11 @@ export function AuthScreen() {
 
               {!verificationRequired ? (
                 <label className="grid gap-2">
-                  <span className="den-label">Password</span>
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                    Password
+                  </span>
                   <input
-                    className="den-input"
+                    className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-[14px] text-gray-900 outline-none transition focus:border-gray-300 focus:ring-4 focus:ring-gray-900/5"
                     type="password"
                     value={password}
                     onChange={(event) => setPassword(event.target.value)}
@@ -252,14 +361,18 @@ export function AuthScreen() {
                 </label>
               ) : (
                 <label className="grid gap-2">
-                  <span className="den-label">Verification code</span>
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                    Verification code
+                  </span>
                   <input
-                    className="den-input text-center text-[18px] font-semibold tracking-[0.35em]"
+                    className="w-full rounded-xl border border-gray-200 bg-white px-4 py-3 text-center text-[18px] font-semibold tracking-[0.35em] text-gray-900 outline-none transition focus:border-gray-300 focus:ring-4 focus:ring-gray-900/5"
                     type="text"
                     inputMode="numeric"
                     pattern="[0-9]*"
                     value={verificationCode}
-                    onChange={(event) => setVerificationCode(event.target.value.replace(/\D+/g, "").slice(0, 6))}
+                    onChange={(event) =>
+                      setVerificationCode(event.target.value.replace(/\D+/g, "").slice(0, 6))
+                    }
                     autoComplete="one-time-code"
                     required
                   />
@@ -268,7 +381,7 @@ export function AuthScreen() {
 
               <button
                 type="submit"
-                className="den-button-primary w-full"
+                className="flex w-full items-center justify-center gap-2 rounded-full bg-gray-900 px-5 py-3 text-[14px] font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
                 disabled={authBusy || desktopRedirectBusy}
               >
                 {authBusy || desktopRedirectBusy
@@ -278,13 +391,14 @@ export function AuthScreen() {
                     : authMode === "sign-in"
                       ? "Sign in to Cloud"
                       : "Create Cloud account"}
+                {!authBusy && !desktopRedirectBusy ? <ArrowRight className="h-4 w-4" /> : null}
               </button>
 
               {verificationRequired ? (
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <button
                     type="button"
-                    className="den-button-secondary w-full"
+                    className="w-full rounded-full border border-gray-200 bg-white px-4 py-3 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
                     onClick={() => void resendVerificationCode()}
                     disabled={authBusy || desktopRedirectBusy}
                   >
@@ -292,7 +406,7 @@ export function AuthScreen() {
                   </button>
                   <button
                     type="button"
-                    className="den-button-secondary w-full"
+                    className="w-full rounded-full border border-gray-200 bg-white px-4 py-3 text-[13px] font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
                     onClick={() => cancelVerification()}
                     disabled={authBusy || desktopRedirectBusy}
                   >
@@ -303,11 +417,11 @@ export function AuthScreen() {
             </form>
 
             {!verificationRequired ? (
-              <div className="flex items-center justify-between gap-3 border-t border-gray-200 pt-1 text-sm text-[var(--dls-text-secondary)]">
+              <div className="mt-4 flex items-center justify-between gap-3 border-t border-gray-200 pt-4 text-sm text-gray-500">
                 <p>{authMode === "sign-in" ? "Need an account?" : "Already have an account?"}</p>
                 <button
                   type="button"
-                  className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
+                  className="font-medium text-gray-900 transition hover:opacity-70"
                   onClick={() => setAuthMode(authMode === "sign-in" ? "sign-up" : "sign-in")}
                 >
                   {authMode === "sign-in" ? "Create account" : "Switch to sign in"}
@@ -316,18 +430,23 @@ export function AuthScreen() {
             ) : null}
 
             {showAuthFeedback ? (
-              <div className="den-frame-inset grid gap-1 rounded-[1.5rem] px-4 py-3 text-center text-[13px] text-[var(--dls-text-secondary)]" aria-live="polite">
+              <div
+                className="mt-4 grid gap-1 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3 text-center text-[13px] text-gray-500"
+                aria-live="polite"
+              >
                 <p>{authInfo}</p>
                 {authError ? <p className="font-medium text-rose-600">{authError}</p> : null}
+                {!authError && verificationRequired ? (
+                  <div className="mt-1 inline-flex items-center justify-center gap-1 text-emerald-600">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    <span>Waiting for your verification code</span>
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </div>
-        </div>
-      ) : (
-        <div className="den-frame-soft grid w-full max-w-[28rem] gap-3 px-6 py-8 text-center">
-          <p className="text-sm text-slate-500">Checking your session...</p>
-        </div>
-      )}
+        )}
+      </div>
     </section>
   );
 }

--- a/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Dithering, MeshGradient } from "@paper-design/shaders-react";
-import { ArrowRight, CheckCircle2, Monitor } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { isSamePathname } from "../_lib/client-route";
@@ -26,28 +24,11 @@ function formatSubscriptionStatus(value: string | null | undefined) {
 function LoadingPanel({ title, body }: { title: string; body: string }) {
   return (
     <section className="den-page py-4">
-      <div className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.22)] md:p-8">
-        <div className="grid gap-3">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-            OpenWork Cloud
-          </p>
-          <h1 className="text-[30px] font-semibold tracking-[-0.05em] text-gray-900">{title}</h1>
-          <p className="text-[14px] leading-relaxed text-gray-500">{body}</p>
-        </div>
-        <div className="mt-6 h-2 overflow-hidden rounded-full bg-gray-100">
-          <div className="h-full w-1/3 animate-pulse rounded-full bg-gray-900/80" />
-        </div>
+      <div className="den-frame-soft grid max-w-[44rem] gap-4 p-6">
+        <h1 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{title}</h1>
+        <p className="text-sm text-[var(--dls-text-secondary)]">{body}</p>
       </div>
     </section>
-  );
-}
-
-function BenefitCard({ title, body }: { title: string; body: string }) {
-  return (
-    <div className="rounded-2xl border border-gray-100 bg-white p-5">
-      <p className="mb-2 text-[14px] font-medium text-gray-900">{title}</p>
-      <p className="text-[13px] leading-[1.6] text-gray-500">{body}</p>
-    </div>
   );
 }
 
@@ -168,8 +149,8 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
   if (!sessionHydrated || (!user && !mockMode)) {
     return (
       <LoadingPanel
-        title="Checking billing access."
-        body="Loading your account and billing state before we continue."
+        title="Checking your billing session..."
+        body="Loading your account and billing state before continuing."
       />
     );
   }
@@ -190,86 +171,49 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
 
   return (
     <section className="den-page grid gap-6 py-4 lg:py-6">
-      <div className="relative overflow-hidden rounded-[32px] border border-gray-100 px-7 py-8 md:px-10 md:py-10">
-        <div className="absolute inset-0 z-0">
-          <Dithering
-            speed={0}
-            shape="warp"
-            type="4x4"
-            size={2.5}
-            scale={1}
-            frame={27618.9}
-            colorBack="#00000000"
-            colorFront="#FEFEFE"
-            style={{ backgroundColor: "#18222F", width: "100%", height: "100%" }}
-          >
-            <MeshGradient
-              speed={0.65}
-              distortion={0.8}
-              swirl={0.1}
-              grainMixer={0}
-              grainOverlay={0}
-              frame={176868.9}
-              colors={["#E0FCFF", "#1D7B9A", "#50F7D4", "#518EF0"]}
-              style={{ width: "100%", height: "100%" }}
-            />
-          </Dithering>
-        </div>
-
-        <div className="relative z-10 grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
-          <div className="grid gap-4 lg:max-w-3xl">
-            <div className="flex items-center gap-3">
-              <img src="/openwork-mark.svg" alt="OpenWork" className="h-9 w-auto" />
-              <span className="text-[13px] font-medium text-white/80">OpenWork Cloud</span>
-            </div>
-
-            <div className="grid gap-3">
-              <span className="inline-flex w-fit rounded-full border border-white/20 bg-white/15 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-white backdrop-blur-md">
-                {TRIAL_DAYS}-day free trial
-              </span>
-              <h1 className="max-w-[12ch] text-[2.25rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white md:text-[3rem]">
-                Provision shared setups for your team.
-              </h1>
-              <p className="max-w-2xl text-[15px] leading-7 text-white/80">
-                Share your setup across your org, launch background workspaces in alpha, and prepare for team-wide provider provisioning.
-              </p>
-            </div>
+      <div className="den-frame grid gap-6 p-6 md:p-8 lg:p-10">
+        <div className="flex flex-col gap-4 lg:max-w-3xl">
+          <div className="grid gap-3">
+            <p className="den-eyebrow">OpenWork Cloud</p>
+            <h1 className="den-title-xl max-w-[12ch]">Provision shared setups for your team.</h1>
+            <p className="den-copy max-w-2xl">
+              Share your setup across your org, launch background agents in alpha, and prepare for team-wide provider provisioning.
+            </p>
           </div>
 
-          <div className="flex flex-wrap gap-3 lg:justify-end">
+          <div className="flex flex-wrap gap-3">
             {checkoutHref ? (
-              <a
-                href={checkoutHref}
-                rel="noreferrer"
-                className="inline-flex min-h-[48px] items-center justify-center gap-2 rounded-full bg-white px-5 py-3 text-[14px] font-medium text-gray-900 transition-colors hover:bg-gray-100"
-              >
+              <a href={checkoutHref} rel="noreferrer" className="den-button-primary w-full sm:w-auto">
                 Start free trial
-                <ArrowRight className="h-4 w-4" />
               </a>
             ) : (
               <button
                 type="button"
-                className="inline-flex min-h-[48px] items-center justify-center rounded-full bg-white px-5 py-3 text-[14px] font-medium text-gray-900 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
+                className="den-button-primary w-full sm:w-auto"
                 onClick={() => void refreshBilling({ includeCheckout: true, quiet: false })}
                 disabled={billingBusy || billingCheckoutBusy}
               >
                 Refresh trial link
               </button>
             )}
-            <a
-              href="https://openworklabs.com/download"
-              className="inline-flex min-h-[48px] items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-5 py-3 text-[14px] font-medium text-white backdrop-blur-md transition-colors hover:bg-white/15"
-            >
-              <Monitor className="h-4 w-4" />
+            <a href="https://openworklabs.com/download" className="den-button-secondary w-full sm:w-auto">
               Use desktop only
             </a>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 text-sm text-[var(--dls-text-secondary)]">
+            <span>{TRIAL_DAYS}-day free trial</span>
+            <span aria-hidden="true">•</span>
+            <span>{planAmountLabel} after trial</span>
+            <span aria-hidden="true">•</span>
+            <span>{user?.email ?? "Signed in"}</span>
           </div>
         </div>
       </div>
 
       {billingError ? <div className="den-notice is-error">{billingError}</div> : null}
       {showLoading ? (
-        <div className="rounded-2xl border border-gray-100 bg-white px-5 py-4 text-sm text-gray-500">
+        <div className="den-frame-soft px-5 py-4 text-sm text-[var(--dls-text-secondary)]">
           Refreshing access state...
         </div>
       ) : null}
@@ -277,136 +221,100 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
       {billingSummary ? (
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px]">
           <div className="grid gap-6">
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              <BenefitCard title="Cloud sharing" body="Share setup across your team and org without reconfiguring every machine." />
-              <BenefitCard title="Shared workspaces" body="Keep selected workflows running in the background for high-leverage team flows." />
-              <BenefitCard title="Provider rollout" body="Prepare for team-wide LLM provider control and more consistent shared setups." />
-            </div>
-
-            <article className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.18)] md:p-7">
+            <article className="den-frame grid gap-6 p-6 md:p-7">
               <div className="grid gap-3">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">Plan summary</p>
-                <h2 className="text-[30px] font-semibold tracking-[-0.05em] text-gray-900">
-                  {billingSummary.hasActivePlan ? "Your Cloud plan is active." : `Start with a ${TRIAL_DAYS}-day trial.`}
-                </h2>
-                <p className="text-[14px] leading-relaxed text-gray-500">
-                  {billingSummary.hasActivePlan
-                    ? "Your team can keep using shared setups and cloud workflows without interruption."
-                    : `Try OpenWork Cloud for ${TRIAL_DAYS} days, then continue at ${planAmountLabel}.`}
+                <span className="den-kicker w-fit">OpenWork Cloud</span>
+                <h2 className="den-title-lg">Share your setup across your team.</h2>
+                <p className="den-copy">
+                  Manage your team&apos;s setup, invite teammates, and keep everything in sync.
                 </p>
               </div>
 
-              <div className="mt-6 grid gap-3 text-sm text-gray-500">
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Share setup across your team and org</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Background workspaces in alpha for selected workflows</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Custom LLM providers for teams, coming soon</div>
+              <div className="grid gap-3 text-sm text-[var(--dls-text-secondary)]">
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Share setup across your team and org</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Background agents in alpha for selected workflows</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Custom LLM providers for teams, coming soon</div>
               </div>
 
-              <div className="mt-6 flex flex-wrap gap-3">
-                {checkoutHref && !billingSummary.hasActivePlan ? (
-                  <a
-                    href={checkoutHref}
-                    rel="noreferrer"
-                    className="inline-flex items-center justify-center gap-2 rounded-full bg-gray-900 px-5 py-3 text-[14px] font-medium text-white transition-colors hover:bg-gray-800"
-                  >
-                    Start free trial
-                    <ArrowRight className="h-4 w-4" />
-                  </a>
-                ) : null}
-                {billingSummary.portalUrl ? (
-                  <a
-                    href={billingSummary.portalUrl}
-                    rel="noreferrer"
-                    target="_blank"
-                    className="inline-flex items-center justify-center rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
-                  >
-                    Open billing portal
-                  </a>
-                ) : null}
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="den-frame-inset rounded-[1.5rem] p-4">
+                  <p className="den-stat-label">Background agents</p>
+                  <p className="mt-3 text-sm text-[var(--dls-text-secondary)]">
+                    Keep selected workflows running in the background. Alpha.
+                  </p>
+                </div>
+                <div className="den-frame-inset rounded-[1.5rem] p-4">
+                  <p className="den-stat-label">Custom LLM providers</p>
+                  <p className="mt-3 text-sm text-[var(--dls-text-secondary)]">
+                    Standardize provider access for your team. Coming soon.
+                  </p>
+                </div>
               </div>
             </article>
 
-            <article className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.18)] md:p-7">
+            <article className="den-frame-soft grid gap-5 p-6 md:p-7">
               <div className="grid gap-3">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">Desktop app</p>
-                <h2 className="text-[30px] font-semibold tracking-[-0.05em] text-gray-900">
-                  Stay local when you need to.
-                </h2>
-                <p className="text-[14px] leading-relaxed text-gray-500">
+                <span className="den-kicker w-fit">Desktop app</span>
+                <h2 className="den-title-lg">Stay local when you need to.</h2>
+                <p className="den-copy">
                   Run locally for free, keep your data on your machine, and add OpenWork Cloud when your team is ready.
                 </p>
               </div>
 
-              <div className="mt-5 grid gap-3 text-sm text-gray-500">
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Run locally for free</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Keep data on your machine</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Move into OpenWork Cloud later</div>
+              <div className="grid gap-3 text-sm text-[var(--dls-text-secondary)]">
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Run locally for free</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Keep data on your machine</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Move into OpenWork Cloud later</div>
               </div>
 
-              <div className="mt-6 pt-1">
-                <a
-                  href="https://openworklabs.com/download"
-                  className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
-                >
-                  <Monitor className="h-4 w-4" />
+              <div className="mt-auto pt-2">
+                <a href="https://openworklabs.com/download" className="den-button-secondary w-full sm:w-auto">
                   Use desktop only
                 </a>
               </div>
             </article>
           </div>
 
-          <aside className="grid h-fit gap-4 rounded-[28px] border border-gray-100 bg-white p-5 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.18)] md:p-6">
+          <aside className="den-frame-soft grid h-fit gap-4 p-5 md:p-6">
             <div className="grid gap-2">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">Billing status</p>
-              <h2 className="text-2xl font-semibold tracking-tight text-gray-900">{subscriptionStatus}</h2>
-              <p className="text-sm leading-relaxed text-gray-500">
-                {billingSummary.hasActivePlan
-                  ? "Your Cloud plan is active."
-                  : `${TRIAL_DAYS}-day free trial before billing starts.`}
+              <p className="den-eyebrow">Billing status</p>
+              <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{subscriptionStatus}</h2>
+              <p className="den-copy text-sm">
+                {billingSummary.hasActivePlan ? "Your Cloud plan is active." : `${TRIAL_DAYS}-day free trial before billing starts.`}
               </p>
             </div>
 
-            <div className="grid gap-3 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4">
+            <div className="den-frame-inset grid gap-3 rounded-[1.5rem] px-4 py-4">
               <div className="flex items-center justify-between gap-3">
-                <span className="text-sm font-medium text-gray-900">Plan</span>
+                <span className="text-sm font-medium text-[var(--dls-text-primary)]">Plan</span>
                 <span className={`den-status-pill ${billingSummary.hasActivePlan ? "is-positive" : "is-neutral"}`}>
                   {subscriptionStatus}
                 </span>
               </div>
-              <div className="flex items-center justify-between gap-3 text-sm text-gray-500">
+              <div className="flex items-center justify-between gap-3 text-sm text-[var(--dls-text-secondary)]">
                 <span>Price</span>
-                <span className="font-medium text-gray-900">{planAmountLabel}</span>
+                <span className="font-medium text-[var(--dls-text-primary)]">{planAmountLabel}</span>
               </div>
-              <div className="flex items-center justify-between gap-3 text-sm text-gray-500">
+              <div className="flex items-center justify-between gap-3 text-sm text-[var(--dls-text-secondary)]">
                 <span>Invoices</span>
-                <span className="font-medium text-gray-900">{billingSummary.invoices.length}</span>
+                <span className="font-medium text-[var(--dls-text-primary)]">{billingSummary.invoices.length}</span>
               </div>
             </div>
 
             <div className="grid gap-3">
               {checkoutHref && !billingSummary.hasActivePlan ? (
-                <a
-                  href={checkoutHref}
-                  rel="noreferrer"
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-gray-900 px-5 py-3 text-[14px] font-medium text-white transition-colors hover:bg-gray-800"
-                >
+                <a href={checkoutHref} rel="noreferrer" className="den-button-primary w-full">
                   Start free trial
-                  <ArrowRight className="h-4 w-4" />
                 </a>
               ) : null}
               {billingSummary.portalUrl ? (
-                <a
-                  href={billingSummary.portalUrl}
-                  rel="noreferrer"
-                  target="_blank"
-                  className="inline-flex w-full items-center justify-center rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
-                >
+                <a href={billingSummary.portalUrl} rel="noreferrer" target="_blank" className="den-button-secondary w-full">
                   Open billing portal
                 </a>
               ) : null}
               <button
                 type="button"
-                className="inline-flex w-full items-center justify-center rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                className="den-button-secondary w-full"
                 onClick={() => void refreshBilling({ includeCheckout: true, quiet: false })}
                 disabled={billingBusy || billingCheckoutBusy}
               >
@@ -414,17 +322,14 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
               </button>
             </div>
 
-            <div className="flex flex-wrap gap-2 text-sm text-gray-500">
+            <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm text-[var(--dls-text-secondary)]">
               {billingSummary.portalUrl ? (
-                <a href={billingSummary.portalUrl} rel="noreferrer" target="_blank" className="font-medium text-gray-900 transition hover:opacity-70">
+                <a href={billingSummary.portalUrl} rel="noreferrer" target="_blank" className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70">
                   Billing portal
                 </a>
               ) : null}
               <span>Invoices {billingSummary.invoices.length > 0 ? `(${billingSummary.invoices.length})` : ""}</span>
-              <span className="inline-flex items-center gap-1 text-emerald-600">
-                <CheckCircle2 className="h-3.5 w-3.5" />
-                Cancel anytime
-              </span>
+              <span>Cancel anytime</span>
             </div>
           </aside>
         </div>

--- a/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { Dithering, MeshGradient } from "@paper-design/shaders-react";
+import { ArrowRight, CheckCircle2, Monitor } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { isSamePathname } from "../_lib/client-route";
 import { formatMoneyMinor } from "../_lib/den-flow";
 import { useDenFlow } from "../_providers/den-flow-provider";
 
@@ -20,10 +23,41 @@ function formatSubscriptionStatus(value: string | null | undefined) {
     .join(" ");
 }
 
+function LoadingPanel({ title, body }: { title: string; body: string }) {
+  return (
+    <section className="den-page py-4">
+      <div className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.22)] md:p-8">
+        <div className="grid gap-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+            OpenWork Cloud
+          </p>
+          <h1 className="text-[30px] font-semibold tracking-[-0.05em] text-gray-900">{title}</h1>
+          <p className="text-[14px] leading-relaxed text-gray-500">{body}</p>
+        </div>
+        <div className="mt-6 h-2 overflow-hidden rounded-full bg-gray-100">
+          <div className="h-full w-1/3 animate-pulse rounded-full bg-gray-900/80" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function BenefitCard({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5">
+      <p className="mb-2 text-[14px] font-medium text-gray-900">{title}</p>
+      <p className="text-[13px] leading-[1.6] text-gray-500">{body}</p>
+    </div>
+  );
+}
+
 export function CheckoutScreen({ customerSessionToken }: { customerSessionToken: string | null }) {
   const router = useRouter();
+  const pathname = usePathname();
   const handledReturnRef = useRef(false);
+  const redirectingRef = useRef(false);
   const [resuming, setResuming] = useState(false);
+  const [redirectMessage, setRedirectMessage] = useState<string | null>(null);
   const {
     user,
     sessionHydrated,
@@ -56,38 +90,40 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
     : realBillingSummary;
 
   useEffect(() => {
-    if (!sessionHydrated || resuming) {
+    if (!sessionHydrated || resuming || user || mockMode) {
       return;
     }
-    if (!user) {
-      if (mockMode) {
-        return;
-      }
+
+    setRedirectMessage("Redirecting to sign in...");
+    if (!isSamePathname(pathname, "/")) {
       router.replace("/");
     }
-  }, [mockMode, resuming, router, sessionHydrated, user]);
+  }, [mockMode, pathname, resuming, router, sessionHydrated, user]);
 
   useEffect(() => {
-    if (!sessionHydrated || !user || handledReturnRef.current) {
-      return;
-    }
-
-    if (!customerSessionToken) {
+    if (!sessionHydrated || !user || handledReturnRef.current || !customerSessionToken) {
       return;
     }
 
     handledReturnRef.current = true;
     setResuming(true);
-    void refreshCheckoutReturn(true).then((target) => {
-      if (target !== "/checkout") {
-        router.replace(target);
-        return;
-      }
+    setRedirectMessage("Finishing your checkout...");
 
-      router.replace("/checkout");
-      setResuming(false);
-    });
-  }, [customerSessionToken, refreshCheckoutReturn, router, sessionHydrated, user]);
+    void refreshCheckoutReturn(true)
+      .then((target) => {
+        if (target && !isSamePathname(pathname, target)) {
+          router.replace(target);
+          return;
+        }
+
+        setRedirectMessage(null);
+        setResuming(false);
+      })
+      .catch(() => {
+        setRedirectMessage(null);
+        setResuming(false);
+      });
+  }, [customerSessionToken, pathname, refreshCheckoutReturn, router, sessionHydrated, user]);
 
   useEffect(() => {
     if (!sessionHydrated || !user || resuming) {
@@ -97,181 +133,280 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
     if (!billingSummary?.hasActivePlan && !effectiveCheckoutUrl && !billingBusy && !billingCheckoutBusy) {
       void refreshBilling({ includeCheckout: true, quiet: true });
     }
-  }, [billingBusy, billingCheckoutBusy, billingSummary?.hasActivePlan, effectiveCheckoutUrl, refreshBilling, resuming, sessionHydrated, user]);
+  }, [
+    billingBusy,
+    billingCheckoutBusy,
+    billingSummary?.hasActivePlan,
+    effectiveCheckoutUrl,
+    refreshBilling,
+    resuming,
+    sessionHydrated,
+    user,
+  ]);
 
   useEffect(() => {
-    if (!sessionHydrated || !user || resuming) {
+    if (!sessionHydrated || !user || resuming || onboardingPending || mockMode || redirectingRef.current) {
       return;
     }
 
-    if (!onboardingPending) {
-      void resolveUserLandingRoute().then((target) => {
-        if (target && target !== "/checkout" && !MOCK_BILLING) {
+    redirectingRef.current = true;
+    void resolveUserLandingRoute()
+      .then((target) => {
+        if (target && !isSamePathname(pathname, target)) {
+          setRedirectMessage("Redirecting to your workspace...");
           router.replace(target);
+          return;
         }
+
+        setRedirectMessage(null);
+      })
+      .finally(() => {
+        redirectingRef.current = false;
       });
-    }
-  }, [onboardingPending, resolveUserLandingRoute, resuming, router, sessionHydrated, user]);
+  }, [mockMode, onboardingPending, pathname, resolveUserLandingRoute, resuming, router, sessionHydrated, user]);
 
   if (!sessionHydrated || (!user && !mockMode)) {
     return (
-      <section className="den-page py-4">
-        <div className="den-frame-soft grid max-w-[44rem] gap-4 p-6">
-          <p className="text-sm text-slate-500">Checking your billing session...</p>
-        </div>
-      </section>
+      <LoadingPanel
+        title="Checking billing access."
+        body="Loading your account and billing state before we continue."
+      />
     );
+  }
+
+  if (redirectMessage) {
+    return <LoadingPanel title="One moment." body={redirectMessage} />;
   }
 
   const billingPrice = billingSummary?.price ?? null;
   const showLoading = resuming || (billingBusy && !billingSummary && !MOCK_BILLING);
   const checkoutHref = effectiveCheckoutUrl ?? MOCK_CHECKOUT_URL ?? null;
-  const planAmountLabel = billingPrice && billingPrice.amount !== null
-    ? `${formatMoneyMinor(billingPrice.amount, billingPrice.currency)}/${billingPrice.recurringInterval}`
-    : "$50.00/month";
+  const planAmountLabel =
+    billingPrice && billingPrice.amount !== null
+      ? `${formatMoneyMinor(billingPrice.amount, billingPrice.currency)}/${billingPrice.recurringInterval}`
+      : "$50.00/month";
   const subscription = billingSummary?.subscription ?? null;
   const subscriptionStatus = formatSubscriptionStatus(subscription?.status);
 
   return (
     <section className="den-page grid gap-6 py-4 lg:py-6">
-      <div className="den-frame grid gap-6 p-6 md:p-8 lg:p-10">
-        <div className="flex flex-col gap-4 lg:max-w-3xl">
-          <div className="grid gap-3">
-            <p className="den-eyebrow">OpenWork Cloud</p>
-            <h1 className="den-title-xl max-w-[12ch]">Provision shared setups for your team.</h1>
-            <p className="den-copy max-w-2xl">
-              Share your setup across your org, launch background agents in alpha, and prepare for team-wide provider provisioning.
-            </p>
+      <div className="relative overflow-hidden rounded-[32px] border border-gray-100 px-7 py-8 md:px-10 md:py-10">
+        <div className="absolute inset-0 z-0">
+          <Dithering
+            speed={0}
+            shape="warp"
+            type="4x4"
+            size={2.5}
+            scale={1}
+            frame={27618.9}
+            colorBack="#00000000"
+            colorFront="#FEFEFE"
+            style={{ backgroundColor: "#18222F", width: "100%", height: "100%" }}
+          >
+            <MeshGradient
+              speed={0.65}
+              distortion={0.8}
+              swirl={0.1}
+              grainMixer={0}
+              grainOverlay={0}
+              frame={176868.9}
+              colors={["#E0FCFF", "#1D7B9A", "#50F7D4", "#518EF0"]}
+              style={{ width: "100%", height: "100%" }}
+            />
+          </Dithering>
+        </div>
+
+        <div className="relative z-10 grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+          <div className="grid gap-4 lg:max-w-3xl">
+            <div className="flex items-center gap-3">
+              <img src="/openwork-mark.svg" alt="OpenWork" className="h-9 w-auto" />
+              <span className="text-[13px] font-medium text-white/80">OpenWork Cloud</span>
+            </div>
+
+            <div className="grid gap-3">
+              <span className="inline-flex w-fit rounded-full border border-white/20 bg-white/15 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.18em] text-white backdrop-blur-md">
+                {TRIAL_DAYS}-day free trial
+              </span>
+              <h1 className="max-w-[12ch] text-[2.25rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white md:text-[3rem]">
+                Provision shared setups for your team.
+              </h1>
+              <p className="max-w-2xl text-[15px] leading-7 text-white/80">
+                Share your setup across your org, launch background workspaces in alpha, and prepare for team-wide provider provisioning.
+              </p>
+            </div>
           </div>
 
-          <div className="flex flex-wrap gap-3">
+          <div className="flex flex-wrap gap-3 lg:justify-end">
             {checkoutHref ? (
-              <a href={checkoutHref} rel="noreferrer" className="den-button-primary w-full sm:w-auto">
+              <a
+                href={checkoutHref}
+                rel="noreferrer"
+                className="inline-flex min-h-[48px] items-center justify-center gap-2 rounded-full bg-white px-5 py-3 text-[14px] font-medium text-gray-900 transition-colors hover:bg-gray-100"
+              >
                 Start free trial
+                <ArrowRight className="h-4 w-4" />
               </a>
             ) : (
               <button
                 type="button"
-                className="den-button-primary w-full sm:w-auto"
+                className="inline-flex min-h-[48px] items-center justify-center rounded-full bg-white px-5 py-3 text-[14px] font-medium text-gray-900 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60"
                 onClick={() => void refreshBilling({ includeCheckout: true, quiet: false })}
                 disabled={billingBusy || billingCheckoutBusy}
               >
                 Refresh trial link
               </button>
             )}
-            <a href="https://openworklabs.com/download" className="den-button-secondary w-full sm:w-auto">
+            <a
+              href="https://openworklabs.com/download"
+              className="inline-flex min-h-[48px] items-center justify-center gap-2 rounded-full border border-white/20 bg-white/10 px-5 py-3 text-[14px] font-medium text-white backdrop-blur-md transition-colors hover:bg-white/15"
+            >
+              <Monitor className="h-4 w-4" />
               Use desktop only
             </a>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-3 text-sm text-[var(--dls-text-secondary)]">
-            <span>{TRIAL_DAYS}-day free trial</span>
-            <span aria-hidden="true">•</span>
-            <span>{planAmountLabel} after trial</span>
-            <span aria-hidden="true">•</span>
-            <span>{user?.email ?? "Signed in"}</span>
           </div>
         </div>
       </div>
 
       {billingError ? <div className="den-notice is-error">{billingError}</div> : null}
-      {showLoading ? <div className="den-frame-soft px-5 py-4 text-sm text-[var(--dls-text-secondary)]">Refreshing access state...</div> : null}
+      {showLoading ? (
+        <div className="rounded-2xl border border-gray-100 bg-white px-5 py-4 text-sm text-gray-500">
+          Refreshing access state...
+        </div>
+      ) : null}
 
       {billingSummary ? (
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_320px]">
           <div className="grid gap-6">
-            <article className="den-frame grid gap-6 p-6 md:p-7">
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <BenefitCard title="Cloud sharing" body="Share setup across your team and org without reconfiguring every machine." />
+              <BenefitCard title="Shared workspaces" body="Keep selected workflows running in the background for high-leverage team flows." />
+              <BenefitCard title="Provider rollout" body="Prepare for team-wide LLM provider control and more consistent shared setups." />
+            </div>
+
+            <article className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.18)] md:p-7">
               <div className="grid gap-3">
-                <span className="den-kicker w-fit">OpenWork Cloud</span>
-                <h2 className="den-title-lg">Share your setup across your team.</h2>
-                <p className="den-copy">
-                  Manage your team&apos;s setup, invite teammates, and keep everything in sync.
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">Plan summary</p>
+                <h2 className="text-[30px] font-semibold tracking-[-0.05em] text-gray-900">
+                  {billingSummary.hasActivePlan ? "Your Cloud plan is active." : `Start with a ${TRIAL_DAYS}-day trial.`}
+                </h2>
+                <p className="text-[14px] leading-relaxed text-gray-500">
+                  {billingSummary.hasActivePlan
+                    ? "Your team can keep using shared setups and cloud workflows without interruption."
+                    : `Try OpenWork Cloud for ${TRIAL_DAYS} days, then continue at ${planAmountLabel}.`}
                 </p>
               </div>
 
-              <div className="grid gap-3 text-sm text-[var(--dls-text-secondary)]">
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Share setup across your team and org</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Background agents in alpha for selected workflows</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Custom LLM providers for teams, coming soon</div>
+              <div className="mt-6 grid gap-3 text-sm text-gray-500">
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Share setup across your team and org</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Background workspaces in alpha for selected workflows</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Custom LLM providers for teams, coming soon</div>
               </div>
 
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="den-frame-inset rounded-[1.5rem] p-4">
-                  <p className="den-stat-label">Background agents</p>
-                  <p className="mt-3 text-sm text-[var(--dls-text-secondary)]">
-                    Keep selected workflows running in the background. Alpha.
-                  </p>
-                </div>
-                <div className="den-frame-inset rounded-[1.5rem] p-4">
-                  <p className="den-stat-label">Custom LLM providers</p>
-                  <p className="mt-3 text-sm text-[var(--dls-text-secondary)]">
-                    Standardize provider access for your team. Coming soon.
-                  </p>
-                </div>
+              <div className="mt-6 flex flex-wrap gap-3">
+                {checkoutHref && !billingSummary.hasActivePlan ? (
+                  <a
+                    href={checkoutHref}
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-gray-900 px-5 py-3 text-[14px] font-medium text-white transition-colors hover:bg-gray-800"
+                  >
+                    Start free trial
+                    <ArrowRight className="h-4 w-4" />
+                  </a>
+                ) : null}
+                {billingSummary.portalUrl ? (
+                  <a
+                    href={billingSummary.portalUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                    className="inline-flex items-center justify-center rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                  >
+                    Open billing portal
+                  </a>
+                ) : null}
               </div>
             </article>
 
-            <article className="den-frame-soft grid gap-5 p-6 md:p-7">
+            <article className="rounded-[28px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.18)] md:p-7">
               <div className="grid gap-3">
-                <span className="den-kicker w-fit">Desktop app</span>
-                <h2 className="den-title-lg">Stay local when you need to.</h2>
-                <p className="den-copy">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">Desktop app</p>
+                <h2 className="text-[30px] font-semibold tracking-[-0.05em] text-gray-900">
+                  Stay local when you need to.
+                </h2>
+                <p className="text-[14px] leading-relaxed text-gray-500">
                   Run locally for free, keep your data on your machine, and add OpenWork Cloud when your team is ready.
                 </p>
               </div>
 
-              <div className="grid gap-3 text-sm text-[var(--dls-text-secondary)]">
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Run locally for free</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Keep data on your machine</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Move into OpenWork Cloud later</div>
+              <div className="mt-5 grid gap-3 text-sm text-gray-500">
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Run locally for free</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Keep data on your machine</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-gray-300" />Move into OpenWork Cloud later</div>
               </div>
 
-              <div className="mt-auto pt-2">
-                <a href="https://openworklabs.com/download" className="den-button-secondary w-full sm:w-auto">
+              <div className="mt-6 pt-1">
+                <a
+                  href="https://openworklabs.com/download"
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                >
+                  <Monitor className="h-4 w-4" />
                   Use desktop only
                 </a>
               </div>
             </article>
           </div>
 
-          <aside className="den-frame-soft grid h-fit gap-4 p-5 md:p-6">
+          <aside className="grid h-fit gap-4 rounded-[28px] border border-gray-100 bg-white p-5 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.18)] md:p-6">
             <div className="grid gap-2">
-              <p className="den-eyebrow">Billing status</p>
-              <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{subscriptionStatus}</h2>
-              <p className="den-copy text-sm">{billingSummary.hasActivePlan ? "Your Cloud plan is active." : `${TRIAL_DAYS}-day free trial before billing starts.`}</p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">Billing status</p>
+              <h2 className="text-2xl font-semibold tracking-tight text-gray-900">{subscriptionStatus}</h2>
+              <p className="text-sm leading-relaxed text-gray-500">
+                {billingSummary.hasActivePlan
+                  ? "Your Cloud plan is active."
+                  : `${TRIAL_DAYS}-day free trial before billing starts.`}
+              </p>
             </div>
 
-            <div className="den-frame-inset grid gap-3 rounded-[1.5rem] px-4 py-4">
+            <div className="grid gap-3 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4">
               <div className="flex items-center justify-between gap-3">
-                <span className="text-sm font-medium text-[var(--dls-text-primary)]">Plan</span>
+                <span className="text-sm font-medium text-gray-900">Plan</span>
                 <span className={`den-status-pill ${billingSummary.hasActivePlan ? "is-positive" : "is-neutral"}`}>
                   {subscriptionStatus}
                 </span>
               </div>
-              <div className="flex items-center justify-between gap-3 text-sm text-[var(--dls-text-secondary)]">
+              <div className="flex items-center justify-between gap-3 text-sm text-gray-500">
                 <span>Price</span>
-                <span className="font-medium text-[var(--dls-text-primary)]">{planAmountLabel}</span>
+                <span className="font-medium text-gray-900">{planAmountLabel}</span>
               </div>
-              <div className="flex items-center justify-between gap-3 text-sm text-[var(--dls-text-secondary)]">
+              <div className="flex items-center justify-between gap-3 text-sm text-gray-500">
                 <span>Invoices</span>
-                <span className="font-medium text-[var(--dls-text-primary)]">{billingSummary.invoices.length}</span>
+                <span className="font-medium text-gray-900">{billingSummary.invoices.length}</span>
               </div>
             </div>
 
             <div className="grid gap-3">
               {checkoutHref && !billingSummary.hasActivePlan ? (
-                <a href={checkoutHref} rel="noreferrer" className="den-button-primary w-full">
+                <a
+                  href={checkoutHref}
+                  rel="noreferrer"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-gray-900 px-5 py-3 text-[14px] font-medium text-white transition-colors hover:bg-gray-800"
+                >
                   Start free trial
+                  <ArrowRight className="h-4 w-4" />
                 </a>
               ) : null}
               {billingSummary.portalUrl ? (
-                <a href={billingSummary.portalUrl} rel="noreferrer" target="_blank" className="den-button-secondary w-full">
+                <a
+                  href={billingSummary.portalUrl}
+                  rel="noreferrer"
+                  target="_blank"
+                  className="inline-flex w-full items-center justify-center rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                >
                   Open billing portal
                 </a>
               ) : null}
               <button
                 type="button"
-                className="den-button-secondary w-full"
+                className="inline-flex w-full items-center justify-center rounded-full border border-gray-200 bg-white px-5 py-3 text-[14px] font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
                 onClick={() => void refreshBilling({ includeCheckout: true, quiet: false })}
                 disabled={billingBusy || billingCheckoutBusy}
               >
@@ -279,14 +414,17 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
               </button>
             </div>
 
-            <div className="flex flex-wrap gap-x-4 gap-y-2 text-sm text-[var(--dls-text-secondary)]">
+            <div className="flex flex-wrap gap-2 text-sm text-gray-500">
               {billingSummary.portalUrl ? (
-                <a href={billingSummary.portalUrl} rel="noreferrer" target="_blank" className="font-medium text-[var(--dls-text-primary)] transition hover:opacity-70">
+                <a href={billingSummary.portalUrl} rel="noreferrer" target="_blank" className="font-medium text-gray-900 transition hover:opacity-70">
                   Billing portal
                 </a>
               ) : null}
               <span>Invoices {billingSummary.invoices.length > 0 ? `(${billingSummary.invoices.length})` : ""}</span>
-              <span>Cancel anytime</span>
+              <span className="inline-flex items-center gap-1 text-emerald-600">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Cancel anytime
+              </span>
             </div>
           </aside>
         </div>

--- a/ee/apps/den-web/app/(den)/_components/dashboard-redirect-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/dashboard-redirect-screen.tsx
@@ -1,26 +1,39 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { isSamePathname } from "../_lib/client-route";
 import { useDenFlow } from "../_providers/den-flow-provider";
 
 export function DashboardRedirectScreen() {
   const router = useRouter();
+  const pathname = usePathname();
+  const redirectingRef = useRef(false);
   const { resolveUserLandingRoute, sessionHydrated } = useDenFlow();
 
   useEffect(() => {
-    if (!sessionHydrated) {
+    if (!sessionHydrated || redirectingRef.current) {
       return;
     }
 
-    void resolveUserLandingRoute().then((target) => {
-      router.replace(target ?? "/");
-    });
-  }, [resolveUserLandingRoute, router, sessionHydrated]);
+    redirectingRef.current = true;
+    void resolveUserLandingRoute()
+      .then((target) => {
+        const nextTarget = target ?? "/";
+        if (!isSamePathname(pathname, nextTarget)) {
+          router.replace(nextTarget);
+        }
+      })
+      .finally(() => {
+        redirectingRef.current = false;
+      });
+  }, [pathname, resolveUserLandingRoute, router, sessionHydrated]);
 
   return (
-    <section className="mx-auto grid w-full max-w-[52rem] gap-4 rounded-[32px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-6">
-      <p className="text-sm text-[var(--dls-text-secondary)]">Loading your workspace...</p>
+    <section className="mx-auto grid w-full max-w-[52rem] gap-4 rounded-[32px] border border-gray-100 bg-white p-6 shadow-[0_10px_30px_-24px_rgba(15,23,42,0.22)]">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">OpenWork Cloud</p>
+      <p className="text-2xl font-semibold tracking-[-0.04em] text-gray-900">Loading your workspace.</p>
+      <p className="text-sm text-gray-500">Routing you to the right organization and billing destination now.</p>
     </section>
   );
 }

--- a/ee/apps/den-web/app/(den)/_lib/client-route.ts
+++ b/ee/apps/den-web/app/(den)/_lib/client-route.ts
@@ -1,0 +1,25 @@
+export function getComparablePathname(target: string | null | undefined): string | null {
+  const trimmed = target?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    try {
+      return new URL(trimmed).pathname;
+    } catch {
+      return trimmed;
+    }
+  }
+
+  return trimmed.split(/[?#]/)[0] ?? trimmed;
+}
+
+export function isSamePathname(currentPathname: string, target: string | null | undefined) {
+  const comparable = getComparablePathname(target);
+  if (!comparable) {
+    return false;
+  }
+
+  return comparable === currentPathname;
+}

--- a/ee/apps/den-web/app/(den)/checkout/page.tsx
+++ b/ee/apps/den-web/app/(den)/checkout/page.tsx
@@ -1,9 +1,15 @@
 import { CheckoutScreen } from "../_components/checkout-screen";
 
-export default function CheckoutPage({
+export default async function CheckoutPage({
   searchParams,
 }: {
-  searchParams?: { customer_session_token?: string };
+  searchParams?: Promise<{ customer_session_token?: string }>;
 }) {
-  return <CheckoutScreen customerSessionToken={searchParams?.customer_session_token ?? null} />;
+  const resolvedSearchParams = await searchParams;
+
+  return (
+    <CheckoutScreen
+      customerSessionToken={resolvedSearchParams?.customer_session_token ?? null}
+    />
+  );
 }

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/layout.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/layout.tsx
@@ -2,15 +2,17 @@ import type { ReactNode } from "react";
 import { OrgDashboardShell } from "./_components/org-dashboard-shell";
 import { OrgDashboardProvider } from "./_providers/org-dashboard-provider";
 
-export default function OrgDashboardLayout({
+export default async function OrgDashboardLayout({
   children,
   params,
 }: {
   children: ReactNode;
-  params: { orgSlug: string };
+  params: Promise<{ orgSlug: string }>;
 }) {
+  const { orgSlug } = await params;
+
   return (
-    <OrgDashboardProvider orgSlug={params.orgSlug}>
+    <OrgDashboardProvider orgSlug={orgSlug}>
       <OrgDashboardShell>{children}</OrgDashboardShell>
     </OrgDashboardProvider>
   );

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/manage-members/page.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/manage-members/page.tsx
@@ -1,9 +1,11 @@
 import { redirect } from "next/navigation";
 
-export default function ManageMembersRedirectPage({
+export default async function ManageMembersRedirectPage({
   params,
 }: {
-  params: { orgSlug: string };
+  params: Promise<{ orgSlug: string }>;
 }) {
-  redirect(`/o/${encodeURIComponent(params.orgSlug)}/dashboard/members`);
+  const { orgSlug } = await params;
+
+  redirect(`/o/${encodeURIComponent(orgSlug)}/dashboard/members`);
 }

--- a/ee/apps/den-web/next-env.d.ts
+++ b/ee/apps/den-web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/ee/apps/den-web/next.config.js
+++ b/ee/apps/den-web/next.config.js
@@ -1,7 +1,10 @@
+const path = require("path");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  skipTrailingSlashRedirect: true
+  skipTrailingSlashRedirect: true,
+  outputFileTracingRoot: path.join(__dirname, "../../.."),
 };
 
 module.exports = nextConfig;

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -12,14 +12,14 @@
   "dependencies": {
     "@paper-design/shaders-react": "0.0.71",
     "lucide-react": "^0.577.0",
-    "next": "14.2.5",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "15.5.14",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
   },
   "devDependencies": {
     "@types/node": "20.12.12",
-    "@types/react": "18.2.79",
-    "@types/react-dom": "18.2.25",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
     "autoprefixer": "10.4.19",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,29 +412,29 @@ importers:
     dependencies:
       '@paper-design/shaders-react':
         specifier: 0.0.71
-        version: 0.0.71(@types/react@18.2.79)(react@18.2.0)
+        version: 0.0.71(@types/react@19.2.14)(react@19.2.0)
       lucide-react:
         specifier: ^0.577.0
-        version: 0.577.0(react@18.2.0)
+        version: 0.577.0(react@19.2.0)
       next:
-        specifier: 14.2.5
-        version: 14.2.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 15.5.14
+        version: 15.5.14(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
-        specifier: 18.2.0
-        version: 18.2.0
+        specifier: 19.2.0
+        version: 19.2.0
       react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
     devDependencies:
       '@types/node':
         specifier: 20.12.12
         version: 20.12.12
       '@types/react':
-        specifier: 18.2.79
-        version: 18.2.79
+        specifier: 19.2.14
+        version: 19.2.14
       '@types/react-dom':
-        specifier: 18.2.25
-        version: 18.2.25
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       autoprefixer:
         specifier: 10.4.19
         version: 10.4.19(postcss@8.4.38)
@@ -1734,11 +1734,20 @@ packages:
   '@next/env@14.2.5':
     resolution: {integrity: sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==}
 
+  '@next/env@15.5.14':
+    resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
+
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
 
   '@next/swc-darwin-arm64@14.2.5':
     resolution: {integrity: sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@15.5.14':
+    resolution: {integrity: sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -1755,6 +1764,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@15.5.14':
+    resolution: {integrity: sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-darwin-x64@16.1.6':
     resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
     engines: {node: '>= 10'}
@@ -1763,6 +1778,12 @@ packages:
 
   '@next/swc-linux-arm64-gnu@14.2.5':
     resolution: {integrity: sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-gnu@15.5.14':
+    resolution: {integrity: sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -1779,6 +1800,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-arm64-musl@15.5.14':
+    resolution: {integrity: sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
@@ -1787,6 +1814,12 @@ packages:
 
   '@next/swc-linux-x64-gnu@14.2.5':
     resolution: {integrity: sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@15.5.14':
+    resolution: {integrity: sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -1803,6 +1836,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-musl@15.5.14':
+    resolution: {integrity: sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
@@ -1811,6 +1850,12 @@ packages:
 
   '@next/swc-win32-arm64-msvc@14.2.5':
     resolution: {integrity: sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-arm64-msvc@15.5.14':
+    resolution: {integrity: sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -1829,6 +1874,12 @@ packages:
 
   '@next/swc-win32-x64-msvc@14.2.5':
     resolution: {integrity: sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.14':
+    resolution: {integrity: sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2827,8 +2878,16 @@ packages:
   '@types/react-dom@18.2.25':
     resolution: {integrity: sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@18.2.79':
     resolution: {integrity: sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==}
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -3976,6 +4035,27 @@ packages:
       sass:
         optional: true
 
+  next@15.5.14:
+    resolution: {integrity: sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   next@16.1.6:
     resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
     engines: {node: '>=20.9.0'}
@@ -4267,6 +4347,11 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
+  react-dom@19.2.0:
+    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+    peerDependencies:
+      react: ^19.2.0
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -4274,6 +4359,10 @@ packages:
 
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.0:
+    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
 
   react@19.2.4:
@@ -6245,9 +6334,14 @@ snapshots:
 
   '@next/env@14.2.5': {}
 
+  '@next/env@15.5.14': {}
+
   '@next/env@16.1.6': {}
 
   '@next/swc-darwin-arm64@14.2.5':
+    optional: true
+
+  '@next/swc-darwin-arm64@15.5.14':
     optional: true
 
   '@next/swc-darwin-arm64@16.1.6':
@@ -6256,10 +6350,16 @@ snapshots:
   '@next/swc-darwin-x64@14.2.5':
     optional: true
 
+  '@next/swc-darwin-x64@15.5.14':
+    optional: true
+
   '@next/swc-darwin-x64@16.1.6':
     optional: true
 
   '@next/swc-linux-arm64-gnu@14.2.5':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.14':
     optional: true
 
   '@next/swc-linux-arm64-gnu@16.1.6':
@@ -6268,10 +6368,16 @@ snapshots:
   '@next/swc-linux-arm64-musl@14.2.5':
     optional: true
 
+  '@next/swc-linux-arm64-musl@15.5.14':
+    optional: true
+
   '@next/swc-linux-arm64-musl@16.1.6':
     optional: true
 
   '@next/swc-linux-x64-gnu@14.2.5':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.14':
     optional: true
 
   '@next/swc-linux-x64-gnu@16.1.6':
@@ -6280,10 +6386,16 @@ snapshots:
   '@next/swc-linux-x64-musl@14.2.5':
     optional: true
 
+  '@next/swc-linux-x64-musl@15.5.14':
+    optional: true
+
   '@next/swc-linux-x64-musl@16.1.6':
     optional: true
 
   '@next/swc-win32-arm64-msvc@14.2.5':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.14':
     optional: true
 
   '@next/swc-win32-arm64-msvc@16.1.6':
@@ -6293,6 +6405,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@14.2.5':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.14':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.1.6':
@@ -6635,6 +6750,13 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 18.2.79
+
+  '@paper-design/shaders-react@0.0.71(@types/react@19.2.14)(react@19.2.0)':
+    dependencies:
+      '@paper-design/shaders': 0.0.71
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@paper-design/shaders@0.0.71': {}
 
@@ -7400,9 +7522,17 @@ snapshots:
     dependencies:
       '@types/react': 18.2.79
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react@18.2.79':
     dependencies:
       '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@types/react@19.2.14':
+    dependencies:
       csstype: 3.2.3
 
   '@types/retry@0.12.0': {}
@@ -8351,6 +8481,10 @@ snapshots:
     dependencies:
       react: 18.2.0
 
+  lucide-react@0.577.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+
   lucide-solid@0.562.0(solid-js@1.9.9):
     dependencies:
       solid-js: 1.9.9
@@ -8468,6 +8602,31 @@ snapshots:
       '@next/swc-win32-x64-msvc': 14.2.5
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.58.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.5.14(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@next/env': 15.5.14
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001764
+      postcss: 8.4.31
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      styled-jsx: 5.1.6(react@19.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.14
+      '@next/swc-darwin-x64': 15.5.14
+      '@next/swc-linux-arm64-gnu': 15.5.14
+      '@next/swc-linux-arm64-musl': 15.5.14
+      '@next/swc-linux-x64-gnu': 15.5.14
+      '@next/swc-linux-x64-musl': 15.5.14
+      '@next/swc-win32-arm64-msvc': 15.5.14
+      '@next/swc-win32-x64-msvc': 15.5.14
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.58.2
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -8737,6 +8896,11 @@ snapshots:
       react: 18.2.0
       scheduler: 0.23.2
 
+  react-dom@19.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -8745,6 +8909,8 @@ snapshots:
   react@18.2.0:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.0: {}
 
   react@19.2.4: {}
 
@@ -9034,6 +9200,11 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+
+  styled-jsx@5.1.6(react@19.2.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.0
 
   styled-jsx@5.1.6(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
- restyle the auth and checkout surfaces so Cloud onboarding carries the same shader-led design language as the refreshed dashboard pages
- smooth client redirects during auth, checkout, and dashboard handoff so the app stops replacing to the same route and shows clearer transition states
- upgrade `ee/apps/den-web` to Next.js 15 with the needed React, route-prop, and tracing-root updates

## Verification
- `pnpm --filter @openwork-ee/den-web build`
- verified `/` in local dev via Chrome DevTools snapshot on `http://127.0.0.1:3005`
- verified mock `/checkout` in local dev via Chrome DevTools snapshot on `http://127.0.0.1:3011/checkout` with `NEXT_PUBLIC_DEN_MOCK_BILLING=1`

## Notes
- `pnpm --filter @openwork-ee/den-web lint` still opens the interactive Next ESLint setup prompt because this app does not yet have an ESLint config checked in