### PR TITLE
Improve desktop update badge visibility

### DIFF
--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -62,8 +62,8 @@ import ShareWorkspaceModal from "../components/share-workspace-modal";
 import WorkspaceSessionList from "../components/session/workspace-session-list";
 import WebUnavailableSurface from "../components/web-unavailable-surface";
 import {
+  ArrowDownToLine,
   Box,
-  Circle,
   History,
   Loader2,
   MessageCircle,
@@ -1120,7 +1120,7 @@ export default function DashboardView(props: DashboardViewProps) {
     if (state === "downloading") {
       return "text-blue-11 hover:text-blue-11 hover:bg-blue-3/30";
     }
-    return "text-dls-secondary hover:text-emerald-11 hover:bg-emerald-3/25";
+    return "text-dls-secondary hover:text-dls-secondary hover:bg-lime-3/15";
   });
 
   const updatePillBorderTone = createMemo(() => {
@@ -1131,7 +1131,7 @@ export default function DashboardView(props: DashboardViewProps) {
     if (state === "downloading") {
       return "border-blue-7/35";
     }
-    return "border-dls-border";
+    return "border-lime-8/60";
   });
 
   const updatePillDotTone = createMemo(() => {
@@ -1142,7 +1142,7 @@ export default function DashboardView(props: DashboardViewProps) {
     if (state === "downloading") {
       return "text-blue-10";
     }
-    return "text-emerald-10 fill-emerald-10";
+    return "text-lime-11 fill-lime-11";
   });
 
   const updatePillVersionTone = createMemo(() => {
@@ -1191,7 +1191,7 @@ export default function DashboardView(props: DashboardViewProps) {
           <Show when={showUpdatePill()}>
             <button
               type="button"
-              class={`group mb-3 w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.2)] ${updatePillButtonTone()}`}
+              class={`group relative mb-3 flex w-full items-center gap-1.5 rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.2)] ${updatePillBorderTone()} ${updatePillButtonTone()}`}
               onClick={handleUpdatePillClick}
               title={updatePillTitle()}
               aria-label={updatePillTitle()}
@@ -1199,18 +1199,19 @@ export default function DashboardView(props: DashboardViewProps) {
               <Show
                 when={props.updateStatus?.state === "downloading"}
                 fallback={
-                  <Circle
-                    size={8}
-                    class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "group-hover:animate-pulse" : ""}`}
+                  <ArrowDownToLine
+                    size={12}
+                    class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "animate-pulse" : ""}`}
+                    style={props.updateStatus?.state === "available" ? { "animation-duration": "3.5s" } : undefined}
                   />
                 }
               >
                 <Loader2 size={13} class={`animate-spin shrink-0 ${updatePillDotTone()}`} />
               </Show>
-              <span class="flex-1 text-left">{updatePillLabel()}</span>
+              <span class="min-w-0 flex-1 truncate whitespace-nowrap text-left">{updatePillLabel()}</span>
               <Show when={props.updateStatus?.version}>
                 {(version) => (
-                  <span class={`ml-auto font-mono text-[10px] ${updatePillVersionTone()}`}>v{version()}</span>
+                  <span class={`ml-auto shrink-0 font-mono text-[10px] ${updatePillVersionTone()}`}>v{version()}</span>
                 )}
               </Show>
             </button>
@@ -1265,9 +1266,10 @@ export default function DashboardView(props: DashboardViewProps) {
                 <Show
                   when={props.updateStatus?.state === "downloading"}
                   fallback={
-                    <Circle
-                      size={8}
+                    <ArrowDownToLine
+                      size={12}
                       class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "animate-pulse" : ""}`}
+                      style={props.updateStatus?.state === "available" ? { "animation-duration": "3.5s" } : undefined}
                     />
                   }
                 >

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -46,8 +46,8 @@ import { getOpenWorkDeployment } from "../lib/openwork-deployment";
 import { createWorkspaceShellLayout } from "../lib/workspace-shell-layout";
 
 import {
+  ArrowDownToLine,
   Check,
-  Circle,
   FolderOpen,
   HardDrive,
   ListTodo,
@@ -3821,7 +3821,7 @@ export default function SessionView(props: SessionViewProps) {
     if (state === "downloading") {
       return "text-blue-11 hover:text-blue-11 hover:bg-blue-3/30";
     }
-    return "text-dls-secondary hover:text-emerald-11 hover:bg-emerald-3/25";
+    return "text-dls-secondary hover:text-dls-secondary hover:bg-lime-3/15";
   });
 
   const updatePillBorderTone = createMemo(() => {
@@ -3832,7 +3832,7 @@ export default function SessionView(props: SessionViewProps) {
     if (state === "downloading") {
       return "border-blue-7/35";
     }
-    return "border-dls-border";
+    return "border-lime-8/60";
   });
 
   const updatePillDotTone = createMemo(() => {
@@ -3845,7 +3845,7 @@ export default function SessionView(props: SessionViewProps) {
     if (state === "downloading") {
       return "text-blue-10";
     }
-    return "text-emerald-10 fill-emerald-10";
+    return "text-lime-11 fill-lime-11";
   });
 
   const updatePillVersionTone = createMemo(() => {
@@ -4007,7 +4007,7 @@ export default function SessionView(props: SessionViewProps) {
             <Show when={showUpdatePill()}>
               <button
                 type="button"
-                class={`group mb-3 w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.2)] ${updatePillButtonTone()}`}
+                class={`group relative mb-3 flex w-full items-center gap-1.5 rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.2)] ${updatePillBorderTone()} ${updatePillButtonTone()}`}
                 onClick={handleUpdatePillClick}
                 title={updatePillTitle()}
                 aria-label={updatePillTitle()}
@@ -4015,9 +4015,10 @@ export default function SessionView(props: SessionViewProps) {
                 <Show
                   when={props.updateStatus?.state === "downloading"}
                   fallback={
-                    <Circle
-                      size={8}
-                      class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "group-hover:animate-pulse" : ""}`}
+                    <ArrowDownToLine
+                      size={12}
+                      class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "animate-pulse" : ""}`}
+                      style={props.updateStatus?.state === "available" ? { "animation-duration": "3.5s" } : undefined}
                     />
                   }
                 >
@@ -4026,11 +4027,11 @@ export default function SessionView(props: SessionViewProps) {
                     class={`animate-spin shrink-0 ${updatePillDotTone()}`}
                   />
                 </Show>
-                <span class="flex-1 text-left">{updatePillLabel()}</span>
+                <span class="min-w-0 flex-1 truncate whitespace-nowrap text-left">{updatePillLabel()}</span>
                 <Show when={props.updateStatus?.version}>
                   {(version) => (
                     <span
-                      class={`ml-auto font-mono text-[10px] ${updatePillVersionTone()}`}
+                      class={`ml-auto shrink-0 font-mono text-[10px] ${updatePillVersionTone()}`}
                     >
                       v{version()}
                     </span>
@@ -4092,9 +4093,10 @@ export default function SessionView(props: SessionViewProps) {
                   <Show
                     when={props.updateStatus?.state === "downloading"}
                     fallback={
-                      <Circle
-                        size={8}
+                      <ArrowDownToLine
+                        size={12}
                         class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "animate-pulse" : ""}`}
+                        style={props.updateStatus?.state === "available" ? { "animation-duration": "3.5s" } : undefined}
                       />
                     }
                   >

--- a/apps/app/src/app/system-state.ts
+++ b/apps/app/src/app/system-state.ts
@@ -16,7 +16,7 @@ import type {
 } from "./types";
 import { addOpencodeCacheHint, isTauriRuntime, safeStringify } from "./utils";
 import { filterProviderList, mapConfigProvidersToList } from "./utils/providers";
-import { createUpdaterState } from "./context/updater";
+import { createUpdaterState, type UpdateStatus } from "./context/updater";
 import {
   resetOpenworkState,
   resetOpencodeCache,
@@ -47,6 +47,21 @@ function throttle<T extends (...args: any[]) => any>(
       }, delayMs - (now - lastCall));
     }
   }
+}
+
+function forcedDevUpdateStatus(): UpdateStatus | null {
+  if (!import.meta.env.DEV) return null;
+
+  const forcedState = String(import.meta.env.VITE_FORCE_UPDATE_STATUS ?? "").trim().toLowerCase();
+  if (forcedState !== "available") return null;
+
+  const version = String(import.meta.env.VITE_FORCE_UPDATE_VERSION ?? "0.11.999").trim() || "0.11.999";
+  return {
+    state: "available",
+    lastCheckedAt: Date.now(),
+    version,
+    notes: "Dev-only forced update state",
+  };
 }
 
 export type NotionState = {
@@ -469,6 +484,13 @@ export function createSystemState(options: {
 
   async function checkForUpdates(optionsCheck?: { quiet?: boolean }) {
     if (!isTauriRuntime()) return;
+
+    const forcedStatus = forcedDevUpdateStatus();
+    if (forcedStatus) {
+      setPendingUpdate(null);
+      setUpdateStatus(forcedStatus);
+      return;
+    }
 
     const env = updateEnv();
     if (env && !env.supported) {


### PR DESCRIPTION
## Summary
- make the desktop sidebar update badge more noticeable with a lime border and cleaner spacing
- replace the status dot with a download icon, keep the pulse off the text, and keep the label on one line
- add a dev-only `VITE_FORCE_UPDATE_STATUS=available` override so the badge can be previewed locally without a real update

## Testing
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app build