### PR TITLE
fix(app): align sidebar session transport query

### DIFF
--- a/apps/app/src/app/context/sidebar-sessions.ts
+++ b/apps/app/src/app/context/sidebar-sessions.ts
@@ -7,7 +7,6 @@ import type { WorkspaceInfo, EngineInfo } from "../lib/tauri";
 import type { SidebarSessionItem, WorkspaceSessionGroup } from "../types";
 import {
   normalizeDirectoryPath,
-  normalizeDirectoryQueryPath,
   safeStringify,
 } from "../utils";
 import { toSessionTransportDirectory } from "../lib/session-scope";
@@ -145,7 +144,7 @@ export function createSidebarSessionsStore(options: {
         }
       }
 
-      const queryDirectory = normalizeDirectoryQueryPath(directory) || undefined;
+      const queryDirectory = toSessionTransportDirectory(directory) || undefined;
       const list = unwrap(
         await client.session.list({ directory: queryDirectory, roots: false, limit: SIDEBAR_SESSION_LIMIT }),
       );


### PR DESCRIPTION
## Summary
- make the sidebar session loader use the same transport directory formatter as session create and main session load
- avoid Windows directory string mismatches when the server does strict `session.directory === query.directory` filtering
- keep the fix scoped to the new sidebar session store introduced in the recent workspace bootstrap refactor

## Testing
- `pnpm --filter @openwork/app test:session-scope`
- `pnpm --filter @openwork/app build`

## Notes
- I temporarily linked existing `node_modules` from the main repo into the worktree to run verification, then removed those symlinks before commit.
- I did not run the full Docker + Chrome MCP flow for this targeted fix.