### PR TITLE
fix(session): stop staging transcript mounts

### DIFF
--- a/apps/app/src/app/components/session/message-list.tsx
+++ b/apps/app/src/app/components/session/message-list.tsx
@@ -4,7 +4,6 @@ import {
   createEffect,
   createMemo,
   createSignal,
-  on,
   onCleanup,
 } from "solid-js";
 import type { JSX } from "solid-js";
@@ -35,7 +34,6 @@ import { perfNow, recordPerfLog } from "../../lib/perf-log";
 
 export type MessageListProps = {
   messages: MessageWithParts[];
-  sessionId?: string | null;
   isStreaming?: boolean;
   developerMode: boolean;
   showThinking: boolean;
@@ -90,9 +88,6 @@ type MessageBlockItem = MessageBlock | StepClusterBlock;
 
 const VIRTUALIZATION_THRESHOLD = 500;
 const VIRTUAL_OVERSCAN = 4;
-const STAGING_THRESHOLD = 24;
-const STAGING_INIT = 12;
-const STAGING_BATCH = 8;
 
 function normalizePath(path: string) {
   const normalized = path.replace(/\\/g, "/").trim().replace(/\/+/g, "/");
@@ -295,15 +290,10 @@ function toolHeadline(part: Part) {
 
 export default function MessageList(props: MessageListProps) {
   const [copyingId, setCopyingId] = createSignal<string | null>(null);
-  const [stagedCount, setStagedCount] = createSignal(0);
   let previousMessagePartCountById = new Map<string, number>();
   let previousMessageBlockById = new Map<string, MessageBlock>();
   let previousBlockRenderKey = "";
   let copyTimeout: number | undefined;
-  let stageFrame: number | undefined;
-  let stageKey = "";
-  let stageTarget = 0;
-  let staging = false;
   const isNestedVariant = () => props.variant === "nested";
   const isAttachmentPart = (part: Part) => {
     if (part.type !== "file") return false;
@@ -328,7 +318,6 @@ export default function MessageList(props: MessageListProps) {
       .filter((attachment) => !!attachment.url);
   const isImageAttachment = (mime: string) => mime.startsWith("image/");
   onCleanup(() => {
-    stopStaging();
     if (copyTimeout !== undefined) {
       window.clearTimeout(copyTimeout);
     }
@@ -553,104 +542,6 @@ export default function MessageList(props: MessageListProps) {
     }
 
     return blocks;
-  });
-
-  const stopStaging = () => {
-    if (stageFrame !== undefined) {
-      window.cancelAnimationFrame(stageFrame);
-      stageFrame = undefined;
-    }
-    staging = false;
-  };
-
-  const searchActive = createMemo(
-    () =>
-      Boolean(props.activeSearchMessageId) ||
-      Boolean(props.searchMatchMessageIds && props.searchMatchMessageIds.size > 0),
-  );
-
-  const shouldStage = createMemo(
-    () =>
-      !isNestedVariant() &&
-      !(Boolean(props.scrollElement?.()) && messageBlocks().length >= VIRTUALIZATION_THRESHOLD) &&
-      !Boolean(props.isStreaming) &&
-      !searchActive() &&
-      messageBlocks().length > STAGING_THRESHOLD,
-  );
-
-  const startStaging = (total: number) => {
-    stopStaging();
-    stageTarget = total;
-    if (total <= STAGING_THRESHOLD) {
-      setStagedCount(total);
-      return;
-    }
-
-    staging = true;
-    setStagedCount(Math.min(total, STAGING_INIT));
-
-    const step = () => {
-      stageFrame = undefined;
-      setStagedCount((current) => {
-        const next = Math.min(stageTarget, current + STAGING_BATCH);
-        if (next >= stageTarget) {
-          staging = false;
-          return next;
-        }
-
-        stageFrame = window.requestAnimationFrame(step);
-        return next;
-      });
-    };
-
-    stageFrame = window.requestAnimationFrame(step);
-  };
-
-  createEffect(
-    on(
-      () => props.sessionId,
-      () => {
-        stageKey = "";
-      },
-      { defer: true },
-    ),
-  );
-
-  createEffect(() => {
-    const total = messageBlocks().length;
-    const key = props.sessionId?.trim() ?? "";
-
-    if (!total) {
-      stopStaging();
-      stageKey = "";
-      setStagedCount(0);
-      return;
-    }
-
-    if (!shouldStage()) {
-      stopStaging();
-      stageKey = key;
-      setStagedCount(total);
-      return;
-    }
-
-    stageTarget = total;
-    if (stageKey !== key) {
-      stageKey = key;
-      startStaging(total);
-      return;
-    }
-
-    if (staging) return;
-    setStagedCount(total);
-  });
-
-  const visibleBlocks = createMemo(() => {
-    const blocks = messageBlocks();
-    if (!shouldStage()) return blocks;
-    const count = stagedCount();
-    if (count >= blocks.length) return blocks;
-    return blocks.slice(Math.max(0, blocks.length - count));
   });
 
   const latestAssistantMessageId = createMemo(() => {
@@ -1279,7 +1170,7 @@ export default function MessageList(props: MessageListProps) {
         when={shouldVirtualize()}
         fallback={
           <div class={isNestedVariant() ? "space-y-3" : "space-y-4"}>
-            <For each={visibleBlocks()}>
+            <For each={messageBlocks()}>
               {(block, blockIndex) => renderBlock(block, blockIndex())}
             </For>
           </div>
@@ -1289,7 +1180,7 @@ export default function MessageList(props: MessageListProps) {
           when={virtualRows().length > 0}
           fallback={
             <div class={isNestedVariant() ? "space-y-3" : "space-y-4"}>
-              <For each={visibleBlocks()}>
+              <For each={messageBlocks()}>
                 {(block, blockIndex) => renderBlock(block, blockIndex())}
               </For>
             </div>

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -3292,7 +3292,6 @@ export default function SessionView(props: SessionViewProps) {
                     <div>
                       <MessageList
                         messages={batchedRenderedMessages()}
-                        sessionId={props.selectedSessionId}
                         isStreaming={showRunIndicator()}
                         developerMode={props.developerMode}
                         showThinking={showThinking()}


### PR DESCRIPTION
## Summary
- remove the transcript mount staging added after `ca971b1dd3a4c4754f675145f21380ac2a708df2`, which was the most likely cause of markdown flicker during composer input
- restore stable message block rendering by rendering the full `messageBlocks()` list directly again
- drop the extra `sessionId` staging plumbing that only existed for the staged transcript path

## Testing
- `pnpm --filter @openwork/app build`

## Notes
- I did not run the full Docker + Chrome MCP flow for this session UI regression fix.