### PR TITLE
fix(workspace): reuse persisted root after workspace creation

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -18,6 +18,7 @@
     "test:events": "node scripts/events.mjs",
     "test:todos": "node scripts/todos.mjs",
     "test:permissions": "node scripts/permissions.mjs",
+    "test:workspace-path": "bun scripts/workspace-path.ts",
     "test:session-scope": "bun scripts/session-scope.ts",
     "test:session-switch": "node scripts/session-switch.mjs",
     "test:fs-engine": "node scripts/fs-engine.mjs",

--- a/apps/app/scripts/workspace-path.ts
+++ b/apps/app/scripts/workspace-path.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+
+import { resolveCreatedLocalWorkspacePath } from "../src/app/lib/workspace-path.ts";
+
+const winRaw = "C:/Users/Test/OpenWork/starter";
+const winCanonical = String.raw`C:\Users\Test\OpenWork\starter`;
+
+const results = {
+  ok: true,
+  steps: [] as Array<Record<string, unknown>>,
+};
+
+async function step(name: string, fn: () => void | Promise<void>) {
+  results.steps.push({ name, status: "running" });
+  const index = results.steps.length - 1;
+
+  try {
+    await fn();
+    results.steps[index] = { name, status: "ok" };
+  } catch (error) {
+    results.ok = false;
+    results.steps[index] = {
+      name,
+      status: "error",
+      error: error instanceof Error ? error.message : String(error),
+    };
+    throw error;
+  }
+}
+
+try {
+  await step("prefers persisted local workspace path over raw picker path", () => {
+    assert.equal(
+      resolveCreatedLocalWorkspacePath({
+        workspaceId: "ws_test",
+        fallbackPath: winRaw,
+        workspaces: [
+          {
+            id: "ws_test",
+            name: "starter",
+            path: winCanonical,
+            preset: "starter",
+            workspaceType: "local",
+            remoteType: null,
+            baseUrl: null,
+            directory: null,
+            displayName: null,
+            openworkHostUrl: null,
+            openworkToken: null,
+            openworkWorkspaceId: null,
+            openworkWorkspaceName: null,
+            sandboxBackend: null,
+            sandboxRunId: null,
+            sandboxContainerName: null,
+          },
+        ],
+      }),
+      winCanonical,
+    );
+  });
+
+  await step("falls back to the original path when no workspace match exists", () => {
+    assert.equal(
+      resolveCreatedLocalWorkspacePath({
+        workspaceId: "ws_missing",
+        fallbackPath: winRaw,
+        workspaces: [],
+      }),
+      winRaw,
+    );
+  });
+
+  await step("ignores remote workspace rows when resolving a local workspace path", () => {
+    assert.equal(
+      resolveCreatedLocalWorkspacePath({
+        workspaceId: "ws_test",
+        fallbackPath: winRaw,
+        workspaces: [
+          {
+            id: "ws_test",
+            name: "starter",
+            path: "",
+            preset: "remote",
+            workspaceType: "remote",
+            remoteType: "openwork",
+            baseUrl: "https://example.com",
+            directory: winCanonical,
+            displayName: null,
+            openworkHostUrl: "https://example.com",
+            openworkToken: null,
+            openworkWorkspaceId: "ow_ws_test",
+            openworkWorkspaceName: "starter",
+            sandboxBackend: null,
+            sandboxRunId: null,
+            sandboxContainerName: null,
+          },
+        ],
+      }),
+      winRaw,
+    );
+  });
+
+  console.log(JSON.stringify(results, null, 2));
+} catch (error) {
+  results.ok = false;
+  console.error(
+    JSON.stringify(
+      {
+        ...results,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exitCode = 1;
+}

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -71,6 +71,7 @@ import type { OpencodeConnectStatus, ProviderListItem } from "../types";
 import { t, currentLocale } from "../../i18n";
 import { filterProviderList, mapConfigProvidersToList } from "../utils/providers";
 import { buildDefaultWorkspaceBlueprint, normalizeWorkspaceOpenworkConfig } from "../lib/workspace-blueprints";
+import { resolveCreatedLocalWorkspacePath } from "../lib/workspace-path";
 import type { OpenworkServerStore } from "../connections/openwork-server-store";
 
 export type WorkspaceStore = ReturnType<typeof createWorkspaceStore>;
@@ -2185,6 +2186,11 @@ export function createWorkspaceStore(options: {
       }
 
       const nextSelectedId = createdWorkspaceId;
+      const createdWorkspacePath = resolveCreatedLocalWorkspacePath({
+        workspaceId: nextSelectedId,
+        workspaces: ws.workspaces,
+        fallbackPath: resolvedFolder,
+      });
       applyServerLocalWorkspaces(ws.workspaces, nextSelectedId);
       if (nextSelectedId) {
         const nextSelectedWorkspace = ws.workspaces.find((workspace) => workspace.id === nextSelectedId) ?? null;
@@ -2200,15 +2206,15 @@ export function createWorkspaceStore(options: {
 
       setCreateWorkspaceOpen(false);
 
-      const opened = await activateFreshLocalWorkspace(nextSelectedId || null, resolvedFolder);
+      const opened = await activateFreshLocalWorkspace(nextSelectedId || null, createdWorkspacePath);
       if (!opened) {
         options.setPendingInitialSessionSelection?.(null);
         return false;
       }
 
       if (preset === "starter") {
-        const materialized = await materializeStarterSessions(resolvedFolder, name, preset);
-        const sessionsReady = await waitForWorkspaceSessionsReady(resolvedFolder);
+        const materialized = await materializeStarterSessions(createdWorkspacePath, name, preset);
+        const sessionsReady = await waitForWorkspaceSessionsReady(createdWorkspacePath);
         if (!sessionsReady) {
           throw new Error("Starter sessions did not finish loading for the new workspace.");
         }
@@ -2225,7 +2231,7 @@ export function createWorkspaceStore(options: {
       }
 
       if (!nextSelectedId) {
-        await openEmptySession(resolvedFolder);
+        await openEmptySession(createdWorkspacePath);
       }
 
       return true;
@@ -3270,11 +3276,16 @@ export function createWorkspaceStore(options: {
 
       setWorkspaces(ws.workspaces);
       const nextSelectedId = pickSelectedWorkspaceId(ws.workspaces, [resolveWorkspaceListSelectedId(ws)], ws);
+      const createdWorkspacePath = resolveCreatedLocalWorkspacePath({
+        workspaceId: nextSelectedId,
+        workspaces: ws.workspaces,
+        fallbackPath: resolvedFolder,
+      });
       syncSelectedWorkspaceId(nextSelectedId);
       setCreateWorkspaceOpen(false);
       setCreateRemoteWorkspaceOpen(false);
 
-      const opened = await activateFreshLocalWorkspace(nextSelectedId || null, resolvedFolder);
+      const opened = await activateFreshLocalWorkspace(nextSelectedId || null, createdWorkspacePath);
       if (!opened) {
         return;
       }

--- a/apps/app/src/app/lib/workspace-path.ts
+++ b/apps/app/src/app/lib/workspace-path.ts
@@ -1,0 +1,15 @@
+import type { WorkspaceInfo } from "./tauri";
+
+export function resolveCreatedLocalWorkspacePath(input: {
+  workspaceId?: string | null;
+  workspaces: WorkspaceInfo[];
+  fallbackPath?: string | null;
+}) {
+  const fallbackPath = input.fallbackPath?.trim() ?? "";
+  const workspaceId = input.workspaceId?.trim() ?? "";
+  if (!workspaceId) return fallbackPath;
+
+  const created = input.workspaces.find((workspace) => workspace.id === workspaceId && workspace.workspaceType === "local");
+  const path = created?.path?.trim() ?? "";
+  return path || fallbackPath;
+}


### PR DESCRIPTION
## Summary
- reuse the persisted local workspace path after create/import instead of continuing to use the raw folder-picker path
- add focused regression coverage for the Windows case where the picker/root string differs from the canonical persisted workspace path
- keep starter-session materialization, workspace activation, and empty-session fallback aligned to the same local root

## Why
On Windows, the folder picker can return a path string that does not exactly match the canonical local workspace path persisted by Tauri/OpenWork (for example `C:/...` vs `C:\...`, or raw picker output vs normalized persisted root).

The new-workspace flow kept using the raw picker path after creation for:
- host activation
- starter session materialization / polling
- empty session fallback

Session filtering uses exact directory equality in OpenCode, so those follow-up steps could miss the sessions that were just materialized under the persisted workspace root. That explains the symptoms where a newly created workspace showed no prepopulated starter sessions and then behaved as if session creation was broken.

## What changed
- added `resolveCreatedLocalWorkspacePath()` in `apps/app/src/app/lib/workspace-path.ts`
- updated `apps/app/src/app/context/workspace.ts` to pivot from the raw picker path to the persisted workspace path after create/import before continuing the workflow
- added `apps/app/scripts/workspace-path.ts` and `pnpm test:workspace-path`

## Verification
Ran from `apps/app`:
- `pnpm typecheck`
- `pnpm test:workspace-path`
- `pnpm test:session-scope`

## Notes
I did **not** run the full Docker + Chrome MCP flow for this PR because the reported bug is Windows-specific and this environment is macOS, so I could not reproduce the real OS boundary here. The focused regression test covers the mismatched-path case directly.