### PR TITLE
refactor(app): move server, session, and model controls behind domain stores

### DIFF
--- a/apps/app/src/app/app-settings/model-controls-provider.tsx
+++ b/apps/app/src/app/app-settings/model-controls-provider.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+
+import type { ModelControlsStore } from "./model-controls-store";
+
+const ModelControlsContext = createContext<ModelControlsStore>();
+
+export function ModelControlsProvider(props: ParentProps<{ store: ModelControlsStore }>) {
+  return (
+    <ModelControlsContext.Provider value={props.store}>
+      {props.children}
+    </ModelControlsContext.Provider>
+  );
+}
+
+export function useModelControls() {
+  const context = useContext(ModelControlsContext);
+  if (!context) {
+    throw new Error("useModelControls must be used within a ModelControlsProvider");
+  }
+  return context;
+}

--- a/apps/app/src/app/app-settings/model-controls-store.ts
+++ b/apps/app/src/app/app-settings/model-controls-store.ts
@@ -1,0 +1,24 @@
+import type { Accessor } from "solid-js";
+
+export type ModelBehaviorOption = { value: string | null; label: string };
+
+export type ModelControlsStore = ReturnType<typeof createModelControlsStore>;
+
+export function createModelControlsStore(options: {
+  selectedSessionModelLabel: Accessor<string>;
+  openSessionModelPicker: (options?: { returnFocusTarget?: "none" | "composer" }) => void;
+  sessionModelVariantLabel: Accessor<string>;
+  sessionModelVariant: Accessor<string | null>;
+  sessionModelBehaviorOptions: Accessor<ModelBehaviorOption[]>;
+  setSessionModelVariant: (value: string | null) => void;
+  defaultModelLabel: Accessor<string>;
+  defaultModelRef: Accessor<string>;
+  openDefaultModelPicker: () => void;
+  autoCompactContext: Accessor<boolean>;
+  toggleAutoCompactContext: () => void;
+  autoCompactContextBusy: Accessor<boolean>;
+  defaultModelVariantLabel: Accessor<string>;
+  editDefaultModelVariant: () => void;
+}) {
+  return options;
+}

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -118,6 +118,8 @@ import {
   workspaceModelVariantsKey,
 } from "./context/model-config";
 import { createProvidersStore } from "./context/providers";
+import { ModelControlsProvider } from "./app-settings/model-controls-provider";
+import { createModelControlsStore } from "./app-settings/model-controls-store";
 import { useSessionDisplayPreferences } from "./app-settings/session-display-preferences";
 import {
   formatGenericBehaviorLabel,
@@ -3344,6 +3346,32 @@ export default function App() {
     return seconds > 0 ? `${label} · ${seconds}s` : label;
   });
 
+  const modelControlsStore = createModelControlsStore({
+    selectedSessionModelLabel,
+    openSessionModelPicker,
+    sessionModelVariantLabel: createMemo(() => getModelBehaviorCopy(selectedSessionModel(), modelVariant()).label),
+    sessionModelVariant: modelVariant,
+    sessionModelBehaviorOptions: createMemo(() => getModelBehaviorCopy(selectedSessionModel(), modelVariant()).options),
+    setSessionModelVariant: (value: string | null) => {
+      const sessionId = selectedSessionId();
+      if (sessionId) {
+        modelConfig.setSessionVariantOverride(sessionId, sanitizeModelVariantForRef(selectedSessionModel(), value));
+        return;
+      }
+      modelConfig.setPendingSessionVariant(sanitizeModelVariantForRef(selectedSessionModel(), value));
+    },
+    defaultModelLabel: createMemo(() => formatModelLabel(defaultModel(), providers())),
+    defaultModelRef: createMemo(() => formatModelRef(defaultModel())),
+    openDefaultModelPicker,
+    autoCompactContext,
+    toggleAutoCompactContext,
+    autoCompactContextBusy: autoCompactContextSaving,
+    defaultModelVariantLabel: createMemo(
+      () => getModelBehaviorCopy(defaultModel(), modelConfig.getWorkspaceVariantFor(defaultModel())).label,
+    ),
+    editDefaultModelVariant: openDefaultModelPicker,
+  });
+
   const settingsShellProps = () => {
     const workspaceType = selectedWorkspaceDisplay().workspaceType;
     const isRemoteWorkspace = workspaceType === "remote";
@@ -3480,16 +3508,8 @@ export default function App() {
       createSessionAndOpen,
       setPrompt,
       selectSession: selectSession,
-      defaultModelLabel: formatModelLabel(defaultModel(), providers()),
-      defaultModelRef: formatModelRef(defaultModel()),
-      openDefaultModelPicker,
-      autoCompactContext: autoCompactContext(),
-      toggleAutoCompactContext,
-      autoCompactContextBusy: autoCompactContextSaving(),
       hideTitlebar: hideTitlebar(),
       toggleHideTitlebar: () => setHideTitlebar((v) => !v),
-      modelVariantLabel: getModelBehaviorCopy(defaultModel(), modelConfig.getWorkspaceVariantFor(defaultModel())).label,
-      editModelVariant: openDefaultModelPicker,
       updateAutoCheck: updateAutoCheck(),
       toggleUpdateAutoCheck: () => setUpdateAutoCheck((v) => !v),
       updateAutoDownload: updateAutoDownload(),
@@ -3599,19 +3619,6 @@ export default function App() {
     updateEnv: updateEnv(),
     anyActiveRuns: anyActiveRuns(),
     installUpdateAndRestart,
-    selectedSessionModelLabel: selectedSessionModelLabel(),
-    openSessionModelPicker: openSessionModelPicker,
-    modelVariantLabel: getModelBehaviorCopy(selectedSessionModel(), modelVariant()).label,
-    modelVariant: modelVariant(),
-    modelBehaviorOptions: getModelBehaviorCopy(selectedSessionModel(), modelVariant()).options,
-    setModelVariant: (value: string | null) => {
-      const sessionId = selectedSessionId();
-      if (sessionId) {
-        modelConfig.setSessionVariantOverride(sessionId, sanitizeModelVariantForRef(selectedSessionModel(), value));
-        return;
-      }
-      modelConfig.setPendingSessionVariant(sanitizeModelVariantForRef(selectedSessionModel(), value));
-    },
     activePlugins: sidebarPluginList(),
     activePluginStatus: sidebarPluginStatus(),
     skills: skills(),
@@ -3785,11 +3792,12 @@ export default function App() {
 
   return (
     <OpenworkServerProvider store={openworkServerStore}>
-      <SessionActionsProvider store={sessionActionsStore}>
-        <ConnectionsProvider store={connectionsStore}>
-          <ExtensionsProvider store={extensionsStore}>
-            <AutomationsProvider store={automationsStore}>
-              <StatusToastsProvider store={statusToastsStore}>
+      <ModelControlsProvider store={modelControlsStore}>
+        <SessionActionsProvider store={sessionActionsStore}>
+          <ConnectionsProvider store={connectionsStore}>
+            <ExtensionsProvider store={extensionsStore}>
+              <AutomationsProvider store={automationsStore}>
+                <StatusToastsProvider store={statusToastsStore}>
             <Switch>
               <Match when={booting()}>
                 <BootShell />
@@ -4097,11 +4105,12 @@ export default function App() {
         subtitle={t("dashboard.edit_remote_workspace_subtitle", currentLocale())}
         confirmLabel={t("dashboard.edit_remote_workspace_confirm", currentLocale())}
       />
-              </StatusToastsProvider>
-            </AutomationsProvider>
-          </ExtensionsProvider>
-        </ConnectionsProvider>
-      </SessionActionsProvider>
+                </StatusToastsProvider>
+              </AutomationsProvider>
+            </ExtensionsProvider>
+          </ConnectionsProvider>
+        </SessionActionsProvider>
+      </ModelControlsProvider>
     </OpenworkServerProvider>
   );
 }

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -11,15 +11,7 @@ import {
 
 import { useLocation, useNavigate } from "@solidjs/router";
 
-import type {
-  Agent,
-  Part,
-  Session,
-  TextPartInput,
-  FilePartInput,
-  AgentPartInput,
-  SubtaskPartInput,
-} from "@opencode-ai/sdk/v2/client";
+import type { Part, Session } from "@opencode-ai/sdk/v2/client";
 
 import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -37,6 +29,8 @@ import { createOpenworkServerStore } from "./connections/openwork-server-store";
 import { ConnectionsProvider } from "./connections/provider";
 import { ExtensionsProvider } from "./extensions/provider";
 import { AutomationsProvider } from "./automations/provider";
+import { SessionActionsProvider } from "./session/actions-provider";
+import { createSessionActionsStore } from "./session/actions-store";
 import BootShell from "./shell/boot-shell";
 import SettingsShell from "./shell/settings-shell";
 import TopRightNotifications from "./shell/top-right-notifications";
@@ -48,15 +42,6 @@ import {
 import SessionView from "./pages/session";
 import { unwrap } from "./lib/opencode";
 import { createDenClient, writeDenSettings } from "./lib/den";
-import {
-  abortSession as abortSessionTyped,
-  abortSessionSafe,
-  compactSession as compactSessionTyped,
-  revertSession,
-  unrevertSession,
-  shellInSession,
-  listCommands as listCommandsTyped,
-} from "./lib/opencode-session";
 import { clearPerfLogs, finishPerf, perfNow, recordPerfLog } from "./lib/perf-log";
 import { deepLinkBridgeEvent, drainPendingDeepLinks, type DeepLinkBridgeDetail } from "./lib/deep-link-bridge";
 import {
@@ -89,9 +74,7 @@ import type {
   View,
   WorkspaceDisplay,
   WorkspaceSessionGroup,
-  ComposerAttachment,
   ComposerDraft,
-  ComposerPart,
   ProviderListItem,
   SessionErrorTurn,
   OpencodeConnectStatus,
@@ -145,19 +128,7 @@ import {
 import {
   describeDirectoryScope,
   shouldRedirectMissingSessionAfterScopedLoad,
-  toSessionTransportDirectory,
 } from "./lib/session-scope";
-
-const fileToDataUrl = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
-    reader.onload = () => {
-      const result = typeof reader.result === "string" ? reader.result : "";
-      resolve(result);
-    };
-    reader.readAsDataURL(file);
-  });
 import { createExtensionsStore } from "./context/extensions";
 import { createConnectionsStore } from "./connections/store";
 import { createAutomationsStore } from "./context/automations";
@@ -505,7 +476,6 @@ export default function App() {
   const [autoCompactContextSaving, setAutoCompactContextSaving] = createSignal(false);
   type PromptFocusReturnTarget = "none" | "composer";
 
-  const [sessionAgentById, setSessionAgentById] = createSignal<Record<string, string>>({});
   const modelConfig = createModelConfigStore();
 
   createEffect(() => {
@@ -651,177 +621,6 @@ export default function App() {
   });
 
   const [prompt, setPrompt] = createSignal("");
-  const [lastPromptSent, setLastPromptSent] = createSignal("");
-
-  type PartInput = TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput;
-
-  const attachmentToFilePart = async (attachment: ComposerAttachment): Promise<FilePartInput> => ({
-    type: "file",
-    url: await fileToDataUrl(attachment.file),
-    filename: attachment.name,
-    mime: attachment.mimeType,
-  });
-
-  const buildPromptParts = async (draft: ComposerDraft): Promise<PartInput[]> => {
-    const parts: PartInput[] = [];
-    const text = draft.resolvedText ?? draft.text;
-    parts.push({ type: "text", text } as TextPartInput);
-
-    const root = workspaceProjectDir().trim();
-    const toAbsolutePath = (path: string) => {
-      const trimmed = path.trim();
-      if (!trimmed) return "";
-      if (trimmed.startsWith("/")) return trimmed;
-      // Windows absolute path, e.g. C:\foo\bar
-      if (/^[a-zA-Z]:\\/.test(trimmed)) return trimmed;
-      // Without a workspace root, we cannot safely resolve relative paths.
-      // Returning "" avoids emitting invalid file:// URLs.
-      if (!root) return "";
-      return (root + "/" + trimmed).replace("//", "/");
-    };
-    const filenameFromPath = (path: string) => {
-      const normalized = path.replace(/\\/g, "/");
-      const segments = normalized.split("/").filter(Boolean);
-      return segments[segments.length - 1] ?? "file";
-    };
-
-    for (const part of draft.parts) {
-      if (part.type === "agent") {
-        parts.push({ type: "agent", name: part.name } as AgentPartInput);
-        continue;
-      }
-      if (part.type === "file") {
-        const absolute = toAbsolutePath(part.path);
-        if (!absolute) continue;
-        parts.push({
-          type: "file",
-          mime: "text/plain",
-          url: `file://${absolute}`,
-          filename: filenameFromPath(part.path),
-        } as FilePartInput);
-      }
-    }
-
-    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
-
-    return parts;
-  };
-
-  const buildCommandFileParts = async (draft: ComposerDraft): Promise<FilePartInput[]> => {
-    const parts: FilePartInput[] = [];
-    const root = workspaceProjectDir().trim();
-
-    const toAbsolutePath = (path: string) => {
-      const trimmed = path.trim();
-      if (!trimmed) return "";
-      if (trimmed.startsWith("/")) return trimmed;
-      if (/^[a-zA-Z]:\\/.test(trimmed)) return trimmed;
-      if (!root) return "";
-      return (root + "/" + trimmed).replace("//", "/");
-    };
-
-    const filenameFromPath = (path: string) => {
-      const normalized = path.replace(/\\/g, "/");
-      const segments = normalized.split("/").filter(Boolean);
-      return segments[segments.length - 1] ?? "file";
-    };
-
-    for (const part of draft.parts) {
-      if (part.type !== "file") continue;
-      const absolute = toAbsolutePath(part.path);
-      if (!absolute) continue;
-      parts.push({
-        type: "file",
-        mime: "text/plain",
-        url: `file://${absolute}`,
-        filename: filenameFromPath(part.path),
-      } as FilePartInput);
-    }
-
-    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
-
-    return parts;
-  };
-
-  const assertNoClientError = (result: unknown) => {
-    const maybe = result as { error?: unknown } | null | undefined;
-    if (!maybe || maybe.error === undefined) return;
-    throw new Error(describeProviderError(maybe.error, "Request failed"));
-  };
-
-  const describeProviderError = (error: unknown, fallback: string) => {
-    const readString = (value: unknown, max = 700) => {
-      if (typeof value !== "string") return null;
-      const trimmed = value.trim();
-      if (!trimmed) return null;
-      if (trimmed.length <= max) return trimmed;
-      return `${trimmed.slice(0, Math.max(0, max - 3))}...`;
-    };
-
-    const records: Record<string, unknown>[] = [];
-    const root = error && typeof error === "object" ? (error as Record<string, unknown>) : null;
-    if (root) {
-      records.push(root);
-      if (root.data && typeof root.data === "object") records.push(root.data as Record<string, unknown>);
-      if (root.cause && typeof root.cause === "object") {
-        const cause = root.cause as Record<string, unknown>;
-        records.push(cause);
-        if (cause.data && typeof cause.data === "object") records.push(cause.data as Record<string, unknown>);
-      }
-    }
-
-    const firstString = (keys: string[]) => {
-      for (const record of records) {
-        for (const key of keys) {
-          const value = readString(record[key]);
-          if (value) return value;
-        }
-      }
-      return null;
-    };
-
-    const firstNumber = (keys: string[]) => {
-      for (const record of records) {
-        for (const key of keys) {
-          const value = record[key];
-          if (typeof value === "number" && Number.isFinite(value)) return value;
-        }
-      }
-      return null;
-    };
-
-    const status = firstNumber(["statusCode", "status"]);
-    const provider = firstString(["providerID", "providerId", "provider"]);
-    const code = firstString(["code", "errorCode"]);
-    const response = firstString(["responseBody", "body", "response"]);
-    const raw =
-      (error instanceof Error ? readString(error.message) : null) ||
-      firstString(["message", "detail", "reason", "error"]) ||
-      (typeof error === "string" ? readString(error) : null);
-
-    const generic = raw && /^unknown\s+error$/i.test(raw);
-    const heading = (() => {
-      if (status === 401 || status === 403) return "Authentication failed";
-      if (status === 429) return "Rate limit exceeded";
-      if (provider) return `Provider error (${provider})`;
-      return fallback;
-    })();
-
-    const lines = [heading];
-    if (raw && !generic && raw !== heading) lines.push(raw);
-    if (status && !heading.includes(String(status))) lines.push(`Status: ${status}`);
-    if (provider && !heading.includes(provider)) lines.push(`Provider: ${provider}`);
-    if (code) lines.push(`Code: ${code}`);
-    if (response) lines.push(`Response: ${response}`);
-    if (lines.length > 1) return lines.join("\n");
-
-    if (raw && !generic) return raw;
-    if (error && typeof error === "object") {
-      const serialized = safeStringify(error);
-      if (serialized && serialized !== "{}") return serialized;
-    }
-    return fallback;
-  };
 
   const ensureSelectedWorkspaceRuntime = async () => {
     const workspaceId = workspaceStore.selectedWorkspaceId().trim();
@@ -832,220 +631,6 @@ export default function App() {
     }
     return ready;
   };
-
-  async function sendPrompt(draft?: ComposerDraft) {
-    const hasExplicitDraft = Boolean(draft);
-    const fallbackText = prompt().trim();
-    const resolvedDraft: ComposerDraft = draft ?? {
-      mode: "prompt",
-      parts: fallbackText ? [{ type: "text", text: fallbackText } as ComposerPart] : [],
-      attachments: [] as ComposerAttachment[],
-      text: fallbackText,
-    };
-    const content = (resolvedDraft.resolvedText ?? resolvedDraft.text).trim();
-    if (!content && !resolvedDraft.attachments.length) return;
-
-    const ready = await ensureSelectedWorkspaceRuntime();
-    if (!ready) return;
-
-    const c = client();
-    if (!c) return;
-
-    const compactShortcut = /^\/compact(?:\s+.*)?$/i.test(content);
-    const compactCommand = resolvedDraft.command?.name === "compact" || compactShortcut;
-    const commandName = compactCommand ? "compact" : (resolvedDraft.command?.name ?? null);
-    if (compactCommand && !selectedSessionId()) {
-      setError("Select a session with messages before running /compact.");
-      return;
-    }
-
-    let sessionID = selectedSessionId();
-    if (!sessionID) {
-      await createSessionAndOpen();
-      sessionID = selectedSessionId();
-    }
-    if (!sessionID) return;
-
-    setBusy(true);
-    setBusyLabel("status.running");
-    setBusyStartedAt(Date.now());
-    setError(null);
-
-    const perfEnabled = developerMode();
-    const startedAt = perfNow();
-    const visible = messages();
-    const visibleParts = visible.reduce((total, message) => total + message.parts.length, 0);
-    recordPerfLog(perfEnabled, "session.prompt", "start", {
-      sessionID,
-      mode: resolvedDraft.mode,
-      command: commandName,
-      charCount: content.length,
-      attachmentCount: resolvedDraft.attachments.length,
-      messageCount: visible.length,
-      partCount: visibleParts,
-    });
-
-    try {
-      if (!compactCommand) {
-        setLastPromptSent(content);
-      }
-      if (!hasExplicitDraft) {
-        setPrompt("");
-      }
-
-      const model = selectedSessionModel();
-      const agent = selectedSessionAgent();
-      const parts = await buildPromptParts(resolvedDraft);
-      const selectedVariant = sanitizeModelVariantForRef(model, modelVariant()) ?? undefined;
-      const reasoningEffort = resolveCodexReasoningEffort(model.modelID, selectedVariant ?? null);
-      const requestVariant = reasoningEffort ? undefined : selectedVariant;
-      const promptOverrides = reasoningEffort
-        ? ({ reasoning_effort: reasoningEffort } as const)
-        : undefined;
-
-      if (resolvedDraft.mode === "shell") {
-        await shellInSession(c, sessionID, content);
-      } else if (resolvedDraft.command || compactCommand) {
-        if (compactCommand) {
-          await compactCurrentSession(sessionID);
-          finishPerf(perfEnabled, "session.prompt", "done", startedAt, {
-            sessionID,
-            mode: resolvedDraft.mode,
-            command: commandName,
-          });
-          return;
-        }
-
-        const command = resolvedDraft.command;
-        if (!command) {
-          throw new Error("Command was not resolved.");
-        }
-
-        // Slash command: route through session.command() API
-        const modelString = `${model.providerID}/${model.modelID}`;
-        const files = await buildCommandFileParts(resolvedDraft);
-
-        // session.command() expects `model` as a provider/model string and only supports file parts.
-        unwrap(
-          await c.session.command({
-            sessionID,
-            command: command.name,
-            arguments: command.arguments,
-            agent: agent ?? undefined,
-            model: modelString,
-            variant: requestVariant,
-            ...(promptOverrides ?? {}),
-            parts: files.length ? files : undefined,
-          }),
-        );
-
-      } else {
-        const result = await c.session.promptAsync({
-          sessionID,
-          model,
-          agent: agent ?? undefined,
-          variant: requestVariant,
-          ...(promptOverrides ?? {}),
-          parts,
-        });
-        assertNoClientError(result);
-
-        modelConfig.setSessionModelById((current) => ({
-          ...current,
-          [sessionID]: model,
-        }));
-
-        modelConfig.clearSessionModelOverride(sessionID);
-      }
-
-      finishPerf(perfEnabled, "session.prompt", "done", startedAt, {
-        sessionID,
-        mode: resolvedDraft.mode,
-        command: commandName,
-      });
-    } catch (e) {
-      finishPerf(perfEnabled, "session.prompt", "error", startedAt, {
-        sessionID,
-        mode: resolvedDraft.mode,
-        command: commandName,
-        error: e instanceof Error ? e.message : safeStringify(e),
-      });
-      const message = e instanceof Error ? e.message : safeStringify(e);
-      sessionStore.appendSessionErrorTurn(sessionID, addOpencodeCacheHint(message));
-    } finally {
-      setBusy(false);
-      setBusyLabel(null);
-      setBusyStartedAt(null);
-    }
-  }
-
-  async function abortSession(sessionID?: string) {
-    const c = client();
-    if (!c) return;
-    const id = (sessionID ?? selectedSessionId() ?? "").trim();
-    if (!id) return;
-    // OpenCode exposes session.abort which interrupts the active prompt/run.
-    // We intentionally don't mutate global busy state here; the SessionView
-    // provides local UX (button disabled + toast) for cancellation.
-    await abortSessionTyped(c, id);
-  }
-
-  function retryLastPrompt() {
-    const text = lastPromptSent().trim();
-    if (!text) return;
-    void sendPrompt({
-      mode: "prompt",
-      text,
-      parts: [{ type: "text", text }],
-      attachments: [],
-    });
-  }
-
-  async function compactCurrentSession(sessionIdOverride?: string) {
-    const c = client();
-    if (!c) {
-      throw new Error("Not connected to a server");
-    }
-
-    const sessionID = (sessionIdOverride ?? selectedSessionId() ?? "").trim();
-    if (!sessionID) {
-      throw new Error("Select a session before compacting.");
-    }
-
-    const visible = messages();
-    if (!visible.length) {
-      throw new Error("Nothing to compact yet.");
-    }
-
-    const model = selectedSessionModel();
-    const startedAt = perfNow();
-    const modelLabel = `${model.providerID}/${model.modelID}`;
-    recordPerfLog(developerMode(), "session.compact", "start", {
-      sessionID,
-      messageCount: visible.length,
-      model: modelLabel,
-      variant: sanitizeModelVariantForRef(model, modelVariant()) ?? null,
-    });
-
-    try {
-      await compactSessionTyped(c, sessionID, model, {
-        directory: workspaceProjectDir().trim() || undefined,
-      });
-      finishPerf(developerMode(), "session.compact", "done", startedAt, {
-        sessionID,
-        messageCount: visible.length,
-        model: modelLabel,
-      });
-    } catch (error) {
-      finishPerf(developerMode(), "session.compact", "error", startedAt, {
-        sessionID,
-        messageCount: visible.length,
-        model: modelLabel,
-        error: error instanceof Error ? error.message : safeStringify(error),
-      });
-      throw error;
-    }
-  }
 
   const messageIdFromInfo = (message: MessageWithParts) => {
     const id = (message.info as { id?: string | number }).id;
@@ -1238,192 +823,6 @@ export default function App() {
       .join("");
     setPrompt(text);
   };
-
-  async function undoLastUserMessage() {
-    const c = client();
-    const sessionID = (selectedSessionId() ?? "").trim();
-    if (!c || !sessionID) return;
-
-    // Revert is rejected while the session is busy. We *usually* have an accurate
-    // session status via SSE, but to be resilient to transient desync we attempt
-    // an abort even when we think we're idle.
-    await abortSessionSafe(c, sessionID);
-
-    const revertMessageID = selectedSession()?.revert?.messageID ?? null;
-    const users = messages().filter((message) => {
-      const role = (message.info as { role?: string }).role;
-      return role === "user";
-    });
-
-    let target: MessageWithParts | null = null;
-    for (let idx = users.length - 1; idx >= 0; idx -= 1) {
-      const candidate = users[idx];
-      const id = messageIdFromInfo(candidate);
-      if (!id) continue;
-      if (!revertMessageID || id < revertMessageID) {
-        target = candidate;
-        break;
-      }
-    }
-
-    if (!target) return;
-    const messageID = messageIdFromInfo(target);
-    if (!messageID) return;
-
-    const next = await revertSession(c, sessionID, messageID);
-    upsertLocalSession(next);
-    restorePromptFromUserMessage(target);
-  }
-
-  async function redoLastUserMessage() {
-    const c = client();
-    const sessionID = (selectedSessionId() ?? "").trim();
-    if (!c || !sessionID) return;
-
-    await abortSessionSafe(c, sessionID);
-
-    const revertMessageID = selectedSession()?.revert?.messageID ?? null;
-    if (!revertMessageID) return;
-
-    const users = messages().filter((message) => {
-      const role = (message.info as { role?: string }).role;
-      return role === "user";
-    });
-
-    const next = users.find((message) => {
-      const id = messageIdFromInfo(message);
-      return Boolean(id) && id > revertMessageID;
-    });
-
-    if (!next) {
-      const session = await unrevertSession(c, sessionID);
-      upsertLocalSession(session);
-      setPrompt("");
-      return;
-    }
-
-    const messageID = messageIdFromInfo(next);
-    if (!messageID) return;
-
-    const nextSession = await revertSession(c, sessionID, messageID);
-    upsertLocalSession(nextSession);
-
-    let prior: MessageWithParts | null = null;
-    for (let idx = users.length - 1; idx >= 0; idx -= 1) {
-      const candidate = users[idx];
-      const id = messageIdFromInfo(candidate);
-      if (id && id < messageID) {
-        prior = candidate;
-        break;
-      }
-    }
-
-    if (prior) {
-      restorePromptFromUserMessage(prior);
-      return;
-    }
-
-    setPrompt("");
-  }
-
-  async function renameSessionTitle(sessionID: string, title: string) {
-    const trimmed = title.trim();
-    if (!trimmed) {
-      throw new Error("Session name is required");
-    }
-    
-    await renameSession(sessionID, trimmed);
-    await refreshSidebarWorkspaceSessions(workspaceStore.selectedWorkspaceId()).catch(() => undefined);
-  }
-
-  async function deleteSessionById(sessionID: string) {
-    const trimmed = sessionID.trim();
-    if (!trimmed) return;
-    const c = client();
-    if (!c) {
-      throw new Error("Not connected to a server");
-    }
-
-    const root = workspaceStore.selectedWorkspaceRoot().trim();
-    const directory = toSessionTransportDirectory(root);
-    const params = directory ? { sessionID: trimmed, directory } : { sessionID: trimmed };
-    unwrap(await c.session.delete(params));
-
-    // Remove the deleted session from the store locally, then refetch the
-    // workspace-scoped sidebar session list from the server source of truth.
-    setSessions(sessions().filter((s) => s.id !== trimmed));
-    const activeWsId = workspaceStore.selectedWorkspaceId();
-    await refreshSidebarWorkspaceSessions(activeWsId).catch(() => undefined);
-
-    // If we're currently routed to the deleted session, navigate away immediately.
-    // (Otherwise the route effect can try to re-select a session that no longer exists.)
-    try {
-      const path = location.pathname.toLowerCase();
-      if (path === `/session/${trimmed.toLowerCase()}`) {
-        navigate("/session", { replace: true });
-      }
-    } catch {
-      // ignore
-    }
-
-    // If the deleted session was selected, clear selection so routing can fall back cleanly.
-    if (selectedSessionId() === trimmed) {
-      setSelectedSessionId(null);
-      const activeWorkspace = workspaceStore.selectedWorkspaceId().trim();
-      if (activeWorkspace) {
-        const map = readSessionByWorkspace();
-        if (map[activeWorkspace] === trimmed) {
-          const next = { ...map };
-          delete next[activeWorkspace];
-          writeSessionByWorkspace(next);
-        }
-      }
-    }
-
-    const nextStatus = { ...sessionStatusById() };
-    if (nextStatus[trimmed]) {
-      delete nextStatus[trimmed];
-      setSessionStatusById(nextStatus);
-    }
-  }
-
-
-  async function listAgents(): Promise<Agent[]> {
-    const c = client();
-    if (!c) return [];
-    const list = unwrap(await c.app.agents());
-    return list.filter((agent) => !agent.hidden && agent.mode !== "subagent");
-  }
-
-  const BUILTIN_COMPACT_COMMAND = {
-    id: "builtin:compact",
-    name: "compact",
-    description: "Summarize this session to reduce context size.",
-    source: "command" as const,
-  };
-
-  async function listCommands(): Promise<{ id: string; name: string; description?: string; source?: "command" | "mcp" | "skill" }[]> {
-    const c = client();
-    if (!c) return [];
-    const list = await listCommandsTyped(c, workspaceStore.selectedWorkspaceRoot().trim() || undefined);
-    if (list.some((entry) => entry.name === "compact")) {
-      return list;
-    }
-    return [BUILTIN_COMPACT_COMMAND, ...list];
-  }
-
-  function setSessionAgent(sessionID: string, agent: string | null) {
-    const trimmed = agent?.trim() ?? "";
-    setSessionAgentById((current) => {
-      const next = { ...current };
-      if (!trimmed) {
-        delete next[sessionID];
-        return next;
-      }
-      next[sessionID] = trimmed;
-      return next;
-    });
-  }
 
   function focusSessionPromptSoon() {
     if (typeof window === "undefined" || currentView() !== "session") return;
@@ -1807,6 +1206,67 @@ export default function App() {
     workspaceGroups: rawSidebarWorkspaceGroups,
     refreshWorkspaceSessions: refreshSidebarWorkspaceSessions,
   } = sidebarSessionsStore;
+
+  const sessionActionsStore = createSessionActionsStore({
+    client,
+    baseUrl,
+    developerMode,
+    prompt,
+    setPrompt,
+    selectedSessionId,
+    selectedSession,
+    sessions,
+    messages,
+    setSessions,
+    sessionStatusById,
+    setSessionStatusById,
+    setBusy,
+    setBusyLabel,
+    setBusyStartedAt,
+    setCreatingSession,
+    setError,
+    workspaceProjectDir: () => workspaceStore.projectDir(),
+    selectedWorkspaceId: () => workspaceStore.selectedWorkspaceId(),
+    selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot(),
+    ensureSelectedWorkspaceRuntime,
+    selectSession,
+    refreshSidebarWorkspaceSessions,
+    abortRefreshes,
+    modelConfig,
+    selectedSessionModel: () => selectedSessionModel(),
+    modelVariant,
+    sanitizeModelVariantForRef: (ref, value) => sanitizeModelVariantForRef(ref, value),
+    resolveCodexReasoningEffort: (modelId, variant) => resolveCodexReasoningEffort(modelId, variant),
+    messageIdFromInfo,
+    restorePromptFromUserMessage,
+    upsertLocalSession,
+    readSessionByWorkspace,
+    writeSessionByWorkspace,
+    setSelectedSessionId,
+    locationPath: () => location.pathname,
+    navigate,
+    renameSession,
+    appendSessionErrorTurn: sessionStore.appendSessionErrorTurn,
+  });
+
+  const {
+    lastPromptSent,
+    selectedSessionAgent,
+    sessionRevertMessageId,
+    createSessionAndOpen,
+    sendPrompt,
+    abortSession,
+    retryLastPrompt,
+    compactCurrentSession,
+    undoLastUserMessage,
+    redoLastUserMessage,
+    renameSessionTitle,
+    deleteSessionById,
+    listAgents,
+    listCommands,
+    setSessionAgent,
+    searchWorkspaceFiles,
+  } = sessionActionsStore;
 
   const sidebarWorkspaceGroups = createMemo<WorkspaceSessionGroup[]>(() => {
     const groups = rawSidebarWorkspaceGroups();
@@ -2860,12 +2320,6 @@ export default function App() {
     return defaultModel();
   });
 
-  const selectedSessionAgent = createMemo(() => {
-    const id = selectedSessionId();
-    if (!id) return null;
-    return sessionAgentById()[id] ?? null;
-  });
-
   const selectedSessionModelLabel = createMemo(() =>
     formatModelLabel(selectedSessionModel(), providers())
   );
@@ -3101,151 +2555,6 @@ export default function App() {
   function openSettingsFromModelPicker() {
     setSettingsTab("general");
     setView("settings");
-  }
-
-  async function createSessionAndOpen() {
-    const ready = await ensureSelectedWorkspaceRuntime();
-    if (!ready) {
-      return;
-    }
-
-    const c = client();
-    if (!c) {
-      return;
-    }
-
-    const perfEnabled = developerMode();
-    const startedAt = perfNow();
-    const runId = (() => {
-      const key = "__openwork_create_session_run__";
-      const w = window as typeof window & { [key]?: number };
-      w[key] = (w[key] ?? 0) + 1;
-      return w[key];
-    })();
-
-    const mark = (event: string, payload?: Record<string, unknown>) => {
-      const elapsed = Math.round((perfNow() - startedAt) * 100) / 100;
-      recordPerfLog(perfEnabled, "session.create", event, {
-        runId,
-        elapsedMs: elapsed,
-        ...(payload ?? {}),
-      });
-    };
-
-    mark("start", {
-      baseUrl: baseUrl(),
-      workspace: workspaceStore.selectedWorkspaceRoot().trim() || null,
-    });
-
-    // Abort any in-flight refresh operations to free up connection resources
-    abortRefreshes();
-
-    // Small delay to allow pending requests to settle
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    setBusy(true);
-    setBusyLabel("status.creating_task");
-    setBusyStartedAt(Date.now());
-    setError(null);
-    setCreatingSession(true);
-
-    const withTimeout = async <T,>(
-      promise: Promise<T>,
-      ms: number,
-      label: string
-    ) => {
-      let timeoutId: ReturnType<typeof setTimeout> | null = null;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error(`Timed out waiting for ${label}`)),
-          ms
-        );
-      });
-      try {
-        return await Promise.race([promise, timeoutPromise]);
-      } finally {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-      }
-    };
-
-    try {
-      // Quick health check to detect stale connection
-      mark("health:start");
-      try {
-        await withTimeout(c.global.health(), 3_000, "health");
-        mark("health:ok");
-      } catch (healthErr) {
-        mark("health:error", {
-          error: healthErr instanceof Error ? healthErr.message : safeStringify(healthErr),
-        });
-        throw new Error(t("app.connection_lost", currentLocale()));
-      }
-
-      let rawResult: Awaited<ReturnType<typeof c.session.create>>;
-      try {
-        const directory = toSessionTransportDirectory(workspaceStore.selectedWorkspaceRoot().trim()) || undefined;
-        logWorkspaceScopeSnapshot("session:create:scope", {
-          transportDirectory: directory ?? null,
-          transportScope: describeDirectoryScope(directory ?? null),
-        });
-        mark("session:create:start");
-        rawResult = await c.session.create({
-          directory,
-        });
-        mark("session:create:ok");
-      } catch (createErr) {
-        mark("session:create:error", {
-          error: createErr instanceof Error ? createErr.message : safeStringify(createErr),
-        });
-        throw createErr;
-      }
-
-      const session = unwrap(rawResult);
-      // Immediately select and show the new session before background list refresh.
-      setBusyLabel("status.loading_session");
-      mark("session:select:start", { sessionID: session.id });
-      await selectSession(session.id);
-      mark("session:select:ok", { sessionID: session.id });
-
-      modelConfig.applyPendingSessionChoice(session.id);
-
-      // Inject the new session into the reactive sessions() store so
-      // the createEffect bridge (sessions → sidebar) will always include it,
-      // even if the background loadSessionsWithReady hasn't returned yet.
-      const currentStoreSessions = sessions();
-      if (!currentStoreSessions.some((s) => s.id === session.id)) {
-        setSessions([session, ...currentStoreSessions]);
-      }
-
-      const wsId = workspaceStore.selectedWorkspaceId().trim();
-      if (wsId) {
-        await refreshSidebarWorkspaceSessions(wsId).catch(() => undefined);
-      }
-
-      // setSessionViewLockUntil(Date.now() + 1200);
-      goToSession(session.id);
-
-      // The new session is already in the sessions() store (injected above).
-      // Sidebar state now refreshes from the server-scoped workspace list.
-      finishPerf(perfEnabled, "session.create", "done", startedAt, {
-        runId,
-        sessionID: session.id,
-      });
-      return session.id;
-    } catch (e) {
-      finishPerf(perfEnabled, "session.create", "error", startedAt, {
-        runId,
-        error: e instanceof Error ? e.message : safeStringify(e),
-      });
-      const message = e instanceof Error ? e.message : t("app.unknown_error", currentLocale());
-      setError(addOpencodeCacheHint(message));
-      return undefined;
-    } finally {
-      setCreatingSession(false);
-      setBusy(false);
-    }
   }
 
 
@@ -4242,27 +3551,6 @@ export default function App() {
     };
   };
 
-  const searchWorkspaceFiles = async (query: string) => {
-    const trimmed = query.trim();
-    if (!trimmed) return [];
-    const activeClient = client();
-    if (!activeClient) return [];
-    try {
-      const directory = workspaceProjectDir().trim();
-      const result = unwrap(
-        await activeClient.find.files({
-          query: trimmed,
-          dirs: "true",
-          limit: 50,
-          directory: directory || undefined,
-        }),
-      );
-      return result;
-    } catch {
-      return [];
-    }
-  };
-
   const sessionProps = () => ({
     providerAuthWorkerType: providerAuthWorkerType(),
     selectedSessionId: activeSessionId(),
@@ -4328,15 +3616,6 @@ export default function App() {
     activePluginStatus: sidebarPluginStatus(),
     skills: skills(),
     skillsStatus: skillsStatus(),
-    createSessionAndOpen: createSessionAndOpen,
-    sendPromptAsync: sendPrompt,
-    abortSession: abortSession,
-    sessionRevertMessageId: selectedSession()?.revert?.messageID ?? null,
-    undoLastUserMessage: undoLastUserMessage,
-    redoLastUserMessage: redoLastUserMessage,
-    compactSession: compactCurrentSession,
-    lastPromptSent: lastPromptSent(),
-    retryLastPrompt: retryLastPrompt,
     newTaskDisabled: newTaskDisabled(),
     workspaceSessionGroups: sidebarWorkspaceGroups(),
     openRenameWorkspace,
@@ -4380,18 +3659,11 @@ export default function App() {
     providerAuthPreferredProviderId: providerAuthPreferredProviderId(),
     providers: providers(),
     providerConnectedIds: providerConnectedIds(),
-    listAgents: listAgents,
-    listCommands: listCommands,
-    selectedSessionAgent: selectedSessionAgent(),
-    setSessionAgent: setSessionAgent,
     sessionStatusById: activeSessionStatusById(),
     hasEarlierMessages: selectedSessionHasEarlierMessages(),
     loadingEarlierMessages: selectedSessionLoadingEarlierMessages(),
     loadEarlierMessages,
-    searchFiles: searchWorkspaceFiles,
-    deleteSession: deleteSessionById,
     sessionStatus: selectedSessionStatus(),
-    renameSession: renameSessionTitle,
     error: error(),
   });
 
@@ -4513,10 +3785,11 @@ export default function App() {
 
   return (
     <OpenworkServerProvider store={openworkServerStore}>
-      <ConnectionsProvider store={connectionsStore}>
-        <ExtensionsProvider store={extensionsStore}>
-          <AutomationsProvider store={automationsStore}>
-            <StatusToastsProvider store={statusToastsStore}>
+      <SessionActionsProvider store={sessionActionsStore}>
+        <ConnectionsProvider store={connectionsStore}>
+          <ExtensionsProvider store={extensionsStore}>
+            <AutomationsProvider store={automationsStore}>
+              <StatusToastsProvider store={statusToastsStore}>
             <Switch>
               <Match when={booting()}>
                 <BootShell />
@@ -4824,10 +4097,11 @@ export default function App() {
         subtitle={t("dashboard.edit_remote_workspace_subtitle", currentLocale())}
         confirmLabel={t("dashboard.edit_remote_workspace_confirm", currentLocale())}
       />
-            </StatusToastsProvider>
-          </AutomationsProvider>
-        </ExtensionsProvider>
-      </ConnectionsProvider>
+              </StatusToastsProvider>
+            </AutomationsProvider>
+          </ExtensionsProvider>
+        </ConnectionsProvider>
+      </SessionActionsProvider>
     </OpenworkServerProvider>
   );
 }

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -32,6 +32,8 @@ import BundleImportModal from "./bundles/import-modal";
 import BundleStartModal from "./bundles/start-modal";
 import RenameWorkspaceModal from "./components/rename-workspace-modal";
 import ConnectionsModals from "./connections/modals";
+import { OpenworkServerProvider } from "./connections/openwork-server-provider";
+import { createOpenworkServerStore } from "./connections/openwork-server-store";
 import { ConnectionsProvider } from "./connections/provider";
 import { ExtensionsProvider } from "./extensions/provider";
 import { AutomationsProvider } from "./automations/provider";
@@ -85,6 +87,7 @@ import type {
   ReloadTrigger,
   SettingsTab,
   View,
+  WorkspaceDisplay,
   WorkspaceSessionGroup,
   ComposerAttachment,
   ComposerDraft,
@@ -165,14 +168,7 @@ import {
   updaterEnvironment,
   readOpencodeConfig,
   writeOpencodeConfig,
-  openworkServerRestart,
-  openworkServerInfo,
-  orchestratorStatus,
-  opencodeRouterInfo,
   setWindowDecorations,
-  type OrchestratorStatus,
-  type OpenworkServerInfo,
-  type OpenCodeRouterInfo,
 } from "./lib/tauri";
 import {
   FONT_ZOOM_STEP,
@@ -187,19 +183,13 @@ import {
   parseOpenworkWorkspaceIdFromUrl,
   readOpenworkConnectInviteFromSearch,
   stripOpenworkConnectInviteFromUrl,
-  createOpenworkServerClient,
   hydrateOpenworkServerSettingsFromEnv,
   normalizeOpenworkServerUrl,
   readOpenworkServerSettings,
   writeOpenworkServerSettings,
-  clearOpenworkServerSettings,
   type OpenworkAuditEntry,
-  type OpenworkServerCapabilities,
   type OpenworkServerDiagnostics,
-  type OpenworkServerStatus,
   type OpenworkServerSettings,
-  type OpenworkServerClient,
-  OpenworkServerError,
 } from "./lib/openwork-server";
 import {
   parseBundleDeepLink,
@@ -323,66 +313,10 @@ export default function App() {
   const [baseUrl, setBaseUrl] = createSignal("http://127.0.0.1:4096");
   const [clientDirectory, setClientDirectory] = createSignal("");
 
-  const [openworkServerSettings, setOpenworkServerSettings] = createSignal<OpenworkServerSettings>({});
-  const [shareRemoteAccessBusy, setShareRemoteAccessBusy] = createSignal(false);
-  const [shareRemoteAccessError, setShareRemoteAccessError] = createSignal<string | null>(null);
-  const [openworkServerUrl, setOpenworkServerUrl] = createSignal("");
-  const [openworkServerStatus, setOpenworkServerStatus] = createSignal<OpenworkServerStatus>("disconnected");
-  const [openworkServerCapabilities, setOpenworkServerCapabilities] = createSignal<OpenworkServerCapabilities | null>(null);
-  const [, setOpenworkServerCheckedAt] = createSignal<number | null>(null);
-  const [openworkServerHostInfo, setOpenworkServerHostInfo] = createSignal<OpenworkServerInfo | null>(null);
-  const [openworkServerDiagnostics, setOpenworkServerDiagnostics] = createSignal<OpenworkServerDiagnostics | null>(null);
-  const [openworkReconnectBusy, setOpenworkReconnectBusy] = createSignal(false);
-  const [opencodeRouterInfoState, setOpenCodeRouterInfoState] = createSignal<OpenCodeRouterInfo | null>(null);
-  const [orchestratorStatusState, setOrchestratorStatusState] = createSignal<OrchestratorStatus | null>(null);
   const [openworkAuditEntries, setOpenworkAuditEntries] = createSignal<OpenworkAuditEntry[]>([]);
   const [openworkAuditStatus, setOpenworkAuditStatus] = createSignal<"idle" | "loading" | "error">("idle");
   const [openworkAuditError, setOpenworkAuditError] = createSignal<string | null>(null);
   const [devtoolsWorkspaceId, setDevtoolsWorkspaceId] = createSignal<string | null>(null);
-
-  const openworkServerBaseUrl = createMemo(() => {
-    const pref = startupPreference();
-    const hostInfo = openworkServerHostInfo();
-    const settingsUrl = normalizeOpenworkServerUrl(openworkServerSettings().urlOverride ?? "") ?? "";
-
-    if (pref === "local") return hostInfo?.baseUrl ?? "";
-    if (pref === "server") return settingsUrl;
-    return hostInfo?.baseUrl ?? settingsUrl;
-  });
-
-  const openworkServerAuth = createMemo(
-    () => {
-      const pref = startupPreference();
-      const hostInfo = openworkServerHostInfo();
-      const settingsToken = openworkServerSettings().token?.trim() ?? "";
-      const clientToken = hostInfo?.clientToken?.trim() ?? "";
-      const hostToken = hostInfo?.hostToken?.trim() ?? "";
-
-      if (pref === "local") {
-        return { token: clientToken || undefined, hostToken: hostToken || undefined };
-      }
-      if (pref === "server") {
-        return { token: settingsToken || undefined, hostToken: undefined };
-      }
-      if (hostInfo?.baseUrl) {
-        return { token: clientToken || undefined, hostToken: hostToken || undefined };
-      }
-      return { token: settingsToken || undefined, hostToken: undefined };
-    },
-    undefined,
-    {
-      equals: (prev, next) => prev?.token === next.token && prev?.hostToken === next.hostToken,
-    },
-  );
-
-  const openworkServerClient = createMemo(() => {
-    const baseUrl = openworkServerBaseUrl().trim();
-    if (!baseUrl) return null;
-    const auth = openworkServerAuth();
-    return createOpenworkServerClient({ baseUrl, token: auth.token, hostToken: auth.hostToken });
-  });
-
-  const devtoolsOpenworkClient = createMemo(() => openworkServerClient());
 
   createEffect(() => {
     if (typeof window === "undefined") return;
@@ -486,178 +420,6 @@ export default function App() {
   });
 
   createEffect(() => {
-    const pref = startupPreference();
-    const info = openworkServerHostInfo();
-    const hostUrl = info?.connectUrl ?? info?.lanUrl ?? info?.mdnsUrl ?? info?.baseUrl ?? "";
-    const settingsUrl = normalizeOpenworkServerUrl(openworkServerSettings().urlOverride ?? "") ?? "";
-
-    if (pref === "local") {
-      setOpenworkServerUrl(hostUrl);
-      return;
-    }
-    if (pref === "server") {
-      setOpenworkServerUrl(settingsUrl);
-      return;
-    }
-    setOpenworkServerUrl(hostUrl || settingsUrl);
-  });
-
-  const checkOpenworkServer = async (url: string, token?: string, hostToken?: string) => {
-    const client = createOpenworkServerClient({ baseUrl: url, token, hostToken });
-    try {
-      await client.health();
-    } catch (error) {
-      if (error instanceof OpenworkServerError && (error.status === 401 || error.status === 403)) {
-        return { status: "limited" as OpenworkServerStatus, capabilities: null };
-      }
-      return { status: "disconnected" as OpenworkServerStatus, capabilities: null };
-    }
-
-    if (!token) {
-      return { status: "limited" as OpenworkServerStatus, capabilities: null };
-    }
-
-    try {
-      const caps = await client.capabilities();
-      return { status: "connected" as OpenworkServerStatus, capabilities: caps };
-    } catch (error) {
-      if (error instanceof OpenworkServerError && (error.status === 401 || error.status === 403)) {
-        return { status: "limited" as OpenworkServerStatus, capabilities: null };
-      }
-      return { status: "disconnected" as OpenworkServerStatus, capabilities: null };
-    }
-  };
-
-  createEffect(() => {
-    if (typeof window === "undefined") return;
-    if (!documentVisible()) return;
-    const url = openworkServerBaseUrl().trim();
-    const auth = openworkServerAuth();
-    const token = auth.token;
-    const hostToken = auth.hostToken;
-
-    if (!url) {
-      setOpenworkServerStatus("disconnected");
-      setOpenworkServerCapabilities(null);
-      setOpenworkServerCheckedAt(Date.now());
-      return;
-    }
-
-    let active = true;
-    let busy = false;
-    let timeoutId: number | undefined;
-    let delayMs = 10_000;
-
-    const scheduleNext = () => {
-      if (!active) return;
-      timeoutId = window.setTimeout(run, delayMs);
-    };
-
-    const run = async () => {
-      if (busy) return;
-      busy = true;
-      try {
-        const result = await checkOpenworkServer(url, token, hostToken);
-        if (!active) return;
-        setOpenworkServerStatus(result.status);
-        setOpenworkServerCapabilities(result.capabilities);
-        delayMs =
-          result.status === "connected" || result.status === "limited"
-            ? 10_000
-            : Math.min(delayMs * 2, 60_000);
-      } catch {
-        delayMs = Math.min(delayMs * 2, 60_000);
-      } finally {
-        if (!active) return;
-        setOpenworkServerCheckedAt(Date.now());
-        busy = false;
-        scheduleNext();
-      }
-    };
-
-    run();
-    onCleanup(() => {
-      active = false;
-      if (timeoutId) window.clearTimeout(timeoutId);
-    });
-  });
-
-  createEffect(() => {
-    if (!isTauriRuntime()) return;
-    if (!documentVisible()) return;
-    let active = true;
-
-    const run = async () => {
-      try {
-        const info = await openworkServerInfo();
-        if (active) setOpenworkServerHostInfo(info);
-      } catch {
-        if (active) setOpenworkServerHostInfo(null);
-      }
-    };
-
-    run();
-    const interval = window.setInterval(run, 10_000);
-    onCleanup(() => {
-      active = false;
-      window.clearInterval(interval);
-    });
-  });
-
-  createEffect(() => {
-    if (!isTauriRuntime()) return;
-    const hostInfo = openworkServerHostInfo();
-    const port = hostInfo?.port;
-    if (!port) return;
-
-    const current = openworkServerSettings();
-    if (current.portOverride === port) return;
-
-    updateOpenworkServerSettings({
-      ...current,
-      portOverride: port,
-    });
-  });
-
-  createEffect(() => {
-    if (typeof window === "undefined") return;
-    if (!documentVisible()) return;
-    if (!developerMode()) {
-      setOpenworkServerDiagnostics(null);
-      return;
-    }
-
-    const client = openworkServerClient();
-    if (!client || openworkServerStatus() === "disconnected") {
-      setOpenworkServerDiagnostics(null);
-      return;
-    }
-
-    let active = true;
-    let busy = false;
-
-    const run = async () => {
-      if (busy) return;
-      busy = true;
-      try {
-        const status = await client.status();
-        if (active) setOpenworkServerDiagnostics(status);
-      } catch {
-        if (active) setOpenworkServerDiagnostics(null);
-      } finally {
-        busy = false;
-      }
-    };
-
-    run();
-    const interval = window.setInterval(run, 10_000);
-    onCleanup(() => {
-      active = false;
-      window.clearInterval(interval);
-    });
-  });
-
-  createEffect(() => {
     if (!isTauriRuntime()) return;
     if (!developerMode()) return;
     if (!documentVisible()) return;
@@ -677,60 +439,6 @@ export default function App() {
     run();
     const interval = window.setInterval(run, 10_000);
     onCleanup(() => {
-      window.clearInterval(interval);
-    });
-  });
-
-  createEffect(() => {
-    if (!isTauriRuntime()) return;
-    if (!developerMode()) {
-      setOpenCodeRouterInfoState(null);
-      return;
-    }
-    if (!documentVisible()) return;
-
-    let active = true;
-
-    const run = async () => {
-      try {
-        const info = await opencodeRouterInfo();
-        if (active) setOpenCodeRouterInfoState(info);
-      } catch {
-        if (active) setOpenCodeRouterInfoState(null);
-      }
-    };
-
-    run();
-    const interval = window.setInterval(run, 10_000);
-    onCleanup(() => {
-      active = false;
-      window.clearInterval(interval);
-    });
-  });
-
-  createEffect(() => {
-    if (!isTauriRuntime()) return;
-    if (!developerMode()) {
-      setOrchestratorStatusState(null);
-      return;
-    }
-    if (!documentVisible()) return;
-
-    let active = true;
-
-    const run = async () => {
-      try {
-        const status = await orchestratorStatus();
-        if (active) setOrchestratorStatusState(status);
-      } catch {
-        if (active) setOrchestratorStatusState(null);
-      }
-    };
-
-    run();
-    const interval = window.setInterval(run, 10_000);
-    onCleanup(() => {
-      active = false;
       window.clearInterval(interval);
     });
   });
@@ -1737,15 +1445,50 @@ export default function App() {
 
   let workspaceStore!: ReturnType<typeof createWorkspaceStore>;
 
+  const openworkServerStore = createOpenworkServerStore({
+    startupPreference,
+    documentVisible,
+    developerMode,
+    runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
+    activeClient: client,
+    selectedWorkspaceDisplay: () =>
+      workspaceStore?.selectedWorkspaceDisplay?.() ?? ({ workspaceType: "local" } as WorkspaceDisplay),
+    restartLocalServer,
+    createRemoteWorkspaceFlow: async (input) =>
+      (await workspaceStore?.createRemoteWorkspaceFlow?.(input)) ?? false,
+  });
+
+  const {
+    openworkServerSettings,
+    setOpenworkServerSettings,
+    updateOpenworkServerSettings,
+    resetOpenworkServerSettings,
+    shareRemoteAccessBusy,
+    shareRemoteAccessError,
+    saveShareRemoteAccess,
+    openworkServerUrl,
+    openworkServerBaseUrl,
+    openworkServerAuth,
+    openworkServerClient,
+    openworkServerStatus,
+    openworkServerCapabilities,
+    openworkServerHostInfo,
+    openworkServerDiagnostics,
+    openworkReconnectBusy,
+    opencodeRouterInfoState,
+    orchestratorStatusState,
+    testOpenworkServerConnection,
+    reconnectOpenworkServer,
+    ensureLocalOpenworkServerClient,
+  } = openworkServerStore;
+
   const extensionsStore = createExtensionsStore({
     client,
     projectDir: () => workspaceProjectDir(),
     selectedWorkspaceId: () => workspaceStore?.selectedWorkspaceId?.() ?? "",
     selectedWorkspaceRoot: () => workspaceStore?.selectedWorkspaceRoot?.() ?? "",
     workspaceType: () => workspaceStore?.selectedWorkspaceDisplay?.().workspaceType ?? "local",
-    openworkServerClient,
-    openworkServerStatus,
-    openworkServerCapabilities,
+    openworkServer: openworkServerStore,
     runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
     setBusy,
     setBusyLabel,
@@ -1775,11 +1518,7 @@ export default function App() {
     selectedWorkspaceId: () => workspaceStore?.selectedWorkspaceId?.() ?? "",
     selectedWorkspaceRoot: () => workspaceStore?.selectedWorkspaceRoot?.() ?? "",
     workspaceType: () => workspaceStore?.selectedWorkspaceDisplay?.().workspaceType ?? "local",
-    openworkServerClient,
-    openworkServerStatus,
-    openworkServerCapabilities,
-    openworkServerBaseUrl,
-    openworkServerAuthToken: () => openworkServerAuth().token,
+    openworkServer: openworkServerStore,
     runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
     ensureRuntimeWorkspaceId: () => workspaceStore?.ensureRuntimeWorkspaceId?.(),
     setProjectDir: (value: string) => workspaceStore?.setProjectDir?.(value),
@@ -1978,13 +1717,8 @@ export default function App() {
     setView,
     setSettingsTab,
     isWindowsPlatform,
-    openworkServerSettings,
-    updateOpenworkServerSettings,
-    openworkServerClient,
-    openworkServerStatus,
-    openworkServerCapabilities,
+    openworkServer: openworkServerStore,
     openworkEnvWorkspaceId: envOpenworkWorkspaceId,
-    ensureLocalOpenworkServerClient,
     onEngineStable: () => {},
     engineRuntime,
     developerMode,
@@ -2026,10 +1760,7 @@ export default function App() {
   const bundlesStore = createBundlesStore({
     booting,
     startupPreference,
-    openworkServerClient,
-    openworkServerStatus,
-    openworkServerHostInfo,
-    openworkServerSettings,
+    openworkServer: openworkServerStore,
     runtimeWorkspaceId,
     workspaceStore,
     setError,
@@ -2235,7 +1966,7 @@ export default function App() {
     }
     if (!documentVisible()) return;
 
-    const client = devtoolsOpenworkClient();
+    const client = openworkServerClient();
     if (!client) {
       setDevtoolsWorkspaceId(null);
       return;
@@ -2271,7 +2002,7 @@ export default function App() {
     }
     if (!documentVisible()) return;
 
-    const client = devtoolsOpenworkClient();
+    const client = openworkServerClient();
     const workspaceId = devtoolsWorkspaceId();
     if (!client || !workspaceId) {
       setOpenworkAuditEntries([]);
@@ -2346,49 +2077,6 @@ export default function App() {
       (resolvedOpenworkCapabilities()?.plugins?.write ?? false),
   );
   const devtoolsCapabilities = createMemo(() => openworkServerCapabilities());
-
-  function updateOpenworkServerSettings(next: OpenworkServerSettings) {
-    const stored = writeOpenworkServerSettings(next);
-    setOpenworkServerSettings(stored);
-  }
-
-  const saveShareRemoteAccess = async (enabled: boolean) => {
-    if (shareRemoteAccessBusy()) return;
-    const previous = openworkServerSettings();
-    const next: OpenworkServerSettings = {
-      ...previous,
-      remoteAccessEnabled: enabled,
-    };
-
-    setShareRemoteAccessBusy(true);
-    setShareRemoteAccessError(null);
-    updateOpenworkServerSettings(next);
-
-    try {
-      if (isTauriRuntime() && workspaceStore.selectedWorkspaceDisplay().workspaceType === "local") {
-        const restarted = await restartLocalServer();
-        if (!restarted) {
-          throw new Error("Failed to restart the local worker with the updated sharing setting.");
-        }
-        await reconnectOpenworkServer();
-      }
-    } catch (error) {
-      updateOpenworkServerSettings(previous);
-      setShareRemoteAccessError(
-        error instanceof Error
-          ? error.message
-          : "Failed to update remote access.",
-      );
-      return;
-    } finally {
-      setShareRemoteAccessBusy(false);
-    }
-  };
-
-  const resetOpenworkServerSettings = () => {
-    clearOpenworkServerSettings();
-    setOpenworkServerSettings({});
-  };
 
   const [editRemoteWorkspaceOpen, setEditRemoteWorkspaceOpen] = createSignal(false);
   const [editRemoteWorkspaceId, setEditRemoteWorkspaceId] = createSignal<string | null>(null);
@@ -2659,128 +2347,7 @@ export default function App() {
     }
   };
 
-  const testOpenworkServerConnection = async (next: OpenworkServerSettings) => {
-    const derived = normalizeOpenworkServerUrl(next.urlOverride ?? "");
-    if (!derived) {
-      setOpenworkServerStatus("disconnected");
-      setOpenworkServerCapabilities(null);
-      setOpenworkServerCheckedAt(Date.now());
-      return false;
-    }
-    const result = await checkOpenworkServer(derived, next.token, openworkServerAuth().hostToken);
-    setOpenworkServerStatus(result.status);
-    setOpenworkServerCapabilities(result.capabilities);
-    setOpenworkServerCheckedAt(Date.now());
-    const ok = result.status === "connected" || result.status === "limited";
-    if (ok && !isTauriRuntime()) {
-      const active = workspaceStore.selectedWorkspaceDisplay();
-      const shouldAttach = !client() || active.workspaceType !== "remote" || active.remoteType !== "openwork";
-      if (shouldAttach) {
-        await workspaceStore
-          .createRemoteWorkspaceFlow({
-            openworkHostUrl: derived,
-            openworkToken: next.token ?? null,
-          })
-          .catch(() => undefined);
-      }
-    }
-    return ok;
-  };
-
-  const reconnectOpenworkServer = async () => {
-    if (openworkReconnectBusy()) return false;
-    setOpenworkReconnectBusy(true);
-    try {
-      let hostInfo = openworkServerHostInfo();
-      if (isTauriRuntime()) {
-        try {
-          hostInfo = await openworkServerInfo();
-          setOpenworkServerHostInfo(hostInfo);
-        } catch {
-          hostInfo = null;
-          setOpenworkServerHostInfo(null);
-        }
-      }
-
-      // Repair stale local token state by syncing settings token from the live host.
-      if (hostInfo?.clientToken?.trim() && startupPreference() !== "server") {
-        const liveToken = hostInfo.clientToken.trim();
-        const settings = openworkServerSettings();
-        if ((settings.token?.trim() ?? "") !== liveToken) {
-          updateOpenworkServerSettings({ ...settings, token: liveToken });
-        }
-      }
-
-      const url = openworkServerBaseUrl().trim();
-      const auth = openworkServerAuth();
-      if (!url) {
-        setOpenworkServerStatus("disconnected");
-        setOpenworkServerCapabilities(null);
-        setOpenworkServerCheckedAt(Date.now());
-        return false;
-      }
-
-      const result = await checkOpenworkServer(url, auth.token, auth.hostToken);
-      setOpenworkServerStatus(result.status);
-      setOpenworkServerCapabilities(result.capabilities);
-      setOpenworkServerCheckedAt(Date.now());
-      return result.status === "connected" || result.status === "limited";
-    } finally {
-      setOpenworkReconnectBusy(false);
-    }
-  };
-
-  async function ensureLocalOpenworkServerClient(): Promise<OpenworkServerClient | null> {
-    let hostInfo = openworkServerHostInfo();
-    if (hostInfo?.baseUrl?.trim() && hostInfo.clientToken?.trim()) {
-      const existing = createOpenworkServerClient({
-        baseUrl: hostInfo.baseUrl.trim(),
-        token: hostInfo.clientToken.trim(),
-        hostToken: hostInfo.hostToken?.trim() || undefined,
-      });
-      try {
-        await existing.health();
-        if (startupPreference() !== "server") {
-          await reconnectOpenworkServer();
-        }
-        return existing;
-      } catch {
-        // restart below
-      }
-    }
-
-    if (!isTauriRuntime()) {
-      return null;
-    }
-
-    try {
-      hostInfo = await openworkServerRestart({
-        remoteAccessEnabled: openworkServerSettings().remoteAccessEnabled === true,
-      });
-      setOpenworkServerHostInfo(hostInfo);
-    } catch {
-      return null;
-    }
-
-    const baseUrl = hostInfo?.baseUrl?.trim() ?? "";
-    const token = hostInfo?.clientToken?.trim() ?? "";
-    const hostToken = hostInfo?.hostToken?.trim() ?? "";
-    if (!baseUrl || !token) {
-      return null;
-    }
-
-    if (startupPreference() !== "server") {
-      await reconnectOpenworkServer();
-    }
-
-    return createOpenworkServerClient({
-      baseUrl,
-      token,
-      hostToken: hostToken || undefined,
-    });
-  }
-
-  const restartLocalServer = async () => {
+  async function restartLocalServer() {
     const activeWorkspace = workspaceStore.selectedWorkspaceDisplay();
     const activeLocalPath =
       activeWorkspace.workspaceType === "local" ? workspaceStore.selectedWorkspacePath().trim() : "";
@@ -2793,7 +2360,7 @@ export default function App() {
     }
 
     return workspaceStore.startHost({ workspacePath, navigate: false });
-  };
+  }
 
   const openWorkspaceConnectionSettings = (workspaceId: string) => {
     const workspace = workspaceStore.workspaces().find((item) => item.id === workspaceId) ?? null;
@@ -2952,8 +2519,7 @@ export default function App() {
       setStartupPreference(null);
       setRememberStartupChoice(false);
 
-      clearOpenworkServerSettings();
-      setOpenworkServerSettings(readOpenworkServerSettings());
+      resetOpenworkServerSettings();
 
       return { ok: true, message: "Reset app config defaults. Restart OpenWork if any stale settings remain." };
     } catch (error) {
@@ -3061,8 +2627,7 @@ export default function App() {
     selectedWorkspaceId: () => workspaceStore.selectedWorkspaceId(),
     selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot(),
     runtimeWorkspaceId,
-    openworkServerClient,
-    openworkServerStatus,
+    openworkServer: openworkServerStore,
     schedulerPluginInstalled,
   });
 
@@ -4947,10 +4512,11 @@ export default function App() {
   });
 
   return (
-    <ConnectionsProvider store={connectionsStore}>
-      <ExtensionsProvider store={extensionsStore}>
-        <AutomationsProvider store={automationsStore}>
-          <StatusToastsProvider store={statusToastsStore}>
+    <OpenworkServerProvider store={openworkServerStore}>
+      <ConnectionsProvider store={connectionsStore}>
+        <ExtensionsProvider store={extensionsStore}>
+          <AutomationsProvider store={automationsStore}>
+            <StatusToastsProvider store={statusToastsStore}>
             <Switch>
               <Match when={booting()}>
                 <BootShell />
@@ -5258,9 +4824,10 @@ export default function App() {
         subtitle={t("dashboard.edit_remote_workspace_subtitle", currentLocale())}
         confirmLabel={t("dashboard.edit_remote_workspace_confirm", currentLocale())}
       />
-          </StatusToastsProvider>
-        </AutomationsProvider>
-      </ExtensionsProvider>
-    </ConnectionsProvider>
+            </StatusToastsProvider>
+          </AutomationsProvider>
+        </ExtensionsProvider>
+      </ConnectionsProvider>
+    </OpenworkServerProvider>
   );
 }

--- a/apps/app/src/app/bundles/store.ts
+++ b/apps/app/src/app/bundles/store.ts
@@ -7,16 +7,11 @@ import type {
   View,
   WorkspacePreset,
 } from "../types";
-import type {
-  OpenworkServerClient,
-  OpenworkServerSettings,
-  OpenworkServerStatus,
-} from "../lib/openwork-server";
 import { normalizeOpenworkServerUrl, parseOpenworkWorkspaceIdFromUrl } from "../lib/openwork-server";
 import { isTauriRuntime, safeStringify, addOpencodeCacheHint } from "../utils";
 import type { WorkspaceStore } from "../context/workspace";
 import type { StartupPreference } from "../types";
-import type { OpenworkServerInfo } from "../lib/tauri";
+import type { OpenworkServerStore } from "../connections/openwork-server-store";
 import {
   buildImportPayloadFromBundle,
   describeWorkspaceForBundleToasts,
@@ -51,10 +46,7 @@ export type BundlesStore = ReturnType<typeof createBundlesStore>;
 export function createBundlesStore(options: {
   booting: Accessor<boolean>;
   startupPreference: Accessor<StartupPreference | null>;
-  openworkServerClient: Accessor<OpenworkServerClient | null>;
-  openworkServerStatus: Accessor<OpenworkServerStatus>;
-  openworkServerHostInfo: Accessor<OpenworkServerInfo | null>;
-  openworkServerSettings: Accessor<OpenworkServerSettings>;
+  openworkServer: OpenworkServerStore;
   runtimeWorkspaceId: Accessor<string | null>;
   workspaceStore: WorkspaceStore;
   setError: (value: string | null) => void;
@@ -98,8 +90,8 @@ export function createBundlesStore(options: {
 
   const resolveBundleWorkerTarget = () => {
     const pref = options.startupPreference();
-    const hostInfo = options.openworkServerHostInfo();
-    const settings = options.openworkServerSettings();
+    const hostInfo = options.openworkServer.openworkServerHostInfo();
+    const settings = options.openworkServer.openworkServerSettings();
 
     const localHostUrl = normalizeOpenworkServerUrl(hostInfo?.baseUrl ?? "") ?? "";
     const localToken = hostInfo?.clientToken?.trim() ?? "";
@@ -152,8 +144,8 @@ export function createBundlesStore(options: {
   const waitForBundleImportTarget = async (timeoutMs = 20_000, target?: BundleImportTarget) => {
     const startedAt = Date.now();
     while (Date.now() - startedAt < timeoutMs) {
-      const client = options.openworkServerClient();
-      if (client && options.openworkServerStatus() === "connected") {
+      const client = options.openworkServer.openworkServerClient();
+      if (client && options.openworkServer.openworkServerStatus() === "connected") {
         if (target?.workspaceId?.trim() || target?.localRoot?.trim() || target?.directoryHint?.trim()) {
           try {
             const matchId = await options.workspaceStore.ensureRuntimeWorkspaceId({
@@ -204,7 +196,9 @@ export function createBundlesStore(options: {
     bundleOverride?: BundleV1,
   ) => {
     try {
-      const bundle = bundleOverride ?? (await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServerClient()));
+      const bundle =
+        bundleOverride ??
+        (await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServer.openworkServerClient()));
       await importBundlePayload(bundle, target);
       options.setError(null);
       return true;
@@ -327,7 +321,7 @@ export function createBundlesStore(options: {
   };
 
   const processBundleRequest = async (request: BundleRequest): Promise<BundleProcessResult> => {
-    const bundle = await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServerClient());
+    const bundle = await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServer.openworkServerClient());
 
     if (bundle.type === "skill") {
       options.setView("settings");
@@ -360,8 +354,8 @@ export function createBundlesStore(options: {
     }
 
     if (request.intent === "import_current") {
-      const client = options.openworkServerClient();
-      const connected = options.openworkServerStatus() === "connected";
+      const client = options.openworkServer.openworkServerClient();
+      const connected = options.openworkServer.openworkServerStatus() === "connected";
       const target = resolveActiveBundleImportTarget();
       const hasTargetHint = Boolean(target.workspaceId?.trim() || target.localRoot?.trim() || target.directoryHint?.trim());
       if (!client || !connected || !hasTargetHint) {

--- a/apps/app/src/app/connections/openwork-server-provider.tsx
+++ b/apps/app/src/app/connections/openwork-server-provider.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+
+import type { OpenworkServerStore } from "./openwork-server-store";
+
+const OpenworkServerContext = createContext<OpenworkServerStore>();
+
+export function OpenworkServerProvider(props: ParentProps<{ store: OpenworkServerStore }>) {
+  return (
+    <OpenworkServerContext.Provider value={props.store}>
+      {props.children}
+    </OpenworkServerContext.Provider>
+  );
+}
+
+export function useOpenworkServer() {
+  const context = useContext(OpenworkServerContext);
+  if (!context) {
+    throw new Error("useOpenworkServer must be used within an OpenworkServerProvider");
+  }
+  return context;
+}

--- a/apps/app/src/app/connections/openwork-server-store.ts
+++ b/apps/app/src/app/connections/openwork-server-store.ts
@@ -1,0 +1,520 @@
+import { createEffect, createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
+
+import type { StartupPreference, WorkspaceDisplay } from "../types";
+import { isTauriRuntime } from "../utils";
+import {
+  openworkServerInfo,
+  openworkServerRestart,
+  opencodeRouterInfo,
+  orchestratorStatus,
+  type OpenCodeRouterInfo,
+  type OpenworkServerInfo,
+  type OrchestratorStatus,
+} from "../lib/tauri";
+import {
+  clearOpenworkServerSettings,
+  createOpenworkServerClient,
+  normalizeOpenworkServerUrl,
+  writeOpenworkServerSettings,
+  type OpenworkServerCapabilities,
+  type OpenworkServerClient,
+  type OpenworkServerDiagnostics,
+  type OpenworkServerError,
+  type OpenworkServerSettings,
+  type OpenworkServerStatus,
+} from "../lib/openwork-server";
+
+export type OpenworkServerStore = ReturnType<typeof createOpenworkServerStore>;
+
+type RemoteWorkspaceInput = {
+  openworkHostUrl: string;
+  openworkToken?: string | null;
+  directory?: string | null;
+  displayName?: string | null;
+};
+
+export function createOpenworkServerStore(options: {
+  startupPreference: Accessor<StartupPreference | null>;
+  documentVisible: Accessor<boolean>;
+  developerMode: Accessor<boolean>;
+  runtimeWorkspaceId: Accessor<string | null>;
+  activeClient: Accessor<unknown | null>;
+  selectedWorkspaceDisplay: Accessor<WorkspaceDisplay>;
+  restartLocalServer: () => Promise<boolean>;
+  createRemoteWorkspaceFlow: (input: RemoteWorkspaceInput) => Promise<boolean>;
+}) {
+  const [openworkServerSettings, setOpenworkServerSettings] = createSignal<OpenworkServerSettings>({});
+  const [shareRemoteAccessBusy, setShareRemoteAccessBusy] = createSignal(false);
+  const [shareRemoteAccessError, setShareRemoteAccessError] = createSignal<string | null>(null);
+  const [openworkServerUrl, setOpenworkServerUrl] = createSignal("");
+  const [openworkServerStatus, setOpenworkServerStatus] = createSignal<OpenworkServerStatus>("disconnected");
+  const [openworkServerCapabilities, setOpenworkServerCapabilities] =
+    createSignal<OpenworkServerCapabilities | null>(null);
+  const [, setOpenworkServerCheckedAt] = createSignal<number | null>(null);
+  const [openworkServerHostInfo, setOpenworkServerHostInfo] = createSignal<OpenworkServerInfo | null>(null);
+  const [openworkServerDiagnostics, setOpenworkServerDiagnostics] =
+    createSignal<OpenworkServerDiagnostics | null>(null);
+  const [openworkReconnectBusy, setOpenworkReconnectBusy] = createSignal(false);
+  const [opencodeRouterInfoState, setOpenCodeRouterInfoState] =
+    createSignal<OpenCodeRouterInfo | null>(null);
+  const [orchestratorStatusState, setOrchestratorStatusState] =
+    createSignal<OrchestratorStatus | null>(null);
+
+  const openworkServerBaseUrl = createMemo(() => {
+    const pref = options.startupPreference();
+    const hostInfo = openworkServerHostInfo();
+    const settingsUrl = normalizeOpenworkServerUrl(openworkServerSettings().urlOverride ?? "") ?? "";
+
+    if (pref === "local") return hostInfo?.baseUrl ?? "";
+    if (pref === "server") return settingsUrl;
+    return hostInfo?.baseUrl ?? settingsUrl;
+  });
+
+  const openworkServerAuth = createMemo(
+    () => {
+      const pref = options.startupPreference();
+      const hostInfo = openworkServerHostInfo();
+      const settingsToken = openworkServerSettings().token?.trim() ?? "";
+      const clientToken = hostInfo?.clientToken?.trim() ?? "";
+      const hostToken = hostInfo?.hostToken?.trim() ?? "";
+
+      if (pref === "local") {
+        return { token: clientToken || undefined, hostToken: hostToken || undefined };
+      }
+      if (pref === "server") {
+        return { token: settingsToken || undefined, hostToken: undefined };
+      }
+      if (hostInfo?.baseUrl) {
+        return { token: clientToken || undefined, hostToken: hostToken || undefined };
+      }
+      return { token: settingsToken || undefined, hostToken: undefined };
+    },
+    undefined,
+    {
+      equals: (prev, next) => prev?.token === next.token && prev?.hostToken === next.hostToken,
+    },
+  );
+
+  const openworkServerClient = createMemo(() => {
+    const baseUrl = openworkServerBaseUrl().trim();
+    if (!baseUrl) return null;
+    const auth = openworkServerAuth();
+    return createOpenworkServerClient({ baseUrl, token: auth.token, hostToken: auth.hostToken });
+  });
+
+  const updateOpenworkServerSettings = (next: OpenworkServerSettings) => {
+    const stored = writeOpenworkServerSettings(next);
+    setOpenworkServerSettings(stored);
+  };
+
+  const resetOpenworkServerSettings = () => {
+    clearOpenworkServerSettings();
+    setOpenworkServerSettings({});
+  };
+
+  const checkOpenworkServer = async (url: string, token?: string, hostToken?: string) => {
+    const client = createOpenworkServerClient({ baseUrl: url, token, hostToken });
+    try {
+      await client.health();
+    } catch (error) {
+      const resolved = error as OpenworkServerError | Error;
+      if ("status" in resolved && (resolved.status === 401 || resolved.status === 403)) {
+        return { status: "limited" as OpenworkServerStatus, capabilities: null };
+      }
+      return { status: "disconnected" as OpenworkServerStatus, capabilities: null };
+    }
+
+    if (!token) {
+      return { status: "limited" as OpenworkServerStatus, capabilities: null };
+    }
+
+    try {
+      const caps = await client.capabilities();
+      return { status: "connected" as OpenworkServerStatus, capabilities: caps };
+    } catch (error) {
+      const resolved = error as OpenworkServerError | Error;
+      if ("status" in resolved && (resolved.status === 401 || resolved.status === 403)) {
+        return { status: "limited" as OpenworkServerStatus, capabilities: null };
+      }
+      return { status: "disconnected" as OpenworkServerStatus, capabilities: null };
+    }
+  };
+
+  createEffect(() => {
+    const pref = options.startupPreference();
+    const info = openworkServerHostInfo();
+    const hostUrl = info?.connectUrl ?? info?.lanUrl ?? info?.mdnsUrl ?? info?.baseUrl ?? "";
+    const settingsUrl = normalizeOpenworkServerUrl(openworkServerSettings().urlOverride ?? "") ?? "";
+
+    if (pref === "local") {
+      setOpenworkServerUrl(hostUrl);
+      return;
+    }
+    if (pref === "server") {
+      setOpenworkServerUrl(settingsUrl);
+      return;
+    }
+    setOpenworkServerUrl(hostUrl || settingsUrl);
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!options.documentVisible()) return;
+    const url = openworkServerBaseUrl().trim();
+    const auth = openworkServerAuth();
+    const token = auth.token;
+    const hostToken = auth.hostToken;
+
+    if (!url) {
+      setOpenworkServerStatus("disconnected");
+      setOpenworkServerCapabilities(null);
+      setOpenworkServerCheckedAt(Date.now());
+      return;
+    }
+
+    let active = true;
+    let busy = false;
+    let timeoutId: number | undefined;
+    let delayMs = 10_000;
+
+    const scheduleNext = () => {
+      if (!active) return;
+      timeoutId = window.setTimeout(run, delayMs);
+    };
+
+    const run = async () => {
+      if (busy) return;
+      busy = true;
+      try {
+        const result = await checkOpenworkServer(url, token, hostToken);
+        if (!active) return;
+        setOpenworkServerStatus(result.status);
+        setOpenworkServerCapabilities(result.capabilities);
+        delayMs =
+          result.status === "connected" || result.status === "limited"
+            ? 10_000
+            : Math.min(delayMs * 2, 60_000);
+      } catch {
+        delayMs = Math.min(delayMs * 2, 60_000);
+      } finally {
+        if (!active) return;
+        setOpenworkServerCheckedAt(Date.now());
+        busy = false;
+        scheduleNext();
+      }
+    };
+
+    run();
+    onCleanup(() => {
+      active = false;
+      if (timeoutId) window.clearTimeout(timeoutId);
+    });
+  });
+
+  createEffect(() => {
+    if (!isTauriRuntime()) return;
+    if (!options.documentVisible()) return;
+    let active = true;
+
+    const run = async () => {
+      try {
+        const info = await openworkServerInfo();
+        if (active) setOpenworkServerHostInfo(info);
+      } catch {
+        if (active) setOpenworkServerHostInfo(null);
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 10_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
+  createEffect(() => {
+    if (!isTauriRuntime()) return;
+    const hostInfo = openworkServerHostInfo();
+    const port = hostInfo?.port;
+    if (!port) return;
+
+    const current = openworkServerSettings();
+    if (current.portOverride === port) return;
+
+    updateOpenworkServerSettings({
+      ...current,
+      portOverride: port,
+    });
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!options.documentVisible()) return;
+    if (!options.developerMode()) {
+      setOpenworkServerDiagnostics(null);
+      return;
+    }
+
+    const client = openworkServerClient();
+    if (!client || openworkServerStatus() === "disconnected") {
+      setOpenworkServerDiagnostics(null);
+      return;
+    }
+
+    let active = true;
+    let busy = false;
+
+    const run = async () => {
+      if (busy) return;
+      busy = true;
+      try {
+        const status = await client.status();
+        if (active) setOpenworkServerDiagnostics(status);
+      } catch {
+        if (active) setOpenworkServerDiagnostics(null);
+      } finally {
+        busy = false;
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 10_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
+  createEffect(() => {
+    if (!isTauriRuntime()) return;
+    if (!options.developerMode()) {
+      setOpenCodeRouterInfoState(null);
+      return;
+    }
+    if (!options.documentVisible()) return;
+
+    let active = true;
+
+    const run = async () => {
+      try {
+        const info = await opencodeRouterInfo();
+        if (active) setOpenCodeRouterInfoState(info);
+      } catch {
+        if (active) setOpenCodeRouterInfoState(null);
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 10_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
+  createEffect(() => {
+    if (!isTauriRuntime()) return;
+    if (!options.developerMode()) {
+      setOrchestratorStatusState(null);
+      return;
+    }
+    if (!options.documentVisible()) return;
+
+    let active = true;
+
+    const run = async () => {
+      try {
+        const status = await orchestratorStatus();
+        if (active) setOrchestratorStatusState(status);
+      } catch {
+        if (active) setOrchestratorStatusState(null);
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 10_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
+  const testOpenworkServerConnection = async (next: OpenworkServerSettings) => {
+    const derived = normalizeOpenworkServerUrl(next.urlOverride ?? "");
+    if (!derived) {
+      setOpenworkServerStatus("disconnected");
+      setOpenworkServerCapabilities(null);
+      setOpenworkServerCheckedAt(Date.now());
+      return false;
+    }
+
+    const result = await checkOpenworkServer(derived, next.token);
+    setOpenworkServerStatus(result.status);
+    setOpenworkServerCapabilities(result.capabilities);
+    setOpenworkServerCheckedAt(Date.now());
+
+    const ok = result.status === "connected" || result.status === "limited";
+    if (ok && !isTauriRuntime()) {
+      const active = options.selectedWorkspaceDisplay();
+      const shouldAttach = !options.activeClient() || active.workspaceType !== "remote" || active.remoteType !== "openwork";
+      if (shouldAttach) {
+        await options.createRemoteWorkspaceFlow({
+          openworkHostUrl: derived,
+          openworkToken: next.token ?? null,
+        }).catch(() => undefined);
+      }
+    }
+    return ok;
+  };
+
+  const reconnectOpenworkServer = async () => {
+    if (openworkReconnectBusy()) return false;
+    setOpenworkReconnectBusy(true);
+    try {
+      let hostInfo = openworkServerHostInfo();
+      if (isTauriRuntime()) {
+        try {
+          hostInfo = await openworkServerInfo();
+          setOpenworkServerHostInfo(hostInfo);
+        } catch {
+          hostInfo = null;
+          setOpenworkServerHostInfo(null);
+        }
+      }
+
+      if (hostInfo?.clientToken?.trim() && options.startupPreference() !== "server") {
+        const liveToken = hostInfo.clientToken.trim();
+        const settings = openworkServerSettings();
+        if ((settings.token?.trim() ?? "") !== liveToken) {
+          updateOpenworkServerSettings({ ...settings, token: liveToken });
+        }
+      }
+
+      const url = openworkServerBaseUrl().trim();
+      const auth = openworkServerAuth();
+      if (!url) {
+        setOpenworkServerStatus("disconnected");
+        setOpenworkServerCapabilities(null);
+        setOpenworkServerCheckedAt(Date.now());
+        return false;
+      }
+
+      const result = await checkOpenworkServer(url, auth.token, auth.hostToken);
+      setOpenworkServerStatus(result.status);
+      setOpenworkServerCapabilities(result.capabilities);
+      setOpenworkServerCheckedAt(Date.now());
+      return result.status === "connected" || result.status === "limited";
+    } finally {
+      setOpenworkReconnectBusy(false);
+    }
+  };
+
+  async function ensureLocalOpenworkServerClient(): Promise<OpenworkServerClient | null> {
+    let hostInfo = openworkServerHostInfo();
+    if (hostInfo?.baseUrl?.trim() && hostInfo.clientToken?.trim()) {
+      const existing = createOpenworkServerClient({
+        baseUrl: hostInfo.baseUrl.trim(),
+        token: hostInfo.clientToken.trim(),
+        hostToken: hostInfo.hostToken?.trim() || undefined,
+      });
+      try {
+        await existing.health();
+        if (options.startupPreference() !== "server") {
+          await reconnectOpenworkServer();
+        }
+        return existing;
+      } catch {
+        // restart below
+      }
+    }
+
+    if (!isTauriRuntime()) {
+      return null;
+    }
+
+    try {
+      hostInfo = await openworkServerRestart({
+        remoteAccessEnabled: openworkServerSettings().remoteAccessEnabled === true,
+      });
+      setOpenworkServerHostInfo(hostInfo);
+    } catch {
+      return null;
+    }
+
+    const baseUrl = hostInfo?.baseUrl?.trim() ?? "";
+    const token = hostInfo?.clientToken?.trim() ?? "";
+    const hostToken = hostInfo?.hostToken?.trim() ?? "";
+    if (!baseUrl || !token) {
+      return null;
+    }
+
+    if (options.startupPreference() !== "server") {
+      await reconnectOpenworkServer();
+    }
+
+    return createOpenworkServerClient({
+      baseUrl,
+      token,
+      hostToken: hostToken || undefined,
+    });
+  }
+
+  const saveShareRemoteAccess = async (enabled: boolean) => {
+    if (shareRemoteAccessBusy()) return;
+    const previous = openworkServerSettings();
+    const next: OpenworkServerSettings = {
+      ...previous,
+      remoteAccessEnabled: enabled,
+    };
+
+    setShareRemoteAccessBusy(true);
+    setShareRemoteAccessError(null);
+    updateOpenworkServerSettings(next);
+
+    try {
+      if (isTauriRuntime() && options.selectedWorkspaceDisplay().workspaceType === "local") {
+        const restarted = await options.restartLocalServer();
+        if (!restarted) {
+          throw new Error("Failed to restart the local worker with the updated sharing setting.");
+        }
+        await reconnectOpenworkServer();
+      }
+    } catch (error) {
+      updateOpenworkServerSettings(previous);
+      setShareRemoteAccessError(
+        error instanceof Error
+          ? error.message
+          : "Failed to update remote access.",
+      );
+      return;
+    } finally {
+      setShareRemoteAccessBusy(false);
+    }
+  };
+
+  return {
+    openworkServerSettings,
+    setOpenworkServerSettings,
+    updateOpenworkServerSettings,
+    resetOpenworkServerSettings,
+    shareRemoteAccessBusy,
+    shareRemoteAccessError,
+    saveShareRemoteAccess,
+    openworkServerUrl,
+    openworkServerBaseUrl,
+    openworkServerAuth,
+    openworkServerClient,
+    openworkServerStatus,
+    openworkServerCapabilities,
+    openworkServerHostInfo,
+    openworkServerDiagnostics,
+    openworkReconnectBusy,
+    opencodeRouterInfoState,
+    orchestratorStatusState,
+    checkOpenworkServer,
+    testOpenworkServerConnection,
+    reconnectOpenworkServer,
+    ensureLocalOpenworkServerClient,
+  };
+}

--- a/apps/app/src/app/connections/store.ts
+++ b/apps/app/src/app/connections/store.ts
@@ -8,11 +8,6 @@ import { CHROME_DEVTOOLS_MCP_ID, MCP_QUICK_CONNECT, type McpDirectoryInfo } from
 import { createClient, unwrap } from "../lib/opencode";
 import { finishPerf, perfNow, recordPerfLog } from "../lib/perf-log";
 import { readOpencodeConfig, writeOpencodeConfig, type OpencodeConfigFile } from "../lib/tauri";
-import type {
-  OpenworkServerCapabilities,
-  OpenworkServerClient,
-  OpenworkServerStatus,
-} from "../lib/openwork-server";
 import {
   parseMcpServersFromContent,
   removeMcpFromConfig,
@@ -22,6 +17,7 @@ import {
 import type { Client, McpServerEntry, McpStatusMap, ReloadReason, ReloadTrigger } from "../types";
 import { isTauriRuntime, normalizeDirectoryQueryPath, safeStringify } from "../utils";
 import { createWorkspaceContextKey } from "../context/workspace-context";
+import type { OpenworkServerStore } from "./openwork-server-store";
 
 export type ConnectionsStore = ReturnType<typeof createConnectionsStore>;
 
@@ -32,11 +28,7 @@ export function createConnectionsStore(options: {
   selectedWorkspaceId: () => string;
   selectedWorkspaceRoot: () => string;
   workspaceType: () => "local" | "remote";
-  openworkServerClient: () => OpenworkServerClient | null;
-  openworkServerStatus: () => OpenworkServerStatus;
-  openworkServerCapabilities: () => OpenworkServerCapabilities | null;
-  openworkServerBaseUrl: () => string;
-  openworkServerAuthToken: () => string | undefined;
+  openworkServer: OpenworkServerStore;
   runtimeWorkspaceId: () => string | null;
   ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
   setProjectDir?: (value: string) => void;
@@ -70,13 +62,13 @@ export function createConnectionsStore(options: {
 
   const readMcpConfigFile = async (scope: "project" | "global"): Promise<OpencodeConfigFile | null> => {
     const projectDir = options.projectDir().trim();
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
-      options.openworkServerCapabilities()?.config?.read;
+      options.openworkServer.openworkServerCapabilities()?.config?.read;
 
     if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
       return openworkClient.readOpencodeConfigFile(openworkWorkspaceId, scope);
@@ -95,8 +87,8 @@ export function createConnectionsStore(options: {
       return activeClient;
     }
 
-    const openworkBaseUrl = options.openworkServerBaseUrl().trim();
-    const token = options.openworkServerAuthToken()?.trim();
+    const openworkBaseUrl = options.openworkServer.openworkServerBaseUrl().trim();
+    const token = options.openworkServer.openworkServerAuth().token?.trim();
     if (!openworkBaseUrl || !token) {
       return null;
     }
@@ -110,15 +102,15 @@ export function createConnectionsStore(options: {
   };
 
   const resolveWritableOpenworkTarget = async () => {
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     let openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
-    if (!openworkWorkspaceId && openworkClient && options.openworkServerStatus() === "connected") {
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
+    if (!openworkWorkspaceId && openworkClient && options.openworkServer.openworkServerStatus() === "connected") {
       openworkWorkspaceId = (await options.ensureRuntimeWorkspaceId?.()) ?? null;
     }
 
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.mcp?.write;
@@ -153,13 +145,13 @@ export function createConnectionsStore(options: {
     const projectDir = options.projectDir().trim();
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = !isRemoteWorkspace;
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
-      options.openworkServerCapabilities()?.mcp?.read;
+      options.openworkServer.openworkServerCapabilities()?.mcp?.read;
 
     if (isRemoteWorkspace) {
       if (!canUseOpenworkServer) {
@@ -286,7 +278,9 @@ export function createConnectionsStore(options: {
 
   async function connectMcp(entry: McpDirectoryInfo) {
     const startedAt = perfNow();
-    const isRemoteWorkspace = options.workspaceType() === "remote" || (!isTauriRuntime() && options.openworkServerStatus() === "connected");
+    const isRemoteWorkspace =
+      options.workspaceType() === "remote" ||
+      (!isTauriRuntime() && options.openworkServer.openworkServerStatus() === "connected");
     const projectDir = options.projectDir().trim();
     const entryType = entry.type ?? "remote";
 
@@ -500,7 +494,9 @@ export function createConnectionsStore(options: {
   }
 
   async function logoutMcpAuth(name: string) {
-    const isRemoteWorkspace = options.workspaceType() === "remote" || (!isTauriRuntime() && options.openworkServerStatus() === "connected");
+    const isRemoteWorkspace =
+      options.workspaceType() === "remote" ||
+      (!isTauriRuntime() && options.openworkServer.openworkServerStatus() === "connected");
     const projectDir = options.projectDir().trim();
 
     const { openworkClient, openworkWorkspaceId, canUseOpenworkServer } = await resolveWritableOpenworkTarget();
@@ -560,13 +556,13 @@ export function createConnectionsStore(options: {
     try {
       setMcpStatus(null);
 
-      const openworkClient = options.openworkServerClient();
+      const openworkClient = options.openworkServer.openworkServerClient();
       const openworkWorkspaceId = options.runtimeWorkspaceId();
       const canUseOpenworkServer =
-        options.openworkServerStatus() === "connected" &&
+        options.openworkServer.openworkServerStatus() === "connected" &&
         openworkClient &&
         openworkWorkspaceId &&
-        options.openworkServerCapabilities()?.mcp?.write;
+        options.openworkServer.openworkServerCapabilities()?.mcp?.write;
 
       if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {
         await openworkClient.removeMcp(openworkWorkspaceId, name);

--- a/apps/app/src/app/context/automations.ts
+++ b/apps/app/src/app/context/automations.ts
@@ -2,9 +2,9 @@ import { createEffect, createMemo, createSignal } from "solid-js";
 
 import type { ScheduledJob } from "../types";
 import { schedulerDeleteJob, schedulerListJobs } from "../lib/tauri";
-import type { OpenworkServerClient, OpenworkServerStatus } from "../lib/openwork-server";
 import { isTauriRuntime } from "../utils";
 import { createWorkspaceContextKey } from "./workspace-context";
+import type { OpenworkServerStore } from "../connections/openwork-server-store";
 
 export type AutomationsStore = ReturnType<typeof createAutomationsStore>;
 
@@ -88,8 +88,7 @@ export function createAutomationsStore(options: {
   selectedWorkspaceId: () => string;
   selectedWorkspaceRoot: () => string;
   runtimeWorkspaceId: () => string | null;
-  openworkServerClient: () => OpenworkServerClient | null;
-  openworkServerStatus: () => OpenworkServerStatus;
+  openworkServer: OpenworkServerStore;
   schedulerPluginInstalled: () => boolean;
 }) {
   const [scheduledJobs, setScheduledJobs] = createSignal<ScheduledJob[]>([]);
@@ -99,9 +98,9 @@ export function createAutomationsStore(options: {
   const [pendingRefreshContextKey, setPendingRefreshContextKey] = createSignal<string | null>(null);
 
   const serverBacked = createMemo(() => {
-    const client = options.openworkServerClient();
+    const client = options.openworkServer.openworkServerClient();
     const runtimeWorkspaceId = (options.runtimeWorkspaceId() ?? "").trim();
-    return options.openworkServerStatus() === "connected" && Boolean(client && runtimeWorkspaceId);
+    return options.openworkServer.openworkServerStatus() === "connected" && Boolean(client && runtimeWorkspaceId);
   });
 
   const scheduledJobsSource = createMemo<"local" | "remote">(() =>
@@ -131,14 +130,14 @@ export function createAutomationsStore(options: {
     }
 
     if (scheduledJobsSource() === "remote") {
-      const client = options.openworkServerClient();
+      const client = options.openworkServer.openworkServerClient();
       const workspaceId = (options.runtimeWorkspaceId() ?? "").trim();
-      if (!client || options.openworkServerStatus() !== "connected" || !workspaceId) {
+      if (!client || options.openworkServer.openworkServerStatus() !== "connected" || !workspaceId) {
         if (scheduledJobsContextKey() !== requestContextKey) return "skipped";
         const status =
-          options.openworkServerStatus() === "disconnected"
+          options.openworkServer.openworkServerStatus() === "disconnected"
             ? "OpenWork server unavailable. Connect to sync scheduled tasks."
-            : options.openworkServerStatus() === "limited"
+            : options.openworkServer.openworkServerStatus() === "limited"
               ? "OpenWork server needs a token to load scheduled tasks."
               : "OpenWork server not ready.";
         setScheduledJobsStatus(status);
@@ -190,7 +189,7 @@ export function createAutomationsStore(options: {
 
   const deleteScheduledJob = async (name: string) => {
     if (scheduledJobsSource() === "remote") {
-      const client = options.openworkServerClient();
+      const client = options.openworkServer.openworkServerClient();
       const workspaceId = (options.runtimeWorkspaceId() ?? "").trim();
       if (!client || !workspaceId) {
         throw new Error("OpenWork server unavailable. Connect to sync scheduled tasks.");

--- a/apps/app/src/app/context/extensions.ts
+++ b/apps/app/src/app/context/extensions.ts
@@ -25,13 +25,9 @@ import {
   writeOpencodeConfig,
   type OpencodeConfigFile,
 } from "../lib/tauri";
-import type {
-  OpenworkHubRepo,
-  OpenworkServerCapabilities,
-  OpenworkServerClient,
-  OpenworkServerStatus,
-} from "../lib/openwork-server";
+import type { OpenworkHubRepo, OpenworkServerClient } from "../lib/openwork-server";
 import { createWorkspaceContextKey } from "./workspace-context";
+import type { OpenworkServerStore } from "../connections/openwork-server-store";
 
 export type ExtensionsStore = ReturnType<typeof createExtensionsStore>;
 
@@ -41,9 +37,7 @@ export function createExtensionsStore(options: {
   selectedWorkspaceId: () => string;
   selectedWorkspaceRoot: () => string;
   workspaceType: () => "local" | "remote";
-  openworkServerClient: () => OpenworkServerClient | null;
-  openworkServerStatus: () => OpenworkServerStatus;
-  openworkServerCapabilities: () => OpenworkServerCapabilities | null;
+  openworkServer: OpenworkServerStore;
   runtimeWorkspaceId: () => string | null;
   setBusy: (value: boolean) => void;
   setBusyLabel: (value: string | null) => void;
@@ -232,10 +226,10 @@ export function createExtensionsStore(options: {
     const root = options.selectedWorkspaceRoot().trim();
     const repo = hubRepo();
     const loadKey = `${root}::${repo ? hubRepoKey(repo) : "none"}`;
-    const openworkClient = options.openworkServerClient();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkClient = options.openworkServer.openworkServerClient();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkCapabilities?.hub?.skills?.read &&
       typeof (openworkClient as any).listHubSkills === "function";
@@ -333,11 +327,11 @@ export function createExtensionsStore(options: {
     }
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.hub?.skills?.install &&
@@ -389,11 +383,11 @@ export function createExtensionsStore(options: {
     const root = options.selectedWorkspaceRoot().trim();
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.skills?.read;
@@ -577,11 +571,11 @@ export function createExtensionsStore(options: {
   async function refreshPlugins(scopeOverride?: PluginScope) {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.plugins?.read;
@@ -719,11 +713,11 @@ export function createExtensionsStore(options: {
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.plugins?.write;
@@ -824,11 +818,11 @@ export function createExtensionsStore(options: {
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.plugins?.write;
@@ -953,11 +947,11 @@ export function createExtensionsStore(options: {
   async function installSkillCreator(): Promise<{ ok: boolean; message: string }> {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.skills?.write;
@@ -1148,11 +1142,11 @@ export function createExtensionsStore(options: {
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.skills?.read &&
@@ -1214,11 +1208,11 @@ export function createExtensionsStore(options: {
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkClient = options.openworkServerClient();
+    const openworkClient = options.openworkServer.openworkServerClient();
     const openworkWorkspaceId = options.runtimeWorkspaceId();
-    const openworkCapabilities = options.openworkServerCapabilities();
+    const openworkCapabilities = options.openworkServer.openworkServerCapabilities();
     const canUseOpenworkServer =
-      options.openworkServerStatus() === "connected" &&
+      options.openworkServer.openworkServerStatus() === "connected" &&
       openworkClient &&
       openworkWorkspaceId &&
       openworkCapabilities?.skills?.write;

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -29,10 +29,7 @@ import {
   normalizeOpenworkServerUrl,
   parseOpenworkWorkspaceIdFromUrl,
   OpenworkServerError,
-  type OpenworkServerCapabilities,
   type OpenworkServerClient,
-  type OpenworkServerSettings,
-  type OpenworkServerStatus,
   type OpenworkWorkspaceInfo,
 } from "../lib/openwork-server";
 import { downloadDir, homeDir } from "@tauri-apps/api/path";
@@ -73,6 +70,7 @@ import type { OpencodeConnectStatus, ProviderListItem } from "../types";
 import { t, currentLocale } from "../../i18n";
 import { filterProviderList, mapConfigProvidersToList } from "../utils/providers";
 import { buildDefaultWorkspaceBlueprint, normalizeWorkspaceOpenworkConfig } from "../lib/workspace-blueprints";
+import type { OpenworkServerStore } from "../connections/openwork-server-store";
 
 export type WorkspaceStore = ReturnType<typeof createWorkspaceStore>;
 
@@ -153,13 +151,8 @@ export function createWorkspaceStore(options: {
   setView: (value: any, sessionId?: string) => void;
   setSettingsTab: (value: any) => void;
   isWindowsPlatform: () => boolean;
-  openworkServerSettings: () => OpenworkServerSettings;
-  updateOpenworkServerSettings: (next: OpenworkServerSettings) => void;
-  openworkServerClient?: () => OpenworkServerClient | null;
-  openworkServerStatus?: () => OpenworkServerStatus;
-  openworkServerCapabilities?: () => OpenworkServerCapabilities | null;
+  openworkServer: OpenworkServerStore;
   openworkEnvWorkspaceId?: string | null;
-  ensureLocalOpenworkServerClient?: () => Promise<OpenworkServerClient | null>;
   setOpencodeConnectStatus?: (status: OpencodeConnectStatus | null) => void;
   onEngineStable?: () => void;
   engineRuntime?: () => EngineRuntime;
@@ -589,8 +582,8 @@ export function createWorkspaceStore(options: {
   });
 
   createEffect(() => {
-    const client = options.openworkServerClient?.();
-    const status = options.openworkServerStatus?.();
+    const client = options.openworkServer.openworkServerClient();
+    const status = options.openworkServer.openworkServerStatus();
     const connectedWorkspace = connectedWorkspaceInfo();
 
     if (!client || status !== "connected" || !connectedWorkspace) {
@@ -619,8 +612,8 @@ export function createWorkspaceStore(options: {
   });
 
   createEffect(() => {
-    const client = options.openworkServerClient?.();
-    const status = options.openworkServerStatus?.();
+    const client = options.openworkServer.openworkServerClient();
+    const status = options.openworkServer.openworkServerStatus();
     const workspaceId = runtimeWorkspaceId()?.trim() ?? "";
 
     if (!client || status !== "connected" || !workspaceId) {
@@ -762,16 +755,16 @@ export function createWorkspaceStore(options: {
   };
 
   const resolveConnectedOpenworkServer = () => {
-    const client = options.openworkServerClient?.();
+    const client = options.openworkServer.openworkServerClient();
     if (!client) return null;
-    if (options.openworkServerStatus?.() !== "connected") return null;
+    if (options.openworkServer.openworkServerStatus() !== "connected") return null;
     return client;
   };
 
   const resolveLocalOpenworkServer = async () => {
     if (!isTauriRuntime()) return null;
     try {
-      return (await options.ensureLocalOpenworkServerClient?.()) ?? null;
+      return (await options.openworkServer.ensureLocalOpenworkServerClient()) ?? null;
     } catch (error) {
       wsDebug("openwork:local-host:unavailable", {
         message: error instanceof Error ? error.message : safeStringify(error),
@@ -887,7 +880,7 @@ export function createWorkspaceStore(options: {
     const workspaceId = (workspaceIdOverride ?? runtimeWorkspaceId() ?? "").trim();
     if (!client || !workspaceId) return null;
 
-    if (options.openworkServerCapabilities?.()?.config?.read === false) {
+    if (options.openworkServer.openworkServerCapabilities()?.config?.read === false) {
       storeRuntimeWorkspaceConfig(workspaceId, null);
       return null;
     }
@@ -1076,7 +1069,7 @@ export function createWorkspaceStore(options: {
         return false;
       }
 
-      const token = workspace.openworkToken?.trim() || options.openworkServerSettings().token || undefined;
+      const token = workspace.openworkToken?.trim() || options.openworkServer.openworkServerSettings().token || undefined;
       try {
         const resolved = await resolveOpenworkHost({
           hostUrl,
@@ -1274,15 +1267,15 @@ export function createWorkspaceStore(options: {
           }
 
           const workspaceToken = next.openworkToken?.trim() ?? "";
-          const fallbackToken = options.openworkServerSettings().token ?? "";
+          const fallbackToken = options.openworkServer.openworkServerSettings().token ?? "";
           const token = workspaceToken || fallbackToken;
 
-          const currentSettings = options.openworkServerSettings();
+          const currentSettings = options.openworkServer.openworkServerSettings();
           if (
             currentSettings.urlOverride?.trim() !== hostUrl ||
             (token && currentSettings.token?.trim() !== token)
           ) {
-            options.updateOpenworkServerSettings({
+            options.openworkServer.updateOpenworkServerSettings({
               ...currentSettings,
               urlOverride: hostUrl,
               token: token || currentSettings.token,
@@ -1672,7 +1665,7 @@ export function createWorkspaceStore(options: {
             opencodeBinPath:
               options.engineSource() === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
             opencodeEnableExa: options.opencodeEnableExa?.() ?? false,
-            openworkRemoteAccess: options.openworkServerSettings().remoteAccessEnabled === true,
+            openworkRemoteAccess: options.openworkServer.openworkServerSettings().remoteAccessEnabled === true,
             runtime,
             workspacePaths: resolveWorkspacePaths(),
           });
@@ -2414,8 +2407,8 @@ export function createWorkspaceStore(options: {
     let resolvedAuth: OpencodeAuth | undefined = undefined;
     let resolvedHostUrl = hostUrl;
 
-    options.updateOpenworkServerSettings({
-      ...options.openworkServerSettings(),
+    options.openworkServer.updateOpenworkServerSettings({
+      ...options.openworkServer.openworkServerSettings(),
       urlOverride: hostUrl,
       token: token || undefined,
     });
@@ -2627,7 +2620,7 @@ export function createWorkspaceStore(options: {
     const token =
       input.openworkToken?.trim() ??
       workspace.openworkToken?.trim() ??
-      options.openworkServerSettings().token ??
+      options.openworkServer.openworkServerSettings().token ??
       "";
     const directory = input.directory?.trim() ?? "";
     const displayName = input.displayName?.trim() || null;
@@ -2646,8 +2639,8 @@ export function createWorkspaceStore(options: {
     let resolvedAuth: OpencodeAuth | undefined = undefined;
     let resolvedHostUrl = hostUrl;
 
-    options.updateOpenworkServerSettings({
-      ...options.openworkServerSettings(),
+    options.openworkServer.updateOpenworkServerSettings({
+      ...options.openworkServer.openworkServerSettings(),
       urlOverride: hostUrl,
       token: token || undefined,
     });
@@ -2881,7 +2874,7 @@ export function createWorkspaceStore(options: {
         openworkToken:
           workspace.openworkClientToken?.trim() ||
           workspace.openworkToken?.trim() ||
-          options.openworkServerSettings().token?.trim() ||
+          options.openworkServer.openworkServerSettings().token?.trim() ||
           null,
         openworkHostToken: workspace.openworkHostToken?.trim() || null,
       });
@@ -3213,7 +3206,7 @@ export function createWorkspaceStore(options: {
         opencodeBinPath:
           options.engineSource() === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
         opencodeEnableExa: options.opencodeEnableExa?.() ?? false,
-        openworkRemoteAccess: options.openworkServerSettings().remoteAccessEnabled === true,
+        openworkRemoteAccess: options.openworkServer.openworkServerSettings().remoteAccessEnabled === true,
         runtime: resolveEngineRuntime(),
         workspacePaths: resolveWorkspacePaths(),
       });
@@ -3416,7 +3409,7 @@ export function createWorkspaceStore(options: {
         opencodeBinPath:
           options.engineSource() === "custom" ? options.engineCustomBinPath?.().trim() || null : null,
         opencodeEnableExa: options.opencodeEnableExa?.() ?? false,
-        openworkRemoteAccess: options.openworkServerSettings().remoteAccessEnabled === true,
+        openworkRemoteAccess: options.openworkServer.openworkServerSettings().remoteAccessEnabled === true,
         runtime,
         workspacePaths: resolveWorkspacePaths(),
       });
@@ -3801,7 +3794,7 @@ export function createWorkspaceStore(options: {
   async function onConnectClient() {
     options.setStartupPreference("server");
     options.setOnboardingStep("connecting");
-    const settings = options.openworkServerSettings();
+    const settings = options.openworkServer.openworkServerSettings();
     const ok = await createRemoteWorkspaceFlow({
       openworkHostUrl: settings.urlOverride ?? null,
       openworkToken: settings.token ?? null,

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -35,6 +35,7 @@ import {
 } from "../lib/tauri";
 import { usePlatform } from "../context/platform";
 import { useSessionActions } from "../session/actions-provider";
+import { useModelControls } from "../app-settings/model-controls-provider";
 import { buildFeedbackUrl } from "../lib/feedback";
 import { getOpenWorkDeployment } from "../lib/openwork-deployment";
 import { createWorkspaceShellLayout } from "../lib/workspace-shell-layout";
@@ -188,14 +189,6 @@ export type SessionViewProps = {
   busy: boolean;
   prompt: string;
   setPrompt: (value: string) => void;
-  selectedSessionModelLabel: string;
-  openSessionModelPicker: (options?: {
-    returnFocusTarget?: "none" | "composer";
-  }) => void;
-  modelVariantLabel: string;
-  modelVariant: string | null;
-  modelBehaviorOptions?: { value: string | null; label: string }[];
-  setModelVariant: (value: string | null) => void;
   activePermission: PendingPermission | null;
   permissionReplyBusy: boolean;
   respondPermission: (
@@ -306,6 +299,7 @@ export default function SessionView(props: SessionViewProps) {
   const { showThinking } = useSessionDisplayPreferences();
   const platform = usePlatform();
   const sessionActions = useSessionActions();
+  const modelControls = useModelControls();
   const statusToasts = useStatusToasts();
   let chatContainerEl: HTMLDivElement | undefined;
   let chatContentEl: HTMLDivElement | undefined;
@@ -2403,11 +2397,11 @@ export default function SessionView(props: SessionViewProps) {
       {
         id: "model",
         title: "Change model",
-        detail: `${props.selectedSessionModelLabel || "Model"} · ${props.modelVariantLabel}`,
+        detail: `${modelControls.selectedSessionModelLabel() || "Model"} · ${modelControls.sessionModelVariantLabel()}`,
         meta: "Open",
         action: () => {
           closeCommandPalette();
-          props.openSessionModelPicker({ returnFocusTarget: "composer" });
+          modelControls.openSessionModelPicker({ returnFocusTarget: "composer" });
         },
       },
       {
@@ -3326,12 +3320,12 @@ export default function SessionView(props: SessionViewProps) {
               onSend={handleSendPrompt}
               onStop={cancelRun}
               onDraftChange={handleDraftChange}
-              selectedModelLabel={props.selectedSessionModelLabel || "Model"}
-              onModelClick={() => props.openSessionModelPicker()}
-              modelVariantLabel={props.modelVariantLabel}
-              modelVariant={props.modelVariant}
-              modelBehaviorOptions={props.modelBehaviorOptions}
-              onModelVariantChange={props.setModelVariant}
+              selectedModelLabel={modelControls.selectedSessionModelLabel() || "Model"}
+              onModelClick={() => modelControls.openSessionModelPicker()}
+              modelVariantLabel={modelControls.sessionModelVariantLabel()}
+              modelVariant={modelControls.sessionModelVariant()}
+              modelBehaviorOptions={modelControls.sessionModelBehaviorOptions()}
+              onModelVariantChange={modelControls.setSessionModelVariant}
               agentLabel={agentLabel()}
               selectedAgent={sessionActions.selectedSessionAgent()}
               agentPickerOpen={agentPickerOpen()}

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -34,6 +34,7 @@ import {
   type WorkspaceInfo,
 } from "../lib/tauri";
 import { usePlatform } from "../context/platform";
+import { useSessionActions } from "../session/actions-provider";
 import { buildFeedbackUrl } from "../lib/feedback";
 import { getOpenWorkDeployment } from "../lib/openwork-deployment";
 import { createWorkspaceShellLayout } from "../lib/workspace-shell-layout";
@@ -157,15 +158,6 @@ export type SessionViewProps = {
   updateEnv: { supported?: boolean; reason?: string | null } | null;
   anyActiveRuns: boolean;
   installUpdateAndRestart: () => void;
-  createSessionAndOpen: () => Promise<string | undefined>;
-  sendPromptAsync: (draft: ComposerDraft) => Promise<void>;
-  abortSession: (sessionId?: string) => Promise<void>;
-  sessionRevertMessageId: string | null;
-  undoLastUserMessage: () => Promise<void>;
-  redoLastUserMessage: () => Promise<void>;
-  compactSession: () => Promise<void>;
-  lastPromptSent: string;
-  retryLastPrompt: () => void;
   newTaskDisabled: boolean;
   workspaceSessionGroups: WorkspaceSessionGroup[];
   openRenameWorkspace: (workspaceId: string) => void;
@@ -220,7 +212,6 @@ export type SessionViewProps = {
   safeStringify: (value: unknown) => string;
   error: string | null;
   sessionStatus: string;
-  renameSession: (sessionId: string, title: string) => Promise<void>;
   startProviderAuth: (providerId?: string, methodIndex?: number) => Promise<ProviderOAuthStartResult>;
   completeProviderAuthOAuth: (
     providerId: string,
@@ -245,23 +236,10 @@ export type SessionViewProps = {
   providerAuthWorkerType: "local" | "remote";
   providers: ProviderListItem[];
   providerConnectedIds: string[];
-  listAgents: () => Promise<Agent[]>;
-  searchFiles: (query: string) => Promise<string[]>;
-  listCommands: () => Promise<
-    {
-      id: string;
-      name: string;
-      description?: string;
-      source?: "command" | "mcp" | "skill";
-    }[]
-  >;
-  selectedSessionAgent: string | null;
-  setSessionAgent: (sessionId: string, agent: string | null) => void;
   sessionStatusById: Record<string, string>;
   hasEarlierMessages: boolean;
   loadingEarlierMessages: boolean;
   loadEarlierMessages: (sessionId: string) => Promise<void>;
-  deleteSession: (sessionId: string) => Promise<void>;
 };
 
 type ResolvedEmptyStateStarter = {
@@ -327,6 +305,7 @@ function describePermissionRequest(permission: PendingPermission | null) {
 export default function SessionView(props: SessionViewProps) {
   const { showThinking } = useSessionDisplayPreferences();
   const platform = usePlatform();
+  const sessionActions = useSessionActions();
   const statusToasts = useStatusToasts();
   let chatContainerEl: HTMLDivElement | undefined;
   let chatContentEl: HTMLDivElement | undefined;
@@ -421,7 +400,7 @@ export default function SessionView(props: SessionViewProps) {
   };
 
   const agentLabel = createMemo(() => {
-    const name = props.selectedSessionAgent ?? "Default agent";
+    const name = sessionActions.selectedSessionAgent() ?? "Default agent";
     return name.charAt(0).toUpperCase() + name.slice(1);
   });
   const workspaceLabel = (workspace: WorkspaceInfo) =>
@@ -825,7 +804,7 @@ export default function SessionView(props: SessionViewProps) {
 
   const canUndoLastMessage = createMemo(() => {
     if (!props.selectedSessionId) return false;
-    const revert = props.sessionRevertMessageId;
+    const revert = sessionActions.sessionRevertMessageId();
     for (const message of props.messages) {
       const role = (message.info as { role?: string }).role;
       if (role !== "user") continue;
@@ -844,7 +823,7 @@ export default function SessionView(props: SessionViewProps) {
 
   const canRedoLastMessage = createMemo(() => {
     if (!props.selectedSessionId) return false;
-    return Boolean(props.sessionRevertMessageId);
+    return Boolean(sessionActions.sessionRevertMessageId());
   });
 
   const canCompactSession = createMemo(
@@ -1143,7 +1122,7 @@ export default function SessionView(props: SessionViewProps) {
     setAgentPickerBusy(true);
     setAgentPickerError(null);
     try {
-      const agents = await props.listAgents();
+      const agents = await sessionActions.listAgents();
       const sorted = agents
         .slice()
         .sort((a, b) => a.name.localeCompare(b.name));
@@ -1722,7 +1701,7 @@ export default function SessionView(props: SessionViewProps) {
     setAbortBusy(true);
     showStatusToast("Stopping the run...", "info");
     try {
-      await props.abortSession(props.selectedSessionId);
+      await sessionActions.abortSession(props.selectedSessionId);
       showStatusToast("Stopped.", "success");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to stop";
@@ -1733,7 +1712,7 @@ export default function SessionView(props: SessionViewProps) {
   };
 
   const retryRun = async () => {
-    const text = props.lastPromptSent.trim();
+    const text = sessionActions.lastPromptSent().trim();
     if (!text) {
       showStatusToast("Nothing to retry yet", "warning");
       return;
@@ -1744,7 +1723,7 @@ export default function SessionView(props: SessionViewProps) {
     showStatusToast("Trying again...", "info");
     try {
       if (showRunIndicator() && props.selectedSessionId) {
-        await props.abortSession(props.selectedSessionId);
+        await sessionActions.abortSession(props.selectedSessionId);
       }
     } catch {
       // If abort fails, still allow the retry. Users care more about forward motion.
@@ -1752,7 +1731,7 @@ export default function SessionView(props: SessionViewProps) {
       setAbortBusy(false);
     }
 
-    props.retryLastPrompt();
+    sessionActions.retryLastPrompt();
   };
 
   const focusSearchInput = () => {
@@ -1840,7 +1819,7 @@ export default function SessionView(props: SessionViewProps) {
 
     setHistoryActionBusy("undo");
     try {
-      await props.undoLastUserMessage();
+      await sessionActions.undoLastUserMessage();
       showStatusToast("Reverted the last user message.", "success");
     } catch (error) {
       const message =
@@ -1860,7 +1839,7 @@ export default function SessionView(props: SessionViewProps) {
 
     setHistoryActionBusy("redo");
     try {
-      await props.redoLastUserMessage();
+      await sessionActions.redoLastUserMessage();
       showStatusToast("Restored the reverted message.", "success");
     } catch (error) {
       const message =
@@ -1883,7 +1862,7 @@ export default function SessionView(props: SessionViewProps) {
     setHistoryActionBusy("compact");
     showStatusToast("Compacting session context...", "info");
     try {
-      await props.compactSession();
+      await sessionActions.compactCurrentSession();
       showStatusToast("Session compacted.", "success");
       finishPerf(props.developerMode, "session.compact", "ui-done", startedAt, {
         sessionID,
@@ -2105,7 +2084,7 @@ export default function SessionView(props: SessionViewProps) {
     if (!next || !renameCanSave()) return;
     setRenameBusy(true);
     try {
-      await props.renameSession(sessionId, next);
+      await sessionActions.renameSessionTitle(sessionId, next);
       finishRenameModal();
     } catch (error) {
       const message =
@@ -2138,7 +2117,7 @@ export default function SessionView(props: SessionViewProps) {
     if (!sessionId) return;
     setDeleteSessionBusy(true);
     try {
-      await props.deleteSession(sessionId);
+      await sessionActions.deleteSessionById(sessionId);
       setDeleteSessionOpen(false);
       setDeleteSessionId(null);
       showStatusToast("Session deleted", "success");
@@ -2173,10 +2152,10 @@ export default function SessionView(props: SessionViewProps) {
     let sessionId = props.selectedSessionId;
     if (!sessionId) {
       // Auto-create a session when none is selected (same pattern as sendPrompt)
-      sessionId = (await props.createSessionAndOpen()) ?? null;
+      sessionId = (await sessionActions.createSessionAndOpen()) ?? null;
       if (!sessionId) return;
     }
-    props.setSessionAgent(sessionId, agent);
+    sessionActions.setSessionAgent(sessionId, agent);
   };
 
   createEffect(() => {
@@ -2255,7 +2234,7 @@ export default function SessionView(props: SessionViewProps) {
     suppressJumpControlsTemporarily();
     sessionScroll.scrollToBottom();
     startRun();
-    props.sendPromptAsync(draft).catch(() => undefined);
+    sessionActions.sendPrompt(draft).catch(() => undefined);
   };
 
   const isSandboxWorkspace = createMemo(() =>
@@ -2358,7 +2337,7 @@ export default function SessionView(props: SessionViewProps) {
     void (async () => {
       const ready = await Promise.resolve(props.switchWorkspace(id));
       if (!ready) return;
-      props.createSessionAndOpen();
+      sessionActions.createSessionAndOpen();
     })();
   };
 
@@ -2371,7 +2350,7 @@ export default function SessionView(props: SessionViewProps) {
         meta: "Create",
         action: () => {
           closeCommandPalette();
-          void Promise.resolve(props.createSessionAndOpen())
+          void Promise.resolve(sessionActions.createSessionAndOpen())
             .then((sessionId) => {
               if (!sessionId) return;
               focusComposer();
@@ -3354,7 +3333,7 @@ export default function SessionView(props: SessionViewProps) {
               modelBehaviorOptions={props.modelBehaviorOptions}
               onModelVariantChange={props.setModelVariant}
               agentLabel={agentLabel()}
-              selectedAgent={props.selectedSessionAgent}
+              selectedAgent={sessionActions.selectedSessionAgent()}
               agentPickerOpen={agentPickerOpen()}
               agentPickerBusy={agentPickerBusy()}
               agentPickerError={agentPickerError()}
@@ -3369,10 +3348,10 @@ export default function SessionView(props: SessionViewProps) {
               }}
               notice={composerNotice()}
               onNotice={showComposerNotice}
-              listAgents={props.listAgents}
+              listAgents={sessionActions.listAgents}
               recentFiles={props.workingFiles}
-              searchFiles={props.searchFiles}
-              listCommands={props.listCommands}
+              searchFiles={sessionActions.searchWorkspaceFiles}
+              listCommands={sessionActions.listCommands}
               isRemoteWorkspace={
                 props.selectedWorkspaceDisplay.workspaceType === "remote"
               }

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -22,6 +22,7 @@ import ProviderIcon from "../components/provider-icon";
 import WebUnavailableSurface from "../components/web-unavailable-surface";
 import DenSettingsPanel from "../components/den-settings-panel";
 import TextInput from "../components/text-input";
+import { useModelControls } from "../app-settings/model-controls-provider";
 import { useSessionDisplayPreferences } from "../app-settings/session-display-preferences";
 import { usePlatform } from "../context/platform";
 import ConfigView from "./config";
@@ -134,16 +135,8 @@ export type SettingsViewProps = {
   opencodeEnableExa: boolean;
   toggleOpencodeEnableExa: () => void;
   isWindows: boolean;
-  defaultModelLabel: string;
-  defaultModelRef: string;
-  openDefaultModelPicker: () => void;
-  autoCompactContext: boolean;
-  toggleAutoCompactContext: () => void;
-  autoCompactContextBusy: boolean;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
-  modelVariantLabel: string;
-  editModelVariant: () => void;
   language: Language;
   setLanguage: (value: Language) => void;
   themeMode: "light" | "dark" | "system";
@@ -256,6 +249,7 @@ export function OpenCodeRouterSettings(_props: {
 }
 
 export default function SettingsView(props: SettingsViewProps) {
+  const modelControls = useModelControls();
   const { showThinking, toggleShowThinking } = useSessionDisplayPreferences();
   const platform = usePlatform();
   const webDeployment = createMemo(() => getOpenWorkDeployment() === "web");
@@ -1581,16 +1575,16 @@ export default function SettingsView(props: SettingsViewProps) {
               <div class="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
                 <div class="min-w-0">
                   <div class="text-sm text-gray-12 truncate">
-                    {props.defaultModelLabel}
+                    {modelControls.defaultModelLabel()}
                   </div>
                   <div class="text-xs text-gray-7 font-mono truncate">
-                    {props.defaultModelRef}
+                    {modelControls.defaultModelRef()}
                   </div>
                 </div>
                 <Button
                   variant="outline"
                   class="text-xs h-8 py-0 px-3 shrink-0"
-                  onClick={props.openDefaultModelPicker}
+                  onClick={modelControls.openDefaultModelPicker}
                   disabled={props.busy}
                 >
                   Change
@@ -1621,13 +1615,13 @@ export default function SettingsView(props: SettingsViewProps) {
                     Open the default model picker to choose reasoning profiles when they are available.
                   </div>
                   <div class="mt-1 text-xs text-gray-8 font-medium truncate">
-                    {props.modelVariantLabel}
+                    {modelControls.defaultModelVariantLabel()}
                   </div>
                 </div>
                 <Button
                   variant="outline"
                   class="text-xs h-8 py-0 px-3 shrink-0"
-                  onClick={props.editModelVariant}
+                  onClick={modelControls.editDefaultModelVariant}
                   disabled={props.busy}
                 >
                   Configure
@@ -1644,10 +1638,10 @@ export default function SettingsView(props: SettingsViewProps) {
                 <Button
                   variant="outline"
                   class="text-xs h-8 py-0 px-3 shrink-0"
-                  onClick={props.toggleAutoCompactContext}
-                  disabled={props.busy || props.autoCompactContextBusy}
+                  onClick={modelControls.toggleAutoCompactContext}
+                  disabled={props.busy || modelControls.autoCompactContextBusy()}
                 >
-                  {props.autoCompactContext ? "On" : "Off"}
+                  {modelControls.autoCompactContext() ? "On" : "Off"}
                 </Button>
               </div>
             </div>

--- a/apps/app/src/app/session/actions-provider.tsx
+++ b/apps/app/src/app/session/actions-provider.tsx
@@ -1,0 +1,21 @@
+import { createContext, useContext, type ParentProps } from "solid-js";
+
+import type { SessionActionsStore } from "./actions-store";
+
+const SessionActionsContext = createContext<SessionActionsStore>();
+
+export function SessionActionsProvider(props: ParentProps<{ store: SessionActionsStore }>) {
+  return (
+    <SessionActionsContext.Provider value={props.store}>
+      {props.children}
+    </SessionActionsContext.Provider>
+  );
+}
+
+export function useSessionActions() {
+  const context = useContext(SessionActionsContext);
+  if (!context) {
+    throw new Error("useSessionActions must be used within a SessionActionsProvider");
+  }
+  return context;
+}

--- a/apps/app/src/app/session/actions-store.ts
+++ b/apps/app/src/app/session/actions-store.ts
@@ -1,0 +1,805 @@
+import { createMemo, createSignal } from "solid-js";
+
+import type {
+  Agent,
+  AgentPartInput,
+  FilePartInput,
+  Session,
+  SubtaskPartInput,
+  TextPartInput,
+} from "@opencode-ai/sdk/v2/client";
+
+import { unwrap } from "../lib/opencode";
+import {
+  abortSession as abortSessionTyped,
+  abortSessionSafe,
+  compactSession as compactSessionTyped,
+  listCommands as listCommandsTyped,
+  revertSession,
+  shellInSession,
+  unrevertSession,
+} from "../lib/opencode-session";
+import { finishPerf, perfNow, recordPerfLog } from "../lib/perf-log";
+import { toSessionTransportDirectory } from "../lib/session-scope";
+import type {
+  Client,
+  ComposerAttachment,
+  ComposerDraft,
+  ComposerPart,
+  MessageWithParts,
+  ModelRef,
+} from "../types";
+import { addOpencodeCacheHint, safeStringify } from "../utils";
+import type { createModelConfigStore } from "../context/model-config";
+
+export type SessionActionsStore = ReturnType<typeof createSessionActionsStore>;
+
+const fileToDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      resolve(result);
+    };
+    reader.readAsDataURL(file);
+  });
+
+export function createSessionActionsStore(options: {
+  client: () => Client | null;
+  baseUrl: () => string;
+  developerMode: () => boolean;
+  prompt: () => string;
+  setPrompt: (value: string) => void;
+  selectedSessionId: () => string | null;
+  selectedSession: () => Session | null;
+  sessions: () => Session[];
+  messages: () => MessageWithParts[];
+  setSessions: (value: Session[]) => void;
+  sessionStatusById: () => Record<string, string>;
+  setSessionStatusById: (value: Record<string, string>) => void;
+  setBusy: (value: boolean) => void;
+  setBusyLabel: (value: string | null) => void;
+  setBusyStartedAt: (value: number | null) => void;
+  setCreatingSession: (value: boolean) => void;
+  setError: (value: string | null) => void;
+  workspaceProjectDir: () => string;
+  selectedWorkspaceId: () => string;
+  selectedWorkspaceRoot: () => string;
+  ensureSelectedWorkspaceRuntime: () => Promise<boolean>;
+  selectSession: (id: string) => Promise<void>;
+  refreshSidebarWorkspaceSessions: (workspaceId: string) => Promise<void>;
+  abortRefreshes: () => void;
+  modelConfig: ReturnType<typeof createModelConfigStore>;
+  selectedSessionModel: () => ModelRef;
+  modelVariant: () => string | null;
+  sanitizeModelVariantForRef: (ref: ModelRef, value: string | null) => string | null;
+  resolveCodexReasoningEffort: (modelId: string, variant: string | null) => string | undefined;
+  messageIdFromInfo: (message: MessageWithParts) => string;
+  restorePromptFromUserMessage: (message: MessageWithParts) => void;
+  upsertLocalSession: (session: Session | null | undefined) => void;
+  readSessionByWorkspace: () => Record<string, string>;
+  writeSessionByWorkspace: (map: Record<string, string>) => void;
+  setSelectedSessionId: (value: string | null) => void;
+  locationPath: () => string;
+  navigate: (path: string, options?: { replace?: boolean }) => void;
+  renameSession: (sessionId: string, title: string) => Promise<void>;
+  appendSessionErrorTurn: (sessionId: string, message: string) => void;
+}) {
+  const [lastPromptSent, setLastPromptSent] = createSignal("");
+  const [sessionAgentById, setSessionAgentById] = createSignal<Record<string, string>>({});
+
+  type PartInput = TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput;
+
+  const attachmentToFilePart = async (attachment: ComposerAttachment): Promise<FilePartInput> => ({
+    type: "file",
+    url: await fileToDataUrl(attachment.file),
+    filename: attachment.name,
+    mime: attachment.mimeType,
+  });
+
+  const buildPromptParts = async (draft: ComposerDraft): Promise<PartInput[]> => {
+    const parts: PartInput[] = [];
+    const text = draft.resolvedText ?? draft.text;
+    parts.push({ type: "text", text } as TextPartInput);
+
+    const root = options.workspaceProjectDir().trim();
+    const toAbsolutePath = (path: string) => {
+      const trimmed = path.trim();
+      if (!trimmed) return "";
+      if (trimmed.startsWith("/")) return trimmed;
+      if (/^[a-zA-Z]:\\/.test(trimmed)) return trimmed;
+      if (!root) return "";
+      return (root + "/" + trimmed).replace("//", "/");
+    };
+    const filenameFromPath = (path: string) => {
+      const normalized = path.replace(/\\/g, "/");
+      const segments = normalized.split("/").filter(Boolean);
+      return segments[segments.length - 1] ?? "file";
+    };
+
+    for (const part of draft.parts) {
+      if (part.type === "agent") {
+        parts.push({ type: "agent", name: part.name } as AgentPartInput);
+        continue;
+      }
+      if (part.type === "file") {
+        const absolute = toAbsolutePath(part.path);
+        if (!absolute) continue;
+        parts.push({
+          type: "file",
+          mime: "text/plain",
+          url: `file://${absolute}`,
+          filename: filenameFromPath(part.path),
+        } as FilePartInput);
+      }
+    }
+
+    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
+    return parts;
+  };
+
+  const buildCommandFileParts = async (draft: ComposerDraft): Promise<FilePartInput[]> => {
+    const parts: FilePartInput[] = [];
+    const root = options.workspaceProjectDir().trim();
+
+    const toAbsolutePath = (path: string) => {
+      const trimmed = path.trim();
+      if (!trimmed) return "";
+      if (trimmed.startsWith("/")) return trimmed;
+      if (/^[a-zA-Z]:\\/.test(trimmed)) return trimmed;
+      if (!root) return "";
+      return (root + "/" + trimmed).replace("//", "/");
+    };
+
+    const filenameFromPath = (path: string) => {
+      const normalized = path.replace(/\\/g, "/");
+      const segments = normalized.split("/").filter(Boolean);
+      return segments[segments.length - 1] ?? "file";
+    };
+
+    for (const part of draft.parts) {
+      if (part.type !== "file") continue;
+      const absolute = toAbsolutePath(part.path);
+      if (!absolute) continue;
+      parts.push({
+        type: "file",
+        mime: "text/plain",
+        url: `file://${absolute}`,
+        filename: filenameFromPath(part.path),
+      } as FilePartInput);
+    }
+
+    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
+    return parts;
+  };
+
+  const describeProviderError = (error: unknown, fallback: string) => {
+    const readString = (value: unknown, max = 700) => {
+      if (typeof value !== "string") return null;
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      if (trimmed.length <= max) return trimmed;
+      return `${trimmed.slice(0, Math.max(0, max - 3))}...`;
+    };
+
+    const records: Record<string, unknown>[] = [];
+    const root = error && typeof error === "object" ? (error as Record<string, unknown>) : null;
+    if (root) {
+      records.push(root);
+      if (root.data && typeof root.data === "object") records.push(root.data as Record<string, unknown>);
+      if (root.cause && typeof root.cause === "object") {
+        const cause = root.cause as Record<string, unknown>;
+        records.push(cause);
+        if (cause.data && typeof cause.data === "object") records.push(cause.data as Record<string, unknown>);
+      }
+    }
+
+    const firstString = (keys: string[]) => {
+      for (const record of records) {
+        for (const key of keys) {
+          const value = readString(record[key]);
+          if (value) return value;
+        }
+      }
+      return null;
+    };
+
+    const firstNumber = (keys: string[]) => {
+      for (const record of records) {
+        for (const key of keys) {
+          const value = record[key];
+          if (typeof value === "number" && Number.isFinite(value)) return value;
+        }
+      }
+      return null;
+    };
+
+    const status = firstNumber(["statusCode", "status"]);
+    const provider = firstString(["providerID", "providerId", "provider"]);
+    const code = firstString(["code", "errorCode"]);
+    const response = firstString(["responseBody", "body", "response"]);
+    const raw =
+      (error instanceof Error ? readString(error.message) : null) ||
+      firstString(["message", "detail", "reason", "error"]) ||
+      (typeof error === "string" ? readString(error) : null);
+
+    const generic = raw && /^unknown\s+error$/i.test(raw);
+    const heading = (() => {
+      if (status === 401 || status === 403) return "Authentication failed";
+      if (status === 429) return "Rate limit exceeded";
+      if (provider) return `Provider error (${provider})`;
+      return fallback;
+    })();
+
+    const lines = [heading];
+    if (raw && !generic && raw !== heading) lines.push(raw);
+    if (status && !heading.includes(String(status))) lines.push(`Status: ${status}`);
+    if (provider && !heading.includes(provider)) lines.push(`Provider: ${provider}`);
+    if (code) lines.push(`Code: ${code}`);
+    if (response) lines.push(`Response: ${response}`);
+    if (lines.length > 1) return lines.join("\n");
+
+    if (raw && !generic) return raw;
+    if (error && typeof error === "object") {
+      const serialized = safeStringify(error);
+      if (serialized && serialized !== "{}") return serialized;
+    }
+    return fallback;
+  };
+
+  const assertNoClientError = (result: unknown) => {
+    const maybe = result as { error?: unknown } | null | undefined;
+    if (!maybe || maybe.error === undefined) return;
+    throw new Error(describeProviderError(maybe.error, "Request failed"));
+  };
+
+  const selectedSessionAgent = createMemo(() => {
+    const id = options.selectedSessionId();
+    if (!id) return null;
+    return sessionAgentById()[id] ?? null;
+  });
+
+  const sessionRevertMessageId = createMemo(() => options.selectedSession()?.revert?.messageID ?? null);
+
+  async function createSessionAndOpen() {
+    const ready = await options.ensureSelectedWorkspaceRuntime();
+    if (!ready) {
+      return;
+    }
+
+    const c = options.client();
+    if (!c) {
+      return;
+    }
+
+    const perfEnabled = options.developerMode();
+    const startedAt = perfNow();
+    const runId = (() => {
+      const key = "__openwork_create_session_run__";
+      const w = window as typeof window & { [key]?: number };
+      w[key] = (w[key] ?? 0) + 1;
+      return w[key];
+    })();
+
+    const mark = (event: string, payload?: Record<string, unknown>) => {
+      const elapsed = Math.round((perfNow() - startedAt) * 100) / 100;
+      recordPerfLog(perfEnabled, "session.create", event, {
+        runId,
+        elapsedMs: elapsed,
+        ...(payload ?? {}),
+      });
+    };
+
+    mark("start", {
+      baseUrl: options.baseUrl(),
+      workspace: options.selectedWorkspaceRoot().trim() || null,
+    });
+
+    options.abortRefreshes();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    options.setBusy(true);
+    options.setBusyLabel("status.creating_task");
+    options.setBusyStartedAt(Date.now());
+    options.setCreatingSession(true);
+    options.setError(null);
+
+    const withTimeout = async <T,>(promise: Promise<T>, ms: number, label: string) => {
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), ms);
+      });
+      try {
+        return await Promise.race([promise, timeoutPromise]);
+      } finally {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      }
+    };
+
+    try {
+      mark("health:start");
+      try {
+        await withTimeout(c.global.health(), 3_000, "health");
+        mark("health:ok");
+      } catch (healthErr) {
+        mark("health:error", {
+          error: healthErr instanceof Error ? healthErr.message : safeStringify(healthErr),
+        });
+        throw new Error("Connection lost");
+      }
+
+      let rawResult: Awaited<ReturnType<typeof c.session.create>>;
+      try {
+        const directory = toSessionTransportDirectory(options.selectedWorkspaceRoot().trim()) || undefined;
+        mark("session:create:start");
+        rawResult = await c.session.create({ directory });
+        mark("session:create:ok");
+      } catch (createErr) {
+        mark("session:create:error", {
+          error: createErr instanceof Error ? createErr.message : safeStringify(createErr),
+        });
+        throw createErr;
+      }
+
+      const session = unwrap(rawResult);
+      options.setBusyLabel("status.loading_session");
+      mark("session:select:start", { sessionID: session.id });
+      await options.selectSession(session.id);
+      mark("session:select:ok", { sessionID: session.id });
+
+      options.modelConfig.applyPendingSessionChoice(session.id);
+
+      const currentStoreSessions = options.sessions();
+      if (!currentStoreSessions.some((s) => s.id === session.id)) {
+        options.setSessions([session, ...currentStoreSessions]);
+      }
+
+      const wsId = options.selectedWorkspaceId().trim();
+      if (wsId) {
+        await options.refreshSidebarWorkspaceSessions(wsId).catch(() => undefined);
+      }
+
+      options.navigate(`/session/${session.id}`);
+
+      finishPerf(perfEnabled, "session.create", "done", startedAt, {
+        runId,
+        sessionID: session.id,
+      });
+      return session.id;
+    } catch (e) {
+      finishPerf(perfEnabled, "session.create", "error", startedAt, {
+        runId,
+        error: e instanceof Error ? e.message : safeStringify(e),
+      });
+      const message = e instanceof Error ? e.message : "Unknown error";
+      options.setError(addOpencodeCacheHint(message));
+      return undefined;
+    } finally {
+      options.setCreatingSession(false);
+      options.setBusy(false);
+      options.setBusyLabel(null);
+      options.setBusyStartedAt(null);
+    }
+  }
+
+  async function sendPrompt(draft?: ComposerDraft) {
+    const hasExplicitDraft = Boolean(draft);
+    const fallbackText = options.prompt().trim();
+    const resolvedDraft: ComposerDraft = draft ?? {
+      mode: "prompt",
+      parts: fallbackText ? [{ type: "text", text: fallbackText } as ComposerPart] : [],
+      attachments: [] as ComposerAttachment[],
+      text: fallbackText,
+    };
+    const content = (resolvedDraft.resolvedText ?? resolvedDraft.text).trim();
+    if (!content && !resolvedDraft.attachments.length) return;
+
+    const ready = await options.ensureSelectedWorkspaceRuntime();
+    if (!ready) return;
+
+    const c = options.client();
+    if (!c) return;
+
+    const compactShortcut = /^\/compact(?:\s+.*)?$/i.test(content);
+    const compactCommand = resolvedDraft.command?.name === "compact" || compactShortcut;
+    const commandName = compactCommand ? "compact" : (resolvedDraft.command?.name ?? null);
+    if (compactCommand && !options.selectedSessionId()) {
+      options.setError("Select a session with messages before running /compact.");
+      return;
+    }
+
+    let sessionID = options.selectedSessionId();
+    if (!sessionID) {
+      await createSessionAndOpen();
+      sessionID = options.selectedSessionId();
+    }
+    if (!sessionID) return;
+
+    options.setBusy(true);
+    options.setBusyLabel("status.running");
+    options.setBusyStartedAt(Date.now());
+    options.setError(null);
+
+    const perfEnabled = options.developerMode();
+    const startedAt = perfNow();
+    const visible = options.messages();
+    const visibleParts = visible.reduce((total, message) => total + message.parts.length, 0);
+    recordPerfLog(perfEnabled, "session.prompt", "start", {
+      sessionID,
+      mode: resolvedDraft.mode,
+      command: commandName,
+      charCount: content.length,
+      attachmentCount: resolvedDraft.attachments.length,
+      messageCount: visible.length,
+      partCount: visibleParts,
+    });
+
+    try {
+      if (!compactCommand) {
+        setLastPromptSent(content);
+      }
+      if (!hasExplicitDraft) {
+        options.setPrompt("");
+      }
+
+      const model = options.selectedSessionModel();
+      const agent = selectedSessionAgent();
+      const parts = await buildPromptParts(resolvedDraft);
+      const selectedVariant = options.sanitizeModelVariantForRef(model, options.modelVariant()) ?? undefined;
+      const reasoningEffort = options.resolveCodexReasoningEffort(model.modelID, selectedVariant ?? null);
+      const requestVariant = reasoningEffort ? undefined : selectedVariant;
+      const promptOverrides = reasoningEffort ? ({ reasoning_effort: reasoningEffort } as const) : undefined;
+
+      if (resolvedDraft.mode === "shell") {
+        await shellInSession(c, sessionID, content);
+      } else if (resolvedDraft.command || compactCommand) {
+        if (compactCommand) {
+          await compactCurrentSession(sessionID);
+          finishPerf(perfEnabled, "session.prompt", "done", startedAt, {
+            sessionID,
+            mode: resolvedDraft.mode,
+            command: commandName,
+          });
+          return;
+        }
+
+        const command = resolvedDraft.command;
+        if (!command) {
+          throw new Error("Command was not resolved.");
+        }
+
+        const modelString = `${model.providerID}/${model.modelID}`;
+        const files = await buildCommandFileParts(resolvedDraft);
+
+        unwrap(
+          await c.session.command({
+            sessionID,
+            command: command.name,
+            arguments: command.arguments,
+            agent: agent ?? undefined,
+            model: modelString,
+            variant: requestVariant,
+            ...(promptOverrides ?? {}),
+            parts: files.length ? files : undefined,
+          }),
+        );
+      } else {
+        const result = await c.session.promptAsync({
+          sessionID,
+          model,
+          agent: agent ?? undefined,
+          variant: requestVariant,
+          ...(promptOverrides ?? {}),
+          parts,
+        });
+        assertNoClientError(result);
+
+        options.modelConfig.setSessionModelById((current) => ({
+          ...current,
+          [sessionID]: model,
+        }));
+
+        options.modelConfig.clearSessionModelOverride(sessionID);
+      }
+
+      finishPerf(perfEnabled, "session.prompt", "done", startedAt, {
+        sessionID,
+        mode: resolvedDraft.mode,
+        command: commandName,
+      });
+    } catch (e) {
+      finishPerf(perfEnabled, "session.prompt", "error", startedAt, {
+        sessionID,
+        mode: resolvedDraft.mode,
+        command: commandName,
+        error: e instanceof Error ? e.message : safeStringify(e),
+      });
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.appendSessionErrorTurn(sessionID, addOpencodeCacheHint(message));
+    } finally {
+      options.setBusy(false);
+      options.setBusyLabel(null);
+      options.setBusyStartedAt(null);
+    }
+  }
+
+  async function abortSession(sessionID?: string) {
+    const c = options.client();
+    if (!c) return;
+    const id = (sessionID ?? options.selectedSessionId() ?? "").trim();
+    if (!id) return;
+    await abortSessionTyped(c, id);
+  }
+
+  function retryLastPrompt() {
+    const text = lastPromptSent().trim();
+    if (!text) return;
+    void sendPrompt({
+      mode: "prompt",
+      text,
+      parts: [{ type: "text", text }],
+      attachments: [],
+    });
+  }
+
+  async function compactCurrentSession(sessionIdOverride?: string) {
+    const c = options.client();
+    if (!c) {
+      throw new Error("Not connected to a server");
+    }
+
+    const sessionID = (sessionIdOverride ?? options.selectedSessionId() ?? "").trim();
+    if (!sessionID) {
+      throw new Error("Select a session before compacting.");
+    }
+
+    const visible = options.messages();
+    if (!visible.length) {
+      throw new Error("Nothing to compact yet.");
+    }
+
+    const model = options.selectedSessionModel();
+    const startedAt = perfNow();
+    const modelLabel = `${model.providerID}/${model.modelID}`;
+    recordPerfLog(options.developerMode(), "session.compact", "start", {
+      sessionID,
+      messageCount: visible.length,
+      model: modelLabel,
+      variant: options.sanitizeModelVariantForRef(model, options.modelVariant()) ?? null,
+    });
+
+    try {
+      await compactSessionTyped(c, sessionID, model, {
+        directory: options.workspaceProjectDir().trim() || undefined,
+      });
+      finishPerf(options.developerMode(), "session.compact", "done", startedAt, {
+        sessionID,
+        messageCount: visible.length,
+        model: modelLabel,
+      });
+    } catch (error) {
+      finishPerf(options.developerMode(), "session.compact", "error", startedAt, {
+        sessionID,
+        messageCount: visible.length,
+        model: modelLabel,
+        error: error instanceof Error ? error.message : safeStringify(error),
+      });
+      throw error;
+    }
+  }
+
+  async function undoLastUserMessage() {
+    const c = options.client();
+    const sessionID = (options.selectedSessionId() ?? "").trim();
+    if (!c || !sessionID) return;
+
+    await abortSessionSafe(c, sessionID);
+
+    const users = options.messages().filter((message) => {
+      const role = (message.info as { role?: string }).role;
+      return role === "user";
+    });
+    const target = users[users.length - 1];
+    if (!target) return;
+
+    const messageID = options.messageIdFromInfo(target);
+    if (!messageID) return;
+
+    const nextSession = await revertSession(c, sessionID, messageID);
+    options.upsertLocalSession(nextSession);
+
+    if (users.length > 1) {
+      options.restorePromptFromUserMessage(users[users.length - 2]);
+      return;
+    }
+
+    options.setPrompt("");
+  }
+
+  async function redoLastUserMessage() {
+    const c = options.client();
+    const sessionID = (options.selectedSessionId() ?? "").trim();
+    if (!c || !sessionID) return;
+
+    await abortSessionSafe(c, sessionID);
+
+    const revertMessageID = options.selectedSession()?.revert?.messageID ?? null;
+    if (!revertMessageID) return;
+
+    const users = options.messages().filter((message) => {
+      const role = (message.info as { role?: string }).role;
+      return role === "user";
+    });
+
+    const next = users.find((message) => {
+      const id = options.messageIdFromInfo(message);
+      return Boolean(id) && id > revertMessageID;
+    });
+
+    if (!next) {
+      const session = await unrevertSession(c, sessionID);
+      options.upsertLocalSession(session);
+      options.setPrompt("");
+      return;
+    }
+
+    const messageID = options.messageIdFromInfo(next);
+    if (!messageID) return;
+
+    const nextSession = await revertSession(c, sessionID, messageID);
+    options.upsertLocalSession(nextSession);
+
+    let prior: MessageWithParts | null = null;
+    for (let idx = users.length - 1; idx >= 0; idx -= 1) {
+      const candidate = users[idx];
+      const id = options.messageIdFromInfo(candidate);
+      if (id && id < messageID) {
+        prior = candidate;
+        break;
+      }
+    }
+
+    if (prior) {
+      options.restorePromptFromUserMessage(prior);
+      return;
+    }
+
+    options.setPrompt("");
+  }
+
+  async function renameSessionTitle(sessionID: string, title: string) {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      throw new Error("Session name is required");
+    }
+
+    await options.renameSession(sessionID, trimmed);
+    await options.refreshSidebarWorkspaceSessions(options.selectedWorkspaceId()).catch(() => undefined);
+  }
+
+  async function deleteSessionById(sessionID: string) {
+    const trimmed = sessionID.trim();
+    if (!trimmed) return;
+    const c = options.client();
+    if (!c) {
+      throw new Error("Not connected to a server");
+    }
+
+    const root = options.selectedWorkspaceRoot().trim();
+    const directory = toSessionTransportDirectory(root);
+    const params = directory ? { sessionID: trimmed, directory } : { sessionID: trimmed };
+    unwrap(await c.session.delete(params));
+
+    options.setSessions(options.sessions().filter((s) => s.id !== trimmed));
+    const activeWsId = options.selectedWorkspaceId();
+    await options.refreshSidebarWorkspaceSessions(activeWsId).catch(() => undefined);
+
+    try {
+      const path = options.locationPath().toLowerCase();
+      if (path === `/session/${trimmed.toLowerCase()}`) {
+        options.navigate("/session", { replace: true });
+      }
+    } catch {
+      // ignore
+    }
+
+    if (options.selectedSessionId() === trimmed) {
+      options.setSelectedSessionId(null);
+      const activeWorkspace = options.selectedWorkspaceId().trim();
+      if (activeWorkspace) {
+        const map = options.readSessionByWorkspace();
+        if (map[activeWorkspace] === trimmed) {
+          const next = { ...map };
+          delete next[activeWorkspace];
+          options.writeSessionByWorkspace(next);
+        }
+      }
+    }
+
+    const nextStatus = { ...options.sessionStatusById() };
+    if (nextStatus[trimmed]) {
+      delete nextStatus[trimmed];
+      options.setSessionStatusById(nextStatus);
+    }
+  }
+
+  async function listAgents(): Promise<Agent[]> {
+    const c = options.client();
+    if (!c) return [];
+    const list = unwrap(await c.app.agents());
+    return list.filter((agent) => !agent.hidden && agent.mode !== "subagent");
+  }
+
+  const BUILTIN_COMPACT_COMMAND = {
+    id: "builtin:compact",
+    name: "compact",
+    description: "Summarize this session to reduce context size.",
+    source: "command" as const,
+  };
+
+  async function listCommands(): Promise<{ id: string; name: string; description?: string; source?: "command" | "mcp" | "skill" }[]> {
+    const c = options.client();
+    if (!c) return [];
+    const list = await listCommandsTyped(c, options.selectedWorkspaceRoot().trim() || undefined);
+    if (list.some((entry) => entry.name === "compact")) {
+      return list;
+    }
+    return [BUILTIN_COMPACT_COMMAND, ...list];
+  }
+
+  function setSessionAgent(sessionID: string, agent: string | null) {
+    const trimmed = agent?.trim() ?? "";
+    setSessionAgentById((current) => {
+      const next = { ...current };
+      if (!trimmed) {
+        delete next[sessionID];
+        return next;
+      }
+      next[sessionID] = trimmed;
+      return next;
+    });
+  }
+
+  const searchWorkspaceFiles = async (query: string) => {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    const activeClient = options.client();
+    if (!activeClient) return [];
+    try {
+      const directory = options.workspaceProjectDir().trim();
+      const result = unwrap(
+        await activeClient.find.files({
+          query: trimmed,
+          dirs: "true",
+          limit: 50,
+          directory: directory || undefined,
+        }),
+      );
+      return result;
+    } catch {
+      return [];
+    }
+  };
+
+  return {
+    lastPromptSent,
+    selectedSessionAgent,
+    sessionRevertMessageId,
+    createSessionAndOpen,
+    sendPrompt,
+    abortSession,
+    retryLastPrompt,
+    compactCurrentSession,
+    undoLastUserMessage,
+    redoLastUserMessage,
+    renameSessionTitle,
+    deleteSessionById,
+    listAgents,
+    listCommands,
+    setSessionAgent,
+    searchWorkspaceFiles,
+  };
+}

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -198,18 +198,10 @@ export type SettingsShellProps = {
   createSessionAndOpen: () => void;
   setPrompt: (value: string) => void;
   selectSession: (sessionId: string) => Promise<void> | void;
-  defaultModelLabel: string;
-  defaultModelRef: string;
-  openDefaultModelPicker: () => void;
-  autoCompactContext: boolean;
-  toggleAutoCompactContext: () => void;
-  autoCompactContextBusy: boolean;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
   opencodeEnableExa: boolean;
   toggleOpencodeEnableExa: () => void;
-  modelVariantLabel: string;
-  editModelVariant: () => void;
   language: Language;
   setLanguage: (value: Language) => void;
   updateAutoCheck: boolean;
@@ -1180,16 +1172,8 @@ export default function SettingsShell(props: SettingsShellProps) {
                   opencodeEnableExa={props.opencodeEnableExa}
                   toggleOpencodeEnableExa={props.toggleOpencodeEnableExa}
                   isWindows={props.isWindows}
-                  defaultModelLabel={props.defaultModelLabel}
-                  defaultModelRef={props.defaultModelRef}
-                  openDefaultModelPicker={props.openDefaultModelPicker}
-                  autoCompactContext={props.autoCompactContext}
-                  toggleAutoCompactContext={props.toggleAutoCompactContext}
-                  autoCompactContextBusy={props.autoCompactContextBusy}
                   hideTitlebar={props.hideTitlebar}
                   toggleHideTitlebar={props.toggleHideTitlebar}
-                  modelVariantLabel={props.modelVariantLabel}
-                  editModelVariant={props.editModelVariant}
                   language={props.language}
                   setLanguage={props.setLanguage}
                   updateAutoCheck={props.updateAutoCheck}


### PR DESCRIPTION
## Summary
- move OpenWork server lifecycle out of `apps/app/src/app/app.tsx` into `apps/app/src/app/connections/openwork-server-store.ts` so dependent domains consume one server store instead of multiple shell-threaded accessors
- move session run actions out of `apps/app/src/app/app.tsx` into `apps/app/src/app/session/actions-store.ts` and let `pages/session.tsx` consume that session-owned API through context
- route model controls through `apps/app/src/app/app-settings/model-controls-store.ts` so settings and session surfaces stop receiving model-control props from the shell

## Verification
- `pnpm --filter app typecheck`
- `pnpm --filter app test:health`
- `pnpm --filter app test:session-scope`
- `pnpm --filter app build`

## Notes
- I used a dedicated worktree branch: `task/app-shell-domain-stores`
- I did not run Docker + Chrome MCP or capture screenshots for this PR because this is an app-architecture refactor with no intended UI behavior change; verification here focused on compile/build and session-scope regressions