### PR TITLE
Cleanup padding/reduce scrolling on landing page

### DIFF
--- a/apps/app/src/app/components/session/composer.tsx
+++ b/apps/app/src/app/components/session/composer.tsx
@@ -1553,7 +1553,7 @@ export default function Composer(props: ComposerProps) {
 
   return (
     <div
-      class={`sticky bottom-0 z-20 bg-gradient-to-t from-dls-surface via-dls-surface/95 to-transparent px-4 md:px-8 ${props.compactTopSpacing ? "pt-0" : "pt-10"} pb-5`}
+      class={`sticky bottom-0 z-20 bg-gradient-to-t from-dls-surface via-dls-surface/95 to-transparent px-4 md:px-8 ${props.compactTopSpacing ? "pt-0" : "pt-3"} pb-5`}
       style={{ contain: "layout style" }}
     >
       <div class="max-w-[800px] mx-auto">

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -3171,7 +3171,7 @@ export default function SessionView(props: SessionViewProps) {
           <div class="flex-1 flex overflow-hidden">
             <div class="relative min-w-0 flex-1 overflow-hidden bg-dls-surface">
               <div
-                class={`h-full overflow-y-auto px-4 sm:px-6 lg:px-10 ${showWorkspaceSetupEmptyState() ? "pt-20 pb-10" : "pt-10 pb-10"} bg-dls-surface`}
+                class={`h-full overflow-y-auto px-4 sm:px-6 lg:px-10 ${showWorkspaceSetupEmptyState() ? "pt-20" : "pt-10"} bg-dls-surface`}
                 style={{ contain: "layout paint style" }}
                 onWheel={(event) => {
                   sessionScroll.markScrollGesture(event.target);
@@ -3226,7 +3226,7 @@ export default function SessionView(props: SessionViewProps) {
                       !deferSessionRender()
                     }
                   >
-                    <div class="text-center py-16 px-6 space-y-6">
+                    <div class="text-center px-6 space-y-6">
                       <div class="w-16 h-16 bg-dls-hover rounded-3xl mx-auto flex items-center justify-center border border-dls-border">
                         <Zap class="text-dls-secondary" />
                       </div>
@@ -3289,7 +3289,7 @@ export default function SessionView(props: SessionViewProps) {
                       </div>
                     </Show>
 
-                    <div>
+                    <Show when={batchedRenderedMessages().length > 0}>
                       <MessageList
                         messages={batchedRenderedMessages()}
                         isStreaming={showRunIndicator()}
@@ -3343,7 +3343,7 @@ export default function SessionView(props: SessionViewProps) {
                           ) : undefined
                         }
                       />
-                    </div>
+                    </Show>
                   </Show>
                 </div>
               </div>


### PR DESCRIPTION
This PR cleanups up the padding and scrolling state on the initial landing page shown in the screenshot.

Currently, it starts in an ugly state where there is more top padding than needed, and it appears to be mid-scroll.

This PR cleans it up. In addition, it reduces the top padding above the prompt input box.

<img width="3865" height="1577" alt="image" src="https://github.com/user-attachments/assets/89f550e9-703c-434a-88ae-8c935d80fc32" />
