### PR TITLE
fix(landing): send cloud nav directly to app

### DIFF
--- a/ee/apps/landing/components/site-nav.tsx
+++ b/ee/apps/landing/components/site-nav.tsx
@@ -34,7 +34,7 @@ export function SiteNav(props: Props) {
   const navItems = [
     { href: "/docs", label: "Docs", key: "docs" },
     { href: "/download", label: "Desktop", key: "download" },
-    { href: "/den", label: "Cloud", key: "den" },
+    { href: "https://app.openworklabs.com", label: "Cloud", key: "den" },
     { href: "/enterprise", label: "Enterprise", key: "enterprise" }
   ] as const;
 
@@ -63,7 +63,7 @@ export function SiteNav(props: Props) {
               <Link
                 key={item.key}
                 href={item.href}
-                {...(item.key === "docs" ? { target: "_blank" } : {})}
+                {...(/^(?:https?:\/\/)/.test(item.href) ? { target: "_blank", rel: "noreferrer" } : {})}
                 className={navLink(props.active === item.key)}
               >
                 {item.label}
@@ -116,7 +116,7 @@ export function SiteNav(props: Props) {
                 <Link
                   key={item.key}
                   href={item.href}
-                  {...(item.key === "docs" ? { target: "_blank" } : {})}
+                  {...(/^(?:https?:\/\/)/.test(item.href) ? { target: "_blank", rel: "noreferrer" } : {})}
                   className={`rounded-2xl px-4 py-3 ${navLink(
                     props.active === item.key
                   )}`}


### PR DESCRIPTION
## Summary
- point the landing page header Cloud nav item directly at `https://app.openworklabs.com`
- treat external nav items consistently so the Cloud link opens as an external destination in both desktop and mobile nav

## Testing
- attempted `pnpm --filter @openwork-ee/landing build`

## Notes
- the landing build is currently blocked locally because `ee/apps/landing/next.config.js` requires `botid/next/config`, but that module is not present in the available `node_modules` snapshot for this workspace
- I did not run the full Docker + Chrome MCP flow for this small link-only change