### PR TITLE
feat(den): move paywall to org creation and add org limits

### DIFF
--- a/ee/apps/den-api/src/organization-limits.ts
+++ b/ee/apps/den-api/src/organization-limits.ts
@@ -1,0 +1,143 @@
+import { eq, sql } from "@openwork-ee/den-db/drizzle"
+import { MemberTable, OrganizationTable, WorkerTable } from "@openwork-ee/den-db/schema"
+import { db } from "./db.js"
+
+export const DEFAULT_ORGANIZATION_LIMITS = {
+  members: 5,
+  workers: 1,
+} as const
+
+export type OrganizationLimitType = keyof typeof DEFAULT_ORGANIZATION_LIMITS
+
+export type OrganizationLimits = {
+  members: number
+  workers: number
+}
+
+type OrganizationId = typeof OrganizationTable.$inferSelect.id
+
+export type OrganizationMetadata = {
+  limits: OrganizationLimits
+} & Record<string, unknown>
+
+type OrganizationMetadataInput = Record<string, unknown> | string | null | undefined
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number) {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed
+    }
+  }
+
+  return fallback
+}
+
+function parseMetadata(input: OrganizationMetadataInput): Record<string, unknown> {
+  if (!input) {
+    return {}
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input) as unknown
+      return isRecord(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return isRecord(input) ? input : {}
+}
+
+export function normalizeOrganizationMetadata(input: OrganizationMetadataInput): {
+  metadata: OrganizationMetadata
+  changed: boolean
+} {
+  const parsed = parseMetadata(input)
+  const rawLimits = isRecord(parsed.limits) ? parsed.limits : null
+  const members = normalizePositiveInteger(rawLimits?.members, DEFAULT_ORGANIZATION_LIMITS.members)
+  const workers = normalizePositiveInteger(rawLimits?.workers ?? rawLimits?.Workers, DEFAULT_ORGANIZATION_LIMITS.workers)
+
+  const metadata: OrganizationMetadata = {
+    ...parsed,
+    limits: {
+      members,
+      workers,
+    },
+  } as OrganizationMetadata
+
+  const changed =
+    !isRecord(parsed.limits) ||
+    Object.keys(parsed).length === 0 ||
+    rawLimits?.members !== members ||
+    (rawLimits?.workers ?? rawLimits?.Workers) !== workers
+
+  return { metadata, changed }
+}
+
+export function serializeOrganizationMetadata(metadata: OrganizationMetadataInput) {
+  const parsed = parseMetadata(metadata)
+  return Object.keys(parsed).length > 0 ? JSON.stringify(parsed) : null
+}
+
+export async function getOrInitializeOrganizationMetadata(organizationId: OrganizationId) {
+  const rows = await db
+    .select({ metadata: OrganizationTable.metadata })
+    .from(OrganizationTable)
+    .where(eq(OrganizationTable.id, organizationId))
+    .limit(1)
+
+  const { metadata, changed } = normalizeOrganizationMetadata(rows[0]?.metadata)
+  if (changed) {
+    await db
+      .update(OrganizationTable)
+      .set({ metadata })
+      .where(eq(OrganizationTable.id, organizationId))
+  }
+
+  return metadata
+}
+
+async function countOrganizationMembers(organizationId: OrganizationId) {
+  const rows = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(MemberTable)
+    .where(eq(MemberTable.organizationId, organizationId))
+
+  return Number(rows[0]?.count ?? 0)
+}
+
+async function countOrganizationWorkers(organizationId: OrganizationId) {
+  const rows = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(WorkerTable)
+    .where(eq(WorkerTable.org_id, organizationId))
+
+  return Number(rows[0]?.count ?? 0)
+}
+
+export async function getOrganizationLimitStatus(organizationId: OrganizationId, limitType: OrganizationLimitType) {
+  const metadata = await getOrInitializeOrganizationMetadata(organizationId)
+  const currentCount =
+    limitType === "members"
+      ? await countOrganizationMembers(organizationId)
+      : await countOrganizationWorkers(organizationId)
+
+  const limit = metadata.limits[limitType]
+
+  return {
+    metadata,
+    currentCount,
+    limit,
+    exceeded: currentCount >= limit,
+  }
+}

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -11,6 +11,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
+import { DEFAULT_ORGANIZATION_LIMITS, serializeOrganizationMetadata } from "./organization-limits.js"
 import { denDefaultDynamicOrganizationRoles, denOrganizationStaticRoles } from "./organization-access.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
@@ -401,16 +402,23 @@ async function createOrganizationRecord(input: {
   userId: UserId
   name: string
   logo?: string | null
-  metadata?: string | null
+  metadata?: Record<string, unknown> | null
 }) {
   const organizationId = createDenTypeId("organization")
+  const metadata =
+    input.metadata ?? {
+      limits: {
+        members: DEFAULT_ORGANIZATION_LIMITS.members,
+        workers: DEFAULT_ORGANIZATION_LIMITS.workers,
+      },
+    }
 
   await db.insert(OrganizationTable).values({
     id: organizationId,
     name: input.name,
     slug: organizationId,
     logo: input.logo ?? null,
-    metadata: input.metadata ?? null,
+    metadata,
   })
 
   await db.insert(MemberTable).values({
@@ -511,7 +519,7 @@ export async function listUserOrgs(userId: UserId) {
     name: row.organization.name,
     slug: row.organization.slug,
     logo: row.organization.logo,
-    metadata: row.organization.metadata,
+    metadata: serializeOrganizationMetadata(row.organization.metadata),
     role: row.role,
     orgMemberId: row.membershipId,
     membershipId: row.membershipId,
@@ -524,7 +532,7 @@ export async function resolveUserOrganizations(input: {
   activeOrganizationId?: string | null
   userId: UserId
 }) {
-  await ensurePersonalOrganizationForUser(input.userId)
+  await ensureUserOrgAccess({ userId: input.userId })
 
   const orgs = await listUserOrgs(input.userId)
 
@@ -628,7 +636,7 @@ export async function getOrganizationContextForUser(input: {
       name: organization.name,
       slug: organization.slug,
       logo: organization.logo,
-      metadata: organization.metadata,
+      metadata: serializeOrganizationMetadata(organization.metadata),
       createdAt: organization.createdAt,
       updatedAt: organization.updatedAt,
     },

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -3,7 +3,9 @@ import { OrganizationTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { z } from "zod"
+import { requireCloudWorkerAccess } from "../../billing/polar.js"
 import { db } from "../../db.js"
+import { env } from "../../env.js"
 import { jsonValidator, paramValidator, queryValidator, requireUserMiddleware, resolveMemberTeamsMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { acceptInvitationForUser, createOrganizationForUser, getInvitationPreview, setSessionActiveOrganization } from "../../orgs.js"
 import { getRequiredUserEmail } from "../../user.js"
@@ -27,6 +29,29 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     const user = c.get("user")
     const session = c.get("session")
     const input = c.req.valid("json")
+    const email = getRequiredUserEmail(user)
+
+    if (!email) {
+      return c.json({ error: "user_email_required" }, 400)
+    }
+
+    const access = await requireCloudWorkerAccess({
+      userId: normalizeDenTypeId("user", user.id),
+      email,
+      name: user.name ?? user.email ?? "OpenWork User",
+    })
+
+    if (!access.allowed) {
+      return c.json({
+        error: "payment_required",
+        message: "Creating a workspace requires an active OpenWork Cloud plan.",
+        polar: {
+          checkoutUrl: access.checkoutUrl,
+          productId: env.polar.productId,
+          benefitId: env.polar.benefitId,
+        },
+      }, 402)
+    }
 
     const organizationId = await createOrganizationForUser({
       userId: normalizeDenTypeId("user", user.id),

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 import { db } from "../../db.js"
 import { sendDenOrganizationInvitationEmail } from "../../email.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
+import { getOrganizationLimitStatus } from "../../organization-limits.js"
 import { listAssignableRoles } from "../../orgs.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { buildInvitationLink, createInvitationId, ensureInviteManager, idParamSchema, normalizeRoleName, orgIdParamSchema } from "./shared.js"
@@ -47,6 +48,17 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       return c.json({
         error: "member_exists",
         message: "That email address is already a member of this organization.",
+      }, 409)
+    }
+
+    const memberLimit = await getOrganizationLimitStatus(payload.organization.id, "members")
+    if (memberLimit.exceeded) {
+      return c.json({
+        error: "org_limit_reached",
+        limitType: "members",
+        limit: memberLimit.limit,
+        currentCount: memberLimit.currentCount,
+        message: `This workspace currently supports up to ${memberLimit.limit} members. Contact support to increase the limit.`,
       }, 409)
     }
 

--- a/ee/apps/den-api/src/routes/workers/core.ts
+++ b/ee/apps/den-api/src/routes/workers/core.ts
@@ -3,13 +3,11 @@ import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { db } from "../../db.js"
-import { env } from "../../env.js"
 import { jsonValidator, paramValidator, queryValidator, requireUserMiddleware, resolveUserOrganizationsMiddleware } from "../../middleware/index.js"
-import { getRequiredUserEmail } from "../../user.js"
+import { getOrganizationLimitStatus } from "../../organization-limits.js"
 import type { WorkerRouteVariables } from "./shared.js"
 import {
   continueCloudProvisioning,
-  countUserCloudWorkers,
   createWorkerSchema,
   deleteWorkerCascade,
   getLatestWorkerInstance,
@@ -17,7 +15,6 @@ import {
   getWorkerTokensAndConnect,
   listWorkersQuerySchema,
   parseWorkerIdParam,
-  requireCloudAccessOrPayment,
   toInstanceResponse,
   toWorkerResponse,
   token,
@@ -68,27 +65,16 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
       return c.json({ error: "workspace_path_required" }, 400)
     }
 
-    if (input.destination === "cloud" && !env.devMode && (await countUserCloudWorkers(user.id)) > 0) {
-      const email = getRequiredUserEmail(user)
-      if (!email) {
-        return c.json({ error: "user_email_required" }, 400)
-      }
-
-      const access = await requireCloudAccessOrPayment({
-        userId: user.id,
-        email,
-        name: user.name ?? user.email ?? "OpenWork User",
-      })
-      if (!access.allowed) {
+    if (input.destination === "cloud") {
+      const workerLimit = await getOrganizationLimitStatus(orgId, "workers")
+      if (workerLimit.exceeded) {
         return c.json({
-          error: "payment_required",
-          message: "Additional cloud workers require an active Den Cloud plan.",
-          polar: {
-            checkoutUrl: access.checkoutUrl,
-            productId: env.polar.productId,
-            benefitId: env.polar.benefitId,
-          },
-        }, 402)
+          error: "org_limit_reached",
+          limitType: "workers",
+          limit: workerLimit.limit,
+          currentCount: workerLimit.currentCount,
+          message: `This workspace currently supports up to ${workerLimit.limit} workers. Contact support to increase the limit.`,
+        }, 409)
       }
     }
 

--- a/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
@@ -125,7 +125,18 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
   ]);
 
   useEffect(() => {
-    if (!sessionHydrated || !user || resuming || onboardingPending || mockMode || redirectingRef.current) {
+    if (
+      !sessionHydrated ||
+      !user ||
+      resuming ||
+      onboardingPending ||
+      mockMode ||
+      redirectingRef.current ||
+      billingBusy ||
+      billingCheckoutBusy ||
+      !billingSummary ||
+      (billingSummary.featureGateEnabled && !billingSummary.hasActivePlan)
+    ) {
       return;
     }
 
@@ -143,7 +154,19 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
       .finally(() => {
         redirectingRef.current = false;
       });
-  }, [mockMode, onboardingPending, pathname, resolveUserLandingRoute, resuming, router, sessionHydrated, user]);
+  }, [
+    billingBusy,
+    billingCheckoutBusy,
+    billingSummary,
+    mockMode,
+    onboardingPending,
+    pathname,
+    resolveUserLandingRoute,
+    resuming,
+    router,
+    sessionHydrated,
+    user,
+  ]);
 
   if (!sessionHydrated || (!user && !mockMode)) {
     return (
@@ -174,16 +197,16 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
         <div className="flex flex-col gap-4 lg:max-w-3xl">
           <div className="grid gap-3">
             <p className="den-eyebrow">OpenWork Cloud</p>
-            <h1 className="den-title-xl max-w-[12ch]">Purchase worker access before launch.</h1>
+            <h1 className="den-title-xl max-w-[14ch]">Purchase a plan before creating your workspace.</h1>
             <p className="den-copy max-w-2xl">
-              Workers are disabled by default. Add one hosted OpenWork worker for $50/month, then launch it from your dashboard.
+              Start with one workspace plan for $50/month. Each plan includes up to 5 members and 1 hosted worker.
             </p>
           </div>
 
           <div className="flex flex-wrap gap-3">
             {checkoutHref ? (
               <a href={checkoutHref} rel="noreferrer" className="den-button-primary w-full sm:w-auto">
-                Purchase worker — $50/month
+                Purchase plan — $50/month
               </a>
             ) : (
               <button
@@ -201,7 +224,7 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
           </div>
 
           <div className="flex flex-wrap items-center gap-3 text-sm text-[var(--dls-text-secondary)]">
-            <span>$50/month per worker</span>
+            <span>$50/month per workspace</span>
             <span aria-hidden="true">•</span>
             <span>{planAmountLabel} billed monthly</span>
             <span aria-hidden="true">•</span>
@@ -279,7 +302,7 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
               <p className="den-eyebrow">Billing status</p>
               <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{subscriptionStatus}</h2>
               <p className="den-copy text-sm">
-                {billingSummary.hasActivePlan ? "Your worker billing is active." : "Purchase a worker to enable hosted launches."}
+                {billingSummary.hasActivePlan ? "Your workspace plan is active." : "Purchase a plan to create your first workspace."}
               </p>
             </div>
 
@@ -303,7 +326,7 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
             <div className="grid gap-3">
               {checkoutHref && !billingSummary.hasActivePlan ? (
                 <a href={checkoutHref} rel="noreferrer" className="den-button-primary w-full">
-                  Purchase worker
+                  Purchase plan
                 </a>
               ) : null}
               {billingSummary.portalUrl ? (

--- a/ee/apps/den-web/app/(den)/_components/org-limit-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/org-limit-dialog.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { DenButton, buttonVariants } from "./ui/button";
+
+export function OrgLimitDialog({
+  open,
+  title,
+  message,
+  detail,
+  feedbackHref,
+  onClose,
+}: {
+  open: boolean;
+  title: string;
+  message: string;
+  detail?: string | null;
+  feedbackHref: string;
+  onClose: () => void;
+}) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6">
+      <div className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]">
+        <div className="grid gap-3">
+          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">Workspace limit</p>
+          <div className="grid gap-2">
+            <h2 className="text-[24px] font-semibold tracking-[-0.03em] text-gray-950">{title}</h2>
+            <p className="text-[15px] leading-7 text-gray-600">{message}</p>
+            {detail ? <p className="text-[13px] leading-6 text-gray-500">{detail}</p> : null}
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <DenButton variant="secondary" onClick={onClose}>
+            Close
+          </DenButton>
+          <a href={feedbackHref} target="_blank" rel="noreferrer" className={buttonVariants({ variant: "primary" })}>
+            Contact support
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { LogOut, Settings } from "lucide-react";
 import { getErrorMessage, requestJson } from "../_lib/den-flow";
-import { type DenOrgSummary, parseOrgListPayload, formatRoleLabel, getOrgDashboardRoute } from "../_lib/den-org";
+import { type DenOrgSummary, formatRoleLabel, getOrgDashboardRoute, parseOrgListPayload } from "../_lib/den-org";
 import { useDenFlow } from "../_providers/den-flow-provider";
 
 type SettingsTab = "profile" | "organizations";
@@ -20,17 +20,21 @@ export function OrganizationScreen() {
   const [createName, setCreateName] = useState("");
   const [createBusy, setCreateBusy] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
   const userDisplayName = useMemo(() => {
     const trimmedName = user?.name?.trim();
     if (trimmedName) return trimmedName;
     const emailLocalPart = user?.email?.split("@")[0]?.trim() ?? "";
     return emailLocalPart || "OpenWork User";
   }, [user?.email, user?.name]);
+
   const userInitials = useMemo(() => {
     const parts = userDisplayName.split(/\s+/).filter(Boolean);
     return ((parts[0]?.slice(0, 1) ?? "O") + (parts[1]?.slice(0, 1) ?? "")).toUpperCase();
   }, [userDisplayName]);
+
   const activeOrg = useMemo(() => orgs.find((org) => org.isActive) ?? null, [orgs]);
+  const showDirectCreateFlow = orgs.length === 0;
 
   useEffect(() => {
     if (!sessionHydrated) return;
@@ -40,17 +44,19 @@ export function OrganizationScreen() {
     }
 
     let isMounted = true;
-    
+
     async function loadOrgs() {
       try {
         const { response, payload } = await requestJson("/v1/me/orgs", { method: "GET" });
         if (!response.ok) {
           throw new Error(getErrorMessage(payload, "Failed to load organizations."));
         }
-        
+
         if (isMounted) {
           const parsed = parseOrgListPayload(payload);
-          setOrgs(parsed.orgs.map((o) => ({ ...o, isActive: o.slug === parsed.activeOrgSlug })));
+          const nextOrgs = parsed.orgs.map((org) => ({ ...org, isActive: org.slug === parsed.activeOrgSlug }));
+          setOrgs(nextOrgs);
+          setShowCreate(nextOrgs.length === 0);
           setBusy(false);
         }
       } catch (err) {
@@ -72,7 +78,7 @@ export function OrganizationScreen() {
     e.preventDefault();
     const trimmed = createName.trim();
     if (!trimmed) return;
-    
+
     setCreateBusy(true);
     setCreateError(null);
     try {
@@ -82,6 +88,11 @@ export function OrganizationScreen() {
       });
 
       if (!response.ok) {
+        if (response.status === 402) {
+          setCreateBusy(false);
+          router.push("/checkout");
+          return;
+        }
         throw new Error(getErrorMessage(payload, "Failed to create organization."));
       }
 
@@ -133,45 +144,97 @@ export function OrganizationScreen() {
       </header>
 
       <main className="flex-1 overflow-y-auto p-6 md:p-12">
-        <div className="mx-auto max-w-5xl">
-          <div className="mb-8">
-            <h1 className="text-2xl font-semibold tracking-tight text-gray-900">Settings</h1>
-            <p className="mt-1 text-sm text-gray-500">Manage your profile and organization memberships.</p>
-          </div>
+        {showDirectCreateFlow ? (
+          <div className="mx-auto max-w-2xl">
+            <section className="rounded-[2rem] border border-gray-200 bg-white p-8 shadow-sm md:p-10">
+              <div className="mb-8 flex items-start gap-4">
+                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[#011627] text-sm font-semibold uppercase tracking-[0.08em] text-white">
+                  {userInitials}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-medium uppercase tracking-[0.18em] text-gray-400">OpenWork Cloud</p>
+                  <h1 className="mt-2 text-3xl font-semibold tracking-[-0.03em] text-gray-950">Create your first organization.</h1>
+                  <p className="mt-3 max-w-xl text-sm leading-6 text-gray-500">
+                    Name the workspace you want to set up for your team. If billing is enabled, the plan step comes right after this.
+                  </p>
+                </div>
+              </div>
 
-          <div className="mb-8 flex gap-8 border-b border-gray-200">
-            <button
-              type="button"
-              onClick={() => setActiveTab("profile")}
-              className={`border-b-2 pb-3 text-sm font-medium transition-colors ${
-                activeTab === "profile"
-                  ? "border-gray-900 text-gray-900"
-                  : "border-transparent text-gray-500 hover:text-gray-700"
-              }`}
-            >
-              Profile
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveTab("organizations")}
-              className={`border-b-2 pb-3 text-sm font-medium transition-colors ${
-                activeTab === "organizations"
-                  ? "border-gray-900 text-gray-900"
-                  : "border-transparent text-gray-500 hover:text-gray-700"
-              }`}
-            >
-              Organizations
-            </button>
-          </div>
+              {error ? (
+                <div className="mb-6 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900">
+                  {error}
+                </div>
+              ) : null}
 
-          {error ? (
-            <div className="mb-6 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900">
-              {error}
+              <form onSubmit={handleCreate} className="grid gap-5">
+                <label className="grid gap-2">
+                  <span className="text-sm font-medium text-gray-700">Organization name</span>
+                  <input
+                    type="text"
+                    value={createName}
+                    onChange={(e) => setCreateName(e.target.value)}
+                    placeholder="Acme Corp"
+                    className="w-full rounded-2xl border border-gray-200 px-4 py-3 text-sm text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
+                    autoFocus
+                    required
+                  />
+                </label>
+
+                {createError ? <p className="text-sm font-medium text-rose-600">{createError}</p> : null}
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="submit"
+                    disabled={createBusy || !createName.trim()}
+                    className="rounded-2xl bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+                  >
+                    {createBusy ? "Creating..." : "Continue"}
+                  </button>
+                  <p className="text-sm text-gray-500">Signed in as {user?.email ?? "your account"}</p>
+                </div>
+              </form>
+            </section>
+          </div>
+        ) : (
+          <div className="mx-auto max-w-5xl">
+            <div className="mb-8">
+              <h1 className="text-2xl font-semibold tracking-tight text-gray-900">Settings</h1>
+              <p className="mt-1 text-sm text-gray-500">Manage your profile and organization memberships.</p>
             </div>
-          ) : null}
 
-          {activeTab === "profile" ? (
-            <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="mb-8 flex gap-8 border-b border-gray-200">
+              <button
+                type="button"
+                onClick={() => setActiveTab("profile")}
+                className={`border-b-2 pb-3 text-sm font-medium transition-colors ${
+                  activeTab === "profile"
+                    ? "border-gray-900 text-gray-900"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                Profile
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab("organizations")}
+                className={`border-b-2 pb-3 text-sm font-medium transition-colors ${
+                  activeTab === "organizations"
+                    ? "border-gray-900 text-gray-900"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                Organizations
+              </button>
+            </div>
+
+            {error ? (
+              <div className="mb-6 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900">
+                {error}
+              </div>
+            ) : null}
+
+            {activeTab === "profile" ? (
+              <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
                 <div className="mb-6 flex items-start gap-4">
                   <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[#011627] text-sm font-semibold uppercase tracking-[0.08em] text-white">
                     {userInitials}
@@ -223,130 +286,119 @@ export function OrganizationScreen() {
                     />
                   </label>
                 </div>
-
               </section>
-          ) : (
-            <>
-              <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <p className="max-w-2xl text-sm text-gray-500">
-                  Organizations are independent environments. In each organization you can collaborate with other members and manage your own resources.
-                </p>
-                <button
-                  onClick={() => setShowCreate(true)}
-                  className="shrink-0 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800"
-                >
-                  + Create New Organization
-                </button>
-              </div>
-
-              {showCreate ? (
-                <div className="mb-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-                  <h2 className="mb-4 text-lg font-medium text-gray-900">Create an Organization</h2>
-                  <form onSubmit={handleCreate} className="grid max-w-md gap-4">
-                    <label className="grid gap-2">
-                      <span className="text-sm font-medium text-gray-700">Organization Name</span>
-                      <input
-                        type="text"
-                        value={createName}
-                        onChange={(e) => setCreateName(e.target.value)}
-                        placeholder="Acme Corp"
-                        className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
-                        autoFocus
-                        required
-                      />
-                    </label>
-
-                    <div className="flex gap-3 pt-2">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setShowCreate(false);
-                          setCreateName("");
-                          setCreateError(null);
-                        }}
-                        className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        type="submit"
-                        disabled={createBusy || !createName.trim()}
-                        className="rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
-                      >
-                        {createBusy ? "Creating..." : "Create"}
-                      </button>
-                    </div>
-
-                    {createError && (
-                      <p className="text-sm font-medium text-rose-600">{createError}</p>
-                    )}
-                  </form>
+            ) : (
+              <>
+                <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="max-w-2xl text-sm text-gray-500">
+                    Organizations are independent environments. In each organization you can collaborate with other members and manage your own resources.
+                  </p>
+                  <button
+                    onClick={() => setShowCreate(true)}
+                    className="shrink-0 rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+                  >
+                    + Create New Organization
+                  </button>
                 </div>
-              ) : null}
 
-              <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-                <div className="overflow-x-auto">
-                  <table className="w-full text-left text-sm">
-                    <thead className="border-b border-gray-200 bg-gray-50/50">
-                      <tr>
-                        <th className="px-6 py-4 font-medium text-gray-500">Organization</th>
-                        <th className="px-6 py-4 font-medium text-gray-500">Seat Type</th>
-                        <th className="px-6 py-4 text-right font-medium text-gray-500">Action</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100">
-                      {orgs.length === 0 && !busy ? (
+                {showCreate ? (
+                  <div className="mb-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+                    <h2 className="mb-4 text-lg font-medium text-gray-900">Create an Organization</h2>
+                    <form onSubmit={handleCreate} className="grid max-w-md gap-4">
+                      <label className="grid gap-2">
+                        <span className="text-sm font-medium text-gray-700">Organization Name</span>
+                        <input
+                          type="text"
+                          value={createName}
+                          onChange={(e) => setCreateName(e.target.value)}
+                          placeholder="Acme Corp"
+                          className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
+                          autoFocus
+                          required
+                        />
+                      </label>
+
+                      <div className="flex gap-3 pt-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setShowCreate(false);
+                            setCreateName("");
+                            setCreateError(null);
+                          }}
+                          className="rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="submit"
+                          disabled={createBusy || !createName.trim()}
+                          className="rounded-xl bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+                        >
+                          {createBusy ? "Creating..." : "Create"}
+                        </button>
+                      </div>
+
+                      {createError ? <p className="text-sm font-medium text-rose-600">{createError}</p> : null}
+                    </form>
+                  </div>
+                ) : null}
+
+                <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left text-sm">
+                      <thead className="border-b border-gray-200 bg-gray-50/50">
                         <tr>
-                          <td colSpan={3} className="px-6 py-8 text-center text-gray-500">
-                            No organizations found. Create one to get started.
-                          </td>
+                          <th className="px-6 py-4 font-medium text-gray-500">Organization</th>
+                          <th className="px-6 py-4 font-medium text-gray-500">Seat Type</th>
+                          <th className="px-6 py-4 text-right font-medium text-gray-500">Action</th>
                         </tr>
-                      ) : null}
-                      {orgs.map((org) => (
-                        <tr key={org.id} className="transition-colors hover:bg-gray-50/50">
-                          <td className="px-6 py-4">
-                            <div className="font-medium text-gray-900">{org.name}</div>
-                            <div className="mt-1 text-xs text-gray-500">
-                              {org.role === "owner" ? "Creator plan" : "Free plan"} • 1 member
-                            </div>
-                          </td>
-                          <td className="px-6 py-4">
-                            <span className="text-gray-700">{formatRoleLabel(org.role)}</span>
-                          </td>
-                          <td className="px-6 py-4 text-right">
-                            {org.isActive ? (
-                              <span className="inline-flex cursor-default items-center rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-500">
-                                Current Organization
-                              </span>
-                            ) : (
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {orgs.map((org) => (
+                          <tr key={org.id} className="transition-colors hover:bg-gray-50/50">
+                            <td className="px-6 py-4">
+                              <div className="font-medium text-gray-900">{org.name}</div>
+                              <div className="mt-1 text-xs text-gray-500">
+                                {org.role === "owner" ? "Creator plan" : "Free plan"} • 1 member
+                              </div>
+                            </td>
+                            <td className="px-6 py-4">
+                              <span className="text-gray-700">{formatRoleLabel(org.role)}</span>
+                            </td>
+                            <td className="px-6 py-4 text-right">
+                              {org.isActive ? (
+                                <span className="inline-flex cursor-default items-center rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-500">
+                                  Current Organization
+                                </span>
+                              ) : (
+                                <button
+                                  onClick={() => handleSwitch(org.slug)}
+                                  className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-50"
+                                >
+                                  Switch
+                                </button>
+                              )}
                               <button
                                 onClick={() => handleSwitch(org.slug)}
-                                className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm transition hover:bg-gray-50"
+                                className="ml-2 inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
+                                aria-label="Organization settings"
                               >
-                                Switch
+                                <Settings className="h-4 w-4" />
                               </button>
-                            )}
-                            <button
-                              onClick={() => handleSwitch(org.slug)}
-                              className="ml-2 inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
-                              aria-label="Organization settings"
-                            >
-                              <Settings className="h-4 w-4" />
-                            </button>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
-              </div>
 
-              <p className="mt-8 text-center text-sm text-gray-500">
-                You have no pending organization invites.
-              </p>
-            </>
-          )}
-        </div>
+                <p className="mt-8 text-center text-sm text-gray-500">You have no pending organization invites.</p>
+              </>
+            )}
+          </div>
+        )}
       </main>
     </div>
   );

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -51,6 +51,14 @@ export type BillingSummary = {
   benefitId: string | null;
 };
 
+export type OrgLimitError = {
+  error: "org_limit_reached";
+  message: string;
+  limitType: "members" | "workers";
+  currentCount: number;
+  limit: number;
+};
+
 export type AuthUser = {
   id: string;
   email: string;
@@ -362,6 +370,29 @@ export function getErrorMessage(payload: unknown, fallback: string): string {
   }
 
   return fallback;
+}
+
+export function getOrgLimitError(payload: unknown): OrgLimitError | null {
+  if (!isRecord(payload) || payload.error !== "org_limit_reached") {
+    return null;
+  }
+
+  if (
+    (payload.limitType !== "members" && payload.limitType !== "workers") ||
+    typeof payload.message !== "string" ||
+    typeof payload.currentCount !== "number" ||
+    typeof payload.limit !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    error: "org_limit_reached",
+    message: payload.message,
+    limitType: payload.limitType,
+    currentCount: payload.currentCount,
+    limit: payload.limit,
+  };
 }
 
 export function getUser(payload: unknown): AuthUser | null {

--- a/ee/apps/den-web/app/(den)/_lib/feedback.ts
+++ b/ee/apps/den-web/app/(den)/_lib/feedback.ts
@@ -1,0 +1,22 @@
+export const OPENWORK_FEEDBACK_URL = "https://openworklabs.com/feedback";
+
+export function buildDenFeedbackUrl(options?: {
+  pathname?: string;
+  orgSlug?: string | null;
+  topic?: string;
+}) {
+  const url = new URL(OPENWORK_FEEDBACK_URL);
+  url.searchParams.set("source", "openwork-web-app");
+  url.searchParams.set("deployment", "web");
+  url.searchParams.set("entrypoint", options?.pathname ?? "dashboard");
+
+  if (options?.orgSlug) {
+    url.searchParams.set("org", options.orgSlug);
+  }
+
+  if (options?.topic) {
+    url.searchParams.set("topic", options.topic);
+  }
+
+  return url.toString();
+}

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -16,6 +16,7 @@ import {
   type BillingSummary,
   type LaunchEvent,
   type OnboardingIntent,
+  type OrgLimitError,
   type RuntimeServiceName,
   type SocialAuthProvider,
   type WorkerLaunch,
@@ -31,6 +32,7 @@ import {
   getCheckoutUrl,
   getEmailDomain,
   getErrorMessage,
+  getOrgLimitError,
   getRuntimeServiceLabel,
   getSocialCallbackUrl,
   getSocialProviderLabel,
@@ -60,7 +62,7 @@ import {
   parseOrgListPayload,
 } from "../_lib/den-org";
 
-type LaunchWorkerResult = "success" | "checkout" | "error";
+type LaunchWorkerResult = "success" | "checkout" | "limit" | "error";
 type AuthNavigationResult = "dashboard" | "checkout" | "join-org" | null;
 
 type DenFlowContextValue = {
@@ -96,6 +98,8 @@ type DenFlowContextValue = {
   billingSubscriptionBusy: boolean;
   billingError: string | null;
   effectiveCheckoutUrl: string | null;
+  orgLimitError: OrgLimitError | null;
+  clearOrgLimitError: () => void;
   refreshBilling: (options?: { includeCheckout?: boolean; quiet?: boolean }) => Promise<BillingSummary | null>;
   handleSubscriptionCancellation: (cancelAtPeriodEnd: boolean) => Promise<void>;
   refreshCheckoutReturn: (sessionTokenPresent: boolean) => Promise<string>;
@@ -150,23 +154,6 @@ type DenFlowContextValue = {
 
 const DenFlowContext = createContext<DenFlowContextValue | null>(null);
 
-function readLocalStorage<T>(key: string): T | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  const raw = window.localStorage.getItem(key);
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    return JSON.parse(raw) as T;
-  } catch {
-    return null;
-  }
-}
-
 function getPendingOrgInvitationId() {
   if (typeof window === "undefined") {
     return null;
@@ -211,6 +198,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   const [billingSubscriptionBusy, setBillingSubscriptionBusy] = useState(false);
   const [billingError, setBillingError] = useState<string | null>(null);
   const [billingLoadedOnce, setBillingLoadedOnce] = useState(false);
+  const [orgLimitError, setOrgLimitError] = useState<OrgLimitError | null>(null);
 
   const [workerName, setWorkerName] = useState(DEFAULT_WORKER_NAME);
   const [worker, setWorker] = useState<WorkerLaunch | null>(null);
@@ -237,7 +225,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
   const [runtimeUpgradeBusy, setRuntimeUpgradeBusy] = useState(false);
 
-  const [onboardingIntent, setOnboardingIntent] = useState<OnboardingIntent | null>(() => readLocalStorage<OnboardingIntent>(ONBOARDING_INTENT_STORAGE_KEY));
+  const [onboardingIntent, setOnboardingIntent] = useState<OnboardingIntent | null>(null);
   const onboardingAutoLaunchKeyRef = useRef<string | null>(null);
   const socialSignupHandledRef = useRef<string | null>(null);
   const pendingWorkersRequestRef = useRef<Promise<{ response: Response; payload: unknown }> | null>(null);
@@ -1039,27 +1027,13 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  async function beginSignupOnboarding(authenticatedUser: AuthUser, authMethod: AuthMethod) {
+  async function beginSignupOnboarding(authenticatedUser: AuthUser, _authMethod: AuthMethod) {
     const autoName = deriveOnboardingWorkerName(authenticatedUser);
     setWorkerName(autoName);
     setLaunchError(null);
-    setLaunchStatus("Preparing your first worker.");
-
-    const intent: OnboardingIntent = {
-      version: 1,
-      workerName: autoName,
-      shouldLaunch: true,
-      completed: false,
-      authMethod
-    };
-
-    persistOnboardingIntent(intent);
-    const summary = await refreshBilling({ includeCheckout: true, quiet: true });
-    if (!summary) {
-      return "checkout" as const;
-    }
-
-    return !summary.featureGateEnabled || summary.hasActivePlan ? ("dashboard" as const) : ("checkout" as const);
+    setLaunchStatus("Create a workspace to get started.");
+    persistOnboardingIntent(null);
+    return "dashboard" as const;
   }
 
   async function resolveUserLandingRoute() {
@@ -1074,19 +1048,11 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     const dashboardRoute = await resolveDashboardRoute();
 
-    if (!onboardingPending) {
+    if (dashboardRoute) {
       return dashboardRoute;
     }
 
-    const summary =
-      billingSummary ??
-      (billingBusy || billingCheckoutBusy ? null : await refreshBilling({ includeCheckout: true, quiet: true }));
-
-    if (!summary) {
-      return "/checkout";
-    }
-
-    return !summary.featureGateEnabled || summary.hasActivePlan ? (dashboardRoute ?? "/") : "/checkout";
+    return "/organization";
   }
 
   async function submitAuth(event: FormEvent<HTMLFormElement>) {
@@ -1254,6 +1220,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     setCheckoutUrl(null);
     setBillingSummary(null);
     setBillingError(null);
+    setOrgLimitError(null);
     setBillingBusy(false);
     setBillingCheckoutBusy(false);
     setBillingSubscriptionBusy(false);
@@ -1298,6 +1265,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     setLaunchBusy(true);
     setLaunchError(null);
+    setOrgLimitError(null);
     setCheckoutUrl(null);
     setLaunchStatus(options.source === "signup_auto" ? "Creating your first worker..." : "Checking worker billing and launch eligibility...");
     appendEvent("info", "Launch requested", resolvedLaunchName);
@@ -1315,6 +1283,15 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
         },
         12000
       );
+
+      const limitError = getOrgLimitError(payload);
+      if (limitError) {
+        setOrgLimitError(limitError);
+        setLaunchStatus(limitError.message);
+        setLaunchError(limitError.message);
+        appendEvent("warning", "Workspace limit reached", limitError.message);
+        return "limit" as const;
+      }
 
       if (response.status === 402) {
         const url = getCheckoutUrl(payload);
@@ -1748,7 +1725,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
 
     if (!summary.featureGateEnabled || summary.hasActivePlan) {
-      return (await resolveDashboardRoute()) ?? "/";
+      return (await resolveUserLandingRoute()) ?? "/organization";
     }
 
     return "/checkout" as const;
@@ -2078,6 +2055,8 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     billingSubscriptionBusy,
     billingError,
     effectiveCheckoutUrl,
+    orgLimitError,
+    clearOrgLimitError: () => setOrgLimitError(null),
     refreshBilling,
     handleSubscriptionCancellation,
     refreshCheckoutReturn,

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/background-agents-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/background-agents-screen.tsx
@@ -21,6 +21,7 @@ import {
 import { DenInput } from "../../../../_components/ui/input";
 import { DashboardPageTemplate } from "../../../../_components/ui/dashboard-page-template";
 import { DenButton, buttonVariants } from "../../../../_components/ui/button";
+import { OrgLimitDialog } from "../../../../_components/org-limit-dialog";
 import {
   OPENWORK_APP_CONNECT_BASE_URL,
   buildOpenworkAppConnectUrl,
@@ -31,6 +32,7 @@ import {
   requestJson,
   type WorkerListItem,
 } from "../../../../_lib/den-flow";
+import { buildDenFeedbackUrl } from "../../../../_lib/feedback";
 import { useDenFlow } from "../../../../_providers/den-flow-provider";
 import { getSharedSetupsRoute } from "../../../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
@@ -309,9 +311,16 @@ export function BackgroundAgentsScreen() {
     workersError,
     launchBusy,
     launchWorker,
+    orgLimitError,
+    clearOrgLimitError,
     renameWorker,
     renameBusyWorkerId,
   } = useDenFlow();
+  const feedbackHref = buildDenFeedbackUrl({
+    pathname: `/o/${orgSlug}/dashboard/background-agents`,
+    orgSlug,
+    topic: "workspace-limits",
+  });
 
   async function handleAddWorkspace() {
     const result = await launchWorker({ source: "manual" });
@@ -403,6 +412,19 @@ export function BackgroundAgentsScreen() {
       description="Keep selected workflows running in the background without asking each teammate to run them locally."
       colors={["#E9FFE0", "#3E9A1D", "#B3F750", "#51F0A3"]}
     >
+      <OrgLimitDialog
+        open={Boolean(orgLimitError)}
+        title={orgLimitError?.limitType === "workers" ? "Worker limit reached" : "Member limit reached"}
+        message={orgLimitError?.message ?? "This workspace reached its current plan limit."}
+        detail={
+          orgLimitError
+            ? `${orgLimitError.currentCount} of ${orgLimitError.limit} ${orgLimitError.limitType} are already in use.`
+            : null
+        }
+        feedbackHref={feedbackHref}
+        onClose={clearOrgLimitError}
+      />
+
       <div className="mb-10 flex items-center gap-3">
         <DenButton
           icon={Plus}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/billing-dashboard-screen.tsx
@@ -93,11 +93,11 @@ export function BillingDashboardScreen() {
 
       <div className="mb-6 rounded-[20px] border border-gray-100 bg-white p-8 shadow-[0_2px_12px_-4px_rgba(0,0,0,0.06)]">
         <div className="mb-8 border-b border-gray-100 pb-6">
-          <p className="text-[15px] text-gray-700">
-            {billingSummary?.hasActivePlan
-              ? `This workspace's plan is currently ${statusLabel.toLowerCase()} and renews on ${nextBillingDate}.`
-              : "Workers are $50/month each. Purchase a worker to enable hosted launches for your team."}
-          </p>
+            <p className="text-[15px] text-gray-700">
+              {billingSummary?.hasActivePlan
+                ? `This workspace's plan is currently ${statusLabel.toLowerCase()} and renews on ${nextBillingDate}.`
+                : "Workspace plans are $50/month and include up to 5 members plus 1 hosted worker."}
+            </p>
         </div>
 
         <div className="mb-10 grid grid-cols-1 gap-x-6 gap-y-8 md:grid-cols-2 lg:grid-cols-3">
@@ -144,7 +144,7 @@ export function BillingDashboardScreen() {
         <div className="flex flex-wrap items-center gap-3">
           {effectiveCheckoutUrl && !billingSummary?.hasActivePlan ? (
             <a href={effectiveCheckoutUrl} rel="noreferrer" className={buttonVariants({ variant: "primary" })}>
-              Purchase worker
+              Purchase plan
             </a>
           ) : null}
 
@@ -175,9 +175,9 @@ export function BillingDashboardScreen() {
             <p className="mt-1 text-[13px] text-gray-500">Free forever · open source</p>
           </div>
           <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
-            <p className="mb-1 text-[12px] font-semibold uppercase tracking-wide text-gray-500">Cloud worker</p>
+            <p className="mb-1 text-[12px] font-semibold uppercase tracking-wide text-gray-500">Workspace plan</p>
             <p className="text-[20px] font-semibold text-gray-900">$50<span className="text-[13px] font-medium text-gray-500">/month</span></p>
-            <p className="mt-1 text-[13px] text-gray-500">Per worker · 5 seats included</p>
+            <p className="mt-1 text-[13px] text-gray-500">5 members included · 1 hosted worker</p>
           </div>
           <div className="rounded-[16px] border border-gray-100 bg-gray-50 p-4">
             <p className="mb-1 text-[12px] font-semibold uppercase tracking-wide text-gray-500">Enterprise</p>

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/manage-members-screen.tsx
@@ -18,8 +18,12 @@ import {
   DEN_ROLE_PERMISSION_OPTIONS,
   formatRoleLabel,
   getOrgAccessFlags,
+  getMembersRoute,
   splitRoleString,
 } from "../../../../_lib/den-org";
+import { type OrgLimitError, getOrgLimitError } from "../../../../_lib/den-flow";
+import { buildDenFeedbackUrl } from "../../../../_lib/feedback";
+import { OrgLimitDialog } from "../../../../_components/org-limit-dialog";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { UnderlineTabs } from "../../../../_components/ui/tabs";
 import { DashboardPageTemplate } from "../../../../_components/ui/dashboard-page-template";
@@ -142,6 +146,7 @@ export function ManageMembersScreen() {
   const [rolePermissionDraft, setRolePermissionDraft] = useState<
     Record<string, string[]>
   >({});
+  const [limitDialogError, setLimitDialogError] = useState<OrgLimitError | null>(null);
 
   const assignableRoles = useMemo(
     () => (orgContext?.roles ?? []).filter((role) => !role.protected),
@@ -188,6 +193,16 @@ export function ManageMembersScreen() {
       ]),
     );
   }, [orgContext?.members, orgContext?.teams]);
+
+  const feedbackHref = useMemo(
+    () =>
+      buildDenFeedbackUrl({
+        pathname: activeOrg ? getMembersRoute(activeOrg.slug) : "/organization",
+        orgSlug: activeOrg?.slug ?? null,
+        topic: "workspace-limits",
+      }),
+    [activeOrg],
+  );
 
   function resetInviteForm() {
     setInviteEmail("");
@@ -263,6 +278,12 @@ export function ManageMembersScreen() {
               await inviteMember({ email: inviteEmail, role: inviteRole });
               resetInviteForm();
             } catch (error) {
+              const limitError = getOrgLimitError(error);
+              if (limitError) {
+                setLimitDialogError(limitError);
+                return;
+              }
+
               setPageError(
                 error instanceof Error
                   ? error.message
@@ -601,6 +622,19 @@ export function ManageMembersScreen() {
       description="Invite teammates, adjust roles, and keep access clean."
       colors={["#F3EEFF", "#4A1D96", "#7C3AED", "#C4B5FD"]}
     >
+      <OrgLimitDialog
+        open={Boolean(limitDialogError)}
+        title={limitDialogError?.limitType === "members" ? "Member limit reached" : "Worker limit reached"}
+        message={limitDialogError?.message ?? "This workspace reached its current plan limit."}
+        detail={
+          limitDialogError
+            ? `${limitDialogError.currentCount} of ${limitDialogError.limit} ${limitDialogError.limitType} are already in use.`
+            : null
+        }
+        feedbackHref={feedbackHref}
+        onClose={() => setLimitDialogError(null)}
+      />
+
       {pageError ? (
         <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
           {pageError}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/shared-setup-data.ts
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/shared-setup-data.ts
@@ -2,25 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
+import { OPENWORK_FEEDBACK_URL, buildDenFeedbackUrl } from "../../../../_lib/feedback";
 
 export const OPENWORK_DOCS_URL = "https://openworklabs.com/docs";
-export const OPENWORK_FEEDBACK_URL = "https://openworklabs.com/feedback";
-
-export function buildDenFeedbackUrl(options?: {
-  pathname?: string;
-  orgSlug?: string;
-}) {
-  const url = new URL(OPENWORK_FEEDBACK_URL);
-  url.searchParams.set("source", "openwork-web-app");
-  url.searchParams.set("deployment", "web");
-  url.searchParams.set("entrypoint", options?.pathname ?? "dashboard");
-
-  if (options?.orgSlug) {
-    url.searchParams.set("org", options.orgSlug);
-  }
-
-  return url.toString();
-}
+export { OPENWORK_FEEDBACK_URL, buildDenFeedbackUrl };
 
 export function formatTemplateTimestamp(value: string | null, options?: { includeTime?: boolean }) {
   if (!value) {

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { useDenFlow } from "../../../../_providers/den-flow-provider";
-import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
+import { getErrorMessage, getOrgLimitError, requestJson } from "../../../../_lib/den-flow";
 import {
   type DenOrgContext,
   type DenOrgSummary,
@@ -158,6 +158,10 @@ export function OrgDashboardProvider({
       );
 
       if (!response.ok) {
+        if (response.status === 402) {
+          router.push("/checkout");
+          return;
+        }
         throw new Error(getErrorMessage(payload, `Failed to create organization (${response.status}).`));
       }
 
@@ -193,6 +197,10 @@ export function OrgDashboardProvider({
       );
 
       if (!response.ok) {
+        const limitError = getOrgLimitError(payload);
+        if (limitError) {
+          throw limitError;
+        }
         throw new Error(getErrorMessage(payload, `Failed to invite member (${response.status}).`));
       }
     });

--- a/ee/packages/den-db/drizzle/0007_organization_metadata_limits.sql
+++ b/ee/packages/den-db/drizzle/0007_organization_metadata_limits.sql
@@ -1,0 +1,27 @@
+UPDATE `organization`
+SET `metadata` = '{}'
+WHERE `metadata` IS NULL
+   OR TRIM(`metadata`) = ''
+   OR JSON_VALID(`metadata`) = 0;
+
+ALTER TABLE `organization`
+  MODIFY COLUMN `metadata` json NULL;
+
+UPDATE `organization`
+SET `metadata` = JSON_SET(
+  `metadata`,
+  '$.limits.members',
+  COALESCE(
+    NULLIF(CAST(JSON_UNQUOTE(JSON_EXTRACT(`metadata`, '$.limits.members')) AS SIGNED), 0),
+    5
+  ),
+  '$.limits.workers',
+  COALESCE(
+    NULLIF(CAST(JSON_UNQUOTE(COALESCE(JSON_EXTRACT(`metadata`, '$.limits.workers'), JSON_EXTRACT(`metadata`, '$.limits.Workers'))) AS SIGNED), 0),
+    1
+  )
+);
+
+UPDATE `organization`
+SET `metadata` = JSON_REMOVE(`metadata`, '$.limits.Workers')
+WHERE JSON_EXTRACT(`metadata`, '$.limits.Workers') IS NOT NULL;

--- a/ee/packages/den-db/drizzle/meta/0007_snapshot.json
+++ b/ee/packages/den-db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,2066 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "0c7f8a74-8ffd-40db-9a67-f5ae72db8656",
+  "prevId": "01bf4a61-490e-449d-b17d-295d8546bd22",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "account_user_id": {
+          "name": "account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "account_id": {
+          "name": "account_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "session_token": {
+          "name": "session_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_id": {
+          "name": "session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_id": {
+          "name": "session_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "user_email": {
+          "name": "user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "verification_identifier": {
+          "name": "verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_id": {
+          "name": "verification_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "desktop_handoff_grant": {
+      "name": "desktop_handoff_grant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "desktop_handoff_grant_user_id": {
+          "name": "desktop_handoff_grant_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "desktop_handoff_grant_expires_at": {
+          "name": "desktop_handoff_grant_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "desktop_handoff_grant_id": {
+          "name": "desktop_handoff_grant_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id": {
+          "name": "invitation_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email": {
+          "name": "invitation_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "invitation_status": {
+          "name": "invitation_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "invitation_team_id": {
+          "name": "invitation_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invitation_id": {
+          "name": "invitation_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "member_organization_id": {
+          "name": "member_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_organization_user": {
+          "name": "member_organization_user",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "member_id": {
+          "name": "member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_slug": {
+          "name": "organization_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_id": {
+          "name": "organization_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organization_role": {
+      "name": "organization_role",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "organization_role_organization_id": {
+          "name": "organization_role_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "organization_role_name": {
+          "name": "organization_role_name",
+          "columns": [
+            "organization_id",
+            "role"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organization_role_id": {
+          "name": "organization_role_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "temp_template_sharing": {
+      "name": "temp_template_sharing",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_member_id": {
+          "name": "creator_member_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_json": {
+          "name": "template_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "temp_template_sharing_org_id": {
+          "name": "temp_template_sharing_org_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "temp_template_sharing_creator_member_id": {
+          "name": "temp_template_sharing_creator_member_id",
+          "columns": [
+            "creator_member_id"
+          ],
+          "isUnique": false
+        },
+        "temp_template_sharing_creator_user_id": {
+          "name": "temp_template_sharing_creator_user_id",
+          "columns": [
+            "creator_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "temp_template_sharing_id": {
+          "name": "temp_template_sharing_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub_member": {
+      "name": "skill_hub_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "skill_hub_member_skill_hub_id": {
+          "name": "skill_hub_member_skill_hub_id",
+          "columns": [
+            "skill_hub_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_org_membership_id": {
+          "name": "skill_hub_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_team_id": {
+          "name": "skill_hub_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_member_hub_org_membership": {
+          "name": "skill_hub_member_hub_org_membership",
+          "columns": [
+            "skill_hub_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        },
+        "skill_hub_member_hub_team": {
+          "name": "skill_hub_member_hub_team",
+          "columns": [
+            "skill_hub_id",
+            "team_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_member_id": {
+          "name": "skill_hub_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub_skill": {
+      "name": "skill_hub_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "skill_hub_skill_skill_hub_id": {
+          "name": "skill_hub_skill_skill_hub_id",
+          "columns": [
+            "skill_hub_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_skill_skill_id": {
+          "name": "skill_hub_skill_skill_id",
+          "columns": [
+            "skill_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_skill_hub_skill": {
+          "name": "skill_hub_skill_hub_skill",
+          "columns": [
+            "skill_hub_id",
+            "skill_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_skill_id": {
+          "name": "skill_hub_skill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill_hub": {
+      "name": "skill_hub",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "skill_hub_organization_id": {
+          "name": "skill_hub_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "skill_hub_created_by_org_membership_id": {
+          "name": "skill_hub_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_hub_id": {
+          "name": "skill_hub_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skill": {
+      "name": "skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_org_membership_id": {
+          "name": "created_by_org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_text": {
+          "name": "skill_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared": {
+          "name": "shared",
+          "type": "enum('org','public')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "skill_organization_id": {
+          "name": "skill_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "skill_created_by_org_membership_id": {
+          "name": "skill_created_by_org_membership_id",
+          "columns": [
+            "created_by_org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "skill_shared": {
+          "name": "skill_shared",
+          "columns": [
+            "shared"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skill_id": {
+          "name": "skill_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_member": {
+      "name": "team_member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_membership_id": {
+          "name": "org_membership_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_member_team_id": {
+          "name": "team_member_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_org_membership_id": {
+          "name": "team_member_org_membership_id",
+          "columns": [
+            "org_membership_id"
+          ],
+          "isUnique": false
+        },
+        "team_member_team_org_membership": {
+          "name": "team_member_team_org_membership",
+          "columns": [
+            "team_id",
+            "org_membership_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_member_id": {
+          "name": "team_member_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "team_organization_id": {
+          "name": "team_organization_id",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "team_organization_name": {
+          "name": "team_organization_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_id": {
+          "name": "team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_event": {
+      "name": "audit_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_event_org_id": {
+          "name": "audit_event_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "audit_event_worker_id": {
+          "name": "audit_event_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "daytona_sandbox": {
+      "name": "daytona_sandbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_volume_id": {
+          "name": "workspace_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_volume_id": {
+          "name": "data_volume_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url": {
+          "name": "signed_preview_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "signed_preview_url_expires_at": {
+          "name": "signed_preview_url_expires_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "daytona_sandbox_worker_id": {
+          "name": "daytona_sandbox_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": true
+        },
+        "daytona_sandbox_sandbox_id": {
+          "name": "daytona_sandbox_sandbox_id",
+          "columns": [
+            "sandbox_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daytona_sandbox_id": {
+          "name": "daytona_sandbox_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_bundle": {
+      "name": "worker_bundle",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_url": {
+          "name": "storage_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "worker_bundle_worker_id": {
+          "name": "worker_bundle_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_bundle_id": {
+          "name": "worker_bundle_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_instance": {
+      "name": "worker_instance",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_instance_worker_id": {
+          "name": "worker_instance_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_instance_id": {
+          "name": "worker_instance_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker": {
+      "name": "worker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "enum('local','cloud')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('provisioning','healthy','failed','stopped')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_version": {
+          "name": "image_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_backend": {
+          "name": "sandbox_backend",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "worker_org_id": {
+          "name": "worker_org_id",
+          "columns": [
+            "org_id"
+          ],
+          "isUnique": false
+        },
+        "worker_created_by_user_id": {
+          "name": "worker_created_by_user_id",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "worker_status": {
+          "name": "worker_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "worker_last_heartbeat_at": {
+          "name": "worker_last_heartbeat_at",
+          "columns": [
+            "last_heartbeat_at"
+          ],
+          "isUnique": false
+        },
+        "worker_last_active_at": {
+          "name": "worker_last_active_at",
+          "columns": [
+            "last_active_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_id": {
+          "name": "worker_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "worker_token": {
+      "name": "worker_token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "enum('client','host','activity')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "worker_token_worker_id": {
+          "name": "worker_token_worker_id",
+          "columns": [
+            "worker_id"
+          ],
+          "isUnique": false
+        },
+        "worker_token_token": {
+          "name": "worker_token_token",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "worker_token_id": {
+          "name": "worker_token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "admin_allowlist": {
+      "name": "admin_allowlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)"
+        }
+      },
+      "indexes": {
+        "admin_allowlist_email": {
+          "name": "admin_allowlist_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "admin_allowlist_id": {
+          "name": "admin_allowlist_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "rate_limit": {
+      "name": "rate_limit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limit_key": {
+          "name": "rate_limit_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_id": {
+          "name": "rate_limit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1775077000006,
       "tag": "0006_skill_hub",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "5",
+      "when": 1775170250887,
+      "tag": "0007_organization_metadata_limits",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/src/schema/org.ts
+++ b/ee/packages/den-db/src/schema/org.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from "drizzle-orm"
-import { index, mysqlTable, text, timestamp, uniqueIndex, varchar } from "drizzle-orm/mysql-core"
+import { index, json, mysqlTable, text, timestamp, uniqueIndex, varchar } from "drizzle-orm/mysql-core"
 import { denTypeIdColumn } from "../columns"
 
 export const DesktopHandoffGrantTable = mysqlTable(
@@ -25,7 +25,7 @@ export const OrganizationTable = mysqlTable(
     name: varchar("name", { length: 255 }).notNull(),
     slug: varchar("slug", { length: 255 }).notNull(),
     logo: varchar("logo", { length: 2048 }),
-    metadata: text("metadata"),
+    metadata: json("metadata").$type<Record<string, unknown> | null>(),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { fsp: 3 })
       .notNull()


### PR DESCRIPTION
## Summary
- move the Den Cloud paywall from worker launch to organization creation and send first-time users straight to the create-organization form
- store organization metadata defaults for member/worker limits and enforce those caps in the API
- show support dialogs for org limit errors and update checkout/billing copy to match workspace-based plans

## Testing
- `git diff --check`
- `tsc -p \"ee/apps/den-api/tsconfig.json\" --noEmit`
- `tsc -p \"ee/apps/den-web/tsconfig.json\" --noEmit` *(still fails on the pre-existing `ee/apps/den-web/app/api/_lib/upstream-proxy.ts:179` BodyInit typing issue)*
- Chrome MCP: verified signup lands on the direct create-organization form, invited users join without checkout, and worker/member limit dialogs open with the feedback CTA

## Evidence
- Local Chrome MCP screenshots captured in `tmp/chrome-org-create-default.png`, `tmp/chrome-invite-accepted.png`, `tmp/chrome-worker-limit-dialog.png`, and `tmp/chrome-member-limit-dialog.png`