### PR TITLE
fix(workspace): show mounted url in edit connection

### DIFF
--- a/apps/app/src/app/context/workspace.ts
+++ b/apps/app/src/app/context/workspace.ts
@@ -473,8 +473,18 @@ export function createWorkspaceStore(options: {
     if (!workspaceId) return null;
     const workspace = workspaces().find((item) => item.id === workspaceId) ?? null;
     if (!workspace || workspace.workspaceType !== "remote") return null;
+    const openworkHostUrl =
+      normalizeRemoteType(workspace.remoteType) === "openwork"
+        ? buildOpenworkWorkspaceBaseUrl(
+            workspace.openworkHostUrl?.trim() ?? "",
+            workspace.openworkWorkspaceId,
+          ) ||
+          workspace.openworkHostUrl?.trim() ||
+          workspace.baseUrl?.trim() ||
+          ""
+        : workspace.openworkHostUrl?.trim() || workspace.baseUrl?.trim() || "";
     return {
-      openworkHostUrl: workspace.openworkHostUrl ?? workspace.baseUrl ?? "",
+      openworkHostUrl,
       openworkToken: workspace.openworkToken ?? options.openworkServer.openworkServerSettings().token ?? "",
       directory: workspace.directory ?? "",
       displayName: workspace.displayName ?? "",


### PR DESCRIPTION
## Summary
- rebuild the full OpenWork worker URL for remote workspace connection defaults so Edit connection shows `/w/<workspaceId>` instead of only the host root
- keep the existing host/workspace-id split for runtime resolution and persistence while fixing the user-facing field value

## Testing
- `pnpm install`
- `pnpm --dir apps/app typecheck`

## Verification blocker
- `packaging/docker/dev-up.sh` did not complete because the `orchestrator` container failed during `esbuild@0.18.20` postinstall with a binary/platform mismatch on Docker, so I could not finish Chrome MCP UI verification in this environment