### PR TITLE
feat(labs): opencode as embedded not cli owned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 packages/*/node_modules/
 apps/*/node_modules/
+apps/labs/.cache/
+apps/labs/runtime/.generated/
 ee/apps/*/node_modules/
 ee/packages/*/node_modules/
 .next/

--- a/apps/app/src/app/components/select-menu.tsx
+++ b/apps/app/src/app/components/select-menu.tsx
@@ -1,0 +1,116 @@
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
+import { Check, ChevronDown } from "lucide-solid";
+
+export type SelectMenuOption = {
+  value: string;
+  label: string;
+};
+
+type SelectMenuProps = {
+  options: SelectMenuOption[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  id?: string;
+  /** For pairing with a visible `<label>` element */
+  ariaLabelledBy?: string;
+  /** When there is no visible label */
+  ariaLabel?: string;
+};
+
+const triggerClass =
+  "flex w-full items-center justify-between gap-2 rounded-xl border border-dls-border bg-dls-surface px-3.5 py-2.5 text-left text-[14px] text-dls-text shadow-none transition-[border-color,box-shadow] hover:border-dls-border focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.14)] disabled:cursor-not-allowed disabled:opacity-60";
+
+const panelClass =
+  "absolute left-0 right-0 top-[calc(100%+6px)] z-[100] max-h-56 overflow-auto rounded-xl border border-dls-border bg-dls-surface py-1 shadow-[var(--dls-shell-shadow)]";
+
+const optionRowClass =
+  "flex w-full items-center gap-2 px-3 py-2.5 text-left text-[13px] text-dls-text transition-colors hover:bg-dls-hover";
+
+export default function SelectMenu(props: SelectMenuProps) {
+  const [open, setOpen] = createSignal(false);
+  let rootEl: HTMLDivElement | undefined;
+
+  const displayLabel = createMemo(() => {
+    const match = props.options.find((o) => o.value === props.value);
+    if (match) return match.label;
+    return props.placeholder?.trim() || "";
+  });
+
+  const close = () => setOpen(false);
+
+  createEffect(() => {
+    if (!open()) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (rootEl && target && !rootEl.contains(target)) {
+        close();
+      }
+    };
+    window.addEventListener("pointerdown", onPointerDown, true);
+    onCleanup(() => window.removeEventListener("pointerdown", onPointerDown, true));
+  });
+
+  createEffect(() => {
+    if (!open()) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    onCleanup(() => window.removeEventListener("keydown", onKeyDown));
+  });
+
+  return (
+    <div ref={(el) => (rootEl = el)} class="relative w-full">
+      <button
+        type="button"
+        id={props.id}
+        class={triggerClass}
+        disabled={props.disabled}
+        aria-expanded={open()}
+        aria-haspopup="listbox"
+        aria-labelledby={props.ariaLabelledBy}
+        aria-label={props.ariaLabel}
+        onClick={() => {
+          if (props.disabled) return;
+          setOpen((o) => !o);
+        }}
+      >
+        <span class="min-w-0 flex-1 truncate">{displayLabel()}</span>
+        <ChevronDown
+          size={18}
+          class={`shrink-0 text-dls-secondary transition-transform duration-200 ${open() ? "rotate-180" : ""}`}
+          aria-hidden
+        />
+      </button>
+
+      <Show when={open() && !props.disabled}>
+        <div class={panelClass} role="listbox">
+          <For each={props.options}>
+            {(opt) => (
+              <button
+                type="button"
+                role="option"
+                aria-selected={opt.value === props.value}
+                class={`${optionRowClass} ${opt.value === props.value ? "bg-dls-hover/80" : ""}`}
+                onClick={() => {
+                  props.onChange(opt.value);
+                  close();
+                }}
+              >
+                <span class="min-w-0 flex-1 truncate">{opt.label}</span>
+                <Show when={opt.value === props.value}>
+                  <Check size={16} class="shrink-0 text-[var(--dls-accent)]" aria-hidden />
+                </Show>
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/apps/app/src/app/pages/skills.tsx
+++ b/apps/app/src/app/pages/skills.tsx
@@ -6,6 +6,7 @@ import type { SkillBundleV1 } from "../bundles/types";
 import { saveInstalledSkillToOpenWorkOrg } from "../bundles/skill-org-publish";
 
 import Button from "../components/button";
+import SelectMenu, { type SelectMenuOption } from "../components/select-menu";
 import {
   ArrowLeft,
   Copy,
@@ -30,17 +31,17 @@ import { buildDenAuthUrl, createDenClient, readDenSettings, type DenOrgSkillHubS
 import { useStatusToasts, type AppStatusToastTone } from "../shell/status-toasts";
 import WorkspaceOptionCard from "../workspace/option-card";
 import {
-  errorBannerClass,
   inputClass,
   modalHeaderButtonClass,
   modalHeaderClass,
+  modalNoticeErrorClass,
+  modalNoticeSuccessClass,
   modalOverlayClass,
   modalShellClass,
   modalSubtitleClass,
   modalTitleClass,
   pillPrimaryClass as sharePillPrimaryClass,
   pillSecondaryClass as sharePillSecondaryClass,
-  successBannerClass,
   surfaceCardClass,
   tagClass as shareTagClass,
 } from "../workspace/modal-styles";
@@ -161,6 +162,13 @@ export default function SkillsView(props: SkillsViewProps) {
         return translate("skills.share_chooser_subtitle");
     }
   });
+
+  const shareHubSelectOptions = createMemo(
+    (): SelectMenuOption[] => [
+      { value: "", label: translate("skills.share_team_hub_none") },
+      ...shareManageableHubs().map((h) => ({ value: h.id, label: h.name })),
+    ],
+  );
 
   createEffect(() => {
     if (!shareOpen()) return;
@@ -1067,7 +1075,7 @@ export default function SkillsView(props: SkillsViewProps) {
                     </div>
 
                     <Show when={shareError()}>
-                      <div class={`mb-3 ${errorBannerClass}`}>{shareError()}</div>
+                      <div class={`mb-3 ${modalNoticeErrorClass}`}>{shareError()}</div>
                     </Show>
 
                     <Show
@@ -1119,15 +1127,15 @@ export default function SkillsView(props: SkillsViewProps) {
                     </div>
 
                     <Show when={shareTeamError()?.trim()}>
-                      <div class={`mt-4 ${errorBannerClass}`}>{shareTeamError()}</div>
+                      <div class={`mt-4 ${modalNoticeErrorClass}`}>{shareTeamError()}</div>
                     </Show>
 
                     <Show when={shareTeamSuccess()?.trim()}>
-                      <div class={`mt-4 ${successBannerClass}`}>{shareTeamSuccess()}</div>
+                      <div class={`mt-4 ${modalNoticeSuccessClass}`}>{shareTeamSuccess()}</div>
                     </Show>
 
                     <Show when={shareHubsError()?.trim()}>
-                      <div class={`mt-4 ${errorBannerClass}`}>{shareHubsError()}</div>
+                      <div class={`mt-4 ${modalNoticeErrorClass}`}>{shareHubsError()}</div>
                     </Show>
 
                     <Show when={shareCloudSignedIn() && shareTeamDisabledReason()?.trim()}>
@@ -1135,22 +1143,21 @@ export default function SkillsView(props: SkillsViewProps) {
                     </Show>
 
                     <Show when={shareCloudSignedIn() && shareManageableHubs().length > 0}>
-                      <label class="mt-4 block">
-                        <span class="mb-1.5 block text-[13px] font-medium text-dls-text">
+                      <div class="mt-4">
+                        <span
+                          id="skills-share-hub-label"
+                          class="mb-1.5 block text-[13px] font-medium text-dls-text"
+                        >
                           {translate("skills.share_team_hub_label")}
                         </span>
-                        <select
-                          class={inputClass}
+                        <SelectMenu
+                          aria-labelledby="skills-share-hub-label"
+                          options={shareHubSelectOptions()}
                           value={shareHubChoice()}
-                          onChange={(e) => setShareHubChoice(e.currentTarget.value)}
+                          onChange={setShareHubChoice}
                           disabled={shareTeamBusy() || Boolean(shareTeamSuccess()?.trim())}
-                        >
-                          <option value="">{translate("skills.share_team_hub_none")}</option>
-                          <For each={shareManageableHubs()}>
-                            {(hub) => <option value={hub.id}>{hub.name}</option>}
-                          </For>
-                        </select>
-                      </label>
+                        />
+                      </div>
                     </Show>
 
                     <Show when={shareCloudSignedIn() && shareHubsLoading()}>

--- a/apps/app/src/app/workspace/modal-styles.ts
+++ b/apps/app/src/app/workspace/modal-styles.ts
@@ -69,3 +69,13 @@ export const errorBannerClass =
 
 export const successBannerClass =
   "rounded-[20px] border border-emerald-7/20 bg-emerald-3/30 px-4 py-3 text-[13px] text-emerald-11";
+
+/** Softer inline notices inside modals (avoids heavy outlines on light surfaces) */
+export const modalNoticeNeutralClass =
+  "rounded-xl border border-dls-border bg-dls-hover px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
+
+export const modalNoticeSuccessClass =
+  "rounded-xl border border-dls-border bg-emerald-2/25 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";
+
+export const modalNoticeErrorClass =
+  "rounded-xl border border-dls-border bg-red-2/20 px-3 py-2.5 text-[13px] leading-relaxed text-dls-text";

--- a/apps/labs/electron/kernel.mjs
+++ b/apps/labs/electron/kernel.mjs
@@ -1,0 +1,709 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import electron from "electron";
+import { access, cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk/v2";
+import { install as installMicrosandbox, isInstalled as isMicrosandboxInstalled, Patch, Sandbox } from "microsandbox";
+
+const { BrowserWindow } = electron;
+
+const LOCAL_URL = "http://127.0.0.1:4096";
+const HEALTH_POLL_MS = 20_000;
+const SESSION_LIMIT = 200;
+const OPENWORK_PORT = 8787;
+const MICROSANDBOX_IMAGE = process.env.LABS_MICROSANDBOX_IMAGE || "node:current-bookworm";
+const KERNEL_DIR = dirname(fileURLToPath(import.meta.url));
+const SDK_DIR = resolve(KERNEL_DIR, "../node_modules/@opencode-ai/sdk");
+const GUEST_START_PATH = resolve(KERNEL_DIR, "../runtime/guest-start.mjs");
+const OPENCODE_CACHE_DIR = resolve(KERNEL_DIR, "../.cache/opencode-linux-arm64");
+const OPENCODE_BINARY_PATH = resolve(OPENCODE_CACHE_DIR, "opencode");
+const OPENCODE_VERSION = "1.3.13";
+const HOME_DIR = process.env.HOME || "";
+const HOST_OPENCODE_DATA_DIR = resolve(HOME_DIR, ".local/share/opencode");
+const HOST_OPENCODE_CONFIG_DIR = resolve(HOME_DIR, ".config/opencode");
+
+function stripTrailingSlash(input) {
+  return String(input ?? "").replace(/\/+$/, "");
+}
+
+function withInferredProtocol(input) {
+  if (/^[a-z]+:\/\//i.test(input)) return input;
+  if (/^(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?(\/|$)/i.test(input)) {
+    return `http://${input}`;
+  }
+  return `https://${input}`;
+}
+
+function normalizeBaseUrl(input) {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) return "";
+
+  try {
+    const url = new URL(withInferredProtocol(trimmed));
+    if (/^localhost$/i.test(url.hostname)) {
+      url.hostname = "127.0.0.1";
+    }
+    const path = stripTrailingSlash(url.pathname || "");
+    const isLocal = /^(127\.0\.0\.1|0\.0\.0\.0)$/i.test(url.hostname);
+    const isWorkspaceProxy = path.startsWith("/w/");
+    if (isLocal) {
+      url.pathname = isWorkspaceProxy ? path : "";
+    } else {
+      url.pathname = isWorkspaceProxy || path.endsWith("/opencode") ? path : `${path || ""}/opencode`;
+    }
+    return stripTrailingSlash(url.toString());
+  } catch {
+    return "";
+  }
+}
+
+function describeError(error) {
+  if (error instanceof Error && error.message.trim()) return error.message.trim();
+  if (typeof error === "string" && error.trim()) return error.trim();
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return "Unknown error";
+  }
+}
+
+function unwrap(result) {
+  if (result && typeof result === "object" && "data" in result) {
+    if (result.data !== undefined) return result.data;
+    throw new Error(describeError(result.error));
+  }
+  return result;
+}
+
+function normalizeEvent(raw) {
+  if (!raw || typeof raw !== "object" || typeof raw.type !== "string") return null;
+  return {
+    type: raw.type,
+    properties: raw.properties,
+  };
+}
+
+function buildClient(baseUrl, token) {
+  return createOpencodeClient({
+    baseUrl,
+    headers: token?.trim()
+      ? {
+          Authorization: `Bearer ${token.trim()}`,
+        }
+      : undefined,
+  });
+}
+
+function broadcast(channel, payload) {
+  const windows = typeof BrowserWindow?.getAllWindows === "function" ? BrowserWindow.getAllWindows() : [];
+  for (const window of windows) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(channel, payload);
+    }
+  }
+}
+
+function slugify(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "workspace";
+}
+
+async function ensurePath(filePath) {
+  await access(filePath);
+  return filePath;
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, options);
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(new Error(stderr || stdout || `${command} exited with code ${code}`));
+    });
+  });
+}
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createNetServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function fetchJson(url, token) {
+  const response = await fetch(url, {
+    headers: token?.trim()
+      ? {
+          Authorization: `Bearer ${token.trim()}`,
+        }
+      : undefined,
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function waitFor(predicate, timeoutMs, delayMs = 1_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      return await predicate();
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+async function ensureLinuxOpencodeBinary() {
+  try {
+    return await ensurePath(OPENCODE_BINARY_PATH);
+  } catch {
+    await mkdir(OPENCODE_CACHE_DIR, { recursive: true });
+    await run(
+      "bash",
+      [
+        "-lc",
+        `curl -fsSL "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-arm64.tar.gz" | tar -xzf - -C "${OPENCODE_CACHE_DIR}"`,
+      ],
+      {},
+    );
+    return ensurePath(OPENCODE_BINARY_PATH);
+  }
+}
+
+async function ensureMicrosandbox() {
+  if (!isMicrosandboxInstalled()) {
+    await installMicrosandbox();
+  }
+}
+
+async function ensureGuestAssets() {
+  await ensurePath(SDK_DIR);
+  await ensurePath(GUEST_START_PATH);
+  await ensureLinuxOpencodeBinary();
+}
+
+async function maybeCopyPatch(source, target, options = {}) {
+  try {
+    await access(source);
+    return Patch.copyFile(source, target, { replace: true, ...options });
+  } catch {
+    return null;
+  }
+}
+
+async function createRepoSnapshot(repoPath, workspaceId) {
+  const snapshotRoot = await mkdtemp(resolve(tmpdir(), `labs-${slugify(workspaceId)}-`));
+  const snapshotPath = resolve(snapshotRoot, "repo");
+  try {
+    const { stdout } = await run(
+      "git",
+      ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+      { cwd: repoPath },
+    );
+    const files = stdout.split("\0").filter(Boolean);
+    for (const relativePath of files) {
+      const source = resolve(repoPath, relativePath);
+      const destination = resolve(snapshotPath, relativePath);
+      await mkdir(dirname(destination), { recursive: true });
+      await cp(source, destination, { recursive: false, dereference: true });
+    }
+  } catch {
+    await cp(repoPath, snapshotPath, {
+      recursive: true,
+      dereference: true,
+      filter: (source) => {
+        const name = source.split(/[\\/]/).filter(Boolean).pop() ?? "";
+        if (name.includes(".bun-build")) return false;
+        return ![
+          "node_modules",
+          ".pnpm-store",
+          ".next",
+          ".turbo",
+          "_worktrees",
+          "sidecars",
+          "dist",
+          "build",
+          "coverage",
+          ".cache",
+          "target",
+          ".git",
+        ].includes(name);
+      },
+    });
+  }
+  return { snapshotRoot, snapshotPath };
+}
+
+async function resolveOpenworkProxyBase(baseUrl, token) {
+  const openworkBaseUrl = normalizeBaseUrl(baseUrl);
+  const workspaces = await fetchJson(`${openworkBaseUrl}/workspaces`, token);
+  const items = Array.isArray(workspaces.items)
+    ? workspaces.items
+    : Array.isArray(workspaces.workspaces)
+      ? workspaces.workspaces
+      : [];
+  const workspace = items[0] ?? null;
+  const workspaceId = typeof workspace?.id === "string" ? workspace.id.trim() : "";
+  if (!workspaceId) {
+    throw new Error("OpenWork server did not return an accessible workspace.");
+  }
+  return {
+    serverType: "openwork",
+    serverWorkspaceId: workspaceId,
+    openworkBaseUrl,
+    baseUrl: `${openworkBaseUrl}/w/${encodeURIComponent(workspaceId)}/opencode`,
+  };
+}
+
+async function maybeResolveRemoteBase(workspace) {
+  const normalized = { ...workspace };
+  normalized.baseUrl = normalizeBaseUrl(normalized.baseUrl);
+  if (!normalized.baseUrl) {
+    throw new Error("Enter a valid server URL.");
+  }
+
+  const pathname = new URL(normalized.baseUrl).pathname;
+  if (pathname.startsWith("/w/") || pathname.endsWith("/opencode")) {
+    normalized.serverType = normalized.serverType === "unknown" ? "opencode" : normalized.serverType;
+    return normalized;
+  }
+
+  try {
+    const resolved = await resolveOpenworkProxyBase(normalized.baseUrl, normalized.token ?? null);
+    return {
+      ...normalized,
+      baseUrl: resolved.baseUrl,
+      serverType: resolved.serverType,
+      serverWorkspaceId: resolved.serverWorkspaceId,
+    };
+  } catch {
+    return {
+      ...normalized,
+      serverType: normalized.serverType === "unknown" ? "opencode" : normalized.serverType,
+    };
+  }
+}
+
+async function ensureMicrosandboxWorkspace(workspace) {
+  if (!workspace.repoPath?.trim()) {
+    throw new Error("Choose a repository folder for this workspace.");
+  }
+
+  await ensureMicrosandbox();
+  await ensureGuestAssets();
+
+  const sandboxName = workspace.sandboxName?.trim() || `labs-${slugify(workspace.id)}`;
+  const hostPort = Number.isFinite(workspace.hostPort) && workspace.hostPort ? workspace.hostPort : await getFreePort();
+  const token = workspace.token?.trim() || `labs-${randomUUID()}`;
+  const existing = runtimeState.locals.get(workspace.id);
+  if (existing) {
+    return {
+      ...workspace,
+      baseUrl: existing.baseUrl,
+      token: existing.token,
+      runtime: "microsandbox",
+      kind: "local",
+      hostPort: existing.hostPort,
+      sandboxName: existing.sandboxName,
+      serverType: "openwork",
+      serverWorkspaceId: "default",
+    };
+  }
+
+  const { snapshotRoot, snapshotPath } = await createRepoSnapshot(workspace.repoPath.trim(), workspace.id);
+  const guestAuth = await Promise.all([
+    maybeCopyPatch(resolve(HOST_OPENCODE_DATA_DIR, "auth.json"), "/persist/openwork/.local/share/opencode/auth.json", { mode: 0o600 }),
+    maybeCopyPatch(resolve(HOST_OPENCODE_DATA_DIR, "mcp-auth.json"), "/persist/openwork/.local/share/opencode/mcp-auth.json", { mode: 0o600 }),
+    maybeCopyPatch(resolve(HOST_OPENCODE_CONFIG_DIR, "opencode.json"), "/persist/openwork/.config/opencode/opencode.json", { mode: 0o600 }),
+  ]).then((items) => items.filter(Boolean));
+
+  let sandbox = null;
+  try {
+    sandbox = await Sandbox.create({
+      name: sandboxName,
+      image: MICROSANDBOX_IMAGE,
+      replace: true,
+      quietLogs: true,
+      network: { policy: "allow-all" },
+      ports: { [String(hostPort)]: OPENWORK_PORT },
+      env: {
+        LABS_OPENWORK_TOKEN: token,
+        LABS_REMOTE_ACCESS: "1",
+      },
+      patches: [
+        Patch.mkdir("/opt/labs"),
+        Patch.mkdir("/opt/labs/node_modules/@opencode-ai"),
+        Patch.mkdir("/persist/openwork/.local/share/opencode"),
+        Patch.mkdir("/persist/openwork/.config/opencode"),
+        Patch.copyDir(SDK_DIR, "/opt/labs/node_modules/@opencode-ai/sdk", { replace: true }),
+        Patch.copyFile(GUEST_START_PATH, "/opt/labs/guest-start.mjs", {
+          mode: 0o755,
+          replace: true,
+        }),
+        Patch.copyFile(OPENCODE_BINARY_PATH, "/usr/local/bin/opencode", {
+          mode: 0o755,
+          replace: true,
+        }),
+        Patch.copyDir(snapshotPath, "/workspace/repo", { replace: true }),
+        Patch.mkdir("/persist/openwork"),
+        ...guestAuth,
+      ],
+      cmd: ["sh", "-lc", "sleep infinity"],
+    });
+    const proc = await sandbox.shellStream("cd /opt/labs && node /opt/labs/guest-start.mjs");
+    void (async () => {
+      while (await proc.recv()) {
+        // keep process output flowing so the guest server can stay attached
+      }
+    })();
+  } finally {
+    await rm(snapshotRoot, { recursive: true, force: true });
+  }
+
+  const openworkBaseUrl = `http://127.0.0.1:${hostPort}`;
+  await waitFor(() => fetchJson(`${openworkBaseUrl}/health`, token), 240_000, 2_000);
+  const resolved = await waitFor(() => resolveOpenworkProxyBase(openworkBaseUrl, token), 60_000, 1_500);
+  runtimeState.locals.set(workspace.id, {
+    sandbox,
+    hostPort,
+    sandboxName,
+    token,
+    baseUrl: resolved.baseUrl,
+  });
+
+  return {
+    ...workspace,
+    baseUrl: resolved.baseUrl,
+    token,
+    runtime: "microsandbox",
+    kind: "local",
+    hostPort,
+    sandboxName,
+    serverType: resolved.serverType,
+    serverWorkspaceId: resolved.serverWorkspaceId,
+  };
+}
+
+const runtimeState = {
+  localRuntime: null,
+  localBoot: null,
+  workspaces: new Map(),
+  locals: new Map(),
+};
+
+async function ensureLocalServer() {
+  if (runtimeState.localRuntime) {
+    return { baseUrl: runtimeState.localRuntime.url };
+  }
+
+  if (runtimeState.localBoot) {
+    return runtimeState.localBoot;
+  }
+
+  runtimeState.localBoot = (async () => {
+    try {
+      const client = buildClient(LOCAL_URL, null);
+      await client.global.health();
+      return { baseUrl: LOCAL_URL };
+    } catch {
+      const runtime = await createOpencode({ port: 4096 });
+      runtimeState.localRuntime = {
+        url: normalizeBaseUrl(runtime.server.url),
+        close: () => runtime.server.close(),
+      };
+      return { baseUrl: runtimeState.localRuntime.url };
+    }
+  })();
+
+  try {
+    return await runtimeState.localBoot;
+  } finally {
+    runtimeState.localBoot = null;
+  }
+}
+
+function getWorkspaceEntry(workspaceId) {
+  return runtimeState.workspaces.get(workspaceId) ?? null;
+}
+
+async function startWorkspaceEvents(workspaceId, client) {
+  const entry = getWorkspaceEntry(workspaceId);
+  if (!entry || entry.eventLoopStarted) return;
+  entry.eventLoopStarted = true;
+
+  let reconnectDelay = 1_000;
+  while (!entry.controller.signal.aborted) {
+    try {
+      const subscription = await client.event.subscribe(undefined, { signal: entry.controller.signal });
+      reconnectDelay = 1_000;
+      for await (const raw of subscription.stream) {
+        if (entry.controller.signal.aborted) return;
+        const event = normalizeEvent(raw);
+        if (!event) continue;
+        broadcast("labs:event", { workspaceId, event });
+      }
+    } catch (error) {
+      if (entry.controller.signal.aborted) return;
+      broadcast("labs:connection", {
+        workspaceId,
+        connection: {
+          status: "disconnected",
+          message: describeError(error),
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, reconnectDelay));
+      reconnectDelay = Math.min(reconnectDelay * 2, 8_000);
+    }
+  }
+}
+
+function cleanupWorkspaceEntry(workspaceId) {
+  const entry = getWorkspaceEntry(workspaceId);
+  if (!entry) return null;
+  if (entry.healthInterval) {
+    clearInterval(entry.healthInterval);
+  }
+  entry.controller.abort();
+  runtimeState.workspaces.delete(workspaceId);
+  return entry.workspace;
+}
+
+async function removeWorkspace(workspaceId) {
+  const workspace = cleanupWorkspaceEntry(workspaceId);
+  const local = runtimeState.locals.get(workspaceId) ?? null;
+  runtimeState.locals.delete(workspaceId);
+  if (!workspace) return true;
+
+  if (local?.sandbox) {
+    try {
+      await local.sandbox.kill().catch(() => {});
+      await Sandbox.remove(local.sandboxName).catch(() => {});
+    } catch {
+      // ignore cleanup failures for removed workspaces
+    }
+    return true;
+  }
+
+  if (workspace.runtime === "microsandbox" && workspace.sandboxName) {
+    try {
+      const handle = await Sandbox.get(workspace.sandboxName);
+      if (handle.status === "running") {
+        await handle.kill();
+      }
+      await handle.remove();
+    } catch {
+      // ignore cleanup failures for removed workspaces
+    }
+  }
+
+  return true;
+}
+
+async function listSessions(client) {
+  return unwrap(await client.session.list({ roots: false, limit: SESSION_LIMIT }));
+}
+
+async function refreshWorkspace(workspaceId) {
+  const entry = getWorkspaceEntry(workspaceId);
+  if (!entry) {
+    throw new Error("Workspace is not registered.");
+  }
+
+  try {
+    const health = unwrap(await entry.client.global.health());
+    if (health?.healthy === false) {
+      throw new Error("Server reported unhealthy state.");
+    }
+    const sessions = await listSessions(entry.client);
+    const payload = {
+      connection: {
+        status: "connected",
+        message: "Connected",
+      },
+      sessions,
+    };
+    broadcast("labs:connection", { workspaceId, connection: payload.connection });
+    return payload;
+  } catch (error) {
+    const payload = {
+      connection: {
+        status: "disconnected",
+        message: describeError(error),
+      },
+      sessions: [],
+    };
+    broadcast("labs:connection", { workspaceId, connection: payload.connection });
+    return payload;
+  }
+}
+
+async function ensureWorkspace(workspace) {
+  let normalized = { ...workspace };
+  if (normalized.kind === "local" || normalized.runtime === "microsandbox" || normalized.repoPath?.trim()) {
+    normalized = await ensureMicrosandboxWorkspace(normalized);
+  } else {
+    normalized = await maybeResolveRemoteBase(normalized);
+  }
+
+  if (!normalized.baseUrl) {
+    throw new Error(normalized.kind === "local"
+      ? "Local runtime is unavailable."
+      : "Enter a valid server URL.");
+  }
+
+  const configKey = JSON.stringify({
+    baseUrl: normalized.baseUrl,
+    token: normalized.token?.trim() ?? "",
+    hostPort: normalized.hostPort ?? null,
+    repoPath: normalized.repoPath?.trim() ?? null,
+    sandboxName: normalized.sandboxName ?? null,
+    serverType: normalized.serverType ?? "unknown",
+  });
+  const existing = getWorkspaceEntry(normalized.id);
+  if (existing && existing.configKey === configKey) {
+    return { workspace: existing.workspace };
+  }
+
+  cleanupWorkspaceEntry(normalized.id);
+  const controller = new AbortController();
+  const client = buildClient(normalized.baseUrl, normalized.token ?? null);
+  runtimeState.workspaces.set(normalized.id, {
+    workspace: normalized,
+    configKey,
+    client,
+    controller,
+    healthInterval: null,
+    eventLoopStarted: false,
+  });
+
+  const entry = getWorkspaceEntry(normalized.id);
+  void startWorkspaceEvents(normalized.id, client);
+  entry.healthInterval = setInterval(() => {
+    void refreshWorkspace(normalized.id);
+  }, HEALTH_POLL_MS);
+  const refreshed = await refreshWorkspace(normalized.id);
+  return {
+    workspace: normalized,
+    connection: refreshed.connection,
+    sessions: refreshed.sessions,
+  };
+}
+
+async function getSessionMessages(workspaceId, sessionId) {
+  const entry = getWorkspaceEntry(workspaceId);
+  if (!entry) {
+    throw new Error("Workspace is not connected.");
+  }
+  return unwrap(await entry.client.session.messages({ sessionID: sessionId, limit: SESSION_LIMIT }));
+}
+
+async function createSession(workspaceId, options = {}) {
+  const entry = getWorkspaceEntry(workspaceId);
+  if (!entry) {
+    throw new Error("Workspace is not connected.");
+  }
+
+  const created = unwrap(await entry.client.session.create({}));
+  const nextTitle = String(options.title ?? "").trim();
+  if (!nextTitle) {
+    return created;
+  }
+
+  try {
+    return unwrap(await entry.client.session.update({ sessionID: created.id, title: nextTitle }));
+  } catch {
+    return {
+      ...created,
+      title: nextTitle,
+    };
+  }
+}
+
+async function sendPrompt(workspaceId, sessionId, prompt) {
+  const entry = getWorkspaceEntry(workspaceId);
+  if (!entry) {
+    throw new Error("Workspace is not connected.");
+  }
+  const trimmed = String(prompt ?? "").trim();
+  if (!trimmed) return { sessionId };
+
+  let resolvedSessionId = sessionId;
+  if (!resolvedSessionId) {
+    const created = await createSession(workspaceId);
+    resolvedSessionId = created.id;
+  }
+
+  await unwrap(
+    await entry.client.session.promptAsync({
+      sessionID: resolvedSessionId,
+      parts: [{ type: "text", text: trimmed }],
+    }),
+  );
+  return { sessionId: resolvedSessionId };
+}
+
+async function abortSession(workspaceId, sessionId) {
+  if (!sessionId) return;
+  const entry = getWorkspaceEntry(workspaceId);
+  if (!entry) {
+    throw new Error("Workspace is not connected.");
+  }
+  await entry.client.session.abort({ sessionID: sessionId });
+}
+
+function teardownKernel() {
+  for (const workspaceId of runtimeState.workspaces.keys()) {
+    cleanupWorkspaceEntry(workspaceId);
+  }
+  for (const [workspaceId] of runtimeState.locals.entries()) {
+    runtimeState.locals.delete(workspaceId);
+  }
+  runtimeState.localRuntime?.close();
+  runtimeState.localRuntime = null;
+}
+
+export const labsKernel = {
+  ensureLocalServer,
+  ensureWorkspace,
+  refreshWorkspace,
+  removeWorkspace,
+  getSessionMessages,
+  createSession,
+  sendPrompt,
+  abortSession,
+  teardownKernel,
+};

--- a/apps/labs/electron/main.mjs
+++ b/apps/labs/electron/main.mjs
@@ -1,46 +1,15 @@
-import { app, BrowserWindow, ipcMain, shell } from "electron";
-import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk/v2";
+import electron from "electron";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { labsKernel } from "./kernel.mjs";
+
+const { app, BrowserWindow, ipcMain, shell } = electron;
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rendererUrl = process.env.LABS_RENDERER_URL || "";
-const localUrl = "http://127.0.0.1:4096";
 
 let mainWindow = null;
-let local = null;
-let boot = null;
-
-async function ensureLocalServer() {
-  if (local) {
-    return { baseUrl: local.url };
-  }
-
-  if (boot) {
-    return boot;
-  }
-
-  boot = (async () => {
-    try {
-      const client = createOpencodeClient({ baseUrl: localUrl });
-      await client.global.health();
-      return { baseUrl: localUrl };
-    } catch {
-      const runtime = await createOpencode();
-      local = {
-        url: runtime.server.url,
-        close: () => runtime.server.close(),
-      };
-      return { baseUrl: runtime.server.url };
-    }
-  })();
-
-  try {
-    return await boot;
-  } finally {
-    boot = null;
-  }
-}
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -73,12 +42,51 @@ function createWindow() {
 }
 
 ipcMain.handle("labs:ensure-local-server", async () => {
-  return ensureLocalServer();
+  return labsKernel.ensureLocalServer();
+});
+
+ipcMain.handle("labs:pick-repo-directory", async () => {
+  const result = await electron.dialog.showOpenDialog({
+    properties: ["openDirectory"],
+    title: "Choose workspace repository",
+  });
+  if (result.canceled) return null;
+  return result.filePaths[0] ?? null;
+});
+
+ipcMain.handle("labs:ensure-workspace", async (_event, workspace) => {
+  return labsKernel.ensureWorkspace(workspace);
+});
+
+ipcMain.handle("labs:refresh-workspace", async (_event, workspaceId) => {
+  return labsKernel.refreshWorkspace(workspaceId);
+});
+
+ipcMain.handle("labs:remove-workspace", async (_event, workspaceId) => {
+  labsKernel.removeWorkspace(workspaceId);
+  return true;
+});
+
+ipcMain.handle("labs:get-session-messages", async (_event, payload) => {
+  return labsKernel.getSessionMessages(payload.workspaceId, payload.sessionId);
+});
+
+ipcMain.handle("labs:create-session", async (_event, payload) => {
+  return labsKernel.createSession(payload.workspaceId, payload.options ?? {});
+});
+
+ipcMain.handle("labs:send-prompt", async (_event, payload) => {
+  return labsKernel.sendPrompt(payload.workspaceId, payload.sessionId ?? null, payload.prompt);
+});
+
+ipcMain.handle("labs:abort-session", async (_event, payload) => {
+  await labsKernel.abortSession(payload.workspaceId, payload.sessionId ?? null);
+  return true;
 });
 
 app.whenReady().then(async () => {
   try {
-    await ensureLocalServer();
+    await labsKernel.ensureLocalServer();
   } catch (error) {
     console.error("Failed to start local OpenCode server", error);
   }
@@ -93,8 +101,7 @@ app.whenReady().then(async () => {
 });
 
 app.on("before-quit", () => {
-  local?.close();
-  local = null;
+  labsKernel.teardownKernel();
 });
 
 app.on("window-all-closed", () => {

--- a/apps/labs/electron/preload.mjs
+++ b/apps/labs/electron/preload.mjs
@@ -1,7 +1,31 @@
-import { contextBridge, ipcRenderer } from "electron";
+import electron from "electron";
+
+const { contextBridge, ipcRenderer } = electron;
 
 contextBridge.exposeInMainWorld("openworkLabsDesktop", {
   isDesktop: true,
   platform: process.platform,
   ensureLocalServer: () => ipcRenderer.invoke("labs:ensure-local-server"),
+  pickRepoDirectory: () => ipcRenderer.invoke("labs:pick-repo-directory"),
+  ensureWorkspace: (workspace) => ipcRenderer.invoke("labs:ensure-workspace", workspace),
+  refreshWorkspace: (workspaceId) => ipcRenderer.invoke("labs:refresh-workspace", workspaceId),
+  removeWorkspace: (workspaceId) => ipcRenderer.invoke("labs:remove-workspace", workspaceId),
+  getSessionMessages: (workspaceId, sessionId) =>
+    ipcRenderer.invoke("labs:get-session-messages", { workspaceId, sessionId }),
+  createSession: (workspaceId, options) =>
+    ipcRenderer.invoke("labs:create-session", { workspaceId, options: options ?? {} }),
+  sendPrompt: (workspaceId, sessionId, prompt) =>
+    ipcRenderer.invoke("labs:send-prompt", { workspaceId, sessionId, prompt }),
+  abortSession: (workspaceId, sessionId) =>
+    ipcRenderer.invoke("labs:abort-session", { workspaceId, sessionId }),
+  subscribeEvents: (listener) => {
+    const eventHandler = (_event, payload) => listener({ kind: "event", ...payload });
+    const connectionHandler = (_event, payload) => listener({ kind: "connection", ...payload });
+    ipcRenderer.on("labs:event", eventHandler);
+    ipcRenderer.on("labs:connection", connectionHandler);
+    return () => {
+      ipcRenderer.off("labs:event", eventHandler);
+      ipcRenderer.off("labs:connection", connectionHandler);
+    };
+  },
 });

--- a/apps/labs/package.json
+++ b/apps/labs/package.json
@@ -9,11 +9,16 @@
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 3340 --strictPort",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "start": "electron ./electron/main.mjs"
+    "start": "electron ./electron/main.mjs",
+    "microsandbox:dry-run": "node ./scripts/microsandbox-dry-run.js",
+    "microsandbox:image-dry-run": "node ./scripts/microsandbox-image-dry-run.js",
+    "runtime:build": "bash ./scripts/build-runtime-image.sh",
+    "runtime:probe": "bash ./scripts/run-runtime-probe.sh"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.1.31",
     "@tanstack/react-virtual": "^3.13.23",
+    "microsandbox": "^0.3.8",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "streamdown": "^2.5.0"

--- a/apps/labs/runtime/Dockerfile
+++ b/apps/labs/runtime/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:current-bookworm
+
+WORKDIR /opt/labs
+
+ENV PNPM_HOME=/root/.local/share/pnpm
+ENV PATH=/opt/labs/node_modules/.bin:/root/.local/share/pnpm:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN node /usr/local/lib/node_modules/npm/bin/npm-cli.js install -g pnpm@10.27.0
+
+COPY package.json /opt/labs/package.json
+RUN node /usr/local/lib/node_modules/pnpm/bin/pnpm.cjs install --prod
+
+COPY guest-start.mjs /opt/labs/guest-start.mjs
+COPY .generated/opencode /usr/local/bin/opencode
+
+RUN mkdir -p /workspace/repo /persist/openwork
+RUN chmod +x /usr/local/bin/opencode
+
+ENV LABS_WORKSPACE_DIR=/workspace/repo
+ENV LABS_STATE_DIR=/persist/openwork
+ENV LABS_SERVER_PORT=8787
+ENV LABS_OPENCODE_PORT=4096
+ENV LABS_REMOTE_ACCESS=1
+
+CMD ["node", "/opt/labs/guest-start.mjs"]

--- a/apps/labs/runtime/guest-start.mjs
+++ b/apps/labs/runtime/guest-start.mjs
@@ -1,0 +1,206 @@
+import { spawn } from "node:child_process"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+import { createServer } from "node:http"
+import { mkdir } from "node:fs/promises"
+import { basename } from "node:path"
+import { Readable } from "node:stream"
+
+const root = process.env.LABS_WORKSPACE_DIR || "/workspace/repo"
+const state = process.env.LABS_STATE_DIR || "/persist/openwork"
+const port = Number(process.env.LABS_SERVER_PORT || "8787")
+const opencodePort = Number(process.env.LABS_OPENCODE_PORT || "4096")
+const host = process.env.LABS_REMOTE_ACCESS === "0" ? "127.0.0.1" : "0.0.0.0"
+const token = (process.env.LABS_OPENWORK_TOKEN || "").trim()
+const workspaceId = process.env.LABS_WORKSPACE_ID || "default"
+const opencodeBin = process.env.LABS_OPENCODE_BIN || "/usr/local/bin/opencode"
+const xdgDataHome = `${state}/.local/share`
+const xdgConfigHome = `${state}/.config`
+
+function json(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" })
+  res.end(JSON.stringify(body))
+}
+
+function unauthorized(res) {
+  json(res, 401, { ok: false, error: "Unauthorized" })
+}
+
+function allowed(req) {
+  if (!token) return true
+  const value = req.headers.authorization || ""
+  return value === `Bearer ${token}`
+}
+
+async function proxy(req, res, base, prefix) {
+  const url = new URL(req.url || "/", `http://${req.headers.host || "127.0.0.1"}`)
+  const next = url.pathname.slice(prefix.length) || "/"
+  const target = new URL(`${next}${url.search}`, base)
+  const headers = new Headers()
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!value) continue
+    if (key === "host") continue
+    if (key === "authorization") continue
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item)
+      continue
+    }
+    headers.set(key, value)
+  }
+
+  const init = {
+    method: req.method,
+    headers,
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : req,
+    duplex: req.method === "GET" || req.method === "HEAD" ? undefined : "half",
+  }
+
+  const upstream = await fetch(target, init)
+  const out = {}
+  upstream.headers.forEach((value, key) => {
+    if (key === "content-encoding") return
+    out[key] = value
+  })
+  res.writeHead(upstream.status, out)
+  if (!upstream.body) {
+    res.end()
+    return
+  }
+  Readable.fromWeb(upstream.body).pipe(res)
+}
+
+async function startOpencode() {
+  const proc = spawn(
+    opencodeBin,
+    ["serve", `--hostname=127.0.0.1`, `--port=${opencodePort}`],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        HOME: state,
+        XDG_DATA_HOME: xdgDataHome,
+        XDG_CONFIG_HOME: xdgConfigHome,
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({}),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  )
+
+  const url = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("Timed out waiting for opencode server"))
+    }, 30_000)
+    let output = ""
+
+    const fail = (err) => {
+      clearTimeout(timer)
+      reject(err)
+    }
+
+    proc.stdout?.on("data", (chunk) => {
+      output += chunk.toString()
+      for (const line of output.split("\n")) {
+        if (!line.startsWith("opencode server listening")) continue
+        const match = line.match(/on\s+(https?:\/\/[^\s]+)/)
+        if (!match) {
+          fail(new Error(`Failed to parse opencode url from: ${line}`))
+          return
+        }
+        clearTimeout(timer)
+        resolve(match[1])
+        return
+      }
+    })
+
+    proc.stderr?.on("data", (chunk) => {
+      output += chunk.toString()
+    })
+
+    proc.once("error", fail)
+    proc.once("exit", (code) => {
+      fail(new Error(`opencode exited with code ${code}\n${output}`))
+    })
+  })
+
+  return {
+    proc,
+    url,
+    client: createOpencodeClient({ baseUrl: url }),
+    close() {
+      proc.kill()
+    },
+  }
+}
+
+async function main() {
+  process.chdir(root)
+  process.env.HOME = state
+  await mkdir(state, { recursive: true })
+
+  const opencode = await startOpencode()
+
+  const base = new URL(opencode.url)
+  const proxyBase = `${base.origin}`
+  const server = createServer(async (req, res) => {
+    if (!allowed(req)) {
+      unauthorized(res)
+      return
+    }
+
+    const url = new URL(req.url || "/", `http://${req.headers.host || "127.0.0.1"}`)
+
+    if (url.pathname === "/health") {
+      json(res, 200, {
+        ok: true,
+        type: "labs-openwork-server",
+        workspace: {
+          id: workspaceId,
+          name: basename(root) || "Workspace",
+          path: root,
+        },
+      })
+      return
+    }
+
+    if (url.pathname === "/workspaces") {
+      json(res, 200, {
+        items: [
+          {
+            id: workspaceId,
+            name: basename(root) || "Workspace",
+            path: root,
+          },
+        ],
+      })
+      return
+    }
+
+    if (url.pathname === `/w/${workspaceId}/opencode` || url.pathname.startsWith(`/w/${workspaceId}/opencode/`)) {
+      await proxy(req, res, proxyBase, `/w/${workspaceId}/opencode`)
+      return
+    }
+
+    if (url.pathname === "/opencode" || url.pathname.startsWith("/opencode/")) {
+      await proxy(req, res, proxyBase, "/opencode")
+      return
+    }
+
+    json(res, 404, { ok: false, error: "Not found" })
+  })
+
+  const close = () => {
+    server.close()
+    opencode.close()
+  }
+
+  process.on("SIGINT", close)
+  process.on("SIGTERM", close)
+
+  server.listen(port, host, () => {
+    console.log(`labs-openwork-server listening on http://${host}:${port}`)
+  })
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/apps/labs/scripts/build-runtime-image.sh
+++ b/apps/labs/scripts/build-runtime-image.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_REF="${1:-labs-openwork-runtime:dev}"
+OPENCODE_VERSION="${OPENCODE_VERSION:-1.3.13}"
+
+OPENWORK_ROOT="$(git rev-parse --show-toplevel)"
+ENTERPRISE_ROOT="${OPENWORK_ROOT%%/_repos/openwork*}"
+RUNTIME_DIR="${OPENWORK_ROOT}/apps/labs/runtime"
+GENERATED_DIR="${RUNTIME_DIR}/.generated"
+ARCHIVE_PATH="${GENERATED_DIR}/opencode-linux-arm64.tar.gz"
+EXTRACT_DIR="${GENERATED_DIR}/opencode-linux-arm64"
+OPENCODE_BIN="${GENERATED_DIR}/opencode"
+
+mkdir -p "$GENERATED_DIR"
+
+if [ ! -x "$OPENCODE_BIN" ]; then
+  printf 'Downloading opencode %s linux-arm64 binary\n' "$OPENCODE_VERSION"
+  rm -rf "$EXTRACT_DIR"
+  mkdir -p "$EXTRACT_DIR"
+  curl -fsSL "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-arm64.tar.gz" -o "$ARCHIVE_PATH"
+  tar -xzf "$ARCHIVE_PATH" -C "$EXTRACT_DIR"
+  cp "$(find "$EXTRACT_DIR" -type f -name opencode | head -1)" "$OPENCODE_BIN"
+  chmod +x "$OPENCODE_BIN"
+fi
+
+docker build \
+  -t "$IMAGE_REF" \
+  -f "./runtime/Dockerfile" \
+  ./runtime
+
+printf 'Built runtime image: %s\n' "$IMAGE_REF"

--- a/apps/labs/scripts/microsandbox-dry-run.js
+++ b/apps/labs/scripts/microsandbox-dry-run.js
@@ -1,0 +1,26 @@
+import { Sandbox } from "microsandbox";
+
+async function main() {
+  const box = await Sandbox.create({
+    name: "labs-microsandbox-dry-run",
+    image: "node:current-bookworm",
+    replace: true,
+    quietLogs: true,
+  });
+
+  try {
+    const out = await box.shell("node -v && echo microsandbox-ok");
+    process.stdout.write(out.stdout());
+    if (out.stderr()) {
+      process.stderr.write(out.stderr());
+    }
+  } finally {
+    await box.stopAndWait();
+    await Sandbox.remove("labs-microsandbox-dry-run");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/labs/scripts/microsandbox-image-dry-run.js
+++ b/apps/labs/scripts/microsandbox-image-dry-run.js
@@ -1,0 +1,33 @@
+import { Sandbox } from "microsandbox";
+
+const image = process.argv[2];
+
+if (!image) {
+  console.error("Usage: node ./scripts/microsandbox-image-dry-run.js <image-ref-or-path>");
+  process.exit(1);
+}
+
+async function main() {
+  const box = await Sandbox.create({
+    name: "labs-microsandbox-image-dry-run",
+    image,
+    replace: true,
+    quietLogs: true,
+  });
+
+  try {
+    const out = await box.shell("node -v && echo image-ok");
+    process.stdout.write(out.stdout());
+    if (out.stderr()) {
+      process.stderr.write(out.stderr());
+    }
+  } finally {
+    await box.stopAndWait();
+    await Sandbox.remove("labs-microsandbox-image-dry-run");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/labs/scripts/microsandbox-node.Dockerfile
+++ b/apps/labs/scripts/microsandbox-node.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:current-bookworm
+
+WORKDIR /workspace
+
+CMD ["node", "-v"]

--- a/apps/labs/scripts/run-runtime-probe.sh
+++ b/apps/labs/scripts/run-runtime-probe.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_REF="${1:-labs-openwork-runtime:test}"
+WORKSPACE_DIR="${2:-/Users/benjaminshafii/openwork-enterprise/_repos/openwork}"
+HOST_PORT="${3:-18787}"
+
+docker rm -f labs-openwork-runtime-probe >/dev/null 2>&1 || true
+
+docker run -d \
+  --name labs-openwork-runtime-probe \
+  -p "${HOST_PORT}:8787" \
+  -e LABS_REMOTE_ACCESS=1 \
+  -v "${WORKSPACE_DIR}:/workspace/repo" \
+  "$IMAGE_REF"
+
+printf 'Runtime probe started: %s\n' "$IMAGE_REF"
+printf 'Mounted workspace: %s\n' "$WORKSPACE_DIR"
+printf 'Expected OpenWork URL: http://127.0.0.1:%s\n' "$HOST_PORT"

--- a/apps/labs/src/app.tsx
+++ b/apps/labs/src/app.tsx
@@ -84,10 +84,12 @@ export function App() {
   const [newWorkspaceName, setNewWorkspaceName] = useState("");
   const [newWorkspaceUrl, setNewWorkspaceUrl] = useState("");
   const [newWorkspaceToken, setNewWorkspaceToken] = useState("");
+  const [newWorkspaceRepoPath, setNewWorkspaceRepoPath] = useState("");
   const [workspaceForm, setWorkspaceForm] = useState({
     name: "",
     baseUrl: "",
     token: "",
+    repoPath: "",
   });
 
   const activeWorkspace = labs.activeWorkspace;
@@ -153,6 +155,7 @@ export function App() {
       setNewWorkspaceName("");
       setNewWorkspaceUrl("");
       setNewWorkspaceToken("");
+      setNewWorkspaceRepoPath("");
     } else if (labs.state.workspaces.length > 0) {
       setTemplateTargetMode("existing");
       setTemplateWorkspaceId(labs.state.workspaces[0]?.id ?? "");
@@ -166,8 +169,26 @@ export function App() {
       name: "",
       baseUrl: "",
       token: "",
+      repoPath: "",
     });
     setWorkspaceModalOpen(true);
+  };
+
+  const pickRepoDirectory = async () => {
+    if (!window.openworkLabsDesktop?.pickRepoDirectory) return null;
+    return window.openworkLabsDesktop.pickRepoDirectory();
+  };
+
+  const handlePickWorkspaceRepo = async () => {
+    const picked = await pickRepoDirectory();
+    if (!picked) return;
+    setWorkspaceForm((current) => ({ ...current, repoPath: picked }));
+  };
+
+  const handlePickTemplateWorkspaceRepo = async () => {
+    const picked = await pickRepoDirectory();
+    if (!picked) return;
+    setNewWorkspaceRepoPath(picked);
   };
 
   const handleWorkspaceSave = async () => {
@@ -176,7 +197,7 @@ export function App() {
     if (workspaceForm.baseUrl.trim()) {
       workspaceId = labs.saveWorkspace(workspaceForm);
     } else {
-      workspaceId = await labs.createLocalWorkspace(workspaceForm.name);
+      workspaceId = await labs.createLocalWorkspace(workspaceForm.name, workspaceForm.repoPath);
     }
     setWorkspaceBusy(false);
     if (!workspaceId) return;
@@ -212,7 +233,7 @@ export function App() {
             baseUrl: newWorkspaceUrl,
             token: newWorkspaceToken,
           })
-        : await labs.createLocalWorkspace(newWorkspaceName);
+        : await labs.createLocalWorkspace(newWorkspaceName, newWorkspaceRepoPath);
     }
 
     if (!workspaceId) {
@@ -385,7 +406,7 @@ export function App() {
                 <p className="eyebrow">Start here</p>
                 <h2>Connect a workspace</h2>
                  <p>
-                    Labs is session-first. Use your local OpenCode server on localhost:4096, or connect an existing remote server and jump straight into the conversations inside it.
+                    Labs is session-first. Use your local OpenCode server on localhost:4096, or connect any OpenWork or OpenCode server with a URL and access token.
                   </p>
                 <button type="button" className="primary-button" onClick={handleAddWorkspace}>
                   Add workspace
@@ -519,7 +540,7 @@ export function App() {
       </main>
 
       {workspaceModalOpen ? (
-        <ModalFrame title="Add workspace" subtitle="Leave the URL blank to use your local OpenCode server on localhost:4096, or paste a remote server URL.">
+        <ModalFrame title="Create workspace" subtitle="Leave the URL blank to launch a local microsandbox workspace from a repo, or paste any OpenWork/OpenCode server URL.">
           <div className="modal-field-grid">
             <label className="modal-field">
               <span>Name</span>
@@ -534,7 +555,7 @@ export function App() {
             </label>
 
             <label className="modal-field">
-              <span>OpenCode server URL</span>
+              <span>OpenWork or OpenCode server URL</span>
               <input
                 name="workspace-url"
                 value={workspaceForm.baseUrl}
@@ -543,8 +564,28 @@ export function App() {
                 }
                 placeholder="https://worker.openworklabs.com/opencode"
               />
-              <small className="modal-help">Leave this blank to use the local OpenCode server on localhost:4096.</small>
+              <small className="modal-help">Leave this blank to launch a local microsandbox workspace from a repo. Add an access token below for protected remote servers.</small>
             </label>
+
+            {!workspaceForm.baseUrl.trim() ? (
+              <label className="modal-field">
+                <span>Repository</span>
+                <div className="field-with-button">
+                  <input
+                    name="workspace-repo-path"
+                    value={workspaceForm.repoPath}
+                    onChange={(event) =>
+                      setWorkspaceForm((current) => ({ ...current, repoPath: event.target.value }))
+                    }
+                    placeholder="/Users/you/code/project"
+                  />
+                  <button type="button" className="secondary-button" onClick={() => void handlePickWorkspaceRepo()}>
+                    Browse
+                  </button>
+                </div>
+                <small className="modal-help">Local workspaces boot OpenWork inside microsandbox using a snapshot of this repo.</small>
+              </label>
+            ) : null}
 
             {workspaceForm.baseUrl.trim() ? (
               <label className="modal-field">
@@ -692,15 +733,32 @@ export function App() {
                           />
                         </label>
                         <label className="modal-field">
-                          <span>OpenCode server URL</span>
+                          <span>OpenWork or OpenCode server URL</span>
                           <input
                             name="new-workspace-url"
                             value={newWorkspaceUrl}
                             onChange={(event) => setNewWorkspaceUrl(event.target.value)}
                             placeholder="https://worker.openworklabs.com/opencode"
                           />
-                          <small className="modal-help">Leave this blank to use the local OpenCode server on localhost:4096.</small>
+                          <small className="modal-help">Leave this blank to launch a local microsandbox workspace from a repo. Add an access token below for protected remote servers.</small>
                         </label>
+                        {!newWorkspaceUrl.trim() ? (
+                          <label className="modal-field">
+                            <span>Repository</span>
+                            <div className="field-with-button">
+                              <input
+                                name="new-workspace-repo-path"
+                                value={newWorkspaceRepoPath}
+                                onChange={(event) => setNewWorkspaceRepoPath(event.target.value)}
+                                placeholder="/Users/you/code/project"
+                              />
+                              <button type="button" className="secondary-button" onClick={() => void handlePickTemplateWorkspaceRepo()}>
+                                Browse
+                              </button>
+                            </div>
+                            <small className="modal-help">Local workspaces boot OpenWork inside microsandbox using a snapshot of this repo.</small>
+                          </label>
+                        ) : null}
                         {newWorkspaceUrl.trim() ? (
                           <label className="modal-field">
                             <span>Access token</span>

--- a/apps/labs/src/opencode.ts
+++ b/apps/labs/src/opencode.ts
@@ -27,7 +27,12 @@ export function normalizeOpencodeBaseUrl(input: string) {
     }
     const path = stripTrailingSlash(url.pathname || "");
     const isLocal = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/i.test(url.hostname);
-    url.pathname = isLocal ? "" : path.endsWith("/opencode") ? path : `${path || ""}/opencode`;
+    const isWorkspaceProxy = path.startsWith("/w/");
+    if (isLocal) {
+      url.pathname = isWorkspaceProxy ? path : "";
+    } else {
+      url.pathname = isWorkspaceProxy || path.endsWith("/opencode") ? path : `${path || ""}/opencode`;
+    }
     return stripTrailingSlash(url.toString());
   } catch {
     return "";

--- a/apps/labs/src/styles.css
+++ b/apps/labs/src/styles.css
@@ -882,6 +882,13 @@ pre,
   color: #7d827d;
 }
 
+.field-with-button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
 .template-modal-layout {
   display: grid;
   gap: 18px;

--- a/apps/labs/src/types.ts
+++ b/apps/labs/src/types.ts
@@ -77,6 +77,12 @@ export type LabsWorkspace = {
   token?: string | null;
   color: string;
   kind?: "local" | "remote";
+  runtime?: "microsandbox" | "remote";
+  repoPath?: string | null;
+  hostPort?: number | null;
+  sandboxName?: string | null;
+  serverType?: "openwork" | "opencode" | "unknown";
+  serverWorkspaceId?: string | null;
   template?: WorkspaceTemplateBinding | null;
 };
 
@@ -118,12 +124,47 @@ export type NormalizedLabsEvent = {
   properties?: unknown;
 };
 
+export type LabsDesktopEventPayload =
+  | {
+      kind: "event";
+      workspaceId: string;
+      event: NormalizedLabsEvent;
+    }
+  | {
+      kind: "connection";
+      workspaceId: string;
+      connection: ConnectionSnapshot;
+    };
+
 declare global {
   interface Window {
     openworkLabsDesktop?: {
       isDesktop: boolean;
       platform: string | null;
       ensureLocalServer?: () => Promise<{ baseUrl: string }>;
+      pickRepoDirectory?: () => Promise<string | null>;
+      ensureWorkspace?: (workspace: LabsWorkspace) => Promise<{
+        workspace: LabsWorkspace;
+        connection?: ConnectionSnapshot;
+        sessions?: Session[];
+      }>;
+      refreshWorkspace?: (workspaceId: string) => Promise<{
+        connection: ConnectionSnapshot;
+        sessions: Session[];
+      }>;
+      removeWorkspace?: (workspaceId: string) => Promise<boolean>;
+      getSessionMessages?: (workspaceId: string, sessionId: string) => Promise<MessageWithParts[]>;
+      createSession?: (
+        workspaceId: string,
+        options?: { title?: string },
+      ) => Promise<Session>;
+      sendPrompt?: (
+        workspaceId: string,
+        sessionId: string | null,
+        prompt: string,
+      ) => Promise<{ sessionId: string | null }>;
+      abortSession?: (workspaceId: string, sessionId: string | null) => Promise<boolean>;
+      subscribeEvents?: (listener: (payload: LabsDesktopEventPayload) => void) => () => void;
     };
   }
 }

--- a/apps/labs/src/use-labs-app.ts
+++ b/apps/labs/src/use-labs-app.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import type { Dispatch, MutableRefObject } from "react";
 import type { Message, Part, Session } from "@opencode-ai/sdk/v2/client";
 
 import {
@@ -34,6 +35,9 @@ const WORKSPACE_COLORS = [
   "#22c55e",
   "#06b6d4",
 ];
+
+const hasDesktopKernel = () =>
+  typeof window !== "undefined" && Boolean(window.openworkLabsDesktop?.ensureWorkspace);
 
 type Action =
   | { type: "app/set-error"; error: string | null }
@@ -82,6 +86,12 @@ type WorkspaceInput = {
   baseUrl: string;
   token?: string | null;
   kind?: "local" | "remote";
+  runtime?: "microsandbox" | "remote";
+  repoPath?: string | null;
+  hostPort?: number | null;
+  sandboxName?: string | null;
+  serverType?: "openwork" | "opencode" | "unknown";
+  serverWorkspaceId?: string | null;
 };
 
 type Controller = {
@@ -90,7 +100,7 @@ type Controller = {
   activeSessions: Session[];
   selectedSessionId: string | null;
   saveWorkspace: (input: WorkspaceInput) => string;
-  createLocalWorkspace: (name?: string | null) => Promise<string | null>;
+  createLocalWorkspace: (name?: string | null, repoPath?: string | null) => Promise<string | null>;
   removeWorkspace: (workspaceId: string) => void;
   setActiveWorkspace: (workspaceId: string) => void;
   selectSession: (workspaceId: string, sessionId: string) => Promise<void>;
@@ -634,6 +644,28 @@ function persistState(state: LabsState) {
   }
 }
 
+async function maybeLoadActiveSessionMessages(
+  workspaceId: string,
+  sessions: Session[],
+  stateRef: MutableRefObject<LabsState>,
+  dispatch: Dispatch<Action>,
+  loadSessionMessages: (workspaceId: string, sessionId: string) => Promise<void>,
+) {
+  const current = stateRef.current.selectedSessionIdByWorkspaceId[workspaceId] ?? null;
+  const nextSelected = current || sessions[0]?.id || null;
+  if (!nextSelected) return;
+
+  dispatch({
+    type: "workspace/set-selected-session",
+    workspaceId,
+    sessionId: nextSelected,
+  });
+
+  if (stateRef.current.activeWorkspaceId === workspaceId) {
+    await loadSessionMessages(workspaceId, nextSelected);
+  }
+}
+
 export function useLabsApp(): Controller {
   const [state, dispatch] = useReducer(reducer, undefined, createInitialState);
   const stateRef = useRef(state);
@@ -656,15 +688,19 @@ export function useLabsApp(): Controller {
   }, []);
 
   const loadSessionMessages = useCallback(async (workspaceId: string, sessionId: string) => {
-    const client = getClient(workspaceId);
-    if (!client) return;
-
     dispatch({ type: "session/set-loading", sessionId, loading: true });
 
     try {
-      const messages = unwrap<MessageWithParts[]>(
-        await client.session.messages({ sessionID: sessionId, limit: SESSION_LIMIT }),
-      );
+      let messages: MessageWithParts[];
+      if (window.openworkLabsDesktop?.getSessionMessages) {
+        messages = await window.openworkLabsDesktop.getSessionMessages(workspaceId, sessionId);
+      } else {
+        const client = getClient(workspaceId);
+        if (!client) return;
+        messages = unwrap<MessageWithParts[]>(
+          await client.session.messages({ sessionID: sessionId, limit: SESSION_LIMIT }),
+        );
+      }
       dispatch({ type: "session/set-messages", sessionId, messages });
     } catch (error) {
       dispatch({ type: "app/set-error", error: describeError(error) });
@@ -682,20 +718,7 @@ export function useLabsApp(): Controller {
         await client.session.list({ roots: false, limit: SESSION_LIMIT }),
       );
       dispatch({ type: "workspace/set-sessions", workspaceId, sessions });
-
-      const current = stateRef.current.selectedSessionIdByWorkspaceId[workspaceId] ?? null;
-      const nextSelected = current || sessions[0]?.id || null;
-      if (nextSelected) {
-        dispatch({
-          type: "workspace/set-selected-session",
-          workspaceId,
-          sessionId: nextSelected,
-        });
-
-        if (stateRef.current.activeWorkspaceId === workspaceId) {
-          await loadSessionMessages(workspaceId, nextSelected);
-        }
-      }
+      await maybeLoadActiveSessionMessages(workspaceId, sessions, stateRef, dispatch, loadSessionMessages);
     } catch (error) {
       dispatch({
         type: "workspace/set-connection",
@@ -709,9 +732,6 @@ export function useLabsApp(): Controller {
   }, [getClient, loadSessionMessages]);
 
   const refreshWorkspace = useCallback(async (workspaceId: string) => {
-    const client = getClient(workspaceId);
-    if (!client) return;
-
     dispatch({
       type: "workspace/set-connection",
       workspaceId,
@@ -722,6 +742,20 @@ export function useLabsApp(): Controller {
     });
 
     try {
+      if (window.openworkLabsDesktop?.refreshWorkspace) {
+        const result = await window.openworkLabsDesktop.refreshWorkspace(workspaceId);
+        dispatch({
+          type: "workspace/set-connection",
+          workspaceId,
+          connection: result.connection,
+        });
+        dispatch({ type: "workspace/set-sessions", workspaceId, sessions: result.sessions });
+        await maybeLoadActiveSessionMessages(workspaceId, result.sessions, stateRef, dispatch, loadSessionMessages);
+        return;
+      }
+
+      const client = getClient(workspaceId);
+      if (!client) return;
       const health = unwrap<{ healthy?: boolean }>(await client.global.health());
       if (health?.healthy === false) {
         throw new Error("Server reported unhealthy state.");
@@ -746,7 +780,7 @@ export function useLabsApp(): Controller {
         },
       });
     }
-  }, [getClient, loadWorkspaceSessions]);
+  }, [getClient, loadSessionMessages, loadWorkspaceSessions]);
 
   const handleEvent = useCallback((workspaceId: string, event: { type: string; properties?: unknown }) => {
     if (event.type === "session.updated" || event.type === "session.created") {
@@ -869,7 +903,58 @@ export function useLabsApp(): Controller {
     }
   }, []);
 
+  useEffect(() => {
+    if (!window.openworkLabsDesktop?.subscribeEvents) return;
+    return window.openworkLabsDesktop.subscribeEvents((payload) => {
+      if ("kind" in payload && payload.kind === "connection") {
+        dispatch({
+          type: "workspace/set-connection",
+          workspaceId: payload.workspaceId,
+          connection: payload.connection,
+        });
+        return;
+      }
+      handleEvent(payload.workspaceId, payload.event);
+    });
+  }, [handleEvent]);
+
   const connectWorkspace = useCallback(async (workspace: LabsWorkspace) => {
+    if (window.openworkLabsDesktop?.ensureWorkspace) {
+      try {
+        const result = await window.openworkLabsDesktop.ensureWorkspace(workspace);
+        const next = result.workspace ?? workspace;
+        if (
+          next.baseUrl !== workspace.baseUrl ||
+          next.name !== workspace.name ||
+          next.token !== workspace.token ||
+          next.kind !== workspace.kind
+        ) {
+          dispatch({ type: "workspace/upsert", workspace: next });
+        }
+        if (result.connection) {
+          dispatch({
+            type: "workspace/set-connection",
+            workspaceId: next.id,
+            connection: result.connection,
+          });
+        }
+        if (result.sessions) {
+          dispatch({ type: "workspace/set-sessions", workspaceId: next.id, sessions: result.sessions });
+          await maybeLoadActiveSessionMessages(next.id, result.sessions, stateRef, dispatch, loadSessionMessages);
+        }
+      } catch (error) {
+        dispatch({
+          type: "workspace/set-connection",
+          workspaceId: workspace.id,
+          connection: {
+            status: "disconnected",
+            message: describeError(error),
+          },
+        });
+      }
+      return;
+    }
+
     let next = workspace;
     if (workspace.kind === "local" && window.openworkLabsDesktop?.ensureLocalServer) {
       try {
@@ -1009,6 +1094,9 @@ export function useLabsApp(): Controller {
     });
 
     return () => {
+      if (window.openworkLabsDesktop?.removeWorkspace) {
+        return;
+      }
       for (const entry of connectionsRef.current.values()) {
         entry.cleanup();
       }
@@ -1052,6 +1140,12 @@ export function useLabsApp(): Controller {
       token: input.token?.trim() || null,
       color: existing?.color ?? pickWorkspaceColor(id),
       kind: input.kind ?? existing?.kind ?? "remote",
+      runtime: input.runtime ?? existing?.runtime ?? (input.kind === "local" ? "microsandbox" : "remote"),
+      repoPath: input.repoPath?.trim() || existing?.repoPath || null,
+      hostPort: input.hostPort ?? existing?.hostPort ?? null,
+      sandboxName: input.sandboxName?.trim() || existing?.sandboxName || null,
+      serverType: input.serverType ?? existing?.serverType ?? "unknown",
+      serverWorkspaceId: input.serverWorkspaceId?.trim() || existing?.serverWorkspaceId || null,
       template: existing?.template ?? null,
     };
 
@@ -1060,28 +1154,28 @@ export function useLabsApp(): Controller {
     return id;
   }, []);
 
-  const createLocalWorkspace = useCallback(async (name?: string | null) => {
+  const createLocalWorkspace = useCallback(async (name?: string | null, repoPath?: string | null) => {
     const title = name?.trim() || "Workspace";
-    let baseUrl = normalizeOpencodeBaseUrl("http://localhost:4096");
-
-    if (window.openworkLabsDesktop?.ensureLocalServer) {
-      try {
-        const local = await window.openworkLabsDesktop.ensureLocalServer();
-        baseUrl = normalizeOpencodeBaseUrl(local.baseUrl);
-      } catch (error) {
-        dispatch({ type: "app/set-error", error: describeError(error) });
-        return null;
-      }
+    const sourceRepo = repoPath?.trim() || null;
+    if (!sourceRepo) {
+      dispatch({ type: "app/set-error", error: "Choose a repository folder for this workspace." });
+      return null;
     }
 
     const id = `workspace-${randomId()}`;
     const workspace: LabsWorkspace = {
       id,
       name: title,
-      baseUrl,
+      baseUrl: "",
       token: null,
       color: pickWorkspaceColor(id),
       kind: "local",
+      runtime: "microsandbox",
+      repoPath: sourceRepo,
+      hostPort: null,
+      sandboxName: `labs-${id}`,
+      serverType: "openwork",
+      serverWorkspaceId: null,
       template: null,
     };
 
@@ -1091,6 +1185,9 @@ export function useLabsApp(): Controller {
   }, [connectWorkspace]);
 
   const removeWorkspace = useCallback((workspaceId: string) => {
+    if (window.openworkLabsDesktop?.removeWorkspace) {
+      void window.openworkLabsDesktop.removeWorkspace(workspaceId);
+    }
     const existing = connectionsRef.current.get(workspaceId);
     existing?.cleanup();
     connectionsRef.current.delete(workspaceId);
@@ -1112,24 +1209,31 @@ export function useLabsApp(): Controller {
     workspaceId: string,
     options?: { title?: string; seedMessages?: SeedMessage[] },
   ) => {
-    const client = getClient(workspaceId);
-    if (!client) {
-      dispatch({ type: "app/set-error", error: "Add a valid workspace URL before creating a chat." });
-      return null;
-    }
-
     try {
-      const created = unwrap<Session>(await client.session.create({}));
-      let session = created;
-      const nextTitle = options?.title?.trim();
-      if (nextTitle) {
-        try {
-          session = unwrap<Session>(await client.session.update({ sessionID: created.id, title: nextTitle }));
-        } catch {
-          session = {
-            ...created,
-            title: nextTitle,
-          } as Session;
+      let session: Session;
+      if (window.openworkLabsDesktop?.createSession) {
+        session = await window.openworkLabsDesktop.createSession(workspaceId, {
+          title: options?.title?.trim() || undefined,
+        });
+      } else {
+        const client = getClient(workspaceId);
+        if (!client) {
+          dispatch({ type: "app/set-error", error: "Add a valid workspace URL before creating a chat." });
+          return null;
+        }
+
+        const created = unwrap<Session>(await client.session.create({}));
+        session = created;
+        const nextTitle = options?.title?.trim();
+        if (nextTitle) {
+          try {
+            session = unwrap<Session>(await client.session.update({ sessionID: created.id, title: nextTitle }));
+          } catch {
+            session = {
+              ...created,
+              title: nextTitle,
+            } as Session;
+          }
         }
       }
 
@@ -1161,12 +1265,6 @@ export function useLabsApp(): Controller {
     const trimmed = prompt.trim();
     if (!trimmed) return sessionId;
 
-    const client = getClient(workspaceId);
-    if (!client) {
-      dispatch({ type: "app/set-error", error: "Connect a workspace before sending a prompt." });
-      return null;
-    }
-
     let resolvedSessionId = sessionId;
     if (!resolvedSessionId) {
       resolvedSessionId = await createSession(workspaceId);
@@ -1176,6 +1274,17 @@ export function useLabsApp(): Controller {
     dispatch({ type: "session/set-status", sessionId: resolvedSessionId, status: "busy" });
 
     try {
+      if (window.openworkLabsDesktop?.sendPrompt) {
+        const result = await window.openworkLabsDesktop.sendPrompt(workspaceId, resolvedSessionId, trimmed);
+        return result.sessionId;
+      }
+
+      const client = getClient(workspaceId);
+      if (!client) {
+        dispatch({ type: "app/set-error", error: "Connect a workspace before sending a prompt." });
+        return null;
+      }
+
       await unwrap(
         await client.session.promptAsync({
           sessionID: resolvedSessionId,
@@ -1192,11 +1301,15 @@ export function useLabsApp(): Controller {
 
   const abortSession = useCallback(async (workspaceId: string, sessionId: string | null) => {
     if (!sessionId) return;
-    const client = getClient(workspaceId);
-    if (!client) return;
 
     try {
-      await client.session.abort({ sessionID: sessionId });
+      if (window.openworkLabsDesktop?.abortSession) {
+        await window.openworkLabsDesktop.abortSession(workspaceId, sessionId);
+      } else {
+        const client = getClient(workspaceId);
+        if (!client) return;
+        await client.session.abort({ sessionID: sessionId });
+      }
       dispatch({ type: "session/set-status", sessionId, status: "idle" });
     } catch (error) {
       dispatch({ type: "app/set-error", error: describeError(error) });
@@ -1228,13 +1341,15 @@ export function useLabsApp(): Controller {
       template: binding,
     });
 
-    const client = getClient(workspaceId);
-    if (!client) {
-      dispatch({
-        type: "app/set-error",
-        error: "Template saved. Connect the workspace to materialize the starter chats.",
-      });
-      return;
+    if (!window.openworkLabsDesktop?.createSession) {
+      const client = getClient(workspaceId);
+      if (!client) {
+        dispatch({
+          type: "app/set-error",
+          error: "Template saved. Connect the workspace to materialize the starter chats.",
+        });
+        return;
+      }
     }
 
     const existingWorkspace = getWorkspace(workspaceId);

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "onlyBuiltDependencies": [
       "@whiskeysockets/baileys",
       "better-sqlite3",
+      "electron",
       "esbuild",
       "protobufjs"
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.13.23
         version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      microsandbox:
+        specifier: ^0.3.8
+        version: 0.3.8
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -2757,6 +2760,24 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@superradcompany/microsandbox-darwin-arm64@0.3.8':
+    resolution: {integrity: sha512-l8+IDUxXu4dEXRDHSxiNmKPO2GBqFVNwquWrHTsCIp00rv4fIJ9h3KpNWaZgf2IX6kAez+YEfRkeRIZcHU+xNQ==}
+    engines: {node: '>= 18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.3.8':
+    resolution: {integrity: sha512-T4+knvMQpHoNiV9wXwVow721/T9w0/pNj1Gv4Tq9uHUlRChCe9JQxgD/Ayaqqu+8CEYPtQYVEVo5e0BZvh2zkg==}
+    engines: {node: '>= 18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@superradcompany/microsandbox-linux-x64-gnu@0.3.8':
+    resolution: {integrity: sha512-9tDzQ5bkY/H71qjtQQ06gW9GyBzXOtttdqEbFC3A+5xvP3F4JDvhTeK5n6O65giDIT86ZL24jSrpPgcofG00lw==}
+    engines: {node: '>= 18'}
+    cpu: [x64]
+    os: [linux]
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -4744,6 +4765,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  microsandbox@0.3.8:
+    resolution: {integrity: sha512-xcixT5H9wk1zQYX9OEBq+0nEJSyHLwJ7NGHd+4J2rbvDMEhtlItD5zz4EL/FtB6TDSQNmMQyCMFa4aF/iFCJ0Q==}
+    engines: {node: '>= 18'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -8418,6 +8443,15 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@superradcompany/microsandbox-darwin-arm64@0.3.8':
+    optional: true
+
+  '@superradcompany/microsandbox-linux-arm64-gnu@0.3.8':
+    optional: true
+
+  '@superradcompany/microsandbox-linux-x64-gnu@0.3.8':
+    optional: true
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -10618,6 +10652,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  microsandbox@0.3.8:
+    optionalDependencies:
+      '@superradcompany/microsandbox-darwin-arm64': 0.3.8
+      '@superradcompany/microsandbox-linux-arm64-gnu': 0.3.8
+      '@superradcompany/microsandbox-linux-x64-gnu': 0.3.8
 
   mime-db@1.52.0: {}
 


### PR DESCRIPTION
## Summary
- move Labs runtime ownership into Electron main and boot local workspaces inside microsandbox
- run a single custom Labs server in the guest that owns OpenCode and exposes `/health`, `/workspaces`, `/w/default/opencode/*`, and `/opencode/*`
- add local repo selection, guest runtime scaffolding, and host auth/config carryover so local chat works through the sandboxed OpenWork proxy

## Testing
- `npm run typecheck`
- `npm run build`
- direct microsandbox kernel smoke test:
  - local workspace booted in microsandbox from a repo path
  - session creation succeeded
  - prompt send succeeded
  - message fetch returned assistant output (`Hello!`)

## Notes
- I did not run the full Docker dev stack + Chrome MCP flow for this branch.
- I verified the runtime path through direct microsandbox/kernel smoke tests instead.
- The branch targets `task/openwork-labs-prd`, which is the existing Labs branch line in this repo.
