### PR TITLE
fix(session): ignore stale workspace session loads

### DIFF
--- a/apps/app/src/app/context/session.ts
+++ b/apps/app/src/app/context/session.ts
@@ -31,7 +31,7 @@ import {
 import { unwrap } from "../lib/opencode";
 import { abortSessionSafe } from "../lib/opencode-session";
 import { finishPerf, perfNow, recordPerfLog } from "../lib/perf-log";
-import { describeDirectoryScope, toSessionTransportDirectory } from "../lib/session-scope";
+import { describeDirectoryScope, shouldApplyScopedSessionLoad, toSessionTransportDirectory } from "../lib/session-scope";
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "../types";
 
 export type SessionModelState = {
@@ -961,17 +961,18 @@ export function createSessionStore(options: {
   async function loadSessions(scopeRoot?: string) {
     const c = options.client();
     if (!c) return;
+    const requestedRoot = scopeRoot ?? "";
 
     // IMPORTANT: OpenCode's session.list() supports server-side filtering by directory.
     // Use it to avoid fetching every session across every workspace root.
     //
     // Note: Use the same transport path format we send for create/delete so the
     // server-side strict directory equality checks hit the same stored value.
-    const queryDirectory = toSessionTransportDirectory(scopeRoot) || undefined;
+    const queryDirectory = toSessionTransportDirectory(requestedRoot) || undefined;
 
     sessionDebug("sessions:load:request", {
-      scopeRoot: scopeRoot ?? null,
-      scopeScope: describeDirectoryScope(scopeRoot),
+      scopeRoot: requestedRoot || null,
+      scopeScope: describeDirectoryScope(requestedRoot),
       queryDirectory: queryDirectory ?? null,
       queryScope: describeDirectoryScope(queryDirectory),
       selectedWorkspaceRoot: options.selectedWorkspaceRoot?.() ?? null,
@@ -980,8 +981,8 @@ export function createSessionStore(options: {
 
     const start = Date.now();
     sessionDebug("sessions:load:start", {
-      scopeRoot: scopeRoot ?? null,
-      scopeScope: describeDirectoryScope(scopeRoot),
+      scopeRoot: requestedRoot || null,
+      scopeScope: describeDirectoryScope(requestedRoot),
       queryDirectory: queryDirectory ?? null,
       queryScope: describeDirectoryScope(queryDirectory),
     });
@@ -1000,7 +1001,7 @@ export function createSessionStore(options: {
 
     // Defensive client-side filter in case the server returns sessions spanning
     // multiple roots (e.g. older servers or proxies).
-    const root = normalizeDirectoryPath(scopeRoot);
+    const root = normalizeDirectoryPath(requestedRoot);
     const filtered = root
       ? list.filter((session) => normalizeDirectoryPath(session.directory) === root)
       : list;
@@ -1015,6 +1016,22 @@ export function createSessionStore(options: {
       })),
     });
     sessionDebug("sessions:load:filtered", { root: root || null, count: filtered.length });
+
+    const activeWorkspaceRoot = options.selectedWorkspaceRoot?.() ?? "";
+    const shouldApply =
+      options.client() === c
+      && shouldApplyScopedSessionLoad({ loadedScopeRoot: requestedRoot, workspaceRoot: activeWorkspaceRoot });
+    if (!shouldApply) {
+      sessionDebug("sessions:load:stale", {
+        requestedRoot: requestedRoot || null,
+        requestedScope: describeDirectoryScope(requestedRoot),
+        activeWorkspaceRoot: activeWorkspaceRoot || null,
+        activeWorkspaceScope: describeDirectoryScope(activeWorkspaceRoot),
+        clientChanged: options.client() !== c,
+      });
+      return;
+    }
+
     setLoadedScopeRoot(root);
     rememberSessions(filtered);
     setStore("sessions", reconcile(sortSessionsByActivity(filtered), { key: "id" }));


### PR DESCRIPTION
## Summary
- drop stale `loadSessions()` results when the active client changed or the selected workspace root moved before the response came back
- wire the existing scoped-root guard into the live session store so post-switch/new-workspace loads cannot overwrite the current workspace sidebar
- keep the fix small and local to `apps/app/src/app/context/session.ts`

## Why
The previous attempt focused on Windows path persistence, but your latest report points much more strongly to a race: after restart everything looks fine.

That lines up with the current code path: we already had `shouldApplyScopedSessionLoad()` in `session-scope.ts` and tests for stale loads, but `context/session.ts` never actually used that guard when applying a `session.list()` response.

So during a workspace create/switch, an older in-flight session load could finish after the new workspace had already become active and then replace the sidebar/session list with stale data. That can make the freshly created workspace look empty until restart.

## What changed
- `apps/app/src/app/context/session.ts`
  - capture the requested scope root up front
  - after `session.list()` returns, only apply the result if:
    - the client instance is still the same, and
    - the selected workspace root still matches the scope that was requested
  - otherwise log a `sessions:load:stale` debug event and drop the response

## Verification
Ran from `apps/app`:
- `pnpm typecheck`
- `pnpm test:session-scope`

## Notes
- This PR supersedes the earlier path-persistence attempt: the stronger signal here is stale async state rather than persisted root mismatch.
- I did **not** run the Docker + Chrome MCP flow because the reported bug is Windows-specific and this environment is macOS. To verify end-to-end on Windows, please create a new local workspace, confirm the starter sessions appear immediately, and create a new session without restarting the app.