### PR TITLE
Remove dashboard concept from app shell

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -39,7 +39,7 @@ import ConnectionsModals from "./connections/modals";
 import { ConnectionsProvider } from "./connections/provider";
 import { ExtensionsProvider } from "./extensions/provider";
 import { AutomationsProvider } from "./automations/provider";
-import DashboardView from "./pages/dashboard";
+import SettingsShell from "./shell/settings-shell";
 import SessionView from "./pages/session";
 import { unwrap } from "./lib/opencode";
 import { createDenClient, writeDenSettings } from "./lib/den";
@@ -70,7 +70,6 @@ import {
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "./types";
 import type {
   Client,
-  DashboardTab,
   MessageWithParts,
   PlaceholderAssistantMessage,
   PlaceholderMessageInfo,
@@ -256,7 +255,7 @@ type SharedBundleImportChoice = {
 
 type SettingsReturnTarget = {
   view: View;
-  tab: DashboardTab;
+  tab: SettingsTab;
   sessionId: string | null;
 };
 
@@ -297,32 +296,31 @@ export default function App() {
   const currentView = createMemo<View>(() => {
     const path = location.pathname.toLowerCase();
     if (path.startsWith("/session")) return "session";
-    return "dashboard";
+    return "settings";
   });
 
-  const [tab, setTabState] = createSignal<DashboardTab>("scheduled");
-  const [settingsTab, setSettingsTab] = createSignal<SettingsTab>("general");
+  const [settingsTab, setSettingsTabState] = createSignal<SettingsTab>("general");
   const [pendingInitialSessionSelection, setPendingInitialSessionSelection] =
     createSignal<PendingInitialSessionSelection | null>(null);
 
-  const goToDashboard = (nextTab: DashboardTab, options?: { replace?: boolean }) => {
-    setTabState(nextTab);
-    navigate(`/dashboard/${nextTab}`, options);
+  const goToSettings = (nextTab: SettingsTab, options?: { replace?: boolean }) => {
+    setSettingsTabState(nextTab);
+    navigate(`/settings/${nextTab}`, options);
   };
 
-  const setTab = (nextTab: DashboardTab) => {
-    if (currentView() === "dashboard") {
-      goToDashboard(nextTab);
+  const setSettingsTab = (nextTab: SettingsTab) => {
+    if (currentView() === "settings") {
+      goToSettings(nextTab);
       return;
     }
-    setTabState(nextTab);
+    setSettingsTabState(nextTab);
   };
 
   const setView = (next: View, sessionId?: string) => {
-    if (next === "dashboard" && creatingSession()) {
+    if (next === "settings" && creatingSession()) {
       return;
     }
-    if (next === "dashboard" && Date.now() < sessionViewLockUntil()) {
+    if (next === "settings" && Date.now() < sessionViewLockUntil()) {
       return;
     }
     if (next === "session") {
@@ -333,7 +331,7 @@ export default function App() {
       navigate("/session");
       return;
     }
-    goToDashboard(tab());
+    goToSettings(settingsTab());
   };
 
   const goToSession = (sessionId: string, options?: { replace?: boolean }) => {
@@ -807,8 +805,8 @@ export default function App() {
     null
   );
   const [settingsReturnTarget, setSettingsReturnTarget] = createSignal<SettingsReturnTarget>({
-    view: "dashboard",
-    tab: "scheduled",
+    view: "settings",
+    tab: "general",
     sessionId: null,
   });
   const SESSION_BY_WORKSPACE_KEY = "openwork.workspace-last-session.v1";
@@ -856,8 +854,8 @@ export default function App() {
 
   createEffect(() => {
     const view = currentView();
-    const currentTab = tab();
-    if (view === "dashboard" && currentTab === "settings") return;
+    const currentTab = settingsTab();
+    if (view === "settings") return;
     setSettingsReturnTarget({
       view,
       tab: currentTab,
@@ -875,17 +873,36 @@ export default function App() {
       navigate("/session");
       return;
     }
-    goToDashboard(target.tab);
+    goToSettings(target.tab);
   };
 
   const toggleSettingsView = (nextTab: SettingsTab = "general") => {
-    const settingsOpen = currentView() === "dashboard" && tab() === "settings";
+    const settingsOpen = currentView() === "settings";
     if (settingsOpen) {
       restoreSettingsReturnTarget();
       return;
     }
     setSettingsTab(nextTab);
-    goToDashboard("settings");
+    goToSettings(nextTab);
+  };
+
+  const mapLegacySurfaceToSettingsTab = (surface: string): SettingsTab => {
+    switch (surface) {
+      case "scheduled":
+        return "automations";
+      case "skills":
+        return "skills";
+      case "plugins":
+      case "mcp":
+        return "extensions";
+      case "identities":
+        return "messaging";
+      case "config":
+        return "advanced";
+      case "settings":
+      default:
+        return "general";
+    }
   };
 
   let markReloadRequiredHandler: ((reason: ReloadReason, trigger?: ReloadTrigger) => void) | undefined;
@@ -2108,7 +2125,7 @@ export default function App() {
     opencodeEnableExa,
     setEngineSource,
     setView,
-    setTab,
+    setSettingsTab,
     isWindowsPlatform,
     openworkServerSettings,
     updateOpenworkServerSettings,
@@ -2582,8 +2599,8 @@ export default function App() {
       return;
     }
 
-    setView("dashboard");
-    setTab("scheduled");
+    setView("settings");
+    setSettingsTab("automations");
     setError(null);
     setSharedSkillDestinationBusyId(workspaceId);
 
@@ -2614,24 +2631,24 @@ export default function App() {
     const bundle = await fetchSharedBundle(request.bundleUrl, openworkServerClient());
 
     if (bundle.type === "skill") {
-      setView("dashboard");
-      setTab("scheduled");
+      setView("settings");
+      setSettingsTab("automations");
       setError(null);
       setSharedSkillDestinationRequest({ request, bundle });
       return { mode: "choice" as const, bundle };
     }
 
     if (bundle.type === "skills-set") {
-      setView("dashboard");
-      setTab("skills");
+      setView("settings");
+      setSettingsTab("skills");
       setError(null);
       setSharedBundleImportChoice({ request, bundle });
       return { mode: "choice" as const, bundle };
     }
 
     if (bundle.type === "workspace-profile" && request.intent === "new_worker" && isTauriRuntime()) {
-      setView("dashboard");
-      setTab("scheduled");
+      setView("settings");
+      setSettingsTab("automations");
       setError(null);
       setSharedBundleCreateWorkerRequest(null);
       setSharedBundleImportChoice(null);
@@ -3102,7 +3119,7 @@ export default function App() {
     }
 
     setError(null);
-    setView("dashboard");
+    setView("settings");
     if (parsed.kind === "bundle") {
       setPendingSharedBundleInvite(null);
       setSharedBundleNoticeShown(false);
@@ -3142,7 +3159,7 @@ export default function App() {
     }
 
     setPendingRemoteConnectDeepLink(parsed.kind === "remote" ? parsed.link : null);
-    setTab("scheduled");
+    setSettingsTab("automations");
     return { ok: true, message: "Queued remote worker link. OpenWork should move into the connect flow." };
   };
 
@@ -3160,8 +3177,8 @@ export default function App() {
   }) => {
     const bundle = parseSharedBundle(input.templateData);
     setError(null);
-    setView("dashboard");
-    setTab("settings");
+    setView("settings");
+    setSettingsTab("general");
     setSharedSkillDestinationBusyId(null);
     setSharedBundleImportError(null);
     setSharedTemplateStartRequest(null);
@@ -3281,8 +3298,8 @@ export default function App() {
     setError(null);
 
     if (isTauriRuntime()) {
-      setView("dashboard");
-      setTab("scheduled");
+      setView("settings");
+      setSettingsTab("automations");
       setSharedBundleCreateWorkerRequest({
         request: choice.request,
         bundle: choice.bundle,
@@ -3333,8 +3350,8 @@ export default function App() {
     setError(null);
 
     try {
-      setView("dashboard");
-      setTab(choice.bundle.type === "workspace-profile" ? "scheduled" : "skills");
+      setView("settings");
+      setSettingsTab(choice.bundle.type === "workspace-profile" ? "automations" : "skills");
       const ok = await workspaceStore.activateWorkspace(workspace.id);
       if (!ok) {
         throw new Error(error() || `Failed to switch to ${workspace.displayName?.trim() || workspace.name || "the selected worker"}.`);
@@ -3360,9 +3377,9 @@ export default function App() {
 
     setProcessingDenAuthDeepLink(true);
     setPendingDenAuthDeepLink(null);
-    setView("dashboard");
+    setView("settings");
     setSettingsTab("den");
-    goToDashboard("settings");
+    goToSettings("den");
 
     void createDenClient({ baseUrl: pending.denBaseUrl })
       .exchangeDesktopHandoff(pending.grant)
@@ -3412,8 +3429,8 @@ export default function App() {
     if (pending.autoConnect) {
       setView("session");
     } else {
-      setView("dashboard");
-      setTab("scheduled");
+      setView("settings");
+      setSettingsTab("automations");
     }
     setPendingRemoteConnectDeepLink(null);
     void completeRemoteConnectDeepLink(pending);
@@ -3635,8 +3652,8 @@ export default function App() {
       setEditRemoteWorkspaceOpen(true);
       return;
     }
-    setTab("config");
-    setView("dashboard");
+    setSettingsTab("advanced");
+    setView("settings");
   };
 
   const canReloadLocalEngine = () =>
@@ -3911,8 +3928,8 @@ export default function App() {
 
   createEffect(() => {
     if (typeof window === "undefined") return;
-    if (currentView() !== "dashboard") return;
-    if (tab() !== "scheduled") return;
+    if (currentView() !== "settings") return;
+    if (settingsTab() !== "automations") return;
     if (!documentVisible()) return;
 
     const pollingAvailable = scheduledJobsPollingAvailable();
@@ -4375,8 +4392,8 @@ export default function App() {
   }
 
   function openSettingsFromModelPicker() {
-    setTab("settings");
-    setView("dashboard");
+    setSettingsTab("general");
+    setView("settings");
   }
 
   async function createSessionAndOpen() {
@@ -5313,7 +5330,7 @@ export default function App() {
     return seconds > 0 ? `${label} · ${seconds}s` : label;
   });
 
-  const dashboardProps = () => {
+  const settingsShellProps = () => {
     const workspaceType = selectedWorkspaceDisplay().workspaceType;
     const isRemoteWorkspace = workspaceType === "remote";
     const openworkStatus = openworkServerStatus();
@@ -5345,8 +5362,6 @@ export default function App() {
       : null;
 
     return {
-      tab: tab(),
-      setTab,
       settingsTab: settingsTab(),
       setSettingsTab,
       providers: providers(),
@@ -5548,9 +5563,7 @@ export default function App() {
     providerAuthWorkerType: providerAuthWorkerType(),
     selectedSessionId: activeSessionId(),
     setView,
-    tab: tab(),
     settingsTab: settingsTab(),
-    setTab,
     setSettingsTab,
     toggleSettings: () => toggleSettingsView("general"),
     selectedWorkspaceDisplay: selectedWorkspaceDisplay(),
@@ -5671,22 +5684,27 @@ export default function App() {
     error: error(),
   });
 
-  const dashboardTabs = new Set<DashboardTab>([
-    "scheduled",
+  const settingsTabs = new Set<SettingsTab>([
+    "general",
+    "den",
+    "model",
+    "automations",
     "skills",
-    "plugins",
-    "mcp",
-    "identities",
-    "config",
-    "settings",
+    "extensions",
+    "messaging",
+    "advanced",
+    "appearance",
+    "updates",
+    "recovery",
+    "debug",
   ]);
 
-  const resolveDashboardTab = (value?: string | null) => {
+  const resolveSettingsTab = (value?: string | null) => {
     const normalized = value?.trim().toLowerCase() ?? "";
-    if (dashboardTabs.has(normalized as DashboardTab)) {
-      return normalized as DashboardTab;
+    if (settingsTabs.has(normalized as SettingsTab)) {
+      return normalized as SettingsTab;
     }
-    return "scheduled";
+    return "general";
   };
 
   const initialRoute = () => {
@@ -5705,13 +5723,19 @@ export default function App() {
 
     if (path.startsWith("/dashboard")) {
       const [, , tabSegment] = path.split("/");
-      const resolvedTab = resolveDashboardTab(tabSegment);
+      goToSettings(mapLegacySurfaceToSettingsTab(tabSegment ?? "settings"), { replace: true });
+      return;
+    }
 
-      if (resolvedTab !== tab()) {
-        setTabState(resolvedTab);
+    if (path.startsWith("/settings")) {
+      const [, , tabSegment] = path.split("/");
+      const resolvedTab = resolveSettingsTab(tabSegment);
+
+      if (resolvedTab !== settingsTab()) {
+        setSettingsTabState(resolvedTab);
       }
       if (!tabSegment || tabSegment !== resolvedTab) {
-        goToDashboard(resolvedTab, { replace: true });
+        goToSettings(resolvedTab, { replace: true });
       }
       return;
     }
@@ -5760,11 +5784,11 @@ export default function App() {
 
     if (path.startsWith("/proto-v1-ux") || path.startsWith("/proto")) {
       if (isTauriRuntime()) {
-        navigate("/dashboard/scheduled", { replace: true });
+        navigate("/settings/automations", { replace: true });
         return;
       }
 
-      navigate("/dashboard/scheduled", { replace: true });
+      navigate("/settings/automations", { replace: true });
       return;
     }
 
@@ -5785,7 +5809,7 @@ export default function App() {
               <SessionView {...sessionProps()} />
             </Match>
             <Match when={true}>
-              <DashboardView {...dashboardProps()} />
+              <SettingsShell {...settingsShellProps()} />
             </Match>
           </Switch>
 

--- a/apps/app/src/app/components/workspace-right-sidebar.tsx
+++ b/apps/app/src/app/components/workspace-right-sidebar.tsx
@@ -11,7 +11,7 @@ import {
   Zap,
 } from "lucide-solid";
 
-import type { DashboardTab, SettingsTab } from "../types";
+import type { SettingsTab } from "../types";
 import type { OpenworkServerClient } from "../lib/openwork-server";
 import InboxPanel from "./session/inbox-panel";
 
@@ -19,7 +19,6 @@ type Props = {
   expanded: boolean;
   mobile?: boolean;
   showSelection?: boolean;
-  tab: DashboardTab;
   settingsTab?: SettingsTab;
   developerMode: boolean;
   activeWorkspaceLabel: string;
@@ -105,32 +104,32 @@ export default function WorkspaceRightSidebar(props: Props) {
           {sidebarButton(
             "Automations",
             <History size={18} />,
-            showSelection() && (props.tab === "scheduled" || (props.tab === "settings" && props.settingsTab === "automations")),
+            showSelection() && props.settingsTab === "automations",
             props.onOpenAutomations,
           )}
           {sidebarButton(
             "Skills",
             <Zap size={18} />,
-            showSelection() && (props.tab === "skills" || (props.tab === "settings" && props.settingsTab === "skills")),
+            showSelection() && props.settingsTab === "skills",
             props.onOpenSkills,
           )}
           {sidebarButton(
             "Extensions",
             <Box size={18} />,
-            showSelection() && (props.tab === "mcp" || props.tab === "plugins" || (props.tab === "settings" && props.settingsTab === "extensions")),
+            showSelection() && props.settingsTab === "extensions",
             props.onOpenExtensions,
           )}
           {sidebarButton(
             "Messaging",
             <MessageCircle size={18} />,
-            showSelection() && (props.tab === "identities" || (props.tab === "settings" && props.settingsTab === "messaging")),
+            showSelection() && props.settingsTab === "messaging",
             props.onOpenMessaging,
           )}
           <Show when={props.developerMode}>
             {sidebarButton(
               "Advanced",
               <SlidersHorizontal size={18} />,
-              showSelection() && (props.tab === "config" || (props.tab === "settings" && props.settingsTab === "advanced")),
+                showSelection() && props.settingsTab === "advanced",
               props.onOpenAdvanced,
             )}
           </Show>
@@ -152,7 +151,7 @@ export default function WorkspaceRightSidebar(props: Props) {
         {sidebarButton(
           "Settings",
           <Settings size={18} />,
-          showSelection() && props.tab === "settings",
+          showSelection() && props.settingsTab === "general",
           props.onOpenSettings,
         )}
       </div>

--- a/apps/app/src/app/context/local.tsx
+++ b/apps/app/src/app/context/local.tsx
@@ -2,12 +2,12 @@ import { createContext, createEffect, useContext, type ParentProps } from "solid
 import { createStore, type SetStoreFunction, type Store } from "solid-js/store";
 
 import { THINKING_PREF_KEY } from "../constants";
-import type { DashboardTab, ModelRef, View } from "../types";
+import type { ModelRef, SettingsTab, View } from "../types";
 import { Persist, persisted } from "../utils/persist";
 
 type LocalUIState = {
   view: View;
-  tab: DashboardTab;
+  tab: SettingsTab;
 };
 
 type LocalPreferences = {
@@ -30,8 +30,8 @@ export function LocalProvider(props: ParentProps) {
   const [ui, setUi, , uiReady] = persisted(
     Persist.global("local.ui", ["openwork.ui"]),
     createStore<LocalUIState>({
-      view: "dashboard",
-      tab: "scheduled",
+      view: "settings",
+      tab: "general",
     }),
   );
 

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -151,7 +151,7 @@ export function createWorkspaceStore(options: {
   opencodeEnableExa?: () => boolean;
   setEngineSource: (value: "path" | "sidecar" | "custom") => void;
   setView: (value: any, sessionId?: string) => void;
-  setTab: (value: any) => void;
+  setSettingsTab: (value: any) => void;
   isWindowsPlatform: () => boolean;
   openworkServerSettings: () => OpenworkServerSettings;
   updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
@@ -1926,7 +1926,7 @@ export function createWorkspaceStore(options: {
         options.setProviderConnectedIds(providerState.connectedIds);
 
         if (navigate && !options.selectedSessionId()) {
-          options.setTab("scheduled");
+          options.setSettingsTab("automations");
           options.setView("session");
         }
 

--- a/apps/app/src/app/pages/extensions.tsx
+++ b/apps/app/src/app/pages/extensions.tsx
@@ -13,7 +13,7 @@ export type ExtensionsSection = "all" | "mcp" | "plugins";
 export type ExtensionsViewProps = PluginsViewProps & {
   isRemoteWorkspace: boolean;
   initialSection?: ExtensionsSection;
-  setDashboardTab?: (tab: "mcp" | "plugins") => void;
+  setSectionRoute?: (tab: "mcp" | "plugins") => void;
   showHeader?: boolean;
 };
 
@@ -50,7 +50,7 @@ export default function ExtensionsView(props: ExtensionsViewProps) {
   const selectSection = (nextSection: ExtensionsSection) => {
     setSection(nextSection);
     if (nextSection === "mcp" || nextSection === "plugins") {
-      props.setDashboardTab?.(nextSection);
+      props.setSectionRoute?.(nextSection);
     }
   };
 

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -10,7 +10,6 @@ import {
 } from "solid-js";
 import type { Agent, Part, Session } from "@opencode-ai/sdk/v2/client";
 import type {
-  DashboardTab,
   ComposerDraft,
   MessageWithParts,
   PendingPermission,
@@ -109,9 +108,7 @@ export type SessionViewProps = {
   booting: boolean;
   selectedSessionId: string | null;
   setView: (view: View, sessionId?: string) => void;
-  tab: DashboardTab;
   settingsTab: SettingsTab;
-  setTab: (tab: DashboardTab) => void;
   setSettingsTab: (tab: SettingsTab) => void;
   toggleSettings: () => void;
   selectedWorkspaceDisplay: WorkspaceDisplay;
@@ -3097,13 +3094,12 @@ export default function SessionView(props: SessionViewProps) {
 
   const openSettings = (tab: SettingsTab = "general") => {
     props.setSettingsTab(tab);
-    props.setTab("settings");
-    props.setView("dashboard");
+    props.setView("settings");
   };
 
   const openConfig = () => {
-    props.setTab(props.developerMode ? "config" : "identities");
-    props.setView("dashboard");
+    props.setSettingsTab(props.developerMode ? "advanced" : "messaging");
+    props.setView("settings");
   };
 
   const showUpdatePill = createMemo(() => {
@@ -3207,8 +3203,7 @@ export default function SessionView(props: SessionViewProps) {
 
   const openMcp = () => {
     props.setSettingsTab("extensions");
-    props.setTab("settings");
-    props.setView("dashboard");
+    props.setView("settings");
   };
 
   const openProviderAuth = (preferredProviderId?: string) => {
@@ -3982,8 +3977,7 @@ export default function SessionView(props: SessionViewProps) {
             onOpenSettings={props.toggleSettings}
             onOpenMessaging={() => {
               props.setSettingsTab("messaging");
-              props.setTab("settings");
-              props.setView("dashboard");
+              props.setView("settings");
             }}
             onOpenProviders={openProviderAuth}
             onOpenMcp={openMcp}
@@ -4198,8 +4192,7 @@ export default function SessionView(props: SessionViewProps) {
         onOpenSingleSkillShare={() => {
           setShareWorkspaceId(null);
           props.setSettingsTab("skills");
-          props.setTab("settings");
-          props.setView("dashboard");
+          props.setView("settings");
         }}
         shareSkillsSetBusy={shareSkillsSetBusy()}
         shareSkillsSetUrl={shareSkillsSetUrl()}

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -24,6 +24,7 @@ import DenSettingsPanel from "../components/den-settings-panel";
 import TextInput from "../components/text-input";
 import { useSessionDisplayPreferences } from "../app-settings/session-display-preferences";
 import { usePlatform } from "../context/platform";
+import ConfigView from "./config";
 import ExtensionsView from "./extensions";
 import IdentitiesView from "./identities";
 import ScheduledTasksView from "./scheduled";
@@ -107,6 +108,9 @@ export type SettingsViewProps = {
   openworkServerHostInfo: OpenworkServerInfo | null;
   openworkServerCapabilities: OpenworkServerCapabilities | null;
   openworkServerDiagnostics: OpenworkServerDiagnostics | null;
+  updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
+  resetOpenworkServerSettings: () => void;
+  testOpenworkServerConnection: (next: OpenworkServerSettings) => Promise<boolean>;
   runtimeWorkspaceId: string | null;
   selectedWorkspaceRoot: string;
   activeWorkspaceType: "local" | "remote";
@@ -201,6 +205,12 @@ export type SettingsViewProps = {
   canReloadWorkspace: boolean;
   reloadWorkspaceEngine: () => Promise<void>;
   reloadBusy: boolean;
+  reloadError: string | null;
+  workspaceAutoReloadAvailable: boolean;
+  workspaceAutoReloadEnabled: boolean;
+  setWorkspaceAutoReloadEnabled: (value: boolean) => void | Promise<void>;
+  workspaceAutoReloadResumeEnabled: boolean;
+  setWorkspaceAutoReloadResumeEnabled: (value: boolean) => void | Promise<void>;
   connectRemoteWorkspace: (input: {
     openworkHostUrl?: string | null;
     openworkToken?: string | null;
@@ -2166,6 +2176,32 @@ export default function SettingsView(props: SettingsViewProps) {
                 {(value) => <div class="text-xs text-red-11">{value()}</div>}
               </Show>
             </div>
+
+            <Show when={props.developerMode}>
+              <ConfigView
+                busy={props.busy}
+                clientConnected={props.clientConnected}
+                anyActiveRuns={props.anyActiveRuns}
+                openworkServerStatus={props.openworkServerStatus}
+                openworkServerUrl={props.openworkServerUrl}
+                openworkServerSettings={props.openworkServerSettings}
+                openworkServerHostInfo={props.openworkServerHostInfo}
+                runtimeWorkspaceId={props.runtimeWorkspaceId}
+                updateOpenworkServerSettings={props.updateOpenworkServerSettings}
+                resetOpenworkServerSettings={props.resetOpenworkServerSettings}
+                testOpenworkServerConnection={props.testOpenworkServerConnection}
+                canReloadWorkspace={props.canReloadWorkspace}
+                reloadWorkspaceEngine={props.reloadWorkspaceEngine}
+                reloadBusy={props.reloadBusy}
+                reloadError={props.reloadError}
+                workspaceAutoReloadAvailable={props.workspaceAutoReloadAvailable}
+                workspaceAutoReloadEnabled={props.workspaceAutoReloadEnabled}
+                setWorkspaceAutoReloadEnabled={props.setWorkspaceAutoReloadEnabled}
+                workspaceAutoReloadResumeEnabled={props.workspaceAutoReloadResumeEnabled}
+                setWorkspaceAutoReloadResumeEnabled={props.setWorkspaceAutoReloadResumeEnabled}
+                developerMode={props.developerMode}
+              />
+            </Show>
 
 
 

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -1,14 +1,8 @@
-import { For, Match, Show, Switch, createEffect, createMemo, createSignal, on, onCleanup } from "solid-js";
+import { For, Show, createEffect, createMemo, createSignal, on, onCleanup } from "solid-js";
 import type {
-  DashboardTab,
   OpencodeConnectStatus,
-  PluginScope,
   ProviderListItem,
   SettingsTab,
-  ScheduledJob,
-  HubSkillCard,
-  HubSkillRepo,
-  SkillCard,
   StartupPreference,
   WorkspaceConnectionState,
   WorkspaceSessionGroup,
@@ -46,8 +40,7 @@ import type { EngineInfo, OrchestratorStatus, OpenworkServerInfo, OpenCodeRouter
 import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
 
 import Button from "../components/button";
-import ConfigView from "./config";
-import SettingsView from "./settings";
+import SettingsView from "../pages/settings";
 import StatusBar from "../components/status-bar";
 import { ProviderAuthModal,
   type ProviderAuthMethod,
@@ -68,9 +61,7 @@ import {
 } from "lucide-solid";
 import type { Language } from "../../i18n";
 
-export type DashboardViewProps = {
-  tab: DashboardTab;
-  setTab: (tab: DashboardTab) => void;
+export type SettingsShellProps = {
   settingsTab: SettingsTab;
   setSettingsTab: (tab: SettingsTab) => void;
   providers: ProviderListItem[];
@@ -297,29 +288,35 @@ type SkillsSetBundleV1 = {
   };
 };
 
-export default function DashboardView(props: DashboardViewProps) {
+export default function SettingsShell(props: SettingsShellProps) {
   const connections = useConnections();
   const extensions = useExtensions();
   const platform = usePlatform();
   const webDeployment = createMemo(() => getOpenWorkDeployment() === "web");
   const title = createMemo(() => {
-    switch (props.tab) {
-      case "scheduled":
+    switch (props.settingsTab) {
+      case "automations":
         return "Automations";
       case "skills":
         return "Skills";
-      case "plugins":
+      case "extensions":
         return "Extensions";
-      case "mcp":
-        return "Extensions";
-      case "identities":
+      case "messaging":
         return "Messaging";
-      case "config":
+      case "advanced":
         return "Advanced";
-      case "settings":
-        return "Settings";
+      case "appearance":
+        return "Appearance";
+      case "updates":
+        return "Updates";
+      case "recovery":
+        return "Recovery";
+      case "den":
+        return "Cloud";
+      case "debug":
+        return "Debug";
       default:
-        return "Automations";
+        return "Settings";
     }
   });
 
@@ -368,7 +365,7 @@ export default function DashboardView(props: DashboardViewProps) {
 
   const openFeedback = () => {
     const resolved = buildFeedbackUrl({
-      entrypoint: "dashboard-status-bar",
+      entrypoint: "settings-shell-status-bar",
       deployment: getOpenWorkDeployment(),
       appVersion: props.appVersion,
       openworkServerVersion: props.openworkServerDiagnostics?.version ?? null,
@@ -433,18 +430,7 @@ export default function DashboardView(props: DashboardViewProps) {
   });
 
   createEffect(() => {
-    const currentTab =
-      props.tab === "settings"
-        ? props.settingsTab
-        : props.tab === "scheduled"
-          ? "automations"
-          : props.tab === "skills"
-            ? "skills"
-            : props.tab === "plugins" || props.tab === "mcp"
-              ? "extensions"
-              : props.tab === "identities"
-                ? "messaging"
-                : props.tab;
+    const currentTab = props.settingsTab;
 
     // Skip if we already refreshed this tab or a refresh is in progress
     if (lastRefreshedTab() === currentTab || refreshInProgress()) {
@@ -485,7 +471,6 @@ export default function DashboardView(props: DashboardViewProps) {
 
   const openSettings = (tab: SettingsTab = "general") => {
     props.setSettingsTab(tab);
-    props.setTab("settings");
   };
 
   const openMessaging = () => {
@@ -496,29 +481,9 @@ export default function DashboardView(props: DashboardViewProps) {
     openSettings("extensions");
   };
 
-  const openConfig = () => {
-    if (props.developerMode) {
-      props.setTab("config");
-      return;
-    }
-    openSettings("messaging");
+  const openAdvanced = () => {
+    openSettings(props.developerMode ? "advanced" : "messaging");
   };
-
-  const resolvedSettingsTab = createMemo<SettingsTab>(() => {
-    switch (props.tab) {
-      case "scheduled":
-        return "automations";
-      case "skills":
-        return "skills";
-      case "plugins":
-      case "mcp":
-        return "extensions";
-      case "identities":
-        return "messaging";
-      default:
-        return props.settingsTab;
-    }
-  });
 
   const revealWorkspaceInFinder = async (workspaceId: string) => {
     const workspace = props.workspaces.find((entry) => entry.id === workspaceId) ?? null;
@@ -536,12 +501,6 @@ export default function DashboardView(props: DashboardViewProps) {
       console.warn("Failed to reveal workspace", error);
     }
   };
-
-  createEffect(() => {
-    if (props.developerMode) return;
-    if (props.tab !== "config") return;
-    openSettings("messaging");
-  });
 
   const shareWorkspace = createMemo(() => {
     const id = shareWorkspaceId();
@@ -1243,11 +1202,9 @@ export default function DashboardView(props: DashboardViewProps) {
               </button>
             </Show>
             <h1 class="truncate text-[15px] font-semibold text-dls-text">{title()}</h1>
-            <Show when={props.tab === "settings"}>
-              <span class="hidden truncate text-[13px] text-dls-secondary lg:inline">
-                {workspaceLabel(props.selectedWorkspaceDisplay)}
-              </span>
-            </Show>
+            <span class="hidden truncate text-[13px] text-dls-secondary lg:inline">
+              {workspaceLabel(props.selectedWorkspaceDisplay)}
+            </span>
             <Show when={props.developerMode}>
               <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.headerStatus}</span>
             </Show>
@@ -1256,56 +1213,26 @@ export default function DashboardView(props: DashboardViewProps) {
             </Show>
           </div>
           <div class="flex items-center text-gray-10">
-            <Show when={props.tab === "settings"}>
-              <button
-                type="button"
-                class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
-                onClick={props.toggleSettings}
-                title="Close settings"
-                aria-label="Close settings"
-              >
-                <X size={18} />
-              </button>
-            </Show>
+            <button
+              type="button"
+              class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
+              onClick={props.toggleSettings}
+              title="Close settings"
+              aria-label="Close settings"
+            >
+              <X size={18} />
+            </button>
           </div>
         </header>
 
-        <div class={props.tab === "config" && props.developerMode ? "mx-auto w-full max-w-[1100px] space-y-10 p-6 md:p-10" : "w-full space-y-10 p-6 md:p-10"}>
-          <Switch>
-            <Match when={props.tab === "config" && props.developerMode}>
-              <ConfigView
-                busy={props.busy}
-                clientConnected={props.clientConnected}
-                anyActiveRuns={props.anyActiveRuns}
-                openworkServerStatus={props.openworkServerStatus}
-                openworkServerUrl={props.openworkServerUrl}
-                openworkServerSettings={props.openworkServerSettings}
-                openworkServerHostInfo={props.openworkServerHostInfo}
-                runtimeWorkspaceId={props.runtimeWorkspaceId}
-                updateOpenworkServerSettings={props.updateOpenworkServerSettings}
-                resetOpenworkServerSettings={props.resetOpenworkServerSettings}
-                testOpenworkServerConnection={props.testOpenworkServerConnection}
-                canReloadWorkspace={props.canReloadWorkspace}
-                reloadWorkspaceEngine={props.reloadWorkspaceEngine}
-                reloadBusy={props.reloadBusy}
-                reloadError={props.reloadError}
-                workspaceAutoReloadAvailable={props.workspaceAutoReloadAvailable}
-                workspaceAutoReloadEnabled={props.workspaceAutoReloadEnabled}
-                setWorkspaceAutoReloadEnabled={props.setWorkspaceAutoReloadEnabled}
-                workspaceAutoReloadResumeEnabled={props.workspaceAutoReloadResumeEnabled}
-                setWorkspaceAutoReloadResumeEnabled={props.setWorkspaceAutoReloadResumeEnabled}
-                developerMode={props.developerMode}
-              />
-            </Match>
-
-            <Match when={true}>
-              <SettingsView
+        <div class="w-full space-y-10 p-6 md:p-10">
+          <SettingsView
                   startupPreference={props.startupPreference}
                   baseUrl={props.baseUrl}
                   headerStatus={props.headerStatus}
                   busy={props.busy}
                   clientConnected={props.clientConnected}
-                  settingsTab={resolvedSettingsTab()}
+                  settingsTab={props.settingsTab}
                   setSettingsTab={props.setSettingsTab}
                   providers={props.providers}
                   providerConnectedIds={props.providerConnectedIds}
@@ -1321,6 +1248,9 @@ export default function DashboardView(props: DashboardViewProps) {
                   openworkServerHostInfo={props.openworkServerHostInfo}
                   openworkServerCapabilities={props.openworkServerCapabilities}
                   openworkServerDiagnostics={props.openworkServerDiagnostics}
+                  updateOpenworkServerSettings={props.updateOpenworkServerSettings}
+                  resetOpenworkServerSettings={props.resetOpenworkServerSettings}
+                  testOpenworkServerConnection={props.testOpenworkServerConnection}
                   runtimeWorkspaceId={props.runtimeWorkspaceId}
                   selectedWorkspaceRoot={props.selectedWorkspaceRoot}
                   activeWorkspaceType={props.activeWorkspaceType}
@@ -1404,11 +1334,15 @@ export default function DashboardView(props: DashboardViewProps) {
                    canReloadWorkspace={props.canReloadWorkspace}
                    reloadWorkspaceEngine={props.reloadWorkspaceEngine}
                    reloadBusy={props.reloadBusy}
+                   reloadError={props.reloadError}
+                   workspaceAutoReloadAvailable={props.workspaceAutoReloadAvailable}
+                   workspaceAutoReloadEnabled={props.workspaceAutoReloadEnabled}
+                   setWorkspaceAutoReloadEnabled={props.setWorkspaceAutoReloadEnabled}
+                   workspaceAutoReloadResumeEnabled={props.workspaceAutoReloadResumeEnabled}
+                   setWorkspaceAutoReloadResumeEnabled={props.setWorkspaceAutoReloadResumeEnabled}
                    connectRemoteWorkspace={props.connectRemoteWorkspace}
                    openCloudTemplate={props.openCloudTemplate}
-               />
-            </Match>
-          </Switch>
+                />
         </div>
 
         <Show when={props.error}>
@@ -1509,7 +1443,7 @@ export default function DashboardView(props: DashboardViewProps) {
               }
           }
           exportDisabledReason={exportDisabledReason()}
-          onOpenBots={openConfig}
+          onOpenBots={openAdvanced}
         />
         </div>
 
@@ -1517,7 +1451,7 @@ export default function DashboardView(props: DashboardViewProps) {
           clientConnected={props.clientConnected}
           openworkServerStatus={props.openworkServerStatus}
           developerMode={props.developerMode}
-          settingsOpen={props.tab === "settings"}
+          settingsOpen={true}
           showSettingsButton={true}
           onSendFeedback={openFeedback}
           onOpenSettings={props.toggleSettings}
@@ -1529,36 +1463,36 @@ export default function DashboardView(props: DashboardViewProps) {
         <nav class="hidden border-t border-dls-border bg-dls-surface">
           <div class={`mx-auto max-w-5xl px-4 py-3 grid gap-2 ${props.developerMode ? "grid-cols-5" : "grid-cols-4"}`}>
             <button
-              class={`flex flex-col items-center gap-1 text-xs ${
-                props.tab === "settings" && props.settingsTab === "automations" ? "text-gray-12" : "text-gray-10"
-              }`}
+                class={`flex flex-col items-center gap-1 text-xs ${
+                  props.settingsTab === "automations" ? "text-gray-12" : "text-gray-10"
+                }`}
               onClick={() => openSettings("automations")}
             >
               <History size={18} />
               Automations
             </button>
             <button
-              class={`flex flex-col items-center gap-1 text-xs ${
-                props.tab === "settings" && props.settingsTab === "skills" ? "text-gray-12" : "text-gray-10"
-              }`}
+                class={`flex flex-col items-center gap-1 text-xs ${
+                  props.settingsTab === "skills" ? "text-gray-12" : "text-gray-10"
+                }`}
               onClick={() => openSettings("skills")}
             >
               <Zap size={18} />
               Skills
             </button>
             <button
-              class={`flex flex-col items-center gap-1 text-xs ${
-                props.tab === "settings" && props.settingsTab === "extensions" ? "text-gray-12" : "text-gray-10"
-              }`}
+                class={`flex flex-col items-center gap-1 text-xs ${
+                  props.settingsTab === "extensions" ? "text-gray-12" : "text-gray-10"
+                }`}
               onClick={() => openSettings("extensions")}
             >
               <Box size={18} />
               Extensions
             </button>
             <button
-              class={`flex flex-col items-center gap-1 text-xs ${
-                props.tab === "settings" && props.settingsTab === "messaging" ? "text-gray-12" : "text-gray-10"
-              }`}
+                class={`flex flex-col items-center gap-1 text-xs ${
+                  props.settingsTab === "messaging" ? "text-gray-12" : "text-gray-10"
+                }`}
               onClick={() => openSettings("messaging")}
             >
               <MessageCircle size={18} />
@@ -1567,9 +1501,9 @@ export default function DashboardView(props: DashboardViewProps) {
             <Show when={props.developerMode}>
               <button
                 class={`flex flex-col items-center gap-1 text-xs ${
-                  props.tab === "config" ? "text-gray-12" : "text-gray-10"
+                  props.settingsTab === "advanced" ? "text-gray-12" : "text-gray-10"
                 }`}
-                onClick={() => props.setTab("config")}
+                onClick={openAdvanced}
               >
                 <SlidersHorizontal size={18} />
                 Advanced

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -150,22 +150,13 @@ export type SessionCompactionState = {
   messageID: string | null;
 };
 
-export type View = "dashboard" | "session";
+export type View = "settings" | "session";
 
 export type StartupPreference = "local" | "server";
 
 export type EngineRuntime = "direct" | "openwork-orchestrator";
 
 export type OnboardingStep = "welcome" | "local" | "server" | "connecting";
-
-export type DashboardTab =
-  | "scheduled"
-  | "skills"
-  | "plugins"
-  | "mcp"
-  | "identities"
-  | "config"
-  | "settings";
 
 export type SettingsTab =
   | "general"


### PR DESCRIPTION
## Summary
- remove the dashboard route/state concept so Settings becomes the single non-session surface
- replace the old dashboard wrapper with a settings shell that owns layout chrome while Settings owns the content tabs
- keep old /dashboard/* URLs as redirects to /settings/:tab for compatibility while deleting DashboardTab and the old dashboard page

## Testing
- pnpm typecheck
- pnpm test:refactor

## Notes
- I did not run the full Docker + Chrome MCP flow in this session.
- Verification here is focused app compile + health/session smoke coverage.