### PR TITLE
fix(app): restore bundle i18n import resolution

### DIFF
--- a/apps/app/src/app/bundles/store.ts
+++ b/apps/app/src/app/bundles/store.ts
@@ -8,7 +8,7 @@ import type {
   WorkspacePreset,
 } from "../types";
 import { normalizeOpenworkServerUrl, parseOpenworkWorkspaceIdFromUrl } from "../lib/openwork-server";
-import { t } from "../i18n";
+import { t } from "../../i18n";
 import { isTauriRuntime, safeStringify, addOpencodeCacheHint } from "../utils";
 import type { WorkspaceStore } from "../context/workspace";
 import type { StartupPreference } from "../types";


### PR DESCRIPTION
## Summary
- point `apps/app/src/app/bundles/store.ts` at the shared `apps/app/src/i18n` module after the app layout move
- restore `vite build` during the desktop `beforeBuildCommand` path so release builds stop failing on the unresolved import

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @openwork/app build`