### PR TITLE
fix: clear stale model ID from config and update DEFAULT_MODEL

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -7,9 +7,12 @@ export const VARIANT_PREF_KEY = "openwork.modelVariant";
 export const LANGUAGE_PREF_KEY = "openwork.language";
 export const HIDE_TITLEBAR_PREF_KEY = "openwork.hideTitlebar";
 
+// UI placeholder shown before providers load. Must reference a real, stable model.
+// If this model is not available for the user, the stale-model reconciliation in
+// model-config.ts will clear it and let the user pick from their connected providers.
 export const DEFAULT_MODEL: ModelRef = {
-  providerID: "opencode",
-  modelID: "big-pickle",
+  providerID: "anthropic",
+  modelID: "claude-sonnet-4-5",
 };
 
 export const SUGGESTED_PLUGINS: SuggestedPlugin[] = [

--- a/apps/app/src/app/context/model-config.ts
+++ b/apps/app/src/app/context/model-config.ts
@@ -541,6 +541,14 @@ export function createModelConfigStore(options: {
     return provider?.models?.[ref.modelID] ?? null;
   };
 
+  // Returns true if the model exists in the loaded provider list.
+  // Returns true when providers are not yet loaded (defer validation until they arrive).
+  const isModelRefValid = (ref: ModelRef) => {
+    const providers = options.providers();
+    if (!providers.length) return true;
+    return findProviderModel(ref) != null;
+  };
+
   const sanitizeModelVariantForRef = (ref: ModelRef, value: string | null) => {
     const modelInfo = findProviderModel(ref);
     if (!modelInfo) return normalizeModelBehaviorValue(value);
@@ -986,6 +994,12 @@ export function createModelConfigStore(options: {
         setPendingDefaultModelForWorkspace(workspaceId, null);
       }
 
+      // If providers are already loaded, validate that the configured model still exists.
+      // This handles workspaces whose opencode.jsonc references a removed model ID.
+      if (configDefault && !isModelRefValid(configDefault)) {
+        configDefault = null;
+      }
+
       setDefaultModelExplicit(Boolean(configDefault));
       const nextDefault = configDefault ?? legacyDefaultModel();
       const currentDefault = defaultModel();
@@ -1011,6 +1025,27 @@ export function createModelConfigStore(options: {
     onCleanup(() => {
       cancelled = true;
     });
+  });
+
+  // Race-condition fix: providers may load after the workspace default has been applied.
+  // Once providers arrive, re-validate the current default model. If it no longer exists
+  // (e.g. a removed alias like "opencode/big-pickle"), clear the explicit override so the
+  // user is prompted to pick a valid model from their connected providers.
+  createEffect(() => {
+    const allProviders = options.providers();
+    if (!allProviders.length) return;
+    if (!workspaceDefaultModelReady()) return;
+    if (!defaultModelExplicit()) return;
+
+    const current = defaultModel();
+    if (findProviderModel(current) != null) return; // model is valid
+
+    // Model no longer exists in any loaded provider — reset to the constant default.
+    // The user will see the model picker pre-selected to DEFAULT_MODEL and can pick
+    // something available from their connected providers.
+    setDefaultModelExplicit(false);
+    setDefaultModel(DEFAULT_MODEL);
+    setLegacyDefaultModel(DEFAULT_MODEL);
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary

Workspace configs (`opencode.jsonc`) written when `opencode/big-pickle` was a valid model now cause silent chat failures because that model no longer exists in any provider.

## Root cause

`DEFAULT_MODEL` in `constants.ts` still references `opencode/big-pickle`. When a workspace is first loaded with no model explicitly chosen, `applyDefault()` reads `"opencode/big-pickle"` from `opencode.jsonc` and sets it as `defaultModel()`. OpenCode then rejects every session with an unknown model error.

## Changes

### `constants.ts`
- Replace removed `opencode/big-pickle` with `anthropic/claude-sonnet-4-5` as the stable fallback placeholder.

### `model-config.ts` — two-part stale-model reconciliation

**In `applyDefault()`** (providers already loaded when workspace config is read):
- Validate `configDefault` against the live provider list before applying it.
- If the model is not found, treat `configDefault` as `null` — the workspace has no valid configured model.

**New `createEffect`** (race condition: providers load *after* `applyDefault()` has already run):
- Once providers arrive, re-validate `defaultModel()`.
- If it no longer exists in any provider (e.g. a removed alias), clear the explicit override and reset to `DEFAULT_MODEL` so the user can select a valid model from their connected providers.

## Behavior after fix

| Scenario | Before | After |
|---|---|---|
| New workspace, no model set | Defaults to `opencode/big-pickle` → chat fails | Defaults to `anthropic/claude-sonnet-4-5` |
| Existing workspace with stale `opencode/big-pickle` in config | Chat fails silently | Stale model is cleared; user selects from connected providers |
| Workspace with valid model in config | Works | Works (unchanged) |

Closes #1237