### PR TITLE
Fix the session boot loading shell

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -39,6 +39,7 @@ import ConnectionsModals from "./connections/modals";
 import { ConnectionsProvider } from "./connections/provider";
 import { ExtensionsProvider } from "./extensions/provider";
 import { AutomationsProvider } from "./automations/provider";
+import BootShell from "./shell/boot-shell";
 import SettingsShell from "./shell/settings-shell";
 import SessionView from "./pages/session";
 import { unwrap } from "./lib/opencode";
@@ -5559,7 +5560,6 @@ export default function App() {
   };
 
   const sessionProps = () => ({
-    booting: booting(),
     providerAuthWorkerType: providerAuthWorkerType(),
     selectedSessionId: activeSessionId(),
     setView,
@@ -5805,6 +5805,9 @@ export default function App() {
       <ExtensionsProvider store={extensionsStore}>
         <AutomationsProvider store={automationsStore}>
           <Switch>
+            <Match when={booting()}>
+              <BootShell />
+            </Match>
             <Match when={currentView() === "session"}>
               <SessionView {...sessionProps()} />
             </Match>

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -105,7 +105,6 @@ import FlyoutItem from "../components/flyout-item";
 import QuestionModal from "../components/question-modal";
 
 export type SessionViewProps = {
-  booting: boolean;
   selectedSessionId: string | null;
   setView: (view: View, sessionId?: string) => void;
   settingsTab: SettingsTab;
@@ -2013,7 +2012,6 @@ export default function SessionView(props: SessionViewProps) {
   const hasWorkspaceConfigured = createMemo(() => props.workspaces.length > 0);
   const showWorkspaceSetupEmptyState = createMemo(
     () =>
-      !props.booting &&
       !hasWorkspaceConfigured() &&
       !props.selectedSessionId &&
       props.messages.length === 0,
@@ -2025,7 +2023,6 @@ export default function SessionView(props: SessionViewProps) {
   });
   const showSessionLoadingState = createMemo(() => {
     if (showPendingSessionTransition()) return true;
-    if (props.booting && !props.selectedSessionId) return true;
     const sessionId = props.selectedSessionId;
     if (!sessionId) return false;
     if (props.messages.length > 0) return false;

--- a/apps/app/src/app/shell/boot-shell.tsx
+++ b/apps/app/src/app/shell/boot-shell.tsx
@@ -1,0 +1,25 @@
+import { createWorkspaceShellLayout } from "../lib/workspace-shell-layout";
+
+export default function BootShell() {
+  const { leftSidebarWidth } = createWorkspaceShellLayout({ expandedRightWidth: 280 });
+
+  return (
+    <div class="h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-dls-text font-sans">
+      <div class="flex h-full w-full gap-3 md:gap-4">
+        <aside
+          class="relative hidden lg:flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"
+          style={{
+            width: `${leftSidebarWidth()}px`,
+            "min-width": `${leftSidebarWidth()}px`,
+          }}
+          aria-hidden="true"
+        />
+
+        <main
+          class="min-w-0 flex-1 overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move the initial loading surface into a shell-owned `BootShell` so the app does not render session-owned controls before bootstrap finishes
- show a truly empty workspace shell while loading: a faint left rail shape and a blank main panel
- remove `booting` ownership from `pages/session.tsx` so the session domain only renders once the app is ready

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm build:ui`

## Notes
- I also tried a local browser preview with throttling, but it did not reproduce the slower desktop/Tauri boot path from the reported screenshot, so I did not attach a misleading UI artifact.