### PR TITLE
improved harness via more explicit socket drop so ai is not stuck awaiting the test

### DIFF
--- a/apps/app/scripts/browser-entry.mjs
+++ b/apps/app/scripts/browser-entry.mjs
@@ -117,6 +117,7 @@ let tmpdir;
 let mock;
 let opencode;
 let sawChromeQuickstartPrompt = false;
+const mockSockets = new Set();
 
 try {
   tmpdir = await mkdtemp(path.join(os.tmpdir(), "openwork-browser-entry-"));
@@ -182,6 +183,12 @@ try {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("not found");
     });
+    mock.on("connection", (socket) => {
+      mockSockets.add(socket);
+      socket.on("close", () => {
+        mockSockets.delete(socket);
+      });
+    });
 
     await new Promise((resolve) => mock.listen(mockPort, "127.0.0.1", resolve));
     return { baseURL };
@@ -246,6 +253,7 @@ try {
 
   await step("assert.no-tool-errors", async () => {
     const start = Date.now();
+    // Keep this internal polling window short: the test should wait up to 12 seconds for the assistant response before failing
     while (Date.now() - start < 12_000) {
       const msgs = await client.session.messages({ sessionID: sessionId, limit: 50 });
       const parts = msgs.flatMap((m) => m.parts ?? []);
@@ -285,7 +293,12 @@ try {
     // ignore
   }
   try {
-    if (mock) await new Promise((resolve) => mock.close(() => resolve()));
+    if (mock) {
+      for (const socket of mockSockets) {
+        socket.destroy();
+      }
+      await new Promise((resolve) => mock.close(() => resolve()));
+    }
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary
- Drop lingering mock server sockets during teardown so `test:browser-entry` exits cleanly.
- Document that the test’s internal assistant wait is capped at 12 seconds.

## Why
- The test could appear to pass but still hang under an outer harness timeout.
- Reviewers and automation need a clear signal for setting a reasonable wrapper timeout.

## Scope
- `apps/app/scripts/browser-entry.mjs`

## Out of scope
- Changing the test’s behavior or expanding browser-entry coverage.
## Testing
### Ran
- `pnpm --filter @openwork/app test:browser-entry`

### Result
- pass

## Manual verification
1. Run `pnpm --filter @openwork/app test:browser-entry`.
2. Confirm the script prints a successful result.
3. Confirm the process exits promptly instead of lingering after success.

## Risk
- Low; teardown-only change plus a clarifying comment.
## Rollback
- Revert the `browser-entry.mjs` teardown/socket tracking change.