### PR TITLE
refactor(session): separate session model choices from workspace defaults

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -121,6 +121,14 @@ import {
 } from "./theme";
 import { createSystemState } from "./system-state";
 import { createSessionStore } from "./context/session";
+import {
+  createModelConfigStore,
+  parseSessionChoiceOverrides,
+  parseWorkspaceModelVariants,
+  serializeSessionChoiceOverrides,
+  sessionModelOverridesKey,
+  workspaceModelVariantsKey,
+} from "./context/model-config";
 import { createProvidersStore } from "./context/providers";
 import { useSessionDisplayPreferences } from "./app-settings/session-display-preferences";
 import {
@@ -775,14 +783,6 @@ export default function App() {
       // ignore
     }
   };
-  const [sessionModelOverrideById, setSessionModelOverrideById] = createSignal<
-    Record<string, ModelRef>
-  >({});
-  const [sessionModelById, setSessionModelById] = createSignal<
-    Record<string, ModelRef>
-  >({});
-  const [pendingSessionModel, setPendingSessionModel] = createSignal<ModelRef | null>(null);
-  const [sessionModelOverridesReady, setSessionModelOverridesReady] = createSignal(false);
   const [workspaceDefaultModelReady, setWorkspaceDefaultModelReady] = createSignal(false);
   const [legacyDefaultModel, setLegacyDefaultModel] = createSignal<ModelRef>(DEFAULT_MODEL);
   const [defaultModelExplicit, setDefaultModelExplicit] = createSignal(false);
@@ -796,6 +796,7 @@ export default function App() {
   type PromptFocusReturnTarget = "none" | "composer";
 
   const [sessionAgentById, setSessionAgentById] = createSignal<Record<string, string>>({});
+  const modelConfig = createModelConfigStore();
 
   createEffect(() => {
     const view = currentView();
@@ -860,19 +861,8 @@ export default function App() {
     selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot().trim(),
     selectedSessionId,
     setSelectedSessionId,
-    sessionModelState: () => ({
-      overrides: sessionModelOverrideById(),
-      resolved: sessionModelById(),
-    }),
-    setSessionModelState: (updater) => {
-      const next = updater({
-        overrides: sessionModelOverrideById(),
-        resolved: sessionModelById(),
-      });
-      setSessionModelOverrideById(next.overrides);
-      setSessionModelById(next.resolved);
-      return next;
-    },
+    sessionModelState: modelConfig.sessionModelState,
+    setSessionModelState: modelConfig.setSessionModelState,
     lastUserModelFromMessages,
     developerMode,
     setError,
@@ -1196,7 +1186,7 @@ export default function App() {
       const model = selectedSessionModel();
       const agent = selectedSessionAgent();
       const parts = await buildPromptParts(resolvedDraft);
-      const selectedVariant = sanitizeModelVariantForRef(model, getVariantFor(model)) ?? undefined;
+      const selectedVariant = sanitizeModelVariantForRef(model, modelVariant()) ?? undefined;
       const reasoningEffort = resolveCodexReasoningEffort(model.modelID, selectedVariant ?? null);
       const requestVariant = reasoningEffort ? undefined : selectedVariant;
       const promptOverrides = reasoningEffort
@@ -1250,17 +1240,12 @@ export default function App() {
         });
         assertNoClientError(result);
 
-        setSessionModelById((current) => ({
+        modelConfig.setSessionModelById((current) => ({
           ...current,
           [sessionID]: model,
         }));
 
-        setSessionModelOverrideById((current) => {
-          if (!current[sessionID]) return current;
-          const copy = { ...current };
-          delete copy[sessionID];
-          return copy;
-        });
+        modelConfig.clearSessionModelOverride(sessionID);
       }
 
       finishPerf(perfEnabled, "session.prompt", "done", startedAt, {
@@ -1329,7 +1314,7 @@ export default function App() {
       sessionID,
       messageCount: visible.length,
       model: modelLabel,
-      variant: sanitizeModelVariantForRef(model, getVariantFor(model)) ?? null,
+      variant: sanitizeModelVariantForRef(model, modelVariant()) ?? null,
     });
 
     try {
@@ -1817,48 +1802,6 @@ export default function App() {
   };
 
   const [defaultModel, setDefaultModel] = createSignal<ModelRef>(DEFAULT_MODEL);
-  const sessionModelOverridesKey = (workspaceId: string) =>
-    `${SESSION_MODEL_PREF_KEY}.${workspaceId}`;
-
-  const parseSessionModelOverrides = (raw: string | null) => {
-    if (!raw) return {} as Record<string, ModelRef>;
-    try {
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        return {} as Record<string, ModelRef>;
-      }
-      const next: Record<string, ModelRef> = {};
-      for (const [sessionId, value] of Object.entries(parsed)) {
-        if (typeof value === "string") {
-          const model = parseModelRef(value);
-          if (model) next[sessionId] = model;
-          continue;
-        }
-        if (!value || typeof value !== "object") continue;
-        const record = value as Record<string, unknown>;
-        if (typeof record.providerID === "string" && typeof record.modelID === "string") {
-          next[sessionId] = {
-            providerID: record.providerID,
-            modelID: record.modelID,
-          };
-        }
-      }
-      return next;
-    } catch {
-      return {} as Record<string, ModelRef>;
-    }
-  };
-
-  const serializeSessionModelOverrides = (overrides: Record<string, ModelRef>) => {
-    const entries = Object.entries(overrides);
-    if (!entries.length) return null;
-    const payload: Record<string, string> = {};
-    for (const [sessionId, model] of entries) {
-      payload[sessionId] = formatModelRef(model);
-    }
-    return JSON.stringify(payload);
-  };
-
   const parseDefaultModelFromConfig = (content: string | null) => {
     if (!content) return null;
     try {
@@ -1972,18 +1915,7 @@ export default function App() {
 
   const [autoCompactContext, setAutoCompactContext] = createSignal(true);
   const [hideTitlebar, setHideTitlebar] = createSignal(false);
-  const [modelVariantMap, setModelVariantMap] = createSignal<Record<string, string>>({});
-  const modelVariant = () => getVariantFor(selectedSessionModel());
-  const getVariantFor = (ref: ModelRef) => modelVariantMap()[`${ref.providerID}/${ref.modelID}`] ?? null;
-  const updateModelVariant = (ref: ModelRef, value: string | null) => {
-    const key = `${ref.providerID}/${ref.modelID}`;
-    setModelVariantMap((prev) => {
-      const next = { ...prev };
-      if (value) next[key] = value;
-      else delete next[key];
-      return next;
-    });
-  };
+  const modelVariant = () => modelConfig.getVariantFor(selectedSessionModel(), selectedSessionId());
   const toggleAutoCompactContext = () => {
     if (autoCompactContextSaving()) return;
     setAutoCompactContext((value) => !value);
@@ -2976,11 +2908,12 @@ export default function App() {
       if (typeof window !== "undefined") {
         try {
           const sessionOverridePrefix = `${SESSION_MODEL_PREF_KEY}.`;
+          const workspaceVariantPrefix = `${VARIANT_PREF_KEY}.`;
           const keysToRemove: string[] = [];
           for (let index = 0; index < window.localStorage.length; index += 1) {
             const key = window.localStorage.key(index);
             if (!key) continue;
-            if (key.startsWith(sessionOverridePrefix)) {
+            if (key.startsWith(sessionOverridePrefix) || key.startsWith(workspaceVariantPrefix) || key === VARIANT_PREF_KEY) {
               keysToRemove.push(key);
             }
           }
@@ -3003,7 +2936,9 @@ export default function App() {
       resetSessionDisplayPreferences();
       setHideTitlebar(false);
       setAutoCompactContext(false);
-      updateModelVariant(selectedSessionModel(), null);
+      modelConfig.clearPendingSessionChoice();
+      modelConfig.setSessionChoiceOverrideById({});
+      modelConfig.setWorkspaceVariantMap({});
       setUpdateAutoCheck(true);
       setUpdateAutoDownload(false);
       setUpdateStatus({ state: "idle", lastCheckedAt: null });
@@ -3341,12 +3276,13 @@ export default function App() {
 
   const selectedSessionModel = createMemo<ModelRef>(() => {
     const id = selectedSessionId();
-    if (!id) return pendingSessionModel() ?? defaultModel();
+    const pendingChoice = modelConfig.pendingSessionChoice();
+    if (!id) return pendingChoice?.model ?? defaultModel();
 
-    const override = sessionModelOverrideById()[id];
+    const override = modelConfig.sessionChoiceOverrideById()[id]?.model;
     if (override) return override;
 
-    const known = sessionModelById()[id];
+    const known = modelConfig.sessionModelById()[id];
     if (known) return known;
 
     const fromMessages = lastUserModelFromMessages(messages());
@@ -3405,7 +3341,7 @@ export default function App() {
     const currentDefault = defaultModel();
 
     if (!allProviders.length) {
-      const behavior = getModelBehaviorCopy(DEFAULT_MODEL, getVariantFor(DEFAULT_MODEL));
+      const behavior = getModelBehaviorCopy(DEFAULT_MODEL, modelConfig.getWorkspaceVariantFor(DEFAULT_MODEL));
       return [
         {
           providerID: DEFAULT_MODEL.providerID,
@@ -3416,7 +3352,7 @@ export default function App() {
           behaviorTitle: behavior.title,
           behaviorLabel: behavior.label,
           behaviorDescription: behavior.description,
-          behaviorValue: normalizeModelBehaviorValue(getVariantFor(DEFAULT_MODEL)),
+          behaviorValue: normalizeModelBehaviorValue(modelConfig.getWorkspaceVariantFor(DEFAULT_MODEL)),
           behaviorOptions: behavior.options,
           isFree: true,
           isConnected: false,
@@ -3447,8 +3383,12 @@ export default function App() {
         const isDefault =
           provider.id === currentDefault.providerID && model.id === currentDefault.modelID;
         const ref = { providerID: provider.id, modelID: model.id };
-        const behavior = getModelBehaviorSummary(provider.id, model, getVariantFor(ref));
-        const behaviorValue = sanitizeModelBehaviorValue(provider.id, model, getVariantFor(ref));
+        const activeVariant =
+          modelPickerTarget() === "session" && modelEquals(ref, selectedSessionModel())
+            ? modelVariant()
+            : modelConfig.getWorkspaceVariantFor(ref);
+        const behavior = getModelBehaviorSummary(provider.id, model, activeVariant);
+        const behaviorValue = sanitizeModelBehaviorValue(provider.id, model, activeVariant);
         const footerBits: string[] = [];
         if (defaultModelID === model.id || isDefault) {
           footerBits.push(t("settings.model_default", currentLocale()));
@@ -3574,19 +3514,18 @@ export default function App() {
 
     if (target === "default") {
       applyDefaultModelChoice(next);
+      closeModelPicker({ restorePromptFocus: false });
       return;
     }
 
     const id = selectedSessionId();
     if (!id) {
-      setPendingSessionModel(next);
-      applyDefaultModelChoice(next);
+      modelConfig.setPendingSessionModel(next);
       closeModelPicker({ restorePromptFocus });
       return;
     }
 
-    setSessionModelOverrideById((current) => ({ ...current, [id]: next }));
-    applyDefaultModelChoice(next);
+    modelConfig.setSessionModelOverride(id, next);
     closeModelPicker({ restorePromptFocus });
   }
 
@@ -3695,20 +3634,13 @@ export default function App() {
       }
 
       const session = unwrap(rawResult);
-      const pendingModel = pendingSessionModel();
       // Immediately select and show the new session before background list refresh.
       setBusyLabel("status.loading_session");
       mark("session:select:start", { sessionID: session.id });
       await selectSession(session.id);
       mark("session:select:ok", { sessionID: session.id });
 
-      if (pendingModel) {
-        setSessionModelOverrideById((current) => ({
-          ...current,
-          [session.id]: pendingModel,
-        }));
-        setPendingSessionModel(null);
-      }
+      modelConfig.applyPendingSessionChoice(session.id);
 
       // Inject the new session into the reactive sessions() store so
       // the createEffect bridge (sessions → sidebar) will always include it,
@@ -3855,20 +3787,6 @@ export default function App() {
           }
         }
 
-        const storedVariant = window.localStorage.getItem(VARIANT_PREF_KEY);
-        if (storedVariant && storedVariant.trim()) {
-          try {
-            const parsed = JSON.parse(storedVariant);
-            if (typeof parsed === "object" && parsed !== null) {
-              setModelVariantMap(parsed);
-            } else {
-              setModelVariantMap({ [`${DEFAULT_MODEL.providerID}/${DEFAULT_MODEL.modelID}`]: normalizeModelBehaviorValue(storedVariant)! });
-            }
-          } catch {
-            setModelVariantMap({ [`${DEFAULT_MODEL.providerID}/${DEFAULT_MODEL.modelID}`]: normalizeModelBehaviorValue(storedVariant)! });
-          }
-        }
-
         const storedUpdateAutoCheck = window.localStorage.getItem(
           "openwork.updateAutoCheck"
         );
@@ -3943,24 +3861,57 @@ export default function App() {
     const workspaceId = workspaceStore.selectedWorkspaceId();
     if (!workspaceId) return;
 
-    setSessionModelOverridesReady(false);
+    modelConfig.setSessionModelOverridesReady(false);
     const raw = window.localStorage.getItem(sessionModelOverridesKey(workspaceId));
-    setSessionModelOverrideById(parseSessionModelOverrides(raw));
-    setSessionModelOverridesReady(true);
+    modelConfig.setSessionChoiceOverrideById(parseSessionChoiceOverrides(raw));
+    modelConfig.setSessionModelOverridesReady(true);
   });
 
   createEffect(() => {
     if (typeof window === "undefined") return;
-    if (!sessionModelOverridesReady()) return;
+    if (!modelConfig.sessionModelOverridesReady()) return;
     const workspaceId = workspaceStore.selectedWorkspaceId();
     if (!workspaceId) return;
 
-    const payload = serializeSessionModelOverrides(sessionModelOverrideById());
+    const payload = serializeSessionChoiceOverrides(modelConfig.sessionChoiceOverrideById());
     try {
       if (payload) {
         window.localStorage.setItem(sessionModelOverridesKey(workspaceId), payload);
       } else {
         window.localStorage.removeItem(sessionModelOverridesKey(workspaceId));
+      }
+    } catch {
+      // ignore
+    }
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    const workspaceId = workspaceStore.selectedWorkspaceId().trim();
+    if (!workspaceId) {
+      modelConfig.setWorkspaceVariantMap({});
+      return;
+    }
+
+    const scopedRaw = window.localStorage.getItem(workspaceModelVariantsKey(workspaceId));
+    const legacyRaw = scopedRaw == null ? window.localStorage.getItem(VARIANT_PREF_KEY) : null;
+    modelConfig.setWorkspaceVariantMap(
+      parseWorkspaceModelVariants(scopedRaw ?? legacyRaw, defaultModel()),
+    );
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    const workspaceId = workspaceStore.selectedWorkspaceId().trim();
+    if (!workspaceId) return;
+
+    try {
+      const map = modelConfig.workspaceVariantMap();
+      const key = workspaceModelVariantsKey(workspaceId);
+      if (Object.keys(map).length > 0) {
+        window.localStorage.setItem(key, JSON.stringify(map));
+      } else {
+        window.localStorage.removeItem(key);
       }
     } catch {
       // ignore
@@ -4425,20 +4376,6 @@ export default function App() {
   });
 
   createEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const map = modelVariantMap();
-      if (Object.keys(map).length > 0) {
-        window.localStorage.setItem(VARIANT_PREF_KEY, JSON.stringify(map));
-      } else {
-        window.localStorage.removeItem(VARIANT_PREF_KEY);
-      }
-    } catch {
-      // ignore
-    }
-  });
-
-  createEffect(() => {
     const state = updateStatus();
     if (typeof window === "undefined") return;
     if (state.state === "idle" && state.lastCheckedAt) {
@@ -4673,7 +4610,7 @@ export default function App() {
       autoCompactContextBusy: autoCompactContextSaving(),
       hideTitlebar: hideTitlebar(),
       toggleHideTitlebar: () => setHideTitlebar((v) => !v),
-      modelVariantLabel: getModelBehaviorCopy(defaultModel(), getVariantFor(defaultModel())).label,
+      modelVariantLabel: getModelBehaviorCopy(defaultModel(), modelConfig.getWorkspaceVariantFor(defaultModel())).label,
       editModelVariant: openDefaultModelPicker,
       updateAutoCheck: updateAutoCheck(),
       toggleUpdateAutoCheck: () => setUpdateAutoCheck((v) => !v),
@@ -4807,10 +4744,17 @@ export default function App() {
     installUpdateAndRestart,
     selectedSessionModelLabel: selectedSessionModelLabel(),
     openSessionModelPicker: openSessionModelPicker,
-    modelVariantLabel: getModelBehaviorCopy(selectedSessionModel(), getVariantFor(selectedSessionModel())).label,
-    modelVariant: getVariantFor(selectedSessionModel()),
-    modelBehaviorOptions: getModelBehaviorCopy(selectedSessionModel(), getVariantFor(selectedSessionModel())).options,
-    setModelVariant: (value: string | null) => updateModelVariant(selectedSessionModel(), value),
+    modelVariantLabel: getModelBehaviorCopy(selectedSessionModel(), modelVariant()).label,
+    modelVariant: modelVariant(),
+    modelBehaviorOptions: getModelBehaviorCopy(selectedSessionModel(), modelVariant()).options,
+    setModelVariant: (value: string | null) => {
+      const sessionId = selectedSessionId();
+      if (sessionId) {
+        modelConfig.setSessionVariantOverride(sessionId, sanitizeModelVariantForRef(selectedSessionModel(), value));
+        return;
+      }
+      modelConfig.setPendingSessionVariant(sanitizeModelVariantForRef(selectedSessionModel(), value));
+    },
     activePlugins: sidebarPluginList(),
     activePluginStatus: sidebarPluginStatus(),
     skills: skills(),
@@ -5024,7 +4968,19 @@ export default function App() {
         current={modelPickerCurrent()}
         onSelect={applyModelSelection}
         onBehaviorChange={(model, value) => {
-          updateModelVariant(model, sanitizeModelVariantForRef(model, value));
+          const nextValue = sanitizeModelVariantForRef(model, value);
+          if (modelPickerTarget() === "default") {
+            modelConfig.setWorkspaceVariant(model, nextValue);
+            return;
+          }
+
+          const sessionId = selectedSessionId();
+          if (sessionId) {
+            modelConfig.setSessionVariantOverride(sessionId, nextValue);
+            return;
+          }
+
+          modelConfig.setPendingSessionVariant(nextValue);
         }}
         onOpenSettings={openSettingsFromModelPicker}
         onClose={closeModelPicker}

--- a/apps/app/src/app/context/model-config.ts
+++ b/apps/app/src/app/context/model-config.ts
@@ -1,0 +1,341 @@
+import { createMemo, createSignal } from "solid-js";
+
+import { DEFAULT_MODEL, SESSION_MODEL_PREF_KEY, VARIANT_PREF_KEY } from "../constants";
+import type { ModelRef } from "../types";
+import { normalizeModelBehaviorValue } from "../lib/model-behavior";
+import { formatModelRef, modelEquals, parseModelRef } from "../utils";
+
+export type SessionChoiceOverride = {
+  model?: ModelRef | null;
+  variant?: string | null;
+};
+
+export type SessionModelState = {
+  overrides: Record<string, ModelRef>;
+  resolved: Record<string, ModelRef>;
+};
+
+const hasOwn = <K extends PropertyKey>(value: object, key: K): value is Record<K, unknown> =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const normalizeVariantOverride = (value: unknown) => {
+  if (typeof value === "string") return normalizeModelBehaviorValue(value);
+  if (value == null) return null;
+  return null;
+};
+
+const parseStoredModel = (value: unknown) => {
+  if (typeof value === "string") return parseModelRef(value);
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.providerID === "string" && typeof record.modelID === "string") {
+    return {
+      providerID: record.providerID,
+      modelID: record.modelID,
+    };
+  }
+
+  return null;
+};
+
+const normalizeSessionChoice = (value: SessionChoiceOverride | null | undefined) => {
+  if (!value || typeof value !== "object") return null;
+
+  const next: SessionChoiceOverride = {};
+  if (value.model) {
+    next.model = value.model;
+  }
+
+  if (hasOwn(value, "variant")) {
+    next.variant = normalizeModelBehaviorValue(value.variant ?? null);
+  }
+
+  return hasOwn(next, "variant") || next.model ? next : null;
+};
+
+const deriveSessionModelOverrides = (choices: Record<string, SessionChoiceOverride>) => {
+  const next: Record<string, ModelRef> = {};
+  for (const [sessionId, choice] of Object.entries(choices)) {
+    if (choice.model) next[sessionId] = choice.model;
+  }
+  return next;
+};
+
+const applySessionModelState = (
+  currentChoices: Record<string, SessionChoiceOverride>,
+  nextState: SessionModelState,
+) => {
+  const nextChoices: Record<string, SessionChoiceOverride> = {};
+
+  for (const [sessionId, choice] of Object.entries(currentChoices)) {
+    if (hasOwn(choice, "variant") && !nextState.overrides[sessionId]) {
+      nextChoices[sessionId] = { variant: choice.variant ?? null };
+    }
+  }
+
+  for (const [sessionId, model] of Object.entries(nextState.overrides)) {
+    const current = currentChoices[sessionId];
+    const nextChoice = normalizeSessionChoice({
+      model,
+      ...(current && hasOwn(current, "variant") ? { variant: current.variant ?? null } : {}),
+    });
+    if (nextChoice) nextChoices[sessionId] = nextChoice;
+  }
+
+  return nextChoices;
+};
+
+export const sessionModelOverridesKey = (workspaceId: string) =>
+  `${SESSION_MODEL_PREF_KEY}.${workspaceId}`;
+
+export const workspaceModelVariantsKey = (workspaceId: string) =>
+  `${VARIANT_PREF_KEY}.${workspaceId}`;
+
+export const parseSessionChoiceOverrides = (raw: string | null) => {
+  if (!raw) return {} as Record<string, SessionChoiceOverride>;
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {} as Record<string, SessionChoiceOverride>;
+    }
+
+    const next: Record<string, SessionChoiceOverride> = {};
+    for (const [sessionId, value] of Object.entries(parsed)) {
+      if (typeof value === "string") {
+        const model = parseModelRef(value);
+        if (model) next[sessionId] = { model };
+        continue;
+      }
+
+      if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+      const record = value as Record<string, unknown>;
+      const model = parseStoredModel(record.model ?? record);
+      const choice = normalizeSessionChoice({
+        ...(model ? { model } : {}),
+        ...(hasOwn(record, "variant") ? { variant: normalizeVariantOverride(record.variant) } : {}),
+      });
+
+      if (choice) next[sessionId] = choice;
+    }
+
+    return next;
+  } catch {
+    return {} as Record<string, SessionChoiceOverride>;
+  }
+};
+
+export const serializeSessionChoiceOverrides = (
+  overrides: Record<string, SessionChoiceOverride>,
+) => {
+  const entries = Object.entries(overrides)
+    .map(([sessionId, choice]) => [sessionId, normalizeSessionChoice(choice)] as const)
+    .filter((entry): entry is readonly [string, SessionChoiceOverride] => Boolean(entry[1]));
+
+  if (!entries.length) return null;
+
+  const payload: Record<string, { model?: string; variant?: string | null }> = {};
+  for (const [sessionId, choice] of entries) {
+    const next: { model?: string; variant?: string | null } = {};
+    if (choice.model) next.model = formatModelRef(choice.model);
+    if (hasOwn(choice, "variant")) next.variant = choice.variant ?? null;
+    payload[sessionId] = next;
+  }
+
+  return JSON.stringify(payload);
+};
+
+export const parseWorkspaceModelVariants = (
+  raw: string | null,
+  fallbackModel: ModelRef = DEFAULT_MODEL,
+) => {
+  if (!raw || !raw.trim()) return {} as Record<string, string>;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      const normalized = normalizeModelBehaviorValue(raw);
+      return normalized ? { [formatModelRef(fallbackModel)]: normalized } : {};
+    }
+
+    const next: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      const normalized = normalizeVariantOverride(value);
+      if (normalized) next[key] = normalized;
+    }
+    return next;
+  } catch {
+    const normalized = normalizeModelBehaviorValue(raw);
+    return normalized ? { [formatModelRef(fallbackModel)]: normalized } : {};
+  }
+};
+
+export function createModelConfigStore() {
+  const [sessionChoiceOverrideById, setSessionChoiceOverrideById] = createSignal<
+    Record<string, SessionChoiceOverride>
+  >({});
+  const [sessionModelById, setSessionModelById] = createSignal<Record<string, ModelRef>>({});
+  const [pendingSessionChoice, setPendingSessionChoice] = createSignal<SessionChoiceOverride | null>(
+    null,
+  );
+  const [sessionModelOverridesReady, setSessionModelOverridesReady] = createSignal(false);
+  const [workspaceVariantMap, setWorkspaceVariantMap] = createSignal<Record<string, string>>({});
+
+  const sessionModelState = createMemo<SessionModelState>(() => ({
+    overrides: deriveSessionModelOverrides(sessionChoiceOverrideById()),
+    resolved: sessionModelById(),
+  }));
+
+  const setSessionModelState = (
+    updater: (current: SessionModelState) => SessionModelState,
+  ) => {
+    const next = updater(sessionModelState());
+    setSessionChoiceOverrideById((current) => applySessionModelState(current, next));
+    setSessionModelById(next.resolved);
+    return next;
+  };
+
+  const setWorkspaceVariant = (ref: ModelRef, value: string | null) => {
+    const key = formatModelRef(ref);
+    const normalized = normalizeModelBehaviorValue(value);
+
+    setWorkspaceVariantMap((current) => {
+      const next = { ...current };
+      if (normalized) next[key] = normalized;
+      else delete next[key];
+      return next;
+    });
+  };
+
+  const setPendingSessionModel = (model: ModelRef) => {
+    setPendingSessionChoice((current) =>
+      normalizeSessionChoice({ model, ...(current && hasOwn(current, "variant") ? { variant: current.variant ?? null } : {}) }),
+    );
+  };
+
+  const setPendingSessionVariant = (value: string | null) => {
+    setPendingSessionChoice((current) =>
+      normalizeSessionChoice({
+        ...(current?.model ? { model: current.model } : {}),
+        variant: normalizeModelBehaviorValue(value),
+      }),
+    );
+  };
+
+  const clearPendingSessionChoice = () => setPendingSessionChoice(null);
+
+  const applyPendingSessionChoice = (sessionId: string) => {
+    const pending = normalizeSessionChoice(pendingSessionChoice());
+    if (!pending) return;
+
+    setSessionChoiceOverrideById((current) => {
+      const existing = current[sessionId];
+      const next = normalizeSessionChoice({
+        ...(existing?.model ? { model: existing.model } : {}),
+        ...(pending.model ? { model: pending.model } : {}),
+        ...(hasOwn(existing ?? {}, "variant") ? { variant: existing?.variant ?? null } : {}),
+        ...(hasOwn(pending, "variant") ? { variant: pending.variant ?? null } : {}),
+      });
+      if (!next) return current;
+      return { ...current, [sessionId]: next };
+    });
+
+    setPendingSessionChoice(null);
+  };
+
+  const setSessionModelOverride = (sessionId: string, model: ModelRef) => {
+    setSessionChoiceOverrideById((current) => {
+      const existing = current[sessionId];
+      const preserveVariant =
+        existing?.model &&
+        modelEquals(existing.model, model) &&
+        hasOwn(existing, "variant")
+          ? { variant: existing.variant ?? null }
+          : hasOwn(existing ?? {}, "variant") && existing?.variant == null
+            ? { variant: null }
+            : {};
+
+      const next = normalizeSessionChoice({ model, ...preserveVariant });
+      if (!next) return current;
+      return { ...current, [sessionId]: next };
+    });
+  };
+
+  const clearSessionModelOverride = (sessionId: string) => {
+    setSessionChoiceOverrideById((current) => {
+      const existing = current[sessionId];
+      if (!existing) return current;
+
+      const next = normalizeSessionChoice(
+        hasOwn(existing, "variant") ? { variant: existing.variant ?? null } : null,
+      );
+
+      const copy = { ...current };
+      if (next) copy[sessionId] = next;
+      else delete copy[sessionId];
+      return copy;
+    });
+  };
+
+  const setSessionVariantOverride = (sessionId: string, value: string | null) => {
+    setSessionChoiceOverrideById((current) => {
+      const existing = current[sessionId];
+      const next = normalizeSessionChoice({
+        ...(existing?.model ? { model: existing.model } : {}),
+        variant: normalizeModelBehaviorValue(value),
+      });
+
+      if (!next) {
+        const copy = { ...current };
+        delete copy[sessionId];
+        return copy;
+      }
+
+      return { ...current, [sessionId]: next };
+    });
+  };
+
+  const getWorkspaceVariantFor = (ref: ModelRef) =>
+    workspaceVariantMap()[formatModelRef(ref)] ?? null;
+
+  const getVariantFor = (ref: ModelRef, sessionId?: string | null) => {
+    if (sessionId) {
+      const choice = sessionChoiceOverrideById()[sessionId];
+      if (choice && hasOwn(choice, "variant")) {
+        return choice.variant ?? null;
+      }
+    } else {
+      const pending = pendingSessionChoice();
+      if (pending && hasOwn(pending, "variant")) {
+        return pending.variant ?? null;
+      }
+    }
+
+    return getWorkspaceVariantFor(ref);
+  };
+
+  return {
+    sessionChoiceOverrideById,
+    setSessionChoiceOverrideById,
+    sessionModelById,
+    setSessionModelById,
+    sessionModelState,
+    setSessionModelState,
+    pendingSessionChoice,
+    setPendingSessionModel,
+    setPendingSessionVariant,
+    clearPendingSessionChoice,
+    applyPendingSessionChoice,
+    sessionModelOverridesReady,
+    setSessionModelOverridesReady,
+    workspaceVariantMap,
+    setWorkspaceVariantMap,
+    setWorkspaceVariant,
+    setSessionModelOverride,
+    clearSessionModelOverride,
+    setSessionVariantOverride,
+    getWorkspaceVariantFor,
+    getVariantFor,
+  };
+}


### PR DESCRIPTION
## Summary
- move session model and reasoning selection state into a dedicated `apps/app/src/app/context/model-config.ts` store so `app.tsx` stops owning the full model/variant state machine
- keep session model picks session-scoped instead of mutating the workspace default model, while persisting workspace model behavior separately from session behavior overrides
- persist session-specific reasoning choices with the session override state so new sessions still inherit workspace defaults but active sessions can remember their own behavior

## Testing
- `apps/app/node_modules/.bin/tsc -p apps/app/tsconfig.json --noEmit`
- `node_modules/.bin/vite build` (from `apps/app`)
- `packaging/docker/dev-up.sh`
- Chrome DevTools verification against the Docker stack:
  - set session behavior to `Deep` on a new session
  - sent `smoke: preserve deep reasoning for this session only`
  - confirmed the session stayed on `Deep` after creation and the stored local state only wrote `openwork.sessionModels...{\"variant\":\"high\"}` without a workspace `openwork.modelVariant...` entry