### PR TITLE
refactor(app): move remaining domain flows out of app.tsx

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -674,6 +674,11 @@ export default function App() {
     openworkServerClient,
     openworkServerStatus,
     openworkServerCapabilities,
+    openworkServerReady,
+    openworkServerWorkspaceReady,
+    resolvedOpenworkCapabilities,
+    openworkServerCanWriteSkills,
+    openworkServerCanWritePlugins,
     openworkServerHostInfo,
     openworkServerDiagnostics,
     openworkReconnectBusy,
@@ -1215,23 +1220,6 @@ export default function App() {
       token: token || settings.token,
     });
   });
-
-  const openworkServerReady = createMemo(() => openworkServerStatus() === "connected");
-  const openworkServerWorkspaceReady = createMemo(() => Boolean(runtimeWorkspaceId()));
-  const resolvedOpenworkCapabilities = createMemo(() => openworkServerCapabilities());
-  const openworkServerCanWriteSkills = createMemo(
-    () =>
-      openworkServerReady() &&
-      openworkServerWorkspaceReady() &&
-      (resolvedOpenworkCapabilities()?.skills?.write ?? false),
-  );
-  const openworkServerCanWritePlugins = createMemo(
-    () =>
-      openworkServerReady() &&
-      openworkServerWorkspaceReady() &&
-      (resolvedOpenworkCapabilities()?.plugins?.write ?? false),
-  );
-  const devtoolsCapabilities = createMemo(() => openworkServerCapabilities());
 
   const [editRemoteWorkspaceOpen, setEditRemoteWorkspaceOpen] = createSignal(false);
   const [editRemoteWorkspaceId, setEditRemoteWorkspaceId] = createSignal<string | null>(null);
@@ -2357,7 +2345,7 @@ export default function App() {
       shareRemoteAccessBusy: shareRemoteAccessBusy(),
       shareRemoteAccessError: shareRemoteAccessError(),
       saveShareRemoteAccess,
-      openworkServerCapabilities: devtoolsCapabilities(),
+      openworkServerCapabilities: openworkServerCapabilities(),
       openworkServerDiagnostics: openworkServerDiagnostics(),
       runtimeWorkspaceId: runtimeWorkspaceId(),
       activeWorkspaceType: workspaceStore.selectedWorkspaceDisplay().workspaceType,

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -125,7 +125,6 @@ import {
   normalizeOpenworkServerUrl,
   readOpenworkServerSettings,
   writeOpenworkServerSettings,
-  type OpenworkAuditEntry,
   type OpenworkServerDiagnostics,
   type OpenworkServerSettings,
 } from "./lib/openwork-server";
@@ -250,11 +249,6 @@ export default function App() {
 
   const [baseUrl, setBaseUrl] = createSignal("http://127.0.0.1:4096");
   const [clientDirectory, setClientDirectory] = createSignal("");
-
-  const [openworkAuditEntries, setOpenworkAuditEntries] = createSignal<OpenworkAuditEntry[]>([]);
-  const [openworkAuditStatus, setOpenworkAuditStatus] = createSignal<"idle" | "loading" | "error">("idle");
-  const [openworkAuditError, setOpenworkAuditError] = createSignal<string | null>(null);
-  const [devtoolsWorkspaceId, setDevtoolsWorkspaceId] = createSignal<string | null>(null);
 
   createEffect(() => {
     if (typeof window === "undefined") return;
@@ -684,6 +678,10 @@ export default function App() {
     openworkReconnectBusy,
     opencodeRouterInfoState,
     orchestratorStatusState,
+    openworkAuditEntries,
+    openworkAuditStatus,
+    openworkAuditError,
+    devtoolsWorkspaceId,
     testOpenworkServerConnection,
     reconnectOpenworkServer,
     ensureLocalOpenworkServerClient,
@@ -1117,89 +1115,6 @@ export default function App() {
     // Keep /session as a draft-ready empty state until the user picks a session
     // or sends a prompt. Avoid auto-selecting prior sessions on app launch.
     return;
-  });
-
-  createEffect(() => {
-    if (!developerMode()) {
-      setDevtoolsWorkspaceId(null);
-      return;
-    }
-    if (!documentVisible()) return;
-
-    const client = openworkServerClient();
-    if (!client) {
-      setDevtoolsWorkspaceId(null);
-      return;
-    }
-    let active = true;
-
-    const run = async () => {
-      try {
-        const response = await client.listWorkspaces();
-        if (!active) return;
-        const items = Array.isArray(response.items) ? response.items : [];
-        const activeMatch = response.activeId ? items.find((item) => item.id === response.activeId) : null;
-        setDevtoolsWorkspaceId(activeMatch?.id ?? items[0]?.id ?? null);
-      } catch {
-        if (active) setDevtoolsWorkspaceId(null);
-      }
-    };
-
-    run();
-    const interval = window.setInterval(run, 20_000);
-    onCleanup(() => {
-      active = false;
-      window.clearInterval(interval);
-    });
-  });
-
-  createEffect(() => {
-    if (!developerMode()) {
-      setOpenworkAuditEntries([]);
-      setOpenworkAuditStatus("idle");
-      setOpenworkAuditError(null);
-      return;
-    }
-    if (!documentVisible()) return;
-
-    const client = openworkServerClient();
-    const workspaceId = devtoolsWorkspaceId();
-    if (!client || !workspaceId) {
-      setOpenworkAuditEntries([]);
-      setOpenworkAuditStatus("idle");
-      setOpenworkAuditError(null);
-      return;
-    }
-
-    let active = true;
-    let busy = false;
-
-    const run = async () => {
-      if (busy) return;
-      busy = true;
-      setOpenworkAuditStatus("loading");
-      setOpenworkAuditError(null);
-      try {
-        const result = await client.listAudit(workspaceId, 50);
-        if (!active) return;
-        setOpenworkAuditEntries(Array.isArray(result.items) ? result.items : []);
-        setOpenworkAuditStatus("idle");
-      } catch (error) {
-        if (!active) return;
-        setOpenworkAuditEntries([]);
-        setOpenworkAuditStatus("error");
-        setOpenworkAuditError(error instanceof Error ? error.message : "Failed to load audit log.");
-      } finally {
-        busy = false;
-      }
-    };
-
-    run();
-    const interval = window.setInterval(run, 15_000);
-    onCleanup(() => {
-      active = false;
-      window.clearInterval(interval);
-    });
   });
 
   createEffect(() => {

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -11,7 +11,7 @@ import {
 
 import { useLocation, useNavigate } from "@solidjs/router";
 
-import type { Part, Session } from "@opencode-ai/sdk/v2/client";
+import type { Session } from "@opencode-ai/sdk/v2/client";
 
 import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -50,12 +50,8 @@ import {
   blueprintMaterializedSessions,
   blueprintSessions,
 } from "./lib/workspace-blueprints";
-import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "./types";
 import type {
   Client,
-  MessageWithParts,
-  PlaceholderAssistantMessage,
-  PlaceholderMessageInfo,
   StartupPreference,
   EngineRuntime,
   OnboardingStep,
@@ -67,14 +63,12 @@ import type {
   WorkspaceSessionGroup,
   ComposerDraft,
   ProviderListItem,
-  SessionErrorTurn,
   OpencodeConnectStatus,
 } from "./types";
 import {
   clearStartupPreference,
   deriveArtifacts,
   deriveWorkingFiles,
-  isVisibleTextPart,
   isTauriRuntime,
   normalizeDirectoryPath,
 } from "./utils";
@@ -412,9 +406,8 @@ export default function App() {
     clearPerfLogs();
   });
 
-  const [selectedSessionId, setSelectedSessionId] = createSignal<string | null>(
-    null
-  );
+  const [selectedSessionId, setSelectedSessionId] = createSignal<string | null>(null);
+  const [prompt, setPrompt] = createSignal("");
   const [settingsReturnTarget, setSettingsReturnTarget] = createSignal<SettingsReturnTarget>({
     view: "settings",
     tab: "general",
@@ -545,6 +538,7 @@ export default function App() {
     selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot().trim(),
     selectedSessionId,
     setSelectedSessionId,
+    setPrompt,
     sessionModelState: modelConfig.sessionModelState,
     setSessionModelState: modelConfig.setSessionModelState,
     lastUserModelFromMessages,
@@ -564,10 +558,12 @@ export default function App() {
     loadedScopeRoot: loadedSessionScopeRoot,
     sessionById,
     sessionStatusById,
+    messageIdFromInfo,
     selectedSession,
     selectedSessionStatus,
     selectedSessionCompactionState,
     messages,
+    visibleMessages,
     messagesBySessionId,
     todos,
     pendingPermissions,
@@ -584,6 +580,9 @@ export default function App() {
     renameSession,
     respondPermission,
     respondQuestion,
+    restorePromptFromUserMessage,
+    upsertLocalSession,
+    setBlueprintSeedMessagesBySessionId,
     setSessions,
     setSessionStatusById,
     setMessages,
@@ -624,8 +623,6 @@ export default function App() {
     }
   });
 
-  const [prompt, setPrompt] = createSignal("");
-
   const ensureSelectedWorkspaceRuntime = async () => {
     const workspaceId = workspaceStore.selectedWorkspaceId().trim();
     if (!workspaceId) return false;
@@ -634,198 +631,6 @@ export default function App() {
       await refreshSidebarWorkspaceSessions(workspaceId).catch(() => undefined);
     }
     return ready;
-  };
-
-  const messageIdFromInfo = (message: MessageWithParts) => {
-    const id = (message.info as { id?: string | number }).id;
-    if (typeof id === "string") return id;
-    if (typeof id === "number") return String(id);
-    return "";
-  };
-
-  const createSyntheticSessionErrorMessage = (
-    sessionID: string,
-    errorTurn: SessionErrorTurn,
-  ): MessageWithParts => {
-    const info: PlaceholderAssistantMessage = {
-      id: errorTurn.id,
-      sessionID,
-      role: "assistant",
-      time: { created: errorTurn.time, completed: errorTurn.time },
-      parentID: errorTurn.afterMessageID ?? "",
-      modelID: "",
-      providerID: "",
-      mode: "",
-      agent: "",
-      path: { cwd: "", root: "" },
-      cost: 0,
-      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-    };
-
-    return {
-      info,
-      parts: [
-        {
-          id: `${errorTurn.id}:text`,
-          sessionID,
-          messageID: errorTurn.id,
-          type: "text",
-          text: errorTurn.text,
-        } as Part,
-      ],
-    };
-  };
-
-  const SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX = "blueprint-seed:";
-
-  const createSyntheticBlueprintSeedMessage = (
-    sessionID: string,
-    index: number,
-    seed: { role?: "assistant" | "user" | null; text?: string | null },
-  ): MessageWithParts => {
-    const messageId = `${SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX}${sessionID}:${index}`;
-    const role = seed.role === "user" ? "user" : "assistant";
-    const text = seed.text?.trim() ?? "";
-    const createdAt = Math.max(1, index + 1);
-    const info: PlaceholderMessageInfo = {
-      id: messageId,
-      sessionID,
-      role,
-      time: { created: createdAt, completed: createdAt },
-      parentID: index > 0 ? `${SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX}${sessionID}:${index - 1}` : "",
-      modelID: "",
-      providerID: "",
-      mode: "",
-      agent: "",
-      path: { cwd: "", root: "" },
-      cost: 0,
-      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-    };
-
-    return {
-      info,
-      parts: [
-        {
-          id: `${messageId}:text`,
-          sessionID,
-          messageID: messageId,
-          type: "text",
-          text,
-        } as Part,
-      ],
-    };
-  };
-
-  const [blueprintSeedMessagesBySessionId, setBlueprintSeedMessagesBySessionId] =
-    createSignal<Record<string, Array<{ role?: "assistant" | "user" | null; text?: string | null }>>>({});
-
-  const blueprintSeedMessagesForSelectedSession = createMemo(() => {
-    const sessionID = selectedSessionId();
-    if (!sessionID) return [];
-
-    const fallback = blueprintSeedMessagesBySessionId()[sessionID];
-    if (Array.isArray(fallback) && fallback.length > 0) {
-      return fallback;
-    }
-
-    const materialized = blueprintMaterializedSessions(resolvedActiveWorkspaceConfig());
-    const match = materialized.find((item) => item.sessionId?.trim() === sessionID);
-    if (!match?.templateId) return [];
-
-    const template = blueprintSessions(resolvedActiveWorkspaceConfig()).find(
-      (entry) => entry.id?.trim() === match.templateId,
-    );
-
-    return Array.isArray(template?.messages)
-      ? template!.messages!.filter((entry) => entry?.text?.trim())
-      : [];
-  });
-
-  const insertSyntheticBlueprintSeedMessages = (
-    list: MessageWithParts[],
-    sessionID: string | null,
-    seeds: Array<{ role?: "assistant" | "user" | null; text?: string | null }>,
-  ) => {
-    if (!sessionID || seeds.length === 0) return list;
-    if (list.length > 0) return list;
-    const existingIds = new Set(list.map((message) => messageIdFromInfo(message)));
-    const synthetic = seeds
-      .map((seed, index) => createSyntheticBlueprintSeedMessage(sessionID, index, seed))
-      .filter((message) => !existingIds.has(messageIdFromInfo(message)));
-    if (!synthetic.length) return list;
-    return [...synthetic, ...list];
-  };
-
-  const insertSyntheticSessionErrors = (
-    list: MessageWithParts[],
-    sessionID: string | null,
-    errorTurns: SessionErrorTurn[],
-  ) => {
-    if (!sessionID || errorTurns.length === 0) return list;
-
-    const next = list.slice();
-    errorTurns.forEach((errorTurn) => {
-      if (next.some((message) => messageIdFromInfo(message) === errorTurn.id)) return;
-      const syntheticMessage = createSyntheticSessionErrorMessage(sessionID, errorTurn);
-      const anchorIndex = errorTurn.afterMessageID
-        ? next.findIndex((message) => messageIdFromInfo(message) === errorTurn.afterMessageID)
-        : -1;
-
-      if (anchorIndex === -1) {
-        next.push(syntheticMessage);
-        return;
-      }
-
-      next.splice(anchorIndex + 1, 0, syntheticMessage);
-    });
-
-    return next;
-  };
-
-  const upsertLocalSession = (next: Session | null | undefined) => {
-    const id = (next as { id?: string } | null)?.id ?? "";
-    if (!id) return;
-
-    const current = sessions();
-    const index = current.findIndex((session) => session.id === id);
-    if (index === -1) {
-      setSessions([...current, next as Session]);
-      return;
-    }
-    const copy = current.slice();
-    copy[index] = next as Session;
-    setSessions(copy);
-  };
-
-  // OpenCode keeps reverted messages in the log and uses `session.revert.messageID`
-  // as the visibility boundary. OpenWork mirrors that behavior by filtering the
-  // displayed transcript.
-  const visibleMessages = createMemo(() => {
-    const sessionID = selectedSessionId();
-    const errorTurns = sessionStore.selectedSessionErrorTurns();
-    const blueprintSeeds = blueprintSeedMessagesForSelectedSession();
-    const list = messages().filter((message) => {
-      const id = messageIdFromInfo(message);
-      return !id.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX) && !id.startsWith(SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX);
-    });
-    const revert = selectedSession()?.revert?.messageID ?? null;
-    const visible = !revert ? list : list.filter((message) => {
-      const id = messageIdFromInfo(message);
-      return Boolean(id) && id < revert;
-    });
-    return insertSyntheticSessionErrors(
-      insertSyntheticBlueprintSeedMessages(visible, sessionID, blueprintSeeds),
-      sessionID,
-      errorTurns,
-    );
-  });
-
-  const restorePromptFromUserMessage = (message: MessageWithParts) => {
-    const text = message.parts
-      .filter(isVisibleTextPart)
-      .map((part) => String((part as { text?: string }).text ?? ""))
-      .join("");
-    setPrompt(text);
   };
 
   function focusSessionPromptSoon() {

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -46,10 +46,6 @@ import {
   HIDE_TITLEBAR_PREF_KEY,
   SUGGESTED_PLUGINS,
 } from "./constants";
-import {
-  blueprintMaterializedSessions,
-  blueprintSessions,
-} from "./lib/workspace-blueprints";
 import type {
   Client,
   StartupPreference,
@@ -791,9 +787,13 @@ export default function App() {
     loadSessions: loadSessionsWithReady,
     refreshPendingPermissions,
     refreshWorkspaceSessions: (workspaceId: string) => refreshSidebarWorkspaceSessions(workspaceId),
+    sessions,
+    sessionsLoaded,
+    creatingSession,
     readLastSessionByWorkspace: readSessionByWorkspace,
     selectedSessionId,
     selectSession,
+    setBlueprintSeedMessagesBySessionId,
     setSelectedSessionId,
     setMessages,
     setTodos,
@@ -815,6 +815,7 @@ export default function App() {
     onEngineStable: () => {},
     engineRuntime,
     developerMode,
+    pendingInitialSessionSelection,
     setPendingInitialSessionSelection,
   });
 
@@ -1845,85 +1846,6 @@ export default function App() {
     authorizedFolders: false,
   });
   const [autoConnectAttempted, setAutoConnectAttempted] = createSignal(false);
-
-  const [blueprintSessionMaterializeBusyByWorkspaceId, setBlueprintSessionMaterializeBusyByWorkspaceId] =
-    createSignal<Record<string, boolean>>({});
-  const [blueprintSessionMaterializeAttemptedByWorkspaceId, setBlueprintSessionMaterializeAttemptedByWorkspaceId] =
-    createSignal<Record<string, boolean>>({});
-
-  createEffect(() => {
-    const workspaceId = (runtimeWorkspaceId() ?? "").trim();
-    const client = openworkServerClient();
-    const connected = openworkServerStatus() === "connected";
-    const root = workspaceStore.selectedWorkspaceRoot().trim();
-    const config = resolvedActiveWorkspaceConfig();
-    const templates = blueprintSessions(config);
-    const materialized = blueprintMaterializedSessions(config);
-    const currentSessions = sessions();
-    const normalizedRoot = normalizeDirectoryPath(root);
-    const hasWorkspaceSessions = currentSessions.some((session) => {
-      const directory = typeof session.directory === "string" ? session.directory : "";
-      return normalizeDirectoryPath(directory) === normalizedRoot;
-    });
-
-    if (!workspaceId || !client || !connected) return;
-    if (!root) return;
-    if (!sessionsLoaded()) return;
-    if (creatingSession()) return;
-    if (selectedSessionId()) return;
-    if (!templates.length) return;
-    if (materialized.length > 0) return;
-    if (hasWorkspaceSessions) return;
-    if (blueprintSessionMaterializeBusyByWorkspaceId()[workspaceId]) return;
-    if (blueprintSessionMaterializeAttemptedByWorkspaceId()[workspaceId]) return;
-
-    setBlueprintSessionMaterializeBusyByWorkspaceId((current) => ({
-      ...current,
-      [workspaceId]: true,
-    }));
-
-    void (async () => {
-      try {
-        const result = await client.materializeBlueprintSessions(workspaceId);
-        const templateMessages = new Map(
-          templates.map((template) => [template.id?.trim(), (template.messages ?? []).filter((entry) => entry?.text?.trim())] as const),
-        );
-        if (result.created.length > 0) {
-          setBlueprintSeedMessagesBySessionId((current) => {
-            const next = { ...current };
-            result.created.forEach((entry) => {
-              const messages = templateMessages.get(entry.templateId?.trim());
-              if (messages && messages.length > 0) {
-                next[entry.sessionId] = messages;
-              }
-            });
-            return next;
-          });
-        }
-        setBlueprintSessionMaterializeAttemptedByWorkspaceId((current) => ({
-          ...current,
-          [workspaceId]: true,
-        }));
-        await refreshActiveWorkspaceServerConfig(workspaceId);
-        await loadSessionsWithReady(root || undefined);
-        const pending = pendingInitialSessionSelection();
-        const shouldDeferInitialOpen = pending && pending.workspaceId === workspaceId;
-        if (result.openSessionId && !shouldDeferInitialOpen) {
-          goToSession(result.openSessionId, { replace: true });
-          await selectSession(result.openSessionId);
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : safeStringify(error);
-        setError(addOpencodeCacheHint(message));
-      } finally {
-        setBlueprintSessionMaterializeBusyByWorkspaceId((current) => {
-          const next = { ...current };
-          delete next[workspaceId];
-          return next;
-        });
-      }
-    })();
-  });
 
   const [appVersion, setAppVersion] = createSignal<string | null>(null);
   const [launchUpdateCheckTriggered, setLaunchUpdateCheckTriggered] = createSignal(false);

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -30,6 +30,7 @@ import { AutomationsProvider } from "./automations/provider";
 import { SessionActionsProvider } from "./session/actions-provider";
 import { createSessionActionsStore } from "./session/actions-store";
 import BootShell from "./shell/boot-shell";
+import { createDeepLinksController } from "./shell/deep-links";
 import SettingsShell from "./shell/settings-shell";
 import TopRightNotifications from "./shell/top-right-notifications";
 import { createStatusToastsStore, StatusToastsProvider } from "./shell/status-toasts";
@@ -39,7 +40,6 @@ import {
 } from "./workspace";
 import SessionView from "./pages/session";
 import { unwrap } from "./lib/opencode";
-import { createDenClient, writeDenSettings } from "./lib/den";
 import { clearPerfLogs, finishPerf, perfNow, recordPerfLog } from "./lib/perf-log";
 import { deepLinkBridgeEvent, drainPendingDeepLinks, type DeepLinkBridgeDetail } from "./lib/deep-link-bridge";
 import {
@@ -133,14 +133,6 @@ import {
   stripBundleQuery,
 } from "./bundles";
 import { createBundlesStore } from "./bundles/store";
-import {
-  parseDebugDeepLinkInput,
-  parseDenAuthDeepLink,
-  parseRemoteConnectDeepLink,
-  stripRemoteConnectQuery,
-  type DenAuthDeepLink,
-  type RemoteWorkspaceDefaults,
- } from "./lib/openwork-links";
 
 type SettingsReturnTarget = {
   view: View;
@@ -281,7 +273,7 @@ export default function App() {
     }
 
     if (invite?.autoConnect) {
-      setPendingRemoteConnectDeepLink({
+      deepLinks.queueRemoteConnectDefaults({
         openworkHostUrl: invite.url,
         openworkToken: invite.token ?? null,
         directory: null,
@@ -681,7 +673,6 @@ export default function App() {
     openworkAuditEntries,
     openworkAuditStatus,
     openworkAuditError,
-    devtoolsWorkspaceId,
     testOpenworkServerConnection,
     reconnectOpenworkServer,
     ensureLocalOpenworkServerClient,
@@ -869,6 +860,16 @@ export default function App() {
     refreshHubSkills,
     markReloadRequired,
     showStatusToast: statusToastsStore.showToast,
+  });
+
+  const deepLinks = createDeepLinksController({
+    booting,
+    setError,
+    setView,
+    setSettingsTab,
+    goToSettings,
+    workspaceStore,
+    bundlesStore,
   });
 
   const logWorkspaceScopeSnapshot = (label: string, extra?: Record<string, unknown>) => {
@@ -1134,212 +1135,6 @@ export default function App() {
       urlOverride: hostUrl,
       token: token || settings.token,
     });
-  });
-
-  const [deepLinkRemoteWorkspaceDefaults, setDeepLinkRemoteWorkspaceDefaults] = createSignal<RemoteWorkspaceDefaults | null>(null);
-  const [pendingRemoteConnectDeepLink, setPendingRemoteConnectDeepLink] = createSignal<RemoteWorkspaceDefaults | null>(null);
-  const [, setAutoConnectRemoteWorkspaceOverlayOpen] = createSignal(false);
-  const [pendingDenAuthDeepLink, setPendingDenAuthDeepLink] = createSignal<DenAuthDeepLink | null>(null);
-  const [processingDenAuthDeepLink, setProcessingDenAuthDeepLink] = createSignal(false);
-  const recentClaimedDeepLinks = new Map<string, number>();
-
-  const queueRemoteConnectDeepLink = (rawUrl: string): boolean => {
-    const parsed = parseRemoteConnectDeepLink(rawUrl);
-    if (!parsed) {
-      return false;
-    }
-    setPendingRemoteConnectDeepLink(parsed);
-    return true;
-  };
-
-  const completeRemoteConnectDeepLink = async (pending: RemoteWorkspaceDefaults) => {
-    const input = {
-      openworkHostUrl: pending.openworkHostUrl,
-      openworkToken: pending.openworkToken,
-      directory: pending.directory,
-      displayName: pending.displayName,
-    };
-
-    if (!pending.autoConnect) {
-      setDeepLinkRemoteWorkspaceDefaults(input);
-      workspaceStore.setCreateRemoteWorkspaceOpen(true);
-      return;
-    }
-
-    setError(null);
-    setAutoConnectRemoteWorkspaceOverlayOpen(true);
-    try {
-      const ok = await workspaceStore.createRemoteWorkspaceFlow(input);
-      if (ok) {
-        setDeepLinkRemoteWorkspaceDefaults(null);
-        return;
-      }
-
-      setDeepLinkRemoteWorkspaceDefaults(input);
-      workspaceStore.setCreateRemoteWorkspaceOpen(true);
-    } finally {
-      setAutoConnectRemoteWorkspaceOverlayOpen(false);
-    }
-  };
-
-  const queueDenAuthDeepLink = (rawUrl: string): boolean => {
-    const parsed = parseDenAuthDeepLink(rawUrl);
-    if (!parsed) {
-      return false;
-    }
-    setPendingDenAuthDeepLink(parsed);
-    return true;
-  };
-
-  const stripHandledBrowserDeepLink = (rawUrl: string) => {
-    if (typeof window === "undefined" || isTauriRuntime()) {
-      return;
-    }
-
-    if (window.location.href !== rawUrl) {
-      return;
-    }
-
-    const remoteStripped = stripRemoteConnectQuery(rawUrl) ?? rawUrl;
-    const bundleStripped = stripBundleQuery(remoteStripped) ?? remoteStripped;
-    if (bundleStripped !== rawUrl) {
-      window.history.replaceState({}, "", bundleStripped);
-    }
-  };
-
-  const consumeDeepLinks = (urls: readonly string[] | null | undefined) => {
-    if (!Array.isArray(urls)) {
-      return;
-    }
-
-    const normalized = urls.map((url) => url.trim()).filter(Boolean);
-    if (normalized.length === 0) {
-      return;
-    }
-
-    const now = Date.now();
-    for (const [url, seenAt] of recentClaimedDeepLinks) {
-      if (now - seenAt > 1500) {
-        recentClaimedDeepLinks.delete(url);
-      }
-    }
-
-    for (const url of normalized) {
-      const seenAt = recentClaimedDeepLinks.get(url) ?? 0;
-      if (now - seenAt < 1500) {
-        continue;
-      }
-
-      const matchedDen = queueDenAuthDeepLink(url);
-      const matchedRemote = !matchedDen && queueRemoteConnectDeepLink(url);
-      const matchedBundle = !matchedDen && !matchedRemote && bundlesStore.queueBundleLink(url);
-      const claimed = matchedDen || matchedRemote || matchedBundle;
-      if (!claimed) {
-        continue;
-      }
-
-      recentClaimedDeepLinks.set(url, now);
-      stripHandledBrowserDeepLink(url);
-      break;
-    }
-  };
-
-  const openDebugDeepLink = async (rawUrl: string): Promise<{ ok: boolean; message: string }> => {
-    const parsed = parseDebugDeepLinkInput(rawUrl);
-    if (!parsed) {
-      return { ok: false, message: "That link is not a recognized OpenWork deep link or share URL." };
-    }
-
-    setError(null);
-    setView("settings");
-    if (parsed.kind === "bundle") {
-      return bundlesStore.openDebugBundleRequest(parsed.link);
-    }
-    if (parsed.kind === "auth") {
-      setPendingDenAuthDeepLink(parsed.link);
-      return { ok: true, message: "Queued the Cloud auth deep link for OpenWork." };
-    }
-
-    setPendingRemoteConnectDeepLink(parsed.kind === "remote" ? parsed.link : null);
-    setSettingsTab("automations");
-    return { ok: true, message: "Queued remote worker link. OpenWork should move into the connect flow." };
-  };
-
-  createEffect(() => {
-    const pending = pendingDenAuthDeepLink();
-    if (!pending || booting() || processingDenAuthDeepLink()) {
-      return;
-    }
-
-    setProcessingDenAuthDeepLink(true);
-    setPendingDenAuthDeepLink(null);
-    setView("settings");
-    setSettingsTab("den");
-    goToSettings("den");
-
-    void createDenClient({ baseUrl: pending.denBaseUrl })
-      .exchangeDesktopHandoff(pending.grant)
-      .then((result) => {
-        if (!result.token) {
-          throw new Error("Desktop sign-in completed, but OpenWork Cloud did not return a session token.");
-        }
-
-        writeDenSettings({
-          baseUrl: pending.denBaseUrl,
-          authToken: result.token,
-          activeOrgId: null,
-          activeOrgSlug: null,
-          activeOrgName: null,
-        });
-
-        window.dispatchEvent(
-          new CustomEvent("openwork-den-session-updated", {
-            detail: {
-              status: "success",
-              email: result.user?.email ?? null,
-            },
-          }),
-        );
-      })
-      .catch((error) => {
-        window.dispatchEvent(
-          new CustomEvent("openwork-den-session-updated", {
-            detail: {
-              status: "error",
-              message: error instanceof Error ? error.message : "Failed to complete OpenWork Cloud sign-in.",
-            },
-          }),
-        );
-      })
-      .finally(() => {
-        setProcessingDenAuthDeepLink(false);
-      });
-  });
-
-  createEffect(() => {
-    const pending = pendingRemoteConnectDeepLink();
-    if (!pending || booting()) {
-      return;
-    }
-
-    if (pending.autoConnect) {
-      setView("session");
-    } else {
-      setView("settings");
-      setSettingsTab("automations");
-    }
-    setPendingRemoteConnectDeepLink(null);
-    void completeRemoteConnectDeepLink(pending);
-  });
-
-  createEffect(() => {
-    if (workspaceStore.createRemoteWorkspaceOpen()) {
-      return;
-    }
-    if (!deepLinkRemoteWorkspaceDefaults()) {
-      return;
-    }
-    setDeepLinkRemoteWorkspaceDefaults(null);
   });
 
   async function restartLocalServer() {
@@ -1863,13 +1658,13 @@ export default function App() {
     }
 
     if (typeof window !== "undefined") {
-      const handleDeepLinkEvent = (event: Event) => {
-        const detail = (event as CustomEvent<DeepLinkBridgeDetail>).detail;
-        consumeDeepLinks(detail?.urls ?? []);
-      };
+        const handleDeepLinkEvent = (event: Event) => {
+          const detail = (event as CustomEvent<DeepLinkBridgeDetail>).detail;
+          deepLinks.consumeDeepLinks(detail?.urls ?? []);
+        };
 
-      consumeDeepLinks(drainPendingDeepLinks(window));
-      window.addEventListener(deepLinkBridgeEvent, handleDeepLinkEvent as EventListener);
+        deepLinks.consumeDeepLinks(drainPendingDeepLinks(window));
+        window.addEventListener(deepLinkBridgeEvent, handleDeepLinkEvent as EventListener);
       onCleanup(() => {
         window.removeEventListener(deepLinkBridgeEvent, handleDeepLinkEvent as EventListener);
       });
@@ -2301,7 +2096,7 @@ export default function App() {
       dockerCleanupResult: dockerCleanupResult(),
       markOpencodeConfigReloadRequired,
       resetAppConfigDefaults,
-      openDebugDeepLink,
+      openDebugDeepLink: deepLinks.openDebugDeepLink,
       language: currentLocale(),
       setLanguage: setLocale,
     };
@@ -2752,10 +2547,10 @@ export default function App() {
               open={workspaceStore.createRemoteWorkspaceOpen()}
               onClose={() => {
                 workspaceStore.setCreateRemoteWorkspaceOpen(false);
-                setDeepLinkRemoteWorkspaceDefaults(null);
+                deepLinks.clearDeepLinkRemoteWorkspaceDefaults();
               }}
               onConfirm={(input) => workspaceStore.createRemoteWorkspaceFlow(input)}
-              initialValues={deepLinkRemoteWorkspaceDefaults() ?? undefined}
+              initialValues={deepLinks.deepLinkRemoteWorkspaceDefaults() ?? undefined}
               submitting={
                 busy() &&
                 (busyLabel() === "status.creating_workspace" || busyLabel() === "status.connecting")

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -1136,19 +1136,12 @@ export default function App() {
     });
   });
 
-  const [editRemoteWorkspaceOpen, setEditRemoteWorkspaceOpen] = createSignal(false);
-  const [editRemoteWorkspaceId, setEditRemoteWorkspaceId] = createSignal<string | null>(null);
-  const [editRemoteWorkspaceError, setEditRemoteWorkspaceError] = createSignal<string | null>(null);
   const [deepLinkRemoteWorkspaceDefaults, setDeepLinkRemoteWorkspaceDefaults] = createSignal<RemoteWorkspaceDefaults | null>(null);
   const [pendingRemoteConnectDeepLink, setPendingRemoteConnectDeepLink] = createSignal<RemoteWorkspaceDefaults | null>(null);
   const [, setAutoConnectRemoteWorkspaceOverlayOpen] = createSignal(false);
   const [pendingDenAuthDeepLink, setPendingDenAuthDeepLink] = createSignal<DenAuthDeepLink | null>(null);
   const [processingDenAuthDeepLink, setProcessingDenAuthDeepLink] = createSignal(false);
   const recentClaimedDeepLinks = new Map<string, number>();
-  const [renameWorkspaceOpen, setRenameWorkspaceOpen] = createSignal(false);
-  const [renameWorkspaceId, setRenameWorkspaceId] = createSignal<string | null>(null);
-  const [renameWorkspaceName, setRenameWorkspaceName] = createSignal("");
-  const [renameWorkspaceBusy, setRenameWorkspaceBusy] = createSignal(false);
 
   const queueRemoteConnectDeepLink = (rawUrl: string): boolean => {
     const parsed = parseRemoteConnectDeepLink(rawUrl);
@@ -1349,62 +1342,6 @@ export default function App() {
     setDeepLinkRemoteWorkspaceDefaults(null);
   });
 
-  const editRemoteWorkspaceDefaults = createMemo(() => {
-    const workspaceId = editRemoteWorkspaceId();
-    if (!workspaceId) return null;
-    const workspace = workspaceStore.workspaces().find((item) => item.id === workspaceId) ?? null;
-    if (!workspace || workspace.workspaceType !== "remote") return null;
-    return {
-      openworkHostUrl: workspace.openworkHostUrl ?? workspace.baseUrl ?? "",
-      openworkToken: workspace.openworkToken ?? openworkServerSettings().token ?? "",
-      directory: workspace.directory ?? "",
-      displayName: workspace.displayName ?? "",
-    };
-  });
-
-  const openRenameWorkspace = (workspaceId: string) => {
-    const workspace = workspaceStore.workspaces().find((item) => item.id === workspaceId) ?? null;
-    if (!workspace) return;
-    setRenameWorkspaceId(workspaceId);
-    setRenameWorkspaceName(
-      workspace.displayName?.trim() ||
-        workspace.openworkWorkspaceName?.trim() ||
-        workspace.name?.trim() ||
-        ""
-    );
-    setRenameWorkspaceOpen(true);
-  };
-
-  const closeRenameWorkspace = () => {
-    if (renameWorkspaceBusy()) return;
-    setRenameWorkspaceOpen(false);
-    setRenameWorkspaceId(null);
-    setRenameWorkspaceName("");
-  };
-
-  const saveRenameWorkspace = async () => {
-    const workspaceId = renameWorkspaceId();
-    if (!workspaceId) return;
-    const nextName = renameWorkspaceName().trim();
-    if (!nextName) return;
-    if (renameWorkspaceBusy()) return;
-
-    setRenameWorkspaceBusy(true);
-    setError(null);
-    try {
-      const ok = await workspaceStore.updateWorkspaceDisplayName(workspaceId, nextName);
-      if (!ok) return;
-      setRenameWorkspaceOpen(false);
-      setRenameWorkspaceId(null);
-      setRenameWorkspaceName("");
-    } catch (e) {
-      const message = e instanceof Error ? e.message : safeStringify(e);
-      setError(addOpencodeCacheHint(message));
-    } finally {
-      setRenameWorkspaceBusy(false);
-    }
-  };
-
   async function restartLocalServer() {
     const activeWorkspace = workspaceStore.selectedWorkspaceDisplay();
     const activeLocalPath =
@@ -1419,24 +1356,6 @@ export default function App() {
 
     return workspaceStore.startHost({ workspacePath, navigate: false });
   }
-
-  const openWorkspaceConnectionSettings = (workspaceId: string) => {
-    const workspace = workspaceStore.workspaces().find((item) => item.id === workspaceId) ?? null;
-    if (workspace?.workspaceType === "remote" && workspace.remoteType === "openwork") {
-      setEditRemoteWorkspaceId(workspace.id);
-      setEditRemoteWorkspaceError(null);
-      setEditRemoteWorkspaceOpen(true);
-      return;
-    }
-    if (workspace?.workspaceType === "remote") {
-      setEditRemoteWorkspaceId(workspace.id);
-      setEditRemoteWorkspaceError(null);
-      setEditRemoteWorkspaceOpen(true);
-      return;
-    }
-    setSettingsTab("advanced");
-    setView("settings");
-  };
 
   const canReloadLocalEngine = () =>
     isTauriRuntime() && workspaceStore.selectedWorkspaceDisplay().workspaceType === "local";
@@ -2307,8 +2226,8 @@ export default function App() {
       pickWorkspaceFolder: workspaceStore.pickWorkspaceFolder,
       workspaceSessionGroups: sidebarWorkspaceGroups(),
       selectedSessionId: activeSessionId(),
-      openRenameWorkspace,
-      editWorkspaceConnection: openWorkspaceConnectionSettings,
+      openRenameWorkspace: workspaceStore.openRenameWorkspace,
+      editWorkspaceConnection: workspaceStore.openWorkspaceConnectionSettings,
       forgetWorkspace: workspaceStore.forgetWorkspace,
       stopSandbox: workspaceStore.stopSandbox,
       schedulerPluginInstalled: schedulerPluginInstalled(),
@@ -2405,7 +2324,7 @@ export default function App() {
     switchWorkspace: workspaceStore.switchWorkspace,
     testWorkspaceConnection: workspaceStore.testWorkspaceConnection,
     recoverWorkspace: workspaceStore.recoverWorkspace,
-    editWorkspaceConnection: openWorkspaceConnectionSettings,
+    editWorkspaceConnection: workspaceStore.openWorkspaceConnectionSettings,
     forgetWorkspace: workspaceStore.forgetWorkspace,
     openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
     pickFolderWorkspace: workspaceStore.createWorkspaceFromPickedFolder,
@@ -2442,7 +2361,7 @@ export default function App() {
     skillsStatus: skillsStatus(),
     newTaskDisabled: newTaskDisabled(),
     workspaceSessionGroups: sidebarWorkspaceGroups(),
-    openRenameWorkspace,
+    openRenameWorkspace: workspaceStore.openRenameWorkspace,
     selectSession: selectSession,
     messages: visibleMessages(),
     getSessionById: sessionById,
@@ -2863,47 +2782,24 @@ export default function App() {
       />
 
       <RenameWorkspaceModal
-        open={renameWorkspaceOpen()}
-        title={renameWorkspaceName()}
-        busy={renameWorkspaceBusy()}
-        canSave={renameWorkspaceName().trim().length > 0 && !renameWorkspaceBusy()}
-        onClose={closeRenameWorkspace}
-        onSave={saveRenameWorkspace}
-        onTitleChange={setRenameWorkspaceName}
+        open={workspaceStore.renameWorkspaceOpen()}
+        title={workspaceStore.renameWorkspaceName()}
+        busy={workspaceStore.renameWorkspaceBusy()}
+        canSave={workspaceStore.renameWorkspaceName().trim().length > 0 && !workspaceStore.renameWorkspaceBusy()}
+        onClose={workspaceStore.closeRenameWorkspace}
+        onSave={workspaceStore.saveRenameWorkspace}
+        onTitleChange={workspaceStore.setRenameWorkspaceName}
       />
 
       <CreateRemoteWorkspaceModal
-        open={editRemoteWorkspaceOpen()}
-        onClose={() => {
-          setEditRemoteWorkspaceOpen(false);
-          setEditRemoteWorkspaceId(null);
-          setEditRemoteWorkspaceError(null);
-        }}
+        open={workspaceStore.editRemoteWorkspaceOpen()}
+        onClose={workspaceStore.closeWorkspaceConnectionSettings}
         onConfirm={(input) => {
-          const workspaceId = editRemoteWorkspaceId();
-          if (!workspaceId) return;
-          setEditRemoteWorkspaceError(null);
-          void (async () => {
-            try {
-              const ok = await workspaceStore.updateRemoteWorkspaceFlow(workspaceId, input);
-              if (ok) {
-                setEditRemoteWorkspaceOpen(false);
-                setEditRemoteWorkspaceId(null);
-                setEditRemoteWorkspaceError(null);
-              } else {
-                setEditRemoteWorkspaceError(error() || "Connection failed. Check the URL and token.");
-                setError(null);
-              }
-            } catch (e) {
-              const message = e instanceof Error ? e.message : "Connection failed";
-              setEditRemoteWorkspaceError(message);
-              setError(null);
-            }
-          })();
+          void workspaceStore.saveWorkspaceConnectionSettings(input);
         }}
-        initialValues={editRemoteWorkspaceDefaults() ?? undefined}
+        initialValues={workspaceStore.editRemoteWorkspaceDefaults() ?? undefined}
         submitting={busy() && busyLabel() === "status.connecting"}
-        error={editRemoteWorkspaceError()}
+        error={workspaceStore.editRemoteWorkspaceError()}
         title={t("dashboard.edit_remote_workspace_title", currentLocale())}
         subtitle={t("dashboard.edit_remote_workspace_subtitle", currentLocale())}
         confirmLabel={t("dashboard.edit_remote_workspace_confirm", currentLocale())}

--- a/apps/app/src/app/connections/openwork-server-store.ts
+++ b/apps/app/src/app/connections/openwork-server-store.ts
@@ -102,6 +102,22 @@ export function createOpenworkServerStore(options: {
     return createOpenworkServerClient({ baseUrl, token: auth.token, hostToken: auth.hostToken });
   });
 
+  const openworkServerReady = createMemo(() => openworkServerStatus() === "connected");
+  const openworkServerWorkspaceReady = createMemo(() => Boolean(options.runtimeWorkspaceId()));
+  const resolvedOpenworkCapabilities = createMemo(() => openworkServerCapabilities());
+  const openworkServerCanWriteSkills = createMemo(
+    () =>
+      openworkServerReady() &&
+      openworkServerWorkspaceReady() &&
+      (resolvedOpenworkCapabilities()?.skills?.write ?? false),
+  );
+  const openworkServerCanWritePlugins = createMemo(
+    () =>
+      openworkServerReady() &&
+      openworkServerWorkspaceReady() &&
+      (resolvedOpenworkCapabilities()?.plugins?.write ?? false),
+  );
+
   const updateOpenworkServerSettings = (next: OpenworkServerSettings) => {
     const stored = writeOpenworkServerSettings(next);
     setOpenworkServerSettings(stored);
@@ -507,6 +523,11 @@ export function createOpenworkServerStore(options: {
     openworkServerClient,
     openworkServerStatus,
     openworkServerCapabilities,
+    openworkServerReady,
+    openworkServerWorkspaceReady,
+    resolvedOpenworkCapabilities,
+    openworkServerCanWriteSkills,
+    openworkServerCanWritePlugins,
     openworkServerHostInfo,
     openworkServerDiagnostics,
     openworkReconnectBusy,

--- a/apps/app/src/app/connections/openwork-server-store.ts
+++ b/apps/app/src/app/connections/openwork-server-store.ts
@@ -16,6 +16,7 @@ import {
   createOpenworkServerClient,
   normalizeOpenworkServerUrl,
   writeOpenworkServerSettings,
+  type OpenworkAuditEntry,
   type OpenworkServerCapabilities,
   type OpenworkServerClient,
   type OpenworkServerDiagnostics,
@@ -59,6 +60,10 @@ export function createOpenworkServerStore(options: {
     createSignal<OpenCodeRouterInfo | null>(null);
   const [orchestratorStatusState, setOrchestratorStatusState] =
     createSignal<OrchestratorStatus | null>(null);
+  const [openworkAuditEntries, setOpenworkAuditEntries] = createSignal<OpenworkAuditEntry[]>([]);
+  const [openworkAuditStatus, setOpenworkAuditStatus] = createSignal<"idle" | "loading" | "error">("idle");
+  const [openworkAuditError, setOpenworkAuditError] = createSignal<string | null>(null);
+  const [devtoolsWorkspaceId, setDevtoolsWorkspaceId] = createSignal<string | null>(null);
 
   const openworkServerBaseUrl = createMemo(() => {
     const pref = options.startupPreference();
@@ -356,6 +361,89 @@ export function createOpenworkServerStore(options: {
     });
   });
 
+  createEffect(() => {
+    if (!options.developerMode()) {
+      setDevtoolsWorkspaceId(null);
+      return;
+    }
+    if (!options.documentVisible()) return;
+
+    const client = openworkServerClient();
+    if (!client) {
+      setDevtoolsWorkspaceId(null);
+      return;
+    }
+    let active = true;
+
+    const run = async () => {
+      try {
+        const response = await client.listWorkspaces();
+        if (!active) return;
+        const items = Array.isArray(response.items) ? response.items : [];
+        const activeMatch = response.activeId ? items.find((item) => item.id === response.activeId) : null;
+        setDevtoolsWorkspaceId(activeMatch?.id ?? items[0]?.id ?? null);
+      } catch {
+        if (active) setDevtoolsWorkspaceId(null);
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 20_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
+  createEffect(() => {
+    if (!options.developerMode()) {
+      setOpenworkAuditEntries([]);
+      setOpenworkAuditStatus("idle");
+      setOpenworkAuditError(null);
+      return;
+    }
+    if (!options.documentVisible()) return;
+
+    const client = openworkServerClient();
+    const workspaceId = devtoolsWorkspaceId();
+    if (!client || !workspaceId) {
+      setOpenworkAuditEntries([]);
+      setOpenworkAuditStatus("idle");
+      setOpenworkAuditError(null);
+      return;
+    }
+
+    let active = true;
+    let busy = false;
+
+    const run = async () => {
+      if (busy) return;
+      busy = true;
+      setOpenworkAuditStatus("loading");
+      setOpenworkAuditError(null);
+      try {
+        const result = await client.listAudit(workspaceId, 50);
+        if (!active) return;
+        setOpenworkAuditEntries(Array.isArray(result.items) ? result.items : []);
+        setOpenworkAuditStatus("idle");
+      } catch (error) {
+        if (!active) return;
+        setOpenworkAuditEntries([]);
+        setOpenworkAuditStatus("error");
+        setOpenworkAuditError(error instanceof Error ? error.message : "Failed to load audit log.");
+      } finally {
+        busy = false;
+      }
+    };
+
+    run();
+    const interval = window.setInterval(run, 15_000);
+    onCleanup(() => {
+      active = false;
+      window.clearInterval(interval);
+    });
+  });
+
   const testOpenworkServerConnection = async (next: OpenworkServerSettings) => {
     const derived = normalizeOpenworkServerUrl(next.urlOverride ?? "");
     if (!derived) {
@@ -533,6 +621,10 @@ export function createOpenworkServerStore(options: {
     openworkReconnectBusy,
     opencodeRouterInfoState,
     orchestratorStatusState,
+    openworkAuditEntries,
+    openworkAuditStatus,
+    openworkAuditError,
+    devtoolsWorkspaceId,
     checkOpenworkServer,
     testOpenworkServerConnection,
     reconnectOpenworkServer,

--- a/apps/app/src/app/context/session.ts
+++ b/apps/app/src/app/context/session.ts
@@ -12,6 +12,7 @@ import type {
   PendingPermission,
   PendingQuestion,
   PlaceholderAssistantMessage,
+  PlaceholderMessageInfo,
   ReloadReason,
   ReloadTrigger,
   SessionCompactionState,
@@ -20,6 +21,7 @@ import type {
 } from "../types";
 import {
   addOpencodeCacheHint,
+  isVisibleTextPart,
   modelFromUserMessage,
   normalizeDirectoryPath,
   normalizeEvent,
@@ -38,6 +40,10 @@ export type SessionModelState = {
 };
 
 export type SessionStore = ReturnType<typeof createSessionStore>;
+
+type BlueprintSeedMessage = { role?: "assistant" | "user" | null; text?: string | null };
+
+const SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX = "blueprint-seed:";
 
 type StoreState = {
   sessions: Session[];
@@ -150,6 +156,7 @@ export function createSessionStore(options: {
   selectedWorkspaceRoot: () => string;
   selectedSessionId: () => string | null;
   setSelectedSessionId: (id: string | null) => void;
+  setPrompt: (value: string) => void;
   sessionModelState: () => SessionModelState;
   setSessionModelState: (updater: (current: SessionModelState) => SessionModelState) => SessionModelState;
   lastUserModelFromMessages: (messages: MessageWithParts[]) => ModelRef | null;
@@ -203,6 +210,9 @@ export function createSessionStore(options: {
     sessionCompaction: {},
   });
   const [permissionReplyBusy, setPermissionReplyBusy] = createSignal(false);
+  const [blueprintSeedMessagesBySessionId, setBlueprintSeedMessagesBySessionId] = createSignal<
+    Record<string, BlueprintSeedMessage[]>
+  >({});
   const [messageLimitBySession, setMessageLimitBySession] = createSignal<Record<string, number>>({});
   const [messageCompleteBySession, setMessageCompleteBySession] = createSignal<Record<string, boolean>>({});
   const [messageLoadBusyBySession, setMessageLoadBusyBySession] = createSignal<Record<string, boolean>>({});
@@ -731,6 +741,143 @@ export function createSessionStore(options: {
     return store.sessionInfoById[id] ?? store.sessions.find((session) => session.id === id) ?? null;
   };
 
+  const messageIdFromInfo = (message: MessageWithParts) => {
+    const id = (message.info as { id?: string | number }).id;
+    if (typeof id === "string") return id;
+    if (typeof id === "number") return String(id);
+    return "";
+  };
+
+  const createSyntheticSessionErrorMessage = (
+    sessionID: string,
+    errorTurn: SessionErrorTurn,
+  ): MessageWithParts => {
+    const info: PlaceholderAssistantMessage = {
+      id: errorTurn.id,
+      sessionID,
+      role: "assistant",
+      time: { created: errorTurn.time, completed: errorTurn.time },
+      parentID: errorTurn.afterMessageID ?? "",
+      modelID: "",
+      providerID: "",
+      mode: "",
+      agent: "",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    };
+
+    return {
+      info,
+      parts: [
+        {
+          id: `${errorTurn.id}:text`,
+          sessionID,
+          messageID: errorTurn.id,
+          type: "text",
+          text: errorTurn.text,
+        } as Part,
+      ],
+    };
+  };
+
+  const createSyntheticBlueprintSeedMessage = (
+    sessionID: string,
+    index: number,
+    seed: BlueprintSeedMessage,
+  ): MessageWithParts => {
+    const messageId = `${SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX}${sessionID}:${index}`;
+    const role = seed.role === "user" ? "user" : "assistant";
+    const text = seed.text?.trim() ?? "";
+    const createdAt = Math.max(1, index + 1);
+    const info: PlaceholderMessageInfo = {
+      id: messageId,
+      sessionID,
+      role,
+      time: { created: createdAt, completed: createdAt },
+      parentID: index > 0 ? `${SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX}${sessionID}:${index - 1}` : "",
+      modelID: "",
+      providerID: "",
+      mode: "",
+      agent: "",
+      path: { cwd: "", root: "" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    };
+
+    return {
+      info,
+      parts: [
+        {
+          id: `${messageId}:text`,
+          sessionID,
+          messageID: messageId,
+          type: "text",
+          text,
+        } as Part,
+      ],
+    };
+  };
+
+  const insertSyntheticBlueprintSeedMessages = (
+    list: MessageWithParts[],
+    sessionID: string | null,
+    seeds: BlueprintSeedMessage[],
+  ) => {
+    if (!sessionID || seeds.length === 0) return list;
+    if (list.length > 0) return list;
+    const existingIds = new Set(list.map((message) => messageIdFromInfo(message)));
+    const synthetic = seeds
+      .map((seed, index) => createSyntheticBlueprintSeedMessage(sessionID, index, seed))
+      .filter((message) => !existingIds.has(messageIdFromInfo(message)));
+    if (!synthetic.length) return list;
+    return [...synthetic, ...list];
+  };
+
+  const insertSyntheticSessionErrors = (
+    list: MessageWithParts[],
+    sessionID: string | null,
+    errorTurns: SessionErrorTurn[],
+  ) => {
+    if (!sessionID || errorTurns.length === 0) return list;
+
+    const next = list.slice();
+    errorTurns.forEach((errorTurn) => {
+      if (next.some((message) => messageIdFromInfo(message) === errorTurn.id)) return;
+      const syntheticMessage = createSyntheticSessionErrorMessage(sessionID, errorTurn);
+      const anchorIndex = errorTurn.afterMessageID
+        ? next.findIndex((message) => messageIdFromInfo(message) === errorTurn.afterMessageID)
+        : -1;
+
+      if (anchorIndex === -1) {
+        next.push(syntheticMessage);
+        return;
+      }
+
+      next.splice(anchorIndex + 1, 0, syntheticMessage);
+    });
+
+    return next;
+  };
+
+  const upsertLocalSession = (next: Session | null | undefined) => {
+    const id = (next as { id?: string } | null)?.id ?? "";
+    if (!id) return;
+
+    const current = sessions();
+    const index = current.findIndex((session) => session.id === id);
+    if (index === -1) {
+      setStore("sessions", sortSessionsByActivity([...current, next as Session]));
+      rememberSession(next as Session);
+      return;
+    }
+
+    const copy = current.slice();
+    copy[index] = next as Session;
+    rememberSession(next as Session);
+    setStore("sessions", sortSessionsByActivity(copy));
+  };
+
   const messagesBySessionId = (id: string | null): MessageWithParts[] => {
     if (!id) return [];
     const list = store.messages[id] ?? [];
@@ -756,6 +903,42 @@ export function createSessionStore(options: {
   const messages = createMemo<MessageWithParts[]>(() => {
     return messagesBySessionId(options.selectedSessionId());
   });
+
+  const blueprintSeedMessagesForSelectedSession = createMemo(() => {
+    const sessionID = options.selectedSessionId();
+    if (!sessionID) return [] as BlueprintSeedMessage[];
+    return blueprintSeedMessagesBySessionId()[sessionID] ?? [];
+  });
+
+  const visibleMessages = createMemo(() => {
+    const sessionID = options.selectedSessionId();
+    const errorTurns = sessionID ? store.sessionErrorTurns[sessionID] ?? [] : [];
+    const blueprintSeeds = blueprintSeedMessagesForSelectedSession();
+    const list = messages().filter((message) => {
+      const id = messageIdFromInfo(message);
+      return !id.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX) && !id.startsWith(SYNTHETIC_BLUEPRINT_SEED_MESSAGE_PREFIX);
+    });
+    const revert = selectedSession()?.revert?.messageID ?? null;
+    const visible = !revert
+      ? list
+      : list.filter((message) => {
+          const id = messageIdFromInfo(message);
+          return Boolean(id) && id < revert;
+        });
+    return insertSyntheticSessionErrors(
+      insertSyntheticBlueprintSeedMessages(visible, sessionID, blueprintSeeds),
+      sessionID,
+      errorTurns,
+    );
+  });
+
+  const restorePromptFromUserMessage = (message: MessageWithParts) => {
+    const text = message.parts
+      .filter(isVisibleTextPart)
+      .map((part) => String((part as { text?: string }).text ?? ""))
+      .join("");
+    options.setPrompt(text);
+  };
 
   const todos = createMemo<TodoItem[]>(() => {
     const id = options.selectedSessionId();
@@ -1848,6 +2031,12 @@ export function createSessionStore(options: {
     sessionStatusById,
     selectedSession,
     selectedSessionStatus,
+    messageIdFromInfo,
+    visibleMessages,
+    blueprintSeedMessagesForSelectedSession,
+    restorePromptFromUserMessage,
+    upsertLocalSession,
+    setBlueprintSeedMessagesBySessionId,
     selectedSessionCompactionState: createMemo(() => {
       const sessionID = options.selectedSessionId();
       return sessionID ? store.sessionCompaction[sessionID] ?? null : null;

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -1,5 +1,6 @@
 import { createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 import { listen, type Event as TauriEvent } from "@tauri-apps/api/event";
+import type { Session } from "@opencode-ai/sdk/v2/client";
 
 import type {
   Client,
@@ -22,7 +23,7 @@ import {
 } from "../utils";
 import { unwrap } from "../lib/opencode";
 import { describeDirectoryScope, resolveScopedClientDirectory } from "../lib/session-scope";
-import { defaultBlueprintSessionsForPreset } from "../lib/workspace-blueprints";
+import { blueprintMaterializedSessions, blueprintSessions, defaultBlueprintSessionsForPreset } from "../lib/workspace-blueprints";
 import {
   buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
@@ -100,6 +101,8 @@ export type SandboxCreateProgressState = {
 
 export type SandboxCreatePhase = "idle" | "preflight" | "provisioning" | "finalizing";
 
+type BlueprintSeedMessage = { role?: "assistant" | "user" | null; text?: string | null };
+
 type RuntimeWorkspaceLookup = {
   workspaceId?: string | null;
   directoryHint?: string | null;
@@ -132,9 +135,15 @@ export function createWorkspaceStore(options: {
   loadSessions: (scopeRoot?: string) => Promise<void>;
   refreshPendingPermissions: () => Promise<void>;
   refreshWorkspaceSessions?: (workspaceId: string) => Promise<void>;
+  sessions: () => Session[];
+  sessionsLoaded: () => boolean;
+  creatingSession: () => boolean;
   readLastSessionByWorkspace?: () => Record<string, string>;
   selectedSessionId: () => string | null;
   selectSession: (id: string) => Promise<void>;
+  setBlueprintSeedMessagesBySessionId: (
+    updater: (current: Record<string, BlueprintSeedMessage[]>) => Record<string, BlueprintSeedMessage[]>,
+  ) => void;
   setSelectedSessionId: (value: string | null) => void;
   setMessages: (value: any[]) => void;
   setTodos: (value: any[]) => void;
@@ -157,6 +166,7 @@ export function createWorkspaceStore(options: {
   onEngineStable?: () => void;
   engineRuntime?: () => EngineRuntime;
   developerMode: () => boolean;
+  pendingInitialSessionSelection?: () => { workspaceId: string; title: string | null; readyAt: number } | null;
   setPendingInitialSessionSelection?: (input: { workspaceId: string; title: string | null; readyAt: number } | null) => void;
 }) {
 
@@ -368,6 +378,10 @@ export function createWorkspaceStore(options: {
   const [workspaceConnectionStateById, setWorkspaceConnectionStateById] = createSignal<
     Record<string, WorkspaceConnectionState>
   >({});
+  const [blueprintSessionMaterializeBusyByWorkspaceId, setBlueprintSessionMaterializeBusyByWorkspaceId] =
+    createSignal<Record<string, boolean>>({});
+  const [blueprintSessionMaterializeAttemptedByWorkspaceId, setBlueprintSessionMaterializeAttemptedByWorkspaceId] =
+    createSignal<Record<string, boolean>>({});
   const [exportingWorkspaceConfig, setExportingWorkspaceConfig] = createSignal(false);
   const [importingWorkspaceConfig, setImportingWorkspaceConfig] = createSignal(false);
   const selectedWorkspaceInfo = createMemo(() => workspaces().find((w) => w.id === selectedWorkspaceId()) ?? null);
@@ -632,6 +646,80 @@ export function createWorkspaceStore(options: {
     onCleanup(() => {
       cancelled = true;
     });
+  });
+
+  createEffect(() => {
+    const workspaceId = (runtimeWorkspaceId() ?? "").trim();
+    const client = options.openworkServer.openworkServerClient();
+    const connected = options.openworkServer.openworkServerStatus() === "connected";
+    const root = selectedWorkspaceRoot().trim();
+    const config = runtimeWorkspaceConfig() ?? workspaceConfig();
+    const templates = blueprintSessions(config);
+    const materialized = blueprintMaterializedSessions(config);
+    const currentSessions = options.sessions();
+    const normalizedRoot = normalizeDirectoryPath(root);
+    const hasWorkspaceSessions = currentSessions.some((session) => {
+      const directory = typeof session.directory === "string" ? session.directory : "";
+      return normalizeDirectoryPath(directory) === normalizedRoot;
+    });
+
+    if (!workspaceId || !client || !connected) return;
+    if (!root) return;
+    if (!options.sessionsLoaded()) return;
+    if (options.creatingSession()) return;
+    if (options.selectedSessionId()) return;
+    if (!templates.length) return;
+    if (materialized.length > 0) return;
+    if (hasWorkspaceSessions) return;
+    if (blueprintSessionMaterializeBusyByWorkspaceId()[workspaceId]) return;
+    if (blueprintSessionMaterializeAttemptedByWorkspaceId()[workspaceId]) return;
+
+    setBlueprintSessionMaterializeBusyByWorkspaceId((current) => ({
+      ...current,
+      [workspaceId]: true,
+    }));
+
+    void (async () => {
+      try {
+        const result = await client.materializeBlueprintSessions(workspaceId);
+        const templateMessages = new Map(
+          templates.map((template) => [template.id?.trim(), (template.messages ?? []).filter((entry) => entry?.text?.trim())] as const),
+        );
+        if (result.created.length > 0) {
+          options.setBlueprintSeedMessagesBySessionId((current) => {
+            const next = { ...current };
+            result.created.forEach((entry) => {
+              const messages = templateMessages.get(entry.templateId?.trim());
+              if (messages && messages.length > 0) {
+                next[entry.sessionId] = messages;
+              }
+            });
+            return next;
+          });
+        }
+        setBlueprintSessionMaterializeAttemptedByWorkspaceId((current) => ({
+          ...current,
+          [workspaceId]: true,
+        }));
+        await refreshRuntimeWorkspaceConfig(workspaceId);
+        await options.loadSessions(root || undefined);
+        const pending = options.pendingInitialSessionSelection?.() ?? null;
+        const shouldDeferInitialOpen = Boolean(pending && pending.workspaceId === workspaceId);
+        if (result.openSessionId && !shouldDeferInitialOpen) {
+          options.setView("session", result.openSessionId);
+          await options.selectSession(result.openSessionId);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : safeStringify(error);
+        options.setError(addOpencodeCacheHint(message));
+      } finally {
+        setBlueprintSessionMaterializeBusyByWorkspaceId((current) => {
+          const next = { ...current };
+          delete next[workspaceId];
+          return next;
+        });
+      }
+    })();
   });
 
   const resolveOpenworkHost = async (input: {

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -369,6 +369,13 @@ export function createWorkspaceStore(options: {
   const [workspaceConfigLoaded, setWorkspaceConfigLoaded] = createSignal(false);
   const [createWorkspaceOpen, setCreateWorkspaceOpen] = createSignal(false);
   const [createRemoteWorkspaceOpen, setCreateRemoteWorkspaceOpen] = createSignal(false);
+  const [editRemoteWorkspaceOpen, setEditRemoteWorkspaceOpen] = createSignal(false);
+  const [editRemoteWorkspaceId, setEditRemoteWorkspaceId] = createSignal<string | null>(null);
+  const [editRemoteWorkspaceError, setEditRemoteWorkspaceError] = createSignal<string | null>(null);
+  const [renameWorkspaceOpen, setRenameWorkspaceOpen] = createSignal(false);
+  const [renameWorkspaceId, setRenameWorkspaceId] = createSignal<string | null>(null);
+  const [renameWorkspaceName, setRenameWorkspaceName] = createSignal("");
+  const [renameWorkspaceBusy, setRenameWorkspaceBusy] = createSignal(false);
   const [connectingWorkspaceId, setConnectingWorkspaceId] = createSignal<string | null>(null);
   const [connectedWorkspaceId, setConnectedWorkspaceId] = createSignal<string | null>(null);
   const [runtimeWorkspaceId, setRuntimeWorkspaceId] = createSignal<string | null>(null);
@@ -434,6 +441,19 @@ export function createWorkspaceStore(options: {
     const id = runtimeWorkspaceId()?.trim() ?? "";
     if (!id) return null;
     return runtimeWorkspaceConfigById()[id] ?? null;
+  });
+
+  const editRemoteWorkspaceDefaults = createMemo(() => {
+    const workspaceId = editRemoteWorkspaceId();
+    if (!workspaceId) return null;
+    const workspace = workspaces().find((item) => item.id === workspaceId) ?? null;
+    if (!workspace || workspace.workspaceType !== "remote") return null;
+    return {
+      openworkHostUrl: workspace.openworkHostUrl ?? workspace.baseUrl ?? "",
+      openworkToken: workspace.openworkToken ?? options.openworkServer.openworkServerSettings().token ?? "",
+      directory: workspace.directory ?? "",
+      displayName: workspace.displayName ?? "",
+    };
   });
 
   const clearSelectedSessionSurface = () => {
@@ -3389,6 +3409,93 @@ export function createWorkspaceStore(options: {
     return true;
   }
 
+  const openRenameWorkspace = (workspaceId: string) => {
+    const workspace = workspaces().find((item) => item.id === workspaceId) ?? null;
+    if (!workspace) return;
+    setRenameWorkspaceId(workspaceId);
+    setRenameWorkspaceName(
+      workspace.displayName?.trim() ||
+        workspace.openworkWorkspaceName?.trim() ||
+        workspace.name?.trim() ||
+        "",
+    );
+    setRenameWorkspaceOpen(true);
+  };
+
+  const closeRenameWorkspace = () => {
+    if (renameWorkspaceBusy()) return;
+    setRenameWorkspaceOpen(false);
+    setRenameWorkspaceId(null);
+    setRenameWorkspaceName("");
+  };
+
+  const saveRenameWorkspace = async () => {
+    const workspaceId = renameWorkspaceId();
+    if (!workspaceId) return;
+    const nextName = renameWorkspaceName().trim();
+    if (!nextName) return;
+    if (renameWorkspaceBusy()) return;
+
+    setRenameWorkspaceBusy(true);
+    options.setError(null);
+    try {
+      const ok = await updateWorkspaceDisplayName(workspaceId, nextName);
+      if (!ok) return;
+      setRenameWorkspaceOpen(false);
+      setRenameWorkspaceId(null);
+      setRenameWorkspaceName("");
+    } catch (e) {
+      const message = e instanceof Error ? e.message : safeStringify(e);
+      options.setError(addOpencodeCacheHint(message));
+    } finally {
+      setRenameWorkspaceBusy(false);
+    }
+  };
+
+  const closeWorkspaceConnectionSettings = () => {
+    setEditRemoteWorkspaceOpen(false);
+    setEditRemoteWorkspaceId(null);
+    setEditRemoteWorkspaceError(null);
+  };
+
+  const saveWorkspaceConnectionSettings = async (input: {
+    openworkHostUrl?: string | null;
+    openworkToken?: string | null;
+    directory?: string | null;
+    displayName?: string | null;
+  }) => {
+    const workspaceId = editRemoteWorkspaceId();
+    if (!workspaceId) return;
+    setEditRemoteWorkspaceError(null);
+    try {
+      const ok = await updateRemoteWorkspaceFlow(workspaceId, input);
+      if (ok) {
+        closeWorkspaceConnectionSettings();
+        return;
+      }
+      setEditRemoteWorkspaceError("Connection failed. Check the URL and token.");
+      options.setError(null);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Connection failed";
+      setEditRemoteWorkspaceError(message);
+      options.setError(null);
+    }
+  };
+
+  const openWorkspaceConnectionSettings = (workspaceId: string) => {
+    const workspace = workspaces().find((item) => item.id === workspaceId) ?? null;
+    if (workspace?.workspaceType === "remote") {
+      setEditRemoteWorkspaceId(workspace.id);
+      setEditRemoteWorkspaceError(null);
+      setEditRemoteWorkspaceOpen(true);
+      return;
+    }
+    setEditRemoteWorkspaceId(null);
+    setEditRemoteWorkspaceError(null);
+    options.setSettingsTab("advanced");
+    options.setView("settings");
+  };
+
   async function stopHost() {
     options.setError(null);
     options.setBusy(true);
@@ -3931,6 +4038,15 @@ export function createWorkspaceStore(options: {
     workspaceConfigLoaded,
     createWorkspaceOpen,
     createRemoteWorkspaceOpen,
+    editRemoteWorkspaceOpen,
+    editRemoteWorkspaceId,
+    editRemoteWorkspaceError,
+    editRemoteWorkspaceDefaults,
+    renameWorkspaceOpen,
+    renameWorkspaceId,
+    renameWorkspaceName,
+    renameWorkspaceBusy,
+    setRenameWorkspaceName,
     connectingWorkspaceId,
     connectedWorkspaceId,
     runtimeWorkspaceId,
@@ -3965,6 +4081,12 @@ export function createWorkspaceStore(options: {
     createRemoteWorkspaceFlow,
     updateRemoteWorkspaceFlow,
     updateWorkspaceDisplayName,
+    openRenameWorkspace,
+    closeRenameWorkspace,
+    saveRenameWorkspace,
+    openWorkspaceConnectionSettings,
+    closeWorkspaceConnectionSettings,
+    saveWorkspaceConnectionSettings,
     forgetWorkspace,
     recoverWorkspace,
     stopSandbox,

--- a/apps/app/src/app/shell/deep-links.ts
+++ b/apps/app/src/app/shell/deep-links.ts
@@ -1,0 +1,250 @@
+import { createEffect, createSignal, type Accessor } from "solid-js";
+
+import { createDenClient, writeDenSettings } from "../lib/den";
+import { stripBundleQuery } from "../bundles";
+import type { createBundlesStore } from "../bundles/store";
+import type { SettingsTab, View } from "../types";
+import type { WorkspaceStore } from "../context/workspace";
+import { isTauriRuntime } from "../utils";
+import {
+  parseDebugDeepLinkInput,
+  parseDenAuthDeepLink,
+  parseRemoteConnectDeepLink,
+  stripRemoteConnectQuery,
+  type DenAuthDeepLink,
+  type RemoteWorkspaceDefaults,
+} from "../lib/openwork-links";
+
+export type DeepLinksController = ReturnType<typeof createDeepLinksController>;
+
+export function createDeepLinksController(options: {
+  booting: Accessor<boolean>;
+  setError: (value: string | null) => void;
+  setView: (next: View, sessionId?: string) => void;
+  setSettingsTab: (value: SettingsTab) => void;
+  goToSettings: (value: SettingsTab) => void;
+  workspaceStore: WorkspaceStore;
+  bundlesStore: ReturnType<typeof createBundlesStore>;
+}) {
+  const [deepLinkRemoteWorkspaceDefaults, setDeepLinkRemoteWorkspaceDefaults] =
+    createSignal<RemoteWorkspaceDefaults | null>(null);
+  const [pendingRemoteConnectDeepLink, setPendingRemoteConnectDeepLink] =
+    createSignal<RemoteWorkspaceDefaults | null>(null);
+  const [pendingDenAuthDeepLink, setPendingDenAuthDeepLink] = createSignal<DenAuthDeepLink | null>(null);
+  const [processingDenAuthDeepLink, setProcessingDenAuthDeepLink] = createSignal(false);
+  const recentClaimedDeepLinks = new Map<string, number>();
+
+  const queueRemoteConnectDefaults = (pending: RemoteWorkspaceDefaults | null) => {
+    setPendingRemoteConnectDeepLink(pending);
+  };
+
+  const clearDeepLinkRemoteWorkspaceDefaults = () => {
+    setDeepLinkRemoteWorkspaceDefaults(null);
+  };
+
+  const queueRemoteConnectDeepLink = (rawUrl: string): boolean => {
+    const parsed = parseRemoteConnectDeepLink(rawUrl);
+    if (!parsed) {
+      return false;
+    }
+    setPendingRemoteConnectDeepLink(parsed);
+    return true;
+  };
+
+  const completeRemoteConnectDeepLink = async (pending: RemoteWorkspaceDefaults) => {
+    const input = {
+      openworkHostUrl: pending.openworkHostUrl,
+      openworkToken: pending.openworkToken,
+      directory: pending.directory,
+      displayName: pending.displayName,
+    };
+
+    if (!pending.autoConnect) {
+      setDeepLinkRemoteWorkspaceDefaults(input);
+      options.workspaceStore.setCreateRemoteWorkspaceOpen(true);
+      return;
+    }
+
+    options.setError(null);
+    try {
+      const ok = await options.workspaceStore.createRemoteWorkspaceFlow(input);
+      if (ok) {
+        setDeepLinkRemoteWorkspaceDefaults(null);
+        return;
+      }
+
+      setDeepLinkRemoteWorkspaceDefaults(input);
+      options.workspaceStore.setCreateRemoteWorkspaceOpen(true);
+    } finally {
+      // no-op overlay placeholder removed; shell has no consumer
+    }
+  };
+
+  const queueDenAuthDeepLink = (rawUrl: string): boolean => {
+    const parsed = parseDenAuthDeepLink(rawUrl);
+    if (!parsed) {
+      return false;
+    }
+    setPendingDenAuthDeepLink(parsed);
+    return true;
+  };
+
+  const stripHandledBrowserDeepLink = (rawUrl: string) => {
+    if (typeof window === "undefined" || isTauriRuntime()) {
+      return;
+    }
+
+    if (window.location.href !== rawUrl) {
+      return;
+    }
+
+    const remoteStripped = stripRemoteConnectQuery(rawUrl) ?? rawUrl;
+    const bundleStripped = stripBundleQuery(remoteStripped) ?? remoteStripped;
+    if (bundleStripped !== rawUrl) {
+      window.history.replaceState({}, "", bundleStripped);
+    }
+  };
+
+  const consumeDeepLinks = (urls: readonly string[] | null | undefined) => {
+    if (!Array.isArray(urls)) {
+      return;
+    }
+
+    const normalized = urls.map((url) => url.trim()).filter(Boolean);
+    if (normalized.length === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    for (const [url, seenAt] of recentClaimedDeepLinks) {
+      if (now - seenAt > 1500) {
+        recentClaimedDeepLinks.delete(url);
+      }
+    }
+
+    for (const url of normalized) {
+      const seenAt = recentClaimedDeepLinks.get(url) ?? 0;
+      if (now - seenAt < 1500) {
+        continue;
+      }
+
+      const matchedDen = queueDenAuthDeepLink(url);
+      const matchedRemote = !matchedDen && queueRemoteConnectDeepLink(url);
+      const matchedBundle = !matchedDen && !matchedRemote && options.bundlesStore.queueBundleLink(url);
+      const claimed = matchedDen || matchedRemote || matchedBundle;
+      if (!claimed) {
+        continue;
+      }
+
+      recentClaimedDeepLinks.set(url, now);
+      stripHandledBrowserDeepLink(url);
+      break;
+    }
+  };
+
+  const openDebugDeepLink = async (rawUrl: string): Promise<{ ok: boolean; message: string }> => {
+    const parsed = parseDebugDeepLinkInput(rawUrl);
+    if (!parsed) {
+      return { ok: false, message: "That link is not a recognized OpenWork deep link or share URL." };
+    }
+
+    options.setError(null);
+    options.setView("settings");
+    if (parsed.kind === "bundle") {
+      return options.bundlesStore.openDebugBundleRequest(parsed.link);
+    }
+    if (parsed.kind === "auth") {
+      setPendingDenAuthDeepLink(parsed.link);
+      return { ok: true, message: "Queued the Cloud auth deep link for OpenWork." };
+    }
+
+    setPendingRemoteConnectDeepLink(parsed.kind === "remote" ? parsed.link : null);
+    options.setSettingsTab("automations");
+    return { ok: true, message: "Queued remote worker link. OpenWork should move into the connect flow." };
+  };
+
+  createEffect(() => {
+    const pending = pendingDenAuthDeepLink();
+    if (!pending || options.booting() || processingDenAuthDeepLink()) {
+      return;
+    }
+
+    setProcessingDenAuthDeepLink(true);
+    setPendingDenAuthDeepLink(null);
+    options.setView("settings");
+    options.setSettingsTab("den");
+    options.goToSettings("den");
+
+    void createDenClient({ baseUrl: pending.denBaseUrl })
+      .exchangeDesktopHandoff(pending.grant)
+      .then((result) => {
+        if (!result.token) {
+          throw new Error("Desktop sign-in completed, but OpenWork Cloud did not return a session token.");
+        }
+
+        writeDenSettings({
+          baseUrl: pending.denBaseUrl,
+          authToken: result.token,
+          activeOrgId: null,
+          activeOrgSlug: null,
+          activeOrgName: null,
+        });
+
+        window.dispatchEvent(
+          new CustomEvent("openwork-den-session-updated", {
+            detail: {
+              status: "success",
+              email: result.user?.email ?? null,
+            },
+          }),
+        );
+      })
+      .catch((error) => {
+        window.dispatchEvent(
+          new CustomEvent("openwork-den-session-updated", {
+            detail: {
+              status: "error",
+              message: error instanceof Error ? error.message : "Failed to complete OpenWork Cloud sign-in.",
+            },
+          }),
+        );
+      })
+      .finally(() => {
+        setProcessingDenAuthDeepLink(false);
+      });
+  });
+
+  createEffect(() => {
+    const pending = pendingRemoteConnectDeepLink();
+    if (!pending || options.booting()) {
+      return;
+    }
+
+    if (pending.autoConnect) {
+      options.setView("session");
+    } else {
+      options.setView("settings");
+      options.setSettingsTab("automations");
+    }
+    setPendingRemoteConnectDeepLink(null);
+    void completeRemoteConnectDeepLink(pending);
+  });
+
+  createEffect(() => {
+    if (options.workspaceStore.createRemoteWorkspaceOpen()) {
+      return;
+    }
+    if (!deepLinkRemoteWorkspaceDefaults()) {
+      return;
+    }
+    setDeepLinkRemoteWorkspaceDefaults(null);
+  });
+
+  return {
+    deepLinkRemoteWorkspaceDefaults,
+    clearDeepLinkRemoteWorkspaceDefaults,
+    queueRemoteConnectDefaults,
+    consumeDeepLinks,
+    openDebugDeepLink,
+  };
+}


### PR DESCRIPTION
## Summary
- move session transcript shaping into `apps/app/src/app/context/session.ts` so `app.tsx` no longer owns synthetic transcript rendering or prompt restore behavior
- move workspace blueprint materialization plus workspace rename/connection-edit modal state into `apps/app/src/app/context/workspace.ts`
- move remaining server-derived capabilities and devtools polling into `apps/app/src/app/connections/openwork-server-store.ts`, and extract shell deep-link routing into `apps/app/src/app/shell/deep-links.ts`

## Commit breakdown
- `9d934666` `refactor(session): move transcript shaping into session store`
- `0045959e` `refactor(workspace): own blueprint session materialization`
- `4db64344` `refactor(connections): colocate server capability memos`
- `2e41af9d` `refactor(connections): move devtools polling into server store`
- `2e9ece7a` `refactor(workspace): move rename and connection edit state`
- `ca002ddc` `refactor(shell): extract deep link routing controller`

## Verification
- `pnpm --filter app typecheck`
- `pnpm --filter app test:health`
- `pnpm --filter app test:session-scope`
- `pnpm --filter app build`
- local browser smoke via Chrome DevTools on `http://127.0.0.1:4176/connect-remote?openworkHostUrl=https%3A%2F%2Fexample.com&openworkToken=test-token&workerName=Demo%20Worker`
  - confirmed the app routed to Settings and opened the `Add Remote Workspace` modal with the expected prefilled worker URL/token/display name

## Notes
- this keeps the shell thinner without adding new providers or extra component layers; most moves extend existing domain stores
- I did not run the Docker dev stack or Chrome MCP browser-broker flow here. I verified with the focused test/build commands above plus a local dev-server smoke in Chrome DevTools because the browser broker was not available in this environment.