### PR TITLE
docs: automated documentation updates 2026-04-06

### DIFF
--- a/packages/docs/how-to-connect-a-custom-provider.mdx
+++ b/packages/docs/how-to-connect-a-custom-provider.mdx
@@ -3,9 +3,25 @@ title: "Adding a custom LLM provider/model"
 description: "How to connect a custom provider with openwork"
 ---
 
-Because `Openwork` is built on `Opencode` primitives, we support everything that you could modify in `.opencode.json`, like adding a [model](https://opencode.ai/docs/models/). However, our recommendation is to add it to `/path-to-your-workspace/.config/opencode/opencode.json` instead of modifying `~/.config/opencode/opencode.json`.
+OpenWork supports two different custom-provider workflows depending on where you want the configuration to live.
 
-The reason for this is that you may want to support different models and permissions across several workspaces, specially when sharing it with a team.
+## Use OpenWork Cloud for shared provider access
+
+If your organization uses OpenWork Cloud, open `LLM Providers` in the org dashboard when you want one shared provider setup for multiple teammates.
+
+- Add the provider credentials once.
+- Choose which models the org should expose.
+- Grant access to specific people or teams.
+
+This is the best option when the provider should be managed centrally instead of copied into each person's local config.
+
+If you also need non-interactive access for automations or backend services, create an org `API Key` in the same dashboard and use the docs site's `API Reference` tab for the current `den-api` routes.
+
+## Use workspace config for local or self-managed providers
+
+Because `OpenWork` is built on `OpenCode` primitives, it also supports the same provider configuration you can add to `opencode.json`, including custom [models](https://opencode.ai/docs/models/). For local or self-managed setups, we recommend adding the provider to `/path-to-your-workspace/.config/opencode/opencode.json` instead of modifying `~/.config/opencode/opencode.json`.
+
+The reason for this is that you may want to support different models and permissions across several workspaces, especially when sharing them with a team.
 
 Inside `/path-to-your-workspace/.config/opencode/opencode.json`:
 ```
@@ -27,6 +43,6 @@ Inside `/path-to-your-workspace/.config/opencode/opencode.json`:
 }
 ```
 
-We've also built a [custom skill](https://share.openworklabs.com/b/01KNBQDQAK41VZSZDF5G9MW4MW) that you can import in Openwork following [this guide](/importing-a-skill). 
+We've also built a [custom skill](https://share.openworklabs.com/b/01KNBQDQAK41VZSZDF5G9MW4MW) that you can import in OpenWork by following [this guide](/importing-a-skill).
 
 The following tutorial covers how to [import a custom provider using the skill](https://x.com/getopenwork/status/2034129039317995908?s=20).

--- a/packages/docs/introduction.mdx
+++ b/packages/docs/introduction.mdx
@@ -2,14 +2,18 @@
 title: "Introduction"
 ---
 
-OpenWork Cloud enables team to move faster by making it easy to share your setup across your org.
+OpenWork Cloud gives your organization one place to share setup, manage access, and keep long-running agent workflows available to the whole team.
 
 [https://app.openworklabs.com/](https://app.openworklabs.com/)
 
-- \*\*Team Templates: \*\*make it easy to share your setup across your team so they spend less time copy and pasting configs.
-- \*\*Members: \*\*Makes it easy to invite members to your org.
-- \*\*Shared Workspace: \*\*Are cloud instances you can use to perform long-running tasks or connect permanent connection to messaging channels like Slack or Telegram.
-- \*\*Custom LLMs: \*\*(coming soon)
+## What you can manage in OpenWork Cloud
+
+- **Team Templates:** publish a starting setup with the skills, MCP servers, and workspace defaults your team should reuse.
+- **Members:** invite teammates, assign roles, and keep access scoped to the right organization.
+- **Shared Workspace:** run long-lived cloud workers for background tasks or messaging-connected workflows.
+- **LLM Providers:** save provider credentials once, choose the exact models to expose, and grant access to specific people or teams.
+- **API Keys:** issue named org keys for automations or backend services. New secrets are shown only once when the key is created.
+- **API Reference:** use the docs site's `API Reference` tab for the current `den-api` endpoints and interactive playground.
 
 <Frame>
   ![Image](/images/image-6.png)

--- a/packages/docs/team-provisioning.mdx
+++ b/packages/docs/team-provisioning.mdx
@@ -1,9 +1,34 @@
 ---
-title: "Team Templates"
+title: "Team Provisioning"
 ---
 
-OpenWork Cloud enables team to move faster by making it easy to share your setup across your org.
+OpenWork Cloud team provisioning covers both the starting setup new teammates inherit and the shared resources your org manages after onboarding.
 
-When your team starts with OpenWork they'll have the option to pick from one of the templates that is uniquely provisioned to them.
+## Recommended setup order
 
-Creating a template is easy: simply create a setup as you would usually. Create your skills, connect your MCPs, and simply click on Share.
+1. **Publish a Team Template**
+
+   Start from a configured workspace, add the skills and MCP servers your team needs, and use Share to publish a reusable template.
+
+2. **Invite members**
+
+   Add people to the org and assign the right role before you hand out shared resources.
+
+3. **Set up shared model access**
+
+   Open `LLM Providers` in the org dashboard to save provider credentials, choose the exact models to expose, and grant access to specific people or teams.
+
+4. **Create API keys for automations**
+
+   Open `API Keys` to issue named org keys for CI jobs, internal tools, or backend services. Copy the secret when it is created because the full key is only shown once.
+
+5. **Run long-lived work in Shared Workspace**
+
+   Use shared cloud workers for background tasks or messaging-connected runtimes that should stay available for the whole team.
+
+## When to use which surface
+
+- **Team Templates:** when a teammate needs the same starting setup.
+- **LLM Providers:** when the org should manage credentials and approved model lists centrally.
+- **API Keys:** when a service needs to call OpenWork without an interactive user session.
+- **API Reference:** when you need the current `den-api` routes, auth shape, and request examples.


### PR DESCRIPTION
Docs refresh for 19:00 PDT. This PR updates documentation to match behavior introduced by commits from the last 24 hours.

Commits reviewed:
- 0589897b feat(den): add org-managed llm provider library (#1343)
- 4f190588 feat(den): add org API key auth and management (#1368)
- d9e5a33e feat(den): document den-api with OpenAPI (#1371)
- d231dc2f openapi docs added as tab (#1372)

Why these docs changed:
- Example: 0589897b feat(den): add org-managed llm provider library (#1343) changed the previous Cloud story from "Custom LLMs (coming soon)" to a real `LLM Providers` dashboard where admins save shared credentials, choose models, and grant access to people or teams. `packages/docs/introduction.mdx`, `packages/docs/team-provisioning.mdx`, and `packages/docs/how-to-connect-a-custom-provider.mdx` had to be updated because they still described shared model management as unavailable or purely local.
- Example: 4f190588 feat(den): add org API key auth and management (#1368) changed the previous workflow from no org-scoped API key management to a dedicated `API Keys` screen with named keys, owner/admin access, and one-time secret reveal. The Cloud docs were incomplete because they did not mention API-key-based automation at all or warn that the full secret is only shown once.
- Example: d9e5a33e feat(den): document den-api with OpenAPI (#1371) changed the previous workflow from code-only API discovery to a generated OpenAPI surface for `den-api`, so narrative docs needed to point people to the current API reference instead of leaving route discovery implicit.
- Example: d231dc2f openapi docs added as tab (#1372) changed the docs navigation from guide-only pages to guide pages plus an `API Reference` tab. The provisioning and provider docs now point readers to that tab because the old pages had no path to the live endpoint reference.

Documentation updates in this PR:
- Updated `packages/docs/introduction.mdx` to replace the outdated Cloud overview with the current Team Templates, Members, Shared Workspace, LLM Providers, API Keys, and API Reference surfaces.
- Updated `packages/docs/team-provisioning.mdx` to replace the old template-only workflow with a current provisioning sequence that includes shared model access, API keys for automations, and the API reference tab.
- Updated `packages/docs/how-to-connect-a-custom-provider.mdx` to distinguish OpenWork Cloud's shared `LLM Providers` flow from workspace-level `opencode.json` setup for local or self-managed providers.
- Removed or rewrote references to unavailable or outdated behavior such as `Custom LLMs` being "coming soon".

Why this merits a docs update:
- Without these changes, the docs would still direct users to an older Cloud workflow that predates org-managed model libraries, API key management, and the new API reference surface, even though the current product now expects those flows.

Validation:
- `git diff --check`
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("packages/docs/docs.json","utf8")); console.log("docs.json OK")'`