### PR TITLE
docs: automated documentation updates 2026-03-29

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,9 +31,8 @@ Auto-detection can exist as a convenience, but should be tiered and explainable:
 The readiness check should be a clear, single command (e.g. `docker info`) and the UI should show the exact error output when it fails.
 
 ## Minimal use of Tauri
+
 We move most of the functionality to the openwork server which interfaces mostly with FS and proxies to opencode.
-
-
 
 ## Filesystem mutation policy
 
@@ -56,12 +55,12 @@ Guidelines:
 
 When OpenWork is edited from `openwork-enterprise`, architecture and runtime behavior should be sourced from this document.
 
-| Entry point | Role | Architecture authority |
-| --- | --- | --- |
-| `openwork-enterprise/AGENTS.md` | OpenWork Factory multi-repo orchestration | Defers OpenWork runtime flow, server-vs-shell ownership, and filesystem mutation behavior to `_repos/openwork/ARCHITECTURE.md`. |
-| `openwork-enterprise/.opencode/agents/openwork-surgeon.md` | Surgical fix agent for `_repos/openwork` | Uses `_repos/openwork/ARCHITECTURE.md` as the runtime and architecture source of truth before changing product behavior. |
-| `_repos/openwork/AGENTS.md` | Product vocabulary, audience, and repo-local development guidance | Refers to `ARCHITECTURE.md` for runtime flow, server ownership, and architectural boundaries. |
-| Skills / commands / agents that mutate workspace state | Capability layer on top of the product runtime | Should assume the OpenWork server path is canonical for workspace creation, config writes, `.opencode/` mutation, and reload signaling. |
+| Entry point                                                | Role                                                              | Architecture authority                                                                                                                  |
+| ---------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `openwork-enterprise/AGENTS.md`                            | OpenWork Factory multi-repo orchestration                         | Defers OpenWork runtime flow, server-vs-shell ownership, and filesystem mutation behavior to `_repos/openwork/ARCHITECTURE.md`.         |
+| `openwork-enterprise/.opencode/agents/openwork-surgeon.md` | Surgical fix agent for `_repos/openwork`                          | Uses `_repos/openwork/ARCHITECTURE.md` as the runtime and architecture source of truth before changing product behavior.                |
+| `_repos/openwork/AGENTS.md`                                | Product vocabulary, audience, and repo-local development guidance | Refers to `ARCHITECTURE.md` for runtime flow, server ownership, and architectural boundaries.                                           |
+| Skills / commands / agents that mutate workspace state     | Capability layer on top of the product runtime                    | Should assume the OpenWork server path is canonical for workspace creation, config writes, `.opencode/` mutation, and reload signaling. |
 
 ### Agent access to server-owned behavior
 
@@ -86,37 +85,38 @@ Tauri or other native shell behavior remains the fallback or shell boundary for:
 If an agent needs one of the server-owned behaviors above and only a Tauri path exists, treat that as an architecture gap to close rather than a parallel capability surface to preserve.
 
 ## opencode primitives
-how to pick the right extension abstraction for 
+
+how to pick the right extension abstraction for
 @opencode
 
 opencode has a lot of extensibility options:
 mcp / plugins / skills / bash / agents / commands
 
 - mcp
-use when you need authenticated third-party flows (oauth) and want to expose that safely to end users
-good fit when "auth + capability surface" is the product boundary
-downside: you're limited to whatever surface area the server exposes
+  use when you need authenticated third-party flows (oauth) and want to expose that safely to end users
+  good fit when "auth + capability surface" is the product boundary
+  downside: you're limited to whatever surface area the server exposes
 
 - bash / raw cli
-use only for the most advanced users or internal power workflows
-highest risk, easiest to get out of hand (context creep + permission creep + footguns)
-great for power users and prototyping, terrifying as a default for non-tech users
+  use only for the most advanced users or internal power workflows
+  highest risk, easiest to get out of hand (context creep + permission creep + footguns)
+  great for power users and prototyping, terrifying as a default for non-tech users
 
 - plugins
-use when you need real tools in code and want to scope permissions around them
-good middle ground: safer than raw cli, more flexible than mcp, reusable and testable
-basically "guardrails + capability packaging"
+  use when you need real tools in code and want to scope permissions around them
+  good middle ground: safer than raw cli, more flexible than mcp, reusable and testable
+  basically "guardrails + capability packaging"
 
 - skills
-use when you want reliable plain-english patterns that shape behavior
-best for repeatability and making workflows legible
-pro tip: pair skills with plugins or cli (i literally embed skills inside plugins right now and expose commands like get_skills / retrieve)
+  use when you want reliable plain-english patterns that shape behavior
+  best for repeatability and making workflows legible
+  pro tip: pair skills with plugins or cli (i literally embed skills inside plugins right now and expose commands like get_skills / retrieve)
 
 - agents
-use when you need to create tasks that are executed by different models than the main one and might have some extra context to find skills or interact with mcps.
+  use when you need to create tasks that are executed by different models than the main one and might have some extra context to find skills or interact with mcps.
 
-- commands 
-`/` commands that trigger tools
+- commands
+  `/` commands that trigger tools
 
 These are all opencode primitives you can read the docs to find out exactly how to set them up.
 
@@ -124,12 +124,13 @@ These are all opencode primitives you can read the docs to find out exactly how 
 
 - uses all these primitives
 - uses native OpenCode commands for reusable flows (markdown files in `.opencode/commands`)
-- adds a new abstraction "workspace" is a project folder and a simple .json file that includes a list of opencode primitives that map perfectly to an opencode workdir (not fully implemented)
-  - openwork can open a workpace.json and decide where to populate a folder with thse settings (not implemented today
+- adds a new abstraction "workspace": a project folder plus OpenWork-managed connection/config state that still maps cleanly to an OpenCode workdir
+- the current product surface treats local and remote workers through the same workspace/session shell rather than a separate dashboard concept
 
 ## Repository/component map
 
 - `/apps/app/`: OpenWork app UI (desktop/mobile/web client experience layer).
+  - the settings shell owns the workspace list plus user-facing tabs for general settings, skills, extensions, automations, messaging, appearance, and recovery.
 - `/apps/desktop/`: Tauri desktop shell that hosts the app UI and manages native process lifecycles.
 - `/apps/server/`: OpenWork server (API/control layer consumed by the app).
 - `/apps/orchestrator/`: OpenWork orchestrator CLI/daemon. In `start`/`serve` host mode it manages OpenWork server + OpenCode + `opencode-router`; in daemon mode it manages workspace activation and OpenCode lifecycle for desktop runtime.
@@ -579,8 +580,9 @@ This is optional and not required for non-technical MVP.
 OpenWork enforces folder access through **two layers**:
 
 1. **OpenWork UI authorization**
-   - user explicitly selects allowed folders via native picker
-   - OpenWork remembers allowed roots per profile
+   - workspace root access is implicit for the active workspace
+   - extra folders are managed from the Authorized folders panel in Settings
+   - OpenWork persists those extra directories through workspace config updates on the OpenWork server
 
 2. **OpenCode server permissions**
    - OpenCode requests permissions as needed

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -3,20 +3,19 @@
 ## Target Users
 
 > Bob the IT guy.
-Bob might already use opencode, he can setup agents and workflows and share them with his team. The only thing he needs is a way to share this. The way he does is by using OpenWork and creating "workpaces".
+> Bob might already use opencode, he can setup agents and workflows and share them with his team. The only thing he needs is a way to share this. The way he does is by using OpenWork and creating "workpaces".
 
 > Susan in accounting
 
 Susan in accounting doesn't use opencode. She certaintly doesn't paly aorund to create workflow create agents. She wants something that works.
-Openwork should be given to give her a good taste of what she can do. 
+Openwork should be given to give her a good taste of what she can do.
 We should also eventually guide ther to:
+
 - creating her own skills
 - adding custom MCP / login into mcp oauth servers through ui)
 - adding skills from a list of skills
 - adding plugins from a list of plugins
 - create her own commands
-
-
 
 1. **knowledge worker**: "Do this for me" workflows with guardrails.
 2. **Mobile-first user**: start/monitor tasks from phone.
@@ -113,13 +112,12 @@ use the design from ./design.ts that is your core reference for building the ent
 
 ## Functional Requirements
 
-### Onboarding
+### Workspace Setup
 
-- Host vs Client selection
-- workspace selection (Host)
-- connect to host (Client)
+- create a local workspace or connect a remote worker from the workspace shell
 - provider/model setup
-- first-run "hello world" task
+- authorized folders management from Settings when a workspace needs paths outside its root
+- first-run task from the session surface
 
 ### Cloud Worker Onboarding (Current)
 
@@ -159,28 +157,26 @@ use the design from ./design.ts that is your core reference for building the ent
 ### 0. Install & Launch
 
 1. User installs OpenWork.
-2. App launches.
-3. App shows "Choose mode: Host / Client".
-4. Host: start local OpenCode via SDK.
-5. Client: connect flow to an existing host.
+2. App launches into the workspace/settings shell.
+3. User either creates a local workspace or chooses `Add a worker` -> `Connect remote`.
+4. Local flow starts the host stack for the selected workspace.
+5. Remote flow stores the worker URL + token and reconnects to that worker.
 
-### 1. First-Run Onboarding (Host)
+### 1. Local Workspace Setup
 
-1. Welcome + safety overview.
-2. Workspace folder selection.
-3. Allowed folders selection (can be multiple).
-4. Provider/model configuration.
-5. `global.health()` check.
-6. Run a test session using `session.create()` + `session.prompt()`.
-7. Success + sample commands.
+1. User picks or creates a workspace folder.
+2. OpenWork starts the local host stack for that workspace.
+3. User configures providers and model defaults.
+4. If needed, user adds extra authorized folders from Settings.
+5. User opens a session and runs the first task.
 
-### 2. Pairing Onboarding (Client / Mobile)
+### 2. Remote Worker Connect
 
-1. User selects "Client".
-2. UI explains it connects to a trusted host.
-3. User scans QR code shown on host device.
-4. Client verifies connection with `global.health()`.
-5. Client can now list sessions and monitor runs.
+1. User chooses `Add a worker` -> `Connect remote`.
+2. UI accepts a shared OpenWork worker URL and token (or deep link).
+3. OpenWork verifies server health and available capabilities.
+4. User lands in the same workspace/session shell used for local workers.
+5. User can now list sessions and monitor runs.
 
 ### 3. Runtime Health & Recovery
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 > OpenWork is the open source alternative to Claude Cowork/Codex (desktop app).
 
-
 ## Core Philosophy
 
 - Local-first, cloud-ready: OpenWork runs on your machine in one click. Send a message instantly.
@@ -15,6 +14,7 @@
 OpenWork is designed around the idea that you can easily ship your agentic workflows as a repeatable, productized process.
 
 ## Alternate UIs
+
 - **OpenWork Orchestrator (CLI host)**: run OpenCode + OpenWork server without the desktop UI.
   - install: `npm install -g openwork-orchestrator`
   - run: `openwork start --workspace /path/to/workspace --approval auto`
@@ -37,14 +37,16 @@ OpenWork is designed to be:
 
 ## What’s Included
 
-- **Host mode**: runs opencode locally on your computer
-- **Client mode**: connect to an existing OpenCode server by URL.
-- **Workspaces**: create local workspaces from the desktop app or connect remote workers from the same sidebar flow.
+- **Local host mode**: run OpenCode locally on your computer.
+- **Remote connect**: attach to an OpenWork worker with a shared URL + token.
+- **Workspaces**: create local workspaces or connect remote workers from the same workspace sidebar.
 - **Sessions**: create/select sessions and send prompts.
 - **Live streaming**: SSE `/event` subscription for realtime updates.
 - **Execution plan**: render OpenCode todos as a timeline.
 - **Permissions**: surface permission requests and reply (allow once / always / deny).
 - **Templates**: save and re-run common workflows (stored locally).
+- **Unified settings shell**: manage skills, extensions, automations, messaging, and appearance from one shell instead of separate dashboard tabs.
+- **Authorized folders**: manage extra filesystem access from Settings when a workspace needs directories outside its root.
 - **Skills manager**:
   - list installed `.opencode/skills` folders
   - install from OpenPackage (`opkg install ...`)
@@ -155,7 +157,7 @@ pnpm dlx opkg install <package>
 
 ## OpenCode Plugins
 
-Plugins are the **native** way to extend OpenCode. OpenWork now manages them from the Skills tab by
+Plugins are the **native** way to extend OpenCode. OpenWork now manages them from `Settings -> Extensions` by
 reading and writing `opencode.json`.
 
 - **Project scope**: `<workspace>/opencode.json`

--- a/VISION.md
+++ b/VISION.md
@@ -20,8 +20,9 @@ Current cloud mental model:
 OpenWork helps users ship agentic workflows to their team. It works on top of opencode (opencode.ai) an agentic coding platform that exposes apis and sdks. We care about maximally using the opencode primitives. And build the thinest possible layer - always favoring opencode apis over custom built ones.
 
 In other words:
+
 - OpenCode is the **engine**.
-- OpenWork is the **experience** : onboarding, safety, permissions, progress, artifacts, and a premium-feeling UI.
+- OpenWork is the **experience** : workspace setup, remote connect, safety, permissions, progress, artifacts, and a premium-feeling UI.
 
 OpenWork competes directly with Anthropic's Cowork conceptually, but stays open, local-first, and standards-based.
 


### PR DESCRIPTION
## Summary
- Split the 2026-03-29 docs automation work out of #1167.
- Update the root product docs in `ARCHITECTURE.md`, `PRODUCT.md`, `README.md`, and `VISION.md`.
- Keep the historical docs stack moving forward one day at a time.