### PR TITLE
docs: automated documentation updates 2026-03-29

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,9 +31,8 @@ Auto-detection can exist as a convenience, but should be tiered and explainable:
 The readiness check should be a clear, single command (e.g. `docker info`) and the UI should show the exact error output when it fails.
 
 ## Minimal use of Tauri
+
 We move most of the functionality to the openwork server which interfaces mostly with FS and proxies to opencode.
-
-
 
 ## Filesystem mutation policy
 
@@ -113,50 +112,48 @@ Do not invent a separate reload banner per feature. New UI that needs restart se
 Current examples that should use this shared flow include MCP changes, auto context compaction, default model changes, authorized folder updates, plugin changes, and other `opencode.json` writes.
 
 ## opencode primitives
-how to pick the right extension abstraction for 
-@opencode
 
-opencode has a lot of extensibility options:
-mcp / plugins / skills / bash / agents / commands
+Use these as the core extension primitives in OpenCode. Pick the one that matches the capability boundary, safety model, and user experience you want.
 
-- mcp
-use when you need authenticated third-party flows (oauth) and want to expose that safely to end users
-good fit when "auth + capability surface" is the product boundary
-downside: you're limited to whatever surface area the server exposes
+- `mcp` | authenticated third-party capability surfaces
+  - use when you need authenticated third-party flows (oauth) and want to expose that safely to end users
+  - good fit when "auth + capability surface" is the product boundary
+  - downside: you're limited to whatever surface area the server exposes
 
-- bash / raw cli
-use only for the most advanced users or internal power workflows
-highest risk, easiest to get out of hand (context creep + permission creep + footguns)
-great for power users and prototyping, terrifying as a default for non-tech users
+- `bash / raw cli` | maximum flexibility, highest risk
+  - use only for the most advanced users or internal power workflows
+  - highest risk, easiest to get out of hand (context creep + permission creep + footguns)
+  - great for power users and prototyping, terrifying as a default for non-tech users
 
-- plugins
-use when you need real tools in code and want to scope permissions around them
-good middle ground: safer than raw cli, more flexible than mcp, reusable and testable
-basically "guardrails + capability packaging"
+- `plugins` | scoped tools with guardrails
+  - use when you need real tools in code and want to scope permissions around them
+  - good middle ground: safer than raw cli, more flexible than mcp, reusable and testable
+  - basically "guardrails + capability packaging"
 
-- skills
-use when you want reliable plain-english patterns that shape behavior
-best for repeatability and making workflows legible
-pro tip: pair skills with plugins or cli (i literally embed skills inside plugins right now and expose commands like get_skills / retrieve)
+- `skills` | reliable behavior patterns
+  - use when you want reliable plain-english patterns that shape behavior
+  - best for repeatability and making workflows legible
+  - pro tip: pair skills with plugins or cli
 
-- agents
-use when you need to create tasks that are executed by different models than the main one and might have some extra context to find skills or interact with mcps.
+- `agents` | delegated tasks with separate context
+  - use when you need to create tasks that are executed by different models than the main one and might have some extra context to find skills or interact with mcps
 
-- commands 
-`/` commands that trigger tools
+- `commands` | slash-command tool entry points
+  - `/` commands that trigger tools
 
-These are all opencode primitives you can read the docs to find out exactly how to set them up.
+These are all OpenCode primitives. Read the upstream docs for setup details and exact implementation behavior.
 
 ## Core Concepts of OpenWork
 
 - uses all these primitives
 - uses native OpenCode commands for reusable flows (markdown files in `.opencode/commands`)
-- adds a new abstraction "workspace" is a project folder and a simple .json file that includes a list of opencode primitives that map perfectly to an opencode workdir (not fully implemented)
-  - openwork can open a workpace.json and decide where to populate a folder with thse settings (not implemented today
+- adds a new abstraction "workspace": a project folder plus OpenWork-managed connection/config state that still maps cleanly to an OpenCode workdir
+- the current product surface treats local and remote workers through the same workspace/session shell rather than a separate dashboard concept
 
 ## Repository/component map
 
 - `/apps/app/`: OpenWork app UI (desktop/mobile/web client experience layer).
+  - the settings shell owns the workspace list plus user-facing tabs for general settings, skills, extensions, automations, messaging, appearance, and recovery.
 - `/apps/desktop/`: Tauri desktop shell that hosts the app UI and manages native process lifecycles.
 - `/apps/server/`: OpenWork server (API/control layer consumed by the app).
 - `/apps/orchestrator/`: OpenWork orchestrator CLI/daemon. In `start`/`serve` host mode it manages OpenWork server + OpenCode + `opencode-router`; in daemon mode it manages workspace activation and OpenCode lifecycle for desktop runtime.
@@ -621,8 +618,9 @@ This is optional and not required for non-technical MVP.
 OpenWork enforces folder access through **two layers**:
 
 1. **OpenWork UI authorization**
-   - user explicitly selects allowed folders via native picker
-   - OpenWork remembers allowed roots per profile
+   - workspace root access is implicit for the active workspace
+   - extra folders are managed from the Authorized folders panel in Settings
+   - OpenWork persists those extra directories through workspace config updates on the OpenWork server
 
 2. **OpenCode server permissions**
    - OpenCode requests permissions as needed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 > OpenWork is the open source alternative to Claude Cowork/Codex (desktop app).
 
-
 ## Core Philosophy
 
 - Local-first, cloud-ready: OpenWork runs on your machine in one click. Send a message instantly.
@@ -15,6 +14,7 @@
 OpenWork is designed around the idea that you can easily ship your agentic workflows as a repeatable, productized process.
 
 ## Alternate UIs
+
 - **OpenWork Orchestrator (CLI host)**: run OpenCode + OpenWork server without the desktop UI.
   - install: `npm install -g openwork-orchestrator`
   - run: `openwork start --workspace /path/to/workspace --approval auto`
@@ -41,15 +41,17 @@ OpenWork is designed to be:
 
 ## What’s Included
 
-- **Host mode**: runs opencode locally on your computer
-- **Client mode**: connect to an existing OpenCode server by URL.
-- **Workspaces**: create local workspaces from the desktop app or connect remote workers from the same sidebar flow.
+- **Local host mode**: run OpenCode locally on your computer.
+- **Remote connect**: attach to an OpenWork worker with a shared URL + token.
+- **Workspaces**: create local workspaces or connect remote workers from the same workspace sidebar.
 - **Sessions**: create/select sessions and send prompts.
 - **Live streaming**: SSE `/event` subscription for realtime updates.
 - **Execution plan**: render OpenCode todos as a timeline.
 - **Permissions**: surface permission requests and reply (allow once / always / deny).
 - **Templates**: save and re-run common workflows (stored locally).
 - **Debug exports**: copy or export the runtime debug report and developer log stream from Settings -> Debug when you need to file a bug.
+- **Unified settings shell**: manage skills, extensions, automations, messaging, and appearance from one shell instead of separate dashboard tabs.
+- **Authorized folders**: manage extra filesystem access from Settings when a workspace needs directories outside its root.
 - **Skills manager**:
   - list installed `.opencode/skills` folders
   - import a local skill folder into `.opencode/skills/<skill-name>`
@@ -151,7 +153,7 @@ Capability permissions are defined in:
 
 ## OpenCode Plugins
 
-Plugins are the **native** way to extend OpenCode. OpenWork now manages them from the Skills tab by
+Plugins are the **native** way to extend OpenCode. OpenWork now manages them from `Settings -> Extensions` by
 reading and writing `opencode.json`.
 
 - **Project scope**: `<workspace>/opencode.json`

--- a/VISION.md
+++ b/VISION.md
@@ -20,8 +20,9 @@ Current cloud mental model:
 OpenWork helps users ship agentic workflows to their team. It works on top of opencode (opencode.ai) an agentic coding platform that exposes apis and sdks. We care about maximally using the opencode primitives. And build the thinest possible layer - always favoring opencode apis over custom built ones.
 
 In other words:
+
 - OpenCode is the **engine**.
-- OpenWork is the **experience** : onboarding, safety, permissions, progress, artifacts, and a premium-feeling UI.
+- OpenWork is the **experience** : workspace setup, remote connect, safety, permissions, progress, artifacts, and a premium-feeling UI.
 
 OpenWork competes directly with Anthropic's Cowork conceptually, but stays open, local-first, and standards-based.
 


### PR DESCRIPTION
## Summary
- Split the 2026-03-29 docs automation work out of #1167 onto the restacked branch chain.
- Refresh `ARCHITECTURE.md`, `PRODUCT.md`, `README.md`, and `VISION.md`.
- Keep the historical doc rewrites landing one day at a time.