### PR TITLE
docs: automated documentation updates 2026-04-08

### DIFF
--- a/packages/docs/cloud-skill-hubs.mdx
+++ b/packages/docs/cloud-skill-hubs.mdx
@@ -3,7 +3,9 @@ title: "Skill hubs for teams"
 description: "Create org skill hubs, assign them to teams, and import them into the desktop app"
 ---
 
-Skill hubs are the team-wide way to distribute shared skills in OpenWork Cloud. You create the skills and team assignments in the Cloud dashboard, then each desktop workspace can import the hub in one step.
+Skill hubs are the team-wide way to distribute grouped skills in OpenWork Cloud. You create the skills and team assignments in the Cloud dashboard, then each desktop workspace can import the hub in one step.
+
+If you only need to publish a single skill, you can also save it directly from the desktop app without adding it to a hub. Those standalone org skills still appear in `Skills -> Cloud` and `Settings -> Cloud -> Skills`, but hubs are the better fit when you want one team-managed collection.
 
 ## 1. Create the organization
 
@@ -19,7 +21,7 @@ If you do not already have one, open [app.openworklabs.com](https://app.openwork
 
 Note: __Only `Owner` and `Admin` members can manage teams.__
 
-## 3. Create the skill
+## 3. Create the skill or upload it from the desktop app
 
 1. Open `Skill Hubs -> All Skills`.
 2. Click `Add Skill`.
@@ -29,6 +31,8 @@ Note: __Only `Owner` and `Admin` members can manage teams.__
 6. Click `Create Skill`.
 
 Skill creators and org admins can manage skills and hubs.
+
+If the skill already exists in a desktop workspace, you can also open `Workspace -> Skills`, click `Share skill`, choose `Team`, and save it to your active organization before attaching it to a hub.
 
 ## 4. Create the hub and assign it to the team
 
@@ -52,8 +56,11 @@ Skill creators and org admins can manage skills and hubs.
 
 OpenWork installs the hub's skills into `.opencode/skills` for that workspace.
 
+If you need just one shared skill instead of the entire hub, open `Skills -> Cloud` or `Settings -> Cloud -> Skills` and install it there.
+
 
 ## Keeping it up to date
 
 - Use `Sync` in `Settings -> Cloud -> Skill hubs` after the hub changes.
+- Use `Settings -> Cloud -> Skills` or `Skills -> Cloud` to sync, uninstall, or review individual skills that came from the org.
 - Use `Remove` to stop managing the hub from this workspace.

--- a/packages/docs/get-started-cloud.mdx
+++ b/packages/docs/get-started-cloud.mdx
@@ -8,7 +8,7 @@ It is intended for teams what want to share `SKILLs.md`, `MCPs` and `configs`.
 
 
 First, you should connect your desktop app with Openwork Cloud.
-Once you're signed in, in the app you'll be able to create teams, share workspaces, import skill hubs and shared providers.
+Once you're signed in, in the app you'll be able to create teams, share workspaces, install org skills or skill hubs, and import shared providers.
 
 ## Sign in from the desktop app
 
@@ -21,7 +21,7 @@ Once you're signed in, in the app you'll be able to create teams, share workspac
 
 After sign-in, pick your org in `Settings -> Cloud -> Active org`.
 
-The selected org controls which `Cloud workers`, `Team templates`, `Skill hubs`, and `Cloud providers` are available in the desktop app.
+The selected org controls which `Cloud workers`, `Team templates`, `Org skills`, `Skill hubs`, and `Cloud providers` are available in the desktop app.
 
 ## If you still need to create the org
 
@@ -33,7 +33,7 @@ The selected org controls which `Cloud workers`, `Team templates`, `Skill hubs`,
 
 ## What to do next
 
-- Use [Skill hubs](/cloud-skill-hubs) to publish shared skills for teams.
+- Use [Skill hubs](/cloud-skill-hubs) to publish grouped skills for teams, or save a single skill directly from the desktop app and install it from `Skills -> Cloud`.
 - Use [Shared workspaces](/cloud-shared-workspaces) to deploy hosted OpenWork runtimes that teammates can open from the desktop app.
 - Use [LLM providers](/cloud-llm-providers) or [custom LLM providers](/cloud-custom-llm-providers) to manage shared model access.
 - Use [Members and RBAC](/cloud-members-and-rbac) to invite people, create teams, and control access.

--- a/packages/docs/importing-a-skill.mdx
+++ b/packages/docs/importing-a-skill.mdx
@@ -3,17 +3,30 @@ title: "Importing a skill"
 description: "How to import an external skill into your workspace in OpenWork"
 ---
 
-There are currently three direct ways to import an external skill.
+There are currently four direct ways to import an external skill.
 
 1. Open an existing skill share link from `share.openworklabs.com`
 2. Paste a skill into the share site, then import it
 3. Create a skill with `Create skill in chat` and paste the external skill into that flow
+4. Install a shared skill from your OpenWork Cloud organization in `Skills -> Cloud` or `Settings -> Cloud`
 
 There is another option if you're technical: place it directly in `.opencode/skills/<skill-name>/SKILL.md` inside your workspace.
 
 We recommend (1) and (3) because they match the built-in OpenWork flows most closely.
 
-For teams, OpenWork Cloud skill hubs can publish shared skills to an org and let each desktop workspace import them from [Settings -> Cloud](/cloud-skill-hubs).
+For teams, OpenWork Cloud can publish shared skills either as standalone org skills or inside a skill hub. Each desktop workspace can install them from the `Cloud` tab on the Skills page or from [Settings -> Cloud](/cloud-skill-hubs).
+
+## Installing a skill from OpenWork Cloud
+
+If someone on your team saved a skill to your active OpenWork Cloud organization, open either `Skills -> Cloud` or `Settings -> Cloud` in the desktop app.
+
+From there you can:
+
+- click `Install` to add the skill to the current workspace
+- click `Sync` when the cloud version changes
+- click `Uninstall` if you no longer want the workspace-managed copy
+
+If the skill belongs to a hub, OpenWork also shows the hub name so you know where it came from.
 
 ## Importing an existing skill with a share URL
 

--- a/packages/docs/sharing-ow-setup.mdx
+++ b/packages/docs/sharing-ow-setup.mdx
@@ -5,7 +5,7 @@ description: "Learn how to share your MCP, agents, skills with others"
 
 There are two main primitives for a template that you can share: `Workspace` and a `Skill`.
 
-For team-wide reuse inside an org, you can also save templates or skills to OpenWork Cloud and let teammates open them from [Settings -> Cloud](/get-started-cloud).
+For team-wide reuse inside an org, you can also save templates or skills to OpenWork Cloud and let teammates open them from the `Cloud` tab on the Skills page or from [Settings -> Cloud](/get-started-cloud).
 
 ## Sharing your entire configuration
 
@@ -36,3 +36,18 @@ This creates a url that you can share with other people so they can `copy the sk
 <Frame>
   ![Shared skill page with Copy and Open in OpenWork buttons](/images/sharing-skill-share-page.png)
 </Frame>
+
+## How to save a skill to your OpenWork Cloud organization
+
+1. Open `Workspace -> Skills` in the desktop app.
+2. Pick the installed skill you want to share.
+3. Click `Share skill`.
+4. Choose the `Team` option.
+5. Sign in to OpenWork Cloud if needed.
+6. Pick the sharing permission:
+   - `Organization Only - Not in hub` keeps the skill available to the active org without adding it to a hub.
+   - `Private for me only` uploads it to the org but keeps it limited to your account.
+   - If a hub is available, you can also attach the skill to that hub during the same flow.
+7. Click `Upload and save`.
+
+After that, teammates can install the skill from `Skills -> Cloud`. If the skill was attached to a hub, it also appears in `Settings -> Cloud -> Skills` with the hub label so people can sync or remove it later.


### PR DESCRIPTION
Docs refresh for 19:00 PDT. This PR updates documentation to match behavior introduced by commits from the last 24 hours.

Commits reviewed:
- e27abd50 feat(den): add cloud skill uploads and sync tracking (#1400)
- e1ccd5e9 docs: add OpenWork Cloud setup guides (#1399)
- 453995b5 ollama mini edits (#1408)
- da5d972a fix(providers): hide anthropic browser auth (#1395)

Why these docs changed:
- Example: e27abd50 feat(den): add cloud skill uploads and sync tracking (#1400) changed Cloud skills from a hub-only workflow to a workflow that also supports saving standalone org skills, installing them from Skills -> Cloud, and syncing or uninstalling them later. packages/docs/importing-a-skill.mdx, packages/docs/sharing-ow-setup.mdx, and packages/docs/cloud-skill-hubs.mdx had to be updated because they still described Cloud skill distribution mostly as a skill-hub flow.
- Example: e1ccd5e9 docs: add OpenWork Cloud setup guides (#1399) introduced the new Cloud setup pages, but packages/docs/get-started-cloud.mdx still described the Cloud app flow in terms of skill hubs and providers only. The guide now calls out org skills explicitly so the documented setup matches what users can actually install after signing in.

Documentation updates in this PR:
- Updated packages/docs/importing-a-skill.mdx to replace the old three-path import guidance with the current four-path flow, including org skill installs from Cloud and follow-up sync/uninstall behavior.
- Updated packages/docs/sharing-ow-setup.mdx to document the Share skill -> Team flow, including org-only, private, and optional hub-backed sharing.
- Updated packages/docs/cloud-skill-hubs.mdx and packages/docs/get-started-cloud.mdx to explain when to use standalone org skills versus hubs and where users manage them in the desktop app.

Why this merits a docs update:
- Without these changes, the docs would still direct users to an older hub-centric workflow, even though the current app now expects some team skill sharing and installation to happen through org skills in the Cloud surfaces.