### PR TITLE
fix(desktop): keep sticky local server ports stable

### DIFF
--- a/apps/desktop/src-tauri/src/openwork_server/mod.rs
+++ b/apps/desktop/src-tauri/src/openwork_server/mod.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 use crate::types::OpenworkServerInfo;
 use crate::utils::now_ms;
 use crate::utils::truncate_output;
+use crate::workspace::state::normalize_local_workspace_path;
 
 pub mod manager;
 pub mod spawn;
@@ -67,6 +68,14 @@ fn openwork_server_state_path(app: &AppHandle) -> Result<PathBuf, String> {
         .app_data_dir()
         .map_err(|e| format!("Failed to resolve app data dir: {e}"))?;
     Ok(data_dir.join("openwork-server-state.json"))
+}
+
+fn normalize_workspace_key(workspace_key: &str) -> String {
+    let trimmed = workspace_key.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    normalize_local_workspace_path(trimmed)
 }
 
 fn load_openwork_server_token_store(
@@ -140,12 +149,14 @@ fn save_openwork_server_state(
     Ok(())
 }
 
-fn read_preferred_openwork_port(app: &AppHandle, workspace_key: &str) -> Result<Option<u16>, String> {
-    let path = openwork_server_state_path(app)?;
-    let state = load_openwork_server_state(&path)?;
-    let trimmed = workspace_key.trim();
-    if !trimmed.is_empty() {
-        if let Some(port) = state.workspace_ports.get(trimmed) {
+fn read_preferred_openwork_port_at_path(
+    path: &Path,
+    workspace_key: &str,
+) -> Result<Option<u16>, String> {
+    let state = load_openwork_server_state(path)?;
+    let normalized = normalize_workspace_key(workspace_key);
+    if !normalized.is_empty() {
+        if let Some(port) = state.workspace_ports.get(&normalized) {
             return Ok(Some(*port));
         }
     }
@@ -155,13 +166,20 @@ fn read_preferred_openwork_port(app: &AppHandle, workspace_key: &str) -> Result<
     Ok(state.preferred_port)
 }
 
-fn reserved_openwork_ports(app: &AppHandle, exclude_workspace_key: &str) -> Result<HashSet<u16>, String> {
+fn read_preferred_openwork_port(app: &AppHandle, workspace_key: &str) -> Result<Option<u16>, String> {
     let path = openwork_server_state_path(app)?;
-    let state = load_openwork_server_state(&path)?;
-    let excluded = exclude_workspace_key.trim();
+    read_preferred_openwork_port_at_path(&path, workspace_key)
+}
+
+fn reserved_openwork_ports_at_path(
+    path: &Path,
+    exclude_workspace_key: &str,
+) -> Result<HashSet<u16>, String> {
+    let state = load_openwork_server_state(path)?;
+    let excluded = normalize_workspace_key(exclude_workspace_key);
     let mut reserved = HashSet::new();
     for (workspace_key, port) in state.workspace_ports {
-        if workspace_key.trim() == excluded {
+        if workspace_key == excluded {
             continue;
         }
         reserved.insert(port);
@@ -174,22 +192,35 @@ fn reserved_openwork_ports(app: &AppHandle, exclude_workspace_key: &str) -> Resu
     Ok(reserved)
 }
 
+fn reserved_openwork_ports(app: &AppHandle, exclude_workspace_key: &str) -> Result<HashSet<u16>, String> {
+    let path = openwork_server_state_path(app)?;
+    reserved_openwork_ports_at_path(&path, exclude_workspace_key)
+}
+
+fn persist_preferred_openwork_port_at_path(
+    path: &Path,
+    workspace_key: &str,
+    port: u16,
+) -> Result<(), String> {
+    let mut state = load_openwork_server_state(path)?;
+    state.version = OPENWORK_SERVER_STATE_VERSION;
+    let normalized = normalize_workspace_key(workspace_key);
+    if normalized.is_empty() {
+        state.preferred_port = Some(port);
+    } else {
+        state.workspace_ports.insert(normalized, port);
+        state.preferred_port = None;
+    }
+    save_openwork_server_state(path, &state)
+}
+
 fn persist_preferred_openwork_port(
     app: &AppHandle,
     workspace_key: &str,
     port: u16,
 ) -> Result<(), String> {
     let path = openwork_server_state_path(app)?;
-    let mut state = load_openwork_server_state(&path)?;
-    state.version = OPENWORK_SERVER_STATE_VERSION;
-    let trimmed = workspace_key.trim();
-    if trimmed.is_empty() {
-        state.preferred_port = Some(port);
-    } else {
-        state.workspace_ports.insert(trimmed.to_string(), port);
-        state.preferred_port = None;
-    }
-    save_openwork_server_state(&path, &state)
+    persist_preferred_openwork_port_at_path(&path, workspace_key, port)
 }
 
 fn load_or_create_workspace_tokens(
@@ -205,7 +236,8 @@ fn load_or_create_workspace_tokens_at_path(
     workspace_key: &str,
 ) -> Result<PersistedOpenworkServerTokens, String> {
     let mut store = load_openwork_server_token_store(path)?;
-    if let Some(tokens) = store.workspaces.get(workspace_key) {
+    let normalized = normalize_workspace_key(workspace_key);
+    if let Some(tokens) = store.workspaces.get(&normalized) {
         return Ok(tokens.clone());
     }
 
@@ -217,7 +249,7 @@ fn load_or_create_workspace_tokens_at_path(
     };
     store
         .workspaces
-        .insert(workspace_key.to_string(), tokens.clone());
+        .insert(normalized, tokens.clone());
     save_openwork_server_token_store(path, &store)?;
     Ok(tokens)
 }
@@ -237,7 +269,8 @@ fn persist_workspace_owner_token_at_path(
     owner_token: &str,
 ) -> Result<(), String> {
     let mut store = load_openwork_server_token_store(path)?;
-    let Some(tokens) = store.workspaces.get_mut(workspace_key) else {
+    let normalized = normalize_workspace_key(workspace_key);
+    let Some(tokens) = store.workspaces.get_mut(&normalized) else {
         return Ok(());
     };
     tokens.owner_token = Some(owner_token.to_string());
@@ -473,5 +506,54 @@ mod tests {
         assert!(state.workspace_ports.is_empty());
 
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn reuses_workspace_tokens_across_canonical_path_aliases() {
+        let path = unique_temp_path("token-path-alias");
+        let workspace = PathBuf::from(format!(
+            "/tmp/openwork-workspace-token-alias-{}-{}",
+            std::process::id(),
+            now_ms()
+        ));
+        fs::create_dir_all(&workspace).expect("create temp workspace");
+        let canonical = fs::canonicalize(&workspace).expect("canonical workspace path");
+
+        let first = load_or_create_workspace_tokens_at_path(&path, &workspace.to_string_lossy())
+            .expect("store tokens using raw path");
+        let second = load_or_create_workspace_tokens_at_path(&path, &canonical.to_string_lossy())
+            .expect("load tokens using canonical path");
+
+        assert_eq!(first.client_token, second.client_token);
+        assert_eq!(first.host_token, second.host_token);
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn reuses_workspace_port_across_canonical_path_aliases() {
+        let path = unique_temp_path("port-path-alias");
+        let workspace = PathBuf::from(format!(
+            "/tmp/openwork-workspace-port-alias-{}-{}",
+            std::process::id(),
+            now_ms()
+        ));
+        fs::create_dir_all(&workspace).expect("create temp workspace");
+        let canonical = fs::canonicalize(&workspace).expect("canonical workspace path");
+
+        persist_preferred_openwork_port_at_path(&path, &workspace.to_string_lossy(), 49_123)
+            .expect("persist preferred port using raw path");
+
+        let preferred = read_preferred_openwork_port_at_path(&path, &canonical.to_string_lossy())
+            .expect("read preferred port using canonical path");
+        let reserved = reserved_openwork_ports_at_path(&path, &canonical.to_string_lossy())
+            .expect("read reserved ports using canonical path");
+
+        assert_eq!(preferred, Some(49_123));
+        assert!(!reserved.contains(&49_123));
+
+        let _ = fs::remove_file(path);
+        let _ = fs::remove_dir_all(workspace);
     }
 }

--- a/apps/desktop/src-tauri/src/openwork_server/spawn.rs
+++ b/apps/desktop/src-tauri/src/openwork_server/spawn.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 use std::net::TcpListener;
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use tauri::async_runtime::Receiver;
 use tauri::AppHandle;
@@ -10,6 +11,8 @@ use tauri_plugin_shell::ShellExt;
 
 pub const OPENWORK_PORT_RANGE_START: u16 = 48_000;
 pub const OPENWORK_PORT_RANGE_END: u16 = 51_000;
+const PREFERRED_PORT_RETRY_ATTEMPTS: usize = 20;
+const PREFERRED_PORT_RETRY_DELAY_MS: u64 = 50;
 
 fn bind_available_port(host: &str, port: u16) -> bool {
     TcpListener::bind((host, port)).is_ok()
@@ -27,13 +30,25 @@ fn random_range_offset() -> usize {
     usize::try_from(nanos).unwrap_or(0) % range_port_count()
 }
 
+fn wait_for_preferred_port(host: &str, port: u16) -> bool {
+    for attempt in 0..=PREFERRED_PORT_RETRY_ATTEMPTS {
+        if bind_available_port(host, port) {
+            return true;
+        }
+        if attempt < PREFERRED_PORT_RETRY_ATTEMPTS {
+            thread::sleep(Duration::from_millis(PREFERRED_PORT_RETRY_DELAY_MS));
+        }
+    }
+    false
+}
+
 pub fn resolve_openwork_port(
     host: &str,
     preferred_port: Option<u16>,
     reserved_ports: &HashSet<u16>,
 ) -> Result<u16, String> {
     if let Some(port) = preferred_port.filter(|port| *port > 0) {
-        if !reserved_ports.contains(&port) && bind_available_port(host, port) {
+        if !reserved_ports.contains(&port) && wait_for_preferred_port(host, port) {
             return Ok(port);
         }
     }
@@ -70,6 +85,7 @@ mod tests {
     use super::{resolve_openwork_port, OPENWORK_PORT_RANGE_END, OPENWORK_PORT_RANGE_START};
     use std::collections::HashSet;
     use std::net::TcpListener;
+    use std::time::Duration;
 
     #[test]
     fn uses_preferred_port_when_available() {
@@ -109,6 +125,23 @@ mod tests {
         assert_ne!(resolved, OPENWORK_PORT_RANGE_START);
         assert!(resolved >= OPENWORK_PORT_RANGE_START);
         assert!(resolved <= OPENWORK_PORT_RANGE_END);
+    }
+
+    #[test]
+    fn waits_briefly_to_reuse_preferred_port_during_restart() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind preferred port");
+        let preferred_port = listener.local_addr().expect("listener addr").port();
+
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            drop(listener);
+        });
+
+        let resolved = resolve_openwork_port("127.0.0.1", Some(preferred_port), &HashSet::new())
+            .expect("resolve restarted preferred port");
+
+        release.join().expect("join release thread");
+        assert_eq!(resolved, preferred_port);
     }
 }
 


### PR DESCRIPTION
## Summary
- normalize desktop workspace keys before persisting and reusing local OpenWork server ports and tokens so path aliases like `/tmp` and `/private/tmp` resolve to the same workspace
- retry a saved preferred port briefly during restart before falling back to a different port so fast relaunches keep the sticky local server port
- add regression coverage for canonical path aliases and restart timing, and verify with a real desktop dev launch, shutdown, and relaunch smoke check

## Testing
- cargo test openwork_server:: --lib
- desktop dev smoke check: launch -> shutdown -> relaunch with isolated HOME and confirm the same local OpenWork server port is reused