### PR TITLE
refactor(session): drop dead prop plumbing

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -125,7 +125,6 @@ import {
   formatModelLabel,
   formatModelRef,
   formatRelativeTime,
-  groupMessageParts,
   isVisibleTextPart,
   isTauriRuntime,
   modelEquals,
@@ -140,7 +139,6 @@ import {
   parseModelRef,
   readStartupPreference,
   safeStringify,
-  summarizeStep,
   addOpencodeCacheHint,
 } from "./utils";
 import {
@@ -8335,7 +8333,6 @@ export default function App() {
     anyActiveRuns: anyActiveRuns(),
     installUpdateAndRestart,
     selectedSessionModelLabel: selectedSessionModelLabel(),
-    selectedProviderID: selectedSessionModel().providerID,
     openSessionModelPicker: openSessionModelPicker,
     modelVariantLabel: getModelBehaviorCopy(selectedSessionModel(), getVariantFor(selectedSessionModel())).label,
     modelVariant: getVariantFor(selectedSessionModel()),
@@ -8371,8 +8368,6 @@ export default function App() {
     developerMode: developerMode(),
     showThinking: showThinking(),
     sessionCompactionState: selectedSessionCompactionState(),
-    groupMessageParts,
-    summarizeStep,
     expandedStepIds: expandedStepIds(),
     setExpandedStepIds: setExpandedStepIds,
     expandedSidebarSections: expandedSidebarSections(),

--- a/apps/app/src/app/components/session/composer.tsx
+++ b/apps/app/src/app/components/session/composer.tsx
@@ -30,7 +30,6 @@ type ComposerProps = {
   onSend: (draft: ComposerDraft) => void;
   onStop: () => void;
   onDraftChange: (draft: ComposerDraft) => void;
-  selectedProviderID?: string | null;
   selectedModelLabel: string;
   onModelClick: () => void;
   modelVariantLabel: string;

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -12,7 +12,6 @@ import type { Agent, Part, Session } from "@opencode-ai/sdk/v2/client";
 import type {
   DashboardTab,
   ComposerDraft,
-  MessageGroup,
   MessageWithParts,
   McpServerEntry,
   McpStatusMap,
@@ -192,8 +191,6 @@ export type SessionViewProps = {
   developerMode: boolean;
   showThinking: boolean;
   sessionCompactionState: SessionCompactionState | null;
-  groupMessageParts: (parts: Part[], messageId: string) => MessageGroup[];
-  summarizeStep: (part: Part) => { title: string; detail?: string };
   expandedStepIds: Set<string>;
   setExpandedStepIds: (
     updater: (current: Set<string>) => Set<string>,


### PR DESCRIPTION
## Summary
- remove unused session prop passthroughs that `MessageList` and `Composer` no longer consume
- trim dead `groupMessageParts`, `summarizeStep`, and `selectedProviderID` plumbing from the app shell and session surface

## Testing
- pnpm typecheck
- pnpm build