### PR TITLE
feat(den): refine LLM provider selection UX

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/combobox.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/combobox.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { Check, ChevronDown } from "lucide-react";
+import { useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type FocusEvent, type KeyboardEvent } from "react";
+import {
+  denDropdownChevronSlotClass,
+  denDropdownFieldBaseClass,
+  denDropdownFieldOpenClass,
+  denDropdownListClass,
+  denDropdownMenuBaseClass,
+  denDropdownRowActiveClass,
+  denDropdownRowBaseClass,
+  denDropdownRowIdleClass,
+  denDropdownRowSelectedClass,
+} from "./dropdown-styles";
+
+export type DenComboboxOption = {
+  value: string;
+  label: string;
+  description?: string;
+  meta?: string;
+  keywords?: string[];
+};
+
+export type DenComboboxProps = {
+  value: string;
+  options: DenComboboxOption[];
+  onChange: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyLabel?: string;
+  disabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+};
+
+function normalizeQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function getOptionSearchText(option: DenComboboxOption) {
+  return [option.label, option.value, option.description ?? "", ...(option.keywords ?? [])]
+    .join(" ")
+    .toLowerCase();
+}
+
+export function DenCombobox({
+  value,
+  options,
+  onChange,
+  placeholder = "Select an option...",
+  searchPlaceholder = "Search...",
+  emptyLabel = "No options match",
+  disabled = false,
+  className,
+  ariaLabel = "Select option",
+}: DenComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [hasTypedSinceOpen, setHasTypedSinceOpen] = useState(false);
+  const [activeValue, setActiveValue] = useState<string | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const listboxId = useId();
+
+  const selectedOption = useMemo(() => options.find((option) => option.value === value) ?? null, [options, value]);
+  const selectedLabel = selectedOption?.label ?? "";
+  const normalizedQuery = hasTypedSinceOpen ? normalizeQuery(query) : "";
+  const filteredOptions = useMemo(() => {
+    if (!normalizedQuery) {
+      return options;
+    }
+
+    return options.filter((option) => getOptionSearchText(option).includes(normalizedQuery));
+  }, [normalizedQuery, options]);
+
+  const activeIndex = activeValue ? filteredOptions.findIndex((option) => option.value === activeValue) : -1;
+  const activeDescendant = activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined;
+  const inputValue = open ? (hasTypedSinceOpen ? query : selectedLabel) : selectedLabel;
+
+  function focusInput(selectText = false) {
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      if (selectText) {
+        inputRef.current?.select();
+      }
+    });
+  }
+
+  function openCombobox({ selectText = false }: { selectText?: boolean } = {}) {
+    if (disabled) {
+      return;
+    }
+
+    setOpen(true);
+    setHasTypedSinceOpen(false);
+    setQuery(selectedLabel);
+    if (selectText) {
+      focusInput(true);
+    }
+  }
+
+  function closeCombobox({ focus = false }: { focus?: boolean } = {}) {
+    setOpen(false);
+    setActiveValue(null);
+    setHasTypedSinceOpen(false);
+    setQuery(selectedLabel);
+    if (focus) {
+      focusInput();
+    }
+  }
+
+  function selectOption(nextValue: string) {
+    const nextOption = options.find((option) => option.value === nextValue) ?? null;
+    onChange(nextValue);
+    setOpen(false);
+    setActiveValue(null);
+    setHasTypedSinceOpen(false);
+    setQuery(nextOption?.label ?? "");
+    focusInput();
+  }
+
+  function moveActive(step: 1 | -1) {
+    if (!filteredOptions.length) {
+      return;
+    }
+
+    if (!activeValue) {
+      setActiveValue(step === 1 ? filteredOptions[0]?.value ?? null : filteredOptions[filteredOptions.length - 1]?.value ?? null);
+      return;
+    }
+
+    const currentIndex = filteredOptions.findIndex((option) => option.value === activeValue);
+    const nextIndex = currentIndex < 0
+      ? 0
+      : (currentIndex + step + filteredOptions.length) % filteredOptions.length;
+    setActiveValue(filteredOptions[nextIndex]?.value ?? null);
+  }
+
+  function handleInputFocus(event: FocusEvent<HTMLInputElement>) {
+    if (disabled) {
+      return;
+    }
+
+    openCombobox();
+
+    if (!open && selectedLabel) {
+      const input = event.currentTarget;
+      requestAnimationFrame(() => input.select());
+    }
+  }
+
+  function handleInputChange(event: ChangeEvent<HTMLInputElement>) {
+    if (!open) {
+      setOpen(true);
+    }
+    setHasTypedSinceOpen(true);
+    setQuery(event.target.value);
+  }
+
+  function handleInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (disabled) {
+      return;
+    }
+
+    if (!open && event.key.length === 1 && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      event.preventDefault();
+      openCombobox();
+      setHasTypedSinceOpen(true);
+      setQuery(event.key);
+      setActiveValue(null);
+      return;
+    }
+
+    if (!open && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+      event.preventDefault();
+      openCombobox();
+      setActiveValue(
+        event.key === "ArrowUp"
+          ? options[options.length - 1]?.value ?? null
+          : selectedOption?.value ?? options[0]?.value ?? null,
+      );
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveActive(1);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveActive(-1);
+      return;
+    }
+
+    if (event.key === "Home") {
+      if (open) {
+        event.preventDefault();
+        setActiveValue(filteredOptions[0]?.value ?? null);
+      }
+      return;
+    }
+
+    if (event.key === "End") {
+      if (open) {
+        event.preventDefault();
+        setActiveValue(filteredOptions[filteredOptions.length - 1]?.value ?? null);
+      }
+      return;
+    }
+
+    if (event.key === "Enter") {
+      if (open && activeValue) {
+        event.preventDefault();
+        selectOption(activeValue);
+      }
+      return;
+    }
+
+    if (event.key === "Escape") {
+      if (open) {
+        event.preventDefault();
+        closeCombobox({ focus: true });
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (open) {
+      return;
+    }
+
+    setQuery(selectedLabel);
+    setHasTypedSinceOpen(false);
+  }, [open, selectedLabel]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      closeCombobox();
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [open, selectedLabel]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    setActiveValue((current) => {
+      if (current && filteredOptions.some((option) => option.value === current)) {
+        return current;
+      }
+      if (selectedOption && filteredOptions.some((option) => option.value === selectedOption.value)) {
+        return selectedOption.value;
+      }
+      return filteredOptions[0]?.value ?? null;
+    });
+  }, [filteredOptions, open, selectedOption]);
+
+  useEffect(() => {
+    if (!open || !activeValue) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      optionRefs.current[activeValue]?.scrollIntoView({ block: "nearest" });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [activeValue, open]);
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative"
+      onBlurCapture={() => {
+        if (!open) {
+          return;
+        }
+
+        requestAnimationFrame(() => {
+          const activeElement = document.activeElement;
+          if (rootRef.current && activeElement instanceof Node && !rootRef.current.contains(activeElement)) {
+            closeCombobox();
+          }
+        });
+      }}
+    >
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="search"
+          value={inputValue}
+          disabled={disabled}
+          readOnly={!open}
+          name={`${listboxId}-search`}
+          autoComplete="new-password"
+          autoCorrect="off"
+          autoCapitalize="none"
+          spellCheck={false}
+          data-form-type="other"
+          data-lpignore="true"
+          data-1p-ignore="true"
+          placeholder={open ? searchPlaceholder : placeholder}
+          aria-label={ariaLabel}
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-activedescendant={activeDescendant}
+          onFocus={handleInputFocus}
+          onChange={handleInputChange}
+          onClick={() => {
+            if (!open) {
+              openCombobox({ selectText: true });
+            }
+          }}
+          onKeyDown={handleInputKeyDown}
+          className={[
+            denDropdownFieldBaseClass,
+            "rounded-lg placeholder:text-gray-400",
+            open ? denDropdownFieldOpenClass : "",
+            disabled ? "cursor-not-allowed opacity-60" : "cursor-text",
+            className ?? "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        />
+        <span className={denDropdownChevronSlotClass}>
+          <ChevronDown size={16} className={disabled ? "text-gray-300" : "text-gray-400"} aria-hidden="true" />
+        </span>
+      </div>
+
+      {open ? (
+        <div className={denDropdownMenuBaseClass}>
+          <div id={listboxId} role="listbox" className={denDropdownListClass}>
+            {filteredOptions.length ? (
+              filteredOptions.map((option, index) => {
+                const selected = option.value === value;
+                const active = option.value === activeValue;
+
+                return (
+                  <button
+                    key={option.value}
+                    ref={(node) => {
+                      optionRefs.current[option.value] = node;
+                    }}
+                    id={`${listboxId}-option-${index}`}
+                    type="button"
+                    role="option"
+                    tabIndex={-1}
+                    aria-selected={selected}
+                    onMouseEnter={() => setActiveValue(option.value)}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      selectOption(option.value);
+                    }}
+                    className={[
+                      denDropdownRowBaseClass,
+                      "items-start",
+                      selected ? denDropdownRowSelectedClass : active ? denDropdownRowActiveClass : denDropdownRowIdleClass,
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[14px] font-medium text-gray-900">{option.label}</p>
+                      {option.description ? (
+                        <p className="mt-1 truncate text-[12px] text-gray-500">{option.description}</p>
+                      ) : null}
+                    </div>
+
+                    <div className="flex shrink-0 items-center gap-3 pl-2">
+                      {option.meta ? <span className="text-[12px] text-gray-400">{option.meta}</span> : null}
+                      {selected ? <Check className="h-4 w-4 text-gray-900" aria-hidden="true" /> : null}
+                    </div>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="px-3 py-4 text-[13px] text-gray-500">
+                {query ? `${emptyLabel} "${query}"` : emptyLabel}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/dropdown-styles.ts
+++ b/ee/apps/den-web/app/(den)/_components/ui/dropdown-styles.ts
@@ -1,0 +1,24 @@
+export const denDropdownFieldBaseClass = [
+  "w-full border border-gray-200 bg-white",
+  "h-[42px] px-4 pr-10 text-[14px] leading-5 text-gray-900",
+  "outline-none transition-all focus:border-gray-300 focus:ring-2 focus:ring-gray-900/5",
+].join(" ");
+
+export const denDropdownFieldOpenClass = "border-gray-300 ring-2 ring-gray-900/5";
+
+export const denDropdownChevronSlotClass = "pointer-events-none absolute inset-y-0 right-3 flex items-center";
+
+export const denDropdownMenuBaseClass = [
+  "absolute left-0 top-[calc(100%+0.375rem)] z-30 w-full overflow-hidden rounded-lg",
+  "border border-gray-200 bg-white shadow-[0_20px_44px_-28px_rgba(15,23,42,0.22)]",
+].join(" ");
+
+export const denDropdownListClass = "max-h-72 overflow-y-auto p-1.5";
+
+export const denDropdownRowBaseClass = "flex w-full justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition";
+
+export const denDropdownRowIdleClass = "bg-white hover:bg-gray-50";
+
+export const denDropdownRowActiveClass = "bg-gray-50";
+
+export const denDropdownRowSelectedClass = "bg-gray-50/80";

--- a/ee/apps/den-web/app/(den)/_components/ui/select.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/select.tsx
@@ -1,57 +1,383 @@
 "use client";
 
-import { ChevronDown } from "lucide-react";
-import type { SelectHTMLAttributes } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  Children,
+  isValidElement,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FocusEvent,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+  type SelectHTMLAttributes,
+} from "react";
+import {
+  denDropdownChevronSlotClass,
+  denDropdownFieldBaseClass,
+  denDropdownFieldOpenClass,
+  denDropdownListClass,
+  denDropdownMenuBaseClass,
+  denDropdownRowActiveClass,
+  denDropdownRowBaseClass,
+  denDropdownRowIdleClass,
+  denDropdownRowSelectedClass,
+} from "./dropdown-styles";
+
+type DenSelectOption = {
+  value: string;
+  disabled: boolean;
+  content: ReactNode;
+};
 
 export type DenSelectProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, "disabled"> & {
-  /**
-   * Disables the select and dims it to 60 % opacity.
-   * Forwarded as the native `disabled` attribute.
-   */
   disabled?: boolean;
 };
 
-/**
- * DenSelect
- *
- * Consistent native select for all dashboard pages, matched to the
- * Shared Workspaces compact field sizing used by DenInput.
- *
- * Defaults: rounded-lg · h-[42px] · px-4/pr-10 · text-[14px]/leading-5
- * Chevron: custom Lucide chevron replaces browser-native control chrome.
- * No className needed at the call site - override only when necessary.
- */
+function getOptionText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(getOptionText).join("");
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return getOptionText(node.props.children);
+  }
+
+  return "";
+}
+
+function createSelectEvent(value: string, name?: string) {
+  return {
+    target: { value, name: name ?? "" },
+    currentTarget: { value, name: name ?? "" },
+  } as ChangeEvent<HTMLSelectElement>;
+}
+
+function createBlurEvent(value: string, name?: string) {
+  return {
+    target: { value, name: name ?? "" },
+    currentTarget: { value, name: name ?? "" },
+  } as FocusEvent<HTMLSelectElement>;
+}
+
+function getFirstEnabledOption(options: DenSelectOption[]) {
+  return options.find((option) => !option.disabled) ?? null;
+}
+
 export function DenSelect({
+  value,
+  defaultValue,
+  name,
+  id,
   disabled = false,
   className,
   children,
-  ...rest
+  onChange,
+  onBlur,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
 }: DenSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [activeValue, setActiveValue] = useState<string | null>(null);
+  const [uncontrolledValue, setUncontrolledValue] = useState<string | null>(defaultValue !== undefined ? String(defaultValue) : null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const listboxId = useId();
+
+  const options = useMemo(() => {
+    return Children.toArray(children).flatMap((child) => {
+      if (!isValidElement(child) || child.type !== "option") {
+        return [];
+      }
+
+      const option = child as ReactElement<{
+        value?: string | number;
+        disabled?: boolean;
+        children?: ReactNode;
+      }>;
+
+      return [
+        {
+          value: option.props.value !== undefined ? String(option.props.value) : getOptionText(option.props.children),
+          disabled: option.props.disabled === true,
+          content: option.props.children,
+        } satisfies DenSelectOption,
+      ];
+    });
+  }, [children]);
+
+  useEffect(() => {
+    if (value === undefined && uncontrolledValue === null && options.length) {
+      setUncontrolledValue(options[0]?.value ?? null);
+    }
+  }, [options, uncontrolledValue, value]);
+
+  const selectedValue = value !== undefined ? String(value) : uncontrolledValue ?? "";
+  const selectedOption = options.find((option) => option.value === selectedValue) ?? options[0] ?? null;
+
+  function focusTrigger() {
+    requestAnimationFrame(() => triggerRef.current?.focus());
+  }
+
+  function openSelect(preferredValue?: string | null) {
+    if (disabled) {
+      return;
+    }
+
+    setOpen(true);
+    const nextActive = options.find((option) => option.value === preferredValue && !option.disabled) ?? getFirstEnabledOption(options);
+    setActiveValue(nextActive?.value ?? null);
+  }
+
+  function closeSelect({ focus = false }: { focus?: boolean } = {}) {
+    setOpen(false);
+    setActiveValue(null);
+    if (focus) {
+      focusTrigger();
+    }
+  }
+
+  function commitValue(nextValue: string) {
+    const nextOption = options.find((option) => option.value === nextValue);
+    if (!nextOption || nextOption.disabled) {
+      return;
+    }
+
+    if (value === undefined) {
+      setUncontrolledValue(nextValue);
+    }
+
+    onChange?.(createSelectEvent(nextValue, name));
+    closeSelect({ focus: true });
+  }
+
+  function moveActive(step: 1 | -1) {
+    const enabledOptions = options.filter((option) => !option.disabled);
+    if (!enabledOptions.length) {
+      return;
+    }
+
+    if (!activeValue) {
+      setActiveValue(step === 1 ? enabledOptions[0]?.value ?? null : enabledOptions[enabledOptions.length - 1]?.value ?? null);
+      return;
+    }
+
+    const currentIndex = enabledOptions.findIndex((option) => option.value === activeValue);
+    const nextIndex = currentIndex < 0
+      ? 0
+      : (currentIndex + step + enabledOptions.length) % enabledOptions.length;
+    setActiveValue(enabledOptions[nextIndex]?.value ?? null);
+  }
+
+  function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (disabled) {
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      if (!open) {
+        openSelect(selectedOption?.value ?? null);
+        return;
+      }
+      moveActive(1);
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      if (!open) {
+        openSelect(selectedOption?.value ?? options[options.length - 1]?.value ?? null);
+        return;
+      }
+      moveActive(-1);
+      return;
+    }
+
+    if (event.key === "Home" && open) {
+      event.preventDefault();
+      setActiveValue(getFirstEnabledOption(options)?.value ?? null);
+      return;
+    }
+
+    if (event.key === "End" && open) {
+      event.preventDefault();
+      const enabledOptions = options.filter((option) => !option.disabled);
+      setActiveValue(enabledOptions[enabledOptions.length - 1]?.value ?? null);
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      if (!open) {
+        openSelect(selectedOption?.value ?? null);
+        return;
+      }
+
+      if (activeValue) {
+        commitValue(activeValue);
+      }
+      return;
+    }
+
+    if (event.key === "Escape" && open) {
+      event.preventDefault();
+      closeSelect({ focus: true });
+    }
+  }
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      closeSelect();
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !activeValue) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      optionRefs.current[activeValue]?.scrollIntoView({ block: "nearest" });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [activeValue, open]);
+
+  const activeIndex = activeValue ? options.findIndex((option) => option.value === activeValue) : -1;
+  const activeDescendant = activeIndex >= 0 ? `${listboxId}-option-${activeIndex}` : undefined;
+
   return (
-    <div className="relative">
-      <select
-        {...rest}
+    <div
+      ref={rootRef}
+      className="relative"
+      onBlurCapture={() => {
+        requestAnimationFrame(() => {
+          const activeElement = document.activeElement;
+          if (rootRef.current && activeElement instanceof Node && !rootRef.current.contains(activeElement)) {
+            if (open) {
+              closeSelect();
+            }
+            onBlur?.(createBlurEvent(selectedValue, name));
+          }
+        });
+      }}
+    >
+      {name ? <input type="hidden" name={name} value={selectedValue} disabled={disabled} /> : null}
+
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
         disabled={disabled}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-activedescendant={activeDescendant}
+        onClick={() => {
+          if (open) {
+            closeSelect();
+            return;
+          }
+          openSelect(selectedOption?.value ?? null);
+        }}
+        onKeyDown={handleTriggerKeyDown}
         className={[
-          "w-full appearance-none rounded-lg border border-gray-200 bg-white",
-          "h-[42px] px-4 pr-10 text-[14px] leading-5 text-gray-900",
-          "outline-none transition-all",
-          "focus:border-gray-300 focus:ring-2 focus:ring-gray-900/5",
-          disabled ? "cursor-not-allowed opacity-60" : "",
+          denDropdownFieldBaseClass,
+          "flex items-center justify-between gap-3 rounded-lg text-left",
+          "focus-visible:border-gray-300 focus-visible:ring-2 focus-visible:ring-gray-900/5",
+          open ? denDropdownFieldOpenClass : "",
+          disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
           className ?? "",
         ]
           .filter(Boolean)
           .join(" ")}
       >
-        {children}
-      </select>
-      <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center">
-        <ChevronDown
-          size={16}
-          className={disabled ? "text-gray-300" : "text-gray-400"}
-          aria-hidden="true"
-        />
-      </div>
+        <span className="truncate">{selectedOption?.content ?? null}</span>
+        <span className={denDropdownChevronSlotClass}>
+          <ChevronDown size={16} className={disabled ? "text-gray-300" : "text-gray-400"} aria-hidden="true" />
+        </span>
+      </button>
+
+      {open ? (
+        <div className={denDropdownMenuBaseClass}>
+          <div id={listboxId} role="listbox" className={denDropdownListClass}>
+            {options.map((option, index) => {
+              const selected = option.value === selectedValue;
+              const active = option.value === activeValue;
+
+              return (
+                <button
+                  key={`${option.value}-${index}`}
+                  ref={(node) => {
+                    optionRefs.current[option.value] = node;
+                  }}
+                  id={`${listboxId}-option-${index}`}
+                  type="button"
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={selected}
+                  disabled={option.disabled}
+                  onMouseEnter={() => {
+                    if (!option.disabled) {
+                      setActiveValue(option.value);
+                    }
+                  }}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    if (!option.disabled) {
+                      commitValue(option.value);
+                    }
+                  }}
+                  className={[
+                    denDropdownRowBaseClass,
+                    "items-center",
+                    option.disabled
+                      ? "cursor-not-allowed opacity-50"
+                      : selected
+                        ? denDropdownRowSelectedClass
+                        : active
+                          ? denDropdownRowActiveClass
+                          : denDropdownRowIdleClass,
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                >
+                  <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-gray-900">
+                    {option.content}
+                  </span>
+                  {selected ? <Check className="h-4 w-4 shrink-0 text-gray-900" aria-hidden="true" /> : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/_components/ui/selectable-row.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/selectable-row.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Check } from "lucide-react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+export type DenSelectableRowProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "type"> & {
+  title: ReactNode;
+  description?: ReactNode;
+  selected?: boolean;
+  aside?: ReactNode;
+};
+
+export function DenSelectableRow({
+  title,
+  description,
+  selected = false,
+  disabled = false,
+  aside,
+  className,
+  ...rest
+}: DenSelectableRowProps) {
+  return (
+    <button
+      {...rest}
+      type="button"
+      disabled={disabled}
+      aria-pressed={selected}
+      className={[
+        "group relative flex w-full items-center gap-3 px-4 py-3 text-left outline-none transition-colors duration-150",
+        "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-gray-900/5",
+        selected
+          ? "bg-gray-100"
+          : "bg-white hover:bg-gray-50/60",
+        disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
+        className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-baseline gap-2">
+          <p className="truncate text-[15px] font-medium leading-[1.15] tracking-[-0.02em] text-gray-950">{title}</p>
+          {description ? <p className="truncate text-[12px] leading-[1.15] text-gray-500">{description}</p> : null}
+        </div>
+      </div>
+
+      {aside ? <div className="shrink-0">{aside}</div> : null}
+
+      {selected ? (
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-[5px] bg-emerald-700 text-white" aria-hidden="true">
+          <Check className="h-3 w-3" />
+        </span>
+      ) : (
+        <span className="h-5 w-5 shrink-0 rounded-[5px] border border-gray-300 bg-white transition-colors group-hover:border-gray-400" aria-hidden="true" />
+      )}
+    </button>
+  );
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-editor-screen.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { ArrowLeft, CheckCircle2, Circle, Cpu, Search } from "lucide-react";
 import { DenButton } from "../../../../_components/ui/button";
+import { DenCombobox } from "../../../../_components/ui/combobox";
 import { DenInput } from "../../../../_components/ui/input";
 import { UnderlineTabs } from "../../../../_components/ui/tabs";
 import { DenTextarea } from "../../../../_components/ui/textarea";
@@ -164,6 +165,17 @@ export function LlmProviderEditorScreen({ llmProviderId }: { llmProviderId?: str
     return models.filter((model) => model.name.toLowerCase().includes(normalizedQuery) || model.id.toLowerCase().includes(normalizedQuery));
   }, [catalogDetail?.models, modelQuery]);
 
+  const catalogProviderOptions = useMemo(
+    () =>
+      catalogProviders.map((catalogProvider) => ({
+        value: catalogProvider.id,
+        label: catalogProvider.name,
+        description: catalogProvider.id,
+        meta: `${catalogProvider.modelCount} ${catalogProvider.modelCount === 1 ? "model" : "models"}`,
+      })),
+    [catalogProviders],
+  );
+
   async function saveProvider() {
     if (!orgId) {
       setSaveError("Organization not found.");
@@ -320,21 +332,18 @@ export function LlmProviderEditorScreen({ llmProviderId }: { llmProviderId?: str
 
         {source === "models_dev" ? (
           <div className="mt-8 grid gap-6">
-            <label className="grid gap-3">
+            <div className="grid gap-3">
               <span className="text-[14px] font-medium text-gray-700">Provider</span>
-              <select
+              <DenCombobox
                 value={selectedProviderId}
-                onChange={(event) => setSelectedProviderId(event.target.value)}
-                className="h-12 rounded-2xl border border-gray-200 bg-white px-4 text-[14px] text-gray-900 outline-none transition focus:border-gray-400"
-              >
-                <option value="">Select a provider...</option>
-                {catalogProviders.map((catalogProvider) => (
-                  <option key={catalogProvider.id} value={catalogProvider.id}>
-                    {catalogProvider.name} ({catalogProvider.modelCount})
-                  </option>
-                ))}
-              </select>
-            </label>
+                options={catalogProviderOptions}
+                onChange={setSelectedProviderId}
+                ariaLabel="Provider"
+                placeholder="Select a provider..."
+                searchPlaceholder="Search providers..."
+                emptyLabel="No providers match"
+              />
+            </div>
 
             {catalogBusy ? <p className="text-[14px] text-gray-500">Loading provider catalog...</p> : null}
             {catalogError ? <p className="text-[14px] text-red-600">{catalogError}</p> : null}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-editor-screen.tsx
@@ -7,6 +7,7 @@ import { ArrowLeft, CheckCircle2, Circle, Cpu, Search } from "lucide-react";
 import { DenButton } from "../../../../_components/ui/button";
 import { DenCombobox } from "../../../../_components/ui/combobox";
 import { DenInput } from "../../../../_components/ui/input";
+import { DenSelectableRow } from "../../../../_components/ui/selectable-row";
 import { UnderlineTabs } from "../../../../_components/ui/tabs";
 import { DenTextarea } from "../../../../_components/ui/textarea";
 import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
@@ -417,7 +418,14 @@ export function LlmProviderEditorScreen({ llmProviderId }: { llmProviderId?: str
         <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
           <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div>
-              <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Models</h2>
+              <div className="flex flex-wrap items-center gap-3">
+                <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Models</h2>
+                {catalogDetail ? (
+                  <span className="rounded-full bg-gray-200 px-3 py-1 text-[12px] font-medium text-gray-700">
+                    {selectedModelIds.length} {selectedModelIds.length === 1 ? "model selected" : "models selected"}
+                  </span>
+                ) : null}
+              </div>
               <p className="mt-2 text-[15px] text-gray-500">Pick the exact models this provider should expose.</p>
             </div>
 
@@ -427,29 +435,39 @@ export function LlmProviderEditorScreen({ llmProviderId }: { llmProviderId?: str
               value={modelQuery}
               onChange={(event) => setModelQuery(event.target.value)}
               placeholder="Search models..."
+              className="lg:w-[360px]"
             />
           </div>
 
           {catalogDetail ? (
-            <div className="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
-              {filteredModels.map((model) => {
-                const selected = selectedModelIds.includes(model.id);
-                return (
-                  <button
-                    key={model.id}
-                    type="button"
-                    onClick={() => setSelectedModelIds((current) => current.includes(model.id) ? current.filter((entry) => entry !== model.id) : [...current, model.id])}
-                    className={`flex items-start gap-4 rounded-[24px] border px-5 py-5 text-left transition ${selected ? "border-[#0f172a] bg-[#f8fafc]" : "border-gray-200 bg-white hover:border-gray-300"}`}
-                  >
-                    {selected ? <CheckCircle2 className="mt-0.5 h-7 w-7 shrink-0 text-[#0f172a]" /> : <Circle className="mt-0.5 h-7 w-7 shrink-0 text-gray-300" />}
-                    <div className="min-w-0">
-                      <p className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">{model.name}</p>
-                      <p className="mt-2 text-[13px] text-gray-500">{model.id}</p>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
+            filteredModels.length ? (
+              <div>
+                <div className="overflow-hidden rounded-[16px] border border-gray-200 bg-white divide-y divide-gray-200">
+                  {filteredModels.map((model) => {
+                    const selected = selectedModelIds.includes(model.id);
+                    return (
+                      <DenSelectableRow
+                        key={model.id}
+                        selected={selected}
+                        title={model.name}
+                        description={model.id}
+                        onClick={() =>
+                          setSelectedModelIds((current) =>
+                            current.includes(model.id)
+                              ? current.filter((entry) => entry !== model.id)
+                              : [...current, model.id],
+                          )
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
+                No models match <span className="font-medium text-gray-700">&quot;{modelQuery}&quot;</span>.
+              </div>
+            )
           ) : (
             <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
               Select a provider to browse its models.


### PR DESCRIPTION
## Summary
- replace the provider picker with a searchable combobox and align Den dropdown styling across combobox/select controls
- rework model selection into a compact selectable list with inline model identifiers and clearer selected state treatment
- keep the Add Provider flow visually consistent while improving dense catalog browsing and selection

## Testing
- `cd ee/apps/den-web && pnpm exec tsc --noEmit`

## Evidence
<img width="954" height="395" alt="01-choose-provider-before" src="https://github.com/user-attachments/assets/dbe19a65-fd38-4d1e-9fe6-51b4ea2f9035" />
<img width="783" height="310" alt="01-choose-provider-after" src="https://github.com/user-attachments/assets/1cc3483d-8d2b-4227-9df1-6548ff7deaf8" />

<img width="938" height="786" alt="02-choose-provider-open-before" src="https://github.com/user-attachments/assets/a8894f95-27a6-4546-9681-5ef1c3f62a4c" />
<img width="764" height="539" alt="02-choose-provider-open-after" src="https://github.com/user-attachments/assets/b57278c8-5ed5-4633-b3c6-b7779b629d5a" />

<img width="975" height="597" alt="03-choose-models-before" src="https://github.com/user-attachments/assets/695cde4e-3aa3-45f3-a34e-012e8ef72dd9" />
<img width="1069" height="529" alt="03-choose-models-after" src="https://github.com/user-attachments/assets/22a9e36f-8bc8-48b8-b36c-c9457d70f24a" />

