### PR TITLE
docs: automated documentation updates 2026-04-07

### DIFF
--- a/packages/docs/how-to-connect-a-custom-provider.mdx
+++ b/packages/docs/how-to-connect-a-custom-provider.mdx
@@ -3,9 +3,11 @@ title: "Adding a custom LLM provider/model"
 description: "How to connect a custom provider with openwork"
 ---
 
-Because `Openwork` is built on `Opencode` primitives, we support everything that you could modify in `.opencode.json`, like adding a [model](https://opencode.ai/docs/models/). However, our recommendation is to add it to `/path-to-your-workspace/.config/opencode/opencode.json` instead of modifying `~/.config/opencode/opencode.json`.
+Because `OpenWork` is built on `OpenCode` primitives, you can still add your own provider config directly in `opencode.json`, including a custom [model](https://opencode.ai/docs/models/). For local or workspace-specific providers, we recommend updating `/path-to-your-workspace/.config/opencode/opencode.json` instead of modifying `~/.config/opencode/opencode.json`.
 
-The reason for this is that you may want to support different models and permissions across several workspaces, specially when sharing it with a team.
+This keeps different models and permissions isolated per workspace, which is especially helpful when you share setups with a team.
+
+If your organization manages providers in OpenWork Cloud, use the cloud flow instead: sign in, open `Settings > Cloud`, pick your org, and import the provider from the Cloud providers section. You can also sync or remove that imported provider from the same screen later.
 
 Inside `/path-to-your-workspace/.config/opencode/opencode.json`:
 ```
@@ -27,6 +29,6 @@ Inside `/path-to-your-workspace/.config/opencode/opencode.json`:
 }
 ```
 
-We've also built a [custom skill](https://share.openworklabs.com/b/01KNBQDQAK41VZSZDF5G9MW4MW) that you can import in Openwork following [this guide](/importing-a-skill). 
+We've also built a [custom skill](https://share.openworklabs.com/b/01KNBQDQAK41VZSZDF5G9MW4MW) that you can import in OpenWork following [this guide](/importing-a-skill).
 
 The following tutorial covers how to [import a custom provider using the skill](https://x.com/getopenwork/status/2034129039317995908?s=20).

--- a/packages/docs/introduction.mdx
+++ b/packages/docs/introduction.mdx
@@ -2,14 +2,15 @@
 title: "Introduction"
 ---
 
-OpenWork Cloud enables team to move faster by making it easy to share your setup across your org.
+OpenWork Cloud helps teams share the setup they want everyone to use across an org.
 
 [https://app.openworklabs.com/](https://app.openworklabs.com/)
 
-- \*\*Team Templates: \*\*make it easy to share your setup across your team so they spend less time copy and pasting configs.
-- \*\*Members: \*\*Makes it easy to invite members to your org.
-- \*\*Shared Workspace: \*\*Are cloud instances you can use to perform long-running tasks or connect permanent connection to messaging channels like Slack or Telegram.
-- \*\*Custom LLMs: \*\*(coming soon)
+- **Team Templates:** share a starting point across your team so people spend less time copying configuration by hand.
+- **Members:** invite teammates into your org.
+- **Shared Workspaces:** run longer-lived cloud instances and keep integrations like Slack or Telegram connected.
+- **Cloud providers:** import org-managed LLM providers into a workspace from `Settings > Cloud`, then sync or remove them later.
+- **Skill hubs:** import shared skill bundles from your org into a workspace from `Settings > Cloud`.
 
 <Frame>
   ![Image](/images/image-6.png)

--- a/packages/docs/team-provisioning.mdx
+++ b/packages/docs/team-provisioning.mdx
@@ -2,8 +2,12 @@
 title: "Team Templates"
 ---
 
-OpenWork Cloud enables team to move faster by making it easy to share your setup across your org.
+OpenWork Cloud helps teams share the setup they want everyone to use across an org.
 
-When your team starts with OpenWork they'll have the option to pick from one of the templates that is uniquely provisioned to them.
+When your team starts with OpenWork, they can pick from templates that are provisioned for their org.
 
-Creating a template is easy: simply create a setup as you would usually. Create your skills, connect your MCPs, and simply click on Share.
+Creating a template is simple: build the setup you want, create your skills, connect your MCPs, and click Share.
+
+Team provisioning can also include shared cloud resources. After signing in on desktop and selecting an org in `Settings > Cloud`, users can import org-managed skill hubs and cloud providers into the current workspace.
+
+Use templates when you want to share a complete starting point. Use cloud providers and skill hubs when you want the team to pull in centrally managed models or skills without manually editing local config files.


### PR DESCRIPTION
Docs refresh for 19:00 PDT. This PR updates documentation to match behavior introduced by commits from the last 24 hours.

Commits reviewed:
- 71a4cb94 docs: add anthropic api key setup tutorial (#1390)
- 31df36ed chore(aur): update PKGBUILD for 0.11.205
- 6b26f776 chore: bump version to 0.11.205
- e6bb4b29 feat(den): add cloud provider and skill hub imports (#1394)
- eee4a847 chore: bump version to 0.11.204
- 9a2deca3 fix(den): reuse a shared Daytona volume for workers (#1392)
- 7e82cb72 fix(den): refresh desktop sign-in state and support local handoff (#1389)
- 60c7e87e fix(workspace): show mounted url in edit connection (#1388)
- d1b23efe fix(composer): stabilize session input sizing (#1387)
- bc2708e4 fix(desktop): keep sticky local server ports stable (#1386)
- 91ffa71c fix(settings): correct ready-to-install update label (#1384)
- cc6b8b15 fix(den): streamline LLM provider and skill hub management (#1383)
- d5459798 chore: bump version to 0.11.203
- fdfb43ca cloud api naming (#1382)
- 222e612f Fix/changelog (#1361)
- 814d0aed ignore: update download stats 2026-04-07
- a16f35bc patch so anthropic oauth doesn't show up (#1378)
- 25356577 feat(den): refine LLM provider selection UX (#1377)

Why these docs changed:
- Example: e6bb4b29 feat(den): add cloud provider and skill hub imports (#1394) changed the Cloud experience from team templates and invites only to a workflow where signed-in desktop users can import, sync, and remove org-managed cloud providers and skill hubs from `Settings > Cloud`, so `packages/docs/introduction.mdx` had to be updated because it still described custom LLMs as coming soon.
- Example: e6bb4b29 feat(den): add cloud provider and skill hub imports (#1394) introduced a new way for teams to distribute shared skills and providers after a workspace already exists; `packages/docs/team-provisioning.mdx` had to be updated because it still described team setup only in terms of picking a template and clicking Share.
- Example: cc6b8b15 fix(den): streamline LLM provider and skill hub management (#1383) and 25356577 feat(den): refine LLM provider selection UX (#1377) reinforced the current provider-management workflow around Cloud-managed providers, so `packages/docs/how-to-connect-a-custom-provider.mdx` now distinguishes local custom-provider config from Cloud-managed provider import.

Documentation updates in this PR:
- Updated `packages/docs/introduction.mdx` to replace the stale `Custom LLMs` coming-soon note with the current Cloud providers and skill hubs workflow.
- Updated `packages/docs/team-provisioning.mdx` to explain when teams should use templates versus Cloud-managed providers and skill hubs.
- Updated `packages/docs/how-to-connect-a-custom-provider.mdx` to separate local `opencode.json` setup from the new Cloud import workflow in `Settings > Cloud`.

Why this merits a docs update:
- Without these changes, the docs would still direct users toward the older template-only and local-config-only mental model, even though the current product now supports importing shared providers and skill hubs directly from OpenWork Cloud.