### PR TITLE
docs: automated documentation updates 2026-04-03 historical

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -44,6 +44,8 @@ Where are workflow hosted:
 
 - Organizations can publish shared skill hubs so members discover approved skills from one managed place instead of collecting local-only installs by hand.
 - Org admins can now manage teams directly in the hosted dashboard and grant each skill hub to the exact teams that should inherit it.
+- Team members install those approved skills from the desktop Skills page through the OpenWork Cloud catalog instead of importing local files manually.
+- Power users can also share an installed desktop skill back to the org hub or publish a public install link from the same Skills page.
 
 ## Actors
 Bob IT guy makes the config.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Download the desktop app from [openworklabs.com/download](https://openworklabs.c
 - Windows access is currently handled through the paid support plan on [openworklabs.com/pricing#windows-support](https://openworklabs.com/pricing#windows-support).
 - Hosted OpenWork Cloud workers are launched from the web app after org setup, including checkout when billing is required, then connected from the desktop app via `Add a worker` -> `Connect remote`.
 - OpenWork Cloud org dashboards now include shared team management and skill hub management so admins can decide who can access each published skill library before workers are launched.
+- Signed-in desktop users can now browse their org's managed cloud skills directly from the Skills page and install them into the current workspace without copying files by hand.
 
 ## Why
 
@@ -53,6 +54,8 @@ OpenWork is designed to be:
 - **Skills manager**:
   - list installed `.opencode/skills` folders
   - import a local skill folder into `.opencode/skills/<skill-name>`
+  - browse OpenWork Cloud team skills from your active org and install them into the current workspace
+  - share an installed skill either as a public link or to an org-managed skill hub
 
 ## Skill Manager
 

--- a/ee/apps/den-web/README.md
+++ b/ee/apps/den-web/README.md
@@ -7,9 +7,11 @@ Frontend for `app.openworklabs.com`.
 - Signs up / signs in users against Den service auth.
 - Handles invited-org signup flows where the invited email stays locked and the user verifies access before joining.
 - Lets org admins manage members, teams, roles, invitations, and shared skill hubs from the hosted dashboard.
+- Saves pending org-creation drafts across checkout so a user can finish setup without re-entering the org name after billing.
 - Launches cloud workers via `POST /v1/workers`.
 - Handles paywall responses (`402 payment_required`), routes users through Polar checkout during org setup or worker launch, and only enables worker launch after purchase.
 - Surfaces org limit states before launch so users know when a plan upgrade or seat change is required.
+- Preserves full `SKILL.md` frontmatter and body when shared skills are saved so the desktop app sees the same title, description, and install payload that admins authored.
 - Offers desktop handoff actions so users can open the generated worker directly in OpenWork or copy the connect credentials manually.
 - Uses a Next.js proxy route (`/api/den/*`) to reach `api.openworklabs.com` without browser CORS issues.
 - Uses a same-origin auth proxy (`/api/auth/*`) so GitHub OAuth callbacks can land on `app.openworklabs.com`.
@@ -18,9 +20,10 @@ Frontend for `app.openworklabs.com`.
 
 1. Sign in with a standard provider or accept an org invite.
 2. Create or join an organization; if that org requires billing, complete checkout before continuing.
-3. Optional admin step: manage members, teams, and shared skill hubs from the org dashboard.
-4. Launch the worker from the cloud dashboard.
-5. Open the worker in the desktop app with the provided deep link, or copy the URL/token into `Connect remote` manually.
+3. If checkout interrupts org creation, the dashboard restores the saved org draft when the user returns.
+4. Optional admin step: manage members, teams, and shared skill hubs from the org dashboard, then publish skills that appear in the desktop Skills page for signed-in org members.
+5. Launch the worker from the cloud dashboard.
+6. Open the worker in the desktop app with the provided deep link, or copy the URL/token into `Connect remote` manually.
 
 ## Local development
 
@@ -57,9 +60,11 @@ Recommended project settings:
 
 - Root directory: `ee/apps/den-web`
 - Framework preset: Next.js
-- Build command: `next build`
+- Build command: `cd ../../.. && pnpm --filter @openwork-ee/den-web build`
 - Output directory: `.next`
-- Install command: `pnpm install --frozen-lockfile`
+- Install command: `cd ../../.. && pnpm install --frozen-lockfile`
+
+These commands should be configured in the Vercel dashboard rather than committed in `vercel.json`, so the app still builds from the monorepo root and can resolve shared workspace packages like `@openwork-ee/utils`.
 
 Then assign custom domain:
 


### PR DESCRIPTION
## Summary
- Split the historical 2026-04-03 docs automation work out of #1167.
- Update `README.md`, `PRODUCT.md`, and `ee/apps/den-web/README.md` for the OpenWork Cloud skills and org-flow docs changes from that day's run.
- Stack this PR on `task/docs-automated-updates-2026-04-02` so the old reused-branch docs updates can merge oldest to newest.