### PR TITLE
docs: automated documentation updates 2026-03-30

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,9 +31,8 @@ Auto-detection can exist as a convenience, but should be tiered and explainable:
 The readiness check should be a clear, single command (e.g. `docker info`) and the UI should show the exact error output when it fails.
 
 ## Minimal use of Tauri
+
 We move most of the functionality to the openwork server which interfaces mostly with FS and proxies to opencode.
-
-
 
 ## Filesystem mutation policy
 
@@ -56,12 +55,12 @@ Guidelines:
 
 When OpenWork is edited from `openwork-enterprise`, architecture and runtime behavior should be sourced from this document.
 
-| Entry point | Role | Architecture authority |
-| --- | --- | --- |
-| `openwork-enterprise/AGENTS.md` | OpenWork Factory multi-repo orchestration | Defers OpenWork runtime flow, server-vs-shell ownership, and filesystem mutation behavior to `_repos/openwork/ARCHITECTURE.md`. |
-| `openwork-enterprise/.opencode/agents/openwork-surgeon.md` | Surgical fix agent for `_repos/openwork` | Uses `_repos/openwork/ARCHITECTURE.md` as the runtime and architecture source of truth before changing product behavior. |
-| `_repos/openwork/AGENTS.md` | Product vocabulary, audience, and repo-local development guidance | Refers to `ARCHITECTURE.md` for runtime flow, server ownership, and architectural boundaries. |
-| Skills / commands / agents that mutate workspace state | Capability layer on top of the product runtime | Should assume the OpenWork server path is canonical for workspace creation, config writes, `.opencode/` mutation, and reload signaling. |
+| Entry point                                                | Role                                                              | Architecture authority                                                                                                                  |
+| ---------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `openwork-enterprise/AGENTS.md`                            | OpenWork Factory multi-repo orchestration                         | Defers OpenWork runtime flow, server-vs-shell ownership, and filesystem mutation behavior to `_repos/openwork/ARCHITECTURE.md`.         |
+| `openwork-enterprise/.opencode/agents/openwork-surgeon.md` | Surgical fix agent for `_repos/openwork`                          | Uses `_repos/openwork/ARCHITECTURE.md` as the runtime and architecture source of truth before changing product behavior.                |
+| `_repos/openwork/AGENTS.md`                                | Product vocabulary, audience, and repo-local development guidance | Refers to `ARCHITECTURE.md` for runtime flow, server ownership, and architectural boundaries.                                           |
+| Skills / commands / agents that mutate workspace state     | Capability layer on top of the product runtime                    | Should assume the OpenWork server path is canonical for workspace creation, config writes, `.opencode/` mutation, and reload signaling. |
 
 ### Agent access to server-owned behavior
 
@@ -113,37 +112,38 @@ Do not invent a separate reload banner per feature. New UI that needs restart se
 Current examples that should use this shared flow include MCP changes, auto context compaction, default model changes, authorized folder updates, plugin changes, and other `opencode.json` writes.
 
 ## opencode primitives
-how to pick the right extension abstraction for 
+
+how to pick the right extension abstraction for
 @opencode
 
 opencode has a lot of extensibility options:
 mcp / plugins / skills / bash / agents / commands
 
 - mcp
-use when you need authenticated third-party flows (oauth) and want to expose that safely to end users
-good fit when "auth + capability surface" is the product boundary
-downside: you're limited to whatever surface area the server exposes
+  use when you need authenticated third-party flows (oauth) and want to expose that safely to end users
+  good fit when "auth + capability surface" is the product boundary
+  downside: you're limited to whatever surface area the server exposes
 
 - bash / raw cli
-use only for the most advanced users or internal power workflows
-highest risk, easiest to get out of hand (context creep + permission creep + footguns)
-great for power users and prototyping, terrifying as a default for non-tech users
+  use only for the most advanced users or internal power workflows
+  highest risk, easiest to get out of hand (context creep + permission creep + footguns)
+  great for power users and prototyping, terrifying as a default for non-tech users
 
 - plugins
-use when you need real tools in code and want to scope permissions around them
-good middle ground: safer than raw cli, more flexible than mcp, reusable and testable
-basically "guardrails + capability packaging"
+  use when you need real tools in code and want to scope permissions around them
+  good middle ground: safer than raw cli, more flexible than mcp, reusable and testable
+  basically "guardrails + capability packaging"
 
 - skills
-use when you want reliable plain-english patterns that shape behavior
-best for repeatability and making workflows legible
-pro tip: pair skills with plugins or cli (i literally embed skills inside plugins right now and expose commands like get_skills / retrieve)
+  use when you want reliable plain-english patterns that shape behavior
+  best for repeatability and making workflows legible
+  pro tip: pair skills with plugins or cli (i literally embed skills inside plugins right now and expose commands like get_skills / retrieve)
 
 - agents
-use when you need to create tasks that are executed by different models than the main one and might have some extra context to find skills or interact with mcps.
+  use when you need to create tasks that are executed by different models than the main one and might have some extra context to find skills or interact with mcps.
 
-- commands 
-`/` commands that trigger tools
+- commands
+  `/` commands that trigger tools
 
 These are all opencode primitives you can read the docs to find out exactly how to set them up.
 
@@ -151,12 +151,13 @@ These are all opencode primitives you can read the docs to find out exactly how 
 
 - uses all these primitives
 - uses native OpenCode commands for reusable flows (markdown files in `.opencode/commands`)
-- adds a new abstraction "workspace" is a project folder and a simple .json file that includes a list of opencode primitives that map perfectly to an opencode workdir (not fully implemented)
-  - openwork can open a workpace.json and decide where to populate a folder with thse settings (not implemented today
+- adds a new abstraction "workspace": a project folder plus OpenWork-managed connection/config state that still maps cleanly to an OpenCode workdir
+- the current product surface treats local and remote workers through the same workspace/session shell rather than a separate dashboard concept
 
 ## Repository/component map
 
 - `/apps/app/`: OpenWork app UI (desktop/mobile/web client experience layer).
+  - the settings shell owns the workspace list plus user-facing tabs for general settings, skills, extensions, automations, messaging, appearance, and recovery.
 - `/apps/desktop/`: Tauri desktop shell that hosts the app UI and manages native process lifecycles.
 - `/apps/server/`: OpenWork server (API/control layer consumed by the app).
 - `/apps/orchestrator/`: OpenWork orchestrator CLI/daemon. In `start`/`serve` host mode it manages OpenWork server + OpenCode + `opencode-router`; in daemon mode it manages workspace activation and OpenCode lifecycle for desktop runtime.
@@ -621,8 +622,9 @@ This is optional and not required for non-technical MVP.
 OpenWork enforces folder access through **two layers**:
 
 1. **OpenWork UI authorization**
-   - user explicitly selects allowed folders via native picker
-   - OpenWork remembers allowed roots per profile
+   - workspace root access is implicit for the active workspace
+   - extra folders are managed from the Authorized folders panel in Settings
+   - OpenWork persists those extra directories through workspace config updates on the OpenWork server
 
 2. **OpenCode server permissions**
    - OpenCode requests permissions as needed

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,60 +1,261 @@
-## Product
+# OpenWork Product
 
-OpenWork helps individual create, consume, and maintain their agentic workflows.
+## Target Users
 
-OpenWork helps companies share their agentic workflows and provision their entire team.
+> Bob the IT guy.
+> Bob might already use opencode, he can setup agents and workflows and share them with his team. The only thing he needs is a way to share this. The way he does is by using OpenWork and creating "workpaces".
 
-The chat interfaces is where people consume the workflows.
+> Susan in accounting
 
-Interfaces for consuming workflows:
-- Desktop app
-- Slack
-- Telegram
+Susan in accounting doesn't use opencode. She certaintly doesn't paly aorund to create workflow create agents. She wants something that works.
+Openwork should be given to give her a good taste of what she can do.
+We should also eventually guide ther to:
 
-What is a "agentic workflow":
-- LLM providers
-- Skills
-- MCP
-- Agents
-- Plugins
-- Tools
-- Background Agents
+- creating her own skills
+- adding custom MCP / login into mcp oauth servers through ui)
+- adding skills from a list of skills
+- adding plugins from a list of plugins
+- create her own commands
 
-Where are workflows created:
-- Desktop app (using slash commands like `/create-skills`)
-- Web App
-- [We need better places for this to happen[
+1. **knowledge worker**: "Do this for me" workflows with guardrails.
+2. **Mobile-first user**: start/monitor tasks from phone.
+3. **Power user**: wants UI parity + speed + inspection.
+4. **Admin/host**: manages a shared machine + profiles.
 
-Where are workflows maintain:
-- In OpenWork Cloud (internal name is Den).
+## Success Metrics
 
-Where are workflow hosted:
-- Local Machine
-- Remote via a OpenWork Host (CLI or desktop)
-- Remote on OpenWork Cloud (via Den sandbox workers)
+- < 5 minutes to first successful task on fresh install.
+- > 80% task success without terminal fallback.
+- Permission prompts understood/accepted (low confusion + low deny-by-accident).
+- UI performance: 60fps; <100ms interaction latency; no jank.
 
-## Current OpenWork Cloud flow
+## Product Primitives (What OpenWork Exposes)
 
-- Users can sign in with the standard web auth providers or accept an org invite through the hosted join flow.
-- Invite signup keeps the invited email fixed, verifies the user by email code, and then drops them into the org join path.
-- Cloud workers are a paid flow: users complete checkout before they can launch hosted workers.
-- After a worker is ready, the user connects from the OpenWork app with `Add a worker` -> `Connect remote`, or opens the generated deep link directly.
+OpenWork must feel like "OpenCode, but for everyone."
 
-## Team distribution
+### 1) Tasks
 
-- Organizations can publish shared skill hubs so members discover approved skills from one managed place instead of collecting local-only installs by hand.
+- A Task = a user-described outcome.
+- A Run = an OpenCode session + event stream.
 
-## Actors
-Bob IT guy makes the config.
-Susan the accountant consumes the config.
+### 2) Plans / Todo Lists
 
-Constraints:
-- We use standards were possible
-- We use opencode where possible
-- We stay platform agnostic
+OpenWork provides a first-class plan UI:
 
+- Plan is generated before execution (editable).
+- Plan is updated during execution (step status + timestamps).
+- Plan is stored as a structured artifact attached to the session (JSON) so it's reconstructable.
 
-How to decide if OpenWork should do something:
-- Does it help Bob share config more easily?
-- Does it help Susan consume automations more easily?
-- Is this something that is coding specific?
+Implementation detail:
+
+- The plan is represented in OpenCode as structured `parts` (or a dedicated "plan message") and mirrored in OpenWork.
+
+### 3) Steps
+
+- Each tool call becomes a step row with:
+  - tool name
+  - arguments summary
+  - permission state
+  - start/end time
+  - output preview
+
+### 4) Artifacts
+
+Artifacts are user-visible outputs:
+
+- files created/modified
+- generated documents/spreadsheets/presentations
+- exported logs and summaries
+
+OpenWork lists artifacts per run and supports open/share/download.
+
+### 5) Audit Log
+
+Every run provides an exportable audit log:
+
+- prompts
+- plan
+- tool calls
+- permission decisions
+- outputs
+
+## UI/UX Requirements (Slick as a Core Goal)
+
+### Design Targets
+
+- premium, calm, high-contrast
+- subtle motion, springy transitions
+- zero "developer vibes" in default mode
+
+### Performance Targets
+
+- 60fps animations
+- <100ms input-to-feedback
+- no blocking spinners (always show progress state)
+
+### Mobile-first Interaction
+
+- bottom navigation
+- swipe gestures (dismiss, approve, cancel)
+- haptics for major events
+- adaptive layouts (phone/tablet)
+
+### Accessibility
+
+- WCAG 2.1 AA
+- reduced motion mode
+- screen-reader labels for steps + permissions
+
+## Design Reference
+
+use the design from ./design.ts that is your core reference for building the entire ui
+
+## Functional Requirements
+
+### Workspace Setup
+
+- create a local workspace or connect a remote worker from the workspace shell
+- provider/model setup
+- authorized folders management from Settings when a workspace needs paths outside its root
+- first-run task from the session surface
+
+### Cloud Worker Onboarding (Current)
+
+- Sign in (or sign up) on OpenWork cloud control surface.
+- Launch worker with a human-readable name.
+- If needed, complete checkout and return.
+- Select launched worker from list/detail shell.
+- Connect from OpenWork app via `Add a worker` -> `Connect remote`.
+- Prefer one-click deep link when available; always provide manual URL + token fallback.
+
+### Task Execution
+
+- create task
+- plan preview and edit
+- run with streaming updates
+- pause/resume/cancel
+- show artifacts and summaries
+
+### Permissions
+
+- clear prompts with "why"
+- allow once/session
+- audit of decisions
+
+### Commands
+
+- save a task as a command
+- arguments + quick run
+
+### Scheduling (Future)
+
+- schedule command runs
+- notify on completion
+
+## User Flow Map (Exhaustive)
+
+### 0. Install & Launch
+
+1. User installs OpenWork.
+2. App launches into the workspace/settings shell.
+3. User either creates a local workspace or chooses `Add a worker` -> `Connect remote`.
+4. Local flow starts the host stack for the selected workspace.
+5. Remote flow stores the worker URL + token and reconnects to that worker.
+
+### 1. Local Workspace Setup
+
+1. User picks or creates a workspace folder.
+2. OpenWork starts the local host stack for that workspace.
+3. User configures providers and model defaults.
+4. If needed, user adds extra authorized folders from Settings.
+5. User opens a session and runs the first task.
+
+### 2. Remote Worker Connect
+
+1. User chooses `Add a worker` -> `Connect remote`.
+2. UI accepts a shared OpenWork worker URL and token (or deep link).
+3. OpenWork verifies server health and available capabilities.
+4. User lands in the same workspace/session shell used for local workers.
+5. User can now list sessions and monitor runs.
+
+### 3. Runtime Health & Recovery
+
+1. UI pings `global.health()`.
+2. If unhealthy:
+   - Host: attempt restart via `createOpencode()`.
+   - Client: show reconnect + diagnostics.
+
+### 4. Quick Task Flow
+
+1. User types goal.
+2. OpenWork generates plan (structured).
+3. User approves.
+4. Create session: `session.create()`.
+5. Send prompt: `session.prompt()`.
+6. Subscribe to events: `event.subscribe()`.
+7. Render streaming output + steps.
+8. Show artifacts.
+
+### 5. Guided Task Flow
+
+1. Wizard collects goal, constraints, outputs.
+2. Plan preview with "risky step" highlights.
+3. Run execution with progress UI.
+
+### 6. File-Driven Task Flow
+
+1. User attaches files.
+2. OpenWork injects context into session.
+3. Execute prompt.
+
+### 7. Permissions Flow (Any)
+
+1. Event indicates permission request.
+2. UI modal shows request.
+3. User chooses allow/deny.
+4. UI calls `client.permission.reply({ requestID, reply })`.
+5. Run continues or fails gracefully.
+
+### 8. Cancel / Abort
+
+1. User clicks "Stop".
+2. UI calls `client.session.abort({ sessionID })`.
+3. UI marks run stopped.
+
+### 9. Summarize
+
+1. User taps "Summarize".
+2. UI calls `client.session.summarize({ sessionID })`.
+3. Summary displayed as an artifact.
+
+### 10. Run History
+
+1. UI calls `session.list()`.
+2. Tap a session to load `session.messages()`.
+3. UI reconstructs plan and steps.
+
+### 11. File Explorer + Search
+
+1. User searches: `find.text()`.
+2. Open file: `file.read()`.
+3. Show changed files: `file.status()`.
+
+### 12. Commands
+
+1. Save a plan + prompt as a command.
+2. Re-run command creates a new session.
+
+### 13. Multi-user (Future)
+
+- separate profiles
+- separate allowed folders
+- separate providers/keys
+
+### 14. Hosted Cloud Worker Connect Flow (Current)
+
+1. User opens OpenWork cloud control page and authenticates.
+2. User launches a worker (with optional checkout).
+3. UI polls until worker is healthy.
+4. UI resolves workspace-scoped connect URL (`/w/ws_*`) and access token.
+5. User clicks `Open in OpenWork` or copies manual credentials.
+6. In OpenWork app, user uses `Add a worker` -> `Connect remote` and starts working.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 > OpenWork is the open source alternative to Claude Cowork/Codex (desktop app).
 
-
 ## Core Philosophy
 
 - Local-first, cloud-ready: OpenWork runs on your machine in one click. Send a message instantly.
@@ -15,6 +14,7 @@
 OpenWork is designed around the idea that you can easily ship your agentic workflows as a repeatable, productized process.
 
 ## Alternate UIs
+
 - **OpenWork Orchestrator (CLI host)**: run OpenCode + OpenWork server without the desktop UI.
   - install: `npm install -g openwork-orchestrator`
   - run: `openwork start --workspace /path/to/workspace --approval auto`
@@ -41,15 +41,17 @@ OpenWork is designed to be:
 
 ## What’s Included
 
-- **Host mode**: runs opencode locally on your computer
-- **Client mode**: connect to an existing OpenCode server by URL.
-- **Workspaces**: create local workspaces from the desktop app or connect remote workers from the same sidebar flow.
+- **Local host mode**: run OpenCode locally on your computer.
+- **Remote connect**: attach to an OpenWork worker with a shared URL + token.
+- **Workspaces**: create local workspaces or connect remote workers from the same workspace sidebar.
 - **Sessions**: create/select sessions and send prompts.
 - **Live streaming**: SSE `/event` subscription for realtime updates.
 - **Execution plan**: render OpenCode todos as a timeline.
 - **Permissions**: surface permission requests and reply (allow once / always / deny).
 - **Templates**: save and re-run common workflows (stored locally).
 - **Debug exports**: copy or export the runtime debug report and developer log stream from Settings -> Debug when you need to file a bug.
+- **Unified settings shell**: manage skills, extensions, automations, messaging, and appearance from one shell instead of separate dashboard tabs.
+- **Authorized folders**: manage extra filesystem access from Settings when a workspace needs directories outside its root.
 - **Skills manager**:
   - list installed `.opencode/skills` folders
   - import a local skill folder into `.opencode/skills/<skill-name>`
@@ -151,7 +153,7 @@ Capability permissions are defined in:
 
 ## OpenCode Plugins
 
-Plugins are the **native** way to extend OpenCode. OpenWork now manages them from the Skills tab by
+Plugins are the **native** way to extend OpenCode. OpenWork now manages them from `Settings -> Extensions` by
 reading and writing `opencode.json`.
 
 - **Project scope**: `<workspace>/opencode.json`

--- a/VISION.md
+++ b/VISION.md
@@ -20,8 +20,9 @@ Current cloud mental model:
 OpenWork helps users ship agentic workflows to their team. It works on top of opencode (opencode.ai) an agentic coding platform that exposes apis and sdks. We care about maximally using the opencode primitives. And build the thinest possible layer - always favoring opencode apis over custom built ones.
 
 In other words:
+
 - OpenCode is the **engine**.
-- OpenWork is the **experience** : onboarding, safety, permissions, progress, artifacts, and a premium-feeling UI.
+- OpenWork is the **experience** : workspace setup, remote connect, safety, permissions, progress, artifacts, and a premium-feeling UI.
 
 OpenWork competes directly with Anthropic's Cowork conceptually, but stays open, local-first, and standards-based.
 

--- a/apps/orchestrator/README.md
+++ b/apps/orchestrator/README.md
@@ -69,10 +69,10 @@ pnpm --filter openwork-orchestrator dev -- \
 
 When `OPENWORK_DEV_MODE=1` is set, orchestrator uses an isolated OpenCode dev state for config, auth, data, cache, and state. OpenWork's repo-level `pnpm dev` commands enable this automatically so local development does not reuse your personal OpenCode environment.
 
-The command prints pairing URLs by default and withholds live credentials from stdout to avoid leaking them into shell history or collected logs. Use `--json` only when you explicitly need the raw pairing secrets in command output.
+The command prints pairing URLs by default and keeps live credentials out of stdout so they do not leak into shell history or collected logs. Use `--json` only when you explicitly need the raw pairing secrets in command output.
 
 Use `--detach` to keep services running and exit the dashboard. The detach summary includes the
-OpenWork URL and a redacted `opencode attach` command, while keeping live credentials out of the detached summary.
+OpenWork URL and a redacted `opencode attach` command while keeping the live tokens out of the summary.
 
 ## Sandbox mode (Docker / Apple container)
 

--- a/packages/docs/accessing-ow-from-slack.mdx
+++ b/packages/docs/accessing-ow-from-slack.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Connecting you slack with your workspace"
-description: "Learn how to connect your slack with your workspace"
+title: "Connecting Slack to your workspace"
+description: "Learn how to connect Slack to an OpenWork workspace"
 ---
 
 In order to connect `slack` with your openwork `workspace`, you will need the following:
@@ -15,7 +15,7 @@ This is one of the most relevant and meaningful applications of Openwork, and we
 
 ## Having the right slack permissions
 
-You should either be a slack `owner`, `admin` or have the right level of approval to be able to add an app into slack.
+You should either be a Slack `owner`, `admin`, or have the right level of approval to add an app into Slack.
 
 ## Creating a slack app
 
@@ -42,7 +42,8 @@ Now, once you have both of these tokens, you can directly paste them into the ap
 <Frame>
   ![Clean Shot 2026 03 24 At 17 15 15@2x](/images/CleanShot2026-03-24at17.15.15@2x.png)
 
-  Paste you `xorb-` and `xapp-` tokens into `Settings` \> `messaging`
+Paste you `xorb-` and `xapp-` tokens into `Settings` \> `messaging`
+
 </Frame>
 
 ## Send test message
@@ -50,7 +51,8 @@ Now, once you have both of these tokens, you can directly paste them into the ap
 Test the bot by sending a message. It should respond instantly indicating that a new session has been initiatied and then send the actual response afterwards. For now, you will have to use `@slack-bot-name` every time you want to talk to it.
 
 <Frame>
-  ![Clean Shot 2026 03 24 At 17 16 43@2x](/images/CleanShot2026-03-24at17.16.43@2x.png)
+  ![Clean Shot 2026 03 24 At 17 16
+  43@2x](/images/CleanShot2026-03-24at17.16.43@2x.png)
 </Frame>
 
 ## Template Manifest Example

--- a/packages/docs/automating-tasks.mdx
+++ b/packages/docs/automating-tasks.mdx
@@ -1,33 +1,35 @@
 ---
-title: "Automating Tasks"
+title: "Automating tasks"
+description: "Create and manage recurring jobs from Settings -> Automations"
 ---
 
-Automations allow you to run prompts on a schedule
+OpenWork can turn a prompt into a recurring automation.
 
-You can find them in `Settings → Automations` 
+You can find the feature in `Settings` -> `Automations`.
 
-Automations are just prompts!
+## Before you start
 
-<Frame>
-  ![Image](/images/image-1.png)
-</Frame>
+- On the desktop app, install the scheduler plugin if OpenWork asks for it.
+- If OpenWork shows `Reload OpenWork to activate automations`, reload the workspace so the scheduler becomes available.
+- If you are connected to a remote OpenWork server, the Automations page shows the jobs already registered on that server.
 
-To create an automation you can simply say something like:
+<Frame>![Automations page in Settings](/images/image-1.png)</Frame>
 
-`Create a schedule job that is going to go to facebook.com every day take a screenshot and report back to me`
+## Create a new automation
 
-<Frame>
-  ![Image](/images/image-3.png)
-</Frame>
+1. Open `Settings` -> `Automations`.
+2. Click `New automation`.
+3. Give the job a name, write the prompt you want OpenWork to run, and choose the schedule.
+4. Click `Prepare in chat`.
 
-If it works you'll see the chat response positively:
+OpenWork currently prepares the scheduler command for you in chat, so you can review it before it runs.
 
-<Frame>
-  ![Image](/images/image-4.png)
-</Frame>
+<Frame>![Create automation modal](/images/image-3.png)</Frame>
 
-And you'll then see it listed here:
+If the setup succeeds, OpenWork confirms the automation in chat.
 
-<Frame>
-  ![Image](/images/image-5.png)
-</Frame>
+<Frame>![Automation prepared successfully in chat](/images/image-4.png)</Frame>
+
+After that, the new job appears in the Automations list, where you can refresh it, run it in chat, or remove it.
+
+<Frame>![Saved automation listed in Settings](/images/image-5.png)</Frame>

--- a/packages/docs/computer-use.mdx
+++ b/packages/docs/computer-use.mdx
@@ -1,25 +1,28 @@
 ---
 title: "Controlling your browser with OpenWork"
-description: "How to use OpenWork to automate your Chrome Browser"
+description: "How to use OpenWork to automate Google Chrome"
 ---
 
-Computer-Use in OpenWork currently works as a browser automation in Google Chrome. It does not yet mean full desktop control of Ubuntu, macOS, or Windows apps.
+Computer Use in OpenWork currently works as browser automation in Google Chrome. It does not yet mean full desktop control of Ubuntu, macOS, or Windows apps.
 
-With the right skills, your OpenWork agent will be able to runs browser actions and take screnshots as proof of having completed said actions. If you connect to a remote OpenWork server, that remote machine also needs to have Chrome installed.
+With the right extension enabled, your OpenWork agent can run browser actions and take screenshots as proof of completion. If you connect to a remote OpenWork server, that remote machine also needs Chrome installed.
 
 Today, the supported path is `Control Chrome`, which uses Chrome DevTools MCP.
 
 ## Requirements
 
 - Google Chrome on the machine running the session
-- In `Settings > Extensions > Control Chrome`
+- `Settings` -> `Extensions` -> `Control Chrome`
 
 <Frame>
-  ![Screenshot 2026 03 25 At 11 47 52](/images/Screenshot2026-03-25at11.47.52.png)
-
-  - Enable it and follow the instructions in the configuration screen _Note_: _do note use "Use my existing Chrome profile". It's currently not well supported._
-    <Frame>
-      ![Image](/images/image.png)
-    </Frame>
-    Go back to the session view and ask it to open a website
+  ![Control Chrome extension in
+  Settings](/images/Screenshot2026-03-25at11.47.52.png)
 </Frame>
+
+Enable `Control Chrome`, then follow the setup steps from the configuration screen.
+
+<Frame>![Control Chrome setup instructions](/images/image.png)</Frame>
+
+Avoid `Use my existing Chrome profile` for now; the isolated profile flow is more reliable.
+
+Once setup is complete, go back to a session and ask OpenWork to open a website or complete a browser task.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -19,37 +19,23 @@
         "pages": [
           "get-started",
           {
-            "group": "Cloud",
-            "pages": [
-              "introduction",
-              "team-provisioning"
-            ]
-          },
-          {
             "group": "Desktop App",
             "pages": [
-              "enable-advanced-search-with-exa",
               "how-to-connect-chat-gpt",
               "how-to-connect-mcps",
               "computer-use",
+              "automating-tasks",
               "sharing-ow-setup",
-              "accessing-ow-from-slack",
-              "how-to-automate-your",
-              "automating-tasks"
+              "accessing-ow-from-slack"
             ]
           },
           {
             "group": "Tutorials",
-            "pages": [
-              "how-to-connect-a-custom-provider",
-              "importing-a-skill"
-            ]
+            "pages": ["how-to-connect-a-custom-provider", "importing-a-skill"]
           },
           {
             "group": "Improve this doc",
-            "pages": [
-              "missing-docs"
-            ]
+            "pages": ["missing-docs"]
           }
         ]
       }

--- a/packages/docs/sharing-ow-setup.mdx
+++ b/packages/docs/sharing-ow-setup.mdx
@@ -12,12 +12,13 @@ There are two main things you can share from OpenWork:
 
 OpenWork can package an entire workspace template into one share link. That bundle can include your skills, commands, agents, MCP/OpenCode settings, `opencode.json` state, and other shareable `.opencode/**` files.
 
-OpenWork does not copy secrets, runtime-only files, or your existing session history into the template.
+OpenWork does not copy secrets, runtime-only files, or your existing session history into the template. If OpenWork detects secret-like provider settings, plugin config, MCP credentials, or portable files that look sensitive, it warns and excludes that data from the exported template.
 
 Click the `...` next to the workspace name, then `Share...`, then `Share a template`.
 
 <Frame>
-  ![Share workspace dialog with template and remote options](/images/sharing-workspace-template-dialog.png)
+  ![Share workspace dialog with template and remote
+  options](/images/sharing-workspace-template-dialog.png)
 </Frame>
 
 When someone opens that link and clicks `Open in OpenWork`, OpenWork now creates a new workspace from the template instead of dropping the bundle into the current workspace.
@@ -54,17 +55,20 @@ After sign-in, teammates can open the template from `Settings` -> `OpenWork Clou
 You can share a `SKILL.md` from `Your_Workspace` > `Skills`.
 
 <Frame>
-  ![Skills management page showing installed skills](/images/sharing-skills-list.png)
+  ![Skills management page showing installed
+  skills](/images/sharing-skills-list.png)
 </Frame>
 
 Click `Create Link` to generate a custom share page for that skill at `share.openwork.software/b/:skill_id`.
 
 <Frame>
-  ![Create share link dialog for a skill](/images/sharing-create-link-dialog.png)
+  ![Create share link dialog for a
+  skill](/images/sharing-create-link-dialog.png)
 </Frame>
 
 That creates a URL you can send to other people so they can `Copy the skill` or `Open in OpenWork`.
 
 <Frame>
-  ![Shared skill page with Copy and Open in OpenWork buttons](/images/sharing-skill-share-page.png)
+  ![Shared skill page with Copy and Open in OpenWork
+  buttons](/images/sharing-skill-share-page.png)
 </Frame>


### PR DESCRIPTION
## Summary
- Split the 2026-03-30 docs automation work out of #1167 onto the restacked branch chain.
- Refresh `apps/orchestrator/README.md`, the affected `packages/docs/*.mdx` pages, and the docs catalog/assets tied to that day's update.
- Preserve the original day-by-day docs review order.