### PR TITLE
docs(cloud): add enterprise CTA page

### DIFF
--- a/packages/docs/cloud-enterprise.mdx
+++ b/packages/docs/cloud-enterprise.mdx
@@ -1,0 +1,21 @@
+---
+title: "Enterprise"
+description: "Deploy OpenWork on your own infrastructure"
+---
+
+Want to run OpenWork on your own infra? We'll help you get there.
+
+OpenWork can be deployed inside your VPC or on-prem, with SSO, audit logs, and controls over which models and tools your team can use. If you're exploring a self-hosted or private-cloud rollout, talk to us.
+
+<Card title="Book a call with our team" icon="calendar" href="https://cal.com/team/openwork/enterprise">
+  Schedule a 30-minute intro at [cal.com/team/openwork/enterprise](https://cal.com/team/openwork/enterprise) to scope your deployment.
+</Card>
+
+## What we'll cover
+
+- Your target environment (cloud provider, VPC, on-prem)
+- Identity, access, and audit requirements
+- Model and tool allowlists
+- Rollout plan and support model
+
+Prefer email? Reach us at [team@openworklabs.com](mailto:team@openworklabs.com?subject=Enterprise%20deployment).

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -55,7 +55,8 @@
           "cloud-shared-workspaces",
           "cloud-llm-providers",
           "cloud-custom-llm-providers",
-          "cloud-members-and-rbac"
+          "cloud-members-and-rbac",
+          "cloud-enterprise"
         ]
       },
       {


### PR DESCRIPTION
## Summary

- Adds `packages/docs/cloud-enterprise.mdx`: a short call-to-action for enterprises that want to deploy OpenWork on their own infrastructure, linking to `cal.com/team/openwork/enterprise` and `team@openworklabs.com` as a fallback.
- Registers the new page in the "Cloud docs" tab of `packages/docs/docs.json` right after `cloud-members-and-rbac`.

## Evidence

No runtime code changed; this is a docs-only addition (new `.mdx` + one-line nav entry). I did not spin up Docker / Chrome MCP because there is nothing product-facing to exercise.

To preview locally (Mintlify):

```
cd packages/docs
mintlify dev
```

Then open the `Cloud docs` tab and verify the `Enterprise` page renders with the booking Card.