### PR TITLE
fix(share): harden legacy publish endpoints

### DIFF
--- a/apps/share/package.json
+++ b/apps/share/package.json
@@ -7,7 +7,7 @@
     "dev": "OPENWORK_DEV_MODE=1 next dev --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
-    "test": "node --test server/b/render-bundle-page.test.ts server/_lib/package-openwork-files.test.ts server/_lib/render-og-image.test.ts server/_lib/share-utils.test.ts",
+    "test": "node --test server/b/render-bundle-page.test.ts server/_lib/package-openwork-files.test.ts server/_lib/publish-security.test.ts server/_lib/render-og-image.test.ts server/_lib/share-utils.test.ts",
     "test:e2e": "playwright test"
   },
   "dependencies": {

--- a/apps/share/server/_lib/publish-security.test.ts
+++ b/apps/share/server/_lib/publish-security.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildCanonicalRequest } from "./request-like.ts";
+import { buildCorsHeaders, validateTrustedOrigin } from "./publish-security.ts";
+
+test("buildCanonicalRequest pins legacy publish routes to the fixed share origin", () => {
+  const request = buildCanonicalRequest({
+    pathname: "/v1/bundles",
+    method: "POST",
+    headers: {
+      host: "evil.example",
+      "x-forwarded-host": "evil.example",
+      origin: "https://openworklabs.com",
+    },
+  });
+
+  assert.equal(new URL(request.url).origin, "https://share.openworklabs.com");
+});
+
+test("buildCorsHeaders reflects only trusted publisher origins", () => {
+  const trustedRequest = buildCanonicalRequest({
+    pathname: "/v1/bundles",
+    method: "POST",
+    headers: { origin: "https://openworklabs.com" },
+  });
+  const trustedHeaders = buildCorsHeaders(trustedRequest);
+
+  assert.equal(trustedHeaders["Access-Control-Allow-Origin"], "https://openworklabs.com");
+  assert.equal(trustedHeaders.Vary, "Origin");
+
+  const untrustedRequest = buildCanonicalRequest({
+    pathname: "/v1/bundles",
+    method: "POST",
+    headers: { origin: "https://evil.example" },
+  });
+  const untrustedHeaders = buildCorsHeaders(untrustedRequest);
+
+  assert.equal(untrustedHeaders["Access-Control-Allow-Origin"], undefined);
+  assert.equal(validateTrustedOrigin(untrustedRequest).ok, false);
+});

--- a/apps/share/server/_lib/request-like.ts
+++ b/apps/share/server/_lib/request-like.ts
@@ -1,4 +1,5 @@
 import type { RequestLike } from "./types.ts";
+import { getPublicBaseUrl } from "./share-utils.ts";
 
 export function headersToObject(
   headersInput: Headers | Record<string, string | string[] | undefined> | null,
@@ -41,4 +42,27 @@ export function buildRequestLike({
     headers: headersToObject(headers ?? null),
     query: searchParamsToQuery(searchParams ?? null),
   };
+}
+
+export function buildCanonicalRequest({
+  pathname,
+  method,
+  headers,
+  searchParams,
+}: {
+  pathname: string;
+  method?: string;
+  headers?: Headers | Record<string, string | string[] | undefined> | null;
+  searchParams?: URLSearchParams | null;
+}): Request {
+  const url = new URL(pathname, `${getPublicBaseUrl()}/`);
+  const query = searchParamsToQuery(searchParams ?? null);
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, value);
+  }
+
+  return new Request(url.toString(), {
+    method: method ?? "GET",
+    headers: new Headers(headersToObject(headers ?? null)),
+  });
 }

--- a/apps/share/server/_lib/share-utils.test.ts
+++ b/apps/share/server/_lib/share-utils.test.ts
@@ -1,8 +1,27 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { buildBundlePreviewSelections, buildOgImageUrls } from "./share-utils.ts";
+import { buildBundlePreviewSelections, buildBundleUrls, buildOgImageUrls } from "./share-utils.ts";
 import type { NormalizedBundle } from "./types.ts";
+
+function withEnv(name: string, value: string | undefined, run: () => void) {
+  const previous = process.env[name];
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+
+  try {
+    run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
+}
 
 test("buildBundlePreviewSelections slugifies shared skill filenames", () => {
   const selections = buildBundlePreviewSelections({
@@ -85,4 +104,41 @@ test("buildOgImageUrls returns typed platform variants", () => {
   assert.equal(urls.byVariant.linkedin, "https://share.openworklabs.com/og/01TESTPREVIEW?variant=linkedin");
   assert.equal(urls.byVariant.slack, "https://share.openworklabs.com/og/01TESTPREVIEW?variant=slack");
   assert.equal(urls.byVariant.whatsapp, "https://share.openworklabs.com/og/01TESTPREVIEW?variant=whatsapp");
+});
+
+test("buildBundleUrls ignores forwarded hosts and uses the fixed default share origin", () => {
+  withEnv("PUBLIC_BASE_URL", undefined, () => {
+    const urls = buildBundleUrls(
+      {
+        headers: {
+          host: "evil.example",
+          "x-forwarded-host": "evil.example",
+          "x-forwarded-proto": "http",
+        },
+        query: {},
+      },
+      "01ABC",
+    );
+
+    assert.equal(urls.shareUrl, "https://share.openworklabs.com/b/01ABC");
+    assert.equal(urls.jsonUrl, "https://share.openworklabs.com/b/01ABC/data");
+    assert.equal(urls.downloadUrl, "https://share.openworklabs.com/b/01ABC/data?download=1");
+  });
+});
+
+test("buildBundleUrls respects PUBLIC_BASE_URL when explicitly configured", () => {
+  withEnv("PUBLIC_BASE_URL", "https://share.staging.openworklabs.com/", () => {
+    const urls = buildBundleUrls(
+      {
+        headers: {
+          host: "ignored.example",
+          "x-forwarded-host": "ignored.example",
+        },
+        query: {},
+      },
+      "01CFG",
+    );
+
+    assert.equal(urls.shareUrl, "https://share.staging.openworklabs.com/b/01CFG");
+  });
 });

--- a/apps/share/server/_lib/share-utils.ts
+++ b/apps/share/server/_lib/share-utils.ts
@@ -47,6 +47,10 @@ export function normalizeBaseUrl(input: unknown): string {
   return String(input ?? "").trim().replace(/\/+$/, "");
 }
 
+export function getPublicBaseUrl(): string {
+  return normalizeBaseUrl(getEnv("PUBLIC_BASE_URL")) || DEFAULT_PUBLIC_BASE_URL;
+}
+
 export function setCors(
   res: { setHeader(name: string, value: string): void },
   options: { methods?: string; headers?: string } = {},
@@ -104,28 +108,8 @@ export function truncate(value: unknown, maxChars = 3200): string {
   return `${text.slice(0, maxChars)}\n\n... (truncated for display)`;
 }
 
-function getOrigin(req: RequestLike): string {
-  const configuredPublicBaseUrl = normalizeBaseUrl(getEnv("PUBLIC_BASE_URL"));
-  if (configuredPublicBaseUrl) {
-    return configuredPublicBaseUrl;
-  }
-
-  const protocolHeader = String(req.headers?.["x-forwarded-proto"] ?? "https")
-    .split(",")[0]
-    .trim();
-  const hostHeader = String(req.headers?.["x-forwarded-host"] ?? req.headers?.host ?? "")
-    .split(",")[0]
-    .trim();
-
-  if (!hostHeader) {
-    return DEFAULT_PUBLIC_BASE_URL;
-  }
-
-  return `${protocolHeader || "https"}://${hostHeader}`;
-}
-
-export function buildRootUrl(req: RequestLike): string {
-  return normalizeBaseUrl(getOrigin(req)) || DEFAULT_PUBLIC_BASE_URL;
+export function buildRootUrl(_req: RequestLike): string {
+  return getPublicBaseUrl();
 }
 
 export function buildOgImageUrlFromOrigin(

--- a/apps/share/server/b/render-bundle-page.test.ts
+++ b/apps/share/server/b/render-bundle-page.test.ts
@@ -22,11 +22,11 @@ test("wantsDownload only enables on download=1", () => {
   assert.equal(wantsDownload(makeReq()), false);
 });
 
-test("buildBundleUrls uses forwarded origin", () => {
+test("buildBundleUrls uses the fixed share origin", () => {
   const urls = buildBundleUrls(makeReq({ host: "example.test" }), "01ABC");
-  assert.equal(urls.shareUrl, "https://example.test/b/01ABC");
-  assert.equal(urls.jsonUrl, "https://example.test/b/01ABC/data");
-  assert.equal(urls.downloadUrl, "https://example.test/b/01ABC/data?download=1");
+  assert.equal(urls.shareUrl, "https://share.openworklabs.com/b/01ABC");
+  assert.equal(urls.jsonUrl, "https://share.openworklabs.com/b/01ABC/data");
+  assert.equal(urls.downloadUrl, "https://share.openworklabs.com/b/01ABC/data?download=1");
 });
 
 test("renderBundlePage includes machine-readable metadata and escaped json script", () => {

--- a/apps/share/server/v1/bundles.ts
+++ b/apps/share/server/v1/bundles.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 import { storeBundleJson } from "../_lib/blob-store.ts";
-import { buildBundleUrls, getEnv, readBody, setCors, validateBundlePayload } from "../_lib/share-utils.ts";
+import { buildCanonicalRequest, buildRequestLike } from "../_lib/request-like.ts";
+import { buildCorsHeaders, rateLimitPublishRequest, validateTrustedOrigin, verifyShareBotProtection } from "../_lib/publish-security.ts";
+import { buildBundleUrls, getEnv, readBody, validateBundlePayload } from "../_lib/share-utils.ts";
 
 interface LegacyApiRequest extends IncomingMessage {
   method?: string;
@@ -21,14 +23,58 @@ function formatPublishError(error: unknown): string {
   return message;
 }
 
+function applyHeaders(res: LegacyApiResponse, headers: Record<string, string>): void {
+  for (const [name, value] of Object.entries(headers)) {
+    res.setHeader(name, value);
+  }
+}
+
+function json(res: LegacyApiResponse, body: unknown, status = 200, headers: Record<string, string> = {}): void {
+  applyHeaders(res, {
+    ...headers,
+    "Content-Type": "application/json",
+  });
+  res.status(status).end(JSON.stringify(body));
+}
+
 export default async function handler(req: LegacyApiRequest, res: LegacyApiResponse): Promise<void> {
-  setCors(res);
+  const request = buildCanonicalRequest({
+    pathname: "/v1/bundles",
+    method: req.method,
+    headers: req.headers,
+  });
+
+  applyHeaders(res, buildCorsHeaders(request));
   if (req.method === "OPTIONS") {
     res.status(204).end();
     return;
   }
+
+  const originCheck = validateTrustedOrigin(request);
+  if (!originCheck.ok) {
+    json(res, { message: originCheck.message }, originCheck.status);
+    return;
+  }
+
+  const rateLimit = rateLimitPublishRequest(request);
+  if (!rateLimit.ok) {
+    json(
+      res,
+      { message: "Publishing is temporarily rate limited." },
+      429,
+      { "X-Retry-After": String(rateLimit.retryAfterSeconds) },
+    );
+    return;
+  }
+
+  const botProtection = await verifyShareBotProtection(request);
+  if (!botProtection.ok) {
+    json(res, { message: botProtection.message }, botProtection.status);
+    return;
+  }
+
   if (req.method !== "POST") {
-    res.status(405).json({ message: "Method not allowed" });
+    json(res, { message: "Method not allowed" }, 405);
     return;
   }
 
@@ -36,33 +82,32 @@ export default async function handler(req: LegacyApiRequest, res: LegacyApiRespo
 
   const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
   if (!contentType.includes("application/json")) {
-    res.status(415).json({ message: "Expected application/json" });
+    json(res, { message: "Expected application/json" }, 415);
     return;
   }
 
   const raw = await readBody(req);
   if (!raw || raw.length === 0) {
-    res.status(400).json({ message: "Body is required" });
+    json(res, { message: "Body is required" }, 400);
     return;
   }
   if (raw.length > maxBytes) {
-    res.status(413).json({ message: "Bundle exceeds upload limit", maxBytes });
+    json(res, { message: "Bundle exceeds upload limit", maxBytes }, 413);
     return;
   }
 
   const rawJson = raw.toString("utf8");
   const validation = validateBundlePayload(rawJson);
   if (!validation.ok) {
-    res.status(422).json({ message: validation.message });
+    json(res, { message: validation.message }, 422);
     return;
   }
 
   try {
     const { id } = await storeBundleJson(rawJson);
-    const urls = buildBundleUrls(req as unknown as import("../_lib/types").RequestLike, id);
-    res.setHeader("Content-Type", "application/json");
-    res.status(200).end(JSON.stringify({ url: urls.shareUrl }));
+    const urls = buildBundleUrls(buildRequestLike({ headers: request.headers }), id);
+    json(res, { url: urls.shareUrl });
   } catch (e) {
-    res.status(500).json({ message: formatPublishError(e) });
+    json(res, { message: formatPublishError(e) }, 500);
   }
 }

--- a/apps/share/server/v1/package.ts
+++ b/apps/share/server/v1/package.ts
@@ -2,7 +2,9 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 import { storeBundleJson } from "../_lib/blob-store.ts";
 import { packageOpenworkFiles } from "../_lib/package-openwork-files.ts";
-import { buildBundleUrls, getEnv, readBody, setCors } from "../_lib/share-utils.ts";
+import { buildCanonicalRequest, buildRequestLike } from "../_lib/request-like.ts";
+import { buildCorsHeaders, rateLimitPublishRequest, validateTrustedOrigin, verifyShareBotProtection } from "../_lib/publish-security.ts";
+import { buildBundleUrls, getEnv, readBody } from "../_lib/share-utils.ts";
 
 interface LegacyApiRequest extends IncomingMessage {
   method?: string;
@@ -22,31 +24,75 @@ function formatPublishError(error: unknown): string {
   return message;
 }
 
+function applyHeaders(res: LegacyApiResponse, headers: Record<string, string>): void {
+  for (const [name, value] of Object.entries(headers)) {
+    res.setHeader(name, value);
+  }
+}
+
+function json(res: LegacyApiResponse, body: unknown, status = 200, headers: Record<string, string> = {}): void {
+  applyHeaders(res, {
+    ...headers,
+    "Content-Type": "application/json",
+  });
+  res.status(status).end(JSON.stringify(body));
+}
+
 export default async function handler(req: LegacyApiRequest, res: LegacyApiResponse): Promise<void> {
-  setCors(res);
+  const request = buildCanonicalRequest({
+    pathname: "/v1/package",
+    method: req.method,
+    headers: req.headers,
+  });
+
+  applyHeaders(res, buildCorsHeaders(request));
   if (req.method === "OPTIONS") {
     res.status(204).end();
     return;
   }
+
+  const originCheck = validateTrustedOrigin(request);
+  if (!originCheck.ok) {
+    json(res, { message: originCheck.message }, originCheck.status);
+    return;
+  }
+
+  const rateLimit = rateLimitPublishRequest(request);
+  if (!rateLimit.ok) {
+    json(
+      res,
+      { message: "Publishing is temporarily rate limited." },
+      429,
+      { "X-Retry-After": String(rateLimit.retryAfterSeconds) },
+    );
+    return;
+  }
+
+  const botProtection = await verifyShareBotProtection(request);
+  if (!botProtection.ok) {
+    json(res, { message: botProtection.message }, botProtection.status);
+    return;
+  }
+
   if (req.method !== "POST") {
-    res.status(405).json({ message: "Method not allowed" });
+    json(res, { message: "Method not allowed" }, 405);
     return;
   }
 
   const maxBytes = Number.parseInt(getEnv("MAX_BYTES", "5242880"), 10);
   const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
   if (!contentType.includes("application/json")) {
-    res.status(415).json({ message: "Expected application/json" });
+    json(res, { message: "Expected application/json" }, 415);
     return;
   }
 
   const raw = await readBody(req);
   if (!raw || raw.length === 0) {
-    res.status(400).json({ message: "Body is required" });
+    json(res, { message: "Body is required" }, 400);
     return;
   }
   if (raw.length > maxBytes) {
-    res.status(413).json({ message: "Package request exceeds upload limit", maxBytes });
+    json(res, { message: "Package request exceeds upload limit", maxBytes }, 413);
     return;
   }
 
@@ -54,25 +100,25 @@ export default async function handler(req: LegacyApiRequest, res: LegacyApiRespo
   try {
     body = JSON.parse(raw.toString("utf8"));
   } catch {
-    res.status(422).json({ message: "Invalid JSON" });
+    json(res, { message: "Invalid JSON" }, 422);
     return;
   }
 
   try {
     const packaged = packageOpenworkFiles(body);
     if (body?.preview) {
-      res.status(200).json(packaged);
+      json(res, packaged);
       return;
     }
 
     const { id } = await storeBundleJson(JSON.stringify(packaged.bundle));
-    const urls = buildBundleUrls(req as unknown as import("../_lib/types").RequestLike, id);
-    res.status(200).json({
+    const urls = buildBundleUrls(buildRequestLike({ headers: request.headers }), id);
+    json(res, {
       ...packaged,
       url: urls.shareUrl,
       id,
     });
   } catch (error) {
-    res.status(422).json({ message: formatPublishError(error) });
+    json(res, { message: formatPublishError(error) }, 422);
   }
 }


### PR DESCRIPTION
## Summary
- align the legacy `apps/share/server/v1` publish handlers with the scoped origin, rate-limit, and bot-protection checks already used by the Next API routes
- stop share URLs from being derived from forwarded host headers by pinning canonical publish requests and bundle URLs to `PUBLIC_BASE_URL` or the fixed share origin
- add regression coverage for canonical URL generation and trusted-vs-untrusted legacy publish requests

## Testing
- `pnpm test` in `apps/share`
- local smoke test on `http://127.0.0.1:3007`: trusted `Origin: https://openworklabs.com` requests to `/v1/package` returned `200` and `/v1/bundles` reached validation with `422`; untrusted `Origin: https://evil.example` requests to both routes returned `403` without an allow-origin header