### PR TITLE
fix(settings): correct ready-to-install update label

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -2711,7 +2711,7 @@ export default {
   "settings.tab_description_updates":
     "Keep the app current with quiet background checks and install controls.",
   "settings.tab_model": "Model",
-  "settings.toolbar_ready_to_install": "Ready to install${version ? ",
+  "settings.toolbar_ready_to_install": "Ready to install",
   "settings.update_available_version": "Update available: v{version}",
   "settings.update_check_button": "Check",
   "settings.update_check_failed": "Update check failed",


### PR DESCRIPTION
## Summary
- fix the settings update badge copy by removing a stray template fragment from the English locale string
- keep the existing version suffix behavior so the ready state renders as `Ready to install · v...`

## Verification
- confirmed the PR diff only updates `apps/app/src/i18n/locales/en.ts`
- attempted `pnpm --filter @openwork/app typecheck`, but this worktree is missing dependencies and failed during `pretypecheck` because `tsup` was not installed