### PR TITLE
refactor(sidebar): isolate workspace session loading

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -4804,7 +4804,6 @@ export default function App() {
   const automationsStore = createAutomationsStore({
     selectedWorkspaceId: () => workspaceStore.selectedWorkspaceId(),
     selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot(),
-    selectedWorkspaceType: () => workspaceStore.selectedWorkspaceDisplay().workspaceType,
     runtimeWorkspaceId,
     openworkServerClient,
     openworkServerStatus,
@@ -4817,7 +4816,6 @@ export default function App() {
     scheduledJobsBusy,
     scheduledJobsUpdatedAt,
     scheduledJobsSource,
-    scheduledJobsSourceReady,
     scheduledJobsPollingAvailable,
     refreshScheduledJobs,
     deleteScheduledJob,
@@ -7348,7 +7346,6 @@ export default function App() {
       stopSandbox: workspaceStore.stopSandbox,
       scheduledJobs: scheduledJobs(),
       scheduledJobsSource: scheduledJobsSource(),
-      scheduledJobsSourceReady: scheduledJobsSourceReady(),
       schedulerPluginInstalled: schedulerPluginInstalled(),
       scheduledJobsStatus: scheduledJobsStatus(),
       scheduledJobsBusy: scheduledJobsBusy(),

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -1212,7 +1212,11 @@ export default function App() {
   const ensureSelectedWorkspaceRuntime = async () => {
     const workspaceId = workspaceStore.selectedWorkspaceId().trim();
     if (!workspaceId) return false;
-    return await workspaceStore.switchWorkspace(workspaceId);
+    const ready = await workspaceStore.switchWorkspace(workspaceId);
+    if (ready) {
+      await refreshSidebarWorkspaceSessions(workspaceId).catch(() => undefined);
+    }
+    return ready;
   };
 
   async function sendPrompt(draft?: ComposerDraft) {
@@ -2932,31 +2936,10 @@ export default function App() {
     }
   };
 
-  const refreshAllSidebarWorkspaceSessions = async (prioritizeWorkspaceId?: string | null) => {
+  const refreshAllSidebarWorkspaceSessions = async () => {
     const list = workspaceStore.workspaces();
     if (!list.length) return;
-    const prioritize = (prioritizeWorkspaceId ?? "").trim();
-    const ordered = prioritize
-      ? [...list.filter((ws) => ws.id === prioritize), ...list.filter((ws) => ws.id !== prioritize)]
-      : list;
-    for (const ws of ordered) {
-      await refreshSidebarWorkspaceSessions(ws.id);
-      // Yield so long refresh passes don't block UI / timers.
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    }
-  };
-
-  const refreshLocalSidebarWorkspaceSessions = async (prioritizeWorkspaceId?: string | null) => {
-    const list = workspaceStore.workspaces().filter((ws) => ws.workspaceType === "local");
-    if (!list.length) return;
-    const prioritize = (prioritizeWorkspaceId ?? "").trim();
-    const ordered = prioritize
-      ? [...list.filter((ws) => ws.id === prioritize), ...list.filter((ws) => ws.id !== prioritize)]
-      : list;
-    for (const ws of ordered) {
-      await refreshSidebarWorkspaceSessions(ws.id);
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    }
+    await Promise.allSettled(list.map((ws) => refreshSidebarWorkspaceSessions(ws.id)));
   };
 
   let lastSidebarEngineKey = "";
@@ -2985,146 +2968,17 @@ export default function App() {
     // potentially disappear) due to auth fallback changes.
     if (engineKey === lastSidebarEngineKey && workspaceKey === lastSidebarWorkspaceKey) return;
 
-    const engineChanged = engineKey !== lastSidebarEngineKey;
-    const workspacesChanged = workspaceKey !== lastSidebarWorkspaceKey;
-
     lastSidebarEngineKey = engineKey;
     lastSidebarWorkspaceKey = workspaceKey;
 
     pruneSidebarSessionState(new Set(workspaceStore.workspaces().map((ws) => ws.id)));
 
     wsDebug("sidebar:refresh", {
-      engineChanged,
-      workspacesChanged,
       selectedWorkspaceId: workspaceStore.selectedWorkspaceId(),
       engineBaseUrl,
     });
 
-    // Avoid refreshing remote workspace sessions when only the local engine auth/baseUrl changes.
-    // Remote->local switches commonly change engineBaseUrl, and refreshing every remote workspace
-    // at the same time can trigger large /session responses and UI hangs.
-    if (engineChanged && !workspacesChanged) {
-      void refreshLocalSidebarWorkspaceSessions(workspaceStore.selectedWorkspaceId()).catch(() => undefined);
-      return;
-    }
-
-    void refreshAllSidebarWorkspaceSessions(workspaceStore.selectedWorkspaceId()).catch(() => undefined);
-  });
-
-  createEffect(() => {
-    const id = workspaceStore.selectedWorkspaceId().trim();
-    if (!id) return;
-    const status = sidebarSessionStatusByWorkspaceId()[id] ?? "idle";
-    // Only auto-load once per workspace activation.
-    // If a remote is offline, repeated retries here can create an endless refresh loop.
-    if (status !== "idle") return;
-    refreshSidebarWorkspaceSessions(id).catch(() => undefined);
-  });
-
-  createEffect(() => {
-    const allSessions = sessions(); // reactive dependency on session store
-    // When switching workers, the session store can update before the selectedWorkspaceId flips.
-    // Use connectingWorkspaceId as the authoritative target during the switch so we don't
-    // accidentally overwrite another worker's sidebar sessions.
-    const wsId = (workspaceStore.connectingWorkspaceId() ?? workspaceStore.selectedWorkspaceId()).trim();
-    if (!wsId) return;
-    const status = sidebarSessionStatusByWorkspaceId()[wsId];
-
-    // Only sync if sidebar is already in 'ready' state (not during initial load)
-    if (status === "ready") {
-      const activeWorkspace = workspaceStore.workspaces().find((workspace) => workspace.id === wsId) ?? null;
-      const selectedWorkspaceRoot = normalizeDirectoryPath(
-        activeWorkspace?.workspaceType === "local"
-          ? activeWorkspace.path
-          : activeWorkspace?.directory ?? activeWorkspace?.path,
-      );
-      if (
-        !shouldApplyScopedSessionLoad({
-          loadedScopeRoot: loadedSessionScopeRoot(),
-          workspaceRoot: selectedWorkspaceRoot,
-        })
-      ) {
-        if (developerMode()) {
-          console.log("[sidebar-sync] skip stale session scope", {
-            wsId,
-            loadedScopeRoot: loadedSessionScopeRoot(),
-            selectedWorkspaceRoot,
-          });
-        }
-        return;
-      }
-      const scopedSessions = selectedWorkspaceRoot
-        ? allSessions.filter((session) => normalizeDirectoryPath(session.directory) === selectedWorkspaceRoot)
-        : allSessions;
-      const sorted = sortSessionsByActivity(scopedSessions);
-      if (developerMode()) {
-        console.log("[sidebar-sync] workspace session scope", {
-          wsId,
-          status,
-          activeWorkspace,
-          selectedWorkspaceRoot,
-          allSessions: allSessions.map((session) => ({
-            id: session.id,
-            title: session.title,
-            directory: session.directory,
-            parentID: session.parentID,
-          })),
-          scopedSessions: scopedSessions.map((session) => ({
-            id: session.id,
-            title: session.title,
-            directory: session.directory,
-            parentID: session.parentID,
-          })),
-        });
-      }
-      const rootItems: SidebarSessionItem[] = sorted.map((s) => ({
-        id: s.id,
-        title: s.title,
-        slug: s.slug,
-        parentID: s.parentID,
-        time: s.time,
-        directory: s.directory,
-      }));
-      setSidebarSessionsByWorkspaceId((prev) => {
-        const current = prev[wsId] ?? [];
-        const hasCurrentChildren = current.some((item) => Boolean(item.parentID?.trim()));
-        const incomingAreRootsOnly = rootItems.every((item) => !item.parentID?.trim());
-        if (!hasCurrentChildren || !incomingAreRootsOnly) {
-          return {
-            ...prev,
-            [wsId]: rootItems,
-          };
-        }
-
-        const byId = new Map(current.map((item) => [item.id, item] as const));
-        for (const item of rootItems) {
-          byId.set(item.id, {
-            ...(byId.get(item.id) ?? {}),
-            ...item,
-          });
-        }
-
-        const rootIDs = new Set(rootItems.map((item) => item.id));
-        const keepChild = (item: SidebarSessionItem, seen = new Set<string>()) => {
-          const parentID = item.parentID?.trim() ?? "";
-          if (!parentID) return false;
-          if (rootIDs.has(parentID)) return true;
-          if (seen.has(parentID)) return false;
-          const parent = byId.get(parentID);
-          if (!parent) return false;
-          seen.add(parentID);
-          return keepChild(parent, seen);
-        };
-
-        return {
-          ...prev,
-          [wsId]: [
-            ...rootItems,
-            ...current.filter((item) => !rootIDs.has(item.id) && keepChild(item)),
-          ],
-        };
-      });
-    }
+    void refreshAllSidebarWorkspaceSessions().catch(() => undefined);
   });
 
   const sidebarWorkspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -176,6 +176,7 @@ const fileToDataUrl = (file: File) =>
   });
 import { createExtensionsStore } from "./context/extensions";
 import { createAutomationsStore } from "./context/automations";
+import { createSidebarSessionsStore } from "./context/sidebar-sessions";
 import { useGlobalSync } from "./context/global-sync";
 import { createWorkspaceStore } from "./context/workspace";
 import {
@@ -1745,10 +1746,7 @@ export default function App() {
     // here races with SSE and can wipe unrelated sessions from the store.
     setSessions(sessions().filter((s) => s.id !== trimmed));
     const activeWsId = workspaceStore.selectedWorkspaceId();
-    setSidebarSessionsByWorkspaceId((prev) => ({
-      ...prev,
-      [activeWsId]: (prev[activeWsId] ?? []).filter((s) => s.id !== trimmed),
-    }));
+    removeSidebarSession(activeWsId, trimmed);
 
     // If we're currently routed to the deleted session, navigate away immediately.
     // (Otherwise the route effect can try to re-select a session that no longer exists.)
@@ -2713,17 +2711,6 @@ export default function App() {
   const runtimeWorkspaceId = createMemo(() => workspaceStore.runtimeWorkspaceId());
   const activeWorkspaceServerConfig = createMemo(() => workspaceStore.runtimeWorkspaceConfig());
 
-  type SidebarWorkspaceSessionsStatus = WorkspaceSessionGroup["status"];
-  const [sidebarSessionsByWorkspaceId, setSidebarSessionsByWorkspaceId] = createSignal<
-    Record<string, SidebarSessionItem[]>
-  >({});
-  const [sidebarSessionStatusByWorkspaceId, setSidebarSessionStatusByWorkspaceId] = createSignal<
-    Record<string, SidebarWorkspaceSessionsStatus>
-  >({});
-  const [sidebarSessionErrorByWorkspaceId, setSidebarSessionErrorByWorkspaceId] = createSignal<
-    Record<string, string | null>
-  >({});
-
   const logWorkspaceScopeSnapshot = (label: string, extra?: Record<string, unknown>) => {
     if (!developerMode()) return;
     const activeWorkspace = workspaceStore.selectedWorkspaceInfo();
@@ -2748,251 +2735,28 @@ export default function App() {
     });
   };
 
-  const pruneSidebarSessionState = (workspaceIds: Set<string>) => {
-    setSidebarSessionsByWorkspaceId((prev) => {
-      let changed = false;
-      const next: Record<string, SidebarSessionItem[]> = {};
-      for (const [id, list] of Object.entries(prev)) {
-        if (!workspaceIds.has(id)) {
-          changed = true;
-          continue;
-        }
-        next[id] = list;
-      }
-      return changed ? next : prev;
-    });
-    setSidebarSessionStatusByWorkspaceId((prev) => {
-      let changed = false;
-      const next: Record<string, SidebarWorkspaceSessionsStatus> = {};
-      for (const [id, status] of Object.entries(prev)) {
-        if (!workspaceIds.has(id)) {
-          changed = true;
-          continue;
-        }
-        next[id] = status;
-      }
-      return changed ? next : prev;
-    });
-    setSidebarSessionErrorByWorkspaceId((prev) => {
-      let changed = false;
-      const next: Record<string, string | null> = {};
-      for (const [id, error] of Object.entries(prev)) {
-        if (!workspaceIds.has(id)) {
-          changed = true;
-          continue;
-        }
-        next[id] = error;
-      }
-      return changed ? next : prev;
-    });
-  };
-
-  const resolveSidebarClientConfig = (workspaceId: string) => {
-    const workspace = workspaceStore.workspaces().find((entry) => entry.id === workspaceId) ?? null;
-    if (!workspace) return null;
-
-    if (workspace.workspaceType === "local") {
-      const info = workspaceStore.engine();
-      const baseUrl = info?.baseUrl?.trim() ?? "";
-      const directory = toSessionTransportDirectory(workspace.path?.trim() ?? "");
-      const username = info?.opencodeUsername?.trim() ?? "";
-      const password = info?.opencodePassword?.trim() ?? "";
-      const auth: OpencodeAuth | undefined = username && password ? { username, password } : undefined;
-      return {
-        baseUrl,
-        directory,
-        auth,
-      };
-    }
-
-    const baseUrl = workspace.baseUrl?.trim() ?? "";
-    const directory = workspace.directory?.trim() ?? "";
-    if (workspace.remoteType === "openwork") {
-      // Sidebar session listing should be per-workspace and should not implicitly depend on
-      // global OpenWork server settings, otherwise switching between remotes can cause other
-      // workspace task lists to appear/disappear.
-      const token = workspace.openworkToken?.trim() ?? "";
-      const auth: OpencodeAuth | undefined = token ? { token, mode: "openwork" } : undefined;
-      return {
-        baseUrl,
-        directory,
-        auth,
-      };
-    }
-    return {
-      baseUrl,
-      directory,
-      auth: undefined as OpencodeAuth | undefined,
-    };
-  };
-
-  const sidebarRefreshSeqByWorkspaceId: Record<string, number> = {};
-  const SIDEBAR_SESSION_LIMIT = 200;
-  const refreshSidebarWorkspaceSessions = async (workspaceId: string) => {
-    const id = workspaceId.trim();
-    if (!id) return;
-
-    const config = resolveSidebarClientConfig(id);
-    if (!config) return;
-
-    // For local workspaces, avoid thrashing UI with errors if the engine is offline.
-    if (!config.baseUrl) {
-      let changed = false;
-      setSidebarSessionStatusByWorkspaceId((prev) => {
-        if (prev[id] === "idle") return prev;
-        changed = true;
-        return { ...prev, [id]: "idle" };
-      });
-      setSidebarSessionErrorByWorkspaceId((prev) => {
-        if ((prev[id] ?? null) === null) return prev;
-        changed = true;
-        return { ...prev, [id]: null };
-      });
-      if (changed) {
-        wsDebug("sidebar:skip", { id, reason: "no-baseUrl" });
-      }
-      return;
-    }
-
-    sidebarRefreshSeqByWorkspaceId[id] = (sidebarRefreshSeqByWorkspaceId[id] ?? 0) + 1;
-    const seq = sidebarRefreshSeqByWorkspaceId[id];
-
-    setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "loading" }));
-    setSidebarSessionErrorByWorkspaceId((prev) => ({ ...prev, [id]: null }));
-
-    try {
-      const start = Date.now();
-      let directory = config.directory;
-      let c = createClient(config.baseUrl, directory || undefined, config.auth);
-      wsDebug("sidebar:list:start", {
-        id,
-        directory: directory || null,
-        directoryScope: describeDirectoryScope(directory),
-        workspacePath: workspaceStore.workspaces().find((entry) => entry.id === id)?.path?.trim() ?? null,
-      });
-
-      if (!directory) {
-        try {
-          const pathInfo = unwrap(await c.path.get());
-          const discovered = toSessionTransportDirectory(pathInfo.directory ?? "");
-          if (discovered) {
-            directory = discovered;
-            c = createClient(config.baseUrl, directory, config.auth);
-          }
-        } catch {
-          // ignore
-        }
-      }
-
-      const queryDirectory = normalizeDirectoryQueryPath(directory) || undefined;
-
-      // Fetch sessions scoped to the workspace directory to avoid loading the
-      // full global session list for every workspace.
-      const list = unwrap(
-        await c.session.list({ directory: queryDirectory, roots: false, limit: SIDEBAR_SESSION_LIMIT }),
-      );
-      wsDebug("sidebar:list", {
-        id,
-        baseUrl: config.baseUrl,
-        directory: directory || null,
-        directoryScope: describeDirectoryScope(directory),
-        queryDirectory: queryDirectory ?? null,
-        queryScope: describeDirectoryScope(queryDirectory),
-        count: list.length,
-        ms: Date.now() - start,
-        sessionDirectories: list.slice(0, 10).map((session) => ({
-          id: session.id,
-          directory: session.directory,
-          directoryScope: describeDirectoryScope(session.directory),
-        })),
-      });
-      if (sidebarRefreshSeqByWorkspaceId[id] !== seq) return;
-
-      // Defensive client-side filter in case upstream ignores the directory query.
-      const root = normalizeDirectoryPath(directory);
-      const filtered = root ? list.filter((session) => normalizeDirectoryPath(session.directory) === root) : list;
-
-      const sorted = sortSessionsByActivity(filtered);
-      const items: SidebarSessionItem[] = sorted.map((session) => ({
-        id: session.id,
-        title: session.title,
-        slug: session.slug,
-        parentID: session.parentID,
-        time: session.time,
-        directory: session.directory,
-      }));
-
-      setSidebarSessionsByWorkspaceId((prev) => ({
-        ...prev,
-        [id]: items,
-      }));
-      setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
-    } catch (error) {
-      if (sidebarRefreshSeqByWorkspaceId[id] !== seq) return;
-      const message = error instanceof Error ? error.message : safeStringify(error);
-      wsDebug("sidebar:error", { id, message });
-      setSidebarSessionStatusByWorkspaceId((prev) => ({ ...prev, [id]: "error" }));
-      setSidebarSessionErrorByWorkspaceId((prev) => ({ ...prev, [id]: message }));
-    }
-  };
-
-  const refreshAllSidebarWorkspaceSessions = async () => {
-    const list = workspaceStore.workspaces();
-    if (!list.length) return;
-    await Promise.allSettled(list.map((ws) => refreshSidebarWorkspaceSessions(ws.id)));
-  };
-
-  let lastSidebarEngineKey = "";
-  let lastSidebarWorkspaceKey = "";
-  createEffect(() => {
-    const engineInfo = workspaceStore.engine();
-    const engineBaseUrl = engineInfo?.baseUrl?.trim() ?? "";
-    const engineUser = engineInfo?.opencodeUsername?.trim() ?? "";
-    const enginePass = engineInfo?.opencodePassword?.trim() ?? "";
-
-    const engineKey = [engineBaseUrl, engineUser, enginePass].join("::");
-    const workspaceKey = workspaceStore
-      .workspaces()
-      .map((ws) => {
-        const root = ws.workspaceType === "local" ? ws.path?.trim() ?? "" : ws.directory?.trim() ?? "";
-        const base = ws.workspaceType === "local" ? "" : ws.baseUrl?.trim() ?? "";
-        const remoteType = ws.workspaceType === "remote" ? (ws.remoteType ?? "") : "";
-        const token = ws.remoteType === "openwork" ? (ws.openworkToken?.trim() ?? "") : "";
-        return [ws.id, ws.workspaceType, remoteType, root, base, token].join("|");
-      })
-      .join(";");
-
-    // Sidebar session refreshes should only be driven by the engine auth/baseUrl or the workspace
-    // definitions themselves. Global OpenWork server settings are intentionally excluded so that
-    // connecting/activating a remote does not cause other workspace task lists to refresh (and
-    // potentially disappear) due to auth fallback changes.
-    if (engineKey === lastSidebarEngineKey && workspaceKey === lastSidebarWorkspaceKey) return;
-
-    lastSidebarEngineKey = engineKey;
-    lastSidebarWorkspaceKey = workspaceKey;
-
-    pruneSidebarSessionState(new Set(workspaceStore.workspaces().map((ws) => ws.id)));
-
-    wsDebug("sidebar:refresh", {
-      selectedWorkspaceId: workspaceStore.selectedWorkspaceId(),
-      engineBaseUrl,
-    });
-
-    void refreshAllSidebarWorkspaceSessions().catch(() => undefined);
+  const sidebarSessionsStore = createSidebarSessionsStore({
+    workspaces: () => workspaceStore.workspaces(),
+    engine: () => workspaceStore.engine(),
   });
 
+  const {
+    workspaceGroups: rawSidebarWorkspaceGroups,
+    refreshWorkspaceSessions: refreshSidebarWorkspaceSessions,
+    prependSession: prependSidebarSession,
+    removeSession: removeSidebarSession,
+  } = sidebarSessionsStore;
+
   const sidebarWorkspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
-    const workspaces = workspaceStore.workspaces();
+    const groups = rawSidebarWorkspaceGroups();
     const selectedWorkspaceId = workspaceStore.selectedWorkspaceId().trim();
     const connectingWorkspaceId = workspaceStore.connectingWorkspaceId()?.trim() ?? "";
-    const sessionsById = sidebarSessionsByWorkspaceId();
-    const statusById = sidebarSessionStatusByWorkspaceId();
-    const errorById = sidebarSessionErrorByWorkspaceId();
-    const dedupedWorkspaces: typeof workspaces = [];
+    const dedupedGroups: typeof groups = [];
     const dedupeKeyToIndex = new Map<string, number>();
-    for (const workspace of workspaces) {
+    for (const group of groups) {
+      const workspace = group.workspace;
       if (workspace.workspaceType !== "remote") {
-        dedupedWorkspaces.push(workspace);
+        dedupedGroups.push(group);
         continue;
       }
       const hostKey =
@@ -3007,27 +2771,28 @@ export default function App() {
       const directoryKey = normalizeDirectoryPath(workspace.directory?.trim() ?? workspace.path?.trim() ?? "");
       const identityKey = workspaceIdKey ? `id:${workspaceIdKey}` : (directoryKey ? `dir:${directoryKey}` : "");
       if (!hostKey || !identityKey) {
-        dedupedWorkspaces.push(workspace);
+        dedupedGroups.push(group);
         continue;
       }
       const dedupeKey = `${workspace.remoteType ?? ""}|${hostKey}|${identityKey}`;
       const existingIndex = dedupeKeyToIndex.get(dedupeKey);
       if (existingIndex === undefined) {
-        dedupeKeyToIndex.set(dedupeKey, dedupedWorkspaces.length);
-        dedupedWorkspaces.push(workspace);
+        dedupeKeyToIndex.set(dedupeKey, dedupedGroups.length);
+        dedupedGroups.push(group);
         continue;
       }
-      const existingWorkspace = dedupedWorkspaces[existingIndex];
+      const existingWorkspace = dedupedGroups[existingIndex].workspace;
       const existingIsPriority =
         existingWorkspace.id === selectedWorkspaceId || existingWorkspace.id === connectingWorkspaceId;
       const currentIsPriority =
         workspace.id === selectedWorkspaceId || workspace.id === connectingWorkspaceId;
       if (currentIsPriority && !existingIsPriority) {
-        dedupedWorkspaces[existingIndex] = workspace;
+        dedupedGroups[existingIndex] = group;
       }
     }
-    return dedupedWorkspaces.map((workspace) => {
-      const groupSessions = sessionsById[workspace.id] ?? [];
+    return dedupedGroups.map((group) => {
+      const workspace = group.workspace;
+      const groupSessions = group.sessions;
       if (developerMode()) {
         console.log("[sidebar-groups] workspace group", {
           workspaceId: workspace.id,
@@ -3047,8 +2812,8 @@ export default function App() {
       return {
         workspace,
         sessions: groupSessions,
-        status: statusById[workspace.id] ?? "idle",
-        error: errorById[workspace.id] ?? null,
+        status: group.status,
+        error: group.error,
       };
     });
   });
@@ -5922,15 +5687,7 @@ export default function App() {
       };
       const wsId = workspaceStore.selectedWorkspaceId().trim();
       if (wsId) {
-        const currentSessions = sidebarSessionsByWorkspaceId()[wsId] || [];
-        setSidebarSessionsByWorkspaceId((prev) => ({
-          ...prev,
-          [wsId]: [newItem, ...currentSessions],
-        }));
-        setSidebarSessionStatusByWorkspaceId((prev) => ({
-          ...prev,
-          [wsId]: "ready",
-        }));
+        prependSidebarSession(wsId, newItem);
       }
 
       // setSessionViewLockUntil(Date.now() + 1200);

--- a/apps/app/src/app/context/automations.ts
+++ b/apps/app/src/app/context/automations.ts
@@ -36,7 +36,6 @@ export function createAutomationsStore(options: {
     selectedWorkspaceId: options.selectedWorkspaceId,
     selectedWorkspaceRoot: options.selectedWorkspaceRoot,
     runtimeWorkspaceId: options.runtimeWorkspaceId,
-    workspaceType: scheduledJobsSource,
   });
 
   const scheduledJobsPollingAvailable = createMemo(() => {

--- a/apps/app/src/app/context/automations.ts
+++ b/apps/app/src/app/context/automations.ts
@@ -11,7 +11,6 @@ export type AutomationsStore = ReturnType<typeof createAutomationsStore>;
 export function createAutomationsStore(options: {
   selectedWorkspaceId: () => string;
   selectedWorkspaceRoot: () => string;
-  selectedWorkspaceType: () => "local" | "remote";
   runtimeWorkspaceId: () => string | null;
   openworkServerClient: () => OpenworkServerClient | null;
   openworkServerStatus: () => OpenworkServerStatus;
@@ -23,8 +22,14 @@ export function createAutomationsStore(options: {
   const [scheduledJobsUpdatedAt, setScheduledJobsUpdatedAt] = createSignal<number | null>(null);
   const [pendingRefreshContextKey, setPendingRefreshContextKey] = createSignal<string | null>(null);
 
+  const serverBacked = createMemo(() => {
+    const client = options.openworkServerClient();
+    const runtimeWorkspaceId = (options.runtimeWorkspaceId() ?? "").trim();
+    return options.openworkServerStatus() === "connected" && Boolean(client && runtimeWorkspaceId);
+  });
+
   const scheduledJobsSource = createMemo<"local" | "remote">(() =>
-    options.selectedWorkspaceType() === "remote" ? "remote" : "local",
+    serverBacked() ? "remote" : "local",
   );
 
   const scheduledJobsContextKey = createWorkspaceContextKey({
@@ -34,19 +39,8 @@ export function createAutomationsStore(options: {
     workspaceType: scheduledJobsSource,
   });
 
-  const scheduledJobsSourceReady = createMemo(() => {
-    if (scheduledJobsSource() !== "remote") return true;
-    const client = options.openworkServerClient();
-    const runtimeWorkspaceId = (options.runtimeWorkspaceId() ?? "").trim();
-    const selectedWorkspaceId = options.selectedWorkspaceId().trim();
-    return (
-      options.openworkServerStatus() === "connected" &&
-      Boolean(client && runtimeWorkspaceId && runtimeWorkspaceId === selectedWorkspaceId)
-    );
-  });
-
   const scheduledJobsPollingAvailable = createMemo(() => {
-    if (scheduledJobsSource() === "remote") return scheduledJobsSourceReady();
+    if (scheduledJobsSource() === "remote") return true;
     return isTauriRuntime() && options.schedulerPluginInstalled();
   });
 
@@ -149,9 +143,7 @@ export function createAutomationsStore(options: {
 
   createEffect(() => {
     const key = scheduledJobsContextKey();
-    const ready = scheduledJobsSourceReady();
     if (!key) return;
-    if (scheduledJobsSource() === "remote" && !ready) return;
     if (scheduledJobsBusy()) return;
     if (scheduledJobsUpdatedAt()) return;
     void refreshScheduledJobs();
@@ -175,7 +167,6 @@ export function createAutomationsStore(options: {
     scheduledJobsBusy,
     scheduledJobsUpdatedAt,
     scheduledJobsSource,
-    scheduledJobsSourceReady,
     scheduledJobsPollingAvailable,
     scheduledJobsContextKey,
     refreshScheduledJobs,

--- a/apps/app/src/app/context/sidebar-sessions.ts
+++ b/apps/app/src/app/context/sidebar-sessions.ts
@@ -176,12 +176,6 @@ export function createSidebarSessionsStore(options: {
     }
   };
 
-  const refreshAllWorkspaceSessions = async () => {
-    const list = options.workspaces();
-    if (!list.length) return;
-    await Promise.allSettled(list.map((workspace) => refreshWorkspaceSessions(workspace.id)));
-  };
-
   const prependSession = (workspaceId: string, item: SidebarSessionItem) => {
     const id = workspaceId.trim();
     if (!id) return;
@@ -206,32 +200,33 @@ export function createSidebarSessionsStore(options: {
     }));
   };
 
-  let lastEngineKey = "";
-  let lastWorkspaceKey = "";
+  let lastFingerprintByWorkspaceId: Record<string, string> = {};
   createEffect(() => {
     const engineInfo = options.engine();
     const engineBaseUrl = engineInfo?.baseUrl?.trim() ?? "";
     const engineUser = engineInfo?.opencodeUsername?.trim() ?? "";
     const enginePass = engineInfo?.opencodePassword?.trim() ?? "";
-    const engineKey = [engineBaseUrl, engineUser, enginePass].join("::");
-    const workspaceKey = options
-      .workspaces()
-      .map((workspace) => {
-        const root = workspace.workspaceType === "local" ? workspace.path?.trim() ?? "" : workspace.directory?.trim() ?? "";
-        const base = workspace.workspaceType === "local" ? "" : workspace.baseUrl?.trim() ?? "";
-        const remoteType = workspace.workspaceType === "remote" ? (workspace.remoteType ?? "") : "";
-        const token = workspace.remoteType === "openwork" ? (workspace.openworkToken?.trim() ?? "") : "";
-        return [workspace.id, workspace.workspaceType, remoteType, root, base, token].join("|");
-      })
-      .join(";");
+    const workspaces = options.workspaces();
+    const workspaceIds = new Set(workspaces.map((workspace) => workspace.id));
+    pruneState(workspaceIds);
 
-    if (engineKey === lastEngineKey && workspaceKey === lastWorkspaceKey) return;
+    const nextFingerprintByWorkspaceId: Record<string, string> = {};
+    for (const workspace of workspaces) {
+      const root = workspace.workspaceType === "local" ? workspace.path?.trim() ?? "" : workspace.directory?.trim() ?? "";
+      const base = workspace.workspaceType === "local" ? engineBaseUrl : workspace.baseUrl?.trim() ?? "";
+      const remoteType = workspace.workspaceType === "remote" ? (workspace.remoteType ?? "") : "";
+      const token = workspace.remoteType === "openwork" ? (workspace.openworkToken?.trim() ?? "") : "";
+      const authKey = workspace.workspaceType === "local" ? `${engineUser}:${enginePass}` : token;
+      nextFingerprintByWorkspaceId[workspace.id] = [workspace.workspaceType, remoteType, root, base, authKey].join("|");
+    }
 
-    lastEngineKey = engineKey;
-    lastWorkspaceKey = workspaceKey;
+    for (const workspace of workspaces) {
+      const nextFingerprint = nextFingerprintByWorkspaceId[workspace.id];
+      if (lastFingerprintByWorkspaceId[workspace.id] === nextFingerprint) continue;
+      void refreshWorkspaceSessions(workspace.id).catch(() => undefined);
+    }
 
-    pruneState(new Set(options.workspaces().map((workspace) => workspace.id)));
-    void refreshAllWorkspaceSessions().catch(() => undefined);
+    lastFingerprintByWorkspaceId = nextFingerprintByWorkspaceId;
   });
 
   const workspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
@@ -250,7 +245,6 @@ export function createSidebarSessionsStore(options: {
   return {
     workspaceGroups,
     refreshWorkspaceSessions,
-    refreshAllWorkspaceSessions,
     prependSession,
     removeSession,
   };

--- a/apps/app/src/app/context/sidebar-sessions.ts
+++ b/apps/app/src/app/context/sidebar-sessions.ts
@@ -1,0 +1,257 @@
+import { createEffect, createMemo, createSignal } from "solid-js";
+
+import type { Session } from "@opencode-ai/sdk/v2/client";
+
+import { createClient, type OpencodeAuth, unwrap } from "../lib/opencode";
+import type { WorkspaceInfo, EngineInfo } from "../lib/tauri";
+import type { SidebarSessionItem, WorkspaceSessionGroup } from "../types";
+import {
+  normalizeDirectoryPath,
+  normalizeDirectoryQueryPath,
+  safeStringify,
+} from "../utils";
+import { toSessionTransportDirectory } from "../lib/session-scope";
+
+const sessionActivity = (session: Session) =>
+  session.time?.updated ?? session.time?.created ?? 0;
+
+const sortSessionsByActivity = (list: Session[]) =>
+  list
+    .slice()
+    .sort((a, b) => {
+      const delta = sessionActivity(b) - sessionActivity(a);
+      if (delta !== 0) return delta;
+      return a.id.localeCompare(b.id);
+    });
+
+type SidebarWorkspaceSessionsStatus = WorkspaceSessionGroup["status"];
+
+export function createSidebarSessionsStore(options: {
+  workspaces: () => WorkspaceInfo[];
+  engine: () => EngineInfo | null;
+}) {
+  const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = createSignal<
+    Record<string, SidebarSessionItem[]>
+  >({});
+  const [statusByWorkspaceId, setStatusByWorkspaceId] = createSignal<
+    Record<string, SidebarWorkspaceSessionsStatus>
+  >({});
+  const [errorByWorkspaceId, setErrorByWorkspaceId] = createSignal<Record<string, string | null>>({});
+
+  const pruneState = (workspaceIds: Set<string>) => {
+    setSessionsByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, SidebarSessionItem[]> = {};
+      for (const [id, list] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = list;
+      }
+      return changed ? next : prev;
+    });
+    setStatusByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, SidebarWorkspaceSessionsStatus> = {};
+      for (const [id, status] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = status;
+      }
+      return changed ? next : prev;
+    });
+    setErrorByWorkspaceId((prev) => {
+      let changed = false;
+      const next: Record<string, string | null> = {};
+      for (const [id, error] of Object.entries(prev)) {
+        if (!workspaceIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = error;
+      }
+      return changed ? next : prev;
+    });
+  };
+
+  const resolveClientConfig = (workspaceId: string) => {
+    const workspace = options.workspaces().find((entry) => entry.id === workspaceId) ?? null;
+    if (!workspace) return null;
+
+    if (workspace.workspaceType === "local") {
+      const info = options.engine();
+      const baseUrl = info?.baseUrl?.trim() ?? "";
+      const directory = toSessionTransportDirectory(workspace.path?.trim() ?? "");
+      const username = info?.opencodeUsername?.trim() ?? "";
+      const password = info?.opencodePassword?.trim() ?? "";
+      const auth: OpencodeAuth | undefined = username && password ? { username, password } : undefined;
+      return { baseUrl, directory, auth };
+    }
+
+    const baseUrl = workspace.baseUrl?.trim() ?? "";
+    const directory = workspace.directory?.trim() ?? "";
+    if (workspace.remoteType === "openwork") {
+      const token = workspace.openworkToken?.trim() ?? "";
+      const auth: OpencodeAuth | undefined = token ? { token, mode: "openwork" } : undefined;
+      return { baseUrl, directory, auth };
+    }
+
+    return {
+      baseUrl,
+      directory,
+      auth: undefined as OpencodeAuth | undefined,
+    };
+  };
+
+  const refreshSeqByWorkspaceId: Record<string, number> = {};
+  const SIDEBAR_SESSION_LIMIT = 200;
+
+  const refreshWorkspaceSessions = async (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+
+    const config = resolveClientConfig(id);
+    if (!config) return;
+
+    if (!config.baseUrl) {
+      setStatusByWorkspaceId((prev) => (prev[id] === "idle" ? prev : { ...prev, [id]: "idle" }));
+      setErrorByWorkspaceId((prev) => ((prev[id] ?? null) === null ? prev : { ...prev, [id]: null }));
+      return;
+    }
+
+    refreshSeqByWorkspaceId[id] = (refreshSeqByWorkspaceId[id] ?? 0) + 1;
+    const seq = refreshSeqByWorkspaceId[id];
+
+    setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "loading" }));
+    setErrorByWorkspaceId((prev) => ({ ...prev, [id]: null }));
+
+    try {
+      let directory = config.directory;
+      let client = createClient(config.baseUrl, directory || undefined, config.auth);
+
+      if (!directory) {
+        try {
+          const pathInfo = unwrap(await client.path.get());
+          const discovered = toSessionTransportDirectory(pathInfo.directory ?? "");
+          if (discovered) {
+            directory = discovered;
+            client = createClient(config.baseUrl, directory, config.auth);
+          }
+        } catch {
+          // Ignore discovery failures and continue with the configured directory.
+        }
+      }
+
+      const queryDirectory = normalizeDirectoryQueryPath(directory) || undefined;
+      const list = unwrap(
+        await client.session.list({ directory: queryDirectory, roots: false, limit: SIDEBAR_SESSION_LIMIT }),
+      );
+      if (refreshSeqByWorkspaceId[id] !== seq) return;
+
+      const root = normalizeDirectoryPath(directory);
+      const filtered = root ? list.filter((session) => normalizeDirectoryPath(session.directory) === root) : list;
+      const sorted = sortSessionsByActivity(filtered);
+      const items: SidebarSessionItem[] = sorted.map((session) => ({
+        id: session.id,
+        title: session.title,
+        slug: session.slug,
+        parentID: session.parentID,
+        time: session.time,
+        directory: session.directory,
+      }));
+
+      setSessionsByWorkspaceId((prev) => ({
+        ...prev,
+        [id]: items,
+      }));
+      setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
+    } catch (error) {
+      if (refreshSeqByWorkspaceId[id] !== seq) return;
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "error" }));
+      setErrorByWorkspaceId((prev) => ({ ...prev, [id]: message }));
+    }
+  };
+
+  const refreshAllWorkspaceSessions = async () => {
+    const list = options.workspaces();
+    if (!list.length) return;
+    await Promise.allSettled(list.map((workspace) => refreshWorkspaceSessions(workspace.id)));
+  };
+
+  const prependSession = (workspaceId: string, item: SidebarSessionItem) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setSessionsByWorkspaceId((prev) => {
+      const current = prev[id] ?? [];
+      const deduped = current.filter((entry) => entry.id !== item.id);
+      return {
+        ...prev,
+        [id]: [item, ...deduped],
+      };
+    });
+    setStatusByWorkspaceId((prev) => ({ ...prev, [id]: "ready" }));
+  };
+
+  const removeSession = (workspaceId: string, sessionId: string) => {
+    const id = workspaceId.trim();
+    const target = sessionId.trim();
+    if (!id || !target) return;
+    setSessionsByWorkspaceId((prev) => ({
+      ...prev,
+      [id]: (prev[id] ?? []).filter((entry) => entry.id !== target),
+    }));
+  };
+
+  let lastEngineKey = "";
+  let lastWorkspaceKey = "";
+  createEffect(() => {
+    const engineInfo = options.engine();
+    const engineBaseUrl = engineInfo?.baseUrl?.trim() ?? "";
+    const engineUser = engineInfo?.opencodeUsername?.trim() ?? "";
+    const enginePass = engineInfo?.opencodePassword?.trim() ?? "";
+    const engineKey = [engineBaseUrl, engineUser, enginePass].join("::");
+    const workspaceKey = options
+      .workspaces()
+      .map((workspace) => {
+        const root = workspace.workspaceType === "local" ? workspace.path?.trim() ?? "" : workspace.directory?.trim() ?? "";
+        const base = workspace.workspaceType === "local" ? "" : workspace.baseUrl?.trim() ?? "";
+        const remoteType = workspace.workspaceType === "remote" ? (workspace.remoteType ?? "") : "";
+        const token = workspace.remoteType === "openwork" ? (workspace.openworkToken?.trim() ?? "") : "";
+        return [workspace.id, workspace.workspaceType, remoteType, root, base, token].join("|");
+      })
+      .join(";");
+
+    if (engineKey === lastEngineKey && workspaceKey === lastWorkspaceKey) return;
+
+    lastEngineKey = engineKey;
+    lastWorkspaceKey = workspaceKey;
+
+    pruneState(new Set(options.workspaces().map((workspace) => workspace.id)));
+    void refreshAllWorkspaceSessions().catch(() => undefined);
+  });
+
+  const workspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
+    const workspaces = options.workspaces();
+    const sessions = sessionsByWorkspaceId();
+    const statuses = statusByWorkspaceId();
+    const errors = errorByWorkspaceId();
+    return workspaces.map((workspace) => ({
+      workspace,
+      sessions: sessions[workspace.id] ?? [],
+      status: statuses[workspace.id] ?? "idle",
+      error: errors[workspace.id] ?? null,
+    }));
+  });
+
+  return {
+    workspaceGroups,
+    refreshWorkspaceSessions,
+    refreshAllWorkspaceSessions,
+    prependSession,
+    removeSession,
+  };
+}

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -177,7 +177,6 @@ export type DashboardViewProps = {
   stopSandbox: (workspaceId: string) => void;
   scheduledJobs: ScheduledJob[];
   scheduledJobsSource: "local" | "remote";
-  scheduledJobsSourceReady: boolean;
   schedulerPluginInstalled: boolean;
   scheduledJobsStatus: string | null;
   scheduledJobsBusy: boolean;
@@ -1315,13 +1314,11 @@ export default function DashboardView(props: DashboardViewProps) {
                 scheduled={{
                   jobs: props.scheduledJobs,
                   source: props.scheduledJobsSource,
-                  sourceReady: props.scheduledJobsSourceReady,
                   status: props.scheduledJobsStatus,
                   busy: props.scheduledJobsBusy,
                   lastUpdatedAt: props.scheduledJobsUpdatedAt,
                   refreshJobs: props.refreshScheduledJobs,
                   deleteJob: props.deleteScheduledJob,
-                  isWindows: props.isWindows,
                   selectedWorkspaceRoot: props.selectedWorkspaceRoot,
                   createSessionAndOpen: props.createSessionAndOpen,
                   setPrompt: props.setPrompt,
@@ -1573,7 +1570,6 @@ export default function DashboardView(props: DashboardViewProps) {
                   openDebugDeepLink={props.openDebugDeepLink}
                   scheduledJobs={props.scheduledJobs}
                   scheduledJobsSource={props.scheduledJobsSource}
-                  scheduledJobsSourceReady={props.scheduledJobsSourceReady}
                   scheduledJobsStatus={props.scheduledJobsStatus}
                   scheduledJobsBusy={props.scheduledJobsBusy}
                   scheduledJobsUpdatedAt={props.scheduledJobsUpdatedAt}

--- a/apps/app/src/app/pages/scheduled.tsx
+++ b/apps/app/src/app/pages/scheduled.tsx
@@ -26,13 +26,11 @@ import {
 export type ScheduledTasksViewProps = {
   jobs: ScheduledJob[];
   source: "local" | "remote";
-  sourceReady: boolean;
   status: string | null;
   busy: boolean;
   lastUpdatedAt: number | null;
   refreshJobs: (options?: { force?: boolean }) => void;
   deleteJob: (name: string) => Promise<void> | void;
-  isWindows: boolean;
   selectedWorkspaceRoot: string;
   createSessionAndOpen: () => void;
   setPrompt: (value: string) => void;
@@ -440,7 +438,7 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
   const [installingScheduler, setInstallingScheduler] = createSignal(false);
   const [schedulerInstallRequested, setSchedulerInstallRequested] = createSignal(false);
   const supported = createMemo(() => {
-    if (props.source === "remote") return props.sourceReady;
+    if (props.source === "remote") return true;
     return isTauriRuntime() && props.schedulerInstalled && !schedulerInstallRequested();
   });
   const schedulerGateActive = createMemo(() => {
@@ -452,7 +450,7 @@ export default function ScheduledTasksView(props: ScheduledTasksViewProps) {
   const automationDisabled = createMemo(() => props.newTaskDisabled || schedulerGateActive());
   const supportNote = createMemo(() => {
     if (props.source === "remote") {
-      return props.sourceReady ? null : "OpenWork server unavailable. Connect to sync scheduled tasks.";
+      return null;
     }
     if (!isTauriRuntime()) return "Scheduled tasks require the desktop app.";
     if (!props.schedulerInstalled || schedulerInstallRequested()) return null;

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -221,7 +221,6 @@ export type SettingsViewProps = {
   ) => Promise<{ ok: boolean; message: string }>;
   scheduledJobs: ScheduledJob[];
   scheduledJobsSource: "local" | "remote";
-  scheduledJobsSourceReady: boolean;
   scheduledJobsStatus: string | null;
   scheduledJobsBusy: boolean;
   scheduledJobsUpdatedAt: number | null;
@@ -2100,13 +2099,11 @@ export default function SettingsView(props: SettingsViewProps) {
               showHeader: false,
               jobs: props.scheduledJobs,
               source: props.scheduledJobsSource,
-              sourceReady: props.scheduledJobsSourceReady,
               status: props.scheduledJobsStatus,
               busy: props.scheduledJobsBusy,
               lastUpdatedAt: props.scheduledJobsUpdatedAt,
               refreshJobs: props.refreshScheduledJobs,
               deleteJob: props.deleteScheduledJob,
-              isWindows: props.isWindows,
               selectedWorkspaceRoot: props.selectedWorkspaceRoot,
               createSessionAndOpen: props.createSessionAndOpen,
               setPrompt: props.setPrompt,


### PR DESCRIPTION
## Summary
- move sidebar workspace session fetching/state out of `app.tsx` into a dedicated `sidebar-sessions` store
- refresh the selected workspace sidebar after workspace switches and make sidebar session reloads react per workspace fingerprint
- reduce app shell complexity while preserving the existing workspace session group UI

## Verification
- `pnpm --filter @openwork/app typecheck`