### PR TITLE
refactor(shell): unify app status toasts

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -33,14 +33,14 @@ import SkillDestinationModal from "./bundles/skill-destination-modal";
 import BundleImportModal from "./bundles/import-modal";
 import BundleStartModal from "./bundles/start-modal";
 import RenameWorkspaceModal from "./components/rename-workspace-modal";
-import ReloadWorkspaceToast from "./components/reload-workspace-toast";
-import StatusToast from "./components/status-toast";
 import ConnectionsModals from "./connections/modals";
 import { ConnectionsProvider } from "./connections/provider";
 import { ExtensionsProvider } from "./extensions/provider";
 import { AutomationsProvider } from "./automations/provider";
 import BootShell from "./shell/boot-shell";
 import SettingsShell from "./shell/settings-shell";
+import TopRightNotifications from "./shell/top-right-notifications";
+import { createStatusToastsStore, StatusToastsProvider } from "./shell/status-toasts";
 import SessionView from "./pages/session";
 import { unwrap } from "./lib/opencode";
 import { createDenClient, writeDenSettings } from "./lib/den";
@@ -2020,6 +2020,7 @@ export default function App() {
 
   const runtimeWorkspaceId = createMemo(() => workspaceStore.runtimeWorkspaceId());
   const activeWorkspaceServerConfig = createMemo(() => workspaceStore.runtimeWorkspaceConfig());
+  const statusToastsStore = createStatusToastsStore();
   const bundlesStore = createBundlesStore({
     booting,
     startupPreference,
@@ -2037,6 +2038,7 @@ export default function App() {
     refreshSkills,
     refreshHubSkills,
     markReloadRequired,
+    showStatusToast: statusToastsStore.showToast,
   });
 
   const logWorkspaceScopeSnapshot = (label: string, extra?: Record<string, unknown>) => {
@@ -4946,17 +4948,18 @@ export default function App() {
     <ConnectionsProvider store={connectionsStore}>
       <ExtensionsProvider store={extensionsStore}>
         <AutomationsProvider store={automationsStore}>
-          <Switch>
-            <Match when={booting()}>
-              <BootShell />
-            </Match>
-            <Match when={currentView() === "session"}>
-              <SessionView {...sessionProps()} />
-            </Match>
-            <Match when={true}>
-              <SettingsShell {...settingsShellProps()} />
-            </Match>
-          </Switch>
+          <StatusToastsProvider store={statusToastsStore}>
+            <Switch>
+              <Match when={booting()}>
+                <BootShell />
+              </Match>
+              <Match when={currentView() === "session"}>
+                <SessionView {...sessionProps()} />
+              </Match>
+              <Match when={true}>
+                <SettingsShell {...settingsShellProps()} />
+              </Match>
+            </Switch>
 
       <ModelPickerModal
         open={modelPickerOpen()}
@@ -5166,54 +5169,38 @@ export default function App() {
         }}
       />
 
-      <CreateRemoteWorkspaceModal
-        open={workspaceStore.createRemoteWorkspaceOpen()}
-        onClose={() => {
-          workspaceStore.setCreateRemoteWorkspaceOpen(false);
-          setDeepLinkRemoteWorkspaceDefaults(null);
+            <CreateRemoteWorkspaceModal
+              open={workspaceStore.createRemoteWorkspaceOpen()}
+              onClose={() => {
+                workspaceStore.setCreateRemoteWorkspaceOpen(false);
+                setDeepLinkRemoteWorkspaceDefaults(null);
+              }}
+              onConfirm={(input) => workspaceStore.createRemoteWorkspaceFlow(input)}
+              initialValues={deepLinkRemoteWorkspaceDefaults() ?? undefined}
+              submitting={
+                busy() &&
+                (busyLabel() === "status.creating_workspace" || busyLabel() === "status.connecting")
+              }
+            />
+
+      <TopRightNotifications
+        reloadOpen={reloadRequired("config", "mcp", "plugin", "skill", "agent", "command")}
+        reloadTitle={reloadCopy().title}
+        reloadDescription={reloadCopy().body}
+        reloadTrigger={reloadTrigger()}
+        reloadError={reloadError()}
+        reloadLabel={activeReloadBlockingSessions().length > 0 ? "Reload & Stop Tasks" : "Reload now"}
+        dismissLabel="Later"
+        reloadBusy={reloadBusy()}
+        canReload={canReloadWorkspace()}
+        hasActiveRuns={activeReloadBlockingSessions().length > 0}
+        onReload={() => {
+          void (activeReloadBlockingSessions().length > 0
+            ? forceStopActiveSessionsAndReload()
+            : reloadWorkspaceEngineAndResume());
         }}
-        onConfirm={(input) => workspaceStore.createRemoteWorkspaceFlow(input)}
-        initialValues={deepLinkRemoteWorkspaceDefaults() ?? undefined}
-        submitting={
-          busy() &&
-          (busyLabel() === "status.creating_workspace" || busyLabel() === "status.connecting")
-        }
+        onDismissReload={clearReloadRequired}
       />
-
-      <div class="pointer-events-none fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-1.5rem))] max-w-full flex-col gap-3 sm:right-6 sm:top-6">
-        <div class="pointer-events-auto">
-          <ReloadWorkspaceToast
-            open={reloadRequired("config", "mcp", "plugin", "skill", "agent", "command")}
-            title={reloadCopy().title}
-            description={reloadCopy().body}
-            trigger={reloadTrigger()}
-            error={reloadError()}
-            reloadLabel={activeReloadBlockingSessions().length > 0 ? "Reload & Stop Tasks" : "Reload now"}
-            dismissLabel="Later"
-            busy={reloadBusy()}
-            canReload={canReloadWorkspace()}
-            hasActiveRuns={activeReloadBlockingSessions().length > 0}
-            onReload={() => {
-              void (activeReloadBlockingSessions().length > 0
-                ? forceStopActiveSessionsAndReload()
-                : reloadWorkspaceEngineAndResume());
-            }}
-            onDismiss={clearReloadRequired}
-          />
-        </div>
-
-        <div class="pointer-events-auto">
-          <StatusToast
-            open={Boolean(bundlesStore.skillSuccessToast())}
-            tone="success"
-            title={bundlesStore.skillSuccessToast()?.title ?? "Skill added"}
-            description={bundlesStore.skillSuccessToast()?.description ?? null}
-            dismissLabel="Dismiss"
-            onDismiss={bundlesStore.clearSkillSuccessToast}
-          />
-        </div>
-
-      </div>
 
       <RenameWorkspaceModal
         open={renameWorkspaceOpen()}
@@ -5261,6 +5248,7 @@ export default function App() {
         subtitle={t("dashboard.edit_remote_workspace_subtitle", currentLocale())}
         confirmLabel={t("dashboard.edit_remote_workspace_confirm", currentLocale())}
       />
+          </StatusToastsProvider>
         </AutomationsProvider>
       </ExtensionsProvider>
     </ConnectionsProvider>

--- a/apps/app/src/app/bundles/store.ts
+++ b/apps/app/src/app/bundles/store.ts
@@ -35,9 +35,9 @@ import type {
   BundleWorkerOption,
   BundleV1,
   SkillDestinationRequest,
-  SkillSuccessToast,
   WorkspaceProfileBundleV1,
 } from "./types";
+import type { AppStatusToastInput } from "../shell/status-toasts";
 
 type BundleProcessResult =
   | { mode: "choice"; bundle: BundleV1 }
@@ -65,6 +65,7 @@ export function createBundlesStore(options: {
   refreshSkills: (input?: { force?: boolean }) => Promise<unknown>;
   refreshHubSkills: (input?: { force?: boolean }) => Promise<unknown>;
   markReloadRequired: (reason: ReloadReason, trigger?: ReloadTrigger) => void;
+  showStatusToast: (toast: AppStatusToastInput) => void;
 }) {
   const [pendingBundleRequest, setPendingBundleRequest] = createSignal<BundleRequest | null>(null);
   const [bundleStartRequest, setBundleStartRequest] = createSignal<BundleStartRequest | null>(null);
@@ -76,34 +77,14 @@ export function createBundlesStore(options: {
   const [bundleImportBusy, setBundleImportBusy] = createSignal(false);
   const [bundleImportError, setBundleImportError] = createSignal<string | null>(null);
   const [bundleNoticeShown, setBundleNoticeShown] = createSignal(false);
-  const [skillSuccessToast, setSkillSuccessToast] = createSignal<SkillSuccessToast | null>(null);
 
-  let skillSuccessToastTimer: number | null = null;
-
-  const clearSkillSuccessToast = () => {
-    if (skillSuccessToastTimer) {
-      window.clearTimeout(skillSuccessToastTimer);
-      skillSuccessToastTimer = null;
-    }
-    setSkillSuccessToast(null);
+  const showSkillSuccessToast = (toast: { title: string; description: string }) => {
+    options.showStatusToast({
+      ...toast,
+      tone: "success",
+      durationMs: 4200,
+    });
   };
-
-  const showSkillSuccessToast = (toast: SkillSuccessToast) => {
-    if (skillSuccessToastTimer) {
-      window.clearTimeout(skillSuccessToastTimer);
-    }
-    setSkillSuccessToast(toast);
-    skillSuccessToastTimer = window.setTimeout(() => {
-      skillSuccessToastTimer = null;
-      setSkillSuccessToast(null);
-    }, 4200);
-  };
-
-  onCleanup(() => {
-    if (skillSuccessToastTimer) {
-      window.clearTimeout(skillSuccessToastTimer);
-    }
-  });
 
   const resetInteractiveBundleState = () => {
     setSkillDestinationRequest(null);
@@ -830,7 +811,6 @@ export function createBundlesStore(options: {
     openRemoteConnectFromSkillDestination,
     handleCreateWorkspaceConfirm,
     handleCreateSandboxConfirm,
-    clearSkillSuccessToast,
     bundleImportChoice,
     bundleImportSummary,
     bundleWorkerOptions,
@@ -844,6 +824,5 @@ export function createBundlesStore(options: {
     skillDestinationRequest,
     skillDestinationWorkspaces,
     skillDestinationBusyId,
-    skillSuccessToast,
   };
 }

--- a/apps/app/src/app/bundles/types.ts
+++ b/apps/app/src/app/bundles/types.ts
@@ -67,11 +67,6 @@ export type SkillDestinationRequest = {
   bundle: SkillBundleV1;
 };
 
-export type SkillSuccessToast = {
-  title: string;
-  description: string;
-};
-
 export type BundleImportChoice = {
   request: BundleRequest;
   bundle: BundleV1;

--- a/apps/app/src/app/components/status-toast.tsx
+++ b/apps/app/src/app/components/status-toast.tsx
@@ -1,6 +1,6 @@
 import { Show } from "solid-js";
 
-import { CheckCircle2, Info, X } from "lucide-solid";
+import { AlertTriangle, CheckCircle2, CircleAlert, Info, X } from "lucide-solid";
 
 import Button from "./button";
 
@@ -8,7 +8,7 @@ export type StatusToastProps = {
   open: boolean;
   title: string;
   description?: string | null;
-  tone?: "success" | "info";
+  tone?: "success" | "info" | "warning" | "error";
   actionLabel?: string;
   onAction?: () => void;
   dismissLabel?: string;
@@ -20,16 +20,31 @@ export default function StatusToast(props: StatusToastProps) {
 
   return (
     <Show when={props.open}>
-      <div class="w-full max-w-[24rem] overflow-hidden rounded-[1.4rem] border border-white/70 bg-white/92 shadow-[0_24px_60px_-28px_rgba(15,23,42,0.28)] backdrop-blur-xl">
+      <div class="w-full max-w-[24rem] overflow-hidden rounded-[1.4rem] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)] backdrop-blur-xl animate-in fade-in slide-in-from-top-4 duration-300">
         <div class="flex items-start gap-3 px-4 py-4">
           <div
             class={`mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border ${
               tone() === "success"
                 ? "border-emerald-6/40 bg-emerald-4/80 text-emerald-11"
+                : tone() === "warning"
+                  ? "border-amber-6/40 bg-amber-4/80 text-amber-11"
+                  : tone() === "error"
+                    ? "border-red-6/40 bg-red-4/80 text-red-11"
                 : "border-sky-6/40 bg-sky-4/80 text-sky-11"
             }`.trim()}
           >
-            <Show when={tone() === "success"} fallback={<Info size={18} />}>
+            <Show
+              when={tone() === "success"}
+              fallback={
+                tone() === "warning" ? (
+                  <AlertTriangle size={18} />
+                ) : tone() === "error" ? (
+                  <CircleAlert size={18} />
+                ) : (
+                  <Info size={18} />
+                )
+              }
+            >
               <CheckCircle2 size={18} />
             </Show>
           </div>

--- a/apps/app/src/app/pages/automations.tsx
+++ b/apps/app/src/app/pages/automations.tsx
@@ -22,6 +22,7 @@ import {
   Trophy,
   X,
 } from "lucide-solid";
+import { useStatusToasts, type AppStatusToastTone } from "../shell/status-toasts";
 
 type AutomationsFilter = "all" | "scheduled" | "templates";
 type ScheduleMode = "daily" | "interval";
@@ -413,8 +414,8 @@ const JobCard = (props: {
 export default function AutomationsView(props: AutomationsViewProps) {
   const automations = useAutomations();
   const platform = usePlatform();
+  const statusToasts = useStatusToasts();
 
-  const [toast, setToast] = createSignal<string | null>(null);
   const [searchQuery, setSearchQuery] = createSignal("");
   const [activeFilter, setActiveFilter] = createSignal<AutomationsFilter>("all");
   const [installingScheduler, setInstallingScheduler] = createSignal(false);
@@ -434,17 +435,14 @@ export default function AutomationsView(props: AutomationsViewProps) {
   const [lastUpdatedNow, setLastUpdatedNow] = createSignal(Date.now());
 
   createEffect(() => {
-    const message = toast();
-    if (!message) return;
-    const id = window.setTimeout(() => setToast(null), 2400);
-    onCleanup(() => window.clearTimeout(id));
-  });
-
-  createEffect(() => {
     if (typeof window === "undefined") return;
     const interval = window.setInterval(() => setLastUpdatedNow(Date.now()), 1_000);
     onCleanup(() => window.clearInterval(interval));
   });
+
+  const showToast = (title: string, tone: AppStatusToastTone = "info") => {
+    statusToasts.showToast({ title, tone });
+  };
 
   const resetDraft = (template?: AutomationTemplate) => {
     setAutomationName(template?.name ?? DEFAULT_AUTOMATION_NAME);
@@ -551,7 +549,7 @@ export default function AutomationsView(props: AutomationsViewProps) {
     setSchedulerInstallRequested(true);
     try {
       await Promise.resolve(props.addPlugin("opencode-scheduler"));
-      setToast("Scheduler install requested.");
+      showToast("Scheduler install requested.", "success");
     } finally {
       setInstallingScheduler(false);
     }
@@ -594,7 +592,7 @@ export default function AutomationsView(props: AutomationsViewProps) {
       props.setPrompt(plan.prompt);
       await Promise.resolve(props.createSessionAndOpen());
       setCreateModalOpen(false);
-      setToast("Prepared automation in chat.");
+      showToast("Prepared automation in chat.", "success");
     } catch (error) {
       setCreateError(
         error instanceof Error ? error.message : "Failed to prepare automation in chat.",
@@ -608,12 +606,12 @@ export default function AutomationsView(props: AutomationsViewProps) {
     if (!supported() || props.busy) return;
     const plan = automations.prepareRunAutomation(job, props.selectedWorkspaceRoot);
     if (!plan.ok) {
-      setToast(plan.error);
+      showToast(plan.error, "warning");
       return;
     }
     props.setPrompt(plan.prompt);
     await Promise.resolve(props.createSessionAndOpen());
-    setToast(`Prepared ${job.name} in chat.`);
+    showToast(`Prepared ${job.name} in chat.`, "success");
   };
 
   const confirmDelete = async () => {
@@ -624,7 +622,7 @@ export default function AutomationsView(props: AutomationsViewProps) {
     try {
       await automations.remove(target.slug);
       setDeleteTarget(null);
-      setToast(`Removed ${target.name}.`);
+      showToast(`Removed ${target.name}.`, "success");
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       setDeleteError(message || "Failed to delete automation.");
@@ -658,12 +656,6 @@ export default function AutomationsView(props: AutomationsViewProps) {
 
   return (
     <section class="space-y-8">
-      <Show when={toast()}>
-        <div class="fixed bottom-6 right-6 z-50 max-w-sm rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-xs text-dls-text shadow-2xl">
-          {toast()}
-        </div>
-      </Show>
-
       <div class="space-y-6">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div class="min-w-0">

--- a/apps/app/src/app/pages/skills.tsx
+++ b/apps/app/src/app/pages/skills.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { For, Show, createMemo, createSignal, onMount } from "solid-js";
 
 import type { HubSkillCard, HubSkillRepo, SkillCard } from "../types";
 import { useExtensions } from "../extensions/provider";
@@ -8,6 +8,7 @@ import Button from "../components/button";
 import { Copy, Edit2, FolderOpen, Loader2, Package, Plus, RefreshCw, Search, Share2, Sparkles, Trash2, Upload } from "lucide-solid";
 import { currentLocale, t } from "../../i18n";
 import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL, publishOpenworkBundleJson } from "../lib/publisher";
+import { useStatusToasts, type AppStatusToastTone } from "../shell/status-toasts";
 
 type InstallResult = { ok: boolean; message: string };
 type SkillsFilter = "all" | "installed" | "hub";
@@ -46,6 +47,7 @@ export type SkillsViewProps = {
 
 export default function SkillsView(props: SkillsViewProps) {
   const extensions = useExtensions();
+  const statusToasts = useStatusToasts();
   // Translation helper that uses current language from i18n
   const translate = (key: string) => t(key, currentLocale());
 
@@ -75,7 +77,6 @@ export default function SkillsView(props: SkillsViewProps) {
   const [selectedDirty, setSelectedDirty] = createSignal(false);
   const [selectedError, setSelectedError] = createSignal<string | null>(null);
 
-  const [toast, setToast] = createSignal<string | null>(null);
   const [installingSkillCreator, setInstallingSkillCreator] = createSignal(false);
   const [installingHubSkill, setInstallingHubSkill] = createSignal<string | null>(null);
 
@@ -83,14 +84,10 @@ export default function SkillsView(props: SkillsViewProps) {
     extensions.ensureHubSkillsFresh();
   });
 
-  createEffect(() => {
-    const message = toast();
-    if (!message) return;
-    const id = window.setTimeout(() => setToast(null), 2400);
-    onCleanup(() => window.clearTimeout(id));
-  });
-
   const maskError = (value: unknown) => (value instanceof Error ? value.message : "Something went wrong");
+  const showToast = (title: string, tone: AppStatusToastTone = "info") => {
+    statusToasts.showToast({ title, tone });
+  };
 
   const hubRepoKey = (repo: HubSkillRepo) => `${repo.owner}/${repo.repo}@${repo.ref}`;
   const defaultHubRepoKey = "different-ai/openwork-hub@main";
@@ -167,16 +164,16 @@ export default function SkillsView(props: SkillsViewProps) {
   const installSkillCreator = async () => {
     if (props.busy || installingSkillCreator()) return;
     if (!props.canInstallSkillCreator) {
-      setToast(props.accessHint ?? translate("skills.host_only_error"));
+      showToast(props.accessHint ?? translate("skills.host_only_error"), "warning");
       return;
     }
     setInstallingSkillCreator(true);
-    setToast(translate("skills.installing_skill_creator"));
+    showToast(translate("skills.installing_skill_creator"));
     try {
       const result = await extensions.installSkillCreator();
-      setToast(result.message);
+      showToast(result.message, "success");
     } catch (e) {
-      setToast(e instanceof Error ? e.message : translate("skills.install_failed"));
+      showToast(e instanceof Error ? e.message : translate("skills.install_failed"), "error");
     } finally {
       setInstallingSkillCreator(false);
     }
@@ -185,12 +182,12 @@ export default function SkillsView(props: SkillsViewProps) {
   const installFromHub = async (skill: HubSkillCard) => {
     if (props.busy || installingHubSkill()) return;
     setInstallingHubSkill(skill.name);
-    setToast(`Installing ${skill.name}…`);
+    showToast(`Installing ${skill.name}…`);
     try {
       const result = await extensions.installHubSkill(skill.name);
-      setToast(result.message);
+      showToast(result.message, "success");
     } catch (e) {
-      setToast(e instanceof Error ? e.message : translate("skills.install_failed"));
+      showToast(e instanceof Error ? e.message : translate("skills.install_failed"), "error");
     } finally {
       setInstallingHubSkill(null);
     }
@@ -252,7 +249,7 @@ export default function SkillsView(props: SkillsViewProps) {
       setShareUrl(result.url);
       try {
         await navigator.clipboard.writeText(result.url);
-        setToast("Link copied");
+        showToast("Link copied", "success");
       } catch {
         // ignore
       }
@@ -268,7 +265,7 @@ export default function SkillsView(props: SkillsViewProps) {
     if (!url) return;
     try {
       await navigator.clipboard.writeText(url);
-      setToast("Link copied");
+      showToast("Link copied", "success");
     } catch {
       setShareError("Failed to copy link");
     }
@@ -340,7 +337,7 @@ export default function SkillsView(props: SkillsViewProps) {
   const runDesktopAction = (action: () => void | Promise<void>) => {
     if (props.busy) return;
     if (!props.canUseDesktopTools) {
-      setToast(translate("skills.desktop_required"));
+      showToast(translate("skills.desktop_required"), "warning");
       return;
     }
     void Promise.resolve(action());
@@ -354,12 +351,6 @@ export default function SkillsView(props: SkillsViewProps) {
 
   return (
     <section class="space-y-8">
-      <Show when={toast()}>
-        <div class="fixed bottom-6 right-6 z-50 max-w-sm rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-xs text-dls-text shadow-2xl">
-          {toast()}
-        </div>
-      </Show>
-
       <div class="space-y-6">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div class="min-w-0">
@@ -552,7 +543,7 @@ export default function SkillsView(props: SkillsViewProps) {
                               e.preventDefault();
                               e.stopPropagation();
                               if (props.busy || !props.canUseDesktopTools) {
-                                if (!props.canUseDesktopTools) setToast(translate("skills.desktop_required"));
+                                if (!props.canUseDesktopTools) showToast(translate("skills.desktop_required"), "warning");
                                 return;
                               }
                               setUninstallTarget(skill);

--- a/apps/app/src/app/shell/status-toasts.tsx
+++ b/apps/app/src/app/shell/status-toasts.tsx
@@ -1,0 +1,127 @@
+import { For, createContext, createSignal, onCleanup, useContext, type ParentProps } from "solid-js";
+
+import StatusToast from "../components/status-toast";
+
+export type AppStatusToastTone = "success" | "info" | "warning" | "error";
+
+export type AppStatusToastInput = {
+  title: string;
+  description?: string | null;
+  tone?: AppStatusToastTone;
+  actionLabel?: string;
+  onAction?: () => void;
+  dismissLabel?: string;
+  durationMs?: number;
+};
+
+export type AppStatusToast = AppStatusToastInput & {
+  id: string;
+};
+
+export type StatusToastsStore = ReturnType<typeof createStatusToastsStore>;
+
+const StatusToastsContext = createContext<StatusToastsStore>();
+
+const defaultDurationForTone = (tone: AppStatusToastTone) => {
+  if (tone === "warning" || tone === "error") return 4200;
+  return 3200;
+};
+
+export function createStatusToastsStore() {
+  const [toasts, setToasts] = createSignal<AppStatusToast[]>([]);
+  const timers = new Map<string, number>();
+  let counter = 0;
+
+  const dismissToast = (id: string) => {
+    const timer = timers.get(id);
+    if (timer) {
+      window.clearTimeout(timer);
+      timers.delete(id);
+    }
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  };
+
+  const showToast = (input: AppStatusToastInput) => {
+    const id = `status-toast-${Date.now()}-${counter++}`;
+    const tone = input.tone ?? "info";
+    const toast: AppStatusToast = {
+      ...input,
+      tone,
+      id,
+    };
+
+    setToasts((current) => [...current, toast].slice(-4));
+
+    const duration = input.durationMs ?? defaultDurationForTone(tone);
+    if (duration > 0) {
+      const timer = window.setTimeout(() => {
+        timers.delete(id);
+        setToasts((current) => current.filter((item) => item.id !== id));
+      }, duration);
+      timers.set(id, timer);
+    }
+
+    return id;
+  };
+
+  const clearToasts = () => {
+    for (const timer of timers.values()) {
+      window.clearTimeout(timer);
+    }
+    timers.clear();
+    setToasts([]);
+  };
+
+  onCleanup(() => {
+    for (const timer of timers.values()) {
+      window.clearTimeout(timer);
+    }
+    timers.clear();
+  });
+
+  return {
+    toasts,
+    showToast,
+    dismissToast,
+    clearToasts,
+  };
+}
+
+export function StatusToastsProvider(props: ParentProps<{ store: StatusToastsStore }>) {
+  return (
+    <StatusToastsContext.Provider value={props.store}>
+      {props.children}
+    </StatusToastsContext.Provider>
+  );
+}
+
+export function useStatusToasts() {
+  const context = useContext(StatusToastsContext);
+  if (!context) {
+    throw new Error("useStatusToasts must be used within a StatusToastsProvider");
+  }
+  return context;
+}
+
+export function StatusToastsViewport() {
+  const statusToasts = useStatusToasts();
+
+  return (
+    <For each={statusToasts.toasts()}>
+      {(toast) => (
+        <div class="pointer-events-auto">
+          <StatusToast
+            open
+            tone={toast.tone}
+            title={toast.title}
+            description={toast.description ?? null}
+            actionLabel={toast.actionLabel}
+            onAction={toast.onAction}
+            dismissLabel={toast.dismissLabel ?? "Dismiss"}
+            onDismiss={() => statusToasts.dismissToast(toast.id)}
+          />
+        </div>
+      )}
+    </For>
+  );
+}

--- a/apps/app/src/app/shell/top-right-notifications.tsx
+++ b/apps/app/src/app/shell/top-right-notifications.tsx
@@ -1,0 +1,44 @@
+import ReloadWorkspaceToast from "../components/reload-workspace-toast";
+import { StatusToastsViewport } from "./status-toasts";
+
+import type { ReloadTrigger } from "../types";
+
+export type TopRightNotificationsProps = {
+  reloadOpen: boolean;
+  reloadTitle: string;
+  reloadDescription: string;
+  reloadTrigger?: ReloadTrigger | null;
+  reloadError?: string | null;
+  reloadLabel: string;
+  dismissLabel: string;
+  reloadBusy?: boolean;
+  canReload: boolean;
+  hasActiveRuns: boolean;
+  onReload: () => void;
+  onDismissReload: () => void;
+};
+
+export default function TopRightNotifications(props: TopRightNotificationsProps) {
+  return (
+    <div class="pointer-events-none fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-1.5rem))] max-w-full flex-col gap-3 sm:right-6 sm:top-6">
+      <div class="pointer-events-auto">
+        <ReloadWorkspaceToast
+          open={props.reloadOpen}
+          title={props.reloadTitle}
+          description={props.reloadDescription}
+          trigger={props.reloadTrigger}
+          error={props.reloadError}
+          reloadLabel={props.reloadLabel}
+          dismissLabel={props.dismissLabel}
+          busy={props.reloadBusy}
+          canReload={props.canReload}
+          hasActiveRuns={props.hasActiveRuns}
+          onReload={props.onReload}
+          onDismiss={props.onDismissReload}
+        />
+      </div>
+
+      <StatusToastsViewport />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- move the ad-hoc page toasts from Skills and Automations onto a shared top-right notification stack so app feedback uses the same polished shell surface as reload notices
- restyle the generic status toast to match the den-web-inspired DLS card treatment and let bundle-import success reuse the same global queue instead of its own one-off signal
- extract the top-right notification wiring out of `app.tsx` into shell-owned pieces (`status-toasts.tsx` and `top-right-notifications.tsx`) to keep the shell thinner

## Testing
- `"/Users/benjaminshafii/openwork-enterprise/_repos/openwork/apps/app/node_modules/.bin/tsc" -p tsconfig.json --noEmit` (from `apps/app`)
- `"/Users/benjaminshafii/openwork-enterprise/_repos/openwork/apps/app/node_modules/.bin/vite" build` (from `apps/app`)

## Notes
- I did not run Docker + Chrome MCP for this PR because the changed surfaces are desktop/Tauri settings notifications and the web build does not exercise the real shell-level toast stack
- to verify the real flow locally, run `pnpm dev` from the repo root, open the desktop app, then trigger a skill install/share action and an automation action to confirm they now appear in the shared top-right stack next to reload notifications