### PR TITLE
docs: automated documentation updates 2026-04-15

### DIFF
--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -1,6 +1,15 @@
 ---
 title: "Changelog"
 ---
+<Update label="April 15th" tags={["🚀 New Features"]}>
+
+  ## OpenWork adds Catalan and Spanish, plus an experimental microsandbox sandbox mode
+
+  - Added Catalan and Spanish to `Settings > Language` so more teams can use the app in their preferred language.
+  - Added a `Feature flags` section in Settings with a `Create Sandbox uses microsandbox image` toggle for testing the new detached-worker sandbox flow.
+
+</Update>
+
 <Update label="April 13th" tags={["🚀 New Features", "🐛 Bug Fixes"]}>
 
   ## [v0.11.207](https://github.com/different-ai/openwork/compare/v0.11.206...v0.11.207): Windows downloads return and OpenWork speaks French


### PR DESCRIPTION
Docs refresh for 19:00 PDT. This PR updates documentation to match behavior introduced by commits from the last 24 hours.

Commits reviewed:
- e232aba9 feat(i18n): add Catalan locale (#1450)
- 1871532e feat(i18n): add Spanish locale (#1451)
- 800602f4 feat: add microsandbox sandbox flow and feature flag toggle (#1446)

Why these docs changed:
- Example: e232aba9 feat(i18n): add Catalan locale (#1450) changed the app from offering seven interface languages to offering Catalan in Settings > Language, so packages/docs/changelog.mdx had to be updated because it still reflected the pre-Catalan language list.
- Example: 1871532e feat(i18n): add Spanish locale (#1451) changed the same language-selection workflow by adding Spanish as a first-class UI option, so the current docs were incomplete about which languages users can choose in the app.
- Example: 800602f4 feat: add microsandbox sandbox flow and feature flag toggle (#1446) changed Create Sandbox from a Docker-only path to an optional microsandbox-backed path behind Settings > Feature flags, so the docs had to be updated because they did not mention the new experimental toggle or the alternative runtime flow.

Documentation updates in this PR:
- Updated packages/docs/changelog.mdx to add an April 15th entry covering the new Catalan and Spanish language options.
- Updated packages/docs/changelog.mdx to document the new Feature flags settings area and the Create Sandbox microsandbox toggle.

Why this merits a docs update:
- Without these changes, the docs would still imply the older language-selection and Create Sandbox behavior, even though the current app now exposes additional languages and an experimental microsandbox workflow.