### PR TITLE
feat(den): gate desktop updates by supported version

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -158,6 +158,11 @@ export type DenDesktopHandoffExchange = {
   token: string | null;
 };
 
+export type DenAppVersionMetadata = {
+  minAppVersion: string;
+  latestAppVersion: string;
+};
+
 type RawJsonResponse<T> = {
   ok: boolean;
   status: number;
@@ -180,6 +185,20 @@ export class DenApiError extends Error {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function getDenAppVersionMetadata(payload: unknown): DenAppVersionMetadata | null {
+  if (!isRecord(payload)) return null;
+
+  const latestAppVersion =
+    typeof payload.latestAppVersion === "string" ? payload.latestAppVersion.trim() : "";
+  if (!latestAppVersion) return null;
+
+  return {
+    minAppVersion:
+      typeof payload.minAppVersion === "string" ? payload.minAppVersion.trim() : "",
+    latestAppVersion,
+  };
 }
 
 export function normalizeDenBaseUrl(input: string | null | undefined): string | null {
@@ -909,6 +928,17 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         throw new DenApiError(500, "invalid_session_payload", "Session response did not include a user.");
       }
       return user;
+    },
+
+    async getAppVersionMetadata(): Promise<DenAppVersionMetadata> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/app-version", {
+        method: "GET",
+      });
+      const appVersionMetadata = getDenAppVersionMetadata(payload);
+      if (!appVersionMetadata) {
+        throw new DenApiError(500, "invalid_app_version_payload", "App version response was missing version details.");
+      }
+      return appVersionMetadata;
     },
 
     async exchangeDesktopHandoff(grant: string): Promise<DenDesktopHandoffExchange> {

--- a/apps/app/src/app/system-state.ts
+++ b/apps/app/src/app/system-state.ts
@@ -18,6 +18,7 @@ import type {
 import { addOpencodeCacheHint, isTauriRuntime, safeStringify } from "./utils";
 import { filterProviderList, mapConfigProvidersToList } from "./utils/providers";
 import { createUpdaterState, type UpdateStatus } from "./context/updater";
+import { createDenClient, readDenSettings } from "./lib/den";
 import {
   resetOpenworkState,
   resetOpencodeCache,
@@ -63,6 +64,84 @@ function forcedDevUpdateStatus(): UpdateStatus | null {
     version,
     notes: "Dev-only forced update state",
   };
+}
+
+function parseComparableVersion(value: string): { release: number[]; prerelease: string[] } | null {
+  const normalized = value.trim().replace(/^v/i, "");
+  if (!normalized) return null;
+
+  const [versionCore] = normalized.split("+", 1);
+  if (!versionCore) return null;
+
+  const [releasePart, prereleasePart = ""] = versionCore.split("-", 2);
+  const release = releasePart.split(".").map((segment) => Number(segment));
+  if (!release.length || release.some((segment) => !Number.isInteger(segment) || segment < 0)) {
+    return null;
+  }
+
+  const prerelease = prereleasePart
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  return { release, prerelease };
+}
+
+function comparePrereleaseIdentifiers(left: string[], right: string[]): number {
+  if (!left.length && !right.length) return 0;
+  if (!left.length) return 1;
+  if (!right.length) return -1;
+
+  const count = Math.max(left.length, right.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+
+    const leftNumeric = /^\d+$/.test(leftPart) ? Number(leftPart) : null;
+    const rightNumeric = /^\d+$/.test(rightPart) ? Number(rightPart) : null;
+
+    if (leftNumeric !== null && rightNumeric !== null) {
+      if (leftNumeric !== rightNumeric) return leftNumeric < rightNumeric ? -1 : 1;
+      continue;
+    }
+
+    if (leftNumeric !== null) return -1;
+    if (rightNumeric !== null) return 1;
+
+    const comparison = leftPart.localeCompare(rightPart);
+    if (comparison !== 0) return comparison < 0 ? -1 : 1;
+  }
+
+  return 0;
+}
+
+function compareVersions(left: string, right: string): number | null {
+  const parsedLeft = parseComparableVersion(left);
+  const parsedRight = parseComparableVersion(right);
+  if (!parsedLeft || !parsedRight) return null;
+
+  const count = Math.max(parsedLeft.release.length, parsedRight.release.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = parsedLeft.release[index] ?? 0;
+    const rightPart = parsedRight.release[index] ?? 0;
+    if (leftPart !== rightPart) return leftPart < rightPart ? -1 : 1;
+  }
+
+  return comparePrereleaseIdentifiers(parsedLeft.prerelease, parsedRight.prerelease);
+}
+
+async function isUpdateSupportedByDen(updateVersion: string) {
+  try {
+    const settings = readDenSettings();
+    const client = createDenClient({ baseUrl: settings.baseUrl });
+    const metadata = await client.getAppVersionMetadata();
+    const comparison = compareVersions(updateVersion, metadata.latestAppVersion);
+    return comparison !== null && comparison <= 0;
+  } catch {
+    return false;
+  }
 }
 
 export function createSystemState(options: {
@@ -444,6 +523,13 @@ export function createSystemState(options: {
       }
 
       const notes = typeof update.body === "string" ? update.body : undefined;
+
+      if (!(await isUpdateSupportedByDen(update.version))) {
+        setPendingUpdate(null);
+        setUpdateStatus({ state: "idle", lastCheckedAt: checkedAt });
+        return;
+      }
+
       setPendingUpdate({ update, version: update.version, notes });
       setUpdateStatus({
         state: "available",

--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 tsx watch src/server.ts",
     "dev:local": "sh -lc 'OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/server.ts'",
-    "build": "pnpm run build:den-db && tsc -p tsconfig.json",
+    "build": "node ./scripts/build.mjs",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",
     "start": "node dist/server.js"
   },

--- a/ee/apps/den-api/scripts/build.mjs
+++ b/ee/apps/den-api/scripts/build.mjs
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const serviceDir = path.resolve(scriptDir, "..")
+const repoRoot = path.resolve(serviceDir, "..", "..", "..")
+const desktopPackagePath = path.join(repoRoot, "apps", "desktop", "package.json")
+const generatedVersionPath = path.join(serviceDir, "src", "generated", "app-version.ts")
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+
+function readDesktopVersion() {
+  const packageJson = JSON.parse(readFileSync(desktopPackagePath, "utf8"))
+  const version = packageJson.version?.trim()
+
+  if (!version) {
+    throw new Error(`Desktop version missing in ${desktopPackagePath}`)
+  }
+
+  return version
+}
+
+function writeGeneratedVersionFile(latestAppVersion) {
+  mkdirSync(path.dirname(generatedVersionPath), { recursive: true })
+  writeFileSync(
+    generatedVersionPath,
+    `export const BUILD_LATEST_APP_VERSION = ${JSON.stringify(latestAppVersion)} as const\n`,
+  )
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: serviceDir,
+    env: process.env,
+    stdio: "inherit",
+  })
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}
+
+process.env.DEN_API_LATEST_APP_VERSION = readDesktopVersion()
+writeGeneratedVersionFile(process.env.DEN_API_LATEST_APP_VERSION)
+
+run(pnpmCommand, ["run", "build:den-db"])
+run(pnpmCommand, ["exec", "tsc", "-p", "tsconfig.json"])

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -15,6 +15,7 @@ import { registerAdminRoutes } from "./routes/admin/index.js"
 import { registerAuthRoutes } from "./routes/auth/index.js"
 import { registerMeRoutes } from "./routes/me/index.js"
 import { registerOrgRoutes } from "./routes/org/index.js"
+import { registerVersionRoutes } from "./routes/version/index.js"
 import { registerWorkerRoutes } from "./routes/workers/index.js"
 import type { AuthContextVariables } from "./session.js"
 import { sessionMiddleware } from "./session.js"
@@ -106,6 +107,7 @@ registerAdminRoutes(app)
 registerAuthRoutes(app)
 registerMeRoutes(app)
 registerOrgRoutes(app)
+registerVersionRoutes(app)
 registerWorkerRoutes(app)
 
 app.get(

--- a/ee/apps/den-api/src/generated/app-version.ts
+++ b/ee/apps/den-api/src/generated/app-version.ts
@@ -1,0 +1,1 @@
+export const BUILD_LATEST_APP_VERSION = "0.11.207" as const

--- a/ee/apps/den-api/src/routes/README.md
+++ b/ee/apps/den-api/src/routes/README.md
@@ -8,6 +8,7 @@ This folder groups Den API endpoints by product surface instead of keeping one l
 - `me/`: current-user routes that describe the signed-in user and their org access
 - `org/`: organization routes split into focused files by concern
 - `admin/`: admin-only operational endpoints
+- `version/`: public app version metadata for desktop update checks
 - `workers/`: worker lifecycle, runtime, billing, and heartbeat routes
 
 ## Conventions

--- a/ee/apps/den-api/src/routes/version/README.md
+++ b/ee/apps/den-api/src/routes/version/README.md
@@ -1,0 +1,3 @@
+# Version Routes
+
+This folder contains public Den API routes that expose app version metadata for desktop clients.

--- a/ee/apps/den-api/src/routes/version/index.ts
+++ b/ee/apps/den-api/src/routes/version/index.ts
@@ -1,0 +1,27 @@
+import type { Env, Hono } from "hono"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { jsonResponse } from "../../openapi.js"
+import { denApiAppVersion } from "../../version.js"
+
+const appVersionResponseSchema = z.object({
+  minAppVersion: z.string(),
+  latestAppVersion: z.string().min(1),
+}).meta({ ref: "DenAppVersionResponse" })
+
+export function registerVersionRoutes<T extends Env>(app: Hono<T>) {
+  app.get(
+    "/v1/app-version",
+    describeRoute({
+      tags: ["System"],
+      summary: "Get desktop app version metadata",
+      description: "Returns the minimum supported desktop app version and the latest desktop app version published with this Den API build.",
+      responses: {
+        200: jsonResponse("Desktop app version metadata returned successfully.", appVersionResponseSchema),
+      },
+    }),
+    (c) => {
+      return c.json(denApiAppVersion)
+    },
+  )
+}

--- a/ee/apps/den-api/src/version.ts
+++ b/ee/apps/den-api/src/version.ts
@@ -1,0 +1,13 @@
+import { BUILD_LATEST_APP_VERSION } from "./generated/app-version.js";
+
+const MIN_APP_VERSION = "0.11.207";
+
+function normalizeVersion(value: string | undefined | null) {
+  const trimmed = value?.trim() ?? "";
+  return trimmed || null;
+}
+
+export const denApiAppVersion = {
+  minAppVersion: MIN_APP_VERSION,
+  latestAppVersion: normalizeVersion(BUILD_LATEST_APP_VERSION) ?? "0.0.0",
+} as const;


### PR DESCRIPTION
## Summary
- add a Den API app-version endpoint backed by the desktop package version so the control plane can declare the latest supported desktop build
- gate Tauri update availability in the desktop app by comparing the GitHub-reported update version against the Den API `latestAppVersion`
- keep the updater semver-aware so prerelease/build metadata do not incorrectly unlock unsupported updates

## Testing
- `pnpm install`
- `pnpm --filter @openwork-ee/den-api build` ✅
- `pnpm --filter @openwork/app typecheck` ❌ fails on existing upstream type errors in `apps/app/src/app/context/model-config.ts`, `apps/app/src/app/lib/model-behavior.ts`, and `apps/app/src/app/utils/providers.ts`
- semver smoke check via `node --input-type=module -e \"...\"` ✅

## Notes
- I did not run the Docker + Chrome MCP end-to-end flow for this updater path in this worktree.