### PR TITLE
feat(settings): add feedback UI visibility toggle

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -42,6 +42,7 @@ import { clearDevLogs } from "./lib/dev-log";
 import { clearPerfLogs } from "./lib/perf-log";
 import { deepLinkBridgeEvent, drainPendingDeepLinks, type DeepLinkBridgeDetail } from "./lib/deep-link-bridge";
 import {
+  FEEDBACK_UI_PREF_KEY,
   HIDE_TITLEBAR_PREF_KEY,
   SUGGESTED_PLUGINS,
 } from "./constants";
@@ -236,6 +237,7 @@ export default function App() {
     createSignal<OnboardingStep>("welcome");
   const [rememberStartupChoice, setRememberStartupChoice] = createSignal(false);
   const [themeMode, setThemeMode] = createSignal<ThemeMode>(getInitialThemeMode());
+  const [feedbackUiEnabled, setFeedbackUiEnabled] = createSignal(true);
 
   const [engineSource, setEngineSource] = createSignal<"path" | "sidecar" | "custom">(
     isTauriRuntime() ? "sidecar" : "path"
@@ -1716,6 +1718,11 @@ export default function App() {
           }
         }
 
+        const storedFeedbackUi = window.localStorage.getItem(FEEDBACK_UI_PREF_KEY);
+        if (storedFeedbackUi === "0" || storedFeedbackUi === "1") {
+          setFeedbackUiEnabled(storedFeedbackUi === "1");
+        }
+
         const storedUpdateAutoCheck = window.localStorage.getItem(
           "openwork.updateAutoCheck"
         );
@@ -1904,6 +1911,18 @@ export default function App() {
       setWindowDecorations(!hide).catch(() => {
         // ignore errors (e.g., window not ready)
       });
+    }
+  });
+
+  createEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(
+        FEEDBACK_UI_PREF_KEY,
+        feedbackUiEnabled() ? "1" : "0",
+      );
+    } catch {
+      // ignore
     }
   });
 
@@ -2146,6 +2165,8 @@ export default function App() {
       createSessionAndOpen,
       hideTitlebar: hideTitlebar(),
       toggleHideTitlebar: () => setHideTitlebar((v) => !v),
+      feedbackUiEnabled: feedbackUiEnabled(),
+      toggleFeedbackUiEnabled: () => setFeedbackUiEnabled((v) => !v),
       updateAutoCheck: updateAutoCheck(),
       toggleUpdateAutoCheck: () => setUpdateAutoCheck((v) => !v),
       updateAutoDownload: updateAutoDownload(),
@@ -2244,6 +2265,7 @@ export default function App() {
     orchestratorStatus: orchestratorStatusState(),
     opencodeRouterInfo: opencodeRouterInfoState(),
     appVersion: appVersion(),
+    feedbackUiEnabled: feedbackUiEnabled(),
     booting: booting(),
     startupPhase: bootPhase(),
     startupBranch: startupBranch(),

--- a/apps/app/src/app/components/status-bar.tsx
+++ b/apps/app/src/app/components/status-bar.tsx
@@ -19,6 +19,7 @@ type StatusBarProps = {
   statusPingClass?: string;
   statusPulse?: boolean;
   showSettingsButton?: boolean;
+  showFeedbackButton?: boolean;
 };
 
 export default function StatusBar(props: StatusBarProps) {
@@ -102,16 +103,18 @@ export default function StatusBar(props: StatusBarProps) {
         </div>
 
         <div class="flex items-center gap-1.5">
-          <button
-            type="button"
-            class="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
-            onClick={props.onSendFeedback}
-            title={t("status.send_feedback")}
-            aria-label={t("status.send_feedback")}
-          >
-            <MessageCircle class="h-4 w-4" />
-            <span class="text-[11px] font-medium">{t("status.feedback")}</span>
-          </button>
+          <Show when={props.showFeedbackButton !== false}>
+            <button
+              type="button"
+              class="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+              onClick={props.onSendFeedback}
+              title={t("status.send_feedback")}
+              aria-label={t("status.send_feedback")}
+            >
+              <MessageCircle class="h-4 w-4" />
+              <span class="text-[11px] font-medium">{t("status.feedback")}</span>
+            </button>
+          </Show>
           <Show when={props.showSettingsButton !== false}>
             <button
               type="button"

--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -7,6 +7,7 @@ export const THINKING_PREF_KEY = "openwork.showThinking";
 export const VARIANT_PREF_KEY = "openwork.modelVariant";
 export const LANGUAGE_PREF_KEY = "openwork.language";
 export const HIDE_TITLEBAR_PREF_KEY = "openwork.hideTitlebar";
+export const FEEDBACK_UI_PREF_KEY = "openwork.feedbackUiEnabled";
 
 export const DEFAULT_MODEL: ModelRef = {
   providerID: "opencode",

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -154,6 +154,7 @@ export type SessionViewProps = {
   orchestratorStatus: OrchestratorStatus | null;
   opencodeRouterInfo: OpenCodeRouterInfo | null;
   appVersion: string | null;
+  feedbackUiEnabled: boolean;
   booting: boolean;
   startupPhase: BootPhase;
   startupBranch: StartupBranch;
@@ -3653,6 +3654,7 @@ export default function SessionView(props: SessionViewProps) {
             developerMode={props.developerMode}
             settingsOpen={false}
             onSendFeedback={openFeedback}
+            showFeedbackButton={props.feedbackUiEnabled}
             showSettingsButton={true}
             onOpenSettings={props.toggleSettings}
             providerConnectedIds={props.providerConnectedIds}

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -145,6 +145,8 @@ export type SettingsViewProps = {
   isWindows: boolean;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
+  feedbackUiEnabled: boolean;
+  toggleFeedbackUiEnabled: () => void;
   language: Language;
   setLanguage: (value: Language) => void;
   themeMode: "light" | "dark" | "system";
@@ -1673,17 +1675,32 @@ export default function SettingsView(props: SettingsViewProps) {
               <div class="pointer-events-none absolute -bottom-12 left-6 h-24 w-24 rounded-full bg-cyan-6/20 blur-2xl" />
 
               <div class="relative space-y-4">
-                <div class="space-y-2">
-                  <div class="inline-flex items-center gap-1.5 rounded-full border border-blue-7/35 bg-blue-4/25 px-2.5 py-1 text-[11px] font-medium text-blue-11">
-                    <LifeBuoy size={12} />
-                    {t("settings.feedback_badge")}
+                <div class="flex items-start justify-between gap-3">
+                  <div class="space-y-2 min-w-0">
+                    <div class="inline-flex items-center gap-1.5 rounded-full border border-blue-7/35 bg-blue-4/25 px-2.5 py-1 text-[11px] font-medium text-blue-11">
+                      <LifeBuoy size={12} />
+                      {t("settings.feedback_badge")}
+                    </div>
+                    <div class="text-sm font-semibold text-gray-12">
+                      {t("settings.feedback_title")}
+                    </div>
+                    <div class="max-w-[58ch] text-xs text-gray-10">
+                      {t("settings.feedback_desc")}
+                    </div>
                   </div>
-                  <div class="text-sm font-semibold text-gray-12">
-                    {t("settings.feedback_title")}
-                  </div>
-                  <div class="max-w-[58ch] text-xs text-gray-10">
-                    {t("settings.feedback_desc")}
-                  </div>
+
+                  <button
+                    type="button"
+                    class="shrink-0 inline-flex items-center gap-1.5 rounded-full border border-blue-7/30 bg-gray-1/70 px-2.5 py-1.5 text-[11px] font-medium text-gray-11 transition-colors hover:border-blue-7/50 hover:text-gray-12 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-7/30"
+                    onClick={props.toggleFeedbackUiEnabled}
+                    disabled={props.busy}
+                    title={t("settings.feedback_ui_toggle_desc")}
+                    aria-label={t("settings.feedback_ui_toggle")}
+                  >
+                    <MessageCircle size={12} />
+                    <span>{t("status.feedback")}</span>
+                    <span class="text-gray-8">{props.feedbackUiEnabled ? t("settings.on") : t("settings.off")}</span>
+                  </button>
                 </div>
 
                 <div class="flex flex-wrap items-center gap-2">

--- a/apps/app/src/app/shell/settings-shell.tsx
+++ b/apps/app/src/app/shell/settings-shell.tsx
@@ -199,6 +199,8 @@ export type SettingsShellProps = {
   createSessionAndOpen: (initialPrompt?: string) => Promise<string | undefined> | string | void;
   hideTitlebar: boolean;
   toggleHideTitlebar: () => void;
+  feedbackUiEnabled: boolean;
+  toggleFeedbackUiEnabled: () => void;
   opencodeEnableExa: boolean;
   toggleOpencodeEnableExa: () => void;
   language: Language;
@@ -1199,6 +1201,8 @@ export default function SettingsShell(props: SettingsShellProps) {
                   isWindows={props.isWindows}
                   hideTitlebar={props.hideTitlebar}
                   toggleHideTitlebar={props.toggleHideTitlebar}
+                  feedbackUiEnabled={props.feedbackUiEnabled}
+                  toggleFeedbackUiEnabled={props.toggleFeedbackUiEnabled}
                   language={props.language}
                   setLanguage={props.setLanguage}
                   updateAutoCheck={props.updateAutoCheck}
@@ -1366,6 +1370,7 @@ export default function SettingsShell(props: SettingsShellProps) {
           settingsOpen={true}
           showSettingsButton={true}
           onSendFeedback={openFeedback}
+          showFeedbackButton={props.feedbackUiEnabled}
           onOpenSettings={props.toggleSettings}
           providerConnectedIds={props.providerConnectedIds}
         />

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1493,6 +1493,8 @@ export default {
   "settings.feedback_badge": "We read every message",
   "settings.feedback_desc": "Tell us what feels great and what feels rough. Feedback goes straight to the team and helps us prioritize what ships next.",
   "settings.feedback_title": "Help shape OpenWork",
+  "settings.feedback_ui_toggle": "Display feedback buttons in UI",
+  "settings.feedback_ui_toggle_desc": "Show or hide feedback entry points like the footer button and the feedback actions in settings.",
   "settings.group_global": "Global",
   "settings.group_workspace": "Workspace",
   "settings.hide_titlebar": "Hide titlebar",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -1493,6 +1493,8 @@ export default {
   "settings.feedback_badge": "Nous lisons chaque message",
   "settings.feedback_desc": "Dites-nous ce qui vous plaît et ce qui vous semble difficile. Les retours vont directement à l'équipe et nous aident à prioriser ce qui sera livré ensuite.",
   "settings.feedback_title": "Aidez à façonner OpenWork",
+  "settings.feedback_ui_toggle": "Afficher les boutons de retour dans l'interface",
+  "settings.feedback_ui_toggle_desc": "Affiche ou masque les entrées de feedback comme le bouton du footer et les actions de feedback dans les paramètres.",
   "settings.group_global": "Global",
   "settings.group_workspace": "Espace de travail",
   "settings.hide_titlebar": "Masquer la barre de titre",


### PR DESCRIPTION
## Summary
- add a persistent settings toggle to show or hide feedback buttons in the main UI
- place the control as a small right-aligned cartouche in the existing feedback card
- keep the feedback actions in Settings available while hiding the main footer feedback button when disabled

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @openwork/app exec vite build`
- `pnpm --filter @openwork/desktop exec tauri build --ci --no-sign --config '{"build":{"beforeBuildCommand":""}}'`