### PR TITLE
feat(den-web): hidden plugins discovery page

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -276,6 +276,14 @@ export function getNewSkillRoute(orgSlug: string): string {
   return `${getSkillHubsRoute(orgSlug)}/skills/new`;
 }
 
+export function getPluginsRoute(orgSlug: string): string {
+  return `${getOrgDashboardRoute(orgSlug)}/plugins`;
+}
+
+export function getPluginRoute(orgSlug: string, pluginId: string): string {
+  return `${getPluginsRoute(orgSlug)}/${encodeURIComponent(pluginId)}`;
+}
+
 export function parseOrgListPayload(payload: unknown): {
   orgs: DenOrgSummary[];
   activeOrgId: string | null;

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
@@ -26,6 +26,7 @@ import {
   getOrgAccessFlags,
   getMembersRoute,
   getOrgDashboardRoute,
+  getPluginsRoute,
   getSharedSetupsRoute,
   getSkillHubsRoute,
 } from "../../../../_lib/den-org";
@@ -109,6 +110,9 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   }
   if (pathname.startsWith(getSkillHubsRoute(orgSlug))) {
     return "Skill Hubs";
+  }
+  if (pathname.startsWith(getPluginsRoute(orgSlug))) {
+    return "Plugins";
   }
   if (pathname.startsWith(getBillingRoute(orgSlug)) || pathname === "/checkout") {
     return "Billing";

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/plugin-data.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/plugin-data.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Plugin primitives — mirror OpenCode / Claude Code's plugin surface:
+ *
+ *  A plugin is a *bundle* of reusable pieces that extend an agent runtime:
+ *   - skills      natural-language playbooks/instructions agents can load on demand
+ *   - hooks       lifecycle callbacks (PreToolUse / PostToolUse / SessionStart, etc.)
+ *   - mcps        Model Context Protocol servers that expose external tools/resources
+ *   - agents      custom sub-agents with their own system prompt and tool set
+ *   - commands    slash-commands that shortcut common workflows
+ *
+ * This file models the frontend shape only. Mock data is served through
+ * React Query so we can swap the queryFn for a real API call later without
+ * touching any consumers.
+ */
+
+// ── Primitive types ────────────────────────────────────────────────────────
+
+export type PluginCategory =
+  | "integrations"
+  | "workflows"
+  | "code-intelligence"
+  | "output-styles"
+  | "infrastructure";
+
+export type PluginSkill = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export type PluginHookEvent =
+  | "PreToolUse"
+  | "PostToolUse"
+  | "SessionStart"
+  | "SessionEnd"
+  | "UserPromptSubmit"
+  | "Notification"
+  | "Stop";
+
+export type PluginHook = {
+  id: string;
+  event: PluginHookEvent;
+  description: string;
+  matcher?: string | null;
+};
+
+export type PluginMcpTransport = "stdio" | "http" | "sse";
+
+export type PluginMcp = {
+  id: string;
+  name: string;
+  description: string;
+  transport: PluginMcpTransport;
+  toolCount: number;
+};
+
+export type PluginAgent = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export type PluginCommand = {
+  id: string;
+  name: string;
+  description: string;
+};
+
+export type PluginSource =
+  | { type: "marketplace"; marketplace: string }
+  | { type: "github"; repo: string }
+  | { type: "local"; path: string };
+
+export type DenPlugin = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  version: string;
+  author: string;
+  category: PluginCategory;
+  installed: boolean;
+  source: PluginSource;
+  skills: PluginSkill[];
+  hooks: PluginHook[];
+  mcps: PluginMcp[];
+  agents: PluginAgent[];
+  commands: PluginCommand[];
+  updatedAt: string;
+};
+
+// ── Display helpers ────────────────────────────────────────────────────────
+
+export function getPluginCategoryLabel(category: PluginCategory): string {
+  switch (category) {
+    case "integrations":
+      return "External Integrations";
+    case "workflows":
+      return "Workflows";
+    case "code-intelligence":
+      return "Code Intelligence";
+    case "output-styles":
+      return "Output Styles";
+    case "infrastructure":
+      return "Infrastructure";
+  }
+}
+
+export function formatPluginTimestamp(value: string | null): string {
+  if (!value) {
+    return "Recently updated";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Recently updated";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+export function getPluginPartsSummary(plugin: DenPlugin): string {
+  const parts: string[] = [];
+  if (plugin.skills.length > 0) {
+    parts.push(`${plugin.skills.length} ${plugin.skills.length === 1 ? "Skill" : "Skills"}`);
+  }
+  if (plugin.hooks.length > 0) {
+    parts.push(`${plugin.hooks.length} ${plugin.hooks.length === 1 ? "Hook" : "Hooks"}`);
+  }
+  if (plugin.mcps.length > 0) {
+    parts.push(`${plugin.mcps.length} ${plugin.mcps.length === 1 ? "MCP" : "MCPs"}`);
+  }
+  if (plugin.agents.length > 0) {
+    parts.push(`${plugin.agents.length} ${plugin.agents.length === 1 ? "Agent" : "Agents"}`);
+  }
+  if (plugin.commands.length > 0) {
+    parts.push(`${plugin.commands.length} ${plugin.commands.length === 1 ? "Command" : "Commands"}`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : "Empty bundle";
+}
+
+// ── Mock data ──────────────────────────────────────────────────────────────
+//
+// These are shaped to mirror real marketplaces (Anthropic's official catalog,
+// internal team bundles, etc.) so the UI exercises realistic content.
+
+const MOCK_PLUGINS: DenPlugin[] = [
+  {
+    id: "plg_github",
+    name: "GitHub",
+    slug: "github",
+    description:
+      "Work with GitHub repositories, pull requests, issues, and Actions directly from chat. Bundles an MCP server and review workflows.",
+    version: "1.4.2",
+    author: "Anthropic",
+    category: "integrations",
+    installed: true,
+    source: { type: "marketplace", marketplace: "claude-plugins-official" },
+    skills: [
+      { id: "sk_gh_pr", name: "Open Pull Request", description: "Draft PR titles and bodies from a diff." },
+      { id: "sk_gh_review", name: "Review Pull Request", description: "Summarize diffs and suggest blocking comments." },
+    ],
+    hooks: [
+      {
+        id: "hk_gh_pre",
+        event: "PreToolUse",
+        description: "Redact GitHub tokens from logs before tool execution.",
+        matcher: "Bash",
+      },
+    ],
+    mcps: [
+      {
+        id: "mcp_gh",
+        name: "github-mcp",
+        description: "Official GitHub MCP server — issues, PRs, releases, Actions.",
+        transport: "http",
+        toolCount: 42,
+      },
+    ],
+    agents: [
+      {
+        id: "ag_gh_reviewer",
+        name: "pr-reviewer",
+        description: "Opinionated pull-request reviewer with context-aware suggestions.",
+      },
+    ],
+    commands: [
+      { id: "cmd_gh_pr", name: "/gh:pr", description: "Create a pull request from the current branch." },
+    ],
+    updatedAt: "2026-04-10T12:00:00Z",
+  },
+  {
+    id: "plg_commit_commands",
+    name: "Commit Commands",
+    slug: "commit-commands",
+    description:
+      "Git commit, push, and PR-creation workflows. Uses conventional-commit heuristics and follows your repo's commit style.",
+    version: "0.9.0",
+    author: "Anthropic",
+    category: "workflows",
+    installed: true,
+    source: { type: "marketplace", marketplace: "claude-plugins-official" },
+    skills: [
+      { id: "sk_cc_commit", name: "Smart Commit", description: "Stage, group, and commit with a generated message." },
+      { id: "sk_cc_push", name: "Push & Open PR", description: "Push current branch and open a PR with autogenerated body." },
+    ],
+    hooks: [],
+    mcps: [],
+    agents: [],
+    commands: [
+      { id: "cmd_cc_commit", name: "/commit", description: "Create a commit for staged changes." },
+      { id: "cmd_cc_push", name: "/push", description: "Push current branch and track upstream." },
+      { id: "cmd_cc_pr", name: "/pr", description: "Open a pull request." },
+    ],
+    updatedAt: "2026-04-07T09:00:00Z",
+  },
+  {
+    id: "plg_typescript_lsp",
+    name: "TypeScript LSP",
+    slug: "typescript-lsp",
+    description:
+      "Connects Claude to the TypeScript language server so it can jump to definitions, find references, and surface type errors immediately after edits.",
+    version: "1.1.0",
+    author: "Anthropic",
+    category: "code-intelligence",
+    installed: false,
+    source: { type: "marketplace", marketplace: "claude-plugins-official" },
+    skills: [],
+    hooks: [
+      {
+        id: "hk_ts_diag",
+        event: "PostToolUse",
+        description: "Run LSP diagnostics after every file edit and report type errors.",
+        matcher: "Edit|Write",
+      },
+    ],
+    mcps: [
+      {
+        id: "mcp_ts",
+        name: "typescript-language-server",
+        description: "LSP bridge for .ts/.tsx diagnostics and navigation.",
+        transport: "stdio",
+        toolCount: 9,
+      },
+    ],
+    agents: [],
+    commands: [],
+    updatedAt: "2026-03-28T16:45:00Z",
+  },
+  {
+    id: "plg_linear",
+    name: "Linear",
+    slug: "linear",
+    description:
+      "Create, update, and triage Linear issues without leaving the session. Bundles a Linear MCP and an issue-grooming agent.",
+    version: "0.6.3",
+    author: "Anthropic",
+    category: "integrations",
+    installed: false,
+    source: { type: "marketplace", marketplace: "claude-plugins-official" },
+    skills: [
+      { id: "sk_lin_triage", name: "Triage Inbox", description: "Sweep the inbox and file issues to the right project." },
+    ],
+    hooks: [],
+    mcps: [
+      {
+        id: "mcp_linear",
+        name: "linear-mcp",
+        description: "Linear MCP — issues, cycles, projects, comments.",
+        transport: "http",
+        toolCount: 24,
+      },
+    ],
+    agents: [
+      { id: "ag_lin_groomer", name: "linear-groomer", description: "Keeps the backlog tidy and flags stale issues." },
+    ],
+    commands: [
+      { id: "cmd_lin_new", name: "/linear:new", description: "File a new issue from the current context." },
+    ],
+    updatedAt: "2026-04-02T18:12:00Z",
+  },
+  {
+    id: "plg_openwork_release",
+    name: "OpenWork Release Kit",
+    slug: "openwork-release-kit",
+    description:
+      "Internal plugin that automates OpenWork release prep, orchestrator sidecar builds, and changelog generation. Shipped by OpenWork infra.",
+    version: "2.3.1",
+    author: "OpenWork",
+    category: "workflows",
+    installed: true,
+    source: { type: "github", repo: "different-ai/openwork-plugins" },
+    skills: [
+      { id: "sk_ow_release_prep", name: "Release Prep", description: "Bump versions across app/desktop/orchestrator in lockstep." },
+      { id: "sk_ow_changelog", name: "Changelog Drafter", description: "Generate markdown release notes from merged PRs." },
+    ],
+    hooks: [
+      {
+        id: "hk_ow_sessionstart",
+        event: "SessionStart",
+        description: "Load the release runbook into context at session start.",
+        matcher: null,
+      },
+    ],
+    mcps: [],
+    agents: [
+      { id: "ag_ow_release", name: "release-captain", description: "Drives the full release flow end-to-end." },
+    ],
+    commands: [
+      { id: "cmd_ow_release", name: "/release", description: "Run the standardized release workflow." },
+    ],
+    updatedAt: "2026-04-14T08:30:00Z",
+  },
+  {
+    id: "plg_sentry",
+    name: "Sentry",
+    slug: "sentry",
+    description:
+      "Connect to Sentry and ingest recent errors into a session. Includes an MCP server and a triage skill that clusters noisy issues.",
+    version: "0.4.0",
+    author: "Anthropic",
+    category: "infrastructure",
+    installed: false,
+    source: { type: "marketplace", marketplace: "claude-plugins-official" },
+    skills: [
+      { id: "sk_sentry_triage", name: "Triage Errors", description: "Cluster Sentry issues and recommend owners." },
+    ],
+    hooks: [],
+    mcps: [
+      {
+        id: "mcp_sentry",
+        name: "sentry-mcp",
+        description: "Sentry MCP — projects, issues, releases, performance.",
+        transport: "http",
+        toolCount: 18,
+      },
+    ],
+    agents: [],
+    commands: [],
+    updatedAt: "2026-03-20T11:00:00Z",
+  },
+  {
+    id: "plg_explanatory_style",
+    name: "Explanatory Output Style",
+    slug: "explanatory-output-style",
+    description:
+      "Response style that adds educational context around implementation choices, trade-offs, and alternatives.",
+    version: "1.0.0",
+    author: "Anthropic",
+    category: "output-styles",
+    installed: false,
+    source: { type: "marketplace", marketplace: "claude-plugins-official" },
+    skills: [],
+    hooks: [
+      {
+        id: "hk_explain_post",
+        event: "Stop",
+        description: "Append an 'Implementation notes' section before stopping.",
+        matcher: null,
+      },
+    ],
+    mcps: [],
+    agents: [],
+    commands: [],
+    updatedAt: "2026-03-12T14:22:00Z",
+  },
+];
+
+async function fetchMockPlugins(): Promise<DenPlugin[]> {
+  // Simulate network latency so loading states render during development.
+  await new Promise((resolve) => setTimeout(resolve, 180));
+  return MOCK_PLUGINS;
+}
+
+async function fetchMockPlugin(id: string): Promise<DenPlugin | null> {
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  return MOCK_PLUGINS.find((plugin) => plugin.id === id) ?? null;
+}
+
+// ── Query hooks ────────────────────────────────────────────────────────────
+//
+// Keep the surface identical to what a real API-backed version would return,
+// so swapping `queryFn` for `requestJson(...)` later is a one-line change.
+
+export const pluginQueryKeys = {
+  all: ["plugins"] as const,
+  list: () => [...pluginQueryKeys.all, "list"] as const,
+  detail: (id: string) => [...pluginQueryKeys.all, "detail", id] as const,
+};
+
+export function usePlugins() {
+  return useQuery({
+    queryKey: pluginQueryKeys.list(),
+    queryFn: fetchMockPlugins,
+  });
+}
+
+export function usePlugin(id: string) {
+  return useQuery({
+    queryKey: pluginQueryKeys.detail(id),
+    queryFn: () => fetchMockPlugin(id),
+    enabled: Boolean(id),
+  });
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/plugin-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/plugin-detail-screen.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, FileText, Puzzle, Server, Terminal, Users, Webhook } from "lucide-react";
+import { PaperMeshGradient } from "@openwork/ui/react";
+import { buttonVariants } from "../../../../_components/ui/button";
+import { getPluginsRoute } from "../../../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import {
+  type DenPlugin,
+  type PluginHook,
+  type PluginMcp,
+  type PluginSkill,
+  type PluginAgent,
+  type PluginCommand,
+  formatPluginTimestamp,
+  getPluginCategoryLabel,
+  getPluginPartsSummary,
+  usePlugin,
+} from "./plugin-data";
+
+export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
+  const { orgSlug } = useOrgDashboard();
+  const { data: plugin, isLoading, error } = usePlugin(pluginId);
+
+  if (isLoading && !plugin) {
+    return (
+      <div className="mx-auto max-w-[900px] px-6 py-8 md:px-8">
+        <div className="rounded-xl border border-gray-100 bg-white px-5 py-8 text-[13px] text-gray-400">
+          Loading plugin details...
+        </div>
+      </div>
+    );
+  }
+
+  if (!plugin) {
+    return (
+      <div className="mx-auto max-w-[900px] px-6 py-8 md:px-8">
+        <div className="rounded-xl border border-red-100 bg-red-50 px-5 py-3.5 text-[13px] text-red-600">
+          {error instanceof Error ? error.message : "That plugin could not be found."}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-[900px] px-6 py-8 md:px-8">
+      {/* Nav */}
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <Link
+          href={getPluginsRoute(orgSlug)}
+          className="inline-flex items-center gap-1.5 text-[13px] text-gray-400 transition hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Link>
+
+        <button
+          type="button"
+          className={buttonVariants({ variant: plugin.installed ? "secondary" : "primary", size: "sm" })}
+          disabled
+          aria-disabled="true"
+          title="Install/uninstall is not wired up yet in this preview."
+        >
+          {plugin.installed ? "Installed" : "Install"}
+        </button>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_240px]">
+        {/* ── Main card ── */}
+        <section className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+          {/* Gradient header — seeded by plugin id to match the list card */}
+          <div className="relative h-40 overflow-hidden border-b border-gray-100">
+            <div className="absolute inset-0">
+              <PaperMeshGradient seed={plugin.id} speed={0} />
+            </div>
+            <div className="absolute bottom-[-20px] left-6 flex h-14 w-14 items-center justify-center rounded-[18px] border border-white/60 bg-white shadow-[0_12px_24px_-12px_rgba(15,23,42,0.3)]">
+              <Puzzle className="h-6 w-6 text-gray-700" />
+            </div>
+          </div>
+
+          <div className="px-6 pb-6 pt-10">
+            {/* Title + description + meta */}
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-[18px] font-semibold text-gray-900">{plugin.name}</h1>
+              <span className="rounded-full bg-gray-100 px-2.5 py-0.5 text-[11px] font-medium text-gray-500">
+                v{plugin.version}
+              </span>
+              <span className="text-[12px] text-gray-400">by {plugin.author}</span>
+            </div>
+            <p className="mt-1.5 text-[13px] leading-relaxed text-gray-500">{plugin.description}</p>
+            <p className="mt-2 text-[12px] text-gray-300">
+              {getPluginPartsSummary(plugin)} · Updated {formatPluginTimestamp(plugin.updatedAt)}
+            </p>
+
+            {/* Skills */}
+            <PrimitiveSection
+              icon={FileText}
+              label="Skills"
+              emptyLabel="This plugin does not ship any skills."
+              items={plugin.skills}
+              render={(skill) => renderSkillRow(skill)}
+            />
+
+            {/* Hooks */}
+            <PrimitiveSection
+              icon={Webhook}
+              label="Hooks"
+              emptyLabel="This plugin does not register any hooks."
+              items={plugin.hooks}
+              render={(hook) => renderHookRow(hook)}
+            />
+
+            {/* MCP Servers */}
+            <PrimitiveSection
+              icon={Server}
+              label="MCP Servers"
+              emptyLabel="This plugin does not bundle any MCP servers."
+              items={plugin.mcps}
+              render={(mcp) => renderMcpRow(mcp)}
+            />
+
+            {/* Agents */}
+            <PrimitiveSection
+              icon={Users}
+              label="Agents"
+              emptyLabel="This plugin does not define any sub-agents."
+              items={plugin.agents}
+              render={(agent) => renderAgentRow(agent)}
+            />
+
+            {/* Commands */}
+            <PrimitiveSection
+              icon={Terminal}
+              label="Commands"
+              emptyLabel="This plugin does not add any slash-commands."
+              items={plugin.commands}
+              render={(command) => renderCommandRow(command)}
+            />
+          </div>
+        </section>
+
+        {/* ── Sidebar ── */}
+        <aside className="grid gap-3 self-start">
+          {/* Category */}
+          <div className="rounded-xl border border-gray-100 bg-white p-4">
+            <p className="mb-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">Category</p>
+            <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] text-gray-500">
+              {getPluginCategoryLabel(plugin.category)}
+            </span>
+          </div>
+
+          {/* Source */}
+          <div className="rounded-xl border border-gray-100 bg-white p-4">
+            <p className="mb-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">Source</p>
+            <p className="text-[13px] font-medium text-gray-900">
+              {plugin.source.type === "marketplace"
+                ? "Marketplace"
+                : plugin.source.type === "github"
+                  ? "GitHub"
+                  : "Local"}
+            </p>
+            <p className="mt-0.5 break-words text-[12px] text-gray-400">
+              {plugin.source.type === "marketplace"
+                ? plugin.source.marketplace
+                : plugin.source.type === "github"
+                  ? plugin.source.repo
+                  : plugin.source.path}
+            </p>
+          </div>
+
+          {/* Status */}
+          <div className="rounded-xl border border-gray-100 bg-white p-4">
+            <p className="mb-3 text-[11px] font-medium uppercase tracking-wide text-gray-400">Status</p>
+            <p className="text-[13px] font-medium text-gray-900">
+              {plugin.installed ? "Installed" : "Not installed"}
+            </p>
+            <p className="mt-0.5 text-[12px] text-gray-400">
+              Install and enable management will land in a follow-up.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+// ── Section + row renderers ──────────────────────────────────────────────────
+
+function PrimitiveSection<T>({
+  icon: Icon,
+  label,
+  items,
+  emptyLabel,
+  render,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  items: T[];
+  emptyLabel: string;
+  render: (item: T) => React.ReactNode;
+}) {
+  return (
+    <div className="mt-6 border-t border-gray-100 pt-5">
+      <p className="mb-3 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-gray-400">
+        <Icon className="h-3.5 w-3.5" />
+        {items.length === 0 ? label : `${items.length} ${label}`}
+      </p>
+
+      {items.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-100 px-5 py-4 text-[13px] text-gray-400">
+          {emptyLabel}
+        </div>
+      ) : (
+        <div className="grid gap-1.5">{items.map((item) => render(item))}</div>
+      )}
+    </div>
+  );
+}
+
+function renderSkillRow(skill: PluginSkill) {
+  return (
+    <div
+      key={skill.id}
+      className="flex items-center justify-between gap-4 rounded-xl border border-gray-100 px-4 py-3"
+    >
+      <div className="min-w-0">
+        <p className="truncate text-[13px] font-medium text-gray-900">{skill.name}</p>
+        <p className="mt-0.5 truncate text-[12px] text-gray-400">{skill.description}</p>
+      </div>
+      <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-0.5 text-[11px] text-gray-400">Skill</span>
+    </div>
+  );
+}
+
+function renderHookRow(hook: PluginHook) {
+  return (
+    <div
+      key={hook.id}
+      className="flex items-center justify-between gap-4 rounded-xl border border-gray-100 px-4 py-3"
+    >
+      <div className="min-w-0">
+        <p className="truncate text-[13px] font-medium text-gray-900">{hook.event}</p>
+        <p className="mt-0.5 truncate text-[12px] text-gray-400">{hook.description}</p>
+      </div>
+      <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-0.5 text-[11px] text-gray-400">
+        {hook.matcher ? `matcher: ${hook.matcher}` : "any"}
+      </span>
+    </div>
+  );
+}
+
+function renderMcpRow(mcp: PluginMcp) {
+  return (
+    <div
+      key={mcp.id}
+      className="flex items-center justify-between gap-4 rounded-xl border border-gray-100 px-4 py-3"
+    >
+      <div className="min-w-0">
+        <p className="truncate text-[13px] font-medium text-gray-900">{mcp.name}</p>
+        <p className="mt-0.5 truncate text-[12px] text-gray-400">{mcp.description}</p>
+      </div>
+      <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-0.5 text-[11px] text-gray-400">
+        {mcp.transport} · {mcp.toolCount} tools
+      </span>
+    </div>
+  );
+}
+
+function renderAgentRow(agent: PluginAgent) {
+  return (
+    <div
+      key={agent.id}
+      className="flex items-center justify-between gap-4 rounded-xl border border-gray-100 px-4 py-3"
+    >
+      <div className="min-w-0">
+        <p className="truncate text-[13px] font-medium text-gray-900">{agent.name}</p>
+        <p className="mt-0.5 truncate text-[12px] text-gray-400">{agent.description}</p>
+      </div>
+      <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-0.5 text-[11px] text-gray-400">Agent</span>
+    </div>
+  );
+}
+
+function renderCommandRow(command: PluginCommand) {
+  return (
+    <div
+      key={command.id}
+      className="flex items-center justify-between gap-4 rounded-xl border border-gray-100 px-4 py-3"
+    >
+      <div className="min-w-0">
+        <p className="truncate font-mono text-[13px] font-medium text-gray-900">{command.name}</p>
+        <p className="mt-0.5 truncate text-[12px] text-gray-400">{command.description}</p>
+      </div>
+      <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-0.5 text-[11px] text-gray-400">Command</span>
+    </div>
+  );
+}
+
+// Satisfy the type parameter of DenPlugin import even if unused at runtime.
+// (Keeps the file importable when you wire in edit forms later.)
+export type { DenPlugin };

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/plugins-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/plugins-screen.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import {
+  FileText,
+  Puzzle,
+  Search,
+  Server,
+  Webhook,
+} from "lucide-react";
+import { PaperMeshGradient } from "@openwork/ui/react";
+import { UnderlineTabs } from "../../../../_components/ui/tabs";
+import { DashboardPageTemplate } from "../../../../_components/ui/dashboard-page-template";
+import { DenInput } from "../../../../_components/ui/input";
+import { getPluginRoute } from "../../../../_lib/den-org";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import {
+  getPluginCategoryLabel,
+  getPluginPartsSummary,
+  usePlugins,
+} from "./plugin-data";
+
+type PluginView = "plugins" | "skills" | "hooks" | "mcps";
+
+const PLUGIN_TABS = [
+  { value: "plugins" as const, label: "Plugins", icon: Puzzle },
+  { value: "skills" as const, label: "All Skills", icon: FileText },
+  { value: "hooks" as const, label: "All Hooks", icon: Webhook },
+  { value: "mcps" as const, label: "All MCPs", icon: Server },
+];
+
+export function PluginsScreen() {
+  const { orgSlug } = useOrgDashboard();
+  const { data: plugins = [], isLoading, error } = usePlugins();
+  const [activeView, setActiveView] = useState<PluginView>("plugins");
+  const [query, setQuery] = useState("");
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredPlugins = useMemo(() => {
+    if (!normalizedQuery) {
+      return plugins;
+    }
+
+    return plugins.filter((plugin) => {
+      return (
+        plugin.name.toLowerCase().includes(normalizedQuery) ||
+        plugin.description.toLowerCase().includes(normalizedQuery) ||
+        plugin.author.toLowerCase().includes(normalizedQuery) ||
+        getPluginCategoryLabel(plugin.category).toLowerCase().includes(normalizedQuery)
+      );
+    });
+  }, [normalizedQuery, plugins]);
+
+  const allSkills = useMemo(
+    () =>
+      plugins.flatMap((plugin) =>
+        plugin.skills.map((skill) => ({ ...skill, pluginId: plugin.id, pluginName: plugin.name })),
+      ),
+    [plugins],
+  );
+
+  const allHooks = useMemo(
+    () =>
+      plugins.flatMap((plugin) =>
+        plugin.hooks.map((hook) => ({ ...hook, pluginId: plugin.id, pluginName: plugin.name })),
+      ),
+    [plugins],
+  );
+
+  const allMcps = useMemo(
+    () =>
+      plugins.flatMap((plugin) =>
+        plugin.mcps.map((mcp) => ({ ...mcp, pluginId: plugin.id, pluginName: plugin.name })),
+      ),
+    [plugins],
+  );
+
+  const filteredSkills = useMemo(() => {
+    if (!normalizedQuery) return allSkills;
+    return allSkills.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(normalizedQuery) ||
+        skill.description.toLowerCase().includes(normalizedQuery) ||
+        skill.pluginName.toLowerCase().includes(normalizedQuery),
+    );
+  }, [normalizedQuery, allSkills]);
+
+  const filteredHooks = useMemo(() => {
+    if (!normalizedQuery) return allHooks;
+    return allHooks.filter(
+      (hook) =>
+        hook.event.toLowerCase().includes(normalizedQuery) ||
+        hook.description.toLowerCase().includes(normalizedQuery) ||
+        hook.pluginName.toLowerCase().includes(normalizedQuery),
+    );
+  }, [normalizedQuery, allHooks]);
+
+  const filteredMcps = useMemo(() => {
+    if (!normalizedQuery) return allMcps;
+    return allMcps.filter(
+      (mcp) =>
+        mcp.name.toLowerCase().includes(normalizedQuery) ||
+        mcp.description.toLowerCase().includes(normalizedQuery) ||
+        mcp.pluginName.toLowerCase().includes(normalizedQuery),
+    );
+  }, [normalizedQuery, allMcps]);
+
+  const searchPlaceholder =
+    activeView === "plugins"
+      ? "Search plugins..."
+      : activeView === "skills"
+        ? "Search skills..."
+        : activeView === "hooks"
+          ? "Search hooks..."
+          : "Search MCPs...";
+
+  return (
+    <DashboardPageTemplate
+      icon={Puzzle}
+      badgeLabel="Preview"
+      title="Plugins"
+      description="Discover and manage plugins — bundles of skills, hooks, MCP servers, agents, and commands that extend your workers."
+      colors={["#EDE9FE", "#4C1D95", "#7C3AED", "#C4B5FD"]}
+    >
+      <div className="mb-8 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex flex-col gap-4">
+          <UnderlineTabs tabs={PLUGIN_TABS} activeTab={activeView} onChange={setActiveView} />
+          <div>
+            <DenInput
+              type="search"
+              icon={Search}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={searchPlaceholder}
+            />
+          </div>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
+          {error instanceof Error ? error.message : "Failed to load plugins."}
+        </div>
+      ) : null}
+
+      {isLoading ? (
+        <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
+          Loading plugin catalog...
+        </div>
+      ) : activeView === "plugins" ? (
+        filteredPlugins.length === 0 ? (
+          <EmptyState
+            title={plugins.length === 0 ? "No plugins available yet." : "No plugins match that search."}
+            description={
+              plugins.length === 0
+                ? "Once you connect a marketplace, discovered plugins will appear here."
+                : "Try a different search term or browse the skills, hooks, or MCPs tabs."
+            }
+          />
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+            {filteredPlugins.map((plugin) => (
+              <Link
+                key={plugin.id}
+                href={getPluginRoute(orgSlug, plugin.id)}
+                className="block overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-8px_rgba(15,23,42,0.1)]"
+              >
+                {/* Gradient header */}
+                <div className="relative h-36 overflow-hidden border-b border-gray-100">
+                  <div className="absolute inset-0">
+                    <PaperMeshGradient seed={plugin.id} speed={0} />
+                  </div>
+                  <div className="absolute bottom-[-20px] left-6 flex h-14 w-14 items-center justify-center rounded-[18px] border border-white/60 bg-white shadow-[0_12px_24px_-12px_rgba(15,23,42,0.3)]">
+                    <Puzzle className="h-6 w-6 text-gray-700" />
+                  </div>
+                  {plugin.installed ? (
+                    <span className="absolute right-4 top-4 rounded-full border border-white/30 bg-white/20 px-2.5 py-1 text-[10px] font-medium uppercase tracking-[1px] text-white backdrop-blur-md">
+                      Installed
+                    </span>
+                  ) : null}
+                </div>
+
+                {/* Body */}
+                <div className="px-6 pb-5 pt-9">
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <h2 className="text-[15px] font-semibold text-gray-900">{plugin.name}</h2>
+                    <span className="text-[11px] font-medium text-gray-400">v{plugin.version}</span>
+                  </div>
+                  <p className="line-clamp-2 text-[13px] leading-[1.6] text-gray-400">{plugin.description}</p>
+
+                  <div className="mt-5 flex items-center gap-2 border-t border-gray-100 pt-4">
+                    <span className="inline-flex rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-500">
+                      {getPluginPartsSummary(plugin)}
+                    </span>
+                    <span className="ml-auto text-[13px] font-medium text-gray-500">View plugin</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )
+      ) : activeView === "skills" ? (
+        <PrimitiveList
+          emptyLabel="No skills in this catalog yet."
+          emptyDescriptionEmpty="Once plugins contribute skills, they will show up here."
+          emptyDescriptionFiltered="No skills match that search."
+          unfilteredCount={allSkills.length}
+          rows={filteredSkills.map((skill) => ({
+            id: skill.id,
+            title: skill.name,
+            description: skill.description,
+            tag: skill.pluginName,
+            href: getPluginRoute(orgSlug, skill.pluginId),
+          }))}
+        />
+      ) : activeView === "hooks" ? (
+        <PrimitiveList
+          emptyLabel="No hooks in this catalog yet."
+          emptyDescriptionEmpty="Hooks declared by plugins will show up here."
+          emptyDescriptionFiltered="No hooks match that search."
+          unfilteredCount={allHooks.length}
+          rows={filteredHooks.map((hook) => ({
+            id: hook.id,
+            title: hook.event,
+            description: hook.description,
+            tag: hook.pluginName,
+            href: getPluginRoute(orgSlug, hook.pluginId),
+          }))}
+        />
+      ) : (
+        <PrimitiveList
+          emptyLabel="No MCP servers in this catalog yet."
+          emptyDescriptionEmpty="MCP servers exposed by plugins will show up here."
+          emptyDescriptionFiltered="No MCPs match that search."
+          unfilteredCount={allMcps.length}
+          rows={filteredMcps.map((mcp) => ({
+            id: mcp.id,
+            title: mcp.name,
+            description: mcp.description,
+            tag: `${mcp.pluginName} · ${mcp.transport}`,
+            href: getPluginRoute(orgSlug, mcp.pluginId),
+          }))}
+        />
+      )}
+    </DashboardPageTemplate>
+  );
+}
+
+function EmptyState({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center">
+      <p className="text-[16px] font-medium tracking-[-0.03em] text-gray-900">{title}</p>
+      <p className="mx-auto mt-3 max-w-[520px] text-[15px] leading-8 text-gray-500">{description}</p>
+    </div>
+  );
+}
+
+type PrimitiveRow = {
+  id: string;
+  title: string;
+  description: string;
+  tag: string;
+  href: string;
+};
+
+function PrimitiveList({
+  rows,
+  unfilteredCount,
+  emptyLabel,
+  emptyDescriptionEmpty,
+  emptyDescriptionFiltered,
+}: {
+  rows: PrimitiveRow[];
+  unfilteredCount: number;
+  emptyLabel: string;
+  emptyDescriptionEmpty: string;
+  emptyDescriptionFiltered: string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title={unfilteredCount === 0 ? emptyLabel : "Nothing matches that search."}
+        description={unfilteredCount === 0 ? emptyDescriptionEmpty : emptyDescriptionFiltered}
+      />
+    );
+  }
+
+  return (
+    <div className="grid gap-1.5">
+      {rows.map((row) => (
+        <Link
+          key={row.id}
+          href={row.href}
+          className="flex items-center justify-between gap-4 rounded-xl border border-gray-100 bg-white px-4 py-3 transition hover:border-gray-200 hover:bg-gray-50/60"
+        >
+          <div className="min-w-0">
+            <p className="truncate text-[13px] font-medium text-gray-900">{row.title}</p>
+            {row.description ? (
+              <p className="mt-0.5 truncate text-[12px] text-gray-400">{row.description}</p>
+            ) : null}
+          </div>
+          <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-0.5 text-[11px] text-gray-400">
+            {row.tag}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}
+

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/query-client-provider.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/query-client-provider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+/**
+ * DashboardQueryClientProvider
+ *
+ * Scopes a single QueryClient instance to the org dashboard subtree.
+ * Keeps den-web's React Query surface narrow — any new dashboard feature
+ * (plugins, etc.) can use useQuery/useMutation without leaking client state
+ * across other top-level routes.
+ */
+export function DashboardQueryClientProvider({ children }: { children: React.ReactNode }) {
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/layout.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 import { OrgDashboardShell } from "./_components/org-dashboard-shell";
 import { OrgDashboardProvider } from "./_providers/org-dashboard-provider";
+import { DashboardQueryClientProvider } from "./_providers/query-client-provider";
 
 export default async function OrgDashboardLayout({
   children,
@@ -11,8 +12,10 @@ export default async function OrgDashboardLayout({
   const { orgSlug } = await params;
 
   return (
-    <OrgDashboardProvider orgSlug={orgSlug}>
-      <OrgDashboardShell>{children}</OrgDashboardShell>
-    </OrgDashboardProvider>
+    <DashboardQueryClientProvider>
+      <OrgDashboardProvider orgSlug={orgSlug}>
+        <OrgDashboardShell>{children}</OrgDashboardShell>
+      </OrgDashboardProvider>
+    </DashboardQueryClientProvider>
   );
 }

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/plugins/[pluginId]/page.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/plugins/[pluginId]/page.tsx
@@ -1,0 +1,11 @@
+import { PluginDetailScreen } from "../../_components/plugin-detail-screen";
+
+export default async function PluginPage({
+  params,
+}: {
+  params: Promise<{ pluginId: string }>;
+}) {
+  const { pluginId } = await params;
+
+  return <PluginDetailScreen pluginId={pluginId} />;
+}

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/plugins/page.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/plugins/page.tsx
@@ -1,0 +1,5 @@
+import { PluginsScreen } from "../_components/plugins-screen";
+
+export default function PluginsPage() {
+  return <PluginsScreen />;
+}

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -14,6 +14,7 @@
     "@openwork-ee/utils": "workspace:*",
     "@openwork/ui": "workspace:*",
     "@paper-design/shaders-react": "0.0.72",
+    "@tanstack/react-query": "^5.96.2",
     "lucide-react": "^0.577.0",
     "next": "16.2.1",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,9 @@ importers:
       '@paper-design/shaders-react':
         specifier: 0.0.72
         version: 0.0.72(@types/react@19.2.14)(react@19.2.4)
+      '@tanstack/react-query':
+        specifier: ^5.96.2
+        version: 5.96.2(react@19.2.4)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)


### PR DESCRIPTION
## Summary

Adds a new **Plugins** page to the Den org dashboard that lists plugins (bundles of skills, hooks, MCP servers, agents, and commands) with a list view, per-plugin detail view, and tabbed cross-cutting views for browsing all skills/hooks/MCPs across the catalog.

The page is **hidden** by design (per request): no sidebar nav entry. It's reachable only via direct URL: \`/o/<slug>/dashboard/plugins\`.

## What's in the bundle (\`DenPlugin\`)

Modeled on Claude Code / OpenCode plugin taxonomy:

- **skills** — natural-language playbooks agents can load on demand
- **hooks** — lifecycle callbacks (\`PreToolUse\`, \`PostToolUse\`, \`SessionStart\`, …)
- **mcps** — Model Context Protocol servers (stdio / http / sse)
- **agents** — custom sub-agents with their own prompts/tools
- **commands** — slash-commands

Each is fully typed in \`plugin-data.tsx\`.

## Approach

- **Reuses existing dashboard primitives**: \`DashboardPageTemplate\`, \`UnderlineTabs\`, \`DenInput\`, \`PaperMeshGradient\` cards, \`buttonVariants\`. Mirrors the \`skill-hubs\` list/detail pattern 1:1 for visual coherence.
- **Introduces \`@tanstack/react-query\`** scoped to the dashboard subtree via a new \`DashboardQueryClientProvider\`. Existing pages are unaffected.
- **Mock data** is served by a \`queryFn\` so swapping to a real API later is a one-line change. The hook surface (\`usePlugins()\`, \`usePlugin(id)\`) is identical to what an API-backed version would expose.
- **Title mapping**: added one branch to \`getDashboardPageTitle\` so the top header reads "Plugins" when manually visiting the URL — no sidebar item.

## Files

- \`app/(den)/o/[orgSlug]/dashboard/plugins/page.tsx\` — list shell
- \`app/(den)/o/[orgSlug]/dashboard/plugins/[pluginId]/page.tsx\` — detail shell
- \`app/(den)/o/[orgSlug]/dashboard/_components/plugins-screen.tsx\` — list + tabs (Plugins / Skills / Hooks / MCPs)
- \`app/(den)/o/[orgSlug]/dashboard/_components/plugin-detail-screen.tsx\` — detail with sections per primitive
- \`app/(den)/o/[orgSlug]/dashboard/_components/plugin-data.tsx\` — types, mock catalog, React Query hooks
- \`app/(den)/o/[orgSlug]/dashboard/_providers/query-client-provider.tsx\` — narrow \`QueryClientProvider\` wrapper
- \`app/(den)/o/[orgSlug]/dashboard/layout.tsx\` — wraps \`OrgDashboardProvider\` in the new query client provider
- \`app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx\` — title mapping only (no nav item)
- \`app/(den)/_lib/den-org.ts\` — adds \`getPluginsRoute\` / \`getPluginRoute\`
- \`package.json\` + \`pnpm-lock.yaml\` — adds \`@tanstack/react-query\`

## Verification

- \`pnpm exec tsc --noEmit\` in \`ee/apps/den-web\` → **passes** (exit 0).
- I did **not** run the Docker dev stack or Chrome MCP for this PR — the change is a hidden, mock-only frontend page with no backend wiring. If reviewers want a runtime smoke test:
  1. \`packaging/docker/dev-up.sh\` (from \`_repos/openwork\`)
  2. Sign in to Den, switch to any org
  3. Navigate to \`/o/<orgSlug>/dashboard/plugins\` directly

## Out of scope

- No install/uninstall flow (the Install button is intentionally disabled with a tooltip).
- No real backend; the mock is a placeholder.
- No sidebar entry — explicit user request to keep it hidden until ready.