### PR TITLE
fix(den-web): stop forcing checkout on uncertain signup routing

### DIFF
--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -344,6 +344,14 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     });
   }
 
+  function shouldRouteToCheckout(summary: BillingSummary | null | undefined) {
+    if (!summary) {
+      return false;
+    }
+
+    return summary.featureGateEnabled && summary.checkoutRequired && !summary.hasActivePlan;
+  }
+
   function setAuthMode(mode: AuthMode) {
     setAuthModeState(mode);
     setVerificationRequired(false);
@@ -1057,11 +1065,8 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     persistOnboardingIntent(intent);
     const summary = await refreshBilling({ includeCheckout: true, quiet: true });
-    if (!summary) {
-      return "checkout" as const;
-    }
 
-    return !summary.featureGateEnabled || summary.hasActivePlan ? ("dashboard" as const) : ("checkout" as const);
+    return shouldRouteToCheckout(summary) ? ("checkout" as const) : ("dashboard" as const);
   }
 
   async function resolveUserLandingRoute() {
@@ -1084,11 +1089,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       billingSummary ??
       (billingBusy || billingCheckoutBusy ? null : await refreshBilling({ includeCheckout: true, quiet: true }));
 
-    if (!summary) {
-      return "/checkout";
-    }
-
-    return !summary.featureGateEnabled || summary.hasActivePlan ? (dashboardRoute ?? "/") : "/checkout";
+    return shouldRouteToCheckout(summary) ? "/checkout" : (dashboardRoute ?? "/");
   }
 
   async function submitAuth(event: FormEvent<HTMLFormElement>) {
@@ -1744,15 +1745,10 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
 
     const summary = await refreshBilling({ includeCheckout: false, quiet: true });
-    if (!summary) {
-      return "/checkout" as const;
-    }
 
-    if (!summary.featureGateEnabled || summary.hasActivePlan) {
-      return (await resolveDashboardRoute()) ?? "/";
-    }
-
-    return "/checkout" as const;
+    return shouldRouteToCheckout(summary)
+      ? ("/checkout" as const)
+      : ((await resolveDashboardRoute()) ?? "/");
   }
 
   function selectWorker(item: WorkerListItem) {


### PR DESCRIPTION
## Summary
- only route auth/signup flows to `/checkout` when billing explicitly confirms the base plan is required
- fall back to the org dashboard when billing is still loading or temporarily unavailable, which avoids repeatedly forcing paid users into the $50 checkout screen
- keep the actual paywall enforcement on the backend and on confirmed billing responses

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @openwork-ee/den-web build`
- `pnpm exec tsc -p tsconfig.json --noEmit` (from `ee/apps/den-web`)

## Notes
- I did not run Docker + Chrome MCP for this PR, so the live end-to-end signup flow still needs browser verification.