### PR TITLE
refactor(app): share workspace tools panel mounts

### DIFF
--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -47,12 +47,8 @@ import type { EngineInfo, OrchestratorStatus, OpenworkServerInfo, OpenCodeRouter
 import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
 
 import Button from "../components/button";
-import ExtensionsView from "./extensions";
-import ScheduledTasksView from "./scheduled";
 import ConfigView from "./config";
 import SettingsView from "./settings";
-import SkillsView from "./skills";
-import IdentitiesView from "./identities";
 import StatusBar from "../components/status-bar";
 import ProviderAuthModal, {
   type ProviderAuthMethod,
@@ -60,7 +56,7 @@ import ProviderAuthModal, {
 } from "../components/provider-auth-modal";
 import ShareWorkspaceModal from "../components/share-workspace-modal";
 import WorkspaceSessionList from "../components/session/workspace-session-list";
-import WebUnavailableSurface from "../components/web-unavailable-surface";
+import WorkspaceToolsPanel from "./workspace-tools-panel";
 import {
   ArrowDownToLine,
   Box,
@@ -1314,119 +1310,123 @@ export default function DashboardView(props: DashboardViewProps) {
         <div class={props.tab === "settings" ? "w-full space-y-10 p-6 md:p-10" : "mx-auto w-full max-w-[1100px] space-y-10 p-6 md:p-10"}>
           <Switch>
             <Match when={props.tab === "scheduled"}>
-              <WebUnavailableSurface unavailable={webDeployment()}>
-                <ScheduledTasksView
-                  jobs={props.scheduledJobs}
-                  source={props.scheduledJobsSource}
-                  sourceReady={props.scheduledJobsSourceReady}
-                  status={props.scheduledJobsStatus}
-                  busy={props.scheduledJobsBusy}
-                  lastUpdatedAt={props.scheduledJobsUpdatedAt}
-                  refreshJobs={props.refreshScheduledJobs}
-                  deleteJob={props.deleteScheduledJob}
-                  isWindows={props.isWindows}
-                  selectedWorkspaceRoot={props.selectedWorkspaceRoot}
-                  createSessionAndOpen={props.createSessionAndOpen}
-                  setPrompt={props.setPrompt}
-                  newTaskDisabled={props.newTaskDisabled}
-                  schedulerInstalled={props.schedulerPluginInstalled}
-                  canEditPlugins={props.canEditPlugins}
-                  addPlugin={props.addPlugin}
-                  reloadWorkspaceEngine={props.reloadWorkspaceEngine}
-                  reloadBusy={props.reloadBusy}
-                  canReloadWorkspace={props.canReloadWorkspace}
-                />
-              </WebUnavailableSurface>
+              <WorkspaceToolsPanel
+                section="scheduled"
+                scheduled={{
+                  jobs: props.scheduledJobs,
+                  source: props.scheduledJobsSource,
+                  sourceReady: props.scheduledJobsSourceReady,
+                  status: props.scheduledJobsStatus,
+                  busy: props.scheduledJobsBusy,
+                  lastUpdatedAt: props.scheduledJobsUpdatedAt,
+                  refreshJobs: props.refreshScheduledJobs,
+                  deleteJob: props.deleteScheduledJob,
+                  isWindows: props.isWindows,
+                  selectedWorkspaceRoot: props.selectedWorkspaceRoot,
+                  createSessionAndOpen: props.createSessionAndOpen,
+                  setPrompt: props.setPrompt,
+                  newTaskDisabled: props.newTaskDisabled,
+                  schedulerInstalled: props.schedulerPluginInstalled,
+                  canEditPlugins: props.canEditPlugins,
+                  addPlugin: props.addPlugin,
+                  reloadWorkspaceEngine: props.reloadWorkspaceEngine,
+                  reloadBusy: props.reloadBusy,
+                  canReloadWorkspace: props.canReloadWorkspace,
+                }}
+              />
             </Match>
             <Match when={props.tab === "skills"}>
-              <WebUnavailableSurface unavailable={webDeployment()}>
-                <SkillsView
-                  workspaceName={props.selectedWorkspaceDisplay.name}
-                  busy={props.busy}
-                  canInstallSkillCreator={props.canInstallSkillCreator}
-                  canUseDesktopTools={props.canUseDesktopTools}
-                  accessHint={props.skillsAccessHint}
-                  refreshSkills={props.refreshSkills}
-                  refreshHubSkills={props.refreshHubSkills}
-                  skills={props.skills}
-                  skillsStatus={props.skillsStatus}
-                  hubSkills={props.hubSkills}
-                  hubSkillsStatus={props.hubSkillsStatus}
-                  hubRepo={props.hubRepo}
-                  hubRepos={props.hubRepos}
-                  importLocalSkill={props.importLocalSkill}
-                  installSkillCreator={props.installSkillCreator}
-                  installHubSkill={props.installHubSkill}
-                  setHubRepo={props.setHubRepo}
-                  addHubRepo={props.addHubRepo}
-                  removeHubRepo={props.removeHubRepo}
-                  revealSkillsFolder={props.revealSkillsFolder}
-                  uninstallSkill={props.uninstallSkill}
-                  readSkill={props.readSkill}
-                  saveSkill={props.saveSkill}
-                  createSessionAndOpen={props.createSessionAndOpen}
-                  setPrompt={props.setPrompt}
-                />
-              </WebUnavailableSurface>
+              <WorkspaceToolsPanel
+                section="skills"
+                skills={{
+                  workspaceName: props.selectedWorkspaceDisplay.name,
+                  busy: props.busy,
+                  canInstallSkillCreator: props.canInstallSkillCreator,
+                  canUseDesktopTools: props.canUseDesktopTools,
+                  accessHint: props.skillsAccessHint,
+                  refreshSkills: props.refreshSkills,
+                  refreshHubSkills: props.refreshHubSkills,
+                  skills: props.skills,
+                  skillsStatus: props.skillsStatus,
+                  hubSkills: props.hubSkills,
+                  hubSkillsStatus: props.hubSkillsStatus,
+                  hubRepo: props.hubRepo,
+                  hubRepos: props.hubRepos,
+                  importLocalSkill: props.importLocalSkill,
+                  installSkillCreator: props.installSkillCreator,
+                  installHubSkill: props.installHubSkill,
+                  setHubRepo: props.setHubRepo,
+                  addHubRepo: props.addHubRepo,
+                  removeHubRepo: props.removeHubRepo,
+                  revealSkillsFolder: props.revealSkillsFolder,
+                  uninstallSkill: props.uninstallSkill,
+                  readSkill: props.readSkill,
+                  saveSkill: props.saveSkill,
+                  createSessionAndOpen: props.createSessionAndOpen,
+                  setPrompt: props.setPrompt,
+                }}
+              />
             </Match>
 
             <Match when={props.tab === "plugins" || props.tab === "mcp"}>
-              <WebUnavailableSurface unavailable={webDeployment()}>
-                <ExtensionsView
-                  initialSection={props.tab === "plugins" ? "plugins" : "mcp"}
-                  setDashboardTab={props.setTab}
-                  busy={props.busy}
-                  selectedWorkspaceRoot={props.selectedWorkspaceRoot}
-                  isRemoteWorkspace={props.isRemoteWorkspace}
-                  refreshMcpServers={props.refreshMcpServers}
-                  mcpServers={props.mcpServers}
-                  mcpStatus={props.mcpStatus}
-                  mcpLastUpdatedAt={props.mcpLastUpdatedAt}
-                  mcpStatuses={props.mcpStatuses}
-                  mcpConnectingName={props.mcpConnectingName}
-                  selectedMcp={props.selectedMcp}
-                  setSelectedMcp={props.setSelectedMcp}
-                  quickConnect={props.quickConnect}
-                  connectMcp={props.connectMcp}
-                  authorizeMcp={props.authorizeMcp}
-                  logoutMcpAuth={props.logoutMcpAuth}
-                  removeMcp={props.removeMcp}
-                  canEditPlugins={props.canEditPlugins}
-                  canUseGlobalScope={props.canUseGlobalPluginScope}
-                  accessHint={props.pluginsAccessHint}
-                  pluginScope={props.pluginScope}
-                  setPluginScope={props.setPluginScope}
-                  pluginConfigPath={props.pluginConfigPath}
-                  pluginList={props.pluginList}
-                  pluginInput={props.pluginInput}
-                  setPluginInput={props.setPluginInput}
-                  pluginStatus={props.pluginStatus}
-                  activePluginGuide={props.activePluginGuide}
-                  setActivePluginGuide={props.setActivePluginGuide}
-                  isPluginInstalled={props.isPluginInstalled}
-                  suggestedPlugins={props.suggestedPlugins}
-                  refreshPlugins={props.refreshPlugins}
-                  addPlugin={props.addPlugin}
-                  removePlugin={props.removePlugin}
-                />
-              </WebUnavailableSurface>
+              <WorkspaceToolsPanel
+                section="extensions"
+                extensions={{
+                  initialSection: props.tab === "plugins" ? "plugins" : "mcp",
+                  setDashboardTab: props.setTab,
+                  busy: props.busy,
+                  selectedWorkspaceRoot: props.selectedWorkspaceRoot,
+                  isRemoteWorkspace: props.isRemoteWorkspace,
+                  refreshMcpServers: props.refreshMcpServers,
+                  mcpServers: props.mcpServers,
+                  mcpStatus: props.mcpStatus,
+                  mcpLastUpdatedAt: props.mcpLastUpdatedAt,
+                  mcpStatuses: props.mcpStatuses,
+                  mcpConnectingName: props.mcpConnectingName,
+                  selectedMcp: props.selectedMcp,
+                  setSelectedMcp: props.setSelectedMcp,
+                  quickConnect: props.quickConnect,
+                  connectMcp: props.connectMcp,
+                  authorizeMcp: props.authorizeMcp,
+                  logoutMcpAuth: props.logoutMcpAuth,
+                  removeMcp: props.removeMcp,
+                  canEditPlugins: props.canEditPlugins,
+                  canUseGlobalScope: props.canUseGlobalPluginScope,
+                  accessHint: props.pluginsAccessHint,
+                  pluginScope: props.pluginScope,
+                  setPluginScope: props.setPluginScope,
+                  pluginConfigPath: props.pluginConfigPath,
+                  pluginList: props.pluginList,
+                  pluginInput: props.pluginInput,
+                  setPluginInput: props.setPluginInput,
+                  pluginStatus: props.pluginStatus,
+                  activePluginGuide: props.activePluginGuide,
+                  setActivePluginGuide: props.setActivePluginGuide,
+                  isPluginInstalled: props.isPluginInstalled,
+                  suggestedPlugins: props.suggestedPlugins,
+                  refreshPlugins: props.refreshPlugins,
+                  addPlugin: props.addPlugin,
+                  removePlugin: props.removePlugin,
+                }}
+              />
             </Match>
 
             <Match when={props.tab === "identities"}>
-              <WebUnavailableSurface unavailable={webDeployment()}>
-                <IdentitiesView
-                  busy={props.busy}
-                  openworkServerStatus={props.openworkServerStatus}
-                  openworkServerUrl={props.openworkServerUrl}
-                  openworkServerClient={props.openworkServerClient}
-                  openworkReconnectBusy={props.openworkReconnectBusy}
-                  reconnectOpenworkServer={props.reconnectOpenworkServer}
-                  restartLocalServer={props.restartLocalServer}
-                  runtimeWorkspaceId={props.runtimeWorkspaceId}
-                  selectedWorkspaceRoot={props.selectedWorkspaceRoot}
-                  developerMode={props.developerMode}
-                />
-              </WebUnavailableSurface>
+              <WorkspaceToolsPanel
+                section="identities"
+                identities={{
+                  busy: props.busy,
+                  openworkServerStatus: props.openworkServerStatus,
+                  openworkServerUrl: props.openworkServerUrl,
+                  openworkServerClient: props.openworkServerClient,
+                  openworkReconnectBusy: props.openworkReconnectBusy,
+                  reconnectOpenworkServer: props.reconnectOpenworkServer,
+                  restartLocalServer: props.restartLocalServer,
+                  runtimeWorkspaceId: props.runtimeWorkspaceId,
+                  selectedWorkspaceRoot: props.selectedWorkspaceRoot,
+                  developerMode: props.developerMode,
+                }}
+              />
             </Match>
 
             <Match when={props.tab === "config" && props.developerMode}>

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -20,15 +20,11 @@ import Button from "../components/button";
 import ProviderIcon from "../components/provider-icon";
 import DenSettingsPanel from "../components/den-settings-panel";
 import TextInput from "../components/text-input";
-import WebUnavailableSurface from "../components/web-unavailable-surface";
 import type { McpDirectoryInfo } from "../constants";
 import { usePlatform } from "../context/platform";
 import { buildFeedbackUrl } from "../lib/feedback";
 import { getOpenWorkDeployment } from "../lib/openwork-deployment";
-import ExtensionsView from "./extensions";
-import IdentitiesView from "./identities";
-import ScheduledTasksView from "./scheduled";
-import SkillsView from "./skills";
+import WorkspaceToolsPanel from "./workspace-tools-panel";
 import {
   ArrowUpRight,
   CircleAlert,
@@ -2097,123 +2093,127 @@ export default function SettingsView(props: SettingsViewProps) {
         </Match>
 
         <Match when={activeTab() === "automations"}>
-          <WebUnavailableSurface unavailable={webDeployment()}>
-            <ScheduledTasksView
-              showHeader={false}
-              jobs={props.scheduledJobs}
-              source={props.scheduledJobsSource}
-              sourceReady={props.scheduledJobsSourceReady}
-              status={props.scheduledJobsStatus}
-              busy={props.scheduledJobsBusy}
-              lastUpdatedAt={props.scheduledJobsUpdatedAt}
-              refreshJobs={props.refreshScheduledJobs}
-              deleteJob={props.deleteScheduledJob}
-              isWindows={props.isWindows}
-              selectedWorkspaceRoot={props.selectedWorkspaceRoot}
-              createSessionAndOpen={props.createSessionAndOpen}
-              setPrompt={props.setPrompt}
-              newTaskDisabled={props.newTaskDisabled}
-              schedulerInstalled={props.schedulerPluginInstalled}
-              canEditPlugins={props.canEditPlugins}
-              addPlugin={props.addPlugin}
-              reloadWorkspaceEngine={props.reloadWorkspaceEngine}
-              reloadBusy={props.reloadBusy}
-              canReloadWorkspace={props.canReloadWorkspace}
-            />
-          </WebUnavailableSurface>
+          <WorkspaceToolsPanel
+            section="scheduled"
+            scheduled={{
+              showHeader: false,
+              jobs: props.scheduledJobs,
+              source: props.scheduledJobsSource,
+              sourceReady: props.scheduledJobsSourceReady,
+              status: props.scheduledJobsStatus,
+              busy: props.scheduledJobsBusy,
+              lastUpdatedAt: props.scheduledJobsUpdatedAt,
+              refreshJobs: props.refreshScheduledJobs,
+              deleteJob: props.deleteScheduledJob,
+              isWindows: props.isWindows,
+              selectedWorkspaceRoot: props.selectedWorkspaceRoot,
+              createSessionAndOpen: props.createSessionAndOpen,
+              setPrompt: props.setPrompt,
+              newTaskDisabled: props.newTaskDisabled,
+              schedulerInstalled: props.schedulerPluginInstalled,
+              canEditPlugins: props.canEditPlugins,
+              addPlugin: props.addPlugin,
+              reloadWorkspaceEngine: props.reloadWorkspaceEngine,
+              reloadBusy: props.reloadBusy,
+              canReloadWorkspace: props.canReloadWorkspace,
+            }}
+          />
         </Match>
 
         <Match when={activeTab() === "skills"}>
-          <WebUnavailableSurface unavailable={webDeployment()}>
-            <SkillsView
-              workspaceName={props.selectedWorkspaceRoot.trim() || "Workspace"}
-              busy={props.busy}
-              showHeader={false}
-              canInstallSkillCreator={props.canInstallSkillCreator}
-              canUseDesktopTools={props.canUseDesktopTools}
-              accessHint={props.skillsAccessHint}
-              refreshSkills={props.refreshSkills}
-              refreshHubSkills={props.refreshHubSkills}
-              skills={props.skills}
-              skillsStatus={props.skillsStatus}
-              hubSkills={props.hubSkills}
-              hubSkillsStatus={props.hubSkillsStatus}
-              hubRepo={props.hubRepo}
-              hubRepos={props.hubRepos}
-              importLocalSkill={props.importLocalSkill}
-              installSkillCreator={props.installSkillCreator}
-              installHubSkill={props.installHubSkill}
-              setHubRepo={props.setHubRepo}
-              addHubRepo={props.addHubRepo}
-              removeHubRepo={props.removeHubRepo}
-              revealSkillsFolder={props.revealSkillsFolder}
-              uninstallSkill={props.uninstallSkill}
-              readSkill={props.readSkill}
-              saveSkill={props.saveSkill}
-              createSessionAndOpen={props.createSessionAndOpen}
-              setPrompt={props.setPrompt}
-            />
-          </WebUnavailableSurface>
+          <WorkspaceToolsPanel
+            section="skills"
+            skills={{
+              workspaceName: props.selectedWorkspaceRoot.trim() || "Workspace",
+              busy: props.busy,
+              showHeader: false,
+              canInstallSkillCreator: props.canInstallSkillCreator,
+              canUseDesktopTools: props.canUseDesktopTools,
+              accessHint: props.skillsAccessHint,
+              refreshSkills: props.refreshSkills,
+              refreshHubSkills: props.refreshHubSkills,
+              skills: props.skills,
+              skillsStatus: props.skillsStatus,
+              hubSkills: props.hubSkills,
+              hubSkillsStatus: props.hubSkillsStatus,
+              hubRepo: props.hubRepo,
+              hubRepos: props.hubRepos,
+              importLocalSkill: props.importLocalSkill,
+              installSkillCreator: props.installSkillCreator,
+              installHubSkill: props.installHubSkill,
+              setHubRepo: props.setHubRepo,
+              addHubRepo: props.addHubRepo,
+              removeHubRepo: props.removeHubRepo,
+              revealSkillsFolder: props.revealSkillsFolder,
+              uninstallSkill: props.uninstallSkill,
+              readSkill: props.readSkill,
+              saveSkill: props.saveSkill,
+              createSessionAndOpen: props.createSessionAndOpen,
+              setPrompt: props.setPrompt,
+            }}
+          />
         </Match>
 
         <Match when={activeTab() === "extensions"}>
-          <WebUnavailableSurface unavailable={webDeployment()}>
-            <ExtensionsView
-              initialSection="all"
-              showHeader={false}
-              busy={props.busy}
-              selectedWorkspaceRoot={props.selectedWorkspaceRoot}
-              isRemoteWorkspace={props.activeWorkspaceType === "remote"}
-              refreshMcpServers={props.refreshMcpServers}
-              mcpServers={props.mcpServers}
-              mcpStatus={props.mcpStatus}
-              mcpLastUpdatedAt={props.mcpLastUpdatedAt}
-              mcpStatuses={props.mcpStatuses}
-              mcpConnectingName={props.mcpConnectingName}
-              selectedMcp={props.selectedMcp}
-              setSelectedMcp={props.setSelectedMcp}
-              quickConnect={props.quickConnect}
-              connectMcp={props.connectMcp}
-              authorizeMcp={props.authorizeMcp}
-              logoutMcpAuth={props.logoutMcpAuth}
-              removeMcp={props.removeMcp}
-              canEditPlugins={props.canEditPlugins}
-              canUseGlobalScope={props.canUseGlobalPluginScope}
-              accessHint={props.pluginsAccessHint}
-              pluginScope={props.pluginScope}
-              setPluginScope={props.setPluginScope}
-              pluginConfigPath={props.pluginConfigPath}
-              pluginList={props.pluginList}
-              pluginInput={props.pluginInput}
-              setPluginInput={props.setPluginInput}
-              pluginStatus={props.pluginStatus}
-              activePluginGuide={props.activePluginGuide}
-              setActivePluginGuide={props.setActivePluginGuide}
-              isPluginInstalled={props.isPluginInstalled}
-              suggestedPlugins={props.suggestedPlugins}
-              refreshPlugins={props.refreshPlugins}
-              addPlugin={props.addPlugin}
-              removePlugin={props.removePlugin}
-            />
-          </WebUnavailableSurface>
+          <WorkspaceToolsPanel
+            section="extensions"
+            extensions={{
+              initialSection: "all",
+              showHeader: false,
+              busy: props.busy,
+              selectedWorkspaceRoot: props.selectedWorkspaceRoot,
+              isRemoteWorkspace: props.activeWorkspaceType === "remote",
+              refreshMcpServers: props.refreshMcpServers,
+              mcpServers: props.mcpServers,
+              mcpStatus: props.mcpStatus,
+              mcpLastUpdatedAt: props.mcpLastUpdatedAt,
+              mcpStatuses: props.mcpStatuses,
+              mcpConnectingName: props.mcpConnectingName,
+              selectedMcp: props.selectedMcp,
+              setSelectedMcp: props.setSelectedMcp,
+              quickConnect: props.quickConnect,
+              connectMcp: props.connectMcp,
+              authorizeMcp: props.authorizeMcp,
+              logoutMcpAuth: props.logoutMcpAuth,
+              removeMcp: props.removeMcp,
+              canEditPlugins: props.canEditPlugins,
+              canUseGlobalScope: props.canUseGlobalPluginScope,
+              accessHint: props.pluginsAccessHint,
+              pluginScope: props.pluginScope,
+              setPluginScope: props.setPluginScope,
+              pluginConfigPath: props.pluginConfigPath,
+              pluginList: props.pluginList,
+              pluginInput: props.pluginInput,
+              setPluginInput: props.setPluginInput,
+              pluginStatus: props.pluginStatus,
+              activePluginGuide: props.activePluginGuide,
+              setActivePluginGuide: props.setActivePluginGuide,
+              isPluginInstalled: props.isPluginInstalled,
+              suggestedPlugins: props.suggestedPlugins,
+              refreshPlugins: props.refreshPlugins,
+              addPlugin: props.addPlugin,
+              removePlugin: props.removePlugin,
+            }}
+          />
         </Match>
 
         <Match when={activeTab() === "messaging"}>
-          <WebUnavailableSurface unavailable={webDeployment()}>
-            <IdentitiesView
-              busy={props.busy}
-              showHeader={false}
-              openworkServerStatus={props.openworkServerStatus}
-              openworkServerUrl={props.openworkServerUrl}
-              openworkServerClient={props.openworkServerClient}
-              openworkReconnectBusy={props.openworkReconnectBusy}
-              reconnectOpenworkServer={props.reconnectOpenworkServer}
-              restartLocalServer={props.restartLocalServer}
-              runtimeWorkspaceId={props.runtimeWorkspaceId}
-              selectedWorkspaceRoot={props.selectedWorkspaceRoot}
-              developerMode={props.developerMode}
-            />
-          </WebUnavailableSurface>
+          <WorkspaceToolsPanel
+            section="identities"
+            identities={{
+              busy: props.busy,
+              showHeader: false,
+              openworkServerStatus: props.openworkServerStatus,
+              openworkServerUrl: props.openworkServerUrl,
+              openworkServerClient: props.openworkServerClient,
+              openworkReconnectBusy: props.openworkReconnectBusy,
+              reconnectOpenworkServer: props.reconnectOpenworkServer,
+              restartLocalServer: props.restartLocalServer,
+              runtimeWorkspaceId: props.runtimeWorkspaceId,
+              selectedWorkspaceRoot: props.selectedWorkspaceRoot,
+              developerMode: props.developerMode,
+            }}
+          />
         </Match>
 
         <Match when={activeTab() === "den"}>

--- a/apps/app/src/app/pages/workspace-tools-panel.tsx
+++ b/apps/app/src/app/pages/workspace-tools-panel.tsx
@@ -1,0 +1,58 @@
+import WebUnavailableSurface from "../components/web-unavailable-surface";
+import { getOpenWorkDeployment } from "../lib/openwork-deployment";
+import ExtensionsView, { type ExtensionsViewProps } from "./extensions";
+import IdentitiesView, { type IdentitiesViewProps } from "./identities";
+import ScheduledTasksView, { type ScheduledTasksViewProps } from "./scheduled";
+import SkillsView, { type SkillsViewProps } from "./skills";
+
+type WorkspaceToolsPanelProps =
+  | {
+      section: "scheduled";
+      scheduled: ScheduledTasksViewProps;
+    }
+  | {
+      section: "skills";
+      skills: SkillsViewProps;
+    }
+  | {
+      section: "extensions";
+      extensions: ExtensionsViewProps;
+    }
+  | {
+      section: "identities";
+      identities: IdentitiesViewProps;
+    };
+
+export default function WorkspaceToolsPanel(props: WorkspaceToolsPanelProps) {
+  const webUnavailable = getOpenWorkDeployment() === "web";
+
+  if (props.section === "scheduled") {
+    return (
+      <WebUnavailableSurface unavailable={webUnavailable}>
+        <ScheduledTasksView {...props.scheduled} />
+      </WebUnavailableSurface>
+    );
+  }
+
+  if (props.section === "skills") {
+    return (
+      <WebUnavailableSurface unavailable={webUnavailable}>
+        <SkillsView {...props.skills} />
+      </WebUnavailableSurface>
+    );
+  }
+
+  if (props.section === "extensions") {
+    return (
+      <WebUnavailableSurface unavailable={webUnavailable}>
+        <ExtensionsView {...props.extensions} />
+      </WebUnavailableSurface>
+    );
+  }
+
+  return (
+    <WebUnavailableSurface unavailable={webUnavailable}>
+      <IdentitiesView {...props.identities} />
+    </WebUnavailableSurface>
+  );
+}


### PR DESCRIPTION
## Summary
- extract the duplicated scheduled, skills, extensions, and identities mounts into a shared `WorkspaceToolsPanel`
- remove repeated `WebUnavailableSurface` and leaf-view wiring from both `dashboard.tsx` and `settings.tsx`

## Testing
- pnpm typecheck
- pnpm build