### PR TITLE
docs(changelog): render headings from tracker titles

### DIFF
--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,548 +1,536 @@
 ---
 title: "Changelog"
 ---
-<Update label="April 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
+<Update label="April 4th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.202 - Translations fill out across the app and shared skill imports work again.](https://github.com/different-ai/openwork/compare/v0.11.201...v0.11.202)
+  ## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
 
-  Adds Thai, restores missing page translations, fixes migrated shared-skill links, and tightens docs and local desktop dev setup.
-
-  ## [v0.11.201 - Workspace lists collapse cleanly and Den organization setup recovers more reliably.](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
-
-  Hides collapsed workspace task rows, steadies session loading, and fixes Den skill saving plus organization draft and invite recovery.
+  Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
 
 </Update>
 
 <Update label="April 3rd" tags={["🚀 New Features"]}>
 
-  ## [v0.11.200 - Cloud skills and team limits move into the core flow](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+  ## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
 
-  - Added an OpenWork Cloud skills catalog to the Skills page, with install and share-to-team flows.
-  - Added Den teams plus full skill hub and skill editing and visibility management.
-  - Moved billing into org creation and enforced organization member limits before setup finishes.
+  - Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
+  - Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
+  - Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
 
 </Update>
 
 <Update label="April 2nd" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.199 - Pricing, skill hubs, and session recovery sharpen up](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+  ## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
 
-  - Added a pricing page and paid Windows messaging, and sent Cloud navigation directly into the app.
-  - Expanded Den with skill hubs, a new `den-api`, and a smoother org-invite signup flow.
-  - Added developer log export, per-conversation draft persistence, and recovery after immediate send failures.
+  - Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
+  - Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
+  - Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
 
 </Update>
 
 <Update label="March 31st" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.198 - Local workspace switches restart the right engine](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+  ## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
 
-  Fixes a local-only switch bug so changing between local workspaces restarts the engine instead of reusing the old connection.
+  Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
 
-  ## [v0.11.197 - Sharing gets safer and startup gets less noisy](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+  ## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
 
-  - Blocked sensitive workspace exports and showed warnings before sharing risky config or secrets.
-  - Trusted bundle imports only from the configured publisher unless users explicitly choose a warning-backed manual path.
-  - Moved OpenWork tokens off CLI args and logs, stopped auto-creating Welcome, and fixed collapsed sidebar session lists.
+  - Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
+  - Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
+  - Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
 
 </Update>
 
 <Update label="March 30th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.196 - OpenWork resumes where you left off](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+  ## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
 
-  - Reopened the last session on workspace boot and routed straight into the session view.
-  - Moved automations onto a dedicated page backed by live local or remote scheduler jobs.
-  - Fixed bootstrap and workspace switching so Welcome setup and loading states stop interrupting startup.
+  - Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
+  - Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
+  - Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
 
 </Update>
 
 <Update label="March 27th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.195 - Local workspace creation and Den worker setup get steadier](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+  ## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
 
-  Routes new local workspaces through the local host, persists model defaults properly, and smooths Den worker-connect and billing flows.
+  Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
 
 </Update>
 
 <Update label="March 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.194 - Auto compaction and live automations become real workflows](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+  ## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
 
-  Wires auto compaction to actual workspace config, keeps scheduled jobs live in-app, and adds a faster Den local-dev path.
+  Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
 
-  ## [v0.11.193 - Team template sharing reaches OpenWork Cloud](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+  ## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
 
-  - Added Save-to-team flows for workspace templates, with org selection and Cloud sign-in prompts.
-  - Introduced Den organizations, member roles, invitations, custom roles, and org-scoped template APIs and screens.
-  - Added a manual Cloud sign-in fallback when automatic team-sharing auth stalls.
+  - Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
+  - Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
+  - Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
 
 </Update>
 
 <Update label="March 25th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.192 - Workspace switching stops hijacking runtime state](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+  ## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
 
-  - Split selected workspace from runtime-connected workspace so browsing no longer flips the active worker.
-  - Kept preferred local server ports sticky and avoided collisions across workspaces.
-  - Let templates carry extra `.opencode` files and starter sessions, and materialized seeded sessions correctly.
+  - Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
+  - Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
+  - Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
 
-  ## [v0.11.191 - Shared detached workers survive restarts](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+  ## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
 
-  Preserves share credentials for detached workers, hides disconnected config-backed providers, and adds clearer Slack and skill-import docs.
+  Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
 
 </Update>
 
 <Update label="March 24th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.190 - Connection guides expand while sharing and auth settle](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+  ## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
 
-  Mostly docs-focused release that reorganizes onboarding around concrete connection guides, while fixing desktop publish routing and headless OpenAI auth timing.
+  Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
 
-  ## [v0.11.189 - Package metadata rolls forward only](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+  ## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
 
-  Updates the release line with a lockfile and version sync only, without any visible product or workflow changes.
+  Rolls the release line forward with no visible product or workflow changes.
 
-  ## [v0.11.188 - Landing feedback returns to the previous flow](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+  ## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
 
-  Backs out the Loops feedback template so the landing feedback endpoint goes back to the simpler email-based path.
+  Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
 
-  ## [v0.11.187 - Windows workspace scoping handles verbatim paths](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+  ## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
 
-  Normalizes Windows path transport, verbatim prefixes, and UNC comparisons so local session scope stays consistent across directory formats.
+  Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
 
-  ## [v0.11.186 - Local reconnects stay scoped to the right workspace](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+  ## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
 
-  Fixes restart and reconnect flows so local sessions and starter workspaces stay attached to the intended directory.
+  Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
 
-  ## [v0.11.185 - Safer local sharing and messaging setup](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+  ## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
 
-  Local workers now stay localhost-only unless users explicitly opt into remote exposure, messaging is disabled until enabled on purpose, public Telegram bot creation shows a risk warning, and Chrome DevTools MCP gets a guided setup flow.
+  - Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
+  - Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
+  - Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
 
 </Update>
 
 <Update label="March 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.184 - CLI quickstart becomes the primary docs path](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+  ## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
 
-  Rebuilds the docs around a single CLI-first quickstart and removes older split onboarding paths that were harder to follow.
+  Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
 
-  ## [v0.11.183 - Exa moves into OpenCode settings](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+  ## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
 
-  Surfaces the Exa search toggle in a clearer OpenCode settings section and rolls back an unready macOS path-normalization change.
+  Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
 
-  ## [v0.11.182 - Local workspaces move under OpenWork server control](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+  ## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
 
-  - Local workspace create, rename, delete, config writes, and reload events now go through OpenWork server first.
-  - First-run starter bootstrap and reconnect logic are more reliable across onboarding and sidebar flows.
-  - Simplified the remote connect modal, moved tool-trace chevrons right, and added Windows ARM64 dev startup support.
+  - Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
+  - Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
+  - Polished session tool traces by moving the chevron affordance to the right for faster scanning.
 
 </Update>
 
 <Update label="March 22nd" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.181 - Version metadata is republished in sync](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+  ## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
 
-  Republishes synchronized package versions only, with no distinct user-facing or developer-facing workflow change.
+  Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
 
-  ## [v0.11.179 - Den checkout and workspace setup get leaner](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+  ## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
 
-  Simplifies Den billing and dashboard surfaces, streamlines workspace creation flows, and removes the desktop tray path.
+  Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
 
-  ## [v0.11.178 - Workspace sharing and model controls get a major refresh](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+  ## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
 
-  - Redesigned workspace sharing and the right sidebar, including cleaner remote credentials and nested child sessions.
-  - Made model pickers model-aware with provider icons and per-model reasoning or behavior controls.
-  - Moved app feedback to a hosted form, added an Exa toggle, and stopped forcing starter workspaces on desktop boot.
+  - Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
+  - Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
+  - Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
 
 </Update>
 
 <Update label="March 20th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.177 - Downloads CTA and npm install fallback land](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+  ## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
 
-  Gets desktop users to the right download path faster and lets `openwork-orchestrator` recover when npm skips its platform binary.
+  Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
 
-  ## [v0.11.175 - Authorized folders and first-run session guidance move into Settings](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+  ## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
 
-  Adds Settings-based folder authorization and server-backed empty states, then tightens sidebar and composer labeling so navigation stays readable.
+  Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
 
-  ## [v0.11.173 - Daytona workers report activity and local Node tools spawn reliably](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+  ## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
 
-  Adds worker heartbeats for Daytona-backed Cloud workers while making local MCP and tool launches work in nvm-managed Node environments.
+  Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
 
 </Update>
 
 <Update label="March 19th" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.172 - Server package naming and session traces line up](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+  ## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
 
-  Renames the published server package to `openwork-server` and polishes trace-row icon and chevron alignment so session runs scan more cleanly.
+  Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
 
-  ## [v0.11.170 - OpenWork Cloud web flows and remote reconnects improve](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+  ## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
 
-  - Rebuilt Den web auth, checkout, and dashboard routes so hosted onboarding and billing feel like the app instead of a one-off page.
-  - Persisted worker share tokens and repeated deeplinks across restarts, with stronger open-in-web auto-connect and connect overlays.
-  - Added self-serve Cloud settings, OpenAI headless auth, and tray-on-close desktop behavior.
+  - Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
+  - Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
+  - Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
 
 </Update>
 
 <Update label="March 18th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.169 - Den handoff and session chrome get steadier](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+  ## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
 
-  Keeps Den browser handoff and worker naming in sync while cleaning up session focus, reload banners, run status, and broken sidebar affordances.
+  Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
 
 </Update>
 
 <Update label="March 17th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.168 - Release recovery with repaired installers](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+  ## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
 
-  Republishes the release with repaired assets; the tagged diff itself is metadata-only, while the intended Cloud tab gating fix landed in `v0.11.167`.
+  Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
 
-  ## [v0.11.166 - Daytona-backed Den Docker flow ships](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+  ## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
 
-  - Added a Daytona-backed Den Docker flow with a dedicated worker proxy and snapshot builder for preloaded runtimes.
-  - Introduced the `den-v2` control plane and shared Den DB packages for the new hosted-worker path.
-  - Fixed unique org slug generation and the `webdev:local` startup script.
+  - Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
+  - Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
+  - Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
 
-  ## [v0.11.165 - Settings can sign into Cloud and open workers](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+  ## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
 
-  - Added a Cloud tab in Settings for sign-in, org selection, worker lists, and opening ready Den workers into OpenWork.
-  - Routed desktop auth through the web handoff flow, including installed-app scheme support and bearer-session handling.
-  - Restored shared bundle installs and fully cleared disconnected provider credentials.
+  - Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
+  - Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
+  - Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
 
 </Update>
 
 <Update label="March 16th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.164 - Owner tokens and child sessions stay visible](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+  ## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
 
-  Clarifies remote approval access with owner tokens, keeps nested child sessions from disappearing in sidebar syncs, and broadens polish across sharing and localization.
+  Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
 
-  ## [v0.11.163 - Custom skill hub repos and steadier session actions](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+  ## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
 
-  Lets teams browse and install skills from any GitHub hub repo while making session switching, composer focus, and reload prompts behave more predictably.
+  Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
 
-  ## [v0.11.162 - Docker dev prints LAN-ready OpenWork URLs](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+  ## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
 
-  Makes local Docker testing easier from phones and other devices by printing public URLs and deriving Den auth and CORS defaults from the detected host.
+  Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
 
 </Update>
 
 <Update label="March 15th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.160 - Den auth, downloads, and nested sessions polish](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+  ## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
 
-  Simplifies the Den auth entry flow, sends landing-page downloads to the right installer, and restores parent-child session browsing in the sidebar.
+  Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
 
-  ## [v0.11.159 - Den cloud billing and worker launch align](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+  ## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
 
-  Aligns the app-hosted Den flow with landing-page messaging, restores checkout handling for extra workers, and fixes visible billing and marketing regressions.
+  Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
 
-  ## [v0.11.155 - Windows release diagnostics stop masking failures](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+  ## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
 
-  Improves release-pipeline diagnostics and normalizes workflow action inputs so broken Windows packaging runs are easier to debug.
+  Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
 
-  ## [v0.11.151 - Feedback emails reach the team inbox again](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+  ## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
 
-  Fixes the in-app feedback email target so reports reach the shared OpenWork inbox again.
+  Makes feedback submissions reach the OpenWork team inbox reliably again.
 
-  ## [v0.11.150 - Faster provider setup and steadier chat rendering](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+  ## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
 
-  Prioritizes common providers in new-session setup, reduces inline image churn while chatting, and routes feedback straight to the team inbox.
+  Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
 
 </Update>
 
 <Update label="March 14th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.149 - Richer skill previews and steadier jump-to-latest](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+  ## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
 
-  Makes shared skill pages easier to evaluate before import, steadies the worker-selection flow, and keeps long chats pinned to the newest reply while thinking.
+  Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
 
-  ## [v0.11.148 - Guided Den onboarding and single-skill Share](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+  ## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
 
-  - Rebuilt Den onboarding as a guided flow with clearer naming, intent, loading, and browser-access states.
-  - Simplified OpenWork Share to publish a single skill, with cleaner frontmatter and fuller shared previews.
-  - Added a polished feedback card and clearer import and status feedback across app surfaces.
+  - Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
+  - OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
+  - Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
 
-  ## [v0.11.147 - Existing-worker imports and local Share publishing](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+  ## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
 
-  Lets shared skills install into existing workers, adds a local Docker-backed Share publisher for self-hosted testing, and keeps Den worker provisioning current.
+  Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
 
 </Update>
 
 <Update label="March 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.146 - Failed worker redeploy and safer skill imports](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+  ## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
 
-  Adds direct Den worker redeploys, makes shared skills pick a destination worker before import, and improves both local Den setup and Chrome-first guidance.
+  Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
 
-  ## [v0.11.145 - Den admin backoffice and support routing](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+  ## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
 
-  Adds a protected Den admin panel for support operations, routes enterprise contact submissions into Loops, and tightens desktop skill reload and settings diagnostics.
+  Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
 
 </Update>
 
 <Update label="March 12th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.144 - Workspace shell recovery and clearer docs entrypoints](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+  ## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
 
-  Restores reliable workspace-shell navigation and reset recovery, seeds Chrome DevTools setup correctly, and splits docs paths for technical and non-technical readers.
+  Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
 
-  ## [v0.11.143 - Free first Den worker and Google signup](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+  ## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
 
-  Den now lets new users create one free cloud worker without billing and sign up with Google.
+  - Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
+  - The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
+  - Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
 
-  Also released:
+  ## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
 
-  - Retired remaining Soul-mode surfaces across the app and server.
-  - Showed session errors inline, removed raw markdown flashes, and refreshed share bundle pages and previews.
+  Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
 
-  ## [v0.11.142 - Version alignment patch](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+  ## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
 
-  Republishes synchronized app, server, orchestrator, and router versions so shipped artifacts stay in lockstep, with no visible workflow changes.
-
-  ## [v0.11.141 - App and worker opens stay on the new session screen](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
-
-  Keeps launch actions anchored on the new session flow while making oversized-context errors, share feedback, and support booking clearer.
+  Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
 
 </Update>
 
 <Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.140 - Shared bundle imports land on the intended worker](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+  ## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
 
-  Makes shared bundle imports resolve to the exact active or newly created worker and adds more actionable sandbox startup diagnostics.
+  Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
 
-  ## [v0.11.138 - Shared bundle links now open the blueprints worker flow](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+  ## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
 
-  Routes shared bundle imports into the blueprints-style worker creation path so new-worker links land in the setup flow users expect.
+  Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
 
-  ## [v0.11.137 - MCP sign-in retries and model setup get clearer](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+  ## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
 
-  Makes MCP OAuth flows recover more reliably and reorganizes the model picker so disconnected providers route users straight to setup.
+  Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
 
 </Update>
 
 <Update label="March 10th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.136 - OpenWork Share turns dropped files into worker packages](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+  ## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
 
-  - OpenWork Share now packages dropped skills, agents, commands, and MCP or OpenWork config into worker bundles.
-  - The share site moves to the Next.js App Router with refreshed home and bundle pages.
-  - Settings now lets users disconnect providers, while OAuth completion and sandbox startup recover more reliably.
+  - Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
+  - Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
+  - Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
 
 </Update>
 
 <Update label="March 6th" tags={["🚀 New Features"]}>
 
-  ## [v0.11.135 - Bundled OpenCode version stays aligned across release paths](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+  ## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
 
-  Pins the packaged OpenCode fallback consistently across CI, prerelease, and release builds, with no notable new app workflow changes.
+  Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
 
-  ## [v0.11.134 - Remote MCP setup gets lighter, with exportable desktop diagnostics](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+  ## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
 
-  Makes remote-workspace MCP connection setup clearer and adds in-app debug exports, sandbox probes, and config actions for faster troubleshooting.
+  Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
 
 </Update>
 
 <Update label="March 5th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.133 - Chat transcripts stop flickering during typing](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+  ## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
 
-  Keeps active and long-running sessions visually stable by fixing typing flicker, remount churn, and collapsed long-message resets.
+  Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
 
-  ## [v0.11.132 - Chat-first startup and faster long-session loading](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+  ## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
 
-  Preserves the new-session launch state, fixes first-run setup, and makes long chats load from the latest messages with less lag.
+  Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
 
 </Update>
 
 <Update label="March 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.131 - Virtualized chats and clearer runtime status](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+  ## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
 
-  - Virtualized long transcripts so large chats stay responsive instead of rendering every message at once.
-  - Replaced split engine and server badges with one Ready indicator that opens a detailed status popover.
-  - Added automatic context compaction after runs, plus persistent language selection and sturdier file opening.
+  - Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
+  - Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
+  - Added persistent language selection and improved file-open reliability for editor and artifact flows.
 
 </Update>
 
 <Update label="March 2nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.130 - Service restarts and steadier local connectivity](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+  ## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
 
-  Adds in-app restart controls, makes router startup recover from local port conflicts, and smooths billing returns from checkout.
+  Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
 
-  ## [v0.11.129 - Self-serve billing and media-rich messaging](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+  ## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
 
-  Expands cloud billing into a self-serve management flow and lets Slack and Telegram carry richer OpenWork Router messages.
+  Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
 
 </Update>
 
 <Update label="March 1st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.128 - Remote file sessions, Obsidian sync, and long-chat readability](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+  ## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
 
-  Adds live remote file sessions with Obsidian-backed editing, then makes long desktop conversations easier to read and follow.
+  Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
 
 </Update>
 
 <Update label="February 28th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.127 - Get back online recovery and smarter Docker dev-up](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+  ## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
 
-  Makes worker recovery clearer and preserves existing access, while smoothing Docker dev stacks for developers using local OpenCode config.
+  Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
 
 </Update>
 
 <Update label="February 27th" tags={["🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.126 - Simpler artifacts and direct workspace actions](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+  ## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
 
-  Simplifies artifact handling and adds direct worker and plugin actions so common cleanup and file workflows take fewer steps.
+  Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
 
 </Update>
 
 <Update label="February 26th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.125 - Unified workspace navigation and smoother downloads](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+  ## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
 
-  Unifies workspace navigation across dashboard and session views while preventing download-heavy operations from freezing the app.
+  Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
 
-  ## [v0.11.124 - Orbita gives sessions a clearer three-pane workspace](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+  ## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
 
-  Reworks the main session screen with a stronger left rail, cleaner timeline canvas, and floating composer while preserving readability across themes.
+  Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
 
-  ## [v0.11.123 - Clearer share links and local server recovery in Settings](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+  ## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
 
-  Refreshes both the in-app share modal and public bundle pages, and adds a one-click local server restart when a local worker gets stuck.
+  Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
 
-  ## [v0.11.122 - Hosted onboarding and share links become app handoffs](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+  ## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
 
-  Hosted OpenWork now hands people straight from the web into the app for connect and import flows.
-
-  Also released:
-
-  - GitHub sign-in plus a dedicated download page for faster first-time setup.
-  - Share links for workspace profiles and skill sets, with deep links that default to a new worker.
-  - Long sessions render more smoothly, local file links resolve correctly, and desktop shutdown is cleaner.
+  - Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
+  - Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
+  - Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
 
 </Update>
 
 <Update label="February 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.121 - Session timelines read naturally, and search hits stand out](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+  ## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
 
-  Removes meta-heavy timeline labels, highlights search hits inside messages, and makes quick actions and composing feel faster in active chats.
+  Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
 
-  ## [v0.11.120 - Worker switching keeps session lists stable](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+  ## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
 
-  Preserves sidebar sessions while moving between workers and refreshes the landing hero with higher contrast, calmer motion, and lighter nav chrome.
+  Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
 
-  ## [v0.11.119 - Long chats stay snappier, and web onboarding looks cleaner](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+  ## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
 
-  Further trims typing lag while tightening the landing hero, Get started path, and hosted worker layout across the web experience.
+  Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
 
-  ## [v0.11.118 - Large sessions type faster, and cloud worker setup stays simpler](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+  ## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
 
-  Cuts composer lag in big chats, renames timeline labels in plainer language, and keeps manual worker controls tucked behind advanced options.
+  Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
 
-  ## [v0.11.117 - Hosted worker connect and cleanup flows get clearer](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+  ## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
 
-  Reworks the web worker shell with clearer status, delete, and custom-domain handling, then makes session runs easier to scan by separating request, work, and result.
+  Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
 
 </Update>
 
 <Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.116 - Cleaner cloud-worker connect with desktop deep links](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+  ## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
 
-  Turns the hosted worker page into a simpler list-detail picker and adds one-click desktop handoff into OpenWork's remote connect flow.
+  Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
 
-  ## [v0.11.115 - Private Telegram bot pairing and sturdier hosted sign-in](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+  ## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
 
-  Requires explicit pairing before a private Telegram chat can control a worker and lets hosted auth recover from broken upstream HTML responses.
+  Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
 
-  ## [v0.11.114 - OpenWork Cloud worker setup and reconnect flows](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+  ## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
 
-  Adds the first full OpenWork Cloud worker setup flow in the web app.
-
-  Also released:
-
-  - A 3-step sign-in, checkout, and launch flow.
-  - Saved workers plus reusable tokens and workspace-scoped connect URLs.
-  - Background provisioning with polling and completed provider OAuth in the app.
+  - Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
+  - Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
+  - Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
 
 </Update>
 
 <Update label="February 21st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.113 - Cmd+K quick actions for session work](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+  ## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
 
-  Adds a keyboard-first palette for jumping between sessions and changing model or thinking settings without leaving chat.
+  Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
 
-  ## [v0.11.112 - Cleaner session tool timelines](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+  ## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
 
-  Hides step lifecycle noise and separates reasoning from tool runs so active sessions are easier to scan.
+  Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
 
 </Update>
 
 <Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.111 - Version metadata sync only](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+  ## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
 
-  Republishes synchronized package and desktop version metadata, with no intended OpenWork app, server, or workflow changes.
+  Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
 
-  ## [v0.11.110 - Release packaging and deploy hardening only](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+  ## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
 
-  Hardens updater metadata generation and share-service deploy behavior, with no visible OpenWork app or workflow changes.
+  Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
 
-  ## [v0.11.109 - Safer automation setup, grouped skills, and global MCP config](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+  ## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
 
-  Keeps automations hidden until the scheduler is installed and lets OpenWork pick up domain-organized skills plus machine-level MCP servers.
+  Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
 
-  ## [v0.11.108 - Readable share pages, sturdier Soul flows, safer drafts](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+  ## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
 
-  Makes shared bundles inspectable in the browser, preserves unsent draft text across tab switches, and strengthens Soul activation and audit flows.
+  Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
 
-  ## [v0.11.107 - Reopening sessions no longer snaps you back to the top](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+  ## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
 
-  Fixes a revisit-specific session bug so returning to an existing conversation preserves a steadier reading position.
+  Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
 
-  ## [v0.11.106 - Packaging-only release lockfile maintenance](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+  ## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
 
-  Refreshes package lock metadata for the release line, with no clear app, desktop, web, or workflow change.
+  Refreshes release metadata only, with no clear user-facing product change in this patch.
 
-  ## [v0.11.105 - Session timelines stop auto-following altogether](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+  ## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
 
-  Removes the remaining automatic follow behavior so live output no longer drags the view while you read older messages.
+  Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
 
-  ## [v0.11.104 - Session follow mode is now in your hands](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+  ## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
 
-  Adds explicit follow-latest and jump-to-latest controls so streaming output stops interrupting people who scroll back to read.
+  Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
 
-  ## [v0.11.103 - Soul setup now runs safely, and sidebar sessions stay scoped](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+  ## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
 
-  - Switched Soul enable flows to run through the slash-command path instead of sending template text directly.
-  - Scoped sidebar session sync by workspace root so session state does not bleed across workspaces.
+  - Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
+  - Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
+  - Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
 
-  ## [v0.11.102 - Migration recovery explains when it can help](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+  ## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
 
-  Clarifies when repair is actually available in the app and resets the landing page back to broader OpenWork messaging.
+  Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
 
 </Update>
 
 <Update label="February 19th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.101 - Local migration repair and clearer Soul controls](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
+  ## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
 
-  Adds a desktop recovery path for broken local OpenCode migrations and makes Soul setup plus compact action buttons easier to steer.
+  Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
 
-  ## v0.11.100 - Composer drafts stop disappearing mid-prompt
+  ## v0.11.100
 
-  Fixes a session composer race so long prompts stay intact instead of getting replaced by stale draft echoes.
+  Stops long prompts from disappearing while typing, making the session composer reliable again.
 
 </Update>

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,536 +1,548 @@
 ---
 title: "Changelog"
 ---
-<Update label="April 4th" tags={["🐛 Bug Fixes"]}>
+<Update label="April 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+  ## [v0.11.202 - Translations fill out across the app and shared skill imports work again.](https://github.com/different-ai/openwork/compare/v0.11.201...v0.11.202)
 
-  Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
+  Adds Thai, restores missing page translations, fixes migrated shared-skill links, and tightens docs and local desktop dev setup.
+
+  ## [v0.11.201 - Workspace lists collapse cleanly and Den organization setup recovers more reliably.](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+
+  Hides collapsed workspace task rows, steadies session loading, and fixes Den skill saving plus organization draft and invite recovery.
 
 </Update>
 
 <Update label="April 3rd" tags={["🚀 New Features"]}>
 
-  ## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+  ## [v0.11.200 - Cloud skills and team limits move into the core flow](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
 
-  - Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
-  - Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
-  - Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
+  - Added an OpenWork Cloud skills catalog to the Skills page, with install and share-to-team flows.
+  - Added Den teams plus full skill hub and skill editing and visibility management.
+  - Moved billing into org creation and enforced organization member limits before setup finishes.
 
 </Update>
 
 <Update label="April 2nd" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+  ## [v0.11.199 - Pricing, skill hubs, and session recovery sharpen up](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
 
-  - Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
-  - Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
-  - Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
+  - Added a pricing page and paid Windows messaging, and sent Cloud navigation directly into the app.
+  - Expanded Den with skill hubs, a new `den-api`, and a smoother org-invite signup flow.
+  - Added developer log export, per-conversation draft persistence, and recovery after immediate send failures.
 
 </Update>
 
 <Update label="March 31st" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+  ## [v0.11.198 - Local workspace switches restart the right engine](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
 
-  Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
+  Fixes a local-only switch bug so changing between local workspaces restarts the engine instead of reusing the old connection.
 
-  ## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+  ## [v0.11.197 - Sharing gets safer and startup gets less noisy](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
 
-  - Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
-  - Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
-  - Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
+  - Blocked sensitive workspace exports and showed warnings before sharing risky config or secrets.
+  - Trusted bundle imports only from the configured publisher unless users explicitly choose a warning-backed manual path.
+  - Moved OpenWork tokens off CLI args and logs, stopped auto-creating Welcome, and fixed collapsed sidebar session lists.
 
 </Update>
 
 <Update label="March 30th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+  ## [v0.11.196 - OpenWork resumes where you left off](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
 
-  - Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
-  - Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
-  - Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
+  - Reopened the last session on workspace boot and routed straight into the session view.
+  - Moved automations onto a dedicated page backed by live local or remote scheduler jobs.
+  - Fixed bootstrap and workspace switching so Welcome setup and loading states stop interrupting startup.
 
 </Update>
 
 <Update label="March 27th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+  ## [v0.11.195 - Local workspace creation and Den worker setup get steadier](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
 
-  Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
+  Routes new local workspaces through the local host, persists model defaults properly, and smooths Den worker-connect and billing flows.
 
 </Update>
 
 <Update label="March 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+  ## [v0.11.194 - Auto compaction and live automations become real workflows](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
 
-  Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
+  Wires auto compaction to actual workspace config, keeps scheduled jobs live in-app, and adds a faster Den local-dev path.
 
-  ## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+  ## [v0.11.193 - Team template sharing reaches OpenWork Cloud](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
 
-  - Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
-  - Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
-  - Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
+  - Added Save-to-team flows for workspace templates, with org selection and Cloud sign-in prompts.
+  - Introduced Den organizations, member roles, invitations, custom roles, and org-scoped template APIs and screens.
+  - Added a manual Cloud sign-in fallback when automatic team-sharing auth stalls.
 
 </Update>
 
 <Update label="March 25th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+  ## [v0.11.192 - Workspace switching stops hijacking runtime state](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
 
-  - Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
-  - Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
-  - Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
+  - Split selected workspace from runtime-connected workspace so browsing no longer flips the active worker.
+  - Kept preferred local server ports sticky and avoided collisions across workspaces.
+  - Let templates carry extra `.opencode` files and starter sessions, and materialized seeded sessions correctly.
 
-  ## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+  ## [v0.11.191 - Shared detached workers survive restarts](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
 
-  Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
+  Preserves share credentials for detached workers, hides disconnected config-backed providers, and adds clearer Slack and skill-import docs.
 
 </Update>
 
 <Update label="March 24th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+  ## [v0.11.190 - Connection guides expand while sharing and auth settle](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
 
-  Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
+  Mostly docs-focused release that reorganizes onboarding around concrete connection guides, while fixing desktop publish routing and headless OpenAI auth timing.
 
-  ## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+  ## [v0.11.189 - Package metadata rolls forward only](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
 
-  Rolls the release line forward with no visible product or workflow changes.
+  Updates the release line with a lockfile and version sync only, without any visible product or workflow changes.
 
-  ## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+  ## [v0.11.188 - Landing feedback returns to the previous flow](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
 
-  Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
+  Backs out the Loops feedback template so the landing feedback endpoint goes back to the simpler email-based path.
 
-  ## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+  ## [v0.11.187 - Windows workspace scoping handles verbatim paths](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
 
-  Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
+  Normalizes Windows path transport, verbatim prefixes, and UNC comparisons so local session scope stays consistent across directory formats.
 
-  ## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+  ## [v0.11.186 - Local reconnects stay scoped to the right workspace](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
 
-  Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
+  Fixes restart and reconnect flows so local sessions and starter workspaces stay attached to the intended directory.
 
-  ## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+  ## [v0.11.185 - Safer local sharing and messaging setup](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
 
-  - Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
-  - Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
-  - Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
+  Local workers now stay localhost-only unless users explicitly opt into remote exposure, messaging is disabled until enabled on purpose, public Telegram bot creation shows a risk warning, and Chrome DevTools MCP gets a guided setup flow.
 
 </Update>
 
 <Update label="March 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+  ## [v0.11.184 - CLI quickstart becomes the primary docs path](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
 
-  Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
+  Rebuilds the docs around a single CLI-first quickstart and removes older split onboarding paths that were harder to follow.
 
-  ## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+  ## [v0.11.183 - Exa moves into OpenCode settings](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
 
-  Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
+  Surfaces the Exa search toggle in a clearer OpenCode settings section and rolls back an unready macOS path-normalization change.
 
-  ## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+  ## [v0.11.182 - Local workspaces move under OpenWork server control](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
 
-  - Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
-  - Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
-  - Polished session tool traces by moving the chevron affordance to the right for faster scanning.
+  - Local workspace create, rename, delete, config writes, and reload events now go through OpenWork server first.
+  - First-run starter bootstrap and reconnect logic are more reliable across onboarding and sidebar flows.
+  - Simplified the remote connect modal, moved tool-trace chevrons right, and added Windows ARM64 dev startup support.
 
 </Update>
 
 <Update label="March 22nd" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+  ## [v0.11.181 - Version metadata is republished in sync](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
 
-  Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
+  Republishes synchronized package versions only, with no distinct user-facing or developer-facing workflow change.
 
-  ## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+  ## [v0.11.179 - Den checkout and workspace setup get leaner](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
 
-  Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
+  Simplifies Den billing and dashboard surfaces, streamlines workspace creation flows, and removes the desktop tray path.
 
-  ## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+  ## [v0.11.178 - Workspace sharing and model controls get a major refresh](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
 
-  - Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
-  - Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
-  - Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
+  - Redesigned workspace sharing and the right sidebar, including cleaner remote credentials and nested child sessions.
+  - Made model pickers model-aware with provider icons and per-model reasoning or behavior controls.
+  - Moved app feedback to a hosted form, added an Exa toggle, and stopped forcing starter workspaces on desktop boot.
 
 </Update>
 
 <Update label="March 20th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+  ## [v0.11.177 - Downloads CTA and npm install fallback land](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
 
-  Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
+  Gets desktop users to the right download path faster and lets `openwork-orchestrator` recover when npm skips its platform binary.
 
-  ## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+  ## [v0.11.175 - Authorized folders and first-run session guidance move into Settings](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
 
-  Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
+  Adds Settings-based folder authorization and server-backed empty states, then tightens sidebar and composer labeling so navigation stays readable.
 
-  ## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+  ## [v0.11.173 - Daytona workers report activity and local Node tools spawn reliably](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
 
-  Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
+  Adds worker heartbeats for Daytona-backed Cloud workers while making local MCP and tool launches work in nvm-managed Node environments.
 
 </Update>
 
 <Update label="March 19th" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+  ## [v0.11.172 - Server package naming and session traces line up](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
 
-  Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
+  Renames the published server package to `openwork-server` and polishes trace-row icon and chevron alignment so session runs scan more cleanly.
 
-  ## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+  ## [v0.11.170 - OpenWork Cloud web flows and remote reconnects improve](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
 
-  - Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
-  - Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
-  - Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
+  - Rebuilt Den web auth, checkout, and dashboard routes so hosted onboarding and billing feel like the app instead of a one-off page.
+  - Persisted worker share tokens and repeated deeplinks across restarts, with stronger open-in-web auto-connect and connect overlays.
+  - Added self-serve Cloud settings, OpenAI headless auth, and tray-on-close desktop behavior.
 
 </Update>
 
 <Update label="March 18th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+  ## [v0.11.169 - Den handoff and session chrome get steadier](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
 
-  Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
+  Keeps Den browser handoff and worker naming in sync while cleaning up session focus, reload banners, run status, and broken sidebar affordances.
 
 </Update>
 
 <Update label="March 17th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+  ## [v0.11.168 - Release recovery with repaired installers](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
 
-  Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
+  Republishes the release with repaired assets; the tagged diff itself is metadata-only, while the intended Cloud tab gating fix landed in `v0.11.167`.
 
-  ## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+  ## [v0.11.166 - Daytona-backed Den Docker flow ships](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
 
-  - Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
-  - Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
-  - Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
+  - Added a Daytona-backed Den Docker flow with a dedicated worker proxy and snapshot builder for preloaded runtimes.
+  - Introduced the `den-v2` control plane and shared Den DB packages for the new hosted-worker path.
+  - Fixed unique org slug generation and the `webdev:local` startup script.
 
-  ## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+  ## [v0.11.165 - Settings can sign into Cloud and open workers](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
 
-  - Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
-  - Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
-  - Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
+  - Added a Cloud tab in Settings for sign-in, org selection, worker lists, and opening ready Den workers into OpenWork.
+  - Routed desktop auth through the web handoff flow, including installed-app scheme support and bearer-session handling.
+  - Restored shared bundle installs and fully cleared disconnected provider credentials.
 
 </Update>
 
 <Update label="March 16th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+  ## [v0.11.164 - Owner tokens and child sessions stay visible](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
 
-  Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
+  Clarifies remote approval access with owner tokens, keeps nested child sessions from disappearing in sidebar syncs, and broadens polish across sharing and localization.
 
-  ## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+  ## [v0.11.163 - Custom skill hub repos and steadier session actions](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
 
-  Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
+  Lets teams browse and install skills from any GitHub hub repo while making session switching, composer focus, and reload prompts behave more predictably.
 
-  ## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+  ## [v0.11.162 - Docker dev prints LAN-ready OpenWork URLs](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
 
-  Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
+  Makes local Docker testing easier from phones and other devices by printing public URLs and deriving Den auth and CORS defaults from the detected host.
 
 </Update>
 
 <Update label="March 15th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+  ## [v0.11.160 - Den auth, downloads, and nested sessions polish](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
 
-  Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
+  Simplifies the Den auth entry flow, sends landing-page downloads to the right installer, and restores parent-child session browsing in the sidebar.
 
-  ## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+  ## [v0.11.159 - Den cloud billing and worker launch align](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
 
-  Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
+  Aligns the app-hosted Den flow with landing-page messaging, restores checkout handling for extra workers, and fixes visible billing and marketing regressions.
 
-  ## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+  ## [v0.11.155 - Windows release diagnostics stop masking failures](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
 
-  Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
+  Improves release-pipeline diagnostics and normalizes workflow action inputs so broken Windows packaging runs are easier to debug.
 
-  ## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+  ## [v0.11.151 - Feedback emails reach the team inbox again](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
 
-  Makes feedback submissions reach the OpenWork team inbox reliably again.
+  Fixes the in-app feedback email target so reports reach the shared OpenWork inbox again.
 
-  ## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+  ## [v0.11.150 - Faster provider setup and steadier chat rendering](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
 
-  Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
+  Prioritizes common providers in new-session setup, reduces inline image churn while chatting, and routes feedback straight to the team inbox.
 
 </Update>
 
 <Update label="March 14th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+  ## [v0.11.149 - Richer skill previews and steadier jump-to-latest](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
 
-  Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
+  Makes shared skill pages easier to evaluate before import, steadies the worker-selection flow, and keeps long chats pinned to the newest reply while thinking.
 
-  ## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+  ## [v0.11.148 - Guided Den onboarding and single-skill Share](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
 
-  - Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
-  - OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
-  - Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
+  - Rebuilt Den onboarding as a guided flow with clearer naming, intent, loading, and browser-access states.
+  - Simplified OpenWork Share to publish a single skill, with cleaner frontmatter and fuller shared previews.
+  - Added a polished feedback card and clearer import and status feedback across app surfaces.
 
-  ## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+  ## [v0.11.147 - Existing-worker imports and local Share publishing](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
 
-  Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
+  Lets shared skills install into existing workers, adds a local Docker-backed Share publisher for self-hosted testing, and keeps Den worker provisioning current.
 
 </Update>
 
 <Update label="March 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+  ## [v0.11.146 - Failed worker redeploy and safer skill imports](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
 
-  Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
+  Adds direct Den worker redeploys, makes shared skills pick a destination worker before import, and improves both local Den setup and Chrome-first guidance.
 
-  ## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+  ## [v0.11.145 - Den admin backoffice and support routing](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
 
-  Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
+  Adds a protected Den admin panel for support operations, routes enterprise contact submissions into Loops, and tightens desktop skill reload and settings diagnostics.
 
 </Update>
 
 <Update label="March 12th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+  ## [v0.11.144 - Workspace shell recovery and clearer docs entrypoints](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
 
-  Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
+  Restores reliable workspace-shell navigation and reset recovery, seeds Chrome DevTools setup correctly, and splits docs paths for technical and non-technical readers.
 
-  ## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+  ## [v0.11.143 - Free first Den worker and Google signup](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
 
-  - Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
-  - The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
-  - Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
+  Den now lets new users create one free cloud worker without billing and sign up with Google.
 
-  ## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+  Also released:
 
-  Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
+  - Retired remaining Soul-mode surfaces across the app and server.
+  - Showed session errors inline, removed raw markdown flashes, and refreshed share bundle pages and previews.
 
-  ## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+  ## [v0.11.142 - Version alignment patch](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
 
-  Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
+  Republishes synchronized app, server, orchestrator, and router versions so shipped artifacts stay in lockstep, with no visible workflow changes.
+
+  ## [v0.11.141 - App and worker opens stay on the new session screen](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+
+  Keeps launch actions anchored on the new session flow while making oversized-context errors, share feedback, and support booking clearer.
 
 </Update>
 
 <Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+  ## [v0.11.140 - Shared bundle imports land on the intended worker](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
 
-  Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
+  Makes shared bundle imports resolve to the exact active or newly created worker and adds more actionable sandbox startup diagnostics.
 
-  ## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+  ## [v0.11.138 - Shared bundle links now open the blueprints worker flow](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
 
-  Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
+  Routes shared bundle imports into the blueprints-style worker creation path so new-worker links land in the setup flow users expect.
 
-  ## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+  ## [v0.11.137 - MCP sign-in retries and model setup get clearer](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
 
-  Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
+  Makes MCP OAuth flows recover more reliably and reorganizes the model picker so disconnected providers route users straight to setup.
 
 </Update>
 
 <Update label="March 10th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+  ## [v0.11.136 - OpenWork Share turns dropped files into worker packages](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
 
-  - Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
-  - Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
-  - Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
+  - OpenWork Share now packages dropped skills, agents, commands, and MCP or OpenWork config into worker bundles.
+  - The share site moves to the Next.js App Router with refreshed home and bundle pages.
+  - Settings now lets users disconnect providers, while OAuth completion and sandbox startup recover more reliably.
 
 </Update>
 
 <Update label="March 6th" tags={["🚀 New Features"]}>
 
-  ## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+  ## [v0.11.135 - Bundled OpenCode version stays aligned across release paths](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
 
-  Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
+  Pins the packaged OpenCode fallback consistently across CI, prerelease, and release builds, with no notable new app workflow changes.
 
-  ## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+  ## [v0.11.134 - Remote MCP setup gets lighter, with exportable desktop diagnostics](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
 
-  Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
+  Makes remote-workspace MCP connection setup clearer and adds in-app debug exports, sandbox probes, and config actions for faster troubleshooting.
 
 </Update>
 
 <Update label="March 5th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+  ## [v0.11.133 - Chat transcripts stop flickering during typing](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
 
-  Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
+  Keeps active and long-running sessions visually stable by fixing typing flicker, remount churn, and collapsed long-message resets.
 
-  ## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+  ## [v0.11.132 - Chat-first startup and faster long-session loading](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
 
-  Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
+  Preserves the new-session launch state, fixes first-run setup, and makes long chats load from the latest messages with less lag.
 
 </Update>
 
 <Update label="March 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+  ## [v0.11.131 - Virtualized chats and clearer runtime status](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
 
-  - Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
-  - Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
-  - Added persistent language selection and improved file-open reliability for editor and artifact flows.
+  - Virtualized long transcripts so large chats stay responsive instead of rendering every message at once.
+  - Replaced split engine and server badges with one Ready indicator that opens a detailed status popover.
+  - Added automatic context compaction after runs, plus persistent language selection and sturdier file opening.
 
 </Update>
 
 <Update label="March 2nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+  ## [v0.11.130 - Service restarts and steadier local connectivity](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
 
-  Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
+  Adds in-app restart controls, makes router startup recover from local port conflicts, and smooths billing returns from checkout.
 
-  ## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+  ## [v0.11.129 - Self-serve billing and media-rich messaging](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
 
-  Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
+  Expands cloud billing into a self-serve management flow and lets Slack and Telegram carry richer OpenWork Router messages.
 
 </Update>
 
 <Update label="March 1st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+  ## [v0.11.128 - Remote file sessions, Obsidian sync, and long-chat readability](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
 
-  Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
+  Adds live remote file sessions with Obsidian-backed editing, then makes long desktop conversations easier to read and follow.
 
 </Update>
 
 <Update label="February 28th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+  ## [v0.11.127 - Get back online recovery and smarter Docker dev-up](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
 
-  Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
+  Makes worker recovery clearer and preserves existing access, while smoothing Docker dev stacks for developers using local OpenCode config.
 
 </Update>
 
 <Update label="February 27th" tags={["🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+  ## [v0.11.126 - Simpler artifacts and direct workspace actions](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
 
-  Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
+  Simplifies artifact handling and adds direct worker and plugin actions so common cleanup and file workflows take fewer steps.
 
 </Update>
 
 <Update label="February 26th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+  ## [v0.11.125 - Unified workspace navigation and smoother downloads](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
 
-  Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
+  Unifies workspace navigation across dashboard and session views while preventing download-heavy operations from freezing the app.
 
-  ## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+  ## [v0.11.124 - Orbita gives sessions a clearer three-pane workspace](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
 
-  Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
+  Reworks the main session screen with a stronger left rail, cleaner timeline canvas, and floating composer while preserving readability across themes.
 
-  ## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+  ## [v0.11.123 - Clearer share links and local server recovery in Settings](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
 
-  Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
+  Refreshes both the in-app share modal and public bundle pages, and adds a one-click local server restart when a local worker gets stuck.
 
-  ## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+  ## [v0.11.122 - Hosted onboarding and share links become app handoffs](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
 
-  - Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
-  - Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
-  - Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
+  Hosted OpenWork now hands people straight from the web into the app for connect and import flows.
+
+  Also released:
+
+  - GitHub sign-in plus a dedicated download page for faster first-time setup.
+  - Share links for workspace profiles and skill sets, with deep links that default to a new worker.
+  - Long sessions render more smoothly, local file links resolve correctly, and desktop shutdown is cleaner.
 
 </Update>
 
 <Update label="February 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+  ## [v0.11.121 - Session timelines read naturally, and search hits stand out](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
 
-  Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
+  Removes meta-heavy timeline labels, highlights search hits inside messages, and makes quick actions and composing feel faster in active chats.
 
-  ## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+  ## [v0.11.120 - Worker switching keeps session lists stable](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
 
-  Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
+  Preserves sidebar sessions while moving between workers and refreshes the landing hero with higher contrast, calmer motion, and lighter nav chrome.
 
-  ## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+  ## [v0.11.119 - Long chats stay snappier, and web onboarding looks cleaner](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
 
-  Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
+  Further trims typing lag while tightening the landing hero, Get started path, and hosted worker layout across the web experience.
 
-  ## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+  ## [v0.11.118 - Large sessions type faster, and cloud worker setup stays simpler](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
 
-  Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
+  Cuts composer lag in big chats, renames timeline labels in plainer language, and keeps manual worker controls tucked behind advanced options.
 
-  ## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+  ## [v0.11.117 - Hosted worker connect and cleanup flows get clearer](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
 
-  Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
+  Reworks the web worker shell with clearer status, delete, and custom-domain handling, then makes session runs easier to scan by separating request, work, and result.
 
 </Update>
 
 <Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+  ## [v0.11.116 - Cleaner cloud-worker connect with desktop deep links](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
 
-  Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
+  Turns the hosted worker page into a simpler list-detail picker and adds one-click desktop handoff into OpenWork's remote connect flow.
 
-  ## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+  ## [v0.11.115 - Private Telegram bot pairing and sturdier hosted sign-in](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
 
-  Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
+  Requires explicit pairing before a private Telegram chat can control a worker and lets hosted auth recover from broken upstream HTML responses.
 
-  ## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+  ## [v0.11.114 - OpenWork Cloud worker setup and reconnect flows](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
 
-  - Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
-  - Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
-  - Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
+  Adds the first full OpenWork Cloud worker setup flow in the web app.
+
+  Also released:
+
+  - A 3-step sign-in, checkout, and launch flow.
+  - Saved workers plus reusable tokens and workspace-scoped connect URLs.
+  - Background provisioning with polling and completed provider OAuth in the app.
 
 </Update>
 
 <Update label="February 21st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+  ## [v0.11.113 - Cmd+K quick actions for session work](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
 
-  Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
+  Adds a keyboard-first palette for jumping between sessions and changing model or thinking settings without leaving chat.
 
-  ## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+  ## [v0.11.112 - Cleaner session tool timelines](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
 
-  Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
+  Hides step lifecycle noise and separates reasoning from tool runs so active sessions are easier to scan.
 
 </Update>
 
 <Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+  ## [v0.11.111 - Version metadata sync only](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
 
-  Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
+  Republishes synchronized package and desktop version metadata, with no intended OpenWork app, server, or workflow changes.
 
-  ## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+  ## [v0.11.110 - Release packaging and deploy hardening only](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
 
-  Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
+  Hardens updater metadata generation and share-service deploy behavior, with no visible OpenWork app or workflow changes.
 
-  ## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+  ## [v0.11.109 - Safer automation setup, grouped skills, and global MCP config](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
 
-  Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
+  Keeps automations hidden until the scheduler is installed and lets OpenWork pick up domain-organized skills plus machine-level MCP servers.
 
-  ## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+  ## [v0.11.108 - Readable share pages, sturdier Soul flows, safer drafts](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
 
-  Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
+  Makes shared bundles inspectable in the browser, preserves unsent draft text across tab switches, and strengthens Soul activation and audit flows.
 
-  ## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+  ## [v0.11.107 - Reopening sessions no longer snaps you back to the top](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
 
-  Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
+  Fixes a revisit-specific session bug so returning to an existing conversation preserves a steadier reading position.
 
-  ## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+  ## [v0.11.106 - Packaging-only release lockfile maintenance](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
 
-  Refreshes release metadata only, with no clear user-facing product change in this patch.
+  Refreshes package lock metadata for the release line, with no clear app, desktop, web, or workflow change.
 
-  ## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+  ## [v0.11.105 - Session timelines stop auto-following altogether](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
 
-  Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
+  Removes the remaining automatic follow behavior so live output no longer drags the view while you read older messages.
 
-  ## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+  ## [v0.11.104 - Session follow mode is now in your hands](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
 
-  Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
+  Adds explicit follow-latest and jump-to-latest controls so streaming output stops interrupting people who scroll back to read.
 
-  ## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+  ## [v0.11.103 - Soul setup now runs safely, and sidebar sessions stay scoped](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
 
-  - Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
-  - Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
-  - Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
+  - Switched Soul enable flows to run through the slash-command path instead of sending template text directly.
+  - Scoped sidebar session sync by workspace root so session state does not bleed across workspaces.
 
-  ## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+  ## [v0.11.102 - Migration recovery explains when it can help](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
 
-  Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
+  Clarifies when repair is actually available in the app and resets the landing page back to broader OpenWork messaging.
 
 </Update>
 
 <Update label="February 19th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
+  ## [v0.11.101 - Local migration repair and clearer Soul controls](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
 
-  Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
+  Adds a desktop recovery path for broken local OpenCode migrations and makes Soul setup plus compact action buttons easier to steer.
 
-  ## v0.11.100
+  ## v0.11.100 - Composer drafts stop disappearing mid-prompt
 
-  Stops long prompts from disappearing while typing, making the session composer reliable again.
+  Fixes a session composer race so long prompts stay intact instead of getting replaced by stale draft echoes.
 
 </Update>

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -6,9 +6,10 @@ import { fileURLToPath } from "node:url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, "..")
-const TRACKER_PATH = resolve(ROOT, "changelog/release-tracker.md")
+const TRACKER_DIR = resolve(ROOT, "changelog")
 const OUTPUT_PATH = resolve(ROOT, "packages/docs/changelog.mdx")
 const COMPARE_BASE = "https://github.com/different-ai/openwork/compare"
+const TRACKER_FILE_PATTERN = /^release-tracker-\d{4}-\d{2}-\d{2}\.md$/
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,7 +63,7 @@ function resolveTags(features, bugs, deprecated) {
 // ---------------------------------------------------------------------------
 
 /**
- * Parse release-tracker.md into structured release objects.
+ * Parse a release-tracker file into structured release objects.
  *
  * Splits on `## v` headings, then extracts `#### ` subsections inside each.
  */
@@ -115,6 +116,7 @@ function toEntry(release, prevVersion) {
 
   const oneLiner = s["One-line summary"]?.trim() || ""
   const mainChanges = s["Main changes"]?.trim() || ""
+  const title = s["Title"]?.trim() || ""
 
   const features = parseInt(s["Number of major improvements"] || "0", 10)
   const bugs = parseInt(s["Number of major bugs resolved"] || "0", 10)
@@ -132,6 +134,7 @@ function toEntry(release, prevVersion) {
     date,
     isMajor,
     tags,
+    title,
     oneLiner,
     mainChanges,
     compareUrl,
@@ -147,12 +150,15 @@ function toEntry(release, prevVersion) {
  */
 function renderVersionBlock(entry) {
   const lines = []
+  const combinedTitle = entry.title
+    ? `${entry.version} - ${entry.title}`
+    : entry.version
 
-  // Version as the section heading, linked to compare URL
+  // Version + title as the section heading, linked to compare URL
   if (entry.compareUrl) {
-    lines.push(`  ## [${entry.version}](${entry.compareUrl})`)
+    lines.push(`  ## [${combinedTitle}](${entry.compareUrl})`)
   } else {
-    lines.push(`  ## ${entry.version}`)
+    lines.push(`  ## ${combinedTitle}`)
   }
 
   lines.push("")
@@ -161,7 +167,7 @@ function renderVersionBlock(entry) {
   if (entry.isMajor && entry.mainChanges) {
     const indented = entry.mainChanges
       .split("\n")
-      .map((l) => `  ${l}`)
+      .map((l) => (l.length > 0 ? `  ${l}` : ""))
       .join("\n")
     lines.push(indented)
   } else {
@@ -230,14 +236,33 @@ function renderChangelog(entries) {
 // Main
 // ---------------------------------------------------------------------------
 
+async function loadTrackerReleases() {
+  const entries = await fs.readdir(TRACKER_DIR, { withFileTypes: true })
+  const trackerFiles = entries
+    .filter((entry) => entry.isFile() && TRACKER_FILE_PATTERN.test(entry.name))
+    .map((entry) => entry.name)
+    .sort()
+
+  if (trackerFiles.length === 0) {
+    throw new Error(`No tracker files found in ${TRACKER_DIR}`)
+  }
+
+  const releases = []
+  for (const fileName of trackerFiles) {
+    const raw = await fs.readFile(resolve(TRACKER_DIR, fileName), "utf-8")
+    releases.push(...parseTracker(raw))
+  }
+
+  return { trackerFiles, releases }
+}
+
 async function main() {
-  const raw = await fs.readFile(TRACKER_PATH, "utf-8")
-  const releases = parseTracker(raw)
+  const { trackerFiles, releases } = await loadTrackerReleases()
   const entries = releases.map((r, i) => toEntry(r, i > 0 ? releases[i - 1].version : null))
   const output = renderChangelog(entries)
 
   await fs.writeFile(OUTPUT_PATH, output, "utf-8")
-  console.log(`Wrote ${entries.length} entries to ${OUTPUT_PATH}`)
+  console.log(`Wrote ${entries.length} entries from ${trackerFiles.length} tracker files to ${OUTPUT_PATH}`)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- update the changelog generator to read all split `changelog/release-tracker-YYYY-MM-DD.md` files instead of the removed single tracker file
- use each release `Title` to render combined headings like `v0.11.202 - ...` when tracker entries include one
- keep the generated docs stable when titles are absent by falling back to version-only headings

## Testing
- `node scripts/generate-changelog.mjs`
- `git diff --check -- scripts/generate-changelog.mjs packages/docs/changelog.mdx`

## Notes
- current `origin/dev` tracker files do not yet include `#### Title`, so the regenerated docs output stays unchanged on this PR until the tracker-title branch lands