### PR TITLE
fix(settings): rename workers scope to workspaces

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -365,7 +365,7 @@ export default {
   "mcp.edit_config_description": "Apps are stored in your workspace config file.",
   "mcp.docs_link": "Learn more",
   "mcp.scope_project": "This workspace",
-  "mcp.scope_global": "All workers",
+  "mcp.scope_global": "All workspaces",
   "mcp.config_label": "Config",
   "mcp.config_file": "Config file",
   "mcp.config_not_loaded": "Not loaded yet",


### PR DESCRIPTION
## Summary
- replace the settings scope label from `All workers` to `All workspaces`
- keep the adjacent `This workspace` terminology consistent in the same UI

## Verification
- confirmed the locale key change in `apps/app/src/i18n/locales/en.ts`
- attempted `packaging/docker/dev-up.sh`, but the Docker dev stack failed before the app booted
- blocker: orchestrator container hit `ERR_PNPM_ENOTEMPTY` during `pnpm install` due to an existing shared pnpm Docker volume state