### PR TITLE
fix(desktop): Set NO_PROXY on Windows to fix engine start with proxy

### DIFF
--- a/scripts/dev-windows.cmd
+++ b/scripts/dev-windows.cmd
@@ -1,5 +1,10 @@
 @echo off
 setlocal
+if defined NO_PROXY (
+  set "NO_PROXY=%NO_PROXY%,127.0.0.1,localhost"
+) else (
+  set "NO_PROXY=127.0.0.1,localhost"
+)
 
 set "TARGET_ARCH=%~1"
 set "VSDEVCMD=%VSDEVCMD_PATH%"


### PR DESCRIPTION
## Summary

This change fixes an issue where the OpenCode engine fails to start on Windows when an HTTP proxy is configured. The problem occurs because local communication to the engine sidecar is attempted through the proxy.

The fix involves updating the `dev-windows.cmd` script to set the `NO_PROXY` environment variable to include `127.0.0.1` and `localhost`. This ensures that local traffic bypasses the system proxy, allowing the desktop application to connect to the OpenCode engine successfully during development.

## Changes

- **scripts/dev-windows.cmd**: Set the NO_PROXY environment variable at the beginning of the Windows development script to ensure local communication with the OpenCode engine bypasses any configured HTTP proxy. This prevents connection failures when a proxy is active on the system.

## Related Issue

Closes #1276

