### PR TITLE
fix(session): restore transcript autoscroll growth detection

### DIFF
--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -3266,7 +3266,7 @@ export default function SessionView(props: SessionViewProps) {
                 }}
               >
                 <div
-                  class="mx-auto h-full w-full max-w-[800px]"
+                  class="mx-auto w-full max-w-[800px]"
                   ref={(el) => {
                     chatContentEl = el;
                   }}


### PR DESCRIPTION
## Summary
- remove the accidental `h-full` sizing from the Solid session transcript content wrapper
- restore the scroll controller's ability to observe real transcript height growth and keep follow-scroll pinned to the latest message
- avoid the recent regression where the message pane stops slightly above the bottom while new text is still arriving

## Likely Regression Source
- `9784c618` originally introduced the `h-full` wrapper change in `apps/app/src/app/pages/session.tsx`
- `5b9da8a8` re-applied that same change onto current `dev`

## Testing
- `pnpm --filter @openwork/app exec vite build`
- `pnpm --filter @openwork/desktop run prepare:sidecar`
- `pnpm --filter @openwork/desktop exec tauri build --ci --no-sign --config '{"build":{"beforeBuildCommand":""}}'`
- launched `apps/desktop/src-tauri/target/release/OpenWork-Dev.exe` for manual verification