### PR TITLE
fix(share): gate sensitive workspace exports

### DIFF
--- a/apps/app/src/app/bundles/publish.ts
+++ b/apps/app/src/app/bundles/publish.ts
@@ -1,6 +1,10 @@
 import { createDenClient, readDenSettings, writeDenSettings } from "../lib/den";
 import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
-import type { OpenworkServerClient, OpenworkWorkspaceExport } from "../lib/openwork-server";
+import type {
+  OpenworkServerClient,
+  OpenworkWorkspaceExport,
+  OpenworkWorkspaceExportSensitiveMode,
+} from "../lib/openwork-server";
 import type { SkillsSetBundleV1, WorkspaceProfileBundleV1 } from "./types";
 
 export function buildWorkspaceProfileBundle(
@@ -44,8 +48,11 @@ export async function publishWorkspaceProfileBundleFromWorkspace(input: {
   workspaceId: string;
   workspaceName: string;
   baseUrl?: string;
+  sensitiveMode?: Exclude<OpenworkWorkspaceExportSensitiveMode, "auto"> | null;
 }) {
-  const exported = await input.client.exportWorkspace(input.workspaceId);
+  const exported = await input.client.exportWorkspace(input.workspaceId, {
+    sensitiveMode: input.sensitiveMode ?? undefined,
+  });
   const payload = buildWorkspaceProfileBundle(input.workspaceName, exported);
   return input.client.publishBundle(payload, "workspace-profile", {
     name: payload.name,
@@ -59,7 +66,9 @@ export async function publishSkillsSetBundleFromWorkspace(input: {
   workspaceName: string;
   baseUrl?: string;
 }) {
-  const exported = await input.client.exportWorkspace(input.workspaceId);
+  const exported = await input.client.exportWorkspace(input.workspaceId, {
+    sensitiveMode: "exclude",
+  });
   const payload = buildSkillsSetBundle(input.workspaceName, exported);
   return input.client.publishBundle(payload, "skills-set", {
     name: payload.name,
@@ -72,8 +81,11 @@ export async function saveWorkspaceProfileBundleToTeam(input: {
   workspaceId: string;
   workspaceName: string;
   requestedName: string;
+  sensitiveMode?: Exclude<OpenworkWorkspaceExportSensitiveMode, "auto"> | null;
 }) {
-  const exported = await input.client.exportWorkspace(input.workspaceId);
+  const exported = await input.client.exportWorkspace(input.workspaceId, {
+    sensitiveMode: input.sensitiveMode ?? undefined,
+  });
   const fallbackName = `${input.workspaceName} template`;
   const name = input.requestedName.trim() || fallbackName;
   const payload = {

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -375,6 +375,14 @@ export type OpenworkWorkspaceExport = {
   files?: Array<{ path: string; content: string }>;
 };
 
+export type OpenworkWorkspaceExportSensitiveMode = "auto" | "include" | "exclude";
+
+export type OpenworkWorkspaceExportWarning = {
+  id: string;
+  label: string;
+  detail: string;
+};
+
 export type OpenworkBlueprintSessionsMaterializeResult = {
   ok: boolean;
   created: Array<{ templateId: string; sessionId: string; title: string }>;
@@ -1003,12 +1011,21 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         `/workspace/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(sessionId)}`,
         { token, hostToken, method: "DELETE", timeoutMs: timeouts.deleteSession },
       ),
-    exportWorkspace: (workspaceId: string) =>
-      requestJson<OpenworkWorkspaceExport>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/export`, {
+    exportWorkspace: (
+      workspaceId: string,
+      options?: { sensitiveMode?: OpenworkWorkspaceExportSensitiveMode },
+    ) => {
+      const query = new URLSearchParams();
+      if (options?.sensitiveMode) {
+        query.set("sensitive", options.sensitiveMode);
+      }
+      const suffix = query.size ? `?${query.toString()}` : "";
+      return requestJson<OpenworkWorkspaceExport>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/export${suffix}`, {
         token,
         hostToken,
         timeoutMs: timeouts.workspaceExport,
-      }),
+      });
+    },
     importWorkspace: (workspaceId: string, payload: Record<string, unknown>) =>
       requestJson<{ ok: boolean }>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/import`, {
         token,

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -3568,6 +3568,9 @@ export default function SessionView(props: SessionViewProps) {
         shareWorkspaceProfileUrl={shareWorkspaceState.shareWorkspaceProfileUrl()}
         shareWorkspaceProfileError={shareWorkspaceState.shareWorkspaceProfileError()}
         shareWorkspaceProfileDisabledReason={shareWorkspaceState.shareServiceDisabledReason()}
+        shareWorkspaceProfileSensitiveWarnings={shareWorkspaceState.shareWorkspaceProfileSensitiveWarnings()}
+        shareWorkspaceProfileSensitiveMode={shareWorkspaceState.shareWorkspaceProfileSensitiveMode()}
+        onShareWorkspaceProfileSensitiveModeChange={shareWorkspaceState.setShareWorkspaceProfileSensitiveMode}
         onShareWorkspaceProfileToTeam={shareWorkspaceState.shareWorkspaceProfileToTeam}
         shareWorkspaceProfileToTeamBusy={shareWorkspaceState.shareWorkspaceProfileTeamBusy()}
         shareWorkspaceProfileToTeamError={shareWorkspaceState.shareWorkspaceProfileTeamError()}

--- a/apps/app/src/app/session/share-workspace.ts
+++ b/apps/app/src/app/session/share-workspace.ts
@@ -16,7 +16,10 @@ import { buildDenAuthUrl, readDenSettings } from "../lib/den";
 import {
   buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
+  OpenworkServerError,
   parseOpenworkWorkspaceIdFromUrl,
+  type OpenworkWorkspaceExportSensitiveMode,
+  type OpenworkWorkspaceExportWarning,
 } from "../lib/openwork-server";
 import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
 import type {
@@ -40,6 +43,8 @@ type ShareWorkspaceStateOptions = {
 };
 
 export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
+  type ShareWorkspaceProfileSensitiveMode = Exclude<OpenworkWorkspaceExportSensitiveMode, "auto">;
+
   const [shareWorkspaceId, setShareWorkspaceId] = createSignal<string | null>(null);
   const [shareLocalOpenworkWorkspaceId, setShareLocalOpenworkWorkspaceId] =
     createSignal<string | null>(null);
@@ -49,6 +54,10 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
     createSignal<string | null>(null);
   const [shareWorkspaceProfileError, setShareWorkspaceProfileError] =
     createSignal<string | null>(null);
+  const [shareWorkspaceProfileSensitiveWarnings, setShareWorkspaceProfileSensitiveWarnings] =
+    createSignal<OpenworkWorkspaceExportWarning[] | null>(null);
+  const [shareWorkspaceProfileSensitiveMode, setShareWorkspaceProfileSensitiveMode] =
+    createSignal<ShareWorkspaceProfileSensitiveMode | null>(null);
   const [shareWorkspaceProfileTeamBusy, setShareWorkspaceProfileTeamBusy] =
     createSignal(false);
   const [shareWorkspaceProfileTeamError, setShareWorkspaceProfileTeamError] =
@@ -99,6 +108,8 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
       setShareWorkspaceProfileBusy(false);
       setShareWorkspaceProfileUrl(null);
       setShareWorkspaceProfileError(null);
+      setShareWorkspaceProfileSensitiveWarnings(null);
+      setShareWorkspaceProfileSensitiveMode(null);
       setShareWorkspaceProfileTeamBusy(false);
       setShareWorkspaceProfileTeamError(null);
       setShareWorkspaceProfileTeamSuccess(null);
@@ -449,6 +460,7 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
         workspaceId,
         workspaceName: options.workspaceLabel(workspace),
         baseUrl: DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
+        sensitiveMode: shareWorkspaceProfileSensitiveMode(),
       });
 
       setShareWorkspaceProfileUrl(result.url);
@@ -458,6 +470,12 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
         // ignore
       }
     } catch (error) {
+      const warnings = readWorkspaceExportWarnings(error);
+      if (warnings) {
+        setShareWorkspaceProfileSensitiveWarnings(warnings);
+        setShareWorkspaceProfileError(null);
+        return;
+      }
       setShareWorkspaceProfileError(
         error instanceof Error
           ? error.message
@@ -481,12 +499,19 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
         workspaceId,
         workspaceName: options.workspaceLabel(workspace),
         requestedName: templateName,
+        sensitiveMode: shareWorkspaceProfileSensitiveMode(),
       });
 
       setShareWorkspaceProfileTeamSuccess(
         `Saved ${created.name} to ${orgName || "your team templates"}.`,
       );
     } catch (error) {
+      const warnings = readWorkspaceExportWarnings(error);
+      if (warnings) {
+        setShareWorkspaceProfileSensitiveWarnings(warnings);
+        setShareWorkspaceProfileTeamError(null);
+        return;
+      }
       setShareWorkspaceProfileTeamError(
         error instanceof Error ? error.message : "Failed to save team template",
       );
@@ -550,6 +575,9 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
     shareWorkspaceProfileBusy,
     shareWorkspaceProfileUrl,
     shareWorkspaceProfileError,
+    shareWorkspaceProfileSensitiveWarnings,
+    shareWorkspaceProfileSensitiveMode,
+    setShareWorkspaceProfileSensitiveMode,
     publishWorkspaceProfileLink,
     shareWorkspaceProfileTeamBusy,
     shareWorkspaceProfileTeamError,
@@ -565,4 +593,25 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
     publishSkillsSetLink,
     exportDisabledReason,
   };
+}
+
+function readWorkspaceExportWarnings(error: unknown): OpenworkWorkspaceExportWarning[] | null {
+  if (!(error instanceof OpenworkServerError) || error.code !== "workspace_export_requires_decision") {
+    return null;
+  }
+  const warnings = Array.isArray((error.details as { warnings?: unknown } | undefined)?.warnings)
+    ? (error.details as { warnings: unknown[] }).warnings
+    : [];
+  const normalized = warnings
+    .map((warning) => {
+      if (!warning || typeof warning !== "object") return null;
+      const record = warning as Record<string, unknown>;
+      const id = typeof record.id === "string" ? record.id.trim() : "";
+      const label = typeof record.label === "string" ? record.label.trim() : "";
+      const detail = typeof record.detail === "string" ? record.detail.trim() : "";
+      if (!id || !label || !detail) return null;
+      return { id, label, detail } satisfies OpenworkWorkspaceExportWarning;
+    })
+    .filter((warning): warning is OpenworkWorkspaceExportWarning => Boolean(warning));
+  return normalized.length ? normalized : null;
 }

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -30,6 +30,7 @@ import {
 import {
   buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
+  OpenworkServerError,
   parseOpenworkWorkspaceIdFromUrl,
 } from "../lib/openwork-server";
 import type {
@@ -39,6 +40,8 @@ import type {
   OpenworkServerDiagnostics,
   OpenworkServerSettings,
   OpenworkServerStatus,
+  OpenworkWorkspaceExportSensitiveMode,
+  OpenworkWorkspaceExportWarning,
 } from "../lib/openwork-server";
 import type { EngineInfo, OrchestratorStatus, OpenworkServerInfo, OpenCodeRouterInfo, WorkspaceInfo } from "../lib/tauri";
 import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
@@ -496,10 +499,14 @@ export default function SettingsShell(props: SettingsShellProps) {
     return ws.path?.trim() || "";
   });
 
+  type ShareWorkspaceProfileSensitiveMode = Exclude<OpenworkWorkspaceExportSensitiveMode, "auto">;
+
   const [shareLocalOpenworkWorkspaceId, setShareLocalOpenworkWorkspaceId] = createSignal<string | null>(null);
   const [shareWorkspaceProfileBusy, setShareWorkspaceProfileBusy] = createSignal(false);
   const [shareWorkspaceProfileUrl, setShareWorkspaceProfileUrl] = createSignal<string | null>(null);
   const [shareWorkspaceProfileError, setShareWorkspaceProfileError] = createSignal<string | null>(null);
+  const [shareWorkspaceProfileSensitiveWarnings, setShareWorkspaceProfileSensitiveWarnings] = createSignal<OpenworkWorkspaceExportWarning[] | null>(null);
+  const [shareWorkspaceProfileSensitiveMode, setShareWorkspaceProfileSensitiveMode] = createSignal<ShareWorkspaceProfileSensitiveMode | null>(null);
   const [shareWorkspaceProfileTeamBusy, setShareWorkspaceProfileTeamBusy] = createSignal(false);
   const [shareWorkspaceProfileTeamError, setShareWorkspaceProfileTeamError] = createSignal<string | null>(null);
   const [shareWorkspaceProfileTeamSuccess, setShareWorkspaceProfileTeamSuccess] = createSignal<string | null>(null);
@@ -513,6 +520,8 @@ export default function SettingsShell(props: SettingsShellProps) {
       setShareWorkspaceProfileBusy(false);
       setShareWorkspaceProfileUrl(null);
       setShareWorkspaceProfileError(null);
+      setShareWorkspaceProfileSensitiveWarnings(null);
+      setShareWorkspaceProfileSensitiveMode(null);
       setShareWorkspaceProfileTeamBusy(false);
       setShareWorkspaceProfileTeamError(null);
       setShareWorkspaceProfileTeamSuccess(null);
@@ -823,6 +832,7 @@ export default function SettingsShell(props: SettingsShellProps) {
         workspaceId,
         workspaceName: workspaceLabel(workspace),
         baseUrl: DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
+        sensitiveMode: shareWorkspaceProfileSensitiveMode(),
       });
 
       setShareWorkspaceProfileUrl(result.url);
@@ -832,6 +842,12 @@ export default function SettingsShell(props: SettingsShellProps) {
         // ignore
       }
     } catch (error) {
+      const warnings = readWorkspaceExportWarnings(error);
+      if (warnings) {
+        setShareWorkspaceProfileSensitiveWarnings(warnings);
+        setShareWorkspaceProfileError(null);
+        return;
+      }
       setShareWorkspaceProfileError(error instanceof Error ? error.message : "Failed to publish workspace profile");
     } finally {
       setShareWorkspaceProfileBusy(false);
@@ -851,12 +867,19 @@ export default function SettingsShell(props: SettingsShellProps) {
         workspaceId,
         workspaceName: workspaceLabel(workspace),
         requestedName: templateName,
+        sensitiveMode: shareWorkspaceProfileSensitiveMode(),
       });
 
       setShareWorkspaceProfileTeamSuccess(
         `Saved ${created.name} to ${orgName || "your team templates"}.`,
       );
     } catch (error) {
+      const warnings = readWorkspaceExportWarnings(error);
+      if (warnings) {
+        setShareWorkspaceProfileSensitiveWarnings(warnings);
+        setShareWorkspaceProfileTeamError(null);
+        return;
+      }
       setShareWorkspaceProfileTeamError(
         error instanceof Error ? error.message : "Failed to save team template",
       );
@@ -1304,6 +1327,9 @@ export default function SettingsShell(props: SettingsShellProps) {
           shareWorkspaceProfileUrl={shareWorkspaceProfileUrl()}
           shareWorkspaceProfileError={shareWorkspaceProfileError()}
           shareWorkspaceProfileDisabledReason={shareServiceDisabledReason()}
+          shareWorkspaceProfileSensitiveWarnings={shareWorkspaceProfileSensitiveWarnings()}
+          shareWorkspaceProfileSensitiveMode={shareWorkspaceProfileSensitiveMode()}
+          onShareWorkspaceProfileSensitiveModeChange={setShareWorkspaceProfileSensitiveMode}
           onShareWorkspaceProfileToTeam={shareWorkspaceProfileToTeam}
           shareWorkspaceProfileToTeamBusy={shareWorkspaceProfileTeamBusy()}
           shareWorkspaceProfileToTeamError={shareWorkspaceProfileTeamError()}
@@ -1400,4 +1426,25 @@ export default function SettingsShell(props: SettingsShellProps) {
 
     </div>
   );
+}
+
+function readWorkspaceExportWarnings(error: unknown): OpenworkWorkspaceExportWarning[] | null {
+  if (!(error instanceof OpenworkServerError) || error.code !== "workspace_export_requires_decision") {
+    return null;
+  }
+  const warnings = Array.isArray((error.details as { warnings?: unknown } | undefined)?.warnings)
+    ? (error.details as { warnings: unknown[] }).warnings
+    : [];
+  const normalized = warnings
+    .map((warning) => {
+      if (!warning || typeof warning !== "object") return null;
+      const record = warning as Record<string, unknown>;
+      const id = typeof record.id === "string" ? record.id.trim() : "";
+      const label = typeof record.label === "string" ? record.label.trim() : "";
+      const detail = typeof record.detail === "string" ? record.detail.trim() : "";
+      if (!id || !label || !detail) return null;
+      return { id, label, detail } satisfies OpenworkWorkspaceExportWarning;
+    })
+    .filter((warning): warning is OpenworkWorkspaceExportWarning => Boolean(warning));
+  return normalized.length ? normalized : null;
 }

--- a/apps/app/src/app/workspace/share-workspace-modal.tsx
+++ b/apps/app/src/app/workspace/share-workspace-modal.tsx
@@ -193,6 +193,9 @@ export default function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
                 shareWorkspaceProfileUrl={props.shareWorkspaceProfileUrl}
                 shareWorkspaceProfileError={props.shareWorkspaceProfileError}
                 shareWorkspaceProfileDisabledReason={props.shareWorkspaceProfileDisabledReason}
+                shareWorkspaceProfileSensitiveWarnings={props.shareWorkspaceProfileSensitiveWarnings}
+                shareWorkspaceProfileSensitiveMode={props.shareWorkspaceProfileSensitiveMode}
+                onShareWorkspaceProfileSensitiveModeChange={props.onShareWorkspaceProfileSensitiveModeChange}
                 onShareWorkspaceProfileToTeam={props.onShareWorkspaceProfileToTeam}
                 shareWorkspaceProfileToTeamBusy={props.shareWorkspaceProfileToTeamBusy}
                 shareWorkspaceProfileToTeamError={props.shareWorkspaceProfileToTeamError}

--- a/apps/app/src/app/workspace/share-workspace-template-panel.tsx
+++ b/apps/app/src/app/workspace/share-workspace-template-panel.tsx
@@ -12,6 +12,7 @@ import {
   successBannerClass,
   surfaceCardClass,
   tagClass,
+  warningBannerClass,
 } from "./modal-styles";
 import type { ShareView } from "./types";
 
@@ -58,6 +59,9 @@ export default function ShareWorkspaceTemplatePanel(props: {
   shareWorkspaceProfileUrl?: string | null;
   shareWorkspaceProfileError?: string | null;
   shareWorkspaceProfileDisabledReason?: string | null;
+  shareWorkspaceProfileSensitiveWarnings?: Array<{ id: string; label: string; detail: string }> | null;
+  shareWorkspaceProfileSensitiveMode?: "include" | "exclude" | null;
+  onShareWorkspaceProfileSensitiveModeChange?: (mode: "include" | "exclude") => void;
   onShareWorkspaceProfileToTeam?: (name: string) => void | Promise<void>;
   shareWorkspaceProfileToTeamBusy?: boolean;
   shareWorkspaceProfileToTeamError?: string | null;
@@ -67,6 +71,17 @@ export default function ShareWorkspaceTemplatePanel(props: {
   shareWorkspaceProfileToTeamNeedsSignIn?: boolean;
   onShareWorkspaceProfileToTeamSignIn?: () => void | Promise<void>;
 }) {
+  const sensitiveWarnings = () => props.shareWorkspaceProfileSensitiveWarnings ?? [];
+  const exportDecisionMissing = () => sensitiveWarnings().length > 0 && !props.shareWorkspaceProfileSensitiveMode;
+  const sensitiveDecisionDisabledReason = () =>
+    exportDecisionMissing()
+      ? "Choose how to handle sensitive config before continuing."
+      : (props.shareWorkspaceProfileDisabledReason ?? null);
+  const teamDecisionDisabledReason = () =>
+    exportDecisionMissing()
+      ? "Choose how to handle sensitive config before continuing."
+      : (props.shareWorkspaceProfileToTeamDisabledReason ?? null);
+
   const renderGeneratedLink = (
     value: string | null | undefined,
     copyKey: string,
@@ -100,6 +115,44 @@ export default function ShareWorkspaceTemplatePanel(props: {
         <button type="button" onClick={() => regenerate?.()} disabled={busy} class={`${pillSecondaryClass} mt-3 w-full`}>
           {busy ? "Publishing…" : regenerateLabel}
         </button>
+      </div>
+    </Show>
+  );
+
+  const SensitiveExportWarningCard = () => (
+    <Show when={sensitiveWarnings().length > 0}>
+      <div class={warningBannerClass}>
+        <div class="text-[13px] font-medium text-dls-text">This export includes sensitive workspace config.</div>
+        <div class="mt-1 text-[12px] leading-relaxed text-dls-secondary">
+          OpenWork found config that can expose secrets, remote endpoints, or persistence points. Choose how to handle it before publishing.
+        </div>
+        <div class="mt-3 space-y-2 text-[12px] leading-relaxed text-dls-secondary">
+          <For each={sensitiveWarnings()}>
+            {(warning) => (
+              <div>
+                <span class="font-medium text-dls-text">{warning.label}:</span> {warning.detail}
+              </div>
+            )}
+          </For>
+        </div>
+        <div class="mt-4 grid gap-2 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={() => props.onShareWorkspaceProfileSensitiveModeChange?.("exclude")}
+            class={`${pillSecondaryClass} ${props.shareWorkspaceProfileSensitiveMode === "exclude" ? "border-[var(--dls-accent)] text-[var(--dls-accent)]" : ""}`}
+            aria-pressed={props.shareWorkspaceProfileSensitiveMode === "exclude"}
+          >
+            Exclude sensitive config
+          </button>
+          <button
+            type="button"
+            onClick={() => props.onShareWorkspaceProfileSensitiveModeChange?.("include")}
+            class={`${pillSecondaryClass} ${props.shareWorkspaceProfileSensitiveMode === "include" ? "border-[var(--dls-accent)] text-[var(--dls-accent)]" : ""}`}
+            aria-pressed={props.shareWorkspaceProfileSensitiveMode === "include"}
+          >
+            Include everything
+          </button>
+        </div>
       </div>
     </Show>
   );
@@ -166,9 +219,11 @@ export default function ShareWorkspaceTemplatePanel(props: {
             <Show when={props.shareWorkspaceProfileError?.trim()}>
               <div class={`mb-3 ${errorBannerClass}`}>{props.shareWorkspaceProfileError}</div>
             </Show>
-            <Show when={props.shareWorkspaceProfileDisabledReason?.trim()}>
-              <div class="mb-3 text-[12px] text-dls-secondary">{props.shareWorkspaceProfileDisabledReason}</div>
+            <Show when={sensitiveDecisionDisabledReason()?.trim()}>
+              <div class="mb-3 text-[12px] text-dls-secondary">{sensitiveDecisionDisabledReason()}</div>
             </Show>
+
+            <SensitiveExportWarningCard />
 
             {renderGeneratedLink(
               props.shareWorkspaceProfileUrl,
@@ -178,7 +233,7 @@ export default function ShareWorkspaceTemplatePanel(props: {
               "Create template link",
               "Regenerate link",
               props.onShareWorkspaceProfile,
-              props.shareWorkspaceProfileDisabledReason,
+              sensitiveDecisionDisabledReason(),
             )}
 
             <IncludedTemplateItems items={templateIncludedItems} />
@@ -216,9 +271,11 @@ export default function ShareWorkspaceTemplatePanel(props: {
               <div class={`mt-4 ${successBannerClass}`}>{props.shareWorkspaceProfileToTeamSuccess}</div>
             </Show>
 
-            <Show when={props.shareWorkspaceProfileToTeamDisabledReason?.trim() && !needsSignIn}>
-              <div class="mt-4 text-[12px] text-dls-secondary">{props.shareWorkspaceProfileToTeamDisabledReason}</div>
+            <Show when={teamDecisionDisabledReason()?.trim() && !needsSignIn}>
+              <div class="mt-4 text-[12px] text-dls-secondary">{teamDecisionDisabledReason()}</div>
             </Show>
+
+            <SensitiveExportWarningCard />
 
             <button
               type="button"
@@ -232,7 +289,7 @@ export default function ShareWorkspaceTemplatePanel(props: {
               disabled={
                 needsSignIn
                   ? !props.onShareWorkspaceProfileToTeamSignIn
-                  : Boolean(props.shareWorkspaceProfileToTeamDisabledReason) ||
+                  : Boolean(teamDecisionDisabledReason()) ||
                     !props.onShareWorkspaceProfileToTeam ||
                     props.shareWorkspaceProfileToTeamBusy ||
                     !props.teamTemplateName.trim()

--- a/apps/app/src/app/workspace/types.ts
+++ b/apps/app/src/app/workspace/types.ts
@@ -1,4 +1,5 @@
 import type { DenTemplate } from "../lib/den";
+import type { OpenworkWorkspaceExportWarning } from "../lib/openwork-server";
 import type { WorkspacePreset } from "../types";
 
 export type CreateWorkspaceScreen = "chooser" | "local" | "remote" | "shared";
@@ -123,6 +124,9 @@ export type ShareWorkspaceModalProps = {
   shareWorkspaceProfileUrl?: string | null;
   shareWorkspaceProfileError?: string | null;
   shareWorkspaceProfileDisabledReason?: string | null;
+  shareWorkspaceProfileSensitiveWarnings?: OpenworkWorkspaceExportWarning[] | null;
+  shareWorkspaceProfileSensitiveMode?: "include" | "exclude" | null;
+  onShareWorkspaceProfileSensitiveModeChange?: (mode: "include" | "exclude") => void;
   onShareWorkspaceProfileToTeam?: (name: string) => void | Promise<void>;
   shareWorkspaceProfileToTeamBusy?: boolean;
   shareWorkspaceProfileToTeamError?: string | null;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -36,6 +36,11 @@ import { inheritWorkspaceOpencodeConnection, resolveWorkspaceOpencodeConnection 
 import { fetchSharedBundle, publishSharedBundle } from "./share-bundles.js";
 import { seedOpencodeSessionMessages } from "./opencode-db.js";
 import { listPortableFiles, planPortableFiles, writePortableFiles } from "./portable-files.js";
+import {
+  collectWorkspaceExportWarnings,
+  stripSensitiveWorkspaceExportData,
+  type WorkspaceExportSensitiveMode,
+} from "./workspace-export-safety.js";
 import pkg from "../package.json" with { type: "json" };
 
 const SERVER_VERSION = pkg.version;
@@ -3581,7 +3586,8 @@ function createRoutes(
 
   addRoute(routes, "GET", "/workspace/:id/export", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
-    const exportPayload = await exportWorkspace(workspace);
+    const sensitiveMode = parseWorkspaceExportSensitiveMode(ctx.url.searchParams.get("sensitive"));
+    const exportPayload = await exportWorkspace(workspace, { sensitiveMode });
     return jsonResponse(exportPayload);
   });
 
@@ -4809,12 +4815,30 @@ async function requireApproval(
   }
 }
 
-async function exportWorkspace(workspace: WorkspaceInfo) {
-  const opencode = sanitizePortableOpencodeConfig(await readOpencodeConfig(workspace.path));
+async function exportWorkspace(
+  workspace: WorkspaceInfo,
+  options?: { sensitiveMode?: WorkspaceExportSensitiveMode },
+) {
+  const sensitiveMode = options?.sensitiveMode ?? "auto";
+  let opencode = sanitizePortableOpencodeConfig(await readOpencodeConfig(workspace.path));
   const openwork = sanitizeOpenworkTemplateConfig(await readOpenworkConfig(workspace.path));
   const skills = await listSkills(workspace.path, false);
   const commands = await listCommands(workspace.path, "workspace");
-  const files = await listPortableFiles(workspace.path);
+  let files = await listPortableFiles(workspace.path);
+  const warnings = collectWorkspaceExportWarnings({ opencode, files });
+  if (warnings.length && sensitiveMode === "auto") {
+    throw new ApiError(
+      409,
+      "workspace_export_requires_decision",
+      "This workspace includes sensitive config. Choose whether to exclude it or include it before exporting.",
+      { warnings },
+    );
+  }
+  if (sensitiveMode === "exclude") {
+    const sanitized = stripSensitiveWorkspaceExportData({ opencode, files });
+    opencode = sanitized.opencode;
+    files = sanitized.files;
+  }
   const skillContents = await Promise.all(
     skills.map(async (skill) => ({
       name: skill.name,
@@ -4839,6 +4863,15 @@ async function exportWorkspace(workspace: WorkspaceInfo) {
     commands: commandContents,
     ...(files.length ? { files } : {}),
   };
+}
+
+function parseWorkspaceExportSensitiveMode(input: string | null): WorkspaceExportSensitiveMode {
+  const trimmed = (input ?? "").trim();
+  if (!trimmed) return "auto";
+  if (trimmed === "auto" || trimmed === "include" || trimmed === "exclude") {
+    return trimmed;
+  }
+  throw new ApiError(400, "invalid_workspace_export_sensitive_mode", `Invalid workspace export sensitive mode: ${trimmed}`);
 }
 
 async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string, unknown>): Promise<void> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4820,12 +4820,13 @@ async function exportWorkspace(
   options?: { sensitiveMode?: WorkspaceExportSensitiveMode },
 ) {
   const sensitiveMode = options?.sensitiveMode ?? "auto";
-  let opencode = sanitizePortableOpencodeConfig(await readOpencodeConfig(workspace.path));
+  const rawOpencode = await readOpencodeConfig(workspace.path);
+  let opencode = sanitizePortableOpencodeConfig(rawOpencode);
   const openwork = sanitizeOpenworkTemplateConfig(await readOpenworkConfig(workspace.path));
   const skills = await listSkills(workspace.path, false);
   const commands = await listCommands(workspace.path, "workspace");
   let files = await listPortableFiles(workspace.path);
-  const warnings = collectWorkspaceExportWarnings({ opencode, files });
+  const warnings = collectWorkspaceExportWarnings({ opencode: rawOpencode, files });
   if (warnings.length && sensitiveMode === "auto") {
     throw new ApiError(
       409,

--- a/apps/server/src/workspace-export-safety.test.ts
+++ b/apps/server/src/workspace-export-safety.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectWorkspaceExportWarnings,
+  stripSensitiveWorkspaceExportData,
+} from "./workspace-export-safety.js";
+
+describe("workspace export safety", () => {
+  test("does not warn for benign mcp, plugin, and portable files", () => {
+    const warnings = collectWorkspaceExportWarnings({
+      opencode: {
+        mcp: { jira: { type: "remote", url: "https://jira.example.com/mcp", key: "primary" } },
+        plugin: { demo: { key: "theme-dark" } },
+      },
+      files: [
+        { path: ".opencode/plugins/demo/index.ts", content: "const key = 'primary'; export default { enabled: true }" },
+        { path: ".opencode/tools/run.ts", content: "console.log('hello')" },
+      ],
+    });
+
+    expect(warnings).toEqual([]);
+  });
+
+  test("warns only when secret-like keys or values are present", () => {
+    const warnings = collectWorkspaceExportWarnings({
+      opencode: {
+        mcp: {
+          jira: {
+            headers: { Authorization: "Bearer abcdefghijklmnop" },
+            apiKey: "super-secret-key",
+          },
+        },
+        plugin: {
+          demo: { token: "ghp_1234567890abcdef", enabled: true, key: "AbCDef1234567890+/token" },
+        },
+      },
+      files: [
+        { path: ".opencode/plugins/demo/index.ts", content: "const apiKey = 'abc123456789';" },
+        {
+          path: ".opencode/tools/run.ts",
+          content: 'const key = "AbCdEf1234567890+/token"; fetch("https://example.com/path/with/a/really/long/url/that/looks/suspicious/123456789")',
+        },
+      ],
+    });
+
+    expect(warnings.map((warning) => warning.id)).toEqual([
+      "mcp-config",
+      "plugin-config",
+      "portable-file:.opencode/plugins/demo/index.ts",
+      "portable-file:.opencode/tools/run.ts",
+    ]);
+    expect(warnings[0]?.detail).toContain("apiKey");
+    expect(warnings[0]?.detail).toContain("Bearer");
+    expect(warnings[1]?.detail).toContain("token");
+    expect(warnings[1]?.detail).toContain("key");
+    expect(warnings[2]?.detail).toContain("apiKey");
+    expect(warnings[3]?.detail).toContain("key");
+    expect(warnings[3]?.detail).toContain("long URL");
+  });
+
+  test("exclude mode removes only flagged values and files", () => {
+    const sanitized = stripSensitiveWorkspaceExportData({
+      opencode: {
+        plugin: {
+          demo: {
+            enabled: true,
+            token: "ghp_1234567890abcdef",
+          },
+        },
+        mcp: {
+          jira: {
+            enabled: true,
+            apiKey: "super-secret-key",
+            url: "https://jira.example.com/mcp",
+          },
+        },
+        command: { review: { template: "Review it" } },
+      },
+      files: [
+        { path: ".opencode/plugins/demo/index.ts", content: "const token = 'secret';" },
+        { path: ".opencode/tools/run.ts", content: "console.log('safe tool');" },
+        { path: ".opencode/agents/reviewer.md", content: "agent" },
+      ],
+    });
+
+    expect(sanitized.opencode).toEqual({
+      plugin: { demo: { enabled: true } },
+      mcp: { jira: { enabled: true, url: "https://jira.example.com/mcp" } },
+      command: { review: { template: "Review it" } },
+    });
+    expect(sanitized.files).toEqual([
+      { path: ".opencode/tools/run.ts", content: "console.log('safe tool');" },
+      { path: ".opencode/agents/reviewer.md", content: "agent" },
+    ]);
+  });
+});

--- a/apps/server/src/workspace-export-safety.test.ts
+++ b/apps/server/src/workspace-export-safety.test.ts
@@ -58,6 +58,26 @@ describe("workspace export safety", () => {
     expect(warnings[3]?.detail).toContain("long URL");
   });
 
+  test("warns when a non-portable provider section still contains secrets", () => {
+    const warnings = collectWorkspaceExportWarnings({
+      opencode: {
+        provider: {
+          openai: {
+            options: {
+              apiKey: "sk_live_1234567890abcdef",
+            },
+          },
+        },
+        mcp: { jira: { type: "remote", url: "https://jira.example.com/mcp" } },
+      },
+      files: [],
+    });
+
+    expect(warnings.map((warning) => warning.id)).toEqual(["provider-config"]);
+    expect(warnings[0]?.label).toBe("Provider settings");
+    expect(warnings[0]?.detail).toContain("apiKey");
+  });
+
   test("exclude mode removes only flagged values and files", () => {
     const sanitized = stripSensitiveWorkspaceExportData({
       opencode: {

--- a/apps/server/src/workspace-export-safety.ts
+++ b/apps/server/src/workspace-export-safety.ts
@@ -8,20 +8,23 @@ export type WorkspaceExportWarning = {
   detail: string;
 };
 
-const SENSITIVE_CONFIG_SECTIONS = [
-  {
-    key: "mcp",
+const CONFIG_SECTION_METADATA: Record<string, { warningId: string; label: string; intro: string }> = {
+  mcp: {
     warningId: "mcp-config",
     label: "MCP servers",
     intro: "Contains secret-like MCP config",
   },
-  {
-    key: "plugin",
+  plugin: {
     warningId: "plugin-config",
     label: "Plugin settings",
     intro: "Contains secret-like plugin config",
   },
-] as const;
+  provider: {
+    warningId: "provider-config",
+    label: "Provider settings",
+    intro: "Contains secret-like provider config",
+  },
+};
 
 const PORTABLE_FILE_PREFIXES = [".opencode/plugins/", ".opencode/tools/"] as const;
 
@@ -240,13 +243,19 @@ export function collectWorkspaceExportWarnings(input: {
   const warnings = new Map<string, WorkspaceExportWarning>();
   const opencode = input.opencode ?? {};
 
-  for (const section of SENSITIVE_CONFIG_SECTIONS) {
-    const signals = collectSignals(opencode[section.key]);
+  for (const [sectionKey, sectionValue] of Object.entries(opencode)) {
+    const signals = collectSignals(sectionValue);
     if (!signals.length) continue;
-    warnings.set(section.warningId, {
-      id: section.warningId,
-      label: section.label,
-      detail: describeSignals(section.intro, signals),
+    const metadata =
+      CONFIG_SECTION_METADATA[sectionKey] ?? {
+        warningId: `config-${sectionKey}`,
+        label: formatSectionLabel(sectionKey),
+        intro: `Contains secret-like ${sectionKey} config`,
+      };
+    warnings.set(metadata.warningId, {
+      id: metadata.warningId,
+      label: metadata.label,
+      detail: describeSignals(metadata.intro, signals),
     });
   }
 
@@ -278,22 +287,21 @@ export function stripSensitiveWorkspaceExportData(input: {
       : {},
   ) as Record<string, unknown>;
 
-  for (const section of SENSITIVE_CONFIG_SECTIONS) {
-    if (!(section.key in opencode)) continue;
-    const sanitized = sanitizeValue(opencode[section.key]);
+  for (const [sectionKey, sectionValue] of Object.entries(opencode)) {
+    const sanitized = sanitizeValue(sectionValue);
     if (sanitized === undefined) {
-      delete opencode[section.key];
+      delete opencode[sectionKey];
       continue;
     }
     if (sanitized && typeof sanitized === "object" && !Array.isArray(sanitized) && Object.keys(sanitized as Record<string, unknown>).length === 0) {
-      delete opencode[section.key];
+      delete opencode[sectionKey];
       continue;
     }
     if (Array.isArray(sanitized) && sanitized.length === 0) {
-      delete opencode[section.key];
+      delete opencode[sectionKey];
       continue;
     }
-    opencode[section.key] = sanitized;
+    opencode[sectionKey] = sanitized;
   }
 
   const files = input.files
@@ -305,4 +313,11 @@ export function stripSensitiveWorkspaceExportData(input: {
     .map((file) => ({ ...file }));
 
   return { opencode, files };
+}
+
+function formatSectionLabel(sectionKey: string): string {
+  return sectionKey
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .replace(/^./, (char) => char.toUpperCase());
 }

--- a/apps/server/src/workspace-export-safety.ts
+++ b/apps/server/src/workspace-export-safety.ts
@@ -1,0 +1,308 @@
+import type { PortableFile } from "./portable-files.js";
+
+export type WorkspaceExportSensitiveMode = "auto" | "include" | "exclude";
+
+export type WorkspaceExportWarning = {
+  id: string;
+  label: string;
+  detail: string;
+};
+
+const SENSITIVE_CONFIG_SECTIONS = [
+  {
+    key: "mcp",
+    warningId: "mcp-config",
+    label: "MCP servers",
+    intro: "Contains secret-like MCP config",
+  },
+  {
+    key: "plugin",
+    warningId: "plugin-config",
+    label: "Plugin settings",
+    intro: "Contains secret-like plugin config",
+  },
+] as const;
+
+const PORTABLE_FILE_PREFIXES = [".opencode/plugins/", ".opencode/tools/"] as const;
+
+const COMMON_SECRET_KEY_PATTERNS = [
+  { id: "apiKey", test: (tokens: string[], normalized: string) => normalized.includes("apikey") || hasWordPair(tokens, "api", "key") },
+  { id: "key", test: (tokens: string[], normalized: string) => tokens.length === 1 && normalized === "key" },
+  { id: "token", test: (tokens: string[], normalized: string) => tokens.includes("token") || normalized.includes("authtoken") || normalized.includes("accesstoken") || normalized.includes("refreshtoken") },
+  { id: "Bearer", test: (tokens: string[], normalized: string) => tokens.includes("bearer") || normalized.includes("authorization") },
+  { id: "secret", test: (tokens: string[], normalized: string) => tokens.includes("secret") || hasWordPair(tokens, "client", "secret") },
+  { id: "password", test: (tokens: string[], normalized: string) => tokens.includes("password") || normalized.includes("passwd") },
+  { id: "credentials", test: (tokens: string[], normalized: string) => tokens.includes("credential") || tokens.includes("credentials") || normalized.includes("credential") },
+  { id: "privateKey", test: (tokens: string[]) => hasWordPair(tokens, "private", "key") },
+] as const;
+
+const KNOWN_SECRET_VALUE_PATTERNS = [
+  { id: "Bearer", test: (value: string) => /\bBearer\s+[A-Za-z0-9._~+\/-]+=*/.test(value) },
+  { id: "token", test: (value: string) => /\b(?:ghp|gho|github_pat|xox[baprs]|sk|rk|AKIA|ASIA|AIza)[-_A-Za-z0-9]{8,}\b/.test(value) },
+  { id: "JWT", test: (value: string) => /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9._-]+\.[A-Za-z0-9._-]+\b/.test(value) },
+] as const;
+
+const RAW_SECRET_TEXT_PATTERNS = [
+  { id: "apiKey", test: (value: string) => /\bapi[_-]?key\b/i.test(value) },
+  { id: "token", test: (value: string) => /\b(?:access[_-]?token|refresh[_-]?token|auth[_-]?token|token)\b/i.test(value) },
+  { id: "Bearer", test: (value: string) => /\bBearer\b/.test(value) },
+  { id: "secret", test: (value: string) => /\b(?:client[_-]?secret|secret)\b/i.test(value) },
+  { id: "password", test: (value: string) => /\b(?:password|passwd)\b/i.test(value) },
+  { id: "credentials", test: (value: string) => /\bcredentials?\b/i.test(value) },
+  { id: "privateKey", test: (value: string) => /\bprivate[_-]?key\b/i.test(value) },
+] as const;
+
+const GENERIC_KEY_ASSIGNMENT_PATTERNS = [
+  /\bkey\b\s*[:=]\s*["'`]([^"'`\n]{12,})["'`]/gi,
+  /["'`]key["'`]\s*:\s*["'`]([^"'`\n]{12,})["'`]/gi,
+] as const;
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function hasWordPair(tokens: string[], left: string, right: string): boolean {
+  return tokens.includes(left) && tokens.includes(right);
+}
+
+function splitNameIntoTokens(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^A-Za-z0-9]+/)
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function detectSensitiveKeySignals(key: string, value: unknown): string[] {
+  const tokens = splitNameIntoTokens(key);
+  if (!tokens.length) return [];
+  const normalized = tokens.join("");
+  const matches = COMMON_SECRET_KEY_PATTERNS.filter((pattern) => pattern.test(tokens, normalized)).map((pattern) => pattern.id);
+
+  if (tokens.includes("public") && tokens.includes("key")) {
+    return matches.filter((match) => match !== "privateKey");
+  }
+
+  const primitive = typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+  const genericKeyOnly = tokens.length === 1 && tokens[0] === "key";
+  if (genericKeyOnly && !primitive) return [];
+  if (genericKeyOnly) {
+    if (typeof value !== "string") return [];
+    if (!looksLikeGenericSecretValue(value)) return [];
+  }
+
+  return matches;
+}
+
+function looksLikeGenericSecretValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length < 16) return false;
+  if (/\s/.test(trimmed)) return false;
+  if (detectSensitiveStringSignals(trimmed).some((match) => match !== "key")) return true;
+  if (/^[a-f0-9]{32,}$/i.test(trimmed)) return true;
+
+  const classes = [/[a-z]/.test(trimmed), /[A-Z]/.test(trimmed), /\d/.test(trimmed), /[-_=+/.]/.test(trimmed)].filter(Boolean).length;
+  return classes >= 3 && /^[A-Za-z0-9._~+\/-=]+$/.test(trimmed);
+}
+
+function detectGenericKeyAssignments(value: string): string[] {
+  const matches = new Set<string>();
+  for (const pattern of GENERIC_KEY_ASSIGNMENT_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of value.matchAll(pattern)) {
+      const candidate = typeof match[1] === "string" ? match[1] : "";
+      if (looksLikeGenericSecretValue(candidate)) {
+        matches.add("key");
+      }
+    }
+  }
+  return Array.from(matches);
+}
+
+function detectSensitiveStringSignals(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  const matches = new Set<string>();
+  for (const pattern of KNOWN_SECRET_VALUE_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      matches.add(pattern.id);
+    }
+  }
+
+  if (/https?:\/\//i.test(trimmed) && trimmed.length > 32) {
+    matches.add("long URL");
+  }
+
+  for (const pattern of RAW_SECRET_TEXT_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      matches.add(pattern.id);
+    }
+  }
+
+  for (const match of detectGenericKeyAssignments(trimmed)) {
+    matches.add(match);
+  }
+
+  return Array.from(matches);
+}
+
+function collectSignals(value: unknown, keyHint?: string): string[] {
+  const matches = new Set<string>();
+
+  if (keyHint) {
+    for (const match of detectSensitiveKeySignals(keyHint, value)) {
+      matches.add(match);
+    }
+  }
+
+  if (typeof value === "string") {
+    for (const match of detectSensitiveStringSignals(value)) {
+      matches.add(match);
+    }
+    return Array.from(matches);
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      for (const match of collectSignals(item)) {
+        matches.add(match);
+      }
+    }
+    return Array.from(matches);
+  }
+
+  if (value && typeof value === "object") {
+    for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+      for (const match of collectSignals(childValue, childKey)) {
+        matches.add(match);
+      }
+    }
+  }
+
+  return Array.from(matches);
+}
+
+function describeSignals(intro: string, signals: string[]): string {
+  const unique = Array.from(new Set(signals));
+  if (!unique.length) return intro + ".";
+  return `${intro}: ${unique.slice(0, 4).join(", ")}${unique.length > 4 ? ", ..." : ""}.`;
+}
+
+function sanitizeValue(value: unknown, keyHint?: string): unknown {
+  const directSignals = new Set<string>();
+  if (keyHint) {
+    for (const match of detectSensitiveKeySignals(keyHint, value)) {
+      directSignals.add(match);
+    }
+  }
+  if (typeof value === "string") {
+    for (const match of detectSensitiveStringSignals(value)) {
+      directSignals.add(match);
+    }
+    return directSignals.size ? undefined : value;
+  }
+
+  if (directSignals.size) return undefined;
+
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => sanitizeValue(item))
+      .filter((item) => item !== undefined);
+    return items;
+  }
+
+  if (value && typeof value === "object") {
+    const next: Record<string, unknown> = {};
+    for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+      const sanitized = sanitizeValue(childValue, childKey);
+      if (sanitized === undefined) continue;
+      if (Array.isArray(sanitized) && sanitized.length === 0) continue;
+      if (sanitized && typeof sanitized === "object" && !Array.isArray(sanitized) && Object.keys(sanitized as Record<string, unknown>).length === 0) {
+        continue;
+      }
+      next[childKey] = sanitized;
+    }
+    return next;
+  }
+
+  return value;
+}
+
+function isPortableFileCandidate(path: string): boolean {
+  return PORTABLE_FILE_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+export function collectWorkspaceExportWarnings(input: {
+  opencode: Record<string, unknown> | null | undefined;
+  files: PortableFile[];
+}): WorkspaceExportWarning[] {
+  const warnings = new Map<string, WorkspaceExportWarning>();
+  const opencode = input.opencode ?? {};
+
+  for (const section of SENSITIVE_CONFIG_SECTIONS) {
+    const signals = collectSignals(opencode[section.key]);
+    if (!signals.length) continue;
+    warnings.set(section.warningId, {
+      id: section.warningId,
+      label: section.label,
+      detail: describeSignals(section.intro, signals),
+    });
+  }
+
+  for (const file of input.files) {
+    const path = String(file.path ?? "").trim();
+    if (!path || !isPortableFileCandidate(path)) continue;
+    const signals = collectSignals(file.content);
+    if (!signals.length) continue;
+    warnings.set(`portable-file:${path}`, {
+      id: `portable-file:${path}`,
+      label: path,
+      detail: describeSignals("Contains secret-like file content", signals),
+    });
+  }
+
+  return Array.from(warnings.values());
+}
+
+export function stripSensitiveWorkspaceExportData(input: {
+  opencode: Record<string, unknown> | null | undefined;
+  files: PortableFile[];
+}): {
+  opencode: Record<string, unknown>;
+  files: PortableFile[];
+} {
+  const opencode = cloneJson(
+    input.opencode && typeof input.opencode === "object" && !Array.isArray(input.opencode)
+      ? input.opencode
+      : {},
+  ) as Record<string, unknown>;
+
+  for (const section of SENSITIVE_CONFIG_SECTIONS) {
+    if (!(section.key in opencode)) continue;
+    const sanitized = sanitizeValue(opencode[section.key]);
+    if (sanitized === undefined) {
+      delete opencode[section.key];
+      continue;
+    }
+    if (sanitized && typeof sanitized === "object" && !Array.isArray(sanitized) && Object.keys(sanitized as Record<string, unknown>).length === 0) {
+      delete opencode[section.key];
+      continue;
+    }
+    if (Array.isArray(sanitized) && sanitized.length === 0) {
+      delete opencode[section.key];
+      continue;
+    }
+    opencode[section.key] = sanitized;
+  }
+
+  const files = input.files
+    .filter((file) => {
+      const path = String(file.path ?? "").trim();
+      if (!isPortableFileCandidate(path)) return true;
+      return collectSignals(file.content).length === 0;
+    })
+    .map((file) => ({ ...file }));
+
+  return { opencode, files };
+}


### PR DESCRIPTION
## Summary
- detect secret-like config and portable file content during workspace export instead of warning on every MCP/plugin entry
- block template export until the user explicitly chooses whether to include or exclude flagged content, and strip only flagged fields/files in exclude mode
- detect provider secrets from the raw workspace `opencode.jsonc` before portable sanitization so `provider.options.apiKey` still triggers the export warning

## Testing
- `pnpm install`
- `pnpm --filter openwork-server test workspace-export-safety.test.ts`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server build:bin`
- Docker + Chrome MCP verification of the public template flow:
  - started the stack with `packaging/docker/dev-up.sh`
  - created a local workspace containing `provider.openai.options.apiKey`
  - confirmed `Create template link` is blocked until a sensitive-content option is chosen
  - confirmed the warning renders in the UI and export proceeds after selecting `Exclude sensitive config`