### PR TITLE
docs: automated documentation updates 2026-03-25

### DIFF
--- a/packages/docs/importing-a-skill.mdx
+++ b/packages/docs/importing-a-skill.mdx
@@ -1,53 +1,53 @@
 ---
 title: "Importing a skill"
-description: "How to import an external skill to your workspace in Openwork"
+description: "How to import an external skill into your workspace in OpenWork"
 ---
 
 There are currently three direct ways to import an external skill.
 
-1. Importing an existing skill with share.openworklabs
-2. Pasting a skill in share.openworklabs, then importing it.
-3. Creating a skill using `Create skill in chat` and pasting the external skill
+1. Open an existing skill share link from `share.openwork.software`
+2. Paste a skill into the share site, then import it
+3. Create a skill with `Create skill in chat` and paste the external skill into that flow
 
-There is another option if you're technical which is pasting it into the `workspace/skills` folder.
+There is another option if you're technical: place it directly in `.opencode/skills/<skill-name>/SKILL.md` inside your workspace.
 
-We recommend using (1) and (3) as they're the options more directly compatible and easy to use.
+We recommend (1) and (3) because they match the built-in OpenWork flows most closely.
 
 ## Importing an existing skill with a share URL
 
-When you have an openwork [Share URL](https://share.openwork.software/b/01KKPSGYSGDRRWNTAACAMZY3PF), you just need to click `Open in Openwork`
+When you have an OpenWork [share URL](https://share.openwork.software/b/01KKPSGYSGDRRWNTAACAMZY3PF), click `Open in OpenWork`.
 
 <Frame>
   ![Share page with Open in OpenWork button](/images/skill-import-share-page.png)
 </Frame>
 
-Then, select the workspace in which you'd like to import it into (eg: in this case, `the-factory`).
+Then select the workspace where you want to install it (for example, `the-factory`).
 
 <Frame>
   ![Select workspace dialog for importing a skill](/images/skill-import-select-workspace.png)
 </Frame>
 
-Once this is installed, Openwork will prompt you to reload so that it can load the skill into your workspace.
+Once the skill is installed, OpenWork prompts you to reload so it can load the new skill into your workspace.
 
 <Frame>
   ![Reload required banner after installing a skill](/images/skill-import-reload-required.png)
 </Frame>
 
-Once you've reloaded the app, you should be able to use it directly into your workspace:
+After you reload the app, you can use the skill directly in that workspace:
 
 <Frame>
   ![Using an imported skill in chat with autocomplete](/images/skill-import-use-in-chat.png)
 </Frame>
 
-## Pasting a skill in share.openworklabs, then importing it.
+## Pasting a skill into the share site, then importing it
 
-In this case, you start at [the skills share page](https://share.openwork.software/) without any skill. Paste or upload the skill there, and click on generate link:
+Start at [the OpenWork share page](https://share.openwork.software/) without any skill loaded. Paste or upload the skill there, then click `Generate link`:
 
 <Frame>
   ![Share your skill page with Generate share link button](/images/skill-import-share-your-skill.png)
 </Frame>
 
-**Note**: In order to import an external skill, the skill needs to adhere to the following structure:
+To import an external skill, the file needs to follow this structure:
 
 ```text
 ---
@@ -58,17 +58,14 @@ description: one line description of what the skill does
 Any markdown text with instructions and description of the skill
 ```
 
-Make sure it follows this format when importing external skills from other marketplaces
+Make sure the file follows that format when importing skills from other marketplaces or other teams.
 
-This then redirects you to the `Share Page` of a valid skill, and you can follow the steps from the previous section directly.
+That redirects you to the share page for the valid skill, and from there you can follow the steps from the previous section.
 
-## Creating a skill using `/skill-creator` in the chat
+## Creating a skill with `/skill-creator` in chat
 
-This option is quite straightforward, you can type `/skill-creator` in the chatand either directly paste the external skill you're seeking to import or describe what you'd like for the skill to do -and then, it will proceed to generate it.
+Type `/skill-creator` in chat, then either paste the external skill you want to import or describe what you want the skill to do. OpenWork will generate a workspace-local skill from that input.
 
 <Frame>
   ![Using the /skill-creator command in chat](/images/skill-import-skill-creator-command.png)
-</Frame>
-
-<Frame>
 </Frame>

--- a/packages/docs/sharing-ow-setup.mdx
+++ b/packages/docs/sharing-ow-setup.mdx
@@ -1,40 +1,54 @@
 ---
 title: "OpenWork Templates: How to share your setup"
-description: "Learn how to share your MCP, agents, skills with others"
+description: "Learn how to share a full workspace template or a single skill in OpenWork"
 ---
 
-There are two main primitives for a template that you can share: `Workspace` and a 
-`Skill`.
+There are two main things you can share from OpenWork:
+
+- a full `Workspace` template
+- a single `Skill`
 
 ## Sharing your entire configuration
 
-OpenWork also allows you to share your entire configuration with others. That includes skills, MCPs, agents, unique LLM providers you might've added, and more.
+OpenWork can package an entire workspace template into one share link. That bundle can include your skills, commands, agents, MCP/OpenCode settings, `opencode.json` state, and other shareable `.opencode/**` files.
 
+OpenWork does not copy secrets, runtime-only files, or your existing session history into the template.
 
-Click on the `...` next to the workspace name, then `Share ...` , then `Share a template`
+Click the `...` next to the workspace name, then `Share...`, then `Share a template`.
 
 <Frame>
   ![Share workspace dialog with template and remote options](/images/sharing-workspace-template-dialog.png)
 </Frame>
 
+When someone opens that link and clicks `Open in OpenWork`, OpenWork now creates a new workspace from the template instead of dropping the bundle into the current workspace.
+
+OpenWork asks the recipient to pick a destination folder first, then creates the workspace there from the shared template.
+
+Some templates can also include starter sessions. Those starter sessions are seeded into the new workspace on first load so the recipient gets the intended prompts and example setup, but OpenWork does not clone the original runtime chat history.
+
+This makes workspace templates a good fit for sharing:
+
+- complete project setup
+- reusable MCP and provider configuration
+- commands, agents, and skills that should travel together
+- example starter flows for a new workspace
 
 ## How to share a SKILL.md
 
-You can share a `SKILL.md` by clicking under `Your_Workspace` \> `Skills`
+You can share a `SKILL.md` from `Your_Workspace` > `Skills`.
 
 <Frame>
   ![Skills management page showing installed skills](/images/sharing-skills-list.png)
 </Frame>
 
-Then, on `Create Link` which will create a custom page for the skill at `share.openwork.software/b/:skill_id`
+Click `Create Link` to generate a custom share page for that skill at `share.openwork.software/b/:skill_id`.
 
 <Frame>
   ![Create share link dialog for a skill](/images/sharing-create-link-dialog.png)
 </Frame>
 
-This creates a url that you can share with other people so they can `copy the skill` or `Open in Openwork`
+That creates a URL you can send to other people so they can `Copy the skill` or `Open in OpenWork`.
 
 <Frame>
   ![Shared skill page with Copy and Open in OpenWork buttons](/images/sharing-skill-share-page.png)
 </Frame>
-

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,12 +1,13 @@
-# Arch Linux AMD64 package
+# Arch Linux package
 
-Use this directory to build and install the AMD64 OpenWork package locally on Arch Linux without Docker.
+Use this directory to build and install the OpenWork package locally on Arch Linux without Docker.
 
 ## What this packaging does
 
 - Targets `x86_64` Arch Linux.
 - Downloads the published GitHub release asset `openwork-desktop-linux-amd64.deb`.
 - Repackages the `.deb` contents into an Arch package with `makepkg`.
+- Removes the bundled `/usr/bin/opencode` file so the package does not conflict with `opencode-bin`.
 
 ## Prerequisites
 
@@ -35,6 +36,14 @@ That will:
 1. download the AMD64 `.deb` pinned in `PKGBUILD`
 2. build an Arch package such as `openwork-<version>-1-x86_64.pkg.tar.zst`
 3. install it locally with `pacman`
+
+After install, `openwork` is available as the desktop launcher. If you also want the standalone OpenCode CLI, install `opencode-bin` separately.
+
+## OpenCode CLI conflict note
+
+Recent `.deb` builds include `/usr/bin/opencode`, but the AUR package intentionally strips that file during repackaging.
+
+That keeps OpenWork compatible with systems that already install the OpenCode CLI from `opencode-bin`, which should remain the owner of the global `opencode` command.
 
 ## Update the package to a newer release
 


### PR DESCRIPTION
## Summary
- Split the 2026-03-25 docs automation work out of #1167.
- Update `packages/docs/sharing-ow-setup.mdx`, `packages/docs/importing-a-skill.mdx`, and `packaging/aur/README.md`.
- Keep the oldest day's docs-only changes reviewable before the later daily updates stack on top.