### PR TITLE
docs(changelog): rebuild tracker drafts and title-aware docs output

### DIFF
--- a/changelog/release-tracker-2026-02-19.md
+++ b/changelog/release-tracker-2026-02-19.md
@@ -10,13 +10,15 @@ Internal preparation file for release summaries. This is not yet published to th
 #### Released at
 `2026-02-19T17:49:05Z`
 
+#### Title
+Composer drafts stop disappearing mid-prompt
+
 #### One-line summary
-Stops long prompts from disappearing while typing, making the session composer reliable again.
+Fixes a session composer race so long prompts stay intact instead of getting replaced by stale draft echoes.
 
 #### Main changes
-- Fixed a composer regression where long prompts could be overwritten by stale draft echoes.
-- Hardened draft retention so typed text stays stable during longer session inputs.
-- Shipped the fix in the `0.11.100` release with the usual package and metadata refresh.
+- Fixed stale draft echoes overriding what you were actively typing in the session composer.
+- Tightened draft state tracking so long prompts stay stable during extended writing.
 
 #### Lines of code changed since previous release
 98 lines changed since `v0.11.99` (58 insertions, 40 deletions).
@@ -52,7 +54,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -65,13 +67,19 @@ False
 #### Released at
 `2026-02-19T21:26:55Z`
 
+#### Title
+Local migration repair and clearer Soul controls
+
 #### One-line summary
-Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
+Adds a desktop recovery path for broken local OpenCode migrations and makes Soul setup plus compact action buttons easier to steer.
 
 #### Main changes
-- Added a local recovery flow for broken OpenCode migrations so desktop startup can repair itself instead of leaving users stuck.
-- Improved Soul starter observability and steering so users can inspect and guide Soul behavior with clearer in-app controls.
-- Refreshed compact action buttons across settings and sidebars to make update and connection actions easier to scan.
+Added migration repair from onboarding and Settings so broken local startup can recover without leaving OpenWork.
+
+Also released:
+
+- Clearer Soul starter steering and observability.
+- Cleaner compact action buttons across settings and sidebars.
 
 #### Lines of code changed since previous release
 1248 lines changed since `v0.11.100` (933 insertions, 315 deletions).
@@ -107,7 +115,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -120,13 +128,15 @@ False
 #### Released at
 `2026-02-20T00:00:11Z`
 
+#### Title
+Migration recovery explains when it can help
+
 #### One-line summary
-Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
+Clarifies when repair is actually available in the app and resets the landing page back to broader OpenWork messaging.
 
 #### Main changes
-- Added clearer in-app feedback about whether migration recovery tooling is available for the current setup.
-- Smoothed the settings and onboarding surfaces that support the migration recovery troubleshooting flow.
-- Shipped as a narrow follow-up patch focused on making the new recovery path easier to understand.
+- Added disabled-state feedback and clearer reasons when migration recovery is unavailable in onboarding and Settings.
+- Reverted the homepage copy from a workers-heavy framing back to the broader OpenWork message.
 
 #### Lines of code changed since previous release
 168 lines changed since `v0.11.101` (100 insertions, 68 deletions).
@@ -162,7 +172,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -175,13 +185,15 @@ False
 #### Released at
 `2026-02-20T00:41:17Z`
 
+#### Title
+Soul setup now runs safely, and sidebar sessions stay scoped
+
 #### One-line summary
-Hardens Soul template safety first, then makes sidebar state more predictable across different workspace roots.
+Prevents Soul quickstart content from being injected as raw prompt text and keeps sidebar session state tied to the active workspace root.
 
 #### Main changes
-- Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
-- Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
-- Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
+- Switched Soul enable flows to run through the slash-command path instead of sending template text directly.
+- Scoped sidebar session sync by workspace root so session state does not bleed across workspaces.
 
 #### Lines of code changed since previous release
 83 lines changed since `v0.11.102` (47 insertions, 36 deletions).
@@ -218,7 +230,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -231,13 +243,15 @@ False
 #### Released at
 `2026-02-20T04:45:27Z`
 
+#### Title
+Session follow mode is now in your hands
+
 #### One-line summary
-Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
+Adds explicit follow-latest and jump-to-latest controls so streaming output stops interrupting people who scroll back to read.
 
 #### Main changes
-- Changed session follow-scroll behavior so users stay in control when they scroll away from the latest output.
-- Reduced unwanted auto-follow jumps while active runs continue streaming into the session view.
-- Focused the patch on reading comfort and session stability rather than broader feature work.
+- Added a follow-latest toggle and a jump-to-latest button in the session timeline.
+- Turned off auto-follow as soon as you scroll away from the live tail.
 
 #### Lines of code changed since previous release
 211 lines changed since `v0.11.103` (123 insertions, 88 deletions).
@@ -273,7 +287,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -286,13 +300,15 @@ False
 #### Released at
 `2026-02-20T05:12:11Z`
 
+#### Title
+Session timelines stop auto-following altogether
+
 #### One-line summary
-Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
+Removes the remaining automatic follow behavior so live output no longer drags the view while you read older messages.
 
 #### Main changes
-- Removed automatic session scroll following from the session view so the app no longer keeps trying to drag users back downward.
-- Simplified scrolling behavior around active runs so reading earlier content feels steadier.
-- Shipped as a very narrow patch focused on the remaining session auto-scroll regression.
+- Removed automatic session follow scrolling during new output and sends.
+- Left only a manual jump-to-latest affordance when you are away from the bottom.
 
 #### Lines of code changed since previous release
 129 lines changed since `v0.11.104` (25 insertions, 104 deletions).
@@ -328,7 +344,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -341,13 +357,14 @@ False
 #### Released at
 `2026-02-20T05:19:07Z`
 
+#### Title
+Packaging-only release lockfile maintenance
+
 #### One-line summary
-Refreshes release metadata only, with no clear user-facing product change in this patch.
+Refreshes package lock metadata for the release line, with no clear app, desktop, web, or workflow change.
 
 #### Main changes
-- No notable end-user app, web, or desktop workflow changes appear in this release beyond release-metadata refresh work.
-- Kept package resolution and shipped artifacts aligned after the prior patch release.
-- Delivered as a maintenance-only follow-up with no visible feature or UX intent.
+Updated release package metadata only, with no notable user-facing or developer-facing workflow change.
 
 #### Lines of code changed since previous release
 26 lines changed since `v0.11.105` (13 insertions, 13 deletions).
@@ -383,7 +400,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -396,13 +413,15 @@ False
 #### Released at
 `2026-02-20T05:40:27Z`
 
+#### Title
+Reopening sessions no longer snaps you back to the top
+
 #### One-line summary
-Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
+Fixes a revisit-specific session bug so returning to an existing conversation preserves a steadier reading position.
 
 #### Main changes
-- Fixed a session bug that could repeatedly reset the view to the top during use.
-- Made scroll position feel more stable while moving around active session content.
-- Shipped as another narrow session UX patch rather than a broader workflow update.
+- Stopped reopened sessions from reinitializing scroll position back to the top.
+- Limited top-of-thread initialization to the first visit for each session.
 
 #### Lines of code changed since previous release
 43 lines changed since `v0.11.106` (29 insertions, 14 deletions).
@@ -438,7 +457,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -451,13 +470,16 @@ False
 #### Released at
 `2026-02-20T18:14:52Z`
 
+#### Title
+Readable share pages, sturdier Soul flows, safer drafts
+
 #### One-line summary
-Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
+Makes shared bundles inspectable in the browser, preserves unsent draft text across tab switches, and strengthens Soul activation and audit flows.
 
 #### Main changes
-- Added human-readable share bundle pages with JSON fallback so shared bundles are easier to inspect in a browser.
-- Hardened Soul enable flows and steering audit behavior so enabling and reviewing Soul actions feels more reliable.
-- Preserved composer drafts across tab switches so unsent work is less likely to disappear mid-session.
+- Added human-readable bundle pages with raw JSON and download fallback for share links.
+- Preserved composer drafts across tab switches.
+- Hardened Soul setup and added clearer activation audit and steering flows.
 
 #### Lines of code changed since previous release
 1160 lines changed since `v0.11.107` (966 insertions, 194 deletions).
@@ -494,7 +516,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -507,13 +529,16 @@ False
 #### Released at
 `2026-02-20T20:51:01Z`
 
+#### Title
+Safer automation setup, grouped skills, and global MCP config
+
 #### One-line summary
-Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
+Keeps automations hidden until the scheduler is installed and lets OpenWork pick up domain-organized skills plus machine-level MCP servers.
 
 #### Main changes
-- Gated automations behind scheduler installation so users are not prompted into automation flows before the required tooling exists.
-- Added support for skills grouped in domain folders so more organized skill libraries work correctly.
-- Added global MCP configuration support so shared machine-level MCP servers can be picked up alongside project config.
+- Hid Automations until the scheduler is installed.
+- Added support for skills stored in domain folders.
+- Included global MCP servers alongside workspace config.
 
 #### Lines of code changed since previous release
 410 lines changed since `v0.11.108` (321 insertions, 89 deletions).
@@ -550,7 +575,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -563,13 +588,14 @@ False
 #### Released at
 `2026-02-20T22:35:16Z`
 
+#### Title
+Release packaging and deploy hardening only
+
 #### One-line summary
-Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
+Hardens updater metadata generation and share-service deploy behavior, with no visible OpenWork app or workflow changes.
 
 #### Main changes
-- No notable user-facing app or workflow changes appear in this release beyond release-process hardening.
-- Made updater platform metadata deterministic so shipped update manifests are generated more consistently.
-- Reduced deployment risk by skipping unnecessary desktop builds during share-service Vercel deploys.
+Mostly packaging only: the release now publishes deterministic updater metadata and skips unnecessary desktop builds during share-service deploys.
 
 #### Lines of code changed since previous release
 294 lines changed since `v0.11.109` (269 insertions, 25 deletions).
@@ -605,7 +631,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -618,13 +644,14 @@ False
 #### Released at
 `2026-02-20T23:04:52Z`
 
+#### Title
+Version metadata sync only
+
 #### One-line summary
-Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
+Republishes synchronized package and desktop version metadata, with no intended OpenWork app, server, or workflow changes.
 
 #### Main changes
-- No notable end-user app, web, or desktop behavior changes are visible in this release.
-- Kept package versions, runtime metadata, and dependency pins aligned for the shipped build.
-- Served as a release-consistency checkpoint rather than a feature or UX update.
+Packaging only: this release just keeps version numbers and shipped metadata aligned across app, desktop, server, router, and orchestrator packages.
 
 #### Lines of code changed since previous release
 26 lines changed since `v0.11.110` (13 insertions, 13 deletions).
@@ -660,7 +687,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -673,13 +700,15 @@ False
 #### Released at
 `2026-02-21T01:19:34Z`
 
+#### Title
+Cleaner session tool timelines
+
 #### One-line summary
-Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
+Hides step lifecycle noise and separates reasoning from tool runs so active sessions are easier to scan.
 
 #### Main changes
-- Removed step start and finish noise from the tool timeline so sessions read more like a clean sequence of meaningful work.
-- Improved grouping around reasoning and tool boundaries so the timeline feels easier to follow during complex runs.
-- Shipped the rest of the patch as release and deployment support work rather than additional visible product changes.
+- Removed step start and finish rows from the session timeline.
+- Split grouped step blocks at reasoning boundaries so tool runs read in a more natural sequence.
 
 #### Lines of code changed since previous release
 233 lines changed since `v0.11.111` (178 insertions, 55 deletions).
@@ -715,7 +744,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -728,13 +757,16 @@ False
 #### Released at
 `2026-02-21T01:58:50Z`
 
+#### Title
+Cmd+K quick actions for session work
+
 #### One-line summary
-Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
+Adds a keyboard-first palette for jumping between sessions and changing model or thinking settings without leaving chat.
 
 #### Main changes
-- Added a Cmd+K quick-actions palette so users can trigger common session actions without leaving the chat view.
-- Made it faster to jump between sessions by searching and filtering them from the keyboard-first palette.
-- Let users switch models and adjust thinking settings directly from quick actions during an active session.
+- Open quick actions with Cmd+K from the session view.
+- Search and jump across sessions from the same palette.
+- Change the active model or thinking level in place during a live session.
 
 #### Lines of code changed since previous release
 558 lines changed since `v0.11.112` (534 insertions, 24 deletions).
@@ -770,7 +802,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -783,13 +815,20 @@ False
 #### Released at
 `2026-02-22T06:00:46Z`
 
+#### Title
+OpenWork Cloud worker setup and reconnect flows
+
 #### One-line summary
-Introduces OpenWork Cloud workers through Den with a new web setup flow, persisted workers, and a much more complete remote-connect path.
+Adds a guided web flow for launching cloud workers, then makes reconnects work with saved workers, usable tokens, and workspace-scoped connect links.
 
 #### Main changes
-- Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
-- Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
-- Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
+Adds the first full OpenWork Cloud worker setup flow in the web app.
+
+Also released:
+
+- A 3-step sign-in, checkout, and launch flow.
+- Saved workers plus reusable tokens and workspace-scoped connect URLs.
+- Background provisioning with polling and completed provider OAuth in the app.
 
 #### Lines of code changed since previous release
 6726 lines changed since `v0.11.113` (6593 insertions, 133 deletions).
@@ -832,7 +871,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -845,13 +884,15 @@ False
 #### Released at
 `2026-02-22T07:45:08Z`
 
+#### Title
+Private Telegram bot pairing and sturdier hosted sign-in
+
 #### One-line summary
-Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
+Requires explicit pairing before a private Telegram chat can control a worker and lets hosted auth recover from broken upstream HTML responses.
 
 #### Main changes
-- Added a Telegram private bot pairing gate so private chats require an explicit `/pair <code>` flow before linking to a workspace.
-- Surfaced the private bot pairing setup in OpenWork identities so users can complete messaging setup more clearly.
-- Improved Den web auth reliability by failing over when the auth proxy receives broken 5xx HTML responses.
+Private Telegram bots now stay closed until a chat is explicitly paired, and hosted sign-in fails over more cleanly when the auth proxy gets bad 5xx HTML.
+    /pair ABCD-1234
 
 #### Lines of code changed since previous release
 790 lines changed since `v0.11.114` (700 insertions, 90 deletions).
@@ -887,7 +928,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -900,13 +941,16 @@ False
 #### Released at
 `2026-02-22T18:26:36Z`
 
+#### Title
+Cleaner cloud-worker connect with desktop deep links
+
 #### One-line summary
-Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
+Turns the hosted worker page into a simpler list-detail picker and adds one-click desktop handoff into OpenWork's remote connect flow.
 
 #### Main changes
-- Reworked the cloud worker web UI into a simpler list-detail layout so picking and connecting to workers feels less cluttered.
-- Wired desktop deep links for `connect-remote` flows so hosted worker actions hand off into the app more smoothly.
-- Tightened the cloud connect controls and layout to make the remote-connect path easier to follow.
+- Reworked hosted workers into a clearer list-detail connect view with status and action panels.
+- Added `openwork://connect-remote` deep links so the desktop app can open remote-connect details directly.
+- Kept manual URL and token copy available when one-click open is unavailable.
 
 #### Lines of code changed since previous release
 870 lines changed since `v0.11.115` (664 insertions, 206 deletions).
@@ -943,7 +987,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -956,13 +1000,16 @@ False
 #### Released at
 `2026-02-23T01:09:20Z`
 
+#### Title
+Hosted worker connect and cleanup flows get clearer
+
 #### One-line summary
-Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
+Reworks the web worker shell with clearer status, delete, and custom-domain handling, then makes session runs easier to scan by separating request, work, and result.
 
 #### Main changes
-- Redesigned the cloud worker shell into a cleaner full-page experience with progressive disclosure, worker deletion, and custom worker domains.
-- Split session turns into intent, execution, and result so tool-heavy chats are easier to scan.
-- Fixed several high-friction reliability issues across hosted workers and messaging, including softer 502 handling, empty router reply recovery, and protection against transient Den database disconnects.
+- Hosted workers now use a full-page list-detail flow with progressive disclosure instead of exposing every manual control up front.
+- You can delete a worker from the web flow, and custom domains resolve more cleanly when available.
+- Session timelines split each turn into request, execution, and result blocks for tool-heavy chats.
 
 #### Lines of code changed since previous release
 2207 lines changed since `v0.11.116` (1719 insertions, 488 deletions).
@@ -1003,7 +1050,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1016,13 +1063,16 @@ False
 #### Released at
 `2026-02-23T02:49:35Z`
 
+#### Title
+Large sessions type faster, and cloud worker setup stays simpler
+
 #### One-line summary
-Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
+Cuts composer lag in big chats, renames timeline labels in plainer language, and keeps manual worker controls tucked behind advanced options.
 
 #### Main changes
-- Reduced composer latency in large conversations so typing stays responsive deeper into long sessions.
-- Replaced technical timeline labels with clearer user-facing segment names for session turns.
-- Hid advanced cloud worker controls behind disclosure and fixed hosted delete and vanity-domain edge cases for a cleaner default worker flow.
+- Typing stays responsive deeper into large conversations by cutting composer layout churn.
+- Session timelines swap technical segment names for clearer user-facing wording.
+- Cloud worker pages hide manual URLs and tokens by default and recover safely when delete or custom-domain responses are incomplete.
 
 #### Lines of code changed since previous release
 758 lines changed since `v0.11.117` (555 insertions, 203 deletions).
@@ -1060,7 +1110,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1073,13 +1123,14 @@ False
 #### Released at
 `2026-02-23T05:13:07Z`
 
+#### Title
+Long chats stay snappier, and web onboarding looks cleaner
+
 #### One-line summary
-Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
+Further trims typing lag while tightening the landing hero, Get started path, and hosted worker layout across the web experience.
 
 #### Main changes
-- Further reduced session composer reflow cost so long chats stay smoother while typing.
-- Stretched cloud shell panels to the viewport so hosted worker screens use space more consistently.
-- Refined the landing experience with clearer Den calls to action and a cleaner hero treatment.
+Further reduces composer reflow in heavy sessions, points Den visitors to a clearer Get started path, and makes both the landing hero and hosted worker panels use space more cleanly.
 
 #### Lines of code changed since previous release
 308 lines changed since `v0.11.118` (197 insertions, 111 deletions).
@@ -1115,7 +1166,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1128,13 +1179,15 @@ False
 #### Released at
 `2026-02-23T06:19:35Z`
 
+#### Title
+Worker switching keeps session lists stable
+
 #### One-line summary
-Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
+Preserves sidebar sessions while moving between workers and refreshes the landing hero with higher contrast, calmer motion, and lighter nav chrome.
 
 #### Main changes
-- Kept session lists visible when switching between workers so navigation stays stable across workspaces.
-- Refreshed the landing hero shader and removed visual clutter for a cleaner first impression.
-- Improved hero readability with stronger contrast, slower background motion, and simpler sticky navigation styling.
+- Switching workers no longer makes sidebar sessions disappear while connection state catches up.
+- The landing hero gets a stronger shader, higher text contrast, slower animation, and simpler sticky navigation.
 
 #### Lines of code changed since previous release
 150 lines changed since `v0.11.119` (94 insertions, 56 deletions).
@@ -1170,7 +1223,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1183,13 +1236,16 @@ False
 #### Released at
 `2026-02-23T06:46:26Z`
 
+#### Title
+Session timelines read naturally, and search hits stand out
+
 #### One-line summary
-Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
+Removes meta-heavy timeline labels, highlights search hits inside messages, and makes quick actions and composing feel faster in active chats.
 
 #### Main changes
-- Replaced technical session meta labels with a more human narrative flow in the timeline.
-- Improved worker quick actions and composer responsiveness so common chat actions feel faster.
-- Added in-message search match highlighting to make scanning session content easier.
+- Session runs now read like a conversation instead of showing Plan, Activity, and Answer labels.
+- Search highlights matching text inside messages, not just matching rows.
+- Worker quick actions and composer updates feel more responsive during active chats.
 
 #### Lines of code changed since previous release
 485 lines changed since `v0.11.120` (311 insertions, 174 deletions).
@@ -1225,7 +1281,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1238,13 +1294,20 @@ False
 #### Released at
 `2026-02-26T01:34:07Z`
 
+#### Title
+Hosted onboarding and share links become app handoffs
+
 #### One-line summary
-Expands hosted onboarding and sharing in a big way while making long sessions, desktop shutdown, and several app surfaces more reliable.
+Adds GitHub sign-in, Open in App worker handoff, and share links for workspace profiles and skill sets while smoothing long-session and desktop reliability.
 
 #### Main changes
-- Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
-- Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
-- Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
+Hosted OpenWork now hands people straight from the web into the app for connect and import flows.
+
+Also released:
+
+- GitHub sign-in plus a dedicated download page for faster first-time setup.
+- Share links for workspace profiles and skill sets, with deep links that default to a new worker.
+- Long sessions render more smoothly, local file links resolve correctly, and desktop shutdown is cleaner.
 
 #### Lines of code changed since previous release
 5651 lines changed since `v0.11.121` (4835 insertions, 816 deletions).
@@ -1288,7 +1351,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1301,13 +1364,16 @@ False
 #### Released at
 `2026-02-26T05:45:34Z`
 
+#### Title
+Clearer share links and local server recovery in Settings
+
 #### One-line summary
-Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
+Refreshes both the in-app share modal and public bundle pages, and adds a one-click local server restart when a local worker gets stuck.
 
 #### Main changes
-- Redesigned the Share Workspace modal so creating share links feels more polished and consistent with the OpenWork app.
-- Restyled generated bundle pages to carry the same OpenWork visual identity when links are opened outside the app.
-- Added a local server restart action in Settings so users can recover local runtime issues without leaving OpenWork.
+- Share Workspace becomes a cleaner split between live access details and public link publishing.
+- Public bundle pages now look and read like OpenWork, with clearer import flows outside the app.
+- Settings adds `Restart local server` so local recovery no longer means leaving OpenWork.
 
 #### Lines of code changed since previous release
 1480 lines changed since `v0.11.122` (1027 insertions, 453 deletions).
@@ -1344,7 +1410,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1357,13 +1423,14 @@ False
 #### Released at
 `2026-02-26T19:33:56Z`
 
+#### Title
+Orbita gives sessions a clearer three-pane workspace
+
 #### One-line summary
-Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
+Reworks the main session screen with a stronger left rail, cleaner timeline canvas, and floating composer while preserving readability across themes.
 
 #### Main changes
-- Reworked the session layout around the Orbita direction so inbox, composer, artifacts, and navigation feel more intentionally organized.
-- Tightened sidebar and session panel presentation to improve readability and flow across the main app workspace.
-- Restored theme-safe contrast while landing the new layout so the updated session view remains readable across themes.
+Applies the Orbita direction across the session view, with a reorganized left rail for workers and sessions, lighter inbox and artifact side panels, and a clearer floating composer and message canvas.
 
 #### Lines of code changed since previous release
 734 lines changed since `v0.11.123` (451 insertions, 283 deletions).
@@ -1399,8 +1466,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
-

--- a/changelog/release-tracker-2026-02-19.md
+++ b/changelog/release-tracker-2026-02-19.md
@@ -53,12 +53,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.101
 
 #### Commit
@@ -114,12 +108,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.102
 
 #### Commit
@@ -170,12 +158,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.103
 
@@ -229,12 +211,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.104
 
 #### Commit
@@ -285,12 +261,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.105
 
@@ -343,12 +313,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.106
 
 #### Commit
@@ -398,12 +362,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.107
 
@@ -455,12 +413,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.108
 
@@ -515,12 +467,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.109
 
 #### Commit
@@ -574,12 +520,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.110
 
 #### Commit
@@ -630,12 +570,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.111
 
 #### Commit
@@ -685,12 +619,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.112
 
@@ -743,12 +671,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.113
 
 #### Commit
@@ -800,12 +722,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.114
 
@@ -870,12 +786,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.115
 
 #### Commit
@@ -926,12 +836,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.116
 
@@ -985,12 +889,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.117
 
@@ -1049,12 +947,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.118
 
 #### Commit
@@ -1109,12 +1001,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.119
 
 #### Commit
@@ -1164,12 +1050,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.120
 
@@ -1222,12 +1102,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.121
 
 #### Commit
@@ -1279,12 +1153,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.122
 
@@ -1350,12 +1218,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.123
 
 #### Commit
@@ -1409,12 +1271,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.124
 
 #### Commit
@@ -1464,9 +1320,3 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False

--- a/changelog/release-tracker-2026-02-26.md
+++ b/changelog/release-tracker-2026-02-26.md
@@ -10,13 +10,16 @@ Internal preparation file for release summaries. This is not yet published to th
 #### Released at
 `2026-02-26T22:26:17Z`
 
+#### Title
+Unified workspace navigation and smoother downloads
+
 #### One-line summary
-Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
+Unifies workspace navigation across dashboard and session views while preventing download-heavy operations from freezing the app.
 
 #### Main changes
-- Unified sidebar navigation and workspace switching so dashboard and session flows behave more consistently.
-- Deduplicated equivalent remote workspace entries and relaxed stale connecting locks so workspace rows stay actionable.
-- Added download throttling to prevent UI freezes during heavier transfer activity.
+- Reused the same workspace and session sidebar in dashboard and session views.
+- Deduplicated equivalent remote workers and kept rows actionable during stale connects.
+- Throttled download updates so large transfers stop freezing the desktop UI.
 
 #### Lines of code changed since previous release
 710 lines changed since `v0.11.124` (160 insertions, 550 deletions).
@@ -53,11 +56,10 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
-
 
 ## v0.11.126
 
@@ -67,13 +69,16 @@ False
 #### Released at
 `2026-02-27T15:47:46Z`
 
+#### Title
+Simpler artifacts and direct workspace actions
+
 #### One-line summary
-Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
+Simplifies artifact handling and adds direct worker and plugin actions so common cleanup and file workflows take fewer steps.
 
 #### Main changes
-- Replaced the in-app artifact editor with simpler artifact actions, including reveal controls and better handling for markdown files.
-- Added quick actions for workers and plugins so users can reveal workspaces, recover flows, and remove plugins directly from the UI.
-- Trimmed session and dashboard complexity around artifacts so the desktop experience feels lighter and easier to scan.
+- Replaced the inline artifact markdown editor with simpler reveal and open actions.
+- Added Open in Obsidian for markdown and Reveal in Finder or Explorer for local workers.
+- Added direct plugin removal and worker reveal actions from the main UI.
 
 #### Lines of code changed since previous release
 885 lines changed since `v0.11.125` (360 insertions, 525 deletions).
@@ -109,7 +114,7 @@ True
 - Replaced the in-app artifact markdown editor with a simpler read-only artifact action flow.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -122,13 +127,16 @@ False
 #### Released at
 `2026-02-28T02:48:07Z`
 
+#### Title
+Get back online recovery and smarter Docker dev-up
+
 #### One-line summary
-Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
+Makes worker recovery clearer and preserves existing access, while smoothing Docker dev stacks for developers using local OpenCode config.
 
 #### Main changes
-- Added a user-facing `Get back online` action in worker menus so recovery is easier to discover.
-- Changed worker recovery to reuse existing OpenWork tokens instead of rotating them during sandbox restarts.
-- Improved reconnection handling so recovering a worker is less likely to interrupt the current workspace flow.
+- Added a plain-language Get back online action for remote worker recovery.
+- Reused existing OpenWork tokens during sandbox restarts so reconnects keep working.
+- Updated `dev-up.sh` to mount host OpenCode config and auth into Docker dev stacks.
 
 #### Lines of code changed since previous release
 370 lines changed since `v0.11.126` (325 insertions, 45 deletions).
@@ -164,7 +172,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -177,13 +185,16 @@ False
 #### Released at
 `2026-03-01T18:40:52Z`
 
+#### Title
+Remote file sessions, Obsidian sync, and long-chat readability
+
 #### One-line summary
-Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
+Adds live remote file sessions with Obsidian-backed editing, then makes long desktop conversations easier to read and follow.
 
 #### Main changes
-- Added just-in-time file sessions and batch sync so remote files can be opened and synced as part of the OpenWork workflow.
-- Made remote worker markdown easier to work with locally by opening mirrored files through local tools such as Obsidian.
-- Added desktop font zoom shortcuts and whole-webview zoom so long conversations and documents are easier to read.
+- Added short-lived file sessions with catalog, event, read, write, rename, and delete batch APIs.
+- Mirrored remote markdown into Obsidian and synced edits back to the worker.
+- Added desktop-wide zoom shortcuts while cleaning transcript noise and live-thinking scroll behavior.
 
 #### Lines of code changed since previous release
 2719 lines changed since `v0.11.127` (2612 insertions, 107 deletions).
@@ -223,7 +234,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -236,13 +247,16 @@ False
 #### Released at
 `2026-03-02T02:35:51Z`
 
+#### Title
+Self-serve billing and media-rich messaging
+
 #### One-line summary
-Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
+Expands cloud billing into a self-serve management flow and lets Slack and Telegram carry richer OpenWork Router messages.
 
 #### Main changes
-- Added billing subscription controls in the web cloud worker dashboard so users can manage subscriptions directly.
-- Added invoice visibility in the billing flow so past charges are easier to review.
-- Added first-class media transport for Slack and Telegram so OpenWork router messages can carry richer content.
+- Added billing plan details, invoices, and subscription actions in the cloud worker dashboard.
+- Extended Slack and Telegram delivery to send richer media, not just plain text.
+- Hardened billing lookups and post-checkout navigation so account state refreshes more reliably.
 
 #### Lines of code changed since previous release
 3238 lines changed since `v0.11.128` (3061 insertions, 177 deletions).
@@ -279,7 +293,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -292,13 +306,16 @@ False
 #### Released at
 `2026-03-02T16:58:05Z`
 
+#### Title
+Service restarts and steadier local connectivity
+
 #### One-line summary
-Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
+Adds in-app restart controls, makes router startup recover from local port conflicts, and smooths billing returns from checkout.
 
 #### Main changes
-- Hardened desktop router startup so local services come up more predictably.
-- Added in-app service restart controls so users can recover local connectivity without leaving the app.
-- Recovered billing sessions after checkout redirects so returning from subscription flows lands back in a usable state.
+- Added Settings actions to restart orchestrator, OpenCode, OpenWork server, and OpenCodeRouter.
+- Moved OpenCodeRouter onto conflict-free localhost health ports and retried startup failures automatically.
+- Restored billing state after checkout returns and dropped Telegram self-echo loops.
 
 #### Lines of code changed since previous release
 637 lines changed since `v0.11.129` (540 insertions, 97 deletions).
@@ -336,7 +353,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -349,13 +366,16 @@ False
 #### Released at
 `2026-03-04T17:15:52Z`
 
+#### Title
+Virtualized chats and clearer runtime status
+
 #### One-line summary
-Upgrades long-session usability with faster rendering, clearer status feedback, and more durable session controls across the app.
+Keeps long sessions responsive with virtualized rendering, clearer runtime status, and optional auto-compaction after runs finish.
 
 #### Main changes
-- Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
-- Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
-- Added persistent language selection and improved file-open reliability for editor and artifact flows.
+- Virtualized long transcripts so large chats stay responsive instead of rendering every message at once.
+- Replaced split engine and server badges with one Ready indicator that opens a detailed status popover.
+- Added automatic context compaction after runs, plus persistent language selection and sturdier file opening.
 
 #### Lines of code changed since previous release
 1494 lines changed since `v0.11.130` (1134 insertions, 360 deletions).
@@ -396,7 +416,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -409,13 +429,16 @@ False
 #### Released at
 `2026-03-05T00:06:28Z`
 
+#### Title
+Chat-first startup and faster long-session loading
+
 #### One-line summary
-Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
+Preserves the new-session launch state, fixes first-run setup, and makes long chats load from the latest messages with less lag.
 
 #### Main changes
-- Preserved the empty-draft `/session` launch state so startup no longer forces users away from a fresh session flow.
-- Fixed first-run behavior by creating an initial chat and routing non-media uploads into the inbox flow.
-- Opened conversations at the latest messages and triggered transcript windowing earlier so long chats feel more responsive.
+- Kept `/session` as an empty draft view instead of bouncing users into an older chat.
+- Added a first-run worker empty state, created the first chat automatically, and routed non-media uploads into inbox links.
+- Opened sessions at the latest messages, paged older history on demand, and collapsed oversized markdown by default.
 
 #### Lines of code changed since previous release
 611 lines changed since `v0.11.131` (447 insertions, 164 deletions).
@@ -454,7 +477,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -467,13 +490,16 @@ False
 #### Released at
 `2026-03-05T15:54:31Z`
 
+#### Title
+Chat transcripts stop flickering during typing
+
 #### One-line summary
-Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
+Keeps active and long-running sessions visually stable by fixing typing flicker, remount churn, and collapsed long-message resets.
 
 #### Main changes
 - Fixed transcript flicker while typing in active chats.
-- Reduced virtualized remount churn in tail-loaded conversations so long sessions feel steadier.
-- Stopped collapsed long-markdown sections from resetting unexpectedly during session use.
+- Kept long sessions steadier by reducing remount churn in tail-loaded message lists.
+- Preserved expanded long-markdown state instead of collapsing it again mid-session.
 
 #### Lines of code changed since previous release
 292 lines changed since `v0.11.132` (163 insertions, 129 deletions).
@@ -511,7 +537,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -524,13 +550,16 @@ False
 #### Released at
 `2026-03-06T07:28:11Z`
 
+#### Title
+Remote MCP setup gets lighter, with exportable desktop diagnostics
+
 #### One-line summary
-Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
+Makes remote-workspace MCP connection setup clearer and adds in-app debug exports, sandbox probes, and config actions for faster troubleshooting.
 
 #### Main changes
-- Simplified remote MCP setup for remote workspaces, including smoother auth and retry handling.
-- Added exportable debug reports and config actions in Settings so troubleshooting can be done directly from the app.
-- Added sandbox probe diagnostics export so desktop failures are easier to inspect and share.
+- Remote workspaces now steer MCP setup toward URL-based connections, with optional OAuth and safer reload prompts.
+- Settings can copy or export a runtime debug report and run a sandbox probe.
+- Settings can also reveal or reset workspace config without leaving the app.
 
 #### Lines of code changed since previous release
 852 lines changed since `v0.11.133` (789 insertions, 63 deletions).
@@ -568,7 +597,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -581,13 +610,14 @@ False
 #### Released at
 `2026-03-06T19:43:28Z`
 
+#### Title
+Bundled OpenCode version stays aligned across release paths
+
 #### One-line summary
-Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
+Pins the packaged OpenCode fallback consistently across CI, prerelease, and release builds, with no notable new app workflow changes.
 
 #### Main changes
-- Kept fallback OpenCode resolution pinned consistently across release paths so packaged builds are less likely to drift.
-- Reduced the chance of mismatched bundled behavior between prerelease and release artifacts.
-- Shipped as a narrow stabilization patch with no notable new end-user features in the app or web surfaces.
+Keeps the bundled OpenCode fallback pinned to the same version across CI, prerelease, and release artifacts so packaged builds drift less, without introducing new user-facing OpenWork workflows.
 
 #### Lines of code changed since previous release
 61 lines changed since `v0.11.134` (31 insertions, 30 deletions).
@@ -623,7 +653,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -636,13 +666,16 @@ False
 #### Released at
 `2026-03-10T04:00:32Z`
 
+#### Title
+OpenWork Share turns dropped files into worker packages
+
 #### One-line summary
-Reshapes OpenWork Share into a more capable packaging flow, upgrades it to the Next.js App Router, and lands a broad set of reliability and polish updates across app and web surfaces.
+Adds a real worker-packaging flow in OpenWork Share, rebuilds the share site on the Next.js App Router, and makes provider connections easier to manage.
 
 #### Main changes
-- Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
-- Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
-- Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
+- OpenWork Share now packages dropped skills, agents, commands, and MCP or OpenWork config into worker bundles.
+- The share site moves to the Next.js App Router with refreshed home and bundle pages.
+- Settings now lets users disconnect providers, while OAuth completion and sandbox startup recover more reliably.
 
 #### Lines of code changed since previous release
 12837 lines changed since `v0.11.135` (9531 insertions, 3306 deletions).
@@ -682,7 +715,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -695,13 +728,16 @@ False
 #### Released at
 `2026-03-11T06:01:10Z`
 
+#### Title
+MCP sign-in retries and model setup get clearer
+
 #### One-line summary
-Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
+Makes MCP OAuth flows recover more reliably and reorganizes the model picker so disconnected providers route users straight to setup.
 
 #### Main changes
-- Stabilized MCP auth browser handoff, reload, and reconnect paths so remote auth succeeds more reliably.
-- Improved model picker provider sections so providers and their setup actions are easier to understand.
-- Kept bundled OpenCode aligned with desktop builds so release validation and packaged behavior stay in sync.
+- MCP auth now waits through reloads, reopens the browser flow clearly, and keeps retry states visible.
+- The model picker separates enabled providers from setup-needed ones and links the latter to Settings.
+- Remote MCP cards now expose login actions before a server is connected.
 
 #### Lines of code changed since previous release
 734 lines changed since `v0.11.136` (562 insertions, 172 deletions).
@@ -738,7 +774,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -751,13 +787,14 @@ False
 #### Released at
 `2026-03-11T15:19:39Z`
 
+#### Title
+Shared bundle links now open the blueprints worker flow
+
 #### One-line summary
-Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
+Routes shared bundle imports into the blueprints-style worker creation path so new-worker links land in the setup flow users expect.
 
 #### Main changes
-- Routed shared bundle imports through the blueprints flow so imports follow the intended setup path.
-- Improved workspace creation handoff during imports so shared bundles connect to the right setup flow.
-- Updated the supporting app copy for the blueprints import path so the flow is easier to understand.
+Shared bundle deep links now open the worker-creation flow with the right blueprints preset, then continue import through the intended setup path instead of dropping users into the wrong workspace flow.
 
 #### Lines of code changed since previous release
 143 lines changed since `v0.11.137` (101 insertions, 42 deletions).
@@ -793,7 +830,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -806,13 +843,16 @@ False
 #### Released at
 `2026-03-11T19:14:14Z`
 
+#### Title
+Shared bundle imports land on the intended worker
+
 #### One-line summary
-Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
+Makes shared bundle imports resolve to the exact active or newly created worker and adds more actionable sandbox startup diagnostics.
 
 #### Main changes
-- Shared bundle imports now target the worker that was just created, so imported skills land in the right place.
-- Sandbox worker startup now surfaces richer diagnostics, making failed launches easier to understand and recover from.
-- Workspace startup flow handling was tightened to reduce friction when bringing a worker online.
+- Imports now match the active or newly created worker by workspace ID, local root, or directory hint.
+- Sandbox startup logs now capture resolved Docker paths and launch arguments in the debug report.
+- Failed detached-worker launches surface clearer stage and spawn diagnostics.
 
 #### Lines of code changed since previous release
 460 lines changed since `v0.11.138` (364 insertions, 96 deletions).
@@ -849,7 +889,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -862,13 +902,16 @@ False
 #### Released at
 `2026-03-12T01:33:57Z`
 
+#### Title
+App and worker opens stay on the new session screen
+
 #### One-line summary
-Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
+Keeps launch actions anchored on the new session flow while making oversized-context errors, share feedback, and support booking clearer.
 
 #### Main changes
-- App and worker launch actions now keep users on the new session screen instead of pulling them into a different view unexpectedly.
-- Session flow feels clearer with the todo strip docked to the composer and friendlier handling for oversized-context errors.
-- Share and landing surfaces were polished with inline success feedback and a richer Book a Call form layout with conversation topics.
+- Opening the app or a new worker now stays on the new-session screen instead of jumping away unexpectedly.
+- The todo strip docks to the composer, and HTTP 413 errors now suggest compaction or a fresh session.
+- OpenWork Share adds inline link-success feedback, and the Book a Call form gets clearer topic cards.
 
 #### Lines of code changed since previous release
 5453 lines changed since `v0.11.140` (3894 insertions, 1559 deletions).
@@ -908,7 +951,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -921,13 +964,14 @@ False
 #### Released at
 `2026-03-12T01:48:01Z`
 
+#### Title
+Version alignment patch
+
 #### One-line summary
-Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
+Republishes synchronized app, server, orchestrator, and router versions so shipped artifacts stay in lockstep, with no visible workflow changes.
 
 #### Main changes
-- Shipped no material user-facing product changes in this release.
-- Kept desktop, server, orchestrator, and router artifacts aligned on the same version so installs resolve consistently.
-- Refreshed release metadata and lockfiles for a clean stable patch cut.
+Republishes synchronized desktop, server, orchestrator, and router packages so installs resolve the same version everywhere. No clear user-facing or developer-facing workflow changes land in this patch.
 
 #### Lines of code changed since previous release
 26 lines changed since `v0.11.141` (13 insertions, 13 deletions).
@@ -963,7 +1007,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -976,13 +1020,19 @@ False
 #### Released at
 `2026-03-12T20:51:40Z`
 
+#### Title
+Free first Den worker and Google signup
+
 #### One-line summary
-Substantially expands Den by lowering signup friction, redesigning the landing flow, and improving how workers and chat errors behave.
+Lets new users create one free Den worker without billing, sign up with Google, and enter a much clearer cloud onboarding path.
 
 #### Main changes
-- Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
-- The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
-- Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
+Den now lets new users create one free cloud worker without billing and sign up with Google.
+
+Also released:
+
+- Retired remaining Soul-mode surfaces across the app and server.
+- Showed session errors inline, removed raw markdown flashes, and refreshed share bundle pages and previews.
 
 #### Lines of code changed since previous release
 9937 lines changed since `v0.11.142` (6244 insertions, 3693 deletions).
@@ -1023,7 +1073,7 @@ True
 - Removed remaining Soul mode surfaces from the app.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1036,13 +1086,16 @@ False
 #### Released at
 `2026-03-12T22:53:50Z`
 
+#### Title
+Workspace shell recovery and clearer docs entrypoints
+
 #### One-line summary
-Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
+Restores reliable workspace-shell navigation and reset recovery, seeds Chrome DevTools setup correctly, and splits docs paths for technical and non-technical readers.
 
 #### Main changes
-- Workspace shell navigation now stays reachable across dashboard and session flows, reducing dead-end navigation states.
-- Desktop fully clears reset state on relaunch so recovery flows behave more reliably after a reset.
-- Den pricing and capability cards were refined, and Control Chrome setup is seeded more predictably for MCP browser tooling.
+- Kept dashboard, session, and Settings navigation inside the workspace shell so sidebars stay reachable.
+- Fully cleared desktop reset state on relaunch and seeded Control Chrome as `chrome-devtools` for smoother MCP setup.
+- Split docs entrypoints into technical and non-technical paths so onboarding starts in the right place.
 
 #### Lines of code changed since previous release
 1185 lines changed since `v0.11.143` (868 insertions, 317 deletions).
@@ -1080,7 +1133,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1093,13 +1146,16 @@ False
 #### Released at
 `2026-03-13T05:47:09Z`
 
+#### Title
+Den admin backoffice and support routing
+
 #### One-line summary
-Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
+Adds a protected Den admin panel for support operations, routes enterprise contact submissions into Loops, and tightens desktop skill reload and settings diagnostics.
 
 #### Main changes
-- Added a protected Den admin backoffice so internal operators can see signup, worker, and billing state without going to the database.
-- Polished Den worker surfaces with clearer overview CTAs, lighter activity styling, and cleaner web/mobile actions.
-- Wired enterprise contact capture into Loops and improved desktop skill sharing and hot-reload feedback.
+- Added a protected Den admin backoffice with signup, worker, and billing visibility for internal support.
+- Routed enterprise contact requests into Loops and restored a mobile logout path in Den.
+- Surfaced skill reload and sharing feedback more clearly and moved runtime status into Settings > Advanced.
 
 #### Lines of code changed since previous release
 2493 lines changed since `v0.11.144` (2031 insertions, 462 deletions).
@@ -1137,7 +1193,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1150,13 +1206,16 @@ False
 #### Released at
 `2026-03-13T19:14:51Z`
 
+#### Title
+Failed worker redeploy and safer skill imports
+
 #### One-line summary
-Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
+Adds direct Den worker redeploys, makes shared skills pick a destination worker before import, and improves both local Den setup and Chrome-first guidance.
 
 #### Main changes
-- Den now offers a redeploy action for failed workers, giving users a direct recovery path instead of leaving the worker stuck.
-- Shared skill import now asks users to choose a destination worker before importing, preventing skills from landing in the wrong place.
-- The workspace shell was restyled closer to the operator layout, with steadier footer behavior and a Chrome-first browser quickstart.
+- Added a redeploy action for failed Den workers so users can recover instead of getting stuck.
+- Made shared skill imports choose a destination worker before import, including new-worker and remote-worker paths.
+- Added a dockerized local Den test stack and pushed browser setup toward the Chrome MCP path.
 
 #### Lines of code changed since previous release
 3499 lines changed since `v0.11.145` (2158 insertions, 1341 deletions).
@@ -1194,7 +1253,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1207,13 +1266,19 @@ False
 #### Released at
 `2026-03-14T01:31:52Z`
 
+#### Title
+Existing-worker imports and local Share publishing
+
 #### One-line summary
-Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
+Lets shared skills install into existing workers, adds a local Docker-backed Share publisher for self-hosted testing, and keeps Den worker provisioning current.
 
 #### Main changes
-- Shared skills can now be imported into an existing worker through a dedicated in-app flow.
-- OpenWork Share handles long pasted skills better and adds a local Docker publisher flow for self-hosted publishing.
-- Den and desktop setup flows were tightened with clearer Chrome extension guidance and fresher bundled OpenCode behavior for workers.
+Shared skills can now be imported straight into an existing worker from the app.
+
+Also released:
+
+- Added a local Docker-backed Share publisher for self-hosted dev flows.
+- Bundled fresh OpenCode builds for Den workers and improved missing Chrome extension guidance.
 
 #### Lines of code changed since previous release
 1727 lines changed since `v0.11.146` (1551 insertions, 176 deletions).
@@ -1253,7 +1318,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1266,13 +1331,16 @@ False
 #### Released at
 `2026-03-14T22:28:03Z`
 
+#### Title
+Guided Den onboarding and single-skill Share
+
 #### One-line summary
-Redesigns Den onboarding into a guided stepper and simplifies OpenWork Share around publishing a single skill.
+Turns Den signup into a calmer guided flow with clearer provisioning states while refocusing OpenWork Share on publishing one skill well.
 
 #### Main changes
-- Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
-- OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
-- Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
+- Rebuilt Den onboarding as a guided flow with clearer naming, intent, loading, and browser-access states.
+- Simplified OpenWork Share to publish a single skill, with cleaner frontmatter and fuller shared previews.
+- Added a polished feedback card and clearer import and status feedback across app surfaces.
 
 #### Lines of code changed since previous release
 4390 lines changed since `v0.11.147` (2764 insertions, 1626 deletions).
@@ -1311,7 +1379,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1324,13 +1392,16 @@ False
 #### Released at
 `2026-03-14T23:56:20Z`
 
+#### Title
+Richer skill previews and steadier jump-to-latest
+
 #### One-line summary
-Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
+Makes shared skill pages easier to evaluate before import, steadies the worker-selection flow, and keeps long chats pinned to the newest reply while thinking.
 
 #### Main changes
-- Shared skill pages were simplified and now show richer workspace previews before import.
-- Shared skill import flow was steadied so destination selection and import actions behave more predictably.
-- Session view stays pinned to the latest response more reliably while the assistant is still thinking.
+- Simplified shared skill pages and added richer workspace previews before import.
+- Steadied shared-skill deep-link handling and worker selection so imports fire once and land more predictably.
+- Kept Jump to latest pinned during assistant thinking and reduced blank tail space in long chats.
 
 #### Lines of code changed since previous release
 3906 lines changed since `v0.11.148` (2531 insertions, 1375 deletions).
@@ -1368,7 +1439,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1381,13 +1452,16 @@ False
 #### Released at
 `2026-03-15T01:05:19Z`
 
+#### Title
+Faster provider setup and steadier chat rendering
+
 #### One-line summary
-Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
+Prioritizes common providers in new-session setup, reduces inline image churn while chatting, and routes feedback straight to the team inbox.
 
 #### Main changes
-- Session setup now prioritizes common providers and removes a redundant ChatGPT prompt.
-- Chat rendering reduces inline image churn so long conversations feel steadier.
-- Settings keeps a more stable shell width and sends feedback directly to the team inbox.
+- Moved common providers like OpenAI and Anthropic to the front and hid the redundant ChatGPT prompt in new-session setup.
+- Reduced inline image rerender churn so active chats feel steadier.
+- Kept Settings width stable and sent feedback from Settings directly to the team inbox.
 
 #### Lines of code changed since previous release
 342 lines changed since `v0.11.149` (241 insertions, 101 deletions).
@@ -1426,9 +1500,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
-
-

--- a/changelog/release-tracker-2026-02-26.md
+++ b/changelog/release-tracker-2026-02-26.md
@@ -55,12 +55,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.126
 
 #### Commit
@@ -113,12 +107,6 @@ True
 #### Deprecated details
 - Replaced the in-app artifact markdown editor with a simpler read-only artifact action flow.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.127
 
 #### Commit
@@ -170,12 +158,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.128
 
@@ -233,12 +215,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.129
 
 #### Commit
@@ -291,12 +267,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.130
 
@@ -351,12 +321,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.131
 
@@ -415,12 +379,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.132
 
 #### Commit
@@ -476,12 +434,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.133
 
 #### Commit
@@ -535,12 +487,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.134
 
@@ -596,12 +542,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.135
 
 #### Commit
@@ -651,12 +591,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.136
 
@@ -714,12 +648,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.137
 
 #### Commit
@@ -773,12 +701,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.138
 
 #### Commit
@@ -828,12 +750,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.140
 
@@ -887,12 +803,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.141
 
@@ -950,12 +860,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.142
 
 #### Commit
@@ -1005,12 +909,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.143
 
@@ -1072,12 +970,6 @@ True
 #### Deprecated details
 - Removed remaining Soul mode surfaces from the app.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.144
 
 #### Commit
@@ -1131,12 +1023,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.145
 
@@ -1192,12 +1078,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.146
 
 #### Commit
@@ -1251,12 +1131,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.147
 
@@ -1317,12 +1191,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.148
 
 #### Commit
@@ -1378,12 +1246,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.149
 
 #### Commit
@@ -1437,12 +1299,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.150
 
@@ -1498,9 +1354,3 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False

--- a/changelog/release-tracker-2026-03-15.md
+++ b/changelog/release-tracker-2026-03-15.md
@@ -52,12 +52,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.152
 
 #### Commit
@@ -107,12 +101,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False
 
 ## v0.11.153
 
@@ -167,12 +155,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-False
-
-#### Published in docs
-False
-
 ## v0.11.154
 
 #### Commit
@@ -222,12 +204,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False
 
 ## v0.11.155
 
@@ -279,12 +255,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.156
 
 #### Commit
@@ -334,12 +304,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False
 
 ## v0.11.157
 
@@ -395,12 +359,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-False
-
-#### Published in docs
-False
-
 ## v0.11.158
 
 #### Commit
@@ -450,12 +408,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False
 
 ## v0.11.159
 
@@ -509,12 +461,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.160
 
@@ -570,12 +516,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.161
 
 #### Commit
@@ -625,12 +565,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False
 
 ## v0.11.162
 
@@ -683,12 +617,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.163
 
@@ -744,12 +672,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.164
 
 #### Commit
@@ -804,12 +726,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.165
 
@@ -867,12 +783,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.166
 
 #### Commit
@@ -926,12 +836,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.167
 
 #### Commit
@@ -981,12 +885,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False
 
 ## v0.11.168
 
@@ -1038,12 +936,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.169
 
@@ -1104,12 +996,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.170
 
 #### Commit
@@ -1167,12 +1053,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.171
 
 #### Commit
@@ -1226,12 +1106,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-False
-
-#### Published in docs
-False
-
 ## v0.11.172
 
 #### Commit
@@ -1284,12 +1158,6 @@ True
 #### Deprecated details
 - Replaced prior published server package references with the standardized `openwork-server` naming.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.173
 
 #### Commit
@@ -1341,12 +1209,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.174
 
@@ -1401,12 +1263,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False
 
 ## v0.11.175
 
@@ -1466,9 +1322,3 @@ True
 
 #### Deprecated details
 - Removed the session sidebar artifacts rail in favor of a cleaner sidebar flow.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False

--- a/changelog/release-tracker-2026-03-15.md
+++ b/changelog/release-tracker-2026-03-15.md
@@ -10,13 +10,14 @@ Internal preparation file for release summaries. This is not yet published to th
 #### Released at
 `2026-03-15T03:20:31Z`
 
+#### Title
+Feedback emails reach the team inbox again
+
 #### One-line summary
-Makes feedback submissions reach the OpenWork team inbox reliably again.
+Fixes the in-app feedback email target so reports reach the shared OpenWork inbox again.
 
 #### Main changes
-- Fixed feedback sending so in-app reports go to the team inbox instead of the wrong destination.
-- Removed a small but user-visible failure point in the feedback path, making it more likely that submitted reports are actually received.
-- Shipped as a narrow feedback reliability patch rather than a broader app or web workflow update.
+Updates the feedback mail link to send reports to `team@openworklabs.com`, restoring the intended shared inbox for in-app feedback.
 
 #### Lines of code changed since previous release
 81 lines changed since `v0.11.150` (55 insertions, 26 deletions).
@@ -52,7 +53,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -65,13 +66,14 @@ False
 #### Released at
 Unreleased tag only. No published GitHub release. Tagged at `2026-03-14T20:53:19-07:00`.
 
+#### Title
+CI workflows move to Blacksmith runners
+
 #### One-line summary
-Refreshes release infrastructure only, with no clear user-facing OpenWork product change in this tag.
+Moves CI and release workflows onto Blacksmith-backed runners, with no visible OpenWork app, web, or server workflow change.
 
 #### Main changes
-- No notable end-user app, web, or desktop workflow changes are visible in this release.
-- Focused on release and CI execution changes rather than product behavior.
-- Served as a maintenance checkpoint to keep shipping flows moving cleanly.
+Repoints CI and release workflows to Blacksmith runners and larger Linux release builders, tightening the release pipeline without changing user-facing product behavior.
 
 #### Lines of code changed since previous release
 70 lines changed since `v0.11.151` (35 insertions, 35 deletions).
@@ -120,13 +122,16 @@ False
 #### Released at
 Unreleased tag only. No published GitHub release. Tagged at `2026-03-14T22:35:30-07:00`.
 
+#### Title
+Live session updates and scroll pinning recover
+
 #### One-line summary
-Restores live session streaming so conversations update in place again and stay pinned to the latest output when expected.
+Restores real-time assistant streaming in sessions while keeping long replies pinned correctly and web event streaming more reliable.
 
 #### Main changes
-- Restored live session updates so new assistant output appears in real time again instead of feeling stalled.
-- Brought back scroll pinning behavior so active sessions stay anchored to the newest output more reliably.
-- Tightened the streaming path across app and web session surfaces to make live conversation state feel coherent again.
+- Restored incremental session text updates so assistant replies stream live again.
+- Reworked chat pinning and jump controls so long responses stay easier to follow.
+- Let the web proxy pass event streams through more safely during fallback handling.
 
 #### Lines of code changed since previous release
 449 lines changed since `v0.11.152` (315 insertions, 134 deletions).
@@ -176,13 +181,14 @@ False
 #### Released at
 Unreleased tag only. No published GitHub release. Tagged at `2026-03-15T07:58:03-07:00`.
 
+#### Title
+Desktop release packaging is reworked
+
 #### One-line summary
-Refreshes release packaging only, with no clear user-facing OpenWork product change in this tag.
+Reorganizes the desktop release pipeline around workflow artifacts and staged asset upload, with no direct product workflow change.
 
 #### Main changes
-- No notable end-user app, web, or desktop workflow changes are visible in this release.
-- Focused on release packaging streamlining rather than product behavior.
-- Shipped as release-process maintenance instead of a feature, UX, or reliability patch for users.
+Rebuilds the desktop release pipeline to package workflow artifacts first, verify bundled sidecar metadata, and upload release assets in a later step, including a dedicated Linux ARM64 path.
 
 #### Lines of code changed since previous release
 976 lines changed since `v0.11.153` (488 insertions, 488 deletions).
@@ -231,13 +237,14 @@ False
 #### Released at
 `2026-03-15T16:08:25Z`
 
+#### Title
+Windows release diagnostics stop masking failures
+
 #### One-line summary
-Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
+Improves release-pipeline diagnostics and normalizes workflow action inputs so broken Windows packaging runs are easier to debug.
 
 #### Main changes
-- No notable end-user app, web, or desktop workflow changes are visible in this release.
-- Focused on fixing Windows release diagnostics and workflow wiring rather than product behavior.
-- Served as a narrow release-reliability patch instead of a user-facing feature or UX update.
+Fixes the Windows GitHub connectivity diagnostic step and aligns release-action input names so maintainers get clearer failure signals during desktop release packaging.
 
 #### Lines of code changed since previous release
 51 lines changed since `v0.11.154` (27 insertions, 24 deletions).
@@ -273,7 +280,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -286,13 +293,14 @@ False
 #### Released at
 Unreleased tag only. No published GitHub release. Tagged at `2026-03-15T10:06:37-07:00`.
 
+#### Title
+Desktop release packaging splits build from upload
+
 #### One-line summary
-Refreshes release packaging structure only, with no clear user-facing OpenWork product change in this tag.
+Restructures desktop release automation to build artifacts first, bundle Linux ARM separately, and upload assets in a final pass.
 
 #### Main changes
-- No notable end-user app, web, or desktop workflow changes are visible in this release.
-- Focused on splitting desktop release packaging work rather than changing product behavior.
-- Served as another maintenance checkpoint in the release pipeline instead of a user-facing patch.
+Splits desktop releases into build, bundle, and upload stages, adds separate Linux ARM packaging, and introduces automated asset upload from workflow artifacts.
 
 #### Lines of code changed since previous release
 602 lines changed since `v0.11.155` (486 insertions, 116 deletions).
@@ -341,13 +349,16 @@ False
 #### Released at
 Unreleased tag only. No published GitHub release. Tagged at `2026-03-15T12:27:44-07:00`.
 
+#### Title
+Den access controls tighten and nested task sessions return
+
 #### One-line summary
-Makes complex sessions easier to follow by nesting subagent work correctly, cleaning up session row actions, and fixing feedback links on web.
+Hardens Den sign-in and worker access while restoring inline subagent transcripts, selected-row session actions, and cleaner feedback links.
 
 #### Main changes
-- Nested spawned subagent sessions under the task step that launched them so tool-heavy runs read as one coherent flow.
-- Moved session actions into the selected row so list actions feel more local and predictable while navigating sessions.
-- Fixed web feedback email links so they open directly without leaving behind an unnecessary blank tab.
+- Requires verified Den accounts, removes exposed host tokens, and limits worker access more tightly by user role.
+- Renders subagent sessions inline under task steps and moves rename/delete actions into the selected session row.
+- Opens feedback mail links in place on the web instead of leaving a blank tab behind.
 
 #### Lines of code changed since previous release
 706 lines changed since `v0.11.156` (485 insertions, 221 deletions).
@@ -398,13 +409,14 @@ False
 #### Released at
 Unreleased tag only. No published GitHub release. Tagged at `2026-03-15T12:43:37-07:00`.
 
+#### Title
+Orchestrator npm publish runs from package cwd
+
 #### One-line summary
-Updates release publishing plumbing only, with no clear user-facing OpenWork product change in this tag.
+Fixes the release workflow so `openwork-orchestrator` publishes from `packages/orchestrator`, with no visible app or web workflow change.
 
 #### Main changes
-- No notable end-user app, web, or desktop workflow changes are visible in this release.
-- Focused on release publishing workflow wiring rather than product behavior.
-- Served as a narrow maintenance patch to keep shipping flows working reliably.
+Corrects the orchestrator publish job to run from the package directory so sidecar build and npm publish steps use the right paths.
 
 #### Lines of code changed since previous release
 33 lines changed since `v0.11.157` (17 insertions, 16 deletions).
@@ -453,13 +465,16 @@ False
 #### Released at
 `2026-03-15T20:36:46Z`
 
+#### Title
+Den cloud billing and worker launch align
+
 #### One-line summary
-Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
+Aligns the app-hosted Den flow with landing-page messaging, restores checkout handling for extra workers, and fixes visible billing and marketing regressions.
 
 #### Main changes
-- Aligned the app cloud-worker flow with the Den landing experience so hosted setup feels more consistent from first touch through worker creation.
-- Fixed the Den marketing rail rendering so the hosted web surface displays correctly again.
-- Removed an impossible billing navigation branch so the cloud control UI no longer exposes a path users cannot actually use.
+- Reworked the app cloud-worker flow to match the Den landing experience and messaging.
+- Restored Polar checkout and return handling for additional cloud workers.
+- Fixed the Den marketing rail and removed a dead billing navigation path.
 
 #### Lines of code changed since previous release
 2472 lines changed since `v0.11.158` (1192 insertions, 1280 deletions).
@@ -496,7 +511,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -509,13 +524,16 @@ False
 #### Released at
 `2026-03-15T23:51:50Z`
 
+#### Title
+Den auth, downloads, and nested sessions polish
+
 #### One-line summary
-Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
+Simplifies the Den auth entry flow, sends landing-page downloads to the right installer, and restores parent-child session browsing in the sidebar.
 
 #### Main changes
-- Simplified the Den auth screen so the hosted entry flow feels cleaner and easier to understand.
-- Mapped landing download calls to action to the detected OS and architecture while also making the app shell behave better on dynamic mobile viewports.
-- Restored nested subagent sessions under their parent tasks and cleaned up session list indentation so complex runs are easier to scan.
+- Simplified the Den auth screen so account entry is lighter and easier to scan.
+- Download buttons now choose the right installer for the visitor's OS and architecture.
+- Sidebar previews now keep subagent sessions nested under their parent tasks.
 
 #### Lines of code changed since previous release
 475 lines changed since `v0.11.159` (303 insertions, 172 deletions).
@@ -553,7 +571,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -566,13 +584,14 @@ False
 #### Released at
 Unreleased tag only. No published GitHub release. Tagged at `2026-03-15T16:48:43-07:00`.
 
+#### Title
+Den first-run goes straight to connect
+
 #### One-line summary
-Refines the Den first-run experience by removing transient marketing noise and making the initial hosted setup flow feel more focused.
+Cuts onboarding friction by removing the intent step, waiting for session hydration cleanly, and ending first-run on a direct connect screen.
 
 #### Main changes
-- Improved the Den first-run flow so hosted setup feels more direct and less cluttered.
-- Removed transient marketing UI that could distract from the primary first-run path.
-- Kept the patch focused on first-run flow polish rather than broader app, desktop, or session changes.
+Removes the extra intent step, drops the transient marketing-heavy auth shell, and adds a dedicated final connect screen so new Den users can launch a worker and open it in OpenWork with fewer detours.
 
 #### Lines of code changed since previous release
 448 lines changed since `v0.11.160` (198 insertions, 250 deletions).
@@ -621,13 +640,16 @@ False
 #### Released at
 `2026-03-16T00:51:15Z`
 
+#### Title
+Docker dev prints LAN-ready OpenWork URLs
+
 #### One-line summary
-Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
+Makes local Docker testing easier from phones and other devices by printing public URLs and deriving Den auth and CORS defaults from the detected host.
 
 #### Main changes
-- Improved Docker dev defaults so local OpenWork stacks are easier to expose on LAN and similar public local-network setups.
-- Reduced friction when testing from another device by making the local networking path more ready to use out of the box.
-- Kept the release tightly focused on local stack accessibility rather than broader end-user app or web workflow changes.
+- `dev-up.sh` now prints localhost, hostname, and LAN IP URLs for the app, server, and share service.
+- `den-dev-up.sh` derives auth URLs and trusted origins for cross-device testing.
+- Added `OPENWORK_PUBLIC_HOST` and `DEN_PUBLIC_HOST` overrides when auto-detection is wrong.
 
 #### Lines of code changed since previous release
 149 lines changed since `v0.11.161` (130 insertions, 19 deletions).
@@ -663,7 +685,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -676,13 +698,16 @@ False
 #### Released at
 `2026-03-16T02:47:00Z`
 
+#### Title
+Custom skill hub repos and steadier session actions
+
 #### One-line summary
-Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
+Lets teams browse and install skills from any GitHub hub repo while making session switching, composer focus, and reload prompts behave more predictably.
 
 #### Main changes
-- Added support for custom GitHub skill hub repositories so teams can point OpenWork at their own skill sources.
-- Kept the composer focused after Cmd+K session actions so keyboard-driven session work no longer breaks flow.
-- Restored the inline skill reload banner and aligned worker status labels for clearer workspace state feedback.
+- Added custom GitHub skill hub repos, including saved repo selection and install-from-that-repo flows.
+- Cmd+K session actions now return focus to the composer after opening or creating sessions.
+- Restored the inline skill reload banner and cleaned up workspace status alignment.
 
 #### Lines of code changed since previous release
 1169 lines changed since `v0.11.162` (1034 insertions, 135 deletions).
@@ -720,7 +745,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -733,13 +758,16 @@ False
 #### Released at
 `2026-03-16T15:14:38Z`
 
+#### Title
+Owner tokens and child sessions stay visible
+
 #### One-line summary
-Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
+Clarifies remote approval access with owner tokens, keeps nested child sessions from disappearing in sidebar syncs, and broadens polish across sharing and localization.
 
 #### Main changes
-- Preserved child task sessions during sidebar re-syncs so nested task context stays visible instead of disappearing.
-- Exposed owner tokens in remote permission prompts to make worker handoff and recovery easier to complete.
-- Improved public-facing polish with HTML-first share links, refined Open Graph preview cards, and full Japanese localization coverage.
+- Remote and cloud connect flows now expose owner tokens separately from collaborator tokens for permission prompts.
+- Sidebar resyncs stop dropping child task sessions when root items refresh.
+- Added Japanese localization and sharper HTML-first share previews.
 
 #### Lines of code changed since previous release
 2418 lines changed since `v0.11.163` (1907 insertions, 511 deletions).
@@ -778,7 +806,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -791,13 +819,16 @@ False
 #### Released at
 `2026-03-17T02:56:06Z`
 
+#### Title
+Settings can sign into Cloud and open workers
+
 #### One-line summary
-Adds OpenWork Cloud sign-in and worker-open flows first, then makes Den auth handoff and shared bundle installs much more dependable.
+Adds an in-app OpenWork Cloud settings flow for sign-in, org selection, and worker opening, while smoothing desktop auth handoff and share reliability.
 
 #### Main changes
-- Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
-- Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
-- Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
+- Added a Cloud tab in Settings for sign-in, org selection, worker lists, and opening ready Den workers into OpenWork.
+- Routed desktop auth through the web handoff flow, including installed-app scheme support and bearer-session handling.
+- Restored shared bundle installs and fully cleared disconnected provider credentials.
 
 #### Lines of code changed since previous release
 3120 lines changed since `v0.11.164` (2391 insertions, 729 deletions).
@@ -837,7 +868,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -850,13 +881,16 @@ False
 #### Released at
 `2026-03-17T05:45:14Z`
 
+#### Title
+Daytona-backed Den Docker flow ships
+
 #### One-line summary
-Introduces a Daytona-backed Den Docker development flow first, then stabilizes local org provisioning and helper scripts for cloud-worker testing.
+Introduces a Daytona-first local Den stack with a worker proxy and snapshot tooling, while tightening org setup and local developer startup paths.
 
 #### Main changes
-- Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
-- Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
-- Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
+- Added a Daytona-backed Den Docker flow with a dedicated worker proxy and snapshot builder for preloaded runtimes.
+- Introduced the `den-v2` control plane and shared Den DB packages for the new hosted-worker path.
+- Fixed unique org slug generation and the `webdev:local` startup script.
 
 #### Lines of code changed since previous release
 13718 lines changed since `v0.11.165` (12760 insertions, 958 deletions).
@@ -893,7 +927,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -906,13 +940,14 @@ False
 #### Released at
 Unreleased draft release. Tagged at `2026-03-16T22:50:30-07:00`.
 
+#### Title
+Cloud settings stay gated by developer mode
+
 #### One-line summary
-Keeps OpenWork Cloud controls reachable in Developer Mode so advanced cloud setup does not get stranded in Settings.
+Keeps the Cloud settings tab and default settings route aligned with developer mode so regular users do not land in unfinished controls.
 
 #### Main changes
-- Kept the Settings Cloud controls visible when Developer Mode is enabled.
-- Preserved the intended Cloud-and-Debug settings layout for advanced users working with OpenWork Cloud.
-- Reduced the chance of users getting stuck in a hidden-cloud-state settings flow while configuring cloud features.
+Fixes the Settings tab list and default settings route so Cloud controls only appear in developer mode, matching the intended rollout of the new OpenWork Cloud panel.
 
 #### Lines of code changed since previous release
 45 lines changed since `v0.11.166` (23 insertions, 22 deletions).
@@ -961,13 +996,14 @@ False
 #### Released at
 `2026-03-17T06:27:40Z`
 
+#### Title
+Release recovery with repaired installers
+
 #### One-line summary
-Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
+Republishes the release with repaired assets; the tagged diff itself is metadata-only, while the intended Cloud tab gating fix landed in `v0.11.167`.
 
 #### Main changes
-- Hid the Settings Cloud tab unless Developer Mode is enabled, while still showing it when advanced users intentionally turn Developer Mode on.
-- Routed desktop Den handoff back to General settings when Developer Mode is off so the UI does not strand users behind a hidden Cloud state.
-- Refreshed lockfile and sidecar manifests and republished the full desktop asset set so release installs work again across platforms.
+This tag mainly recovers the release process: `v0.11.167..v0.11.168` only bumps package versions, while the user-visible Cloud settings gating change was already in the prior tag.
 
 #### Lines of code changed since previous release
 26 lines changed since `v0.11.167` (13 insertions, 13 deletions).
@@ -1004,7 +1040,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1017,13 +1053,19 @@ False
 #### Released at
 `2026-03-18T00:11:42Z`
 
+#### Title
+Den handoff and session chrome get steadier
+
 #### One-line summary
-Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
+Keeps Den browser handoff and worker naming in sync while cleaning up session focus, reload banners, run status, and broken sidebar affordances.
 
 #### Main changes
-- Separated Den browser and API base URLs and tightened proxy-safe handoff behavior so sign-in and worker launch flows stay reliable.
-- Cleaned up session UX by removing the broken artifacts rail, flattening the reload banner, restoring composer focus after command actions, and polishing run status feedback.
-- Simplified OpenWork Share preview cards and updated landing/onboarding routing so CTAs and preview surfaces behave more consistently.
+Hardened Den sign-in and worker-open handoff by separating browser and API base URLs and returning proxy-safe desktop auth URLs.
+
+Also released:
+
+- Restored composer focus, flattened reload banners, and removed the broken artifacts rail.
+- Simplified OpenWork Share OG previews and cleaned up Den landing CTAs.
 
 #### Lines of code changed since previous release
 3699 lines changed since `v0.11.168` (2421 insertions, 1278 deletions).
@@ -1063,7 +1105,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1076,13 +1118,16 @@ False
 #### Released at
 `2026-03-19T17:27:40Z`
 
+#### Title
+OpenWork Cloud web flows and remote reconnects improve
+
 #### One-line summary
-Tailors the hosted web app for OpenWork Cloud first, then makes remote connection, billing, and desktop share-token flows much steadier.
+Reworks the hosted Cloud web flow while making remote worker links, persisted share tokens, provider auth, and desktop close behavior more dependable.
 
 #### Main changes
-- Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
-- Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
-- Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
+- Rebuilt Den web auth, checkout, and dashboard routes so hosted onboarding and billing feel like the app instead of a one-off page.
+- Persisted worker share tokens and repeated deeplinks across restarts, with stronger open-in-web auto-connect and connect overlays.
+- Added self-serve Cloud settings, OpenAI headless auth, and tray-on-close desktop behavior.
 
 #### Lines of code changed since previous release
 20054 lines changed since `v0.11.169` (7642 insertions, 12412 deletions).
@@ -1123,7 +1168,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1136,13 +1181,16 @@ False
 #### Released at
 Unreleased draft release. Tagged at `2026-03-19T14:01:13-07:00`.
 
+#### Title
+Session trace rows only open when they have details
+
 #### One-line summary
-Reduces desktop startup risk first, then makes session traces expand only when useful while the repo layout moves into a cleaner structure.
+Stops empty trace rows from expanding, removes stray desktop token-store test code from releases, and moves the repo into the new apps and ee layout.
 
 #### Main changes
-- Removed stray desktop token-store test code that could interfere with release reliability and startup behavior.
-- Changed session traces so rows only expand when they actually have details, with better mobile and wrapped-detail presentation.
-- Reworked the repository folder structure to keep builds, release tooling, and package paths aligned after the workspace move.
+- Only trace rows with real details expand, with tighter mobile wrapping and clearer tool icons.
+- Removed stray token-store test code from desktop release code.
+- Reorganized the repo into `apps/` and `ee/` paths without changing app behavior.
 
 #### Lines of code changed since previous release
 1577 lines changed since `v0.11.170` (986 insertions, 591 deletions).
@@ -1192,13 +1240,15 @@ False
 #### Released at
 `2026-03-19T22:28:14Z`
 
+#### Title
+Server package naming and session traces line up
+
 #### One-line summary
-Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
+Renames the published server package to `openwork-server` and polishes trace-row icon and chevron alignment so session runs scan more cleanly.
 
 #### Main changes
-- Renamed the published OpenWork server package references to `openwork-server` so install, publish, and version checks all agree.
-- Aligned session trace icons with their summaries for a cleaner timeline row.
-- Centered the session trace chevrons with summaries so expansion controls read more clearly.
+- Renamed the published server package to `openwork-server`, updating orchestrator, release, and dev tooling to resolve the same package consistently.
+- Tightened trace-row icon and chevron alignment so session summaries read cleanly.
 
 #### Lines of code changed since previous release
 3006 lines changed since `v0.11.171` (2296 insertions, 710 deletions).
@@ -1235,7 +1285,7 @@ True
 - Replaced prior published server package references with the standardized `openwork-server` naming.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1248,13 +1298,16 @@ False
 #### Released at
 `2026-03-20T00:55:12Z`
 
+#### Title
+Daytona workers report activity and local Node tools spawn reliably
+
 #### One-line summary
-Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
+Adds worker heartbeats for Daytona-backed Cloud workers while making local MCP and tool launches work in nvm-managed Node environments.
 
 #### Main changes
-- Added Daytona worker activity heartbeats so worker liveness and activity can be tracked more reliably.
-- Added Daytona snapshot release automation so released runtime snapshots can stay in sync with the current worker environment.
-- Exposed nvm-managed Node tools to local spawns so local OpenWork commands can find the expected Node toolchain.
+- Added Daytona worker activity heartbeats so Cloud worker state stays fresher.
+- Added release snapshot automation for Daytona images.
+- Exposed `nvm`-managed Node paths to local spawns so MCP tools and local commands find Node more reliably.
 
 #### Lines of code changed since previous release
 805 lines changed since `v0.11.172` (762 insertions, 43 deletions).
@@ -1290,7 +1343,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1303,13 +1356,16 @@ False
 #### Released at
 Unreleased draft release. Tagged at `2026-03-19T18:59:35-07:00`.
 
+#### Title
+Session traces go back to the familiar behavior
+
 #### One-line summary
-Restores the original session trace behavior first, then brings back copy actions and better worker-name readability in compact sidebars.
+Restores the original trace interaction model, brings back summary copy actions, and keeps worker names readable in narrow sidebars.
 
 #### Main changes
-- Restored the original session trace behavior for a more predictable run timeline.
-- Brought back trace summary copy actions so users can copy key run details again.
-- Preserved worker names in narrow sidebars so active context stays readable in compact layouts.
+- Reverted the newer expandable trace treatment and restored the original session trace behavior.
+- Brought back trace summary copy actions.
+- Kept worker names visible in narrow sidebars instead of collapsing them away.
 
 #### Lines of code changed since previous release
 508 lines changed since `v0.11.173` (107 insertions, 401 deletions).
@@ -1360,13 +1416,19 @@ False
 #### Released at
 `2026-03-20T05:53:41Z`
 
+#### Title
+Authorized folders and first-run session guidance move into Settings
+
 #### One-line summary
-Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
+Adds Settings-based folder authorization and server-backed empty states, then tightens sidebar and composer labeling so navigation stays readable.
 
 #### Main changes
-- Added settings support for managing authorized folders so users can control filesystem access without leaving the product flow.
-- Added server-backed session empty states to give clearer first-run and worker-setup guidance.
-- Refined the app shell and session sidebar by removing the artifacts rail, restoring composer action labels, and improving action, title, timestamp, and footer visibility.
+Adds a server-backed way to manage authorized folders and to seed first-run session empty states from workspace blueprints.
+
+Also released:
+
+- Cleaner sidebar titles, status labels, footer pinning, and hidden generated timestamps.
+- Restored composer action labels and removed the dead artifacts rail.
 
 #### Lines of code changed since previous release
 1685 lines changed since `v0.11.174` (1313 insertions, 372 deletions).
@@ -1406,9 +1468,7 @@ True
 - Removed the session sidebar artifacts rail in favor of a cleaner sidebar flow.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
-
-

--- a/changelog/release-tracker-2026-03-20.md
+++ b/changelog/release-tracker-2026-03-20.md
@@ -10,13 +10,16 @@ Internal preparation file for release summaries. This is not yet published to th
 #### Released at
 Unreleased draft release. Tagged at `2026-03-20T12:51:31-07:00`.
 
+#### Title
+OpenAI setup points new chats the right way
+
 #### One-line summary
-Improves provider setup and remote messaging reliability so first-run connection flows feel less brittle.
+Makes first-run provider setup clearer by sending new chats into the ChatGPT flow and fixing remote messaging health reporting.
 
 #### Main changes
-- Improved OpenAI provider onboarding so new-session setup points users into the right ChatGPT connection flow and better distinguishes local versus remote workers.
-- Stabilized remote messaging router health checks so remote workers stop appearing unconfigured when messaging is actually available.
-- Kept this release focused on setup and connection reliability rather than introducing broader new workflows.
+- Swapped the starter CTA to Connect ChatGPT and hid it once OpenAI is already connected.
+- Made OpenAI auth worker-aware so remote workers use the device flow with copyable codes and manual browser launch.
+- Fixed worker-scoped router health so remote messaging no longer appears unconfigured in Settings and identities.
 
 #### Lines of code changed since previous release
 1079 lines changed since `v0.11.175` (618 insertions, 461 deletions).
@@ -66,13 +69,19 @@ False
 #### Released at
 `2026-03-20T20:54:48Z`
 
+#### Title
+Downloads CTA and npm install fallback land
+
 #### One-line summary
-Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
+Gets desktop users to the right download path faster and lets `openwork-orchestrator` recover when npm skips its platform binary.
 
 #### Main changes
-- Routed the main landing-page CTA straight to downloads so new users land on the desktop install surface instead of an extra intermediate step.
-- Added an npm install fallback to published OpenWork Orchestrator binaries so local installs can still complete when building from source is unavailable.
-- Kept release outputs aligned with the shipped orchestrator build so install behavior stays more predictable across environments.
+Routes the desktop landing CTA to the Download page so the install path is clearer.
+
+Also released:
+
+- `openwork-orchestrator` postinstall now downloads the matching release binary when optional platform packages are missing.
+- Daytona snapshot builds now use the source orchestrator binary.
 
 #### Lines of code changed since previous release
 175 lines changed since `v0.11.176` (139 insertions, 36 deletions).
@@ -109,7 +118,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -122,13 +131,16 @@ False
 #### Released at
 `2026-03-22T03:08:43Z`
 
+#### Title
+Workspace sharing and model controls get a major refresh
+
 #### One-line summary
-Redesigns core app navigation and sharing first, then makes model controls clearer and smooths several session and feedback flows.
+Redesigns workspace sharing and sidebar structure, makes reasoning controls model-aware, and adds a hosted feedback flow.
 
 #### Main changes
-- Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
-- Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
-- Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
+- Redesigned workspace sharing and the right sidebar, including cleaner remote credentials and nested child sessions.
+- Made model pickers model-aware with provider icons and per-model reasoning or behavior controls.
+- Moved app feedback to a hosted form, added an Exa toggle, and stopped forcing starter workspaces on desktop boot.
 
 #### Lines of code changed since previous release
 8432 lines changed since `v0.11.177` (5335 insertions, 3097 deletions).
@@ -167,7 +179,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -180,13 +192,16 @@ False
 #### Released at
 `2026-03-22T05:34:34Z`
 
+#### Title
+Den checkout and workspace setup get leaner
+
 #### One-line summary
-Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
+Simplifies Den billing and dashboard surfaces, streamlines workspace creation flows, and removes the desktop tray path.
 
 #### Main changes
-- Simplified Den cloud checkout and dashboard surfaces so trial signup and cloud navigation feel lighter and more direct.
-- Refreshed remote workspace creation and folder-selection flows to reduce friction when creating a new workspace.
-- Improved share previews with favicon and social metadata and removed desktop tray behavior that made close and reopen behavior less predictable.
+- Simplified the create-workspace and connect-remote modals so setup fields read more clearly.
+- Refreshed Den checkout and dashboard screens into a flatter, cleaner shell.
+- Removed desktop tray support and now requires contact details on hosted feedback submissions.
 
 #### Lines of code changed since previous release
 1025 lines changed since `v0.11.178` (539 insertions, 486 deletions).
@@ -223,7 +238,7 @@ True
 - Removed desktop tray support from the app.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -236,13 +251,14 @@ False
 #### Released at
 Unreleased draft release. Tagged at `2026-03-22T09:29:16-07:00`.
 
+#### Title
+Den landing and provisioning visuals get pared back
+
 #### One-line summary
-Strips down Den landing and provisioning visuals so the cloud onboarding experience feels lighter and less distracting.
+Mostly a docs-and-artifact cleanup release, with a small Den landing and provisioning UI simplification.
 
 #### Main changes
-- Simplified the landing hero so the first impression focuses more on the core message and less on decorative UI.
-- Removed the hero activity mockup from Den marketing surfaces to reduce visual noise.
-- Simplified the provisioning connection animation and dropped the background cube artwork from the dashboard flow.
+Mostly removes internal PR docs and screenshots, while trimming the Den landing hero and simplifying the worker provisioning animation. No clear core app, server, or developer workflow changes land in this tag.
 
 #### Lines of code changed since previous release
 3020 lines changed since `v0.11.179` (23 insertions, 2997 deletions).
@@ -291,13 +307,14 @@ False
 #### Released at
 `2026-03-22T17:02:23Z`
 
+#### Title
+Version metadata is republished in sync
+
 #### One-line summary
-Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
+Republishes synchronized package versions only, with no distinct user-facing or developer-facing workflow change.
 
 #### Main changes
-- No material app, server, or workflow changes are visible in this release beyond the new tagged build.
-- Desktop, server, orchestrator, and router package metadata were kept in sync for the `0.11.181` cut.
-- This patch appears to focus on shipping refreshed artifacts rather than changing how OpenWork behaves.
+Packaging-only release that syncs version metadata across app, desktop, server, router, and orchestrator packages. No material workflow, UI, API, or docs behavior changes are visible from the code.
 
 #### Lines of code changed since previous release
 58 lines changed since `v0.11.180` (40 insertions, 18 deletions).
@@ -333,7 +350,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -346,13 +363,16 @@ False
 #### Released at
 `2026-03-23T01:48:48Z`
 
+#### Title
+Local workspaces move under OpenWork server control
+
 #### One-line summary
-Moves local workspace ownership into OpenWork server so reconnect and onboarding flows stay more reliable, while making remote connect UX simpler.
+Shifts local workspace ownership into OpenWork server so creation, reconnects, config writes, and starter bootstrap stay aligned across the app.
 
 #### Main changes
-- Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
-- Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
-- Polished session tool traces by moving the chevron affordance to the right for faster scanning.
+- Local workspace create, rename, delete, config writes, and reload events now go through OpenWork server first.
+- First-run starter bootstrap and reconnect logic are more reliable across onboarding and sidebar flows.
+- Simplified the remote connect modal, moved tool-trace chevrons right, and added Windows ARM64 dev startup support.
 
 #### Lines of code changed since previous release
 1792 lines changed since `v0.11.181` (1510 insertions, 282 deletions).
@@ -389,7 +409,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -402,13 +422,16 @@ False
 #### Released at
 `2026-03-23T05:01:53Z`
 
+#### Title
+Exa moves into OpenCode settings
+
 #### One-line summary
-Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
+Surfaces the Exa search toggle in a clearer OpenCode settings section and rolls back an unready macOS path-normalization change.
 
 #### Main changes
-- Added Exa to Advanced settings so power users can configure it alongside other advanced tooling in the app.
-- Reverted the prior macOS path case-folding change after it proved not ready for release.
-- Kept the patch narrowly focused on advanced-settings follow-up and platform stability.
+- Added an OpenCode settings panel that exposes the Exa web-search toggle in a clearer place.
+- Reverted the macOS path case-folding change to avoid destabilizing session and workspace matching.
+- Also removed leftover docs-plan and screenshot artifacts.
 
 #### Lines of code changed since previous release
 614 lines changed since `v0.11.182` (53 insertions, 561 deletions).
@@ -444,7 +467,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -457,13 +480,14 @@ False
 #### Released at
 `2026-03-23T15:04:42Z`
 
+#### Title
+CLI quickstart becomes the primary docs path
+
 #### One-line summary
-Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
+Rebuilds the docs around a single CLI-first quickstart and removes older split onboarding paths that were harder to follow.
 
 #### Main changes
-- Simplified the docs experience around a refreshed Quickstart so new users have a clearer primary onboarding path.
-- Removed older docs pages and tutorials in favor of a leaner documentation surface.
-- Updated docs structure and metadata to match the reduced set of guides.
+Collapses the docs nav to a single quickstart, rewrites onboarding around the remote CLI plus desktop connect flow, and removes older introduction, technical, non-technical, and tutorial pages so first-run guidance is much narrower and easier to scan.
 
 #### Lines of code changed since previous release
 898 lines changed since `v0.11.183` (121 insertions, 777 deletions).
@@ -499,7 +523,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -512,13 +536,14 @@ False
 #### Released at
 `2026-03-24T05:34:00Z`
 
+#### Title
+Safer local sharing and messaging setup
+
 #### One-line summary
-Hardens sharing and messaging defaults first, then adds guided Control Chrome setup and Brazilian Portuguese localization.
+Defaults local workers to loopback-only, makes public messaging exposure more deliberate, and adds guided setup for Chrome control.
 
 #### Main changes
-- Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
-- Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
-- Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
+Local workers now stay localhost-only unless users explicitly opt into remote exposure, messaging is disabled until enabled on purpose, public Telegram bot creation shows a risk warning, and Chrome DevTools MCP gets a guided setup flow.
 
 #### Lines of code changed since previous release
 5434 lines changed since `v0.11.184` (4780 insertions, 654 deletions).
@@ -556,7 +581,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -569,13 +594,14 @@ False
 #### Released at
 `2026-03-24T06:16:26Z`
 
+#### Title
+Local reconnects stay scoped to the right workspace
+
 #### One-line summary
-Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
+Fixes restart and reconnect flows so local sessions and starter workspaces stay attached to the intended directory.
 
 #### Main changes
-- Kept workspace history scoped to the active local workspace during reconnects so switching and reopening do not pull in the wrong session list.
-- Normalized starter workspace paths during desktop bootstrap so persisted local paths reconnect to the correct directory.
-- Kept this release tightly focused on local startup and reconnect reliability instead of new features.
+Keeps local session history scoped to the active workspace during reconnects and normalizes persisted starter paths on desktop bootstrap, so restarts stop reopening or creating sessions against the wrong local directory.
 
 #### Lines of code changed since previous release
 397 lines changed since `v0.11.185` (343 insertions, 54 deletions).
@@ -612,7 +638,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -625,13 +651,14 @@ False
 #### Released at
 `2026-03-24T15:09:03Z`
 
+#### Title
+Windows workspace scoping handles verbatim paths
+
 #### One-line summary
-Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
+Normalizes Windows path transport, verbatim prefixes, and UNC comparisons so local session scope stays consistent across directory formats.
 
 #### Main changes
-- Normalized Windows directory transport so local session create, delete, and sidebar scope checks all compare the same path shape.
-- Stripped verbatim Windows path prefixes before scope comparison so reconnect and switch flows stop drifting across equivalent paths.
-- Normalized verbatim UNC scope comparisons so Windows remote and local session transitions stay attached to the right workspace.
+Normalizes Windows directory strings end to end, strips verbatim path prefixes, and fixes UNC comparison logic so session lists, deletes, and workspace switching all target the same local workspace scope.
 
 #### Lines of code changed since previous release
 210 lines changed since `v0.11.186` (173 insertions, 37 deletions).
@@ -669,7 +696,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -682,13 +709,14 @@ False
 #### Released at
 `2026-03-24T16:29:47Z`
 
+#### Title
+Landing feedback returns to the previous flow
+
 #### One-line summary
-Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
+Backs out the Loops feedback template so the landing feedback endpoint goes back to the simpler email-based path.
 
 #### Main changes
-- Reverted the Loops feedback template change so app feedback submissions return to the earlier behavior.
-- Removed the template files and config tied to the reverted feedback email path.
-- Kept this patch narrowly focused on making feedback submission behavior predictable again.
+Reverts the Loops-based landing feedback template and config, restoring the earlier app-feedback route behavior without introducing any broader app, worker, or docs workflow changes.
 
 #### Lines of code changed since previous release
 328 lines changed since `v0.11.187` (30 insertions, 298 deletions).
@@ -724,7 +752,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -737,13 +765,14 @@ False
 #### Released at
 `2026-03-24T17:16:24Z`
 
+#### Title
+Package metadata rolls forward only
+
 #### One-line summary
-Rolls the release line forward with no visible product or workflow changes.
+Updates the release line with a lockfile and version sync only, without any visible product or workflow changes.
 
 #### Main changes
-- Kept the shipped OpenWork app, server, and cloud behavior effectively unchanged for end users.
-- Refreshed release metadata so the package set stays aligned for the next follow-up patch.
-- Landed as a no-op user-facing release without new workflows, fixes, or removals.
+Packaging-only release: version metadata and the pnpm lockfile are synchronized, with no meaningful user-facing or developer-facing workflow changes in the shipped code.
 
 #### Lines of code changed since previous release
 26 lines changed since `v0.11.188` (13 insertions, 13 deletions).
@@ -779,7 +808,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -792,13 +821,14 @@ False
 #### Released at
 `2026-03-24T23:32:21Z`
 
+#### Title
+Connection guides expand while sharing and auth settle
+
 #### One-line summary
-Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
+Mostly docs-focused release that reorganizes onboarding around concrete connection guides, while fixing desktop publish routing and headless OpenAI auth timing.
 
 #### Main changes
-- Fixed sharing so public routes keep resolving correctly and packaged desktop builds can publish to the OpenWork share surface.
-- Deferred headless OpenAI auth polling so provider connection flows are less likely to churn while waiting for authorization.
-- Removed the right-sidebar-heavy shell in favor of a flatter app layout that keeps the main workspace flow more focused.
+Mostly docs-only: the site shifts to task guides for remote setup, ChatGPT, custom providers, MCPs, sharing, and skill import, while the app fixes public share routing and waits to poll headless OpenAI auth until users actually open the browser.
 
 #### Lines of code changed since previous release
 3837 lines changed since `v0.11.189` (2654 insertions, 1183 deletions).
@@ -835,7 +865,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -848,13 +878,14 @@ False
 #### Released at
 `2026-03-25T01:04:43Z`
 
+#### Title
+Shared detached workers survive restarts
+
 #### One-line summary
-Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
+Preserves share credentials for detached workers, hides disconnected config-backed providers, and adds clearer Slack and skill-import docs.
 
 #### Main changes
-- Preserved detached worker share credentials across restarts so reopened workers stay connected more reliably.
-- Disabled disconnected config-backed providers correctly so settings state no longer appears active after a disconnect.
-- Kept authorized-folder removal controls visible in settings so cleanup actions remain available when needed.
+Detached Docker-backed workers now keep the right share credentials after restart so share links and reconnect flows keep working, disconnected config-backed providers disappear cleanly from Settings, and docs add clearer Slack and skill-import walkthroughs.
 
 #### Lines of code changed since previous release
 495 lines changed since `v0.11.190` (413 insertions, 82 deletions).
@@ -891,7 +922,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -904,13 +935,16 @@ False
 #### Released at
 `2026-03-25T22:30:34Z`
 
+#### Title
+Workspace switching stops hijacking runtime state
+
 #### One-line summary
-Decouples workspace switching from runtime activation, adds richer template imports, and fixes seeded starter sessions.
+Separates workspace selection from runtime activation, keeps local worker ports stable, and makes shared templates carry starter content correctly.
 
 #### Main changes
-- Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
-- Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
-- Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
+- Split selected workspace from runtime-connected workspace so browsing no longer flips the active worker.
+- Kept preferred local server ports sticky and avoided collisions across workspaces.
+- Let templates carry extra `.opencode` files and starter sessions, and materialized seeded sessions correctly.
 
 #### Lines of code changed since previous release
 4896 lines changed since `v0.11.191` (3899 insertions, 997 deletions).
@@ -948,7 +982,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -961,13 +995,16 @@ False
 #### Released at
 `2026-03-26T05:23:19Z`
 
+#### Title
+Team template sharing reaches OpenWork Cloud
+
 #### One-line summary
-Introduces Cloud team template sharing and Den organization workflows while adding safer Cloud sign-in fallbacks.
+Adds Save-to-team template flows in the app, while Den gains organizations, member roles, invitations, and a manual Cloud sign-in fallback.
 
 #### Main changes
-- Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
-- Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
-- Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
+- Added Save-to-team flows for workspace templates, with org selection and Cloud sign-in prompts.
+- Introduced Den organizations, member roles, invitations, custom roles, and org-scoped template APIs and screens.
+- Added a manual Cloud sign-in fallback when automatic team-sharing auth stalls.
 
 #### Lines of code changed since previous release
 7841 lines changed since `v0.11.192` (6406 insertions, 1435 deletions).
@@ -1004,7 +1041,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1017,13 +1054,16 @@ False
 #### Released at
 `2026-03-26T20:46:09Z`
 
+#### Title
+Auto compaction and live automations become real workflows
+
 #### One-line summary
-Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
+Wires auto compaction to actual workspace config, keeps scheduled jobs live in-app, and adds a faster Den local-dev path.
 
 #### Main changes
-- Wired automatic context compaction through to OpenCode so the app's compaction control now affects real long-session behavior.
-- Simplified Den local development and sandbox dashboard flows with clearer manual sandbox creation and less intrusive startup behavior.
-- Kept setup and operations flows steadier by leaving custom app MCP adds in settings, polling scheduled jobs live, and routing update notices to the right settings destination.
+- Wired Auto context compaction to workspace config so the setting actually changes `compaction.auto`.
+- Kept scheduled jobs live by polling while the Automations view is open.
+- Added a faster Den local-dev path and expanded the Cloud dashboard with shared setups and background-agent links.
 
 #### Lines of code changed since previous release
 5198 lines changed since `v0.11.193` (3852 insertions, 1346 deletions).
@@ -1061,7 +1101,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1074,13 +1114,16 @@ False
 #### Released at
 `2026-03-27T22:02:59Z`
 
+#### Title
+Local workspace creation and Den worker setup get steadier
+
 #### One-line summary
-Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
+Routes new local workspaces through the local host, persists model defaults properly, and smooths Den worker-connect and billing flows.
 
 #### Main changes
-- Restored Den worker connect actions with smoother inline controls and less polling jank across the background agents view.
-- Preserved desktop default model changes and made update badges easier to notice so session setup and maintenance feel more dependable.
-- Fixed local workspace creation and remote workspace binding so switching into active workspaces completes more reliably.
+- Created local workspaces through the local host so setup and binding finish correctly.
+- Preserved workspace default model changes and added a quick compact-session action in chat.
+- Simplified Den organization, worker-connect, and billing flows with less polling jank.
 
 #### Lines of code changed since previous release
 5137 lines changed since `v0.11.194` (3875 insertions, 1262 deletions).
@@ -1118,7 +1161,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1131,13 +1174,16 @@ False
 #### Released at
 `2026-03-30T21:27:27Z`
 
+#### Title
+OpenWork resumes where you left off
+
 #### One-line summary
-Reorients the app around session-first navigation, replaces the old dashboard model, and overhauls automations and workspace state ownership.
+Boots back into the last session, routes straight into session view, and moves automations onto a live scheduler-backed page.
 
 #### Main changes
-- Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
-- Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
-- Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
+- Reopened the last session on workspace boot and routed straight into the session view.
+- Moved automations onto a dedicated page backed by live local or remote scheduler jobs.
+- Fixed bootstrap and workspace switching so Welcome setup and loading states stop interrupting startup.
 
 #### Lines of code changed since previous release
 34577 lines changed since `v0.11.195` (15875 insertions, 18702 deletions).
@@ -1175,7 +1221,7 @@ True
 - Removed the old dashboard-first app concept in favor of session-first navigation and settings-owned tool surfaces.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1188,13 +1234,16 @@ False
 #### Released at
 `2026-03-31T05:21:16Z`
 
+#### Title
+Sharing gets safer and startup gets less noisy
+
 #### One-line summary
-Hardens sharing and secret handling while cleaning up sidebar session behavior and unwanted welcome-workspace creation.
+Hardens workspace sharing, keeps orchestrator secrets out of CLI args and logs, and removes noisy sidebar and Welcome-workspace boot behavior.
 
 #### Main changes
-- Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
-- Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
-- Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
+- Blocked sensitive workspace exports and showed warnings before sharing risky config or secrets.
+- Trusted bundle imports only from the configured publisher unless users explicitly choose a warning-backed manual path.
+- Moved OpenWork tokens off CLI args and logs, stopped auto-creating Welcome, and fixed collapsed sidebar session lists.
 
 #### Lines of code changed since previous release
 6399 lines changed since `v0.11.196` (5657 insertions, 742 deletions).
@@ -1233,7 +1282,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1246,13 +1295,14 @@ False
 #### Released at
 `2026-03-31T06:00:47Z`
 
+#### Title
+Local workspace switches restart the right engine
+
 #### One-line summary
-Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
+Fixes a local-only switch bug so changing between local workspaces restarts the engine instead of reusing the old connection.
 
 #### Main changes
-- Restarted the engine correctly when switching between local workspaces instead of reusing stale runtime state.
-- Carried the previous workspace path through activation so local workspace changes are detected reliably.
-- Applied the same race fix to workspace-forget flows so local engine state stays consistent during cleanup.
+Captures the previous local workspace path before selection changes so switching between local workspaces restarts the engine instead of reusing the old connection.
 
 #### Lines of code changed since previous release
 100 lines changed since `v0.11.197` (59 insertions, 41 deletions).
@@ -1288,7 +1338,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1301,13 +1351,16 @@ False
 #### Released at
 `2026-04-02T02:18:50Z`
 
+#### Title
+Pricing, skill hubs, and session recovery sharpen up
+
 #### One-line summary
-Adds pricing and paid Windows flows, expands Den team capabilities, and improves debugging and session recovery across the app.
+Adds pricing and paid Windows messaging, expands Den with skill hubs and `den-api`, and improves everyday session recovery and debugging.
 
 #### Main changes
-- Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
-- Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
-- Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
+- Added a pricing page and paid Windows messaging, and sent Cloud navigation directly into the app.
+- Expanded Den with skill hubs, a new `den-api`, and a smoother org-invite signup flow.
+- Added developer log export, per-conversation draft persistence, and recovery after immediate send failures.
 
 #### Lines of code changed since previous release
 19623 lines changed since `v0.11.198` (12501 insertions, 7122 deletions).
@@ -1347,7 +1400,7 @@ True
 - Removed the legacy `opkg` CLI integration as part of the release cleanup.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
@@ -1360,13 +1413,16 @@ False
 #### Released at
 `2026-04-03T15:22:13Z`
 
+#### Title
+Cloud skills and team limits move into the core flow
+
 #### One-line summary
-Brings Cloud team skills into the app and greatly expands Den team, skill hub, and billing management flows.
+Brings Cloud team skills into the app, adds Den teams and deeper skill-hub management, and enforces org limits during creation.
 
 #### Main changes
-- Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
-- Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
-- Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
+- Added an OpenWork Cloud skills catalog to the Skills page, with install and share-to-team flows.
+- Added Den teams plus full skill hub and skill editing and visibility management.
+- Moved billing into org creation and enforced organization member limits before setup finishes.
 
 #### Lines of code changed since previous release
 9000 lines changed since `v0.11.199` (7881 insertions, 1119 deletions).
@@ -1404,8 +1460,7 @@ False
 None.
 
 #### Published in changelog page
-False
+True
 
 #### Published in docs
 False
-

--- a/changelog/release-tracker-2026-03-20.md
+++ b/changelog/release-tracker-2026-03-20.md
@@ -55,12 +55,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-False
-
-#### Published in docs
-False
-
 ## v0.11.177
 
 #### Commit
@@ -117,12 +111,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.178
 
 #### Commit
@@ -178,12 +166,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.179
 
 #### Commit
@@ -237,12 +219,6 @@ True
 #### Deprecated details
 - Removed desktop tray support from the app.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.180
 
 #### Commit
@@ -293,12 +269,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-False
-
-#### Published in docs
-False
-
 ## v0.11.181
 
 #### Commit
@@ -348,12 +318,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.182
 
@@ -408,12 +372,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.183
 
 #### Commit
@@ -466,12 +424,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.184
 
 #### Commit
@@ -521,12 +473,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.185
 
@@ -580,12 +526,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.186
 
 #### Commit
@@ -636,12 +576,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.187
 
@@ -695,12 +629,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.188
 
 #### Commit
@@ -751,12 +679,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.189
 
 #### Commit
@@ -806,12 +728,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.190
 
@@ -864,12 +780,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.191
 
 #### Commit
@@ -920,12 +830,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.192
 
@@ -981,12 +885,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.193
 
 #### Commit
@@ -1039,12 +937,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.194
 
@@ -1100,12 +992,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.195
 
 #### Commit
@@ -1160,12 +1046,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.196
 
 #### Commit
@@ -1219,12 +1099,6 @@ True
 
 #### Deprecated details
 - Removed the old dashboard-first app concept in favor of session-first navigation and settings-owned tool surfaces.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.197
 
@@ -1281,12 +1155,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.198
 
 #### Commit
@@ -1336,12 +1204,6 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False
 
 ## v0.11.199
 
@@ -1399,12 +1261,6 @@ True
 #### Deprecated details
 - Removed the legacy `opkg` CLI integration as part of the release cleanup.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.200
 
 #### Commit
@@ -1458,9 +1314,3 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-True
-
-#### Published in docs
-False

--- a/changelog/release-tracker-2026-04-04.md
+++ b/changelog/release-tracker-2026-04-04.md
@@ -56,12 +56,6 @@ False
 #### Deprecated details
 None.
 
-#### Published in changelog page
-True
-
-#### Published in docs
-False
-
 ## v0.11.202
 
 #### Commit
@@ -119,9 +113,3 @@ False
 
 #### Deprecated details
 None.
-
-#### Published in changelog page
-False
-
-#### Published in docs
-False

--- a/changelog/release-tracker-2026-04-04.md
+++ b/changelog/release-tracker-2026-04-04.md
@@ -10,13 +10,16 @@ Internal preparation file for release summaries. This is not yet published to th
 #### Released at
 `2026-04-04T01:59:47Z`
 
+#### Title
+Workspace lists collapse cleanly and Den organization setup recovers more reliably.
+
 #### One-line summary
-Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
+Hides collapsed workspace task rows, steadies session loading, and fixes Den skill saving plus organization draft and invite recovery.
 
 #### Main changes
-- Fully collapses workspace session lists when closed so collapsed workspaces stop showing preview rows, loading shells, or empty states.
-- Reduced session load churn and stream-batch flicker so transcripts feel steadier during first load and early streaming.
-- Fixed Den organization editing flows by parsing skill frontmatter on save and restoring pending-invite counts and org draft state.
+- Collapsed workspaces now hide task rows, empty states, and loading shells until reopened.
+- Session loading stops refetch churn and early stream flicker.
+- Den now saves skill metadata from frontmatter and restores pending org drafts and invite counts.
 
 #### Lines of code changed since previous release
 3956 lines changed since `v0.11.200` (2440 insertions, 1516 deletions).
@@ -43,6 +46,70 @@ True
 - Fixed collapsed workspace lists so hidden workspaces no longer leak session previews or loading states.
 - Fixed session loading and streaming churn that could cause repeated fetches or visible flicker.
 - Fixed Den skill saving and org management by parsing skill frontmatter correctly and restoring pending invite and draft state.
+
+#### Deprecated features
+False
+
+#### Number of deprecated features
+0
+
+#### Deprecated details
+None.
+
+#### Published in changelog page
+True
+
+#### Published in docs
+False
+
+## v0.11.202
+
+#### Commit
+`ff981742`
+
+#### Released at
+`2026-04-04T20:45:30Z`
+
+#### Title
+Translations fill out across the app and shared skill imports work again.
+
+#### One-line summary
+Adds Thai, restores missing page translations, fixes migrated shared-skill links, and tightens docs and local desktop dev setup.
+
+#### Main changes
+Completed localization coverage across the app and added Thai as a selectable language.
+
+Also released:
+
+- Restored shared-skill import links and canonical bundle fetch URLs.
+- Added clearer automations and skill-import docs.
+- Stopped desktop dev from reusing another checkout's Vite server.
+
+#### Lines of code changed since previous release
+8103 lines changed since `v0.11.201` (7198 insertions, 905 deletions).
+
+#### Release importance
+Minor release: expands localization coverage and fixes important import and desktop-dev paths without changing the core product model.
+
+#### Major improvements
+True
+
+#### Number of major improvements
+1
+
+#### Major improvement details
+- Added Thai and completed translation coverage across the app's shipped locales.
+
+#### Major bugs resolved
+True
+
+#### Number of major bugs resolved
+3
+
+#### Major bug fix details
+- Restored missing page translations and corrected locale labels so translated screens stop falling back unexpectedly.
+- Restored migrated shared-skill links and canonical bundle fetch URLs so docs imports work again.
+- Stopped desktop dev from reusing another checkout's Vite server.
 
 #### Deprecated features
 False

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -3,11 +3,11 @@ title: "Changelog"
 ---
 <Update label="April 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.202 - Translations fill out across the app and shared skill imports work again.](https://github.com/different-ai/openwork/compare/v0.11.201...v0.11.202)
+  ## [v0.11.202](https://github.com/different-ai/openwork/compare/v0.11.201...v0.11.202): Translations fill out across the app and shared skill imports work again.
 
   Adds Thai, restores missing page translations, fixes migrated shared-skill links, and tightens docs and local desktop dev setup.
 
-  ## [v0.11.201 - Workspace lists collapse cleanly and Den organization setup recovers more reliably.](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+  ## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201): Workspace lists collapse cleanly and Den organization setup recovers more reliably.
 
   Hides collapsed workspace task rows, steadies session loading, and fixes Den skill saving plus organization draft and invite recovery.
 
@@ -15,7 +15,7 @@ title: "Changelog"
 
 <Update label="April 3rd" tags={["🚀 New Features"]}>
 
-  ## [v0.11.200 - Cloud skills and team limits move into the core flow](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+  ## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200): Cloud skills and team limits move into the core flow
 
   - Added an OpenWork Cloud skills catalog to the Skills page, with install and share-to-team flows.
   - Added Den teams plus full skill hub and skill editing and visibility management.
@@ -25,7 +25,7 @@ title: "Changelog"
 
 <Update label="April 2nd" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.199 - Pricing, skill hubs, and session recovery sharpen up](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+  ## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199): Pricing, skill hubs, and session recovery sharpen up
 
   - Added a pricing page and paid Windows messaging, and sent Cloud navigation directly into the app.
   - Expanded Den with skill hubs, a new `den-api`, and a smoother org-invite signup flow.
@@ -35,11 +35,11 @@ title: "Changelog"
 
 <Update label="March 31st" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.198 - Local workspace switches restart the right engine](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+  ## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198): Local workspace switches restart the right engine
 
   Fixes a local-only switch bug so changing between local workspaces restarts the engine instead of reusing the old connection.
 
-  ## [v0.11.197 - Sharing gets safer and startup gets less noisy](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+  ## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197): Sharing gets safer and startup gets less noisy
 
   - Blocked sensitive workspace exports and showed warnings before sharing risky config or secrets.
   - Trusted bundle imports only from the configured publisher unless users explicitly choose a warning-backed manual path.
@@ -49,7 +49,7 @@ title: "Changelog"
 
 <Update label="March 30th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.196 - OpenWork resumes where you left off](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+  ## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196): OpenWork resumes where you left off
 
   - Reopened the last session on workspace boot and routed straight into the session view.
   - Moved automations onto a dedicated page backed by live local or remote scheduler jobs.
@@ -59,7 +59,7 @@ title: "Changelog"
 
 <Update label="March 27th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.195 - Local workspace creation and Den worker setup get steadier](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+  ## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195): Local workspace creation and Den worker setup get steadier
 
   Routes new local workspaces through the local host, persists model defaults properly, and smooths Den worker-connect and billing flows.
 
@@ -67,11 +67,11 @@ title: "Changelog"
 
 <Update label="March 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.194 - Auto compaction and live automations become real workflows](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+  ## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194): Auto compaction and live automations become real workflows
 
   Wires auto compaction to actual workspace config, keeps scheduled jobs live in-app, and adds a faster Den local-dev path.
 
-  ## [v0.11.193 - Team template sharing reaches OpenWork Cloud](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+  ## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193): Team template sharing reaches OpenWork Cloud
 
   - Added Save-to-team flows for workspace templates, with org selection and Cloud sign-in prompts.
   - Introduced Den organizations, member roles, invitations, custom roles, and org-scoped template APIs and screens.
@@ -81,13 +81,13 @@ title: "Changelog"
 
 <Update label="March 25th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.192 - Workspace switching stops hijacking runtime state](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+  ## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192): Workspace switching stops hijacking runtime state
 
   - Split selected workspace from runtime-connected workspace so browsing no longer flips the active worker.
   - Kept preferred local server ports sticky and avoided collisions across workspaces.
   - Let templates carry extra `.opencode` files and starter sessions, and materialized seeded sessions correctly.
 
-  ## [v0.11.191 - Shared detached workers survive restarts](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+  ## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191): Shared detached workers survive restarts
 
   Preserves share credentials for detached workers, hides disconnected config-backed providers, and adds clearer Slack and skill-import docs.
 
@@ -95,27 +95,27 @@ title: "Changelog"
 
 <Update label="March 24th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.190 - Connection guides expand while sharing and auth settle](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+  ## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190): Connection guides expand while sharing and auth settle
 
   Mostly docs-focused release that reorganizes onboarding around concrete connection guides, while fixing desktop publish routing and headless OpenAI auth timing.
 
-  ## [v0.11.189 - Package metadata rolls forward only](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+  ## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189): Package metadata rolls forward only
 
   Updates the release line with a lockfile and version sync only, without any visible product or workflow changes.
 
-  ## [v0.11.188 - Landing feedback returns to the previous flow](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+  ## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188): Landing feedback returns to the previous flow
 
   Backs out the Loops feedback template so the landing feedback endpoint goes back to the simpler email-based path.
 
-  ## [v0.11.187 - Windows workspace scoping handles verbatim paths](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+  ## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187): Windows workspace scoping handles verbatim paths
 
   Normalizes Windows path transport, verbatim prefixes, and UNC comparisons so local session scope stays consistent across directory formats.
 
-  ## [v0.11.186 - Local reconnects stay scoped to the right workspace](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+  ## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186): Local reconnects stay scoped to the right workspace
 
   Fixes restart and reconnect flows so local sessions and starter workspaces stay attached to the intended directory.
 
-  ## [v0.11.185 - Safer local sharing and messaging setup](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+  ## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185): Safer local sharing and messaging setup
 
   Local workers now stay localhost-only unless users explicitly opt into remote exposure, messaging is disabled until enabled on purpose, public Telegram bot creation shows a risk warning, and Chrome DevTools MCP gets a guided setup flow.
 
@@ -123,15 +123,15 @@ title: "Changelog"
 
 <Update label="March 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.184 - CLI quickstart becomes the primary docs path](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+  ## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184): CLI quickstart becomes the primary docs path
 
   Rebuilds the docs around a single CLI-first quickstart and removes older split onboarding paths that were harder to follow.
 
-  ## [v0.11.183 - Exa moves into OpenCode settings](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+  ## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183): Exa moves into OpenCode settings
 
   Surfaces the Exa search toggle in a clearer OpenCode settings section and rolls back an unready macOS path-normalization change.
 
-  ## [v0.11.182 - Local workspaces move under OpenWork server control](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+  ## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182): Local workspaces move under OpenWork server control
 
   - Local workspace create, rename, delete, config writes, and reload events now go through OpenWork server first.
   - First-run starter bootstrap and reconnect logic are more reliable across onboarding and sidebar flows.
@@ -141,15 +141,15 @@ title: "Changelog"
 
 <Update label="March 22nd" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.181 - Version metadata is republished in sync](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+  ## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181): Version metadata is republished in sync
 
   Republishes synchronized package versions only, with no distinct user-facing or developer-facing workflow change.
 
-  ## [v0.11.179 - Den checkout and workspace setup get leaner](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+  ## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179): Den checkout and workspace setup get leaner
 
   Simplifies Den billing and dashboard surfaces, streamlines workspace creation flows, and removes the desktop tray path.
 
-  ## [v0.11.178 - Workspace sharing and model controls get a major refresh](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+  ## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178): Workspace sharing and model controls get a major refresh
 
   - Redesigned workspace sharing and the right sidebar, including cleaner remote credentials and nested child sessions.
   - Made model pickers model-aware with provider icons and per-model reasoning or behavior controls.
@@ -159,15 +159,15 @@ title: "Changelog"
 
 <Update label="March 20th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.177 - Downloads CTA and npm install fallback land](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+  ## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177): Downloads CTA and npm install fallback land
 
   Gets desktop users to the right download path faster and lets `openwork-orchestrator` recover when npm skips its platform binary.
 
-  ## [v0.11.175 - Authorized folders and first-run session guidance move into Settings](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+  ## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175): Authorized folders and first-run session guidance move into Settings
 
   Adds Settings-based folder authorization and server-backed empty states, then tightens sidebar and composer labeling so navigation stays readable.
 
-  ## [v0.11.173 - Daytona workers report activity and local Node tools spawn reliably](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+  ## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173): Daytona workers report activity and local Node tools spawn reliably
 
   Adds worker heartbeats for Daytona-backed Cloud workers while making local MCP and tool launches work in nvm-managed Node environments.
 
@@ -175,11 +175,11 @@ title: "Changelog"
 
 <Update label="March 19th" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.172 - Server package naming and session traces line up](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+  ## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172): Server package naming and session traces line up
 
   Renames the published server package to `openwork-server` and polishes trace-row icon and chevron alignment so session runs scan more cleanly.
 
-  ## [v0.11.170 - OpenWork Cloud web flows and remote reconnects improve](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+  ## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170): OpenWork Cloud web flows and remote reconnects improve
 
   - Rebuilt Den web auth, checkout, and dashboard routes so hosted onboarding and billing feel like the app instead of a one-off page.
   - Persisted worker share tokens and repeated deeplinks across restarts, with stronger open-in-web auto-connect and connect overlays.
@@ -189,7 +189,7 @@ title: "Changelog"
 
 <Update label="March 18th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.169 - Den handoff and session chrome get steadier](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+  ## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169): Den handoff and session chrome get steadier
 
   Keeps Den browser handoff and worker naming in sync while cleaning up session focus, reload banners, run status, and broken sidebar affordances.
 
@@ -197,17 +197,17 @@ title: "Changelog"
 
 <Update label="March 17th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.168 - Release recovery with repaired installers](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+  ## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168): Release recovery with repaired installers
 
   Republishes the release with repaired assets; the tagged diff itself is metadata-only, while the intended Cloud tab gating fix landed in `v0.11.167`.
 
-  ## [v0.11.166 - Daytona-backed Den Docker flow ships](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+  ## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166): Daytona-backed Den Docker flow ships
 
   - Added a Daytona-backed Den Docker flow with a dedicated worker proxy and snapshot builder for preloaded runtimes.
   - Introduced the `den-v2` control plane and shared Den DB packages for the new hosted-worker path.
   - Fixed unique org slug generation and the `webdev:local` startup script.
 
-  ## [v0.11.165 - Settings can sign into Cloud and open workers](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+  ## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165): Settings can sign into Cloud and open workers
 
   - Added a Cloud tab in Settings for sign-in, org selection, worker lists, and opening ready Den workers into OpenWork.
   - Routed desktop auth through the web handoff flow, including installed-app scheme support and bearer-session handling.
@@ -217,15 +217,15 @@ title: "Changelog"
 
 <Update label="March 16th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.164 - Owner tokens and child sessions stay visible](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+  ## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164): Owner tokens and child sessions stay visible
 
   Clarifies remote approval access with owner tokens, keeps nested child sessions from disappearing in sidebar syncs, and broadens polish across sharing and localization.
 
-  ## [v0.11.163 - Custom skill hub repos and steadier session actions](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+  ## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163): Custom skill hub repos and steadier session actions
 
   Lets teams browse and install skills from any GitHub hub repo while making session switching, composer focus, and reload prompts behave more predictably.
 
-  ## [v0.11.162 - Docker dev prints LAN-ready OpenWork URLs](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+  ## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162): Docker dev prints LAN-ready OpenWork URLs
 
   Makes local Docker testing easier from phones and other devices by printing public URLs and deriving Den auth and CORS defaults from the detected host.
 
@@ -233,23 +233,23 @@ title: "Changelog"
 
 <Update label="March 15th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.160 - Den auth, downloads, and nested sessions polish](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+  ## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160): Den auth, downloads, and nested sessions polish
 
   Simplifies the Den auth entry flow, sends landing-page downloads to the right installer, and restores parent-child session browsing in the sidebar.
 
-  ## [v0.11.159 - Den cloud billing and worker launch align](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+  ## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159): Den cloud billing and worker launch align
 
   Aligns the app-hosted Den flow with landing-page messaging, restores checkout handling for extra workers, and fixes visible billing and marketing regressions.
 
-  ## [v0.11.155 - Windows release diagnostics stop masking failures](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+  ## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155): Windows release diagnostics stop masking failures
 
   Improves release-pipeline diagnostics and normalizes workflow action inputs so broken Windows packaging runs are easier to debug.
 
-  ## [v0.11.151 - Feedback emails reach the team inbox again](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+  ## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151): Feedback emails reach the team inbox again
 
   Fixes the in-app feedback email target so reports reach the shared OpenWork inbox again.
 
-  ## [v0.11.150 - Faster provider setup and steadier chat rendering](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+  ## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150): Faster provider setup and steadier chat rendering
 
   Prioritizes common providers in new-session setup, reduces inline image churn while chatting, and routes feedback straight to the team inbox.
 
@@ -257,17 +257,17 @@ title: "Changelog"
 
 <Update label="March 14th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.149 - Richer skill previews and steadier jump-to-latest](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+  ## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149): Richer skill previews and steadier jump-to-latest
 
   Makes shared skill pages easier to evaluate before import, steadies the worker-selection flow, and keeps long chats pinned to the newest reply while thinking.
 
-  ## [v0.11.148 - Guided Den onboarding and single-skill Share](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+  ## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148): Guided Den onboarding and single-skill Share
 
   - Rebuilt Den onboarding as a guided flow with clearer naming, intent, loading, and browser-access states.
   - Simplified OpenWork Share to publish a single skill, with cleaner frontmatter and fuller shared previews.
   - Added a polished feedback card and clearer import and status feedback across app surfaces.
 
-  ## [v0.11.147 - Existing-worker imports and local Share publishing](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+  ## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147): Existing-worker imports and local Share publishing
 
   Lets shared skills install into existing workers, adds a local Docker-backed Share publisher for self-hosted testing, and keeps Den worker provisioning current.
 
@@ -275,11 +275,11 @@ title: "Changelog"
 
 <Update label="March 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.146 - Failed worker redeploy and safer skill imports](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+  ## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146): Failed worker redeploy and safer skill imports
 
   Adds direct Den worker redeploys, makes shared skills pick a destination worker before import, and improves both local Den setup and Chrome-first guidance.
 
-  ## [v0.11.145 - Den admin backoffice and support routing](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+  ## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145): Den admin backoffice and support routing
 
   Adds a protected Den admin panel for support operations, routes enterprise contact submissions into Loops, and tightens desktop skill reload and settings diagnostics.
 
@@ -287,11 +287,11 @@ title: "Changelog"
 
 <Update label="March 12th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.144 - Workspace shell recovery and clearer docs entrypoints](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+  ## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144): Workspace shell recovery and clearer docs entrypoints
 
   Restores reliable workspace-shell navigation and reset recovery, seeds Chrome DevTools setup correctly, and splits docs paths for technical and non-technical readers.
 
-  ## [v0.11.143 - Free first Den worker and Google signup](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+  ## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143): Free first Den worker and Google signup
 
   Den now lets new users create one free cloud worker without billing and sign up with Google.
 
@@ -300,11 +300,11 @@ title: "Changelog"
   - Retired remaining Soul-mode surfaces across the app and server.
   - Showed session errors inline, removed raw markdown flashes, and refreshed share bundle pages and previews.
 
-  ## [v0.11.142 - Version alignment patch](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+  ## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142): Version alignment patch
 
   Republishes synchronized app, server, orchestrator, and router versions so shipped artifacts stay in lockstep, with no visible workflow changes.
 
-  ## [v0.11.141 - App and worker opens stay on the new session screen](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+  ## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141): App and worker opens stay on the new session screen
 
   Keeps launch actions anchored on the new session flow while making oversized-context errors, share feedback, and support booking clearer.
 
@@ -312,15 +312,15 @@ title: "Changelog"
 
 <Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.140 - Shared bundle imports land on the intended worker](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+  ## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140): Shared bundle imports land on the intended worker
 
   Makes shared bundle imports resolve to the exact active or newly created worker and adds more actionable sandbox startup diagnostics.
 
-  ## [v0.11.138 - Shared bundle links now open the blueprints worker flow](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+  ## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138): Shared bundle links now open the blueprints worker flow
 
   Routes shared bundle imports into the blueprints-style worker creation path so new-worker links land in the setup flow users expect.
 
-  ## [v0.11.137 - MCP sign-in retries and model setup get clearer](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+  ## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137): MCP sign-in retries and model setup get clearer
 
   Makes MCP OAuth flows recover more reliably and reorganizes the model picker so disconnected providers route users straight to setup.
 
@@ -328,7 +328,7 @@ title: "Changelog"
 
 <Update label="March 10th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.136 - OpenWork Share turns dropped files into worker packages](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+  ## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136): OpenWork Share turns dropped files into worker packages
 
   - OpenWork Share now packages dropped skills, agents, commands, and MCP or OpenWork config into worker bundles.
   - The share site moves to the Next.js App Router with refreshed home and bundle pages.
@@ -338,11 +338,11 @@ title: "Changelog"
 
 <Update label="March 6th" tags={["🚀 New Features"]}>
 
-  ## [v0.11.135 - Bundled OpenCode version stays aligned across release paths](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+  ## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135): Bundled OpenCode version stays aligned across release paths
 
   Pins the packaged OpenCode fallback consistently across CI, prerelease, and release builds, with no notable new app workflow changes.
 
-  ## [v0.11.134 - Remote MCP setup gets lighter, with exportable desktop diagnostics](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+  ## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134): Remote MCP setup gets lighter, with exportable desktop diagnostics
 
   Makes remote-workspace MCP connection setup clearer and adds in-app debug exports, sandbox probes, and config actions for faster troubleshooting.
 
@@ -350,11 +350,11 @@ title: "Changelog"
 
 <Update label="March 5th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.133 - Chat transcripts stop flickering during typing](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+  ## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133): Chat transcripts stop flickering during typing
 
   Keeps active and long-running sessions visually stable by fixing typing flicker, remount churn, and collapsed long-message resets.
 
-  ## [v0.11.132 - Chat-first startup and faster long-session loading](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+  ## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132): Chat-first startup and faster long-session loading
 
   Preserves the new-session launch state, fixes first-run setup, and makes long chats load from the latest messages with less lag.
 
@@ -362,7 +362,7 @@ title: "Changelog"
 
 <Update label="March 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.131 - Virtualized chats and clearer runtime status](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+  ## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131): Virtualized chats and clearer runtime status
 
   - Virtualized long transcripts so large chats stay responsive instead of rendering every message at once.
   - Replaced split engine and server badges with one Ready indicator that opens a detailed status popover.
@@ -372,11 +372,11 @@ title: "Changelog"
 
 <Update label="March 2nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.130 - Service restarts and steadier local connectivity](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+  ## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130): Service restarts and steadier local connectivity
 
   Adds in-app restart controls, makes router startup recover from local port conflicts, and smooths billing returns from checkout.
 
-  ## [v0.11.129 - Self-serve billing and media-rich messaging](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+  ## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129): Self-serve billing and media-rich messaging
 
   Expands cloud billing into a self-serve management flow and lets Slack and Telegram carry richer OpenWork Router messages.
 
@@ -384,7 +384,7 @@ title: "Changelog"
 
 <Update label="March 1st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.128 - Remote file sessions, Obsidian sync, and long-chat readability](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+  ## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128): Remote file sessions, Obsidian sync, and long-chat readability
 
   Adds live remote file sessions with Obsidian-backed editing, then makes long desktop conversations easier to read and follow.
 
@@ -392,7 +392,7 @@ title: "Changelog"
 
 <Update label="February 28th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.127 - Get back online recovery and smarter Docker dev-up](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+  ## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127): Get back online recovery and smarter Docker dev-up
 
   Makes worker recovery clearer and preserves existing access, while smoothing Docker dev stacks for developers using local OpenCode config.
 
@@ -400,7 +400,7 @@ title: "Changelog"
 
 <Update label="February 27th" tags={["🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.126 - Simpler artifacts and direct workspace actions](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+  ## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126): Simpler artifacts and direct workspace actions
 
   Simplifies artifact handling and adds direct worker and plugin actions so common cleanup and file workflows take fewer steps.
 
@@ -408,19 +408,19 @@ title: "Changelog"
 
 <Update label="February 26th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.125 - Unified workspace navigation and smoother downloads](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+  ## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125): Unified workspace navigation and smoother downloads
 
   Unifies workspace navigation across dashboard and session views while preventing download-heavy operations from freezing the app.
 
-  ## [v0.11.124 - Orbita gives sessions a clearer three-pane workspace](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+  ## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124): Orbita gives sessions a clearer three-pane workspace
 
   Reworks the main session screen with a stronger left rail, cleaner timeline canvas, and floating composer while preserving readability across themes.
 
-  ## [v0.11.123 - Clearer share links and local server recovery in Settings](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+  ## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123): Clearer share links and local server recovery in Settings
 
   Refreshes both the in-app share modal and public bundle pages, and adds a one-click local server restart when a local worker gets stuck.
 
-  ## [v0.11.122 - Hosted onboarding and share links become app handoffs](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+  ## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122): Hosted onboarding and share links become app handoffs
 
   Hosted OpenWork now hands people straight from the web into the app for connect and import flows.
 
@@ -434,23 +434,23 @@ title: "Changelog"
 
 <Update label="February 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.121 - Session timelines read naturally, and search hits stand out](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+  ## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121): Session timelines read naturally, and search hits stand out
 
   Removes meta-heavy timeline labels, highlights search hits inside messages, and makes quick actions and composing feel faster in active chats.
 
-  ## [v0.11.120 - Worker switching keeps session lists stable](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+  ## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120): Worker switching keeps session lists stable
 
   Preserves sidebar sessions while moving between workers and refreshes the landing hero with higher contrast, calmer motion, and lighter nav chrome.
 
-  ## [v0.11.119 - Long chats stay snappier, and web onboarding looks cleaner](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+  ## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119): Long chats stay snappier, and web onboarding looks cleaner
 
   Further trims typing lag while tightening the landing hero, Get started path, and hosted worker layout across the web experience.
 
-  ## [v0.11.118 - Large sessions type faster, and cloud worker setup stays simpler](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+  ## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118): Large sessions type faster, and cloud worker setup stays simpler
 
   Cuts composer lag in big chats, renames timeline labels in plainer language, and keeps manual worker controls tucked behind advanced options.
 
-  ## [v0.11.117 - Hosted worker connect and cleanup flows get clearer](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+  ## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117): Hosted worker connect and cleanup flows get clearer
 
   Reworks the web worker shell with clearer status, delete, and custom-domain handling, then makes session runs easier to scan by separating request, work, and result.
 
@@ -458,15 +458,15 @@ title: "Changelog"
 
 <Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.116 - Cleaner cloud-worker connect with desktop deep links](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+  ## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116): Cleaner cloud-worker connect with desktop deep links
 
   Turns the hosted worker page into a simpler list-detail picker and adds one-click desktop handoff into OpenWork's remote connect flow.
 
-  ## [v0.11.115 - Private Telegram bot pairing and sturdier hosted sign-in](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+  ## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115): Private Telegram bot pairing and sturdier hosted sign-in
 
   Requires explicit pairing before a private Telegram chat can control a worker and lets hosted auth recover from broken upstream HTML responses.
 
-  ## [v0.11.114 - OpenWork Cloud worker setup and reconnect flows](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+  ## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114): OpenWork Cloud worker setup and reconnect flows
 
   Adds the first full OpenWork Cloud worker setup flow in the web app.
 
@@ -480,11 +480,11 @@ title: "Changelog"
 
 <Update label="February 21st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.113 - Cmd+K quick actions for session work](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+  ## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113): Cmd+K quick actions for session work
 
   Adds a keyboard-first palette for jumping between sessions and changing model or thinking settings without leaving chat.
 
-  ## [v0.11.112 - Cleaner session tool timelines](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+  ## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112): Cleaner session tool timelines
 
   Hides step lifecycle noise and separates reasoning from tool runs so active sessions are easier to scan.
 
@@ -492,44 +492,44 @@ title: "Changelog"
 
 <Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.111 - Version metadata sync only](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+  ## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111): Version metadata sync only
 
   Republishes synchronized package and desktop version metadata, with no intended OpenWork app, server, or workflow changes.
 
-  ## [v0.11.110 - Release packaging and deploy hardening only](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+  ## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110): Release packaging and deploy hardening only
 
   Hardens updater metadata generation and share-service deploy behavior, with no visible OpenWork app or workflow changes.
 
-  ## [v0.11.109 - Safer automation setup, grouped skills, and global MCP config](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+  ## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109): Safer automation setup, grouped skills, and global MCP config
 
   Keeps automations hidden until the scheduler is installed and lets OpenWork pick up domain-organized skills plus machine-level MCP servers.
 
-  ## [v0.11.108 - Readable share pages, sturdier Soul flows, safer drafts](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+  ## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108): Readable share pages, sturdier Soul flows, safer drafts
 
   Makes shared bundles inspectable in the browser, preserves unsent draft text across tab switches, and strengthens Soul activation and audit flows.
 
-  ## [v0.11.107 - Reopening sessions no longer snaps you back to the top](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+  ## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107): Reopening sessions no longer snaps you back to the top
 
   Fixes a revisit-specific session bug so returning to an existing conversation preserves a steadier reading position.
 
-  ## [v0.11.106 - Packaging-only release lockfile maintenance](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+  ## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106): Packaging-only release lockfile maintenance
 
   Refreshes package lock metadata for the release line, with no clear app, desktop, web, or workflow change.
 
-  ## [v0.11.105 - Session timelines stop auto-following altogether](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+  ## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105): Session timelines stop auto-following altogether
 
   Removes the remaining automatic follow behavior so live output no longer drags the view while you read older messages.
 
-  ## [v0.11.104 - Session follow mode is now in your hands](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+  ## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104): Session follow mode is now in your hands
 
   Adds explicit follow-latest and jump-to-latest controls so streaming output stops interrupting people who scroll back to read.
 
-  ## [v0.11.103 - Soul setup now runs safely, and sidebar sessions stay scoped](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+  ## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103): Soul setup now runs safely, and sidebar sessions stay scoped
 
   - Switched Soul enable flows to run through the slash-command path instead of sending template text directly.
   - Scoped sidebar session sync by workspace root so session state does not bleed across workspaces.
 
-  ## [v0.11.102 - Migration recovery explains when it can help](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+  ## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102): Migration recovery explains when it can help
 
   Clarifies when repair is actually available in the app and resets the landing page back to broader OpenWork messaging.
 
@@ -537,11 +537,11 @@ title: "Changelog"
 
 <Update label="February 19th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.101 - Local migration repair and clearer Soul controls](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
+  ## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101): Local migration repair and clearer Soul controls
 
   Adds a desktop recovery path for broken local OpenCode migrations and makes Soul setup plus compact action buttons easier to steer.
 
-  ## v0.11.100 - Composer drafts stop disappearing mid-prompt
+  ## [v0.11.100](https://github.com/different-ai/openwork/compare/v0.11.99...v0.11.100): Composer drafts stop disappearing mid-prompt
 
   Fixes a session composer race so long prompts stay intact instead of getting replaced by stale draft echoes.
 

--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,536 +1,548 @@
 ---
 title: "Changelog"
 ---
-<Update label="April 4th" tags={["🐛 Bug Fixes"]}>
+<Update label="April 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.201](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+  ## [v0.11.202 - Translations fill out across the app and shared skill imports work again.](https://github.com/different-ai/openwork/compare/v0.11.201...v0.11.202)
 
-  Cleans up workspace list behavior, reduces session flicker, and fixes Den skill editing and invite-state handling.
+  Adds Thai, restores missing page translations, fixes migrated shared-skill links, and tightens docs and local desktop dev setup.
+
+  ## [v0.11.201 - Workspace lists collapse cleanly and Den organization setup recovers more reliably.](https://github.com/different-ai/openwork/compare/v0.11.200...v0.11.201)
+
+  Hides collapsed workspace task rows, steadies session loading, and fixes Den skill saving plus organization draft and invite recovery.
 
 </Update>
 
 <Update label="April 3rd" tags={["🚀 New Features"]}>
 
-  ## [v0.11.200](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
+  ## [v0.11.200 - Cloud skills and team limits move into the core flow](https://github.com/different-ai/openwork/compare/v0.11.199...v0.11.200)
 
-  - Added an OpenWork Cloud team skills catalog to the app's Skills page, including refresh, install, and share-to-team flows.
-  - Added Den teams and full skill hub management so organizations can structure, edit, and browse shared skill collections.
-  - Moved billing into org creation and enforced org limits so team setup reflects plan constraints earlier in the workflow.
+  - Added an OpenWork Cloud skills catalog to the Skills page, with install and share-to-team flows.
+  - Added Den teams plus full skill hub and skill editing and visibility management.
+  - Moved billing into org creation and enforced organization member limits before setup finishes.
 
 </Update>
 
 <Update label="April 2nd" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.199](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
+  ## [v0.11.199 - Pricing, skill hubs, and session recovery sharpen up](https://github.com/different-ai/openwork/compare/v0.11.198...v0.11.199)
 
-  - Added a new landing pricing flow with paid Windows messaging and cleaner Cloud navigation into the app.
-  - Expanded Den with skill hubs, a Hono-based `den-api`, and a smoother org-invite signup path for team administration.
-  - Improved day-to-day reliability with developer log export, per-conversation draft persistence, and recovery after immediate send failures.
+  - Added a pricing page and paid Windows messaging, and sent Cloud navigation directly into the app.
+  - Expanded Den with skill hubs, a new `den-api`, and a smoother org-invite signup flow.
+  - Added developer log export, per-conversation draft persistence, and recovery after immediate send failures.
 
 </Update>
 
 <Update label="March 31st" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.198](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
+  ## [v0.11.198 - Local workspace switches restart the right engine](https://github.com/different-ai/openwork/compare/v0.11.197...v0.11.198)
 
-  Fixes a local-workspace switching race so the engine restarts correctly when moving between local workspaces.
+  Fixes a local-only switch bug so changing between local workspaces restarts the engine instead of reusing the old connection.
 
-  ## [v0.11.197](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
+  ## [v0.11.197 - Sharing gets safer and startup gets less noisy](https://github.com/different-ai/openwork/compare/v0.11.196...v0.11.197)
 
-  - Protected workspace sharing by gating sensitive exports and forcing bundle fetches to stay on the configured publisher unless users explicitly opt into a warning-backed manual import.
-  - Kept orchestrator secrets out of process arguments and logs so local and hosted runs leak less sensitive data.
-  - Fixed sidebar and boot behavior by stopping automatic Welcome workspace creation and correcting which sessions appear in collapsed workspace lists.
+  - Blocked sensitive workspace exports and showed warnings before sharing risky config or secrets.
+  - Trusted bundle imports only from the configured publisher unless users explicitly choose a warning-backed manual path.
+  - Moved OpenWork tokens off CLI args and logs, stopped auto-creating Welcome, and fixed collapsed sidebar session lists.
 
 </Update>
 
 <Update label="March 30th" tags={["🚀 New Features", "🐛 Bug Fixes", "🏗️ Refactoring"]}>
 
-  ## [v0.11.196](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
+  ## [v0.11.196 - OpenWork resumes where you left off](https://github.com/different-ai/openwork/compare/v0.11.195...v0.11.196)
 
-  - Made OpenWork boot back into the last session and land on the session view instead of routing users through a dashboard-first shell.
-  - Rebuilt automations around live scheduler jobs with a dedicated Automations page and more direct settings ownership.
-  - Smoothed workspace startup and switching by fixing welcome-workspace bootstrap, sidebar refresh behavior, and several shell-level loading interruptions.
+  - Reopened the last session on workspace boot and routed straight into the session view.
+  - Moved automations onto a dedicated page backed by live local or remote scheduler jobs.
+  - Fixed bootstrap and workspace switching so Welcome setup and loading states stop interrupting startup.
 
 </Update>
 
 <Update label="March 27th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.195](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
+  ## [v0.11.195 - Local workspace creation and Den worker setup get steadier](https://github.com/different-ai/openwork/compare/v0.11.194...v0.11.195)
 
-  Sharpens Den worker connection flows while making desktop model, update, and local workspace behavior more reliable.
+  Routes new local workspaces through the local host, persists model defaults properly, and smooths Den worker-connect and billing flows.
 
 </Update>
 
 <Update label="March 26th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.194](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
+  ## [v0.11.194 - Auto compaction and live automations become real workflows](https://github.com/different-ai/openwork/compare/v0.11.193...v0.11.194)
 
-  Turns auto compaction into a working app flow, simplifies Den local development, and keeps more settings and automation flows live in place.
+  Wires auto compaction to actual workspace config, keeps scheduled jobs live in-app, and adds a faster Den local-dev path.
 
-  ## [v0.11.193](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
+  ## [v0.11.193 - Team template sharing reaches OpenWork Cloud](https://github.com/different-ai/openwork/compare/v0.11.192...v0.11.193)
 
-  - Added Cloud team template sharing flows so teams can publish and reuse workspace templates directly from the app.
-  - Introduced Den organizations, member permissions, and org-scoped template sharing surfaces for multi-user Cloud administration.
-  - Added clearer Cloud sign-in prompts and a manual fallback so team-sharing flows can recover when the automatic sign-in path stalls.
+  - Added Save-to-team flows for workspace templates, with org selection and Cloud sign-in prompts.
+  - Introduced Den organizations, member roles, invitations, custom roles, and org-scoped template APIs and screens.
+  - Added a manual Cloud sign-in fallback when automatic team-sharing auth stalls.
 
 </Update>
 
 <Update label="March 25th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.192](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
+  ## [v0.11.192 - Workspace switching stops hijacking runtime state](https://github.com/different-ai/openwork/compare/v0.11.191...v0.11.192)
 
-  - Made workspace switching feel safer and steadier by keeping selection separate from runtime activation and preserving sticky local worker ports.
-  - Expanded workspace templates so shared imports can carry extra `.opencode` files and starter sessions end to end.
-  - Fixed blueprint-seeded session materialization so starter conversations render correctly instead of dropping their initial state.
+  - Split selected workspace from runtime-connected workspace so browsing no longer flips the active worker.
+  - Kept preferred local server ports sticky and avoided collisions across workspaces.
+  - Let templates carry extra `.opencode` files and starter sessions, and materialized seeded sessions correctly.
 
-  ## [v0.11.191](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
+  ## [v0.11.191 - Shared detached workers survive restarts](https://github.com/different-ai/openwork/compare/v0.11.190...v0.11.191)
 
-  Makes detached worker sharing survive restarts and tightens settings behavior around disconnected providers.
+  Preserves share credentials for detached workers, hides disconnected config-backed providers, and adds clearer Slack and skill-import docs.
 
 </Update>
 
 <Update label="March 24th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.190](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
+  ## [v0.11.190 - Connection guides expand while sharing and auth settle](https://github.com/different-ai/openwork/compare/v0.11.189...v0.11.190)
 
-  Stabilizes sharing first, then smooths provider auth timing and refreshes the app shell layout.
+  Mostly docs-focused release that reorganizes onboarding around concrete connection guides, while fixing desktop publish routing and headless OpenAI auth timing.
 
-  ## [v0.11.189](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
+  ## [v0.11.189 - Package metadata rolls forward only](https://github.com/different-ai/openwork/compare/v0.11.188...v0.11.189)
 
-  Rolls the release line forward with no visible product or workflow changes.
+  Updates the release line with a lockfile and version sync only, without any visible product or workflow changes.
 
-  ## [v0.11.188](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
+  ## [v0.11.188 - Landing feedback returns to the previous flow](https://github.com/different-ai/openwork/compare/v0.11.187...v0.11.188)
 
-  Restores the prior feedback flow by removing the Loops feedback template from the landing feedback route.
+  Backs out the Loops feedback template so the landing feedback endpoint goes back to the simpler email-based path.
 
-  ## [v0.11.187](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
+  ## [v0.11.187 - Windows workspace scoping handles verbatim paths](https://github.com/different-ai/openwork/compare/v0.11.186...v0.11.187)
 
-  Fixes Windows path handling so session and workspace scope comparisons stay consistent across standard, verbatim, and UNC-prefixed directories.
+  Normalizes Windows path transport, verbatim prefixes, and UNC comparisons so local session scope stays consistent across directory formats.
 
-  ## [v0.11.186](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
+  ## [v0.11.186 - Local reconnects stay scoped to the right workspace](https://github.com/different-ai/openwork/compare/v0.11.185...v0.11.186)
 
-  Fixes local workspace scoping during reconnects and bootstrap so sessions stay attached to the right directory.
+  Fixes restart and reconnect flows so local sessions and starter workspaces stay attached to the intended directory.
 
-  ## [v0.11.185](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
+  ## [v0.11.185 - Safer local sharing and messaging setup](https://github.com/different-ai/openwork/compare/v0.11.184...v0.11.185)
 
-  - Defaulted local workers to localhost-only and hardened public auth and publishing flows so sharing surfaces are safer unless users explicitly opt in.
-  - Put messaging behind explicit opt-in and added a warning before creating public Telegram bots so public exposure is more deliberate.
-  - Added a guided Control Chrome setup flow and Brazilian Portuguese localization to make setup clearer for more users.
+  Local workers now stay localhost-only unless users explicitly opt into remote exposure, messaging is disabled until enabled on purpose, public Telegram bot creation shows a risk warning, and Chrome DevTools MCP gets a guided setup flow.
 
 </Update>
 
 <Update label="March 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.184](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
+  ## [v0.11.184 - CLI quickstart becomes the primary docs path](https://github.com/different-ai/openwork/compare/v0.11.183...v0.11.184)
 
-  Refocuses the docs around a slimmer Quickstart so the main onboarding path is easier to follow.
+  Rebuilds the docs around a single CLI-first quickstart and removes older split onboarding paths that were harder to follow.
 
-  ## [v0.11.183](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
+  ## [v0.11.183 - Exa moves into OpenCode settings](https://github.com/different-ai/openwork/compare/v0.11.182...v0.11.183)
 
-  Adds Exa to Advanced settings while backing out an unready macOS path-handling change to keep the release stable.
+  Surfaces the Exa search toggle in a clearer OpenCode settings section and rolls back an unready macOS path-normalization change.
 
-  ## [v0.11.182](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
+  ## [v0.11.182 - Local workspaces move under OpenWork server control](https://github.com/different-ai/openwork/compare/v0.11.181...v0.11.182)
 
-  - Moved local workspace ownership into OpenWork server so reconnects, starter-workspace setup, and sidebar state stay aligned across app surfaces.
-  - Simplified the remote workspace connect modal so adding a worker feels clearer and lighter.
-  - Polished session tool traces by moving the chevron affordance to the right for faster scanning.
+  - Local workspace create, rename, delete, config writes, and reload events now go through OpenWork server first.
+  - First-run starter bootstrap and reconnect logic are more reliable across onboarding and sidebar flows.
+  - Simplified the remote connect modal, moved tool-trace chevrons right, and added Windows ARM64 dev startup support.
 
 </Update>
 
 <Update label="March 22nd" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.181](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
+  ## [v0.11.181 - Version metadata is republished in sync](https://github.com/different-ai/openwork/compare/v0.11.180...v0.11.181)
 
-  Republishes the release line with synchronized package metadata and no clear additional user-facing product changes.
+  Republishes synchronized package versions only, with no distinct user-facing or developer-facing workflow change.
 
-  ## [v0.11.179](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
+  ## [v0.11.179 - Den checkout and workspace setup get leaner](https://github.com/different-ai/openwork/compare/v0.11.178...v0.11.179)
 
-  Simplifies Den checkout and workspace setup flows while cleaning up a few visible desktop and sharing rough edges.
+  Simplifies Den billing and dashboard surfaces, streamlines workspace creation flows, and removes the desktop tray path.
 
-  ## [v0.11.178](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
+  ## [v0.11.178 - Workspace sharing and model controls get a major refresh](https://github.com/different-ai/openwork/compare/v0.11.177...v0.11.178)
 
-  - Redesigned workspace sharing and the right sidebar, including nested child sessions and cleaner session chrome so navigation feels more structured.
-  - Made model behavior controls model-aware with clearer provider and picker behavior across the composer and settings.
-  - Routed in-app feedback to a hosted form and restored key session affordances like the in-composer Run action while polishing settings and transcript surfaces.
+  - Redesigned workspace sharing and the right sidebar, including cleaner remote credentials and nested child sessions.
+  - Made model pickers model-aware with provider icons and per-model reasoning or behavior controls.
+  - Moved app feedback to a hosted form, added an Exa toggle, and stopped forcing starter workspaces on desktop boot.
 
 </Update>
 
 <Update label="March 20th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.177](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
+  ## [v0.11.177 - Downloads CTA and npm install fallback land](https://github.com/different-ai/openwork/compare/v0.11.176...v0.11.177)
 
-  Gets new users to the right install path faster and makes orchestrator installs recover more reliably when local binaries are missing.
+  Gets desktop users to the right download path faster and lets `openwork-orchestrator` recover when npm skips its platform binary.
 
-  ## [v0.11.175](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
+  ## [v0.11.175 - Authorized folders and first-run session guidance move into Settings](https://github.com/different-ai/openwork/compare/v0.11.174...v0.11.175)
 
-  Adds settings-based folder authorization and clearer server-backed empty states first, then tightens sidebar and composer readability across the app shell.
+  Adds Settings-based folder authorization and server-backed empty states, then tightens sidebar and composer labeling so navigation stays readable.
 
-  ## [v0.11.173](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
+  ## [v0.11.173 - Daytona workers report activity and local Node tools spawn reliably](https://github.com/different-ai/openwork/compare/v0.11.172...v0.11.173)
 
-  Adds Daytona worker activity heartbeats first, then improves local tool spawning so nvm-managed Node setups work more reliably.
+  Adds worker heartbeats for Daytona-backed Cloud workers while making local MCP and tool launches work in nvm-managed Node environments.
 
 </Update>
 
 <Update label="March 19th" tags={["🐛 Bug Fixes", "🏗️ Refactoring", "🚀 New Features"]}>
 
-  ## [v0.11.172](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
+  ## [v0.11.172 - Server package naming and session traces line up](https://github.com/different-ai/openwork/compare/v0.11.171...v0.11.172)
 
-  Standardizes the published server package name first, then tightens session trace alignment so run timelines are easier to scan.
+  Renames the published server package to `openwork-server` and polishes trace-row icon and chevron alignment so session runs scan more cleanly.
 
-  ## [v0.11.170](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
+  ## [v0.11.170 - OpenWork Cloud web flows and remote reconnects improve](https://github.com/different-ai/openwork/compare/v0.11.169...v0.11.170)
 
-  - Tailored the hosted web app and Den onboarding flow for OpenWork Cloud with smoother app routes, checkout, and billing recovery.
-  - Kept remote connections steadier by persisting worker share tokens across restarts, restoring repeated shared-skill deeplinks, and preserving open-in-web auto-connect behavior.
-  - Improved day-to-day usability with self-serve Cloud settings, OpenAI headless auth in the provider modal, worker overlays during connect, and tray-on-close desktop behavior.
+  - Rebuilt Den web auth, checkout, and dashboard routes so hosted onboarding and billing feel like the app instead of a one-off page.
+  - Persisted worker share tokens and repeated deeplinks across restarts, with stronger open-in-web auto-connect and connect overlays.
+  - Added self-serve Cloud settings, OpenAI headless auth, and tray-on-close desktop behavior.
 
 </Update>
 
 <Update label="March 18th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.169](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
+  ## [v0.11.169 - Den handoff and session chrome get steadier](https://github.com/different-ai/openwork/compare/v0.11.168...v0.11.169)
 
-  Hardens Den web handoff and open-in-web routing first, then restores a cleaner, more predictable session and sharing experience.
+  Keeps Den browser handoff and worker naming in sync while cleaning up session focus, reload banners, run status, and broken sidebar affordances.
 
 </Update>
 
 <Update label="March 17th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.168](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
+  ## [v0.11.168 - Release recovery with repaired installers](https://github.com/different-ai/openwork/compare/v0.11.167...v0.11.168)
 
-  Recovers the release with the intended Cloud-settings gating behavior and repaired release assets so installs can proceed cleanly again.
+  Republishes the release with repaired assets; the tagged diff itself is metadata-only, while the intended Cloud tab gating fix landed in `v0.11.167`.
 
-  ## [v0.11.166](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
+  ## [v0.11.166 - Daytona-backed Den Docker flow ships](https://github.com/different-ai/openwork/compare/v0.11.165...v0.11.166)
 
-  - Added a Daytona-backed Den Docker dev flow with the new `den-v2` service set, worker proxy, shared DB package, and provisioning helpers.
-  - Improved Den org and environment handling so local and dev setups sync more reliably and generate unique org slugs.
-  - Fixed the local web helper path so `webdev:local` starts reliably from the script-driven workflow.
+  - Added a Daytona-backed Den Docker flow with a dedicated worker proxy and snapshot builder for preloaded runtimes.
+  - Introduced the `den-v2` control plane and shared Den DB packages for the new hosted-worker path.
+  - Fixed unique org slug generation and the `webdev:local` startup script.
 
-  ## [v0.11.165](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
+  ## [v0.11.165 - Settings can sign into Cloud and open workers](https://github.com/different-ai/openwork/compare/v0.11.164...v0.11.165)
 
-  - Added OpenWork Cloud auth and worker-open flows in Settings so users can sign in and open cloud workers directly from the app.
-  - Improved Den desktop sign-in handoff through the web, including installed desktop scheme support and Better Auth trusted-origin handling.
-  - Restored shared bundle installs and polished share previews, while also improving provider credential cleanup and Den landing CTA routing.
+  - Added a Cloud tab in Settings for sign-in, org selection, worker lists, and opening ready Den workers into OpenWork.
+  - Routed desktop auth through the web handoff flow, including installed-app scheme support and bearer-session handling.
+  - Restored shared bundle installs and fully cleared disconnected provider credentials.
 
 </Update>
 
 <Update label="March 16th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.164](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
+  ## [v0.11.164 - Owner tokens and child sessions stay visible](https://github.com/different-ai/openwork/compare/v0.11.163...v0.11.164)
 
-  Keeps nested task context and remote permission recovery clearer first, then broadens sharing and localization polish across the product.
+  Clarifies remote approval access with owner tokens, keeps nested child sessions from disappearing in sidebar syncs, and broadens polish across sharing and localization.
 
-  ## [v0.11.163](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
+  ## [v0.11.163 - Custom skill hub repos and steadier session actions](https://github.com/different-ai/openwork/compare/v0.11.162...v0.11.163)
 
-  Adds custom GitHub skill hub repositories first, then smooths session interactions so cloud and extension workflows feel more reliable.
+  Lets teams browse and install skills from any GitHub hub repo while making session switching, composer focus, and reload prompts behave more predictably.
 
-  ## [v0.11.162](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
+  ## [v0.11.162 - Docker dev prints LAN-ready OpenWork URLs](https://github.com/different-ai/openwork/compare/v0.11.161...v0.11.162)
 
-  Improves local Docker dev-stack defaults so OpenWork is easier to test from other devices over LAN or other public local-network paths.
+  Makes local Docker testing easier from phones and other devices by printing public URLs and deriving Den auth and CORS defaults from the detected host.
 
 </Update>
 
 <Update label="March 15th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.160](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
+  ## [v0.11.160 - Den auth, downloads, and nested sessions polish](https://github.com/different-ai/openwork/compare/v0.11.159...v0.11.160)
 
-  Polishes several high-traffic web and session surfaces so Den entry, downloads, and nested session browsing feel clearer and more reliable.
+  Simplifies the Den auth entry flow, sends landing-page downloads to the right installer, and restores parent-child session browsing in the sidebar.
 
-  ## [v0.11.159](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
+  ## [v0.11.159 - Den cloud billing and worker launch align](https://github.com/different-ai/openwork/compare/v0.11.158...v0.11.159)
 
-  Brings the app cloud-worker flow in line with the Den landing experience and cleans up a couple of visible web regressions around billing and marketing surfaces.
+  Aligns the app-hosted Den flow with landing-page messaging, restores checkout handling for extra workers, and fixes visible billing and marketing regressions.
 
-  ## [v0.11.155](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
+  ## [v0.11.155 - Windows release diagnostics stop masking failures](https://github.com/different-ai/openwork/compare/v0.11.154...v0.11.155)
 
-  Hardens release diagnostics behind the scenes, with no clear new end-user OpenWork behavior in this release.
+  Improves release-pipeline diagnostics and normalizes workflow action inputs so broken Windows packaging runs are easier to debug.
 
-  ## [v0.11.151](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
+  ## [v0.11.151 - Feedback emails reach the team inbox again](https://github.com/different-ai/openwork/compare/v0.11.150...v0.11.151)
 
-  Makes feedback submissions reach the OpenWork team inbox reliably again.
+  Fixes the in-app feedback email target so reports reach the shared OpenWork inbox again.
 
-  ## [v0.11.150](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
+  ## [v0.11.150 - Faster provider setup and steadier chat rendering](https://github.com/different-ai/openwork/compare/v0.11.149...v0.11.150)
 
-  Smooths session setup and chat rendering while routing in-app feedback to the team inbox and keeping settings layout steady.
+  Prioritizes common providers in new-session setup, reduces inline image churn while chatting, and routes feedback straight to the team inbox.
 
 </Update>
 
 <Update label="March 14th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.149](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
+  ## [v0.11.149 - Richer skill previews and steadier jump-to-latest](https://github.com/different-ai/openwork/compare/v0.11.148...v0.11.149)
 
-  Simplifies shared skill pages and stabilizes both skill importing and staying pinned to the latest reply during long chats.
+  Makes shared skill pages easier to evaluate before import, steadies the worker-selection flow, and keeps long chats pinned to the newest reply while thinking.
 
-  ## [v0.11.148](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
+  ## [v0.11.148 - Guided Den onboarding and single-skill Share](https://github.com/different-ai/openwork/compare/v0.11.147...v0.11.148)
 
-  - Den onboarding is now a guided stepper with clearer loading, provisioning, and browser-access states.
-  - OpenWork Share now centers on publishing a single skill, with cleaner frontmatter handling and a smoother import path.
-  - Settings gained a polished feedback entrypoint, while session surfaces were tightened with slimmer sidebars and clearer quickstart tips.
+  - Rebuilt Den onboarding as a guided flow with clearer naming, intent, loading, and browser-access states.
+  - Simplified OpenWork Share to publish a single skill, with cleaner frontmatter and fuller shared previews.
+  - Added a polished feedback card and clearer import and status feedback across app surfaces.
 
-  ## [v0.11.147](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
+  ## [v0.11.147 - Existing-worker imports and local Share publishing](https://github.com/different-ai/openwork/compare/v0.11.146...v0.11.147)
 
-  Expands shared-skill importing to existing workers and makes Share more reliable for long skills and Den worker provisioning.
+  Lets shared skills install into existing workers, adds a local Docker-backed Share publisher for self-hosted testing, and keeps Den worker provisioning current.
 
 </Update>
 
 <Update label="March 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
+  ## [v0.11.146 - Failed worker redeploy and safer skill imports](https://github.com/different-ai/openwork/compare/v0.11.145...v0.11.146)
 
-  Adds direct failed-worker recovery and smarter shared-skill importing while refreshing the workspace shell toward a calmer operator layout.
+  Adds direct Den worker redeploys, makes shared skills pick a destination worker before import, and improves both local Den setup and Chrome-first guidance.
 
-  ## [v0.11.145](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
+  ## [v0.11.145 - Den admin backoffice and support routing](https://github.com/different-ai/openwork/compare/v0.11.144...v0.11.145)
 
-  Adds a Den admin backoffice while sharpening Den worker flows, support capture, and desktop skill-sharing reliability.
+  Adds a protected Den admin panel for support operations, routes enterprise contact submissions into Loops, and tightens desktop skill reload and settings diagnostics.
 
 </Update>
 
 <Update label="March 12th" tags={["🐛 Bug Fixes", "🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.144](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
+  ## [v0.11.144 - Workspace shell recovery and clearer docs entrypoints](https://github.com/different-ai/openwork/compare/v0.11.143...v0.11.144)
 
-  Restores reliable workspace-shell navigation and desktop recovery while polishing Den pricing surfaces and MCP browser setup.
+  Restores reliable workspace-shell navigation and reset recovery, seeds Chrome DevTools setup correctly, and splits docs paths for technical and non-technical readers.
 
-  ## [v0.11.143](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
+  ## [v0.11.143 - Free first Den worker and Google signup](https://github.com/different-ai/openwork/compare/v0.11.142...v0.11.143)
 
-  - Den now allows one free cloud worker without billing and adds Google signup, making it much easier to get started.
-  - The Den landing page was overhauled with a new hero, comparison, support, and CTA flow that explains the product more clearly.
-  - Session and sharing surfaces were polished with inline chat errors, no raw markdown flash during streaming, and refreshed share bundle pages and previews.
+  Den now lets new users create one free cloud worker without billing and sign up with Google.
 
-  ## [v0.11.142](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
+  Also released:
 
-  Rolls a coordinated patch cut that keeps shipped OpenWork artifacts aligned without adding material user-facing changes.
+  - Retired remaining Soul-mode surfaces across the app and server.
+  - Showed session errors inline, removed raw markdown flashes, and refreshed share bundle pages and previews.
 
-  ## [v0.11.141](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+  ## [v0.11.142 - Version alignment patch](https://github.com/different-ai/openwork/compare/v0.11.141...v0.11.142)
 
-  Keeps app and worker launches on the new session screen while improving session clarity and polishing sharing and support flows.
+  Republishes synchronized app, server, orchestrator, and router versions so shipped artifacts stay in lockstep, with no visible workflow changes.
+
+  ## [v0.11.141 - App and worker opens stay on the new session screen](https://github.com/different-ai/openwork/compare/v0.11.140...v0.11.141)
+
+  Keeps launch actions anchored on the new session flow while making oversized-context errors, share feedback, and support booking clearer.
 
 </Update>
 
 <Update label="March 11th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.140](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
+  ## [v0.11.140 - Shared bundle imports land on the intended worker](https://github.com/different-ai/openwork/compare/v0.11.138...v0.11.140)
 
-  Makes shared skill imports land on the newly created worker and gives users clearer sandbox startup diagnostics.
+  Makes shared bundle imports resolve to the exact active or newly created worker and adds more actionable sandbox startup diagnostics.
 
-  ## [v0.11.138](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
+  ## [v0.11.138 - Shared bundle links now open the blueprints worker flow](https://github.com/different-ai/openwork/compare/v0.11.137...v0.11.138)
 
-  Fixes shared bundle imports so they route through the blueprints flow and land in the expected workspace setup path.
+  Routes shared bundle imports into the blueprints-style worker creation path so new-worker links land in the setup flow users expect.
 
-  ## [v0.11.137](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
+  ## [v0.11.137 - MCP sign-in retries and model setup get clearer](https://github.com/different-ai/openwork/compare/v0.11.136...v0.11.137)
 
-  Stabilizes MCP authentication and improves model picker clarity so provider connection and model selection feel more dependable.
+  Makes MCP OAuth flows recover more reliably and reorganizes the model picker so disconnected providers route users straight to setup.
 
 </Update>
 
 <Update label="March 10th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.136](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
+  ## [v0.11.136 - OpenWork Share turns dropped files into worker packages](https://github.com/different-ai/openwork/compare/v0.11.135...v0.11.136)
 
-  - Turned OpenWork Share into a worker packager and simplified package creation so shared bundles are more useful as real setup artifacts.
-  - Replatformed OpenWork Share onto the Next.js App Router and refreshed its landing and bundle pages for a cleaner public sharing experience.
-  - Fixed provider OAuth polling and added provider disconnect controls in Settings so account connection management is more reliable.
+  - OpenWork Share now packages dropped skills, agents, commands, and MCP or OpenWork config into worker bundles.
+  - The share site moves to the Next.js App Router with refreshed home and bundle pages.
+  - Settings now lets users disconnect providers, while OAuth completion and sandbox startup recover more reliably.
 
 </Update>
 
 <Update label="March 6th" tags={["🚀 New Features"]}>
 
-  ## [v0.11.135](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
+  ## [v0.11.135 - Bundled OpenCode version stays aligned across release paths](https://github.com/different-ai/openwork/compare/v0.11.134...v0.11.135)
 
-  Keeps packaged OpenCode resolution more consistent across CI, prerelease, and release paths, with no notable direct product-surface changes.
+  Pins the packaged OpenCode fallback consistently across CI, prerelease, and release builds, with no notable new app workflow changes.
 
-  ## [v0.11.134](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
+  ## [v0.11.134 - Remote MCP setup gets lighter, with exportable desktop diagnostics](https://github.com/different-ai/openwork/compare/v0.11.133...v0.11.134)
 
-  Simplifies remote MCP connection setup and adds stronger desktop diagnostics so setup and troubleshooting are easier from inside OpenWork.
+  Makes remote-workspace MCP connection setup clearer and adds in-app debug exports, sandbox probes, and config actions for faster troubleshooting.
 
 </Update>
 
 <Update label="March 5th" tags={["🐛 Bug Fixes"]}>
 
-  ## [v0.11.133](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
+  ## [v0.11.133 - Chat transcripts stop flickering during typing](https://github.com/different-ai/openwork/compare/v0.11.132...v0.11.133)
 
-  Stabilizes active chat rendering so transcripts stop flickering while typing and long-message state holds together more reliably.
+  Keeps active and long-running sessions visually stable by fixing typing flicker, remount churn, and collapsed long-message resets.
 
-  ## [v0.11.132](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
+  ## [v0.11.132 - Chat-first startup and faster long-session loading](https://github.com/different-ai/openwork/compare/v0.11.131...v0.11.132)
 
-  Makes session startup feel steadier by preserving empty-draft launches, opening chats at the latest messages, and reducing long-chat typing lag.
+  Preserves the new-session launch state, fixes first-run setup, and makes long chats load from the latest messages with less lag.
 
 </Update>
 
 <Update label="March 4th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.131](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
+  ## [v0.11.131 - Virtualized chats and clearer runtime status](https://github.com/different-ai/openwork/compare/v0.11.130...v0.11.131)
 
-  - Virtualized session message rendering and fixed blank transcript regressions so long conversations stay responsive.
-  - Added a unified status indicator with detail popover plus automatic context compaction controls for clearer session oversight.
-  - Added persistent language selection and improved file-open reliability for editor and artifact flows.
+  - Virtualized long transcripts so large chats stay responsive instead of rendering every message at once.
+  - Replaced split engine and server badges with one Ready indicator that opens a detailed status popover.
+  - Added automatic context compaction after runs, plus persistent language selection and sturdier file opening.
 
 </Update>
 
 <Update label="March 2nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.130](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
+  ## [v0.11.130 - Service restarts and steadier local connectivity](https://github.com/different-ai/openwork/compare/v0.11.129...v0.11.130)
 
-  Makes local connectivity more dependable by hardening router startup, adding restart controls, and smoothing checkout return handling in billing.
+  Adds in-app restart controls, makes router startup recover from local port conflicts, and smooths billing returns from checkout.
 
-  ## [v0.11.129](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
+  ## [v0.11.129 - Self-serve billing and media-rich messaging](https://github.com/different-ai/openwork/compare/v0.11.128...v0.11.129)
 
-  Adds self-serve billing controls in the web cloud dashboard and expands messaging connectors with first-class media delivery.
+  Expands cloud billing into a self-serve management flow and lets Slack and Telegram carry richer OpenWork Router messages.
 
 </Update>
 
 <Update label="March 1st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.128](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
+  ## [v0.11.128 - Remote file sessions, Obsidian sync, and long-chat readability](https://github.com/different-ai/openwork/compare/v0.11.127...v0.11.128)
 
-  Expands remote file workflows with just-in-time file sessions and local mirror support, then makes long desktop sessions easier to read and follow.
+  Adds live remote file sessions with Obsidian-backed editing, then makes long desktop conversations easier to read and follow.
 
 </Update>
 
 <Update label="February 28th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.127](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
+  ## [v0.11.127 - Get back online recovery and smarter Docker dev-up](https://github.com/different-ai/openwork/compare/v0.11.126...v0.11.127)
 
-  Makes worker recovery clearer and more reliable by adding a plain-language recovery action that keeps existing OpenWork access working.
+  Makes worker recovery clearer and preserves existing access, while smoothing Docker dev stacks for developers using local OpenCode config.
 
 </Update>
 
 <Update label="February 27th" tags={["🚀 New Features", "🏗️ Refactoring"]}>
 
-  ## [v0.11.126](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
+  ## [v0.11.126 - Simpler artifacts and direct workspace actions](https://github.com/different-ai/openwork/compare/v0.11.125...v0.11.126)
 
-  Simplifies artifact handling first, then adds quicker worker and plugin actions so common workspace management tasks take fewer steps.
+  Simplifies artifact handling and adds direct worker and plugin actions so common cleanup and file workflows take fewer steps.
 
 </Update>
 
 <Update label="February 26th" tags={["🐛 Bug Fixes", "🚀 New Features"]}>
 
-  ## [v0.11.125](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
+  ## [v0.11.125 - Unified workspace navigation and smoother downloads](https://github.com/different-ai/openwork/compare/v0.11.124...v0.11.125)
 
-  Makes navigation more consistent across dashboard and session views and prevents large downloads from freezing the UI.
+  Unifies workspace navigation across dashboard and session views while preventing download-heavy operations from freezing the app.
 
-  ## [v0.11.124](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
+  ## [v0.11.124 - Orbita gives sessions a clearer three-pane workspace](https://github.com/different-ai/openwork/compare/v0.11.123...v0.11.124)
 
-  Applies the Orbita session layout direction to make the core OpenWork session view feel more structured, readable, and cohesive.
+  Reworks the main session screen with a stronger left rail, cleaner timeline canvas, and floating composer while preserving readability across themes.
 
-  ## [v0.11.123](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
+  ## [v0.11.123 - Clearer share links and local server recovery in Settings](https://github.com/different-ai/openwork/compare/v0.11.122...v0.11.123)
 
-  Refreshes sharing to match OpenWork’s visual identity and adds a built-in local server restart action for easier recovery.
+  Refreshes both the in-app share modal and public bundle pages, and adds a one-click local server restart when a local worker gets stuck.
 
-  ## [v0.11.122](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
+  ## [v0.11.122 - Hosted onboarding and share links become app handoffs](https://github.com/different-ai/openwork/compare/v0.11.121...v0.11.122)
 
-  - Streamlined cloud onboarding with Open in App handoff, GitHub sign-in, a dedicated download page, and stronger hosted auth and callback handling.
-  - Added richer sharing flows with workspace profile and skills-set sharing plus deep-linked bundle imports into new workers.
-  - Improved day-to-day app usability with grouped exploration steps, faster markdown rendering in long sessions, clearer workspace and share surfaces, and better file-link handling.
+  Hosted OpenWork now hands people straight from the web into the app for connect and import flows.
+
+  Also released:
+
+  - GitHub sign-in plus a dedicated download page for faster first-time setup.
+  - Share links for workspace profiles and skill sets, with deep links that default to a new worker.
+  - Long sessions render more smoothly, local file links resolve correctly, and desktop shutdown is cleaner.
 
 </Update>
 
 <Update label="February 23rd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.121](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
+  ## [v0.11.121 - Session timelines read naturally, and search hits stand out](https://github.com/different-ai/openwork/compare/v0.11.120...v0.11.121)
 
-  Makes session timelines read more naturally and improves the speed of quick actions, search, and composing in active chats.
+  Removes meta-heavy timeline labels, highlights search hits inside messages, and makes quick actions and composing feel faster in active chats.
 
-  ## [v0.11.120](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
+  ## [v0.11.120 - Worker switching keeps session lists stable](https://github.com/different-ai/openwork/compare/v0.11.119...v0.11.120)
 
-  Stabilizes session switching across workers and refreshes the landing hero so the product is easier to navigate and read.
+  Preserves sidebar sessions while moving between workers and refreshes the landing hero with higher contrast, calmer motion, and lighter nav chrome.
 
-  ## [v0.11.119](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
+  ## [v0.11.119 - Long chats stay snappier, and web onboarding looks cleaner](https://github.com/different-ai/openwork/compare/v0.11.118...v0.11.119)
 
-  Keeps long chats more responsive and polishes the landing and hosted web surfaces for a cleaner first-run experience.
+  Further trims typing lag while tightening the landing hero, Get started path, and hosted worker layout across the web experience.
 
-  ## [v0.11.118](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
+  ## [v0.11.118 - Large sessions type faster, and cloud worker setup stays simpler](https://github.com/different-ai/openwork/compare/v0.11.117...v0.11.118)
 
-  Makes long sessions feel faster and clearer while reducing technical noise in hosted worker controls.
+  Cuts composer lag in big chats, renames timeline labels in plainer language, and keeps manual worker controls tucked behind advanced options.
 
-  ## [v0.11.117](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
+  ## [v0.11.117 - Hosted worker connect and cleanup flows get clearer](https://github.com/different-ai/openwork/compare/v0.11.116...v0.11.117)
 
-  Improves hosted worker management and session readability while hardening messaging and Den reliability in several user-visible failure paths.
+  Reworks the web worker shell with clearer status, delete, and custom-domain handling, then makes session runs easier to scan by separating request, work, and result.
 
 </Update>
 
 <Update label="February 22nd" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.116](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
+  ## [v0.11.116 - Cleaner cloud-worker connect with desktop deep links](https://github.com/different-ai/openwork/compare/v0.11.115...v0.11.116)
 
-  Simplifies cloud-worker connection with a cleaner list-detail web flow and desktop deep links that open remote connects more directly.
+  Turns the hosted worker page into a simpler list-detail picker and adds one-click desktop handoff into OpenWork's remote connect flow.
 
-  ## [v0.11.115](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
+  ## [v0.11.115 - Private Telegram bot pairing and sturdier hosted sign-in](https://github.com/different-ai/openwork/compare/v0.11.114...v0.11.115)
 
-  Makes Telegram identity setup safer with private bot pairing codes and improves hosted auth recovery when the web proxy gets bad upstream responses.
+  Requires explicit pairing before a private Telegram chat can control a worker and lets hosted auth recover from broken upstream HTML responses.
 
-  ## [v0.11.114](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
+  ## [v0.11.114 - OpenWork Cloud worker setup and reconnect flows](https://github.com/different-ai/openwork/compare/v0.11.113...v0.11.114)
 
-  - Added the Den control plane and web app so users can provision real cloud workers through a guided 3-step setup flow.
-  - Made cloud workers easier to reconnect by persisting worker records, surfacing OpenWork connect credentials, and returning compatible workspace-scoped connect links.
-  - Improved cloud reliability and access control with completed OAuth setup, asynchronous worker provisioning with auto-polling, and Polar-gated paid access.
+  Adds the first full OpenWork Cloud worker setup flow in the web app.
+
+  Also released:
+
+  - A 3-step sign-in, checkout, and launch flow.
+  - Saved workers plus reusable tokens and workspace-scoped connect URLs.
+  - Background provisioning with polling and completed provider OAuth in the app.
 
 </Update>
 
 <Update label="February 21st" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.113](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
+  ## [v0.11.113 - Cmd+K quick actions for session work](https://github.com/different-ai/openwork/compare/v0.11.112...v0.11.113)
 
-  Speeds up session work with a new Cmd+K command palette for jumping between sessions and changing key chat settings in place.
+  Adds a keyboard-first palette for jumping between sessions and changing model or thinking settings without leaving chat.
 
-  ## [v0.11.112](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
+  ## [v0.11.112 - Cleaner session tool timelines](https://github.com/different-ai/openwork/compare/v0.11.111...v0.11.112)
 
-  Cleans up the session tool timeline by removing step lifecycle noise so active runs are easier to scan.
+  Hides step lifecycle noise and separates reasoning from tool runs so active sessions are easier to scan.
 
 </Update>
 
 <Update label="February 20th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.111](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
+  ## [v0.11.111 - Version metadata sync only](https://github.com/different-ai/openwork/compare/v0.11.110...v0.11.111)
 
-  Ships synchronized version metadata only, with no distinct user-facing change evident in this release.
+  Republishes synchronized package and desktop version metadata, with no intended OpenWork app, server, or workflow changes.
 
-  ## [v0.11.110](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
+  ## [v0.11.110 - Release packaging and deploy hardening only](https://github.com/different-ai/openwork/compare/v0.11.109...v0.11.110)
 
-  Improves release and deployment plumbing behind the scenes, with no clear new end-user product behavior in this patch.
+  Hardens updater metadata generation and share-service deploy behavior, with no visible OpenWork app or workflow changes.
 
-  ## [v0.11.109](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
+  ## [v0.11.109 - Safer automation setup, grouped skills, and global MCP config](https://github.com/different-ai/openwork/compare/v0.11.108...v0.11.109)
 
-  Makes automation setup less confusing while expanding skill discovery and MCP configuration support for more flexible setups.
+  Keeps automations hidden until the scheduler is installed and lets OpenWork pick up domain-organized skills plus machine-level MCP servers.
 
-  ## [v0.11.108](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
+  ## [v0.11.108 - Readable share pages, sturdier Soul flows, safer drafts](https://github.com/different-ai/openwork/compare/v0.11.107...v0.11.108)
 
-  Adds readable share bundle pages first, then makes Soul enable flows sturdier and preserves unsent drafts across tab switches.
+  Makes shared bundles inspectable in the browser, preserves unsent draft text across tab switches, and strengthens Soul activation and audit flows.
 
-  ## [v0.11.107](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
+  ## [v0.11.107 - Reopening sessions no longer snaps you back to the top](https://github.com/different-ai/openwork/compare/v0.11.106...v0.11.107)
 
-  Stops sessions from repeatedly snapping back to the top, making long conversations easier to stay anchored in.
+  Fixes a revisit-specific session bug so returning to an existing conversation preserves a steadier reading position.
 
-  ## [v0.11.106](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
+  ## [v0.11.106 - Packaging-only release lockfile maintenance](https://github.com/different-ai/openwork/compare/v0.11.105...v0.11.106)
 
-  Refreshes release metadata only, with no clear user-facing product change in this patch.
+  Refreshes package lock metadata for the release line, with no clear app, desktop, web, or workflow change.
 
-  ## [v0.11.105](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
+  ## [v0.11.105 - Session timelines stop auto-following altogether](https://github.com/different-ai/openwork/compare/v0.11.104...v0.11.105)
 
-  Removes automatic session scroll following so the timeline stops fighting users who are reading older output.
+  Removes the remaining automatic follow behavior so live output no longer drags the view while you read older messages.
 
-  ## [v0.11.104](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
+  ## [v0.11.104 - Session follow mode is now in your hands](https://github.com/different-ai/openwork/compare/v0.11.103...v0.11.104)
 
-  Makes session follow-scroll user-controlled so reviewing earlier output is less likely to be interrupted.
+  Adds explicit follow-latest and jump-to-latest controls so streaming output stops interrupting people who scroll back to read.
 
-  ## [v0.11.103](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
+  ## [v0.11.103 - Soul setup now runs safely, and sidebar sessions stay scoped](https://github.com/different-ai/openwork/compare/v0.11.102...v0.11.103)
 
-  - Prevented Soul template prompt-injection abuse so unsafe template content is less likely to steer users into unintended behavior.
-  - Scoped sidebar synchronization to the active workspace root so switching between workspaces feels more predictable.
-  - Kept the patch tightly focused on safety and multi-workspace consistency rather than adding new visible workflows.
+  - Switched Soul enable flows to run through the slash-command path instead of sending template text directly.
+  - Scoped sidebar session sync by workspace root so session state does not bleed across workspaces.
 
-  ## [v0.11.102](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
+  ## [v0.11.102 - Migration recovery explains when it can help](https://github.com/different-ai/openwork/compare/v0.11.101...v0.11.102)
 
-  Clarifies when migration recovery is available so troubleshooting local startup issues feels more predictable.
+  Clarifies when repair is actually available in the app and resets the landing page back to broader OpenWork messaging.
 
 </Update>
 
 <Update label="February 19th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
-  ## [v0.11.101](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
+  ## [v0.11.101 - Local migration repair and clearer Soul controls](https://github.com/different-ai/openwork/compare/v0.11.100...v0.11.101)
 
-  Improves local session recovery first, then makes Soul easier to steer and cleans up compact controls across key app surfaces.
+  Adds a desktop recovery path for broken local OpenCode migrations and makes Soul setup plus compact action buttons easier to steer.
 
-  ## v0.11.100
+  ## v0.11.100 - Composer drafts stop disappearing mid-prompt
 
-  Stops long prompts from disappearing while typing, making the session composer reliable again.
+  Fixes a session composer race so long prompts stay intact instead of getting replaced by stale draft echoes.
 
 </Update>

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -58,6 +58,16 @@ function resolveTags(features, bugs, deprecated) {
   return tags.length > 0 ? tags : ["🔧 Misc"]
 }
 
+function inferPreviousVersion(version) {
+  const match = version.match(/^v(\d+)\.(\d+)\.(\d+)$/)
+  if (!match) return null
+
+  const [major, minor, patch] = match.slice(1).map(Number)
+  if (patch <= 0) return null
+
+  return `v${major}.${minor}.${patch - 1}`
+}
+
 // ---------------------------------------------------------------------------
 // Parser
 // ---------------------------------------------------------------------------
@@ -125,8 +135,9 @@ function toEntry(release, prevVersion) {
   const tags = resolveTags(features, bugs, deprecated)
 
   // Build compare URL from consecutive versions: v0.11.200...v0.11.201
-  const compareUrl = prevVersion
-    ? `${COMPARE_BASE}/${prevVersion}...${release.version}`
+  const compareBaseVersion = prevVersion || inferPreviousVersion(release.version)
+  const compareUrl = compareBaseVersion
+    ? `${COMPARE_BASE}/${compareBaseVersion}...${release.version}`
     : ""
 
   return {
@@ -150,15 +161,16 @@ function toEntry(release, prevVersion) {
  */
 function renderVersionBlock(entry) {
   const lines = []
-  const combinedTitle = entry.title
-    ? `${entry.version} - ${entry.title}`
-    : entry.version
 
-  // Version + title as the section heading, linked to compare URL
+  // Version is the linked heading; title is appended after it.
   if (entry.compareUrl) {
-    lines.push(`  ## [${combinedTitle}](${entry.compareUrl})`)
+    lines.push(
+      entry.title
+        ? `  ## [${entry.version}](${entry.compareUrl}): ${entry.title}`
+        : `  ## [${entry.version}](${entry.compareUrl})`,
+    )
   } else {
-    lines.push(`  ## ${combinedTitle}`)
+    lines.push(entry.title ? `  ## ${entry.version}: ${entry.title}` : `  ## ${entry.version}`)
   }
 
   lines.push("")

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -6,9 +6,10 @@ import { fileURLToPath } from "node:url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, "..")
-const TRACKER_PATH = resolve(ROOT, "changelog/release-tracker.md")
+const TRACKER_DIR = resolve(ROOT, "changelog")
 const OUTPUT_PATH = resolve(ROOT, "packages/docs/changelog.mdx")
 const COMPARE_BASE = "https://github.com/different-ai/openwork/compare"
+const TRACKER_FILE_PATTERN = /^release-tracker-\d{4}-\d{2}-\d{2}\.md$/
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,7 +63,7 @@ function resolveTags(features, bugs, deprecated) {
 // ---------------------------------------------------------------------------
 
 /**
- * Parse release-tracker.md into structured release objects.
+ * Parse a release-tracker file into structured release objects.
  *
  * Splits on `## v` headings, then extracts `#### ` subsections inside each.
  */
@@ -115,6 +116,7 @@ function toEntry(release, prevVersion) {
 
   const oneLiner = s["One-line summary"]?.trim() || ""
   const mainChanges = s["Main changes"]?.trim() || ""
+  const title = s["Title"]?.trim() || ""
 
   const features = parseInt(s["Number of major improvements"] || "0", 10)
   const bugs = parseInt(s["Number of major bugs resolved"] || "0", 10)
@@ -132,6 +134,7 @@ function toEntry(release, prevVersion) {
     date,
     isMajor,
     tags,
+    title,
     oneLiner,
     mainChanges,
     compareUrl,
@@ -147,12 +150,15 @@ function toEntry(release, prevVersion) {
  */
 function renderVersionBlock(entry) {
   const lines = []
+  const combinedTitle = entry.title
+    ? `${entry.version} - ${entry.title}`
+    : entry.version
 
-  // Version as the section heading, linked to compare URL
+  // Version + title as the section heading, linked to compare URL
   if (entry.compareUrl) {
-    lines.push(`  ## [${entry.version}](${entry.compareUrl})`)
+    lines.push(`  ## [${combinedTitle}](${entry.compareUrl})`)
   } else {
-    lines.push(`  ## ${entry.version}`)
+    lines.push(`  ## ${combinedTitle}`)
   }
 
   lines.push("")
@@ -161,7 +167,7 @@ function renderVersionBlock(entry) {
   if (entry.isMajor && entry.mainChanges) {
     const indented = entry.mainChanges
       .split("\n")
-      .map((l) => `  ${l}`)
+      .map((l) => (l.length > 0 ? `  ${l}` : ""))
       .join("\n")
     lines.push(indented)
   } else {
@@ -230,14 +236,33 @@ function renderChangelog(entries) {
 // Main
 // ---------------------------------------------------------------------------
 
+async function loadTrackerReleases() {
+  const entries = await fs.readdir(TRACKER_DIR, { withFileTypes: true })
+  const trackerFiles = entries
+    .filter((entry) => entry.isFile() && TRACKER_FILE_PATTERN.test(entry.name))
+    .map((entry) => entry.name)
+    .sort()
+
+  if (trackerFiles.length === 0) {
+    throw new Error(`No tracker files found in ${TRACKER_DIR}`)
+  }
+
+  const releases = []
+  for (const fileName of trackerFiles) {
+    const raw = await fs.readFile(resolve(TRACKER_DIR, fileName), "utf-8")
+    releases.push(...parseTracker(raw))
+  }
+
+  return { trackerFiles, releases }
+}
+
 async function main() {
-  const raw = await fs.readFile(TRACKER_PATH, "utf-8")
-  const releases = parseTracker(raw)
+  const { trackerFiles, releases } = await loadTrackerReleases()
   const entries = releases.map((r, i) => toEntry(r, i > 0 ? releases[i - 1].version : null))
   const output = renderChangelog(entries)
 
   await fs.writeFile(OUTPUT_PATH, output, "utf-8")
-  console.log(`Wrote ${entries.length} entries to ${OUTPUT_PATH}`)
+  console.log(`Wrote ${entries.length} entries from ${trackerFiles.length} tracker files to ${OUTPUT_PATH}`)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- rebuild the date-split changelog tracker files through `v0.11.202` with richer `Title`, `One-line summary`, and `Main changes` content based on the actual release diffs
- remove the tracker publication flag fields and update the changelog generator to read all split tracker files and render `version - title` headings when titles exist
- regenerate `packages/docs/changelog.mdx` from the updated tracker structure

## Testing
- `node scripts/generate-changelog.mjs`
- `git diff --check -- changelog/release-tracker-2026-02-19.md changelog/release-tracker-2026-02-26.md changelog/release-tracker-2026-03-15.md changelog/release-tracker-2026-03-20.md changelog/release-tracker-2026-04-04.md scripts/generate-changelog.mjs packages/docs/changelog.mdx`

## Notes
- this PR supersedes the earlier generator-only PR because it includes the tracker content changes that supply the new title fields