### PR TITLE
fix(share): lock bundle fetches to the configured publisher

### DIFF
--- a/apps/app/scripts/bundle-url-policy.ts
+++ b/apps/app/scripts/bundle-url-policy.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from "node:assert";
+
+import { describeBundleUrlTrust, isConfiguredBundlePublisherUrl } from "../src/app/bundles/url-policy";
+
+const trusted = describeBundleUrlTrust(
+  "https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  "https://share.openworklabs.com",
+);
+
+assert.deepEqual(trusted, {
+  trusted: true,
+  bundleId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  actualOrigin: "https://share.openworklabs.com",
+  configuredOrigin: "https://share.openworklabs.com",
+});
+
+const untrusted = describeBundleUrlTrust(
+  "https://evil.example/b/01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  "https://share.openworklabs.com",
+);
+
+assert.deepEqual(untrusted, {
+  trusted: false,
+  bundleId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  actualOrigin: "https://evil.example",
+  configuredOrigin: "https://share.openworklabs.com",
+});
+
+assert.equal(
+  isConfiguredBundlePublisherUrl(
+    "https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    "https://share.openworklabs.com",
+  ),
+  true,
+);
+
+assert.equal(
+  isConfiguredBundlePublisherUrl(
+    "https://share.openworklabs.com/not-a-bundle",
+    "https://share.openworklabs.com",
+  ),
+  false,
+);
+
+console.log("bundle-url-policy ok");

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -16,6 +16,7 @@ import type { Session } from "@opencode-ai/sdk/v2/client";
 import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import ModelPickerModal from "./components/model-picker-modal";
+import ConfirmModal from "./components/confirm-modal";
 import ResetModal from "./components/reset-modal";
 import SkillDestinationModal from "./bundles/skill-destination-modal";
 import BundleImportModal from "./bundles/import-modal";
@@ -2398,6 +2399,24 @@ export default function App() {
         onSelectWorker={(workspaceId) => {
           void bundlesStore.importBundleIntoExistingWorkspace(workspaceId);
         }}
+      />
+
+      <ConfirmModal
+        open={Boolean(bundlesStore.untrustedBundleWarning())}
+        title="Import from an untrusted bundle link?"
+        message={(() => {
+          const warning = bundlesStore.untrustedBundleWarning();
+          const actualOrigin = warning?.actualOrigin?.trim() || "an unknown origin";
+          const configuredOrigin = warning?.configuredOrigin?.trim() || "the configured OpenWork share service";
+          return `This link points to ${actualOrigin}, but OpenWork only auto-imports bundles from ${configuredOrigin}. Untrusted bundles can contain malicious instructions or settings. Only continue if you trust the sender and expect this import.`;
+        })()}
+        confirmLabel="Import anyway"
+        cancelLabel="Cancel"
+        variant="warning"
+        onConfirm={() => {
+          void bundlesStore.confirmUntrustedBundleWarning();
+        }}
+        onCancel={bundlesStore.dismissUntrustedBundleWarning}
       />
 
       <BundleStartModal

--- a/apps/app/src/app/bundles/publish.ts
+++ b/apps/app/src/app/bundles/publish.ts
@@ -1,5 +1,4 @@
 import { createDenClient, readDenSettings, writeDenSettings } from "../lib/den";
-import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
 import type {
   OpenworkServerClient,
   OpenworkWorkspaceExport,
@@ -47,7 +46,6 @@ export async function publishWorkspaceProfileBundleFromWorkspace(input: {
   client: OpenworkServerClient;
   workspaceId: string;
   workspaceName: string;
-  baseUrl?: string;
   sensitiveMode?: Exclude<OpenworkWorkspaceExportSensitiveMode, "auto"> | null;
 }) {
   const exported = await input.client.exportWorkspace(input.workspaceId, {
@@ -56,7 +54,6 @@ export async function publishWorkspaceProfileBundleFromWorkspace(input: {
   const payload = buildWorkspaceProfileBundle(input.workspaceName, exported);
   return input.client.publishBundle(payload, "workspace-profile", {
     name: payload.name,
-    baseUrl: input.baseUrl ?? DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
   });
 }
 
@@ -64,7 +61,6 @@ export async function publishSkillsSetBundleFromWorkspace(input: {
   client: OpenworkServerClient;
   workspaceId: string;
   workspaceName: string;
-  baseUrl?: string;
 }) {
   const exported = await input.client.exportWorkspace(input.workspaceId, {
     sensitiveMode: "exclude",
@@ -72,7 +68,6 @@ export async function publishSkillsSetBundleFromWorkspace(input: {
   const payload = buildSkillsSetBundle(input.workspaceName, exported);
   return input.client.publishBundle(payload, "skills-set", {
     name: payload.name,
-    baseUrl: input.baseUrl ?? DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
   });
 }
 

--- a/apps/app/src/app/bundles/sources.ts
+++ b/apps/app/src/app/bundles/sources.ts
@@ -4,6 +4,7 @@ import type { OpenworkServerClient } from "../lib/openwork-server";
 import { isTauriRuntime, safeStringify } from "../utils";
 import { parseBundlePayload } from "./schema";
 import type { BundleImportIntent, BundleRequest, BundleV1 } from "./types";
+import { extractBundleId, isConfiguredBundlePublisherUrl } from "./url-policy";
 
 function isSupportedDeepLinkProtocol(protocol: string): boolean {
   const normalized = protocol.toLowerCase();
@@ -44,14 +45,7 @@ export function parseBundleDeepLink(rawUrl: string): BundleRequest | null {
 
   try {
     if ((protocol === "https:" || protocol === "http:") && !rawBundleUrl.trim()) {
-      const host = url.hostname.toLowerCase();
-      const path = url.pathname.replace(/^\/+/, "");
-      const segments = path.split("/").filter(Boolean);
-      if (
-        (host === "share.openworklabs.com" || host.endsWith(".openworklabs.com") || host === "share.openwork.software" || host.endsWith(".openwork.software"))
-        && segments[0] === "b"
-        && segments[1]
-      ) {
+      if (isConfiguredBundlePublisherUrl(url.toString())) {
         return {
           bundleUrl: url.toString(),
           intent: normalizeBundleImportIntent(url.searchParams.get("ow_intent") ?? url.searchParams.get("intent")),
@@ -100,7 +94,11 @@ export function stripBundleQuery(rawUrl: string): string | null {
   return `${url.pathname}${search ? `?${search}` : ""}${url.hash}`;
 }
 
-export async function fetchBundle(bundleUrl: string, serverClient?: OpenworkServerClient | null): Promise<BundleV1> {
+export async function fetchBundle(
+  bundleUrl: string,
+  serverClient?: OpenworkServerClient | null,
+  options?: { forceClientFetch?: boolean },
+): Promise<BundleV1> {
   let targetUrl: URL;
   try {
     targetUrl = new URL(bundleUrl);
@@ -112,11 +110,9 @@ export async function fetchBundle(bundleUrl: string, serverClient?: OpenworkServ
     throw new Error("Bundle URL must use http(s).");
   }
 
-  const segments = targetUrl.pathname.split("/").filter(Boolean);
-  if (segments[0] === "b" && segments[1] && segments.length === 2) {
-    targetUrl.pathname = `/b/${segments[1]}/data`;
-    targetUrl.searchParams.delete("format");
-  } else if (segments[0] === "b" && segments[1] && segments[2] === "data") {
+  const bundleId = extractBundleId(targetUrl);
+  if (bundleId) {
+    targetUrl.pathname = `/b/${bundleId}/data`;
     targetUrl.searchParams.delete("format");
   }
 
@@ -124,7 +120,7 @@ export async function fetchBundle(bundleUrl: string, serverClient?: OpenworkServ
     targetUrl.searchParams.set("format", "json");
   }
 
-  if (serverClient) {
+  if (serverClient && !options?.forceClientFetch) {
     return parseBundlePayload(await serverClient.fetchBundle(targetUrl.toString()));
   }
 

--- a/apps/app/src/app/bundles/store.ts
+++ b/apps/app/src/app/bundles/store.ts
@@ -20,6 +20,7 @@ import {
 } from "./apply";
 import { defaultPresetFromWorkspaceProfileBundle, describeBundleImport, parseBundlePayload } from "./schema";
 import { fetchBundle, parseBundleDeepLink } from "./sources";
+import { describeBundleUrlTrust } from "./url-policy";
 import type {
   BundleCreateWorkspaceRequest,
   BundleImportChoice,
@@ -39,7 +40,14 @@ type BundleProcessResult =
   | { mode: "start_modal"; bundle: BundleV1 }
   | { mode: "blocked_import_current"; bundle: BundleV1 }
   | { mode: "blocked_new_worker"; bundle: BundleV1 }
+  | { mode: "untrusted_warning" }
   | { mode: "imported"; bundle: BundleV1 };
+
+type UntrustedBundleWarning = {
+  request: BundleRequest;
+  actualOrigin: string | null;
+  configuredOrigin: string | null;
+};
 
 export type BundlesStore = ReturnType<typeof createBundlesStore>;
 
@@ -69,6 +77,7 @@ export function createBundlesStore(options: {
   const [bundleImportBusy, setBundleImportBusy] = createSignal(false);
   const [bundleImportError, setBundleImportError] = createSignal<string | null>(null);
   const [bundleNoticeShown, setBundleNoticeShown] = createSignal(false);
+  const [untrustedBundleWarning, setUntrustedBundleWarning] = createSignal<UntrustedBundleWarning | null>(null);
 
   const showSkillSuccessToast = (toast: { title: string; description: string }) => {
     options.showStatusToast({
@@ -86,6 +95,20 @@ export function createBundlesStore(options: {
     setCreateWorkspaceRequest(null);
     setBundleImportError(null);
     setBundleNoticeShown(false);
+    setUntrustedBundleWarning(null);
+  };
+
+  const maybeWarnAboutUntrustedBundle = (request: BundleRequest, options?: { allowUntrustedClientFetch?: boolean }) => {
+    const rawUrl = request.bundleUrl?.trim() ?? "";
+    if (!rawUrl || options?.allowUntrustedClientFetch) return false;
+    const trust = describeBundleUrlTrust(rawUrl);
+    if (trust.trusted) return false;
+    setUntrustedBundleWarning({
+      request,
+      actualOrigin: trust.actualOrigin,
+      configuredOrigin: trust.configuredOrigin,
+    });
+    return true;
   };
 
   const resolveBundleWorkerTarget = () => {
@@ -194,11 +217,14 @@ export function createBundlesStore(options: {
     request: BundleRequest,
     target?: BundleImportTarget,
     bundleOverride?: BundleV1,
+    importOptions?: { allowUntrustedClientFetch?: boolean },
   ) => {
     try {
       const bundle =
         bundleOverride ??
-        (await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServer.openworkServerClient()));
+        (await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServer.openworkServerClient(), {
+          forceClientFetch: importOptions?.allowUntrustedClientFetch,
+        }));
       await importBundlePayload(bundle, target);
       options.setError(null);
       return true;
@@ -320,8 +346,17 @@ export function createBundlesStore(options: {
     }
   };
 
-  const processBundleRequest = async (request: BundleRequest): Promise<BundleProcessResult> => {
-    const bundle = await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServer.openworkServerClient());
+  const processBundleRequest = async (
+    request: BundleRequest,
+    processOptions?: { allowUntrustedClientFetch?: boolean },
+  ): Promise<BundleProcessResult> => {
+    if (maybeWarnAboutUntrustedBundle(request, processOptions)) {
+      return { mode: "untrusted_warning" };
+    }
+
+    const bundle = await fetchBundle(request.bundleUrl?.trim() ?? "", options.openworkServer.openworkServerClient(), {
+      forceClientFetch: processOptions?.allowUntrustedClientFetch,
+    });
 
     if (bundle.type === "skill") {
       options.setView("settings");
@@ -454,6 +489,8 @@ export function createBundlesStore(options: {
         case "blocked_import_current":
         case "blocked_new_worker":
           return { ok: false, message: options.error() || "The bundle needs more worker setup before it can open." };
+        case "untrusted_warning":
+          return { ok: false, message: "Showed a security warning for an untrusted bundle link." };
         case "imported":
           return { ok: true, message: "Imported the bundle into the current worker." };
       }
@@ -471,6 +508,30 @@ export function createBundlesStore(options: {
     if (bundleImportBusy()) return;
     setBundleImportChoice(null);
     setBundleImportError(null);
+  };
+
+  const dismissUntrustedBundleWarning = () => {
+    if (bundleImportBusy()) return;
+    setUntrustedBundleWarning(null);
+  };
+
+  const confirmUntrustedBundleWarning = async () => {
+    const warning = untrustedBundleWarning();
+    if (!warning || bundleImportBusy()) return;
+    setUntrustedBundleWarning(null);
+    setBundleImportError(null);
+    options.setError(null);
+
+    try {
+      setBundleImportBusy(true);
+      await processBundleRequest(warning.request, { allowUntrustedClientFetch: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : safeStringify(error);
+      const friendly = addOpencodeCacheHint(message);
+      options.setError(friendly);
+    } finally {
+      setBundleImportBusy(false);
+    }
   };
 
   const openTeamBundle = async (input: {
@@ -805,6 +866,8 @@ export function createBundlesStore(options: {
     openRemoteConnectFromSkillDestination,
     handleCreateWorkspaceConfirm,
     handleCreateSandboxConfirm,
+    dismissUntrustedBundleWarning,
+    confirmUntrustedBundleWarning,
     bundleImportChoice,
     bundleImportSummary,
     bundleWorkerOptions,
@@ -815,6 +878,7 @@ export function createBundlesStore(options: {
     bundleStartBusy,
     createWorkspaceRequest,
     createWorkspaceDefaultPreset,
+    untrustedBundleWarning,
     skillDestinationRequest,
     skillDestinationWorkspaces,
     skillDestinationBusyId,

--- a/apps/app/src/app/bundles/url-policy.ts
+++ b/apps/app/src/app/bundles/url-policy.ts
@@ -1,0 +1,49 @@
+import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
+
+export type BundleUrlTrust = {
+  trusted: boolean;
+  bundleId: string | null;
+  actualOrigin: string | null;
+  configuredOrigin: string | null;
+};
+
+export function extractBundleId(url: URL): string | null {
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments[0] === "b" && segments[1] && (segments.length === 2 || (segments.length === 3 && segments[2] === "data"))) {
+    return segments[1];
+  }
+  return null;
+}
+
+export function resolveConfiguredBundlePublisherOrigin(baseUrl = DEFAULT_OPENWORK_PUBLISHER_BASE_URL): string | null {
+  try {
+    return new URL(baseUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function describeBundleUrlTrust(bundleUrl: string, baseUrl = DEFAULT_OPENWORK_PUBLISHER_BASE_URL): BundleUrlTrust {
+  const configuredOrigin = resolveConfiguredBundlePublisherOrigin(baseUrl);
+  try {
+    const url = new URL(bundleUrl);
+    const bundleId = extractBundleId(url);
+    return {
+      trusted: Boolean(configuredOrigin && url.origin === configuredOrigin && bundleId),
+      bundleId,
+      actualOrigin: url.origin,
+      configuredOrigin,
+    };
+  } catch {
+    return {
+      trusted: false,
+      bundleId: null,
+      actualOrigin: null,
+      configuredOrigin,
+    };
+  }
+}
+
+export function isConfiguredBundlePublisherUrl(bundleUrl: string, baseUrl = DEFAULT_OPENWORK_PUBLISHER_BASE_URL): boolean {
+  return describeBundleUrlTrust(bundleUrl, baseUrl).trusted;
+}

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -1043,7 +1043,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
           timeoutMs: timeouts.workspaceImport,
         },
       ),
-    publishBundle: (payload: unknown, bundleType: "skill" | "workspace-profile" | "skills-set", options?: { name?: string; baseUrl?: string | null; timeoutMs?: number }) =>
+    publishBundle: (payload: unknown, bundleType: "skill" | "workspace-profile" | "skills-set", options?: { name?: string; timeoutMs?: number }) =>
       requestJson<{ url: string }>(baseUrl, "/share/bundles/publish", {
         token,
         hostToken,
@@ -1052,7 +1052,6 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
           payload,
           bundleType,
           name: options?.name,
-          baseUrl: options?.baseUrl ?? undefined,
           timeoutMs: options?.timeoutMs,
         },
         timeoutMs: options?.timeoutMs ?? timeouts.shareBundle,

--- a/apps/app/src/app/session/share-workspace.ts
+++ b/apps/app/src/app/session/share-workspace.ts
@@ -21,7 +21,6 @@ import {
   type OpenworkWorkspaceExportSensitiveMode,
   type OpenworkWorkspaceExportWarning,
 } from "../lib/openwork-server";
-import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
 import type {
   EngineInfo,
   OpenworkServerInfo,
@@ -459,7 +458,6 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
         client,
         workspaceId,
         workspaceName: options.workspaceLabel(workspace),
-        baseUrl: DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
         sensitiveMode: shareWorkspaceProfileSensitiveMode(),
       });
 
@@ -532,7 +530,6 @@ export function createShareWorkspaceState(options: ShareWorkspaceStateOptions) {
         client,
         workspaceId,
         workspaceName: options.workspaceLabel(workspace),
-        baseUrl: DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
       });
 
       setShareSkillsSetUrl(result.url);

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -44,7 +44,6 @@ import type {
   OpenworkWorkspaceExportWarning,
 } from "../lib/openwork-server";
 import type { EngineInfo, OrchestratorStatus, OpenworkServerInfo, OpenCodeRouterInfo, WorkspaceInfo } from "../lib/tauri";
-import { DEFAULT_OPENWORK_PUBLISHER_BASE_URL } from "../lib/publisher";
 
 import Button from "../components/button";
 import SettingsView from "../pages/settings";
@@ -831,7 +830,6 @@ export default function SettingsShell(props: SettingsShellProps) {
         client,
         workspaceId,
         workspaceName: workspaceLabel(workspace),
-        baseUrl: DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
         sensitiveMode: shareWorkspaceProfileSensitiveMode(),
       });
 
@@ -900,7 +898,6 @@ export default function SettingsShell(props: SettingsShellProps) {
         client,
         workspaceId,
         workspaceName: workspaceLabel(workspace),
-        baseUrl: DEFAULT_OPENWORK_PUBLISHER_BASE_URL,
       });
 
       setShareSkillsSetUrl(result.url);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3559,11 +3559,17 @@ function createRoutes(
   addRoute(routes, "POST", "/share/bundles/publish", "client", async (ctx) => {
     requireClientScope(ctx, "viewer");
     const body = await readJsonBody(ctx.request);
+    if (typeof body.baseUrl === "string" && body.baseUrl.trim()) {
+      throw new ApiError(
+        400,
+        "publisher_base_url_forbidden",
+        "Bundle publishing always uses the configured OpenWork publisher. Remove baseUrl from the request.",
+      );
+    }
     const result = await publishSharedBundle({
       payload: body.payload,
       bundleType: String(body.bundleType ?? "").trim(),
       name: typeof body.name === "string" ? body.name : undefined,
-      baseUrl: typeof body.baseUrl === "string" ? body.baseUrl : undefined,
       timeoutMs: typeof body.timeoutMs === "number" ? body.timeoutMs : undefined,
     });
     return jsonResponse(result);

--- a/apps/server/src/share-bundles.test.ts
+++ b/apps/server/src/share-bundles.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { normalizeSharedBundleFetchUrl } from "./share-bundles.js";
+import { ApiError } from "./errors.js";
+import { normalizeSharedBundleFetchUrl, resolveTrustedSharedBundleFetchUrl } from "./share-bundles.js";
 
 describe("normalizeSharedBundleFetchUrl", () => {
   test("rewrites human share pages to the canonical data endpoint", () => {
@@ -18,6 +19,30 @@ describe("normalizeSharedBundleFetchUrl", () => {
 
     expect(normalized.toString()).toBe(
       "https://share.openwork.software/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?download=1",
+    );
+  });
+});
+
+describe("resolveTrustedSharedBundleFetchUrl", () => {
+  test("rebuilds fetch URLs from the configured publisher origin", () => {
+    const resolved = resolveTrustedSharedBundleFetchUrl("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV?download=1");
+
+    expect(resolved.toString()).toBe("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?format=json");
+  });
+
+  test("rejects bundle URLs that use another origin", () => {
+    expect(() => resolveTrustedSharedBundleFetchUrl("https://evil.example/b/01ARZ3NDEKTSV4RRFFQ69G5FAV")).toThrow(
+      new ApiError(
+        400,
+        "untrusted_bundle_url",
+        "Shared bundle URLs must use the configured OpenWork publisher (https://share.openworklabs.com). Import only bundles from trusted sources.",
+      ),
+    );
+  });
+
+  test("rejects bundle URLs without a bundle id path", () => {
+    expect(() => resolveTrustedSharedBundleFetchUrl("https://share.openworklabs.com/not-a-bundle")).toThrow(
+      new ApiError(400, "invalid_bundle_url", "Shared bundle URL must point to a bundle id"),
     );
   });
 });

--- a/apps/server/src/share-bundles.ts
+++ b/apps/server/src/share-bundles.ts
@@ -4,11 +4,10 @@ type PublishBundleInput = {
   payload: unknown;
   bundleType: string;
   name?: string;
-  baseUrl?: string;
   timeoutMs?: number;
 };
 
-const DEFAULT_PUBLISHER_BASE_URL = String(process.env.OPENWORK_PUBLISHER_BASE_URL ?? "").trim() || "https://share.openwork.software";
+const DEFAULT_PUBLISHER_BASE_URL = String(process.env.OPENWORK_PUBLISHER_BASE_URL ?? "").trim() || "https://share.openworklabs.com";
 const DEFAULT_PUBLISHER_ORIGIN = String(process.env.OPENWORK_PUBLISHER_REQUEST_ORIGIN ?? "").trim() || "https://app.openwork.software";
 const ALLOWED_BUNDLE_TYPES = new Set(["skill", "skills-set", "workspace-profile"]);
 
@@ -30,6 +29,46 @@ function normalizeBaseUrl(input: unknown): string {
     throw new ApiError(500, "publisher_base_url_missing", "Publisher base URL is required");
   }
   return trimmed.replace(/\/+$/, "");
+}
+
+function resolvePublisherBaseUrl(): string {
+  return normalizeBaseUrl(DEFAULT_PUBLISHER_BASE_URL);
+}
+
+function extractBundleId(url: URL): string {
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments[0] === "b" && segments[1] && (segments.length === 2 || (segments.length === 3 && segments[2] === "data"))) {
+    return segments[1];
+  }
+  throw new ApiError(400, "invalid_bundle_url", "Shared bundle URL must point to a bundle id");
+}
+
+export function resolveTrustedSharedBundleFetchUrl(bundleUrl: unknown): URL {
+  let inputUrl: URL;
+  try {
+    inputUrl = new URL(String(bundleUrl ?? "").trim());
+  } catch {
+    throw new ApiError(400, "invalid_bundle_url", "Invalid shared bundle URL");
+  }
+
+  if (inputUrl.protocol !== "https:" && inputUrl.protocol !== "http:") {
+    throw new ApiError(400, "invalid_bundle_url", "Shared bundle URL must use http(s)");
+  }
+
+  const trustedBaseUrl = new URL(resolvePublisherBaseUrl());
+  if (inputUrl.origin !== trustedBaseUrl.origin) {
+    throw new ApiError(
+      400,
+      "untrusted_bundle_url",
+      `Shared bundle URLs must use the configured OpenWork publisher (${trustedBaseUrl.origin}). Import only bundles from trusted sources.`,
+    );
+  }
+
+  const bundleId = extractBundleId(inputUrl);
+  trustedBaseUrl.pathname = `/b/${bundleId}/data`;
+  trustedBaseUrl.search = "";
+  trustedBaseUrl.searchParams.set("format", "json");
+  return trustedBaseUrl;
 }
 
 async function readErrorMessage(response: Response): Promise<string> {
@@ -56,7 +95,7 @@ export async function publishSharedBundle(input: PublishBundleInput): Promise<{ 
     throw new ApiError(400, "invalid_bundle_type", `Unsupported bundle type: ${bundleType || "unknown"}`);
   }
 
-  const baseUrl = normalizeBaseUrl(input.baseUrl ?? DEFAULT_PUBLISHER_BASE_URL);
+  const baseUrl = resolvePublisherBaseUrl();
   const timeoutMs = typeof input.timeoutMs === "number" && Number.isFinite(input.timeoutMs) ? input.timeoutMs : 15_000;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), Math.max(1_000, timeoutMs));
@@ -64,6 +103,7 @@ export async function publishSharedBundle(input: PublishBundleInput): Promise<{ 
   try {
     const response = await fetch(`${baseUrl}/v1/bundles`, {
       method: "POST",
+      redirect: "manual",
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
@@ -75,6 +115,10 @@ export async function publishSharedBundle(input: PublishBundleInput): Promise<{ 
       body: JSON.stringify(input.payload),
       signal: controller.signal,
     });
+
+    if (response.status >= 300 && response.status < 400) {
+      throw new ApiError(502, "bundle_publish_failed", "Publisher redirects are not allowed");
+    }
 
     if (!response.ok) {
       const details = await readErrorMessage(response);
@@ -98,22 +142,7 @@ export async function publishSharedBundle(input: PublishBundleInput): Promise<{ 
 }
 
 export async function fetchSharedBundle(bundleUrl: unknown, options?: { timeoutMs?: number }): Promise<unknown> {
-  let url: URL;
-  try {
-    url = new URL(String(bundleUrl ?? "").trim());
-  } catch {
-    throw new ApiError(400, "invalid_bundle_url", "Invalid shared bundle URL");
-  }
-
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    throw new ApiError(400, "invalid_bundle_url", "Shared bundle URL must use http(s)");
-  }
-
-  url = normalizeSharedBundleFetchUrl(url);
-
-  if (!url.searchParams.has("format")) {
-    url.searchParams.set("format", "json");
-  }
+  const url = resolveTrustedSharedBundleFetchUrl(bundleUrl);
 
   const timeoutMs = typeof options?.timeoutMs === "number" && Number.isFinite(options.timeoutMs) ? options.timeoutMs : 15_000;
   const controller = new AbortController();
@@ -122,9 +151,14 @@ export async function fetchSharedBundle(bundleUrl: unknown, options?: { timeoutM
   try {
     const response = await fetch(url.toString(), {
       method: "GET",
+      redirect: "manual",
       headers: { Accept: "application/json" },
       signal: controller.signal,
     });
+
+    if (response.status >= 300 && response.status < 400) {
+      throw new ApiError(502, "bundle_fetch_failed", "Shared bundle redirects are not allowed");
+    }
 
     if (!response.ok) {
       const details = await readErrorMessage(response);

--- a/packaging/docker/docker-compose.dev.yml
+++ b/packaging/docker/docker-compose.dev.yml
@@ -119,6 +119,7 @@ services:
       OPENWORK_HOST_TOKEN: ${OPENWORK_HOST_TOKEN:-}
       OPENWORK_DEV_ID: ${OPENWORK_DEV_ID:-default}
       OPENWORK_DEV_MODE: ${OPENWORK_DEV_MODE:-1}
+      OPENWORK_PUBLISHER_BASE_URL: http://${OPENWORK_PUBLIC_HOST:-localhost}:${SHARE_PORT:-3006}
       OPENWORK_DEV_OPENCODE_IMPORT_CONFIG_DIR: /persist/.config/opencode
       OPENWORK_DEV_OPENCODE_IMPORT_DATA_DIR: /persist/.openwork-host-opencode-data
       OPENWORK_SIDECAR_SOURCE: external


### PR DESCRIPTION
## Summary
- keep server-side share publish and fetch traffic pinned to the configured OpenWork publisher so bundle links cannot steer host requests to arbitrary targets
- warn on untrusted bundle links in the app and only allow manual import through a client-side fallback after explicit confirmation
- align the Docker dev stack so the app and OpenWork server use the same local share publisher during verification

## Testing
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server build:bin`
- `bun test src/share-bundles.test.ts`
- `bun scripts/bundle-url-policy.ts`
- runtime verification against the Docker dev stack:
  - trusted `POST /share/bundles/fetch` succeeds for the configured share origin
  - untrusted `POST /share/bundles/fetch` is rejected with `untrusted_bundle_url`
  - publish override attempts are rejected with `publisher_base_url_forbidden`

## Verification blocker
- Chrome MCP/browser broker was unavailable in this environment (`/Users/omar/.opencode-browser/broker.sock` missing), so I could not complete the in-browser flow or capture screenshots
- I repaired the local Docker stack and verified the share security behavior through the running OpenWork server and share service instead