### PR TITLE
docs: automated documentation updates 2026-03-27

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ OpenWork is designed to be:
 
 - **Host mode**: runs opencode locally on your computer
 - **Client mode**: connect to an existing OpenCode server by URL.
+- **Workspaces**: create local workspaces from the desktop app or connect remote workers from the same sidebar flow.
 - **Sessions**: create/select sessions and send prompts.
 - **Live streaming**: SSE `/event` subscription for realtime updates.
 - **Execution plan**: render OpenCode todos as a timeline.

--- a/packages/docs/how-to-connect-chat-gpt.mdx
+++ b/packages/docs/how-to-connect-chat-gpt.mdx
@@ -19,8 +19,6 @@ Then, login into `openai Auth`  with a valid subscription email
 
 Once you have finished the auth, open `Settings` -> `Default model` if you want new chats in that workspace to keep using ChatGPT by default.
 
-If the model supports reasoning profiles, configure that on the model card before closing the picker. OpenWork now keeps those default-model changes instead of dropping them on refresh.
-
 You can still switch the model for a single chat from the picker in the chat view.
 
 <Frame>

--- a/packages/docs/how-to-connect-chat-gpt.mdx
+++ b/packages/docs/how-to-connect-chat-gpt.mdx
@@ -17,7 +17,11 @@ Then, login into `openai Auth`  with a valid subscription email
   ![OpenAI authentication login page](/images/chatgpt-openai-auth-login.png)
 </Frame>
 
-Once you have finished the auth, you can change the model below in the chat.
+Once you have finished the auth, open `Settings` -> `Default model` if you want new chats in that workspace to keep using ChatGPT by default.
+
+If the model supports reasoning profiles, configure that on the model card before closing the picker. OpenWork now keeps those default-model changes instead of dropping them on refresh.
+
+You can still switch the model for a single chat from the picker in the chat view.
 
 <Frame>
   ![Model selector dropdown in chat](/images/chatgpt-model-selector.png)


### PR DESCRIPTION
## Summary
- Split the 2026-03-27 docs automation work out of #1167 onto the restacked branch chain.
- Update `README.md` and `packages/docs/how-to-connect-chat-gpt.mdx` while preserving the newer Den web README content already on `dev`.
- Continue the docs split in chronological order.