### PR TITLE
fix welcome workspace bootstrap flow

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -283,6 +283,12 @@ type SettingsReturnTarget = {
   sessionId: string | null;
 };
 
+type PendingInitialSessionSelection = {
+  workspaceId: string;
+  title: string | null;
+  readyAt: number;
+};
+
 export default function App() {
   const envOpenworkWorkspaceId =
     typeof import.meta.env?.VITE_OPENWORK_WORKSPACE_ID === "string"
@@ -329,6 +335,8 @@ export default function App() {
 
   const [tab, setTabState] = createSignal<DashboardTab>("scheduled");
   const [settingsTab, setSettingsTab] = createSignal<SettingsTab>("general");
+  const [pendingInitialSessionSelection, setPendingInitialSessionSelection] =
+    createSignal<PendingInitialSessionSelection | null>(null);
 
   const goToDashboard = (nextTab: DashboardTab, options?: { replace?: boolean }) => {
     setTabState(nextTab);
@@ -1006,7 +1014,15 @@ export default function App() {
     deriveArtifacts(messages(), { maxMessages: ARTIFACT_SCAN_MESSAGE_WINDOW }),
   );
   const workingFiles = createMemo(() => deriveWorkingFiles(artifacts()));
-  const activeSessionId = createMemo(() => selectedSessionId());
+  const activeSessionId = createMemo(() => {
+    const path = location.pathname.trim();
+    const [, sessionSegment, idSegment] = path.split("/");
+    if (sessionSegment?.toLowerCase() === "session") {
+      const routeId = (idSegment ?? "").trim();
+      if (routeId) return routeId;
+    }
+    return selectedSessionId();
+  });
   const activeSessions = createMemo(() => sessions());
   const activeSessionStatusById = createMemo(() => sessionStatusById());
   const activeMessages = createMemo(() => messages());
@@ -2704,6 +2720,7 @@ export default function App() {
     onEngineStable: () => {},
     engineRuntime,
     developerMode,
+    setPendingInitialSessionSelection,
   });
 
   const runtimeWorkspaceId = createMemo(() => workspaceStore.runtimeWorkspaceId());
@@ -3211,8 +3228,61 @@ export default function App() {
   });
 
   createEffect(() => {
+    if (typeof window === "undefined") return;
+    const pending = pendingInitialSessionSelection();
+    if (!pending) return;
+    const delayMs = pending.readyAt - Date.now();
+    if (delayMs <= 0) return;
+    const timer = window.setTimeout(() => {
+      setPendingInitialSessionSelection((current) =>
+        current && current.workspaceId === pending.workspaceId && current.readyAt === pending.readyAt
+          ? { ...current }
+          : current,
+      );
+    }, delayMs);
+    onCleanup(() => window.clearTimeout(timer));
+  });
+
+  createEffect(() => {
+    const pending = pendingInitialSessionSelection();
+    if (!pending) return;
+    const workspaceId = workspaceStore.selectedWorkspaceId().trim();
+    if (!workspaceId || pending.workspaceId !== workspaceId) return;
+    const path = location.pathname.trim().toLowerCase();
+    if (path.startsWith("/session/") || !!selectedSessionId()) {
+      setPendingInitialSessionSelection(null);
+    }
+  });
+
+  createEffect(() => {
     // Only auto-select on bare /session. If the URL already includes /session/:id,
     // let the route-driven selector own the fetch to avoid duplicate selection runs.
+    const pending = pendingInitialSessionSelection();
+    const workspaceId = workspaceStore.selectedWorkspaceId().trim();
+    if (pending && pending.workspaceId === workspaceId) {
+      if (Date.now() < pending.readyAt) return;
+      if (!sessionsLoaded()) return;
+      if (sessions().length === 0) return;
+      const workspaceRoot = normalizeDirectoryPath(workspaceStore.selectedWorkspaceRoot().trim());
+      const normalizedTitle = pending.title?.trim().toLowerCase() ?? "";
+      const match = normalizedTitle
+        ? sessions().find((session) => {
+            const sessionTitle = session.title?.trim().toLowerCase() ?? "";
+            if (sessionTitle !== normalizedTitle) return false;
+            if (!workspaceRoot) return true;
+            const sessionRoot = normalizeDirectoryPath(typeof session.directory === "string" ? session.directory : "");
+            return sessionRoot === workspaceRoot;
+          })
+        : null;
+      if (match) {
+        goToSession(match.id, { replace: true });
+        return;
+      }
+      setPendingInitialSessionSelection(null);
+      setView("session");
+      return;
+    }
+
     if (currentView() !== "session") return;
     const normalizedPath = location.pathname.toLowerCase().replace(/\/+$/, "");
     if (normalizedPath !== "/session") return;
@@ -4989,8 +5059,10 @@ export default function App() {
         }));
         await refreshActiveWorkspaceServerConfig(workspaceId);
         await loadSessionsWithReady(root || undefined);
-        if (result.openSessionId) {
-          setView("session");
+        const pending = pendingInitialSessionSelection();
+        const shouldDeferInitialOpen = pending && pending.workspaceId === workspaceId;
+        if (result.openSessionId && !shouldDeferInitialOpen) {
+          goToSession(result.openSessionId, { replace: true });
           await selectSession(result.openSessionId);
         }
       } catch (error) {
@@ -7105,8 +7177,26 @@ export default function App() {
     return selectedWorkspaceDisplay();
   });
 
+  // Avoid flashing the full-screen switch overlay for fast workspace switches.
+  // Only show it if a switch is still in progress after a short delay.
+  const [workspaceSwitchDelayElapsed, setWorkspaceSwitchDelayElapsed] = createSignal(false);
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    const switchingId = workspaceStore.connectingWorkspaceId();
+    if (!switchingId) {
+      setWorkspaceSwitchDelayElapsed(false);
+      return;
+    }
+
+    setWorkspaceSwitchDelayElapsed(false);
+    const timer = window.setTimeout(() => setWorkspaceSwitchDelayElapsed(true), 250);
+    onCleanup(() => window.clearTimeout(timer));
+  });
+
   const workspaceSwitchOpen = createMemo(() => {
     if (booting()) return true;
+    if (pendingInitialSessionSelection()) return true;
+    if (workspaceStore.connectingWorkspaceId()) return workspaceSwitchDelayElapsed();
     if (!busy() || !busyLabel()) return false;
     const label = busyLabel();
     return (
@@ -7116,6 +7206,7 @@ export default function App() {
   });
 
   const workspaceSwitchStatusKey = createMemo(() => {
+    if (pendingInitialSessionSelection()) return "workspace.switching_status_loading";
     const label = busyLabel();
     if (label === "status.connecting") return "workspace.switching_status_connecting";
     if (label === "status.starting_engine" || label === "status.restarting_engine") {
@@ -7327,7 +7418,6 @@ export default function App() {
       testWorkspaceConnection: workspaceStore.testWorkspaceConnection,
       recoverWorkspace: workspaceStore.recoverWorkspace,
       openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
-      getStartedWorkspace: workspaceStore.quickStartWorkspaceFlow,
       pickFolderWorkspace: workspaceStore.createWorkspaceFromPickedFolder,
       openCreateRemoteWorkspace: () => workspaceStore.setCreateRemoteWorkspaceOpen(true),
       connectRemoteWorkspace: workspaceStore.createRemoteWorkspaceFlow,
@@ -7563,7 +7653,6 @@ export default function App() {
     editWorkspaceConnection: openWorkspaceConnectionSettings,
     forgetWorkspace: workspaceStore.forgetWorkspace,
     openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
-    getStartedWorkspace: workspaceStore.quickStartWorkspaceFlow,
     pickFolderWorkspace: workspaceStore.createWorkspaceFromPickedFolder,
     openCreateRemoteWorkspace: () => workspaceStore.setCreateRemoteWorkspaceOpen(true),
     importWorkspaceConfig: workspaceStore.importWorkspaceConfig,
@@ -7704,7 +7793,10 @@ export default function App() {
   };
 
   const initialRoute = () => {
-    if (typeof window === "undefined") return "/session";
+    if (typeof window === "undefined") return "/onboarding";
+    if (booting() || pendingInitialSessionSelection() || workspaceStore.workspaces().length === 0) {
+      return "/onboarding";
+    }
     return "/session";
   };
 
@@ -7743,6 +7835,7 @@ export default function App() {
 
       // If the URL points at a session that no longer exists (e.g. after deletion),
       // route back to /session so the app can fall back safely.
+      const pendingInitialSelection = pendingInitialSessionSelection();
       const selectedWorkspaceRoot = normalizeDirectoryPath(workspaceStore.selectedWorkspaceRoot().trim());
       const matchingSession = sessions().find((session) => session.id === id) ?? null;
       const hasMatchingSessionInScope = matchingSession
@@ -7750,6 +7843,7 @@ export default function App() {
         : false;
       if (
         sessionsLoaded() &&
+        !pendingInitialSelection &&
         shouldRedirectMissingSessionAfterScopedLoad({
           loadedScopeRoot: loadedSessionScopeRoot(),
           workspaceRoot: workspaceStore.selectedWorkspaceRoot().trim(),
@@ -7764,6 +7858,7 @@ export default function App() {
       }
 
       if (selectedSessionId() !== id) {
+        setSelectedSessionId(id);
         void selectSession(id);
       }
       return;
@@ -7780,13 +7875,16 @@ export default function App() {
     }
 
     if (path.startsWith("/onboarding")) {
-      navigate("/session", { replace: true });
       return;
     }
 
     const fallback = activeSessionId();
     if (fallback) {
       goToSession(fallback, { replace: true });
+      return;
+    }
+    if (booting() || pendingInitialSessionSelection() || workspaceStore.workspaces().length === 0) {
+      navigate("/onboarding", { replace: true });
       return;
     }
     navigate("/session", { replace: true });
@@ -7805,7 +7903,10 @@ export default function App() {
 
       <WorkspaceSwitchOverlay
         open={workspaceSwitchOpen()}
-        workspace={workspaceSwitchWorkspace()}
+        workspace={pendingInitialSessionSelection()
+          ? (workspaceStore.workspaces().find((ws) => ws.id === pendingInitialSessionSelection()!.workspaceId)
+            ?? workspaceSwitchWorkspace())
+          : workspaceSwitchWorkspace()}
         statusKey={workspaceSwitchStatusKey()}
       />
 
@@ -8069,7 +8170,7 @@ export default function App() {
                 setSharedBundleCreateWorkerRequest({
                   request: request.request,
                   bundle: request.bundle,
-                  defaultPreset: "starter",
+                  defaultPreset: "minimal",
                 });
                 workspaceStore.setCreateWorkspaceOpen(true);
               }

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -1757,12 +1757,11 @@ export default function App() {
     const params = directory ? { sessionID: trimmed, directory } : { sessionID: trimmed };
     unwrap(await c.session.delete(params));
 
-    // Remove the deleted session from the store and sidebar locally.
-    // SSE will handle any further sync — calling loadSessions/refreshSidebarWorkspaceSessions
-    // here races with SSE and can wipe unrelated sessions from the store.
+    // Remove the deleted session from the store locally, then refetch the
+    // workspace-scoped sidebar session list from the server source of truth.
     setSessions(sessions().filter((s) => s.id !== trimmed));
     const activeWsId = workspaceStore.selectedWorkspaceId();
-    removeSidebarSession(activeWsId, trimmed);
+    await refreshSidebarWorkspaceSessions(activeWsId).catch(() => undefined);
 
     // If we're currently routed to the deleted session, navigate away immediately.
     // (Otherwise the route effect can try to re-select a session that no longer exists.)
@@ -2694,6 +2693,7 @@ export default function App() {
     setOpencodeConnectStatus,
     loadSessions: loadSessionsWithReady,
     refreshPendingPermissions,
+    refreshWorkspaceSessions: (workspaceId: string) => refreshSidebarWorkspaceSessions(workspaceId),
     selectedSessionId,
     selectSession,
     setSelectedSessionId,
@@ -2760,8 +2760,6 @@ export default function App() {
   const {
     workspaceGroups: rawSidebarWorkspaceGroups,
     refreshWorkspaceSessions: refreshSidebarWorkspaceSessions,
-    prependSession: prependSidebarSession,
-    removeSession: removeSidebarSession,
   } = sidebarSessionsStore;
 
   const sidebarWorkspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
@@ -5749,28 +5747,16 @@ export default function App() {
         setSessions([session, ...currentStoreSessions]);
       }
 
-      const newItem: SidebarSessionItem = {
-        id: session.id,
-        title: session.title,
-        slug: session.slug,
-        parentID: session.parentID,
-        time: session.time,
-        directory: session.directory,
-      };
       const wsId = workspaceStore.selectedWorkspaceId().trim();
       if (wsId) {
-        prependSidebarSession(wsId, newItem);
+        await refreshSidebarWorkspaceSessions(wsId).catch(() => undefined);
       }
 
       // setSessionViewLockUntil(Date.now() + 1200);
       goToSession(session.id);
 
-      // The new session is already in the sessions() store (injected above)
-      // and in the sidebar signal. SSE session.created events will handle
-      // any further syncing. Calling loadSessionsWithReady() here would
-      // race with the store injection — the server may not have indexed the
-      // session yet, so reconcile() would wipe it from the store, causing
-      // the sidebar to flash and the route guard to bounce back.
+      // The new session is already in the sessions() store (injected above).
+      // Sidebar state now refreshes from the server-scoped workspace list.
       finishPerf(perfEnabled, "session.create", "done", startedAt, {
         runId,
         sessionID: session.id,

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -176,6 +176,7 @@ const fileToDataUrl = (file: File) =>
   });
 import { createExtensionsStore } from "./context/extensions";
 import { createAutomationsStore } from "./context/automations";
+import { createSidebarSessionsStore } from "./context/sidebar-sessions";
 import { useGlobalSync } from "./context/global-sync";
 import { createWorkspaceStore } from "./context/workspace";
 import {
@@ -1761,10 +1762,7 @@ export default function App() {
     // here races with SSE and can wipe unrelated sessions from the store.
     setSessions(sessions().filter((s) => s.id !== trimmed));
     const activeWsId = workspaceStore.selectedWorkspaceId();
-    setSidebarSessionsByWorkspaceId((prev) => ({
-      ...prev,
-      [activeWsId]: (prev[activeWsId] ?? []).filter((s) => s.id !== trimmed),
-    }));
+    removeSidebarSession(activeWsId, trimmed);
 
     // If we're currently routed to the deleted session, navigate away immediately.
     // (Otherwise the route effect can try to re-select a session that no longer exists.)
@@ -2730,17 +2728,6 @@ export default function App() {
   const runtimeWorkspaceId = createMemo(() => workspaceStore.runtimeWorkspaceId());
   const activeWorkspaceServerConfig = createMemo(() => workspaceStore.runtimeWorkspaceConfig());
 
-  type SidebarWorkspaceSessionsStatus = WorkspaceSessionGroup["status"];
-  const [sidebarSessionsByWorkspaceId, setSidebarSessionsByWorkspaceId] = createSignal<
-    Record<string, SidebarSessionItem[]>
-  >({});
-  const [sidebarSessionStatusByWorkspaceId, setSidebarSessionStatusByWorkspaceId] = createSignal<
-    Record<string, SidebarWorkspaceSessionsStatus>
-  >({});
-  const [sidebarSessionErrorByWorkspaceId, setSidebarSessionErrorByWorkspaceId] = createSignal<
-    Record<string, string | null>
-  >({});
-
   const logWorkspaceScopeSnapshot = (label: string, extra?: Record<string, unknown>) => {
     if (!developerMode()) return;
     const activeWorkspace = workspaceStore.selectedWorkspaceInfo();
@@ -2765,251 +2752,28 @@ export default function App() {
     });
   };
 
-  const pruneSidebarSessionState = (workspaceIds: Set<string>) => {
-    setSidebarSessionsByWorkspaceId((prev) => {
-      let changed = false;
-      const next: Record<string, SidebarSessionItem[]> = {};
-      for (const [id, list] of Object.entries(prev)) {
-        if (!workspaceIds.has(id)) {
-          changed = true;
-          continue;
-        }
-        next[id] = list;
-      }
-      return changed ? next : prev;
-    });
-    setSidebarSessionStatusByWorkspaceId((prev) => {
-      let changed = false;
-      const next: Record<string, SidebarWorkspaceSessionsStatus> = {};
-      for (const [id, status] of Object.entries(prev)) {
-        if (!workspaceIds.has(id)) {
-          changed = true;
-          continue;
-        }
-        next[id] = status;
-      }
-      return changed ? next : prev;
-    });
-    setSidebarSessionErrorByWorkspaceId((prev) => {
-      let changed = false;
-      const next: Record<string, string | null> = {};
-      for (const [id, error] of Object.entries(prev)) {
-        if (!workspaceIds.has(id)) {
-          changed = true;
-          continue;
-        }
-        next[id] = error;
-      }
-      return changed ? next : prev;
-    });
-  };
-
-  const resolveSidebarClientConfig = (workspaceId: string) => {
-    const workspace = workspaceStore.workspaces().find((entry) => entry.id === workspaceId) ?? null;
-    if (!workspace) return null;
-
-    if (workspace.workspaceType === "local") {
-      const info = workspaceStore.engine();
-      const baseUrl = info?.baseUrl?.trim() ?? "";
-      const directory = toSessionTransportDirectory(workspace.path?.trim() ?? "");
-      const username = info?.opencodeUsername?.trim() ?? "";
-      const password = info?.opencodePassword?.trim() ?? "";
-      const auth: OpencodeAuth | undefined = username && password ? { username, password } : undefined;
-      return {
-        baseUrl,
-        directory,
-        auth,
-      };
-    }
-
-    const baseUrl = workspace.baseUrl?.trim() ?? "";
-    const directory = workspace.directory?.trim() ?? "";
-    if (workspace.remoteType === "openwork") {
-      // Sidebar session listing should be per-workspace and should not implicitly depend on
-      // global OpenWork server settings, otherwise switching between remotes can cause other
-      // workspace task lists to appear/disappear.
-      const token = workspace.openworkToken?.trim() ?? "";
-      const auth: OpencodeAuth | undefined = token ? { token, mode: "openwork" } : undefined;
-      return {
-        baseUrl,
-        directory,
-        auth,
-      };
-    }
-    return {
-      baseUrl,
-      directory,
-      auth: undefined as OpencodeAuth | undefined,
-    };
-  };
-
-  const sidebarRefreshSeqByWorkspaceId: Record<string, number> = {};
-  const SIDEBAR_SESSION_LIMIT = 200;
-  const refreshSidebarWorkspaceSessions = async (workspaceId: string) => {
-    const id = workspaceId.trim();
-    if (!id) return;
-
-    const config = resolveSidebarClientConfig(id);
-    if (!config) return;
-
-    // For local workspaces, avoid thrashing UI with errors if the engine is offline.
-    if (!config.baseUrl) {
-      let changed = false;
-      setSidebarSessionStatusByWorkspaceId((prev) => {
-        if (prev[id] === "idle") return prev;
-        changed = true;
-        return { ...prev, [id]: "idle" };
-      });
-      setSidebarSessionErrorByWorkspaceId((prev) => {
-        if ((prev[id] ?? null) === null) return prev;
-        changed = true;
-        return { ...prev, [id]: null };
-      });
-      if (changed) {
-        wsDebug("sidebar:skip", { id, reason: "no-baseUrl" });
-      }
-      return;
-    }
-
-    sidebarRefreshSeqByWorkspaceId[id] = (sidebarRefreshSeqByWorkspaceId[id] ?? 0) + 1;
-    const seq = sidebarRefreshSeqByWorkspaceId[id];
-
-    setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "loading" }));
-    setSidebarSessionErrorByWorkspaceId((prev) => ({ ...prev, [id]: null }));
-
-    try {
-      const start = Date.now();
-      let directory = config.directory;
-      let c = createClient(config.baseUrl, directory || undefined, config.auth);
-      wsDebug("sidebar:list:start", {
-        id,
-        directory: directory || null,
-        directoryScope: describeDirectoryScope(directory),
-        workspacePath: workspaceStore.workspaces().find((entry) => entry.id === id)?.path?.trim() ?? null,
-      });
-
-      if (!directory) {
-        try {
-          const pathInfo = unwrap(await c.path.get());
-          const discovered = toSessionTransportDirectory(pathInfo.directory ?? "");
-          if (discovered) {
-            directory = discovered;
-            c = createClient(config.baseUrl, directory, config.auth);
-          }
-        } catch {
-          // ignore
-        }
-      }
-
-      const queryDirectory = normalizeDirectoryQueryPath(directory) || undefined;
-
-      // Fetch sessions scoped to the workspace directory to avoid loading the
-      // full global session list for every workspace.
-      const list = unwrap(
-        await c.session.list({ directory: queryDirectory, roots: false, limit: SIDEBAR_SESSION_LIMIT }),
-      );
-      wsDebug("sidebar:list", {
-        id,
-        baseUrl: config.baseUrl,
-        directory: directory || null,
-        directoryScope: describeDirectoryScope(directory),
-        queryDirectory: queryDirectory ?? null,
-        queryScope: describeDirectoryScope(queryDirectory),
-        count: list.length,
-        ms: Date.now() - start,
-        sessionDirectories: list.slice(0, 10).map((session) => ({
-          id: session.id,
-          directory: session.directory,
-          directoryScope: describeDirectoryScope(session.directory),
-        })),
-      });
-      if (sidebarRefreshSeqByWorkspaceId[id] !== seq) return;
-
-      // Defensive client-side filter in case upstream ignores the directory query.
-      const root = normalizeDirectoryPath(directory);
-      const filtered = root ? list.filter((session) => normalizeDirectoryPath(session.directory) === root) : list;
-
-      const sorted = sortSessionsByActivity(filtered);
-      const items: SidebarSessionItem[] = sorted.map((session) => ({
-        id: session.id,
-        title: session.title,
-        slug: session.slug,
-        parentID: session.parentID,
-        time: session.time,
-        directory: session.directory,
-      }));
-
-      setSidebarSessionsByWorkspaceId((prev) => ({
-        ...prev,
-        [id]: items,
-      }));
-      setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
-    } catch (error) {
-      if (sidebarRefreshSeqByWorkspaceId[id] !== seq) return;
-      const message = error instanceof Error ? error.message : safeStringify(error);
-      wsDebug("sidebar:error", { id, message });
-      setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "error" }));
-      setSidebarSessionErrorByWorkspaceId((prev) => ({ ...prev, [id]: message }));
-    }
-  };
-
-  const refreshAllSidebarWorkspaceSessions = async () => {
-    const list = workspaceStore.workspaces();
-    if (!list.length) return;
-    await Promise.allSettled(list.map((ws) => refreshSidebarWorkspaceSessions(ws.id)));
-  };
-
-  let lastSidebarEngineKey = "";
-  let lastSidebarWorkspaceKey = "";
-  createEffect(() => {
-    const engineInfo = workspaceStore.engine();
-    const engineBaseUrl = engineInfo?.baseUrl?.trim() ?? "";
-    const engineUser = engineInfo?.opencodeUsername?.trim() ?? "";
-    const enginePass = engineInfo?.opencodePassword?.trim() ?? "";
-
-    const engineKey = [engineBaseUrl, engineUser, enginePass].join("::");
-    const workspaceKey = workspaceStore
-      .workspaces()
-      .map((ws) => {
-        const root = ws.workspaceType === "local" ? ws.path?.trim() ?? "" : ws.directory?.trim() ?? "";
-        const base = ws.workspaceType === "local" ? "" : ws.baseUrl?.trim() ?? "";
-        const remoteType = ws.workspaceType === "remote" ? (ws.remoteType ?? "") : "";
-        const token = ws.remoteType === "openwork" ? (ws.openworkToken?.trim() ?? "") : "";
-        return [ws.id, ws.workspaceType, remoteType, root, base, token].join("|");
-      })
-      .join(";");
-
-    // Sidebar session refreshes should only be driven by the engine auth/baseUrl or the workspace
-    // definitions themselves. Global OpenWork server settings are intentionally excluded so that
-    // connecting/activating a remote does not cause other workspace task lists to refresh (and
-    // potentially disappear) due to auth fallback changes.
-    if (engineKey === lastSidebarEngineKey && workspaceKey === lastSidebarWorkspaceKey) return;
-
-    lastSidebarEngineKey = engineKey;
-    lastSidebarWorkspaceKey = workspaceKey;
-
-    pruneSidebarSessionState(new Set(workspaceStore.workspaces().map((ws) => ws.id)));
-
-    wsDebug("sidebar:refresh", {
-      selectedWorkspaceId: workspaceStore.selectedWorkspaceId(),
-      engineBaseUrl,
-    });
-
-    void refreshAllSidebarWorkspaceSessions().catch(() => undefined);
+  const sidebarSessionsStore = createSidebarSessionsStore({
+    workspaces: () => workspaceStore.workspaces(),
+    engine: () => workspaceStore.engine(),
   });
 
+  const {
+    workspaceGroups: rawSidebarWorkspaceGroups,
+    refreshWorkspaceSessions: refreshSidebarWorkspaceSessions,
+    prependSession: prependSidebarSession,
+    removeSession: removeSidebarSession,
+  } = sidebarSessionsStore;
+
   const sidebarWorkspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
-    const workspaces = workspaceStore.workspaces();
+    const groups = rawSidebarWorkspaceGroups();
     const selectedWorkspaceId = workspaceStore.selectedWorkspaceId().trim();
     const connectingWorkspaceId = workspaceStore.connectingWorkspaceId()?.trim() ?? "";
-    const sessionsById = sidebarSessionsByWorkspaceId();
-    const statusById = sidebarSessionStatusByWorkspaceId();
-    const errorById = sidebarSessionErrorByWorkspaceId();
-    const dedupedWorkspaces: typeof workspaces = [];
+    const dedupedGroups: typeof groups = [];
     const dedupeKeyToIndex = new Map<string, number>();
-    for (const workspace of workspaces) {
+    for (const group of groups) {
+      const workspace = group.workspace;
       if (workspace.workspaceType !== "remote") {
-        dedupedWorkspaces.push(workspace);
+        dedupedGroups.push(group);
         continue;
       }
       const hostKey =
@@ -3024,27 +2788,28 @@ export default function App() {
       const directoryKey = normalizeDirectoryPath(workspace.directory?.trim() ?? workspace.path?.trim() ?? "");
       const identityKey = workspaceIdKey ? `id:${workspaceIdKey}` : (directoryKey ? `dir:${directoryKey}` : "");
       if (!hostKey || !identityKey) {
-        dedupedWorkspaces.push(workspace);
+        dedupedGroups.push(group);
         continue;
       }
       const dedupeKey = `${workspace.remoteType ?? ""}|${hostKey}|${identityKey}`;
       const existingIndex = dedupeKeyToIndex.get(dedupeKey);
       if (existingIndex === undefined) {
-        dedupeKeyToIndex.set(dedupeKey, dedupedWorkspaces.length);
-        dedupedWorkspaces.push(workspace);
+        dedupeKeyToIndex.set(dedupeKey, dedupedGroups.length);
+        dedupedGroups.push(group);
         continue;
       }
-      const existingWorkspace = dedupedWorkspaces[existingIndex];
+      const existingWorkspace = dedupedGroups[existingIndex].workspace;
       const existingIsPriority =
         existingWorkspace.id === selectedWorkspaceId || existingWorkspace.id === connectingWorkspaceId;
       const currentIsPriority =
         workspace.id === selectedWorkspaceId || workspace.id === connectingWorkspaceId;
       if (currentIsPriority && !existingIsPriority) {
-        dedupedWorkspaces[existingIndex] = workspace;
+        dedupedGroups[existingIndex] = group;
       }
     }
-    return dedupedWorkspaces.map((workspace) => {
-      const groupSessions = sessionsById[workspace.id] ?? [];
+    return dedupedGroups.map((group) => {
+      const workspace = group.workspace;
+      const groupSessions = group.sessions;
       if (developerMode()) {
         console.log("[sidebar-groups] workspace group", {
           workspaceId: workspace.id,
@@ -3064,8 +2829,8 @@ export default function App() {
       return {
         workspace,
         sessions: groupSessions,
-        status: statusById[workspace.id] ?? "idle",
-        error: errorById[workspace.id] ?? null,
+        status: group.status,
+        error: group.error,
       };
     });
   });
@@ -5994,15 +5759,7 @@ export default function App() {
       };
       const wsId = workspaceStore.selectedWorkspaceId().trim();
       if (wsId) {
-        const currentSessions = sidebarSessionsByWorkspaceId()[wsId] || [];
-        setSidebarSessionsByWorkspaceId((prev) => ({
-          ...prev,
-          [wsId]: [newItem, ...currentSessions],
-        }));
-        setSidebarSessionStatusByWorkspaceId((prev) => ({
-          ...prev,
-          [wsId]: "ready",
-        }));
+        prependSidebarSession(wsId, newItem);
       }
 
       // setSessionViewLockUntil(Date.now() + 1200);

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -4874,7 +4874,6 @@ export default function App() {
   const automationsStore = createAutomationsStore({
     selectedWorkspaceId: () => workspaceStore.selectedWorkspaceId(),
     selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot(),
-    selectedWorkspaceType: () => workspaceStore.selectedWorkspaceDisplay().workspaceType,
     runtimeWorkspaceId,
     openworkServerClient,
     openworkServerStatus,
@@ -4887,7 +4886,6 @@ export default function App() {
     scheduledJobsBusy,
     scheduledJobsUpdatedAt,
     scheduledJobsSource,
-    scheduledJobsSourceReady,
     scheduledJobsPollingAvailable,
     refreshScheduledJobs,
     deleteScheduledJob,
@@ -7438,7 +7436,6 @@ export default function App() {
       stopSandbox: workspaceStore.stopSandbox,
       scheduledJobs: scheduledJobs(),
       scheduledJobsSource: scheduledJobsSource(),
-      scheduledJobsSourceReady: scheduledJobsSourceReady(),
       schedulerPluginInstalled: schedulerPluginInstalled(),
       scheduledJobsStatus: scheduledJobsStatus(),
       scheduledJobsBusy: scheduledJobsBusy(),

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -1228,7 +1228,11 @@ export default function App() {
   const ensureSelectedWorkspaceRuntime = async () => {
     const workspaceId = workspaceStore.selectedWorkspaceId().trim();
     if (!workspaceId) return false;
-    return await workspaceStore.switchWorkspace(workspaceId);
+    const ready = await workspaceStore.switchWorkspace(workspaceId);
+    if (ready) {
+      await refreshSidebarWorkspaceSessions(workspaceId).catch(() => undefined);
+    }
+    return ready;
   };
 
   async function sendPrompt(draft?: ComposerDraft) {
@@ -2949,31 +2953,10 @@ export default function App() {
     }
   };
 
-  const refreshAllSidebarWorkspaceSessions = async (prioritizeWorkspaceId?: string | null) => {
+  const refreshAllSidebarWorkspaceSessions = async () => {
     const list = workspaceStore.workspaces();
     if (!list.length) return;
-    const prioritize = (prioritizeWorkspaceId ?? "").trim();
-    const ordered = prioritize
-      ? [...list.filter((ws) => ws.id === prioritize), ...list.filter((ws) => ws.id !== prioritize)]
-      : list;
-    for (const ws of ordered) {
-      await refreshSidebarWorkspaceSessions(ws.id);
-      // Yield so long refresh passes don't block UI / timers.
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    }
-  };
-
-  const refreshLocalSidebarWorkspaceSessions = async (prioritizeWorkspaceId?: string | null) => {
-    const list = workspaceStore.workspaces().filter((ws) => ws.workspaceType === "local");
-    if (!list.length) return;
-    const prioritize = (prioritizeWorkspaceId ?? "").trim();
-    const ordered = prioritize
-      ? [...list.filter((ws) => ws.id === prioritize), ...list.filter((ws) => ws.id !== prioritize)]
-      : list;
-    for (const ws of ordered) {
-      await refreshSidebarWorkspaceSessions(ws.id);
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    }
+    await Promise.allSettled(list.map((ws) => refreshSidebarWorkspaceSessions(ws.id)));
   };
 
   let lastSidebarEngineKey = "";
@@ -3002,146 +2985,17 @@ export default function App() {
     // potentially disappear) due to auth fallback changes.
     if (engineKey === lastSidebarEngineKey && workspaceKey === lastSidebarWorkspaceKey) return;
 
-    const engineChanged = engineKey !== lastSidebarEngineKey;
-    const workspacesChanged = workspaceKey !== lastSidebarWorkspaceKey;
-
     lastSidebarEngineKey = engineKey;
     lastSidebarWorkspaceKey = workspaceKey;
 
     pruneSidebarSessionState(new Set(workspaceStore.workspaces().map((ws) => ws.id)));
 
     wsDebug("sidebar:refresh", {
-      engineChanged,
-      workspacesChanged,
       selectedWorkspaceId: workspaceStore.selectedWorkspaceId(),
       engineBaseUrl,
     });
 
-    // Avoid refreshing remote workspace sessions when only the local engine auth/baseUrl changes.
-    // Remote->local switches commonly change engineBaseUrl, and refreshing every remote workspace
-    // at the same time can trigger large /session responses and UI hangs.
-    if (engineChanged && !workspacesChanged) {
-      void refreshLocalSidebarWorkspaceSessions(workspaceStore.selectedWorkspaceId()).catch(() => undefined);
-      return;
-    }
-
-    void refreshAllSidebarWorkspaceSessions(workspaceStore.selectedWorkspaceId()).catch(() => undefined);
-  });
-
-  createEffect(() => {
-    const id = workspaceStore.selectedWorkspaceId().trim();
-    if (!id) return;
-    const status = sidebarSessionStatusByWorkspaceId()[id] ?? "idle";
-    // Only auto-load once per workspace activation.
-    // If a remote is offline, repeated retries here can create an endless refresh loop.
-    if (status !== "idle") return;
-    refreshSidebarWorkspaceSessions(id).catch(() => undefined);
-  });
-
-  createEffect(() => {
-    const allSessions = sessions(); // reactive dependency on session store
-    // When switching workers, the session store can update before the selectedWorkspaceId flips.
-    // Use connectingWorkspaceId as the authoritative target during the switch so we don't
-    // accidentally overwrite another worker's sidebar sessions.
-    const wsId = (workspaceStore.connectingWorkspaceId() ?? workspaceStore.selectedWorkspaceId()).trim();
-    if (!wsId) return;
-    const status = sidebarSessionStatusByWorkspaceId()[wsId];
-
-    // Only sync if sidebar is already in 'ready' state (not during initial load)
-    if (status === "ready") {
-      const activeWorkspace = workspaceStore.workspaces().find((workspace) => workspace.id === wsId) ?? null;
-      const selectedWorkspaceRoot = normalizeDirectoryPath(
-        activeWorkspace?.workspaceType === "local"
-          ? activeWorkspace.path
-          : activeWorkspace?.directory ?? activeWorkspace?.path,
-      );
-      if (
-        !shouldApplyScopedSessionLoad({
-          loadedScopeRoot: loadedSessionScopeRoot(),
-          workspaceRoot: selectedWorkspaceRoot,
-        })
-      ) {
-        if (developerMode()) {
-          console.log("[sidebar-sync] skip stale session scope", {
-            wsId,
-            loadedScopeRoot: loadedSessionScopeRoot(),
-            selectedWorkspaceRoot,
-          });
-        }
-        return;
-      }
-      const scopedSessions = selectedWorkspaceRoot
-        ? allSessions.filter((session) => normalizeDirectoryPath(session.directory) === selectedWorkspaceRoot)
-        : allSessions;
-      const sorted = sortSessionsByActivity(scopedSessions);
-      if (developerMode()) {
-        console.log("[sidebar-sync] workspace session scope", {
-          wsId,
-          status,
-          activeWorkspace,
-          selectedWorkspaceRoot,
-          allSessions: allSessions.map((session) => ({
-            id: session.id,
-            title: session.title,
-            directory: session.directory,
-            parentID: session.parentID,
-          })),
-          scopedSessions: scopedSessions.map((session) => ({
-            id: session.id,
-            title: session.title,
-            directory: session.directory,
-            parentID: session.parentID,
-          })),
-        });
-      }
-      const rootItems: SidebarSessionItem[] = sorted.map((s) => ({
-        id: s.id,
-        title: s.title,
-        slug: s.slug,
-        parentID: s.parentID,
-        time: s.time,
-        directory: s.directory,
-      }));
-      setSidebarSessionsByWorkspaceId((prev) => {
-        const current = prev[wsId] ?? [];
-        const hasCurrentChildren = current.some((item) => Boolean(item.parentID?.trim()));
-        const incomingAreRootsOnly = rootItems.every((item) => !item.parentID?.trim());
-        if (!hasCurrentChildren || !incomingAreRootsOnly) {
-          return {
-            ...prev,
-            [wsId]: rootItems,
-          };
-        }
-
-        const byId = new Map(current.map((item) => [item.id, item] as const));
-        for (const item of rootItems) {
-          byId.set(item.id, {
-            ...(byId.get(item.id) ?? {}),
-            ...item,
-          });
-        }
-
-        const rootIDs = new Set(rootItems.map((item) => item.id));
-        const keepChild = (item: SidebarSessionItem, seen = new Set<string>()) => {
-          const parentID = item.parentID?.trim() ?? "";
-          if (!parentID) return false;
-          if (rootIDs.has(parentID)) return true;
-          if (seen.has(parentID)) return false;
-          const parent = byId.get(parentID);
-          if (!parent) return false;
-          seen.add(parentID);
-          return keepChild(parent, seen);
-        };
-
-        return {
-          ...prev,
-          [wsId]: [
-            ...rootItems,
-            ...current.filter((item) => !rootIDs.has(item.id) && keepChild(item)),
-          ],
-        };
-      });
-    }
+    void refreshAllSidebarWorkspaceSessions().catch(() => undefined);
   });
 
   const sidebarWorkspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {

--- a/apps/app/src/app/components/create-workspace-modal.tsx
+++ b/apps/app/src/app/components/create-workspace-modal.tsx
@@ -47,13 +47,13 @@ type RemoteWorkspaceInput = {
 function statusBadgeClass(kind: "ready" | "warning" | "neutral" | "error") {
   switch (kind) {
     case "ready":
-      return "border-emerald-200 bg-emerald-50 text-emerald-700";
+      return "border-emerald-500/25 bg-emerald-500/12 text-emerald-11";
     case "warning":
-      return "border-amber-200 bg-amber-50 text-amber-700";
+      return "border-amber-500/25 bg-amber-500/12 text-amber-11";
     case "error":
-      return "border-rose-200 bg-rose-50 text-rose-700";
+      return "border-rose-500/25 bg-rose-500/12 text-rose-11";
     default:
-      return "border-gray-200 bg-gray-50 text-gray-600";
+      return "border-dls-border bg-dls-sidebar text-dls-secondary";
   }
 }
 
@@ -456,9 +456,9 @@ export default function CreateWorkspaceModal(props: {
   const headerButtonClass =
     "inline-flex h-9 w-9 items-center justify-center rounded-full text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-50";
   const chooserCardClass =
-    "group flex w-full items-center gap-4 rounded-2xl border border-gray-200/80 bg-white/70 px-5 py-4 text-left transition-all duration-150 hover:-translate-y-0.5 hover:border-gray-300 hover:bg-white hover:shadow-[0_12px_28px_-22px_rgba(15,23,42,0.22)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.16)]";
+    "group flex w-full items-center gap-4 rounded-2xl border border-dls-border bg-dls-surface px-5 py-4 text-left transition-all duration-150 hover:-translate-y-0.5 hover:border-dls-accent hover:bg-dls-hover hover:shadow-[var(--dls-card-shadow)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.16)]";
   const cardButtonClass =
-    "w-full rounded-2xl border border-gray-200/80 bg-white/70 p-5 text-left transition-all duration-150 hover:border-gray-300 hover:bg-white hover:shadow-[0_12px_28px_-22px_rgba(15,23,42,0.22)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.16)]";
+    "w-full rounded-2xl border border-dls-border bg-dls-surface p-5 text-left transition-all duration-150 hover:border-dls-accent hover:bg-dls-hover hover:shadow-[var(--dls-card-shadow)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.16)]";
   const fieldLabelClass = "text-[13px] font-medium text-dls-text";
   const fieldHintClass = "text-[12px] leading-5 text-dls-secondary";
   const inputClass =
@@ -467,7 +467,7 @@ export default function CreateWorkspaceModal(props: {
   const chooserBody = (
     <div class="space-y-3 px-6 py-6">
       <button type="button" class={chooserCardClass} onClick={() => setScreen("local")}>
-        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-gray-100 bg-gray-50 text-dls-text">
+        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-sidebar text-dls-text">
           <FolderPlus size={18} />
         </div>
         <div class="min-w-0 flex-1">
@@ -478,7 +478,7 @@ export default function CreateWorkspaceModal(props: {
       </button>
 
       <button type="button" class={chooserCardClass} onClick={() => setScreen("remote")}>
-        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-gray-100 bg-gray-50 text-dls-text">
+        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-sidebar text-dls-text">
           <Globe size={18} />
         </div>
         <div class="min-w-0 flex-1">
@@ -489,7 +489,7 @@ export default function CreateWorkspaceModal(props: {
       </button>
 
       <button type="button" class={chooserCardClass} onClick={() => setScreen("shared")}>
-        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-gray-100 bg-gray-50 text-dls-text">
+        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-sidebar text-dls-text">
           <Cloud size={18} />
         </div>
         <div class="min-w-0 flex-1">
@@ -507,7 +507,7 @@ export default function CreateWorkspaceModal(props: {
         <div class="ow-soft-card p-5">
           <div class="text-[15px] font-semibold text-dls-text">Workspace folder</div>
           <div class="mt-1 text-[13px] text-dls-secondary">Choose where this workspace should live on your device.</div>
-          <div class="mt-4 rounded-2xl border border-gray-200 bg-white/80 px-4 py-3">
+          <div class="mt-4 rounded-2xl border border-dls-border bg-dls-sidebar px-4 py-3">
             <Show when={hasSelectedFolder()} fallback={<span class="text-sm text-dls-secondary">No folder selected yet.</span>}>
               <span class="block truncate font-mono text-xs text-dls-text">{selectedFolder()}</span>
             </Show>
@@ -541,7 +541,7 @@ export default function CreateWorkspaceModal(props: {
                 </div>
               </div>
               <Show when={templateCacheSnapshot().busy}>
-                <div class="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-[11px] font-medium text-dls-secondary shadow-[0_0_0_1px_rgba(0,0,0,0.04)]">
+                <div class="inline-flex items-center gap-2 rounded-full border border-dls-border bg-dls-surface px-3 py-1 text-[11px] font-medium text-dls-secondary">
                   <Loader2 size={12} class="animate-spin" />
                   Syncing
                 </div>
@@ -559,7 +559,7 @@ export default function CreateWorkspaceModal(props: {
             <Show
               when={cloudWorkspaceTemplates().length > 0}
               fallback={
-                <div class="mt-4 rounded-2xl border border-dashed border-gray-200 bg-white/70 px-4 py-4 text-sm text-dls-secondary">
+                  <div class="mt-4 rounded-2xl border border-dashed border-dls-border bg-dls-sidebar px-4 py-4 text-sm text-dls-secondary">
                   No shared workspace templates found for this org yet.
                 </div>
               }
@@ -591,7 +591,7 @@ export default function CreateWorkspaceModal(props: {
                               {templateCreatorLabel(template)} · {formatTemplateTimestamp(template.updatedAt ?? template.createdAt)}
                             </div>
                           </div>
-                          <div class={`mt-1 h-4 w-4 shrink-0 rounded-full border ${selected() ? "border-[var(--dls-accent)] bg-[var(--dls-accent)] shadow-[inset_0_0_0_3px_white]" : "border-gray-300 bg-white"}`.trim()} />
+                          <div class={`mt-1 h-4 w-4 shrink-0 rounded-full border ${selected() ? "border-[var(--dls-accent)] bg-[var(--dls-accent)]" : "border-dls-border bg-dls-surface"}`.trim()} />
                         </div>
                       </button>
                     );
@@ -610,7 +610,7 @@ export default function CreateWorkspaceModal(props: {
       <div class="space-y-4">
         <div class="ow-soft-card p-5">
           <div class="flex items-start gap-3">
-            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-gray-100 bg-gray-50 text-dls-text">
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-sidebar text-dls-text">
               <Server size={17} />
             </div>
             <div class="min-w-0">
@@ -678,7 +678,7 @@ export default function CreateWorkspaceModal(props: {
     <div class="flex-1 overflow-y-auto px-6 py-6">
       <div class="flex min-h-[320px] items-center justify-center">
         <div class="ow-soft-card w-full max-w-[420px] p-8 text-center">
-          <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-gray-100 bg-gray-50 text-dls-text">
+          <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-sidebar text-dls-text">
             <Cloud size={24} />
           </div>
           <div class="mt-5 text-[20px] font-semibold text-dls-text">Sign in to OpenWork Cloud</div>
@@ -730,7 +730,7 @@ export default function CreateWorkspaceModal(props: {
           </div>
 
           <div class="mt-4">
-            <label class="flex items-center gap-3 rounded-2xl border border-gray-200 bg-white px-4 py-3">
+            <label class="flex items-center gap-3 rounded-2xl border border-dls-border bg-dls-surface px-4 py-3">
               <Search size={15} class="shrink-0 text-dls-secondary" />
               <input
                 type="text"
@@ -744,10 +744,10 @@ export default function CreateWorkspaceModal(props: {
         </div>
 
         <Show when={orgsError()}>
-          {(value) => <div class="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{value()}</div>}
+          {(value) => <div class="rounded-xl border border-red-500/25 bg-red-500/10 px-3 py-2 text-sm text-red-11">{value()}</div>}
         </Show>
         <Show when={workersError()}>
-          {(value) => <div class="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{value()}</div>}
+          {(value) => <div class="rounded-xl border border-red-500/25 bg-red-500/10 px-3 py-2 text-sm text-red-11">{value()}</div>}
         </Show>
 
         <Show when={workersBusy() && workers().length === 0}>
@@ -765,24 +765,24 @@ export default function CreateWorkspaceModal(props: {
             {(worker) => {
               const status = createMemo(() => workerStatusMeta(worker.status));
               return (
-                <div class="rounded-2xl border border-gray-100 bg-white p-5 transition-all duration-150 hover:border-gray-200 hover:shadow-[0_12px_28px_-22px_rgba(15,23,42,0.22)]">
+                <div class="rounded-2xl border border-dls-border bg-dls-surface p-5 transition-all duration-150 hover:border-dls-accent hover:shadow-[var(--dls-card-shadow)]">
                   <div class="flex items-center gap-4">
-                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-gray-100 bg-gray-50 text-gray-500">
+                    <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-sidebar text-dls-secondary">
                       <Boxes size={18} />
                     </div>
                     <div class="min-w-0 flex-1">
                       <div class="flex flex-wrap items-center gap-2">
-                        <div class="truncate text-[14px] font-medium text-gray-900">{worker.workerName}</div>
+                        <div class="truncate text-[14px] font-medium text-dls-text">{worker.workerName}</div>
                         <span class={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${statusBadgeClass(status().tone)}`.trim()}>
                           <span class="h-1.5 w-1.5 rounded-full bg-current opacity-80" />
                           {status().label}
                         </span>
                       </div>
-                      <div class="mt-1 truncate text-[12px] text-gray-400">{workerSecondaryLine(worker)}</div>
+                      <div class="mt-1 truncate text-[12px] text-dls-secondary">{workerSecondaryLine(worker)}</div>
                     </div>
                     <button
                       type="button"
-                      class="inline-flex h-9 shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-white px-3.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                      class="inline-flex h-9 shrink-0 items-center justify-center rounded-lg border border-dls-border bg-dls-surface px-3.5 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover disabled:cursor-not-allowed disabled:opacity-50"
                       disabled={openingWorkerId() !== null || !status().canOpen || !props.onConfirmRemote}
                       title={!props.onConfirmRemote ? "Connecting shared workspaces is unavailable here." : !status().canOpen ? "This workspace is not ready to connect yet." : undefined}
                       onClick={() => void handleOpenWorker(worker)}
@@ -821,18 +821,18 @@ export default function CreateWorkspaceModal(props: {
           <div class="ow-soft-card-quiet animate-in fade-in slide-in-from-bottom-2 rounded-xl px-4 py-3 duration-300">
             <div class="flex items-start justify-between gap-3">
               <div class="min-w-0">
-                <div class="flex items-center gap-2 text-xs font-semibold text-gray-12">
+                <div class="flex items-center gap-2 text-xs font-semibold text-dls-text">
                   <Show when={!p().error} fallback={<XCircle size={14} class="text-red-11" />}>
                     <Loader2 size={14} class="animate-spin text-indigo-11" />
                   </Show>
                   Sandbox setup
                 </div>
-                <div class="mt-1 truncate text-sm leading-snug text-gray-11">{p().stage}</div>
-                <div class="mt-1 font-mono text-[10px] uppercase tracking-wider text-gray-9">{elapsedSeconds()}s</div>
+                <div class="mt-1 truncate text-sm leading-snug text-dls-text">{p().stage}</div>
+                <div class="mt-1 font-mono text-[10px] uppercase tracking-wider text-dls-secondary">{elapsedSeconds()}s</div>
               </div>
               <button
                 type="button"
-                class="shrink-0 rounded-full px-3 py-1.5 text-xs text-gray-10 transition-colors hover:bg-white hover:text-gray-12"
+                class="shrink-0 rounded-full px-3 py-1.5 text-xs text-dls-secondary transition-colors hover:bg-dls-surface hover:text-dls-text"
                 onClick={() => setShowProgressDetails((prev) => !prev)}
               >
                 {showProgressDetails() ? "Hide logs" : "Show logs"}
@@ -841,7 +841,7 @@ export default function CreateWorkspaceModal(props: {
 
             <Show when={p().error}>
               {(err) => (
-                <div class="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 animate-in fade-in">
+                <div class="mt-3 rounded-lg border border-red-500/25 bg-red-500/10 px-3 py-2 text-xs text-red-11 animate-in fade-in">
                   {err()}
                 </div>
               )}
@@ -854,14 +854,14 @@ export default function CreateWorkspaceModal(props: {
                     if (step.status === "done") return <XCircle size={16} class="text-emerald-10" />;
                     if (step.status === "active") return <Loader2 size={16} class="animate-spin text-indigo-11" />;
                     if (step.status === "error") return <XCircle size={16} class="text-red-10" />;
-                    return <div class="h-4 w-4 rounded-full border-2 border-gray-6" />;
+                    return <div class="h-4 w-4 rounded-full border-2 border-dls-border" />;
                   };
 
                   const textClass = () => {
-                    if (step.status === "done") return "text-gray-11 font-medium";
-                    if (step.status === "active") return "text-gray-12 font-semibold";
+                    if (step.status === "done") return "text-dls-text font-medium";
+                    if (step.status === "active") return "text-dls-text font-semibold";
                     if (step.status === "error") return "text-red-11 font-medium";
-                    return "text-gray-9";
+                    return "text-dls-secondary";
                   };
 
                   return (
@@ -870,7 +870,7 @@ export default function CreateWorkspaceModal(props: {
                       <div class="flex min-w-0 flex-1 items-center justify-between gap-2">
                         <div class={`text-xs ${textClass()} transition-colors duration-200`.trim()}>{step.label}</div>
                         <Show when={(step.detail ?? "").trim()}>
-                          <div class="max-w-[120px] truncate rounded-full bg-white px-2 py-0.5 font-mono text-[10px] text-gray-9 shadow-[0_0_0_1px_rgba(0,0,0,0.04)]">
+                          <div class="max-w-[120px] truncate rounded-full border border-dls-border bg-dls-surface px-2 py-0.5 font-mono text-[10px] text-dls-secondary">
                             {step.detail}
                           </div>
                         </Show>
@@ -882,11 +882,11 @@ export default function CreateWorkspaceModal(props: {
             </div>
 
             <Show when={showProgressDetails() && (p().logs?.length ?? 0) > 0}>
-              <div class="mt-3 rounded-lg bg-white/70 px-3 py-2 animate-in fade-in shadow-[inset_0_0_0_1px_rgba(0,0,0,0.05)]">
-                <div class="mb-2 text-[10px] font-semibold uppercase tracking-wide text-gray-10">Live Logs</div>
+              <div class="mt-3 rounded-lg border border-dls-border bg-dls-sidebar px-3 py-2 animate-in fade-in">
+                <div class="mb-2 text-[10px] font-semibold uppercase tracking-wide text-dls-secondary">Live Logs</div>
                 <div class="max-h-[120px] space-y-0.5 overflow-y-auto">
                   <For each={p().logs.slice(-10)}>
-                    {(line) => <div class="break-all font-mono text-[10px] leading-tight text-gray-11">{line}</div>}
+                    {(line) => <div class="break-all font-mono text-[10px] leading-tight text-dls-text">{line}</div>}
                   </For>
                 </div>
               </div>
@@ -896,8 +896,8 @@ export default function CreateWorkspaceModal(props: {
       </Show>
 
       <Show when={props.onConfirmWorker && workerDisabled() && workerDisabledReason()}>
-        <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800">
-          <div class="font-semibold text-amber-900">{translate("dashboard.sandbox_get_ready_title")}</div>
+        <div class="rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-xs text-amber-11">
+          <div class="font-semibold text-amber-12">{translate("dashboard.sandbox_get_ready_title")}</div>
           <div class="mt-1 leading-relaxed">{workerDisabledReason() || props.workerCtaDescription?.trim()}</div>
           <div class="mt-3 flex flex-wrap items-center gap-2">
             <Show when={props.onWorkerCta && props.workerCtaLabel?.trim()}>
@@ -912,8 +912,8 @@ export default function CreateWorkspaceModal(props: {
             </Show>
           </div>
           <Show when={workerDebugLines().length > 0}>
-            <details class="mt-3 rounded-lg bg-white/70 px-3 py-2 text-[11px] text-gray-11 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.05)]">
-              <summary class="cursor-pointer text-xs font-semibold text-gray-12">Docker debug details</summary>
+            <details class="mt-3 rounded-lg border border-dls-border bg-dls-sidebar px-3 py-2 text-[11px] text-dls-text">
+              <summary class="cursor-pointer text-xs font-semibold text-dls-text">Docker debug details</summary>
               <div class="mt-2 space-y-1 break-words font-mono">
                 <For each={workerDebugLines()}>{(line) => <div>{line}</div>}</For>
               </div>
@@ -965,7 +965,7 @@ export default function CreateWorkspaceModal(props: {
   const remoteFooter = (
     <div class="space-y-3 px-6 py-5">
       <Show when={remoteError()}>
-        {(value) => <div class="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{value()}</div>}
+        {(value) => <div class="rounded-xl border border-red-500/25 bg-red-500/10 px-3 py-2 text-sm text-red-11">{value()}</div>}
       </Show>
       <div class="flex justify-end gap-3">
         <button type="button" class="ow-button-secondary px-4 py-2 text-xs" onClick={props.onClose} disabled={remoteSubmitting()}>
@@ -1013,7 +1013,7 @@ export default function CreateWorkspaceModal(props: {
   });
 
   const content = (
-    <div class={`ow-soft-shell flex max-h-[90vh] w-full ${modalWidthClass()} flex-col overflow-hidden rounded-[24px] bg-[#fbfbfc] shadow-[0_24px_60px_-34px_rgba(15,23,42,0.28)]`}>
+    <div class={`ow-soft-shell flex max-h-[90vh] w-full ${modalWidthClass()} flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]`}>
       <div class="flex items-start justify-between gap-4 px-6 py-5">
         <div class="flex min-w-0 items-start gap-3">
           <Show when={screen() !== "chooser"}>

--- a/apps/app/src/app/components/onboarding-workspace-selector.tsx
+++ b/apps/app/src/app/components/onboarding-workspace-selector.tsx
@@ -6,19 +6,14 @@ import Button from "./button";
 
 export default function OnboardingWorkspaceSelector(props: {
   defaultPath: string;
-  onConfirm: (preset: "starter" | "automation" | "minimal", folder: string | null) => void;
+  onConfirm: (preset: "automation" | "minimal", folder: string | null) => void;
   onPickFolder: () => Promise<string | null>;
 }) {
-  const [preset, setPreset] = createSignal<"starter" | "automation" | "minimal">("starter");
+  const [preset, setPreset] = createSignal<"automation" | "minimal">("minimal");
   const [selectedFolder, setSelectedFolder] = createSignal(props.defaultPath);
   const [pickingFolder, setPickingFolder] = createSignal(false);
 
   const options = () => [
-    {
-      id: "starter" as const,
-      name: "Starter worker",
-      desc: "Preconfigured to show you how to use plugins, commands, and skills.",
-    },
     {
       id: "minimal" as const,
       name: "Empty worker",

--- a/apps/app/src/app/context/automations.ts
+++ b/apps/app/src/app/context/automations.ts
@@ -36,7 +36,6 @@ export function createAutomationsStore(options: {
     selectedWorkspaceId: options.selectedWorkspaceId,
     selectedWorkspaceRoot: options.selectedWorkspaceRoot,
     runtimeWorkspaceId: options.runtimeWorkspaceId,
-    workspaceType: scheduledJobsSource,
   });
 
   const scheduledJobsPollingAvailable = createMemo(() => {

--- a/apps/app/src/app/context/automations.ts
+++ b/apps/app/src/app/context/automations.ts
@@ -11,7 +11,6 @@ export type AutomationsStore = ReturnType<typeof createAutomationsStore>;
 export function createAutomationsStore(options: {
   selectedWorkspaceId: () => string;
   selectedWorkspaceRoot: () => string;
-  selectedWorkspaceType: () => "local" | "remote";
   runtimeWorkspaceId: () => string | null;
   openworkServerClient: () => OpenworkServerClient | null;
   openworkServerStatus: () => OpenworkServerStatus;
@@ -23,8 +22,14 @@ export function createAutomationsStore(options: {
   const [scheduledJobsUpdatedAt, setScheduledJobsUpdatedAt] = createSignal<number | null>(null);
   const [pendingRefreshContextKey, setPendingRefreshContextKey] = createSignal<string | null>(null);
 
+  const serverBacked = createMemo(() => {
+    const client = options.openworkServerClient();
+    const runtimeWorkspaceId = (options.runtimeWorkspaceId() ?? "").trim();
+    return options.openworkServerStatus() === "connected" && Boolean(client && runtimeWorkspaceId);
+  });
+
   const scheduledJobsSource = createMemo<"local" | "remote">(() =>
-    options.selectedWorkspaceType() === "remote" ? "remote" : "local",
+    serverBacked() ? "remote" : "local",
   );
 
   const scheduledJobsContextKey = createWorkspaceContextKey({
@@ -34,19 +39,8 @@ export function createAutomationsStore(options: {
     workspaceType: scheduledJobsSource,
   });
 
-  const scheduledJobsSourceReady = createMemo(() => {
-    if (scheduledJobsSource() !== "remote") return true;
-    const client = options.openworkServerClient();
-    const runtimeWorkspaceId = (options.runtimeWorkspaceId() ?? "").trim();
-    const selectedWorkspaceId = options.selectedWorkspaceId().trim();
-    return (
-      options.openworkServerStatus() === "connected" &&
-      Boolean(client && runtimeWorkspaceId && runtimeWorkspaceId === selectedWorkspaceId)
-    );
-  });
-
   const scheduledJobsPollingAvailable = createMemo(() => {
-    if (scheduledJobsSource() === "remote") return scheduledJobsSourceReady();
+    if (scheduledJobsSource() === "remote") return true;
     return isTauriRuntime() && options.schedulerPluginInstalled();
   });
 
@@ -149,9 +143,7 @@ export function createAutomationsStore(options: {
 
   createEffect(() => {
     const key = scheduledJobsContextKey();
-    const ready = scheduledJobsSourceReady();
     if (!key) return;
-    if (scheduledJobsSource() === "remote" && !ready) return;
     if (scheduledJobsBusy()) return;
     if (scheduledJobsUpdatedAt()) return;
     void refreshScheduledJobs();
@@ -175,7 +167,6 @@ export function createAutomationsStore(options: {
     scheduledJobsBusy,
     scheduledJobsUpdatedAt,
     scheduledJobsSource,
-    scheduledJobsSourceReady,
     scheduledJobsPollingAvailable,
     scheduledJobsContextKey,
     refreshScheduledJobs,

--- a/apps/app/src/app/context/sidebar-sessions.ts
+++ b/apps/app/src/app/context/sidebar-sessions.ts
@@ -176,12 +176,6 @@ export function createSidebarSessionsStore(options: {
     }
   };
 
-  const refreshAllWorkspaceSessions = async () => {
-    const list = options.workspaces();
-    if (!list.length) return;
-    await Promise.allSettled(list.map((workspace) => refreshWorkspaceSessions(workspace.id)));
-  };
-
   const prependSession = (workspaceId: string, item: SidebarSessionItem) => {
     const id = workspaceId.trim();
     if (!id) return;
@@ -206,32 +200,33 @@ export function createSidebarSessionsStore(options: {
     }));
   };
 
-  let lastEngineKey = "";
-  let lastWorkspaceKey = "";
+  let lastFingerprintByWorkspaceId: Record<string, string> = {};
   createEffect(() => {
     const engineInfo = options.engine();
     const engineBaseUrl = engineInfo?.baseUrl?.trim() ?? "";
     const engineUser = engineInfo?.opencodeUsername?.trim() ?? "";
     const enginePass = engineInfo?.opencodePassword?.trim() ?? "";
-    const engineKey = [engineBaseUrl, engineUser, enginePass].join("::");
-    const workspaceKey = options
-      .workspaces()
-      .map((workspace) => {
-        const root = workspace.workspaceType === "local" ? workspace.path?.trim() ?? "" : workspace.directory?.trim() ?? "";
-        const base = workspace.workspaceType === "local" ? "" : workspace.baseUrl?.trim() ?? "";
-        const remoteType = workspace.workspaceType === "remote" ? (workspace.remoteType ?? "") : "";
-        const token = workspace.remoteType === "openwork" ? (workspace.openworkToken?.trim() ?? "") : "";
-        return [workspace.id, workspace.workspaceType, remoteType, root, base, token].join("|");
-      })
-      .join(";");
+    const workspaces = options.workspaces();
+    const workspaceIds = new Set(workspaces.map((workspace) => workspace.id));
+    pruneState(workspaceIds);
 
-    if (engineKey === lastEngineKey && workspaceKey === lastWorkspaceKey) return;
+    const nextFingerprintByWorkspaceId: Record<string, string> = {};
+    for (const workspace of workspaces) {
+      const root = workspace.workspaceType === "local" ? workspace.path?.trim() ?? "" : workspace.directory?.trim() ?? "";
+      const base = workspace.workspaceType === "local" ? engineBaseUrl : workspace.baseUrl?.trim() ?? "";
+      const remoteType = workspace.workspaceType === "remote" ? (workspace.remoteType ?? "") : "";
+      const token = workspace.remoteType === "openwork" ? (workspace.openworkToken?.trim() ?? "") : "";
+      const authKey = workspace.workspaceType === "local" ? `${engineUser}:${enginePass}` : token;
+      nextFingerprintByWorkspaceId[workspace.id] = [workspace.workspaceType, remoteType, root, base, authKey].join("|");
+    }
 
-    lastEngineKey = engineKey;
-    lastWorkspaceKey = workspaceKey;
+    for (const workspace of workspaces) {
+      const nextFingerprint = nextFingerprintByWorkspaceId[workspace.id];
+      if (lastFingerprintByWorkspaceId[workspace.id] === nextFingerprint) continue;
+      void refreshWorkspaceSessions(workspace.id).catch(() => undefined);
+    }
 
-    pruneState(new Set(options.workspaces().map((workspace) => workspace.id)));
-    void refreshAllWorkspaceSessions().catch(() => undefined);
+    lastFingerprintByWorkspaceId = nextFingerprintByWorkspaceId;
   });
 
   const workspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
@@ -250,7 +245,6 @@ export function createSidebarSessionsStore(options: {
   return {
     workspaceGroups,
     refreshWorkspaceSessions,
-    refreshAllWorkspaceSessions,
     prependSession,
     removeSession,
   };

--- a/apps/app/src/app/context/sidebar-sessions.ts
+++ b/apps/app/src/app/context/sidebar-sessions.ts
@@ -176,30 +176,6 @@ export function createSidebarSessionsStore(options: {
     }
   };
 
-  const prependSession = (workspaceId: string, item: SidebarSessionItem) => {
-    const id = workspaceId.trim();
-    if (!id) return;
-    setSessionsByWorkspaceId((prev) => {
-      const current = prev[id] ?? [];
-      const deduped = current.filter((entry) => entry.id !== item.id);
-      return {
-        ...prev,
-        [id]: [item, ...deduped],
-      };
-    });
-    setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
-  };
-
-  const removeSession = (workspaceId: string, sessionId: string) => {
-    const id = workspaceId.trim();
-    const target = sessionId.trim();
-    if (!id || !target) return;
-    setSessionsByWorkspaceId((prev) => ({
-      ...prev,
-      [id]: (prev[id] ?? []).filter((entry) => entry.id !== target),
-    }));
-  };
-
   let lastFingerprintByWorkspaceId: Record<string, string> = {};
   createEffect(() => {
     const engineInfo = options.engine();
@@ -245,7 +221,5 @@ export function createSidebarSessionsStore(options: {
   return {
     workspaceGroups,
     refreshWorkspaceSessions,
-    prependSession,
-    removeSession,
   };
 }

--- a/apps/app/src/app/context/sidebar-sessions.ts
+++ b/apps/app/src/app/context/sidebar-sessions.ts
@@ -1,0 +1,257 @@
+import { createEffect, createMemo, createSignal } from "solid-js";
+
+import type { Session } from "@opencode-ai/sdk/v2/client";
+
+import { createClient, type OpencodeAuth, unwrap } from "../lib/opencode";
+import type { WorkspaceInfo, EngineInfo } from "../lib/tauri";
+import type { SidebarSessionItem, WorkspaceSessionGroup } from "../types";
+import {
+  normalizeDirectoryPath,
+  normalizeDirectoryQueryPath,
+  safeStringify,
+} from "../utils";
+import { toSessionTransportDirectory } from "../lib/session-scope";
+
+const sessionActivity = (session: Session) =>
+  session.time?.updated ?? session.time?.created ?? 0;
+
+const sortSessionsByActivity = (list: Session[]) =>
+  list
+    .slice()
+    .sort((a, b) => {
+      const delta = sessionActivity(b) - sessionActivity(a);
+      if (delta !== 0) return delta;
+      return a.id.localeCompare(b.id);
+    });
+
+type SidebarWorkspaceSessionsStatus = WorkspaceSessionGroup["status"];
+
+export function createSidebarSessionsStore(options: {
+  workspaces: () => WorkspaceInfo[];
+  engine: () => EngineInfo | null;
+}) {
+  const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = createSignal<
+    Record<string, SidebarSessionItem[]>
+  >({});
+  const [statusByWorkspaceId, setStatusByWorkspaceId] = createSignal<
+    Record<string, SidebarWorkspaceSessionsStatus>
+  >({});
+  const [errorByWorkspaceId, setErrorByWorkspaceId] = createSignal<Record<string, string | null>>({});
+
+  const pruneState = (workspaceIds: Set<string>) => {
+    setSessionsByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, SidebarSessionItem[]> = {};
+      for (const [id, list] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = list;
+      }
+      return changed ? next : prev;
+    });
+    setStatusByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, SidebarWorkspaceSessionsStatus> = {};
+      for (const [id, status] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = status;
+      }
+      return changed ? next : prev;
+    });
+    setErrorByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, string | null> = {};
+      for (const [id, error] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = error;
+      }
+      return changed ? next : prev;
+    });
+  };
+
+  const resolveClientConfig = (workspaceId: string) => {
+    const workspace = options.workspaces().find((entry) => entry.id === workspaceId) ?? null;
+    if (!workspace) return null;
+
+    if (workspace.workspaceType === "local") {
+      const info = options.engine();
+      const baseUrl = info?.baseUrl?.trim() ?? "";
+      const directory = toSessionTransportDirectory(workspace.path?.trim() ?? "");
+      const username = info?.opencodeUsername?.trim() ?? "";
+      const password = info?.opencodePassword?.trim() ?? "";
+      const auth: OpencodeAuth | undefined = username && password ? { username, password } : undefined;
+      return { baseUrl, directory, auth };
+    }
+
+    const baseUrl = workspace.baseUrl?.trim() ?? "";
+    const directory = workspace.directory?.trim() ?? "";
+    if (workspace.remoteType === "openwork") {
+      const token = workspace.openworkToken?.trim() ?? "";
+      const auth: OpencodeAuth | undefined = token ? { token, mode: "openwork" } : undefined;
+      return { baseUrl, directory, auth };
+    }
+
+    return {
+      baseUrl,
+      directory,
+      auth: undefined as OpencodeAuth | undefined,
+    };
+  };
+
+  const refreshSeqByWorkspaceId: Record<string, number> = {};
+  const SIDEBAR_SESSION_LIMIT = 200;
+
+  const refreshWorkspaceSessions = async (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+
+    const config = resolveClientConfig(id);
+    if (!config) return;
+
+    if (!config.baseUrl) {
+      setStatusByWorkspaceId((prev) => (prev[id] === "idle" ? prev : { ...prev, [id]: "idle" }));
+      setErrorByWorkspaceId((prev) => ((prev[id] ?? null) === null ? prev : { ...prev, [id]: null }));
+      return;
+    }
+
+    refreshSeqByWorkspaceId[id] = (refreshSeqByWorkspaceId[id] ?? 0) + 1;
+    const seq = refreshSeqByWorkspaceId[id];
+
+    setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "loading" }));
+    setErrorByWorkspaceId((prev) => ({ ...prev, [id]: null }));
+
+    try {
+      let directory = config.directory;
+      let client = createClient(config.baseUrl, directory || undefined, config.auth);
+
+      if (!directory) {
+        try {
+          const pathInfo = unwrap(await client.path.get());
+          const discovered = toSessionTransportDirectory(pathInfo.directory ?? "");
+          if (discovered) {
+            directory = discovered;
+            client = createClient(config.baseUrl, directory, config.auth);
+          }
+        } catch {
+          // Ignore discovery failures and continue with the configured directory.
+        }
+      }
+
+      const queryDirectory = normalizeDirectoryQueryPath(directory) || undefined;
+      const list = unwrap(
+        await client.session.list({ directory: queryDirectory, roots: false, limit: SIDEBAR_SESSION_LIMIT }),
+      );
+      if (refreshSeqByWorkspaceId[id] !== seq) return;
+
+      const root = normalizeDirectoryPath(directory);
+      const filtered = root ? list.filter((session) => normalizeDirectoryPath(session.directory) === root) : list;
+      const sorted = sortSessionsByActivity(filtered);
+      const items: SidebarSessionItem[] = sorted.map((session) => ({
+        id: session.id,
+        title: session.title,
+        slug: session.slug,
+        parentID: session.parentID,
+        time: session.time,
+        directory: session.directory,
+      }));
+
+      setSessionsByWorkspaceId((prev) => ({
+        ...prev,
+        [id]: items,
+      }));
+      setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
+    } catch (error) {
+      if (refreshSeqByWorkspaceId[id] !== seq) return;
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "error" }));
+      setErrorByWorkspaceId((prev) => ({ ...prev, [id]: message }));
+    }
+  };
+
+  const refreshAllWorkspaceSessions = async () => {
+    const list = options.workspaces();
+    if (!list.length) return;
+    await Promise.allSettled(list.map((workspace) => refreshWorkspaceSessions(workspace.id)));
+  };
+
+  const prependSession = (workspaceId: string, item: SidebarSessionItem) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setSessionsByWorkspaceId((prev) => {
+      const current = prev[id] ?? [];
+      const deduped = current.filter((entry) => entry.id !== item.id);
+      return {
+        ...prev,
+        [id]: [item, ...deduped],
+      };
+    });
+    setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
+  };
+
+  const removeSession = (workspaceId: string, sessionId: string) => {
+    const id = workspaceId.trim();
+    const target = sessionId.trim();
+    if (!id || !target) return;
+    setSessionsByWorkspaceId((prev) => ({
+      ...prev,
+      [id]: (prev[id] ?? []).filter((entry) => entry.id !== target),
+    }));
+  };
+
+  let lastEngineKey = "";
+  let lastWorkspaceKey = "";
+  createEffect(() => {
+    const engineInfo = options.engine();
+    const engineBaseUrl = engineInfo?.baseUrl?.trim() ?? "";
+    const engineUser = engineInfo?.opencodeUsername?.trim() ?? "";
+    const enginePass = engineInfo?.opencodePassword?.trim() ?? "";
+    const engineKey = [engineBaseUrl, engineUser, enginePass].join("::");
+    const workspaceKey = options
+      .workspaces()
+      .map((workspace) => {
+        const root = workspace.workspaceType === "local" ? workspace.path?.trim() ?? "" : workspace.directory?.trim() ?? "";
+        const base = workspace.workspaceType === "local" ? "" : workspace.baseUrl?.trim() ?? "";
+        const remoteType = workspace.workspaceType === "remote" ? (workspace.remoteType ?? "") : "";
+        const token = workspace.remoteType === "openwork" ? (workspace.openworkToken?.trim() ?? "") : "";
+        return [workspace.id, workspace.workspaceType, remoteType, root, base, token].join("|");
+      })
+      .join(";");
+
+    if (engineKey === lastEngineKey && workspaceKey === lastWorkspaceKey) return;
+
+    lastEngineKey = engineKey;
+    lastWorkspaceKey = workspaceKey;
+
+    pruneState(new Set(options.workspaces().map((workspace) => workspace.id)));
+    void refreshAllWorkspaceSessions().catch(() => undefined);
+  });
+
+  const workspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
+    const workspaces = options.workspaces();
+    const sessions = sessionsByWorkspaceId();
+    const statuses = statusByWorkspaceId();
+    const errors = errorByWorkspaceId();
+    return workspaces.map((workspace) => ({
+      workspace,
+      sessions: sessions[workspace.id] ?? [],
+      status: statuses[workspace.id] ?? "idle",
+      error: errors[workspace.id] ?? null,
+    }));
+  });
+
+  return {
+    workspaceGroups,
+    refreshWorkspaceSessions,
+    refreshAllWorkspaceSessions,
+    prependSession,
+    removeSession,
+  };
+}

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -22,6 +22,7 @@ import {
 } from "../utils";
 import { unwrap } from "../lib/opencode";
 import { describeDirectoryScope, resolveScopedClientDirectory } from "../lib/session-scope";
+import { defaultBlueprintSessionsForPreset } from "../lib/workspace-blueprints";
 import {
   buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
@@ -153,7 +154,7 @@ export function createWorkspaceStore(options: {
   engineCustomBinPath?: () => string;
   opencodeEnableExa?: () => boolean;
   setEngineSource: (value: "path" | "sidecar" | "custom") => void;
-  setView: (value: any) => void;
+  setView: (value: any, sessionId?: string) => void;
   setTab: (value: any) => void;
   isWindowsPlatform: () => boolean;
   openworkServerSettings: () => OpenworkServerSettings;
@@ -167,6 +168,7 @@ export function createWorkspaceStore(options: {
   onEngineStable?: () => void;
   engineRuntime?: () => EngineRuntime;
   developerMode: () => boolean;
+  setPendingInitialSessionSelection?: (input: { workspaceId: string; title: string | null; readyAt: number } | null) => void;
 }) {
 
   const wsDebugEnabled = () => options.developerMode();
@@ -205,17 +207,33 @@ export function createWorkspaceStore(options: {
   const DEFAULT_CONNECT_HEALTH_TIMEOUT_MS = 12_000;
   const LOCAL_BOOT_CONNECT_HEALTH_TIMEOUT_MS = 180_000;
   const LONG_BOOT_CONNECT_REASONS = new Set(["host-start", "bootstrap-local"]);
-  const INITIAL_WORKSPACE_SETUP_COMPLETE_KEY = "openwork.initialWorkspaceSetupComplete";
-  const LEGACY_ONBOARDING_COMPLETE_KEY = "openwork.onboardingComplete";
-  const STARTER_BOOTSTRAP_STATE_KEY = "openwork.starterBootstrapState";
-  const STARTER_BOOTSTRAP_FOLDER_NAME = "OpenWork";
-  const STARTER_BOOTSTRAP_WORKSPACE_NAME = "starter";
+  const DEFAULT_WORKSPACE_HOME_FOLDER_NAME = "OpenWork";
+  const FIRST_RUN_WELCOME_WORKSPACE_NAME = "Welcome";
   const DB_MIGRATE_UNSUPPORTED_PATTERNS = [
     /unknown(?:\s+sub)?command\s+['"`]?db['"`]?/i,
     /unrecognized(?:\s+sub)?command\s+['"`]?db['"`]?/i,
     /no such command[:\s]+db/i,
     /found argument ['"`]db['"`] which wasn't expected/i,
   ] as const;
+
+  const preferredInitialSessionTitleForPreset = (preset: WorkspacePreset) => {
+    const trimmed = defaultBlueprintSessionsForPreset(preset)
+      .find((session) => session.openOnFirstLoad === true)?.title?.trim();
+    return trimmed || null;
+  };
+
+  const queuePendingInitialSessionSelection = (workspaceId: string | null, preset: WorkspacePreset) => {
+    const preferredInitialSessionTitle = preferredInitialSessionTitleForPreset(preset);
+    if (!workspaceId) {
+      options.setPendingInitialSessionSelection?.(null);
+      return;
+    }
+    options.setPendingInitialSessionSelection?.({
+      workspaceId,
+      title: preferredInitialSessionTitle,
+      readyAt: Date.now() + 2_000,
+    });
+  };
 
   const connectRequestKey = (
     nextBaseUrl: string,
@@ -326,51 +344,9 @@ export function createWorkspaceStore(options: {
   let lastEngineReconnectAt = 0;
   let reconnectingEngine = false;
 
-  const readInitialWorkspaceSetupComplete = () => {
-    if (typeof window === "undefined") return false;
-    try {
-      return (
-        window.localStorage.getItem(INITIAL_WORKSPACE_SETUP_COMPLETE_KEY) === "1" ||
-        window.localStorage.getItem(LEGACY_ONBOARDING_COMPLETE_KEY) === "1"
-      );
-    } catch {
-      return false;
-    }
-  };
-
-  type StarterBootstrapState = "not_started" | "in_progress" | "completed" | "failed" | "skipped";
-
-  const readStarterBootstrapState = (): StarterBootstrapState => {
-    if (typeof window === "undefined") return "not_started";
-    try {
-      const raw = window.localStorage.getItem(STARTER_BOOTSTRAP_STATE_KEY);
-      if (raw === "in_progress" || raw === "completed" || raw === "failed" || raw === "skipped") {
-        return raw;
-      }
-      return "not_started";
-    } catch {
-      return "not_started";
-    }
-  };
-
-  const persistStarterBootstrapState = (next: StarterBootstrapState) => {
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(STARTER_BOOTSTRAP_STATE_KEY, next);
-    } catch {
-      // ignore
-    }
-  };
-
   const [projectDir, setProjectDir] = createSignal("");
   const [workspaces, setWorkspaces] = createSignal<WorkspaceInfo[]>([]);
   const [selectedWorkspaceId, setSelectedWorkspaceId] = createSignal<string>("");
-  const [initialWorkspaceSetupComplete, setInitialWorkspaceSetupComplete] = createSignal(
-    readInitialWorkspaceSetupComplete(),
-  );
-  const [starterBootstrapState, setStarterBootstrapState] = createSignal<StarterBootstrapState>(
-    readStarterBootstrapState(),
-  );
 
   const syncSelectedWorkspaceId = (id: string) => {
     setSelectedWorkspaceId(id);
@@ -433,13 +409,6 @@ export function createWorkspaceStore(options: {
     if (!id) return null;
     return workspaces().find((workspace) => workspace.id === id) ?? null;
   });
-  const firstRunWorkspaceSetup = createMemo(
-    () => isTauriRuntime() && !initialWorkspaceSetupComplete() && workspaces().length === 0,
-  );
-  const setPersistedStarterBootstrapState = (next: StarterBootstrapState) => {
-    setStarterBootstrapState(next);
-    persistStarterBootstrapState(next);
-  };
 
   const selectedWorkspaceDisplay = createMemo<WorkspaceDisplay>(() => {
     const ws = selectedWorkspaceInfo();
@@ -448,7 +417,7 @@ export function createWorkspaceStore(options: {
         id: "",
         name: "Worker",
         path: "",
-        preset: "starter",
+        preset: "minimal",
         workspaceType: "local",
         remoteType: "opencode",
         baseUrl: null,
@@ -973,16 +942,113 @@ export function createWorkspaceStore(options: {
     }
   }
 
-  const findOpenworkWorkspaceByPath = async (workspacePath: string) => {
-    const client = resolveConnectedOpenworkServer();
+  const findOpenworkWorkspaceByPathWithClient = async (
+    client: OpenworkServerClient,
+    workspacePath: string,
+  ) => {
     const targetPath = normalizeDirectoryPath(workspacePath);
-    if (!client || !targetPath) return null;
+    if (!targetPath) return null;
 
     const response = await client.listWorkspaces();
     const items = Array.isArray(response.items) ? response.items : [];
     const match = items.find((entry) => normalizeDirectoryPath(entry.path) === targetPath);
     if (!match?.id) return null;
     return { client, workspaceId: match.id, response };
+  };
+
+  const findOpenworkWorkspaceByPath = async (workspacePath: string) => {
+    const client = resolveConnectedOpenworkServer();
+    if (!client) return null;
+    return findOpenworkWorkspaceByPathWithClient(client, workspacePath);
+  };
+
+  const listWorkspaceSessions = async (workspacePath: string) => {
+    const client = options.client();
+    if (!client) return [];
+
+    const root = normalizeDirectoryPath(workspacePath);
+    const queryDirectory = resolveScopedClientDirectory({
+      targetRoot: workspacePath,
+      workspaceType: "local",
+    }) || undefined;
+    const list = unwrap(await client.session.list({ directory: queryDirectory, roots: true }));
+    return root
+      ? list.filter((session) => normalizeDirectoryPath(session.directory) === root)
+      : list;
+  };
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const ensureBackendWorkspaceReady = async (
+    workspacePath: string,
+    name: string,
+    preset: WorkspacePreset,
+    input?: { timeoutMs?: number; pollMs?: number },
+  ) => {
+    const timeoutMs = input?.timeoutMs ?? 15_000;
+    const pollMs = input?.pollMs ?? 500;
+    const start = Date.now();
+    const localServer = await resolveLocalOpenworkServer();
+    if (!localServer) {
+      throw new Error("Local OpenWork server is unavailable after opening the workspace.");
+    }
+
+    let createAttempted = false;
+    while (Date.now() - start < timeoutMs) {
+      const resolved = await findOpenworkWorkspaceByPathWithClient(localServer, workspacePath);
+      if (resolved?.workspaceId) {
+        return resolved;
+      }
+
+      if (!createAttempted) {
+        createAttempted = true;
+        await localServer.createLocalWorkspace({ folderPath: workspacePath, name, preset });
+      }
+
+      await sleep(pollMs);
+    }
+
+    throw new Error("Local OpenWork server never registered the created workspace.");
+  };
+
+  const materializeStarterSessions = async (
+    workspacePath: string,
+    name: string,
+    preset: WorkspacePreset,
+  ) => {
+    if (preset !== "starter") return null;
+    const localWorkspace = await ensureBackendWorkspaceReady(workspacePath, name, preset);
+    return await localWorkspace.client.materializeBlueprintSessions(localWorkspace.workspaceId);
+  };
+
+  const waitForWorkspaceSessionsReady = async (
+    workspacePath: string,
+    input?: { timeoutMs?: number; pollMs?: number },
+  ) => {
+    const timeoutMs = input?.timeoutMs ?? 30_000;
+    const pollMs = input?.pollMs ?? 500;
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const sessions = await listWorkspaceSessions(workspacePath);
+        if (sessions.length > 0) {
+          await options.loadSessions(workspacePath);
+          return true;
+        }
+      } catch {
+        // keep polling while the local engine/session index settles
+      }
+
+      await sleep(pollMs);
+    }
+
+    try {
+      await options.loadSessions(workspacePath);
+      return (await listWorkspaceSessions(workspacePath)).length > 0;
+    } catch {
+      return false;
+    }
   };
 
   const loadWorkspaceConfigFromOpenworkServer = async (workspacePath: string): Promise<WorkspaceOpenworkConfig | null> => {
@@ -1890,9 +1956,6 @@ export function createWorkspaceStore(options: {
           options.setView("session");
         }
 
-        // If the user successfully connected, treat onboarding as complete so we
-        // don't force the onboarding flow on subsequent launches.
-        markOnboardingComplete();
         options.onEngineStable?.();
         connectMetrics.totalMs = Date.now() - connectStart;
         options.setOpencodeConnectStatus?.({ ...connectMeta, status: "connected", metrics: connectMetrics });
@@ -1957,21 +2020,16 @@ export function createWorkspaceStore(options: {
   };
 
   const activateFreshLocalWorkspace = async (workspaceId: string | null, workspacePath: string) => {
-    if (!workspaceId) {
-      await openEmptySession(workspacePath);
-      return true;
-    }
-
     const hasClient = Boolean(options.client());
     const ok = hasClient
-      ? await activateWorkspace(workspaceId)
+      ? workspaceId
+        ? await activateWorkspace(workspaceId)
+        : true
       : await startHost({ workspacePath, navigate: false });
 
     if (!ok) {
       return false;
     }
-
-    await openEmptySession(selectedWorkspaceRoot().trim() || workspacePath);
     return true;
   };
 
@@ -2006,6 +2064,8 @@ export function createWorkspaceStore(options: {
         ? await openworkServer.createLocalWorkspace({ folderPath: resolvedFolder, name, preset })
         : await workspaceCreate({ folderPath: resolvedFolder, name, preset });
 
+      const createdWorkspaceId = pickSelectedWorkspaceId(ws.workspaces, [resolveWorkspaceListSelectedId(ws)], ws);
+
       if (openworkServer && isTauriRuntime()) {
         try {
           await workspaceCreate({ folderPath: resolvedFolder, name, preset });
@@ -2014,21 +2074,46 @@ export function createWorkspaceStore(options: {
         }
       }
 
-      const nextSelectedId = pickSelectedWorkspaceId(ws.workspaces, [resolveWorkspaceListSelectedId(ws)], ws);
+      const nextSelectedId = createdWorkspaceId;
       applyServerLocalWorkspaces(ws.workspaces, nextSelectedId);
       if (nextSelectedId) {
-        syncSelectedWorkspaceId(nextSelectedId);
+        const nextSelectedWorkspace = ws.workspaces.find((workspace) => workspace.id === nextSelectedId) ?? null;
+        if (nextSelectedWorkspace) {
+          await applySelectedWorkspacePresentation(nextSelectedWorkspace);
+        } else {
+          syncSelectedWorkspaceId(nextSelectedId);
+        }
         updateWorkspaceConnectionState(nextSelectedId, { status: "connected", message: null });
       }
+
+      queuePendingInitialSessionSelection(nextSelectedId || null, preset);
 
       setCreateWorkspaceOpen(false);
 
       const opened = await activateFreshLocalWorkspace(nextSelectedId || null, resolvedFolder);
       if (!opened) {
+        options.setPendingInitialSessionSelection?.(null);
         return false;
       }
 
-      markOnboardingComplete();
+      if (preset === "starter") {
+        const materialized = await materializeStarterSessions(resolvedFolder, name, preset);
+        const sessionsReady = await waitForWorkspaceSessionsReady(resolvedFolder);
+        if (!sessionsReady) {
+          throw new Error("Starter sessions did not finish loading for the new workspace.");
+        }
+        const openSessionId = materialized?.openSessionId?.trim() || "";
+        if (openSessionId) {
+          options.setPendingInitialSessionSelection?.(null);
+          options.setSelectedSessionId(openSessionId);
+          options.setView("session", openSessionId);
+          await options.selectSession(openSessionId);
+        }
+      }
+
+      if (!nextSelectedId) {
+        await openEmptySession(resolvedFolder);
+      }
 
       return true;
     } catch (e) {
@@ -2252,8 +2337,6 @@ export function createWorkspaceStore(options: {
         setSandboxStage("Connecting to sandbox...");
 
         setSandboxStep("connect", { status: "active", detail: null });
-
-        markOnboardingComplete();
 
         const ok = await createRemoteWorkspaceFlow({
           openworkHostUrl: host.openworkUrl,
@@ -2960,66 +3043,12 @@ export function createWorkspaceStore(options: {
   }
 
   function deriveWorkspaceName(folderPath: string, preset: WorkspacePreset) {
-    const leaf = folderPath.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? "Worker";
-    if (preset === "starter" && leaf.trim().toLowerCase() === STARTER_BOOTSTRAP_WORKSPACE_NAME) {
-      return "Starter";
-    }
-    return leaf;
+    return folderPath.replace(/\\/g, "/").split("/").filter(Boolean).pop() ?? "Worker";
   }
 
-  async function resolveStarterBootstrapFolder() {
+  async function resolveFirstRunWelcomeFolder() {
     const base = (await homeDir()).replace(/[\\/]+$/, "");
-    return joinNativePath(joinNativePath(base, STARTER_BOOTSTRAP_FOLDER_NAME), STARTER_BOOTSTRAP_WORKSPACE_NAME);
-  }
-
-  async function quickStartWorkspaceFlow() {
-    if (!isTauriRuntime()) {
-      options.setError(t("app.error.tauri_required", currentLocale()));
-      return false;
-    }
-
-    try {
-      const server = await options.ensureLocalOpenworkServerClient?.();
-      if (!server) {
-        throw new Error("OpenWork server is unavailable. Restart the app and try again.");
-      }
-      return await createWorkspaceFlow("starter", await resolveStarterBootstrapFolder());
-    } catch (e) {
-      const message = e instanceof Error ? e.message : safeStringify(e);
-      options.setError(addOpencodeCacheHint(message));
-      return false;
-    }
-  }
-
-  async function autoBootstrapStarterWorkspace() {
-    if (!isTauriRuntime()) return false;
-
-    options.setStartupPreference("local");
-    options.setOnboardingStep("bootstrap");
-    setPersistedStarterBootstrapState("in_progress");
-    options.setError(null);
-
-    try {
-      const server = await options.ensureLocalOpenworkServerClient?.();
-      if (!server) {
-        throw new Error("OpenWork server is unavailable. Restart the app and try again.");
-      }
-      const ok = await createWorkspaceFlow("starter", await resolveStarterBootstrapFolder());
-      if (!ok) {
-        setPersistedStarterBootstrapState("failed");
-        options.setOnboardingStep("local");
-        return false;
-      }
-
-      setPersistedStarterBootstrapState("completed");
-      return true;
-    } catch (e) {
-      const message = e instanceof Error ? e.message : safeStringify(e);
-      options.setError(addOpencodeCacheHint(message));
-      setPersistedStarterBootstrapState("failed");
-      options.setOnboardingStep("local");
-      return false;
-    }
+    return joinNativePath(joinNativePath(base, DEFAULT_WORKSPACE_HOME_FOLDER_NAME), FIRST_RUN_WELCOME_WORKSPACE_NAME);
   }
 
   async function createWorkspaceFromPickedFolder() {
@@ -3128,7 +3157,6 @@ export function createWorkspaceStore(options: {
       syncSelectedWorkspaceId(nextSelectedId);
       setCreateWorkspaceOpen(false);
       setCreateRemoteWorkspaceOpen(false);
-      markOnboardingComplete();
 
       const opened = await activateFreshLocalWorkspace(nextSelectedId || null, resolvedFolder);
       if (!opened) {
@@ -3334,7 +3362,6 @@ export function createWorkspaceStore(options: {
         if (!ok) return false;
       }
 
-      markOnboardingComplete();
       return true;
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
@@ -3614,17 +3641,6 @@ export function createWorkspaceStore(options: {
     return trimmed;
   }
 
-  function markOnboardingComplete() {
-    setInitialWorkspaceSetupComplete(true);
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(INITIAL_WORKSPACE_SETUP_COMPLETE_KEY, "1");
-      window.localStorage.setItem(LEGACY_ONBOARDING_COMPLETE_KEY, "1");
-    } catch {
-      // ignore
-    }
-  }
-
   async function persistAuthorizedRoots(nextRoots: string[]) {
     if (!isTauriRuntime()) return;
     if (selectedWorkspaceInfo()?.workspaceType === "remote") return;
@@ -3734,11 +3750,6 @@ export function createWorkspaceStore(options: {
 
   async function bootstrapOnboarding() {
     const startupPref = readStartupPreference();
-    const onboardingComplete = readInitialWorkspaceSetupComplete();
-    const persistedBootstrapState = readStarterBootstrapState();
-    setInitialWorkspaceSetupComplete(onboardingComplete);
-    setStarterBootstrapState(persistedBootstrapState);
-
     if (isTauriRuntime()) {
       try {
         const ws = await workspaceBootstrap();
@@ -3749,16 +3760,18 @@ export function createWorkspaceStore(options: {
       }
     }
 
-    if (isTauriRuntime() && persistedBootstrapState === "in_progress") {
-      if (workspaces().length > 0) {
-        setPersistedStarterBootstrapState("completed");
-      } else {
-        setPersistedStarterBootstrapState("failed");
-      }
-    }
-
     await refreshEngine();
     await refreshEngineDoctor();
+
+    if (isTauriRuntime() && workspaces().length === 0) {
+      options.setStartupPreference("local");
+      const welcomeFolder = await resolveFirstRunWelcomeFolder();
+      const ok = await createWorkspaceFlow("starter", welcomeFolder);
+      if (!ok) {
+        options.setOnboardingStep("local");
+      }
+      return;
+    }
 
     if (isTauriRuntime()) {
       const active = workspaces().find((w) => w.id === selectedWorkspaceId()) ?? null;
@@ -3831,7 +3844,6 @@ export function createWorkspaceStore(options: {
           options.setOnboardingStep("welcome");
           return;
         }
-        markOnboardingComplete();
         return;
       }
 
@@ -3841,18 +3853,6 @@ export function createWorkspaceStore(options: {
         options.setOnboardingStep("local");
         return;
       }
-      markOnboardingComplete();
-      return;
-    }
-
-    if (firstRunWorkspaceSetup()) {
-      if (starterBootstrapState() === "not_started") {
-        await autoBootstrapStarterWorkspace();
-        return;
-      }
-
-      options.setStartupPreference("local");
-      options.setOnboardingStep("local");
       return;
     }
 
@@ -3873,10 +3873,6 @@ export function createWorkspaceStore(options: {
   }
 
   function onBackToWelcome() {
-    if (firstRunWorkspaceSetup()) {
-      markOnboardingComplete();
-      clearStartupPreference();
-    }
     options.setStartupPreference(null);
     options.setOnboardingStep("welcome");
   }
@@ -3989,7 +3985,6 @@ export function createWorkspaceStore(options: {
     testWorkspaceConnection,
     connectToServer,
     createWorkspaceFlow,
-    quickStartWorkspaceFlow,
     createWorkspaceFromPickedFolder,
     createSandboxFlow,
     createRemoteWorkspaceFlow,

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -139,6 +139,7 @@ export function createWorkspaceStore(options: {
   setBusyStartedAt: (value: number | null) => void;
   loadSessions: (scopeRoot?: string) => Promise<void>;
   refreshPendingPermissions: () => Promise<void>;
+  refreshWorkspaceSessions?: (workspaceId: string) => Promise<void>;
   selectedSessionId: () => string | null;
   selectSession: (id: string) => Promise<void>;
   setSelectedSessionId: (value: string | null) => void;
@@ -2101,6 +2102,9 @@ export function createWorkspaceStore(options: {
         const sessionsReady = await waitForWorkspaceSessionsReady(resolvedFolder);
         if (!sessionsReady) {
           throw new Error("Starter sessions did not finish loading for the new workspace.");
+        }
+        if (nextSelectedId) {
+          await options.refreshWorkspaceSessions?.(nextSelectedId);
         }
         const openSessionId = materialized?.openSessionId?.trim() || "";
         if (openSessionId) {

--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -75,21 +75,22 @@ body {
 }
 
 .ow-soft-shell {
-  border: 1px solid #eceef1;
-  background: #fbfbfc;
+  border: 1px solid var(--dls-border);
+  background: var(--dls-surface);
   border-radius: 2rem;
+  box-shadow: var(--dls-shell-shadow);
 }
 
 .ow-soft-card {
-  border: 1px solid #eceef1;
-  background: #ffffff;
+  border: 1px solid var(--dls-border);
+  background: var(--dls-surface);
   border-radius: 1.5rem;
-  box-shadow: 0 10px 24px -22px rgba(15, 23, 42, 0.14);
+  box-shadow: var(--dls-card-shadow);
 }
 
 .ow-soft-card-quiet {
-  border: 1px solid #eceef1;
-  background: #f8fafc;
+  border: 1px solid var(--dls-border);
+  background: var(--dls-sidebar);
   border-radius: 1.5rem;
 }
 
@@ -99,13 +100,13 @@ body {
   align-items: center;
   justify-content: center;
   border-radius: 9999px;
-  background: #011627;
+  background: var(--dls-accent);
   color: #ffffff;
-  box-shadow: 0 8px 20px -16px rgba(1, 22, 39, 0.45);
+  box-shadow: 0 8px 20px -16px rgba(var(--dls-accent-rgb), 0.45);
 }
 
 .ow-button-primary:hover:not(:disabled) {
-  background: #000000;
+  background: var(--dls-accent-hover);
 }
 
 .ow-button-secondary {
@@ -114,14 +115,14 @@ body {
   align-items: center;
   justify-content: center;
   border-radius: 9999px;
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
-  color: #011627;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.04), 0 1px 2px 0 rgba(0,0,0,0.04);
+  border: 1px solid var(--dls-border);
+  background: var(--dls-surface);
+  color: var(--dls-text-primary);
+  box-shadow: var(--dls-card-shadow);
 }
 
 .ow-button-secondary:hover:not(:disabled) {
-  background: #f9fafb;
+  background: var(--dls-hover);
 }
 
 .ow-button-primary,

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -177,7 +177,6 @@ export type DashboardViewProps = {
   stopSandbox: (workspaceId: string) => void;
   scheduledJobs: ScheduledJob[];
   scheduledJobsSource: "local" | "remote";
-  scheduledJobsSourceReady: boolean;
   schedulerPluginInstalled: boolean;
   scheduledJobsStatus: string | null;
   scheduledJobsBusy: boolean;
@@ -1315,13 +1314,11 @@ export default function DashboardView(props: DashboardViewProps) {
                 scheduled={{
                   jobs: props.scheduledJobs,
                   source: props.scheduledJobsSource,
-                  sourceReady: props.scheduledJobsSourceReady,
                   status: props.scheduledJobsStatus,
                   busy: props.scheduledJobsBusy,
                   lastUpdatedAt: props.scheduledJobsUpdatedAt,
                   refreshJobs: props.refreshScheduledJobs,
                   deleteJob: props.deleteScheduledJob,
-                  isWindows: props.isWindows,
                   selectedWorkspaceRoot: props.selectedWorkspaceRoot,
                   createSessionAndOpen: props.createSessionAndOpen,
                   setPrompt: props.setPrompt,
@@ -1573,7 +1570,6 @@ export default function DashboardView(props: DashboardViewProps) {
                   openDebugDeepLink={props.openDebugDeepLink}
                   scheduledJobs={props.scheduledJobs}
                   scheduledJobsSource={props.scheduledJobsSource}
-                  scheduledJobsSourceReady={props.scheduledJobsSourceReady}
                   scheduledJobsStatus={props.scheduledJobsStatus}
                   scheduledJobsBusy={props.scheduledJobsBusy}
                   scheduledJobsUpdatedAt={props.scheduledJobsUpdatedAt}

--- a/apps/app/src/app/pages/scheduled.tsx
+++ b/apps/app/src/app/pages/scheduled.tsx
@@ -26,13 +26,11 @@ import {
 export type ScheduledTasksViewProps = {
   jobs: ScheduledJob[];
   source: "local" | "remote";
-  sourceReady: boolean;
   status: string | null;
   busy: boolean;
   lastUpdatedAt: number | null;
   refreshJobs: (options?: { force?: boolean }) => void;
   deleteJob: (name: string) => Promise<void> | void;
-  isWindows: boolean;
   selectedWorkspaceRoot: string;
   createSessionAndOpen: () => void;
   setPrompt: (value: string) => void;
@@ -440,7 +438,7 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
   const [installingScheduler, setInstallingScheduler] = createSignal(false);
   const [schedulerInstallRequested, setSchedulerInstallRequested] = createSignal(false);
   const supported = createMemo(() => {
-    if (props.source === "remote") return props.sourceReady;
+    if (props.source === "remote") return true;
     return isTauriRuntime() && props.schedulerInstalled && !schedulerInstallRequested();
   });
   const schedulerGateActive = createMemo(() => {
@@ -452,7 +450,7 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
   const automationDisabled = createMemo(() => props.newTaskDisabled || schedulerGateActive());
   const supportNote = createMemo(() => {
     if (props.source === "remote") {
-      return props.sourceReady ? null : "OpenWork server unavailable. Connect to sync scheduled tasks.";
+      return null;
     }
     if (!isTauriRuntime()) return "Scheduled tasks require the desktop app.";
     if (!props.schedulerInstalled || schedulerInstallRequested()) return null;

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -129,7 +129,6 @@ export type SessionViewProps = {
   editWorkspaceConnection: (workspaceId: string) => void;
   forgetWorkspace: (workspaceId: string) => void;
   openCreateWorkspace: () => void;
-  getStartedWorkspace: () => Promise<boolean>;
   pickFolderWorkspace: () => Promise<boolean>;
   openCreateRemoteWorkspace: () => void;
   importWorkspaceConfig: () => void;
@@ -4371,6 +4370,67 @@ export default function SessionView(props: SessionViewProps) {
                           <p class="text-sm text-dls-secondary">
                             Pulling in the latest messages for this task.
                           </p>
+                        </div>
+                      </div>
+                    </div>
+                  </Show>
+
+                  <Show when={showWorkspaceSetupEmptyState()}>
+                    <div class="mx-auto max-w-2xl rounded-[32px] border border-dls-border bg-dls-sidebar/95 p-5 shadow-[var(--dls-shell-shadow)] sm:p-8">
+                      <div class="rounded-[28px] border border-dls-border bg-dls-surface p-6 sm:p-8">
+                        <div class="flex flex-col gap-6">
+                          <div class="flex flex-col items-center text-center">
+                            <div class="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-sidebar text-gray-11 shadow-[var(--dls-card-shadow)]">
+                              <HardDrive size={24} />
+                            </div>
+                            <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-dls-secondary">
+                              Workspace setup
+                            </div>
+                            <h3 class="mt-3 text-3xl font-semibold tracking-tight text-gray-12">
+                              Set up your first workspace
+                            </h3>
+                            <p class="mt-3 max-w-xl text-sm leading-6 text-dls-secondary sm:text-[15px]">
+                              Start with a guided OpenWork workspace, or choose an existing folder you want to work in.
+                            </p>
+                          </div>
+
+                          <div class="grid gap-3 sm:grid-cols-[1.2fr_1fr]">
+                            <button
+                              type="button"
+                              class="group rounded-[24px] border border-transparent bg-dls-accent px-5 py-5 text-left text-white shadow-[var(--dls-card-shadow)] transition-all hover:-translate-y-0.5 hover:bg-[var(--dls-accent-hover)]"
+                              onClick={props.openCreateWorkspace}
+                            >
+                              <div class="flex items-start gap-4">
+                                <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-white/20 bg-white/10">
+                                  <HardDrive size={18} />
+                                </div>
+                                <div class="min-w-0">
+                                  <div class="text-base font-semibold">Create workspace</div>
+                                  <div class="mt-1 text-sm leading-6 text-white/80">
+                                    Open the workspace creator and choose how you want to start.
+                                  </div>
+                                </div>
+                              </div>
+                            </button>
+
+                            <button
+                              type="button"
+                              class="group rounded-[24px] border border-dls-border bg-dls-sidebar px-5 py-5 text-left text-gray-12 transition-all hover:-translate-y-0.5 hover:border-gray-7 hover:bg-gray-2/80"
+                              onClick={() => void props.pickFolderWorkspace()}
+                            >
+                              <div class="flex items-start gap-4">
+                                <div class="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-dls-border bg-dls-surface text-gray-11">
+                                  <FolderOpen size={18} />
+                                </div>
+                                <div class="min-w-0">
+                                  <div class="text-base font-semibold">Pick a folder you want to work in</div>
+                                  <div class="mt-1 text-sm leading-6 text-dls-secondary">
+                                    Choose an existing project or notes folder and OpenWork will use it as your workspace.
+                                  </div>
+                                </div>
+                              </div>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -221,7 +221,6 @@ export type SettingsViewProps = {
   ) => Promise<{ ok: boolean; message: string }>;
   scheduledJobs: ScheduledJob[];
   scheduledJobsSource: "local" | "remote";
-  scheduledJobsSourceReady: boolean;
   scheduledJobsStatus: string | null;
   scheduledJobsBusy: boolean;
   scheduledJobsUpdatedAt: number | null;
@@ -2100,13 +2099,11 @@ export default function SettingsView(props: SettingsViewProps) {
               showHeader: false,
               jobs: props.scheduledJobs,
               source: props.scheduledJobsSource,
-              sourceReady: props.scheduledJobsSourceReady,
               status: props.scheduledJobsStatus,
               busy: props.scheduledJobsBusy,
               lastUpdatedAt: props.scheduledJobsUpdatedAt,
               refreshJobs: props.refreshScheduledJobs,
               deleteJob: props.deleteScheduledJob,
-              isWindows: props.isWindows,
               selectedWorkspaceRoot: props.selectedWorkspaceRoot,
               createSessionAndOpen: props.createSessionAndOpen,
               setPrompt: props.setPrompt,

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -156,7 +156,7 @@ export type StartupPreference = "local" | "server";
 
 export type EngineRuntime = "direct" | "openwork-orchestrator";
 
-export type OnboardingStep = "welcome" | "local" | "server" | "connecting" | "bootstrap";
+export type OnboardingStep = "welcome" | "local" | "server" | "connecting";
 
 export type DashboardTab =
   | "scheduled"

--- a/apps/desktop/src-tauri/src/commands/misc.rs
+++ b/apps/desktop/src-tauri/src/commands/misc.rs
@@ -148,7 +148,7 @@ fn opencode_standard_state_paths() -> Vec<PathBuf> {
 }
 
 fn current_openwork_state_paths(app: &AppHandle) -> Result<Vec<PathBuf>, String> {
-    Ok(vec![
+    let mut paths = vec![
         app.path()
             .app_cache_dir()
             .map_err(|e| format!("Failed to resolve app cache dir: {e}"))?,
@@ -162,7 +162,18 @@ fn current_openwork_state_paths(app: &AppHandle) -> Result<Vec<PathBuf>, String>
             .app_data_dir()
             .map_err(|e| format!("Failed to resolve app data dir: {e}"))?,
         PathBuf::from(orchestrator::resolve_orchestrator_data_dir()),
-    ])
+    ];
+
+    if let Some(home) = home_dir() {
+        paths.push(
+            home.join("OpenWork")
+                .join("Welcome")
+                .join(".opencode")
+                .join("openwork.json"),
+        );
+    }
+
+    Ok(paths)
 }
 
 fn stop_host_services(


### PR DESCRIPTION
## Summary
- route first-run and new local workspace creation through the backend workspace/session materialization flow so starter sessions and seeded messages land in the right workspace
- auto-open the backend-selected `Welcome to OpenWork` session and keep sidebar/session state aligned during bootstrap and workspace switches
- update the create-workspace modal and shared soft-shell/card styles to use dark-theme-aware surfaces instead of hardcoded light colors

## Testing
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-server build:bin
- cargo check