### PR TITLE
docs: automated documentation updates 2026-04-13

### DIFF
--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,15 @@
 ---
 title: "Changelog"
 ---
+<Update label="April 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
+
+  ## [v0.11.207](https://github.com/different-ai/openwork/compare/v0.11.206...v0.11.207): Windows downloads return and OpenWork speaks French
+
+  - Restored free public Windows desktop downloads across the landing and download flows so Windows users can download installers again without a paid checkout path.
+  - Added French localization for the OpenWork app so users can navigate core product surfaces in French.
+
+</Update>
+
 <Update label="April 7th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.205](https://github.com/different-ai/openwork/compare/v0.11.202...v0.11.205): OpenWork Cloud launches for teams


### PR DESCRIPTION
Docs refresh for 19:00 PDT. This PR updates documentation to match behavior introduced by commits from the last 24 hours.

Commits reviewed:
- e4ef3e28 revert(landing): restore free Windows downloads and builds (#1442)
- 2ffdf5db feat(i18n): add French locale (#1438)

Why these docs changed:
- Example: e4ef3e28 revert(landing): restore free Windows downloads and builds (#1442) changed the previous paid Windows download workflow back to free public installers, so packages/docs/changelog.mdx had to be updated because the latest published changelog did not mention that Windows downloads are public again.
- Example: 2ffdf5db feat(i18n): add French locale (#1438) added a new French app locale, so packages/docs/changelog.mdx had to be updated because the latest published changelog did not document the new language option.

Documentation updates in this PR:
- Updated packages/docs/changelog.mdx to add an April 13th entry for v0.11.207 covering restored free Windows downloads and the new French localization.
- Kept the rest of the changelog intact so historical release notes still reflect the previously shipped workflow changes.

Why this merits a docs update:
- Without these changes, the docs would still miss two user-visible changes from the current release line: Windows users can once again download installers without a paid checkout path, and French is now available as an in-app language.