### PR TITLE
fix(den): streamline LLM provider and skill hub management

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/button.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/button.tsx
@@ -8,18 +8,17 @@ export type ButtonVariant = "primary" | "secondary" | "destructive";
 export type ButtonSize = "md" | "sm";
 
 const variantClasses: Record<ButtonVariant, string> = {
-  primary:
-    "bg-[#0f172a] text-white hover:bg-[#111c33]",
-  secondary:
-    "border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900",
-  destructive:
-    "border border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300",
+    primary: "bg-[#0f172a] text-white hover:bg-[#111c33]",
+    secondary:
+        "border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-900",
+    destructive:
+        "border border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300",
 };
 
 // md is sized to match the Shared Workspaces reference buttons (px-5 py-2.5 ≈ h-10)
 const sizeClasses: Record<ButtonSize, string> = {
-  md: "h-10 px-5 text-[13px] gap-2",
-  sm: "h-8 px-3.5 text-[12px] gap-1.5",
+    md: "h-10 px-5 text-[13px] gap-2",
+    sm: "h-8 px-3.5 text-[12px] gap-1.5",
 };
 
 // ─── buttonVariants helper (for <Link> / <a> elements) ───────────────────────
@@ -29,123 +28,134 @@ const sizeClasses: Record<ButtonSize, string> = {
  * Use this on <Link> and <a> elements that should look like buttons.
  */
 export function buttonVariants({
-  variant = "primary",
-  size = "md",
-  className = "",
+    variant = "primary",
+    size = "md",
+    className = "",
 }: {
-  variant?: ButtonVariant;
-  size?: ButtonSize;
-  className?: string;
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    className?: string;
 } = {}): string {
-  return [
-    "inline-flex items-center justify-center rounded-full font-medium transition-colors",
-    variantClasses[variant],
-    sizeClasses[size],
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
+    return [
+        "inline-flex items-center justify-center rounded-full font-medium transition-colors",
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+    ]
+        .filter(Boolean)
+        .join(" ");
 }
 
 // ─── Spinner ──────────────────────────────────────────────────────────────────
 
 function Spinner({ px }: { px: number }) {
-  return (
-    <svg
-      aria-hidden="true"
-      className="animate-spin"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      width={px}
-      height={px}
-    >
-      <circle
-        className="opacity-25"
-        cx="12"
-        cy="12"
-        r="10"
-        stroke="currentColor"
-        strokeWidth="4"
-      />
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-      />
-    </svg>
-  );
+    return (
+        <svg
+            aria-hidden="true"
+            className="animate-spin"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            width={px}
+            height={px}
+        >
+            <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+            />
+            <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+        </svg>
+    );
 }
 
 // ─── DenButton ────────────────────────────────────────────────────────────────
 
 export type DenButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: ButtonVariant;
-  size?: ButtonSize;
-  /**
-   * Lucide icon component rendered on the left.
-   * In loading state the icon is replaced by a spinner.
-   */
-  icon?: ElementType<{ size?: number; className?: string; strokeWidth?: number }>;
-  /**
-   * Shows a spinner and forces the button into a disabled state.
-   * - With icon: spinner replaces the icon; text stays visible.
-   * - Without icon: text becomes invisible (preserving button width) and a
-   *   spinner appears centered over it.
-   */
-  loading?: boolean;
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    /**
+     * Lucide icon component rendered on the left.
+     * In loading state the icon is replaced by a spinner.
+     */
+    icon?: ElementType<{
+        size?: number;
+        className?: string;
+        strokeWidth?: number;
+    }>;
+    /**
+     * Shows a spinner and forces the button into a disabled state.
+     * - With icon: spinner replaces the icon; text stays visible.
+     * - Without icon: text becomes invisible (preserving button width) and a
+     *   spinner appears centered over it.
+     */
+    loading?: boolean;
 };
 
 export function DenButton({
-  variant = "primary",
-  size = "md",
-  icon: Icon,
-  loading = false,
-  disabled = false,
-  children,
-  className,
-  ...rest
+    variant = "primary",
+    size = "md",
+    icon: Icon,
+    loading = false,
+    disabled = false,
+    children,
+    className,
+    ...rest
 }: DenButtonProps) {
-  const isDisabled = disabled || loading;
-  const iconPx = size === "sm" ? 13 : 15;
-  const hasText = children !== null && children !== undefined;
-  // No-icon loading: hide text but keep its width, overlay centered spinner
-  const noIconLoading = loading && !Icon;
+    const isDisabled = disabled || loading;
+    const iconPx = size === "sm" ? 13 : 15;
+    const hasText = children !== null && children !== undefined;
+    // No-icon loading: hide text but keep its width, overlay centered spinner
+    const noIconLoading = loading && !Icon;
 
-  return (
-    <button
-      {...rest}
-      type={rest.type ?? "button"}
-      disabled={isDisabled}
-      className={[
-        "relative inline-flex items-center justify-center rounded-full font-medium transition-colors",
-        variantClasses[variant],
-        sizeClasses[size],
-        isDisabled ? "cursor-not-allowed opacity-70" : "",
-        className ?? "",
-      ]
-        .filter(Boolean)
-        .join(" ")}
-    >
-      {/* Leading icon slot ─ shows icon normally, or spinner when loading */}
-      {Icon && !loading && (
-        <Icon size={iconPx} strokeWidth={1.75} aria-hidden="true" />
-      )}
-      {Icon && loading && <Spinner px={iconPx} />}
+    return (
+        <button
+            {...rest}
+            type={rest.type ?? "button"}
+            disabled={isDisabled}
+            className={[
+                "relative flex flex-row gap-2 items-center justify-center rounded-full font-medium transition-colors",
+                variantClasses[variant],
+                sizeClasses[size],
+                isDisabled ? "cursor-not-allowed opacity-70" : "",
+                className ?? "",
+            ]
+                .filter(Boolean)
+                .join(" ")}
+        >
+            {/* Leading icon slot ─ shows icon normally, or spinner when loading */}
+            {Icon && !loading && (
+                <Icon size={iconPx} strokeWidth={1.75} aria-hidden="true" />
+            )}
+            {Icon && loading && <Spinner px={iconPx} />}
 
-      {/* Text — invisible (not removed) when in no-icon loading state */}
-      {hasText && (
-        <span className={noIconLoading ? "invisible" : undefined}>
-          {children}
-        </span>
-      )}
+            {/* Text — invisible (not removed) when in no-icon loading state */}
+            {hasText && (
+                <div
+                    className={[
+                        noIconLoading ? "invisible" : undefined,
+                        "flex flex-row gap-2 items-center",
+                    ]
+                        .filter(Boolean)
+                        .join(" ")}
+                >
+                    {children}
+                </div>
+            )}
 
-      {/* Centered overlay spinner when there is no icon */}
-      {noIconLoading && (
-        <span className="absolute inset-0 flex items-center justify-center">
-          <Spinner px={iconPx} />
-        </span>
-      )}
-    </button>
-  );
+            {/* Centered overlay spinner when there is no icon */}
+            {noIconLoading && (
+                <span className="absolute inset-0 flex items-center justify-center">
+                    <Spinner px={iconPx} />
+                </span>
+            )}
+        </button>
+    );
 }

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/api-keys-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/api-keys-screen.tsx
@@ -363,10 +363,6 @@ export function ApiKeysScreen() {
                                     <p className="text-[16px] font-semibold tracking-[-0.03em] text-gray-900">
                                         Create a new API key
                                     </p>
-                                    <p className="mt-1 text-[14px] leading-6 text-gray-500">
-                                        Create a new API key for this
-                                        organization.
-                                    </p>
                                 </div>
                                 <DenButton onClick={openCreateForm}>
                                     New key

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-detail-screen.tsx
@@ -7,285 +7,384 @@ import { ArrowLeft, ExternalLink, KeyRound, Trash2, Users } from "lucide-react";
 import { DenButton } from "../../../../_components/ui/button";
 import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
 import {
-  getEditLlmProviderRoute,
-  getLlmProvidersRoute,
+    getEditLlmProviderRoute,
+    getLlmProvidersRoute,
 } from "../../../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
-  formatProviderTimestamp,
-  getProviderApiBase,
-  getProviderDocUrl,
-  getProviderEnvNames,
-  getProviderNpmPackage,
-  useOrgLlmProviders,
+    formatProviderTimestamp,
+    getProviderApiBase,
+    getProviderDocUrl,
+    getProviderEnvNames,
+    getProviderNpmPackage,
+    useOrgLlmProviders,
 } from "./llm-provider-data";
 
 function formatCountLabel(count: number, singular: string, plural: string) {
-  return `${count} ${count === 1 ? singular : plural}`;
+    return `${count} ${count === 1 ? singular : plural}`;
 }
 
 function getLimitLabel(config: Record<string, unknown>) {
-  const limit = typeof config.limit === "object" && config.limit !== null ? config.limit as Record<string, unknown> : null;
-  const context = typeof limit?.context === "number" ? limit.context : null;
-  return context ? `${context.toLocaleString()} ctx` : null;
+    const limit =
+        typeof config.limit === "object" && config.limit !== null
+            ? (config.limit as Record<string, unknown>)
+            : null;
+    const context = typeof limit?.context === "number" ? limit.context : null;
+    return context ? `${context.toLocaleString()} ctx` : null;
 }
 
-export function LlmProviderDetailScreen({ llmProviderId }: { llmProviderId: string }) {
-  const router = useRouter();
-  const { orgId, orgSlug } = useOrgDashboard();
-  const { llmProviders, busy, error, reloadProviders } = useOrgLlmProviders(orgId);
-  const [deleteBusy, setDeleteBusy] = useState(false);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
+export function LlmProviderDetailScreen({
+    llmProviderId,
+}: {
+    llmProviderId: string;
+}) {
+    const router = useRouter();
+    const { orgId, orgSlug } = useOrgDashboard();
+    const { llmProviders, busy, error, reloadProviders } =
+        useOrgLlmProviders(orgId);
+    const [deleteBusy, setDeleteBusy] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  const provider = useMemo(
-    () => llmProviders.find((entry) => entry.id === llmProviderId) ?? null,
-    [llmProviderId, llmProviders],
-  );
-
-  async function deleteProvider() {
-    if (!orgId || !provider) {
-      return;
-    }
-
-    if (!window.confirm(`Delete ${provider.name}? This will remove its saved model list and access rules.`)) {
-      return;
-    }
-
-    setDeleteBusy(true);
-    setDeleteError(null);
-    try {
-      const { response, payload } = await requestJson(
-        `/v1/orgs/${encodeURIComponent(orgId)}/llm-providers/${encodeURIComponent(provider.id)}`,
-        { method: "DELETE" },
-        12000,
-      );
-
-      if (response.status !== 204 && !response.ok) {
-        throw new Error(getErrorMessage(payload, `Failed to delete provider (${response.status}).`));
-      }
-
-      await reloadProviders();
-      router.push(getLlmProvidersRoute(orgSlug));
-      router.refresh();
-    } catch (nextError) {
-      setDeleteError(nextError instanceof Error ? nextError.message : "Could not delete the provider.");
-    } finally {
-      setDeleteBusy(false);
-    }
-  }
-
-  if (busy && !provider) {
-    return (
-      <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-        <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
-          Loading provider details...
-        </div>
-      </div>
+    const provider = useMemo(
+        () => llmProviders.find((entry) => entry.id === llmProviderId) ?? null,
+        [llmProviderId, llmProviders],
     );
-  }
 
-  if (!provider) {
-    return (
-      <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-        <div className="rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[15px] text-red-700">
-          {error ?? "That provider could not be found."}
-        </div>
-      </div>
-    );
-  }
+    async function deleteProvider() {
+        if (!orgId || !provider) {
+            return;
+        }
 
-  const envNames = getProviderEnvNames(provider.providerConfig);
-  const npmPackage = getProviderNpmPackage(provider.providerConfig);
-  const apiBase = getProviderApiBase(provider.providerConfig);
-  const docUrl = getProviderDocUrl(provider.providerConfig);
+        if (
+            !window.confirm(
+                `Delete ${provider.name}? This will remove its saved model list and access rules.`,
+            )
+        ) {
+            return;
+        }
 
-  return (
-    <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-      <div className="mb-8 flex flex-col gap-3">
-        <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">LLM provider</p>
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div>
-            <h1 className="text-[34px] font-semibold tracking-[-0.07em] text-gray-950">{provider.name}</h1>
-            <p className="mt-3 max-w-[720px] text-[16px] leading-8 text-gray-500">
-              Control which models this provider exposes, keep the credential in one place, and share access with the right people or teams.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-3 text-[13px] font-medium text-gray-600">
-            <span className="rounded-full border border-gray-200 bg-white px-4 py-2">{provider.source === "custom" ? "Custom" : "Catalog"}</span>
-            <span className="rounded-full border border-gray-200 bg-white px-4 py-2">{formatCountLabel(provider.models.length, "model", "models")}</span>
-            <span className="rounded-full border border-gray-200 bg-white px-4 py-2">{provider.hasApiKey ? "Credential saved" : "Credential missing"}</span>
-          </div>
-        </div>
-      </div>
-
-      <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
-        <Link
-          href={getLlmProvidersRoute(orgSlug)}
-          className="inline-flex items-center gap-2 text-[15px] font-medium text-gray-500 transition hover:text-gray-900"
-        >
-          <ArrowLeft className="h-5 w-5" />
-          Back to providers
-        </Link>
-
-        <div className="flex flex-wrap gap-3">
-          {provider.canManage ? (
-            <>
-              <Link href={getEditLlmProviderRoute(orgSlug, provider.id)}>
-                <DenButton variant="secondary">Edit Provider</DenButton>
-              </Link>
-              <DenButton variant="destructive" loading={deleteBusy} onClick={() => void deleteProvider()}>
-                <Trash2 className="h-4 w-4" />
-                Delete
-              </DenButton>
-            </>
-          ) : null}
-        </div>
-      </div>
-
-      {deleteError ? (
-        <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
-          {deleteError}
-        </div>
-      ) : null}
-
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Provider configuration</h2>
-            <p className="mt-2 text-[15px] text-gray-500">The core provider metadata and credential state stored for this workspace.</p>
-          </div>
-
-          <div className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-[13px] font-medium ${provider.hasApiKey ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>
-            <KeyRound className="h-4 w-4" />
-            {provider.hasApiKey ? "Credential saved" : "Credential missing"}
-          </div>
-        </div>
-
-        <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-[24px] bg-gray-50 p-5">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">Provider id</p>
-            <p className="mt-3 text-[16px] font-medium text-gray-900">{provider.providerId}</p>
-          </div>
-          <div className="rounded-[24px] bg-gray-50 p-5">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">NPM package</p>
-            <p className="mt-3 text-[16px] font-medium text-gray-900">{npmPackage ?? "Not set"}</p>
-          </div>
-          <div className="rounded-[24px] bg-gray-50 p-5">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">API base</p>
-            <p className="mt-3 break-all text-[16px] font-medium text-gray-900">{apiBase ?? "Not set"}</p>
-          </div>
-          <div className="rounded-[24px] bg-gray-50 p-5">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">Updated</p>
-            <p className="mt-3 text-[16px] font-medium text-gray-900">{formatProviderTimestamp(provider.updatedAt)}</p>
-          </div>
-        </div>
-
-        <div className="mt-6 flex flex-wrap gap-2">
-          {envNames.map((envName) => (
-            <span key={envName} className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-              {envName}
-            </span>
-          ))}
-          {docUrl ? (
-            <a
-              href={docUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600 transition hover:bg-gray-200"
-            >
-              Docs
-              <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          ) : null}
-        </div>
-      </section>
-
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Selected models</h2>
-            <p className="mt-2 text-[15px] text-gray-500">The exact models this provider configuration exposes today.</p>
-          </div>
-          <div className="rounded-full bg-gray-100 px-4 py-2 text-[13px] font-medium text-gray-600">
-            {formatCountLabel(provider.models.length, "model", "models")}
-          </div>
-        </div>
-
-        <div className="mt-8 grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
-          {provider.models.map((model) => {
-            const limitLabel = getLimitLabel(model.config);
-            return (
-              <div key={model.id} className="rounded-[24px] border border-gray-200 bg-gray-50 p-5">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-[17px] font-semibold tracking-[-0.03em] text-gray-950">{model.name}</p>
-                    <p className="mt-1 text-[13px] text-gray-500">{model.id}</p>
-                  </div>
-                  {limitLabel ? (
-                    <span className="rounded-full bg-white px-3 py-1 text-[12px] font-medium text-gray-600">
-                      {limitLabel}
-                    </span>
-                  ) : null}
-                </div>
-              </div>
+        setDeleteBusy(true);
+        setDeleteError(null);
+        try {
+            const { response, payload } = await requestJson(
+                `/v1/orgs/${encodeURIComponent(orgId)}/llm-providers/${encodeURIComponent(provider.id)}`,
+                { method: "DELETE" },
+                12000,
             );
-          })}
-        </div>
-      </section>
 
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Access</h2>
-            <p className="mt-2 text-[15px] text-gray-500">People and teams who can use this provider.</p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full bg-gray-100 px-4 py-2 text-[13px] font-medium text-gray-600">
-            <Users className="h-4 w-4" />
-            {provider.access.members.length + provider.access.teams.length} grants
-          </div>
-        </div>
+            if (response.status !== 204 && !response.ok) {
+                throw new Error(
+                    getErrorMessage(
+                        payload,
+                        `Failed to delete provider (${response.status}).`,
+                    ),
+                );
+            }
 
-        <div className="mt-8 grid gap-6 xl:grid-cols-2">
-          <div className="rounded-[24px] bg-gray-50 p-5">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">People</p>
-            <div className="mt-4 grid gap-3">
-              {provider.access.members.length === 0 ? (
-                <p className="text-[14px] text-gray-500">No direct people access yet.</p>
-              ) : provider.access.members.map((member) => (
-                <div key={member.id} className="rounded-[18px] border border-gray-200 bg-white px-4 py-3">
-                  <p className="text-[15px] font-medium text-gray-900">{member.user.name}</p>
-                  <p className="mt-1 text-[13px] text-gray-500">{member.user.email}</p>
+            await reloadProviders();
+            router.push(getLlmProvidersRoute(orgSlug));
+            router.refresh();
+        } catch (nextError) {
+            setDeleteError(
+                nextError instanceof Error
+                    ? nextError.message
+                    : "Could not delete the provider.",
+            );
+        } finally {
+            setDeleteBusy(false);
+        }
+    }
+
+    if (busy && !provider) {
+        return (
+            <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+                <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
+                    Loading provider details...
                 </div>
-              ))}
             </div>
-          </div>
+        );
+    }
 
-          <div className="rounded-[24px] bg-gray-50 p-5">
-            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">Teams</p>
-            <div className="mt-4 grid gap-3">
-              {provider.access.teams.length === 0 ? (
-                <p className="text-[14px] text-gray-500">No team access yet.</p>
-              ) : provider.access.teams.map((team) => (
-                <div key={team.id} className="rounded-[18px] border border-gray-200 bg-white px-4 py-3">
-                  <p className="text-[15px] font-medium text-gray-900">{team.name}</p>
-                  <p className="mt-1 text-[13px] text-gray-500">Updated {formatProviderTimestamp(team.updatedAt)}</p>
+    if (!provider) {
+        return (
+            <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+                <div className="rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[15px] text-red-700">
+                    {error ?? "That provider could not be found."}
                 </div>
-              ))}
             </div>
-          </div>
-        </div>
-      </section>
+        );
+    }
 
-      {provider.source === "custom" ? (
-        <section className="rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-          <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Custom provider payload</h2>
-          <p className="mt-2 text-[15px] text-gray-500">The raw provider config saved for this custom source.</p>
-          <pre className="mt-6 overflow-x-auto rounded-[24px] bg-[#0f172a] p-5 text-[13px] leading-6 text-slate-100">
-            {JSON.stringify(provider.providerConfig, null, 2)}
-          </pre>
-        </section>
-      ) : null}
-    </div>
-  );
+    const envNames = getProviderEnvNames(provider.providerConfig);
+    const npmPackage = getProviderNpmPackage(provider.providerConfig);
+    const apiBase = getProviderApiBase(provider.providerConfig);
+    const docUrl = getProviderDocUrl(provider.providerConfig);
+
+    return (
+        <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+            <div className="mb-8 flex flex-col gap-3">
+                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                    LLM provider
+                </p>
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+                    <div>
+                        <h1 className="text-[34px] font-semibold tracking-[-0.07em] text-gray-950">
+                            {provider.name}
+                        </h1>
+                    </div>
+                </div>
+            </div>
+
+            <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
+                <Link
+                    href={getLlmProvidersRoute(orgSlug)}
+                    className="inline-flex items-center gap-2 text-[15px] font-medium text-gray-500 transition hover:text-gray-900"
+                >
+                    <ArrowLeft className="h-5 w-5" />
+                    Back to providers
+                </Link>
+
+                <div className="flex flex-wrap gap-3">
+                    {provider.canManage ? (
+                        <>
+                            <Link
+                                href={getEditLlmProviderRoute(
+                                    orgSlug,
+                                    provider.id,
+                                )}
+                            >
+                                <DenButton variant="secondary">
+                                    Edit Provider
+                                </DenButton>
+                            </Link>
+                            <DenButton
+                                variant="destructive"
+                                loading={deleteBusy}
+                                onClick={() => void deleteProvider()}
+                            >
+                                <Trash2 className="h-4 w-4" />
+                                Delete
+                            </DenButton>
+                        </>
+                    ) : null}
+                </div>
+            </div>
+
+            {deleteError ? (
+                <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
+                    {deleteError}
+                </div>
+            ) : null}
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                            Provider configuration
+                        </h2>
+                    </div>
+
+                    <div
+                        className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-[13px] font-medium ${provider.hasApiKey ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}
+                    >
+                        <KeyRound className="h-4 w-4" />
+                        {provider.hasApiKey
+                            ? "Credential saved"
+                            : "Credential missing"}
+                    </div>
+                </div>
+
+                <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                    <div className="rounded-[24px] bg-gray-50 p-5">
+                        <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                            Provider id
+                        </p>
+                        <p className="mt-3 text-[16px] font-medium text-gray-900">
+                            {provider.providerId}
+                        </p>
+                    </div>
+                    <div className="rounded-[24px] bg-gray-50 p-5">
+                        <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                            NPM package
+                        </p>
+                        <p className="mt-3 text-[16px] font-medium text-gray-900">
+                            {npmPackage ?? "Not set"}
+                        </p>
+                    </div>
+                    <div className="rounded-[24px] bg-gray-50 p-5">
+                        <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                            API base
+                        </p>
+                        <p className="mt-3 break-all text-[16px] font-medium text-gray-900">
+                            {apiBase ?? "Not set"}
+                        </p>
+                    </div>
+                    <div className="rounded-[24px] bg-gray-50 p-5">
+                        <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                            Updated
+                        </p>
+                        <p className="mt-3 text-[16px] font-medium text-gray-900">
+                            {formatProviderTimestamp(provider.updatedAt)}
+                        </p>
+                    </div>
+                </div>
+
+                <div className="mt-6 flex flex-wrap gap-2">
+                    {envNames.map((envName) => (
+                        <span
+                            key={envName}
+                            className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600"
+                        >
+                            {envName}
+                        </span>
+                    ))}
+                    {docUrl ? (
+                        <a
+                            href={docUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600 transition hover:bg-gray-200"
+                        >
+                            Docs
+                            <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                    ) : null}
+                </div>
+            </section>
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                            Selected models
+                        </h2>
+                    </div>
+                    <div className="rounded-full bg-gray-100 px-4 py-2 text-[13px] font-medium text-gray-600">
+                        {formatCountLabel(
+                            provider.models.length,
+                            "model",
+                            "models",
+                        )}
+                    </div>
+                </div>
+
+                <div className="mt-8 grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+                    {provider.models.map((model) => {
+                        const limitLabel = getLimitLabel(model.config);
+                        return (
+                            <div
+                                key={model.id}
+                                className="rounded-[24px] border border-gray-200 bg-gray-50 p-5"
+                            >
+                                <div className="flex items-start justify-between gap-3">
+                                    <div>
+                                        <p className="text-[17px] font-semibold tracking-[-0.03em] text-gray-950">
+                                            {model.name}
+                                        </p>
+                                        <p className="mt-1 text-[13px] text-gray-500">
+                                            {model.id}
+                                        </p>
+                                    </div>
+                                    {limitLabel ? (
+                                        <span className="rounded-full bg-white px-3 py-1 text-[12px] font-medium text-gray-600">
+                                            {limitLabel}
+                                        </span>
+                                    ) : null}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </section>
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                            Access
+                        </h2>
+                    </div>
+                    <div className="inline-flex items-center gap-2 rounded-full bg-gray-100 px-4 py-2 text-[13px] font-medium text-gray-600">
+                        <Users className="h-4 w-4" />
+                        {provider.access.members.length +
+                            provider.access.teams.length}{" "}
+                        grants
+                    </div>
+                </div>
+
+                <div className="mt-8 grid gap-6 xl:grid-cols-2">
+                    <div className="rounded-[24px] bg-gray-50 p-5">
+                        <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                            People
+                        </p>
+                        <div className="mt-4 grid gap-3">
+                            {provider.access.members.length === 0 ? (
+                                <p className="text-[14px] text-gray-500">
+                                    No direct people access yet.
+                                </p>
+                            ) : (
+                                provider.access.members.map((member) => (
+                                    <div
+                                        key={member.id}
+                                        className="rounded-[18px] border border-gray-200 bg-white px-4 py-3"
+                                    >
+                                        <p className="text-[15px] font-medium text-gray-900">
+                                            {member.user.name}
+                                        </p>
+                                        <p className="mt-1 text-[13px] text-gray-500">
+                                            {member.user.email}
+                                        </p>
+                                    </div>
+                                ))
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="rounded-[24px] bg-gray-50 p-5">
+                        <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+                            Teams
+                        </p>
+                        <div className="mt-4 grid gap-3">
+                            {provider.access.teams.length === 0 ? (
+                                <p className="text-[14px] text-gray-500">
+                                    No team access yet.
+                                </p>
+                            ) : (
+                                provider.access.teams.map((team) => (
+                                    <div
+                                        key={team.id}
+                                        className="rounded-[18px] border border-gray-200 bg-white px-4 py-3"
+                                    >
+                                        <p className="text-[15px] font-medium text-gray-900">
+                                            {team.name}
+                                        </p>
+                                        <p className="mt-1 text-[13px] text-gray-500">
+                                            Updated{" "}
+                                            {formatProviderTimestamp(
+                                                team.updatedAt,
+                                            )}
+                                        </p>
+                                    </div>
+                                ))
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {provider.source === "custom" ? (
+                <section className="rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                    <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                        Custom provider payload
+                    </h2>
+                    <p className="mt-2 text-[15px] text-gray-500">
+                        The raw provider config saved for this custom source.
+                    </p>
+                    <pre className="mt-6 overflow-x-auto rounded-[24px] bg-[#0f172a] p-5 text-[13px] leading-6 text-slate-100">
+                        {JSON.stringify(provider.providerConfig, null, 2)}
+                    </pre>
+                </section>
+            ) : null}
+        </div>
+    );
 }

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/llm-provider-editor-screen.tsx
@@ -12,530 +12,732 @@ import { UnderlineTabs } from "../../../../_components/ui/tabs";
 import { DenTextarea } from "../../../../_components/ui/textarea";
 import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
 import {
-  getLlmProviderRoute,
-  getLlmProvidersRoute,
+    getLlmProviderRoute,
+    getLlmProvidersRoute,
 } from "../../../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
-  buildCustomProviderTemplate,
-  buildEditableCustomProviderText,
-  getProviderApiBase,
-  getProviderDocUrl,
-  getProviderEnvNames,
-  getProviderNpmPackage,
-  requestLlmProviderCatalog,
-  requestLlmProviderCatalogDetail,
-  useOrgLlmProviders,
-  type DenLlmProvider,
-  type DenModelsDevProviderDetail,
-  type DenModelsDevProviderSummary,
-  type DenLlmProviderSource,
+    buildCustomProviderTemplate,
+    buildEditableCustomProviderText,
+    getProviderApiBase,
+    getProviderDocUrl,
+    getProviderEnvNames,
+    getProviderNpmPackage,
+    requestLlmProviderCatalog,
+    requestLlmProviderCatalogDetail,
+    useOrgLlmProviders,
+    type DenLlmProvider,
+    type DenModelsDevProviderDetail,
+    type DenModelsDevProviderSummary,
+    type DenLlmProviderSource,
 } from "./llm-provider-data";
 
 const SOURCE_TABS = [
-  { value: "models_dev" as const, label: "Catalog provider", icon: Cpu },
-  { value: "custom" as const, label: "Custom provider", icon: Cpu },
+    { value: "models_dev" as const, label: "Catalog provider", icon: Cpu },
+    { value: "custom" as const, label: "Custom provider", icon: Cpu },
 ];
 
-function getLockMemberId(provider: DenLlmProvider | null, currentMemberId: string | null) {
-  return provider?.createdByOrgMembershipId ?? currentMemberId;
+function getLockMemberId(
+    provider: DenLlmProvider | null,
+    currentMemberId: string | null,
+) {
+    return provider?.createdByOrgMembershipId ?? currentMemberId;
 }
 
-export function LlmProviderEditorScreen({ llmProviderId }: { llmProviderId?: string }) {
-  const router = useRouter();
-  const { orgId, orgSlug, orgContext } = useOrgDashboard();
-  const { llmProviders, busy, error, reloadProviders } = useOrgLlmProviders(orgId);
-  const provider = useMemo(
-    () => (llmProviderId ? llmProviders.find((entry) => entry.id === llmProviderId) ?? null : null),
-    [llmProviderId, llmProviders],
-  );
-  const [source, setSource] = useState<DenLlmProviderSource>("models_dev");
-  const [catalogProviders, setCatalogProviders] = useState<DenModelsDevProviderSummary[]>([]);
-  const [catalogBusy, setCatalogBusy] = useState(false);
-  const [catalogError, setCatalogError] = useState<string | null>(null);
-  const [selectedProviderId, setSelectedProviderId] = useState("");
-  const [catalogDetail, setCatalogDetail] = useState<DenModelsDevProviderDetail | null>(null);
-  const [detailBusy, setDetailBusy] = useState(false);
-  const [detailError, setDetailError] = useState<string | null>(null);
-  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
-  const [modelQuery, setModelQuery] = useState("");
-  const [customConfigText, setCustomConfigText] = useState(buildCustomProviderTemplate());
-  const [apiKey, setApiKey] = useState("");
-  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
-  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
-  const [saveBusy, setSaveBusy] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!orgId) {
-      setCatalogProviders([]);
-      return;
-    }
-
-    let canceled = false;
-    setCatalogBusy(true);
-    setCatalogError(null);
-    void requestLlmProviderCatalog(orgId)
-      .then((providers) => {
-        if (!canceled) {
-          setCatalogProviders(providers);
-        }
-      })
-      .catch((loadError) => {
-        if (!canceled) {
-          setCatalogError(loadError instanceof Error ? loadError.message : "Failed to load the provider catalog.");
-        }
-      })
-      .finally(() => {
-        if (!canceled) {
-          setCatalogBusy(false);
-        }
-      });
-
-    return () => {
-      canceled = true;
-    };
-  }, [orgId]);
-
-  useEffect(() => {
-    if (provider) {
-      setSource(provider.source);
-      setSelectedProviderId(provider.providerId);
-      setSelectedModelIds(provider.models.map((entry) => entry.id));
-      setSelectedMemberIds(provider.access.members.map((entry) => entry.orgMembershipId));
-      setSelectedTeamIds(provider.access.teams.map((entry) => entry.teamId));
-      setCustomConfigText(provider.source === "custom" ? buildEditableCustomProviderText(provider) : buildCustomProviderTemplate());
-      setApiKey("");
-      return;
-    }
-
-    setSource("models_dev");
-    setSelectedProviderId("");
-    setSelectedModelIds([]);
-    setSelectedMemberIds(orgContext?.currentMember.id ? [orgContext.currentMember.id] : []);
-    setSelectedTeamIds([]);
-    setCustomConfigText(buildCustomProviderTemplate());
-    setApiKey("");
-  }, [orgContext?.currentMember.id, provider]);
-
-  useEffect(() => {
-    if (source !== "models_dev" || !orgId || !selectedProviderId) {
-      setCatalogDetail(null);
-      setDetailError(null);
-      setDetailBusy(false);
-      return;
-    }
-
-    let canceled = false;
-    setDetailBusy(true);
-    setDetailError(null);
-    void requestLlmProviderCatalogDetail(orgId, selectedProviderId)
-      .then((detail) => {
-        if (!canceled) {
-          setCatalogDetail(detail);
-          setSelectedModelIds((current) => current.filter((entry) => detail.models.some((model) => model.id === entry)));
-        }
-      })
-      .catch((loadError) => {
-        if (!canceled) {
-          setCatalogDetail(null);
-          setDetailError(loadError instanceof Error ? loadError.message : "Failed to load provider details.");
-        }
-      })
-      .finally(() => {
-        if (!canceled) {
-          setDetailBusy(false);
-        }
-      });
-
-    return () => {
-      canceled = true;
-    };
-  }, [orgId, selectedProviderId, source]);
-
-  const currentMemberId = orgContext?.currentMember.id ?? null;
-  const lockedMemberId = getLockMemberId(provider, currentMemberId);
-
-  const filteredModels = useMemo(() => {
-    const models = catalogDetail?.models ?? [];
-    const normalizedQuery = modelQuery.trim().toLowerCase();
-    if (!normalizedQuery) {
-      return models;
-    }
-
-    return models.filter((model) => model.name.toLowerCase().includes(normalizedQuery) || model.id.toLowerCase().includes(normalizedQuery));
-  }, [catalogDetail?.models, modelQuery]);
-
-  const catalogProviderOptions = useMemo(
-    () =>
-      catalogProviders.map((catalogProvider) => ({
-        value: catalogProvider.id,
-        label: catalogProvider.name,
-        description: catalogProvider.id,
-        meta: `${catalogProvider.modelCount} ${catalogProvider.modelCount === 1 ? "model" : "models"}`,
-      })),
-    [catalogProviders],
-  );
-
-  async function saveProvider() {
-    if (!orgId) {
-      setSaveError("Organization not found.");
-      return;
-    }
-
-    if (source === "models_dev") {
-      if (!selectedProviderId) {
-        setSaveError("Select a provider.");
-        return;
-      }
-      if (!selectedModelIds.length) {
-        setSaveError("Select at least one model.");
-        return;
-      }
-    }
-
-    if (source === "custom" && !customConfigText.trim()) {
-      setSaveError("Paste a custom provider config.");
-      return;
-    }
-
-    setSaveBusy(true);
-    setSaveError(null);
-    try {
-      const body: Record<string, unknown> = {
-        source,
-        memberIds: [...new Set(selectedMemberIds)],
-        teamIds: [...new Set(selectedTeamIds)],
-      };
-
-      if (source === "models_dev") {
-        body.providerId = selectedProviderId;
-        body.modelIds = selectedModelIds;
-      } else {
-        body.customConfigText = customConfigText;
-      }
-
-      if (apiKey.trim() || !provider) {
-        body.apiKey = apiKey.trim();
-      }
-
-      const path = provider
-        ? `/v1/orgs/${encodeURIComponent(orgId)}/llm-providers/${encodeURIComponent(provider.id)}`
-        : `/v1/orgs/${encodeURIComponent(orgId)}/llm-providers`;
-      const method = provider ? "PATCH" : "POST";
-
-      const { response, payload } = await requestJson(
-        path,
-        {
-          method,
-          body: JSON.stringify(body),
-        },
-        20000,
-      );
-
-      if (!response.ok) {
-        throw new Error(getErrorMessage(payload, `Failed to save provider (${response.status}).`));
-      }
-
-      const nextProvider = payload && typeof payload === "object" && payload && "llmProvider" in payload && payload.llmProvider && typeof payload.llmProvider === "object"
-        ? payload.llmProvider as { id?: unknown }
-        : null;
-      const nextProviderId = typeof nextProvider?.id === "string" ? nextProvider.id : provider?.id ?? null;
-      if (!nextProviderId) {
-        throw new Error("The provider was saved, but no provider id was returned.");
-      }
-
-      await reloadProviders();
-      router.push(getLlmProviderRoute(orgSlug, nextProviderId));
-      router.refresh();
-    } catch (nextError) {
-      setSaveError(nextError instanceof Error ? nextError.message : "Could not save the provider.");
-    } finally {
-      setSaveBusy(false);
-    }
-  }
-
-  if (busy && llmProviderId && !provider) {
-    return (
-      <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-        <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
-          Loading provider details...
-        </div>
-      </div>
+export function LlmProviderEditorScreen({
+    llmProviderId,
+}: {
+    llmProviderId?: string;
+}) {
+    const router = useRouter();
+    const { orgId, orgSlug, orgContext } = useOrgDashboard();
+    const { llmProviders, busy, error, reloadProviders } =
+        useOrgLlmProviders(orgId);
+    const provider = useMemo(
+        () =>
+            llmProviderId
+                ? (llmProviders.find((entry) => entry.id === llmProviderId) ??
+                  null)
+                : null,
+        [llmProviderId, llmProviders],
     );
-  }
-
-  if (llmProviderId && !provider) {
-    return (
-      <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-        <div className="rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[15px] text-red-700">
-          {error ?? "That provider could not be found."}
-        </div>
-      </div>
+    const [source, setSource] = useState<DenLlmProviderSource>("models_dev");
+    const [catalogProviders, setCatalogProviders] = useState<
+        DenModelsDevProviderSummary[]
+    >([]);
+    const [catalogBusy, setCatalogBusy] = useState(false);
+    const [catalogError, setCatalogError] = useState<string | null>(null);
+    const [selectedProviderId, setSelectedProviderId] = useState("");
+    const [catalogDetail, setCatalogDetail] =
+        useState<DenModelsDevProviderDetail | null>(null);
+    const [detailBusy, setDetailBusy] = useState(false);
+    const [detailError, setDetailError] = useState<string | null>(null);
+    const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
+    const [modelQuery, setModelQuery] = useState("");
+    const [customConfigText, setCustomConfigText] = useState(
+        buildCustomProviderTemplate(),
     );
-  }
+    const [apiKey, setApiKey] = useState("");
+    const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+    const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+    const [saveBusy, setSaveBusy] = useState(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
 
-  const providerDoc = catalogDetail ? getProviderDocUrl(catalogDetail.config) : null;
-  const providerNpm = catalogDetail ? getProviderNpmPackage(catalogDetail.config) : null;
-  const providerApiBase = catalogDetail ? getProviderApiBase(catalogDetail.config) : null;
-  const providerEnv = catalogDetail ? getProviderEnvNames(catalogDetail.config) : [];
+    useEffect(() => {
+        if (!orgId) {
+            setCatalogProviders([]);
+            return;
+        }
 
-  return (
-    <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-      <div className="mb-8 flex flex-col gap-3">
-        <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-          {provider ? "Edit provider" : "Add provider"}
-        </p>
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div>
-            <h1 className="text-[34px] font-semibold tracking-[-0.07em] text-gray-950">
-              {provider ? provider.name : "Add a new LLM provider"}
-            </h1>
-            <p className="mt-3 max-w-[720px] text-[16px] leading-8 text-gray-500">
-              Pick a models.dev provider or paste a custom config, then decide which models and teammates can use it.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-3 text-[13px] font-medium text-gray-600">
-            <span className="rounded-full border border-gray-200 bg-white px-4 py-2">
-              {selectedModelIds.length} {selectedModelIds.length === 1 ? "model selected" : "models selected"}
-            </span>
-            <span className="rounded-full border border-gray-200 bg-white px-4 py-2">
-              {selectedMemberIds.length} people · {selectedTeamIds.length} teams
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <div className="mb-8 flex items-center justify-between gap-4">
-        <Link
-          href={provider ? getLlmProviderRoute(orgSlug, provider.id) : getLlmProvidersRoute(orgSlug)}
-          className="inline-flex items-center gap-2 text-[15px] font-medium text-gray-500 transition hover:text-gray-900"
-        >
-          <ArrowLeft className="h-5 w-5" />
-          Back
-        </Link>
-
-        <DenButton loading={saveBusy} onClick={() => void saveProvider()}>
-          {provider ? "Save Provider" : "Create Provider"}
-        </DenButton>
-      </div>
-
-      {saveError ? (
-        <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
-          {saveError}
-        </div>
-      ) : null}
-
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <h2 className="mb-6 text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Provider type</h2>
-        <UnderlineTabs tabs={SOURCE_TABS} activeTab={source} onChange={setSource} />
-
-        {source === "models_dev" ? (
-          <div className="mt-8 grid gap-6">
-            <div className="grid gap-3">
-              <span className="text-[14px] font-medium text-gray-700">Provider</span>
-              <DenCombobox
-                value={selectedProviderId}
-                options={catalogProviderOptions}
-                onChange={setSelectedProviderId}
-                ariaLabel="Provider"
-                placeholder="Select a provider..."
-                searchPlaceholder="Search providers..."
-                emptyLabel="No providers match"
-              />
-            </div>
-
-            {catalogBusy ? <p className="text-[14px] text-gray-500">Loading provider catalog...</p> : null}
-            {catalogError ? <p className="text-[14px] text-red-600">{catalogError}</p> : null}
-
-            {detailBusy ? <p className="text-[14px] text-gray-500">Loading provider details...</p> : null}
-            {detailError ? <p className="text-[14px] text-red-600">{detailError}</p> : null}
-
-            {catalogDetail ? (
-              <div className="rounded-[28px] bg-gray-50 p-6">
-                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                  <div>
-                    <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">NPM package</p>
-                    <p className="mt-2 text-[15px] font-medium text-gray-900">{providerNpm ?? "Not set"}</p>
-                  </div>
-                  <div>
-                    <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">API base</p>
-                    <p className="mt-2 break-all text-[15px] font-medium text-gray-900">{providerApiBase ?? "Not set"}</p>
-                  </div>
-                  <div>
-                    <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">Env keys</p>
-                    <p className="mt-2 text-[15px] font-medium text-gray-900">{providerEnv.join(", ") || "None listed"}</p>
-                  </div>
-                  <div>
-                    <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">Docs</p>
-                    <p className="mt-2 text-[15px] font-medium text-gray-900">{providerDoc ?? "Not set"}</p>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-          </div>
-        ) : (
-          <div className="mt-8 grid gap-3">
-            <span className="text-[14px] font-medium text-gray-700">Custom provider JSON</span>
-            <DenTextarea
-              value={customConfigText}
-              onChange={(event) => setCustomConfigText(event.target.value)}
-              rows={18}
-            />
-            <p className="text-[13px] text-gray-500">
-              Use the models.dev-style schema and include a <code className="rounded bg-gray-100 px-1 py-0.5">models</code> array.
-            </p>
-          </div>
-        )}
-      </section>
-
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Credential</h2>
-            <p className="mt-2 text-[15px] text-gray-500">
-              Save the provider credential in a dedicated text column for now. Leave this blank on edit to keep the existing saved value.
-            </p>
-          </div>
-          {provider?.hasApiKey ? (
-            <span className="rounded-full bg-emerald-50 px-4 py-2 text-[13px] font-medium text-emerald-700">Existing credential saved</span>
-          ) : null}
-        </div>
-
-        <label className="grid gap-3">
-          <span className="text-[14px] font-medium text-gray-700">API key / credential</span>
-          <DenInput
-            type="password"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-            placeholder={provider?.hasApiKey ? "Leave blank to keep current credential" : "Paste the provider credential"}
-          />
-        </label>
-      </section>
-
-      {source === "models_dev" ? (
-        <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-          <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div>
-              <div className="flex flex-wrap items-center gap-3">
-                <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Models</h2>
-                {catalogDetail ? (
-                  <span className="rounded-full bg-gray-200 px-3 py-1 text-[12px] font-medium text-gray-700">
-                    {selectedModelIds.length} {selectedModelIds.length === 1 ? "model selected" : "models selected"}
-                  </span>
-                ) : null}
-              </div>
-              <p className="mt-2 text-[15px] text-gray-500">Pick the exact models this provider should expose.</p>
-            </div>
-
-            <DenInput
-              type="search"
-              icon={Search}
-              value={modelQuery}
-              onChange={(event) => setModelQuery(event.target.value)}
-              placeholder="Search models..."
-              className="lg:w-[360px]"
-            />
-          </div>
-
-          {catalogDetail ? (
-            filteredModels.length ? (
-              <div>
-                <div className="overflow-hidden rounded-[16px] border border-gray-200 bg-white divide-y divide-gray-200">
-                  {filteredModels.map((model) => {
-                    const selected = selectedModelIds.includes(model.id);
-                    return (
-                      <DenSelectableRow
-                        key={model.id}
-                        selected={selected}
-                        title={model.name}
-                        description={model.id}
-                        onClick={() =>
-                          setSelectedModelIds((current) =>
-                            current.includes(model.id)
-                              ? current.filter((entry) => entry !== model.id)
-                              : [...current, model.id],
-                          )
-                        }
-                      />
+        let canceled = false;
+        setCatalogBusy(true);
+        setCatalogError(null);
+        void requestLlmProviderCatalog(orgId)
+            .then((providers) => {
+                if (!canceled) {
+                    setCatalogProviders(providers);
+                }
+            })
+            .catch((loadError) => {
+                if (!canceled) {
+                    setCatalogError(
+                        loadError instanceof Error
+                            ? loadError.message
+                            : "Failed to load the provider catalog.",
                     );
-                  })}
-                </div>
-              </div>
-            ) : (
-              <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
-                No models match <span className="font-medium text-gray-700">&quot;{modelQuery}&quot;</span>.
-              </div>
-            )
-          ) : (
-            <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
-              Select a provider to browse its models.
-            </div>
-          )}
-        </section>
-      ) : null}
+                }
+            })
+            .finally(() => {
+                if (!canceled) {
+                    setCatalogBusy(false);
+                }
+            });
 
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">People access</h2>
-        <p className="mt-2 text-[15px] text-gray-500">Grant direct access to specific members. The provider creator always keeps access.</p>
+        return () => {
+            canceled = true;
+        };
+    }, [orgId]);
 
-        <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {orgContext?.members.map((member) => {
-            const selected = selectedMemberIds.includes(member.id);
-            const locked = lockedMemberId === member.id;
-            return (
-              <button
-                key={member.id}
-                type="button"
-                disabled={locked}
-                onClick={() => setSelectedMemberIds((current) => current.includes(member.id) ? current.filter((entry) => entry !== member.id) : [...current, member.id])}
-                className={`flex min-h-[88px] items-center gap-4 rounded-[24px] border px-5 py-4 text-left transition ${selected ? "border-[#0f172a] bg-[#0f172a] text-white" : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"} ${locked ? "cursor-default" : "cursor-pointer"}`}
-              >
-                {selected ? <CheckCircle2 className="h-7 w-7 shrink-0" /> : <Circle className="h-7 w-7 shrink-0 text-gray-300" />}
-                <div>
-                  <p className="text-[16px] font-medium tracking-[-0.03em]">{member.user.name}</p>
-                  <p className={`mt-1 text-[13px] ${selected ? "text-white/70" : "text-gray-400"}`}>{member.user.email}</p>
-                  {locked ? <p className={`mt-1 text-[12px] ${selected ? "text-white/60" : "text-gray-400"}`}>Creator access is locked</p> : null}
-                </div>
-              </button>
+    useEffect(() => {
+        if (provider) {
+            setSource(provider.source);
+            setSelectedProviderId(provider.providerId);
+            setSelectedModelIds(provider.models.map((entry) => entry.id));
+            setSelectedMemberIds(
+                provider.access.members.map((entry) => entry.orgMembershipId),
             );
-          }) ?? null}
-        </div>
-      </section>
+            setSelectedTeamIds(
+                provider.access.teams.map((entry) => entry.teamId),
+            );
+            setCustomConfigText(
+                provider.source === "custom"
+                    ? buildEditableCustomProviderText(provider)
+                    : buildCustomProviderTemplate(),
+            );
+            setApiKey("");
+            return;
+        }
 
-      <section className="rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Team access</h2>
-        <p className="mt-2 text-[15px] text-gray-500">Grant access to entire teams in one step.</p>
+        setSource("models_dev");
+        setSelectedProviderId("");
+        setSelectedModelIds([]);
+        setSelectedMemberIds(
+            orgContext?.currentMember.id ? [orgContext.currentMember.id] : [],
+        );
+        setSelectedTeamIds([]);
+        setCustomConfigText(buildCustomProviderTemplate());
+        setApiKey("");
+    }, [orgContext?.currentMember.id, provider]);
 
-        {orgContext?.teams.length ? (
-          <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {orgContext.teams.map((team) => {
-              const selected = selectedTeamIds.includes(team.id);
-              return (
-                <button
-                  key={team.id}
-                  type="button"
-                  onClick={() => setSelectedTeamIds((current) => current.includes(team.id) ? current.filter((entry) => entry !== team.id) : [...current, team.id])}
-                  className={`flex min-h-[88px] items-center gap-4 rounded-[24px] border px-5 py-4 text-left transition ${selected ? "border-[#0f172a] bg-[#0f172a] text-white" : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"}`}
+    useEffect(() => {
+        if (source !== "models_dev" || !orgId || !selectedProviderId) {
+            setCatalogDetail(null);
+            setDetailError(null);
+            setDetailBusy(false);
+            return;
+        }
+
+        let canceled = false;
+        setDetailBusy(true);
+        setDetailError(null);
+        void requestLlmProviderCatalogDetail(orgId, selectedProviderId)
+            .then((detail) => {
+                if (!canceled) {
+                    setCatalogDetail(detail);
+                    setSelectedModelIds((current) =>
+                        current.filter((entry) =>
+                            detail.models.some((model) => model.id === entry),
+                        ),
+                    );
+                }
+            })
+            .catch((loadError) => {
+                if (!canceled) {
+                    setCatalogDetail(null);
+                    setDetailError(
+                        loadError instanceof Error
+                            ? loadError.message
+                            : "Failed to load provider details.",
+                    );
+                }
+            })
+            .finally(() => {
+                if (!canceled) {
+                    setDetailBusy(false);
+                }
+            });
+
+        return () => {
+            canceled = true;
+        };
+    }, [orgId, selectedProviderId, source]);
+
+    const currentMemberId = orgContext?.currentMember.id ?? null;
+    const lockedMemberId = getLockMemberId(provider, currentMemberId);
+
+    const filteredModels = useMemo(() => {
+        const models = catalogDetail?.models ?? [];
+        const normalizedQuery = modelQuery.trim().toLowerCase();
+        if (!normalizedQuery) {
+            return models;
+        }
+
+        return models.filter(
+            (model) =>
+                model.name.toLowerCase().includes(normalizedQuery) ||
+                model.id.toLowerCase().includes(normalizedQuery),
+        );
+    }, [catalogDetail?.models, modelQuery]);
+
+    const catalogProviderOptions = useMemo(
+        () =>
+            catalogProviders.map((catalogProvider) => ({
+                value: catalogProvider.id,
+                label: catalogProvider.name,
+                description: catalogProvider.id,
+                meta: `${catalogProvider.modelCount} ${catalogProvider.modelCount === 1 ? "model" : "models"}`,
+            })),
+        [catalogProviders],
+    );
+
+    async function saveProvider() {
+        if (!orgId) {
+            setSaveError("Organization not found.");
+            return;
+        }
+
+        if (source === "models_dev") {
+            if (!selectedProviderId) {
+                setSaveError("Select a provider.");
+                return;
+            }
+            if (!selectedModelIds.length) {
+                setSaveError("Select at least one model.");
+                return;
+            }
+        }
+
+        if (source === "custom" && !customConfigText.trim()) {
+            setSaveError("Paste a custom provider config.");
+            return;
+        }
+
+        setSaveBusy(true);
+        setSaveError(null);
+        try {
+            const body: Record<string, unknown> = {
+                source,
+                memberIds: [...new Set(selectedMemberIds)],
+                teamIds: [...new Set(selectedTeamIds)],
+            };
+
+            if (source === "models_dev") {
+                body.providerId = selectedProviderId;
+                body.modelIds = selectedModelIds;
+            } else {
+                body.customConfigText = customConfigText;
+            }
+
+            if (apiKey.trim() || !provider) {
+                body.apiKey = apiKey.trim();
+            }
+
+            const path = provider
+                ? `/v1/orgs/${encodeURIComponent(orgId)}/llm-providers/${encodeURIComponent(provider.id)}`
+                : `/v1/orgs/${encodeURIComponent(orgId)}/llm-providers`;
+            const method = provider ? "PATCH" : "POST";
+
+            const { response, payload } = await requestJson(
+                path,
+                {
+                    method,
+                    body: JSON.stringify(body),
+                },
+                20000,
+            );
+
+            if (!response.ok) {
+                throw new Error(
+                    getErrorMessage(
+                        payload,
+                        `Failed to save provider (${response.status}).`,
+                    ),
+                );
+            }
+
+            const nextProvider =
+                payload &&
+                typeof payload === "object" &&
+                payload &&
+                "llmProvider" in payload &&
+                payload.llmProvider &&
+                typeof payload.llmProvider === "object"
+                    ? (payload.llmProvider as { id?: unknown })
+                    : null;
+            const nextProviderId =
+                typeof nextProvider?.id === "string"
+                    ? nextProvider.id
+                    : (provider?.id ?? null);
+            if (!nextProviderId) {
+                throw new Error(
+                    "The provider was saved, but no provider id was returned.",
+                );
+            }
+
+            await reloadProviders();
+            router.push(getLlmProviderRoute(orgSlug, nextProviderId));
+            router.refresh();
+        } catch (nextError) {
+            setSaveError(
+                nextError instanceof Error
+                    ? nextError.message
+                    : "Could not save the provider.",
+            );
+        } finally {
+            setSaveBusy(false);
+        }
+    }
+
+    if (busy && llmProviderId && !provider) {
+        return (
+            <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+                <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
+                    Loading provider details...
+                </div>
+            </div>
+        );
+    }
+
+    if (llmProviderId && !provider) {
+        return (
+            <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+                <div className="rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[15px] text-red-700">
+                    {error ?? "That provider could not be found."}
+                </div>
+            </div>
+        );
+    }
+
+    const providerDoc = catalogDetail
+        ? getProviderDocUrl(catalogDetail.config)
+        : null;
+    const providerNpm = catalogDetail
+        ? getProviderNpmPackage(catalogDetail.config)
+        : null;
+    const providerApiBase = catalogDetail
+        ? getProviderApiBase(catalogDetail.config)
+        : null;
+    const providerEnv = catalogDetail
+        ? getProviderEnvNames(catalogDetail.config)
+        : [];
+
+    return (
+        <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+            <div className="mb-8 flex flex-col gap-3">
+                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                    {provider ? "Edit provider" : "Add provider"}
+                </p>
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+                    <div>
+                        <h1 className="text-[34px] font-semibold tracking-[-0.07em] text-gray-950">
+                            {provider
+                                ? provider.name
+                                : "Add a new LLM provider"}
+                        </h1>
+                        <p className="mt-3 max-w-[720px] text-[16px] leading-8 text-gray-500">
+                            Pick a provider or paste a custom config, then
+                            decide which models to allow and which teammates can
+                            use it.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div className="mb-8 flex items-center justify-between gap-4">
+                <Link
+                    href={
+                        provider
+                            ? getLlmProviderRoute(orgSlug, provider.id)
+                            : getLlmProvidersRoute(orgSlug)
+                    }
+                    className="inline-flex items-center gap-2 text-[15px] font-medium text-gray-500 transition hover:text-gray-900"
                 >
-                  {selected ? <CheckCircle2 className="h-7 w-7 shrink-0" /> : <Circle className="h-7 w-7 shrink-0 text-gray-300" />}
-                  <div>
-                    <p className="text-[16px] font-medium tracking-[-0.03em]">{team.name}</p>
-                    <p className={`mt-1 text-[13px] ${selected ? "text-white/70" : "text-gray-400"}`}>
-                      {team.memberIds.length} {team.memberIds.length === 1 ? "member" : "members"}
-                    </p>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="mt-8 rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
-            Create teams from the Members page before assigning team access.
-          </div>
-        )}
-      </section>
-    </div>
-  );
+                    <ArrowLeft className="h-5 w-5" />
+                    Back
+                </Link>
+
+                <DenButton
+                    loading={saveBusy}
+                    onClick={() => void saveProvider()}
+                >
+                    {provider ? "Save Provider" : "Create Provider"}
+                </DenButton>
+            </div>
+
+            {saveError ? (
+                <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
+                    {saveError}
+                </div>
+            ) : null}
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <h2 className="mb-6 text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                    Provider type
+                </h2>
+                <UnderlineTabs
+                    tabs={SOURCE_TABS}
+                    activeTab={source}
+                    onChange={setSource}
+                />
+
+                {source === "models_dev" ? (
+                    <div className="mt-8 grid gap-6">
+                        <div className="grid gap-3">
+                            <span className="text-[14px] font-medium text-gray-700">
+                                Provider
+                            </span>
+                            <DenCombobox
+                                value={selectedProviderId}
+                                options={catalogProviderOptions}
+                                onChange={setSelectedProviderId}
+                                ariaLabel="Provider"
+                                placeholder="Select a provider..."
+                                searchPlaceholder="Search providers..."
+                                emptyLabel="No providers match"
+                            />
+                        </div>
+
+                        {catalogBusy ? (
+                            <p className="text-[14px] text-gray-500">
+                                Loading provider catalog...
+                            </p>
+                        ) : null}
+                        {catalogError ? (
+                            <p className="text-[14px] text-red-600">
+                                {catalogError}
+                            </p>
+                        ) : null}
+
+                        {detailBusy ? (
+                            <p className="text-[14px] text-gray-500">
+                                Loading provider details...
+                            </p>
+                        ) : null}
+                        {detailError ? (
+                            <p className="text-[14px] text-red-600">
+                                {detailError}
+                            </p>
+                        ) : null}
+
+                        {catalogDetail ? (
+                            <div className="rounded-[28px] bg-gray-50 p-6">
+                                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                                    <div>
+                                        <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+                                            NPM package
+                                        </p>
+                                        <p className="mt-2 text-[15px] font-medium text-gray-900">
+                                            {providerNpm ?? "Not set"}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+                                            API base
+                                        </p>
+                                        <p className="mt-2 break-all text-[15px] font-medium text-gray-900">
+                                            {providerApiBase ?? "Not set"}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+                                            Env keys
+                                        </p>
+                                        <p className="mt-2 text-[15px] font-medium text-gray-900">
+                                            {providerEnv.join(", ") ||
+                                                "None listed"}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-[12px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+                                            Docs
+                                        </p>
+                                        <p className="mt-2 text-[15px] font-medium text-gray-900">
+                                            {providerDoc ?? "Not set"}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        ) : null}
+                    </div>
+                ) : (
+                    <div className="mt-8 grid gap-3">
+                        <span className="text-[14px] font-medium text-gray-700">
+                            Custom provider JSON
+                        </span>
+                        <DenTextarea
+                            value={customConfigText}
+                            onChange={(event) =>
+                                setCustomConfigText(event.target.value)
+                            }
+                            rows={18}
+                        />
+                        <p className="text-[13px] text-gray-500">
+                            Use the models.dev-style schema and include a{" "}
+                            <code className="rounded bg-gray-100 px-1 py-0.5">
+                                models
+                            </code>{" "}
+                            array.
+                        </p>
+                    </div>
+                )}
+            </section>
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                    <div>
+                        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                            Credential
+                        </h2>
+                    </div>
+                    {provider?.hasApiKey ? (
+                        <span className="rounded-full bg-emerald-50 px-4 py-2 text-[13px] font-medium text-emerald-700">
+                            Existing credential saved
+                        </span>
+                    ) : null}
+                </div>
+
+                <label className="grid gap-3">
+                    <span className="text-[14px] font-medium text-gray-700">
+                        API key / credential
+                    </span>
+                    <DenInput
+                        type="password"
+                        value={apiKey}
+                        onChange={(event) => setApiKey(event.target.value)}
+                        placeholder={
+                            provider?.hasApiKey
+                                ? "Leave blank to keep current credential"
+                                : "Paste the provider credential"
+                        }
+                    />
+                </label>
+            </section>
+
+            {source === "models_dev" ? (
+                <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                    <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                        <div>
+                            <div className="flex flex-wrap items-center gap-3">
+                                <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                                    Models
+                                </h2>
+                                {catalogDetail ? (
+                                    <span className="rounded-full bg-gray-200 px-3 py-1 text-[12px] font-medium text-gray-700">
+                                        {selectedModelIds.length}{" "}
+                                        {selectedModelIds.length === 1
+                                            ? "model selected"
+                                            : "models selected"}
+                                    </span>
+                                ) : null}
+                            </div>
+                            <p className="mt-2 text-[15px] text-gray-500">
+                                Pick the exact models this provider should
+                                allow.
+                            </p>
+                        </div>
+
+                        <DenInput
+                            type="search"
+                            icon={Search}
+                            value={modelQuery}
+                            onChange={(event) =>
+                                setModelQuery(event.target.value)
+                            }
+                            placeholder="Search models..."
+                            className="lg:w-[360px]"
+                        />
+                    </div>
+
+                    {catalogDetail ? (
+                        filteredModels.length ? (
+                            <div>
+                                <div className="overflow-hidden rounded-[16px] border border-gray-200 bg-white divide-y divide-gray-200">
+                                    {filteredModels.map((model) => {
+                                        const selected =
+                                            selectedModelIds.includes(model.id);
+                                        return (
+                                            <DenSelectableRow
+                                                key={model.id}
+                                                selected={selected}
+                                                title={model.name}
+                                                description={model.id}
+                                                onClick={() =>
+                                                    setSelectedModelIds(
+                                                        (current) =>
+                                                            current.includes(
+                                                                model.id,
+                                                            )
+                                                                ? current.filter(
+                                                                      (entry) =>
+                                                                          entry !==
+                                                                          model.id,
+                                                                  )
+                                                                : [
+                                                                      ...current,
+                                                                      model.id,
+                                                                  ],
+                                                    )
+                                                }
+                                            />
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
+                                No models match{" "}
+                                <span className="font-medium text-gray-700">
+                                    &quot;{modelQuery}&quot;
+                                </span>
+                                .
+                            </div>
+                        )
+                    ) : (
+                        <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
+                            Select a provider to browse its models.
+                        </div>
+                    )}
+                </section>
+            ) : null}
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                    People access
+                </h2>
+
+                <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    {orgContext?.members.map((member) => {
+                        const selected = selectedMemberIds.includes(member.id);
+                        const locked = lockedMemberId === member.id;
+                        return (
+                            <button
+                                key={member.id}
+                                type="button"
+                                disabled={locked}
+                                onClick={() =>
+                                    setSelectedMemberIds((current) =>
+                                        current.includes(member.id)
+                                            ? current.filter(
+                                                  (entry) =>
+                                                      entry !== member.id,
+                                              )
+                                            : [...current, member.id],
+                                    )
+                                }
+                                className={`flex min-h-[88px] items-center gap-4 rounded-[24px] border px-5 py-4 text-left transition ${selected ? "border-[#0f172a] bg-[#0f172a] text-white" : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"} ${locked ? "cursor-default" : "cursor-pointer"}`}
+                            >
+                                {selected ? (
+                                    <CheckCircle2 className="h-7 w-7 shrink-0" />
+                                ) : (
+                                    <Circle className="h-7 w-7 shrink-0 text-gray-300" />
+                                )}
+                                <div>
+                                    <p className="text-[16px] font-medium tracking-[-0.03em]">
+                                        {member.user.name}
+                                    </p>
+                                    <p
+                                        className={`mt-1 text-[13px] ${selected ? "text-white/70" : "text-gray-400"}`}
+                                    >
+                                        {member.user.email}
+                                    </p>
+                                    {locked ? (
+                                        <p
+                                            className={`mt-1 text-[12px] ${selected ? "text-white/60" : "text-gray-400"}`}
+                                        >
+                                            Creator access is locked
+                                        </p>
+                                    ) : null}
+                                </div>
+                            </button>
+                        );
+                    }) ?? null}
+                </div>
+            </section>
+
+            <section className="rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                    Team access
+                </h2>
+
+                {orgContext?.teams.length ? (
+                    <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        {orgContext.teams.map((team) => {
+                            const selected = selectedTeamIds.includes(team.id);
+                            return (
+                                <button
+                                    key={team.id}
+                                    type="button"
+                                    onClick={() =>
+                                        setSelectedTeamIds((current) =>
+                                            current.includes(team.id)
+                                                ? current.filter(
+                                                      (entry) =>
+                                                          entry !== team.id,
+                                                  )
+                                                : [...current, team.id],
+                                        )
+                                    }
+                                    className={`flex min-h-[88px] items-center gap-4 rounded-[24px] border px-5 py-4 text-left transition ${selected ? "border-[#0f172a] bg-[#0f172a] text-white" : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"}`}
+                                >
+                                    {selected ? (
+                                        <CheckCircle2 className="h-7 w-7 shrink-0" />
+                                    ) : (
+                                        <Circle className="h-7 w-7 shrink-0 text-gray-300" />
+                                    )}
+                                    <div>
+                                        <p className="text-[16px] font-medium tracking-[-0.03em]">
+                                            {team.name}
+                                        </p>
+                                        <p
+                                            className={`mt-1 text-[13px] ${selected ? "text-white/70" : "text-gray-400"}`}
+                                        >
+                                            {team.memberIds.length}{" "}
+                                            {team.memberIds.length === 1
+                                                ? "member"
+                                                : "members"}
+                                        </p>
+                                    </div>
+                                </button>
+                            );
+                        })}
+                    </div>
+                ) : (
+                    <div className="mt-8 rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
+                        Create teams from the Members page before assigning team
+                        access.
+                    </div>
+                )}
+            </section>
+        </div>
+    );
 }

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/skill-hub-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/skill-hub-editor-screen.tsx
@@ -3,442 +3,597 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import { ArrowLeft, BookOpen, CheckCircle2, Circle, Search } from "lucide-react";
+import {
+    ArrowLeft,
+    BookOpen,
+    CheckCircle2,
+    Circle,
+    Search,
+} from "lucide-react";
 import { DenButton } from "../../../../_components/ui/button";
 import { DenInput } from "../../../../_components/ui/input";
 import { DenTextarea } from "../../../../_components/ui/textarea";
 import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
 import {
-  getOrgAccessFlags,
-  getSkillHubsRoute,
-  getSkillHubRoute,
+    getOrgAccessFlags,
+    getSkillHubsRoute,
+    getSkillHubRoute,
 } from "../../../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
-  getSkillVisibilityLabel,
-  parseSkillCategory,
-  useOrgSkillLibrary,
+    getSkillVisibilityLabel,
+    parseSkillCategory,
+    useOrgSkillLibrary,
 } from "./skill-hub-data";
 
 export function SkillHubEditorScreen({ skillHubId }: { skillHubId?: string }) {
-  const router = useRouter();
-  const { orgId, orgSlug, orgContext } = useOrgDashboard();
-  const { skills, skillHubs, busy, error, reloadLibrary } = useOrgSkillLibrary(orgId);
-  const skillHub = useMemo(
-    () => (skillHubId ? skillHubs.find((entry) => entry.id === skillHubId) ?? null : null),
-    [skillHubId, skillHubs],
-  );
-
-  const access = useMemo(
-    () => getOrgAccessFlags(orgContext?.currentMember.role ?? "member", orgContext?.currentMember.isOwner ?? false),
-    [orgContext?.currentMember.isOwner, orgContext?.currentMember.role],
-  );
-
-  const canManage = skillHubId ? skillHub?.canManage === true : true;
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
-  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
-  const [skillQuery, setSkillQuery] = useState("");
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    if (skillHubId) {
-      if (!skillHub) {
-        return;
-      }
-
-      setName(skillHub.name);
-      setDescription(skillHub.description ?? "");
-      setSelectedTeamIds(skillHub.access.teams.map((entry) => entry.teamId));
-      setSelectedSkillIds(skillHub.skills.map((entry) => entry.id));
-      return;
-    }
-
-    setName("");
-    setDescription("");
-    setSelectedTeamIds([]);
-    setSelectedSkillIds([]);
-  }, [skillHub, skillHubId]);
-
-  const filteredSkills = useMemo(() => {
-    const normalizedQuery = skillQuery.trim().toLowerCase();
-    if (!normalizedQuery) {
-      return skills;
-    }
-
-    return skills.filter((skill) => {
-      const category = parseSkillCategory(skill.skillText) ?? "";
-      return (
-        skill.title.toLowerCase().includes(normalizedQuery) ||
-        (skill.description ?? "").toLowerCase().includes(normalizedQuery) ||
-        category.toLowerCase().includes(normalizedQuery)
-      );
-    });
-  }, [skillQuery, skills]);
-
-  const currentTeamAccessById = useMemo(
-    () => new Map((skillHub?.access.teams ?? []).map((entry) => [entry.teamId, entry.id])),
-    [skillHub?.access.teams],
-  );
-
-  const currentSkillIds = useMemo(() => new Set(skillHub?.skills.map((entry) => entry.id) ?? []), [skillHub?.skills]);
-
-  async function saveHub() {
-    if (!orgId) {
-      setSaveError("Organization not found.");
-      return;
-    }
-
-    if (!name.trim()) {
-      setSaveError("Enter a hub name.");
-      return;
-    }
-
-    setSaving(true);
-    setSaveError(null);
-    try {
-      let nextSkillHubId = skillHubId ?? null;
-
-      if (!nextSkillHubId) {
-        const { response, payload } = await requestJson(
-          `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs`,
-          {
-            method: "POST",
-            body: JSON.stringify({
-              name: name.trim(),
-              description: description.trim() || null,
-            }),
-          },
-          12000,
-        );
-
-        if (!response.ok) {
-          throw new Error(getErrorMessage(payload, `Failed to create hub (${response.status}).`));
-        }
-
-        const nextHub = payload && typeof payload === "object" && payload && "skillHub" in payload && payload.skillHub && typeof payload.skillHub === "object"
-          ? payload.skillHub as { id?: unknown }
-          : null;
-        nextSkillHubId = typeof nextHub?.id === "string" ? nextHub.id : null;
-        if (!nextSkillHubId) {
-          throw new Error("The hub was created, but no hub id was returned.");
-        }
-      } else if (skillHub && (skillHub.name !== name.trim() || (skillHub.description ?? "") !== description.trim())) {
-        const { response, payload } = await requestJson(
-          `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}`,
-          {
-            method: "PATCH",
-            body: JSON.stringify({
-              name: name.trim(),
-              description: description.trim() || null,
-            }),
-          },
-          12000,
-        );
-
-        if (!response.ok) {
-          throw new Error(getErrorMessage(payload, `Failed to update hub (${response.status}).`));
-        }
-      }
-
-      const teamIdsToAdd = selectedTeamIds.filter((teamId) => !currentTeamAccessById.has(teamId));
-      const teamAccessIdsToRemove = [...currentTeamAccessById.entries()]
-        .filter(([teamId]) => !selectedTeamIds.includes(teamId))
-        .map(([, accessId]) => accessId);
-      const skillIdsToAdd = selectedSkillIds.filter((entry) => !currentSkillIds.has(entry));
-      const skillIdsToRemove = [...currentSkillIds].filter((entry) => !selectedSkillIds.includes(entry));
-
-      await Promise.all(teamIdsToAdd.map(async (teamId) => {
-        const { response, payload } = await requestJson(
-          `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/access`,
-          {
-            method: "POST",
-            body: JSON.stringify({ teamId }),
-          },
-          12000,
-        );
-
-        if (!response.ok) {
-          throw new Error(getErrorMessage(payload, `Failed to grant team access (${response.status}).`));
-        }
-      }));
-
-      await Promise.all(teamAccessIdsToRemove.map(async (accessId) => {
-        const { response, payload } = await requestJson(
-          `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/access/${encodeURIComponent(accessId)}`,
-          { method: "DELETE" },
-          12000,
-        );
-
-        if (response.status !== 204 && !response.ok) {
-          throw new Error(getErrorMessage(payload, `Failed to remove team access (${response.status}).`));
-        }
-      }));
-
-      await Promise.all(skillIdsToAdd.map(async (entry) => {
-        const { response, payload } = await requestJson(
-          `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/skills`,
-          {
-            method: "POST",
-            body: JSON.stringify({ skillId: entry }),
-          },
-          12000,
-        );
-
-        if (!response.ok) {
-          throw new Error(getErrorMessage(payload, `Failed to add a skill (${response.status}).`));
-        }
-      }));
-
-      await Promise.all(skillIdsToRemove.map(async (entry) => {
-        const { response, payload } = await requestJson(
-          `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/skills/${encodeURIComponent(entry)}`,
-          { method: "DELETE" },
-          12000,
-        );
-
-        if (response.status !== 204 && !response.ok) {
-          throw new Error(getErrorMessage(payload, `Failed to remove a skill (${response.status}).`));
-        }
-      }));
-
-      await reloadLibrary();
-      router.push(skillHubId ? getSkillHubRoute(orgSlug, nextSkillHubId) : getSkillHubsRoute(orgSlug));
-      router.refresh();
-    } catch (nextError) {
-      setSaveError(nextError instanceof Error ? nextError.message : "Could not save the hub.");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  if (busy && skillHubId && !skillHub) {
-    return (
-      <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-        <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
-          Loading hub details...
-        </div>
-      </div>
+    const router = useRouter();
+    const { orgId, orgSlug, orgContext } = useOrgDashboard();
+    const { skills, skillHubs, busy, error, reloadLibrary } =
+        useOrgSkillLibrary(orgId);
+    const skillHub = useMemo(
+        () =>
+            skillHubId
+                ? (skillHubs.find((entry) => entry.id === skillHubId) ?? null)
+                : null,
+        [skillHubId, skillHubs],
     );
-  }
 
-  if (skillHubId && !skillHub) {
-    return (
-      <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-        <div className="rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[15px] text-red-700">
-          {error ?? "That hub could not be found."}
-        </div>
-      </div>
+    const access = useMemo(
+        () =>
+            getOrgAccessFlags(
+                orgContext?.currentMember.role ?? "member",
+                orgContext?.currentMember.isOwner ?? false,
+            ),
+        [orgContext?.currentMember.isOwner, orgContext?.currentMember.role],
     );
-  }
 
-  return (
-    <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
-      <div className="mb-8 flex flex-col gap-3">
-        <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">
-          {skillHubId ? "Skill hub editor" : "Create a hub"}
-        </p>
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div>
-            <h1 className="text-[34px] font-semibold tracking-[-0.07em] text-gray-950">
-              {skillHubId ? skillHub?.name ?? "Hub details" : "Create a new skill hub"}
-            </h1>
-            <p className="mt-3 max-w-[700px] text-[16px] leading-8 text-gray-500">
-              Shape who can access this collection, then pick the exact skills each team should inherit.
-            </p>
-          </div>
+    const canManage = skillHubId ? skillHub?.canManage === true : true;
+    const [name, setName] = useState("");
+    const [description, setDescription] = useState("");
+    const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+    const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+    const [skillQuery, setSkillQuery] = useState("");
+    const [saveError, setSaveError] = useState<string | null>(null);
+    const [saving, setSaving] = useState(false);
 
-          <div className="flex flex-wrap gap-3 text-[13px] font-medium text-gray-600">
-            <span className="rounded-full border border-gray-200 bg-white px-4 py-2">
-              {selectedTeamIds.length} {selectedTeamIds.length === 1 ? "team selected" : "teams selected"}
-            </span>
-            <span className="rounded-full border border-gray-200 bg-white px-4 py-2">
-              {selectedSkillIds.length} {selectedSkillIds.length === 1 ? "skill selected" : "skills selected"}
-            </span>
-          </div>
-        </div>
-      </div>
+    useEffect(() => {
+        if (skillHubId) {
+            if (!skillHub) {
+                return;
+            }
 
-      <div className="mb-8 flex items-center justify-between gap-4">
-        <Link
-          href={skillHubId ? getSkillHubRoute(orgSlug, skillHubId) : getSkillHubsRoute(orgSlug)}
-          className="inline-flex items-center gap-2 text-[15px] font-medium text-gray-500 transition hover:text-gray-900"
-        >
-          <ArrowLeft className="h-5 w-5" />
-          Back
-        </Link>
+            setName(skillHub.name);
+            setDescription(skillHub.description ?? "");
+            setSelectedTeamIds(
+                skillHub.access.teams.map((entry) => entry.teamId),
+            );
+            setSelectedSkillIds(skillHub.skills.map((entry) => entry.id));
+            return;
+        }
 
-        {canManage ? (
-          <DenButton loading={saving} onClick={() => void saveHub()}>
-            {skillHubId ? "Save Hub" : "Create Hub"}
-          </DenButton>
-        ) : (
-          <span className="rounded-full border border-gray-200 bg-white px-4 py-2 text-[13px] font-medium text-gray-500">
-            Read only
-          </span>
-        )}
-      </div>
+        setName("");
+        setDescription("");
+        setSelectedTeamIds([]);
+        setSelectedSkillIds([]);
+    }, [skillHub, skillHubId]);
 
-      {saveError ? (
-        <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
-          {saveError}
-        </div>
-      ) : null}
+    const filteredSkills = useMemo(() => {
+        const normalizedQuery = skillQuery.trim().toLowerCase();
+        if (!normalizedQuery) {
+            return skills;
+        }
 
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <h2 className="mb-8 text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Hub Details</h2>
-        <div className="grid gap-6">
-          <label className="grid gap-3">
-            <span className="text-[14px] font-medium text-gray-700">Hub Name</span>
-            <DenInput
-              type="text"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              disabled={!canManage}
-            />
-          </label>
-          <label className="grid gap-3">
-            <span className="text-[14px] font-medium text-gray-700">Description</span>
-            <DenTextarea
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              disabled={!canManage}
-              rows={4}
-            />
-          </label>
-        </div>
-      </section>
+        return skills.filter((skill) => {
+            const category = parseSkillCategory(skill.skillText) ?? "";
+            return (
+                skill.title.toLowerCase().includes(normalizedQuery) ||
+                (skill.description ?? "")
+                    .toLowerCase()
+                    .includes(normalizedQuery) ||
+                category.toLowerCase().includes(normalizedQuery)
+            );
+        });
+    }, [skillQuery, skills]);
 
-      <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Assigned Teams</h2>
-        <p className="mt-2 text-[15px] text-gray-500">Select which teams have access to this hub.</p>
-        {skillHub?.access.members.length ? (
-          <p className="mt-3 text-[13px] text-gray-400">
-            {skillHub.access.members.length} direct member grant{skillHub.access.members.length === 1 ? "" : "s"} already exist and will stay in place.
-          </p>
-        ) : null}
+    const currentTeamAccessById = useMemo(
+        () =>
+            new Map(
+                (skillHub?.access.teams ?? []).map((entry) => [
+                    entry.teamId,
+                    entry.id,
+                ]),
+            ),
+        [skillHub?.access.teams],
+    );
 
-        {orgContext?.teams.length ? (
-          <div className="mt-8 grid gap-4 md:grid-cols-2">
-            {orgContext.teams.map((team) => {
-              const selected = selectedTeamIds.includes(team.id);
-              return (
-                <button
-                  key={team.id}
-                  type="button"
-                  disabled={!canManage}
-                  onClick={() => {
-                    if (!canManage) {
-                      return;
-                    }
-                    setSelectedTeamIds((current) =>
-                      current.includes(team.id)
-                        ? current.filter((entry) => entry !== team.id)
-                        : [...current, team.id],
-                    );
-                  }}
-                  className={`flex min-h-[84px] items-center gap-4 rounded-[24px] border px-5 py-4 text-left transition ${
-                    selected
-                      ? "border-[#0f172a] bg-[#0f172a] text-white"
-                      : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"
-                  } ${!canManage ? "cursor-default" : "cursor-pointer"}`}
-                >
-                  {selected ? <CheckCircle2 className="h-7 w-7 shrink-0" /> : <Circle className="h-7 w-7 shrink-0 text-gray-300" />}
-                  <div>
-                    <p className="text-[17px] font-medium tracking-[-0.03em]">{team.name}</p>
-                    <p className={`mt-1 text-[13px] ${selected ? "text-white/70" : "text-gray-400"}`}>
-                      {team.memberIds.length} {team.memberIds.length === 1 ? "member" : "members"}
-                    </p>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="mt-8 rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
-            Create teams from the Members page before assigning hub access.
-          </div>
-        )}
-      </section>
+    const currentSkillIds = useMemo(
+        () => new Set(skillHub?.skills.map((entry) => entry.id) ?? []),
+        [skillHub?.skills],
+    );
 
-      <section className="rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
-        <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">Hub Skills</h2>
-            <p className="mt-2 text-[15px] text-gray-500">Select the skills to include in this hub.</p>
-          </div>
+    async function saveHub() {
+        if (!orgId) {
+            setSaveError("Organization not found.");
+            return;
+        }
 
-          <div>
-            <DenInput
-              type="search"
-              icon={Search}
-              value={skillQuery}
-              onChange={(event) => setSkillQuery(event.target.value)}
-              placeholder="Search skills..."
-            />
-          </div>
-        </div>
+        if (!name.trim()) {
+            setSaveError("Enter a hub name.");
+            return;
+        }
 
-        <div className="max-h-[560px] overflow-y-auto border-t border-gray-100 pt-6">
-          {filteredSkills.length === 0 ? (
-            <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
-              No skills match that search.
-            </div>
-          ) : (
-            <div className="grid gap-4">
-              {filteredSkills.map((skill) => {
-                const selected = selectedSkillIds.includes(skill.id);
-                const isPrivateRestricted = skill.shared === null && !skill.canManage && !access.isAdmin;
-                return (
-                  <button
-                    key={skill.id}
-                    type="button"
-                    disabled={!canManage || isPrivateRestricted}
-                    onClick={() => {
-                      if (!canManage || isPrivateRestricted) {
-                        return;
-                      }
-                      setSelectedSkillIds((current) =>
-                        current.includes(skill.id)
-                          ? current.filter((entry) => entry !== skill.id)
-                          : [...current, skill.id],
-                      );
-                    }}
-                    className={`flex items-start gap-4 rounded-[24px] border px-5 py-5 text-left transition ${
-                      selected
-                        ? "border-[#0f172a] bg-[#f8fafc]"
-                        : "border-gray-200 bg-white hover:border-gray-300"
-                    } ${isPrivateRestricted ? "cursor-not-allowed opacity-60" : !canManage ? "cursor-default" : "cursor-pointer"}`}
-                  >
-                    {selected ? <CheckCircle2 className="mt-0.5 h-7 w-7 shrink-0 text-[#0f172a]" /> : <Circle className="mt-0.5 h-7 w-7 shrink-0 text-gray-300" />}
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-3">
-                        <span className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">{skill.title}</span>
-                        <span className="rounded-full bg-gray-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500">
-                          {parseSkillCategory(skill.skillText) ?? getSkillVisibilityLabel(skill.shared)}
-                        </span>
-                        <span className="rounded-full bg-gray-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500">
-                          {getSkillVisibilityLabel(skill.shared)}
-                        </span>
-                      </div>
-                      <p className="mt-2 text-[15px] leading-7 text-gray-500">
-                        {skill.description || "No description yet."}
-                      </p>
-                      {isPrivateRestricted ? (
-                        <p className="mt-3 text-[13px] text-amber-600">
-                          Private skills can only be added by their creator or an org admin.
-                        </p>
-                      ) : null}
-                    </div>
-                  </button>
+        setSaving(true);
+        setSaveError(null);
+        try {
+            let nextSkillHubId = skillHubId ?? null;
+
+            if (!nextSkillHubId) {
+                const { response, payload } = await requestJson(
+                    `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs`,
+                    {
+                        method: "POST",
+                        body: JSON.stringify({
+                            name: name.trim(),
+                            description: description.trim() || null,
+                        }),
+                    },
+                    12000,
                 );
-              })}
+
+                if (!response.ok) {
+                    throw new Error(
+                        getErrorMessage(
+                            payload,
+                            `Failed to create hub (${response.status}).`,
+                        ),
+                    );
+                }
+
+                const nextHub =
+                    payload &&
+                    typeof payload === "object" &&
+                    payload &&
+                    "skillHub" in payload &&
+                    payload.skillHub &&
+                    typeof payload.skillHub === "object"
+                        ? (payload.skillHub as { id?: unknown })
+                        : null;
+                nextSkillHubId =
+                    typeof nextHub?.id === "string" ? nextHub.id : null;
+                if (!nextSkillHubId) {
+                    throw new Error(
+                        "The hub was created, but no hub id was returned.",
+                    );
+                }
+            } else if (
+                skillHub &&
+                (skillHub.name !== name.trim() ||
+                    (skillHub.description ?? "") !== description.trim())
+            ) {
+                const { response, payload } = await requestJson(
+                    `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}`,
+                    {
+                        method: "PATCH",
+                        body: JSON.stringify({
+                            name: name.trim(),
+                            description: description.trim() || null,
+                        }),
+                    },
+                    12000,
+                );
+
+                if (!response.ok) {
+                    throw new Error(
+                        getErrorMessage(
+                            payload,
+                            `Failed to update hub (${response.status}).`,
+                        ),
+                    );
+                }
+            }
+
+            const teamIdsToAdd = selectedTeamIds.filter(
+                (teamId) => !currentTeamAccessById.has(teamId),
+            );
+            const teamAccessIdsToRemove = [...currentTeamAccessById.entries()]
+                .filter(([teamId]) => !selectedTeamIds.includes(teamId))
+                .map(([, accessId]) => accessId);
+            const skillIdsToAdd = selectedSkillIds.filter(
+                (entry) => !currentSkillIds.has(entry),
+            );
+            const skillIdsToRemove = [...currentSkillIds].filter(
+                (entry) => !selectedSkillIds.includes(entry),
+            );
+
+            await Promise.all(
+                teamIdsToAdd.map(async (teamId) => {
+                    const { response, payload } = await requestJson(
+                        `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/access`,
+                        {
+                            method: "POST",
+                            body: JSON.stringify({ teamId }),
+                        },
+                        12000,
+                    );
+
+                    if (!response.ok) {
+                        throw new Error(
+                            getErrorMessage(
+                                payload,
+                                `Failed to grant team access (${response.status}).`,
+                            ),
+                        );
+                    }
+                }),
+            );
+
+            await Promise.all(
+                teamAccessIdsToRemove.map(async (accessId) => {
+                    const { response, payload } = await requestJson(
+                        `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/access/${encodeURIComponent(accessId)}`,
+                        { method: "DELETE" },
+                        12000,
+                    );
+
+                    if (response.status !== 204 && !response.ok) {
+                        throw new Error(
+                            getErrorMessage(
+                                payload,
+                                `Failed to remove team access (${response.status}).`,
+                            ),
+                        );
+                    }
+                }),
+            );
+
+            await Promise.all(
+                skillIdsToAdd.map(async (entry) => {
+                    const { response, payload } = await requestJson(
+                        `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/skills`,
+                        {
+                            method: "POST",
+                            body: JSON.stringify({ skillId: entry }),
+                        },
+                        12000,
+                    );
+
+                    if (!response.ok) {
+                        throw new Error(
+                            getErrorMessage(
+                                payload,
+                                `Failed to add a skill (${response.status}).`,
+                            ),
+                        );
+                    }
+                }),
+            );
+
+            await Promise.all(
+                skillIdsToRemove.map(async (entry) => {
+                    const { response, payload } = await requestJson(
+                        `/v1/orgs/${encodeURIComponent(orgId)}/skill-hubs/${encodeURIComponent(nextSkillHubId)}/skills/${encodeURIComponent(entry)}`,
+                        { method: "DELETE" },
+                        12000,
+                    );
+
+                    if (response.status !== 204 && !response.ok) {
+                        throw new Error(
+                            getErrorMessage(
+                                payload,
+                                `Failed to remove a skill (${response.status}).`,
+                            ),
+                        );
+                    }
+                }),
+            );
+
+            await reloadLibrary();
+            router.push(
+                skillHubId
+                    ? getSkillHubRoute(orgSlug, nextSkillHubId)
+                    : getSkillHubsRoute(orgSlug),
+            );
+            router.refresh();
+        } catch (nextError) {
+            setSaveError(
+                nextError instanceof Error
+                    ? nextError.message
+                    : "Could not save the hub.",
+            );
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    if (busy && skillHubId && !skillHub) {
+        return (
+            <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+                <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
+                    Loading hub details...
+                </div>
             </div>
-          )}
+        );
+    }
+
+    if (skillHubId && !skillHub) {
+        return (
+            <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+                <div className="rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[15px] text-red-700">
+                    {error ?? "That hub could not be found."}
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="mx-auto max-w-[1180px] px-6 py-8 md:px-8">
+            <div className="mb-8 flex flex-col gap-3">
+                <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+                    {skillHubId ? "Skill hub editor" : "Create a hub"}
+                </p>
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+                    <div>
+                        <h1 className="text-[34px] font-semibold tracking-[-0.07em] text-gray-950">
+                            {skillHubId
+                                ? (skillHub?.name ?? "Hub details")
+                                : "Create a new skill hub"}
+                        </h1>
+                        <p className="mt-3 max-w-[700px] text-[16px] leading-8 text-gray-500">
+                            Shape who can access this collection, then pick the
+                            exact skills each team should inherit.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div className="mb-8 flex items-center justify-between gap-4">
+                <Link
+                    href={
+                        skillHubId
+                            ? getSkillHubRoute(orgSlug, skillHubId)
+                            : getSkillHubsRoute(orgSlug)
+                    }
+                    className="inline-flex items-center gap-2 text-[15px] font-medium text-gray-500 transition hover:text-gray-900"
+                >
+                    <ArrowLeft className="h-5 w-5" />
+                    Back
+                </Link>
+
+                {canManage ? (
+                    <DenButton loading={saving} onClick={() => void saveHub()}>
+                        {skillHubId ? "Save Hub" : "Create Hub"}
+                    </DenButton>
+                ) : (
+                    <span className="rounded-full border border-gray-200 bg-white px-4 py-2 text-[13px] font-medium text-gray-500">
+                        Read only
+                    </span>
+                )}
+            </div>
+
+            {saveError ? (
+                <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
+                    {saveError}
+                </div>
+            ) : null}
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <h2 className="mb-8 text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                    Hub Details
+                </h2>
+                <div className="grid gap-6">
+                    <label className="grid gap-3">
+                        <span className="text-[14px] font-medium text-gray-700">
+                            Hub Name
+                        </span>
+                        <DenInput
+                            type="text"
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                            disabled={!canManage}
+                        />
+                    </label>
+                    <label className="grid gap-3">
+                        <span className="text-[14px] font-medium text-gray-700">
+                            Description
+                        </span>
+                        <DenTextarea
+                            value={description}
+                            onChange={(event) =>
+                                setDescription(event.target.value)
+                            }
+                            disabled={!canManage}
+                            rows={4}
+                        />
+                    </label>
+                </div>
+            </section>
+
+            <section className="mb-8 rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                    Assigned Teams
+                </h2>
+                <p className="mt-2 text-[15px] text-gray-500">
+                    Select which teams have access to this hub.
+                </p>
+                {skillHub?.access.members.length ? (
+                    <p className="mt-3 text-[13px] text-gray-400">
+                        {skillHub.access.members.length} direct member grant
+                        {skillHub.access.members.length === 1 ? "" : "s"}{" "}
+                        already exist and will stay in place.
+                    </p>
+                ) : null}
+
+                {orgContext?.teams.length ? (
+                    <div className="mt-8 grid gap-4 md:grid-cols-2">
+                        {orgContext.teams.map((team) => {
+                            const selected = selectedTeamIds.includes(team.id);
+                            return (
+                                <button
+                                    key={team.id}
+                                    type="button"
+                                    disabled={!canManage}
+                                    onClick={() => {
+                                        if (!canManage) {
+                                            return;
+                                        }
+                                        setSelectedTeamIds((current) =>
+                                            current.includes(team.id)
+                                                ? current.filter(
+                                                      (entry) =>
+                                                          entry !== team.id,
+                                                  )
+                                                : [...current, team.id],
+                                        );
+                                    }}
+                                    className={`flex min-h-[84px] items-center gap-4 rounded-[24px] border px-5 py-4 text-left transition ${
+                                        selected
+                                            ? "border-[#0f172a] bg-[#0f172a] text-white"
+                                            : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"
+                                    } ${!canManage ? "cursor-default" : "cursor-pointer"}`}
+                                >
+                                    {selected ? (
+                                        <CheckCircle2 className="h-7 w-7 shrink-0" />
+                                    ) : (
+                                        <Circle className="h-7 w-7 shrink-0 text-gray-300" />
+                                    )}
+                                    <div>
+                                        <p className="text-[17px] font-medium tracking-[-0.03em]">
+                                            {team.name}
+                                        </p>
+                                        <p
+                                            className={`mt-1 text-[13px] ${selected ? "text-white/70" : "text-gray-400"}`}
+                                        >
+                                            {team.memberIds.length}{" "}
+                                            {team.memberIds.length === 1
+                                                ? "member"
+                                                : "members"}
+                                        </p>
+                                    </div>
+                                </button>
+                            );
+                        })}
+                    </div>
+                ) : (
+                    <div className="mt-8 rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
+                        Create teams from the Members page before assigning hub
+                        access.
+                    </div>
+                )}
+            </section>
+
+            <section className="rounded-[36px] border border-gray-200 bg-white p-8 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.24)]">
+                <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                    <div>
+                        <h2 className="text-[24px] font-semibold tracking-[-0.05em] text-gray-950">
+                            Hub Skills
+                        </h2>
+                        <p className="mt-2 text-[15px] text-gray-500">
+                            Select the skills to include in this hub.
+                        </p>
+                    </div>
+
+                    <div>
+                        <DenInput
+                            type="search"
+                            icon={Search}
+                            value={skillQuery}
+                            onChange={(event) =>
+                                setSkillQuery(event.target.value)
+                            }
+                            placeholder="Search skills..."
+                        />
+                    </div>
+                </div>
+
+                <div className="max-h-[560px] overflow-y-auto border-t border-gray-100 pt-6">
+                    {filteredSkills.length === 0 ? (
+                        <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-6 text-[15px] text-gray-500">
+                            No skills match that search.
+                        </div>
+                    ) : (
+                        <div className="grid gap-4">
+                            {filteredSkills.map((skill) => {
+                                const selected = selectedSkillIds.includes(
+                                    skill.id,
+                                );
+                                const isPrivateRestricted =
+                                    skill.shared === null &&
+                                    !skill.canManage &&
+                                    !access.isAdmin;
+                                return (
+                                    <button
+                                        key={skill.id}
+                                        type="button"
+                                        disabled={
+                                            !canManage || isPrivateRestricted
+                                        }
+                                        onClick={() => {
+                                            if (
+                                                !canManage ||
+                                                isPrivateRestricted
+                                            ) {
+                                                return;
+                                            }
+                                            setSelectedSkillIds((current) =>
+                                                current.includes(skill.id)
+                                                    ? current.filter(
+                                                          (entry) =>
+                                                              entry !==
+                                                              skill.id,
+                                                      )
+                                                    : [...current, skill.id],
+                                            );
+                                        }}
+                                        className={`flex items-start gap-4 rounded-[24px] border px-5 py-5 text-left transition ${
+                                            selected
+                                                ? "border-[#0f172a] bg-[#f8fafc]"
+                                                : "border-gray-200 bg-white hover:border-gray-300"
+                                        } ${isPrivateRestricted ? "cursor-not-allowed opacity-60" : !canManage ? "cursor-default" : "cursor-pointer"}`}
+                                    >
+                                        {selected ? (
+                                            <CheckCircle2 className="mt-0.5 h-7 w-7 shrink-0 text-[#0f172a]" />
+                                        ) : (
+                                            <Circle className="mt-0.5 h-7 w-7 shrink-0 text-gray-300" />
+                                        )}
+                                        <div className="min-w-0">
+                                            <div className="flex flex-wrap items-center gap-3">
+                                                <span className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">
+                                                    {skill.title}
+                                                </span>
+                                                <span className="rounded-full bg-gray-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500">
+                                                    {parseSkillCategory(
+                                                        skill.skillText,
+                                                    ) ??
+                                                        getSkillVisibilityLabel(
+                                                            skill.shared,
+                                                        )}
+                                                </span>
+                                                <span className="rounded-full bg-gray-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500">
+                                                    {getSkillVisibilityLabel(
+                                                        skill.shared,
+                                                    )}
+                                                </span>
+                                            </div>
+                                            <p className="mt-2 text-[15px] leading-7 text-gray-500">
+                                                {skill.description ||
+                                                    "No description yet."}
+                                            </p>
+                                            {isPrivateRestricted ? (
+                                                <p className="mt-3 text-[13px] text-amber-600">
+                                                    Private skills can only be
+                                                    added by their creator or an
+                                                    org admin.
+                                                </p>
+                                            ) : null}
+                                        </div>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </section>
         </div>
-      </section>
-    </div>
-  );
+    );
 }

--- a/ee/apps/den-web/next-env.d.ts
+++ b/ee/apps/den-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- simplify the Den LLM provider detail, editor, and skill hub editor screens by removing redundant helper copy and tightening the layouts
- clarify provider/model selection wording and align button content so action rows render more consistently
- include the generated `next-env.d.ts` update produced by the successful den-web build

## Testing
- `pnpm build` (from `ee/apps/den-web`) ✅
- `pnpm lint` (from `ee/apps/den-web`) ⚠️ fails in this workspace because the app still uses `next lint`, which Next 16 treats as an invalid project directory invocation