### PR TITLE
feat(workspace): add microsandbox worker option

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,23 @@ Auto-detection can exist as a convenience, but should be tiered and explainable:
 
 The readiness check should be a clear, single command (e.g. `docker info`) and the UI should show the exact error output when it fails.
 
+### Example: MicroSandbox-backed sandboxes (desktop)
+
+When enabling MicroSandbox-backed sandbox mode, prefer an explicit override for the `msb` binary:
+
+- `OPENWORK_MICROSANDBOX_BIN` (absolute path to `msb`)
+
+This keeps the desktop app predictable on systems where GUI PATH resolution differs from shell PATH.
+
+Default expectations:
+
+1. Honor `OPENWORK_MICROSANDBOX_BIN` if set.
+2. Try the process PATH.
+3. On macOS, try the login PATH from `/usr/libexec/path_helper`.
+4. Fall back to well-known locations like `~/.microsandbox/bin/msb`.
+
+The readiness check should be a clear, single command (for example `msb ls --format json`) and the UI should show the exact error output when it fails. On macOS, MicroSandbox should be treated as Apple Silicon-only. On Linux, it should be treated as requiring hardware virtualization (KVM).
+
 ## Minimal use of Tauri
 We move most of the functionality to the openwork server which interfaces mostly with FS and proxies to opencode.
 

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -2528,7 +2528,8 @@ export default function App() {
           workspaceStore.sandboxActiveBackend?.() !== "microsandbox"
         }
         extraWorkerSubmitting={
-          (workspaceStore.sandboxPreflightBusy?.() ?? false) &&
+          ((workspaceStore.sandboxPreflightBusy?.() ?? false) ||
+            (workspaceStore.sandboxCreatePhase?.() ?? "idle") !== "idle") &&
           workspaceStore.sandboxActiveBackend?.() === "microsandbox"
         }
         localDisabled={!isTauriRuntime()}

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -2463,6 +2463,13 @@ export default function App() {
             ? bundlesStore.handleCreateSandboxConfirm
             : undefined
         }
+        onConfirmExtraWorker={
+          isTauriRuntime()
+            ? bundlesStore.handleCreateMicrosandboxConfirm
+            : undefined
+        }
+        workerLabel="Create Docker sandbox"
+        extraWorkerLabel="Create MicroSandbox"
         workerDisabled={(() => {
           if (!isTauriRuntime()) return true;
           if (workspaceStore.sandboxDoctorBusy?.()) return true;
@@ -2516,7 +2523,14 @@ export default function App() {
         onWorkerRetry={() => {
           void workspaceStore.refreshSandboxDoctor?.();
         }}
-        workerSubmitting={workspaceStore.sandboxPreflightBusy?.() ?? false}
+        workerSubmitting={
+          (workspaceStore.sandboxPreflightBusy?.() ?? false) &&
+          workspaceStore.sandboxActiveBackend?.() !== "microsandbox"
+        }
+        extraWorkerSubmitting={
+          (workspaceStore.sandboxPreflightBusy?.() ?? false) &&
+          workspaceStore.sandboxActiveBackend?.() === "microsandbox"
+        }
         localDisabled={!isTauriRuntime()}
         localDisabledReason={
           !isTauriRuntime()

--- a/apps/app/src/app/bundles/skill-destination-modal.tsx
+++ b/apps/app/src/app/bundles/skill-destination-modal.tsx
@@ -51,7 +51,8 @@ export default function SkillDestinationModal(props: {
   const workspaceBadge = (workspace: WorkspaceInfo) => {
     if (
       workspace.workspaceType === "remote" &&
-      (workspace.sandboxBackend === "docker" ||
+      ((workspace.sandboxBackend === "docker" ||
+        workspace.sandboxBackend === "microsandbox") ||
         Boolean(workspace.sandboxRunId?.trim()) ||
         Boolean(workspace.sandboxContainerName?.trim()))
     ) {
@@ -80,7 +81,8 @@ export default function SkillDestinationModal(props: {
 
   const isSandboxWorkspace = (workspace: WorkspaceInfo) =>
     workspace.workspaceType === "remote" &&
-    (workspace.sandboxBackend === "docker" ||
+    ((workspace.sandboxBackend === "docker" ||
+      workspace.sandboxBackend === "microsandbox") ||
       Boolean(workspace.sandboxRunId?.trim()) ||
       Boolean(workspace.sandboxContainerName?.trim()));
 

--- a/apps/app/src/app/bundles/store.ts
+++ b/apps/app/src/app/bundles/store.ts
@@ -662,6 +662,7 @@ export function createBundlesStore(options: {
       const badge =
         workspace.workspaceType === "remote"
           ? workspace.sandboxBackend === "docker" ||
+            workspace.sandboxBackend === "microsandbox" ||
             Boolean(workspace.sandboxRunId?.trim()) ||
             Boolean(workspace.sandboxContainerName?.trim())
             ? "Sandbox"
@@ -805,9 +806,14 @@ export function createBundlesStore(options: {
     }
   };
 
-  const handleCreateSandboxConfirm = async (preset: WorkspacePreset, folder: string | null) => {
+  const handleCreateManagedSandboxConfirm = async (
+    backend: "docker" | "microsandbox",
+    preset: WorkspacePreset,
+    folder: string | null,
+  ) => {
     const request = createWorkspaceRequest();
     const ok = await options.workspaceStore.createSandboxFlow(
+      backend,
       preset,
       folder,
       request
@@ -843,6 +849,16 @@ export function createBundlesStore(options: {
     }
   };
 
+  const handleCreateSandboxConfirm = async (
+    preset: WorkspacePreset,
+    folder: string | null,
+  ) => handleCreateManagedSandboxConfirm("docker", preset, folder);
+
+  const handleCreateMicrosandboxConfirm = async (
+    preset: WorkspacePreset,
+    folder: string | null,
+  ) => handleCreateManagedSandboxConfirm("microsandbox", preset, folder);
+
   return {
     queueBundleLink,
     openDebugBundleRequest,
@@ -866,6 +882,7 @@ export function createBundlesStore(options: {
     openRemoteConnectFromSkillDestination,
     handleCreateWorkspaceConfirm,
     handleCreateSandboxConfirm,
+    handleCreateMicrosandboxConfirm,
     dismissUntrustedBundleWarning,
     confirmUntrustedBundleWarning,
     bundleImportChoice,

--- a/apps/app/src/app/components/session/sidebar.tsx
+++ b/apps/app/src/app/components/session/sidebar.tsx
@@ -292,7 +292,8 @@ export default function SessionSidebar(props: SidebarProps) {
                   const detailLabel = () => workspaceDetailLabel(group.workspace);
                   const isSandboxWorkspace = () =>
                     group.workspace.workspaceType === "remote" &&
-                    (group.workspace.sandboxBackend === "docker" ||
+                    ((group.workspace.sandboxBackend === "docker" ||
+                      group.workspace.sandboxBackend === "microsandbox") ||
                       Boolean(group.workspace.sandboxRunId?.trim()) ||
                       Boolean(group.workspace.sandboxContainerName?.trim()));
                   const sessions = () => group.sessions;

--- a/apps/app/src/app/components/session/workspace-session-list.tsx
+++ b/apps/app/src/app/components/session/workspace-session-list.tsx
@@ -165,6 +165,7 @@ const workspaceLabel = (workspace: WorkspaceInfo) =>
 const workspaceKindLabel = (workspace: WorkspaceInfo) =>
   workspace.workspaceType === "remote"
     ? workspace.sandboxBackend === "docker" ||
+      workspace.sandboxBackend === "microsandbox" ||
       Boolean(workspace.sandboxRunId?.trim()) ||
       Boolean(workspace.sandboxContainerName?.trim())
       ? "Sandbox"

--- a/apps/app/src/app/components/workspace-chip.tsx
+++ b/apps/app/src/app/components/workspace-chip.tsx
@@ -24,7 +24,8 @@ export default function WorkspaceChip(props: {
       : props.workspace.path;
   const isSandboxWorkspace =
     props.workspace.workspaceType === "remote" &&
-    (props.workspace.sandboxBackend === "docker" ||
+    ((props.workspace.sandboxBackend === "docker" ||
+      props.workspace.sandboxBackend === "microsandbox") ||
       Boolean(props.workspace.sandboxRunId?.trim()) ||
       Boolean(props.workspace.sandboxContainerName?.trim()));
   const translate = (key: string) => t(key, currentLocale());

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -83,14 +83,18 @@ export type WorkspaceDebugEvent = {
 
 export type SandboxCreateProgressStepStatus = "pending" | "active" | "done" | "error";
 
+export type LocalSandboxBackend = "docker" | "microsandbox";
+
 export type SandboxCreateProgressStep = {
-  key: "docker" | "workspace" | "sandbox" | "health" | "connect";
+  key: "runtime" | "workspace" | "sandbox" | "health" | "connect";
   label: string;
   status: SandboxCreateProgressStepStatus;
   detail?: string | null;
 };
 
 export type SandboxCreateProgressState = {
+  backend: LocalSandboxBackend;
+  backendLabel: string;
   runId: string;
   startedAt: number;
   stage: string;
@@ -269,6 +273,7 @@ export function createWorkspaceStore(options: {
   const [sandboxDoctorBusy, setSandboxDoctorBusy] = createSignal(false);
   const [sandboxPreflightBusy, setSandboxPreflightBusy] = createSignal(false);
   const [sandboxCreatePhase, setSandboxCreatePhase] = createSignal<SandboxCreatePhase>("idle");
+  const [sandboxActiveBackend, setSandboxActiveBackend] = createSignal<LocalSandboxBackend | null>(null);
 
   const [sandboxCreateProgress, setSandboxCreateProgress] = createSignal<SandboxCreateProgressState | null>(null);
   const [lastSandboxCreateProgress, setLastSandboxCreateProgress] =
@@ -314,6 +319,17 @@ export function createWorkspaceStore(options: {
     const value = String(message ?? "").trim() || "Sandbox failed to start";
     setSandboxCreateProgress((prev) => (prev ? { ...prev, error: value } : prev));
   };
+
+  const sandboxBackendLabel = (backend: LocalSandboxBackend) =>
+    backend === "microsandbox" ? "MicroSandbox" : "Docker";
+
+  const sandboxReadinessLabel = (backend: LocalSandboxBackend) =>
+    `${sandboxBackendLabel(backend)} ready`;
+
+  const sandboxUnavailableMessage = (backend: LocalSandboxBackend) =>
+    backend === "microsandbox"
+      ? "MicroSandbox is required for this worker. Install it and try again."
+      : "Docker is required for sandboxes. Install Docker Desktop, start it, then retry.";
 
   const makeRunId = () => {
     if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -1315,17 +1331,21 @@ export function createWorkspaceStore(options: {
     }
   }
 
-  async function refreshSandboxDoctor() {
+  async function refreshManagedSandboxDoctor(backend: LocalSandboxBackend) {
     if (!isTauriRuntime()) {
-      setSandboxDoctorResult(null);
-      setSandboxDoctorCheckedAt(Date.now());
+      if (backend === "docker") {
+        setSandboxDoctorResult(null);
+        setSandboxDoctorCheckedAt(Date.now());
+      }
       return null;
     }
     if (sandboxDoctorBusy()) return sandboxDoctorResult();
     setSandboxDoctorBusy(true);
     try {
-      const result = await sandboxDoctor();
-      setSandboxDoctorResult(result);
+      const result = await sandboxDoctor(backend);
+      if (backend === "docker") {
+        setSandboxDoctorResult(result);
+      }
       return result;
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
@@ -1336,12 +1356,20 @@ export function createWorkspaceStore(options: {
         ready: false,
         error: message,
       };
-      setSandboxDoctorResult(fallback);
+      if (backend === "docker") {
+        setSandboxDoctorResult(fallback);
+      }
       return fallback;
     } finally {
-      setSandboxDoctorCheckedAt(Date.now());
+      if (backend === "docker") {
+        setSandboxDoctorCheckedAt(Date.now());
+      }
       setSandboxDoctorBusy(false);
     }
+  }
+
+  async function refreshSandboxDoctor() {
+    return await refreshManagedSandboxDoctor("docker");
   }
 
   async function activateWorkspace(
@@ -2241,6 +2269,7 @@ export function createWorkspaceStore(options: {
   }
 
   async function createSandboxFlow(
+    backend: LocalSandboxBackend,
     preset: WorkspacePreset,
     folder: string | null,
     input?: { onReady?: () => Promise<void> | void },
@@ -2257,22 +2286,26 @@ export function createWorkspaceStore(options: {
 
     const runId = makeRunId();
     const startedAt = Date.now();
+    const backendLabel = sandboxBackendLabel(backend);
+    setSandboxActiveBackend(backend);
     setSandboxCreatePhase("preflight");
     setSandboxPreflightBusy(true);
     options.setError(null);
     clearSandboxCreateProgress();
 
-    const doctor = await refreshSandboxDoctor();
+    const doctor = await refreshManagedSandboxDoctor(backend);
     setSandboxPreflightBusy(false);
     setSandboxCreatePhase("provisioning");
     setSandboxCreateProgress({
+      backend,
+      backendLabel,
       runId,
       startedAt,
-      stage: "Checking Docker...",
+      stage: `Checking ${backendLabel}...`,
       error: null,
       logs: [],
       steps: [
-        { key: "docker", label: "Docker ready", status: "active", detail: null },
+        { key: "runtime", label: sandboxReadinessLabel(backend), status: "active", detail: null },
         { key: "workspace", label: "Prepare worker", status: "pending", detail: null },
         { key: "sandbox", label: "Start sandbox services", status: "pending", detail: null },
         { key: "health", label: "Wait for OpenWork", status: "pending", detail: null },
@@ -2283,35 +2316,35 @@ export function createWorkspaceStore(options: {
     if (doctor?.debug) {
       const selectedBin = doctor.debug.selectedBin?.trim();
       if (selectedBin) {
-        pushSandboxCreateLog(`Docker binary: ${selectedBin}`);
+        pushSandboxCreateLog(`${backendLabel} binary: ${selectedBin}`);
       }
       const candidates = (doctor.debug.candidates ?? []).filter((item) => item?.trim());
       if (candidates.length) {
-        pushSandboxCreateLog(`Docker candidates: ${candidates.join(", ")}`);
+        pushSandboxCreateLog(`${backendLabel} candidates: ${candidates.join(", ")}`);
       }
       const versionDebug = doctor.debug.versionCommand;
       if (versionDebug) {
-        pushSandboxCreateLog(`docker --version exit=${versionDebug.status}`);
-        if (versionDebug.stderr?.trim()) pushSandboxCreateLog(`docker --version stderr: ${versionDebug.stderr.trim()}`);
+        const versionLabel = backend === "microsandbox" ? "msb --version" : "docker --version";
+        pushSandboxCreateLog(`${versionLabel} exit=${versionDebug.status}`);
+        if (versionDebug.stderr?.trim()) pushSandboxCreateLog(`${versionLabel} stderr: ${versionDebug.stderr.trim()}`);
       }
       const infoDebug = doctor.debug.infoCommand;
       if (infoDebug) {
-        pushSandboxCreateLog(`docker info exit=${infoDebug.status}`);
-        if (infoDebug.stderr?.trim()) pushSandboxCreateLog(`docker info stderr: ${infoDebug.stderr.trim()}`);
+        const infoLabel = backend === "microsandbox" ? "msb ls --format json" : "docker info";
+        pushSandboxCreateLog(`${infoLabel} exit=${infoDebug.status}`);
+        if (infoDebug.stderr?.trim()) pushSandboxCreateLog(`${infoLabel} stderr: ${infoDebug.stderr.trim()}`);
       }
     }
     if (!doctor?.ready) {
-      const detail =
-        doctor?.error?.trim() ||
-        "Docker is required for sandboxes. Install Docker Desktop, start it, then retry.";
+      const detail = doctor?.error?.trim() || sandboxUnavailableMessage(backend);
       options.setError(detail);
-      setSandboxStep("docker", { status: "error", detail });
+      setSandboxStep("runtime", { status: "error", detail });
       setSandboxError(detail);
-      setSandboxStage("Docker not ready");
+      setSandboxStage(`${backendLabel} not ready`);
       setSandboxCreatePhase("idle");
       return false;
     }
-    setSandboxStep("docker", { status: "done", detail: doctor.serverVersion ?? null });
+    setSandboxStep("runtime", { status: "done", detail: doctor.serverVersion ?? doctor.clientVersion ?? null });
     setSandboxStage("Preparing worker...");
 
     try {
@@ -2391,20 +2424,40 @@ export function createWorkspaceStore(options: {
               }
             }
 
-            if (stage === "docker.config") {
-              const selected = String(payload.payload?.openworkDockerBin ?? "").trim();
+            if (stage === "docker.config" || stage === "microsandbox.config") {
+              const selected = String(
+                stage === "microsandbox.config"
+                  ? payload.payload?.openworkMicrosandboxBin
+                  : payload.payload?.openworkDockerBin ?? "",
+              ).trim();
               if (selected) {
-                pushSandboxCreateLog(`OPENWORK_DOCKER_BIN=${selected}`);
+                pushSandboxCreateLog(
+                  stage === "microsandbox.config"
+                    ? `OPENWORK_MICROSANDBOX_BIN=${selected}`
+                    : `OPENWORK_DOCKER_BIN=${selected}`,
+                );
               }
-              const resolved = String(payload.payload?.resolvedDockerBin ?? "").trim();
+              const resolved = String(
+                stage === "microsandbox.config"
+                  ? payload.payload?.resolvedMicrosandboxBin
+                  : payload.payload?.resolvedDockerBin ?? "",
+              ).trim();
               if (resolved) {
-                pushSandboxCreateLog(`Resolved docker: ${resolved}`);
+                pushSandboxCreateLog(
+                  stage === "microsandbox.config"
+                    ? `Resolved MicroSandbox: ${resolved}`
+                    : `Resolved docker: ${resolved}`,
+                );
               }
               const candidates = Array.isArray(payload.payload?.candidates)
                 ? payload.payload.candidates.filter((item: unknown) => String(item ?? "").trim())
                 : [];
               if (candidates.length) {
-                pushSandboxCreateLog(`Docker probe paths: ${candidates.join(", ")}`);
+                pushSandboxCreateLog(
+                  stage === "microsandbox.config"
+                    ? `MicroSandbox probe paths: ${candidates.join(", ")}`
+                    : `Docker probe paths: ${candidates.join(", ")}`,
+                );
               }
             }
 
@@ -2442,7 +2495,7 @@ export function createWorkspaceStore(options: {
 
         const host = await orchestratorStartDetached({
           workspacePath: resolvedFolder,
-          sandboxBackend: "docker",
+          sandboxBackend: backend,
           runId,
         });
         setSandboxStep("sandbox", { status: "done", detail: host.sandboxContainerName ?? null });
@@ -2458,7 +2511,7 @@ export function createWorkspaceStore(options: {
           openworkHostToken: host.hostToken,
           directory: resolvedFolder,
           displayName: name,
-          sandboxBackend: host.sandboxBackend ?? "docker",
+          sandboxBackend: host.sandboxBackend ?? backend,
           sandboxRunId: host.sandboxRunId ?? runId,
           sandboxContainerName: host.sandboxContainerName ?? null,
           manageBusy: false,
@@ -2497,6 +2550,7 @@ export function createWorkspaceStore(options: {
     } finally {
       setSandboxPreflightBusy(false);
       setSandboxCreatePhase("idle");
+      setSandboxActiveBackend(null);
     }
   }
 
@@ -2511,7 +2565,7 @@ export function createWorkspaceStore(options: {
     closeModal?: boolean;
 
     // Sandbox lifecycle metadata (desktop-managed)
-    sandboxBackend?: "docker" | null;
+    sandboxBackend?: LocalSandboxBackend | null;
     sandboxRunId?: string | null;
     sandboxContainerName?: string | null;
   }) {
@@ -2567,7 +2621,7 @@ export function createWorkspaceStore(options: {
       } catch (error) {
         // Sandbox workers can report healthy before listWorkspaces is fully ready.
         // Fall back to host-level OpenCode URL so the worker can still be registered.
-        if (input.sandboxBackend !== "docker") {
+        if (!input.sandboxBackend) {
           throw error;
         }
         wsDebug("sandbox:openwork-resolve-fallback:error", {
@@ -2582,7 +2636,7 @@ export function createWorkspaceStore(options: {
         openworkWorkspace = resolved.workspace;
         resolvedHostUrl = resolved.hostUrl;
         resolvedAuth = resolved.auth;
-      } else if (input.sandboxBackend === "docker") {
+      } else if (input.sandboxBackend) {
         resolvedHostUrl = hostUrl;
         resolvedBaseUrl = `${hostUrl.replace(/\/+$/, "")}/opencode`;
         resolvedDirectory = directory || resolvedDirectory;
@@ -2982,7 +3036,9 @@ export function createWorkspaceStore(options: {
       }
 
       const isSandboxWorkspace =
-        workspace.sandboxBackend === "docker" || Boolean(workspace.sandboxContainerName?.trim());
+        workspace.sandboxBackend === "docker" ||
+        workspace.sandboxBackend === "microsandbox" ||
+        Boolean(workspace.sandboxContainerName?.trim());
 
       if (!isSandboxWorkspace) {
         return Boolean(await reconnect());
@@ -3005,17 +3061,18 @@ export function createWorkspaceStore(options: {
         return false;
       }
 
-      const doctor = await refreshSandboxDoctor();
+      const backend = workspace.sandboxBackend ?? "docker";
+      const backendLabel = sandboxBackendLabel(backend);
+      const doctor = await refreshManagedSandboxDoctor(backend);
       if (!doctor?.ready) {
         const detail =
-          doctor?.error?.trim() ||
-          "Docker needs to be running before we can get this worker back online.";
+          doctor?.error?.trim() || `${backendLabel} needs to be running before we can get this worker back online.`;
         throw new Error(detail);
       }
 
       const host = await orchestratorStartDetached({
         workspacePath,
-        sandboxBackend: "docker",
+        sandboxBackend: backend,
         runId: workspace.sandboxRunId?.trim() || null,
         openworkToken:
           workspace.openworkClientToken?.trim() ||
@@ -3046,7 +3103,7 @@ export function createWorkspaceStore(options: {
         openworkHostToken: host.hostToken,
         openworkWorkspaceId: resolved.workspace.id,
         openworkWorkspaceName: resolved.workspace.name ?? workspace.openworkWorkspaceName ?? null,
-        sandboxBackend: host.sandboxBackend ?? "docker",
+        sandboxBackend: host.sandboxBackend ?? backend,
         sandboxRunId: host.sandboxRunId ?? workspace.sandboxRunId ?? null,
         sandboxContainerName: host.sandboxContainerName ?? workspace.sandboxContainerName ?? null,
       });
@@ -3086,6 +3143,7 @@ export function createWorkspaceStore(options: {
 
     const workspace = workspaces().find((entry) => entry.id === id) ?? null;
     const containerName = workspace?.sandboxContainerName?.trim() ?? "";
+    const backend = workspace?.sandboxBackend === "microsandbox" ? "microsandbox" : "docker";
     if (!containerName) {
       options.setError("Sandbox container name missing.");
       return;
@@ -3097,7 +3155,7 @@ export function createWorkspaceStore(options: {
     options.setError(null);
 
     try {
-      const result = await sandboxStop(containerName);
+      const result = await sandboxStop(containerName, backend);
       if (!result.ok) {
         const details = [result.stderr?.trim(), result.stdout?.trim()]
           .filter(Boolean)
@@ -4067,6 +4125,7 @@ export function createWorkspaceStore(options: {
     sandboxDoctorBusy,
     sandboxPreflightBusy,
     sandboxCreatePhase,
+    sandboxActiveBackend,
     projectDir,
     workspaces,
     selectedWorkspaceId,

--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -2287,13 +2287,16 @@ export function createWorkspaceStore(options: {
     const runId = makeRunId();
     const startedAt = Date.now();
     const backendLabel = sandboxBackendLabel(backend);
+    const usesRuntimeDoctor = backend === "docker";
     setSandboxActiveBackend(backend);
-    setSandboxCreatePhase("preflight");
-    setSandboxPreflightBusy(true);
+    setSandboxCreatePhase(usesRuntimeDoctor ? "preflight" : "provisioning");
+    setSandboxPreflightBusy(usesRuntimeDoctor);
     options.setError(null);
     clearSandboxCreateProgress();
 
-    const doctor = await refreshManagedSandboxDoctor(backend);
+    const doctor = usesRuntimeDoctor
+      ? await refreshManagedSandboxDoctor(backend)
+      : null;
     setSandboxPreflightBusy(false);
     setSandboxCreatePhase("provisioning");
     setSandboxCreateProgress({
@@ -2301,7 +2304,9 @@ export function createWorkspaceStore(options: {
       backendLabel,
       runId,
       startedAt,
-      stage: `Checking ${backendLabel}...`,
+      stage: usesRuntimeDoctor
+        ? `Checking ${backendLabel}...`
+        : `Preparing ${backendLabel} runtime...`,
       error: null,
       logs: [],
       steps: [
@@ -2335,7 +2340,7 @@ export function createWorkspaceStore(options: {
         if (infoDebug.stderr?.trim()) pushSandboxCreateLog(`${infoLabel} stderr: ${infoDebug.stderr.trim()}`);
       }
     }
-    if (!doctor?.ready) {
+    if (usesRuntimeDoctor && !doctor?.ready) {
       const detail = doctor?.error?.trim() || sandboxUnavailableMessage(backend);
       options.setError(detail);
       setSandboxStep("runtime", { status: "error", detail });
@@ -2344,8 +2349,15 @@ export function createWorkspaceStore(options: {
       setSandboxCreatePhase("idle");
       return false;
     }
-    setSandboxStep("runtime", { status: "done", detail: doctor.serverVersion ?? doctor.clientVersion ?? null });
-    setSandboxStage("Preparing worker...");
+    if (usesRuntimeDoctor) {
+      setSandboxStep("runtime", {
+        status: "done",
+        detail: doctor?.serverVersion ?? doctor?.clientVersion ?? null,
+      });
+      setSandboxStage("Preparing worker...");
+    } else {
+      pushSandboxCreateLog("MicroSandbox runtime is managed by OpenWork.");
+    }
 
     try {
       const resolvedFolder = await resolveWorkspacePath(folder);
@@ -2498,6 +2510,9 @@ export function createWorkspaceStore(options: {
           sandboxBackend: backend,
           runId,
         });
+        if (!usesRuntimeDoctor) {
+          setSandboxStep("runtime", { status: "done", detail: "Managed by OpenWork" });
+        }
         setSandboxStep("sandbox", { status: "done", detail: host.sandboxContainerName ?? null });
         setSandboxStep("health", { status: "done" });
         setSandboxStage("Connecting to sandbox...");
@@ -2544,6 +2559,9 @@ export function createWorkspaceStore(options: {
     } catch (e) {
       const message = e instanceof Error ? e.message : safeStringify(e);
       options.setError(addOpencodeCacheHint(message));
+      if (!usesRuntimeDoctor) {
+        setSandboxStep("runtime", { status: "error", detail: message });
+      }
       setSandboxError(message);
       setSandboxStage("Sandbox failed");
       return false;
@@ -3062,12 +3080,14 @@ export function createWorkspaceStore(options: {
       }
 
       const backend = workspace.sandboxBackend ?? "docker";
-      const backendLabel = sandboxBackendLabel(backend);
-      const doctor = await refreshManagedSandboxDoctor(backend);
-      if (!doctor?.ready) {
-        const detail =
-          doctor?.error?.trim() || `${backendLabel} needs to be running before we can get this worker back online.`;
-        throw new Error(detail);
+      if (backend === "docker") {
+        const backendLabel = sandboxBackendLabel(backend);
+        const doctor = await refreshManagedSandboxDoctor(backend);
+        if (!doctor?.ready) {
+          const detail =
+            doctor?.error?.trim() || `${backendLabel} needs to be running before we can get this worker back online.`;
+          throw new Error(detail);
+        }
       }
 
       const host = await orchestratorStartDetached({

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -15,7 +15,10 @@ export type OpenworkServerCapabilities = {
   mcp: { read: boolean; write: boolean };
   commands: { read: boolean; write: boolean };
   config: { read: boolean; write: boolean };
-  sandbox?: { enabled: boolean; backend: "none" | "docker" | "container" };
+  sandbox?: {
+    enabled: boolean;
+    backend: "none" | "docker" | "container" | "microsandbox";
+  };
   proxy?: { opencode: boolean; opencodeRouter: boolean };
   toolProviders?: {
     browser?: {

--- a/apps/app/src/app/lib/tauri.ts
+++ b/apps/app/src/app/lib/tauri.ts
@@ -124,7 +124,7 @@ export type WorkspaceInfo = {
   openworkWorkspaceName?: string | null;
 
   // Sandbox lifecycle metadata (desktop-managed)
-  sandboxBackend?: "docker" | null;
+  sandboxBackend?: "docker" | "microsandbox" | null;
   sandboxRunId?: string | null;
   sandboxContainerName?: string | null;
 };
@@ -210,7 +210,7 @@ export async function workspaceCreateRemote(input: {
   openworkWorkspaceName?: string | null;
 
   // Sandbox lifecycle metadata (desktop-managed)
-  sandboxBackend?: "docker" | null;
+  sandboxBackend?: "docker" | "microsandbox" | null;
   sandboxRunId?: string | null;
   sandboxContainerName?: string | null;
 }): Promise<WorkspaceList> {
@@ -245,7 +245,7 @@ export async function workspaceUpdateRemote(input: {
   openworkWorkspaceName?: string | null;
 
   // Sandbox lifecycle metadata (desktop-managed)
-  sandboxBackend?: "docker" | null;
+  sandboxBackend?: "docker" | "microsandbox" | null;
   sandboxRunId?: string | null;
   sandboxContainerName?: string | null;
 }): Promise<WorkspaceList> {
@@ -441,14 +441,14 @@ export type OrchestratorDetachedHost = {
   ownerToken?: string | null;
   hostToken: string;
   port: number;
-  sandboxBackend?: "docker" | null;
+  sandboxBackend?: "docker" | "microsandbox" | null;
   sandboxRunId?: string | null;
   sandboxContainerName?: string | null;
 };
 
 export async function orchestratorStartDetached(input: {
   workspacePath: string;
-  sandboxBackend?: "none" | "docker" | null;
+  sandboxBackend?: "none" | "docker" | "microsandbox" | null;
   runId?: string | null;
   openworkToken?: string | null;
   openworkHostToken?: string | null;
@@ -486,12 +486,22 @@ export type SandboxDoctorResult = {
   } | null;
 };
 
-export async function sandboxDoctor(): Promise<SandboxDoctorResult> {
-  return invoke<SandboxDoctorResult>("sandbox_doctor");
+export async function sandboxDoctor(
+  sandboxBackend?: "docker" | "microsandbox" | null,
+): Promise<SandboxDoctorResult> {
+  return invoke<SandboxDoctorResult>("sandbox_doctor", {
+    sandboxBackend: sandboxBackend ?? null,
+  });
 }
 
-export async function sandboxStop(containerName: string): Promise<ExecResult> {
-  return invoke<ExecResult>("sandbox_stop", { containerName });
+export async function sandboxStop(
+  containerName: string,
+  sandboxBackend?: "docker" | "microsandbox" | null,
+): Promise<ExecResult> {
+  return invoke<ExecResult>("sandbox_stop", {
+    containerName,
+    sandboxBackend: sandboxBackend ?? null,
+  });
 }
 
 export type OpenworkDockerCleanupResult = {

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -301,6 +301,7 @@ export default function SettingsShell(props: SettingsShellProps) {
   const workspaceKindLabel = (workspace: WorkspaceInfo) =>
     workspace.workspaceType === "remote"
       ? workspace.sandboxBackend === "docker" ||
+        workspace.sandboxBackend === "microsandbox" ||
         Boolean(workspace.sandboxRunId?.trim()) ||
         Boolean(workspace.sandboxContainerName?.trim())
         ? "Sandbox"

--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -336,7 +336,8 @@ const SANDBOX_NETWORK_HINTS = [
 export function isSandboxWorkspace(workspace: WorkspaceInfo) {
   return (
     workspace.workspaceType === "remote" &&
-    (workspace.sandboxBackend === "docker" ||
+    ((workspace.sandboxBackend === "docker" ||
+      workspace.sandboxBackend === "microsandbox") ||
       Boolean(workspace.sandboxRunId?.trim()) ||
       Boolean(workspace.sandboxContainerName?.trim()))
   );
@@ -369,7 +370,10 @@ export function getWorkspaceTaskLoadErrorDisplay(workspace: WorkspaceInfo, error
     };
   }
 
-  const message = "Sandbox is offline. Start Docker Desktop, then test connection.";
+  const message =
+    workspace.sandboxBackend === "microsandbox"
+      ? "Sandbox is offline. Start MicroSandbox, then test connection."
+      : "Sandbox is offline. Start Docker Desktop, then test connection.";
   return {
     tone: "offline" as const,
     label: "Offline",

--- a/apps/app/src/app/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/app/workspace/create-workspace-local-panel.tsx
@@ -41,8 +41,11 @@ export default function CreateWorkspaceLocalPanel(props: {
   confirmLabel?: string;
   workerLabel?: string;
   onConfirmWorker?: (preset: WorkspacePreset, folder: string | null) => void;
+  extraWorkerLabel?: string;
+  onConfirmExtraWorker?: (preset: WorkspacePreset, folder: string | null) => void;
   preset: WorkspacePreset;
   workerSubmitting: boolean;
+  extraWorkerSubmitting: boolean;
   workerDisabled: boolean;
   workerDisabledReason: string | null;
   workerCtaLabel?: string;
@@ -52,6 +55,8 @@ export default function CreateWorkspaceLocalPanel(props: {
   onWorkerRetry?: () => void;
   workerDebugLines: string[];
   progress: {
+    backend?: "docker" | "microsandbox";
+    backendLabel?: string;
     runId: string;
     startedAt: number;
     stage: string;
@@ -176,7 +181,7 @@ export default function CreateWorkspaceLocalPanel(props: {
                     <Show when={!progress().error} fallback={<XCircle size={14} class="text-red-11" />}>
                       <Loader2 size={14} class="animate-spin text-dls-accent" />
                     </Show>
-                    Sandbox setup
+                    {progress().backendLabel || "Sandbox"} setup
                   </div>
                   <div class="mt-1 truncate text-[14px] leading-snug text-dls-text">{progress().stage}</div>
                   <div class="mt-1 font-mono text-[10px] uppercase tracking-wider text-dls-secondary">{props.elapsedSeconds}s</div>
@@ -279,6 +284,22 @@ export default function CreateWorkspaceLocalPanel(props: {
                 <span class="inline-flex items-center gap-2">
                   <Loader2 size={16} class="animate-spin" />
                   {props.translate("dashboard.sandbox_checking_docker")}
+                </span>
+              </Show>
+            </button>
+          </Show>
+          <Show when={props.onConfirmExtraWorker}>
+            <button
+              type="button"
+              onClick={() => props.onConfirmExtraWorker?.(props.preset, props.selectedFolder)}
+              disabled={!props.selectedFolder || props.submitting || props.extraWorkerSubmitting}
+              title={!props.selectedFolder ? props.translate("dashboard.choose_folder_continue") : undefined}
+              class={pillSecondaryClass}
+            >
+              <Show when={props.extraWorkerSubmitting} fallback={props.extraWorkerLabel ?? "Create MicroSandbox"}>
+                <span class="inline-flex items-center gap-2">
+                  <Loader2 size={16} class="animate-spin" />
+                  Checking MicroSandbox…
                 </span>
               </Show>
             </button>

--- a/apps/app/src/app/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/app/workspace/create-workspace-local-panel.tsx
@@ -299,7 +299,7 @@ export default function CreateWorkspaceLocalPanel(props: {
               <Show when={props.extraWorkerSubmitting} fallback={props.extraWorkerLabel ?? "Create MicroSandbox"}>
                 <span class="inline-flex items-center gap-2">
                   <Loader2 size={16} class="animate-spin" />
-                  Checking MicroSandbox…
+                  Starting MicroSandbox…
                 </span>
               </Show>
             </button>

--- a/apps/app/src/app/workspace/create-workspace-modal.tsx
+++ b/apps/app/src/app/workspace/create-workspace-modal.tsx
@@ -534,8 +534,11 @@ export default function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
           confirmLabel={props.confirmLabel}
           workerLabel={props.workerLabel}
           onConfirmWorker={props.onConfirmWorker}
+          extraWorkerLabel={props.extraWorkerLabel}
+          onConfirmExtraWorker={props.onConfirmExtraWorker}
           preset={preset()}
           workerSubmitting={workerSubmitting()}
+          extraWorkerSubmitting={props.extraWorkerSubmitting ?? false}
           workerDisabled={workerDisabled()}
           workerDisabledReason={workerDisabledReason()}
           workerCtaLabel={props.workerCtaLabel}

--- a/apps/app/src/app/workspace/types.ts
+++ b/apps/app/src/app/workspace/types.ts
@@ -15,6 +15,8 @@ export type RemoteWorkspaceInput = {
 };
 
 export type CreateWorkspaceProgress = {
+  backend?: "docker" | "microsandbox";
+  backendLabel?: string;
   runId: string;
   startedAt: number;
   stage: string;
@@ -34,6 +36,7 @@ export type CreateWorkspaceModalProps = {
   onConfirm: (preset: WorkspacePreset, folder: string | null) => void;
   onConfirmRemote?: (input: RemoteWorkspaceInput) => Promise<boolean> | boolean | void;
   onConfirmWorker?: (preset: WorkspacePreset, folder: string | null) => void;
+  onConfirmExtraWorker?: (preset: WorkspacePreset, folder: string | null) => void;
   onConfirmTemplate?: (
     template: DenTemplate,
     preset: WorkspacePreset,
@@ -61,6 +64,8 @@ export type CreateWorkspaceModalProps = {
   onWorkerRetry?: () => void;
   workerDebugLines?: string[];
   workerSubmitting?: boolean;
+  extraWorkerLabel?: string;
+  extraWorkerSubmitting?: boolean;
   submittingProgress?: CreateWorkspaceProgress | null;
   localDisabled?: boolean;
   localDisabledReason?: string | null;

--- a/apps/desktop/src-tauri/src/commands/orchestrator.rs
+++ b/apps/desktop/src-tauri/src/commands/orchestrator.rs
@@ -371,8 +371,91 @@ fn resolve_docker_candidates() -> Vec<PathBuf> {
         .collect()
 }
 
+fn microsandbox_platform_error() -> Option<String> {
+    if cfg!(target_os = "windows") {
+        return Some("MicroSandbox is not available on Windows yet.".to_string());
+    }
+    if cfg!(target_os = "macos") && !cfg!(target_arch = "aarch64") {
+        return Some("MicroSandbox on macOS requires Apple Silicon (M-series).".to_string());
+    }
+    None
+}
+
+fn resolve_microsandbox_candidates() -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+
+    for key in ["OPENWORK_MICROSANDBOX_BIN", "MICROSANDBOX_BIN", "MSB_BIN"] {
+        if let Some(value) = env::var_os(key) {
+            let raw = value.to_string_lossy().trim().to_string();
+            if !raw.is_empty() {
+                let path = PathBuf::from(raw);
+                if seen.insert(path.clone()) {
+                    out.push(path);
+                }
+            }
+        }
+    }
+
+    if let Some(paths) = env::var_os("PATH") {
+        for dir in env::split_paths(&paths) {
+            let candidate = dir.join("msb");
+            if seen.insert(candidate.clone()) {
+                out.push(candidate);
+            }
+        }
+    }
+
+    if cfg!(target_os = "macos") {
+        if let Ok((status, stdout, _stderr)) =
+            run_local_command("/usr/libexec/path_helper", &["-s"])
+        {
+            if status == 0 {
+                if let Some(path_value) = parse_path_export_value(&stdout) {
+                    for dir in env::split_paths(&path_value) {
+                        let candidate = dir.join("msb");
+                        if seen.insert(candidate.clone()) {
+                            out.push(candidate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for raw in [
+        "/opt/homebrew/bin/msb",
+        "/usr/local/bin/msb",
+        "~/.microsandbox/bin/msb",
+    ] {
+        let expanded = if let Some(stripped) = raw.strip_prefix("~/") {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("~"))
+                .join(stripped)
+        } else {
+            PathBuf::from(raw)
+        };
+        if seen.insert(expanded.clone()) {
+            out.push(expanded);
+        }
+    }
+
+    out.into_iter()
+        .filter(|path| is_executable_file(path))
+        .collect()
+}
+
 fn run_docker_command(args: &[&str], timeout: Duration) -> Result<(i32, String, String), String> {
     let result = run_docker_command_detailed(args, timeout)?;
+    Ok((result.status, result.stdout, result.stderr))
+}
+
+fn run_microsandbox_command(
+    args: &[&str],
+    timeout: Duration,
+) -> Result<(i32, String, String), String> {
+    let result = run_microsandbox_command_detailed(args, timeout)?;
     Ok((result.status, result.stdout, result.stderr))
 }
 
@@ -415,6 +498,44 @@ fn run_docker_command_detailed(
     ))
 }
 
+fn run_microsandbox_command_detailed(
+    args: &[&str],
+    timeout: Duration,
+) -> Result<DockerCommandResult, String> {
+    if let Some(platform_error) = microsandbox_platform_error() {
+        return Err(platform_error);
+    }
+
+    let candidates = resolve_microsandbox_candidates();
+    let mut tried: Vec<String> = candidates
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    tried.push("msb".to_string());
+
+    let mut errors: Vec<String> = Vec::new();
+    for program in tried {
+        match run_local_command_with_timeout(&program, args, timeout) {
+            Ok((status, stdout, stderr)) => {
+                return Ok(DockerCommandResult {
+                    status,
+                    stdout,
+                    stderr,
+                    program,
+                })
+            }
+            Err(err) => errors.push(err),
+        }
+    }
+
+    let hint = "Install MicroSandbox with `curl -fsSL https://install.microsandbox.dev | sh`, or set OPENWORK_MICROSANDBOX_BIN to your msb binary";
+    Err(format!(
+        "Failed to run MicroSandbox CLI: {} ({})",
+        errors.join("; "),
+        hint
+    ))
+}
+
 fn parse_docker_client_version(stdout: &str) -> Option<String> {
     // Example: "Docker version 26.1.1, build 4cf5afa"
     let line = stdout.lines().next().unwrap_or("").trim();
@@ -436,6 +557,14 @@ fn parse_docker_server_version(stdout: &str) -> Option<String> {
         }
     }
     None
+}
+
+fn parse_microsandbox_version(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .map(|line| line.trim())
+        .find(|line| !line.is_empty())
+        .map(|line| line.to_string())
 }
 
 fn truncate_for_debug(input: &str) -> String {
@@ -817,20 +946,29 @@ pub fn orchestrator_start_detached(
         .trim()
         .to_lowercase();
     let wants_docker_sandbox = sandbox_backend == "docker";
+    let wants_microsandbox = sandbox_backend == "microsandbox";
+    let wants_managed_sandbox = wants_docker_sandbox || wants_microsandbox;
     let sandbox_run_id = run_id
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| Uuid::new_v4().to_string());
-    let sandbox_container_name = if wants_docker_sandbox {
+    let sandbox_container_name = if wants_managed_sandbox {
         Some(derive_orchestrator_container_name(&sandbox_run_id))
     } else {
         None
+    };
+    let sandbox_backend_label = if wants_docker_sandbox {
+        "docker"
+    } else if wants_microsandbox {
+        "microsandbox"
+    } else {
+        "none"
     };
     eprintln!(
         "[sandbox-create][at={start_ts}][runId={}][stage=entry] workspacePath={} sandboxBackend={} container={}",
         sandbox_run_id,
         workspace_path,
-        if wants_docker_sandbox { "docker" } else { "none" },
+        sandbox_backend_label,
         sandbox_container_name.as_deref().unwrap_or("<none>")
     );
 
@@ -854,7 +992,7 @@ pub fn orchestrator_start_detached(
             "workspacePath": workspace_path,
             "openworkUrl": openwork_url,
             "port": port,
-            "sandboxBackend": if wants_docker_sandbox { "docker" } else { "none" },
+            "sandboxBackend": sandbox_backend_label,
             "containerName": sandbox_container_name,
         }),
     );
@@ -872,10 +1010,34 @@ pub fn orchestrator_start_detached(
             "Inspecting Docker configuration...",
             json!({
                 "candidateCount": candidates.len(),
+                "candidates": candidates,
                 "resolvedDockerBin": resolved,
+                "openworkDockerBin": env::var("OPENWORK_DOCKER_BIN").ok(),
                 "hasOpenworkDockerBinOverride": env::var("OPENWORK_DOCKER_BIN").ok().is_some(),
                 "hasOpenwrkDockerBinOverride": env::var("OPENWRK_DOCKER_BIN").ok().is_some(),
                 "hasDockerBinOverride": env::var("DOCKER_BIN").ok().is_some(),
+            }),
+        );
+    }
+    if wants_microsandbox {
+        let candidates = resolve_microsandbox_candidates()
+            .into_iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        let resolved = candidates.first().cloned();
+        emit_sandbox_progress(
+            &app,
+            &sandbox_run_id,
+            "microsandbox.config",
+            "Inspecting MicroSandbox configuration...",
+            json!({
+                "candidateCount": candidates.len(),
+                "candidates": candidates,
+                "resolvedMicrosandboxBin": resolved,
+                "openworkMicrosandboxBin": env::var("OPENWORK_MICROSANDBOX_BIN").ok(),
+                "hasOpenworkMicrosandboxBinOverride": env::var("OPENWORK_MICROSANDBOX_BIN").ok().is_some(),
+                "hasMicrosandboxBinOverride": env::var("MICROSANDBOX_BIN").ok().is_some(),
+                "hasMsbBinOverride": env::var("MSB_BIN").ok().is_some(),
             }),
         );
     }
@@ -903,9 +1065,9 @@ pub fn orchestrator_start_detached(
             sandbox_run_id.clone(),
         ];
 
-        if wants_docker_sandbox {
+        if wants_managed_sandbox {
             args.push("--sandbox".to_string());
-            args.push("docker".to_string());
+            args.push(sandbox_backend_label.to_string());
         }
 
         // Convert to &str for the shell command builder.
@@ -927,6 +1089,9 @@ pub fn orchestrator_start_detached(
                 "hasDockerOverrides": env::var("OPENWORK_DOCKER_BIN").ok().is_some()
                     || env::var("OPENWRK_DOCKER_BIN").ok().is_some()
                     || env::var("DOCKER_BIN").ok().is_some(),
+                "hasMicrosandboxOverrides": env::var("OPENWORK_MICROSANDBOX_BIN").ok().is_some()
+                    || env::var("MICROSANDBOX_BIN").ok().is_some()
+                    || env::var("MSB_BIN").ok().is_some(),
             }),
         );
 
@@ -965,7 +1130,13 @@ pub fn orchestrator_start_detached(
         }),
     );
 
-    let health_timeout_ms = if wants_docker_sandbox { 90_000 } else { 12_000 };
+    let health_timeout_ms = if wants_docker_sandbox {
+        90_000
+    } else if wants_microsandbox {
+        20_000
+    } else {
+        12_000
+    };
     let start = Instant::now();
     let mut last_tick = Instant::now() - Duration::from_secs(5);
     let mut last_container_check = Instant::now() - Duration::from_secs(10);
@@ -1115,12 +1286,12 @@ pub fn orchestrator_start_detached(
         owner_token,
         host_token,
         port,
-        sandbox_backend: if wants_docker_sandbox {
-            Some("docker".to_string())
+        sandbox_backend: if wants_managed_sandbox {
+            Some(sandbox_backend_label.to_string())
         } else {
             None
         },
-        sandbox_run_id: if wants_docker_sandbox {
+        sandbox_run_id: if wants_managed_sandbox {
             Some(sandbox_run_id)
         } else {
             None
@@ -1129,20 +1300,161 @@ pub fn orchestrator_start_detached(
     })
 }
 
-#[tauri::command]
-pub fn sandbox_doctor() -> SandboxDoctorResult {
+fn sandbox_doctor_for_backend(backend: &str) -> SandboxDoctorResult {
     let doctor_start = Instant::now();
-    eprintln!("[sandbox-doctor][at={}] start", now_ms());
-    let candidates = resolve_docker_candidates()
-        .into_iter()
-        .map(|p| p.to_string_lossy().to_string())
-        .collect::<Vec<_>>();
+    let normalized = backend.trim().to_ascii_lowercase();
+    let use_microsandbox = normalized == "microsandbox";
+    eprintln!(
+        "[sandbox-doctor][at={}] start backend={}",
+        now_ms(),
+        if use_microsandbox {
+            "microsandbox"
+        } else {
+            "docker"
+        }
+    );
+    let candidates = if use_microsandbox {
+        resolve_microsandbox_candidates()
+            .into_iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+    } else {
+        resolve_docker_candidates()
+            .into_iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+    };
     let mut debug = SandboxDoctorDebug {
         candidates,
         selected_bin: None,
         version_command: None,
         info_command: None,
     };
+
+    if use_microsandbox {
+        if let Some(platform_error) = microsandbox_platform_error() {
+            return SandboxDoctorResult {
+                installed: false,
+                daemon_running: false,
+                permission_ok: false,
+                ready: false,
+                client_version: None,
+                server_version: None,
+                error: Some(platform_error),
+                debug: Some(debug),
+            };
+        }
+
+        let version =
+            match run_microsandbox_command_detailed(&["--version"], Duration::from_secs(2)) {
+                Ok(result) => result,
+                Err(err) => {
+                    eprintln!(
+                        "[sandbox-doctor][at={}][elapsed={}ms] msb --version failed: {}",
+                        now_ms(),
+                        doctor_start.elapsed().as_millis(),
+                        err
+                    );
+                    return SandboxDoctorResult {
+                        installed: false,
+                        daemon_running: false,
+                        permission_ok: false,
+                        ready: false,
+                        client_version: None,
+                        server_version: None,
+                        error: Some(err),
+                        debug: Some(debug),
+                    };
+                }
+            };
+
+        debug.selected_bin = Some(version.program.clone());
+        debug.version_command = Some(SandboxDoctorCommandDebug {
+            status: version.status,
+            stdout: truncate_for_debug(&version.stdout),
+            stderr: truncate_for_debug(&version.stderr),
+        });
+
+        if version.status != 0 {
+            return SandboxDoctorResult {
+                installed: false,
+                daemon_running: false,
+                permission_ok: false,
+                ready: false,
+                client_version: None,
+                server_version: None,
+                error: Some(format!(
+                    "msb --version failed (status {}): {}",
+                    version.status,
+                    version.stderr.trim()
+                )),
+                debug: Some(debug),
+            };
+        }
+
+        let client_version = parse_microsandbox_version(&version.stdout);
+        let info = match run_microsandbox_command_detailed(
+            &["ls", "--format", "json"],
+            Duration::from_secs(8),
+        ) {
+            Ok(result) => result,
+            Err(err) => {
+                eprintln!(
+                    "[sandbox-doctor][at={}][elapsed={}ms] msb ls failed: {}",
+                    now_ms(),
+                    doctor_start.elapsed().as_millis(),
+                    err
+                );
+                return SandboxDoctorResult {
+                    installed: true,
+                    daemon_running: false,
+                    permission_ok: false,
+                    ready: false,
+                    client_version,
+                    server_version: None,
+                    error: Some(err),
+                    debug: Some(debug),
+                };
+            }
+        };
+
+        debug.info_command = Some(SandboxDoctorCommandDebug {
+            status: info.status,
+            stdout: truncate_for_debug(&info.stdout),
+            stderr: truncate_for_debug(&info.stderr),
+        });
+
+        if info.status == 0 {
+            return SandboxDoctorResult {
+                installed: true,
+                daemon_running: true,
+                permission_ok: true,
+                ready: true,
+                client_version,
+                server_version: None,
+                error: None,
+                debug: Some(debug),
+            };
+        }
+
+        let combined = format!("{}\n{}", info.stdout.trim(), info.stderr.trim())
+            .trim()
+            .to_string();
+        return SandboxDoctorResult {
+            installed: true,
+            daemon_running: false,
+            permission_ok: false,
+            ready: false,
+            client_version,
+            server_version: None,
+            error: Some(if combined.is_empty() {
+                format!("msb ls failed (status {})", info.status)
+            } else {
+                combined
+            }),
+            debug: Some(debug),
+        };
+    }
 
     let version = match run_docker_command_detailed(&["--version"], Duration::from_secs(2)) {
         Ok(result) => result,
@@ -1301,7 +1613,19 @@ pub fn sandbox_doctor() -> SandboxDoctorResult {
 }
 
 #[tauri::command]
-pub fn sandbox_stop(container_name: String) -> Result<ExecResult, String> {
+pub fn sandbox_doctor(sandbox_backend: Option<String>) -> SandboxDoctorResult {
+    let backend = sandbox_backend
+        .unwrap_or_else(|| "docker".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    sandbox_doctor_for_backend(&backend)
+}
+
+#[tauri::command]
+pub fn sandbox_stop(
+    container_name: String,
+    sandbox_backend: Option<String>,
+) -> Result<ExecResult, String> {
     let name = container_name.trim().to_string();
     if name.is_empty() {
         return Err("containerName is required".to_string());
@@ -1319,7 +1643,15 @@ pub fn sandbox_stop(container_name: String) -> Result<ExecResult, String> {
         return Err("containerName contains invalid characters".to_string());
     }
 
-    let (status, stdout, stderr) = run_docker_command(&["stop", &name], Duration::from_secs(15))?;
+    let backend = sandbox_backend
+        .unwrap_or_else(|| "docker".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    let (status, stdout, stderr) = if backend == "microsandbox" {
+        run_microsandbox_command(&["stop", &name], Duration::from_secs(15))?
+    } else {
+        run_docker_command(&["stop", &name], Duration::from_secs(15))?
+    };
     Ok(ExecResult {
         ok: status == 0,
         status,
@@ -1387,7 +1719,7 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
             run_id,
             workspace_path,
             ready: false,
-            doctor: sandbox_doctor(),
+            doctor: sandbox_doctor(None),
             detached_host: None,
             docker_inspect: None,
             docker_logs: None,
@@ -1402,7 +1734,7 @@ pub fn sandbox_debug_probe(app: AppHandle) -> SandboxDebugProbeResult {
         };
     }
 
-    let doctor = sandbox_doctor();
+    let doctor = sandbox_doctor(None);
     let mut detached_host: Option<OrchestratorDetachedHost> = None;
     let mut docker_inspect: Option<SandboxDoctorCommandDebug> = None;
     let mut docker_logs: Option<SandboxDoctorCommandDebug> = None;
@@ -1707,7 +2039,7 @@ exit 0
         let _docker_alt = EnvGuard::unset("OPENWRK_DOCKER_BIN");
         let _docker_bin = EnvGuard::unset("DOCKER_BIN");
 
-        let result = sandbox_doctor();
+        let result = sandbox_doctor(None);
         assert!(result.installed);
         assert!(result.ready);
         assert_eq!(result.server_version.as_deref(), Some("0.0.0"));

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -47,6 +47,7 @@
     "@opencode-ai/sdk": "^1.1.31",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
+    "microsandbox": "0.3.7",
     "opencode-router": "0.11.198",
     "openwork-server": "0.11.198",
     "solid-js": "1.9.9"

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -41,6 +41,15 @@ import { once } from "node:events";
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { TuiHandle } from "./tui/app.js";
 
+const microsandboxRequire = createRequire(import.meta.url);
+const {
+  Sandbox: MicroSandbox,
+  Mount: MicroSandboxMount,
+  NetworkPolicy: MicroSandboxNetworkPolicy,
+  install: installMicrosandboxRuntime,
+  isInstalled: isMicrosandboxRuntimeInstalled,
+} = microsandboxRequire("microsandbox") as typeof import("microsandbox");
+
 type ApprovalMode = "manual" | "auto";
 
 type SandboxMode =
@@ -1118,74 +1127,26 @@ function microsandboxPlatformError(): string | null {
   return null;
 }
 
-async function resolveMicrosandboxCandidates(): Promise<string[]> {
-  const out: string[] = [];
-  const seen = new Set<string>();
-  const push = (value: string) => {
-    const trimmed = value.trim();
-    if (!trimmed || seen.has(trimmed)) return;
-    seen.add(trimmed);
-    out.push(trimmed);
-  };
+let microsandboxInstallPromise: Promise<void> | null = null;
 
-  for (const key of [
-    "OPENWORK_MICROSANDBOX_BIN",
-    "MICROSANDBOX_BIN",
-    "MSB_BIN",
-  ]) {
-    const value = process.env[key];
-    if (value) push(value);
-  }
-
-  const addFromPath = (value?: string | null) => {
-    if (!value) return;
-    for (const dir of value.split(delimiter)) {
-      if (!dir.trim()) continue;
-      push(join(dir, "msb"));
-    }
-  };
-
-  addFromPath(process.env.PATH ?? "");
-
-  if (process.platform === "darwin") {
-    const helperPaths = await readPathHelperPaths();
-    for (const dir of helperPaths) {
-      push(join(dir, "msb"));
-    }
-  }
-
-  for (const raw of [
-    "/opt/homebrew/bin/msb",
-    "/usr/local/bin/msb",
-    join(homedir(), ".microsandbox", "bin", "msb"),
-  ]) {
-    push(raw);
-  }
-
-  const valid: string[] = [];
-  for (const candidate of out) {
-    if (await isExecutable(candidate)) {
-      valid.push(candidate);
-    }
-  }
-  return valid;
-}
-
-async function resolveMicrosandboxCommand(): Promise<string> {
-  const candidates = await resolveMicrosandboxCandidates();
-  return candidates[0] ?? "msb";
-}
-
-async function ensureMicrosandboxSystemReady(
-  microsandboxCommand: string,
-): Promise<void> {
+async function ensureMicrosandboxSystemReady(logger?: Logger): Promise<void> {
   const platformError = microsandboxPlatformError();
   if (platformError) {
     throw new Error(platformError);
   }
-  if (!(await probeCommand(microsandboxCommand, ["--version"]))) {
+  if (isMicrosandboxRuntimeInstalled()) {
+    return;
+  }
+  if (!microsandboxInstallPromise) {
+    logger?.info("Installing MicroSandbox runtime", undefined, "sandbox");
+    microsandboxInstallPromise = installMicrosandboxRuntime().finally(() => {
+      microsandboxInstallPromise = null;
+    });
+  }
+  await microsandboxInstallPromise;
+  if (!isMicrosandboxRuntimeInstalled()) {
     throw new Error(
-      "MicroSandbox CLI not found. Install it with `curl -fsSL https://install.microsandbox.dev | sh`, or set OPENWORK_MICROSANDBOX_BIN to the full msb path.",
+      "MicroSandbox runtime is still unavailable after automatic installation.",
     );
   }
 }
@@ -4119,18 +4080,15 @@ async function stopAppleContainer(name: string): Promise<void> {
   });
 }
 
-async function stopMicrosandbox(
-  name: string,
-  microsandboxCommand: string,
-): Promise<void> {
+async function stopMicrosandbox(name: string): Promise<void> {
   if (!name.trim()) return;
-  await new Promise<void>((resolve) => {
-    const child = spawnProcess(microsandboxCommand, ["stop", name], {
-      stdio: ["ignore", "ignore", "ignore"],
-    });
-    child.on("error", () => resolve());
-    child.on("exit", () => resolve());
-  });
+  try {
+    await ensureMicrosandboxSystemReady();
+    const handle = await MicroSandbox.get(name);
+    await handle.stop();
+  } catch {
+    // ignore stop failures to match docker/container behavior
+  }
 }
 
 async function runQuiet(
@@ -4382,18 +4340,6 @@ async function writeSandboxEntrypoint(options: {
   await writeFile(options.entrypointHostPath, `${script}\n`, "utf8");
 }
 
-async function writeSandboxSecretEnvFile(
-  filePath: string,
-  values: Record<string, string | undefined>,
-): Promise<void> {
-  const lines = Object.entries(values)
-    .filter(([, value]) => typeof value === "string" && value.length > 0)
-    .map(([key, value]) => `export ${key}=${shQuote(value!)}`);
-  if (!lines.length) return;
-  await writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
-  await chmod(filePath, 0o600);
-}
-
 async function stageMicrosandboxCopy(
   sourcePath: string,
   targetPath: string,
@@ -4411,8 +4357,8 @@ async function stageMicrosandboxCopy(
 async function prepareMicrosandboxHostMounts(options: {
   baseDir: string;
   extraMounts: SandboxMount[];
-}): Promise<Array<{ hostPath: string; guestPath: string }>> {
-  const mounts: Array<{ hostPath: string; guestPath: string }> = [];
+}): Promise<Array<{ hostPath: string; guestPath: string; readonly: boolean }>> {
+  const mounts: Array<{ hostPath: string; guestPath: string; readonly: boolean }> = [];
   const hostMountRoot = join(options.baseDir, "microsandbox-host");
   await mkdir(hostMountRoot, { recursive: true });
 
@@ -4425,6 +4371,7 @@ async function prepareMicrosandboxHostMounts(options: {
     mounts.push({
       hostPath: staged,
       guestPath: SANDBOX_OPENCODE_GLOBAL_CONFIG_CONTAINER_PATH,
+      readonly: true,
     });
   }
 
@@ -4437,6 +4384,7 @@ async function prepareMicrosandboxHostMounts(options: {
     mounts.push({
       hostPath: staged,
       guestPath: SANDBOX_OPENCODE_GLOBAL_DATA_IMPORT_CONTAINER_PATH,
+      readonly: true,
     });
   }
 
@@ -4453,7 +4401,11 @@ async function prepareMicrosandboxHostMounts(options: {
           ),
         )
       : mount.hostPath;
-    mounts.push({ hostPath, guestPath: mount.containerPath });
+    mounts.push({
+      hostPath,
+      guestPath: mount.containerPath,
+      readonly: mount.readonly,
+    });
   }
 
   return mounts;
@@ -4836,7 +4788,6 @@ async function startAppleContainerSandbox(options: {
 
 async function startMicrosandboxSandbox(options: {
   image: string;
-  microsandboxCommand: string;
   containerName: string;
   workspace: string;
   persistDir: string;
@@ -4869,8 +4820,13 @@ async function startMicrosandboxSandbox(options: {
   logFormat: LogFormat;
   detach: boolean;
   logger: Logger;
-}): Promise<{ child: ReturnType<typeof spawn>; cleanup: () => Promise<void> }> {
-  await ensureMicrosandboxSystemReady(options.microsandboxCommand);
+}): Promise<{ child?: ReturnType<typeof spawn>; cleanup: () => Promise<void> }> {
+  if (!options.detach) {
+    throw new Error(
+      "MicroSandbox-backed OpenWork workers currently require detached startup.",
+    );
+  }
+  await ensureMicrosandboxSystemReady(options.logger);
 
   const staged = await stageSandboxRuntime({
     persistDir: options.persistDir,
@@ -4879,23 +4835,12 @@ async function startMicrosandboxSandbox(options: {
     detach: options.detach,
   });
 
-  const secretEnvHostPath = join(staged.baseDir, "sandbox-secrets.env");
-  const secretEnvPathInContainer = `${staged.rootInContainer}/sandbox-secrets.env`;
-  await writeSandboxSecretEnvFile(secretEnvHostPath, {
-    OPENWORK_TOKEN: options.openwork.token,
-    OPENWORK_HOST_TOKEN: options.openwork.hostToken,
-    OPENCODE_SERVER_USERNAME: options.opencode.username,
-    OPENCODE_SERVER_PASSWORD: options.opencode.password,
-    OPENWORK_OPENCODE_USERNAME: options.openwork.opencodeUsername,
-    OPENWORK_OPENCODE_PASSWORD: options.openwork.opencodePassword,
-  });
-
   await writeSandboxEntrypoint({
     entrypointHostPath: staged.entrypointHostPath,
     rootInContainer: staged.rootInContainer,
     opencodeConfigDirInContainer: "/opencode-config",
     backend: "microsandbox",
-    secretEnvPathInContainer,
+    secretEnvPathInContainer: null,
     opencode: options.opencode,
     openwork: {
       token: options.openwork.token,
@@ -4918,67 +4863,65 @@ async function startMicrosandboxSandbox(options: {
     extraMounts: options.extraMounts,
   });
 
-  const args: string[] = [
-    "run",
-    "--replace",
-    "--name",
-    options.containerName,
-    "-p",
-    `${options.ports.openwork}:${SANDBOX_INTERNAL_OPENWORK_PORT}`,
-    "-v",
-    `${options.workspace}:/workspace`,
-    "-v",
-    `${options.persistDir}:/persist`,
-    "-v",
-    `${options.opencodeConfigDir}:/opencode-config`,
-  ];
-
-  if (options.sidecars.opencodeRouter && options.ports.opencodeRouterHealth) {
-    args.push(
-      "-p",
-      `${options.ports.opencodeRouterHealth}:${SANDBOX_INTERNAL_OPENCODE_ROUTER_HEALTH_PORT}`,
-    );
-  }
-
-  for (const mount of preparedMounts) {
-    args.push("-v", `${mount.hostPath}:${mount.guestPath}`);
-  }
-
-  if (options.detach) {
-    args.push("-d");
-  }
-
   const scriptInContainer = `${staged.rootInContainer}/entrypoint.sh`;
-  args.push(options.image, "--", "sh", scriptInContainer);
+  const volumes: Record<string, import("microsandbox").MountConfig> = {
+    "/workspace": MicroSandboxMount.bind(options.workspace),
+    "/persist": MicroSandboxMount.bind(options.persistDir),
+    "/opencode-config": MicroSandboxMount.bind(options.opencodeConfigDir),
+  };
+  for (const mount of preparedMounts) {
+    volumes[mount.guestPath] = MicroSandboxMount.bind(mount.hostPath, {
+      readonly: mount.readonly,
+    });
+  }
 
-  options.logger.debug("sandbox: microsandbox run", {
-    microsandboxCommand: options.microsandboxCommand,
-    args,
+  const ports: Record<string, number> = {
+    [String(options.ports.openwork)]: SANDBOX_INTERNAL_OPENWORK_PORT,
+  };
+  if (options.sidecars.opencodeRouter && options.ports.opencodeRouterHealth) {
+    ports[String(options.ports.opencodeRouterHealth)] =
+      SANDBOX_INTERNAL_OPENCODE_ROUTER_HEALTH_PORT;
+  }
+
+  options.logger.debug("sandbox: microsandbox createDetached", {
     containerName: options.containerName,
     workspace: options.workspace,
     persistDir: options.persistDir,
+    ports,
+    volumeCount: Object.keys(volumes).length,
   });
 
-  const child = spawnProcess(options.microsandboxCommand, args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: { ...process.env },
+  await MicroSandbox.createDetached({
+    name: options.containerName,
+    image: options.image,
+    replace: true,
+    cpus: 2,
+    memoryMib: 2048,
+    shell: "/bin/sh",
+    cmd: ["sh", scriptInContainer],
+    env: {
+      OPENWORK_TOKEN: options.openwork.token,
+      OPENWORK_HOST_TOKEN: options.openwork.hostToken,
+      ...(options.opencode.username
+        ? { OPENCODE_SERVER_USERNAME: options.opencode.username }
+        : {}),
+      ...(options.opencode.password
+        ? { OPENCODE_SERVER_PASSWORD: options.opencode.password }
+        : {}),
+      ...(options.openwork.opencodeUsername
+        ? { OPENWORK_OPENCODE_USERNAME: options.openwork.opencodeUsername }
+        : {}),
+      ...(options.openwork.opencodePassword
+        ? { OPENWORK_OPENCODE_PASSWORD: options.openwork.opencodePassword }
+        : {}),
+    },
+    volumes,
+    ports,
+    network: MicroSandboxNetworkPolicy.allowAll(),
+    quietLogs: false,
   });
-  prefixStream(
-    child.stdout,
-    "sandbox",
-    "stdout",
-    options.logger,
-    child.pid ?? undefined,
-  );
-  prefixStream(
-    child.stderr,
-    "sandbox",
-    "stderr",
-    options.logger,
-    child.pid ?? undefined,
-  );
 
-  return { child, cleanup: staged.cleanup };
+  return { cleanup: staged.cleanup };
 }
 
 async function verifyOpenCodeRouterVersion(
@@ -7355,17 +7298,13 @@ async function runStart(args: ParsedArgs) {
   }
   const dockerCommand =
     sandboxMode === "docker" ? await resolveDockerCommand() : null;
-  const microsandboxCommand =
-    sandboxMode === "microsandbox"
-      ? await resolveMicrosandboxCommand()
-      : null;
   logVerbose(`cli version: ${cliVersion}`);
   logVerbose(`sandbox: ${sandboxMode}`);
   if (dockerCommand) {
     logVerbose(`docker bin: ${dockerCommand}`);
   }
-  if (microsandboxCommand) {
-    logVerbose(`microsandbox bin: ${microsandboxCommand}`);
+  if (sandboxMode === "microsandbox") {
+    logVerbose(`microsandbox runtime: sdk`);
   }
   if (sandboxMode !== "none") {
     logVerbose(`sandbox image: ${sandboxImage}`);
@@ -7416,7 +7355,7 @@ async function runStart(args: ParsedArgs) {
       }
     }
     if (sandboxMode === "microsandbox") {
-      await ensureMicrosandboxSystemReady(microsandboxCommand ?? "msb");
+      await ensureMicrosandboxSystemReady(logger);
     }
   }
   const opencodeRouterMode = await resolveOpencodeRouterEnabled(
@@ -8214,15 +8153,14 @@ async function runStart(args: ParsedArgs) {
         sandboxMode === "container"
           ? stopAppleContainer
           : sandboxMode === "microsandbox"
-            ? (name: string) =>
-                stopMicrosandbox(name, microsandboxCommand ?? "msb")
+            ? stopMicrosandbox
           : (name: string) =>
               stopDockerContainer(name, dockerCommand ?? "docker");
       sandboxStopCommand =
         sandboxMode === "container"
           ? "container stop"
           : sandboxMode === "microsandbox"
-            ? `${microsandboxCommand ?? "msb"} stop`
+            ? "microsandbox sdk stop"
             : "docker stop";
       const opencodeInternalBaseUrl = `http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`;
 
@@ -8273,7 +8211,6 @@ async function runStart(args: ParsedArgs) {
           : sandboxMode === "microsandbox"
             ? await startMicrosandboxSandbox({
                 image: sandboxImage,
-                microsandboxCommand: microsandboxCommand ?? "msb",
                 containerName,
                 workspace: resolvedWorkspace,
                 persistDir: sandboxPersistDir,
@@ -8369,7 +8306,7 @@ async function runStart(args: ParsedArgs) {
         tui?.updateService("router", { status: "running", port: undefined });
       }
 
-      if (!detachRequested) {
+      if (!detachRequested && sandboxChild.child) {
         children.push({ name: "sandbox", child: sandboxChild.child });
         logger.info(
           "Process spawned",

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -43,9 +43,14 @@ import type { TuiHandle } from "./tui/app.js";
 
 type ApprovalMode = "manual" | "auto";
 
-type SandboxMode = "none" | "auto" | "docker" | "container";
+type SandboxMode =
+  | "none"
+  | "auto"
+  | "docker"
+  | "container"
+  | "microsandbox";
 
-type ResolvedSandboxMode = "none" | "docker" | "container";
+type ResolvedSandboxMode = "none" | "docker" | "container" | "microsandbox";
 
 type LogFormat = "pretty" | "json";
 
@@ -575,12 +580,13 @@ function readSandboxMode(
     normalized === "none" ||
     normalized === "auto" ||
     normalized === "docker" ||
-    normalized === "container"
+    normalized === "container" ||
+    normalized === "microsandbox"
   ) {
     return normalized as SandboxMode;
   }
   throw new Error(
-    `Invalid ${key} value: ${raw}. Use none|auto|docker|container.`,
+    `Invalid ${key} value: ${raw}. Use none|auto|docker|container|microsandbox.`,
   );
 }
 
@@ -1100,6 +1106,88 @@ async function resolveDockerCandidates(): Promise<string[]> {
 async function resolveDockerCommand(): Promise<string> {
   const candidates = await resolveDockerCandidates();
   return candidates[0] ?? "docker";
+}
+
+function microsandboxPlatformError(): string | null {
+  if (process.platform === "win32") {
+    return "MicroSandbox is not available on Windows yet.";
+  }
+  if (process.platform === "darwin" && process.arch !== "arm64") {
+    return "MicroSandbox on macOS requires Apple Silicon (M-series).";
+  }
+  return null;
+}
+
+async function resolveMicrosandboxCandidates(): Promise<string[]> {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    out.push(trimmed);
+  };
+
+  for (const key of [
+    "OPENWORK_MICROSANDBOX_BIN",
+    "MICROSANDBOX_BIN",
+    "MSB_BIN",
+  ]) {
+    const value = process.env[key];
+    if (value) push(value);
+  }
+
+  const addFromPath = (value?: string | null) => {
+    if (!value) return;
+    for (const dir of value.split(delimiter)) {
+      if (!dir.trim()) continue;
+      push(join(dir, "msb"));
+    }
+  };
+
+  addFromPath(process.env.PATH ?? "");
+
+  if (process.platform === "darwin") {
+    const helperPaths = await readPathHelperPaths();
+    for (const dir of helperPaths) {
+      push(join(dir, "msb"));
+    }
+  }
+
+  for (const raw of [
+    "/opt/homebrew/bin/msb",
+    "/usr/local/bin/msb",
+    join(homedir(), ".microsandbox", "bin", "msb"),
+  ]) {
+    push(raw);
+  }
+
+  const valid: string[] = [];
+  for (const candidate of out) {
+    if (await isExecutable(candidate)) {
+      valid.push(candidate);
+    }
+  }
+  return valid;
+}
+
+async function resolveMicrosandboxCommand(): Promise<string> {
+  const candidates = await resolveMicrosandboxCandidates();
+  return candidates[0] ?? "msb";
+}
+
+async function ensureMicrosandboxSystemReady(
+  microsandboxCommand: string,
+): Promise<void> {
+  const platformError = microsandboxPlatformError();
+  if (platformError) {
+    throw new Error(platformError);
+  }
+  if (!(await probeCommand(microsandboxCommand, ["--version"]))) {
+    throw new Error(
+      "MicroSandbox CLI not found. Install it with `curl -fsSL https://install.microsandbox.dev | sh`, or set OPENWORK_MICROSANDBOX_BIN to the full msb path.",
+    );
+  }
 }
 
 async function ensureWorkspace(workspace: string): Promise<string> {
@@ -1713,7 +1801,7 @@ function resolveSandboxSidecarTarget(
   mode: ResolvedSandboxMode,
 ): SidecarTarget | null {
   if (mode === "none") return resolveSidecarTarget();
-  // Sandbox runs inside Linux (docker / container).
+  // Sandbox runs inside Linux (docker / container / microsandbox).
   if (process.arch === "arm64") return "linux-arm64";
   if (process.arch === "x64") return "linux-x64";
   return null;
@@ -1780,6 +1868,7 @@ async function resolveSandboxMode(
   if (mode === "none") return "none";
   if (mode === "docker") return "docker";
   if (mode === "container") return "container";
+  if (mode === "microsandbox") return "microsandbox";
 
   // auto
   if (process.platform === "darwin" && process.arch === "arm64") {
@@ -3637,7 +3726,7 @@ function printHelp(): void {
     "  --tui                     Force interactive dashboard (TTY only)",
     "  --no-tui                  Disable interactive dashboard",
     "  --detach                  Detach after start and keep services running",
-    "  --sandbox <mode>          none | auto | docker | container (default: none)",
+    "  --sandbox <mode>          none | auto | docker | container | microsandbox (default: none)",
     "  --sandbox-image <ref>     Container image for sandbox mode",
     "  --sandbox-persist-dir <p> Persist dir mounted into sandbox (default: per-workspace)",
     "  --sandbox-mount <specs>   Extra mounts (validated): hostPath:subpath[:ro|rw] (requires allowlist)",
@@ -4030,6 +4119,20 @@ async function stopAppleContainer(name: string): Promise<void> {
   });
 }
 
+async function stopMicrosandbox(
+  name: string,
+  microsandboxCommand: string,
+): Promise<void> {
+  if (!name.trim()) return;
+  await new Promise<void>((resolve) => {
+    const child = spawnProcess(microsandboxCommand, ["stop", name], {
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    child.on("error", () => resolve());
+    child.on("exit", () => resolve());
+  });
+}
+
 async function runQuiet(
   command: string,
   args: string[],
@@ -4147,7 +4250,8 @@ async function writeSandboxEntrypoint(options: {
   entrypointHostPath: string;
   rootInContainer: string;
   opencodeConfigDirInContainer: string;
-  backend: "docker" | "container";
+  backend: "docker" | "container" | "microsandbox";
+  secretEnvPathInContainer?: string | null;
   opencode: {
     corsOrigins: string[];
     username?: string;
@@ -4242,6 +4346,9 @@ async function writeSandboxEntrypoint(options: {
     `export OPENWORK_SANDBOX_ENABLED=1`,
     `export OPENWORK_SANDBOX_BACKEND=${shQuote(options.backend)}`,
     opencodeRouterEnv,
+    options.secretEnvPathInContainer
+      ? `if [ -f ${shQuote(options.secretEnvPathInContainer)} ]; then . ${shQuote(options.secretEnvPathInContainer)}; rm -f ${shQuote(options.secretEnvPathInContainer)} || true; fi`
+      : "",
     requiredSecretEnv,
     'opencode_pid=""',
     'opencodeRouter_pid=""',
@@ -4273,6 +4380,83 @@ async function writeSandboxEntrypoint(options: {
     .join("\n");
 
   await writeFile(options.entrypointHostPath, `${script}\n`, "utf8");
+}
+
+async function writeSandboxSecretEnvFile(
+  filePath: string,
+  values: Record<string, string | undefined>,
+): Promise<void> {
+  const lines = Object.entries(values)
+    .filter(([, value]) => typeof value === "string" && value.length > 0)
+    .map(([key, value]) => `export ${key}=${shQuote(value!)}`);
+  if (!lines.length) return;
+  await writeFile(filePath, `${lines.join("\n")}\n`, "utf8");
+  await chmod(filePath, 0o600);
+}
+
+async function stageMicrosandboxCopy(
+  sourcePath: string,
+  targetPath: string,
+): Promise<string> {
+  const sourceInfo = await stat(sourcePath);
+  await rm(targetPath, { recursive: true, force: true });
+  await mkdir(dirname(targetPath), { recursive: true });
+  await cp(sourcePath, targetPath, {
+    recursive: sourceInfo.isDirectory(),
+    force: true,
+  });
+  return targetPath;
+}
+
+async function prepareMicrosandboxHostMounts(options: {
+  baseDir: string;
+  extraMounts: SandboxMount[];
+}): Promise<Array<{ hostPath: string; guestPath: string }>> {
+  const mounts: Array<{ hostPath: string; guestPath: string }> = [];
+  const hostMountRoot = join(options.baseDir, "microsandbox-host");
+  await mkdir(hostMountRoot, { recursive: true });
+
+  const hostOpencodeConfig = await resolveHostOpencodeGlobalConfigDir();
+  if (hostOpencodeConfig) {
+    const staged = await stageMicrosandboxCopy(
+      hostOpencodeConfig,
+      join(hostMountRoot, "opencode-config"),
+    );
+    mounts.push({
+      hostPath: staged,
+      guestPath: SANDBOX_OPENCODE_GLOBAL_CONFIG_CONTAINER_PATH,
+    });
+  }
+
+  const hostOpencodeData = await resolveHostOpencodeGlobalDataDir();
+  if (hostOpencodeData) {
+    const staged = await stageMicrosandboxCopy(
+      hostOpencodeData,
+      join(hostMountRoot, "opencode-data"),
+    );
+    mounts.push({
+      hostPath: staged,
+      guestPath: SANDBOX_OPENCODE_GLOBAL_DATA_IMPORT_CONTAINER_PATH,
+    });
+  }
+
+  for (const mount of options.extraMounts) {
+    const hostPath = mount.readonly
+      ? await stageMicrosandboxCopy(
+          mount.hostPath,
+          join(
+            hostMountRoot,
+            `readonly-${createHash("sha1")
+              .update(`${mount.containerPath}:${mount.hostPath}`)
+              .digest("hex")
+              .slice(0, 12)}`,
+          ),
+        )
+      : mount.hostPath;
+    mounts.push({ hostPath, guestPath: mount.containerPath });
+  }
+
+  return mounts;
 }
 
 async function startDockerSandbox(options: {
@@ -4323,6 +4507,7 @@ async function startDockerSandbox(options: {
     rootInContainer: staged.rootInContainer,
     opencodeConfigDirInContainer: "/opencode-config",
     backend: "docker",
+    secretEnvPathInContainer: null,
     opencode: options.opencode,
     openwork: {
       token: options.openwork.token,
@@ -4511,6 +4696,7 @@ async function startAppleContainerSandbox(options: {
     rootInContainer: staged.rootInContainer,
     opencodeConfigDirInContainer: "/opencode-config",
     backend: "container",
+    secretEnvPathInContainer: null,
     opencode: options.opencode,
     openwork: {
       token: options.openwork.token,
@@ -4629,6 +4815,153 @@ async function startAppleContainerSandbox(options: {
         ? { OPENWORK_OPENCODE_PASSWORD: options.openwork.opencodePassword }
         : {}),
     },
+  });
+  prefixStream(
+    child.stdout,
+    "sandbox",
+    "stdout",
+    options.logger,
+    child.pid ?? undefined,
+  );
+  prefixStream(
+    child.stderr,
+    "sandbox",
+    "stderr",
+    options.logger,
+    child.pid ?? undefined,
+  );
+
+  return { child, cleanup: staged.cleanup };
+}
+
+async function startMicrosandboxSandbox(options: {
+  image: string;
+  microsandboxCommand: string;
+  containerName: string;
+  workspace: string;
+  persistDir: string;
+  opencodeConfigDir: string;
+  extraMounts: SandboxMount[];
+  sidecars: {
+    opencode: string;
+    openworkServer: string;
+    opencodeRouter?: string | null;
+  };
+  ports: { openwork: number; opencodeRouterHealth?: number | null };
+  opencode: {
+    corsOrigins: string[];
+    username?: string;
+    password?: string;
+    hotReload: OpencodeHotReload;
+  };
+  openwork: {
+    token: string;
+    hostToken: string;
+    approvalMode: ApprovalMode;
+    approvalTimeoutMs: number;
+    readOnly: boolean;
+    corsOrigins: string[];
+    opencodeUsername?: string;
+    opencodePassword?: string;
+    logFormat: LogFormat;
+  };
+  runId: string;
+  logFormat: LogFormat;
+  detach: boolean;
+  logger: Logger;
+}): Promise<{ child: ReturnType<typeof spawn>; cleanup: () => Promise<void> }> {
+  await ensureMicrosandboxSystemReady(options.microsandboxCommand);
+
+  const staged = await stageSandboxRuntime({
+    persistDir: options.persistDir,
+    containerName: options.containerName,
+    sidecars: options.sidecars,
+    detach: options.detach,
+  });
+
+  const secretEnvHostPath = join(staged.baseDir, "sandbox-secrets.env");
+  const secretEnvPathInContainer = `${staged.rootInContainer}/sandbox-secrets.env`;
+  await writeSandboxSecretEnvFile(secretEnvHostPath, {
+    OPENWORK_TOKEN: options.openwork.token,
+    OPENWORK_HOST_TOKEN: options.openwork.hostToken,
+    OPENCODE_SERVER_USERNAME: options.opencode.username,
+    OPENCODE_SERVER_PASSWORD: options.opencode.password,
+    OPENWORK_OPENCODE_USERNAME: options.openwork.opencodeUsername,
+    OPENWORK_OPENCODE_PASSWORD: options.openwork.opencodePassword,
+  });
+
+  await writeSandboxEntrypoint({
+    entrypointHostPath: staged.entrypointHostPath,
+    rootInContainer: staged.rootInContainer,
+    opencodeConfigDirInContainer: "/opencode-config",
+    backend: "microsandbox",
+    secretEnvPathInContainer,
+    opencode: options.opencode,
+    openwork: {
+      token: options.openwork.token,
+      hostToken: options.openwork.hostToken,
+      approvalMode: options.openwork.approvalMode,
+      approvalTimeoutMs: options.openwork.approvalTimeoutMs,
+      readOnly: options.openwork.readOnly,
+      corsOrigins: options.openwork.corsOrigins,
+      opencodeUsername: options.openwork.opencodeUsername,
+      opencodePassword: options.openwork.opencodePassword,
+      logFormat: options.openwork.logFormat,
+      opencodeRouterEnabled: !!options.sidecars.opencodeRouter,
+    },
+    runId: options.runId,
+    logFormat: options.logFormat,
+  });
+
+  const preparedMounts = await prepareMicrosandboxHostMounts({
+    baseDir: staged.baseDir,
+    extraMounts: options.extraMounts,
+  });
+
+  const args: string[] = [
+    "run",
+    "--replace",
+    "--name",
+    options.containerName,
+    "-p",
+    `${options.ports.openwork}:${SANDBOX_INTERNAL_OPENWORK_PORT}`,
+    "-v",
+    `${options.workspace}:/workspace`,
+    "-v",
+    `${options.persistDir}:/persist`,
+    "-v",
+    `${options.opencodeConfigDir}:/opencode-config`,
+  ];
+
+  if (options.sidecars.opencodeRouter && options.ports.opencodeRouterHealth) {
+    args.push(
+      "-p",
+      `${options.ports.opencodeRouterHealth}:${SANDBOX_INTERNAL_OPENCODE_ROUTER_HEALTH_PORT}`,
+    );
+  }
+
+  for (const mount of preparedMounts) {
+    args.push("-v", `${mount.hostPath}:${mount.guestPath}`);
+  }
+
+  if (options.detach) {
+    args.push("-d");
+  }
+
+  const scriptInContainer = `${staged.rootInContainer}/entrypoint.sh`;
+  args.push(options.image, "--", "sh", scriptInContainer);
+
+  options.logger.debug("sandbox: microsandbox run", {
+    microsandboxCommand: options.microsandboxCommand,
+    args,
+    containerName: options.containerName,
+    workspace: options.workspace,
+    persistDir: options.persistDir,
+  });
+
+  const child = spawnProcess(options.microsandboxCommand, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env },
   });
   prefixStream(
     child.stdout,
@@ -7022,10 +7355,17 @@ async function runStart(args: ParsedArgs) {
   }
   const dockerCommand =
     sandboxMode === "docker" ? await resolveDockerCommand() : null;
+  const microsandboxCommand =
+    sandboxMode === "microsandbox"
+      ? await resolveMicrosandboxCommand()
+      : null;
   logVerbose(`cli version: ${cliVersion}`);
   logVerbose(`sandbox: ${sandboxMode}`);
   if (dockerCommand) {
     logVerbose(`docker bin: ${dockerCommand}`);
+  }
+  if (microsandboxCommand) {
+    logVerbose(`microsandbox bin: ${microsandboxCommand}`);
   }
   if (sandboxMode !== "none") {
     logVerbose(`sandbox image: ${sandboxImage}`);
@@ -7074,6 +7414,9 @@ async function runStart(args: ParsedArgs) {
           "Apple container CLI not found. Install https://github.com/apple/container",
         );
       }
+    }
+    if (sandboxMode === "microsandbox") {
+      await ensureMicrosandboxSystemReady(microsandboxCommand ?? "msb");
     }
   }
   const opencodeRouterMode = await resolveOpencodeRouterEnabled(
@@ -7870,10 +8213,17 @@ async function runStart(args: ParsedArgs) {
       sandboxStop =
         sandboxMode === "container"
           ? stopAppleContainer
+          : sandboxMode === "microsandbox"
+            ? (name: string) =>
+                stopMicrosandbox(name, microsandboxCommand ?? "msb")
           : (name: string) =>
               stopDockerContainer(name, dockerCommand ?? "docker");
       sandboxStopCommand =
-        sandboxMode === "container" ? "container stop" : "docker stop";
+        sandboxMode === "container"
+          ? "container stop"
+          : sandboxMode === "microsandbox"
+            ? `${microsandboxCommand ?? "msb"} stop`
+            : "docker stop";
       const opencodeInternalBaseUrl = `http://127.0.0.1:${SANDBOX_INTERNAL_OPENCODE_PORT}`;
 
       const sandboxChild =
@@ -7920,6 +8270,48 @@ async function runStart(args: ParsedArgs) {
               detach: detachRequested,
               logger,
             })
+          : sandboxMode === "microsandbox"
+            ? await startMicrosandboxSandbox({
+                image: sandboxImage,
+                microsandboxCommand: microsandboxCommand ?? "msb",
+                containerName,
+                workspace: resolvedWorkspace,
+                persistDir: sandboxPersistDir,
+                opencodeConfigDir,
+                extraMounts: sandboxExtraMounts,
+                sidecars: {
+                  opencode: opencodeBinary.bin,
+                  openworkServer: openworkServerBinary.bin,
+                  opencodeRouter: opencodeRouterEnabled
+                    ? (opencodeRouterBinary?.bin ?? null)
+                    : null,
+                },
+                ports: {
+                  openwork: openworkPort,
+                  opencodeRouterHealth: null,
+                },
+                opencode: {
+                  corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+                  username: opencodeUsername,
+                  password: opencodePassword,
+                  hotReload: opencodeHotReload,
+                },
+                openwork: {
+                  token: openworkToken,
+                  hostToken: openworkHostToken,
+                  approvalMode: approvalMode === "auto" ? "auto" : "manual",
+                  approvalTimeoutMs,
+                  readOnly,
+                  corsOrigins: corsOrigins.length ? corsOrigins : ["*"],
+                  opencodeUsername,
+                  opencodePassword,
+                  logFormat,
+                },
+                runId,
+                logFormat,
+                detach: detachRequested,
+                logger,
+              })
           : await startDockerSandbox({
               image: sandboxImage,
               dockerCommand: dockerCommand ?? "docker",
@@ -7991,7 +8383,7 @@ async function runStart(args: ParsedArgs) {
           handleSpawnError("sandbox", error),
         );
       } else {
-        // docker run -d exits quickly; the container continues to run.
+        // Detached sandbox launchers exit quickly; the sandbox continues to run.
         logger.info("Sandbox detached", { containerName }, "sandbox");
       }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -738,6 +738,7 @@ function resolveSandboxBackend(): Capabilities["sandbox"]["backend"] {
   const raw = (process.env.OPENWORK_SANDBOX_BACKEND ?? "").trim().toLowerCase();
   if (raw === "docker") return "docker";
   if (raw === "container") return "container";
+  if (raw === "microsandbox") return "microsandbox";
   return "none";
 }
 

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -6,7 +6,7 @@ export type ApprovalMode = "manual" | "auto";
 
 export type TokenScope = "owner" | "collaborator" | "viewer";
 
-export type SandboxBackend = "none" | "docker" | "container";
+export type SandboxBackend = "none" | "docker" | "container" | "microsandbox";
 
 export type ProviderPlacement = "in-sandbox" | "host-machine" | "client-machine" | "external";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@opentui/solid':
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      microsandbox:
+        specifier: 0.3.7
+        version: 0.3.7
       opencode-router:
         specifier: 0.11.198
         version: link:../opencode-router
@@ -2589,6 +2592,24 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@superradcompany/microsandbox-darwin-arm64@0.3.7':
+    resolution: {integrity: sha512-huSPzAqxxUavBmsHAR6cCI8ZIqTvSXF0c58yleEEqND0URtNp7Boc1GvvNAsKER4xZKUhJcpBRokXKV1QP1wCQ==}
+    engines: {node: '>= 18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.3.7':
+    resolution: {integrity: sha512-cdWrhrTK3euIrVHkVVZr1zy0jQ23QmkCWM08vxnt3x3dIyndB62NKks1XrLySHDSnob06yh7v4+kyi8Y6nGiCw==}
+    engines: {node: '>= 18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@superradcompany/microsandbox-linux-x64-gnu@0.3.7':
+    resolution: {integrity: sha512-6rJaNvZyuZOGSx5Ut25R9Of/1oNZ8dlMHW7KqxtY0gjWqwWgdGW7uI2TjRzTa8EORNdLJDDXSuoHTyoVUQxHmA==}
+    engines: {node: '>= 18'}
+    cpu: [x64]
+    os: [linux]
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -3981,6 +4002,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  microsandbox@0.3.7:
+    resolution: {integrity: sha512-o53QxSak1zaJnjynTwIK/zNa3/lh0H6HYXSx9GECvBsSVZRiZbhl9yLPn4ztRhLGLb8DNjtejOIUNG3sih2GQA==}
+    engines: {node: '>= 18'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -7362,6 +7387,15 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@superradcompany/microsandbox-darwin-arm64@0.3.7':
+    optional: true
+
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.3.7':
+    optional: true
+
+  '@superradcompany/microsandbox-linux-x64-gnu@0.3.7':
+    optional: true
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -8639,6 +8673,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  microsandbox@0.3.7:
+    optionalDependencies:
+      '@superradcompany/microsandbox-darwin-arm64': 0.3.7
+      '@superradcompany/microsandbox-linux-arm64-gnu': 0.3.7
+      '@superradcompany/microsandbox-linux-x64-gnu': 0.3.7
 
   mime-db@1.52.0: {}
 


### PR DESCRIPTION
## Summary
- add a second local worker action in the create-workspace flow so desktop users can start MicroSandbox-backed workers alongside the existing Docker sandbox path
- route the MicroSandbox worker path through the OpenWork orchestrator using the microsandbox SDK, including automatic runtime provisioning, instead of requiring users to preinstall msb
- keep Docker-specific readiness checks on the Docker path while letting the MicroSandbox flow provision its own runtime on demand

## Testing
- `pnpm typecheck && pnpm build` in `apps/app`
- `pnpm typecheck && pnpm build && pnpm build:bin` in `apps/orchestrator`
- `pnpm build:bin` in `apps/server`
- `cargo check` in `apps/desktop/src-tauri`

## Validation limits
- I did not run the full desktop/Tauri create-worker flow end to end in this environment.
- I did not force a real MicroSandbox runtime install here, so first-run download behavior still needs live desktop validation.
- Chrome MCP evidence was not captured because this feature is in the desktop-only local worker flow rather than a browser-only surface.