### PR TITLE
refactor(app-settings): isolate authorized folders panel

### DIFF
--- a/apps/app/src/app/app-settings/authorized-folders-panel.tsx
+++ b/apps/app/src/app/app-settings/authorized-folders-panel.tsx
@@ -1,0 +1,492 @@
+import {
+  For,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+} from "solid-js";
+
+import { Folder, FolderLock, FolderSearch, X } from "lucide-solid";
+
+import { currentLocale, t } from "../../i18n";
+import Button from "../components/button";
+import type {
+  OpenworkServerCapabilities,
+  OpenworkServerClient,
+  OpenworkServerStatus,
+} from "../lib/openwork-server";
+import { pickDirectory } from "../lib/tauri";
+import {
+  isTauriRuntime,
+  normalizeDirectoryQueryPath,
+  safeStringify,
+} from "../utils";
+
+type AuthorizedFoldersPanelProps = {
+  openworkServerClient: OpenworkServerClient | null;
+  openworkServerStatus: OpenworkServerStatus;
+  openworkServerCapabilities: OpenworkServerCapabilities | null;
+  runtimeWorkspaceId: string | null;
+  selectedWorkspaceRoot: string;
+  activeWorkspaceType: "local" | "remote";
+  onConfigUpdated: () => void;
+};
+
+const panelClass = "rounded-[28px] border border-dls-border bg-dls-surface p-5 md:p-6";
+const softPanelClass = "rounded-2xl border border-gray-6/60 bg-gray-1/40 p-4";
+
+const ensureRecord = (value: unknown): Record<string, unknown> => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+};
+
+const normalizeAuthorizedFolderPath = (input: string | null | undefined) => {
+  const trimmed = (input ?? "").trim();
+  if (!trimmed) return "";
+  const withoutWildcard = trimmed.replace(/[\\/]\*+$/, "");
+  return normalizeDirectoryQueryPath(withoutWildcard);
+};
+
+const authorizedFolderToExternalDirectoryKey = (folder: string) => {
+  const normalized = normalizeAuthorizedFolderPath(folder);
+  if (!normalized) return "";
+  return normalized === "/" ? "/*" : `${normalized}/*`;
+};
+
+const externalDirectoryKeyToAuthorizedFolder = (key: string, value: unknown) => {
+  if (value !== "allow") return null;
+  const trimmed = key.trim();
+  if (!trimmed) return null;
+  if (trimmed === "/*") return "/";
+  if (!trimmed.endsWith("/*")) return null;
+  return normalizeAuthorizedFolderPath(trimmed.slice(0, -2));
+};
+
+const readAuthorizedFoldersFromConfig = (opencodeConfig: Record<string, unknown>) => {
+  const permission = ensureRecord(opencodeConfig.permission);
+  const externalDirectory = ensureRecord(permission.external_directory);
+  const folders: string[] = [];
+  const hiddenEntries: Record<string, unknown> = {};
+  const seen = new Set<string>();
+
+  for (const [key, value] of Object.entries(externalDirectory)) {
+    const folder = externalDirectoryKeyToAuthorizedFolder(key, value);
+    if (!folder) {
+      hiddenEntries[key] = value;
+      continue;
+    }
+    if (seen.has(folder)) continue;
+    seen.add(folder);
+    folders.push(folder);
+  }
+
+  return { folders, hiddenEntries };
+};
+
+const buildAuthorizedFoldersStatus = (preservedCount: number, action?: string) => {
+  const preservedLabel =
+    preservedCount > 0
+      ? `Preserving ${preservedCount} non-folder permission ${preservedCount === 1 ? "entry" : "entries"}.`
+      : null;
+  if (action && preservedLabel) return `${action} ${preservedLabel}`;
+  return action ?? preservedLabel;
+};
+
+const mergeAuthorizedFoldersIntoExternalDirectory = (
+  folders: string[],
+  hiddenEntries: Record<string, unknown>,
+): Record<string, unknown> | undefined => {
+  const next: Record<string, unknown> = { ...hiddenEntries };
+  for (const folder of folders) {
+    const key = authorizedFolderToExternalDirectoryKey(folder);
+    if (!key) continue;
+    next[key] = "allow";
+  }
+  return Object.keys(next).length ? next : undefined;
+};
+
+export default function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
+  const [authorizedFolders, setAuthorizedFolders] = createSignal<string[]>([]);
+  const [authorizedFolderDraft, setAuthorizedFolderDraft] = createSignal("");
+  const [authorizedFoldersLoading, setAuthorizedFoldersLoading] = createSignal(false);
+  const [authorizedFoldersSaving, setAuthorizedFoldersSaving] = createSignal(false);
+  const [authorizedFoldersStatus, setAuthorizedFoldersStatus] = createSignal<string | null>(null);
+  const [authorizedFoldersError, setAuthorizedFoldersError] = createSignal<string | null>(null);
+
+  const openworkServerReady = createMemo(
+    () => props.openworkServerStatus === "connected",
+  );
+  const openworkServerWorkspaceReady = createMemo(
+    () => Boolean(props.runtimeWorkspaceId),
+  );
+  const canReadConfig = createMemo(
+    () =>
+      openworkServerReady() &&
+      openworkServerWorkspaceReady() &&
+      (props.openworkServerCapabilities?.config?.read ?? false),
+  );
+  const canWriteConfig = createMemo(
+    () =>
+      openworkServerReady() &&
+      openworkServerWorkspaceReady() &&
+      (props.openworkServerCapabilities?.config?.write ?? false),
+  );
+  const authorizedFoldersHint = createMemo(() => {
+    if (!openworkServerReady()) return "OpenWork server is disconnected.";
+    if (!openworkServerWorkspaceReady()) return "No active server workspace is selected.";
+    if (!canReadConfig()) {
+      return "OpenWork server config access is unavailable for this workspace.";
+    }
+    if (!canWriteConfig()) {
+      return "OpenWork server is connected read-only for workspace config.";
+    }
+    return null;
+  });
+  const canPickAuthorizedFolder = createMemo(
+    () => isTauriRuntime() && canWriteConfig() && props.activeWorkspaceType === "local",
+  );
+  const workspaceRootFolder = createMemo(() => props.selectedWorkspaceRoot.trim());
+  const visibleAuthorizedFolders = createMemo(() => {
+    const root = workspaceRootFolder();
+    return root ? [root, ...authorizedFolders()] : authorizedFolders();
+  });
+
+  createEffect(() => {
+    const openworkClient = props.openworkServerClient;
+    const openworkWorkspaceId = props.runtimeWorkspaceId;
+    const readable = canReadConfig();
+
+    if (!openworkClient || !openworkWorkspaceId || !readable) {
+      setAuthorizedFolders([]);
+      setAuthorizedFolderDraft("");
+      setAuthorizedFoldersLoading(false);
+      setAuthorizedFoldersSaving(false);
+      setAuthorizedFoldersStatus(null);
+      setAuthorizedFoldersError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setAuthorizedFolderDraft("");
+    setAuthorizedFoldersLoading(true);
+    setAuthorizedFoldersError(null);
+    setAuthorizedFoldersStatus(null);
+
+    const loadAuthorizedFolders = async () => {
+      try {
+        const config = await openworkClient.getConfig(openworkWorkspaceId);
+        if (cancelled) return;
+        const next = readAuthorizedFoldersFromConfig(ensureRecord(config.opencode));
+        setAuthorizedFolders(next.folders);
+        setAuthorizedFoldersStatus(
+          buildAuthorizedFoldersStatus(Object.keys(next.hiddenEntries).length),
+        );
+      } catch (error) {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : safeStringify(error);
+        setAuthorizedFolders([]);
+        setAuthorizedFoldersError(message);
+      } finally {
+        if (!cancelled) {
+          setAuthorizedFoldersLoading(false);
+        }
+      }
+    };
+
+    void loadAuthorizedFolders();
+
+    onCleanup(() => {
+      cancelled = true;
+    });
+  });
+
+  const persistAuthorizedFolders = async (nextFolders: string[]) => {
+    const openworkClient = props.openworkServerClient;
+    const openworkWorkspaceId = props.runtimeWorkspaceId;
+    if (!openworkClient || !openworkWorkspaceId || !canWriteConfig()) {
+      setAuthorizedFoldersError(
+        "A writable OpenWork server workspace is required to update authorized folders.",
+      );
+      return false;
+    }
+
+    setAuthorizedFoldersSaving(true);
+    setAuthorizedFoldersError(null);
+    setAuthorizedFoldersStatus("Saving authorized folders...");
+
+    try {
+      const currentConfig = await openworkClient.getConfig(openworkWorkspaceId);
+      const currentAuthorizedFolders = readAuthorizedFoldersFromConfig(
+        ensureRecord(currentConfig.opencode),
+      );
+      const nextExternalDirectory = mergeAuthorizedFoldersIntoExternalDirectory(
+        nextFolders,
+        currentAuthorizedFolders.hiddenEntries,
+      );
+
+      await openworkClient.patchConfig(openworkWorkspaceId, {
+        opencode: {
+          permission: {
+            external_directory: nextExternalDirectory,
+          },
+        },
+      });
+      setAuthorizedFolders(nextFolders);
+      setAuthorizedFoldersStatus(
+        buildAuthorizedFoldersStatus(
+          Object.keys(currentAuthorizedFolders.hiddenEntries).length,
+          "Authorized folders updated.",
+        ),
+      );
+      props.onConfigUpdated();
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setAuthorizedFoldersError(message);
+      setAuthorizedFoldersStatus(null);
+      return false;
+    } finally {
+      setAuthorizedFoldersSaving(false);
+    }
+  };
+
+  const addAuthorizedFolder = async () => {
+    const normalized = normalizeAuthorizedFolderPath(authorizedFolderDraft());
+    const workspaceRoot = normalizeAuthorizedFolderPath(workspaceRootFolder());
+    if (!normalized) return;
+    if (workspaceRoot && normalized === workspaceRoot) {
+      setAuthorizedFolderDraft("");
+      setAuthorizedFoldersStatus("Workspace root is already available.");
+      setAuthorizedFoldersError(null);
+      return;
+    }
+    if (authorizedFolders().includes(normalized)) {
+      setAuthorizedFolderDraft("");
+      setAuthorizedFoldersStatus("Folder is already authorized.");
+      setAuthorizedFoldersError(null);
+      return;
+    }
+
+    const ok = await persistAuthorizedFolders([...authorizedFolders(), normalized]);
+    if (ok) {
+      setAuthorizedFolderDraft("");
+    }
+  };
+
+  const removeAuthorizedFolder = async (folder: string) => {
+    const nextFolders = authorizedFolders().filter((entry) => entry !== folder);
+    await persistAuthorizedFolders(nextFolders);
+  };
+
+  const pickAuthorizedFolder = async () => {
+    if (!isTauriRuntime()) return;
+    try {
+      const selection = await pickDirectory({
+        title: t("onboarding.authorize_folder", currentLocale()),
+      });
+      const folder =
+        typeof selection === "string"
+          ? selection
+          : Array.isArray(selection)
+            ? selection[0]
+            : null;
+      const normalized = normalizeAuthorizedFolderPath(folder);
+      const workspaceRoot = normalizeAuthorizedFolderPath(workspaceRootFolder());
+      if (!normalized) return;
+      setAuthorizedFolderDraft(normalized);
+      if (workspaceRoot && normalized === workspaceRoot) {
+        setAuthorizedFolderDraft("");
+        setAuthorizedFoldersStatus("Workspace root is already available.");
+        setAuthorizedFoldersError(null);
+        return;
+      }
+      if (authorizedFolders().includes(normalized)) {
+        setAuthorizedFoldersStatus("Folder is already authorized.");
+        setAuthorizedFoldersError(null);
+        return;
+      }
+      const ok = await persistAuthorizedFolders([...authorizedFolders(), normalized]);
+      if (ok) {
+        setAuthorizedFolderDraft("");
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      setAuthorizedFoldersError(message);
+    }
+  };
+
+  return (
+    <div class={`${panelClass} space-y-4`}>
+      <div class="space-y-1">
+        <div class="flex items-center gap-2 text-sm font-semibold text-gray-12">
+          <FolderLock size={16} class="text-gray-10" />
+          Authorized folders
+        </div>
+        <div class="text-xs text-gray-9 leading-relaxed max-w-[65ch]">
+          Grant this workspace access to read and edit files in directories outside of its root.
+        </div>
+      </div>
+
+      <Show
+        when={canReadConfig()}
+        fallback={
+          <div class={`${softPanelClass} px-3 py-3 text-xs text-gray-10`}>
+            {authorizedFoldersHint() ??
+              "Connect to a writable OpenWork server workspace to edit authorized folders."}
+          </div>
+        }
+      >
+        <div class="flex flex-col overflow-hidden rounded-xl border border-gray-5/60 bg-gray-1/50 shadow-sm">
+          <Show when={authorizedFoldersHint()}>
+            {(hint) => (
+              <div class="bg-gray-2/60 px-3 py-2 text-[11px] text-gray-10 border-b border-gray-5/40">
+                {hint()}
+              </div>
+            )}
+          </Show>
+
+          <Show
+            when={visibleAuthorizedFolders().length > 0}
+            fallback={
+              <div class="flex flex-col items-center justify-center p-6 text-center">
+                <div class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-3/30 text-blue-11 mb-3">
+                  <Folder size={20} />
+                </div>
+                <div class="text-sm font-medium text-gray-11">No external folders authorized</div>
+                <div class="text-[11px] text-gray-9 mt-1 max-w-[40ch]">
+                  Add a folder to let this workspace read and edit files outside its root directory.
+                </div>
+              </div>
+            }
+          >
+            <div class="flex flex-col divide-y divide-gray-5/40 max-h-[300px] overflow-y-auto">
+              <For each={visibleAuthorizedFolders()}>
+                {(folder) => {
+                  const isWorkspaceRoot = folder === workspaceRootFolder();
+                  const folderName = folder.split(/[\/\\]/).filter(Boolean).pop() || folder;
+                  return (
+                    <div
+                      class={`flex items-center justify-between px-3 py-2.5 transition-colors ${
+                        isWorkspaceRoot ? "bg-blue-2/20" : "hover:bg-gray-2/50"
+                      }`}
+                    >
+                      <div class="flex items-center gap-3 overflow-hidden">
+                        <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-3/30 text-blue-11">
+                          <Folder size={15} />
+                        </div>
+                        <div class="flex min-w-0 flex-col">
+                          <div class="flex items-center gap-2">
+                            <span class="truncate text-sm font-medium text-gray-12">{folderName}</span>
+                            <Show when={isWorkspaceRoot}>
+                              <span class="rounded-full border border-blue-7/30 bg-blue-3/25 px-2 py-0.5 text-[10px] font-medium text-blue-11">
+                                Workspace root
+                              </span>
+                            </Show>
+                          </div>
+                          <span class="truncate font-mono text-[10px] text-gray-8">{folder}</span>
+                        </div>
+                      </div>
+                      <Show
+                        when={!isWorkspaceRoot}
+                        fallback={
+                          <span class="shrink-0 text-[10px] font-medium text-gray-8">
+                            Always available
+                          </span>
+                        }
+                      >
+                        <Button
+                          variant="ghost"
+                          class="h-6 w-6 shrink-0 !rounded-full !p-0 border-0 bg-transparent text-red-10 shadow-none hover:bg-red-3/15 hover:text-red-11 focus:ring-red-7/25"
+                          onClick={() => void removeAuthorizedFolder(folder)}
+                          disabled={
+                            authorizedFoldersLoading() ||
+                            authorizedFoldersSaving() ||
+                            !canWriteConfig()
+                          }
+                          aria-label={`Remove ${folderName}`}
+                        >
+                          <X size={16} class="text-current" />
+                        </Button>
+                      </Show>
+                    </div>
+                  );
+                }}
+              </For>
+            </div>
+          </Show>
+
+          <Show when={authorizedFoldersStatus()}>
+            {(status) => (
+              <div class="bg-blue-2/30 px-3 py-2 text-[11px] text-blue-11 border-t border-gray-5/40">
+                {status()}
+              </div>
+            )}
+          </Show>
+          <Show when={authorizedFoldersError()}>
+            {(error) => (
+              <div class="bg-red-2/30 px-3 py-2 text-[11px] text-red-11 border-t border-gray-5/40">
+                {error()}
+              </div>
+            )}
+          </Show>
+
+          <form
+            class="flex items-center gap-2 bg-gray-2/60 border-t border-gray-5/60 p-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void addAuthorizedFolder();
+            }}
+          >
+            <div class="relative flex-1">
+              <input
+                class="w-full rounded-lg border border-gray-5/60 bg-gray-1 px-3 py-1.5 text-xs text-gray-12 placeholder:text-gray-8 focus:outline-none focus:ring-2 focus:ring-blue-7/30 disabled:opacity-50"
+                value={authorizedFolderDraft()}
+                onInput={(event) => setAuthorizedFolderDraft(event.currentTarget.value)}
+                onPaste={(event) => {
+                  event.preventDefault();
+                }}
+                placeholder="Type a folder path to authorize..."
+                disabled={
+                  authorizedFoldersLoading() ||
+                  authorizedFoldersSaving() ||
+                  !canWriteConfig()
+                }
+              />
+            </div>
+
+            <Show when={canPickAuthorizedFolder()}>
+              <Button
+                type="button"
+                variant="outline"
+                class="h-8 px-3 text-xs bg-gray-1 hover:bg-gray-2"
+                onClick={() => void pickAuthorizedFolder()}
+                disabled={
+                  authorizedFoldersLoading() ||
+                  authorizedFoldersSaving() ||
+                  !canWriteConfig()
+                }
+              >
+                <FolderSearch size={13} class="mr-1.5" /> Browse
+              </Button>
+            </Show>
+
+            <Button
+              type="submit"
+              variant="primary"
+              class="h-8 px-3 text-xs bg-gray-3 text-gray-12 hover:bg-gray-4 border border-gray-5/60"
+              disabled={
+                authorizedFoldersLoading() ||
+                authorizedFoldersSaving() ||
+                !canWriteConfig() ||
+                !authorizedFolderDraft().trim()
+              }
+            >
+              {authorizedFoldersSaving() ? "Adding..." : "Add"}
+            </Button>
+          </form>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -172,7 +172,6 @@ import {
   openworkServerInfo,
   orchestratorStatus,
   opencodeRouterInfo,
-  pickDirectory,
   setWindowDecorations,
   type OrchestratorStatus,
   type OpenworkServerInfo,
@@ -2055,70 +2054,6 @@ export default function App() {
     return typeof compaction.auto === "boolean" ? compaction.auto : null;
   };
 
-  const normalizeAuthorizedFolderPath = (input: string | null | undefined) => {
-    const trimmed = (input ?? "").trim();
-    if (!trimmed) return "";
-    const withoutWildcard = trimmed.replace(/[\\/]\*+$/, "");
-    return normalizeDirectoryQueryPath(withoutWildcard);
-  };
-
-  const authorizedFolderToExternalDirectoryKey = (folder: string) => {
-    const normalized = normalizeAuthorizedFolderPath(folder);
-    if (!normalized) return "";
-    return normalized === "/" ? "/*" : `${normalized}/*`;
-  };
-
-  const externalDirectoryKeyToAuthorizedFolder = (key: string, value: unknown) => {
-    if (value !== "allow") return null;
-    const trimmed = key.trim();
-    if (!trimmed) return null;
-    if (trimmed === "/*") return "/";
-    if (!trimmed.endsWith("/*")) return null;
-    return normalizeAuthorizedFolderPath(trimmed.slice(0, -2));
-  };
-
-  const readAuthorizedFoldersFromConfig = (opencodeConfig: Record<string, unknown>) => {
-    const permission = ensureRecord(opencodeConfig.permission);
-    const externalDirectory = ensureRecord(permission.external_directory);
-    const folders: string[] = [];
-    const hiddenEntries: Record<string, unknown> = {};
-    const seen = new Set<string>();
-
-    for (const [key, value] of Object.entries(externalDirectory)) {
-      const folder = externalDirectoryKeyToAuthorizedFolder(key, value);
-      if (!folder) {
-        hiddenEntries[key] = value;
-        continue;
-      }
-      if (seen.has(folder)) continue;
-      seen.add(folder);
-      folders.push(folder);
-    }
-
-    return { folders, hiddenEntries };
-  };
-
-  const buildAuthorizedFoldersStatus = (preservedCount: number, action?: string) => {
-    const preservedLabel =
-      preservedCount > 0
-        ? `Preserving ${preservedCount} non-folder permission ${preservedCount === 1 ? "entry" : "entries"}.`
-        : null;
-    if (action && preservedLabel) return `${action} ${preservedLabel}`;
-    return action ?? preservedLabel;
-  };
-
-  const mergeAuthorizedFoldersIntoExternalDirectory = (
-    folders: string[],
-    hiddenEntries: Record<string, unknown>,
-  ): Record<string, unknown> | undefined => {
-    const next: Record<string, unknown> = { ...hiddenEntries };
-    for (const folder of folders) {
-      const key = authorizedFolderToExternalDirectoryKey(folder);
-      if (!key) continue;
-      next[key] = "allow";
-    }
-    return Object.keys(next).length ? next : undefined;
-  };
   const [modelPickerOpen, setModelPickerOpen] = createSignal(false);
   const [modelPickerTarget, setModelPickerTarget] = createSignal<
     "session" | "default"
@@ -2147,14 +2082,6 @@ export default function App() {
     setAutoCompactContext((value) => !value);
     setAutoCompactContextDirty(true);
   };
-  const [authorizedFolders, setAuthorizedFolders] = createSignal<string[]>([]);
-  const [authorizedFolderDraft, setAuthorizedFolderDraft] = createSignal("");
-  const [, setAuthorizedFolderHiddenEntries] = createSignal<Record<string, unknown>>({});
-  const [authorizedFoldersLoading, setAuthorizedFoldersLoading] = createSignal(false);
-  const [authorizedFoldersSaving, setAuthorizedFoldersSaving] = createSignal(false);
-  const [authorizedFoldersStatus, setAuthorizedFoldersStatus] = createSignal<string | null>(null);
-  const [authorizedFoldersError, setAuthorizedFoldersError] = createSignal<string | null>(null);
-
   const resolveCodexReasoningEffort = (modelID: string, variant: string | null) => {
     if (!modelID.trim().toLowerCase().includes("codex")) return undefined;
     const normalized = normalizeModelBehaviorValue(variant);
@@ -2933,18 +2860,6 @@ export default function App() {
       openworkServerReady() &&
       openworkServerWorkspaceReady() &&
       (resolvedOpenworkCapabilities()?.plugins?.write ?? false),
-  );
-  const openworkServerCanReadConfig = createMemo(
-    () =>
-      openworkServerReady() &&
-      openworkServerWorkspaceReady() &&
-      (resolvedOpenworkCapabilities()?.config?.read ?? false),
-  );
-  const openworkServerCanWriteConfig = createMemo(
-    () =>
-      openworkServerReady() &&
-      openworkServerWorkspaceReady() &&
-      (resolvedOpenworkCapabilities()?.config?.write ?? false),
   );
   const devtoolsCapabilities = createMemo(() => openworkServerCapabilities());
 
@@ -5558,166 +5473,6 @@ export default function App() {
   });
 
   createEffect(() => {
-    const openworkClient = openworkServerClient();
-    const openworkWorkspaceId = runtimeWorkspaceId();
-    const canReadConfig = openworkServerCanReadConfig();
-
-    if (!openworkClient || !openworkWorkspaceId || !canReadConfig) {
-      setAuthorizedFolders([]);
-      setAuthorizedFolderDraft("");
-      setAuthorizedFolderHiddenEntries({});
-      setAuthorizedFoldersLoading(false);
-      setAuthorizedFoldersStatus(null);
-      setAuthorizedFoldersError(null);
-      return;
-    }
-
-    let cancelled = false;
-    setAuthorizedFolderDraft("");
-    setAuthorizedFoldersLoading(true);
-    setAuthorizedFoldersError(null);
-    setAuthorizedFoldersStatus(null);
-
-    const loadAuthorizedFolders = async () => {
-      try {
-        const config = await openworkClient.getConfig(openworkWorkspaceId);
-        if (cancelled) return;
-        const next = readAuthorizedFoldersFromConfig(ensureRecord(config.opencode));
-        setAuthorizedFolders(next.folders);
-        setAuthorizedFolderHiddenEntries(next.hiddenEntries);
-        setAuthorizedFoldersStatus(
-          buildAuthorizedFoldersStatus(Object.keys(next.hiddenEntries).length),
-        );
-      } catch (error) {
-        if (cancelled) return;
-        const message = error instanceof Error ? error.message : safeStringify(error);
-        setAuthorizedFolders([]);
-        setAuthorizedFolderHiddenEntries({});
-        setAuthorizedFoldersError(message);
-      } finally {
-        if (!cancelled) {
-          setAuthorizedFoldersLoading(false);
-        }
-      }
-    };
-
-    void loadAuthorizedFolders();
-
-    onCleanup(() => {
-      cancelled = true;
-    });
-  });
-
-  const persistAuthorizedFolders = async (nextFolders: string[]) => {
-    const openworkClient = openworkServerClient();
-    const openworkWorkspaceId = runtimeWorkspaceId();
-    if (!openworkClient || !openworkWorkspaceId || !openworkServerCanWriteConfig()) {
-      setAuthorizedFoldersError(
-        "A writable OpenWork server workspace is required to update authorized folders.",
-      );
-      return false;
-    }
-
-    setAuthorizedFoldersSaving(true);
-    setAuthorizedFoldersError(null);
-    setAuthorizedFoldersStatus("Saving authorized folders...");
-
-    try {
-      const currentConfig = await openworkClient.getConfig(openworkWorkspaceId);
-      const currentAuthorizedFolders = readAuthorizedFoldersFromConfig(
-        ensureRecord(currentConfig.opencode),
-      );
-      const nextExternalDirectory = mergeAuthorizedFoldersIntoExternalDirectory(
-        nextFolders,
-        currentAuthorizedFolders.hiddenEntries,
-      );
-
-      await openworkClient.patchConfig(openworkWorkspaceId, {
-        opencode: {
-          permission: {
-            external_directory: nextExternalDirectory,
-          },
-        },
-      });
-      setAuthorizedFolders(nextFolders);
-      setAuthorizedFolderHiddenEntries(currentAuthorizedFolders.hiddenEntries);
-      setAuthorizedFoldersStatus(
-        buildAuthorizedFoldersStatus(
-          Object.keys(currentAuthorizedFolders.hiddenEntries).length,
-          "Authorized folders updated.",
-        ),
-      );
-      markOpencodeConfigReloadRequired();
-      return true;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : safeStringify(error);
-      setAuthorizedFoldersError(message);
-      setAuthorizedFoldersStatus(null);
-      return false;
-    } finally {
-      setAuthorizedFoldersSaving(false);
-    }
-  };
-
-  const addAuthorizedFolder = async () => {
-    const normalized = normalizeAuthorizedFolderPath(authorizedFolderDraft());
-    const workspaceRoot = normalizeAuthorizedFolderPath(workspaceStore.selectedWorkspaceRoot().trim());
-    if (!normalized) return;
-    if (workspaceRoot && normalized === workspaceRoot) {
-      setAuthorizedFolderDraft("");
-      setAuthorizedFoldersStatus("Workspace root is already available.");
-      setAuthorizedFoldersError(null);
-      return;
-    }
-    if (authorizedFolders().includes(normalized)) {
-      setAuthorizedFolderDraft("");
-      setAuthorizedFoldersStatus("Folder is already authorized.");
-      setAuthorizedFoldersError(null);
-      return;
-    }
-
-    const ok = await persistAuthorizedFolders([...authorizedFolders(), normalized]);
-    if (ok) {
-      setAuthorizedFolderDraft("");
-    }
-  };
-
-  const removeAuthorizedFolder = async (folder: string) => {
-    const nextFolders = authorizedFolders().filter((entry) => entry !== folder);
-    await persistAuthorizedFolders(nextFolders);
-  };
-
-  const pickAuthorizedFolder = async () => {
-    if (!isTauriRuntime()) return;
-    try {
-      const selection = await pickDirectory({ title: t("onboarding.authorize_folder", currentLocale()) });
-      const folder = typeof selection === "string" ? selection : Array.isArray(selection) ? selection[0] : null;
-      const normalized = normalizeAuthorizedFolderPath(folder);
-      const workspaceRoot = normalizeAuthorizedFolderPath(workspaceStore.selectedWorkspaceRoot().trim());
-      if (!normalized) return;
-      setAuthorizedFolderDraft(normalized);
-      if (workspaceRoot && normalized === workspaceRoot) {
-        setAuthorizedFolderDraft("");
-        setAuthorizedFoldersStatus("Workspace root is already available.");
-        setAuthorizedFoldersError(null);
-        return;
-      }
-      if (authorizedFolders().includes(normalized)) {
-        setAuthorizedFoldersStatus("Folder is already authorized.");
-        setAuthorizedFoldersError(null);
-        return;
-      }
-      const ok = await persistAuthorizedFolders([...authorizedFolders(), normalized]);
-      if (ok) {
-        setAuthorizedFolderDraft("");
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : safeStringify(error);
-      setAuthorizedFoldersError(message);
-    }
-  };
-
-  createEffect(() => {
     if (typeof window === "undefined") return;
     const workspaceId = workspaceStore.selectedWorkspaceId();
     if (!workspaceId) return;
@@ -6539,27 +6294,7 @@ export default function App() {
       cleanupOpenworkDockerContainers,
       dockerCleanupBusy: dockerCleanupBusy(),
       dockerCleanupResult: dockerCleanupResult(),
-      authorizedFolders: authorizedFolders(),
-      authorizedFolderDraft: authorizedFolderDraft(),
-      setAuthorizedFolderDraft,
-      authorizedFoldersLoading: authorizedFoldersLoading(),
-      authorizedFoldersSaving: authorizedFoldersSaving(),
-      authorizedFoldersError: authorizedFoldersError(),
-      authorizedFoldersStatus: authorizedFoldersStatus(),
-      authorizedFoldersAvailable: openworkServerCanReadConfig(),
-      authorizedFoldersEditable: openworkServerCanWriteConfig(),
-      authorizedFoldersHint: !openworkServerReady()
-        ? "OpenWork server is disconnected."
-        : !openworkServerWorkspaceReady()
-          ? "No active server workspace is selected."
-          : !openworkServerCanReadConfig()
-            ? "OpenWork server config access is unavailable for this workspace."
-            : !openworkServerCanWriteConfig()
-              ? "OpenWork server is connected read-only for workspace config."
-              : null,
-      addAuthorizedFolder,
-      pickAuthorizedFolder,
-      removeAuthorizedFolder,
+      markOpencodeConfigReloadRequired,
       resetAppConfigDefaults,
       notionStatus: notionStatus(),
       notionStatusDetail: notionStatusDetail(),

--- a/apps/app/src/app/pages/dashboard.tsx
+++ b/apps/app/src/app/pages/dashboard.tsx
@@ -134,6 +134,7 @@ export type DashboardViewProps = {
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
   resetOpenworkServerSettings: () => void;
   testOpenworkServerConnection: (next: OpenworkServerSettings) => Promise<boolean>;
+  markOpencodeConfigReloadRequired: () => void;
   canReloadWorkspace: boolean;
   reloadWorkspaceEngine: () => Promise<void>;
   reloadBusy: boolean;
@@ -325,19 +326,6 @@ export type DashboardViewProps = {
   cleanupOpenworkDockerContainers: () => void;
   dockerCleanupBusy: boolean;
   dockerCleanupResult: string | null;
-  authorizedFolders: string[];
-  authorizedFolderDraft: string;
-  setAuthorizedFolderDraft: (value: string) => void;
-  authorizedFoldersLoading: boolean;
-  authorizedFoldersSaving: boolean;
-  authorizedFoldersError: string | null;
-  authorizedFoldersStatus: string | null;
-  authorizedFoldersAvailable: boolean;
-  authorizedFoldersEditable: boolean;
-  authorizedFoldersHint: string | null;
-  addAuthorizedFolder: () => Promise<void>;
-  pickAuthorizedFolder: () => Promise<void>;
-  removeAuthorizedFolder: (folder: string) => Promise<void>;
   resetAppConfigDefaults: () => Promise<{ ok: boolean; message: string }>;
   openDebugDeepLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
 };
@@ -1543,19 +1531,7 @@ export default function DashboardView(props: DashboardViewProps) {
                   cleanupOpenworkDockerContainers={props.cleanupOpenworkDockerContainers}
                   dockerCleanupBusy={props.dockerCleanupBusy}
                   dockerCleanupResult={props.dockerCleanupResult}
-                  authorizedFolders={props.authorizedFolders}
-                  authorizedFolderDraft={props.authorizedFolderDraft}
-                  setAuthorizedFolderDraft={props.setAuthorizedFolderDraft}
-                  authorizedFoldersLoading={props.authorizedFoldersLoading}
-                  authorizedFoldersSaving={props.authorizedFoldersSaving}
-                  authorizedFoldersError={props.authorizedFoldersError}
-                  authorizedFoldersStatus={props.authorizedFoldersStatus}
-                  authorizedFoldersAvailable={props.authorizedFoldersAvailable}
-                  authorizedFoldersEditable={props.authorizedFoldersEditable}
-                  authorizedFoldersHint={props.authorizedFoldersHint}
-                  addAuthorizedFolder={props.addAuthorizedFolder}
-                  pickAuthorizedFolder={props.pickAuthorizedFolder}
-                  removeAuthorizedFolder={props.removeAuthorizedFolder}
+                  markOpencodeConfigReloadRequired={props.markOpencodeConfigReloadRequired}
                   resetAppConfigDefaults={props.resetAppConfigDefaults}
                   openDebugDeepLink={props.openDebugDeepLink}
                   scheduledJobs={props.scheduledJobs}

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -16,6 +16,7 @@ import {
   isWindowsPlatform,
 } from "../utils";
 
+import AuthorizedFoldersPanel from "../app-settings/authorized-folders-panel";
 import Button from "../components/button";
 import ProviderIcon from "../components/provider-icon";
 import DenSettingsPanel from "../components/den-settings-panel";
@@ -32,9 +33,6 @@ import {
   Cpu,
   Download,
   FolderOpen,
-  FolderLock,
-  FolderSearch,
-  Folder,
   HardDrive,
   LifeBuoy,
   MessageCircle,
@@ -42,7 +40,6 @@ import {
   RefreshCcw,
   Server,
   Smartphone,
-  X,
   Zap,
 } from "lucide-solid";
 import type {
@@ -196,19 +193,7 @@ export type SettingsViewProps = {
   cleanupOpenworkDockerContainers: () => void;
   dockerCleanupBusy: boolean;
   dockerCleanupResult: string | null;
-  authorizedFolders: string[];
-  authorizedFolderDraft: string;
-  setAuthorizedFolderDraft: (value: string) => void;
-  authorizedFoldersLoading: boolean;
-  authorizedFoldersSaving: boolean;
-  authorizedFoldersError: string | null;
-  authorizedFoldersStatus: string | null;
-  authorizedFoldersAvailable: boolean;
-  authorizedFoldersEditable: boolean;
-  authorizedFoldersHint: string | null;
-  addAuthorizedFolder: () => Promise<void>;
-  pickAuthorizedFolder: () => Promise<void>;
-  removeAuthorizedFolder: (folder: string) => Promise<void>;
+  markOpencodeConfigReloadRequired: () => void;
   resetAppConfigDefaults: () => Promise<{ ok: boolean; message: string }>;
   engineDoctorVersion: string | null;
   openDebugDeepLink: (
@@ -327,14 +312,6 @@ export default function SettingsView(props: SettingsViewProps) {
   const translate = (key: string) => t(key, currentLocale());
   const engineCustomBinPathLabel = () =>
     props.engineCustomBinPath.trim() || "No binary selected.";
-  const canPickAuthorizedFolder = createMemo(
-    () => isTauriRuntime() && props.authorizedFoldersEditable && props.activeWorkspaceType === "local",
-  );
-  const workspaceRootFolder = createMemo(() => props.selectedWorkspaceRoot.trim());
-  const visibleAuthorizedFolders = createMemo(() => {
-    const root = workspaceRootFolder();
-    return root ? [root, ...props.authorizedFolders] : props.authorizedFolders;
-  });
 
   const openExternalLink = (url: string) => {
     const resolved = url.trim();
@@ -1532,177 +1509,15 @@ export default function SettingsView(props: SettingsViewProps) {
         <Switch>
         <Match when={activeTab() === "general"}>
           <div class="space-y-6">
-            <div class={`${settingsPanelClass} space-y-4`}>
-              <div class="space-y-1">
-                <div class="flex items-center gap-2 text-sm font-semibold text-gray-12">
-                    <FolderLock size={16} class="text-gray-10" />
-                    Authorized folders
-                  </div>
-                  <div class="text-xs text-gray-9 leading-relaxed max-w-[65ch]">
-                    Grant this workspace access to read and edit files in directories outside of its root.
-                  </div>
-                </div>
-
-                <Show
-                  when={props.authorizedFoldersAvailable}
-                  fallback={
-                    <div class={`${settingsPanelSoftClass} px-3 py-3 text-xs text-gray-10`}>
-                      {props.authorizedFoldersHint ??
-                        "Connect to a writable OpenWork server workspace to edit authorized folders."}
-                    </div>
-                  }
-                >
-                  <div class="flex flex-col overflow-hidden rounded-xl border border-gray-5/60 bg-gray-1/50 shadow-sm">
-                    <Show when={props.authorizedFoldersHint}>
-                      {(hint) => (
-                        <div class="bg-gray-2/60 px-3 py-2 text-[11px] text-gray-10 border-b border-gray-5/40">
-                          {hint()}
-                        </div>
-                      )}
-                    </Show>
-
-                    <Show
-                      when={visibleAuthorizedFolders().length > 0}
-                      fallback={
-                        <div class="flex flex-col items-center justify-center p-6 text-center">
-                          <div class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-3/30 text-blue-11 mb-3">
-                            <Folder size={20} />
-                          </div>
-                          <div class="text-sm font-medium text-gray-11">No external folders authorized</div>
-                          <div class="text-[11px] text-gray-9 mt-1 max-w-[40ch]">
-                            Add a folder to let this workspace read and edit files outside its root directory.
-                          </div>
-                        </div>
-                      }
-                    >
-                      <div class="flex flex-col divide-y divide-gray-5/40 max-h-[300px] overflow-y-auto">
-                        <For each={visibleAuthorizedFolders()}>
-                          {(folder) => {
-                            const isWorkspaceRoot = folder === workspaceRootFolder();
-                            const folderName = folder.split(/[/\\]/).filter(Boolean).pop() || folder;
-                            return (
-                              <div class={`flex items-center justify-between px-3 py-2.5 transition-colors ${
-                                isWorkspaceRoot ? "bg-blue-2/20" : "hover:bg-gray-2/50"
-                              }`}>
-                                <div class="flex items-center gap-3 overflow-hidden">
-                                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-3/30 text-blue-11">
-                                    <Folder size={15} />
-                                  </div>
-                                  <div class="flex min-w-0 flex-col">
-                                    <div class="flex items-center gap-2">
-                                      <span class="truncate text-sm font-medium text-gray-12">{folderName}</span>
-                                      <Show when={isWorkspaceRoot}>
-                                        <span class="rounded-full border border-blue-7/30 bg-blue-3/25 px-2 py-0.5 text-[10px] font-medium text-blue-11">
-                                          Workspace root
-                                        </span>
-                                      </Show>
-                                    </div>
-                                    <span class="truncate font-mono text-[10px] text-gray-8">{folder}</span>
-                                  </div>
-                                </div>
-                                <Show
-                                  when={!isWorkspaceRoot}
-                                  fallback={
-                                    <span class="shrink-0 text-[10px] font-medium text-gray-8">
-                                      Always available
-                                    </span>
-                                  }
-                                >
-                                  <Button
-                                    variant="ghost"
-                                    class="h-6 w-6 shrink-0 !rounded-full !p-0 border-0 bg-transparent text-red-10 shadow-none hover:bg-red-3/15 hover:text-red-11 focus:ring-red-7/25"
-                                    onClick={() => void props.removeAuthorizedFolder(folder)}
-                                    disabled={
-                                      props.authorizedFoldersLoading ||
-                                      props.authorizedFoldersSaving ||
-                                      !props.authorizedFoldersEditable
-                                    }
-                                    aria-label={`Remove ${folderName}`}
-                                  >
-                                    <X size={16} class="text-current" />
-                                  </Button>
-                                </Show>
-                              </div>
-                            );
-                          }}
-                        </For>
-                      </div>
-                    </Show>
-
-                    <Show when={props.authorizedFoldersStatus}>
-                      {(status) => (
-                        <div class="bg-blue-2/30 px-3 py-2 text-[11px] text-blue-11 border-t border-gray-5/40">
-                          {status()}
-                        </div>
-                      )}
-                    </Show>
-                    <Show when={props.authorizedFoldersError}>
-                      {(error) => (
-                        <div class="bg-red-2/30 px-3 py-2 text-[11px] text-red-11 border-t border-gray-5/40">
-                          {error()}
-                        </div>
-                      )}
-                    </Show>
-
-                    <form
-                      class="flex items-center gap-2 bg-gray-2/60 border-t border-gray-5/60 p-2"
-                      onSubmit={(event) => {
-                        event.preventDefault();
-                        void props.addAuthorizedFolder();
-                      }}
-                    >
-                      <div class="relative flex-1">
-                        <input
-                          class="w-full rounded-lg border border-gray-5/60 bg-gray-1 px-3 py-1.5 text-xs text-gray-12 placeholder:text-gray-8 focus:outline-none focus:ring-2 focus:ring-blue-7/30 disabled:opacity-50"
-                          value={props.authorizedFolderDraft}
-                          onInput={(event) =>
-                            props.setAuthorizedFolderDraft(event.currentTarget.value)
-                          }
-                          onPaste={(event) => {
-                            event.preventDefault();
-                          }}
-                          placeholder="Type a folder path to authorize..."
-                          disabled={
-                            props.authorizedFoldersLoading ||
-                            props.authorizedFoldersSaving ||
-                            !props.authorizedFoldersEditable
-                          }
-                        />
-                      </div>
-                      
-                      <Show when={canPickAuthorizedFolder()}>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          class="h-8 px-3 text-xs bg-gray-1 hover:bg-gray-2"
-                          onClick={() => void props.pickAuthorizedFolder()}
-                          disabled={
-                            props.authorizedFoldersLoading ||
-                            props.authorizedFoldersSaving ||
-                            !props.authorizedFoldersEditable
-                          }
-                        >
-                          <FolderSearch size={13} class="mr-1.5" /> Browse
-                        </Button>
-                      </Show>
-                      
-                      <Button
-                        type="submit"
-                        variant="primary"
-                        class="h-8 px-3 text-xs bg-gray-3 text-gray-12 hover:bg-gray-4 border border-gray-5/60"
-                        disabled={
-                          props.authorizedFoldersLoading ||
-                          props.authorizedFoldersSaving ||
-                          !props.authorizedFoldersEditable ||
-                          !props.authorizedFolderDraft.trim()
-                        }
-                      >
-                        {props.authorizedFoldersSaving ? "Adding..." : "Add"}
-                      </Button>
-                    </form>
-                  </div>
-                </Show>
-              </div>
+            <AuthorizedFoldersPanel
+              openworkServerClient={props.openworkServerClient}
+              openworkServerStatus={props.openworkServerStatus}
+              openworkServerCapabilities={props.openworkServerCapabilities}
+              runtimeWorkspaceId={props.runtimeWorkspaceId}
+              selectedWorkspaceRoot={props.selectedWorkspaceRoot}
+              activeWorkspaceType={props.activeWorkspaceType}
+              onConfigUpdated={props.markOpencodeConfigReloadRequired}
+            />
 
             <div class={`${settingsPanelClass} space-y-4`}>
               <div class="flex items-start justify-between gap-4">


### PR DESCRIPTION
Move the authorized-folder config flow into a dedicated settings owner so the app shell and dashboard stop carrying state they do not own while preserving the existing workspace/server behavior.

## Summary
-

## Why
-

## Issue
- Closes #

## Scope
-

## Out of scope
-

## Testing
### Ran
- `...`

### Result
- pass/fail:
- if fail, exact files/errors:

## CI status
- pass:
- code-related failures:
- external/env/auth blockers:

## Manual verification
1.
2.
3.

## Evidence
- video/screenshot link, or `N/A (docs-only)`

## Risk
-

## Rollback
-
