### PR TITLE
fix: restore migrated share skill links

### DIFF
--- a/apps/server/src/share-bundles.test.ts
+++ b/apps/server/src/share-bundles.test.ts
@@ -3,35 +3,33 @@ import { describe, expect, test } from "bun:test";
 import { ApiError } from "./errors.js";
 import { normalizeSharedBundleFetchUrl, resolveTrustedSharedBundleFetchUrl } from "./share-bundles.js";
 
+const VALID_SKILL_BUNDLE_ID = "01KNBQDQAK41VZSZDF5G9MW4MW";
+const VALID_SKILL_SHARE_URL = `https://share.openworklabs.com/b/${VALID_SKILL_BUNDLE_ID}`;
+const VALID_SKILL_DATA_URL = `${VALID_SKILL_SHARE_URL}/data`;
+
 describe("normalizeSharedBundleFetchUrl", () => {
   test("rewrites human share pages to the canonical data endpoint", () => {
-    const normalized = normalizeSharedBundleFetchUrl(
-      new URL("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV?format=json"),
-    );
+    const normalized = normalizeSharedBundleFetchUrl(new URL(`${VALID_SKILL_SHARE_URL}?format=json`));
 
-    expect(normalized.toString()).toBe("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data");
+    expect(normalized.toString()).toBe(VALID_SKILL_DATA_URL);
   });
 
   test("keeps existing data endpoints and strips redundant format", () => {
-    const normalized = normalizeSharedBundleFetchUrl(
-      new URL("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?format=json&download=1"),
-    );
+    const normalized = normalizeSharedBundleFetchUrl(new URL(`${VALID_SKILL_DATA_URL}?format=json&download=1`));
 
-    expect(normalized.toString()).toBe(
-      "https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?download=1",
-    );
+    expect(normalized.toString()).toBe(`${VALID_SKILL_DATA_URL}?download=1`);
   });
 });
 
 describe("resolveTrustedSharedBundleFetchUrl", () => {
   test("rebuilds fetch URLs from the configured publisher origin", () => {
-    const resolved = resolveTrustedSharedBundleFetchUrl("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV?download=1");
+    const resolved = resolveTrustedSharedBundleFetchUrl(`${VALID_SKILL_SHARE_URL}?download=1`);
 
-    expect(resolved.toString()).toBe("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?format=json");
+    expect(resolved.toString()).toBe(VALID_SKILL_DATA_URL);
   });
 
   test("rejects bundle URLs that use another origin", () => {
-    expect(() => resolveTrustedSharedBundleFetchUrl("https://evil.example/b/01ARZ3NDEKTSV4RRFFQ69G5FAV")).toThrow(
+    expect(() => resolveTrustedSharedBundleFetchUrl(`https://evil.example/b/${VALID_SKILL_BUNDLE_ID}`)).toThrow(
       new ApiError(
         400,
         "untrusted_bundle_url",

--- a/apps/server/src/share-bundles.test.ts
+++ b/apps/server/src/share-bundles.test.ts
@@ -6,19 +6,19 @@ import { normalizeSharedBundleFetchUrl, resolveTrustedSharedBundleFetchUrl } fro
 describe("normalizeSharedBundleFetchUrl", () => {
   test("rewrites human share pages to the canonical data endpoint", () => {
     const normalized = normalizeSharedBundleFetchUrl(
-      new URL("https://share.openwork.software/b/01ARZ3NDEKTSV4RRFFQ69G5FAV?format=json"),
+      new URL("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV?format=json"),
     );
 
-    expect(normalized.toString()).toBe("https://share.openwork.software/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data");
+    expect(normalized.toString()).toBe("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data");
   });
 
   test("keeps existing data endpoints and strips redundant format", () => {
     const normalized = normalizeSharedBundleFetchUrl(
-      new URL("https://share.openwork.software/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?format=json&download=1"),
+      new URL("https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?format=json&download=1"),
     );
 
     expect(normalized.toString()).toBe(
-      "https://share.openwork.software/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?download=1",
+      "https://share.openworklabs.com/b/01ARZ3NDEKTSV4RRFFQ69G5FAV/data?download=1",
     );
   });
 });

--- a/apps/server/src/share-bundles.ts
+++ b/apps/server/src/share-bundles.ts
@@ -67,7 +67,6 @@ export function resolveTrustedSharedBundleFetchUrl(bundleUrl: unknown): URL {
   const bundleId = extractBundleId(inputUrl);
   trustedBaseUrl.pathname = `/b/${bundleId}/data`;
   trustedBaseUrl.search = "";
-  trustedBaseUrl.searchParams.set("format", "json");
   return trustedBaseUrl;
 }
 

--- a/ee/apps/landing/components/landing-cloud-workers-card.tsx
+++ b/ee/apps/landing/components/landing-cloud-workers-card.tsx
@@ -31,7 +31,7 @@ export function LandingCloudWorkersCard(props: Props) {
             <path d="M7 11V7a5 5 0 0 1 10 0v4" />
           </svg>
           <span className="truncate text-[11px] text-gray-400">
-            share.openwork.software/b/01KMK...
+            share.openworklabs.com/b/01KNB...
           </span>
         </div>
       </div>

--- a/packages/docs/how-to-connect-a-custom-provider.mdx
+++ b/packages/docs/how-to-connect-a-custom-provider.mdx
@@ -27,6 +27,6 @@ Inside `/path-to-your-workspace/.config/opencode/opencode.json`:
 }
 ```
 
-We've also built a [custom skill](https://share.openwork.software/b/01KKZHV7CX178KH4FB5XGCM4XW) that you can import in Openwork following [this guide](/importing-a-skill). 
+We've also built a [custom skill](https://share.openworklabs.com/b/01KNBQDQAK41VZSZDF5G9MW4MW) that you can import in Openwork following [this guide](/importing-a-skill). 
 
 The following tutorial covers how to [import a custom provider using the skill](https://x.com/getopenwork/status/2034129039317995908?s=20).

--- a/packages/docs/importing-a-skill.mdx
+++ b/packages/docs/importing-a-skill.mdx
@@ -15,7 +15,7 @@ We recommend (1) and (3) because they match the built-in OpenWork flows most clo
 
 ## Importing an existing skill with a share URL
 
-When you have an OpenWork [share URL](https://share.openwork.software/b/01KKPSGYSGDRRWNTAACAMZY3PF), click `Open in OpenWork`.
+When you have an OpenWork [share URL](https://share.openworklabs.com/b/01KNBQDPGSS39J4AG3MN9FVZ73), click `Open in OpenWork`.
 
 <Frame>
   ![Share page with Open in OpenWork button](/images/skill-import-share-page.png)

--- a/packages/docs/sharing-ow-setup.mdx
+++ b/packages/docs/sharing-ow-setup.mdx
@@ -23,7 +23,7 @@ You can share a `SKILL.md` by clicking under `Your_Workspace` \> `Skills`
   ![Skills management page showing installed skills](/images/sharing-skills-list.png)
 </Frame>
 
-Then, on `Create Link` which will create a custom page for the skill at `share.openwork.software/b/:skill_id`
+Then, on `Create Link` which will create a custom page for the skill at `share.openworklabs.com/b/:skill_id`
 
 <Frame>
   ![Create share link dialog for a skill](/images/sharing-create-link-dialog.png)


### PR DESCRIPTION
## Summary
- republish the documented `workspace-guide` and `provider-config-helper` bundles on `share.openworklabs.com` and replace the stale `share.openwork.software` links with the new live bundle URLs
- align server-side bundle fetch reconstruction with the share service's canonical raw endpoint (`/b/:id/data`) and cover it with the known-good live `provider-config-helper` bundle URL
- update the remaining in-repo `share.openwork.software` references and align `apps/server/src/share-bundles.test.ts` with the current publisher host

## Before
- `packages/docs/importing-a-skill.mdx` pointed to `https://share.openwork.software/b/01KKPSGYSGDRRWNTAACAMZY3PF`
- `packages/docs/how-to-connect-a-custom-provider.mdx` pointed to `https://share.openwork.software/b/01KKZHV7CX178KH4FB5XGCM4XW`
- `apps/server/src/share-bundles.test.ts` still used a placeholder bundle id and expected the legacy `?format=json` suffix on the fetch URL

## After
- `workspace-guide` now points to `https://share.openworklabs.com/b/01KNBQDPGSS39J4AG3MN9FVZ73`
- `provider-config-helper` now points to `https://share.openworklabs.com/b/01KNBQDQAK41VZSZDF5G9MW4MW`
- trusted bundle fetch URLs now normalize to the canonical share-service raw endpoint: `https://share.openworklabs.com/b/:id/data`
- all `share.openwork.software` references in the repo now use `share.openworklabs.com`

## Verification
- `bun test src/share-bundles.test.ts`
- `bun test server/_lib/share-utils.test.ts server/b/render-bundle-page.test.ts`
- `pnpm --filter openwork-server build:bin`
- fetched both old and new `/data` endpoints and confirmed the republished payloads are identical for `workspace-guide` and `provider-config-helper`
- opened both new share pages in the browser and confirmed they render with the expected bundle content and `Open in OpenWork`
- installed workspace dependencies in the task worktree with `pnpm install --frozen-lockfile` so the share-service tests and server binary build could run there
- no video/screenshot attached; this PR changes docs/examples/tests plus server URL normalization, and the live share pages were verified directly from the CLI browser session