### PR TITLE
fix(automations): clear stale scheduler install gate

### DIFF
--- a/apps/app/src/app/pages/automations.tsx
+++ b/apps/app/src/app/pages/automations.tsx
@@ -441,6 +441,12 @@ export default function AutomationsView(props: AutomationsViewProps) {
     onCleanup(() => window.clearInterval(interval));
   });
 
+  createEffect(() => {
+    if (props.schedulerInstalled) {
+      setSchedulerInstallRequested(false);
+    }
+  });
+
   const showToast = (title: string, tone: AppStatusToastTone = "info") => {
     statusToasts.showToast({ title, tone });
   };
@@ -551,6 +557,12 @@ export default function AutomationsView(props: AutomationsViewProps) {
     try {
       await Promise.resolve(props.addPlugin("opencode-scheduler"));
       showToast(t("scheduled.scheduler_install_requested"), "success");
+    } catch (error) {
+      setSchedulerInstallRequested(false);
+      showToast(
+        error instanceof Error ? error.message : t("scheduled.prepare_error_fallback"),
+        "error",
+      );
     } finally {
       setInstallingScheduler(false);
     }


### PR DESCRIPTION
## Summary
- clear the local `schedulerInstallRequested` gate once the scheduler plugin actually appears as installed
- also clear that gate when plugin installation fails, so the Automations UI does not stay stuck in a pseudo-installed state
- keep the existing reload/install flow intact while removing the stale local state that could block automations after a successful install

## Context
- fixes #1422

## Testing
- `pnpm --filter @openwork/app exec vite build`