### PR TITLE
docs: automated documentation updates

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -33,6 +33,17 @@ Where are workflow hosted:
 - Remote via a OpenWork Host (CLI or desktop)
 - Remote on OpenWork Cloud (via Den sandbox workers)
 
+## Current OpenWork Cloud flow
+
+- Users can sign in with the standard web auth providers or accept an org invite through the hosted join flow.
+- Invite signup keeps the invited email fixed, verifies the user by email code, and then drops them into the org join path.
+- Cloud workers are a paid flow: users complete checkout before they can launch hosted workers.
+- After a worker is ready, the user connects from the OpenWork app with `Add a worker` -> `Connect remote`, or opens the generated deep link directly.
+
+## Team distribution
+
+- Organizations can publish shared skill hubs so members discover approved skills from one managed place instead of collecting local-only installs by hand.
+
 ## Actors
 Bob IT guy makes the config.
 Susan the accountant consumes the config.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ OpenWork is designed around the idea that you can easily ship your agentic workf
 
 ## Quick start
 
-Download the correct version in [here](https://openworklabs.com/download), in the latest [releases](https://github.com/different-ai/openwork/releases) or install from source below.
+Download the desktop app from [openworklabs.com/download](https://openworklabs.com/download), grab the latest [GitHub release](https://github.com/different-ai/openwork/releases), or install from source below.
+
+- macOS and Linux downloads are available directly.
+- Windows access is currently handled through the paid support plan on [openworklabs.com/pricing#windows-support](https://openworklabs.com/pricing#windows-support).
+- Hosted OpenWork Cloud workers are launched from the web app after checkout, then connected from the desktop app via `Add a worker` -> `Connect remote`.
 
 ## Why
 
@@ -44,6 +48,7 @@ OpenWork is designed to be:
 - **Execution plan**: render OpenCode todos as a timeline.
 - **Permissions**: surface permission requests and reply (allow once / always / deny).
 - **Templates**: save and re-run common workflows (stored locally).
+- **Debug exports**: copy or export the runtime debug report and developer log stream from Settings -> Debug when you need to file a bug.
 - **Skills manager**:
   - list installed `.opencode/skills` folders
   - import a local skill folder into `.opencode/skills/<skill-name>`
@@ -172,6 +177,8 @@ pnpm test:e2e
 ```
 
 ## Troubleshooting
+
+If you need to report a desktop or session bug, open Settings -> Debug and export both the runtime debug report and developer logs before filing an issue.
 
 ### Linux / Wayland (Hyprland)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,7 +13,10 @@ Use the right channel to get faster help:
 
 - Search existing issues to avoid duplicates.
 - Include exact OpenWork/OpenCode versions, OS, and reproduction steps.
-- Add logs/screenshots when possible.
+- For desktop, worker, or session bugs, open Settings -> Debug and include both:
+  - the runtime debug report
+  - the developer log export
+- Add screenshots when they help explain the flow or failure state.
 
 ## Maintainer triage
 

--- a/ee/apps/den-web/README.md
+++ b/ee/apps/den-web/README.md
@@ -5,10 +5,19 @@ Frontend for `app.openworklabs.com`.
 ## What it does
 
 - Signs up / signs in users against Den service auth.
+- Handles invited-org signup flows where the invited email stays locked and the user verifies access before joining.
 - Launches cloud workers via `POST /v1/workers`.
-- Handles paywall responses (`402 payment_required`) and shows Polar checkout links.
+- Handles paywall responses (`402 payment_required`), routes users through Polar checkout, and only enables worker launch after purchase.
+- Offers desktop handoff actions so users can open the generated worker directly in OpenWork or copy the connect credentials manually.
 - Uses a Next.js proxy route (`/api/den/*`) to reach `api.openworklabs.com` without browser CORS issues.
 - Uses a same-origin auth proxy (`/api/auth/*`) so GitHub OAuth callbacks can land on `app.openworklabs.com`.
+
+## Current hosted user flow
+
+1. Sign in with a standard provider or accept an org invite.
+2. If the org requires billing, complete checkout before launching a worker.
+3. Launch the worker from the cloud dashboard.
+4. Open the worker in the desktop app with the provided deep link, or copy the URL/token into `Connect remote` manually.
 
 ## Local development
 


### PR DESCRIPTION
Docs refresh for 19:00 PDT. This PR updates documentation to match behavior introduced by commits from the last 24 hours.

Commits reviewed:
- b9b0f83a feat(landing): add pricing and paid windows flow
- 9973b8b7 fix(den): streamline org invite signup (#1291)
- 4caf1780 feat(den): add skill hubs and restore den-db migrations (#1285)
- bac16892 feat(debug): capture and export developer logs (#1280)

Why these docs changed:
- Example: b9b0f83a feat(landing): add pricing and paid windows flow changed the previous generic download story into a split flow where macOS/Linux remain direct downloads, Windows is handled through a paid support plan, and hosted workers are launched after checkout, so README.md and ee/apps/den-web/README.md had to be updated because they still described a simpler pre-pricing workflow.
- Example: 9973b8b7 fix(den): streamline org invite signup (#1291) changed the previous Den invite flow into a more explicit invited-email signup and org join path, so PRODUCT.md and ee/apps/den-web/README.md had to be updated because they did not explain the new hosted onboarding behavior.
- Example: 4caf1780 feat(den): add skill hubs and restore den-db migrations (#1285) added organization skill hubs for shared discovery, so PRODUCT.md had to be updated because the product docs still described cloud hosting without the new team distribution surface.
- Example: bac16892 feat(debug): capture and export developer logs (#1280) changed support troubleshooting from vague log gathering to a concrete Settings > Debug export flow, so README.md and SUPPORT.md had to be updated because they still told users only to add logs/screenshots when possible.

Documentation updates in this PR:
- Updated README.md to replace the old generic download and bug-reporting guidance with the current pricing, Windows support, hosted worker checkout, and Settings > Debug export workflow.
- Updated PRODUCT.md to describe the current OpenWork Cloud signup, billing, remote connect, and skill hub workflows.
- Updated SUPPORT.md to point users to the runtime debug report and developer log export.
- Updated ee/apps/den-web/README.md to explain the current hosted auth, checkout, and desktop handoff flow.

Why this merits a docs update:
- Without these changes, the docs would still direct users to older download, signup, and support flows even though the current product now expects checkout-gated worker launch, invited-email signup, shared skill hubs, and exported debug artifacts.