### PR TITLE
docs: add roadmap tab

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -39,6 +39,18 @@
             ]
           },
           {
+            "group": "Roadmap",
+            "pages": [
+              "roadmap"
+            ]
+          },
+          {
+            "group": "Changelog",
+            "pages": [
+              "changelog"
+            ]
+          },
+          {
             "group": "Improve this doc",
             "pages": [
               "missing-docs"

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -39,18 +39,6 @@
             ]
           },
           {
-            "group": "Roadmap",
-            "pages": [
-              "roadmap"
-            ]
-          },
-          {
-            "group": "Changelog",
-            "pages": [
-              "changelog"
-            ]
-          },
-          {
             "group": "Improve this doc",
             "pages": [
               "missing-docs"
@@ -73,6 +61,12 @@
       {
         "tab": "Cloud API",
         "openapi": "https://api.openworklabs.com/openapi.json"
+      },
+      {
+        "tab": "Roadmap",
+        "pages": [
+          "roadmap"
+        ]
       },
       {
         "tab": "Changelog",

--- a/packages/docs/roadmap.mdx
+++ b/packages/docs/roadmap.mdx
@@ -19,9 +19,9 @@ Last updated: 04/15/2026
 
 ## Roadmap
 
+- New Openwork Server
 - New Desktop infraestructure
 - Better, more reliable Automations
-- New Openwork Server
 - Claude-compatible plugin marketplace.
 - Git-based provisioning for plugins, skills, and MCPs.
 - Automatic push-based provisioning and sync.

--- a/packages/docs/roadmap.mdx
+++ b/packages/docs/roadmap.mdx
@@ -1,0 +1,20 @@
+---
+title: "Roadmap"
+description: "What OpenWork supports today and what is coming next."
+---
+
+## Live today
+
+- Desktop app on Windows, Mac, and Linux.
+- Any LLM, BYOK, or sign in with OpenAI Auth.
+- Skills, Agents, and MCPs.
+- Org Hub with provisioned Skills, Agents, and MCPs.
+- RBAC, teams within an org, cloud sandboxes, and self-hosting.
+
+## Roadmap
+
+- Plugin marketplace as the main distribution model beyond standalone skill hubs.
+- Plugin bundles composed of skills, agents, scripts, MCPs, and workspace configs.
+- Git-based connector path that can start simple and deepen over time.
+- Provisioning and sync engine for team-based rollout and app/config distribution.
+- Advanced RBAC, audit trails, SSO/SAML, MDM provisioning, and SOC 2 Type II compliance.

--- a/packages/docs/roadmap.mdx
+++ b/packages/docs/roadmap.mdx
@@ -3,18 +3,26 @@ title: "Roadmap"
 description: "What OpenWork supports today and what is coming next."
 ---
 
+Sharing the upcoming items in our roadmap:
+
+Last updated: 04/15/2026
+
 ## Live today
 
 - Desktop app on Windows, Mac, and Linux.
-- Any LLM, BYOK, or sign in with OpenAI Auth.
-- Skills, Agents, and MCPs.
-- Org Hub with provisioned Skills, Agents, and MCPs.
-- RBAC, teams within an org, cloud sandboxes, and self-hosting.
+- Shared agents, skills, Agents, and MCPs.
+- Sign in with OpenAI Auth or other LLM providers.
+- Use any LLM, including LiteLLM and Cloudflare Gateaway.
+- Connect to a remote workspace or a cloud worker for long running tasks.
+- Cloud: Org Hub with provisioned Skills, Agents, and MCPs.
+- Cloud: RBAC, teams within an org, and the ability to deploy cloud workers.
 
 ## Roadmap
 
-- Plugin marketplace as the main distribution model beyond standalone skill hubs.
-- Plugin bundles composed of skills, agents, scripts, MCPs, and workspace configs.
-- Git-based connector path that can start simple and deepen over time.
-- Provisioning and sync engine for team-based rollout and app/config distribution.
-- Advanced RBAC, audit trails, SSO/SAML, MDM provisioning, and SOC 2 Type II compliance.
+- New Desktop infraestructure
+- Better, more reliable Automations
+- New Openwork Server
+- Claude-compatible plugin marketplace.
+- Git-based provisioning for plugins, skills, and MCPs.
+- Automatic push-based provisioning and sync.
+- Advanced enterprise controls: RBAC, audit trails, SSO/SAML, MDM provisioning...


### PR DESCRIPTION
## Summary
- add a dedicated `Roadmap` docs tab that mirrors the top-level `Changelog` navigation pattern
- publish a basic roadmap page with separate `Live today` and `Roadmap` sections using the provided copy
- keep the change docs-only so it can ship as a separate PR

## Testing
- `python3 -m json.tool packages/docs/docs.json`
- `git diff --check`

## Notes
- I did not run `packaging/docker/dev-up.sh`, Chrome MCP verification, or capture screenshots because this is a Mintlify docs-only change and this repo/worktree does not include a local docs preview command or Mintlify CLI to render the page locally.