### PR TITLE
fix(app): include root sessions in sidebar

### DIFF
--- a/apps/app/src/app/context/sidebar-sessions.ts
+++ b/apps/app/src/app/context/sidebar-sessions.ts
@@ -147,7 +147,7 @@ export function createSidebarSessionsStore(options: {
 
       const queryDirectory = normalizeDirectoryQueryPath(directory) || undefined;
       const list = unwrap(
-        await client.session.list({ directory: queryDirectory, roots: false, limit: SIDEBAR_SESSION_LIMIT }),
+        await client.session.list({ directory: queryDirectory, roots: true, limit: SIDEBAR_SESSION_LIMIT }),
       );
       if (refreshSeqByWorkspaceId[id] !== seq) return;
 


### PR DESCRIPTION
## Summary
- switch the sidebar workspace session query back to `roots: true` so top-level sessions remain visible
- keep the targeted fix scoped to the new sidebar session store introduced in the recent refactor

## Testing
- `pnpm --filter @openwork/app build`

## Notes
- I temporarily linked existing `node_modules` from the main repo into the worktree to run the build, then removed those symlinks before commit.
- I did not run the full Docker + Chrome MCP flow for this change.