### PR TITLE
feat: add Lilac as an OpenAI-compatible provider

### DIFF
--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -35,6 +35,7 @@ const FRIENDLY_PROVIDER_LABELS: Record<string, string> = {
   anthropic: "Anthropic",
   google: "Google",
   openrouter: "OpenRouter",
+  lilac: "Lilac",
 };
 
 const humanizeModelLabel = (value: string) => {

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -35,6 +35,7 @@
             "pages": [
               "how-to-get-an-anthropic-api-key",
               "how-to-connect-a-custom-provider",
+              "how-to-connect-lilac",
               "importing-a-skill"
             ]
           },

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -31,7 +31,8 @@ If Lilac doesn't appear as a built-in provider yet, add it manually to your work
       "npm": "@ai-sdk/openai-compatible",
       "name": "Lilac",
       "options": {
-        "baseURL": "https://api.getlilac.com/v1"
+        "baseURL": "https://api.getlilac.com/v1",
+        "apiKey": "your-api-key"
       },
       "models": {
         "z-ai/glm-5.1": {
@@ -46,11 +47,7 @@ If Lilac doesn't appear as a built-in provider yet, add it manually to your work
 }
 ```
 
-Set your API key as an environment variable:
-
-```bash
-export LILAC_API_KEY="your-api-key"
-```
+<Note>You can also set the API key via the `LILAC_API_KEY` environment variable instead of `options.apiKey`.</Note>
 
 Reload the workspace when OpenWork asks, then select a Lilac model from the model picker.
 

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -11,15 +11,14 @@ You can get an API key from the [Lilac console](https://console.getlilac.com). S
 
 Lilac is available as a built-in provider in OpenWork. To connect:
 
-1. Set your API key as an environment variable:
+1. Open **Connect providers** from the sidebar or settings.
+2. Find **Lilac** in the provider list and click it.
+3. Paste your `LILAC_API_KEY` into the API key field. Keys are stored locally by OpenCode.
+4. Open the model picker in a session and select a Lilac model (e.g. `Lilac · GLM 5.1` or `Lilac · Kimi K2.5`).
 
-```bash
-export LILAC_API_KEY="your-api-key"
-```
+That's it — no manual configuration needed. If you don't see Lilac in the provider list yet, see the manual setup below.
 
-2. Open the model picker in a session and select a Lilac model (e.g. `Lilac · GLM 5.1` or `Lilac · Kimi K2.5`).
-
-That's it — no manual configuration needed. If you don't see Lilac in the model picker, see the manual setup below.
+<Note>You can also set the API key as an environment variable (`export LILAC_API_KEY="your-api-key"`) if you prefer the CLI path.</Note>
 
 ## Manual setup (desktop)
 

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -7,9 +7,23 @@ description: "Connect Lilac's OpenAI-compatible API and use models like GLM 5.1 
 
 You can get an API key from the [Lilac console](https://console.getlilac.com). See [Lilac's API key guide](https://docs.getlilac.com/inference/api-keys) for details.
 
-## Desktop setup
+## Quick setup (built-in provider)
 
-Add the following to your workspace `.opencode.json` (or `~/.config/opencode/opencode.json` for a global setup):
+Lilac is available as a built-in provider in OpenWork. To connect:
+
+1. Set your API key as an environment variable:
+
+```bash
+export LILAC_API_KEY="your-api-key"
+```
+
+2. Open the model picker in a session and select a Lilac model (e.g. `Lilac · GLM 5.1` or `Lilac · Kimi K2.5`).
+
+That's it — no manual configuration needed. If you don't see Lilac in the model picker, see the manual setup below.
+
+## Manual setup (desktop)
+
+If Lilac doesn't appear as a built-in provider yet, add it manually to your workspace `.opencode.json` (or `~/.config/opencode/opencode.json` for a global setup):
 
 ```json
 {
@@ -69,8 +83,8 @@ Use this when you want your OpenWork org to manage the Lilac credential and mode
       "tool_call": true,
       "structured_output": true,
       "temperature": true,
-      "release_date": "2025-01-01",
-      "last_updated": "2025-01-01",
+      "release_date": "2026-04-07",
+      "last_updated": "2026-04-07",
       "open_weights": true,
       "limit": {
         "context": 202800,
@@ -94,13 +108,13 @@ Use this when you want your OpenWork org to manage the Lilac credential and mode
       "tool_call": true,
       "structured_output": true,
       "temperature": true,
-      "release_date": "2025-01-01",
-      "last_updated": "2025-01-01",
-      "open_weights": false,
+      "release_date": "2026-01-27",
+      "last_updated": "2026-01-27",
+      "open_weights": true,
       "limit": {
         "context": 262144,
         "input": 262144,
-        "output": 8192
+        "output": 32768
       },
       "modalities": {
         "input": [

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -1,0 +1,147 @@
+---
+title: "How to connect Lilac to OpenWork"
+description: "Connect Lilac's OpenAI-compatible API and use models like GLM 5.1 and Kimi K2.5"
+---
+
+[Lilac](https://getlilac.com) provides an OpenAI-compatible API at `api.getlilac.com`. You can connect it to OpenWork as a custom provider and use any model available on the [Lilac console](https://console.getlilac.com).
+
+## Desktop setup
+
+Add the following to your workspace `.opencode.json` (or `~/.config/opencode/opencode.json` for a global setup):
+
+```json
+{
+  "provider": {
+    "lilac": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Lilac",
+      "options": {
+        "baseURL": "https://api.getlilac.com/v1"
+      },
+      "models": {
+        "zai-org/glm-5.1": {
+          "name": "GLM 5.1"
+        },
+        "moonshotai/kimi-k2.5": {
+          "name": "Kimi K2.5"
+        }
+      }
+    }
+  }
+}
+```
+
+Set your API key as an environment variable:
+
+```bash
+export LILAC_API_KEY="your-api-key"
+```
+
+You can get an API key from the [Lilac console](https://console.getlilac.com).
+
+Reload the workspace when OpenWork asks, then select a Lilac model from the model picker.
+
+## Cloud setup (for teams)
+
+Use this when you want the org to manage the Lilac credential and model list centrally.
+
+1. Open `LLM Providers` in OpenWork Cloud.
+2. Click `Add Provider`.
+3. Switch to `Custom provider`.
+4. Paste the following JSON:
+
+```json
+{
+  "id": "lilac",
+  "name": "Lilac",
+  "npm": "@ai-sdk/openai-compatible",
+  "env": [
+    "LILAC_API_KEY"
+  ],
+  "doc": "https://getlilac.com",
+  "api": "https://api.getlilac.com/v1",
+  "models": [
+    {
+      "id": "zai-org/glm-5.1",
+      "name": "GLM 5.1",
+      "attachment": false,
+      "reasoning": false,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "release_date": "2025-01-01",
+      "last_updated": "2025-01-01",
+      "open_weights": false,
+      "limit": {
+        "context": 128000,
+        "input": 128000,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    },
+    {
+      "id": "moonshotai/kimi-k2.5",
+      "name": "Kimi K2.5",
+      "attachment": false,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "release_date": "2025-01-01",
+      "last_updated": "2025-01-01",
+      "open_weights": false,
+      "limit": {
+        "context": 128000,
+        "input": 128000,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      }
+    }
+  ]
+}
+```
+
+5. Paste your shared `LILAC_API_KEY` credential.
+6. Choose `People access` and/or `Team access`.
+7. Click `Create Provider`.
+
+Then import it into the desktop app:
+
+1. Open `Settings -> Cloud`.
+2. Choose the correct `Active org`.
+3. Under `Cloud providers`, click `Import`.
+4. Reload the workspace when OpenWork asks.
+
+For more detail on the Cloud provider flow, see [Adding a custom LLM provider](/cloud-custom-llm-providers).
+
+## Verifying the connection
+
+After setup, open the model picker in a session. You should see `Lilac · GLM 5.1` and `Lilac · Kimi K2.5` (or whichever models you configured). Select one and send a message to confirm the connection is working.
+
+You can also verify the API directly:
+
+```bash
+curl https://api.getlilac.com/v1/chat/completions \
+  -H "Authorization: Bearer $LILAC_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "zai-org/glm-5.1",
+    "messages": [
+      {"role": "user", "content": "Hello!"}
+    ]
+  }'
+```

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -3,7 +3,7 @@ title: "How to connect Lilac to OpenWork"
 description: "Connect Lilac's OpenAI-compatible API and use models like GLM 5.1 and Kimi K2.5"
 ---
 
-[Lilac](https://getlilac.com) provides affordable GPU inference through an OpenAI-compatible API at `api.getlilac.com/v1`. It supports chat completions, streaming, vision, tool/function calling, reasoning, and structured output — everything OpenWork needs. See [Lilac's OpenAI compatibility docs](https://docs.getlilac.com/inference/openai-compatibility) for the full feature matrix.
+[Lilac](https://getlilac.com) provides affordable GPU inference through an OpenAI-compatible API at `api.getlilac.com/v1`. It supports chat completions, streaming, tool/function calling, reasoning, and structured output; some models (like Kimi K2.5) also support vision/image inputs. See [Lilac's OpenAI compatibility docs](https://docs.getlilac.com/inference/openai-compatibility) for the full feature matrix.
 
 You can get an API key from the [Lilac console](https://console.getlilac.com). See [Lilac's API key guide](https://docs.getlilac.com/inference/api-keys) for details.
 
@@ -64,7 +64,7 @@ Use this when you want the org to manage the Lilac credential and model list cen
     {
       "id": "zai-org/glm-5.1",
       "name": "GLM 5.1",
-      "attachment": true,
+      "attachment": false,
       "reasoning": true,
       "tool_call": true,
       "structured_output": true,
@@ -79,8 +79,7 @@ Use this when you want the org to manage the Lilac credential and model list cen
       },
       "modalities": {
         "input": [
-          "text",
-          "image"
+          "text"
         ],
         "output": [
           "text"

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -3,7 +3,9 @@ title: "How to connect Lilac to OpenWork"
 description: "Connect Lilac's OpenAI-compatible API and use models like GLM 5.1 and Kimi K2.5"
 ---
 
-[Lilac](https://getlilac.com) provides an OpenAI-compatible API at `api.getlilac.com`. You can connect it to OpenWork as a custom provider and use any model available on the [Lilac console](https://console.getlilac.com).
+[Lilac](https://getlilac.com) provides affordable GPU inference through an OpenAI-compatible API at `api.getlilac.com/v1`. It supports chat completions, streaming, vision, tool/function calling, reasoning, and structured output — everything OpenWork needs. See [Lilac's OpenAI compatibility docs](https://docs.getlilac.com/inference/openai-compatibility) for the full feature matrix.
+
+You can get an API key from the [Lilac console](https://console.getlilac.com). See [Lilac's API key guide](https://docs.getlilac.com/inference/api-keys) for details.
 
 ## Desktop setup
 
@@ -37,8 +39,6 @@ Set your API key as an environment variable:
 export LILAC_API_KEY="your-api-key"
 ```
 
-You can get an API key from the [Lilac console](https://console.getlilac.com).
-
 Reload the workspace when OpenWork asks, then select a Lilac model from the model picker.
 
 ## Cloud setup (for teams)
@@ -58,38 +58,13 @@ Use this when you want the org to manage the Lilac credential and model list cen
   "env": [
     "LILAC_API_KEY"
   ],
-  "doc": "https://getlilac.com",
+  "doc": "https://docs.getlilac.com/inference/openai-compatibility",
   "api": "https://api.getlilac.com/v1",
   "models": [
     {
       "id": "zai-org/glm-5.1",
       "name": "GLM 5.1",
-      "attachment": false,
-      "reasoning": false,
-      "tool_call": true,
-      "structured_output": true,
-      "temperature": true,
-      "release_date": "2025-01-01",
-      "last_updated": "2025-01-01",
-      "open_weights": false,
-      "limit": {
-        "context": 128000,
-        "input": 128000,
-        "output": 8192
-      },
-      "modalities": {
-        "input": [
-          "text"
-        ],
-        "output": [
-          "text"
-        ]
-      }
-    },
-    {
-      "id": "moonshotai/kimi-k2.5",
-      "name": "Kimi K2.5",
-      "attachment": false,
+      "attachment": true,
       "reasoning": true,
       "tool_call": true,
       "structured_output": true,
@@ -104,7 +79,34 @@ Use this when you want the org to manage the Lilac credential and model list cen
       },
       "modalities": {
         "input": [
+          "text",
+          "image"
+        ],
+        "output": [
           "text"
+        ]
+      }
+    },
+    {
+      "id": "moonshotai/kimi-k2.5",
+      "name": "Kimi K2.5",
+      "attachment": true,
+      "reasoning": true,
+      "tool_call": true,
+      "structured_output": true,
+      "temperature": true,
+      "release_date": "2025-01-01",
+      "last_updated": "2025-01-01",
+      "open_weights": false,
+      "limit": {
+        "context": 128000,
+        "input": 128000,
+        "output": 8192
+      },
+      "modalities": {
+        "input": [
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -145,3 +147,10 @@ curl https://api.getlilac.com/v1/chat/completions \
     ]
   }'
 ```
+
+## More Lilac resources
+
+- [Available models](https://docs.getlilac.com/inference/models) — full model catalog with pricing
+- [OpenAI compatibility](https://docs.getlilac.com/inference/openai-compatibility) — supported endpoints and features
+- [Connect to local coding tools](https://docs.getlilac.com/inference/local-tools) — Lilac's own guide for connecting to local dev tools
+- [Pricing](https://docs.getlilac.com/inference/pricing) — per-token pricing details

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -41,9 +41,9 @@ export LILAC_API_KEY="your-api-key"
 
 Reload the workspace when OpenWork asks, then select a Lilac model from the model picker.
 
-## Cloud setup (for teams)
+## OpenWork Cloud setup (for teams)
 
-Use this when you want the org to manage the Lilac credential and model list centrally.
+Use this when you want your OpenWork org to manage the Lilac credential and model list centrally, so team members don't each need to configure it locally.
 
 1. Open `LLM Providers` in OpenWork Cloud.
 2. Click `Add Provider`.

--- a/packages/docs/how-to-connect-lilac.mdx
+++ b/packages/docs/how-to-connect-lilac.mdx
@@ -21,7 +21,7 @@ Add the following to your workspace `.opencode.json` (or `~/.config/opencode/ope
         "baseURL": "https://api.getlilac.com/v1"
       },
       "models": {
-        "zai-org/glm-5.1": {
+        "z-ai/glm-5.1": {
           "name": "GLM 5.1"
         },
         "moonshotai/kimi-k2.5": {
@@ -62,7 +62,7 @@ Use this when you want the org to manage the Lilac credential and model list cen
   "api": "https://api.getlilac.com/v1",
   "models": [
     {
-      "id": "zai-org/glm-5.1",
+      "id": "z-ai/glm-5.1",
       "name": "GLM 5.1",
       "attachment": false,
       "reasoning": true,
@@ -71,11 +71,11 @@ Use this when you want the org to manage the Lilac credential and model list cen
       "temperature": true,
       "release_date": "2025-01-01",
       "last_updated": "2025-01-01",
-      "open_weights": false,
+      "open_weights": true,
       "limit": {
-        "context": 128000,
-        "input": 128000,
-        "output": 8192
+        "context": 202800,
+        "input": 202800,
+        "output": 131072
       },
       "modalities": {
         "input": [
@@ -98,8 +98,8 @@ Use this when you want the org to manage the Lilac credential and model list cen
       "last_updated": "2025-01-01",
       "open_weights": false,
       "limit": {
-        "context": 128000,
-        "input": 128000,
+        "context": 262144,
+        "input": 262144,
         "output": 8192
       },
       "modalities": {
@@ -140,12 +140,21 @@ curl https://api.getlilac.com/v1/chat/completions \
   -H "Authorization: Bearer $LILAC_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "zai-org/glm-5.1",
+    "model": "z-ai/glm-5.1",
     "messages": [
       {"role": "user", "content": "Hello!"}
     ]
   }'
 ```
+
+## Model details
+
+| Model | Model ID | Context | Vision | Reasoning | Tool calling | Input price | Output price |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| GLM 5.1 | `z-ai/glm-5.1` | 202,800 | No | Yes (on by default) | Yes | $0.90/M tokens | $3.00/M tokens |
+| Kimi K2.5 | `moonshotai/kimi-k2.5` | 262,144 | Yes | Yes (on by default) | Yes | $0.40/M tokens | $2.00/M tokens |
+
+Pricing is from [Lilac's models page](https://docs.getlilac.com/inference/models) and may change.
 
 ## More Lilac resources
 


### PR DESCRIPTION
## Summary

Add Lilac as a provider in OpenWork with documentation and a friendly display label.

> **⚠️ Blocked by models.dev PR [#1416](https://github.com/anomalyco/models.dev/pull/1416)** — That PR adds Lilac to the upstream provider catalog (models.dev), which is what makes Lilac appear as a built-in, selectable provider in OpenWork's model picker. This OpenWork PR is supplementary: it adds the friendly label and documentation.

### Changes

- **`apps/app/src/app/utils/index.ts`** — Add `lilac: "Lilac"` to `FRIENDLY_PROVIDER_LABELS` so the provider displays as "Lilac" instead of the raw ID
- **`packages/docs/how-to-connect-lilac.mdx`** — New doc page with three setup paths:
  - Quick setup (built-in, once models.dev merges)
  - Manual setup (desktop `.opencode.json` fallback)
  - OpenWork Cloud setup (for teams)
- **`packages/docs/docs.json`** — Add nav entry under Tutorials

### Models

| Model | Model ID | Context | Vision | Reasoning | Tool calling | Input price | Output price |
| --- | --- | --- | --- | --- | --- | --- | --- |
| GLM 5.1 | `z-ai/glm-5.1` | 202,800 | No | Yes | Yes | $0.90/M tokens | $3.00/M tokens |
| Kimi K2.5 | `moonshotai/kimi-k2.5` | 262,144 | Yes | Yes | Yes | $0.40/M tokens | $2.00/M tokens |

### Related
- **models.dev PR**: https://github.com/anomalyco/models.dev/pull/1416 (adds Lilac to the upstream provider catalog)
- **Lilac**: https://getlilac.com | https://docs.getlilac.com