### PR TITLE
revert(landing): restore free Windows downloads and builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -106,6 +106,10 @@ jobs:
             os_type: linux
             target: aarch64-unknown-linux-gnu
             args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
+          - platform: windows-2022
+            os_type: windows
+            target: x86_64-pc-windows-msvc
+            args: "--target x86_64-pc-windows-msvc --bundles msi"
 
     steps:
       - name: Log runner selection
@@ -121,6 +125,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+
+      - name: Enable git long paths (Windows)
+        if: matrix.os_type == 'windows'
+        shell: pwsh
+        run: git config --global core.longpaths true
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -198,6 +207,9 @@ jobs:
             aarch64-unknown-linux-gnu)
               opencode_asset="opencode-linux-arm64.tar.gz"
               ;;
+            x86_64-pc-windows-msvc)
+              opencode_asset="opencode-windows-x64-baseline.zip"
+              ;;
             *)
               echo "Unsupported target: ${{ matrix.target }}"
               exit 1
@@ -236,6 +248,9 @@ jobs:
           fi
 
           target_name="opencode-${{ matrix.target }}"
+          if [ "${{ matrix.os_type }}" = "windows" ]; then
+            target_name="${target_name}.exe"
+          fi
 
           mkdir -p apps/desktop/src-tauri/sidecars
           cp "$bin_path" "apps/desktop/src-tauri/sidecars/${target_name}"

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -275,6 +275,10 @@ jobs:
             os_type: linux
             target: aarch64-unknown-linux-gnu
             args: "--target aarch64-unknown-linux-gnu --bundles deb,rpm"
+          - platform: windows-2022
+            os_type: windows
+            target: x86_64-pc-windows-msvc
+            args: "--target x86_64-pc-windows-msvc --bundles msi"
 
     steps:
       - name: Log runner selection
@@ -291,6 +295,11 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+
+      - name: Enable git long paths (Windows)
+        if: matrix.os_type == 'windows'
+        shell: pwsh
+        run: git config --global core.longpaths true
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -395,6 +404,9 @@ jobs:
             aarch64-unknown-linux-gnu)
               opencode_asset="opencode-linux-arm64.tar.gz"
               ;;
+            x86_64-pc-windows-msvc)
+              opencode_asset="opencode-windows-x64-baseline.zip"
+              ;;
             *)
               echo "Unsupported target: ${{ matrix.target }}" >&2
               exit 1
@@ -433,6 +445,9 @@ jobs:
           fi
 
           target_name="opencode-${{ matrix.target }}"
+          if [ "${{ matrix.os_type }}" = "windows" ]; then
+            target_name="${target_name}.exe"
+          fi
 
           mkdir -p apps/desktop/src-tauri/sidecars
           cp "$bin_path" "apps/desktop/src-tauri/sidecars/${target_name}"

--- a/ee/apps/landing/README.md
+++ b/ee/apps/landing/README.md
@@ -11,7 +11,6 @@
 
 - `NEXT_PUBLIC_CAL_URL` - enterprise booking link
 - `NEXT_PUBLIC_DEN_CHECKOUT_URL` - Polar checkout URL for the Den preorder CTA
-- `NEXT_PUBLIC_WINDOWS_CHECKOUT_URL` - Polar checkout URL for the Windows support plan CTA
 - `LOOPS_API_KEY` - Loops API key for feedback/contact submissions
 - `LOOPS_TRANSACTIONAL_ID_APP_FEEDBACK` - Loops transactional template ID for app feedback emails
 - `LOOPS_INTERNAL_FEEDBACK_EMAIL` - optional override for the internal feedback recipient (defaults to `team@openworklabs.com`)

--- a/ee/apps/landing/app/download/page.tsx
+++ b/ee/apps/landing/app/download/page.tsx
@@ -5,16 +5,13 @@ import { getGithubData } from "../../lib/github";
 export const metadata = {
   title: "OpenWork - Download",
   description:
-    "Download OpenWork desktop for macOS and Linux, or purchase Windows support for binary access and updates.",
+    "Download OpenWork desktop for macOS, Windows, and Linux. Includes AUR install instructions and direct package downloads.",
 };
 
 export default async function Download() {
   const github = await getGithubData();
   const releaseLabel = github.releaseTag || "latest";
   const releaseUrl = github.releaseUrl;
-  const windowsCheckoutUrl =
-    process.env.NEXT_PUBLIC_WINDOWS_CHECKOUT_URL || "/pricing#windows-support";
-  const windowsCheckoutExternal = /^https?:\/\//.test(windowsCheckoutUrl);
 
   return (
     <div className="min-h-screen">
@@ -63,7 +60,7 @@ export default async function Download() {
               className="feature-card border-violet-100 bg-violet-50/50 transition hover:border-violet-200"
             >
               <h2 className="mb-2 text-[16px] font-semibold text-gray-900">Windows</h2>
-              <p className="text-[14px] text-gray-700">$99/year support plan with manual build delivery</p>
+              <p className="text-[14px] text-gray-700">x64 MSI installer</p>
             </a>
             <a
               href="#linux"
@@ -114,31 +111,16 @@ export default async function Download() {
           <section id="windows" className="py-6">
             <h2 className="mb-2 text-2xl font-bold md:text-3xl">Windows</h2>
             <p className="mb-6 text-[15px] text-gray-700">
-              Windows access is sold as an annual support plan. It includes one seat,
-              Windows binary access, and one year of updates.
+              OpenWork for Windows is available as an x64 MSI installer.
             </p>
-
-            <div className="feature-card max-w-2xl border-violet-100 bg-white/90 ring-1 ring-violet-100/70">
-              <h3 className="mb-2 text-[18px] font-semibold text-gray-900">
-                Windows support — $99/year
-              </h3>
-              <p className="mb-5 text-[14px] leading-7 text-gray-600">
-                Purchase through Polar and we will send your Windows build link after checkout.
-              </p>
-              <div className="flex flex-wrap gap-3">
-                <a
-                  href={windowsCheckoutUrl}
-                  className="doc-button"
-                  rel={windowsCheckoutExternal ? "noreferrer" : undefined}
-                  target={windowsCheckoutExternal ? "_blank" : undefined}
-                >
-                  Purchase Windows support
-                </a>
-                <a href="/pricing#windows-support" className="secondary-button">
-                  See pricing details
-                </a>
-              </div>
-            </div>
+            <a
+              href={github.installers.windows.x64}
+              className="doc-button"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Download Windows x64 (.msi)
+            </a>
           </section>
 
           <hr />

--- a/ee/apps/landing/app/enterprise/page.tsx
+++ b/ee/apps/landing/app/enterprise/page.tsx
@@ -3,7 +3,7 @@ import { getGithubData } from "../../lib/github";
 
 export const metadata = {
   title: "OpenWork — Enterprise",
-  description: "Enterprise OpenWork licensing with deployment support, rollout help, and included Windows support."
+  description: "Secure hosting for safe, permissioned AI employees."
 };
 
 export default async function Enterprise() {

--- a/ee/apps/landing/app/page.tsx
+++ b/ee/apps/landing/app/page.tsx
@@ -5,8 +5,6 @@ import { headers } from "next/headers";
 export default async function Home() {
   const github = await getGithubData();
   const cal = process.env.NEXT_PUBLIC_CAL_URL || "/enterprise#book";
-  const windowsCheckoutUrl =
-    process.env.NEXT_PUBLIC_WINDOWS_CHECKOUT_URL || "/download#windows-support";
   const userAgent = headers().get("user-agent")?.toLowerCase() || "";
   const isMobileVisitor = /android|iphone|ipad|ipod|mobile/.test(userAgent);
 
@@ -15,7 +13,6 @@ export default async function Home() {
       stars={github.stars}
       downloadHref={github.downloads.macos}
       callHref={cal}
-      windowsCheckoutUrl={windowsCheckoutUrl}
       isMobileVisitor={isMobileVisitor}
     />
   );

--- a/ee/apps/landing/app/pricing/page.tsx
+++ b/ee/apps/landing/app/pricing/page.tsx
@@ -13,8 +13,6 @@ export const metadata = {
 export default async function PricingPage() {
   const github = await getGithubData();
   const callUrl = process.env.NEXT_PUBLIC_CAL_URL || "/enterprise#book";
-  const windowsCheckoutUrl =
-    process.env.NEXT_PUBLIC_WINDOWS_CHECKOUT_URL || "/download#windows-support";
 
   return (
     <div className="relative min-h-screen overflow-hidden text-[#011627]">
@@ -38,7 +36,6 @@ export default async function PricingPage() {
           </section>
 
           <PricingGrid
-            windowsCheckoutUrl={windowsCheckoutUrl}
             callUrl={callUrl}
             showHeader={false}
           />

--- a/ee/apps/landing/components/landing-enterprise.tsx
+++ b/ee/apps/landing/components/landing-enterprise.tsx
@@ -214,8 +214,7 @@ export function LandingEnterprise(props: Props) {
                 <p className="text-[14px] leading-relaxed text-slate-600">
                   Deploy inside your own environment or work with us on a
                   managed rollout, with your gateway, MCP servers, skills, and
-                  internal data sources connected. Windows support is included in
-                  enterprise licensing.
+                  internal data sources connected.
                 </p>
               </div>
             </div>

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -11,7 +11,6 @@ import {
   landingDemoFlows,
   landingDemoFlowTimes
 } from "./landing-demo-flows";
-import { PricingGrid } from "./pricing-grid";
 import { LandingSharePackageCard } from "./landing-share-package-card";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
@@ -21,7 +20,6 @@ type Props = {
   stars: string;
   downloadHref: string;
   callHref: string;
-  windowsCheckoutUrl: string;
   isMobileVisitor: boolean;
 };
 
@@ -44,6 +42,7 @@ export function LandingHome(props: Props) {
     [activeDemoId]
   );
 
+  const callLinkProps = externalLinkProps(props.callHref);
   const primaryCtaHref = props.isMobileVisitor
     ? "https://app.openworklabs.com"
     : "/download";
@@ -90,10 +89,11 @@ export function LandingHome(props: Props) {
                   {primaryCtaLabel} <Download size={18} />
                 </a>
                 <a
-                  href="/pricing"
+                  href={props.callHref}
                   className="secondary-button"
+                  {...callLinkProps}
                 >
-                  See pricing
+                  Contact sales
                 </a>
               </div>
 
@@ -208,14 +208,6 @@ export function LandingHome(props: Props) {
                 </div>
               </div>
             </div>
-          </section>
-
-          <section className="landing-shell rounded-[2.5rem] p-8 md:p-12">
-            <PricingGrid
-              windowsCheckoutUrl={props.windowsCheckoutUrl}
-              callUrl={props.callHref}
-              showHeader={true}
-            />
           </section>
 
           <section

--- a/ee/apps/landing/components/pricing-grid.tsx
+++ b/ee/apps/landing/components/pricing-grid.tsx
@@ -4,7 +4,6 @@ import { ArrowUpRight, Cloud, Download, Shield } from "lucide-react";
 import { ResponsiveGrain } from "./responsive-grain";
 
 type PricingGridProps = {
-  windowsCheckoutUrl: string;
   callUrl: string;
   showHeader?: boolean;
 };
@@ -150,7 +149,7 @@ export function PricingGrid(props: PricingGridProps) {
       href: props.callUrl,
       external: /^https?:\/\//.test(props.callUrl),
       features: [
-        { text: "Includes Windows support", icon: Shield },
+        { text: "Enterprise rollout support", icon: Shield },
         { text: "Deployment guidance", icon: Shield },
         { text: "Custom commercial terms", icon: Shield },
       ],

--- a/ee/apps/landing/lib/github.ts
+++ b/ee/apps/landing/lib/github.ts
@@ -72,7 +72,7 @@ export const getGithubData = async () => {
   const [repo, releases] = await Promise.all([
     fetchJson<Repo>("https://api.github.com/repos/different-ai/openwork"),
     fetchJson<Release[]>(
-      "https://api.github.com/repos/different-ai/openwork/releases?per_page=10"
+      "https://api.github.com/repos/different-ai/openwork/releases?per_page=50"
     )
   ]);
 
@@ -82,6 +82,17 @@ export const getGithubData = async () => {
       : "—";
 
   const releaseList = Array.isArray(releases) ? releases : [];
+  const hasDownloadAsset = (release: Release) => {
+    const assets = Array.isArray(release?.assets) ? release.assets : [];
+    return assets.some((asset) => asset?.browser_download_url);
+  };
+  const hasWindowsDesktopAsset = (release: Release) => {
+    const assets = Array.isArray(release?.assets) ? release.assets : [];
+    return assets.some((asset) => {
+      const name = String(asset?.name || "").toLowerCase();
+      return name.startsWith("openwork-desktop-windows-") && (name.endsWith(".msi") || name.endsWith(".exe"));
+    });
+  };
 
   const isStableDesktopRelease = (release: Release) => {
     if (!release || release.draft || release.prerelease) return false;
@@ -96,19 +107,24 @@ export const getGithubData = async () => {
 
   const pick =
     releaseList.find((release) => isStableDesktopRelease(release)) ||
-    releaseList.find((release) => {
-      if (!release || release.draft) return false;
-      const assets = Array.isArray(release.assets) ? release.assets : [];
-      return assets.some((asset) => asset?.browser_download_url);
-    });
+    releaseList.find((release) => !release?.draft && hasDownloadAsset(release));
+
+  const windowsPick =
+    releaseList.find((release) => isStableDesktopRelease(release) && hasWindowsDesktopAsset(release)) ||
+    releaseList.find((release) => !release?.draft && hasWindowsDesktopAsset(release));
 
   const assets = Array.isArray(pick?.assets) ? pick.assets : [];
   const releaseUrl = pick?.html_url || FALLBACK_RELEASE;
+  const windowsAssets = Array.isArray(windowsPick?.assets) ? windowsPick.assets : assets;
+  const windowsReleaseUrl = windowsPick?.html_url || releaseUrl;
   const dmg = selectAsset(assets, [".dmg"]);
+  const exe = selectAsset(windowsAssets, [".exe", ".msi"], ["win", "windows"]);
   const appImage = selectAsset(assets, [".appimage"], ["linux"]);
 
   const macosApple = selectAsset(assets, [".dmg"], ["darwin-aarch64"]);
   const macosIntel = selectAsset(assets, [".dmg"], ["darwin-x64"]);
+  const windowsX64 =
+    selectAsset(windowsAssets, [".msi", ".exe"], ["windows-x64"]) || exe;
 
   const linuxDebX64 = selectAsset(assets, [".deb"], ["linux-amd64", "linux-x64"]);
   const linuxDebArm64 = selectAsset(assets, [".deb"], ["linux-arm64", "linux-aarch64"]);
@@ -121,6 +137,7 @@ export const getGithubData = async () => {
     releaseTag: pick?.tag_name || "",
     downloads: {
       macos: dmg?.browser_download_url || FALLBACK_RELEASE,
+      windows: exe?.browser_download_url || FALLBACK_RELEASE,
       linux:
         appImage?.browser_download_url ||
         linuxDebX64?.browser_download_url ||
@@ -131,6 +148,9 @@ export const getGithubData = async () => {
       macos: {
         appleSilicon: macosApple?.browser_download_url || dmg?.browser_download_url || releaseUrl,
         intel: macosIntel?.browser_download_url || dmg?.browser_download_url || releaseUrl
+      },
+      windows: {
+        x64: windowsX64?.browser_download_url || windowsReleaseUrl
       },
       linux: {
         aur: "https://aur.archlinux.org/packages/openwork",


### PR DESCRIPTION
## Summary
- restore Windows desktop builds in prerelease and release workflows, including the Windows runner, sidecar asset mapping, and `.exe` sidecar naming
- revert the paid Windows landing flow so `/download` exposes a direct public MSI download again and the home page no longer routes users into Windows pricing
- make landing release resolution fall back to the latest stable Windows desktop asset when the newest stable desktop release does not include Windows artifacts

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @openwork-ee/landing build`
- verified with Chrome DevTools MCP that `/` shows `Download for free` and `Contact sales`
- verified with Chrome DevTools MCP that `/download` shows `Download Windows x64 (.msi)` and resolves to a direct public MSI URL