### PR TITLE
refactor(app): prepare the shell for React migration

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -58,11 +58,15 @@
     "jsonc-parser": "^3.2.1",
     "lucide-solid": "^0.562.0",
     "marked": "^17.0.1",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "solid-js": "^1.9.0"
   },
   "devDependencies": {
     "@solid-devtools/overlay": "^0.33.5",
     "@tailwindcss/vite": "^4.1.18",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "solid-devtools": "^0.34.5",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.6.3",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -56,6 +56,7 @@
     "@tauri-apps/plugin-updater": "~2.9.0",
     "fuzzysort": "^3.1.0",
     "jsonc-parser": "^3.2.1",
+    "lucide-react": "^0.577.0",
     "lucide-solid": "^0.562.0",
     "marked": "^17.0.1",
     "react": "^19.2.4",

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -29,6 +29,7 @@ import SettingsShell from "./shell/settings-shell";
 import { createStatusToastsStore, StatusToastsProvider } from "./shell/status-toasts";
 import SessionView from "./pages/session";
 import ReactSessionViewV2 from "./session-v2/react-session-view-v2";
+import ReactSettingsViewV2 from "./settings-v2/react-settings-view-v2";
 import { clearDevLogs, recordDevLog } from "./lib/dev-log";
 import { unwrap } from "./lib/opencode";
 import { clearPerfLogs, finishPerf, perfNow, recordPerfLog } from "./lib/perf-log";
@@ -184,6 +185,13 @@ export default function App() {
       : true;
   const preferReactSessionV2 = createMemo(
     () => reactSessionV2KillSwitch && local.prefs.reactSessionV2,
+  );
+  const reactSettingsV2KillSwitch =
+    typeof import.meta.env?.VITE_OPENWORK_REACT_SETTINGS_V2 === "string"
+      ? import.meta.env.VITE_OPENWORK_REACT_SETTINGS_V2 !== "0"
+      : true;
+  const preferReactSettingsV2 = createMemo(
+    () => reactSettingsV2KillSwitch && local.prefs.reactSettingsV2,
   );
   const currentView = createMemo<View>(() => {
     const path = location.pathname.toLowerCase();
@@ -2285,6 +2293,7 @@ export default function App() {
                   <ReactShellHost
                     currentView={currentView()}
                     preferReactSession={preferReactSessionV2()}
+                    preferReactSettings={preferReactSettingsV2()}
                     renderSession={() =>
                       renderReactOwnedSurface(() => <SessionView {...sessionSurface()} />)
                     }
@@ -2299,6 +2308,11 @@ export default function App() {
                     }
                     renderSettings={() =>
                       renderReactOwnedSurface(() => <SettingsShell {...settingsSurface()} />)
+                    }
+                    renderSettingsReact={() =>
+                      createElement(ReactSettingsViewV2, {
+                        legacySurface: settingsSurface(),
+                      })
                     }
                   />
                   <ModalHost

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -8,6 +8,7 @@ import {
   onMount,
   untrack,
 } from "solid-js";
+import type { JSX } from "solid-js";
 
 import { useLocation, useNavigate } from "@solidjs/router";
 
@@ -85,7 +86,11 @@ import { createExtensionsStore } from "./context/extensions";
 import { createConnectionsStore } from "./connections/store";
 import { createAutomationsStore } from "./context/automations";
 import { createSidebarSessionsStore } from "./context/sidebar-sessions";
+import { useGlobalSDK } from "./context/global-sdk";
 import { useGlobalSync } from "./context/global-sync";
+import { useLocal } from "./context/local";
+import { usePlatform } from "./context/platform";
+import { useServer } from "./context/server";
 import { createWorkspaceStore } from "./context/workspace";
 import {
   updaterEnvironment,
@@ -120,9 +125,11 @@ import {
 import { createBundlesStore } from "./bundles/store";
 import { createBootstrapCoordinator } from "./shell/bootstrap-coordinator";
 import ModalHost from "./shell/modal-host";
+import ReactShellHost from "./shell/react-shell-host";
 import { syncShellRoute } from "./shell/route-sync";
 import { buildSessionSurface } from "./shell/session-surface";
 import { buildSettingsSurface } from "./shell/settings-surface";
+import SolidContextBridge from "./shell/solid-context-bridge";
 
 type SettingsReturnTarget = {
   view: View;
@@ -162,6 +169,10 @@ export default function App() {
   };
   const location = useLocation();
   const navigate = useNavigate();
+  const platform = usePlatform();
+  const server = useServer();
+  const globalSDK = useGlobalSDK();
+  const local = useLocal();
 
   const [creatingSession, setCreatingSession] = createSignal(false);
   const [sessionViewLockUntil] = createSignal(0);
@@ -2203,6 +2214,32 @@ export default function App() {
     goToSession,
   });
 
+  const renderReactOwnedSurface = (content: () => JSX.Element) => (
+    <SolidContextBridge
+      platform={platform}
+      server={server}
+      globalSDK={globalSDK}
+      globalSync={globalSync}
+      local={local}
+    >
+      <OpenworkServerProvider store={openworkServerStore}>
+        <ModelControlsProvider store={modelControlsStore}>
+          <SessionActionsProvider store={sessionActionsStore}>
+            <ConnectionsProvider store={connectionsStore}>
+              <ExtensionsProvider store={extensionsStore}>
+                <AutomationsProvider store={automationsStore}>
+                  <StatusToastsProvider store={statusToastsStore}>
+                    {content()}
+                  </StatusToastsProvider>
+                </AutomationsProvider>
+              </ExtensionsProvider>
+            </ConnectionsProvider>
+          </SessionActionsProvider>
+        </ModelControlsProvider>
+      </OpenworkServerProvider>
+    </SolidContextBridge>
+  );
+
   return (
     <OpenworkServerProvider store={openworkServerStore}>
       <ModelControlsProvider store={modelControlsStore}>
@@ -2211,14 +2248,15 @@ export default function App() {
             <ExtensionsProvider store={extensionsStore}>
               <AutomationsProvider store={automationsStore}>
                 <StatusToastsProvider store={statusToastsStore}>
-                  <Switch>
-                    <Match when={currentView() === "session"}>
-                      <SessionView {...sessionSurface()} />
-                    </Match>
-                    <Match when={true}>
-                      <SettingsShell {...settingsSurface()} />
-                    </Match>
-                  </Switch>
+                  <ReactShellHost
+                    currentView={currentView()}
+                    renderSession={() =>
+                      renderReactOwnedSurface(() => <SessionView {...sessionSurface()} />)
+                    }
+                    renderSettings={() =>
+                      renderReactOwnedSurface(() => <SettingsShell {...settingsSurface()} />)
+                    }
+                  />
                   <ModalHost
                     modelConfig={modelConfig}
                     workspaceStore={workspaceStore}

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -2307,12 +2307,14 @@ export default function App() {
                     currentView={currentView()}
                     preferReactSession={preferReactSessionV2()}
                     preferReactSettings={preferReactSettingsV2()}
+                    sessionReactSurface={sessionSurface()}
+                    settingsReactSurface={settingsSurface()}
                     renderSession={() =>
                       renderReactOwnedSurface(() => <SessionView {...sessionSurface()} />)
                     }
-                    renderSessionReact={() =>
+                    renderSessionReact={(surface) =>
                       createElement(ReactSessionViewV2, {
-                        legacySurface: sessionSurface(),
+                        legacySurface: surface ?? sessionSurface(),
                         sendPrompt: sendReactSessionPrompt,
                         abortPrompt: abortReactSessionPrompt,
                         undoLastMessage: undoReactSessionMessage,
@@ -2322,9 +2324,9 @@ export default function App() {
                     renderSettings={() =>
                       renderReactOwnedSurface(() => <SettingsShell {...settingsSurface()} />)
                     }
-                    renderSettingsReact={() =>
+                    renderSettingsReact={(surface) =>
                       createElement(ReactSettingsViewV2, {
-                        legacySurface: settingsSurface(),
+                        legacySurface: surface ?? settingsSurface(),
                       })
                     }
                   />

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -2215,6 +2215,19 @@ export default function App() {
   const sendReactSessionPrompt = async (text: string) => {
     const trimmed = text.trim();
     if (!trimmed) return;
+    let workspaceId = workspaceStore.selectedWorkspaceId().trim();
+    if (!workspaceId) {
+      const fallbackWorkspaceId =
+        sidebarWorkspaceGroups()[0]?.workspace.id?.trim() ||
+        workspaceStore.workspaces()[0]?.id?.trim() ||
+        "";
+      if (fallbackWorkspaceId) {
+        const ready = await Promise.resolve(workspaceStore.switchWorkspace(fallbackWorkspaceId));
+        if (!ready) return;
+        workspaceId = workspaceStore.selectedWorkspaceId().trim();
+      }
+    }
+    if (!workspaceId) return;
     const draft: ComposerDraft = {
       mode: "prompt",
       text: trimmed,

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -15,14 +15,6 @@ import type { Session } from "@opencode-ai/sdk/v2/client";
 
 import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import ModelPickerModal from "./components/model-picker-modal";
-import ConfirmModal from "./components/confirm-modal";
-import ResetModal from "./components/reset-modal";
-import SkillDestinationModal from "./bundles/skill-destination-modal";
-import BundleImportModal from "./bundles/import-modal";
-import BundleStartModal from "./bundles/start-modal";
-import RenameWorkspaceModal from "./components/rename-workspace-modal";
-import ConnectionsModals from "./connections/modals";
 import { OpenworkServerProvider } from "./connections/openwork-server-provider";
 import { createOpenworkServerStore } from "./connections/openwork-server-store";
 import { ConnectionsProvider } from "./connections/provider";
@@ -32,12 +24,7 @@ import { SessionActionsProvider } from "./session/actions-provider";
 import { createSessionActionsStore } from "./session/actions-store";
 import { createDeepLinksController } from "./shell/deep-links";
 import SettingsShell from "./shell/settings-shell";
-import TopRightNotifications from "./shell/top-right-notifications";
 import { createStatusToastsStore, StatusToastsProvider } from "./shell/status-toasts";
-import {
-  CreateRemoteWorkspaceModal,
-  CreateWorkspaceModal,
-} from "./workspace";
 import SessionView from "./pages/session";
 import { clearDevLogs, recordDevLog } from "./lib/dev-log";
 import { unwrap } from "./lib/opencode";
@@ -93,10 +80,7 @@ import { createProvidersStore } from "./context/providers";
 import { ModelControlsProvider } from "./app-settings/model-controls-provider";
 import { createModelControlsStore } from "./app-settings/model-controls-store";
 import { useSessionDisplayPreferences } from "./app-settings/session-display-preferences";
-import {
-  describeDirectoryScope,
-  shouldRedirectMissingSessionAfterScopedLoad,
-} from "./lib/session-scope";
+import { describeDirectoryScope } from "./lib/session-scope";
 import { createExtensionsStore } from "./context/extensions";
 import { createConnectionsStore } from "./connections/store";
 import { createAutomationsStore } from "./context/automations";
@@ -134,6 +118,11 @@ import {
   stripBundleQuery,
 } from "./bundles";
 import { createBundlesStore } from "./bundles/store";
+import { createBootstrapCoordinator } from "./shell/bootstrap-coordinator";
+import ModalHost from "./shell/modal-host";
+import { syncShellRoute } from "./shell/route-sync";
+import { buildSessionSurface } from "./shell/session-surface";
+import { buildSettingsSurface } from "./shell/settings-surface";
 
 type SettingsReturnTarget = {
   view: View;
@@ -436,9 +425,7 @@ export default function App() {
     globalSync.set("provider", "connected", value);
   };
 
-  let workspaceStore!: ReturnType<typeof createWorkspaceStore>;
-  let sessionStore!: ReturnType<typeof createSessionStore>;
-  let openworkServerStore!: ReturnType<typeof createOpenworkServerStore>;
+  const bootstrapCoordinator = createBootstrapCoordinator();
 
   const modelConfig = createModelConfigStore({
     client,
@@ -447,14 +434,16 @@ export default function App() {
     providers,
     providerDefaults,
     providerConnectedIds,
-    selectedWorkspaceId: () => workspaceStore?.selectedWorkspaceId?.() ?? "",
+    selectedWorkspaceId: () => bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceId?.() ?? "",
     selectedWorkspaceDisplay: () =>
-      workspaceStore?.selectedWorkspaceDisplay?.() ?? ({ workspaceType: "local" } as WorkspaceDisplay),
-    selectedWorkspacePath: () => workspaceStore?.selectedWorkspacePath?.() ?? "",
-    openworkServerClient: () => openworkServerStore?.openworkServerClient?.() ?? null,
-    openworkServerStatus: () => openworkServerStore?.openworkServerStatus?.() ?? "disconnected",
-    openworkServerCapabilities: () => openworkServerStore?.openworkServerCapabilities?.() ?? null,
-    runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
+      bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceDisplay?.() ??
+      ({ workspaceType: "local" } as WorkspaceDisplay),
+    selectedWorkspacePath: () => bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspacePath?.() ?? "",
+    openworkServerClient: () => bootstrapCoordinator.peekOpenworkServerStore()?.openworkServerClient?.() ?? null,
+    openworkServerStatus: () => bootstrapCoordinator.peekOpenworkServerStore()?.openworkServerStatus?.() ?? "disconnected",
+    openworkServerCapabilities: () =>
+      bootstrapCoordinator.peekOpenworkServerStore()?.openworkServerCapabilities?.() ?? null,
+    runtimeWorkspaceId: () => bootstrapCoordinator.peekWorkspaceStore()?.runtimeWorkspaceId?.() ?? null,
     focusSessionPromptSoon: () => focusSessionPromptSoon(),
     setError,
     setLastKnownConfigSnapshot,
@@ -496,33 +485,12 @@ export default function App() {
     goToSettings(nextTab);
   };
 
-  const mapLegacySurfaceToSettingsTab = (surface: string): SettingsTab => {
-    switch (surface) {
-      case "scheduled":
-        return "automations";
-      case "skills":
-        return "skills";
-      case "plugins":
-      case "mcp":
-        return "extensions";
-      case "identities":
-        return "messaging";
-      case "config":
-        return "advanced";
-      case "settings":
-      default:
-        return "general";
-    }
-  };
+  const markReloadRequired = bootstrapCoordinator.markReloadRequired;
 
-  let markReloadRequiredHandler: ((reason: ReloadReason, trigger?: ReloadTrigger) => void) | undefined;
-  const markReloadRequired = (reason: ReloadReason, trigger?: ReloadTrigger) => {
-    markReloadRequiredHandler?.(reason, trigger);
-  };
-
-  sessionStore = createSessionStore({
+  const sessionStore = bootstrapCoordinator.setSessionStore(createSessionStore({
     client,
-    selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot().trim(),
+    selectedWorkspaceRoot: () =>
+      bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceRoot?.().trim() ?? "",
     selectedSessionId,
     setSelectedSessionId,
     setPrompt,
@@ -538,7 +506,7 @@ export default function App() {
       void refreshPlugins(pluginScope());
       void refreshMcpServers();
     },
-  });
+  }));
 
   const {
     sessions,
@@ -639,18 +607,19 @@ export default function App() {
     await respondPermission(requestID, reply);
   }
 
-  openworkServerStore = createOpenworkServerStore({
+  const openworkServerStore = bootstrapCoordinator.setOpenworkServerStore(createOpenworkServerStore({
     startupPreference,
     documentVisible,
     developerMode,
-    runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
+    runtimeWorkspaceId: () => bootstrapCoordinator.peekWorkspaceStore()?.runtimeWorkspaceId?.() ?? null,
     activeClient: client,
     selectedWorkspaceDisplay: () =>
-      workspaceStore?.selectedWorkspaceDisplay?.() ?? ({ workspaceType: "local" } as WorkspaceDisplay),
+      bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceDisplay?.() ??
+      ({ workspaceType: "local" } as WorkspaceDisplay),
     restartLocalServer,
     createRemoteWorkspaceFlow: async (input) =>
-      (await workspaceStore?.createRemoteWorkspaceFlow?.(input)) ?? false,
-  });
+      (await bootstrapCoordinator.peekWorkspaceStore()?.createRemoteWorkspaceFlow?.(input)) ?? false,
+  }));
 
   const {
     openworkServerSettings,
@@ -687,11 +656,12 @@ export default function App() {
   const extensionsStore = createExtensionsStore({
     client,
     projectDir: () => workspaceProjectDir(),
-    selectedWorkspaceId: () => workspaceStore?.selectedWorkspaceId?.() ?? "",
-    selectedWorkspaceRoot: () => workspaceStore?.selectedWorkspaceRoot?.() ?? "",
-    workspaceType: () => workspaceStore?.selectedWorkspaceDisplay?.().workspaceType ?? "local",
+    selectedWorkspaceId: () => bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceId?.() ?? "",
+    selectedWorkspaceRoot: () => bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceRoot?.() ?? "",
+    workspaceType: () =>
+      bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceDisplay?.().workspaceType ?? "local",
     openworkServer: openworkServerStore,
-    runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
+    runtimeWorkspaceId: () => bootstrapCoordinator.peekWorkspaceStore()?.runtimeWorkspaceId?.() ?? null,
     setBusy,
     setBusyLabel,
     setBusyStartedAt,
@@ -717,13 +687,15 @@ export default function App() {
     client,
     setClient,
     projectDir: () => workspaceProjectDir(),
-    selectedWorkspaceId: () => workspaceStore?.selectedWorkspaceId?.() ?? "",
-    selectedWorkspaceRoot: () => workspaceStore?.selectedWorkspaceRoot?.() ?? "",
-    workspaceType: () => workspaceStore?.selectedWorkspaceDisplay?.().workspaceType ?? "local",
+    selectedWorkspaceId: () => bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceId?.() ?? "",
+    selectedWorkspaceRoot: () => bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceRoot?.() ?? "",
+    workspaceType: () =>
+      bootstrapCoordinator.peekWorkspaceStore()?.selectedWorkspaceDisplay?.().workspaceType ?? "local",
     openworkServer: openworkServerStore,
-    runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
-    ensureRuntimeWorkspaceId: () => workspaceStore?.ensureRuntimeWorkspaceId?.(),
-    setProjectDir: (value: string) => workspaceStore?.setProjectDir?.(value),
+    runtimeWorkspaceId: () => bootstrapCoordinator.peekWorkspaceStore()?.runtimeWorkspaceId?.() ?? null,
+    ensureRuntimeWorkspaceId: async () =>
+      await bootstrapCoordinator.peekWorkspaceStore()?.ensureRuntimeWorkspaceId?.(),
+    setProjectDir: (value: string) => bootstrapCoordinator.peekWorkspaceStore()?.setProjectDir?.(value),
     developerMode,
     markReloadRequired,
   });
@@ -761,7 +733,7 @@ export default function App() {
     autoCompactContextSaving,
   } = modelConfig;
 
-  workspaceStore = createWorkspaceStore({
+  const workspaceStore = bootstrapCoordinator.setWorkspaceStore(createWorkspaceStore({
     startupPreference,
     setStartupPreference,
     onboardingStep,
@@ -817,7 +789,7 @@ export default function App() {
     developerMode,
     pendingInitialSessionSelection,
     setPendingInitialSessionSelection,
-  });
+  }));
 
   const {
     providerAuthModalOpen,
@@ -1250,7 +1222,7 @@ export default function App() {
     anyActiveRuns,
   } = systemState;
 
-  markReloadRequiredHandler = systemState.markReloadRequired;
+  bootstrapCoordinator.setReloadHandler(systemState.markReloadRequired);
 
   const UPDATE_AUTO_CHECK_EVERY_MS = 12 * 60 * 60_000;
   const UPDATE_AUTO_CHECK_POLL_MS = 60_000;
@@ -1912,7 +1884,7 @@ export default function App() {
     editDefaultModelVariant: openDefaultModelPicker,
   });
 
-  const settingsShellProps = () => {
+  const settingsSurface = createMemo(() => {
     const workspaceType = selectedWorkspaceDisplay().workspaceType;
     const isRemoteWorkspace = workspaceType === "remote";
     const openworkStatus = openworkServerStatus();
@@ -1943,7 +1915,7 @@ export default function App() {
             : t("app.plugins_hint_readonly")
       : null;
 
-    return {
+    return buildSettingsSurface({
       settingsTab: settingsTab(),
       setSettingsTab,
       providers: providers(),
@@ -2017,7 +1989,6 @@ export default function App() {
       testWorkspaceConnection: workspaceStore.testWorkspaceConnection,
       recoverWorkspace: workspaceStore.recoverWorkspace,
       openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
-      pickFolderWorkspace: workspaceStore.createWorkspaceFromPickedFolder,
       openCreateRemoteWorkspace: () => workspaceStore.setCreateRemoteWorkspaceOpen(true),
       connectRemoteWorkspace: workspaceStore.createRemoteWorkspaceFlow,
       openTeamBundle: bundlesStore.openTeamBundle,
@@ -2025,10 +1996,6 @@ export default function App() {
       importingWorkspaceConfig: workspaceStore.importingWorkspaceConfig(),
       exportWorkspaceConfig: workspaceStore.exportWorkspaceConfig,
       exportWorkspaceBusy: workspaceStore.exportingWorkspaceConfig(),
-      createWorkspaceOpen: workspaceStore.createWorkspaceOpen(),
-      setCreateWorkspaceOpen: workspaceStore.setCreateWorkspaceOpen,
-      createWorkspaceFlow: workspaceStore.createWorkspaceFlow,
-      pickWorkspaceFolder: workspaceStore.pickWorkspaceFolder,
       workspaceSessionGroups: sidebarWorkspaceGroups(),
       selectedSessionId: activeSessionId(),
       openRenameWorkspace: workspaceStore.openRenameWorkspace,
@@ -2109,10 +2076,10 @@ export default function App() {
       openDebugDeepLink: deepLinks.openDebugDeepLink,
       language: currentLocale(),
       setLanguage: setLocale,
-    };
-  };
+    });
+  });
 
-  const sessionProps = () => ({
+  const sessionSurface = createMemo(() => buildSessionSurface({
     providerAuthWorkerType: providerAuthWorkerType(),
     selectedSessionId: activeSessionId(),
     setView,
@@ -2215,122 +2182,25 @@ export default function App() {
     sessionErrorTurns: selectedSessionErrorTurns(),
     sessionStatus: selectedSessionStatus(),
     error: error(),
-  });
+  }));
 
-  const settingsTabs = new Set<SettingsTab>([
-    "general",
-    "den",
-    "model",
-    "automations",
-    "skills",
-    "extensions",
-    "messaging",
-    "advanced",
-    "appearance",
-    "updates",
-    "recovery",
-    "debug",
-  ]);
-
-  const resolveSettingsTab = (value?: string | null) => {
-    const normalized = value?.trim().toLowerCase() ?? "";
-    if (settingsTabs.has(normalized as SettingsTab)) {
-      return normalized as SettingsTab;
-    }
-    return "general";
-  };
-
-  const initialRoute = () => {
-    if (typeof window === "undefined") return "/session";
-    return "/session";
-  };
-
-  createEffect(() => {
-    const rawPath = location.pathname.trim();
-    const path = rawPath.toLowerCase();
-
-    if (path === "" || path === "/") {
-      navigate(initialRoute(), { replace: true });
-      return;
-    }
-
-    if (path.startsWith("/dashboard")) {
-      const [, , tabSegment] = path.split("/");
-      goToSettings(mapLegacySurfaceToSettingsTab(tabSegment ?? "settings"), { replace: true });
-      return;
-    }
-
-    if (path.startsWith("/settings")) {
-      const [, , tabSegment] = path.split("/");
-      const resolvedTab = resolveSettingsTab(tabSegment);
-
-      if (resolvedTab !== settingsTab()) {
-        setSettingsTabState(resolvedTab);
-      }
-      if (!tabSegment || tabSegment !== resolvedTab) {
-        goToSettings(resolvedTab, { replace: true });
-      }
-      return;
-    }
-
-    if (path.startsWith("/session")) {
-      const [, , sessionSegment] = rawPath.split("/");
-      const id = (sessionSegment ?? "").trim();
-
-      if (!id) {
-        if (selectedSessionId()) {
-          workspaceStore.clearSelectedSessionSurface();
-        }
-        return;
-      }
-
-      // If the URL points at a session that no longer exists (e.g. after deletion),
-      // route back to /session so the app can fall back safely.
-      const pendingInitialSelection = pendingInitialSessionSelection();
-      const selectedWorkspaceRoot = normalizeDirectoryPath(workspaceStore.selectedWorkspaceRoot().trim());
-      const matchingSession = sessions().find((session) => session.id === id) ?? null;
-      const hasMatchingSessionInScope = matchingSession
-        ? !selectedWorkspaceRoot || normalizeDirectoryPath(matchingSession.directory) === selectedWorkspaceRoot
-        : false;
-      if (
-        sessionsLoaded() &&
-        !pendingInitialSelection &&
-        shouldRedirectMissingSessionAfterScopedLoad({
-          loadedScopeRoot: loadedSessionScopeRoot(),
-          workspaceRoot: workspaceStore.selectedWorkspaceRoot().trim(),
-          hasMatchingSession: hasMatchingSessionInScope,
-        })
-      ) {
-        if (selectedSessionId() === id) {
-          setSelectedSessionId(null);
-        }
-        navigate("/session", { replace: true });
-        return;
-      }
-
-      if (selectedSessionId() !== id) {
-        setSelectedSessionId(id);
-        void selectSession(id);
-      }
-      return;
-    }
-
-    if (path.startsWith("/proto-v1-ux") || path.startsWith("/proto")) {
-      if (isTauriRuntime()) {
-        navigate("/settings/automations", { replace: true });
-        return;
-      }
-
-      navigate("/settings/automations", { replace: true });
-      return;
-    }
-
-    const fallback = activeSessionId();
-    if (fallback) {
-      goToSession(fallback, { replace: true });
-      return;
-    }
-    navigate("/session", { replace: true });
+  syncShellRoute({
+    pathname: () => location.pathname,
+    navigate,
+    settingsTab,
+    setSettingsTabState,
+    setSelectedSessionId,
+    selectedSessionId,
+    selectSession,
+    pendingInitialSessionSelection,
+    sessions,
+    sessionsLoaded,
+    loadedSessionScopeRoot,
+    selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot(),
+    clearSelectedSessionSurface: workspaceStore.clearSelectedSessionSurface,
+    activeSessionId,
+    goToSettings,
+    goToSession,
   });
 
   return (
@@ -2341,291 +2211,51 @@ export default function App() {
             <ExtensionsProvider store={extensionsStore}>
               <AutomationsProvider store={automationsStore}>
                 <StatusToastsProvider store={statusToastsStore}>
-            <Switch>
-              <Match when={currentView() === "session"}>
-                <SessionView {...sessionProps()} />
-              </Match>
-              <Match when={true}>
-                <SettingsShell {...settingsShellProps()} />
-              </Match>
-            </Switch>
-
-      <ModelPickerModal
-        open={modelPickerOpen()}
-        options={modelOptions()}
-        filteredOptions={filteredModelOptions()}
-        query={modelPickerQuery()}
-        setQuery={setModelPickerQuery}
-        target={modelPickerTarget()}
-        current={modelPickerCurrent()}
-        onSelect={applyModelSelection}
-        onBehaviorChange={setModelPickerBehavior}
-        onOpenSettings={openSettingsFromModelPicker}
-        onClose={closeModelPicker}
-      />
-
-      <ResetModal
-        open={resetModalOpen()}
-        mode={resetModalMode()}
-        text={resetModalText()}
-        busy={resetModalBusy()}
-        canReset={
-          !resetModalBusy() &&
-          !anyActiveRuns() &&
-          resetModalText().trim().toUpperCase() === "RESET"
-        }
-        hasActiveRuns={anyActiveRuns()}
-        language={currentLocale()}
-        onClose={() => setResetModalOpen(false)}
-        onConfirm={confirmReset}
-        onTextChange={setResetModalText}
-      />
-
-      <ConnectionsModals
-        client={client()}
-        projectDir={workspaceProjectDir()}
-        language={currentLocale()}
-        reloadBlocked={activeReloadBlockingSessions().length > 0}
-        activeSessions={activeReloadBlockingSessions()}
-        isRemoteWorkspace={selectedWorkspaceDisplay().workspaceType === "remote"}
-        onForceStopSession={(sessionID) => abortSession(sessionID)}
-        onReloadEngine={() => reloadWorkspaceEngineAndResume()}
-      />
-
-      <BundleImportModal
-        open={Boolean(bundlesStore.bundleImportChoice())}
-        title={bundlesStore.bundleImportSummary()?.title ?? t("app.import_shared_bundle")}
-        description={bundlesStore.bundleImportSummary()?.description ?? t("app.import_bundle_desc")}
-        items={bundlesStore.bundleImportSummary()?.items ?? []}
-        workers={bundlesStore.bundleWorkerOptions()}
-        busy={bundlesStore.bundleImportBusy()}
-        error={bundlesStore.bundleImportError()}
-        onClose={bundlesStore.closeBundleImportChoice}
-        onCreateNewWorker={() => {
-          void bundlesStore.openCreateWorkspaceFromChoice();
-        }}
-        onSelectWorker={(workspaceId) => {
-          void bundlesStore.importBundleIntoExistingWorkspace(workspaceId);
-        }}
-      />
-
-      <ConfirmModal
-        open={Boolean(bundlesStore.untrustedBundleWarning())}
-        title="Import from an untrusted bundle link?"
-        message={(() => {
-          const warning = bundlesStore.untrustedBundleWarning();
-          const actualOrigin = warning?.actualOrigin?.trim() || "an unknown origin";
-          const configuredOrigin = warning?.configuredOrigin?.trim() || "the configured OpenWork share service";
-          return `This link points to ${actualOrigin}, but OpenWork only auto-imports bundles from ${configuredOrigin}. Untrusted bundles can contain malicious instructions or settings. Only continue if you trust the sender and expect this import.`;
-        })()}
-        confirmLabel="Import anyway"
-        cancelLabel="Cancel"
-        variant="warning"
-        onConfirm={() => {
-          void bundlesStore.confirmUntrustedBundleWarning();
-        }}
-        onCancel={bundlesStore.dismissUntrustedBundleWarning}
-      />
-
-      <BundleStartModal
-        open={Boolean(bundlesStore.bundleStartRequest())}
-        templateName={bundlesStore.bundleStartRequest()?.bundle.name?.trim() || "this template"}
-        description={bundlesStore.bundleStartRequest()?.bundle.description ?? ""}
-        items={bundlesStore.bundleStartItems()}
-        busy={bundlesStore.bundleStartBusy()}
-        onClose={() => {
-          bundlesStore.clearBundleStartRequest();
-        }}
-        onPickFolder={workspaceStore.pickWorkspaceFolder}
-        onConfirm={(folder) => {
-          void bundlesStore.startWorkspaceFromBundle(folder);
-        }}
-      />
-
-      <CreateWorkspaceModal
-        open={workspaceStore.createWorkspaceOpen()}
-        onClose={() => {
-          workspaceStore.setCreateWorkspaceOpen(false);
-          workspaceStore.clearSandboxCreateProgress?.();
-          bundlesStore.clearCreateWorkspaceRequest();
-        }}
-        onPickFolder={workspaceStore.pickWorkspaceFolder}
-        onImportConfig={isTauriRuntime() ? workspaceStore.importWorkspaceConfig : undefined}
-        importingConfig={workspaceStore.importingWorkspaceConfig()}
-        defaultPreset={bundlesStore.createWorkspaceDefaultPreset()}
-        onConfirmRemote={(input) => workspaceStore.createRemoteWorkspaceFlow(input)}
-        onConfirmTemplate={(template, preset, folder) =>
-          bundlesStore.startWorkspaceFromTeamTemplate({
-            name: template.name,
-            templateData: template.templateData,
-            folder,
-            preset,
-          })
-        }
-        onConfirm={bundlesStore.handleCreateWorkspaceConfirm}
-        onConfirmWorker={
-          isTauriRuntime()
-            ? bundlesStore.handleCreateSandboxConfirm
-            : undefined
-        }
-        workerDisabled={(() => {
-          if (!isTauriRuntime()) return true;
-          if (workspaceStore.sandboxDoctorBusy?.()) return true;
-          const doctor = workspaceStore.sandboxDoctorResult?.();
-          if (!doctor) return false;
-          return !doctor?.ready;
-        })()}
-        workerDisabledReason={(() => {
-          if (!isTauriRuntime()) return t("app.error.tauri_required", currentLocale());
-          if (workspaceStore.sandboxDoctorBusy?.()) {
-            return t("dashboard.sandbox_checking_docker", currentLocale());
-          }
-          const doctor = workspaceStore.sandboxDoctorResult?.();
-          if (!doctor || doctor.ready) return null;
-          const message = doctor?.error?.trim();
-          return message || t("dashboard.sandbox_get_ready_desc", currentLocale());
-        })()}
-        workerCtaLabel={t("dashboard.sandbox_get_ready_action", currentLocale())}
-        workerCtaDescription={t("dashboard.sandbox_get_ready_desc", currentLocale())}
-        onWorkerCta={async () => {
-          const url = "https://www.docker.com/products/docker-desktop/";
-          if (isTauriRuntime()) {
-            const { openUrl } = await import("@tauri-apps/plugin-opener");
-            await openUrl(url);
-          } else {
-            window.open(url, "_blank", "noopener,noreferrer");
-          }
-        }}
-        workerRetryLabel={t("common.retry", currentLocale())}
-        workerDebugLines={(() => {
-          const doctor = workspaceStore.sandboxDoctorResult?.();
-          const lines: string[] = [];
-          if (!doctor?.debug) return lines;
-          const selected = doctor.debug.selectedBin?.trim();
-          if (selected) lines.push(`selected: ${selected}`);
-          if (doctor.debug.candidates?.length) {
-            lines.push(`candidates: ${doctor.debug.candidates.join(", ")}`);
-          }
-          if (doctor.debug.versionCommand) {
-            const cmd = doctor.debug.versionCommand;
-            lines.push(`docker --version exit=${cmd.status}`);
-            if (cmd.stderr?.trim()) lines.push(`docker --version stderr: ${cmd.stderr.trim()}`);
-          }
-          if (doctor.debug.infoCommand) {
-            const cmd = doctor.debug.infoCommand;
-            lines.push(`docker info exit=${cmd.status}`);
-            if (cmd.stderr?.trim()) lines.push(`docker info stderr: ${cmd.stderr.trim()}`);
-          }
-          return lines;
-        })()}
-        onWorkerRetry={() => {
-          void workspaceStore.refreshSandboxDoctor?.();
-        }}
-        workerSubmitting={workspaceStore.sandboxPreflightBusy?.() ?? false}
-        localDisabled={!isTauriRuntime()}
-        localDisabledReason={
-          !isTauriRuntime()
-            ? t("app.local_disabled_reason")
-            : null
-        }
-        remoteSubmitting={busy() && busyLabel() === "status.connecting"}
-        remoteError={busyLabel() === "status.connecting" ? error() : null}
-        submitting={(() => {
-          const phase = workspaceStore.sandboxCreatePhase?.() ?? "idle";
-          if (phase === "provisioning" || phase === "finalizing") return true;
-          return busy() && busyLabel() === "status.creating_workspace";
-        })()}
-        submittingProgress={workspaceStore.sandboxCreateProgress?.() ?? null}
-      />
-
-      <SkillDestinationModal
-        open={
-          Boolean(bundlesStore.skillDestinationRequest()) &&
-          !workspaceStore.createWorkspaceOpen() &&
-          !workspaceStore.createRemoteWorkspaceOpen()
-        }
-        skill={(() => {
-          const request = bundlesStore.skillDestinationRequest();
-          if (!request) return null;
-          return {
-            name: request.bundle.name,
-            description: request.bundle.description ?? null,
-            trigger: request.bundle.trigger ?? null,
-          };
-        })()}
-        workspaces={bundlesStore.skillDestinationWorkspaces()}
-        selectedWorkspaceId={workspaceStore.selectedWorkspaceId()}
-        busyWorkspaceId={bundlesStore.skillDestinationBusyId()}
-        onClose={() => {
-          bundlesStore.clearSkillDestinationRequest();
-        }}
-        onSubmitWorkspace={bundlesStore.importSkillIntoWorkspace}
-        onCreateWorker={
-          isTauriRuntime()
-            ? bundlesStore.openCreateWorkspaceFromSkillDestination
-            : undefined
-        }
-        onConnectRemote={() => {
-          bundlesStore.openRemoteConnectFromSkillDestination();
-        }}
-      />
-
-            <CreateRemoteWorkspaceModal
-              open={workspaceStore.createRemoteWorkspaceOpen()}
-              onClose={() => {
-                workspaceStore.setCreateRemoteWorkspaceOpen(false);
-                deepLinks.clearDeepLinkRemoteWorkspaceDefaults();
-              }}
-              onConfirm={(input) => workspaceStore.createRemoteWorkspaceFlow(input)}
-              initialValues={deepLinks.deepLinkRemoteWorkspaceDefaults() ?? undefined}
-              submitting={
-                busy() &&
-                (busyLabel() === "status.creating_workspace" || busyLabel() === "status.connecting")
-              }
-            />
-
-      <TopRightNotifications
-        reloadOpen={reloadRequired("config", "mcp", "plugin", "skill", "agent", "command")}
-        reloadTitle={reloadCopy().title}
-        reloadDescription={reloadCopy().body}
-        reloadTrigger={reloadTrigger()}
-        reloadError={reloadError()}
-        reloadLabel={activeReloadBlockingSessions().length > 0 ? t("app.reload_stop_tasks") : t("app.reload_now")}
-        dismissLabel={t("app.reload_later")}
-        reloadBusy={reloadBusy()}
-        canReload={canReloadWorkspace()}
-        hasActiveRuns={activeReloadBlockingSessions().length > 0}
-        onReload={() => {
-          void (activeReloadBlockingSessions().length > 0
-            ? forceStopActiveSessionsAndReload()
-            : reloadWorkspaceEngineAndResume());
-        }}
-        onDismissReload={clearReloadRequired}
-      />
-
-      <RenameWorkspaceModal
-        open={workspaceStore.renameWorkspaceOpen()}
-        title={workspaceStore.renameWorkspaceName()}
-        busy={workspaceStore.renameWorkspaceBusy()}
-        canSave={workspaceStore.renameWorkspaceName().trim().length > 0 && !workspaceStore.renameWorkspaceBusy()}
-        onClose={workspaceStore.closeRenameWorkspace}
-        onSave={workspaceStore.saveRenameWorkspace}
-        onTitleChange={workspaceStore.setRenameWorkspaceName}
-      />
-
-      <CreateRemoteWorkspaceModal
-        open={workspaceStore.editRemoteWorkspaceOpen()}
-        onClose={workspaceStore.closeWorkspaceConnectionSettings}
-        onConfirm={(input) => {
-          void workspaceStore.saveWorkspaceConnectionSettings(input);
-        }}
-        initialValues={workspaceStore.editRemoteWorkspaceDefaults() ?? undefined}
-        submitting={busy() && busyLabel() === "status.connecting"}
-        error={workspaceStore.editRemoteWorkspaceError()}
-        title={t("dashboard.edit_remote_workspace_title", currentLocale())}
-        subtitle={t("dashboard.edit_remote_workspace_subtitle", currentLocale())}
-        confirmLabel={t("dashboard.edit_remote_workspace_confirm", currentLocale())}
-      />
+                  <Switch>
+                    <Match when={currentView() === "session"}>
+                      <SessionView {...sessionSurface()} />
+                    </Match>
+                    <Match when={true}>
+                      <SettingsShell {...settingsSurface()} />
+                    </Match>
+                  </Switch>
+                  <ModalHost
+                    modelConfig={modelConfig}
+                    workspaceStore={workspaceStore}
+                    bundlesStore={bundlesStore}
+                    client={client}
+                    workspaceProjectDir={workspaceProjectDir}
+                    resetModalOpen={resetModalOpen}
+                    resetModalMode={resetModalMode}
+                    resetModalText={resetModalText}
+                    resetModalBusy={resetModalBusy}
+                    setResetModalOpen={setResetModalOpen}
+                    confirmReset={confirmReset}
+                    setResetModalText={setResetModalText}
+                    openSettingsFromModelPicker={openSettingsFromModelPicker}
+                    anyActiveRuns={anyActiveRuns}
+                    activeReloadBlockingSessions={activeReloadBlockingSessions}
+                    abortSession={abortSession}
+                    reloadWorkspaceEngineAndResume={reloadWorkspaceEngineAndResume}
+                    busy={busy}
+                    busyLabel={busyLabel}
+                    error={error}
+                    reloadOpen={() =>
+                      reloadRequired("config", "mcp", "plugin", "skill", "agent", "command")
+                    }
+                    reloadTitle={() => reloadCopy().title}
+                    reloadDescription={() => reloadCopy().body}
+                    reloadTrigger={() => reloadTrigger() ?? undefined}
+                    reloadError={reloadError}
+                    reloadBusy={reloadBusy}
+                    canReloadWorkspace={canReloadWorkspace}
+                    clearReloadRequired={clearReloadRequired}
+                    forceStopActiveSessionsAndReload={forceStopActiveSessionsAndReload}
+                    deepLinkRemoteWorkspaceDefaults={deepLinks.deepLinkRemoteWorkspaceDefaults}
+                    clearDeepLinkRemoteWorkspaceDefaults={
+                      deepLinks.clearDeepLinkRemoteWorkspaceDefaults
+                    }
+                  />
                 </StatusToastsProvider>
               </AutomationsProvider>
             </ExtensionsProvider>

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -9,6 +9,7 @@ import {
   untrack,
 } from "solid-js";
 import type { JSX } from "solid-js";
+import { createElement } from "react";
 
 import { useLocation, useNavigate } from "@solidjs/router";
 
@@ -27,6 +28,7 @@ import { createDeepLinksController } from "./shell/deep-links";
 import SettingsShell from "./shell/settings-shell";
 import { createStatusToastsStore, StatusToastsProvider } from "./shell/status-toasts";
 import SessionView from "./pages/session";
+import ReactSessionViewV2 from "./session-v2/react-session-view-v2";
 import { clearDevLogs, recordDevLog } from "./lib/dev-log";
 import { unwrap } from "./lib/opencode";
 import { clearPerfLogs, finishPerf, perfNow, recordPerfLog } from "./lib/perf-log";
@@ -176,6 +178,13 @@ export default function App() {
 
   const [creatingSession, setCreatingSession] = createSignal(false);
   const [sessionViewLockUntil] = createSignal(0);
+  const reactSessionV2KillSwitch =
+    typeof import.meta.env?.VITE_OPENWORK_REACT_SESSION_V2 === "string"
+      ? import.meta.env.VITE_OPENWORK_REACT_SESSION_V2 !== "0"
+      : true;
+  const preferReactSessionV2 = createMemo(
+    () => reactSessionV2KillSwitch && local.prefs.reactSessionV2,
+  );
   const currentView = createMemo<View>(() => {
     const path = location.pathname.toLowerCase();
     if (path.startsWith("/session")) return "session";
@@ -2250,8 +2259,14 @@ export default function App() {
                 <StatusToastsProvider store={statusToastsStore}>
                   <ReactShellHost
                     currentView={currentView()}
+                    preferReactSession={preferReactSessionV2()}
                     renderSession={() =>
                       renderReactOwnedSurface(() => <SessionView {...sessionSurface()} />)
+                    }
+                    renderSessionReact={() =>
+                      createElement(ReactSessionViewV2, {
+                        legacySurface: sessionSurface(),
+                      })
                     }
                     renderSettings={() =>
                       renderReactOwnedSurface(() => <SettingsShell {...settingsSurface()} />)

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -2204,6 +2204,31 @@ export default function App() {
     error: error(),
   }));
 
+  const sendReactSessionPrompt = async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const draft: ComposerDraft = {
+      mode: "prompt",
+      text: trimmed,
+      resolvedText: trimmed,
+      parts: [{ type: "text", text: trimmed }],
+      attachments: [],
+    };
+    await sessionActionsStore.sendPrompt(draft);
+  };
+
+  const abortReactSessionPrompt = async () => {
+    await sessionActionsStore.abortSession();
+  };
+
+  const undoReactSessionMessage = async () => {
+    await sessionActionsStore.undoLastUserMessage();
+  };
+
+  const redoReactSessionMessage = async () => {
+    await sessionActionsStore.redoLastUserMessage();
+  };
+
   syncShellRoute({
     pathname: () => location.pathname,
     navigate,
@@ -2266,6 +2291,10 @@ export default function App() {
                     renderSessionReact={() =>
                       createElement(ReactSessionViewV2, {
                         legacySurface: sessionSurface(),
+                        sendPrompt: sendReactSessionPrompt,
+                        abortPrompt: abortReactSessionPrompt,
+                        undoLastMessage: undoReactSessionMessage,
+                        redoLastMessage: redoReactSessionMessage,
                       })
                     }
                     renderSettings={() =>

--- a/apps/app/src/app/context/global-sdk.tsx
+++ b/apps/app/src/app/context/global-sdk.tsx
@@ -13,7 +13,7 @@ import {
 import { usePlatform } from "./platform";
 import { useServer } from "./server";
 
-type GlobalSDKContextValue = {
+export type GlobalSDKContextValue = {
   url: () => string;
   client: () => ReturnType<typeof createOpencodeClient>;
   event: ReturnType<typeof createGlobalEmitter<{ [key: string]: Event }>>;
@@ -161,6 +161,16 @@ export function GlobalSDKProvider(props: ParentProps) {
   };
 
   return <GlobalSDKContext.Provider value={value}>{props.children}</GlobalSDKContext.Provider>;
+}
+
+export function GlobalSDKValueProvider(
+  props: ParentProps<{ value: GlobalSDKContextValue }>,
+) {
+  return (
+    <GlobalSDKContext.Provider value={props.value}>
+      {props.children}
+    </GlobalSDKContext.Provider>
+  );
 }
 
 export function useGlobalSDK() {

--- a/apps/app/src/app/context/global-sync.tsx
+++ b/apps/app/src/app/context/global-sync.tsx
@@ -54,7 +54,7 @@ type GlobalState = {
   vcs: Record<string, VcsInfo | null>;
 };
 
-type GlobalSyncContextValue = {
+export type GlobalSyncContextValue = {
   data: Store<GlobalState>;
   set: SetStoreFunction<GlobalState>;
   child: (directory: string) => WorkspaceStore;
@@ -290,6 +290,16 @@ export function GlobalSyncProvider(props: ParentProps) {
   }
 
   return <GlobalSyncContext.Provider value={value}>{props.children}</GlobalSyncContext.Provider>;
+}
+
+export function GlobalSyncValueProvider(
+  props: ParentProps<{ value: GlobalSyncContextValue }>,
+) {
+  return (
+    <GlobalSyncContext.Provider value={props.value}>
+      {props.children}
+    </GlobalSyncContext.Provider>
+  );
 }
 
 export function useGlobalSync() {

--- a/apps/app/src/app/context/local.tsx
+++ b/apps/app/src/app/context/local.tsx
@@ -16,7 +16,7 @@ type LocalPreferences = {
   defaultModel: ModelRef | null;
 };
 
-type LocalContextValue = {
+export type LocalContextValue = {
   ui: Store<LocalUIState>;
   setUi: SetStoreFunction<LocalUIState>;
   prefs: Store<LocalPreferences>;
@@ -78,6 +78,16 @@ export function LocalProvider(props: ParentProps) {
   };
 
   return <LocalContext.Provider value={value}>{props.children}</LocalContext.Provider>;
+}
+
+export function LocalValueProvider(
+  props: ParentProps<{ value: LocalContextValue }>,
+) {
+  return (
+    <LocalContext.Provider value={props.value}>
+      {props.children}
+    </LocalContext.Provider>
+  );
 }
 
 export function useLocal() {

--- a/apps/app/src/app/context/local.tsx
+++ b/apps/app/src/app/context/local.tsx
@@ -15,6 +15,7 @@ type LocalPreferences = {
   modelVariant: string | null;
   defaultModel: ModelRef | null;
   reactSessionV2: boolean;
+  reactSettingsV2: boolean;
 };
 
 export type LocalContextValue = {
@@ -43,6 +44,7 @@ export function LocalProvider(props: ParentProps) {
       modelVariant: null,
       defaultModel: null,
       reactSessionV2: true,
+      reactSettingsV2: true,
     }),
   );
 

--- a/apps/app/src/app/context/local.tsx
+++ b/apps/app/src/app/context/local.tsx
@@ -14,6 +14,7 @@ type LocalPreferences = {
   showThinking: boolean;
   modelVariant: string | null;
   defaultModel: ModelRef | null;
+  reactSessionV2: boolean;
 };
 
 export type LocalContextValue = {
@@ -41,6 +42,7 @@ export function LocalProvider(props: ParentProps) {
       showThinking: false,
       modelVariant: null,
       defaultModel: null,
+      reactSessionV2: false,
     }),
   );
 

--- a/apps/app/src/app/context/local.tsx
+++ b/apps/app/src/app/context/local.tsx
@@ -42,7 +42,7 @@ export function LocalProvider(props: ParentProps) {
       showThinking: false,
       modelVariant: null,
       defaultModel: null,
-      reactSessionV2: false,
+      reactSessionV2: true,
     }),
   );
 

--- a/apps/app/src/app/context/server.tsx
+++ b/apps/app/src/app/context/server.tsx
@@ -17,7 +17,7 @@ export function serverDisplayName(url: string) {
   return url.replace(/^https?:\/\//, "").replace(/\/+$/, "");
 }
 
-type ServerContextValue = {
+export type ServerContextValue = {
   url: string;
   name: string;
   list: string[];
@@ -202,6 +202,16 @@ export function ServerProvider(props: ParentProps & { defaultUrl: string }) {
   };
 
   return <ServerContext.Provider value={value}>{props.children}</ServerContext.Provider>;
+}
+
+export function ServerValueProvider(
+  props: ParentProps & { value: ServerContextValue },
+) {
+  return (
+    <ServerContext.Provider value={props.value}>
+      {props.children}
+    </ServerContext.Provider>
+  );
 }
 
 export function useServer() {

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -97,7 +97,6 @@ import MessageList from "../components/session/message-list";
 import Composer from "../components/session/composer";
 import type { ComposerNotice } from "../components/session/composer-notice";
 import { createSessionScrollController } from "../components/session/scroll-controller";
-import WorkspaceSessionList from "../components/session/workspace-session-list";
 import type { SidebarSectionState } from "../components/session/sidebar";
 import FlyoutItem from "../components/flyout-item";
 import QuestionModal from "../components/question-modal";
@@ -2916,37 +2915,6 @@ export default function SessionView(props: SessionViewProps) {
       t("session.workspace_fallback"),
   );
 
-  const renderSessionSidebar = () => (
-    <WorkspaceSessionList
-      workspaceSessionGroups={props.workspaceSessionGroups}
-      selectedWorkspaceId={props.selectedWorkspaceId}
-      developerMode={props.developerMode}
-      selectedSessionId={props.selectedSessionId}
-      showSessionActions
-      sessionStatusById={props.sessionStatusById}
-      connectingWorkspaceId={props.connectingWorkspaceId}
-      workspaceConnectionStateById={props.workspaceConnectionStateById}
-      newTaskDisabled={props.newTaskDisabled}
-      onSelectWorkspace={props.selectWorkspace}
-      onOpenSession={openSessionFromList}
-      onPrefetchSession={(workspaceId, sessionId) => {
-        if (workspaceId !== props.selectedWorkspaceId) return;
-        void props.ensureSessionLoaded(sessionId);
-      }}
-      onCreateTaskInWorkspace={createTaskInWorkspace}
-      onOpenRenameSession={openRenameModal}
-      onOpenDeleteSession={openDeleteSessionModal}
-      onOpenRenameWorkspace={props.openRenameWorkspace}
-      onShareWorkspace={shareWorkspaceState.openShareWorkspace}
-      onRevealWorkspace={revealWorkspaceInFinder}
-      onRecoverWorkspace={props.recoverWorkspace}
-      onTestWorkspaceConnection={props.testWorkspaceConnection}
-      onEditWorkspaceConnection={props.editWorkspaceConnection}
-      onForgetWorkspace={props.forgetWorkspace}
-      onOpenCreateWorkspace={props.openCreateWorkspace}
-    />
-  );
-
   const renderSessionHeaderActions = () => (
     <>
       <button
@@ -3033,7 +3001,34 @@ export default function SessionView(props: SessionViewProps) {
           updateVersion={props.updateStatus?.version ?? null}
           onUpdatePillClick={handleUpdatePillClick}
           onStartResize={startLeftSidebarResize}
-          renderSidebar={renderSessionSidebar}
+          sidebarProps={{
+            workspaceSessionGroups: props.workspaceSessionGroups,
+            selectedWorkspaceId: props.selectedWorkspaceId,
+            developerMode: props.developerMode,
+            selectedSessionId: props.selectedSessionId,
+            showSessionActions: true,
+            sessionStatusById: props.sessionStatusById,
+            connectingWorkspaceId: props.connectingWorkspaceId,
+            workspaceConnectionStateById: props.workspaceConnectionStateById,
+            newTaskDisabled: props.newTaskDisabled,
+            onSelectWorkspace: props.selectWorkspace,
+            onOpenSession: openSessionFromList,
+            onPrefetchSession: (workspaceId, sessionId) => {
+              if (workspaceId !== props.selectedWorkspaceId) return;
+              void props.ensureSessionLoaded(sessionId);
+            },
+            onCreateTaskInWorkspace: createTaskInWorkspace,
+            onOpenRenameSession: openRenameModal,
+            onOpenDeleteSession: openDeleteSessionModal,
+            onOpenRenameWorkspace: props.openRenameWorkspace,
+            onShareWorkspace: shareWorkspaceState.openShareWorkspace,
+            onRevealWorkspace: revealWorkspaceInFinder,
+            onRecoverWorkspace: props.recoverWorkspace,
+            onTestWorkspaceConnection: props.testWorkspaceConnection,
+            onEditWorkspaceConnection: props.editWorkspaceConnection,
+            onForgetWorkspace: props.forgetWorkspace,
+            onOpenCreateWorkspace: props.openCreateWorkspace,
+          }}
         />
 
         <main class="min-w-0 flex-1 flex flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -97,6 +97,7 @@ import MessageList from "../components/session/message-list";
 import Composer from "../components/session/composer";
 import type { ComposerNotice } from "../components/session/composer-notice";
 import { createSessionScrollController } from "../components/session/scroll-controller";
+import WorkspaceSessionList from "../components/session/workspace-session-list";
 import type { SidebarSectionState } from "../components/session/sidebar";
 import FlyoutItem from "../components/flyout-item";
 import QuestionModal from "../components/question-modal";
@@ -2914,6 +2915,36 @@ export default function SessionView(props: SessionViewProps) {
       props.selectedWorkspaceDisplay.name ||
       t("session.workspace_fallback"),
   );
+  const renderSessionSidebar = () => (
+    <WorkspaceSessionList
+      workspaceSessionGroups={props.workspaceSessionGroups}
+      selectedWorkspaceId={props.selectedWorkspaceId}
+      developerMode={props.developerMode}
+      selectedSessionId={props.selectedSessionId}
+      showSessionActions
+      sessionStatusById={props.sessionStatusById}
+      connectingWorkspaceId={props.connectingWorkspaceId}
+      workspaceConnectionStateById={props.workspaceConnectionStateById}
+      newTaskDisabled={props.newTaskDisabled}
+      onSelectWorkspace={props.selectWorkspace}
+      onOpenSession={openSessionFromList}
+      onPrefetchSession={(workspaceId, sessionId) => {
+        if (workspaceId !== props.selectedWorkspaceId) return;
+        void props.ensureSessionLoaded(sessionId);
+      }}
+      onCreateTaskInWorkspace={createTaskInWorkspace}
+      onOpenRenameSession={openRenameModal}
+      onOpenDeleteSession={openDeleteSessionModal}
+      onOpenRenameWorkspace={props.openRenameWorkspace}
+      onShareWorkspace={shareWorkspaceState.openShareWorkspace}
+      onRevealWorkspace={revealWorkspaceInFinder}
+      onRecoverWorkspace={props.recoverWorkspace}
+      onTestWorkspaceConnection={props.testWorkspaceConnection}
+      onEditWorkspaceConnection={props.editWorkspaceConnection}
+      onForgetWorkspace={props.forgetWorkspace}
+      onOpenCreateWorkspace={props.openCreateWorkspace}
+    />
+  );
 
   const renderSessionHeaderActions = () => (
     <>
@@ -2990,6 +3021,390 @@ export default function SessionView(props: SessionViewProps) {
       </button>
     </>
   );
+  const renderSessionSearchPanel = () => (
+    <div class="border-b border-dls-border bg-dls-sidebar/70 px-4 py-2 md:px-6">
+      <div class="mx-auto flex w-full max-w-[800px] items-center gap-2 rounded-[16px] border border-dls-border bg-dls-surface px-3 py-2 shadow-[var(--dls-card-shadow)]">
+        <Search size={14} class="text-gray-9" />
+        <input
+          ref={(el) => (searchInputEl = el)}
+          type="text"
+          value={searchQuery()}
+          onInput={(event) => {
+            setSearchQuery(event.currentTarget.value);
+            setActiveSearchHitIndex(0);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              moveSearchHit(event.shiftKey ? -1 : 1);
+              return;
+            }
+            if (event.key === "Escape") {
+              event.preventDefault();
+              closeSearch();
+            }
+          }}
+          class="min-w-0 flex-1 bg-transparent text-sm text-gray-11 placeholder:text-gray-9 focus:outline-none"
+          placeholder={t("session.search_placeholder")}
+          aria-label={t("session.search_placeholder")}
+        />
+        <span class="text-[11px] text-gray-10 tabular-nums">
+          {activeSearchPositionLabel()}
+        </span>
+        <button
+          type="button"
+          class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
+          disabled={searchHits().length === 0}
+          onClick={() => moveSearchHit(-1)}
+          aria-label={t("session.prev_match")}
+        >
+          {t("session.search_prev")}
+        </button>
+        <button
+          type="button"
+          class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
+          disabled={searchHits().length === 0}
+          onClick={() => moveSearchHit(1)}
+          aria-label={t("session.next_match")}
+        >
+          {t("session.search_next")}
+        </button>
+        <button
+          type="button"
+          class="flex h-7 w-7 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12"
+          onClick={closeSearch}
+          aria-label={t("session.close_search")}
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  );
+  const renderSessionMessageContent = () => (
+    <>
+      <div
+        class={`h-full overflow-y-auto px-4 sm:px-6 lg:px-10 ${showWorkspaceSetupEmptyState() ? "pt-20" : "pt-10"} bg-dls-surface`}
+        style={{ contain: "layout paint style" }}
+        onWheel={(event) => {
+          sessionScroll.markScrollGesture(event.target);
+        }}
+        onTouchStart={(event) => {
+          sessionScroll.markScrollGesture(event.target);
+        }}
+        onTouchMove={(event) => {
+          sessionScroll.markScrollGesture(event.target);
+        }}
+        onPointerDown={(event) => {
+          if (event.target !== event.currentTarget) return;
+          sessionScroll.markScrollGesture(event.currentTarget);
+        }}
+        onScroll={sessionScroll.handleScroll}
+        ref={(el) => {
+          chatContainerEl = el;
+        }}
+      >
+        <div
+          class="mx-auto w-full max-w-[800px]"
+          ref={(el) => {
+            chatContentEl = el;
+          }}
+        >
+          <Show when={showDelayedSessionLoadingState()}>
+            <div class="px-6 py-24">
+              <div
+                class="mx-auto flex max-w-sm flex-col items-center gap-4 rounded-3xl border border-dls-border bg-dls-hover/60 px-8 py-10 text-center"
+                role="status"
+                aria-live="polite"
+              >
+                <div class="flex h-14 w-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-surface">
+                  <Loader2 size={20} class="animate-spin text-dls-secondary" />
+                </div>
+                <div class="space-y-1">
+                  <h3 class="text-base font-medium text-dls-text">{t("session.loading_title")}</h3>
+                  <p class="text-sm text-dls-secondary">
+                    {t("session.loading_detail")}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Show>
+
+          <Show
+            when={
+              props.messages.length === 0 &&
+              !showWorkspaceSetupEmptyState() &&
+              !showSessionLoadingState() &&
+              !deferSessionRender()
+            }
+          >
+            <div class="text-center px-6 space-y-6">
+              <div class="w-16 h-16 bg-dls-hover rounded-3xl mx-auto flex items-center justify-center border border-dls-border">
+                <Zap class="text-dls-secondary" />
+              </div>
+              <div class="space-y-2">
+                <h3 class="text-xl font-medium">
+                  {emptyStateTitle()}
+                </h3>
+                <p class="text-dls-secondary text-sm max-w-sm mx-auto">
+                  {emptyStateBody()}
+                </p>
+              </div>
+              <Show when={emptyStateStarters().length > 0}>
+                <div class="grid gap-3 max-w-lg mx-auto text-left">
+                  <For each={emptyStateStarters()}>
+                    {(starter) => (
+                      <button
+                        type="button"
+                        class="rounded-2xl border border-dls-border bg-dls-hover p-4 transition-all hover:bg-dls-active hover:border-gray-7"
+                        onClick={() => handleEmptyStateStarter(starter)}
+                      >
+                        <div class="text-sm font-semibold text-dls-text">
+                          {starter.title}
+                        </div>
+                        <Show when={starter.description}>
+                          <div class="mt-1 text-xs text-dls-secondary leading-relaxed">
+                            {starter.description}
+                          </div>
+                        </Show>
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </Show>
+            </div>
+          </Show>
+
+          <Show
+            when={!showDelayedSessionLoadingState() && !deferSessionRender()}
+          >
+            <Show
+              when={
+                hiddenMessageCount() > 0 || hasServerEarlierMessages()
+              }
+            >
+              <div class="mb-4 flex justify-center">
+                <button
+                  type="button"
+                  class="rounded-full border border-dls-border bg-dls-hover/70 px-3 py-1 text-xs text-dls-secondary transition-colors hover:bg-dls-active hover:text-dls-text"
+                  onClick={() => {
+                    void revealEarlierMessages();
+                  }}
+                  disabled={props.loadingEarlierMessages}
+                >
+                  {props.loadingEarlierMessages
+                    ? t("session.loading_earlier")
+                    : hiddenMessageCount() > 0
+                      ? t("session.show_earlier", undefined, { count: nextRevealCount().toLocaleString(), plural: nextRevealCount() === 1 ? "" : "s" })
+                      : t("session.load_earlier")}
+                </button>
+              </div>
+            </Show>
+
+            <Show when={batchedRenderedMessages().length > 0}>
+              <MessageList
+                messages={batchedRenderedMessages()}
+                isStreaming={showRunIndicator()}
+                developerMode={props.developerMode}
+                showThinking={showThinking()}
+                getSessionById={props.getSessionById}
+                getMessagesBySessionId={props.getMessagesBySessionId}
+                ensureSessionLoaded={props.ensureSessionLoaded}
+                sessionLoadingById={props.sessionLoadingById}
+                workspaceRoot={props.selectedWorkspaceRoot}
+                expandedStepIds={props.expandedStepIds}
+                setExpandedStepIds={props.setExpandedStepIds}
+                openSessionById={(sessionId) => {
+                  flushComposerDraft();
+                  props.setView("session", sessionId);
+                }}
+                searchMatchMessageIds={searchMatchMessageIds()}
+                activeSearchMessageId={activeSearchHit()?.messageId ?? null}
+                searchHighlightQuery={searchQueryDebounced().trim()}
+                scrollElement={() => chatContainerEl}
+                setScrollToMessageById={(handler) => {
+                  scrollMessageIntoViewById = handler;
+                }}
+                footer={
+                  showRunIndicator() && showFooterRunStatus() ? (
+                    <div class="flex justify-start">
+                      <div class="w-full max-w-[760px]">
+                        <div
+                          class={`mt-3 flex items-center gap-2 py-1 text-xs ${runPhase() === "error" ? "text-red-11" : "text-gray-9"}`}
+                          role="status"
+                          aria-live="polite"
+                        >
+                          <span
+                            class={`truncate ${
+                              runPhase() === "thinking" ||
+                              runPhase() === "responding"
+                                ? "animate-pulse"
+                                : ""
+                            }`}
+                          >
+                            {thinkingStatus() || runLabel()}
+                          </span>
+                          <Show when={props.developerMode}>
+                            <span class="text-[10px] text-gray-8 ml-auto shrink-0">
+                              {runElapsedLabel()}
+                            </span>
+                          </Show>
+                        </div>
+                      </div>
+                    </div>
+                  ) : undefined
+                }
+              />
+            </Show>
+          </Show>
+        </div>
+      </div>
+
+      <Show when={!showDelayedSessionLoadingState() && !deferSessionRender() && props.messages.length > 0 && !jumpControlsSuppressed() && (!sessionScroll.isAtBottom() || Boolean(sessionScroll.topClippedMessageId()))}>
+        <div class="absolute bottom-4 left-0 right-0 z-20 flex justify-center pointer-events-none">
+          <div class="pointer-events-auto flex items-center gap-2 rounded-full border border-dls-border bg-dls-surface/95 p-1 shadow-[var(--dls-card-shadow)] backdrop-blur-md">
+            <Show when={Boolean(sessionScroll.topClippedMessageId())}>
+              <button
+                type="button"
+                class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
+                onClick={() => {
+                  suppressJumpControlsTemporarily();
+                  sessionScroll.jumpToStartOfMessage("smooth");
+                }}
+              >
+                {t("session.jump_to_start")}
+              </button>
+            </Show>
+            <Show when={!sessionScroll.isAtBottom()}>
+              <button
+                type="button"
+                class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
+                onClick={() => {
+                  suppressJumpControlsTemporarily();
+                  sessionScroll.jumpToLatest("smooth");
+                }}
+              >
+                {t("session.jump_to_latest")}
+              </button>
+            </Show>
+          </div>
+        </div>
+      </Show>
+    </>
+  );
+  const renderTodoPanel = () => (
+    <div class="mx-auto w-full max-w-[800px] px-4">
+      <div class="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
+        <button
+          type="button"
+          class="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
+          onClick={() => setTodoExpanded((prev) => !prev)}
+        >
+          <div class="flex items-center gap-2">
+            <ListTodo size={14} class="text-gray-8" />
+            <span class="text-gray-11 font-medium">{todoLabel()}</span>
+          </div>
+          <Minimize2
+            size={12}
+            class={`text-gray-8 transition-transform ${todoExpanded() ? "" : "rotate-180"}`}
+          />
+        </button>
+        <Show when={todoExpanded()}>
+          <div class="max-h-60 overflow-auto border-t border-dls-border px-4 pb-3 space-y-2.5">
+            <For each={todoList()}>
+              {(todo, index) => {
+                const done = () => todo.status === "completed";
+                const cancelled = () => todo.status === "cancelled";
+                const active = () => todo.status === "in_progress";
+                return (
+                  <div class="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
+                    <div class="flex items-center gap-1.5 pt-0.5">
+                      <div
+                        class={`h-4.5 w-4.5 rounded-full border flex items-center justify-center ${
+                          done()
+                            ? "border-green-6 bg-green-2 text-green-11"
+                            : active()
+                              ? "border-amber-6 bg-amber-2 text-amber-11"
+                              : cancelled()
+                                ? "border-gray-6 bg-gray-2 text-gray-8"
+                                : "border-gray-6 bg-gray-1 text-gray-8"
+                        }`}
+                      >
+                        <Show when={done()}>
+                          <Check size={10} />
+                        </Show>
+                        <Show when={!done() && active()}>
+                          <span class="h-1.5 w-1.5 rounded-full bg-amber-9" />
+                        </Show>
+                      </div>
+                    </div>
+                    <div
+                      class={`flex-1 text-sm leading-relaxed ${
+                        cancelled()
+                          ? "text-gray-9 line-through"
+                          : "text-gray-12"
+                      }`}
+                    >
+                      <span class="text-gray-9 mr-1.5">
+                        {index() + 1}.
+                      </span>
+                      {todo.content}
+                    </div>
+                  </div>
+                );
+              }}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+  const renderComposerPanel = () => (
+    <Composer
+      prompt={props.prompt}
+      draftMode={composerDraftMode()}
+      draftScopeKey={composerDraftScopeKey()}
+      developerMode={props.developerMode}
+      busy={props.busy}
+      isStreaming={showRunIndicator()}
+      compactTopSpacing={todoCount() > 0}
+      onSend={handleSendPrompt}
+      onStop={cancelRun}
+      onDraftChange={handleDraftChange}
+      selectedModelLabel={modelControls.selectedSessionModelLabel() || t("session.model_fallback")}
+      onModelClick={() => modelControls.openSessionModelPicker()}
+      modelVariantLabel={modelControls.sessionModelVariantLabel()}
+      modelVariant={modelControls.sessionModelVariant()}
+      modelBehaviorOptions={modelControls.sessionModelBehaviorOptions()}
+      onModelVariantChange={modelControls.setSessionModelVariant}
+      agentLabel={agentLabel()}
+      selectedAgent={sessionActions.selectedSessionAgent()}
+      agentPickerOpen={agentPickerOpen()}
+      agentPickerBusy={agentPickerBusy()}
+      agentPickerError={agentPickerError()}
+      agentOptions={agentOptions()}
+      onToggleAgentPicker={openAgentPicker}
+      onSelectAgent={(agent) => {
+        applySessionAgent(agent);
+        setAgentPickerOpen(false);
+      }}
+      setAgentPickerRef={(el) => {
+        agentPickerRef = el;
+      }}
+      notice={composerNotice()}
+      onNotice={showComposerNotice}
+      listAgents={sessionActions.listAgents}
+      recentFiles={props.workingFiles}
+      searchFiles={sessionActions.searchWorkspaceFiles}
+      listCommands={sessionActions.listCommands}
+      isRemoteWorkspace={
+        props.selectedWorkspaceDisplay.workspaceType === "remote"
+      }
+      isSandboxWorkspace={isSandboxWorkspace()}
+      onUploadInboxFiles={uploadInboxFiles}
+      attachmentsEnabled={attachmentsEnabled()}
+      attachmentsDisabledReason={attachmentsDisabledReason()}
+    />
+  );
   return (
     <div class="h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-gray-12 font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
@@ -3001,34 +3416,7 @@ export default function SessionView(props: SessionViewProps) {
           updateVersion={props.updateStatus?.version ?? null}
           onUpdatePillClick={handleUpdatePillClick}
           onStartResize={startLeftSidebarResize}
-          sidebarProps={{
-            workspaceSessionGroups: props.workspaceSessionGroups,
-            selectedWorkspaceId: props.selectedWorkspaceId,
-            developerMode: props.developerMode,
-            selectedSessionId: props.selectedSessionId,
-            showSessionActions: true,
-            sessionStatusById: props.sessionStatusById,
-            connectingWorkspaceId: props.connectingWorkspaceId,
-            workspaceConnectionStateById: props.workspaceConnectionStateById,
-            newTaskDisabled: props.newTaskDisabled,
-            onSelectWorkspace: props.selectWorkspace,
-            onOpenSession: openSessionFromList,
-            onPrefetchSession: (workspaceId, sessionId) => {
-              if (workspaceId !== props.selectedWorkspaceId) return;
-              void props.ensureSessionLoaded(sessionId);
-            },
-            onCreateTaskInWorkspace: createTaskInWorkspace,
-            onOpenRenameSession: openRenameModal,
-            onOpenDeleteSession: openDeleteSessionModal,
-            onOpenRenameWorkspace: props.openRenameWorkspace,
-            onShareWorkspace: shareWorkspaceState.openShareWorkspace,
-            onRevealWorkspace: revealWorkspaceInFinder,
-            onRecoverWorkspace: props.recoverWorkspace,
-            onTestWorkspaceConnection: props.testWorkspaceConnection,
-            onEditWorkspaceConnection: props.editWorkspaceConnection,
-            onForgetWorkspace: props.forgetWorkspace,
-            onOpenCreateWorkspace: props.openCreateWorkspace,
-          }}
+          renderSidebar={renderSessionSidebar}
         />
 
         <main class="min-w-0 flex-1 flex flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
@@ -3047,394 +3435,16 @@ export default function SessionView(props: SessionViewProps) {
             renderActions={renderSessionHeaderActions}
           />
 
-          <Show when={searchOpen()}>
-            <div class="border-b border-dls-border bg-dls-sidebar/70 px-4 py-2 md:px-6">
-              <div class="mx-auto flex w-full max-w-[800px] items-center gap-2 rounded-[16px] border border-dls-border bg-dls-surface px-3 py-2 shadow-[var(--dls-card-shadow)]">
-                <Search size={14} class="text-gray-9" />
-                <input
-                  ref={(el) => (searchInputEl = el)}
-                  type="text"
-                  value={searchQuery()}
-                  onInput={(event) => {
-                    setSearchQuery(event.currentTarget.value);
-                    setActiveSearchHitIndex(0);
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      moveSearchHit(event.shiftKey ? -1 : 1);
-                      return;
-                    }
-                    if (event.key === "Escape") {
-                      event.preventDefault();
-                      closeSearch();
-                    }
-                  }}
-                  class="min-w-0 flex-1 bg-transparent text-sm text-gray-11 placeholder:text-gray-9 focus:outline-none"
-                  placeholder={t("session.search_placeholder")}
-                  aria-label={t("session.search_placeholder")}
-                />
-                <span class="text-[11px] text-gray-10 tabular-nums">
-                  {activeSearchPositionLabel()}
-                </span>
-                <button
-                  type="button"
-                  class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
-                  disabled={searchHits().length === 0}
-                  onClick={() => moveSearchHit(-1)}
-                  aria-label={t("session.prev_match")}
-                >
-                  {t("session.search_prev")}
-                </button>
-                <button
-                  type="button"
-                  class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
-                  disabled={searchHits().length === 0}
-                  onClick={() => moveSearchHit(1)}
-                  aria-label={t("session.next_match")}
-                >
-                  {t("session.search_next")}
-                </button>
-                <button
-                  type="button"
-                  class="flex h-7 w-7 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12"
-                  onClick={closeSearch}
-                  aria-label={t("session.close_search")}
-                >
-                  <X size={14} />
-                </button>
-              </div>
-            </div>
-          </Show>
+          <Show when={searchOpen()}>{renderSessionSearchPanel()}</Show>
 
           <div class="flex-1 flex overflow-hidden">
             <div class="relative min-w-0 flex-1 overflow-hidden bg-dls-surface">
-              <div
-                class={`h-full overflow-y-auto px-4 sm:px-6 lg:px-10 ${showWorkspaceSetupEmptyState() ? "pt-20" : "pt-10"} bg-dls-surface`}
-                style={{ contain: "layout paint style" }}
-                onWheel={(event) => {
-                  sessionScroll.markScrollGesture(event.target);
-                }}
-                onTouchStart={(event) => {
-                  sessionScroll.markScrollGesture(event.target);
-                }}
-                onTouchMove={(event) => {
-                  sessionScroll.markScrollGesture(event.target);
-                }}
-                onPointerDown={(event) => {
-                  if (event.target !== event.currentTarget) return;
-                  sessionScroll.markScrollGesture(event.currentTarget);
-                }}
-                onScroll={sessionScroll.handleScroll}
-                ref={(el) => {
-                  chatContainerEl = el;
-                }}
-              >
-                <div
-                  class="mx-auto w-full max-w-[800px]"
-                  ref={(el) => {
-                    chatContentEl = el;
-                  }}
-                >
-                  <Show when={showDelayedSessionLoadingState()}>
-                    <div class="px-6 py-24">
-                      <div
-                        class="mx-auto flex max-w-sm flex-col items-center gap-4 rounded-3xl border border-dls-border bg-dls-hover/60 px-8 py-10 text-center"
-                        role="status"
-                        aria-live="polite"
-                      >
-                        <div class="flex h-14 w-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-surface">
-                          <Loader2 size={20} class="animate-spin text-dls-secondary" />
-                        </div>
-                        <div class="space-y-1">
-                          <h3 class="text-base font-medium text-dls-text">{t("session.loading_title")}</h3>
-                          <p class="text-sm text-dls-secondary">
-                            {t("session.loading_detail")}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  </Show>
-
-
-                  <Show
-                    when={
-                      props.messages.length === 0 &&
-                      !showWorkspaceSetupEmptyState() &&
-                      !showSessionLoadingState() &&
-                      !deferSessionRender()
-                    }
-                  >
-                    <div class="text-center px-6 space-y-6">
-                      <div class="w-16 h-16 bg-dls-hover rounded-3xl mx-auto flex items-center justify-center border border-dls-border">
-                        <Zap class="text-dls-secondary" />
-                      </div>
-                      <div class="space-y-2">
-                        <h3 class="text-xl font-medium">
-                          {emptyStateTitle()}
-                        </h3>
-                        <p class="text-dls-secondary text-sm max-w-sm mx-auto">
-                          {emptyStateBody()}
-                        </p>
-                      </div>
-                      <Show when={emptyStateStarters().length > 0}>
-                        <div class="grid gap-3 max-w-lg mx-auto text-left">
-                          <For each={emptyStateStarters()}>
-                            {(starter) => (
-                              <button
-                                type="button"
-                                class="rounded-2xl border border-dls-border bg-dls-hover p-4 transition-all hover:bg-dls-active hover:border-gray-7"
-                                onClick={() => handleEmptyStateStarter(starter)}
-                              >
-                                <div class="text-sm font-semibold text-dls-text">
-                                  {starter.title}
-                                </div>
-                                <Show when={starter.description}>
-                                  <div class="mt-1 text-xs text-dls-secondary leading-relaxed">
-                                    {starter.description}
-                                  </div>
-                                </Show>
-                              </button>
-                            )}
-                          </For>
-                        </div>
-                      </Show>
-                    </div>
-                  </Show>
-
-                  <Show
-                    when={!showDelayedSessionLoadingState() && !deferSessionRender()}
-                  >
-                    <Show
-                      when={
-                        hiddenMessageCount() > 0 || hasServerEarlierMessages()
-                      }
-                    >
-                      <div class="mb-4 flex justify-center">
-                        <button
-                          type="button"
-                          class="rounded-full border border-dls-border bg-dls-hover/70 px-3 py-1 text-xs text-dls-secondary transition-colors hover:bg-dls-active hover:text-dls-text"
-                          onClick={() => {
-                            void revealEarlierMessages();
-                          }}
-                          disabled={props.loadingEarlierMessages}
-                        >
-                          {props.loadingEarlierMessages
-                            ? t("session.loading_earlier")
-                            : hiddenMessageCount() > 0
-                              ? t("session.show_earlier", undefined, { count: nextRevealCount().toLocaleString(), plural: nextRevealCount() === 1 ? "" : "s" })
-                              : t("session.load_earlier")}
-                        </button>
-                      </div>
-                    </Show>
-
-                    <Show when={batchedRenderedMessages().length > 0}>
-                      <MessageList
-                        messages={batchedRenderedMessages()}
-                        isStreaming={showRunIndicator()}
-                        developerMode={props.developerMode}
-                        showThinking={showThinking()}
-                        getSessionById={props.getSessionById}
-                        getMessagesBySessionId={props.getMessagesBySessionId}
-                        ensureSessionLoaded={props.ensureSessionLoaded}
-                        sessionLoadingById={props.sessionLoadingById}
-                        workspaceRoot={props.selectedWorkspaceRoot}
-                        expandedStepIds={props.expandedStepIds}
-                        setExpandedStepIds={props.setExpandedStepIds}
-                        openSessionById={(sessionId) => {
-                          flushComposerDraft();
-                          props.setView("session", sessionId);
-                        }}
-                        searchMatchMessageIds={searchMatchMessageIds()}
-                        activeSearchMessageId={activeSearchHit()?.messageId ?? null}
-                        searchHighlightQuery={searchQueryDebounced().trim()}
-                        scrollElement={() => chatContainerEl}
-                        setScrollToMessageById={(handler) => {
-                          scrollMessageIntoViewById = handler;
-                        }}
-                        footer={
-                          showRunIndicator() && showFooterRunStatus() ? (
-                            <div class="flex justify-start">
-                              <div class="w-full max-w-[760px]">
-                                <div
-                                  class={`mt-3 flex items-center gap-2 py-1 text-xs ${runPhase() === "error" ? "text-red-11" : "text-gray-9"}`}
-                                  role="status"
-                                  aria-live="polite"
-                                >
-                                  <span
-                                    class={`truncate ${
-                                      runPhase() === "thinking" ||
-                                      runPhase() === "responding"
-                                        ? "animate-pulse"
-                                        : ""
-                                    }`}
-                                  >
-                                    {thinkingStatus() || runLabel()}
-                                  </span>
-                                  <Show when={props.developerMode}>
-                                    <span class="text-[10px] text-gray-8 ml-auto shrink-0">
-                                      {runElapsedLabel()}
-                                    </span>
-                                  </Show>
-                                </div>
-                              </div>
-                            </div>
-                          ) : undefined
-                        }
-                      />
-                    </Show>
-                  </Show>
-                </div>
-              </div>
-
-              <Show when={!showDelayedSessionLoadingState() && !deferSessionRender() && props.messages.length > 0 && !jumpControlsSuppressed() && (!sessionScroll.isAtBottom() || Boolean(sessionScroll.topClippedMessageId()))}>
-                <div class="absolute bottom-4 left-0 right-0 z-20 flex justify-center pointer-events-none">
-                  <div class="pointer-events-auto flex items-center gap-2 rounded-full border border-dls-border bg-dls-surface/95 p-1 shadow-[var(--dls-card-shadow)] backdrop-blur-md">
-                    <Show when={Boolean(sessionScroll.topClippedMessageId())}>
-                      <button
-                        type="button"
-                        class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
-                        onClick={() => {
-                          suppressJumpControlsTemporarily();
-                          sessionScroll.jumpToStartOfMessage("smooth");
-                        }}
-                      >
-                        {t("session.jump_to_start")}
-                      </button>
-                    </Show>
-                    <Show when={!sessionScroll.isAtBottom()}>
-                      <button
-                        type="button"
-                        class="rounded-full px-3 py-1.5 text-xs text-gray-11 transition-colors hover:bg-gray-2"
-                        onClick={() => {
-                          suppressJumpControlsTemporarily();
-                          sessionScroll.jumpToLatest("smooth");
-                        }}
-                      >
-                        {t("session.jump_to_latest")}
-                      </button>
-                    </Show>
-                  </div>
-                </div>
-              </Show>
+              {renderSessionMessageContent()}
             </div>
           </div>
 
-          <Show when={todoCount() > 0}>
-            <div class="mx-auto w-full max-w-[800px] px-4">
-              <div class="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
-                <button
-                  type="button"
-                  class="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
-                  onClick={() => setTodoExpanded((prev) => !prev)}
-                >
-                  <div class="flex items-center gap-2">
-                    <ListTodo size={14} class="text-gray-8" />
-                    <span class="text-gray-11 font-medium">{todoLabel()}</span>
-                  </div>
-                  <Minimize2
-                    size={12}
-                    class={`text-gray-8 transition-transform ${todoExpanded() ? "" : "rotate-180"}`}
-                  />
-                </button>
-                <Show when={todoExpanded()}>
-                  <div class="max-h-60 overflow-auto border-t border-dls-border px-4 pb-3 space-y-2.5">
-                    <For each={todoList()}>
-                      {(todo, index) => {
-                        const done = () => todo.status === "completed";
-                        const cancelled = () => todo.status === "cancelled";
-                        const active = () => todo.status === "in_progress";
-                        return (
-                          <div class="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
-                            <div class="flex items-center gap-1.5 pt-0.5">
-                              <div
-                                class={`h-4.5 w-4.5 rounded-full border flex items-center justify-center ${
-                                  done()
-                                    ? "border-green-6 bg-green-2 text-green-11"
-                                    : active()
-                                      ? "border-amber-6 bg-amber-2 text-amber-11"
-                                      : cancelled()
-                                        ? "border-gray-6 bg-gray-2 text-gray-8"
-                                        : "border-gray-6 bg-gray-1 text-gray-8"
-                                }`}
-                              >
-                                <Show when={done()}>
-                                  <Check size={10} />
-                                </Show>
-                                <Show when={!done() && active()}>
-                                  <span class="h-1.5 w-1.5 rounded-full bg-amber-9" />
-                                </Show>
-                              </div>
-                            </div>
-                            <div
-                              class={`flex-1 text-sm leading-relaxed ${
-                                cancelled()
-                                  ? "text-gray-9 line-through"
-                                  : "text-gray-12"
-                              }`}
-                            >
-                              <span class="text-gray-9 mr-1.5">
-                                {index() + 1}.
-                              </span>
-                              {todo.content}
-                            </div>
-                          </div>
-                        );
-                      }}
-                    </For>
-                  </div>
-                </Show>
-              </div>
-            </div>
-          </Show>
-
-          <Show when={!showWorkspaceSetupEmptyState()}>
-            <Composer
-              prompt={props.prompt}
-              draftMode={composerDraftMode()}
-              draftScopeKey={composerDraftScopeKey()}
-              developerMode={props.developerMode}
-              busy={props.busy}
-              isStreaming={showRunIndicator()}
-              compactTopSpacing={todoCount() > 0}
-              onSend={handleSendPrompt}
-              onStop={cancelRun}
-              onDraftChange={handleDraftChange}
-              selectedModelLabel={modelControls.selectedSessionModelLabel() || t("session.model_fallback")}
-              onModelClick={() => modelControls.openSessionModelPicker()}
-              modelVariantLabel={modelControls.sessionModelVariantLabel()}
-              modelVariant={modelControls.sessionModelVariant()}
-              modelBehaviorOptions={modelControls.sessionModelBehaviorOptions()}
-              onModelVariantChange={modelControls.setSessionModelVariant}
-              agentLabel={agentLabel()}
-              selectedAgent={sessionActions.selectedSessionAgent()}
-              agentPickerOpen={agentPickerOpen()}
-              agentPickerBusy={agentPickerBusy()}
-              agentPickerError={agentPickerError()}
-              agentOptions={agentOptions()}
-              onToggleAgentPicker={openAgentPicker}
-              onSelectAgent={(agent) => {
-                applySessionAgent(agent);
-                setAgentPickerOpen(false);
-              }}
-              setAgentPickerRef={(el) => {
-                agentPickerRef = el;
-              }}
-              notice={composerNotice()}
-              onNotice={showComposerNotice}
-              listAgents={sessionActions.listAgents}
-              recentFiles={props.workingFiles}
-              searchFiles={sessionActions.searchWorkspaceFiles}
-              listCommands={sessionActions.listCommands}
-              isRemoteWorkspace={
-                props.selectedWorkspaceDisplay.workspaceType === "remote"
-              }
-              isSandboxWorkspace={isSandboxWorkspace()}
-              onUploadInboxFiles={uploadInboxFiles}
-              attachmentsEnabled={attachmentsEnabled()}
-              attachmentsDisabledReason={attachmentsDisabledReason()}
-            />
-          </Show>
+          <Show when={todoCount() > 0}>{renderTodoPanel()}</Show>
+          <Show when={!showWorkspaceSetupEmptyState()}>{renderComposerPanel()}</Show>
 
           <StatusBar
             clientConnected={props.clientConnected}

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -104,6 +104,7 @@ import {
 } from "../shell/status-toasts";
 import { createShareWorkspaceState } from "../session/share-workspace";
 import ReactSessionHeaderHost from "../session/react-session-header-host";
+import ReactSessionCommandPaletteHost from "../session/react-session-command-palette-host";
 import ReactSessionSearchPanelHost from "../session/react-session-search-panel-host";
 import ReactSessionSidebarShellHost from "../session/react-session-sidebar-shell-host";
 import ReactSessionTodoPanelHost from "../session/react-session-todo-panel-host";
@@ -3372,107 +3373,30 @@ export default function SessionView(props: SessionViewProps) {
       </div>
 
       <Show when={commandPaletteOpen()}>
-        <div
-          class="fixed inset-0 z-50 bg-gray-1/60 backdrop-blur-sm flex items-start justify-center p-4 overflow-y-auto"
-          onClick={closeCommandPalette}
-        >
-          <div
-            class="w-full max-w-2xl mt-12 rounded-2xl border border-dls-border bg-dls-surface shadow-2xl overflow-hidden"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div class="border-b border-dls-border px-4 py-3 space-y-2">
-              <div class="flex items-center gap-2">
-                <Show when={commandPaletteMode() !== "root"}>
-                  <button
-                    type="button"
-                    class="h-8 px-2 rounded-md text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors"
-                    onClick={returnToCommandRoot}
-                  >
-                    {t("session.back")}
-                  </button>
-                </Show>
-                <Search size={14} class="text-dls-secondary shrink-0" />
-                <input
-                  ref={(el) => (commandPaletteInputEl = el)}
-                  type="text"
-                  value={commandPaletteQuery()}
-                  onInput={(event) =>
-                    setCommandPaletteQuery(event.currentTarget.value)
-                  }
-                  placeholder={commandPalettePlaceholder()}
-                  class="min-w-0 flex-1 bg-transparent text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none"
-                  aria-label={commandPaletteTitle()}
-                />
-                <button
-                  type="button"
-                  class="h-8 w-8 flex items-center justify-center rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors"
-                  onClick={closeCommandPalette}
-                  aria-label={t("session.close_quick_actions")}
-                >
-                  <X size={14} />
-                </button>
-              </div>
-              <div class="text-[11px] text-dls-secondary">
-                {commandPaletteTitle()}
-              </div>
-            </div>
-
-            <div class="max-h-[56vh] overflow-y-auto p-2">
-              <Show
-                when={commandPaletteItems().length > 0}
-                fallback={
-                  <div class="px-3 py-6 text-sm text-dls-secondary text-center">
-                    {t("session.no_matches_command")}
-                  </div>
-                }
-              >
-                <For each={commandPaletteItems()}>
-                  {(item, index) => {
-                    const idx = () => index();
-                    return (
-                      <button
-                        ref={(el) => {
-                          commandPaletteOptionRefs[idx()] = el;
-                        }}
-                        type="button"
-                        class={`w-full text-left rounded-xl px-3 py-2.5 transition-colors ${
-                          idx() === commandPaletteActiveIndex()
-                            ? "bg-dls-active text-dls-text"
-                            : "text-dls-text hover:bg-dls-hover"
-                        }`}
-                        onMouseEnter={() => setCommandPaletteActiveIndex(idx())}
-                        onClick={item.action}
-                      >
-                        <div class="flex items-start justify-between gap-3">
-                          <div class="min-w-0">
-                            <div class="text-sm font-medium truncate">
-                              {item.title}
-                            </div>
-                            <Show when={item.detail}>
-                              <div class="text-xs text-dls-secondary mt-1 truncate">
-                                {item.detail}
-                              </div>
-                            </Show>
-                          </div>
-                          <Show when={item.meta}>
-                            <span class="text-[10px] uppercase tracking-wide text-dls-secondary shrink-0">
-                              {item.meta}
-                            </span>
-                          </Show>
-                        </div>
-                      </button>
-                    );
-                  }}
-                </For>
-              </Show>
-            </div>
-
-            <div class="border-t border-dls-border px-3 py-2 text-[11px] text-dls-secondary flex items-center justify-between gap-2">
-              <span>{t("session.palette_hint_navigate")}</span>
-              <span>{t("session.palette_hint_run")}</span>
-            </div>
-          </div>
-        </div>
+        <ReactSessionCommandPaletteHost
+          mode={commandPaletteMode()}
+          query={commandPaletteQuery()}
+          title={commandPaletteTitle()}
+          placeholder={commandPalettePlaceholder()}
+          items={commandPaletteItems()}
+          activeIndex={commandPaletteActiveIndex()}
+          noMatchesLabel={t("session.no_matches_command")}
+          backLabel={t("session.back")}
+          closeLabel={t("session.close_quick_actions")}
+          hintNavigateLabel={t("session.palette_hint_navigate")}
+          hintRunLabel={t("session.palette_hint_run")}
+          setInputRef={(element) => {
+            commandPaletteInputEl = element ?? undefined;
+          }}
+          setOptionRef={(index, element) => {
+            if (!element) return;
+            commandPaletteOptionRefs[index] = element;
+          }}
+          onClose={closeCommandPalette}
+          onBack={returnToCommandRoot}
+          onQueryChange={setCommandPaletteQuery}
+          onHoverIndex={setCommandPaletteActiveIndex}
+        />
       </Show>
 
       <ProviderAuthModal

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -107,6 +107,7 @@ import {
 } from "../shell/status-toasts";
 import { createShareWorkspaceState } from "../session/share-workspace";
 import ReactSessionHeaderHost from "../session/react-session-header-host";
+import ReactSessionSearchPanelHost from "../session/react-session-search-panel-host";
 import ReactSessionSidebarShellHost from "../session/react-session-sidebar-shell-host";
 import { latestSessionErrorTurnTime, shouldResetRunState } from "../session/run-state";
 import {
@@ -3021,65 +3022,6 @@ export default function SessionView(props: SessionViewProps) {
       </button>
     </>
   );
-  const renderSessionSearchPanel = () => (
-    <div class="border-b border-dls-border bg-dls-sidebar/70 px-4 py-2 md:px-6">
-      <div class="mx-auto flex w-full max-w-[800px] items-center gap-2 rounded-[16px] border border-dls-border bg-dls-surface px-3 py-2 shadow-[var(--dls-card-shadow)]">
-        <Search size={14} class="text-gray-9" />
-        <input
-          ref={(el) => (searchInputEl = el)}
-          type="text"
-          value={searchQuery()}
-          onInput={(event) => {
-            setSearchQuery(event.currentTarget.value);
-            setActiveSearchHitIndex(0);
-          }}
-          onKeyDown={(event) => {
-            if (event.key === "Enter") {
-              event.preventDefault();
-              moveSearchHit(event.shiftKey ? -1 : 1);
-              return;
-            }
-            if (event.key === "Escape") {
-              event.preventDefault();
-              closeSearch();
-            }
-          }}
-          class="min-w-0 flex-1 bg-transparent text-sm text-gray-11 placeholder:text-gray-9 focus:outline-none"
-          placeholder={t("session.search_placeholder")}
-          aria-label={t("session.search_placeholder")}
-        />
-        <span class="text-[11px] text-gray-10 tabular-nums">
-          {activeSearchPositionLabel()}
-        </span>
-        <button
-          type="button"
-          class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
-          disabled={searchHits().length === 0}
-          onClick={() => moveSearchHit(-1)}
-          aria-label={t("session.prev_match")}
-        >
-          {t("session.search_prev")}
-        </button>
-        <button
-          type="button"
-          class="rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60"
-          disabled={searchHits().length === 0}
-          onClick={() => moveSearchHit(1)}
-          aria-label={t("session.next_match")}
-        >
-          {t("session.search_next")}
-        </button>
-        <button
-          type="button"
-          class="flex h-7 w-7 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12"
-          onClick={closeSearch}
-          aria-label={t("session.close_search")}
-        >
-          <X size={14} />
-        </button>
-      </div>
-    </div>
-  );
   const renderSessionMessageContent = () => (
     <>
       <div
@@ -3435,7 +3377,28 @@ export default function SessionView(props: SessionViewProps) {
             renderActions={renderSessionHeaderActions}
           />
 
-          <Show when={searchOpen()}>{renderSessionSearchPanel()}</Show>
+          <Show when={searchOpen()}>
+            <ReactSessionSearchPanelHost
+              query={searchQuery()}
+              positionLabel={activeSearchPositionLabel()}
+              hasHits={searchHits().length > 0}
+              placeholder={t("session.search_placeholder")}
+              prevLabel={t("session.search_prev")}
+              nextLabel={t("session.search_next")}
+              closeLabel={t("session.close_search")}
+              setInputRef={(element) => {
+                searchInputEl = element ?? undefined;
+              }}
+              onQueryChange={(value) => {
+                setSearchQuery(value);
+                setActiveSearchHitIndex(0);
+              }}
+              onMovePrev={() => moveSearchHit(-1)}
+              onMoveNext={() => moveSearchHit(1)}
+              onClose={closeSearch}
+              onSubmitStep={(direction) => moveSearchHit(direction)}
+            />
+          </Show>
 
           <div class="flex-1 flex overflow-hidden">
             <div class="relative min-w-0 flex-1 overflow-hidden bg-dls-surface">

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -106,6 +106,8 @@ import {
   type AppStatusToastTone,
 } from "../shell/status-toasts";
 import { createShareWorkspaceState } from "../session/share-workspace";
+import ReactSessionHeaderHost from "../session/react-session-header-host";
+import ReactSessionSidebarShellHost from "../session/react-session-sidebar-shell-host";
 import { latestSessionErrorTurnTime, shouldResetRunState } from "../session/run-state";
 import {
   getSessionDraft,
@@ -2907,228 +2909,148 @@ export default function SessionView(props: SessionViewProps) {
     }
     applyStarterPrompt(starter.prompt);
   };
+  const sessionWorkspaceLabel = createMemo(
+    () =>
+      props.selectedWorkspaceDisplay.displayName ||
+      props.selectedWorkspaceDisplay.name ||
+      t("session.workspace_fallback"),
+  );
+
+  const renderSessionSidebar = () => (
+    <WorkspaceSessionList
+      workspaceSessionGroups={props.workspaceSessionGroups}
+      selectedWorkspaceId={props.selectedWorkspaceId}
+      developerMode={props.developerMode}
+      selectedSessionId={props.selectedSessionId}
+      showSessionActions
+      sessionStatusById={props.sessionStatusById}
+      connectingWorkspaceId={props.connectingWorkspaceId}
+      workspaceConnectionStateById={props.workspaceConnectionStateById}
+      newTaskDisabled={props.newTaskDisabled}
+      onSelectWorkspace={props.selectWorkspace}
+      onOpenSession={openSessionFromList}
+      onPrefetchSession={(workspaceId, sessionId) => {
+        if (workspaceId !== props.selectedWorkspaceId) return;
+        void props.ensureSessionLoaded(sessionId);
+      }}
+      onCreateTaskInWorkspace={createTaskInWorkspace}
+      onOpenRenameSession={openRenameModal}
+      onOpenDeleteSession={openDeleteSessionModal}
+      onOpenRenameWorkspace={props.openRenameWorkspace}
+      onShareWorkspace={shareWorkspaceState.openShareWorkspace}
+      onRevealWorkspace={revealWorkspaceInFinder}
+      onRecoverWorkspace={props.recoverWorkspace}
+      onTestWorkspaceConnection={props.testWorkspaceConnection}
+      onEditWorkspaceConnection={props.editWorkspaceConnection}
+      onForgetWorkspace={props.forgetWorkspace}
+      onOpenCreateWorkspace={props.openCreateWorkspace}
+    />
+  );
+
+  const renderSessionHeaderActions = () => (
+    <>
+      <button
+        type="button"
+        class={`hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors sm:flex ${
+          commandPaletteOpen()
+            ? "bg-gray-2 text-dls-text"
+            : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
+        }`}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (commandPaletteOpen()) {
+            closeCommandPalette();
+            return;
+          }
+          window.setTimeout(() => openCommandPalette(), 0);
+        }}
+        title={t("session.quick_actions_title")}
+        aria-label={t("session.quick_actions_label")}
+      >
+        <Menu size={15} />
+        <span>{t("session.menu_label")}</span>
+        <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">
+          ⌘K
+        </span>
+      </button>
+      <button
+        type="button"
+        class={`flex h-9 w-9 items-center justify-center rounded-md transition-colors ${
+          searchOpen()
+            ? "bg-gray-2 text-dls-text"
+            : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
+        }`}
+        onClick={() => {
+          if (searchOpen()) {
+            closeSearch();
+            return;
+          }
+          openSearch();
+        }}
+        title={t("session.search_conversation_title")}
+        aria-label={t("session.search_conversation_label")}
+      >
+        <Search size={16} />
+      </button>
+      <div class="hidden h-4 w-px bg-dls-border sm:block" />
+      <button
+        type="button"
+        class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
+        onClick={undoLastMessage}
+        disabled={!canUndoLastMessage() || historyActionBusy() !== null}
+        title={t("session.undo_title")}
+        aria-label={t("session.undo_label")}
+      >
+        <Show when={historyActionBusy() === "undo"} fallback={<Undo2 size={16} />}>
+          <Loader2 size={16} class="animate-spin" />
+        </Show>
+        <span class="hidden lg:inline">{t("session.revert_label")}</span>
+      </button>
+      <button
+        type="button"
+        class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
+        onClick={redoLastMessage}
+        disabled={!canRedoLastMessage() || historyActionBusy() !== null}
+        title={t("session.redo_title")}
+        aria-label={t("session.redo_aria_label")}
+      >
+        <Show when={historyActionBusy() === "redo"} fallback={<Redo2 size={16} />}>
+          <Loader2 size={16} class="animate-spin" />
+        </Show>
+        <span class="hidden lg:inline">{t("session.redo_label")}</span>
+      </button>
+    </>
+  );
   return (
     <div class="h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-gray-12 font-sans">
       <div class="flex h-full w-full gap-3 md:gap-4">
-        <aside
-          class="relative hidden lg:flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5"
-          style={{
-            width: `${leftSidebarWidth()}px`,
-            "min-width": `${leftSidebarWidth()}px`,
-          }}
-        >
-          <div class="shrink-0">
-            <Show when={showUpdatePill()}>
-              <button
-                type="button"
-                class={`group relative mb-3 flex w-full items-center gap-1.5 rounded-xl border px-3.5 py-2 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.2)] ${updatePillBorderTone()} ${updatePillButtonTone()}`}
-                onClick={handleUpdatePillClick}
-                title={updatePillTitle()}
-                aria-label={updatePillTitle()}
-              >
-                <Show
-                  when={props.updateStatus?.state === "downloading"}
-                  fallback={
-                    <ArrowDownToLine
-                      size={12}
-                      class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "animate-pulse" : ""}`}
-                      style={props.updateStatus?.state === "available" ? { "animation-duration": "3.5s" } : undefined}
-                    />
-                  }
-                >
-                  <Loader2
-                    size={13}
-                    class={`animate-spin shrink-0 ${updatePillDotTone()}`}
-                  />
-                </Show>
-                <span class="min-w-0 flex-1 truncate whitespace-nowrap text-left">{updatePillLabel()}</span>
-                <Show when={props.updateStatus?.version}>
-                  {(version) => (
-                    <span
-                      class={`ml-auto shrink-0 font-mono text-[10px] ${updatePillVersionTone()}`}
-                    >
-                      v{version()}
-                    </span>
-                  )}
-                </Show>
-              </button>
-            </Show>
-          </div>
-          <div class="flex min-h-0 flex-1">
-            <WorkspaceSessionList
-              workspaceSessionGroups={props.workspaceSessionGroups}
-              selectedWorkspaceId={props.selectedWorkspaceId}
-              developerMode={props.developerMode}
-              selectedSessionId={props.selectedSessionId}
-              showSessionActions
-              sessionStatusById={props.sessionStatusById}
-              connectingWorkspaceId={props.connectingWorkspaceId}
-              workspaceConnectionStateById={props.workspaceConnectionStateById}
-              newTaskDisabled={props.newTaskDisabled}
-              onSelectWorkspace={props.selectWorkspace}
-              onOpenSession={openSessionFromList}
-              onPrefetchSession={(workspaceId, sessionId) => {
-                if (workspaceId !== props.selectedWorkspaceId) return;
-                void props.ensureSessionLoaded(sessionId);
-              }}
-              onCreateTaskInWorkspace={createTaskInWorkspace}
-              onOpenRenameSession={openRenameModal}
-              onOpenDeleteSession={openDeleteSessionModal}
-              onOpenRenameWorkspace={props.openRenameWorkspace}
-              onShareWorkspace={shareWorkspaceState.openShareWorkspace}
-              onRevealWorkspace={revealWorkspaceInFinder}
-              onRecoverWorkspace={props.recoverWorkspace}
-              onTestWorkspaceConnection={props.testWorkspaceConnection}
-              onEditWorkspaceConnection={props.editWorkspaceConnection}
-              onForgetWorkspace={props.forgetWorkspace}
-              onOpenCreateWorkspace={props.openCreateWorkspace}
-            />
-          </div>
-          <div
-            class="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 lg:block"
-            onPointerDown={startLeftSidebarResize}
-            title={t("session.resize_workspace_column")}
-            aria-label={t("session.resize_workspace_column")}
-          />
-        </aside>
+        <ReactSessionSidebarShellHost
+          leftSidebarWidth={leftSidebarWidth()}
+          showUpdatePill={showUpdatePill()}
+          updatePillLabel={updatePillLabel()}
+          updatePillTitle={updatePillTitle()}
+          updateVersion={props.updateStatus?.version ?? null}
+          onUpdatePillClick={handleUpdatePillClick}
+          onStartResize={startLeftSidebarResize}
+          renderSidebar={renderSessionSidebar}
+        />
 
         <main class="min-w-0 flex-1 flex flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
-          <header class="z-10 flex h-12 shrink-0 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6">
-            <div class="flex min-w-0 items-center gap-3">
-              <Show when={showUpdatePill()}>
-                <button
-                  type="button"
-                  class={`md:hidden flex items-center gap-1.5 rounded-full border bg-dls-surface px-2.5 py-1 text-xs font-medium shadow-sm transition-colors active:scale-[0.99] focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.2)] ${updatePillBorderTone()} ${updatePillButtonTone()}`}
-                  onClick={handleUpdatePillClick}
-                  title={updatePillTitle()}
-                  aria-label={updatePillTitle()}
-                >
-                  <Show
-                    when={props.updateStatus?.state === "downloading"}
-                    fallback={
-                      <ArrowDownToLine
-                        size={12}
-                        class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "animate-pulse" : ""}`}
-                        style={props.updateStatus?.state === "available" ? { "animation-duration": "3.5s" } : undefined}
-                      />
-                    }
-                  >
-                    <Loader2
-                      size={13}
-                      class={`animate-spin shrink-0 ${updatePillDotTone()}`}
-                    />
-                  </Show>
-                  <span class="text-[11px]">{updatePillLabel()}</span>
-                  <Show when={props.updateStatus?.version}>
-                    {(version) => (
-                      <span
-                        class={`hidden sm:inline font-mono text-[10px] ${updatePillVersionTone()}`}
-                      >
-                        v{version()}
-                      </span>
-                    )}
-                  </Show>
-                </button>
-              </Show>
-
-              <h1 class="truncate text-[15px] font-semibold text-dls-text">
-                {sessionHeaderTitle()}
-              </h1>
-              <span class="hidden truncate text-[13px] text-dls-secondary lg:inline">
-                {props.selectedWorkspaceDisplay.displayName || props.selectedWorkspaceDisplay.name || t("session.workspace_fallback")}
-              </span>
-              <Show when={props.developerMode}>
-                <span class="hidden text-[12px] text-dls-secondary lg:inline">
-                  {props.headerStatus}
-                </span>
-              </Show>
-              <Show when={props.busyHint}>
-                <span class="hidden text-[12px] text-dls-secondary lg:inline">
-                  {props.busyHint}
-                </span>
-              </Show>
-            </div>
-
-            <div class="flex items-center gap-1.5 text-gray-10">
-              <button
-                type="button"
-                class={`hidden items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors sm:flex ${
-                  commandPaletteOpen()
-                    ? "bg-gray-2 text-dls-text"
-                    : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
-                }`}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  if (commandPaletteOpen()) {
-                    closeCommandPalette();
-                    return;
-                  }
-                  window.setTimeout(() => openCommandPalette(), 0);
-                }}
-                title={t("session.quick_actions_title")}
-                aria-label={t("session.quick_actions_label")}
-              >
-                <Menu size={15} />
-                <span>{t("session.menu_label")}</span>
-                <span class="ml-1 rounded border border-dls-border px-1 text-[10px] text-gray-9">
-                  ⌘K
-                </span>
-              </button>
-              <button
-                type="button"
-                class={`flex h-9 w-9 items-center justify-center rounded-md transition-colors ${
-                  searchOpen()
-                    ? "bg-gray-2 text-dls-text"
-                    : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
-                }`}
-                onClick={() => {
-                  if (searchOpen()) {
-                    closeSearch();
-                    return;
-                  }
-                  openSearch();
-                }}
-                title={t("session.search_conversation_title")}
-                aria-label={t("session.search_conversation_label")}
-              >
-                <Search size={16} />
-              </button>
-              <div class="hidden h-4 w-px bg-dls-border sm:block" />
-              <button
-                type="button"
-                class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
-                onClick={undoLastMessage}
-                disabled={!canUndoLastMessage() || historyActionBusy() !== null}
-                title={t("session.undo_title")}
-                aria-label={t("session.undo_label")}
-              >
-                <Show
-                  when={historyActionBusy() === "undo"}
-                  fallback={<Undo2 size={16} />}
-                >
-                  <Loader2 size={16} class="animate-spin" />
-                </Show>
-                <span class="hidden lg:inline">{t("session.revert_label")}</span>
-              </button>
-              <button
-                type="button"
-                class="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
-                onClick={redoLastMessage}
-                disabled={!canRedoLastMessage() || historyActionBusy() !== null}
-                title={t("session.redo_title")}
-                aria-label={t("session.redo_aria_label")}
-              >
-                <Show
-                  when={historyActionBusy() === "redo"}
-                  fallback={<Redo2 size={16} />}
-                >
-                  <Loader2 size={16} class="animate-spin" />
-                </Show>
-                <span class="hidden lg:inline">{t("session.redo_label")}</span>
-              </button>
-            </div>
-          </header>
+          <ReactSessionHeaderHost
+            title={sessionHeaderTitle()}
+            workspaceLabel={sessionWorkspaceLabel()}
+            developerMode={props.developerMode}
+            headerStatus={props.headerStatus}
+            busyHint={props.busyHint}
+            showUpdatePill={showUpdatePill()}
+            updatePillLabel={updatePillLabel()}
+            updatePillTitle={updatePillTitle()}
+            updateVersion={props.updateStatus?.version ?? null}
+            onUpdatePillClick={handleUpdatePillClick}
+            onOpenSettings={props.toggleSettings}
+            renderActions={renderSessionHeaderActions}
+          />
 
           <Show when={searchOpen()}>
             <div class="border-b border-dls-border bg-dls-sidebar/70 px-4 py-2 md:px-6">

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -46,13 +46,10 @@ import { createWorkspaceShellLayout } from "../lib/workspace-shell-layout";
 
 import {
   ArrowDownToLine,
-  Check,
   FolderOpen,
   HardDrive,
-  ListTodo,
   Loader2,
   Menu,
-  Minimize2,
   RefreshCcw,
   Redo2,
   Search,
@@ -109,6 +106,7 @@ import { createShareWorkspaceState } from "../session/share-workspace";
 import ReactSessionHeaderHost from "../session/react-session-header-host";
 import ReactSessionSearchPanelHost from "../session/react-session-search-panel-host";
 import ReactSessionSidebarShellHost from "../session/react-session-sidebar-shell-host";
+import ReactSessionTodoPanelHost from "../session/react-session-todo-panel-host";
 import { latestSessionErrorTurnTime, shouldResetRunState } from "../session/run-state";
 import {
   getSessionDraft,
@@ -3233,73 +3231,6 @@ export default function SessionView(props: SessionViewProps) {
       </Show>
     </>
   );
-  const renderTodoPanel = () => (
-    <div class="mx-auto w-full max-w-[800px] px-4">
-      <div class="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
-        <button
-          type="button"
-          class="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
-          onClick={() => setTodoExpanded((prev) => !prev)}
-        >
-          <div class="flex items-center gap-2">
-            <ListTodo size={14} class="text-gray-8" />
-            <span class="text-gray-11 font-medium">{todoLabel()}</span>
-          </div>
-          <Minimize2
-            size={12}
-            class={`text-gray-8 transition-transform ${todoExpanded() ? "" : "rotate-180"}`}
-          />
-        </button>
-        <Show when={todoExpanded()}>
-          <div class="max-h-60 overflow-auto border-t border-dls-border px-4 pb-3 space-y-2.5">
-            <For each={todoList()}>
-              {(todo, index) => {
-                const done = () => todo.status === "completed";
-                const cancelled = () => todo.status === "cancelled";
-                const active = () => todo.status === "in_progress";
-                return (
-                  <div class="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
-                    <div class="flex items-center gap-1.5 pt-0.5">
-                      <div
-                        class={`h-4.5 w-4.5 rounded-full border flex items-center justify-center ${
-                          done()
-                            ? "border-green-6 bg-green-2 text-green-11"
-                            : active()
-                              ? "border-amber-6 bg-amber-2 text-amber-11"
-                              : cancelled()
-                                ? "border-gray-6 bg-gray-2 text-gray-8"
-                                : "border-gray-6 bg-gray-1 text-gray-8"
-                        }`}
-                      >
-                        <Show when={done()}>
-                          <Check size={10} />
-                        </Show>
-                        <Show when={!done() && active()}>
-                          <span class="h-1.5 w-1.5 rounded-full bg-amber-9" />
-                        </Show>
-                      </div>
-                    </div>
-                    <div
-                      class={`flex-1 text-sm leading-relaxed ${
-                        cancelled()
-                          ? "text-gray-9 line-through"
-                          : "text-gray-12"
-                      }`}
-                    >
-                      <span class="text-gray-9 mr-1.5">
-                        {index() + 1}.
-                      </span>
-                      {todo.content}
-                    </div>
-                  </div>
-                );
-              }}
-            </For>
-          </div>
-        </Show>
-      </div>
-    </div>
-  );
   const renderComposerPanel = () => (
     <Composer
       prompt={props.prompt}
@@ -3406,7 +3337,14 @@ export default function SessionView(props: SessionViewProps) {
             </div>
           </div>
 
-          <Show when={todoCount() > 0}>{renderTodoPanel()}</Show>
+          <Show when={todoCount() > 0}>
+            <ReactSessionTodoPanelHost
+              items={todoList()}
+              expanded={todoExpanded()}
+              label={todoLabel()}
+              onToggleExpanded={() => setTodoExpanded((prev) => !prev)}
+            />
+          </Show>
           <Show when={!showWorkspaceSetupEmptyState()}>{renderComposerPanel()}</Show>
 
           <StatusBar

--- a/apps/app/src/app/session-v2/contracts.ts
+++ b/apps/app/src/app/session-v2/contracts.ts
@@ -1,0 +1,54 @@
+import type { MessageWithParts, TodoItem, WorkspaceSessionGroup } from "../types";
+
+export type SessionV2ViewModel = {
+  selectedSessionId: string | null;
+  selectedWorkspaceId: string;
+  sessionTitle: string;
+  workspaceLabel: string;
+  headerStatus: string;
+  busyHint: string | null;
+  searchOpen: boolean;
+  searchQuery: string;
+  searchPositionLabel: string;
+  searchHasHits: boolean;
+  commandPaletteOpen: boolean;
+  commandPaletteTitle: string;
+  commandPaletteMode: string;
+  commandPaletteQuery: string;
+  commandPalettePlaceholder: string;
+  messages: MessageWithParts[];
+  todos: TodoItem[];
+  todoExpanded: boolean;
+  todoLabel: string;
+  workspaceSessionGroups: WorkspaceSessionGroup[];
+  sessionStatusById: Record<string, string>;
+  newTaskDisabled: boolean;
+};
+
+export type SessionV2CommandPaletteItem = {
+  id: string;
+  title: string;
+  detail?: string;
+  meta?: string;
+  action: () => void;
+};
+
+export type SessionV2CommandPort = {
+  openSettings: () => void;
+  openSession: (sessionId: string) => void;
+  selectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  createTaskInWorkspace: (workspaceId: string) => void;
+  openCreateWorkspace: () => void;
+  toggleSearch: () => void;
+  setSearchQuery: (value: string) => void;
+  moveSearchHit: (direction: -1 | 1) => void;
+  closeSearch: () => void;
+  setTodoExpanded: (value: boolean | ((current: boolean) => boolean)) => void;
+  sendPrompt: (text: string) => Promise<void>;
+  setPrompt: (value: string) => void;
+  openCommandPalette: () => void;
+  closeCommandPalette: () => void;
+  returnToCommandRoot: () => void;
+  setCommandPaletteQuery: (value: string) => void;
+  setCommandPaletteActiveIndex: (value: number | ((current: number) => number)) => void;
+};

--- a/apps/app/src/app/session-v2/react-session-view-v2.tsx
+++ b/apps/app/src/app/session-v2/react-session-view-v2.tsx
@@ -1,4 +1,4 @@
-import { createElement, useMemo, useState } from "react";
+import { createElement, useEffect, useMemo, useRef, useState } from "react";
 
 import type { SessionViewProps } from "../pages/session";
 import ReactSessionCommandPalette from "../session/react-session-command-palette";
@@ -8,6 +8,10 @@ import ReactSessionWorkspaceListV2 from "./react-session-workspace-list-v2";
 
 type ReactSessionViewV2Props = {
   legacySurface: SessionViewProps;
+  sendPrompt: (text: string) => Promise<void>;
+  abortPrompt: () => Promise<void>;
+  undoLastMessage: () => Promise<void>;
+  redoLastMessage: () => Promise<void>;
 };
 
 const readMessageText = (parts: SessionViewProps["messages"][number]["parts"]) => {
@@ -25,12 +29,15 @@ const readMessageText = (parts: SessionViewProps["messages"][number]["parts"]) =
 
 export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
   const surface = props.legacySurface;
+  const timelineRef = useRef<HTMLDivElement | null>(null);
   const [prompt, setPrompt] = useState(surface.prompt || "");
   const [searchQuery, setSearchQuery] = useState("");
   const [searchIndex, setSearchIndex] = useState(0);
   const [searchOpen, setSearchOpen] = useState(false);
   const [todoExpanded, setTodoExpanded] = useState(true);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [followLatest, setFollowLatest] = useState(true);
+
   const [paletteQuery, setPaletteQuery] = useState("");
   const [paletteIndex, setPaletteIndex] = useState(0);
 
@@ -125,8 +132,16 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
     if (!text || surface.busy) return;
     setPrompt("");
     surface.setPrompt(text);
-    surface.selectSession(surface.selectedSessionId || "");
+    await props.sendPrompt(text);
   };
+
+  const isRunning = surface.sessionStatus !== "idle";
+
+  useEffect(() => {
+    const node = timelineRef.current;
+    if (!node || !followLatest) return;
+    node.scrollTop = node.scrollHeight;
+  }, [followLatest, messageItems.length, isRunning]);
 
   const messageCards = messageItems.map((message) =>
     createElement(
@@ -247,7 +262,35 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
             : null,
           createElement(
             "div",
-            { className: "min-h-0 flex-1 overflow-y-auto space-y-3 p-3" },
+            {
+              className: "min-h-0 flex-1 overflow-y-auto space-y-3 p-3",
+              ref: timelineRef,
+              onScroll: (event: any) => {
+                const el = event.currentTarget as HTMLDivElement;
+                const distanceFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight);
+                setFollowLatest(distanceFromBottom < 80);
+              },
+            },
+            surface.hasEarlierMessages || surface.loadingEarlierMessages
+              ? createElement(
+                  "div",
+                  { className: "mb-2 flex justify-center" },
+                  createElement(
+                    "button",
+                    {
+                      type: "button",
+                      className:
+                        "rounded-full border border-dls-border bg-dls-hover/70 px-3 py-1 text-xs text-dls-secondary transition-colors hover:bg-dls-active hover:text-dls-text disabled:opacity-60",
+                      disabled: surface.loadingEarlierMessages || !surface.selectedSessionId,
+                      onClick: () => {
+                        if (!surface.selectedSessionId) return;
+                        void surface.loadEarlierMessages(surface.selectedSessionId);
+                      },
+                    },
+                    surface.loadingEarlierMessages ? "Loading earlier..." : "Load earlier messages",
+                  ),
+                )
+              : null,
             messageCards.length > 0
               ? messageCards
               : createElement(
@@ -258,7 +301,38 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
                   },
                   "No messages yet.",
                 ),
+            isRunning
+              ? createElement(
+                  "div",
+                  {
+                    className:
+                      "sticky bottom-0 mt-2 rounded-md border border-dls-border bg-dls-hover/80 px-3 py-1 text-xs text-dls-secondary backdrop-blur",
+                  },
+                  "Session is running...",
+                )
+              : null,
           ),
+          !followLatest && messageCards.length > 0
+            ? createElement(
+                "div",
+                { className: "absolute bottom-[112px] right-6" },
+                createElement(
+                  "button",
+                  {
+                    type: "button",
+                    className:
+                      "rounded-full border border-dls-border bg-dls-surface px-3 py-1 text-xs text-dls-secondary shadow-[var(--dls-card-shadow)] transition-colors hover:bg-dls-hover hover:text-dls-text",
+                    onClick: () => {
+                      setFollowLatest(true);
+                      const el = timelineRef.current;
+                      if (!el) return;
+                      el.scrollTop = el.scrollHeight;
+                    },
+                  },
+                  "Jump to latest",
+                ),
+              )
+            : null,
           surface.todos.length > 0
             ? createElement(ReactSessionTodoPanel, {
                 items: surface.todos,
@@ -273,9 +347,43 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
             createElement(
               "div",
               { className: "flex items-end gap-2" },
+              createElement(
+                "div",
+                { className: "flex shrink-0 items-center gap-1.5 pb-1" },
+                createElement(
+                  "button",
+                  {
+                    type: "button",
+                    className:
+                      "rounded-md border border-dls-border px-2 py-1 text-[11px] text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
+                    onClick: () => {
+                      void props.undoLastMessage();
+                    },
+                  },
+                  "Undo",
+                ),
+                createElement(
+                  "button",
+                  {
+                    type: "button",
+                    className:
+                      "rounded-md border border-dls-border px-2 py-1 text-[11px] text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
+                    onClick: () => {
+                      void props.redoLastMessage();
+                    },
+                  },
+                  "Redo",
+                ),
+              ),
               createElement("textarea", {
                 value: prompt,
                 onChange: (event: any) => setPrompt(event.currentTarget.value),
+                onKeyDown: (event: any) => {
+                  if (event.key !== "Enter") return;
+                  if (event.shiftKey) return;
+                  event.preventDefault();
+                  void sendPrompt();
+                },
                 className:
                   "min-h-[64px] flex-1 resize-y rounded-md border border-dls-border bg-dls-surface px-3 py-2 text-sm text-dls-text focus:outline-none",
                 placeholder: "Ask OpenWork anything...",
@@ -291,8 +399,22 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
                     void sendPrompt();
                   },
                 },
-                surface.busy ? "Sending..." : "Send",
+                "Send",
               ),
+              isRunning
+                ? createElement(
+                    "button",
+                    {
+                      type: "button",
+                      className:
+                        "rounded-md border border-red-8 px-3 py-2 text-xs text-red-11 transition-colors hover:bg-red-2/40",
+                      onClick: () => {
+                        void props.abortPrompt();
+                      },
+                    },
+                    "Abort",
+                  )
+                : null,
             ),
           ),
         ),

--- a/apps/app/src/app/session-v2/react-session-view-v2.tsx
+++ b/apps/app/src/app/session-v2/react-session-view-v2.tsx
@@ -1,0 +1,91 @@
+import { createElement } from "react";
+
+import type { SessionViewProps } from "../pages/session";
+
+type ReactSessionViewV2Props = {
+  legacySurface: SessionViewProps;
+};
+
+const readMessageText = (parts: SessionViewProps["messages"][number]["parts"]) => {
+  const chunks: string[] = [];
+  for (const part of parts) {
+    if (part.type !== "text") continue;
+    const text = typeof (part as { text?: unknown }).text === "string"
+      ? (part as { text: string }).text.trim()
+      : "";
+    if (!text) continue;
+    chunks.push(text);
+  }
+  return chunks.join("\n").trim();
+};
+
+export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
+  const surface = props.legacySurface;
+  const title =
+    surface.getSessionById(surface.selectedSessionId)?.title?.trim() || "Session";
+
+  const messages = surface.messages.map((message, index) => {
+    const body = readMessageText(message.parts);
+    return createElement(
+      "div",
+      {
+        key: `${index}-${(message.info as { id?: string | number }).id ?? "msg"}`,
+        className: "rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-sm text-dls-text",
+      },
+      body || "[Non-text message content]",
+    );
+  });
+
+  return createElement(
+    "div",
+    {
+      className:
+        "h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-gray-12 font-sans",
+    },
+    createElement(
+      "div",
+      {
+        className:
+          "mx-auto flex h-full w-full max-w-[1200px] flex-col gap-3 rounded-[24px] border border-dls-border bg-dls-surface p-4 shadow-[var(--dls-shell-shadow)]",
+      },
+      createElement(
+        "div",
+        { className: "flex items-center justify-between border-b border-dls-border pb-3" },
+        createElement(
+          "div",
+          { className: "min-w-0" },
+          createElement("h1", { className: "truncate text-base font-semibold text-dls-text" }, title),
+          createElement(
+            "p",
+            { className: "truncate text-xs text-dls-secondary" },
+            `React Session V2 (flagged) · ${surface.selectedWorkspaceDisplay.displayName || surface.selectedWorkspaceDisplay.name}`,
+          ),
+        ),
+        createElement(
+          "button",
+          {
+            type: "button",
+            className:
+              "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
+            onClick: surface.toggleSettings,
+          },
+          "Settings",
+        ),
+      ),
+      createElement(
+        "div",
+        { className: "min-h-0 flex-1 overflow-y-auto space-y-3" },
+        messages.length > 0
+          ? messages
+          : createElement(
+              "div",
+              {
+                className:
+                  "rounded-xl border border-dls-border bg-dls-hover/40 px-4 py-6 text-center text-sm text-dls-secondary",
+              },
+              "No messages yet.",
+            ),
+      ),
+    ),
+  );
+}

--- a/apps/app/src/app/session-v2/react-session-view-v2.tsx
+++ b/apps/app/src/app/session-v2/react-session-view-v2.tsx
@@ -1,6 +1,10 @@
-import { createElement } from "react";
+import { createElement, useMemo, useState } from "react";
 
 import type { SessionViewProps } from "../pages/session";
+import ReactSessionCommandPalette from "../session/react-session-command-palette";
+import ReactSessionSearchPanel from "../session/react-session-search-panel";
+import ReactSessionTodoPanel from "../session/react-session-todo-panel";
+import ReactSessionWorkspaceListV2 from "./react-session-workspace-list-v2";
 
 type ReactSessionViewV2Props = {
   legacySurface: SessionViewProps;
@@ -21,20 +25,128 @@ const readMessageText = (parts: SessionViewProps["messages"][number]["parts"]) =
 
 export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
   const surface = props.legacySurface;
+  const [prompt, setPrompt] = useState(surface.prompt || "");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchIndex, setSearchIndex] = useState(0);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [todoExpanded, setTodoExpanded] = useState(true);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [paletteQuery, setPaletteQuery] = useState("");
+  const [paletteIndex, setPaletteIndex] = useState(0);
+
   const title =
     surface.getSessionById(surface.selectedSessionId)?.title?.trim() || "Session";
+  const workspaceLabel =
+    surface.selectedWorkspaceDisplay.displayName ||
+    surface.selectedWorkspaceDisplay.name ||
+    "Workspace";
 
-  const messages = surface.messages.map((message, index) => {
-    const body = readMessageText(message.parts);
-    return createElement(
+  const messageItems = useMemo(
+    () =>
+      surface.messages.map((message, index) => {
+        const id = String((message.info as { id?: string | number }).id ?? index);
+        return {
+          id,
+          role: message.info.role,
+          body: readMessageText(message.parts),
+        };
+      }),
+    [surface.messages],
+  );
+
+  const searchHits = useMemo(() => {
+    const needle = searchQuery.trim().toLowerCase();
+    if (!needle) return [];
+    return messageItems
+      .filter((message) => message.body.toLowerCase().includes(needle))
+      .map((message) => message.id);
+  }, [messageItems, searchQuery]);
+
+  const activeSearchId = searchHits.length
+    ? searchHits[Math.max(0, Math.min(searchIndex, searchHits.length - 1))]
+    : null;
+
+  const paletteItems = useMemo(() => {
+    const base = [
+      {
+        id: "settings",
+        title: "Open settings",
+        meta: "app",
+        action: () => {
+          setPaletteOpen(false);
+          surface.toggleSettings();
+        },
+      },
+      {
+        id: "search",
+        title: "Search conversation",
+        meta: "session",
+        action: () => {
+          setPaletteOpen(false);
+          setSearchOpen(true);
+        },
+      },
+      ...surface.workspaceSessionGroups.flatMap((group) =>
+        group.sessions.slice(0, 6).map((session) => ({
+          id: `session-${session.id}`,
+          title: session.title?.trim() || "Untitled session",
+          detail: group.workspace.displayName || group.workspace.name || group.workspace.id,
+          meta: "session",
+          action: () => {
+            setPaletteOpen(false);
+            surface.setView("session", session.id);
+          },
+        })),
+      ),
+    ];
+
+    const needle = paletteQuery.trim().toLowerCase();
+    if (!needle) return base;
+    return base.filter((item) =>
+      [item.title, (item as { detail?: string }).detail ?? "", item.meta ?? ""]
+        .join(" ")
+        .toLowerCase()
+        .includes(needle),
+    );
+  }, [paletteQuery, surface]);
+
+  const moveSearchHit = (direction: -1 | 1) => {
+    if (!searchHits.length) return;
+    setSearchIndex((current) => {
+      const next = current + direction;
+      if (next < 0) return searchHits.length - 1;
+      if (next >= searchHits.length) return 0;
+      return next;
+    });
+  };
+
+  const sendPrompt = async () => {
+    const text = prompt.trim();
+    if (!text || surface.busy) return;
+    setPrompt("");
+    surface.setPrompt(text);
+    surface.selectSession(surface.selectedSessionId || "");
+  };
+
+  const messageCards = messageItems.map((message) =>
+    createElement(
       "div",
       {
-        key: `${index}-${(message.info as { id?: string | number }).id ?? "msg"}`,
-        className: "rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-sm text-dls-text",
+        key: message.id,
+        className: `rounded-xl border px-4 py-3 text-sm ${
+          message.id === activeSearchId
+            ? "border-blue-8 bg-blue-2/20"
+            : "border-dls-border bg-dls-surface"
+        }`,
       },
-      body || "[Non-text message content]",
-    );
-  });
+      createElement(
+        "div",
+        { className: "mb-1 text-[11px] uppercase tracking-wide text-dls-secondary" },
+        message.role,
+      ),
+      message.body || "[Non-text message content]",
+    ),
+  );
 
   return createElement(
     "div",
@@ -58,34 +170,152 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
           createElement(
             "p",
             { className: "truncate text-xs text-dls-secondary" },
-            `React Session V2 (flagged) · ${surface.selectedWorkspaceDisplay.displayName || surface.selectedWorkspaceDisplay.name}`,
+            `React Session V2 (flagged) · ${workspaceLabel}`,
           ),
         ),
-        createElement(
-          "button",
-          {
-            type: "button",
-            className:
-              "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
-            onClick: surface.toggleSettings,
-          },
-          "Settings",
+        createElement("div", { className: "flex items-center gap-2" },
+          createElement(
+            "button",
+            {
+              type: "button",
+              className:
+                "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
+              onClick: () => setSearchOpen((current) => !current),
+            },
+            "Search",
+          ),
+          createElement(
+            "button",
+            {
+              type: "button",
+              className:
+                "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
+              onClick: () => setPaletteOpen(true),
+            },
+            "Actions",
+          ),
+          createElement(
+            "button",
+            {
+              type: "button",
+              className:
+                "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
+              onClick: surface.toggleSettings,
+            },
+            "Settings",
+          ),
         ),
       ),
       createElement(
         "div",
-        { className: "min-h-0 flex-1 overflow-y-auto space-y-3" },
-        messages.length > 0
-          ? messages
-          : createElement(
+        { className: "min-h-0 flex-1 grid grid-cols-12 gap-3" },
+        createElement(
+          "aside",
+          { className: "col-span-4 min-h-0 rounded-xl border border-dls-border bg-dls-sidebar p-2.5" },
+          createElement(ReactSessionWorkspaceListV2, {
+            groups: surface.workspaceSessionGroups,
+            selectedWorkspaceId: surface.selectedWorkspaceId,
+            selectedSessionId: surface.selectedSessionId,
+            sessionStatusById: surface.sessionStatusById,
+            onSelectWorkspace: surface.selectWorkspace,
+            onOpenSession: (sessionId: string) => surface.setView("session", sessionId),
+          }),
+        ),
+        createElement(
+          "section",
+          { className: "col-span-8 min-h-0 flex flex-col overflow-hidden rounded-xl border border-dls-border bg-dls-surface" },
+          searchOpen
+            ? createElement(ReactSessionSearchPanel, {
+                query: searchQuery,
+                positionLabel: searchHits.length
+                  ? `${Math.min(searchIndex + 1, searchHits.length)} / ${searchHits.length}`
+                  : "0 / 0",
+                hasHits: searchHits.length > 0,
+                placeholder: "Search this conversation",
+                prevLabel: "Prev",
+                nextLabel: "Next",
+                closeLabel: "Close search",
+                onQueryChange: (value: string) => {
+                  setSearchQuery(value);
+                  setSearchIndex(0);
+                },
+                onMovePrev: () => moveSearchHit(-1),
+                onMoveNext: () => moveSearchHit(1),
+                onClose: () => setSearchOpen(false),
+                onSubmitStep: moveSearchHit,
+              })
+            : null,
+          createElement(
+            "div",
+            { className: "min-h-0 flex-1 overflow-y-auto space-y-3 p-3" },
+            messageCards.length > 0
+              ? messageCards
+              : createElement(
+                  "div",
+                  {
+                    className:
+                      "rounded-xl border border-dls-border bg-dls-hover/40 px-4 py-6 text-center text-sm text-dls-secondary",
+                  },
+                  "No messages yet.",
+                ),
+          ),
+          surface.todos.length > 0
+            ? createElement(ReactSessionTodoPanel, {
+                items: surface.todos,
+                expanded: todoExpanded,
+                label: `${surface.todos.length} task${surface.todos.length === 1 ? "" : "s"}`,
+                onToggleExpanded: () => setTodoExpanded((current) => !current),
+              })
+            : null,
+          createElement(
+            "div",
+            { className: "border-t border-dls-border p-3" },
+            createElement(
               "div",
-              {
+              { className: "flex items-end gap-2" },
+              createElement("textarea", {
+                value: prompt,
+                onChange: (event: any) => setPrompt(event.currentTarget.value),
                 className:
-                  "rounded-xl border border-dls-border bg-dls-hover/40 px-4 py-6 text-center text-sm text-dls-secondary",
-              },
-              "No messages yet.",
+                  "min-h-[64px] flex-1 resize-y rounded-md border border-dls-border bg-dls-surface px-3 py-2 text-sm text-dls-text focus:outline-none",
+                placeholder: "Ask OpenWork anything...",
+              }),
+              createElement(
+                "button",
+                {
+                  type: "button",
+                  className:
+                    "rounded-md border border-dls-border px-3 py-2 text-xs text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-60",
+                  disabled: surface.busy || !prompt.trim(),
+                  onClick: () => {
+                    void sendPrompt();
+                  },
+                },
+                surface.busy ? "Sending..." : "Send",
+              ),
             ),
+          ),
+        ),
       ),
+      paletteOpen
+        ? createElement(ReactSessionCommandPalette, {
+            mode: "root",
+            query: paletteQuery,
+            title: "Session actions",
+            placeholder: "Search actions",
+            items: paletteItems,
+            activeIndex: Math.max(0, Math.min(paletteIndex, Math.max(0, paletteItems.length - 1))),
+            noMatchesLabel: "No matching actions",
+            backLabel: "Back",
+            closeLabel: "Close quick actions",
+            hintNavigateLabel: "Use arrows to navigate",
+            hintRunLabel: "Press Enter to run",
+            onClose: () => setPaletteOpen(false),
+            onBack: () => {},
+            onQueryChange: setPaletteQuery,
+            onHoverIndex: setPaletteIndex,
+          })
+        : null,
     ),
   );
 }

--- a/apps/app/src/app/session-v2/react-session-view-v2.tsx
+++ b/apps/app/src/app/session-v2/react-session-view-v2.tsx
@@ -73,6 +73,15 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
     ? searchHits[Math.max(0, Math.min(searchIndex, searchHits.length - 1))]
     : null;
 
+  const openSessionFromWorkspace = async (workspaceId: string, sessionId: string) => {
+    const wid = workspaceId.trim();
+    const sid = sessionId.trim();
+    if (!wid || !sid) return;
+    const ready = await Promise.resolve(surface.switchWorkspace(wid));
+    if (!ready) return;
+    surface.setView("session", sid);
+  };
+
   const paletteItems = useMemo(() => {
     const base = [
       {
@@ -101,7 +110,7 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
           meta: "session",
           action: () => {
             setPaletteOpen(false);
-            surface.setView("session", session.id);
+            void openSessionFromWorkspace(group.workspace.id, session.id);
           },
         })),
       ),
@@ -233,7 +242,9 @@ export default function ReactSessionViewV2(props: ReactSessionViewV2Props) {
             selectedSessionId: surface.selectedSessionId,
             sessionStatusById: surface.sessionStatusById,
             onSelectWorkspace: surface.selectWorkspace,
-            onOpenSession: (sessionId: string) => surface.setView("session", sessionId),
+            onOpenSession: (workspaceId: string, sessionId: string) => {
+              void openSessionFromWorkspace(workspaceId, sessionId);
+            },
           }),
         ),
         createElement(

--- a/apps/app/src/app/session-v2/react-session-workspace-list-v2.tsx
+++ b/apps/app/src/app/session-v2/react-session-workspace-list-v2.tsx
@@ -1,0 +1,89 @@
+import { createElement } from "react";
+
+import { DEFAULT_SESSION_TITLE, getDisplaySessionTitle } from "../lib/session-title";
+import type { WorkspaceSessionGroup } from "../types";
+
+type ReactSessionWorkspaceListV2Props = {
+  groups: WorkspaceSessionGroup[];
+  selectedWorkspaceId: string;
+  selectedSessionId: string | null;
+  sessionStatusById: Record<string, string>;
+  onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onOpenSession: (sessionId: string) => void;
+};
+
+const sessionTitle = (raw: string | null | undefined) =>
+  getDisplaySessionTitle(raw ?? "", DEFAULT_SESSION_TITLE);
+
+export default function ReactSessionWorkspaceListV2(
+  props: ReactSessionWorkspaceListV2Props,
+) {
+  return createElement(
+    "div",
+    { className: "min-h-0 flex-1 overflow-auto space-y-3" },
+    props.groups.map((group) => {
+      const workspace = group.workspace;
+      const isWorkspaceSelected = workspace.id === props.selectedWorkspaceId;
+      return createElement(
+        "section",
+        {
+          key: workspace.id,
+          className: "rounded-xl border border-dls-border bg-dls-surface/60 p-2",
+        },
+        createElement(
+          "button",
+          {
+            type: "button",
+            className: `mb-2 flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-left text-xs ${
+              isWorkspaceSelected
+                ? "bg-dls-active text-dls-text"
+                : "text-dls-secondary hover:bg-dls-hover hover:text-dls-text"
+            }`,
+            onClick: () => {
+              void props.onSelectWorkspace(workspace.id);
+            },
+          },
+          createElement(
+            "span",
+            { className: "truncate font-medium" },
+            workspace.displayName || workspace.name || workspace.id,
+          ),
+          createElement(
+            "span",
+            { className: "ml-2 rounded border border-dls-border px-1.5 py-0.5 text-[10px]" },
+            String(group.sessions.length),
+          ),
+        ),
+        createElement(
+          "div",
+          { className: "space-y-1" },
+          group.sessions.slice(0, 12).map((session) => {
+            const selected = props.selectedSessionId === session.id;
+            const status = props.sessionStatusById[session.id];
+            return createElement(
+              "button",
+              {
+                key: session.id,
+                type: "button",
+                className: `flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-[12px] ${
+                  selected
+                    ? "bg-dls-active text-dls-text"
+                    : "text-dls-secondary hover:bg-dls-hover hover:text-dls-text"
+                }`,
+                onClick: () => props.onOpenSession(session.id),
+              },
+              createElement("span", { className: "truncate" }, sessionTitle(session.title)),
+              status && status !== "idle"
+                ? createElement(
+                    "span",
+                    { className: "ml-2 rounded px-1.5 py-0.5 text-[10px] bg-dls-hover" },
+                    status,
+                  )
+                : null,
+            );
+          }),
+        ),
+      );
+    }),
+  );
+}

--- a/apps/app/src/app/session-v2/react-session-workspace-list-v2.tsx
+++ b/apps/app/src/app/session-v2/react-session-workspace-list-v2.tsx
@@ -9,7 +9,7 @@ type ReactSessionWorkspaceListV2Props = {
   selectedSessionId: string | null;
   sessionStatusById: Record<string, string>;
   onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
-  onOpenSession: (sessionId: string) => void;
+  onOpenSession: (workspaceId: string, sessionId: string) => void;
 };
 
 const sessionTitle = (raw: string | null | undefined) =>
@@ -70,7 +70,7 @@ export default function ReactSessionWorkspaceListV2(
                     ? "bg-dls-active text-dls-text"
                     : "text-dls-secondary hover:bg-dls-hover hover:text-dls-text"
                 }`,
-                onClick: () => props.onOpenSession(session.id),
+                onClick: () => props.onOpenSession(workspace.id, session.id),
               },
               createElement("span", { className: "truncate" }, sessionTitle(session.title)),
               status && status !== "idle"

--- a/apps/app/src/app/session/react-session-command-palette-host.tsx
+++ b/apps/app/src/app/session/react-session-command-palette-host.tsx
@@ -1,0 +1,49 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createEffect, onCleanup } from "solid-js";
+
+import ReactSessionCommandPalette, {
+  type ReactSessionCommandPaletteProps,
+} from "./react-session-command-palette";
+
+export default function ReactSessionCommandPaletteHost(
+  props: ReactSessionCommandPaletteProps,
+) {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  createEffect(() => {
+    const snapshot: ReactSessionCommandPaletteProps = {
+      mode: props.mode,
+      query: props.query,
+      title: props.title,
+      placeholder: props.placeholder,
+      items: props.items,
+      activeIndex: props.activeIndex,
+      noMatchesLabel: props.noMatchesLabel,
+      backLabel: props.backLabel,
+      closeLabel: props.closeLabel,
+      hintNavigateLabel: props.hintNavigateLabel,
+      hintRunLabel: props.hintRunLabel,
+      setInputRef: props.setInputRef,
+      setOptionRef: props.setOptionRef,
+      onClose: props.onClose,
+      onBack: props.onBack,
+      onQueryChange: props.onQueryChange,
+      onHoverIndex: props.onHoverIndex,
+    };
+
+    if (!container) return;
+    if (!root) {
+      root = createRoot(container);
+    }
+
+    root.render(createElement(ReactSessionCommandPalette, snapshot));
+  });
+
+  onCleanup(() => {
+    root?.unmount();
+  });
+
+  return <div ref={container} data-openwork-react-session-command-palette="" />;
+}

--- a/apps/app/src/app/session/react-session-command-palette-host.tsx
+++ b/apps/app/src/app/session/react-session-command-palette-host.tsx
@@ -42,7 +42,12 @@ export default function ReactSessionCommandPaletteHost(
   });
 
   onCleanup(() => {
-    root?.unmount();
+    const currentRoot = root;
+    root = undefined;
+    if (!currentRoot) return;
+    queueMicrotask(() => {
+      currentRoot.unmount();
+    });
   });
 
   return <div ref={container} data-openwork-react-session-command-palette="" />;

--- a/apps/app/src/app/session/react-session-command-palette.tsx
+++ b/apps/app/src/app/session/react-session-command-palette.tsx
@@ -1,0 +1,161 @@
+import { createElement } from "react";
+import { Search, X } from "lucide-react";
+
+export type ReactSessionCommandPaletteItem = {
+  id: string;
+  title: string;
+  detail?: string;
+  meta?: string;
+  action: () => void;
+};
+
+export type ReactSessionCommandPaletteProps = {
+  mode: string;
+  query: string;
+  title: string;
+  placeholder: string;
+  items: ReactSessionCommandPaletteItem[];
+  activeIndex: number;
+  noMatchesLabel: string;
+  backLabel: string;
+  closeLabel: string;
+  hintNavigateLabel: string;
+  hintRunLabel: string;
+  setInputRef?: (element: HTMLInputElement | null) => void;
+  setOptionRef?: (index: number, element: HTMLButtonElement | null) => void;
+  onClose: () => void;
+  onBack: () => void;
+  onQueryChange: (value: string) => void;
+  onHoverIndex: (index: number) => void;
+};
+
+export default function ReactSessionCommandPalette(
+  props: ReactSessionCommandPaletteProps,
+) {
+  return createElement(
+    "div",
+    {
+      className:
+        "fixed inset-0 z-50 bg-gray-1/60 backdrop-blur-sm flex items-start justify-center p-4 overflow-y-auto",
+      onClick: props.onClose,
+    },
+    createElement(
+      "div",
+      {
+        className:
+          "w-full max-w-2xl mt-12 rounded-2xl border border-dls-border bg-dls-surface shadow-2xl overflow-hidden",
+        onClick: (event: any) => event.stopPropagation(),
+      },
+      createElement(
+        "div",
+        { className: "border-b border-dls-border px-4 py-3 space-y-2" },
+        createElement(
+          "div",
+          { className: "flex items-center gap-2" },
+          props.mode !== "root"
+            ? createElement(
+                "button",
+                {
+                  type: "button",
+                  className:
+                    "h-8 px-2 rounded-md text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors",
+                  onClick: props.onBack,
+                },
+                props.backLabel,
+              )
+            : null,
+          createElement(Search, { size: 14, className: "text-dls-secondary shrink-0" }),
+          createElement("input", {
+            ref: props.setInputRef,
+            type: "text",
+            value: props.query,
+            onChange: (event: any) => props.onQueryChange(event.currentTarget.value),
+            placeholder: props.placeholder,
+            className:
+              "min-w-0 flex-1 bg-transparent text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none",
+            "aria-label": props.title,
+          }),
+          createElement(
+            "button",
+            {
+              type: "button",
+              className:
+                "h-8 w-8 flex items-center justify-center rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors",
+              onClick: props.onClose,
+              "aria-label": props.closeLabel,
+            },
+            createElement(X, { size: 14 }),
+          ),
+        ),
+        createElement("div", { className: "text-[11px] text-dls-secondary" }, props.title),
+      ),
+      createElement(
+        "div",
+        { className: "max-h-[56vh] overflow-y-auto p-2" },
+        props.items.length > 0
+          ? props.items.map((item, index) =>
+              createElement(
+                "button",
+                {
+                  key: item.id,
+                  ref: (element: HTMLButtonElement | null) =>
+                    props.setOptionRef?.(index, element),
+                  type: "button",
+                  className: `w-full text-left rounded-xl px-3 py-2.5 transition-colors ${
+                    index === props.activeIndex
+                      ? "bg-dls-active text-dls-text"
+                      : "text-dls-text hover:bg-dls-hover"
+                  }`,
+                  onMouseEnter: () => props.onHoverIndex(index),
+                  onClick: item.action,
+                },
+                createElement(
+                  "div",
+                  { className: "flex items-start justify-between gap-3" },
+                  createElement(
+                    "div",
+                    { className: "min-w-0" },
+                    createElement(
+                      "div",
+                      { className: "text-sm font-medium truncate" },
+                      item.title,
+                    ),
+                    item.detail
+                      ? createElement(
+                          "div",
+                          { className: "text-xs text-dls-secondary mt-1 truncate" },
+                          item.detail,
+                        )
+                      : null,
+                  ),
+                  item.meta
+                    ? createElement(
+                        "span",
+                        {
+                          className:
+                            "text-[10px] uppercase tracking-wide text-dls-secondary shrink-0",
+                        },
+                        item.meta,
+                      )
+                    : null,
+                ),
+              ),
+            )
+          : createElement(
+              "div",
+              { className: "px-3 py-6 text-sm text-dls-secondary text-center" },
+              props.noMatchesLabel,
+            ),
+      ),
+      createElement(
+        "div",
+        {
+          className:
+            "border-t border-dls-border px-3 py-2 text-[11px] text-dls-secondary flex items-center justify-between gap-2",
+        },
+        createElement("span", null, props.hintNavigateLabel),
+        createElement("span", null, props.hintRunLabel),
+      ),
+    ),
+  );
+}

--- a/apps/app/src/app/session/react-session-header-host.tsx
+++ b/apps/app/src/app/session/react-session-header-host.tsx
@@ -35,7 +35,12 @@ export default function ReactSessionHeaderHost(props: ReactSessionHeaderProps) {
   });
 
   onCleanup(() => {
-    root?.unmount();
+    const currentRoot = root;
+    root = undefined;
+    if (!currentRoot) return;
+    queueMicrotask(() => {
+      currentRoot.unmount();
+    });
   });
 
   return <div ref={container} data-openwork-react-session-header="" />;

--- a/apps/app/src/app/session/react-session-header-host.tsx
+++ b/apps/app/src/app/session/react-session-header-host.tsx
@@ -1,0 +1,27 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createEffect, onCleanup } from "solid-js";
+
+import ReactSessionHeader, {
+  type ReactSessionHeaderProps,
+} from "./react-session-header";
+
+export default function ReactSessionHeaderHost(props: ReactSessionHeaderProps) {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  createEffect(() => {
+    if (!container) return;
+    if (!root) {
+      root = createRoot(container);
+    }
+
+    root.render(createElement(ReactSessionHeader, props));
+  });
+
+  onCleanup(() => {
+    root?.unmount();
+  });
+
+  return <div ref={container} data-openwork-react-session-header="" />;
+}

--- a/apps/app/src/app/session/react-session-header-host.tsx
+++ b/apps/app/src/app/session/react-session-header-host.tsx
@@ -11,12 +11,27 @@ export default function ReactSessionHeaderHost(props: ReactSessionHeaderProps) {
   let root: Root | undefined;
 
   createEffect(() => {
+    const snapshot: ReactSessionHeaderProps = {
+      title: props.title,
+      workspaceLabel: props.workspaceLabel,
+      developerMode: props.developerMode,
+      headerStatus: props.headerStatus,
+      busyHint: props.busyHint,
+      showUpdatePill: props.showUpdatePill,
+      updatePillLabel: props.updatePillLabel,
+      updatePillTitle: props.updatePillTitle,
+      updateVersion: props.updateVersion,
+      onUpdatePillClick: props.onUpdatePillClick,
+      onOpenSettings: props.onOpenSettings,
+      renderActions: props.renderActions,
+    };
+
     if (!container) return;
     if (!root) {
       root = createRoot(container);
     }
 
-    root.render(createElement(ReactSessionHeader, props));
+    root.render(createElement(ReactSessionHeader, snapshot));
   });
 
   onCleanup(() => {

--- a/apps/app/src/app/session/react-session-header.ts
+++ b/apps/app/src/app/session/react-session-header.ts
@@ -1,0 +1,105 @@
+import { Fragment, createElement } from "react";
+
+import { SolidSlot } from "../shell/solid-slot";
+
+export type ReactSessionHeaderProps = {
+  title: string;
+  workspaceLabel: string;
+  developerMode: boolean;
+  headerStatus: string;
+  busyHint: string | null;
+  showUpdatePill: boolean;
+  updatePillLabel: string;
+  updatePillTitle: string;
+  updateVersion?: string | null;
+  onUpdatePillClick: () => void;
+  onOpenSettings: () => void;
+  renderActions: () => any;
+};
+
+export default function ReactSessionHeader(props: ReactSessionHeaderProps) {
+  const updatePill = props.showUpdatePill
+    ? createElement(
+        "button",
+        {
+          type: "button",
+          className:
+            "md:hidden flex items-center gap-1.5 rounded-full border border-dls-border bg-dls-surface px-2.5 py-1 text-xs font-medium shadow-sm transition-colors",
+          onClick: props.onUpdatePillClick,
+          title: props.updatePillTitle,
+          "aria-label": props.updatePillTitle,
+        },
+        createElement("span", { className: "text-[11px]" }, props.updatePillLabel),
+        props.updateVersion
+          ? createElement(
+              "span",
+              {
+                className: "hidden sm:inline font-mono text-[10px] text-dls-secondary",
+              },
+              `v${props.updateVersion}`,
+            )
+          : null,
+      )
+    : null;
+
+  return createElement(
+    Fragment,
+    null,
+    createElement(
+      "header",
+      {
+        className:
+          "z-10 flex h-12 shrink-0 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6",
+      },
+      createElement(
+        "div",
+        { className: "flex min-w-0 items-center gap-3" },
+        updatePill,
+        createElement(
+          "h1",
+          { className: "truncate text-[15px] font-semibold text-dls-text" },
+          props.title,
+        ),
+        createElement(
+          "span",
+          { className: "hidden truncate text-[13px] text-dls-secondary lg:inline" },
+          props.workspaceLabel,
+        ),
+        props.developerMode
+          ? createElement(
+              "span",
+              { className: "hidden text-[12px] text-dls-secondary lg:inline" },
+              props.headerStatus,
+            )
+          : null,
+        props.busyHint
+          ? createElement(
+              "span",
+              { className: "hidden text-[12px] text-dls-secondary lg:inline" },
+              props.busyHint,
+            )
+          : null,
+      ),
+      createElement(
+        "div",
+        { className: "flex items-center gap-1.5 text-gray-10" },
+        createElement(SolidSlot, {
+          slotId: "session-header-actions-slot",
+          renderContent: props.renderActions,
+        }),
+        createElement(
+          "button",
+          {
+            type: "button",
+            className:
+              "flex h-9 items-center justify-center rounded-md px-3 text-sm text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text",
+            onClick: props.onOpenSettings,
+            title: "Open settings",
+            "aria-label": "Open settings",
+          },
+          "Settings",
+        ),
+      ),
+    ),
+  );
+}

--- a/apps/app/src/app/session/react-session-search-panel-host.tsx
+++ b/apps/app/src/app/session/react-session-search-panel-host.tsx
@@ -1,0 +1,43 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createEffect, onCleanup } from "solid-js";
+
+import ReactSessionSearchPanel, {
+  type ReactSessionSearchPanelProps,
+} from "./react-session-search-panel";
+
+export default function ReactSessionSearchPanelHost(props: ReactSessionSearchPanelProps) {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  createEffect(() => {
+    const snapshot: ReactSessionSearchPanelProps = {
+      query: props.query,
+      positionLabel: props.positionLabel,
+      hasHits: props.hasHits,
+      placeholder: props.placeholder,
+      prevLabel: props.prevLabel,
+      nextLabel: props.nextLabel,
+      closeLabel: props.closeLabel,
+      setInputRef: props.setInputRef,
+      onQueryChange: props.onQueryChange,
+      onMovePrev: props.onMovePrev,
+      onMoveNext: props.onMoveNext,
+      onClose: props.onClose,
+      onSubmitStep: props.onSubmitStep,
+    };
+
+    if (!container) return;
+    if (!root) {
+      root = createRoot(container);
+    }
+
+    root.render(createElement(ReactSessionSearchPanel, snapshot));
+  });
+
+  onCleanup(() => {
+    root?.unmount();
+  });
+
+  return <div ref={container} data-openwork-react-session-search="" />;
+}

--- a/apps/app/src/app/session/react-session-search-panel-host.tsx
+++ b/apps/app/src/app/session/react-session-search-panel-host.tsx
@@ -36,7 +36,12 @@ export default function ReactSessionSearchPanelHost(props: ReactSessionSearchPan
   });
 
   onCleanup(() => {
-    root?.unmount();
+    const currentRoot = root;
+    root = undefined;
+    if (!currentRoot) return;
+    queueMicrotask(() => {
+      currentRoot.unmount();
+    });
   });
 
   return <div ref={container} data-openwork-react-session-search="" />;

--- a/apps/app/src/app/session/react-session-search-panel.tsx
+++ b/apps/app/src/app/session/react-session-search-panel.tsx
@@ -1,0 +1,94 @@
+import { createElement } from "react";
+import { Search, X } from "lucide-react";
+
+export type ReactSessionSearchPanelProps = {
+  query: string;
+  positionLabel: string;
+  hasHits: boolean;
+  placeholder: string;
+  prevLabel: string;
+  nextLabel: string;
+  closeLabel: string;
+  setInputRef?: (element: HTMLInputElement | null) => void;
+  onQueryChange: (value: string) => void;
+  onMovePrev: () => void;
+  onMoveNext: () => void;
+  onClose: () => void;
+  onSubmitStep: (direction: -1 | 1) => void;
+};
+
+export default function ReactSessionSearchPanel(props: ReactSessionSearchPanelProps) {
+  return createElement(
+    "div",
+    { className: "border-b border-dls-border bg-dls-sidebar/70 px-4 py-2 md:px-6" },
+    createElement(
+      "div",
+      {
+        className:
+          "mx-auto flex w-full max-w-[800px] items-center gap-2 rounded-[16px] border border-dls-border bg-dls-surface px-3 py-2 shadow-[var(--dls-card-shadow)]",
+      },
+      createElement(Search, { size: 14, className: "text-gray-9" }),
+      createElement("input", {
+        ref: props.setInputRef,
+        type: "text",
+        value: props.query,
+        onChange: (event: any) => props.onQueryChange(event.currentTarget.value),
+        onKeyDown: (event: any) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            props.onSubmitStep(event.shiftKey ? -1 : 1);
+            return;
+          }
+          if (event.key === "Escape") {
+            event.preventDefault();
+            props.onClose();
+          }
+        },
+        className:
+          "min-w-0 flex-1 bg-transparent text-sm text-gray-11 placeholder:text-gray-9 focus:outline-none",
+        placeholder: props.placeholder,
+        "aria-label": props.placeholder,
+      }),
+      createElement(
+        "span",
+        { className: "text-[11px] text-gray-10 tabular-nums" },
+        props.positionLabel,
+      ),
+      createElement(
+        "button",
+        {
+          type: "button",
+          className:
+            "rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60",
+          disabled: !props.hasHits,
+          onClick: props.onMovePrev,
+          "aria-label": props.prevLabel,
+        },
+        props.prevLabel,
+      ),
+      createElement(
+        "button",
+        {
+          type: "button",
+          className:
+            "rounded-md border border-dls-border px-2 py-1 text-[11px] text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12 disabled:opacity-60",
+          disabled: !props.hasHits,
+          onClick: props.onMoveNext,
+          "aria-label": props.nextLabel,
+        },
+        props.nextLabel,
+      ),
+      createElement(
+        "button",
+        {
+          type: "button",
+          className:
+            "flex h-7 w-7 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2 hover:text-gray-12",
+          onClick: props.onClose,
+          "aria-label": props.closeLabel,
+        },
+        createElement(X, { size: 14 }),
+      ),
+    ),
+  );
+}

--- a/apps/app/src/app/session/react-session-sidebar-shell-host.tsx
+++ b/apps/app/src/app/session/react-session-sidebar-shell-host.tsx
@@ -1,0 +1,29 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createEffect, onCleanup } from "solid-js";
+
+import ReactSessionSidebarShell, {
+  type ReactSessionSidebarShellProps,
+} from "./react-session-sidebar-shell";
+
+export default function ReactSessionSidebarShellHost(
+  props: ReactSessionSidebarShellProps,
+) {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  createEffect(() => {
+    if (!container) return;
+    if (!root) {
+      root = createRoot(container);
+    }
+
+    root.render(createElement(ReactSessionSidebarShell, props));
+  });
+
+  onCleanup(() => {
+    root?.unmount();
+  });
+
+  return <div ref={container} data-openwork-react-session-sidebar="" />;
+}

--- a/apps/app/src/app/session/react-session-sidebar-shell-host.tsx
+++ b/apps/app/src/app/session/react-session-sidebar-shell-host.tsx
@@ -13,12 +13,23 @@ export default function ReactSessionSidebarShellHost(
   let root: Root | undefined;
 
   createEffect(() => {
+    const snapshot: ReactSessionSidebarShellProps = {
+      leftSidebarWidth: props.leftSidebarWidth,
+      showUpdatePill: props.showUpdatePill,
+      updatePillLabel: props.updatePillLabel,
+      updatePillTitle: props.updatePillTitle,
+      updateVersion: props.updateVersion,
+      onUpdatePillClick: props.onUpdatePillClick,
+      onStartResize: props.onStartResize,
+      renderSidebar: props.renderSidebar,
+    };
+
     if (!container) return;
     if (!root) {
       root = createRoot(container);
     }
 
-    root.render(createElement(ReactSessionSidebarShell, props));
+    root.render(createElement(ReactSessionSidebarShell, snapshot));
   });
 
   onCleanup(() => {

--- a/apps/app/src/app/session/react-session-sidebar-shell-host.tsx
+++ b/apps/app/src/app/session/react-session-sidebar-shell-host.tsx
@@ -33,7 +33,12 @@ export default function ReactSessionSidebarShellHost(
   });
 
   onCleanup(() => {
-    root?.unmount();
+    const currentRoot = root;
+    root = undefined;
+    if (!currentRoot) return;
+    queueMicrotask(() => {
+      currentRoot.unmount();
+    });
   });
 
   return <div ref={container} data-openwork-react-session-sidebar="" />;

--- a/apps/app/src/app/session/react-session-sidebar-shell.ts
+++ b/apps/app/src/app/session/react-session-sidebar-shell.ts
@@ -1,8 +1,6 @@
 import { Fragment, createElement } from "react";
 
-import ReactWorkspaceSessionList, {
-  type ReactWorkspaceSessionListProps,
-} from "./react-workspace-session-list";
+import { SolidSlot } from "../shell/solid-slot";
 
 export type ReactSessionSidebarShellProps = {
   leftSidebarWidth: number;
@@ -12,7 +10,7 @@ export type ReactSessionSidebarShellProps = {
   updateVersion?: string | null;
   onUpdatePillClick: () => void;
   onStartResize: (event: any) => void;
-  sidebarProps: ReactWorkspaceSessionListProps;
+  renderSidebar: () => any;
 };
 
 export default function ReactSessionSidebarShell(
@@ -25,7 +23,7 @@ export default function ReactSessionSidebarShell(
       "aside",
       {
         className:
-          "relative hidden lg:flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5",
+          "relative hidden md:flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5",
         style: {
           width: `${props.leftSidebarWidth}px`,
           minWidth: `${props.leftSidebarWidth}px`,
@@ -66,11 +64,14 @@ export default function ReactSessionSidebarShell(
       createElement(
         "div",
         { className: "flex min-h-0 flex-1" },
-        createElement(ReactWorkspaceSessionList, props.sidebarProps),
+        createElement(SolidSlot, {
+          slotId: "session-sidebar-shell-slot",
+          renderContent: props.renderSidebar,
+        }),
       ),
       createElement("div", {
         className:
-          "absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 lg:block",
+          "absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 md:block",
         onPointerDown: props.onStartResize as any,
         title: "Resize workspace column",
         "aria-label": "Resize workspace column",

--- a/apps/app/src/app/session/react-session-sidebar-shell.ts
+++ b/apps/app/src/app/session/react-session-sidebar-shell.ts
@@ -1,6 +1,8 @@
 import { Fragment, createElement } from "react";
 
-import { SolidSlot } from "../shell/solid-slot";
+import ReactWorkspaceSessionList, {
+  type ReactWorkspaceSessionListProps,
+} from "./react-workspace-session-list";
 
 export type ReactSessionSidebarShellProps = {
   leftSidebarWidth: number;
@@ -10,7 +12,7 @@ export type ReactSessionSidebarShellProps = {
   updateVersion?: string | null;
   onUpdatePillClick: () => void;
   onStartResize: (event: any) => void;
-  renderSidebar: () => any;
+  sidebarProps: ReactWorkspaceSessionListProps;
 };
 
 export default function ReactSessionSidebarShell(
@@ -64,10 +66,7 @@ export default function ReactSessionSidebarShell(
       createElement(
         "div",
         { className: "flex min-h-0 flex-1" },
-        createElement(SolidSlot, {
-          slotId: "session-sidebar-shell-slot",
-          renderContent: props.renderSidebar,
-        }),
+        createElement(ReactWorkspaceSessionList, props.sidebarProps),
       ),
       createElement("div", {
         className:

--- a/apps/app/src/app/session/react-session-sidebar-shell.ts
+++ b/apps/app/src/app/session/react-session-sidebar-shell.ts
@@ -1,0 +1,81 @@
+import { Fragment, createElement } from "react";
+
+import { SolidSlot } from "../shell/solid-slot";
+
+export type ReactSessionSidebarShellProps = {
+  leftSidebarWidth: number;
+  showUpdatePill: boolean;
+  updatePillLabel: string;
+  updatePillTitle: string;
+  updateVersion?: string | null;
+  onUpdatePillClick: () => void;
+  onStartResize: (event: any) => void;
+  renderSidebar: () => any;
+};
+
+export default function ReactSessionSidebarShell(
+  props: ReactSessionSidebarShellProps,
+) {
+  return createElement(
+    Fragment,
+    null,
+    createElement(
+      "aside",
+      {
+        className:
+          "relative hidden lg:flex shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5",
+        style: {
+          width: `${props.leftSidebarWidth}px`,
+          minWidth: `${props.leftSidebarWidth}px`,
+        },
+      },
+      createElement(
+        "div",
+        { className: "shrink-0" },
+        props.showUpdatePill
+          ? createElement(
+              "button",
+              {
+                type: "button",
+                className:
+                  "group relative mb-3 flex w-full items-center gap-1.5 rounded-xl border border-dls-border px-3.5 py-2 text-xs font-medium transition-colors",
+                onClick: props.onUpdatePillClick,
+                title: props.updatePillTitle,
+                "aria-label": props.updatePillTitle,
+              },
+              createElement(
+                "span",
+                { className: "min-w-0 flex-1 truncate whitespace-nowrap text-left" },
+                props.updatePillLabel,
+              ),
+              props.updateVersion
+                ? createElement(
+                    "span",
+                    {
+                      className:
+                        "ml-auto shrink-0 font-mono text-[10px] text-dls-secondary",
+                    },
+                    `v${props.updateVersion}`,
+                  )
+                : null,
+            )
+          : null,
+      ),
+      createElement(
+        "div",
+        { className: "flex min-h-0 flex-1" },
+        createElement(SolidSlot, {
+          slotId: "session-sidebar-shell-slot",
+          renderContent: props.renderSidebar,
+        }),
+      ),
+      createElement("div", {
+        className:
+          "absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 lg:block",
+        onPointerDown: props.onStartResize as any,
+        title: "Resize workspace column",
+        "aria-label": "Resize workspace column",
+      }),
+    ),
+  );
+}

--- a/apps/app/src/app/session/react-session-todo-panel-host.tsx
+++ b/apps/app/src/app/session/react-session-todo-panel-host.tsx
@@ -27,7 +27,12 @@ export default function ReactSessionTodoPanelHost(props: ReactSessionTodoPanelPr
   });
 
   onCleanup(() => {
-    root?.unmount();
+    const currentRoot = root;
+    root = undefined;
+    if (!currentRoot) return;
+    queueMicrotask(() => {
+      currentRoot.unmount();
+    });
   });
 
   return <div ref={container} data-openwork-react-session-todos="" />;

--- a/apps/app/src/app/session/react-session-todo-panel-host.tsx
+++ b/apps/app/src/app/session/react-session-todo-panel-host.tsx
@@ -1,0 +1,34 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createEffect, onCleanup } from "solid-js";
+
+import ReactSessionTodoPanel, {
+  type ReactSessionTodoPanelProps,
+} from "./react-session-todo-panel";
+
+export default function ReactSessionTodoPanelHost(props: ReactSessionTodoPanelProps) {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  createEffect(() => {
+    const snapshot: ReactSessionTodoPanelProps = {
+      items: props.items,
+      expanded: props.expanded,
+      label: props.label,
+      onToggleExpanded: props.onToggleExpanded,
+    };
+
+    if (!container) return;
+    if (!root) {
+      root = createRoot(container);
+    }
+
+    root.render(createElement(ReactSessionTodoPanel, snapshot));
+  });
+
+  onCleanup(() => {
+    root?.unmount();
+  });
+
+  return <div ref={container} data-openwork-react-session-todos="" />;
+}

--- a/apps/app/src/app/session/react-session-todo-panel.tsx
+++ b/apps/app/src/app/session/react-session-todo-panel.tsx
@@ -1,0 +1,96 @@
+import { createElement } from "react";
+import { Check, ListTodo, Minimize2 } from "lucide-react";
+
+import type { TodoItem } from "../types";
+
+export type ReactSessionTodoPanelProps = {
+  items: TodoItem[];
+  expanded: boolean;
+  label: string;
+  onToggleExpanded: () => void;
+};
+
+export default function ReactSessionTodoPanel(props: ReactSessionTodoPanelProps) {
+  return createElement(
+    "div",
+    { className: "mx-auto w-full max-w-[800px] px-4" },
+    createElement(
+      "div",
+      {
+        className:
+          "rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]",
+      },
+      createElement(
+        "button",
+        {
+          type: "button",
+          className:
+            "flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50",
+          onClick: props.onToggleExpanded,
+        },
+        createElement(
+          "div",
+          { className: "flex items-center gap-2" },
+          createElement(ListTodo, { size: 14, className: "text-gray-8" }),
+          createElement("span", { className: "text-gray-11 font-medium" }, props.label),
+        ),
+        createElement(Minimize2, {
+          size: 12,
+          className: `text-gray-8 transition-transform ${props.expanded ? "" : "rotate-180"}`,
+        }),
+      ),
+      props.expanded
+        ? createElement(
+            "div",
+            {
+              className:
+                "max-h-60 overflow-auto border-t border-dls-border px-4 pb-3 space-y-2.5",
+            },
+            props.items.map((todo, index) => {
+              const done = todo.status === "completed";
+              const cancelled = todo.status === "cancelled";
+              const active = todo.status === "in_progress";
+              return createElement(
+                "div",
+                { key: todo.id, className: "flex items-start gap-2.5 pt-2.5 first:pt-2.5" },
+                createElement(
+                  "div",
+                  { className: "flex items-center gap-1.5 pt-0.5" },
+                  createElement(
+                    "div",
+                    {
+                      className: `h-4.5 w-4.5 rounded-full border flex items-center justify-center ${
+                        done
+                          ? "border-green-6 bg-green-2 text-green-11"
+                          : active
+                            ? "border-amber-6 bg-amber-2 text-amber-11"
+                            : cancelled
+                              ? "border-gray-6 bg-gray-2 text-gray-8"
+                              : "border-gray-6 bg-gray-1 text-gray-8"
+                      }`,
+                    },
+                    done ? createElement(Check, { size: 10 }) : null,
+                    !done && active
+                      ? createElement("span", {
+                          className: "h-1.5 w-1.5 rounded-full bg-amber-9",
+                        })
+                      : null,
+                  ),
+                ),
+                createElement(
+                  "div",
+                  {
+                    className: `flex-1 text-sm leading-relaxed ${
+                      cancelled ? "text-gray-9 line-through" : "text-gray-12"
+                    }`,
+                  },
+                  createElement("span", { className: "text-gray-9 mr-1.5" }, `${index + 1}.`),
+                  todo.content,
+                ),
+              );
+            }),
+          )
+        : null,
+    ),
+  );
+}

--- a/apps/app/src/app/session/react-workspace-session-list.tsx
+++ b/apps/app/src/app/session/react-workspace-session-list.tsx
@@ -1,0 +1,808 @@
+/** @jsxImportSource react */
+import {
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  MoreHorizontal,
+  Plus,
+} from "lucide-react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import { t } from "../../i18n";
+import { DEFAULT_SESSION_TITLE, getDisplaySessionTitle } from "../lib/session-title";
+import type { WorkspaceInfo } from "../lib/tauri";
+import type {
+  WorkspaceConnectionState,
+  WorkspaceSessionGroup,
+} from "../types";
+import {
+  getWorkspaceTaskLoadErrorDisplay,
+  isWindowsPlatform,
+} from "../utils";
+
+export type ReactWorkspaceSessionListProps = {
+  workspaceSessionGroups: WorkspaceSessionGroup[];
+  selectedWorkspaceId: string;
+  developerMode: boolean;
+  selectedSessionId: string | null;
+  showSessionActions?: boolean;
+  sessionStatusById?: Record<string, string>;
+  connectingWorkspaceId: string | null;
+  workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
+  newTaskDisabled: boolean;
+  onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onOpenSession: (workspaceId: string, sessionId: string) => void;
+  onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
+  onCreateTaskInWorkspace: (workspaceId: string) => void;
+  onOpenRenameSession?: () => void;
+  onOpenDeleteSession?: () => void;
+  onOpenRenameWorkspace: (workspaceId: string) => void;
+  onShareWorkspace: (workspaceId: string) => void;
+  onRevealWorkspace: (workspaceId: string) => void;
+  onRecoverWorkspace: (
+    workspaceId: string,
+  ) => Promise<boolean> | boolean | void;
+  onTestWorkspaceConnection: (
+    workspaceId: string,
+  ) => Promise<boolean> | boolean | void;
+  onEditWorkspaceConnection: (workspaceId: string) => void;
+  onForgetWorkspace: (workspaceId: string) => void;
+  onOpenCreateWorkspace: () => void;
+};
+
+const MAX_SESSIONS_PREVIEW = 6;
+const WORKSPACE_SWATCHES = ["#2563eb", "#5a67d8", "#f97316", "#10b981"];
+
+type SessionListItem = WorkspaceSessionGroup["sessions"][number];
+type FlattenedSessionRow = { session: SessionListItem; depth: number };
+type SessionTreeState = {
+  childrenByParent: Map<string, SessionListItem[]>;
+  ancestorIdsBySessionId: Map<string, string[]>;
+  descendantCountBySessionId: Map<string, number>;
+  activeIds: Set<string>;
+};
+
+const normalizeSessionParentID = (session: SessionListItem) => {
+  const parentID = session.parentID?.trim();
+  return parentID || "";
+};
+
+const getRootSessions = (sessions: WorkspaceSessionGroup["sessions"]) => {
+  const byID = new Set(sessions.map((session) => session.id));
+  return sessions.filter((session) => {
+    const parentID = normalizeSessionParentID(session);
+    return !parentID || !byID.has(parentID);
+  });
+};
+
+const buildSessionTreeState = (
+  sessions: WorkspaceSessionGroup["sessions"],
+  sessionStatusById: Record<string, string> | undefined,
+): SessionTreeState => {
+  const childrenByParent = new Map<string, SessionListItem[]>();
+  const ancestorIdsBySessionId = new Map<string, string[]>();
+  const descendantCountBySessionId = new Map<string, number>();
+  const activeIds = new Set<string>();
+  const sessionIds = new Set(sessions.map((session) => session.id));
+
+  sessions.forEach((session) => {
+    const parentID = normalizeSessionParentID(session);
+    if (!parentID || !sessionIds.has(parentID)) return;
+    const siblings = childrenByParent.get(parentID) ?? [];
+    siblings.push(session);
+    childrenByParent.set(parentID, siblings);
+  });
+
+  const walk = (session: SessionListItem, ancestors: string[]) => {
+    ancestorIdsBySessionId.set(session.id, ancestors);
+    const children = childrenByParent.get(session.id) ?? [];
+    let descendantCount = 0;
+    let subtreeActive = (sessionStatusById?.[session.id] ?? "idle") !== "idle";
+
+    children.forEach((child) => {
+      const childState = walk(child, [...ancestors, session.id]);
+      descendantCount += 1 + childState.descendantCount;
+      subtreeActive = subtreeActive || childState.subtreeActive;
+    });
+
+    descendantCountBySessionId.set(session.id, descendantCount);
+    if (subtreeActive) activeIds.add(session.id);
+    return { descendantCount, subtreeActive };
+  };
+
+  getRootSessions(sessions).forEach((session) => {
+    walk(session, []);
+  });
+
+  return {
+    childrenByParent,
+    ancestorIdsBySessionId,
+    descendantCountBySessionId,
+    activeIds,
+  };
+};
+
+const flattenSessionRows = (
+  sessions: WorkspaceSessionGroup["sessions"],
+  rootLimit: number,
+  tree: SessionTreeState,
+  expandedSessionIds: Set<string>,
+  forcedExpandedSessionIds: Set<string>,
+) => {
+  const roots = getRootSessions(sessions).slice(0, rootLimit);
+  const rows: FlattenedSessionRow[] = [];
+  const visited = new Set<string>();
+
+  const walk = (session: SessionListItem, depth: number) => {
+    if (visited.has(session.id)) return;
+    visited.add(session.id);
+    rows.push({ session, depth });
+    const children = tree.childrenByParent.get(session.id) ?? [];
+    if (!children.length) return;
+    const expanded =
+      expandedSessionIds.has(session.id) || forcedExpandedSessionIds.has(session.id);
+    if (!expanded) return;
+    children.forEach((child) => walk(child, depth + 1));
+  };
+
+  roots.forEach((root) => walk(root, 0));
+  return rows;
+};
+
+const workspaceLabel = (workspace: WorkspaceInfo) =>
+  workspace.displayName?.trim() ||
+  workspace.openworkWorkspaceName?.trim() ||
+  workspace.name?.trim() ||
+  workspace.path?.trim() ||
+  t("workspace_list.workspace_fallback");
+
+const workspaceKindLabel = (workspace: WorkspaceInfo) =>
+  workspace.workspaceType === "remote"
+    ? workspace.sandboxBackend === "docker" ||
+      Boolean(workspace.sandboxRunId?.trim()) ||
+      Boolean(workspace.sandboxContainerName?.trim())
+      ? t("workspace.sandbox_badge")
+      : t("workspace.remote_badge")
+    : t("workspace.local_badge");
+
+const workspaceSwatchColor = (seed: string) => {
+  const value = seed.trim() || "workspace";
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return WORKSPACE_SWATCHES[Math.abs(hash) % WORKSPACE_SWATCHES.length];
+};
+
+export default function ReactWorkspaceSessionList(
+  props: ReactWorkspaceSessionListProps,
+) {
+  const revealLabel = isWindowsPlatform()
+    ? t("workspace_list.reveal_explorer")
+    : t("workspace_list.reveal_finder");
+
+  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = useState<
+    Record<string, number>
+  >({});
+  const [workspaceMenuId, setWorkspaceMenuId] = useState<string | null>(null);
+  const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
+  const [expandedSessionIds, setExpandedSessionIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const workspaceMenuRef = useRef<HTMLDivElement | null>(null);
+  const sessionMenuRef = useRef<HTMLDivElement | null>(null);
+
+  const isWorkspaceExpanded = (workspaceId: string) =>
+    expandedWorkspaceIds.has(workspaceId);
+
+  const expandWorkspace = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((prev) => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  };
+
+  const toggleWorkspaceExpanded = (workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    expandWorkspace(props.selectedWorkspaceId);
+  }, [props.selectedWorkspaceId]);
+
+  useEffect(() => {
+    if (!workspaceMenuId) return;
+    const closeMenu = (event: PointerEvent) => {
+      if (!workspaceMenuRef.current) return;
+      const target = event.target as Node | null;
+      if (target && workspaceMenuRef.current.contains(target)) return;
+      setWorkspaceMenuId(null);
+    };
+    window.addEventListener("pointerdown", closeMenu);
+    return () => window.removeEventListener("pointerdown", closeMenu);
+  }, [workspaceMenuId]);
+
+  useEffect(() => {
+    setSessionMenuOpen(false);
+  }, [props.selectedSessionId]);
+
+  useEffect(() => {
+    const workspaceId = props.selectedWorkspaceId.trim();
+    if (!workspaceId) return;
+
+    const group = props.workspaceSessionGroups.find(
+      (entry) => entry.workspace.id === workspaceId,
+    );
+    if (!group?.sessions.length) return;
+
+    const selectedId = props.selectedSessionId?.trim() ?? "";
+    const selectedIndex = selectedId
+      ? group.sessions.findIndex((session) => session.id === selectedId)
+      : -1;
+    const start = selectedIndex >= 0 ? Math.max(0, selectedIndex - 2) : 0;
+    const end =
+      selectedIndex >= 0
+        ? Math.min(group.sessions.length, selectedIndex + 3)
+        : Math.min(group.sessions.length, 4);
+
+    group.sessions.slice(start, end).forEach((session) => {
+      props.onPrefetchSession?.(workspaceId, session.id);
+    });
+  }, [
+    props.workspaceSessionGroups,
+    props.selectedWorkspaceId,
+    props.selectedSessionId,
+    props.onPrefetchSession,
+  ]);
+
+  useEffect(() => {
+    if (!sessionMenuOpen) return;
+    const closeMenu = (event: PointerEvent) => {
+      if (!sessionMenuRef.current) return;
+      const target = event.target as Node | null;
+      if (target && sessionMenuRef.current.contains(target)) return;
+      setSessionMenuOpen(false);
+    };
+    window.addEventListener("pointerdown", closeMenu);
+    return () => window.removeEventListener("pointerdown", closeMenu);
+  }, [sessionMenuOpen]);
+
+  const previewCount = (workspaceId: string) =>
+    previewCountByWorkspaceId[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+
+  const toggleSessionExpanded = (sessionId: string) => {
+    const id = sessionId.trim();
+    if (!id) return;
+    setExpandedSessionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const showMoreSessions = (workspaceId: string, totalRoots: number) => {
+    expandWorkspace(workspaceId);
+    setPreviewCountByWorkspaceId((current) => {
+      const next = { ...current };
+      const existing = next[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+      next[workspaceId] = Math.min(existing + MAX_SESSIONS_PREVIEW, totalRoots);
+      return next;
+    });
+  };
+
+  const showMoreLabel = (workspaceId: string, totalRoots: number) => {
+    const remaining = Math.max(0, totalRoots - previewCount(workspaceId));
+    const nextCount = Math.min(MAX_SESSIONS_PREVIEW, remaining);
+    return nextCount > 0
+      ? t("workspace_list.show_more", undefined, { count: nextCount })
+      : t("workspace_list.show_more_fallback");
+  };
+
+  const renderSessionRow = (
+    workspaceId: string,
+    row: FlattenedSessionRow,
+    tree: SessionTreeState,
+    forcedExpandedSessionIds: Set<string>,
+  ) => {
+    const session = row.session;
+    const depth = row.depth;
+    const isSelected = props.selectedSessionId === session.id;
+    const displayTitle = getDisplaySessionTitle(
+      session.title,
+      DEFAULT_SESSION_TITLE,
+    );
+    const descendantCount =
+      tree.descendantCountBySessionId.get(session.id) ?? 0;
+    const hasChildren = descendantCount > 0;
+    const isExpanded =
+      expandedSessionIds.has(session.id) ||
+      forcedExpandedSessionIds.has(session.id);
+    const isSessionActive = tree.activeIds.has(session.id);
+    const canManageSession = Boolean(
+      props.showSessionActions &&
+        isSelected &&
+        (props.onOpenRenameSession || props.onOpenDeleteSession),
+    );
+
+    const openSession = () => {
+      setSessionMenuOpen(false);
+      props.onOpenSession(workspaceId, session.id);
+    };
+
+    const prefetchSession = () => {
+      if (workspaceId !== props.selectedWorkspaceId) return;
+      props.onPrefetchSession?.(workspaceId, session.id);
+    };
+
+    const onRowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      if ((event.nativeEvent as any).isComposing) return;
+      event.preventDefault();
+      openSession();
+    };
+
+    return (
+      <div className="relative" key={session.id}>
+        <div
+          role="button"
+          tabIndex={0}
+          className={`group flex min-h-9 w-full items-center justify-between rounded-xl px-3 py-1.5 text-left text-[13px] transition-colors ${
+            isSelected
+              ? "bg-gray-3 text-gray-12"
+              : "text-gray-10 hover:bg-gray-1/70 hover:text-gray-11"
+          }`}
+          style={{ marginLeft: `${Math.min(depth, 4) * 16}px` }}
+          onPointerEnter={prefetchSession}
+          onFocus={prefetchSession}
+          onClick={openSession}
+          onKeyDown={onRowKeyDown}
+        >
+          <div className="mr-2.5 flex min-w-0 flex-1 items-center gap-2">
+            {hasChildren ? (
+              <button
+                type="button"
+                className="-ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
+                aria-label={
+                  isExpanded
+                    ? t("workspace_list.hide_child_sessions")
+                    : t("workspace_list.show_child_sessions")
+                }
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  toggleSessionExpanded(session.id);
+                }}
+              >
+                {isExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+              </button>
+            ) : depth > 0 ? (
+              <span className="h-[1px] w-3 shrink-0 rounded-full bg-dls-border" />
+            ) : null}
+            {isSessionActive ? (
+              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" />
+            ) : null}
+            <span
+              className={`block min-w-0 truncate ${
+                isSelected ? "font-medium text-gray-12" : "font-normal text-current"
+              }`}
+              title={displayTitle}
+            >
+              {displayTitle}
+            </span>
+          </div>
+
+          <div className="ml-auto flex shrink-0 items-center gap-1">
+            {canManageSession ? (
+              <button
+                type="button"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
+                aria-label={t("workspace_list.session_actions")}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setSessionMenuOpen((current) => !current);
+                }}
+              >
+                <MoreHorizontal size={14} />
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        {canManageSession && sessionMenuOpen ? (
+          <div
+            ref={sessionMenuRef}
+            className="absolute right-0 top-[calc(100%+6px)] z-20 w-48 rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {props.onOpenRenameSession ? (
+              <button
+                type="button"
+                className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                onClick={() => {
+                  setSessionMenuOpen(false);
+                  props.onOpenRenameSession?.();
+                }}
+              >
+                {t("workspace_list.rename_session")}
+              </button>
+            ) : null}
+
+            {props.onOpenDeleteSession ? (
+              <button
+                type="button"
+                className="w-full rounded-xl px-3 py-2 text-left text-sm text-red-11 transition-colors hover:bg-red-1/40"
+                onClick={() => {
+                  setSessionMenuOpen(false);
+                  props.onOpenDeleteSession?.();
+                }}
+              >
+                {t("workspace_list.delete_session")}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+      <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1">
+        <div className="space-y-2 pb-3">
+          {props.workspaceSessionGroups.map((group) => {
+            const tree = buildSessionTreeState(
+              group.sessions,
+              props.sessionStatusById,
+            );
+            const forcedExpandedSessionIds = new Set(
+              props.selectedSessionId
+                ? tree.ancestorIdsBySessionId.get(props.selectedSessionId) ?? []
+                : [],
+            );
+            const workspace = group.workspace;
+            const isConnecting = props.connectingWorkspaceId === workspace.id;
+            const connectionState =
+              props.workspaceConnectionStateById[workspace.id] ?? {
+                status: "idle",
+                message: null,
+              };
+            const isConnectionActionBusy =
+              isConnecting || connectionState.status === "connecting";
+            const canRecover =
+              workspace.workspaceType === "remote" &&
+              connectionState.status === "error";
+            const isMenuOpen = workspaceMenuId === workspace.id;
+            const taskLoadError = getWorkspaceTaskLoadErrorDisplay(
+              workspace,
+              group.error,
+            );
+            const statusLabel =
+              group.status === "error"
+                ? taskLoadError.label
+                : isConnectionActionBusy
+                  ? t("workspace_list.connecting")
+                  : !props.developerMode
+                    ? ""
+                    : props.selectedWorkspaceId === workspace.id
+                      ? t("workspace.selected")
+                      : workspaceKindLabel(workspace);
+            const statusTone =
+              group.status === "error"
+                ? taskLoadError.tone === "offline"
+                  ? "text-amber-11"
+                  : "text-red-11"
+                : "text-gray-9";
+
+            return (
+              <div className="space-y-2" key={workspace.id}>
+                <div className="relative group">
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className={`w-full flex items-center justify-between rounded-xl px-3.5 py-2.5 text-left text-[13px] transition-colors ${
+                      props.selectedWorkspaceId === workspace.id
+                        ? "bg-gray-2/70 text-gray-12"
+                        : "text-gray-10 hover:bg-gray-1/70 hover:text-gray-12"
+                    } ${isConnecting ? "opacity-75" : ""}`}
+                    onClick={() => {
+                      expandWorkspace(workspace.id);
+                      void Promise.resolve(props.onSelectWorkspace(workspace.id));
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" && event.key !== " ") return;
+                      if ((event.nativeEvent as any).isComposing) return;
+                      event.preventDefault();
+                      expandWorkspace(workspace.id);
+                      void Promise.resolve(props.onSelectWorkspace(workspace.id));
+                    }}
+                  >
+                    <div className="flex min-w-0 items-center gap-3.5">
+                      <div
+                        className="flex h-5.5 w-5.5 shrink-0 items-center justify-center rounded-full"
+                        style={{
+                          backgroundColor: workspaceSwatchColor(
+                            workspace.id || workspaceLabel(workspace),
+                          ),
+                        }}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="min-w-0 truncate text-[14px] font-normal text-dls-text">
+                          {workspaceLabel(workspace)}
+                        </div>
+                        {statusLabel ? (
+                          <div className={`mt-0.5 text-[11px] ${statusTone}`}>
+                            {statusLabel}
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div className="ml-4 flex shrink-0 items-center gap-1.5">
+                      {group.status === "loading" || isConnecting ? (
+                        <Loader2 size={14} className="animate-spin text-gray-9" />
+                      ) : null}
+
+                      <div className="hidden items-center gap-0.5 group-hover:flex group-focus-within:flex">
+                        <button
+                          type="button"
+                          className="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            props.onCreateTaskInWorkspace(workspace.id);
+                          }}
+                          disabled={props.newTaskDisabled}
+                          aria-label={t("session.new_task")}
+                        >
+                          <Plus size={14} />
+                        </button>
+
+                        <button
+                          type="button"
+                          className="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setWorkspaceMenuId((current) =>
+                              current === workspace.id ? null : workspace.id,
+                            );
+                          }}
+                          aria-label={t("workspace_list.workspace_options")}
+                        >
+                          <MoreHorizontal size={14} />
+                        </button>
+                      </div>
+
+                      <button
+                        type="button"
+                        className="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
+                        aria-label={
+                          isWorkspaceExpanded(workspace.id)
+                            ? t("sidebar.collapse")
+                            : t("sidebar.expand")
+                        }
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          toggleWorkspaceExpanded(workspace.id);
+                        }}
+                      >
+                        {isWorkspaceExpanded(workspace.id) ? (
+                          <ChevronDown size={14} />
+                        ) : (
+                          <ChevronRight size={14} />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+
+                  {isMenuOpen ? (
+                    <div
+                      ref={workspaceMenuRef}
+                      className="absolute right-0 top-[calc(100%+6px)] z-20 w-48 rounded-[18px] border border-dls-border bg-dls-surface p-1.5 shadow-[var(--dls-shell-shadow)]"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <button
+                        type="button"
+                        className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                        onClick={() => {
+                          props.onOpenRenameWorkspace(workspace.id);
+                          setWorkspaceMenuId(null);
+                        }}
+                      >
+                        {t("workspace_list.edit_name")}
+                      </button>
+                      <button
+                        type="button"
+                        className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                        onClick={() => {
+                          props.onShareWorkspace(workspace.id);
+                          setWorkspaceMenuId(null);
+                        }}
+                      >
+                        {t("workspace_list.share")}
+                      </button>
+                      {workspace.workspaceType === "local" ? (
+                        <button
+                          type="button"
+                          className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                          onClick={() => {
+                            props.onRevealWorkspace(workspace.id);
+                            setWorkspaceMenuId(null);
+                          }}
+                        >
+                          {revealLabel}
+                        </button>
+                      ) : null}
+                      {workspace.workspaceType === "remote" ? (
+                        <>
+                          {canRecover ? (
+                            <button
+                              type="button"
+                              className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                              onClick={() => {
+                                void Promise.resolve(
+                                  props.onRecoverWorkspace(workspace.id),
+                                );
+                                setWorkspaceMenuId(null);
+                              }}
+                              disabled={isConnectionActionBusy}
+                            >
+                              {t("workspace_list.recover")}
+                            </button>
+                          ) : null}
+                          <button
+                            type="button"
+                            className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                            onClick={() => {
+                              void Promise.resolve(
+                                props.onTestWorkspaceConnection(workspace.id),
+                              );
+                              setWorkspaceMenuId(null);
+                            }}
+                            disabled={isConnectionActionBusy}
+                          >
+                            {t("workspace_list.test_connection")}
+                          </button>
+                          <button
+                            type="button"
+                            className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-11 transition-colors hover:bg-gray-2"
+                            onClick={() => {
+                              props.onEditWorkspaceConnection(workspace.id);
+                              setWorkspaceMenuId(null);
+                            }}
+                            disabled={isConnectionActionBusy}
+                          >
+                            {t("workspace_list.edit_connection")}
+                          </button>
+                        </>
+                      ) : null}
+                      <button
+                        type="button"
+                        className="w-full rounded-xl px-3 py-2 text-left text-sm text-red-11 transition-colors hover:bg-red-1/40"
+                        onClick={() => {
+                          props.onForgetWorkspace(workspace.id);
+                          setWorkspaceMenuId(null);
+                        }}
+                      >
+                        {t("workspace_list.remove_workspace")}
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+
+                {isWorkspaceExpanded(workspace.id) ? (
+                  <div className="mt-3 px-1 pb-1">
+                    <div className="relative flex flex-col gap-1 pl-2.5 before:absolute before:bottom-2 before:left-0 before:top-2 before:w-[2px] before:bg-gray-3 before:content-['']">
+                      {group.status === "loading" && group.sessions.length === 0 ? (
+                        <div className="w-full rounded-[15px] px-3 py-2.5 text-left text-[11px] text-gray-10">
+                          {t("workspace.loading_tasks")}
+                        </div>
+                      ) : group.sessions.length > 0 ? (
+                        <>
+                          {flattenSessionRows(
+                            group.sessions,
+                            previewCount(workspace.id),
+                            tree,
+                            expandedSessionIds,
+                            forcedExpandedSessionIds,
+                          ).map((row) =>
+                            renderSessionRow(
+                              workspace.id,
+                              row,
+                              tree,
+                              forcedExpandedSessionIds,
+                            ),
+                          )}
+                          {getRootSessions(group.sessions).length >
+                          previewCount(workspace.id) ? (
+                            <button
+                              type="button"
+                              className="w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
+                              onClick={() =>
+                                showMoreSessions(
+                                  workspace.id,
+                                  getRootSessions(group.sessions).length,
+                                )
+                              }
+                            >
+                              {showMoreLabel(
+                                workspace.id,
+                                getRootSessions(group.sessions).length,
+                              )}
+                            </button>
+                          ) : null}
+                        </>
+                      ) : group.status === "error" ? (
+                        <div
+                          className={`w-full rounded-[15px] border px-3 py-2.5 text-left text-[11px] ${
+                            taskLoadError.tone === "offline"
+                              ? "border-amber-7/35 bg-amber-2/50 text-amber-11"
+                              : "border-red-7/35 bg-red-1/40 text-red-11"
+                          }`}
+                          title={taskLoadError.title}
+                        >
+                          {taskLoadError.message}
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          className="group/empty w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
+                          onClick={() => props.onCreateTaskInWorkspace(workspace.id)}
+                          disabled={props.newTaskDisabled}
+                        >
+                          <span className="group-hover/empty:hidden">
+                            {t("workspace.no_tasks")}
+                          </span>
+                          <span className="hidden group-hover/empty:inline font-medium">
+                            {t("workspace.new_task_inline")}
+                          </span>
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="relative mt-auto border-t border-dls-border/80 bg-dls-sidebar pt-3">
+        <button
+          type="button"
+          className="w-full flex items-center justify-center gap-2 rounded-[18px] border border-dls-border bg-dls-surface px-3.5 py-2.5 text-[12px] font-medium text-gray-11 shadow-[var(--dls-card-shadow)] transition-colors hover:bg-gray-2"
+          onClick={props.onOpenCreateWorkspace}
+        >
+          <Plus size={14} />
+          {t("workspace_list.add_workspace")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/settings-v2/react-settings-view-v2.tsx
+++ b/apps/app/src/app/settings-v2/react-settings-view-v2.tsx
@@ -1,0 +1,179 @@
+import { createElement } from "react";
+
+type ReactSettingsViewV2Props = {
+  legacySurface: any;
+};
+
+const SETTINGS_TABS = [
+  "general",
+  "models",
+  "providers",
+  "workspace",
+  "plugins",
+  "extensions",
+  "skills",
+  "automations",
+  "about",
+];
+
+export default function ReactSettingsViewV2(props: ReactSettingsViewV2Props) {
+  const surface = props.legacySurface;
+  const selectedTab = typeof surface.settingsTab === "string" ? surface.settingsTab : "general";
+  const setTab =
+    typeof surface.setSettingsTab === "function" ? surface.setSettingsTab : (_: string) => {};
+
+  return createElement(
+    "div",
+    {
+      className:
+        "h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 md:p-4 text-gray-12 font-sans",
+    },
+    createElement(
+      "div",
+      {
+        className:
+          "mx-auto flex h-full w-full max-w-[1200px] flex-col gap-3 rounded-[24px] border border-dls-border bg-dls-surface p-4 shadow-[var(--dls-shell-shadow)]",
+      },
+      createElement(
+        "div",
+        { className: "flex items-center justify-between border-b border-dls-border pb-3" },
+        createElement(
+          "div",
+          { className: "min-w-0" },
+          createElement(
+            "h1",
+            { className: "truncate text-base font-semibold text-dls-text" },
+            "Settings",
+          ),
+          createElement(
+            "p",
+            { className: "truncate text-xs text-dls-secondary" },
+            `React Settings V2 · ${surface.selectedWorkspaceDisplay?.displayName || surface.selectedWorkspaceDisplay?.name || "Workspace"}`,
+          ),
+        ),
+        createElement(
+          "button",
+          {
+            type: "button",
+            className:
+              "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text",
+            onClick: () => {
+              if (typeof surface.setView === "function") {
+                surface.setView("session");
+              }
+            },
+          },
+          "Back to session",
+        ),
+      ),
+      createElement(
+        "div",
+        { className: "flex min-h-0 flex-1 gap-3" },
+        createElement(
+          "aside",
+          {
+            className:
+              "w-[250px] shrink-0 overflow-auto rounded-xl border border-dls-border bg-dls-sidebar p-2.5",
+          },
+          SETTINGS_TABS.map((tab) =>
+            createElement(
+              "button",
+              {
+                key: tab,
+                type: "button",
+                className: `mb-1 w-full rounded-md px-2.5 py-2 text-left text-xs ${
+                  selectedTab === tab
+                    ? "bg-dls-active text-dls-text"
+                    : "text-dls-secondary hover:bg-dls-hover hover:text-dls-text"
+                }`,
+                onClick: () => setTab(tab),
+              },
+              tab,
+            ),
+          ),
+        ),
+        createElement(
+          "section",
+          {
+            className:
+              "min-h-0 flex-1 overflow-auto rounded-xl border border-dls-border bg-dls-surface p-4",
+          },
+          createElement(
+            "div",
+            { className: "space-y-3" },
+            createElement(
+              "div",
+              {
+                className:
+                  "rounded-lg border border-dls-border bg-dls-hover/40 px-3 py-2 text-sm text-dls-text",
+              },
+              `Current tab: ${selectedTab}`,
+            ),
+            createElement(
+              "div",
+              {
+                className:
+                  "rounded-lg border border-dls-border bg-dls-hover/40 px-3 py-2 text-sm text-dls-text",
+              },
+              `Connection status: ${surface.clientConnected ? "connected" : "disconnected"}`,
+            ),
+            createElement(
+              "div",
+              {
+                className:
+                  "rounded-lg border border-dls-border bg-dls-hover/40 px-3 py-2 text-sm text-dls-text",
+              },
+              `OpenWork server: ${surface.openworkServerStatus || "unknown"}`,
+            ),
+            createElement(
+              "div",
+              { className: "flex flex-wrap gap-2" },
+              createElement(
+                "button",
+                {
+                  type: "button",
+                  className:
+                    "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary hover:bg-dls-hover hover:text-dls-text",
+                  onClick: () => {
+                    if (typeof surface.openProviderAuthModal === "function") {
+                      void surface.openProviderAuthModal();
+                    }
+                  },
+                },
+                "Open providers",
+              ),
+              createElement(
+                "button",
+                {
+                  type: "button",
+                  className:
+                    "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary hover:bg-dls-hover hover:text-dls-text",
+                  onClick: () => {
+                    if (typeof surface.openCreateWorkspace === "function") {
+                      surface.openCreateWorkspace();
+                    }
+                  },
+                },
+                "Create workspace",
+              ),
+              createElement(
+                "button",
+                {
+                  type: "button",
+                  className:
+                    "rounded-md border border-dls-border px-3 py-1.5 text-xs text-dls-secondary hover:bg-dls-hover hover:text-dls-text",
+                  onClick: () => {
+                    if (typeof surface.toggleDeveloperMode === "function") {
+                      surface.toggleDeveloperMode();
+                    }
+                  },
+                },
+                `Developer mode: ${surface.developerMode ? "on" : "off"}`,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/apps/app/src/app/shell/bootstrap-coordinator.ts
+++ b/apps/app/src/app/shell/bootstrap-coordinator.ts
@@ -1,0 +1,65 @@
+import type { ReloadReason, ReloadTrigger } from "../types";
+import { createOpenworkServerStore } from "../connections/openwork-server-store";
+import { createSessionStore } from "../context/session";
+import { createWorkspaceStore } from "../context/workspace";
+
+type SessionStore = ReturnType<typeof createSessionStore>;
+type WorkspaceStore = ReturnType<typeof createWorkspaceStore>;
+type OpenworkServerStore = ReturnType<typeof createOpenworkServerStore>;
+
+type ReloadHandler = (reason: ReloadReason, trigger?: ReloadTrigger) => void;
+
+export function createBootstrapCoordinator() {
+  let workspaceStore: WorkspaceStore | undefined;
+  let sessionStore: SessionStore | undefined;
+  let openworkServerStore: OpenworkServerStore | undefined;
+  let reloadHandler: ReloadHandler | undefined;
+
+  return {
+    peekWorkspaceStore() {
+      return workspaceStore ?? null;
+    },
+    peekSessionStore() {
+      return sessionStore ?? null;
+    },
+    peekOpenworkServerStore() {
+      return openworkServerStore ?? null;
+    },
+    get workspaceStore() {
+      if (!workspaceStore) {
+        throw new Error("Workspace store accessed before bootstrap completed");
+      }
+      return workspaceStore;
+    },
+    get sessionStore() {
+      if (!sessionStore) {
+        throw new Error("Session store accessed before bootstrap completed");
+      }
+      return sessionStore;
+    },
+    get openworkServerStore() {
+      if (!openworkServerStore) {
+        throw new Error("OpenWork server store accessed before bootstrap completed");
+      }
+      return openworkServerStore;
+    },
+    setWorkspaceStore(value: WorkspaceStore) {
+      workspaceStore = value;
+      return value;
+    },
+    setSessionStore(value: SessionStore) {
+      sessionStore = value;
+      return value;
+    },
+    setOpenworkServerStore(value: OpenworkServerStore) {
+      openworkServerStore = value;
+      return value;
+    },
+    setReloadHandler(value: ReloadHandler) {
+      reloadHandler = value;
+    },
+    markReloadRequired(reason: ReloadReason, trigger?: ReloadTrigger) {
+      reloadHandler?.(reason, trigger);
+    },
+  };
+}

--- a/apps/app/src/app/shell/modal-host.tsx
+++ b/apps/app/src/app/shell/modal-host.tsx
@@ -1,0 +1,347 @@
+import type { Accessor } from "solid-js";
+import ModelPickerModal from "../components/model-picker-modal";
+import ConfirmModal from "../components/confirm-modal";
+import ResetModal from "../components/reset-modal";
+import RenameWorkspaceModal from "../components/rename-workspace-modal";
+import TopRightNotifications from "./top-right-notifications";
+import SkillDestinationModal from "../bundles/skill-destination-modal";
+import BundleImportModal from "../bundles/import-modal";
+import BundleStartModal from "../bundles/start-modal";
+import ConnectionsModals from "../connections/modals";
+import { CreateRemoteWorkspaceModal, CreateWorkspaceModal } from "../workspace";
+import { currentLocale, t } from "../../i18n";
+import { isTauriRuntime } from "../utils";
+import { createModelConfigStore } from "../context/model-config";
+import { createWorkspaceStore } from "../context/workspace";
+import { createBundlesStore } from "../bundles/store";
+import type { Client, ReloadTrigger } from "../types";
+
+type ActiveBlockingSession = {
+  id: string;
+  title: string;
+};
+
+type ShellModalHostProps = {
+  modelConfig: ReturnType<typeof createModelConfigStore>;
+  workspaceStore: ReturnType<typeof createWorkspaceStore>;
+  bundlesStore: ReturnType<typeof createBundlesStore>;
+  client: Accessor<Client | null>;
+  workspaceProjectDir: Accessor<string>;
+  resetModalOpen: Accessor<boolean>;
+  resetModalMode: Accessor<"onboarding" | "all">;
+  resetModalText: Accessor<string>;
+  resetModalBusy: Accessor<boolean>;
+  setResetModalOpen: (value: boolean) => void;
+  confirmReset: () => void;
+  setResetModalText: (value: string) => void;
+  openSettingsFromModelPicker: () => void;
+  anyActiveRuns: Accessor<boolean>;
+  activeReloadBlockingSessions: Accessor<ActiveBlockingSession[]>;
+  abortSession: (sessionId: string) => Promise<void>;
+  reloadWorkspaceEngineAndResume: () => Promise<void>;
+  busy: Accessor<boolean>;
+  busyLabel: Accessor<string | null>;
+  error: Accessor<string | null>;
+  reloadOpen: Accessor<boolean>;
+  reloadTitle: Accessor<string>;
+  reloadDescription: Accessor<string>;
+  reloadTrigger: Accessor<ReloadTrigger | undefined>;
+  reloadError: Accessor<string | null>;
+  reloadBusy: Accessor<boolean>;
+  canReloadWorkspace: Accessor<boolean>;
+  clearReloadRequired: () => void;
+  forceStopActiveSessionsAndReload: () => Promise<void>;
+  deepLinkRemoteWorkspaceDefaults: Accessor<{
+    openworkHostUrl?: string | null;
+    openworkToken?: string | null;
+    directory?: string | null;
+    displayName?: string | null;
+  } | null>;
+  clearDeepLinkRemoteWorkspaceDefaults: () => void;
+};
+
+export default function ModalHost(props: ShellModalHostProps) {
+  return (
+    <>
+      <ModelPickerModal
+        open={props.modelConfig.modelPickerOpen()}
+        options={props.modelConfig.modelOptions()}
+        filteredOptions={props.modelConfig.filteredModelOptions()}
+        query={props.modelConfig.modelPickerQuery()}
+        setQuery={props.modelConfig.setModelPickerQuery}
+        target={props.modelConfig.modelPickerTarget()}
+        current={props.modelConfig.modelPickerCurrent()}
+        onSelect={props.modelConfig.applyModelSelection}
+        onBehaviorChange={props.modelConfig.setModelPickerBehavior}
+        onOpenSettings={props.openSettingsFromModelPicker}
+        onClose={props.modelConfig.closeModelPicker}
+      />
+
+      <ResetModal
+        open={props.resetModalOpen()}
+        mode={props.resetModalMode()}
+        text={props.resetModalText()}
+        busy={props.resetModalBusy()}
+        canReset={
+          !props.resetModalBusy() &&
+          !props.anyActiveRuns() &&
+          props.resetModalText().trim().toUpperCase() === "RESET"
+        }
+        hasActiveRuns={props.anyActiveRuns()}
+        language={currentLocale()}
+        onClose={() => props.setResetModalOpen(false)}
+        onConfirm={props.confirmReset}
+        onTextChange={props.setResetModalText}
+      />
+
+      <ConnectionsModals
+        client={props.client()}
+        projectDir={props.workspaceProjectDir()}
+        language={currentLocale()}
+        reloadBlocked={props.activeReloadBlockingSessions().length > 0}
+        activeSessions={props.activeReloadBlockingSessions()}
+        isRemoteWorkspace={props.workspaceStore.selectedWorkspaceDisplay().workspaceType === "remote"}
+        onForceStopSession={(sessionID) => props.abortSession(sessionID)}
+        onReloadEngine={() => props.reloadWorkspaceEngineAndResume()}
+      />
+
+      <BundleImportModal
+        open={Boolean(props.bundlesStore.bundleImportChoice())}
+        title={props.bundlesStore.bundleImportSummary()?.title ?? t("app.import_shared_bundle")}
+        description={props.bundlesStore.bundleImportSummary()?.description ?? t("app.import_bundle_desc")}
+        items={props.bundlesStore.bundleImportSummary()?.items ?? []}
+        workers={props.bundlesStore.bundleWorkerOptions()}
+        busy={props.bundlesStore.bundleImportBusy()}
+        error={props.bundlesStore.bundleImportError()}
+        onClose={props.bundlesStore.closeBundleImportChoice}
+        onCreateNewWorker={() => {
+          void props.bundlesStore.openCreateWorkspaceFromChoice();
+        }}
+        onSelectWorker={(workspaceId) => {
+          void props.bundlesStore.importBundleIntoExistingWorkspace(workspaceId);
+        }}
+      />
+
+      <ConfirmModal
+        open={Boolean(props.bundlesStore.untrustedBundleWarning())}
+        title="Import from an untrusted bundle link?"
+        message={(() => {
+          const warning = props.bundlesStore.untrustedBundleWarning();
+          const actualOrigin = warning?.actualOrigin?.trim() || "an unknown origin";
+          const configuredOrigin =
+            warning?.configuredOrigin?.trim() || "the configured OpenWork share service";
+          return `This link points to ${actualOrigin}, but OpenWork only auto-imports bundles from ${configuredOrigin}. Untrusted bundles can contain malicious instructions or settings. Only continue if you trust the sender and expect this import.`;
+        })()}
+        confirmLabel="Import anyway"
+        cancelLabel="Cancel"
+        variant="warning"
+        onConfirm={() => {
+          void props.bundlesStore.confirmUntrustedBundleWarning();
+        }}
+        onCancel={props.bundlesStore.dismissUntrustedBundleWarning}
+      />
+
+      <BundleStartModal
+        open={Boolean(props.bundlesStore.bundleStartRequest())}
+        templateName={props.bundlesStore.bundleStartRequest()?.bundle.name?.trim() || "this template"}
+        description={props.bundlesStore.bundleStartRequest()?.bundle.description ?? ""}
+        items={props.bundlesStore.bundleStartItems()}
+        busy={props.bundlesStore.bundleStartBusy()}
+        onClose={() => {
+          props.bundlesStore.clearBundleStartRequest();
+        }}
+        onPickFolder={props.workspaceStore.pickWorkspaceFolder}
+        onConfirm={(folder) => {
+          void props.bundlesStore.startWorkspaceFromBundle(folder);
+        }}
+      />
+
+      <CreateWorkspaceModal
+        open={props.workspaceStore.createWorkspaceOpen()}
+        onClose={() => {
+          props.workspaceStore.setCreateWorkspaceOpen(false);
+          props.workspaceStore.clearSandboxCreateProgress?.();
+          props.bundlesStore.clearCreateWorkspaceRequest();
+        }}
+        onPickFolder={props.workspaceStore.pickWorkspaceFolder}
+        onImportConfig={isTauriRuntime() ? props.workspaceStore.importWorkspaceConfig : undefined}
+        importingConfig={props.workspaceStore.importingWorkspaceConfig()}
+        defaultPreset={props.bundlesStore.createWorkspaceDefaultPreset()}
+        onConfirmRemote={(input) => props.workspaceStore.createRemoteWorkspaceFlow(input)}
+        onConfirmTemplate={(template, preset, folder) =>
+          props.bundlesStore.startWorkspaceFromTeamTemplate({
+            name: template.name,
+            templateData: template.templateData,
+            folder,
+            preset,
+          })
+        }
+        onConfirm={props.bundlesStore.handleCreateWorkspaceConfirm}
+        onConfirmWorker={
+          isTauriRuntime() ? props.bundlesStore.handleCreateSandboxConfirm : undefined
+        }
+        workerDisabled={(() => {
+          if (!isTauriRuntime()) return true;
+          if (props.workspaceStore.sandboxDoctorBusy?.()) return true;
+          const doctor = props.workspaceStore.sandboxDoctorResult?.();
+          if (!doctor) return false;
+          return !doctor?.ready;
+        })()}
+        workerDisabledReason={(() => {
+          if (!isTauriRuntime()) return t("app.error.tauri_required", currentLocale());
+          if (props.workspaceStore.sandboxDoctorBusy?.()) {
+            return t("dashboard.sandbox_checking_docker", currentLocale());
+          }
+          const doctor = props.workspaceStore.sandboxDoctorResult?.();
+          if (!doctor || doctor.ready) return null;
+          const message = doctor?.error?.trim();
+          return message || t("dashboard.sandbox_get_ready_desc", currentLocale());
+        })()}
+        workerCtaLabel={t("dashboard.sandbox_get_ready_action", currentLocale())}
+        workerCtaDescription={t("dashboard.sandbox_get_ready_desc", currentLocale())}
+        onWorkerCta={async () => {
+          const url = "https://www.docker.com/products/docker-desktop/";
+          if (isTauriRuntime()) {
+            const { openUrl } = await import("@tauri-apps/plugin-opener");
+            await openUrl(url);
+          } else {
+            window.open(url, "_blank", "noopener,noreferrer");
+          }
+        }}
+        workerRetryLabel={t("common.retry", currentLocale())}
+        workerDebugLines={(() => {
+          const doctor = props.workspaceStore.sandboxDoctorResult?.();
+          const lines: string[] = [];
+          if (!doctor?.debug) return lines;
+          const selected = doctor.debug.selectedBin?.trim();
+          if (selected) lines.push(`selected: ${selected}`);
+          if (doctor.debug.candidates?.length) {
+            lines.push(`candidates: ${doctor.debug.candidates.join(", ")}`);
+          }
+          if (doctor.debug.versionCommand) {
+            const cmd = doctor.debug.versionCommand;
+            lines.push(`docker --version exit=${cmd.status}`);
+            if (cmd.stderr?.trim()) lines.push(`docker --version stderr: ${cmd.stderr.trim()}`);
+          }
+          if (doctor.debug.infoCommand) {
+            const cmd = doctor.debug.infoCommand;
+            lines.push(`docker info exit=${cmd.status}`);
+            if (cmd.stderr?.trim()) lines.push(`docker info stderr: ${cmd.stderr.trim()}`);
+          }
+          return lines;
+        })()}
+        onWorkerRetry={() => {
+          void props.workspaceStore.refreshSandboxDoctor?.();
+        }}
+        workerSubmitting={props.workspaceStore.sandboxPreflightBusy?.() ?? false}
+        localDisabled={!isTauriRuntime()}
+        localDisabledReason={!isTauriRuntime() ? t("app.local_disabled_reason") : null}
+        remoteSubmitting={props.busy() && props.busyLabel() === "status.connecting"}
+        remoteError={props.busyLabel() === "status.connecting" ? props.error() : null}
+        submitting={(() => {
+          const phase = props.workspaceStore.sandboxCreatePhase?.() ?? "idle";
+          if (phase === "provisioning" || phase === "finalizing") return true;
+          return props.busy() && props.busyLabel() === "status.creating_workspace";
+        })()}
+        submittingProgress={props.workspaceStore.sandboxCreateProgress?.() ?? null}
+      />
+
+      <SkillDestinationModal
+        open={
+          Boolean(props.bundlesStore.skillDestinationRequest()) &&
+          !props.workspaceStore.createWorkspaceOpen() &&
+          !props.workspaceStore.createRemoteWorkspaceOpen()
+        }
+        skill={(() => {
+          const request = props.bundlesStore.skillDestinationRequest();
+          if (!request) return null;
+          return {
+            name: request.bundle.name,
+            description: request.bundle.description ?? null,
+            trigger: request.bundle.trigger ?? null,
+          };
+        })()}
+        workspaces={props.bundlesStore.skillDestinationWorkspaces()}
+        selectedWorkspaceId={props.workspaceStore.selectedWorkspaceId()}
+        busyWorkspaceId={props.bundlesStore.skillDestinationBusyId()}
+        onClose={() => {
+          props.bundlesStore.clearSkillDestinationRequest();
+        }}
+        onSubmitWorkspace={props.bundlesStore.importSkillIntoWorkspace}
+        onCreateWorker={
+          isTauriRuntime()
+            ? props.bundlesStore.openCreateWorkspaceFromSkillDestination
+            : undefined
+        }
+        onConnectRemote={() => {
+          props.bundlesStore.openRemoteConnectFromSkillDestination();
+        }}
+      />
+
+      <CreateRemoteWorkspaceModal
+        open={props.workspaceStore.createRemoteWorkspaceOpen()}
+        onClose={() => {
+          props.workspaceStore.setCreateRemoteWorkspaceOpen(false);
+          props.clearDeepLinkRemoteWorkspaceDefaults();
+        }}
+        onConfirm={(input) => props.workspaceStore.createRemoteWorkspaceFlow(input)}
+        initialValues={props.deepLinkRemoteWorkspaceDefaults() ?? undefined}
+        submitting={
+          props.busy() &&
+          (props.busyLabel() === "status.creating_workspace" ||
+            props.busyLabel() === "status.connecting")
+        }
+      />
+
+      <TopRightNotifications
+        reloadOpen={props.reloadOpen()}
+        reloadTitle={props.reloadTitle()}
+        reloadDescription={props.reloadDescription()}
+        reloadTrigger={props.reloadTrigger()}
+        reloadError={props.reloadError()}
+        reloadLabel={
+          props.activeReloadBlockingSessions().length > 0
+            ? t("app.reload_stop_tasks")
+            : t("app.reload_now")
+        }
+        dismissLabel={t("app.reload_later")}
+        reloadBusy={props.reloadBusy()}
+        canReload={props.canReloadWorkspace()}
+        hasActiveRuns={props.activeReloadBlockingSessions().length > 0}
+        onReload={() => {
+          void (props.activeReloadBlockingSessions().length > 0
+            ? props.forceStopActiveSessionsAndReload()
+            : props.reloadWorkspaceEngineAndResume());
+        }}
+        onDismissReload={props.clearReloadRequired}
+      />
+
+      <RenameWorkspaceModal
+        open={props.workspaceStore.renameWorkspaceOpen()}
+        title={props.workspaceStore.renameWorkspaceName()}
+        busy={props.workspaceStore.renameWorkspaceBusy()}
+        canSave={
+          props.workspaceStore.renameWorkspaceName().trim().length > 0 &&
+          !props.workspaceStore.renameWorkspaceBusy()
+        }
+        onClose={props.workspaceStore.closeRenameWorkspace}
+        onSave={props.workspaceStore.saveRenameWorkspace}
+        onTitleChange={props.workspaceStore.setRenameWorkspaceName}
+      />
+
+      <CreateRemoteWorkspaceModal
+        open={props.workspaceStore.editRemoteWorkspaceOpen()}
+        onClose={props.workspaceStore.closeWorkspaceConnectionSettings}
+        onConfirm={(input) => {
+          void props.workspaceStore.saveWorkspaceConnectionSettings(input);
+        }}
+        initialValues={props.workspaceStore.editRemoteWorkspaceDefaults() ?? undefined}
+        submitting={props.busy() && props.busyLabel() === "status.connecting"}
+        error={props.workspaceStore.editRemoteWorkspaceError()}
+        title={t("dashboard.edit_remote_workspace_title", currentLocale())}
+        subtitle={t("dashboard.edit_remote_workspace_subtitle", currentLocale())}
+        confirmLabel={t("dashboard.edit_remote_workspace_confirm", currentLocale())}
+      />
+    </>
+  );
+}

--- a/apps/app/src/app/shell/react-app-shell.ts
+++ b/apps/app/src/app/shell/react-app-shell.ts
@@ -6,6 +6,8 @@ import { SolidSlot } from "./solid-slot";
 export type ReactAppShellProps = {
   currentView: "session" | "settings";
   renderSession: () => JSX.Element;
+  renderSessionReact?: () => any;
+  preferReactSession?: boolean;
   renderSettings: () => JSX.Element;
   renderOverlays?: () => JSX.Element;
 };
@@ -15,10 +17,12 @@ export default function ReactAppShell(props: ReactAppShellProps) {
     Fragment,
     null,
     props.currentView === "session"
-      ? createElement(SolidSlot, {
-          slotId: "session-surface",
-          renderContent: props.renderSession,
-        })
+      ? props.preferReactSession && props.renderSessionReact
+        ? props.renderSessionReact()
+        : createElement(SolidSlot, {
+            slotId: "session-surface",
+            renderContent: props.renderSession,
+          })
       : createElement(SolidSlot, {
           slotId: "settings-surface",
           renderContent: props.renderSettings,

--- a/apps/app/src/app/shell/react-app-shell.ts
+++ b/apps/app/src/app/shell/react-app-shell.ts
@@ -9,6 +9,8 @@ export type ReactAppShellProps = {
   renderSessionReact?: () => any;
   preferReactSession?: boolean;
   renderSettings: () => JSX.Element;
+  renderSettingsReact?: () => any;
+  preferReactSettings?: boolean;
   renderOverlays?: () => JSX.Element;
 };
 
@@ -23,10 +25,12 @@ export default function ReactAppShell(props: ReactAppShellProps) {
             slotId: "session-surface",
             renderContent: props.renderSession,
           })
-      : createElement(SolidSlot, {
-          slotId: "settings-surface",
-          renderContent: props.renderSettings,
-        }),
+      : props.preferReactSettings && props.renderSettingsReact
+        ? props.renderSettingsReact()
+        : createElement(SolidSlot, {
+            slotId: "settings-surface",
+            renderContent: props.renderSettings,
+          }),
     props.renderOverlays
       ? createElement(SolidSlot, {
           slotId: "shell-overlays",

--- a/apps/app/src/app/shell/react-app-shell.ts
+++ b/apps/app/src/app/shell/react-app-shell.ts
@@ -1,0 +1,31 @@
+import type { JSX } from "solid-js";
+import { Fragment, createElement } from "react";
+
+import { SolidSlot } from "./solid-slot";
+
+export type ReactAppShellProps = {
+  currentView: "session" | "settings";
+  renderSession: () => JSX.Element;
+  renderSettings: () => JSX.Element;
+  renderOverlays: () => JSX.Element;
+};
+
+export default function ReactAppShell(props: ReactAppShellProps) {
+  return createElement(
+    Fragment,
+    null,
+    props.currentView === "session"
+      ? createElement(SolidSlot, {
+          slotId: "session-surface",
+          renderContent: props.renderSession,
+        })
+      : createElement(SolidSlot, {
+          slotId: "settings-surface",
+          renderContent: props.renderSettings,
+        }),
+    createElement(SolidSlot, {
+      slotId: "shell-overlays",
+      renderContent: props.renderOverlays,
+    }),
+  );
+}

--- a/apps/app/src/app/shell/react-app-shell.ts
+++ b/apps/app/src/app/shell/react-app-shell.ts
@@ -7,7 +7,7 @@ export type ReactAppShellProps = {
   currentView: "session" | "settings";
   renderSession: () => JSX.Element;
   renderSettings: () => JSX.Element;
-  renderOverlays: () => JSX.Element;
+  renderOverlays?: () => JSX.Element;
 };
 
 export default function ReactAppShell(props: ReactAppShellProps) {
@@ -23,9 +23,11 @@ export default function ReactAppShell(props: ReactAppShellProps) {
           slotId: "settings-surface",
           renderContent: props.renderSettings,
         }),
-    createElement(SolidSlot, {
-      slotId: "shell-overlays",
-      renderContent: props.renderOverlays,
-    }),
+    props.renderOverlays
+      ? createElement(SolidSlot, {
+          slotId: "shell-overlays",
+          renderContent: props.renderOverlays,
+        })
+      : null,
   );
 }

--- a/apps/app/src/app/shell/react-app-shell.ts
+++ b/apps/app/src/app/shell/react-app-shell.ts
@@ -6,10 +6,12 @@ import { SolidSlot } from "./solid-slot";
 export type ReactAppShellProps = {
   currentView: "session" | "settings";
   renderSession: () => JSX.Element;
-  renderSessionReact?: () => any;
+  renderSessionReact?: (surface?: any) => any;
+  sessionReactSurface?: any;
   preferReactSession?: boolean;
   renderSettings: () => JSX.Element;
-  renderSettingsReact?: () => any;
+  renderSettingsReact?: (surface?: any) => any;
+  settingsReactSurface?: any;
   preferReactSettings?: boolean;
   renderOverlays?: () => JSX.Element;
 };
@@ -20,13 +22,13 @@ export default function ReactAppShell(props: ReactAppShellProps) {
     null,
     props.currentView === "session"
       ? props.preferReactSession && props.renderSessionReact
-        ? props.renderSessionReact()
+        ? props.renderSessionReact(props.sessionReactSurface)
         : createElement(SolidSlot, {
             slotId: "session-surface",
             renderContent: props.renderSession,
           })
       : props.preferReactSettings && props.renderSettingsReact
-        ? props.renderSettingsReact()
+        ? props.renderSettingsReact(props.settingsReactSurface)
         : createElement(SolidSlot, {
             slotId: "settings-surface",
             renderContent: props.renderSettings,

--- a/apps/app/src/app/shell/react-settings-shell-host.tsx
+++ b/apps/app/src/app/shell/react-settings-shell-host.tsx
@@ -1,0 +1,26 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createEffect, onCleanup } from "solid-js";
+
+import ReactSettingsShell from "./react-settings-shell";
+import type { SettingsShellProps } from "./settings-shell";
+
+export default function ReactSettingsShellHost(props: SettingsShellProps) {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  createEffect(() => {
+    if (!container) return;
+    if (!root) {
+      root = createRoot(container);
+    }
+
+    root.render(createElement(ReactSettingsShell, props));
+  });
+
+  onCleanup(() => {
+    root?.unmount();
+  });
+
+  return <div ref={container} data-openwork-react-settings-shell="" />;
+}

--- a/apps/app/src/app/shell/react-settings-shell-host.tsx
+++ b/apps/app/src/app/shell/react-settings-shell-host.tsx
@@ -19,7 +19,12 @@ export default function ReactSettingsShellHost(props: SettingsShellProps) {
   });
 
   onCleanup(() => {
-    root?.unmount();
+    const currentRoot = root;
+    root = undefined;
+    if (!currentRoot) return;
+    queueMicrotask(() => {
+      currentRoot.unmount();
+    });
   });
 
   return <div ref={container} data-openwork-react-settings-shell="" />;

--- a/apps/app/src/app/shell/react-settings-shell.tsx
+++ b/apps/app/src/app/shell/react-settings-shell.tsx
@@ -1,0 +1,103 @@
+import { createElement } from "react";
+
+import type { SettingsShellProps } from "./settings-shell";
+
+function settingsTitle(tab: SettingsShellProps["settingsTab"]) {
+  switch (tab) {
+    case "automations":
+      return "Automations";
+    case "skills":
+      return "Skills";
+    case "extensions":
+      return "Extensions";
+    case "messaging":
+      return "Messaging";
+    case "advanced":
+      return "Advanced";
+    case "appearance":
+      return "Appearance";
+    case "updates":
+      return "Updates";
+    case "recovery":
+      return "Recovery";
+    case "den":
+      return "Cloud";
+    case "debug":
+      return "Debug";
+    case "model":
+      return "Model";
+    default:
+      return "General";
+  }
+}
+
+function workspaceLabel(settings: SettingsShellProps) {
+  const workspace = settings.selectedWorkspaceDisplay;
+  return (
+    workspace.displayName?.trim() ||
+    workspace.openworkWorkspaceName?.trim() ||
+    workspace.name?.trim() ||
+    workspace.path?.trim() ||
+    "Workspace"
+  );
+}
+
+export default function ReactSettingsShell(settings: SettingsShellProps) {
+  return createElement(
+    "div",
+    {
+      className:
+        "sticky top-0 z-10 flex h-12 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6",
+    },
+    createElement(
+      "div",
+      {
+        className: "flex min-w-0 items-center gap-3",
+      },
+      createElement(
+        "div",
+        {
+          className: "truncate text-[15px] font-semibold text-dls-text",
+        },
+        settingsTitle(settings.settingsTab),
+      ),
+      createElement(
+        "div",
+        {
+          className: "hidden truncate text-[13px] text-dls-secondary lg:block",
+        },
+        workspaceLabel(settings),
+      ),
+      settings.developerMode
+        ? createElement(
+            "div",
+            {
+              className: "hidden truncate text-[12px] text-dls-secondary lg:block",
+            },
+            settings.headerStatus,
+          )
+        : null,
+      settings.busyHint
+        ? createElement(
+            "div",
+            {
+              className: "hidden truncate text-[12px] text-dls-secondary lg:block",
+            },
+            settings.busyHint,
+          )
+        : null,
+    ),
+    createElement(
+      "button",
+      {
+        type: "button",
+        className:
+          "flex h-9 items-center justify-center rounded-md px-3 text-sm text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text",
+        onClick: settings.toggleSettings,
+        title: "Close settings",
+        "aria-label": "Close settings",
+      },
+      "Close",
+    ),
+  );
+}

--- a/apps/app/src/app/shell/react-shell-host.tsx
+++ b/apps/app/src/app/shell/react-shell-host.tsx
@@ -1,0 +1,25 @@
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { createEffect, onCleanup } from "solid-js";
+
+import ReactAppShell, { type ReactAppShellProps } from "./react-app-shell";
+
+export default function ReactShellHost(props: ReactAppShellProps) {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  createEffect(() => {
+    if (!container) return;
+    if (!root) {
+      root = createRoot(container);
+    }
+
+    root.render(createElement(ReactAppShell, props));
+  });
+
+  onCleanup(() => {
+    root?.unmount();
+  });
+
+  return <div ref={container} data-openwork-react-shell="" />;
+}

--- a/apps/app/src/app/shell/react-shell-host.tsx
+++ b/apps/app/src/app/shell/react-shell-host.tsx
@@ -38,7 +38,12 @@ export default function ReactShellHost(props: ReactAppShellProps) {
   });
 
   onCleanup(() => {
-    root?.unmount();
+    const currentRoot = root;
+    root = undefined;
+    if (!currentRoot) return;
+    queueMicrotask(() => {
+      currentRoot.unmount();
+    });
   });
 
   return <div ref={container} data-openwork-react-shell="" />;

--- a/apps/app/src/app/shell/react-shell-host.tsx
+++ b/apps/app/src/app/shell/react-shell-host.tsx
@@ -12,9 +12,11 @@ export default function ReactShellHost(props: ReactAppShellProps) {
     const currentView = props.currentView;
     const renderSession = props.renderSession;
     const renderSessionReact = props.renderSessionReact;
+    const sessionReactSurface = props.sessionReactSurface;
     const preferReactSession = props.preferReactSession;
     const renderSettings = props.renderSettings;
     const renderSettingsReact = props.renderSettingsReact;
+    const settingsReactSurface = props.settingsReactSurface;
     const preferReactSettings = props.preferReactSettings;
     const renderOverlays = props.renderOverlays;
 
@@ -28,9 +30,11 @@ export default function ReactShellHost(props: ReactAppShellProps) {
         currentView,
         renderSession,
         renderSessionReact,
+        sessionReactSurface,
         preferReactSession,
         renderSettings,
         renderSettingsReact,
+        settingsReactSurface,
         preferReactSettings,
         renderOverlays,
       }),

--- a/apps/app/src/app/shell/react-shell-host.tsx
+++ b/apps/app/src/app/shell/react-shell-host.tsx
@@ -11,6 +11,8 @@ export default function ReactShellHost(props: ReactAppShellProps) {
   createEffect(() => {
     const currentView = props.currentView;
     const renderSession = props.renderSession;
+    const renderSessionReact = props.renderSessionReact;
+    const preferReactSession = props.preferReactSession;
     const renderSettings = props.renderSettings;
     const renderOverlays = props.renderOverlays;
 
@@ -23,6 +25,8 @@ export default function ReactShellHost(props: ReactAppShellProps) {
       createElement(ReactAppShell, {
         currentView,
         renderSession,
+        renderSessionReact,
+        preferReactSession,
         renderSettings,
         renderOverlays,
       }),

--- a/apps/app/src/app/shell/react-shell-host.tsx
+++ b/apps/app/src/app/shell/react-shell-host.tsx
@@ -9,12 +9,24 @@ export default function ReactShellHost(props: ReactAppShellProps) {
   let root: Root | undefined;
 
   createEffect(() => {
+    const currentView = props.currentView;
+    const renderSession = props.renderSession;
+    const renderSettings = props.renderSettings;
+    const renderOverlays = props.renderOverlays;
+
     if (!container) return;
     if (!root) {
       root = createRoot(container);
     }
 
-    root.render(createElement(ReactAppShell, props));
+    root.render(
+      createElement(ReactAppShell, {
+        currentView,
+        renderSession,
+        renderSettings,
+        renderOverlays,
+      }),
+    );
   });
 
   onCleanup(() => {

--- a/apps/app/src/app/shell/react-shell-host.tsx
+++ b/apps/app/src/app/shell/react-shell-host.tsx
@@ -14,6 +14,8 @@ export default function ReactShellHost(props: ReactAppShellProps) {
     const renderSessionReact = props.renderSessionReact;
     const preferReactSession = props.preferReactSession;
     const renderSettings = props.renderSettings;
+    const renderSettingsReact = props.renderSettingsReact;
+    const preferReactSettings = props.preferReactSettings;
     const renderOverlays = props.renderOverlays;
 
     if (!container) return;
@@ -28,6 +30,8 @@ export default function ReactShellHost(props: ReactAppShellProps) {
         renderSessionReact,
         preferReactSession,
         renderSettings,
+        renderSettingsReact,
+        preferReactSettings,
         renderOverlays,
       }),
     );

--- a/apps/app/src/app/shell/route-sync.ts
+++ b/apps/app/src/app/shell/route-sync.ts
@@ -1,0 +1,160 @@
+import { createEffect } from "solid-js";
+import type { Accessor } from "solid-js";
+
+import { shouldRedirectMissingSessionAfterScopedLoad } from "../lib/session-scope";
+import { isTauriRuntime, normalizeDirectoryPath } from "../utils";
+import type { SettingsTab } from "../types";
+
+type RouteSyncArgs = {
+  pathname: Accessor<string>;
+  navigate: (href: string, options?: { replace?: boolean }) => void;
+  settingsTab: Accessor<SettingsTab>;
+  setSettingsTabState: (tab: SettingsTab) => void;
+  setSelectedSessionId: (value: string | null) => void;
+  selectedSessionId: Accessor<string | null>;
+  selectSession: (sessionId: string) => Promise<void> | void;
+  pendingInitialSessionSelection: Accessor<unknown>;
+  sessions: Accessor<Array<{ id: string; directory?: string | null }>>;
+  sessionsLoaded: Accessor<boolean>;
+  loadedSessionScopeRoot: Accessor<string>;
+  selectedWorkspaceRoot: Accessor<string>;
+  clearSelectedSessionSurface: () => void;
+  activeSessionId: Accessor<string | null>;
+  goToSettings: (tab: SettingsTab, options?: { replace?: boolean }) => void;
+  goToSession: (sessionId: string, options?: { replace?: boolean }) => void;
+};
+
+const settingsTabs = new Set<SettingsTab>([
+  "general",
+  "den",
+  "model",
+  "automations",
+  "skills",
+  "extensions",
+  "messaging",
+  "advanced",
+  "appearance",
+  "updates",
+  "recovery",
+  "debug",
+]);
+
+const mapLegacySurfaceToSettingsTab = (surface: string): SettingsTab => {
+  switch (surface) {
+    case "scheduled":
+      return "automations";
+    case "skills":
+      return "skills";
+    case "plugins":
+    case "mcp":
+      return "extensions";
+    case "identities":
+      return "messaging";
+    case "config":
+      return "advanced";
+    case "settings":
+    default:
+      return "general";
+  }
+};
+
+const resolveSettingsTab = (value?: string | null) => {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  if (settingsTabs.has(normalized as SettingsTab)) {
+    return normalized as SettingsTab;
+  }
+  return "general";
+};
+
+const initialRoute = () => "/session";
+
+export function syncShellRoute(args: RouteSyncArgs) {
+  createEffect(() => {
+    const rawPath = args.pathname().trim();
+    const path = rawPath.toLowerCase();
+
+    if (path === "" || path === "/") {
+      args.navigate(initialRoute(), { replace: true });
+      return;
+    }
+
+    if (path.startsWith("/dashboard")) {
+      const [, , tabSegment] = path.split("/");
+      args.goToSettings(mapLegacySurfaceToSettingsTab(tabSegment ?? "settings"), {
+        replace: true,
+      });
+      return;
+    }
+
+    if (path.startsWith("/settings")) {
+      const [, , tabSegment] = path.split("/");
+      const resolvedTab = resolveSettingsTab(tabSegment);
+
+      if (resolvedTab !== args.settingsTab()) {
+        args.setSettingsTabState(resolvedTab);
+      }
+      if (!tabSegment || tabSegment !== resolvedTab) {
+        args.goToSettings(resolvedTab, { replace: true });
+      }
+      return;
+    }
+
+    if (path.startsWith("/session")) {
+      const [, , sessionSegment] = rawPath.split("/");
+      const id = (sessionSegment ?? "").trim();
+
+      if (!id) {
+        if (args.selectedSessionId()) {
+          args.clearSelectedSessionSurface();
+        }
+        return;
+      }
+
+      const pendingInitialSelection = args.pendingInitialSessionSelection();
+      const selectedWorkspaceRoot = normalizeDirectoryPath(args.selectedWorkspaceRoot().trim());
+      const matchingSession = args.sessions().find((session) => session.id === id) ?? null;
+      const hasMatchingSessionInScope = matchingSession
+        ? !selectedWorkspaceRoot ||
+          normalizeDirectoryPath(matchingSession.directory ?? "") === selectedWorkspaceRoot
+        : false;
+      if (
+        args.sessionsLoaded() &&
+        !pendingInitialSelection &&
+        shouldRedirectMissingSessionAfterScopedLoad({
+          loadedScopeRoot: args.loadedSessionScopeRoot(),
+          workspaceRoot: args.selectedWorkspaceRoot().trim(),
+          hasMatchingSession: hasMatchingSessionInScope,
+        })
+      ) {
+        if (args.selectedSessionId() === id) {
+          args.setSelectedSessionId(null);
+        }
+        args.navigate("/session", { replace: true });
+        return;
+      }
+
+      if (args.selectedSessionId() !== id) {
+        args.setSelectedSessionId(id);
+        void args.selectSession(id);
+      }
+      return;
+    }
+
+    if (path.startsWith("/proto-v1-ux") || path.startsWith("/proto")) {
+      if (isTauriRuntime()) {
+        args.navigate("/settings/automations", { replace: true });
+        return;
+      }
+
+      args.navigate("/settings/automations", { replace: true });
+      return;
+    }
+
+    const fallback = args.activeSessionId();
+    if (fallback) {
+      args.goToSession(fallback, { replace: true });
+      return;
+    }
+    args.navigate("/session", { replace: true });
+  });
+}

--- a/apps/app/src/app/shell/session-surface.ts
+++ b/apps/app/src/app/shell/session-surface.ts
@@ -1,0 +1,5 @@
+import type { SessionViewProps } from "../pages/session";
+
+export function buildSessionSurface(props: SessionViewProps): SessionViewProps {
+  return props;
+}

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -67,6 +67,7 @@ import {
 } from "lucide-solid";
 import type { Language } from "../../i18n";
 import { t } from "../../i18n";
+import ReactSettingsShellHost from "./react-settings-shell-host";
 
 export type SettingsShellProps = {
   settingsTab: SettingsTab;
@@ -259,6 +260,7 @@ export type SettingsShellProps = {
   dockerCleanupResult: string | null;
   resetAppConfigDefaults: () => Promise<{ ok: boolean; message: string }>;
   openDebugDeepLink: (rawUrl: string) => Promise<{ ok: boolean; message: string }>;
+  hideShellHeader?: boolean;
 };
 
 export default function SettingsShell(props: SettingsShellProps) {
@@ -1088,59 +1090,9 @@ export default function SettingsShell(props: SettingsShellProps) {
 
       <main class="min-w-0 flex-1 flex flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
         <div class="flex-1 overflow-y-auto">
-        <header class="sticky top-0 z-10 flex h-12 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6">
-          <div class="flex min-w-0 items-center gap-3">
-            <Show when={showUpdatePill()}>
-              <button
-                type="button"
-                class={`md:hidden flex items-center gap-1.5 rounded-full border bg-dls-surface px-2.5 py-1 text-xs font-medium shadow-sm transition-colors active:scale-[0.99] focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.2)] ${updatePillBorderTone()} ${updatePillButtonTone()}`}
-                onClick={handleUpdatePillClick}
-                title={updatePillTitle()}
-                aria-label={updatePillTitle()}
-              >
-                <Show
-                  when={props.updateStatus?.state === "downloading"}
-                  fallback={
-                    <ArrowDownToLine
-                      size={12}
-                      class={`${updatePillDotTone()} shrink-0 ${props.updateStatus?.state === "available" ? "animate-pulse" : ""}`}
-                      style={props.updateStatus?.state === "available" ? { "animation-duration": "3.5s" } : undefined}
-                    />
-                  }
-                >
-                  <Loader2 size={13} class={`animate-spin shrink-0 ${updatePillDotTone()}`} />
-                </Show>
-                <span class="text-[11px]">{updatePillLabel()}</span>
-                <Show when={props.updateStatus?.version}>
-                  {(version) => (
-                    <span class={`hidden sm:inline font-mono text-[10px] ${updatePillVersionTone()}`}>v{version()}</span>
-                  )}
-                </Show>
-              </button>
-            </Show>
-            <h1 class="truncate text-[15px] font-semibold text-dls-text">{title()}</h1>
-            <span class="hidden truncate text-[13px] text-dls-secondary lg:inline">
-              {workspaceLabel(props.selectedWorkspaceDisplay)}
-            </span>
-            <Show when={props.developerMode}>
-              <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.headerStatus}</span>
-            </Show>
-            <Show when={props.busyHint}>
-              <span class="hidden text-[12px] text-dls-secondary lg:inline">{props.busyHint}</span>
-            </Show>
-          </div>
-          <div class="flex items-center text-gray-10">
-            <button
-              type="button"
-              class="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
-              onClick={props.toggleSettings}
-              title={t("dashboard.close_settings")}
-              aria-label={t("dashboard.close_settings")}
-            >
-              <X size={18} />
-            </button>
-          </div>
-        </header>
+        <Show when={!props.hideShellHeader}>
+          <ReactSettingsShellHost {...props} />
+        </Show>
 
         <div class="w-full space-y-10 p-6 md:p-10">
           <SettingsView

--- a/apps/app/src/app/shell/settings-surface.ts
+++ b/apps/app/src/app/shell/settings-surface.ts
@@ -1,0 +1,5 @@
+import type { SettingsShellProps } from "./settings-shell";
+
+export function buildSettingsSurface(props: SettingsShellProps): SettingsShellProps {
+  return props;
+}

--- a/apps/app/src/app/shell/solid-context-bridge.tsx
+++ b/apps/app/src/app/shell/solid-context-bridge.tsx
@@ -1,0 +1,34 @@
+import type { ParentProps } from "solid-js";
+
+import { PlatformProvider, type Platform } from "../context/platform";
+import { LocalValueProvider, type LocalContextValue } from "../context/local";
+import type { GlobalSDKContextValue } from "../context/global-sdk";
+import { GlobalSDKValueProvider } from "../context/global-sdk";
+import type { GlobalSyncContextValue } from "../context/global-sync";
+import { GlobalSyncValueProvider } from "../context/global-sync";
+import type { ServerContextValue } from "../context/server";
+import { ServerValueProvider } from "../context/server";
+
+type SolidContextBridgeProps = ParentProps<{
+  platform: Platform;
+  server: ServerContextValue;
+  globalSDK: GlobalSDKContextValue;
+  globalSync: GlobalSyncContextValue;
+  local: LocalContextValue;
+}>;
+
+export default function SolidContextBridge(props: SolidContextBridgeProps) {
+  return (
+    <PlatformProvider value={props.platform}>
+      <ServerValueProvider value={props.server}>
+        <GlobalSDKValueProvider value={props.globalSDK}>
+          <GlobalSyncValueProvider value={props.globalSync}>
+            <LocalValueProvider value={props.local}>
+              {props.children}
+            </LocalValueProvider>
+          </GlobalSyncValueProvider>
+        </GlobalSDKValueProvider>
+      </ServerValueProvider>
+    </PlatformProvider>
+  );
+}

--- a/apps/app/src/app/shell/solid-slot.ts
+++ b/apps/app/src/app/shell/solid-slot.ts
@@ -1,3 +1,4 @@
+import { createRoot, createSignal } from "solid-js";
 import { render } from "solid-js/web";
 import type { JSX } from "solid-js";
 import { createElement, useLayoutEffect, useRef } from "react";
@@ -9,17 +10,30 @@ export type SolidSlotProps = {
 
 export function SolidSlot(props: SolidSlotProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const renderRef = useRef(props.renderContent);
-
-  renderRef.current = props.renderContent;
+  const setContentRef = useRef<((next: () => JSX.Element) => void) | null>(null);
 
   useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    const dispose = render(() => renderRef.current(), container);
+    const dispose = createRoot((disposeRoot) => {
+      const [content, setContent] = createSignal(props.renderContent);
+      setContentRef.current = (next) => {
+        setContent(() => next);
+      };
+      const disposeRender = render(() => content()(), container);
+      return () => {
+        setContentRef.current = null;
+        disposeRender();
+        disposeRoot();
+      };
+    });
     return () => dispose();
   }, []);
+
+  useLayoutEffect(() => {
+    setContentRef.current?.(props.renderContent);
+  }, [props.slotId, props.renderContent]);
 
   return createElement("div", {
     "data-openwork-react-slot": props.slotId,

--- a/apps/app/src/app/shell/solid-slot.ts
+++ b/apps/app/src/app/shell/solid-slot.ts
@@ -1,0 +1,28 @@
+import { render } from "solid-js/web";
+import type { JSX } from "solid-js";
+import { createElement, useLayoutEffect, useRef } from "react";
+
+export type SolidSlotProps = {
+  slotId: string;
+  renderContent: () => JSX.Element;
+};
+
+export function SolidSlot(props: SolidSlotProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const renderRef = useRef(props.renderContent);
+
+  renderRef.current = props.renderContent;
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const dispose = render(() => renderRef.current(), container);
+    return () => dispose();
+  }, []);
+
+  return createElement("div", {
+    "data-openwork-react-slot": props.slotId,
+    ref: containerRef,
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,12 @@ importers:
       marked:
         specifier: ^17.0.1
         version: 17.0.1
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
       solid-js:
         specifier: ^1.9.0
         version: 1.9.9
@@ -98,6 +104,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       solid-devtools:
         specifier: ^0.34.5
         version: 0.34.5(solid-js@1.9.9)(vite@6.4.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
@@ -7892,7 +7904,7 @@ snapshots:
 
   '@types/react-dom@18.2.25':
     dependencies:
-      '@types/react': 18.2.79
+      '@types/react': 19.2.14
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       jsonc-parser:
         specifier: ^3.2.1
         version: 3.3.1
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.4)
       lucide-solid:
         specifier: ^0.562.0
         version: 0.562.0(solid-js@1.9.9)


### PR DESCRIPTION
## Summary
- extract route sync, modal mounting, and bootstrap/reload coordination out of `apps/app/src/app/app.tsx` so the app shell is easier to migrate incrementally
- add React runtime dependencies and shell bridge components that let OpenWork introduce React without breaking the existing Solid provider tree
- make the settings route visibly exercise React by rendering the settings header as a React leaf while keeping the heavier settings body in Solid for now

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:browser-entry`
- [x] `pnpm test:session-switch`
- [ ] Run the full app manually from `_repos/openwork-worktrees/react-shell-migration`

Made with [Cursor](https://cursor.com)