### PR TITLE
docs: automated documentation updates 2026-03-26

### DIFF
--- a/packages/docs/get-started.mdx
+++ b/packages/docs/get-started.mdx
@@ -34,13 +34,15 @@ Copy:
 
 On your local machine, open the OpenWork desktop app and connect into a remote workspace with:
 
-- On the bottom left click `+ Add workspace`
-- Then click `+ Connect Remote workspace`
-- Type in the `OpenWork URL and OpenWork Owner Token` from earlier
+- On the bottom left click `+ Add a worker`
+- Then click `Connect remote`
+- Paste in the `OpenWork URL` and `OpenWork Owner Token` from earlier
 
 <Frame>
   ![Add Remote Workspace dialog in OpenWork desktop app](/images/get-started-add-remote-workspace.png)
 </Frame>
+
+If you launched the worker from OpenWork Cloud, `Open in OpenWork` can prefill that remote-connect flow for you. The manual fallback is still the same `Add a worker` -> `Connect remote` path with the worker URL and token.
 
 ## What this gives you right away
 

--- a/packages/docs/sharing-ow-setup.mdx
+++ b/packages/docs/sharing-ow-setup.mdx
@@ -33,6 +33,22 @@ This makes workspace templates a good fit for sharing:
 - commands, agents, and skills that should travel together
 - example starter flows for a new workspace
 
+## Sharing a template with your Cloud team
+
+OpenWork can also save a workspace template directly to your active OpenWork Cloud organization.
+
+Open the same `Share a template` flow, then choose `Share with team`.
+
+From there you can:
+
+- pick the template name your teammates will see
+- save it to the currently selected Cloud organization
+- sign in to OpenWork Cloud first if the app prompts you to
+
+Team templates do not create a public share URL. Instead, they show up in the OpenWork Cloud area inside the app so other members of that organization can open them later.
+
+After sign-in, teammates can open the template from `Settings` -> `OpenWork Cloud` -> `Team templates`.
+
 ## How to share a SKILL.md
 
 You can share a `SKILL.md` from `Your_Workspace` > `Skills`.


### PR DESCRIPTION
## Summary
- Split the 2026-03-26 docs automation work out of #1167.
- Refresh `packages/docs/get-started.mdx` and `packages/docs/sharing-ow-setup.mdx`.
- Stack this PR on `task/docs-automated-updates-2026-03-25` so the historical docs updates merge oldest to newest.