### PR TITLE
feat(docs): add changelog page generated from release tracker

### DIFF
--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Changelog"
 ---
-<Update label="April 4th" tags={["Improvements"]}>
+<Update label="April 4th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
 
@@ -9,7 +9,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="April 3rd" tags={["New releases"]}>
+<Update label="April 3rd" tags={["🚀 New Features"]}>
 
   ## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
 
@@ -19,7 +19,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="April 2nd" tags={["New releases", "Improvements", "Deprecations"]}>
+<Update label="April 2nd" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
 
@@ -29,7 +29,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 31st" tags={["Improvements"]}>
+<Update label="March 31st" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
 
@@ -37,7 +37,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 31st" tags={["Improvements"]}>
+<Update label="March 31st" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
 
@@ -47,7 +47,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 30th" tags={["New releases", "Improvements", "Deprecations"]}>
+<Update label="March 30th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
 
@@ -57,7 +57,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 27th" tags={["New releases", "Improvements"]}>
+<Update label="March 27th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
 
@@ -65,7 +65,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 26th" tags={["New releases", "Improvements"]}>
+<Update label="March 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
 
@@ -73,7 +73,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 26th" tags={["New releases", "Improvements"]}>
+<Update label="March 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
 
@@ -83,7 +83,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 25th" tags={["New releases", "Improvements"]}>
+<Update label="March 25th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
 
@@ -93,7 +93,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 25th" tags={["Improvements"]}>
+<Update label="March 25th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
 
@@ -101,7 +101,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 24th" tags={["Improvements"]}>
+<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
 
@@ -117,7 +117,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 24th" tags={["Improvements"]}>
+<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
 
@@ -125,7 +125,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 24th" tags={["Improvements"]}>
+<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
 
@@ -133,7 +133,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 24th" tags={["Improvements"]}>
+<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
 
@@ -141,7 +141,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 24th" tags={["New releases", "Improvements"]}>
+<Update label="March 24th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
 
@@ -159,7 +159,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 23rd" tags={["New releases", "Improvements"]}>
+<Update label="March 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
 
@@ -167,7 +167,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 23rd" tags={["Improvements"]}>
+<Update label="March 23rd" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
 
@@ -185,7 +185,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 22nd" tags={["Improvements", "Deprecations"]}>
+<Update label="March 22nd" tags={["🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
 
@@ -193,7 +193,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 22nd" tags={["New releases", "Improvements"]}>
+<Update label="March 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
 
@@ -203,7 +203,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 20th" tags={["Improvements"]}>
+<Update label="March 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
 
@@ -211,7 +211,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 20th" tags={["New releases", "Improvements", "Deprecations"]}>
+<Update label="March 20th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
 
@@ -219,7 +219,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 20th" tags={["New releases", "Improvements"]}>
+<Update label="March 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
 
@@ -227,7 +227,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 19th" tags={["Improvements", "Deprecations"]}>
+<Update label="March 19th" tags={["🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
 
@@ -235,7 +235,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 19th" tags={["New releases", "Improvements"]}>
+<Update label="March 19th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
 
@@ -245,7 +245,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 18th" tags={["Improvements"]}>
+<Update label="March 18th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
 
@@ -253,7 +253,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 17th" tags={["Improvements"]}>
+<Update label="March 17th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
 
@@ -261,7 +261,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 17th" tags={["New releases", "Improvements"]}>
+<Update label="March 17th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
 
@@ -271,7 +271,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 17th" tags={["New releases", "Improvements"]}>
+<Update label="March 17th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
 
@@ -281,7 +281,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 16th" tags={["New releases", "Improvements"]}>
+<Update label="March 16th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
 
@@ -289,7 +289,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 16th" tags={["New releases", "Improvements"]}>
+<Update label="March 16th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
 
@@ -297,7 +297,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 16th" tags={["New releases"]}>
+<Update label="March 16th" tags={["🚀 New Features"]}>
 
   ## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
 
@@ -305,7 +305,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 15th" tags={["Improvements"]}>
+<Update label="March 15th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
 
@@ -313,7 +313,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 15th" tags={["New releases", "Improvements"]}>
+<Update label="March 15th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
 
@@ -329,7 +329,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 15th" tags={["Improvements"]}>
+<Update label="March 15th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
 
@@ -337,7 +337,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 15th" tags={["Improvements"]}>
+<Update label="March 15th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
 
@@ -345,7 +345,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 14th" tags={["Improvements"]}>
+<Update label="March 14th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
 
@@ -353,7 +353,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 14th" tags={["New releases", "Improvements"]}>
+<Update label="March 14th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
 
@@ -363,7 +363,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 14th" tags={["New releases", "Improvements"]}>
+<Update label="March 14th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
 
@@ -371,7 +371,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 13th" tags={["New releases", "Improvements"]}>
+<Update label="March 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
 
@@ -379,7 +379,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 13th" tags={["New releases", "Improvements"]}>
+<Update label="March 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
 
@@ -387,7 +387,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 12th" tags={["Improvements"]}>
+<Update label="March 12th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
 
@@ -395,7 +395,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 12th" tags={["New releases", "Improvements", "Deprecations"]}>
+<Update label="March 12th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
 
@@ -413,7 +413,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 12th" tags={["New releases", "Improvements"]}>
+<Update label="March 12th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
 
@@ -421,7 +421,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 11th" tags={["Improvements"]}>
+<Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
 
@@ -429,7 +429,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 11th" tags={["Improvements"]}>
+<Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
 
@@ -437,7 +437,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 11th" tags={["Improvements"]}>
+<Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
 
@@ -445,7 +445,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 10th" tags={["New releases", "Improvements"]}>
+<Update label="March 10th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
 
@@ -463,7 +463,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 6th" tags={["New releases"]}>
+<Update label="March 6th" tags={["🚀 New Features"]}>
 
   ## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
 
@@ -471,7 +471,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 5th" tags={["Improvements"]}>
+<Update label="March 5th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
 
@@ -479,7 +479,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 5th" tags={["Improvements"]}>
+<Update label="March 5th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
 
@@ -487,7 +487,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 4th" tags={["New releases", "Improvements"]}>
+<Update label="March 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
 
@@ -497,7 +497,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 2nd" tags={["New releases", "Improvements"]}>
+<Update label="March 2nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
 
@@ -505,7 +505,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 2nd" tags={["New releases", "Improvements"]}>
+<Update label="March 2nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
 
@@ -513,7 +513,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 1st" tags={["New releases", "Improvements"]}>
+<Update label="March 1st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
 
@@ -521,7 +521,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 28th" tags={["New releases", "Improvements"]}>
+<Update label="February 28th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
 
@@ -529,7 +529,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 27th" tags={["New releases", "Deprecations"]}>
+<Update label="February 27th" tags={["🚀 New Features", "🏗️ Refactoring"]}>
 
   ## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
 
@@ -537,7 +537,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 26th" tags={["Improvements"]}>
+<Update label="February 26th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
 
@@ -545,7 +545,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 26th" tags={["New releases", "Improvements"]}>
+<Update label="February 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
 
@@ -553,7 +553,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 26th" tags={["New releases"]}>
+<Update label="February 26th" tags={["🚀 New Features"]}>
 
   ## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
 
@@ -561,7 +561,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 26th" tags={["New releases", "Improvements"]}>
+<Update label="February 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
 
@@ -571,7 +571,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 23rd" tags={["New releases"]}>
+<Update label="February 23rd" tags={["🚀 New Features"]}>
 
   ## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
 
@@ -579,7 +579,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 23rd" tags={["Improvements"]}>
+<Update label="February 23rd" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
 
@@ -587,7 +587,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 23rd" tags={["Improvements"]}>
+<Update label="February 23rd" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
 
@@ -595,7 +595,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 23rd" tags={["Improvements"]}>
+<Update label="February 23rd" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
 
@@ -603,7 +603,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 23rd" tags={["New releases", "Improvements"]}>
+<Update label="February 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
 
@@ -611,7 +611,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 22nd" tags={["New releases"]}>
+<Update label="February 22nd" tags={["🚀 New Features"]}>
 
   ## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
 
@@ -619,7 +619,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 22nd" tags={["New releases", "Improvements"]}>
+<Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
 
@@ -627,7 +627,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 22nd" tags={["New releases", "Improvements"]}>
+<Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
 
@@ -637,7 +637,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 21st" tags={["New releases"]}>
+<Update label="February 21st" tags={["🚀 New Features"]}>
 
   ## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
 
@@ -645,7 +645,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 21st" tags={["Improvements"]}>
+<Update label="February 21st" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
 
@@ -669,7 +669,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["New releases", "Improvements"]}>
+<Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
 
@@ -677,7 +677,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["New releases", "Improvements"]}>
+<Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
 
@@ -685,7 +685,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["Improvements"]}>
+<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
 
@@ -701,7 +701,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["Improvements"]}>
+<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
 
@@ -709,7 +709,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["Improvements"]}>
+<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
 
@@ -717,7 +717,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["Improvements"]}>
+<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
 
@@ -727,7 +727,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["Improvements"]}>
+<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
 
@@ -735,7 +735,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 19th" tags={["New releases", "Improvements"]}>
+<Update label="February 19th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
 
@@ -743,7 +743,7 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 19th" tags={["Improvements"]}>
+<Update label="February 19th" tags={["🐛 Bug Fixes"]}>
 
   ## v0.11.100
 

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,569 +1,745 @@
 ---
 title: "Changelog"
 ---
-<Update label="April 4th" description="[v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)" tags={["Improved"]}>
+<Update label="April 4th" description="v0.11.201" tags={["Improved"]}>
 
 Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+
 </Update>
 
-<Update label="April 3rd" description="[v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)" tags={["New"]}>
+<Update label="April 3rd" description="v0.11.200" tags={["New"]}>
 
 - Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
 - Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
 - Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+
 </Update>
 
-<Update label="April 2nd" description="[v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)" tags={["New"]}>
+<Update label="April 2nd" description="v0.11.199" tags={["New"]}>
 
 - Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
 - Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
 - Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+
 </Update>
 
-<Update label="March 31st" description="[v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)" tags={["Improved"]}>
+<Update label="March 31st" description="v0.11.198" tags={["Improved"]}>
 
 Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+
 </Update>
 
-<Update label="March 31st" description="[v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)" tags={["Improved"]}>
+<Update label="March 31st" description="v0.11.197" tags={["Improved"]}>
 
 - Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
 - Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
 - Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+
 </Update>
 
-<Update label="March 30th" description="[v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)" tags={["New"]}>
+<Update label="March 30th" description="v0.11.196" tags={["New"]}>
 
 - Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
 - Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
 - Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+
 </Update>
 
-<Update label="March 27th" description="[v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)" tags={["Improved"]}>
+<Update label="March 27th" description="v0.11.195" tags={["Improved"]}>
 
 Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+
 </Update>
 
-<Update label="March 26th" description="[v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)" tags={["Improved"]}>
+<Update label="March 26th" description="v0.11.194" tags={["Improved"]}>
 
 Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+
 </Update>
 
-<Update label="March 26th" description="[v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)" tags={["New"]}>
+<Update label="March 26th" description="v0.11.193" tags={["New"]}>
 
 - Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
 - Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
 - Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+
 </Update>
 
-<Update label="March 25th" description="[v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)" tags={["New"]}>
+<Update label="March 25th" description="v0.11.192" tags={["New"]}>
 
 - Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
 - Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
 - Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+
 </Update>
 
-<Update label="March 25th" description="[v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)" tags={["Improved"]}>
+<Update label="March 25th" description="v0.11.191" tags={["Improved"]}>
 
 Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+
 </Update>
 
-<Update label="March 24th" description="[v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)" tags={["Improved"]}>
+<Update label="March 24th" description="v0.11.190" tags={["Improved"]}>
 
 Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+
 </Update>
 
-<Update label="March 24th" description="[v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)" tags={["Misc"]}>
+<Update label="March 24th" description="v0.11.189" tags={["Misc"]}>
 
 Rolls the release line forward with no visible product or workflow changes.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+
 </Update>
 
-<Update label="March 24th" description="[v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)" tags={["Improved"]}>
+<Update label="March 24th" description="v0.11.188" tags={["Improved"]}>
 
 Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+
 </Update>
 
-<Update label="March 24th" description="[v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)" tags={["Improved"]}>
+<Update label="March 24th" description="v0.11.187" tags={["Improved"]}>
 
 Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+
 </Update>
 
-<Update label="March 24th" description="[v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)" tags={["Improved"]}>
+<Update label="March 24th" description="v0.11.186" tags={["Improved"]}>
 
 Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+
 </Update>
 
-<Update label="March 24th" description="[v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)" tags={["New"]}>
+<Update label="March 24th" description="v0.11.185" tags={["New"]}>
 
 - Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
 - Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
 - Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+
 </Update>
 
-<Update label="March 23rd" description="[v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)" tags={["Misc"]}>
+<Update label="March 23rd" description="v0.11.184" tags={["Misc"]}>
 
 Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+
 </Update>
 
-<Update label="March 23rd" description="[v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)" tags={["New"]}>
+<Update label="March 23rd" description="v0.11.183" tags={["New"]}>
 
 Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+
 </Update>
 
-<Update label="March 23rd" description="[v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)" tags={["Improved"]}>
+<Update label="March 23rd" description="v0.11.182" tags={["Improved"]}>
 
 - Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
 - Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
 - Polished session tool traces by moving the chevron affordance to the right for faster scanning.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+
 </Update>
 
-<Update label="March 22nd" description="[v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)" tags={["Misc"]}>
+<Update label="March 22nd" description="v0.11.181" tags={["Misc"]}>
 
 Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+
 </Update>
 
-<Update label="March 22nd" description="[v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)" tags={["Improved"]}>
+<Update label="March 22nd" description="v0.11.179" tags={["Improved"]}>
 
 Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+
 </Update>
 
-<Update label="March 22nd" description="[v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)" tags={["New"]}>
+<Update label="March 22nd" description="v0.11.178" tags={["New"]}>
 
 - Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
 - Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
 - Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+
 </Update>
 
-<Update label="March 20th" description="[v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)" tags={["Improved"]}>
+<Update label="March 20th" description="v0.11.177" tags={["Improved"]}>
 
 Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+
 </Update>
 
-<Update label="March 20th" description="[v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)" tags={["Improved"]}>
+<Update label="March 20th" description="v0.11.175" tags={["Improved"]}>
 
 Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+
 </Update>
 
-<Update label="March 20th" description="[v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)" tags={["New"]}>
+<Update label="March 20th" description="v0.11.173" tags={["New"]}>
 
 Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+
 </Update>
 
-<Update label="March 19th" description="[v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)" tags={["Improved"]}>
+<Update label="March 19th" description="v0.11.172" tags={["Improved"]}>
 
 Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+
 </Update>
 
-<Update label="March 19th" description="[v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)" tags={["Improved"]}>
+<Update label="March 19th" description="v0.11.170" tags={["Improved"]}>
 
 - Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
 - Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
 - Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+
 </Update>
 
-<Update label="March 18th" description="[v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)" tags={["Improved"]}>
+<Update label="March 18th" description="v0.11.169" tags={["Improved"]}>
 
 Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+
 </Update>
 
-<Update label="March 17th" description="[v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)" tags={["Improved"]}>
+<Update label="March 17th" description="v0.11.168" tags={["Improved"]}>
 
 Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+
 </Update>
 
-<Update label="March 17th" description="[v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)" tags={["Improved"]}>
+<Update label="March 17th" description="v0.11.166" tags={["Improved"]}>
 
 - Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
 - Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
 - Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+
 </Update>
 
-<Update label="March 17th" description="[v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)" tags={["Improved"]}>
+<Update label="March 17th" description="v0.11.165" tags={["Improved"]}>
 
 - Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
 - Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
 - Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+
 </Update>
 
-<Update label="March 16th" description="[v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)" tags={["Improved"]}>
+<Update label="March 16th" description="v0.11.164" tags={["Improved"]}>
 
 Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+
 </Update>
 
-<Update label="March 16th" description="[v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)" tags={["Improved"]}>
+<Update label="March 16th" description="v0.11.163" tags={["Improved"]}>
 
 Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+
 </Update>
 
-<Update label="March 16th" description="[v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)" tags={["New"]}>
+<Update label="March 16th" description="v0.11.162" tags={["New"]}>
 
 Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+
 </Update>
 
-<Update label="March 15th" description="[v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)" tags={["Improved"]}>
+<Update label="March 15th" description="v0.11.160" tags={["Improved"]}>
 
 Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+
 </Update>
 
-<Update label="March 15th" description="[v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)" tags={["Improved"]}>
+<Update label="March 15th" description="v0.11.159" tags={["Improved"]}>
 
 Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+
 </Update>
 
-<Update label="March 15th" description="[v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)" tags={["Misc"]}>
+<Update label="March 15th" description="v0.11.155" tags={["Misc"]}>
 
 Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+
 </Update>
 
-<Update label="March 15th" description="[v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)" tags={["Improved"]}>
+<Update label="March 15th" description="v0.11.151" tags={["Improved"]}>
 
 Makes feedback submissions reach the OpenWork team inbox reliably again.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+
 </Update>
 
-<Update label="March 15th" description="[v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)" tags={["Improved"]}>
+<Update label="March 15th" description="v0.11.150" tags={["Improved"]}>
 
 Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+
 </Update>
 
-<Update label="March 14th" description="[v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)" tags={["Improved"]}>
+<Update label="March 14th" description="v0.11.149" tags={["Improved"]}>
 
 Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+
 </Update>
 
-<Update label="March 14th" description="[v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)" tags={["New"]}>
+<Update label="March 14th" description="v0.11.148" tags={["New"]}>
 
 - Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
 - OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
 - Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+
 </Update>
 
-<Update label="March 14th" description="[v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)" tags={["New"]}>
+<Update label="March 14th" description="v0.11.147" tags={["New"]}>
 
 Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+
 </Update>
 
-<Update label="March 13th" description="[v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)" tags={["New"]}>
+<Update label="March 13th" description="v0.11.146" tags={["New"]}>
 
 Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+
 </Update>
 
-<Update label="March 13th" description="[v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)" tags={["New"]}>
+<Update label="March 13th" description="v0.11.145" tags={["New"]}>
 
 Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+
 </Update>
 
-<Update label="March 12th" description="[v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)" tags={["Improved"]}>
+<Update label="March 12th" description="v0.11.144" tags={["Improved"]}>
 
 Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+
 </Update>
 
-<Update label="March 12th" description="[v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)" tags={["New"]}>
+<Update label="March 12th" description="v0.11.143" tags={["New"]}>
 
 - Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
 - The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
 - Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+
 </Update>
 
-<Update label="March 12th" description="[v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)" tags={["Misc"]}>
+<Update label="March 12th" description="v0.11.142" tags={["Misc"]}>
 
 Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+
 </Update>
 
-<Update label="March 12th" description="[v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)" tags={["Improved"]}>
+<Update label="March 12th" description="v0.11.141" tags={["Improved"]}>
 
 Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+
 </Update>
 
-<Update label="March 11th" description="[v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)" tags={["Improved"]}>
+<Update label="March 11th" description="v0.11.140" tags={["Improved"]}>
 
 Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+
 </Update>
 
-<Update label="March 11th" description="[v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)" tags={["Improved"]}>
+<Update label="March 11th" description="v0.11.138" tags={["Improved"]}>
 
 Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+
 </Update>
 
-<Update label="March 11th" description="[v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)" tags={["Improved"]}>
+<Update label="March 11th" description="v0.11.137" tags={["Improved"]}>
 
 Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+
 </Update>
 
-<Update label="March 10th" description="[v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)" tags={["New"]}>
+<Update label="March 10th" description="v0.11.136" tags={["New"]}>
 
 - Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
 - Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
 - Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+
 </Update>
 
-<Update label="March 6th" description="[v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)" tags={["Misc"]}>
+<Update label="March 6th" description="v0.11.135" tags={["Misc"]}>
 
 Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+
 </Update>
 
-<Update label="March 6th" description="[v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)" tags={["New"]}>
+<Update label="March 6th" description="v0.11.134" tags={["New"]}>
 
 Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+
 </Update>
 
-<Update label="March 5th" description="[v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)" tags={["Improved"]}>
+<Update label="March 5th" description="v0.11.133" tags={["Improved"]}>
 
 Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+
 </Update>
 
-<Update label="March 5th" description="[v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)" tags={["Improved"]}>
+<Update label="March 5th" description="v0.11.132" tags={["Improved"]}>
 
 Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+
 </Update>
 
-<Update label="March 4th" description="[v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)" tags={["New"]}>
+<Update label="March 4th" description="v0.11.131" tags={["New"]}>
 
 - Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
 - Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
 - Added persistent language selection and improved file-open reliability for editor and artifact flows.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+
 </Update>
 
-<Update label="March 2nd" description="[v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)" tags={["Improved"]}>
+<Update label="March 2nd" description="v0.11.130" tags={["Improved"]}>
 
 Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+
 </Update>
 
-<Update label="March 2nd" description="[v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)" tags={["New"]}>
+<Update label="March 2nd" description="v0.11.129" tags={["New"]}>
 
 Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+
 </Update>
 
-<Update label="March 1st" description="[v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)" tags={["New"]}>
+<Update label="March 1st" description="v0.11.128" tags={["New"]}>
 
 Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+
 </Update>
 
-<Update label="February 28th" description="[v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)" tags={["New"]}>
+<Update label="February 28th" description="v0.11.127" tags={["New"]}>
 
 Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+
 </Update>
 
-<Update label="February 27th" description="[v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)" tags={["New"]}>
+<Update label="February 27th" description="v0.11.126" tags={["New"]}>
 
 Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+
 </Update>
 
-<Update label="February 26th" description="[v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)" tags={["Improved"]}>
+<Update label="February 26th" description="v0.11.125" tags={["Improved"]}>
 
 Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+
 </Update>
 
-<Update label="February 26th" description="[v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)" tags={["New"]}>
+<Update label="February 26th" description="v0.11.124" tags={["New"]}>
 
 Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+
 </Update>
 
-<Update label="February 26th" description="[v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)" tags={["New"]}>
+<Update label="February 26th" description="v0.11.123" tags={["New"]}>
 
 Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+
 </Update>
 
-<Update label="February 26th" description="[v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)" tags={["New"]}>
+<Update label="February 26th" description="v0.11.122" tags={["New"]}>
 
 - Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
 - Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
 - Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+
 </Update>
 
-<Update label="February 23rd" description="[v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)" tags={["New"]}>
+<Update label="February 23rd" description="v0.11.121" tags={["New"]}>
 
 Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+
 </Update>
 
-<Update label="February 23rd" description="[v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)" tags={["Improved"]}>
+<Update label="February 23rd" description="v0.11.120" tags={["Improved"]}>
 
 Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+
 </Update>
 
-<Update label="February 23rd" description="[v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)" tags={["Improved"]}>
+<Update label="February 23rd" description="v0.11.119" tags={["Improved"]}>
 
 Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+
 </Update>
 
-<Update label="February 23rd" description="[v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)" tags={["Improved"]}>
+<Update label="February 23rd" description="v0.11.118" tags={["Improved"]}>
 
 Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+
 </Update>
 
-<Update label="February 23rd" description="[v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)" tags={["Improved"]}>
+<Update label="February 23rd" description="v0.11.117" tags={["Improved"]}>
 
 Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+
 </Update>
 
-<Update label="February 22nd" description="[v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)" tags={["New"]}>
+<Update label="February 22nd" description="v0.11.116" tags={["New"]}>
 
 Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+
 </Update>
 
-<Update label="February 22nd" description="[v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)" tags={["New"]}>
+<Update label="February 22nd" description="v0.11.115" tags={["New"]}>
 
 Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+
 </Update>
 
-<Update label="February 22nd" description="[v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)" tags={["Improved"]}>
+<Update label="February 22nd" description="v0.11.114" tags={["Improved"]}>
 
 - Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
 - Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
 - Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+
 </Update>
 
-<Update label="February 21st" description="[v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)" tags={["New"]}>
+<Update label="February 21st" description="v0.11.113" tags={["New"]}>
 
 Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+
 </Update>
 
-<Update label="February 21st" description="[v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)" tags={["Improved"]}>
+<Update label="February 21st" description="v0.11.112" tags={["Improved"]}>
 
 Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)" tags={["Misc"]}>
+<Update label="February 20th" description="v0.11.111" tags={["Misc"]}>
 
 Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)" tags={["Misc"]}>
+<Update label="February 20th" description="v0.11.110" tags={["Misc"]}>
 
 Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)" tags={["New"]}>
+<Update label="February 20th" description="v0.11.109" tags={["New"]}>
 
 Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)" tags={["Improved"]}>
+<Update label="February 20th" description="v0.11.108" tags={["Improved"]}>
 
 Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)" tags={["Improved"]}>
+<Update label="February 20th" description="v0.11.107" tags={["Improved"]}>
 
 Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)" tags={["Misc"]}>
+<Update label="February 20th" description="v0.11.106" tags={["Misc"]}>
 
 Refreshes release metadata only, with no clear user-facing product change in this patch.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)" tags={["Improved"]}>
+<Update label="February 20th" description="v0.11.105" tags={["Improved"]}>
 
 Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)" tags={["Improved"]}>
+<Update label="February 20th" description="v0.11.104" tags={["Improved"]}>
 
 Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)" tags={["Improved"]}>
+<Update label="February 20th" description="v0.11.103" tags={["Improved"]}>
 
 - Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
 - Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
 - Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+
 </Update>
 
-<Update label="February 20th" description="[v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)" tags={["Improved"]}>
+<Update label="February 20th" description="v0.11.102" tags={["Improved"]}>
 
 Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
 
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+
 </Update>
 
-<Update label="February 19th" description="[v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)" tags={["New"]}>
+<Update label="February 19th" description="v0.11.101" tags={["New"]}>
 
 Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
+
+[View changes](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
 
 </Update>
 

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,750 +1,752 @@
 ---
 title: "Changelog"
 ---
-<Update label="April 4th" description="v0.11.201" tags={["Improved"]}>
+<Update label="April 4th" tags={["Improvements"]}>
 
-Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
+  ## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+  Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
 
 </Update>
 
-<Update label="April 3rd" description="v0.11.200" tags={["New"]}>
+<Update label="April 3rd" tags={["New releases"]}>
 
-- Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
-- Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
-- Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
+  ## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+  - Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
+  - Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
+  - Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
 
 </Update>
 
-<Update label="April 2nd" description="v0.11.199" tags={["New"]}>
+<Update label="April 2nd" tags={["New releases", "Improvements", "Deprecations"]}>
 
-- Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
-- Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
-- Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
+  ## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+  - Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
+  - Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
+  - Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
 
 </Update>
 
-<Update label="March 31st" description="v0.11.198" tags={["Improved"]}>
+<Update label="March 31st" tags={["Improvements"]}>
 
-Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
+  ## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+  Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
 
 </Update>
 
-<Update label="March 31st" description="v0.11.197" tags={["Improved"]}>
+<Update label="March 31st" tags={["Improvements"]}>
 
-- Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
-- Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
-- Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
+  ## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+  - Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
+  - Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
+  - Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
 
 </Update>
 
-<Update label="March 30th" description="v0.11.196" tags={["New"]}>
+<Update label="March 30th" tags={["New releases", "Improvements", "Deprecations"]}>
 
-- Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
-- Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
-- Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
+  ## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+  - Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
+  - Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
+  - Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
 
 </Update>
 
-<Update label="March 27th" description="v0.11.195" tags={["Improved"]}>
+<Update label="March 27th" tags={["New releases", "Improvements"]}>
 
-Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
+  ## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+  Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
 
 </Update>
 
-<Update label="March 26th" description="v0.11.194" tags={["Improved"]}>
+<Update label="March 26th" tags={["New releases", "Improvements"]}>
 
-Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
+  ## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+  Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
 
 </Update>
 
-<Update label="March 26th" description="v0.11.193" tags={["New"]}>
+<Update label="March 26th" tags={["New releases", "Improvements"]}>
 
-- Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
-- Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
-- Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
+  ## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+  - Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
+  - Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
+  - Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
 
 </Update>
 
-<Update label="March 25th" description="v0.11.192" tags={["New"]}>
+<Update label="March 25th" tags={["New releases", "Improvements"]}>
 
-- Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
-- Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
-- Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
+  ## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+  - Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
+  - Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
+  - Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
 
 </Update>
 
-<Update label="March 25th" description="v0.11.191" tags={["Improved"]}>
+<Update label="March 25th" tags={["Improvements"]}>
 
-Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
+  ## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+  Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
 
 </Update>
 
-<Update label="March 24th" description="v0.11.190" tags={["Improved"]}>
+<Update label="March 24th" tags={["Improvements"]}>
 
-Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
+  ## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+  Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
 
 </Update>
 
-<Update label="March 24th" description="v0.11.189" tags={["Misc"]}>
+<Update label="March 24th" tags={["Misc"]}>
 
-Rolls the release line forward with no visible product or workflow changes.
+  ## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+  Rolls the release line forward with no visible product or workflow changes.
 
 </Update>
 
-<Update label="March 24th" description="v0.11.188" tags={["Improved"]}>
+<Update label="March 24th" tags={["Improvements"]}>
 
-Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
+  ## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+  Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
 
 </Update>
 
-<Update label="March 24th" description="v0.11.187" tags={["Improved"]}>
+<Update label="March 24th" tags={["Improvements"]}>
 
-Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
+  ## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+  Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
 
 </Update>
 
-<Update label="March 24th" description="v0.11.186" tags={["Improved"]}>
+<Update label="March 24th" tags={["Improvements"]}>
 
-Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
+  ## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+  Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
 
 </Update>
 
-<Update label="March 24th" description="v0.11.185" tags={["New"]}>
+<Update label="March 24th" tags={["New releases", "Improvements"]}>
 
-- Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
-- Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
-- Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
+  ## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+  - Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
+  - Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
+  - Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
 
 </Update>
 
-<Update label="March 23rd" description="v0.11.184" tags={["Misc"]}>
+<Update label="March 23rd" tags={["Misc"]}>
 
-Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
+  ## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+  Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
 
 </Update>
 
-<Update label="March 23rd" description="v0.11.183" tags={["New"]}>
+<Update label="March 23rd" tags={["New releases", "Improvements"]}>
 
-Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
+  ## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+  Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
 
 </Update>
 
-<Update label="March 23rd" description="v0.11.182" tags={["Improved"]}>
+<Update label="March 23rd" tags={["Improvements"]}>
 
-- Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
-- Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
-- Polished session tool traces by moving the chevron affordance to the right for faster scanning.
+  ## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+  - Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
+  - Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
+  - Polished session tool traces by moving the chevron affordance to the right for faster scanning.
 
 </Update>
 
-<Update label="March 22nd" description="v0.11.181" tags={["Misc"]}>
+<Update label="March 22nd" tags={["Misc"]}>
 
-Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
+  ## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+  Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
 
 </Update>
 
-<Update label="March 22nd" description="v0.11.179" tags={["Improved"]}>
+<Update label="March 22nd" tags={["Improvements", "Deprecations"]}>
 
-Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
+  ## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+  Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
 
 </Update>
 
-<Update label="March 22nd" description="v0.11.178" tags={["New"]}>
+<Update label="March 22nd" tags={["New releases", "Improvements"]}>
 
-- Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
-- Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
-- Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
+  ## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+  - Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
+  - Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
+  - Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
 
 </Update>
 
-<Update label="March 20th" description="v0.11.177" tags={["Improved"]}>
+<Update label="March 20th" tags={["Improvements"]}>
 
-Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
+  ## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+  Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
 
 </Update>
 
-<Update label="March 20th" description="v0.11.175" tags={["Improved"]}>
+<Update label="March 20th" tags={["New releases", "Improvements", "Deprecations"]}>
 
-Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
+  ## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+  Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
 
 </Update>
 
-<Update label="March 20th" description="v0.11.173" tags={["New"]}>
+<Update label="March 20th" tags={["New releases", "Improvements"]}>
 
-Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
+  ## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+  Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
 
 </Update>
 
-<Update label="March 19th" description="v0.11.172" tags={["Improved"]}>
+<Update label="March 19th" tags={["Improvements", "Deprecations"]}>
 
-Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
+  ## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+  Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
 
 </Update>
 
-<Update label="March 19th" description="v0.11.170" tags={["Improved"]}>
+<Update label="March 19th" tags={["New releases", "Improvements"]}>
 
-- Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
-- Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
-- Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
+  ## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+  - Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
+  - Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
+  - Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
 
 </Update>
 
-<Update label="March 18th" description="v0.11.169" tags={["Improved"]}>
+<Update label="March 18th" tags={["Improvements"]}>
 
-Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
+  ## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+  Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
 
 </Update>
 
-<Update label="March 17th" description="v0.11.168" tags={["Improved"]}>
+<Update label="March 17th" tags={["Improvements"]}>
 
-Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
+  ## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+  Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
 
 </Update>
 
-<Update label="March 17th" description="v0.11.166" tags={["Improved"]}>
+<Update label="March 17th" tags={["New releases", "Improvements"]}>
 
-- Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
-- Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
-- Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
+  ## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+  - Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
+  - Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
+  - Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
 
 </Update>
 
-<Update label="March 17th" description="v0.11.165" tags={["Improved"]}>
+<Update label="March 17th" tags={["New releases", "Improvements"]}>
 
-- Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
-- Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
-- Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
+  ## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+  - Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
+  - Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
+  - Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
 
 </Update>
 
-<Update label="March 16th" description="v0.11.164" tags={["Improved"]}>
+<Update label="March 16th" tags={["New releases", "Improvements"]}>
 
-Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
+  ## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+  Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
 
 </Update>
 
-<Update label="March 16th" description="v0.11.163" tags={["Improved"]}>
+<Update label="March 16th" tags={["New releases", "Improvements"]}>
 
-Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
+  ## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+  Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
 
 </Update>
 
-<Update label="March 16th" description="v0.11.162" tags={["New"]}>
+<Update label="March 16th" tags={["New releases"]}>
 
-Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
+  ## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+  Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
 
 </Update>
 
-<Update label="March 15th" description="v0.11.160" tags={["Improved"]}>
+<Update label="March 15th" tags={["Improvements"]}>
 
-Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
+  ## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+  Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
 
 </Update>
 
-<Update label="March 15th" description="v0.11.159" tags={["Improved"]}>
+<Update label="March 15th" tags={["New releases", "Improvements"]}>
 
-Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
+  ## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+  Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
 
 </Update>
 
-<Update label="March 15th" description="v0.11.155" tags={["Misc"]}>
+<Update label="March 15th" tags={["Misc"]}>
 
-Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
+  ## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+  Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
 
 </Update>
 
-<Update label="March 15th" description="v0.11.151" tags={["Improved"]}>
+<Update label="March 15th" tags={["Improvements"]}>
 
-Makes feedback submissions reach the OpenWork team inbox reliably again.
+  ## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+  Makes feedback submissions reach the OpenWork team inbox reliably again.
 
 </Update>
 
-<Update label="March 15th" description="v0.11.150" tags={["Improved"]}>
+<Update label="March 15th" tags={["Improvements"]}>
 
-Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
+  ## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+  Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
 
 </Update>
 
-<Update label="March 14th" description="v0.11.149" tags={["Improved"]}>
+<Update label="March 14th" tags={["Improvements"]}>
 
-Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
+  ## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+  Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
 
 </Update>
 
-<Update label="March 14th" description="v0.11.148" tags={["New"]}>
+<Update label="March 14th" tags={["New releases", "Improvements"]}>
 
-- Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
-- OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
-- Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
+  ## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+  - Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
+  - OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
+  - Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
 
 </Update>
 
-<Update label="March 14th" description="v0.11.147" tags={["New"]}>
+<Update label="March 14th" tags={["New releases", "Improvements"]}>
 
-Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
+  ## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+  Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
 
 </Update>
 
-<Update label="March 13th" description="v0.11.146" tags={["New"]}>
+<Update label="March 13th" tags={["New releases", "Improvements"]}>
 
-Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
+  ## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+  Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
 
 </Update>
 
-<Update label="March 13th" description="v0.11.145" tags={["New"]}>
+<Update label="March 13th" tags={["New releases", "Improvements"]}>
 
-Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
+  ## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+  Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
 
 </Update>
 
-<Update label="March 12th" description="v0.11.144" tags={["Improved"]}>
+<Update label="March 12th" tags={["Improvements"]}>
 
-Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
+  ## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+  Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
 
 </Update>
 
-<Update label="March 12th" description="v0.11.143" tags={["New"]}>
+<Update label="March 12th" tags={["New releases", "Improvements", "Deprecations"]}>
 
-- Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
-- The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
-- Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
+  ## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+  - Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
+  - The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
+  - Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
 
 </Update>
 
-<Update label="March 12th" description="v0.11.142" tags={["Misc"]}>
+<Update label="March 12th" tags={["Misc"]}>
 
-Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
+  ## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+  Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
 
 </Update>
 
-<Update label="March 12th" description="v0.11.141" tags={["Improved"]}>
+<Update label="March 12th" tags={["New releases", "Improvements"]}>
 
-Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
+  ## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+  Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
 
 </Update>
 
-<Update label="March 11th" description="v0.11.140" tags={["Improved"]}>
+<Update label="March 11th" tags={["Improvements"]}>
 
-Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
+  ## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+  Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
 
 </Update>
 
-<Update label="March 11th" description="v0.11.138" tags={["Improved"]}>
+<Update label="March 11th" tags={["Improvements"]}>
 
-Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
+  ## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+  Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
 
 </Update>
 
-<Update label="March 11th" description="v0.11.137" tags={["Improved"]}>
+<Update label="March 11th" tags={["Improvements"]}>
 
-Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
+  ## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+  Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
 
 </Update>
 
-<Update label="March 10th" description="v0.11.136" tags={["New"]}>
+<Update label="March 10th" tags={["New releases", "Improvements"]}>
 
-- Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
-- Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
-- Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
+  ## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+  - Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
+  - Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
+  - Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
 
 </Update>
 
-<Update label="March 6th" description="v0.11.135" tags={["Misc"]}>
+<Update label="March 6th" tags={["Misc"]}>
 
-Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
+  ## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+  Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
 
 </Update>
 
-<Update label="March 6th" description="v0.11.134" tags={["New"]}>
+<Update label="March 6th" tags={["New releases"]}>
 
-Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
+  ## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+  Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
 
 </Update>
 
-<Update label="March 5th" description="v0.11.133" tags={["Improved"]}>
+<Update label="March 5th" tags={["Improvements"]}>
 
-Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
+  ## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+  Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
 
 </Update>
 
-<Update label="March 5th" description="v0.11.132" tags={["Improved"]}>
+<Update label="March 5th" tags={["Improvements"]}>
 
-Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
+  ## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+  Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
 
 </Update>
 
-<Update label="March 4th" description="v0.11.131" tags={["New"]}>
+<Update label="March 4th" tags={["New releases", "Improvements"]}>
 
-- Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
-- Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
-- Added persistent language selection and improved file-open reliability for editor and artifact flows.
+  ## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+  - Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
+  - Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
+  - Added persistent language selection and improved file-open reliability for editor and artifact flows.
 
 </Update>
 
-<Update label="March 2nd" description="v0.11.130" tags={["Improved"]}>
+<Update label="March 2nd" tags={["New releases", "Improvements"]}>
 
-Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
+  ## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+  Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
 
 </Update>
 
-<Update label="March 2nd" description="v0.11.129" tags={["New"]}>
+<Update label="March 2nd" tags={["New releases", "Improvements"]}>
 
-Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
+  ## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+  Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
 
 </Update>
 
-<Update label="March 1st" description="v0.11.128" tags={["New"]}>
+<Update label="March 1st" tags={["New releases", "Improvements"]}>
 
-Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
+  ## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+  Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
 
 </Update>
 
-<Update label="February 28th" description="v0.11.127" tags={["New"]}>
+<Update label="February 28th" tags={["New releases", "Improvements"]}>
 
-Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
+  ## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+  Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
 
 </Update>
 
-<Update label="February 27th" description="v0.11.126" tags={["New"]}>
+<Update label="February 27th" tags={["New releases", "Deprecations"]}>
 
-Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
+  ## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+  Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
 
 </Update>
 
-<Update label="February 26th" description="v0.11.125" tags={["Improved"]}>
+<Update label="February 26th" tags={["Improvements"]}>
 
-Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
+  ## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+  Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
 
 </Update>
 
-<Update label="February 26th" description="v0.11.124" tags={["New"]}>
+<Update label="February 26th" tags={["New releases", "Improvements"]}>
 
-Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
+  ## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+  Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
 
 </Update>
 
-<Update label="February 26th" description="v0.11.123" tags={["New"]}>
+<Update label="February 26th" tags={["New releases"]}>
 
-Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
+  ## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+  Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
 
 </Update>
 
-<Update label="February 26th" description="v0.11.122" tags={["New"]}>
+<Update label="February 26th" tags={["New releases", "Improvements"]}>
 
-- Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
-- Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
-- Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
+  ## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+  - Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
+  - Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
+  - Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
 
 </Update>
 
-<Update label="February 23rd" description="v0.11.121" tags={["New"]}>
+<Update label="February 23rd" tags={["New releases"]}>
 
-Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
+  ## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+  Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
 
 </Update>
 
-<Update label="February 23rd" description="v0.11.120" tags={["Improved"]}>
+<Update label="February 23rd" tags={["Improvements"]}>
 
-Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
+  ## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+  Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
 
 </Update>
 
-<Update label="February 23rd" description="v0.11.119" tags={["Improved"]}>
+<Update label="February 23rd" tags={["Improvements"]}>
 
-Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
+  ## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+  Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
 
 </Update>
 
-<Update label="February 23rd" description="v0.11.118" tags={["Improved"]}>
+<Update label="February 23rd" tags={["Improvements"]}>
 
-Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
+  ## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+  Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
 
 </Update>
 
-<Update label="February 23rd" description="v0.11.117" tags={["Improved"]}>
+<Update label="February 23rd" tags={["New releases", "Improvements"]}>
 
-Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
+  ## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+  Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
 
 </Update>
 
-<Update label="February 22nd" description="v0.11.116" tags={["New"]}>
+<Update label="February 22nd" tags={["New releases"]}>
 
-Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
+  ## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+  Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
 
 </Update>
 
-<Update label="February 22nd" description="v0.11.115" tags={["New"]}>
+<Update label="February 22nd" tags={["New releases", "Improvements"]}>
 
-Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
+  ## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+  Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
 
 </Update>
 
-<Update label="February 22nd" description="v0.11.114" tags={["Improved"]}>
+<Update label="February 22nd" tags={["New releases", "Improvements"]}>
 
-- Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
-- Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
-- Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
+  ## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+  - Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
+  - Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
+  - Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
 
 </Update>
 
-<Update label="February 21st" description="v0.11.113" tags={["New"]}>
+<Update label="February 21st" tags={["New releases"]}>
 
-Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
+  ## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+  Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
 
 </Update>
 
-<Update label="February 21st" description="v0.11.112" tags={["Improved"]}>
+<Update label="February 21st" tags={["Improvements"]}>
 
-Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
+  ## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+  Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.111" tags={["Misc"]}>
+<Update label="February 20th" tags={["Misc"]}>
 
-Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
+  ## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+  Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.110" tags={["Misc"]}>
+<Update label="February 20th" tags={["Misc"]}>
 
-Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
+  ## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+  Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.109" tags={["New"]}>
+<Update label="February 20th" tags={["New releases", "Improvements"]}>
 
-Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
+  ## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+  Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.108" tags={["Improved"]}>
+<Update label="February 20th" tags={["New releases", "Improvements"]}>
 
-Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
+  ## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+  Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.107" tags={["Improved"]}>
+<Update label="February 20th" tags={["Improvements"]}>
 
-Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
+  ## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+  Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.106" tags={["Misc"]}>
+<Update label="February 20th" tags={["Misc"]}>
 
-Refreshes release metadata only, with no clear user-facing product change in this patch.
+  ## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+  Refreshes release metadata only, with no clear user-facing product change in this patch.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.105" tags={["Improved"]}>
+<Update label="February 20th" tags={["Improvements"]}>
 
-Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
+  ## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+  Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.104" tags={["Improved"]}>
+<Update label="February 20th" tags={["Improvements"]}>
 
-Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
+  ## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+  Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.103" tags={["Improved"]}>
+<Update label="February 20th" tags={["Improvements"]}>
 
-- Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
-- Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
-- Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
+  ## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+  - Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
+  - Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
+  - Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
 
 </Update>
 
-<Update label="February 20th" description="v0.11.102" tags={["Improved"]}>
+<Update label="February 20th" tags={["Improvements"]}>
 
-Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
+  ## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+  Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
 
 </Update>
 
-<Update label="February 19th" description="v0.11.101" tags={["New"]}>
+<Update label="February 19th" tags={["New releases", "Improvements"]}>
 
-Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
+  ## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
 
-[View changes](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
+  Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
 
 </Update>
 
-<Update label="February 19th" description="v0.11.100" tags={["Improved"]}>
+<Update label="February 19th" tags={["Improvements"]}>
 
-Stops long prompts from disappearing while typing, making the session composer reliable again.
+  ## v0.11.100
+
+  Stops long prompts from disappearing while typing, making the session composer reliable again.
 
 </Update>

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,0 +1,750 @@
+---
+title: "Changelog"
+---
+April 4th `Improved`
+
+## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+
+Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
+
+---
+
+April 3rd `New`
+
+## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+
+- Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
+- Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
+- Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
+
+---
+
+April 2nd `New`
+
+## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+
+- Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
+- Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
+- Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
+
+---
+
+March 31st `Improved`
+
+## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+
+Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
+
+---
+
+March 31st `Improved`
+
+## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+
+- Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
+- Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
+- Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
+
+---
+
+March 30th `New`
+
+## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+
+- Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
+- Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
+- Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
+
+---
+
+March 27th `Improved`
+
+## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+
+Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
+
+---
+
+March 26th `Improved`
+
+## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+
+Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
+
+---
+
+March 26th `New`
+
+## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+
+- Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
+- Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
+- Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
+
+---
+
+March 25th `New`
+
+## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+
+- Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
+- Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
+- Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
+
+---
+
+March 25th `Improved`
+
+## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+
+Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
+
+---
+
+March 24th `Improved`
+
+## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+
+Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
+
+---
+
+March 24th `Misc`
+
+## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+
+Rolls the release line forward with no visible product or workflow changes.
+
+---
+
+March 24th `Improved`
+
+## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+
+Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
+
+---
+
+March 24th `Improved`
+
+## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+
+Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
+
+---
+
+March 24th `Improved`
+
+## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+
+Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
+
+---
+
+March 24th `New`
+
+## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+
+- Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
+- Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
+- Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
+
+---
+
+March 23rd `Misc`
+
+## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+
+Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
+
+---
+
+March 23rd `New`
+
+## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+
+Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
+
+---
+
+March 23rd `Improved`
+
+## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+
+- Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
+- Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
+- Polished session tool traces by moving the chevron affordance to the right for faster scanning.
+
+---
+
+March 22nd `Misc`
+
+## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+
+Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
+
+---
+
+March 22nd `Improved`
+
+## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+
+Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
+
+---
+
+March 22nd `New`
+
+## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+
+- Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
+- Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
+- Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
+
+---
+
+March 20th `Improved`
+
+## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+
+Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
+
+---
+
+March 20th `Improved`
+
+## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+
+Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
+
+---
+
+March 20th `New`
+
+## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+
+Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
+
+---
+
+March 19th `Improved`
+
+## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+
+Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
+
+---
+
+March 19th `Improved`
+
+## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+
+- Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
+- Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
+- Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
+
+---
+
+March 18th `Improved`
+
+## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+
+Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
+
+---
+
+March 17th `Improved`
+
+## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+
+Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
+
+---
+
+March 17th `Improved`
+
+## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+
+- Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
+- Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
+- Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
+
+---
+
+March 17th `Improved`
+
+## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+
+- Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
+- Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
+- Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
+
+---
+
+March 16th `Improved`
+
+## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+
+Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
+
+---
+
+March 16th `Improved`
+
+## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+
+Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
+
+---
+
+March 16th `New`
+
+## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+
+Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
+
+---
+
+March 15th `Improved`
+
+## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+
+Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
+
+---
+
+March 15th `Improved`
+
+## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+
+Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
+
+---
+
+March 15th `Misc`
+
+## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+
+Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
+
+---
+
+March 15th `Improved`
+
+## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+
+Makes feedback submissions reach the OpenWork team inbox reliably again.
+
+---
+
+March 15th `Improved`
+
+## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+
+Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
+
+---
+
+March 14th `Improved`
+
+## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+
+Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
+
+---
+
+March 14th `New`
+
+## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+
+- Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
+- OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
+- Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
+
+---
+
+March 14th `New`
+
+## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+
+Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
+
+---
+
+March 13th `New`
+
+## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+
+Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
+
+---
+
+March 13th `New`
+
+## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+
+Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
+
+---
+
+March 12th `Improved`
+
+## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+
+Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
+
+---
+
+March 12th `New`
+
+## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+
+- Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
+- The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
+- Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
+
+---
+
+March 12th `Misc`
+
+## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+
+Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
+
+---
+
+March 12th `Improved`
+
+## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+
+Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
+
+---
+
+March 11th `Improved`
+
+## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+
+Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
+
+---
+
+March 11th `Improved`
+
+## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+
+Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
+
+---
+
+March 11th `Improved`
+
+## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+
+Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
+
+---
+
+March 10th `New`
+
+## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+
+- Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
+- Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
+- Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
+
+---
+
+March 6th `Misc`
+
+## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+
+Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
+
+---
+
+March 6th `New`
+
+## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+
+Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
+
+---
+
+March 5th `Improved`
+
+## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+
+Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
+
+---
+
+March 5th `Improved`
+
+## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+
+Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
+
+---
+
+March 4th `New`
+
+## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+
+- Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
+- Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
+- Added persistent language selection and improved file-open reliability for editor and artifact flows.
+
+---
+
+March 2nd `Improved`
+
+## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+
+Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
+
+---
+
+March 2nd `New`
+
+## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+
+Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
+
+---
+
+March 1st `New`
+
+## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+
+Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
+
+---
+
+February 28th `New`
+
+## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+
+Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
+
+---
+
+February 27th `New`
+
+## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+
+Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
+
+---
+
+February 26th `Improved`
+
+## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+
+Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
+
+---
+
+February 26th `New`
+
+## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+
+Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
+
+---
+
+February 26th `New`
+
+## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+
+Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
+
+---
+
+February 26th `New`
+
+## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+
+- Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
+- Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
+- Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
+
+---
+
+February 23rd `New`
+
+## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+
+Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
+
+---
+
+February 23rd `Improved`
+
+## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+
+Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
+
+---
+
+February 23rd `Improved`
+
+## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+
+Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
+
+---
+
+February 23rd `Improved`
+
+## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+
+Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
+
+---
+
+February 23rd `Improved`
+
+## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+
+Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
+
+---
+
+February 22nd `New`
+
+## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+
+Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
+
+---
+
+February 22nd `New`
+
+## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+
+Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
+
+---
+
+February 22nd `Improved`
+
+## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+
+- Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
+- Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
+- Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
+
+---
+
+February 21st `New`
+
+## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+
+Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
+
+---
+
+February 21st `Improved`
+
+## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+
+Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
+
+---
+
+February 20th `Misc`
+
+## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+
+Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
+
+---
+
+February 20th `Misc`
+
+## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+
+Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
+
+---
+
+February 20th `New`
+
+## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+
+Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
+
+---
+
+February 20th `Improved`
+
+## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+
+Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
+
+---
+
+February 20th `Improved`
+
+## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+
+Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
+
+---
+
+February 20th `Misc`
+
+## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+
+Refreshes release metadata only, with no clear user-facing product change in this patch.
+
+---
+
+February 20th `Improved`
+
+## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+
+Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
+
+---
+
+February 20th `Improved`
+
+## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+
+Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
+
+---
+
+February 20th `Improved`
+
+## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+
+- Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
+- Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
+- Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
+
+---
+
+February 20th `Improved`
+
+## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+
+Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
+
+---
+
+February 19th `New`
+
+## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
+
+Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
+
+---
+
+February 19th `Improved`
+
+## v0.11.100
+
+Stops long prompts from disappearing while typing, making the session composer reliable again.

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,750 +1,574 @@
 ---
 title: "Changelog"
 ---
-April 4th `Improved`
-
-## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+<Update label="April 4th" description="[v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)" tags={["Improved"]}>
 
 Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
 
----
+</Update>
 
-April 3rd `New`
-
-## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+<Update label="April 3rd" description="[v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)" tags={["New"]}>
 
 - Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
 - Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
 - Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
 
----
+</Update>
 
-April 2nd `New`
-
-## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+<Update label="April 2nd" description="[v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)" tags={["New"]}>
 
 - Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
 - Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
 - Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
 
----
+</Update>
 
-March 31st `Improved`
-
-## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+<Update label="March 31st" description="[v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)" tags={["Improved"]}>
 
 Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
 
----
+</Update>
 
-March 31st `Improved`
-
-## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+<Update label="March 31st" description="[v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)" tags={["Improved"]}>
 
 - Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
 - Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
 - Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
 
----
+</Update>
 
-March 30th `New`
-
-## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+<Update label="March 30th" description="[v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)" tags={["New"]}>
 
 - Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
 - Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
 - Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
 
----
+</Update>
 
-March 27th `Improved`
-
-## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+<Update label="March 27th" description="[v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)" tags={["Improved"]}>
 
 Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
 
----
+</Update>
 
-March 26th `Improved`
-
-## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+<Update label="March 26th" description="[v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)" tags={["Improved"]}>
 
 Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
 
----
+</Update>
 
-March 26th `New`
-
-## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+<Update label="March 26th" description="[v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)" tags={["New"]}>
 
 - Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
 - Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
 - Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
 
----
+</Update>
 
-March 25th `New`
-
-## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+<Update label="March 25th" description="[v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)" tags={["New"]}>
 
 - Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
 - Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
 - Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
 
----
+</Update>
 
-March 25th `Improved`
-
-## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+<Update label="March 25th" description="[v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)" tags={["Improved"]}>
 
 Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
 
----
+</Update>
 
-March 24th `Improved`
-
-## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+<Update label="March 24th" description="[v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)" tags={["Improved"]}>
 
 Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
 
----
+</Update>
 
-March 24th `Misc`
-
-## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+<Update label="March 24th" description="[v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)" tags={["Misc"]}>
 
 Rolls the release line forward with no visible product or workflow changes.
 
----
+</Update>
 
-March 24th `Improved`
-
-## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+<Update label="March 24th" description="[v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)" tags={["Improved"]}>
 
 Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
 
----
+</Update>
 
-March 24th `Improved`
-
-## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+<Update label="March 24th" description="[v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)" tags={["Improved"]}>
 
 Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
 
----
+</Update>
 
-March 24th `Improved`
-
-## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+<Update label="March 24th" description="[v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)" tags={["Improved"]}>
 
 Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
 
----
+</Update>
 
-March 24th `New`
-
-## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+<Update label="March 24th" description="[v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)" tags={["New"]}>
 
 - Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
 - Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
 - Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
 
----
+</Update>
 
-March 23rd `Misc`
-
-## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+<Update label="March 23rd" description="[v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)" tags={["Misc"]}>
 
 Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
 
----
+</Update>
 
-March 23rd `New`
-
-## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+<Update label="March 23rd" description="[v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)" tags={["New"]}>
 
 Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
 
----
+</Update>
 
-March 23rd `Improved`
-
-## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+<Update label="March 23rd" description="[v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)" tags={["Improved"]}>
 
 - Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
 - Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
 - Polished session tool traces by moving the chevron affordance to the right for faster scanning.
 
----
+</Update>
 
-March 22nd `Misc`
-
-## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+<Update label="March 22nd" description="[v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)" tags={["Misc"]}>
 
 Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
 
----
+</Update>
 
-March 22nd `Improved`
-
-## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+<Update label="March 22nd" description="[v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)" tags={["Improved"]}>
 
 Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
 
----
+</Update>
 
-March 22nd `New`
-
-## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+<Update label="March 22nd" description="[v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)" tags={["New"]}>
 
 - Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
 - Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
 - Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
 
----
+</Update>
 
-March 20th `Improved`
-
-## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+<Update label="March 20th" description="[v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)" tags={["Improved"]}>
 
 Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
 
----
+</Update>
 
-March 20th `Improved`
-
-## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+<Update label="March 20th" description="[v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)" tags={["Improved"]}>
 
 Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
 
----
+</Update>
 
-March 20th `New`
-
-## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+<Update label="March 20th" description="[v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)" tags={["New"]}>
 
 Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
 
----
+</Update>
 
-March 19th `Improved`
-
-## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+<Update label="March 19th" description="[v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)" tags={["Improved"]}>
 
 Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
 
----
+</Update>
 
-March 19th `Improved`
-
-## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+<Update label="March 19th" description="[v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)" tags={["Improved"]}>
 
 - Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
 - Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
 - Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
 
----
+</Update>
 
-March 18th `Improved`
-
-## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+<Update label="March 18th" description="[v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)" tags={["Improved"]}>
 
 Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
 
----
+</Update>
 
-March 17th `Improved`
-
-## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+<Update label="March 17th" description="[v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)" tags={["Improved"]}>
 
 Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
 
----
+</Update>
 
-March 17th `Improved`
-
-## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+<Update label="March 17th" description="[v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)" tags={["Improved"]}>
 
 - Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
 - Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
 - Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
 
----
+</Update>
 
-March 17th `Improved`
-
-## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+<Update label="March 17th" description="[v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)" tags={["Improved"]}>
 
 - Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
 - Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
 - Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
 
----
+</Update>
 
-March 16th `Improved`
-
-## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+<Update label="March 16th" description="[v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)" tags={["Improved"]}>
 
 Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
 
----
+</Update>
 
-March 16th `Improved`
-
-## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+<Update label="March 16th" description="[v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)" tags={["Improved"]}>
 
 Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
 
----
+</Update>
 
-March 16th `New`
-
-## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+<Update label="March 16th" description="[v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)" tags={["New"]}>
 
 Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
 
----
+</Update>
 
-March 15th `Improved`
-
-## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+<Update label="March 15th" description="[v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)" tags={["Improved"]}>
 
 Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
 
----
+</Update>
 
-March 15th `Improved`
-
-## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+<Update label="March 15th" description="[v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)" tags={["Improved"]}>
 
 Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
 
----
+</Update>
 
-March 15th `Misc`
-
-## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+<Update label="March 15th" description="[v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)" tags={["Misc"]}>
 
 Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
 
----
+</Update>
 
-March 15th `Improved`
-
-## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+<Update label="March 15th" description="[v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)" tags={["Improved"]}>
 
 Makes feedback submissions reach the OpenWork team inbox reliably again.
 
----
+</Update>
 
-March 15th `Improved`
-
-## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+<Update label="March 15th" description="[v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)" tags={["Improved"]}>
 
 Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
 
----
+</Update>
 
-March 14th `Improved`
-
-## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+<Update label="March 14th" description="[v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)" tags={["Improved"]}>
 
 Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
 
----
+</Update>
 
-March 14th `New`
-
-## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+<Update label="March 14th" description="[v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)" tags={["New"]}>
 
 - Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
 - OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
 - Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
 
----
+</Update>
 
-March 14th `New`
-
-## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+<Update label="March 14th" description="[v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)" tags={["New"]}>
 
 Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
 
----
+</Update>
 
-March 13th `New`
-
-## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+<Update label="March 13th" description="[v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)" tags={["New"]}>
 
 Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
 
----
+</Update>
 
-March 13th `New`
-
-## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+<Update label="March 13th" description="[v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)" tags={["New"]}>
 
 Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
 
----
+</Update>
 
-March 12th `Improved`
-
-## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+<Update label="March 12th" description="[v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)" tags={["Improved"]}>
 
 Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
 
----
+</Update>
 
-March 12th `New`
-
-## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+<Update label="March 12th" description="[v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)" tags={["New"]}>
 
 - Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
 - The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
 - Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
 
----
+</Update>
 
-March 12th `Misc`
-
-## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+<Update label="March 12th" description="[v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)" tags={["Misc"]}>
 
 Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
 
----
+</Update>
 
-March 12th `Improved`
-
-## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+<Update label="March 12th" description="[v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)" tags={["Improved"]}>
 
 Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
 
----
+</Update>
 
-March 11th `Improved`
-
-## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+<Update label="March 11th" description="[v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)" tags={["Improved"]}>
 
 Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
 
----
+</Update>
 
-March 11th `Improved`
-
-## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+<Update label="March 11th" description="[v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)" tags={["Improved"]}>
 
 Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
 
----
+</Update>
 
-March 11th `Improved`
-
-## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+<Update label="March 11th" description="[v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)" tags={["Improved"]}>
 
 Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
 
----
+</Update>
 
-March 10th `New`
-
-## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+<Update label="March 10th" description="[v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)" tags={["New"]}>
 
 - Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
 - Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
 - Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
 
----
+</Update>
 
-March 6th `Misc`
-
-## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+<Update label="March 6th" description="[v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)" tags={["Misc"]}>
 
 Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
 
----
+</Update>
 
-March 6th `New`
-
-## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+<Update label="March 6th" description="[v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)" tags={["New"]}>
 
 Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
 
----
+</Update>
 
-March 5th `Improved`
-
-## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+<Update label="March 5th" description="[v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)" tags={["Improved"]}>
 
 Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
 
----
+</Update>
 
-March 5th `Improved`
-
-## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+<Update label="March 5th" description="[v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)" tags={["Improved"]}>
 
 Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
 
----
+</Update>
 
-March 4th `New`
-
-## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+<Update label="March 4th" description="[v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)" tags={["New"]}>
 
 - Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
 - Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
 - Added persistent language selection and improved file-open reliability for editor and artifact flows.
 
----
+</Update>
 
-March 2nd `Improved`
-
-## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+<Update label="March 2nd" description="[v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)" tags={["Improved"]}>
 
 Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
 
----
+</Update>
 
-March 2nd `New`
-
-## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+<Update label="March 2nd" description="[v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)" tags={["New"]}>
 
 Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
 
----
+</Update>
 
-March 1st `New`
-
-## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+<Update label="March 1st" description="[v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)" tags={["New"]}>
 
 Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
 
----
+</Update>
 
-February 28th `New`
-
-## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+<Update label="February 28th" description="[v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)" tags={["New"]}>
 
 Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
 
----
+</Update>
 
-February 27th `New`
-
-## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+<Update label="February 27th" description="[v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)" tags={["New"]}>
 
 Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
 
----
+</Update>
 
-February 26th `Improved`
-
-## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+<Update label="February 26th" description="[v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)" tags={["Improved"]}>
 
 Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
 
----
+</Update>
 
-February 26th `New`
-
-## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+<Update label="February 26th" description="[v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)" tags={["New"]}>
 
 Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
 
----
+</Update>
 
-February 26th `New`
-
-## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+<Update label="February 26th" description="[v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)" tags={["New"]}>
 
 Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
 
----
+</Update>
 
-February 26th `New`
-
-## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+<Update label="February 26th" description="[v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)" tags={["New"]}>
 
 - Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
 - Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
 - Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
 
----
+</Update>
 
-February 23rd `New`
-
-## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+<Update label="February 23rd" description="[v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)" tags={["New"]}>
 
 Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
 
----
+</Update>
 
-February 23rd `Improved`
-
-## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+<Update label="February 23rd" description="[v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)" tags={["Improved"]}>
 
 Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
 
----
+</Update>
 
-February 23rd `Improved`
-
-## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+<Update label="February 23rd" description="[v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)" tags={["Improved"]}>
 
 Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
 
----
+</Update>
 
-February 23rd `Improved`
-
-## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+<Update label="February 23rd" description="[v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)" tags={["Improved"]}>
 
 Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
 
----
+</Update>
 
-February 23rd `Improved`
-
-## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+<Update label="February 23rd" description="[v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)" tags={["Improved"]}>
 
 Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
 
----
+</Update>
 
-February 22nd `New`
-
-## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+<Update label="February 22nd" description="[v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)" tags={["New"]}>
 
 Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
 
----
+</Update>
 
-February 22nd `New`
-
-## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+<Update label="February 22nd" description="[v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)" tags={["New"]}>
 
 Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
 
----
+</Update>
 
-February 22nd `Improved`
-
-## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+<Update label="February 22nd" description="[v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)" tags={["Improved"]}>
 
 - Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
 - Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
 - Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
 
----
+</Update>
 
-February 21st `New`
-
-## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+<Update label="February 21st" description="[v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)" tags={["New"]}>
 
 Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
 
----
+</Update>
 
-February 21st `Improved`
-
-## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+<Update label="February 21st" description="[v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)" tags={["Improved"]}>
 
 Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
 
----
+</Update>
 
-February 20th `Misc`
-
-## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+<Update label="February 20th" description="[v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)" tags={["Misc"]}>
 
 Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
 
----
+</Update>
 
-February 20th `Misc`
-
-## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+<Update label="February 20th" description="[v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)" tags={["Misc"]}>
 
 Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
 
----
+</Update>
 
-February 20th `New`
-
-## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+<Update label="February 20th" description="[v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)" tags={["New"]}>
 
 Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
 
----
+</Update>
 
-February 20th `Improved`
-
-## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+<Update label="February 20th" description="[v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)" tags={["Improved"]}>
 
 Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
 
----
+</Update>
 
-February 20th `Improved`
-
-## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+<Update label="February 20th" description="[v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)" tags={["Improved"]}>
 
 Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
 
----
+</Update>
 
-February 20th `Misc`
-
-## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+<Update label="February 20th" description="[v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)" tags={["Misc"]}>
 
 Refreshes release metadata only, with no clear user-facing product change in this patch.
 
----
+</Update>
 
-February 20th `Improved`
-
-## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+<Update label="February 20th" description="[v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)" tags={["Improved"]}>
 
 Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
 
----
+</Update>
 
-February 20th `Improved`
-
-## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+<Update label="February 20th" description="[v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)" tags={["Improved"]}>
 
 Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
 
----
+</Update>
 
-February 20th `Improved`
-
-## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+<Update label="February 20th" description="[v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)" tags={["Improved"]}>
 
 - Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
 - Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
 - Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
 
----
+</Update>
 
-February 20th `Improved`
-
-## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+<Update label="February 20th" description="[v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)" tags={["Improved"]}>
 
 Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
 
----
+</Update>
 
-February 19th `New`
-
-## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
+<Update label="February 19th" description="[v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)" tags={["New"]}>
 
 Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
 
----
+</Update>
 
-February 19th `Improved`
-
-## v0.11.100
+<Update label="February 19th" description="v0.11.100" tags={["Improved"]}>
 
 Stops long prompts from disappearing while typing, making the session composer reliable again.
+
+</Update>

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -35,10 +35,6 @@ title: "Changelog"
 
   Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
 
-</Update>
-
-<Update label="March 31st" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
 
   - Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
@@ -71,10 +67,6 @@ title: "Changelog"
 
   Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
 
-</Update>
-
-<Update label="March 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
 
   - Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
@@ -91,57 +83,33 @@ title: "Changelog"
   - Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
   - Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
 
-</Update>
-
-<Update label="March 25th" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
 
   Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
 
 </Update>
 
-<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
+<Update label="March 24th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
   ## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
 
   Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
 
-</Update>
-
-<Update label="March 24th" tags={["Misc"]}>
-
   ## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
 
   Rolls the release line forward with no visible product or workflow changes.
-
-</Update>
-
-<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
 
   Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
 
-</Update>
-
-<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
 
   Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
 
-</Update>
-
-<Update label="March 24th" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
 
   Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
-
-</Update>
-
-<Update label="March 24th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
 
@@ -151,23 +119,15 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 23rd" tags={["Misc"]}>
+<Update label="March 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
 
   Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
 
-</Update>
-
-<Update label="March 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
 
   Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
-
-</Update>
-
-<Update label="March 23rd" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
 
@@ -177,23 +137,15 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 22nd" tags={["Misc"]}>
+<Update label="March 22nd" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
   ## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
 
   Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
 
-</Update>
-
-<Update label="March 22nd" tags={["🐛 Bug Fixes", "🏗️ Refactoring"]}>
-
   ## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
 
   Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
-
-</Update>
-
-<Update label="March 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
 
@@ -203,23 +155,15 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 20th" tags={["🐛 Bug Fixes"]}>
+<Update label="March 20th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
   ## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
 
   Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
 
-</Update>
-
-<Update label="March 20th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
-
   ## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
 
   Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
-
-</Update>
-
-<Update label="March 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
 
@@ -227,15 +171,11 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 19th" tags={["🐛 Bug Fixes", "🏗️ Refactoring"]}>
+<Update label="March 19th" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
   ## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
 
   Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
-
-</Update>
-
-<Update label="March 19th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
 
@@ -253,25 +193,17 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 17th" tags={["🐛 Bug Fixes"]}>
+<Update label="March 17th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
   ## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
 
   Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
-
-</Update>
-
-<Update label="March 17th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
 
   - Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
   - Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
   - Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
-
-</Update>
-
-<Update label="March 17th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
 
@@ -287,17 +219,9 @@ title: "Changelog"
 
   Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
 
-</Update>
-
-<Update label="March 16th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
 
   Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
-
-</Update>
-
-<Update label="March 16th" tags={["🚀 New Features"]}>
 
   ## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
 
@@ -305,39 +229,23 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 15th" tags={["🐛 Bug Fixes"]}>
+<Update label="March 15th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
   ## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
 
   Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
 
-</Update>
-
-<Update label="March 15th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
 
   Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
-
-</Update>
-
-<Update label="March 15th" tags={["Misc"]}>
 
   ## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
 
   Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
 
-</Update>
-
-<Update label="March 15th" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
 
   Makes feedback submissions reach the OpenWork team inbox reliably again.
-
-</Update>
-
-<Update label="March 15th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
 
@@ -345,25 +253,17 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 14th" tags={["🐛 Bug Fixes"]}>
+<Update label="March 14th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
   ## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
 
   Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
-
-</Update>
-
-<Update label="March 14th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
 
   - Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
   - OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
   - Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
-
-</Update>
-
-<Update label="March 14th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
 
@@ -377,25 +277,17 @@ title: "Changelog"
 
   Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
 
-</Update>
-
-<Update label="March 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
 
   Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
 
 </Update>
 
-<Update label="March 12th" tags={["🐛 Bug Fixes"]}>
+<Update label="March 12th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
   ## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
 
   Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
-
-</Update>
-
-<Update label="March 12th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
   ## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
 
@@ -403,17 +295,9 @@ title: "Changelog"
   - The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
   - Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
 
-</Update>
-
-<Update label="March 12th" tags={["Misc"]}>
-
   ## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
 
   Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
-
-</Update>
-
-<Update label="March 12th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
 
@@ -427,17 +311,9 @@ title: "Changelog"
 
   Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
 
-</Update>
-
-<Update label="March 11th" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
 
   Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
-
-</Update>
-
-<Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
 
@@ -455,15 +331,11 @@ title: "Changelog"
 
 </Update>
 
-<Update label="March 6th" tags={["Misc"]}>
+<Update label="March 6th" tags={["🚀 New Features"]}>
 
   ## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
 
   Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
-
-</Update>
-
-<Update label="March 6th" tags={["🚀 New Features"]}>
 
   ## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
 
@@ -476,10 +348,6 @@ title: "Changelog"
   ## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
 
   Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
-
-</Update>
-
-<Update label="March 5th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
 
@@ -502,10 +370,6 @@ title: "Changelog"
   ## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
 
   Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
-
-</Update>
-
-<Update label="March 2nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
 
@@ -537,31 +401,19 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 26th" tags={["🐛 Bug Fixes"]}>
+<Update label="February 26th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
   ## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
 
   Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
 
-</Update>
-
-<Update label="February 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
 
   Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
 
-</Update>
-
-<Update label="February 26th" tags={["🚀 New Features"]}>
-
   ## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
 
   Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
-
-</Update>
-
-<Update label="February 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
 
@@ -571,39 +423,23 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 23rd" tags={["🚀 New Features"]}>
+<Update label="February 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
 
   Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
 
-</Update>
-
-<Update label="February 23rd" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
 
   Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
-
-</Update>
-
-<Update label="February 23rd" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
 
   Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
 
-</Update>
-
-<Update label="February 23rd" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
 
   Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
-
-</Update>
-
-<Update label="February 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
 
@@ -611,23 +447,15 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 22nd" tags={["🚀 New Features"]}>
+<Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
 
   Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
 
-</Update>
-
-<Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
 
   Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
-
-</Update>
-
-<Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
 
@@ -637,15 +465,11 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 21st" tags={["🚀 New Features"]}>
+<Update label="February 21st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
 
   Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
-
-</Update>
-
-<Update label="February 21st" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
 
@@ -653,81 +477,45 @@ title: "Changelog"
 
 </Update>
 
-<Update label="February 20th" tags={["Misc"]}>
+<Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
 
   Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
 
-</Update>
-
-<Update label="February 20th" tags={["Misc"]}>
-
   ## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
 
   Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
-
-</Update>
-
-<Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
 
   Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
 
-</Update>
-
-<Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
-
   ## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
 
   Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
-
-</Update>
-
-<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
 
   Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
 
-</Update>
-
-<Update label="February 20th" tags={["Misc"]}>
-
   ## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
 
   Refreshes release metadata only, with no clear user-facing product change in this patch.
-
-</Update>
-
-<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
 
   Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
 
-</Update>
-
-<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
-
   ## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
 
   Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
-
-</Update>
-
-<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
 
   - Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
   - Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
   - Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
-
-</Update>
-
-<Update label="February 20th" tags={["🐛 Bug Fixes"]}>
 
   ## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
 
@@ -740,10 +528,6 @@ title: "Changelog"
   ## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
 
   Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
-
-</Update>
-
-<Update label="February 19th" tags={["🐛 Bug Fixes"]}>
 
   ## v0.11.100
 

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -51,6 +51,12 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Changelog",
+        "pages": [
+          "changelog"
+        ]
       }
     ]
   },

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -45,16 +45,18 @@
             ]
           },
           {
+            "group": "Changelog",
+            "pages": [
+              "changelog"
+            ]
+          },
+          {
             "group": "Improve this doc",
             "pages": [
               "missing-docs"
             ]
           }
         ]
-      },
-      {
-        "tab": "Changelog",
-        "href": "/changelog"
       }
     ]
   },

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -54,9 +54,7 @@
       },
       {
         "tab": "Changelog",
-        "pages": [
-          "changelog"
-        ]
+        "href": "/changelog"
       }
     ]
   },

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -51,9 +51,9 @@ function formatDate(raw) {
  */
 function resolveTags(features, bugs, deprecated) {
   const tags = []
-  if (features > 0) tags.push("New releases")
-  if (bugs > 0) tags.push("Improvements")
-  if (deprecated > 0) tags.push("Deprecations")
+  if (features > 0) tags.push("🚀 New Features")
+  if (bugs > 0) tags.push("🐛 Bug Fixes")
+  if (deprecated > 0) tags.push("🏗️ Refactoring")
   return tags.length > 0 ? tags : ["Misc"]
 }
 

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -54,7 +54,7 @@ function resolveTags(features, bugs, deprecated) {
   if (features > 0) tags.push("🚀 New Features")
   if (bugs > 0) tags.push("🐛 Bug Fixes")
   if (deprecated > 0) tags.push("🏗️ Refactoring")
-  return tags.length > 0 ? tags : ["Misc"]
+  return tags.length > 0 ? tags : ["🔧 Misc"]
 }
 
 // ---------------------------------------------------------------------------
@@ -142,15 +142,11 @@ function toEntry(release, prevVersion) {
 // Renderer
 // ---------------------------------------------------------------------------
 
-function renderEntry(entry) {
+/**
+ * Render a single version block (used inside a grouped day).
+ */
+function renderVersionBlock(entry) {
   const lines = []
-
-  // Tags array as JSX
-  const tagsJsx = entry.tags.map((t) => `"${t}"`).join(", ")
-
-  // Open <Update> with date label and tags (no description)
-  lines.push(`<Update label="${entry.date}" tags={[${tagsJsx}]}>`)
-  lines.push("")
 
   // Version as the section heading, linked to compare URL
   if (entry.compareUrl) {
@@ -163,7 +159,6 @@ function renderEntry(entry) {
 
   // Body: major → bullet points, minor → one-liner
   if (entry.isMajor && entry.mainChanges) {
-    // Indent each line 2 spaces to match Mintlify convention
     const indented = entry.mainChanges
       .split("\n")
       .map((l) => `  ${l}`)
@@ -171,6 +166,31 @@ function renderEntry(entry) {
     lines.push(indented)
   } else {
     lines.push(`  ${entry.oneLiner}`)
+  }
+
+  return lines.join("\n")
+}
+
+/**
+ * Group entries by date and render each group as a single <Update>.
+ * Tags are unioned across all entries in the day.
+ * "🔧 Misc" is dropped if any real tag exists.
+ */
+function renderDayGroup(dayEntries) {
+  // Union tags, dedup, drop Misc if real tags exist
+  const allTags = [...new Set(dayEntries.flatMap((e) => e.tags))]
+  const filtered = allTags.filter((t) => t !== "🔧 Misc")
+  const tags = filtered.length > 0 ? filtered : ["🔧 Misc"]
+
+  const tagsJsx = tags.map((t) => `"${t}"`).join(", ")
+  const date = dayEntries[0].date
+
+  const lines = []
+  lines.push(`<Update label="${date}" tags={[${tagsJsx}]}>`)
+
+  for (const entry of dayEntries) {
+    lines.push("")
+    lines.push(renderVersionBlock(entry))
   }
 
   lines.push("")
@@ -187,10 +207,20 @@ function renderChangelog(entries) {
     "",
   ].join("\n")
 
-  const body = entries
-    .filter((e) => e.date !== null) // skip unparseable dates
-    .reverse() // newest first
-    .map(renderEntry)
+  // Filter, reverse (newest first), then group by date
+  const valid = entries.filter((e) => e.date !== null).reverse()
+  const grouped = []
+  for (const entry of valid) {
+    const last = grouped[grouped.length - 1]
+    if (last && last[0].date === entry.date) {
+      last.push(entry)
+    } else {
+      grouped.push([entry])
+    }
+  }
+
+  const body = grouped
+    .map(renderDayGroup)
     .join("\n\n")
 
   return header + body + "\n"

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -151,17 +151,13 @@ function toEntry(release, prevVersion) {
 function renderEntry(entry) {
   const lines = []
 
-  // Date + tag line
-  lines.push(`${entry.date} \`${entry.tag}\``)
-  lines.push("")
+  // Version description with optional compare link
+  const description = entry.compareUrl
+    ? `[${entry.version}](${entry.compareUrl})`
+    : entry.version
 
-  // Version heading with optional compare link
-  if (entry.compareUrl) {
-    lines.push(`## [${entry.version}](${entry.compareUrl})`)
-  } else {
-    lines.push(`## ${entry.version}`)
-  }
-
+  // Open <Update> with date label, version description, and tag
+  lines.push(`<Update label="${entry.date}" description="${description}" tags={["${entry.tag}"]}>`)
   lines.push("")
 
   // Body: major → bullet points, minor → one-liner
@@ -170,6 +166,9 @@ function renderEntry(entry) {
   } else {
     lines.push(entry.oneLiner)
   }
+
+  lines.push("")
+  lines.push("</Update>")
 
   return lines.join("\n")
 }
@@ -186,7 +185,7 @@ function renderChangelog(entries) {
     .filter((e) => e.date !== null) // skip unparseable dates
     .reverse() // newest first
     .map(renderEntry)
-    .join("\n\n---\n\n")
+    .join("\n\n")
 
   return header + body + "\n"
 }

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import { resolve, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, "..")
+const TRACKER_PATH = resolve(ROOT, "changelog/release-tracker.md")
+const OUTPUT_PATH = resolve(ROOT, "packages/docs/changelog.mdx")
+const COMPARE_BASE = "https://github.com/different-ai/openwork/compare"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ORDINAL_RULES = new Map([
+  [1, "st"], [2, "nd"], [3, "rd"],
+  [21, "st"], [22, "nd"], [23, "rd"],
+  [31, "st"],
+])
+
+function ordinal(day) {
+  return ORDINAL_RULES.get(day) || "th"
+}
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+]
+
+/** "2026-02-19T17:49:05Z" → "February 19th" */
+function formatDate(raw) {
+  // Handle non-standard values like "Unreleased draft release. Tagged at `2026-03-22T09:29:16-07:00`."
+  const isoMatch = raw.match(/(\d{4}-\d{2}-\d{2}T[\d:.Z+-]+)/)
+  if (!isoMatch) return null
+
+  const d = new Date(isoMatch[1])
+  if (isNaN(d.getTime())) return null
+
+  const month = MONTHS[d.getUTCMonth()]
+  const day = d.getUTCDate()
+  return `${month} ${day}${ordinal(day)}`
+}
+
+/**
+ * Determine the tag for a release.
+ *
+ * Pick the category with the highest count.
+ * Ties are broken by priority: Feature > Bug > Deprecated.
+ * If all counts are 0, return "Misc".
+ *
+ * Returns exactly one of: "New" | "Improved" | "Adjusted" | "Misc"
+ */
+function resolveTag(features, bugs, deprecated) {
+  if (features === 0 && bugs === 0 && deprecated === 0) return "Misc"
+
+  const max = Math.max(features, bugs, deprecated)
+
+  // Priority order: features first, then bugs, then deprecated
+  if (features >= max) return "New"
+  if (bugs >= max) return "Improved"
+  return "Adjusted"
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse release-tracker.md into structured release objects.
+ *
+ * Splits on `## v` headings, then extracts `#### ` subsections inside each.
+ */
+function parseTracker(text) {
+  // Split into release blocks. First element is the file header.
+  const blocks = text.split(/^## /m).slice(1)
+
+  return blocks.map((block) => {
+    const lines = block.split("\n")
+    const versionLine = lines[0].trim() // e.g. "v0.11.100"
+    const version = versionLine
+
+    // Extract subsections keyed by their #### title
+    const sections = {}
+    let currentKey = null
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i]
+      const heading = line.match(/^#### (.+)/)
+      if (heading) {
+        currentKey = heading[1].trim()
+        sections[currentKey] = []
+      } else if (currentKey !== null) {
+        sections[currentKey].push(line)
+      }
+    }
+
+    // Trim and join each section's content
+    for (const key of Object.keys(sections)) {
+      sections[key] = sections[key].join("\n").trim()
+    }
+
+    return { version, sections }
+  })
+}
+
+/**
+ * Transform a parsed release into a changelog entry object.
+ *
+ * @param {object} release  - parsed release block
+ * @param {string|null} prevVersion - previous version string for compare URL
+ */
+function toEntry(release, prevVersion) {
+  const s = release.sections
+
+  const releasedAt = s["Released at"]?.replace(/`/g, "").trim() || ""
+  const date = releasedAt ? formatDate(releasedAt) : null
+
+  const importance = (s["Release importance"] || "").toLowerCase()
+  const isMajor = importance.startsWith("major")
+
+  const oneLiner = s["One-line summary"]?.trim() || ""
+  const mainChanges = s["Main changes"]?.trim() || ""
+
+  const features = parseInt(s["Number of major improvements"] || "0", 10)
+  const bugs = parseInt(s["Number of major bugs resolved"] || "0", 10)
+  const deprecated = parseInt(s["Number of deprecated features"] || "0", 10)
+
+  const tag = resolveTag(features, bugs, deprecated)
+
+  // Build compare URL from consecutive versions: v0.11.200...v0.11.201
+  const compareUrl = prevVersion
+    ? `${COMPARE_BASE}/${prevVersion}...${release.version}`
+    : ""
+
+  return {
+    version: release.version,
+    date,
+    isMajor,
+    tag,
+    oneLiner,
+    mainChanges,
+    compareUrl,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Renderer
+// ---------------------------------------------------------------------------
+
+function renderEntry(entry) {
+  const lines = []
+
+  // Date + tag line
+  lines.push(`${entry.date} \`${entry.tag}\``)
+  lines.push("")
+
+  // Version heading with optional compare link
+  if (entry.compareUrl) {
+    lines.push(`## [${entry.version}](${entry.compareUrl})`)
+  } else {
+    lines.push(`## ${entry.version}`)
+  }
+
+  lines.push("")
+
+  // Body: major → bullet points, minor → one-liner
+  if (entry.isMajor && entry.mainChanges) {
+    lines.push(entry.mainChanges)
+  } else {
+    lines.push(entry.oneLiner)
+  }
+
+  return lines.join("\n")
+}
+
+function renderChangelog(entries) {
+  const header = [
+    "---",
+    'title: "Changelog"',
+    "---",
+    "",
+  ].join("\n")
+
+  const body = entries
+    .filter((e) => e.date !== null) // skip unparseable dates
+    .reverse() // newest first
+    .map(renderEntry)
+    .join("\n\n---\n\n")
+
+  return header + body + "\n"
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const raw = await fs.readFile(TRACKER_PATH, "utf-8")
+  const releases = parseTracker(raw)
+  const entries = releases.map((r, i) => toEntry(r, i > 0 ? releases[i - 1].version : null))
+  const output = renderChangelog(entries)
+
+  await fs.writeFile(OUTPUT_PATH, output, "utf-8")
+  console.log(`Wrote ${entries.length} entries to ${OUTPUT_PATH}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -44,23 +44,17 @@ function formatDate(raw) {
 }
 
 /**
- * Determine the tag for a release.
+ * Build an array of applicable tags for a release.
  *
- * Pick the category with the highest count.
- * Ties are broken by priority: Feature > Bug > Deprecated.
- * If all counts are 0, return "Misc".
- *
- * Returns exactly one of: "New" | "Improved" | "Adjusted" | "Misc"
+ * Returns all categories that have count > 0.
+ * If none apply, returns ["Misc"].
  */
-function resolveTag(features, bugs, deprecated) {
-  if (features === 0 && bugs === 0 && deprecated === 0) return "Misc"
-
-  const max = Math.max(features, bugs, deprecated)
-
-  // Priority order: features first, then bugs, then deprecated
-  if (features >= max) return "New"
-  if (bugs >= max) return "Improved"
-  return "Adjusted"
+function resolveTags(features, bugs, deprecated) {
+  const tags = []
+  if (features > 0) tags.push("New releases")
+  if (bugs > 0) tags.push("Improvements")
+  if (deprecated > 0) tags.push("Deprecations")
+  return tags.length > 0 ? tags : ["Misc"]
 }
 
 // ---------------------------------------------------------------------------
@@ -126,7 +120,7 @@ function toEntry(release, prevVersion) {
   const bugs = parseInt(s["Number of major bugs resolved"] || "0", 10)
   const deprecated = parseInt(s["Number of deprecated features"] || "0", 10)
 
-  const tag = resolveTag(features, bugs, deprecated)
+  const tags = resolveTags(features, bugs, deprecated)
 
   // Build compare URL from consecutive versions: v0.11.200...v0.11.201
   const compareUrl = prevVersion
@@ -137,7 +131,7 @@ function toEntry(release, prevVersion) {
     version: release.version,
     date,
     isMajor,
-    tag,
+    tags,
     oneLiner,
     mainChanges,
     compareUrl,
@@ -151,21 +145,32 @@ function toEntry(release, prevVersion) {
 function renderEntry(entry) {
   const lines = []
 
-  // Open <Update> with date label, plain version description, and tag
-  lines.push(`<Update label="${entry.date}" description="${entry.version}" tags={["${entry.tag}"]}>`)
+  // Tags array as JSX
+  const tagsJsx = entry.tags.map((t) => `"${t}"`).join(", ")
+
+  // Open <Update> with date label and tags (no description)
+  lines.push(`<Update label="${entry.date}" tags={[${tagsJsx}]}>`)
+  lines.push("")
+
+  // Version as the section heading, linked to compare URL
+  if (entry.compareUrl) {
+    lines.push(`  ## [${entry.version}](${entry.compareUrl})`)
+  } else {
+    lines.push(`  ## ${entry.version}`)
+  }
+
   lines.push("")
 
   // Body: major → bullet points, minor → one-liner
   if (entry.isMajor && entry.mainChanges) {
-    lines.push(entry.mainChanges)
+    // Indent each line 2 spaces to match Mintlify convention
+    const indented = entry.mainChanges
+      .split("\n")
+      .map((l) => `  ${l}`)
+      .join("\n")
+    lines.push(indented)
   } else {
-    lines.push(entry.oneLiner)
-  }
-
-  // Compare link at the end
-  if (entry.compareUrl) {
-    lines.push("")
-    lines.push(`[View changes](${entry.compareUrl})`)
+    lines.push(`  ${entry.oneLiner}`)
   }
 
   lines.push("")

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -151,13 +151,8 @@ function toEntry(release, prevVersion) {
 function renderEntry(entry) {
   const lines = []
 
-  // Version description with optional compare link
-  const description = entry.compareUrl
-    ? `[${entry.version}](${entry.compareUrl})`
-    : entry.version
-
-  // Open <Update> with date label, version description, and tag
-  lines.push(`<Update label="${entry.date}" description="${description}" tags={["${entry.tag}"]}>`)
+  // Open <Update> with date label, plain version description, and tag
+  lines.push(`<Update label="${entry.date}" description="${entry.version}" tags={["${entry.tag}"]}>`)
   lines.push("")
 
   // Body: major → bullet points, minor → one-liner
@@ -165,6 +160,12 @@ function renderEntry(entry) {
     lines.push(entry.mainChanges)
   } else {
     lines.push(entry.oneLiner)
+  }
+
+  // Compare link at the end
+  if (entry.compareUrl) {
+    lines.push("")
+    lines.push(`[View changes](${entry.compareUrl})`)
   }
 
   lines.push("")


### PR DESCRIPTION
## Summary
Add a script (scripts/generate-changelog.mjs) that parses changelog/release-tracker.md and generates a minimalistic changelog.mdx for the Mintlify docs. Each entry shows the date, a tag (New/Improved/Adjusted/Misc), and either a one-liner (minor) or bullet points (major). Version headings link to GitHub compare URLs derived from consecutive versions.