### PR TITLE
fix(workspace): reveal shared access tokens reliably

### DIFF
--- a/apps/app/src/app/workspace/share-workspace-access-panel.tsx
+++ b/apps/app/src/app/workspace/share-workspace-access-panel.tsx
@@ -30,8 +30,8 @@ export default function ShareWorkspaceAccessPanel(props: {
   fields: ShareField[];
   copiedKey: string | null;
   onCopy: (value: string, key: string) => void;
-  revealedByIndex: Record<number, boolean>;
-  onToggleReveal: (index: number) => void;
+  revealedByKey: Record<string, boolean>;
+  onToggleReveal: (key: string) => void;
   collaboratorExpanded: boolean;
   onToggleCollaboratorExpanded: () => void;
   remoteAccess?: {
@@ -52,14 +52,14 @@ export default function ShareWorkspaceAccessPanel(props: {
   const renderCredentialField = (field: ShareField, index: number, keyPrefix: string) => {
     const key = `${keyPrefix}:${field.label}:${index}`;
     const isSecret = Boolean(field.secret);
-    const revealed = Boolean(props.revealedByIndex[index]);
+    const revealed = () => Boolean(props.revealedByKey[key]);
 
     return (
       <div>
         <label class="mb-1.5 block text-[13px] font-medium text-dls-text">{displayFieldLabel(field)}</label>
         <div class="relative flex items-center gap-2">
           <input
-            type={isSecret && !revealed ? "password" : "text"}
+            type={isSecret && !revealed() ? "password" : "text"}
             readonly
             value={field.value || field.placeholder || ""}
             class={`${inputClass} font-mono text-[12px]`}
@@ -67,12 +67,12 @@ export default function ShareWorkspaceAccessPanel(props: {
           <Show when={isSecret}>
             <button
               type="button"
-              onClick={() => props.onToggleReveal(index)}
+              onClick={() => props.onToggleReveal(key)}
               disabled={!field.value}
               class={pillSecondaryClass}
-              title={revealed ? "Hide password" : "Reveal password"}
+              title={revealed() ? "Hide password" : "Reveal password"}
             >
-              <Show when={revealed} fallback={<Eye size={14} />}>
+              <Show when={revealed()} fallback={<Eye size={14} />}>
                 <EyeOff size={14} />
               </Show>
             </button>

--- a/apps/app/src/app/workspace/share-workspace-modal.tsx
+++ b/apps/app/src/app/workspace/share-workspace-modal.tsx
@@ -17,7 +17,7 @@ import type { ShareView, ShareWorkspaceModalProps } from "./types";
 
 export default function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
   const [activeView, setActiveView] = createSignal<ShareView>("chooser");
-  const [revealedByIndex, setRevealedByIndex] = createSignal<Record<number, boolean>>({});
+  const [revealedByKey, setRevealedByKey] = createSignal<Record<string, boolean>>({});
   const [copiedKey, setCopiedKey] = createSignal<string | null>(null);
   const [collaboratorExpanded, setCollaboratorExpanded] = createSignal(false);
   const [remoteAccessEnabled, setRemoteAccessEnabled] = createSignal(false);
@@ -36,7 +36,7 @@ export default function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
       (open) => {
         if (!open) return;
         setActiveView("chooser");
-        setRevealedByIndex({});
+        setRevealedByKey({});
         setCopiedKey(null);
         setCollaboratorExpanded(false);
         setRemoteAccessEnabled(props.remoteAccess?.enabled === true);
@@ -213,11 +213,11 @@ export default function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
                 fields={props.fields}
                 copiedKey={copiedKey()}
                 onCopy={(value, key) => void handleCopy(value, key)}
-                revealedByIndex={revealedByIndex()}
-                onToggleReveal={(index) =>
-                  setRevealedByIndex((prev) => ({
+                revealedByKey={revealedByKey()}
+                onToggleReveal={(key) =>
+                  setRevealedByKey((prev) => ({
                     ...prev,
-                    [index]: !prev[index],
+                    [key]: !prev[key],
                   }))
                 }
                 collaboratorExpanded={collaboratorExpanded()}


### PR DESCRIPTION
## Summary
- keep the share-workspace credential reveal state reactive by keying it per rendered field instead of taking a stale index snapshot
- ensure the Show token / Show password control updates the input type and icon for the specific credential row the user clicked
- keep the fix colocated in the workspace share modal/access panel without changing the underlying share token sources

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @openwork/app typecheck

## Notes
- I did not run the Docker + Chrome MCP end-to-end flow for this PR; this change was verified with focused static checks in the app worktree only.