### PR TITLE
show only two sessions per workspace when collapsed

### DIFF
--- a/apps/app/src/app/components/session/workspace-session-list.tsx
+++ b/apps/app/src/app/components/session/workspace-session-list.tsx
@@ -58,7 +58,7 @@ type Props = {
 };
 
 const MAX_SESSIONS_PREVIEW = 6;
-const COLLAPSED_SESSIONS_PREVIEW = MAX_SESSIONS_PREVIEW;
+const COLLAPSED_SESSIONS_PREVIEW = 2;
 
 type SessionListItem = WorkspaceSessionGroup["sessions"][number];
 type FlattenedSessionRow = { session: SessionListItem; depth: number };


### PR DESCRIPTION
## Summary
`COLLAPSED_SESSIONS_PREVIEW = 2;` instead of being set to MAX_SESSIONS_PREVIEW (=6)