### PR TITLE
Repo: switch EE licensing to FSL-1.1-MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Copyright (c) 2026-present Different AI, Inc.
 
 Portions of this software are licensed as follows:
 
-* All content that resides under the /ee directory of this repository (Fair Source License) is licensed under the license defined in "ee/LICENSE".
+* All content that resides under the /ee directory of this repository is licensed under the license defined in "ee/LICENSE" (Fair Source License).
 * All third party components incorporated into the OpenWork Software are licensed under the original license provided by the owner of the applicable component.
 * Content outside of the above mentioned directories or restrictions above is available under the "MIT" license as defined below.
 

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,33 +1,105 @@
-The Different AI Inc Commercial License (the “Commercial License”)
-Copyright (c) 2026-present Different AI Inc
+# Functional Source License, Version 1.1, MIT Future License
 
-With regard to the Different AI Inc OpenWork Software:
+## Abbreviation
 
-This software and associated documentation files (the "Software") may only be
-used in production, if you (and any entity that you represent) have agreed to,
-and are in compliance with, the Different AI Inc OpenWork Subscription Terms available
-at https://openworklabs.com/, or other agreements governing
-the use of the Software, as mutually agreed by you and Different AI Inc,
-and otherwise have a valid Different AI Inc OpenWork Enterprise Edition subscription ("Commercial Subscription")
-for the correct number of hosts as defined in the "Commercial Terms ("Hosts"). Subject to the foregoing sentence,
-you are free to modify this Software and publish patches to the Software. You agree
-that Different AI Inc and/or its licensors (as applicable) retain all right, title and interest in
-and to all such modifications and/or patches, and all such modifications and/or
-patches may only be used, copied, modified, displayed, distributed, or otherwise
-exploited with a valid Commercial Subscription for the correct number of hosts.
-Notwithstanding the foregoing, you may copy and modify the Software for development
-and testing purposes, without requiring a subscription. You agree that Different AI Inc and/or
-its licensors (as applicable) retain all right, title and interest in and to all such
-modifications. You are not granted any other rights beyond what is expressly stated herein.
-Subject to the foregoing, it is forbidden to copy, merge, publish, distribute, sublicense,
-and/or sell the Software.
+FSL-1.1-MIT
 
-This Commercial License applies only to the part of this Software that is not distributed under
-the MIT license. Any part of this Software distributed under the MIT license or which
-is served client-side as an image, font, cascading stylesheet (CSS), file which produces
-or is compiled, arranged, augmented, or combined into client-side JavaScript, in whole or
-in part, is copyrighted under the MIT license. The full text of this Commercial License shall
-be included in all copies or substantial portions of the Software.
+## Notice
+
+Copyright 2026 Different AI Inc
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the MIT license that is effective on the second anniversary of the date we make
+the Software available. On or after that date, you may use the Software under
+the MIT license, in which case the following will apply:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -36,7 +108,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-For all third party components incorporated into the Different AI Inc OpenWork Software, those
-components are licensed under the original license provided by the owner of the
-applicable component.


### PR DESCRIPTION
This adjusts the license for code in the `/ee` folder to be licensed under `Functional Source License 1.1 plus the MIT future license grant` [https://fsl.software/](https://fsl.software/)
This effectively licenses all code under `/ee` to MIT 2 years after the code has been published

## Summary
- replace the enterprise `ee/LICENSE` text with the Functional Source License 1.1 plus the MIT future license grant
- clarify the root `LICENSE` reference so the `/ee` directory points readers to the governing enterprise terms