### PR TITLE
fix: remove HTML from reset confirmation translations

### DIFF
--- a/apps/app/src/app/components/reset-modal.tsx
+++ b/apps/app/src/app/components/reset-modal.tsx
@@ -1,10 +1,13 @@
 import { Match, Show, Switch } from "solid-js";
 
 import { X } from "lucide-solid";
-import { t, currentLocale, type Language } from "../../i18n";
+import { t, type Language } from "../../i18n";
 
 import Button from "./button";
 import TextInput from "./text-input";
+
+const RESET_CONFIRM_PLACEHOLDER = "{resetWord}";
+const RESET_CONFIRM_WORD = "RESET";
 
 export type ResetModalProps = {
   open: boolean;
@@ -21,6 +24,18 @@ export type ResetModalProps = {
 
 export default function ResetModal(props: ResetModalProps) {
   const translate = (key: string) => t(key, props.language);
+  const resetConfirmationHint = () => {
+    const template = translate("settings.reset_confirmation_hint");
+    const parts = template.split(RESET_CONFIRM_PLACEHOLDER);
+
+    if (parts.length === 1) return template;
+
+    return parts.flatMap((part, index) =>
+      index < parts.length - 1
+        ? [part, <span class="font-mono">{RESET_CONFIRM_WORD}</span>]
+        : [part],
+    );
+  };
 
   return (
     <Show when={props.open}>
@@ -35,7 +50,7 @@ export default function ResetModal(props: ResetModalProps) {
                     <Match when={true}>{translate("settings.reset_app_data_title")}</Match>
                   </Switch>
                 </h3>
-                <p class="text-sm text-gray-11 mt-1" innerHTML={translate("settings.reset_confirmation_hint")} />
+                <p class="text-sm text-gray-11 mt-1">{resetConfirmationHint()}</p>
               </div>
               <Button
                 variant="ghost"

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1574,7 +1574,7 @@ export default {
   "settings.reset_config_defaults": "Resetting...",
   "settings.reset_config_failed": "Failed to reset app config.",
   "settings.reset_confirm_button": "Reset & Restart",
-  "settings.reset_confirmation_hint": "Type <span class=\"font-mono\">RESET</span> to confirm. OpenWork will restart.",
+  "settings.reset_confirmation_hint": "Type {resetWord} to confirm. OpenWork will restart.",
   "settings.reset_confirmation_label": "Confirmation",
   "settings.reset_confirmation_placeholder": "Type RESET",
   "settings.reset_onboarding": "Reset onboarding",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -1573,7 +1573,7 @@ export default {
   "settings.reset_config_defaults": "リセット中…",
   "settings.reset_config_failed": "アプリ設定のリセットに失敗しました。",
   "settings.reset_confirm_button": "リセットして再起動",
-  "settings.reset_confirmation_hint": "確認のため <span class=\"font-mono\">RESET</span> と入力してください。OpenWorkが再起動されます。",
+  "settings.reset_confirmation_hint": "確認のため {resetWord} と入力してください。OpenWorkが再起動されます。",
   "settings.reset_confirmation_label": "確認",
   "settings.reset_confirmation_placeholder": "RESETと入力",
   "settings.reset_onboarding": "オンボーディングをリセット",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -1574,7 +1574,7 @@ export default {
   "settings.reset_config_defaults": "Redefinindo...",
   "settings.reset_config_failed": "Falha ao redefinir configurações do app.",
   "settings.reset_confirm_button": "Redefinir e Reiniciar",
-  "settings.reset_confirmation_hint": "Digite <span class=\"font-mono\">RESET</span> para confirmar. O OpenWork será reiniciado.",
+  "settings.reset_confirmation_hint": "Digite {resetWord} para confirmar. O OpenWork será reiniciado.",
   "settings.reset_confirmation_label": "Confirmação",
   "settings.reset_confirmation_placeholder": "Digite RESET",
   "settings.reset_onboarding": "Redefinir onboarding",

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -1574,7 +1574,7 @@ export default {
   "settings.reset_config_defaults": "กำลังรีเซ็ต...",
   "settings.reset_config_failed": "รีเซ็ต app config ไม่สำเร็จ",
   "settings.reset_confirm_button": "รีเซ็ตและรีสตาร์ท",
-  "settings.reset_confirmation_hint": "พิมพ์ <span class=\"font-mono\">RESET</span> เพื่อยืนยัน OpenWork จะรีสตาร์ท",
+  "settings.reset_confirmation_hint": "พิมพ์ {resetWord} เพื่อยืนยัน OpenWork จะรีสตาร์ท",
   "settings.reset_confirmation_label": "การยืนยัน",
   "settings.reset_confirmation_placeholder": "พิมพ์ RESET",
   "settings.reset_onboarding": "รีเซ็ต onboarding",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -1574,7 +1574,7 @@ export default {
   "settings.reset_config_defaults": "Đang đặt lại...",
   "settings.reset_config_failed": "Đặt lại cấu hình ứng dụng thất bại.",
   "settings.reset_confirm_button": "Đặt lại & Khởi động lại",
-  "settings.reset_confirmation_hint": "Nhập <span class=\"font-mono\">RESET</span> để xác nhận. OpenWork sẽ khởi động lại.",
+  "settings.reset_confirmation_hint": "Nhập {resetWord} để xác nhận. OpenWork sẽ khởi động lại.",
   "settings.reset_confirmation_label": "Xác nhận",
   "settings.reset_confirmation_placeholder": "Nhập RESET",
   "settings.reset_onboarding": "Đặt lại thiết lập ban đầu",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -1577,7 +1577,7 @@ export default {
   "settings.reset_config_defaults": "正在重置…",
   "settings.reset_config_failed": "重置应用配置失败。",
   "settings.reset_confirm_button": "重置并重启",
-  "settings.reset_confirmation_hint": "输入 <span class=\"font-mono\">RESET</span> 以确认。OpenWork将重启。",
+  "settings.reset_confirmation_hint": "输入 {resetWord} 以确认。OpenWork将重启。",
   "settings.reset_confirmation_label": "确认",
   "settings.reset_confirmation_placeholder": "输入RESET",
   "settings.reset_onboarding": "重置入门",


### PR DESCRIPTION
## Summary
- remove embedded HTML from the reset confirmation locale strings across supported languages
- render the styled `RESET` token in `ResetModal` JSX with a `{resetWord}` placeholder instead of `innerHTML`
- keep the reset confirmation copy and formatting intact while eliminating translation-driven HTML rendering

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @openwork/app typecheck`
- verified no HTML tags remain in locale files
- verified no translation-driven `innerHTML` usages remain in app TSX files