### PR TITLE
docs: automated documentation updates 2026-03-31

### DIFF
--- a/packages/docs/get-started.mdx
+++ b/packages/docs/get-started.mdx
@@ -22,13 +22,13 @@ openwork start --workspace /path/to/your/workspace --approval auto
 ```
 
 <Frame>
-  ![OpenWork CLI terminal output showing URL and owner token](/images/get-started-cli-output.png)
+  ![OpenWork CLI terminal output showing the connect URL and owner token](/images/get-started-cli-output.png)
 </Frame>
 
 Copy:
 
 - `OpenWork URL`
-- `OpenWork Owner Token`
+- `OpenWork owner token`
 
 ## Step 3: Connect the OpenWork desktop app
 
@@ -36,7 +36,9 @@ On your local machine, open the OpenWork desktop app and connect into a remote w
 
 - On the bottom left click `+ Add a worker`
 - Then click `Connect remote`
-- Paste in the `OpenWork URL` and `OpenWork Owner Token` from earlier
+- Paste in the `OpenWork URL` and the token from earlier
+
+The connect form accepts a collaborator token or an owner token. If you started the worker yourself with `openwork start`, the token shown in the terminal is the owner token and works for this flow.
 
 <Frame>
   ![Add Remote Workspace dialog in OpenWork desktop app](/images/get-started-add-remote-workspace.png)

--- a/packages/docs/sharing-ow-setup.mdx
+++ b/packages/docs/sharing-ow-setup.mdx
@@ -34,6 +34,25 @@ This makes workspace templates a good fit for sharing:
 - commands, agents, and skills that should travel together
 - example starter flows for a new workspace
 
+## Accessing a live workspace remotely
+
+The same `Share...` menu also includes `Access workspace remotely` for the running workspace itself.
+
+That flow is different from a template link:
+
+- a template creates a reusable copy someone can import into a new workspace
+- remote access reveals live connection details for the current running workspace
+
+Remote access is off by default. Turn it on only when you want this worker reachable from another machine, then click `Save` so OpenWork can restart the worker and reveal the current connection details.
+
+OpenWork can show:
+
+- the worker URL to paste into `Add a worker` -> `Connect remote`
+- an owner/access token for full control
+- an optional collaborator token for routine access without permission approvals
+
+Treat those credentials like passwords. Anyone who has them can connect to the live workspace.
+
 ## Sharing a template with your Cloud team
 
 OpenWork can also save a workspace template directly to your active OpenWork Cloud organization.


### PR DESCRIPTION
## Summary
- Split the 2026-03-31 docs automation work out of #1167.
- Update `packages/docs/get-started.mdx` and `packages/docs/sharing-ow-setup.mdx`.
- Keep the restacked historical docs PRs mergeable in chronological order.