### PR TITLE
fix(workspaces): create local workspaces via local host

### DIFF
--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -743,6 +743,18 @@ export function createWorkspaceStore(options: {
     return client;
   };
 
+  const resolveLocalOpenworkServer = async () => {
+    if (!isTauriRuntime()) return null;
+    try {
+      return (await options.ensureLocalOpenworkServerClient?.()) ?? null;
+    } catch (error) {
+      wsDebug("openwork:local-host:unavailable", {
+        message: error instanceof Error ? error.message : safeStringify(error),
+      });
+      return null;
+    }
+  };
+
   const resolveActiveOpenworkWorkspace = () => {
     const client = resolveConnectedOpenworkServer();
     const workspaceId = options.runtimeWorkspaceId?.()?.trim() ?? "";
@@ -1771,7 +1783,7 @@ export function createWorkspaceStore(options: {
       }
 
       const name = deriveWorkspaceName(resolvedFolder, preset);
-      const openworkServer = resolveConnectedOpenworkServer();
+      const openworkServer = await resolveLocalOpenworkServer();
       const ws = openworkServer
         ? await openworkServer.createLocalWorkspace({ folderPath: resolvedFolder, name, preset })
         : await workspaceCreate({ folderPath: resolvedFolder, name, preset });
@@ -1901,7 +1913,7 @@ export function createWorkspaceStore(options: {
       pushSandboxCreateLog(`Worker: ${resolvedFolder}`);
 
       // Ensure the workspace folder has baseline OpenWork/OpenCode files.
-      const openworkServer = resolveConnectedOpenworkServer();
+      const openworkServer = await resolveLocalOpenworkServer();
       const created = openworkServer
         ? await openworkServer.createLocalWorkspace({ folderPath: resolvedFolder, name, preset })
         : await workspaceCreate({ folderPath: resolvedFolder, name, preset });


### PR DESCRIPTION
## Summary
- route local workspace creation through the local OpenWork host instead of the currently connected remote server
- apply the same local-host resolution to sandbox bootstrap so local filesystem setup does not target a remote worker by mistake
- keep the existing desktop mirror behavior while avoiding the remote-active modal failure state

## Testing
- pnpm install
- pnpm --filter @openwork/app typecheck
- git diff --check -- apps/app/src/app/context/workspace.ts
- started the Docker dev stack and verified the local server health endpoint and web session route responded
- Chrome MCP UI verification is still blocked in this environment because the local browser broker is not connected
