### PR TITLE
fix(docs): use OpenWork brand colors in Mintlify docs

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -8,9 +8,9 @@
     "dark": "/logo/dark.svg"
   },
   "colors": {
-    "primary": "#0F766E",
-    "light": "#14B8A6",
-    "dark": "#0F766E"
+    "primary": "#011627",
+    "light": "#3b82f6",
+    "dark": "#011627"
   },
   "navigation": {
     "tabs": [


### PR DESCRIPTION
## Summary
- Replaces Mintlify's default teal palette with OpenWork's actual brand colors
- Light mode accent: `#011627` (dark navy, matches landing page CTAs)
- Dark mode accent: `#3b82f6` (blue, matches app dark mode theme)
- Buttons: `#011627` (dark navy, consistent with openworklabs.com)

## Test plan
- [ ] Verify docs site renders with correct button colors in light mode
- [ ] Verify docs site renders with correct accent colors in dark mode
- [ ] Confirm links and highlights use navy instead of teal