### PR TITLE
feat(desktop): persist desktop bootstrap and org restrictions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -231,7 +231,7 @@ This model keeps the user experience consistent across self-hosted and hosted pa
 
 - `/ee/apps/den-web/` is the hosted web control surface (sign-in, worker create, upcoming user management).
 - `/ee/apps/den-api/` (formerly `/ee/apps/den-controller/`) is the cloud control plane API (auth/session + worker CRUD + provisioning orchestration).
-- Desktop org runtime config is fetched from Den after sign-in and is treated as server-owned runtime policy, while install/bootstrap config remains shell-owned in the external bootstrap file and only contains base URL, optional API base URL, and the `forceSignin` startup flag.
+- Desktop org runtime config is fetched from Den after sign-in and is treated as server-owned runtime policy. It is stored per organization in Den (`organization.desktop_app_restrictions`) as sparse negative restriction flags (for example `blockZenModel`) and managed from the cloud org settings UI, while install/bootstrap config remains shell-owned in the external bootstrap file and only contains base URL, optional API base URL, and the `forceSignin` startup flag.
 - Daytona-backed workers mount a single shared provider volume and isolate each worker's persistent data by subpaths (`workers/<workerId>/workspace` and `workers/<workerId>/data`) rather than creating dedicated provider volumes per worker.
 - `/ee/apps/den-worker-runtime/` defines the runtime packaging and boot path used inside cloud workers (including Docker/snapshot artifacts and `openwork serve` startup assumptions).
 - `/ee/apps/den-worker-proxy/` fronts Daytona worker preview URLs, refreshes signed links with provider credentials, and proxies traffic to the worker runtime.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,6 +200,7 @@ This model keeps the user experience consistent across self-hosted and hosted pa
 
 - `/apps/app/` runs as the product UI; on desktop it is hosted inside `/apps/desktop/` (Tauri webview).
 - `/apps/desktop/` exposes native commands (`engine_*`, `orchestrator_*`, `openwork_server_*`, `opencodeRouter_*`) to start/stop local services and report status to the UI.
+- `/apps/desktop/` is also the source of truth for desktop bootstrap config that must survive updates, including Den server targeting and forced-sign-in startup behavior. The shell reads a predictable external `desktop-bootstrap.json` from the host config directory (or `OPENWORK_DESKTOP_BOOTSTRAP_PATH` when explicitly overridden). Default builds consume that file when present; custom builds seed or overwrite it when their bundled bootstrap differs from the standard default.
 - Runtime selection in desktop:
   - `openwork-orchestrator` (default): Tauri launches `openwork daemon run` and uses it for workspace activation plus OpenCode lifecycle.
   - `direct`: Tauri starts OpenCode directly.
@@ -230,6 +231,7 @@ This model keeps the user experience consistent across self-hosted and hosted pa
 
 - `/ee/apps/den-web/` is the hosted web control surface (sign-in, worker create, upcoming user management).
 - `/ee/apps/den-api/` (formerly `/ee/apps/den-controller/`) is the cloud control plane API (auth/session + worker CRUD + provisioning orchestration).
+- Desktop org runtime config is fetched from Den after sign-in and is treated as server-owned runtime policy, while install/bootstrap config remains shell-owned in the external bootstrap file and only contains base URL, optional API base URL, and the `forceSignin` startup flag.
 - Daytona-backed workers mount a single shared provider volume and isolate each worker's persistent data by subpaths (`workers/<workerId>/workspace` and `workers/<workerId>/data`) rather than creating dedicated provider volumes per worker.
 - `/ee/apps/den-worker-runtime/` defines the runtime packaging and boot path used inside cloud workers (including Docker/snapshot artifacts and `openwork serve` startup assumptions).
 - `/ee/apps/den-worker-proxy/` fronts Daytona worker preview URLs, refreshes signed links with provider credentials, and proxies traffic to the worker runtime.

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -43,6 +43,7 @@
     "@codemirror/view": "^6.38.0",
     "@lexical/react": "^0.35.0",
     "@opencode-ai/sdk": "^1.4.9",
+    "@openwork/types": "workspace:*",
     "@openwork/ui": "workspace:*",
     "@radix-ui/colors": "^3.0.0",
     "@solid-primitives/event-bus": "^1.1.2",

--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -20,6 +20,8 @@ import ResetModal from "./components/reset-modal";
 import SkillDestinationModal from "./bundles/skill-destination-modal";
 import BundleImportModal from "./bundles/import-modal";
 import BundleStartModal from "./bundles/start-modal";
+import { useDenAuth } from "./cloud/den-auth-provider";
+import ForcedSigninPage from "./cloud/forced-signin-page";
 import RenameWorkspaceModal from "./components/rename-workspace-modal";
 import ConnectionsModals from "./connections/modals";
 import { OpenworkServerProvider } from "./connections/openwork-server-provider";
@@ -45,6 +47,7 @@ import {
   HIDE_TITLEBAR_PREF_KEY,
   SUGGESTED_PLUGINS,
 } from "./constants";
+import { readDenBootstrapConfig } from "./lib/den";
 import type {
   Client,
   StartupPreference,
@@ -173,6 +176,7 @@ type StartupSessionSnapshot = {
 };
 
 export default function App() {
+  const denAuth = useDenAuth();
   const { resetSessionDisplayPreferences } = useSessionDisplayPreferences();
   const { microsandboxCreateSandboxEnabled } = useFeatureFlagsPreferences();
   const envOpenworkWorkspaceId =
@@ -186,9 +190,14 @@ export default function App() {
   const [creatingSession, setCreatingSession] = createSignal(false);
   const currentView = createMemo<View>(() => {
     const path = location.pathname.toLowerCase();
+    if (path.startsWith("/signin")) return "signin";
     if (path.startsWith("/session")) return "session";
     return "settings";
   });
+  const forceSigninEnabled = createMemo(() => readDenBootstrapConfig().requireSignin);
+  const blockingSigninPending = createMemo(
+    () => forceSigninEnabled() && denAuth.status() === "checking",
+  );
 
   const [settingsTab, setSettingsTabState] = createSignal<SettingsTab>("general");
   const [pendingInitialSessionSelection, setPendingInitialSessionSelection] =
@@ -208,6 +217,10 @@ export default function App() {
   };
 
   const setView = (next: View, sessionId?: string) => {
+    if (next === "signin") {
+      navigate("/signin");
+      return;
+    }
     if (next === "settings" && creatingSession()) {
       return;
     }
@@ -502,7 +515,7 @@ export default function App() {
   createEffect(() => {
     const view = currentView();
     const currentTab = settingsTab();
-    if (view === "settings") return;
+    if (view === "settings" || view === "signin") return;
     setSettingsReturnTarget({
       view,
       tab: currentTab,
@@ -2352,6 +2365,27 @@ export default function App() {
     const rawPath = location.pathname.trim();
     const path = rawPath.toLowerCase();
 
+    if (forceSigninEnabled()) {
+      if (denAuth.status() === "checking") {
+        return;
+      }
+
+      if (!denAuth.isSignedIn()) {
+        if (path !== "/signin") {
+          navigate("/signin", { replace: true });
+        }
+        return;
+      }
+
+      if (path === "/signin") {
+        navigate("/session", { replace: true });
+        return;
+      }
+    } else if (path === "/signin") {
+      navigate("/session", { replace: true });
+      return;
+    }
+
     if (path === "" || path === "/") {
       navigate("/session", { replace: true });
       return;
@@ -2441,6 +2475,10 @@ export default function App() {
                     />
                   </Show>
             <Switch>
+              <Match when={blockingSigninPending()}>{null}</Match>
+              <Match when={currentView() === "signin"}>
+                <ForcedSigninPage developerMode={developerMode()} />
+              </Match>
               <Match when={currentView() === "session"}>
                 <SessionView {...sessionProps()} />
               </Match>

--- a/apps/app/src/app/bundles/publish.ts
+++ b/apps/app/src/app/bundles/publish.ts
@@ -94,7 +94,7 @@ export async function saveWorkspaceProfileBundleToTeam(input: {
     throw new Error("Sign in to OpenWork Cloud in Settings to share with your team.");
   }
 
-  const cloudClient = createDenClient({ baseUrl: settings.baseUrl, token });
+  const cloudClient = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
   let orgId = settings.activeOrgId?.trim() ?? "";
   let orgSlug = settings.activeOrgSlug?.trim() ?? "";
   let orgName = settings.activeOrgName?.trim() ?? "";

--- a/apps/app/src/app/bundles/skill-org-publish.ts
+++ b/apps/app/src/app/bundles/skill-org-publish.ts
@@ -11,7 +11,7 @@ export async function saveInstalledSkillToOpenWorkOrg(input: {
     throw new Error("Sign in to OpenWork Cloud in Settings to share with your team.");
   }
 
-  const cloudClient = createDenClient({ baseUrl: settings.baseUrl, token });
+  const cloudClient = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
   let orgId = settings.activeOrgId?.trim() ?? "";
   let orgSlug = settings.activeOrgSlug?.trim() ?? "";
   let orgName = settings.activeOrgName?.trim() ?? "";

--- a/apps/app/src/app/cloud/den-auth-provider.tsx
+++ b/apps/app/src/app/cloud/den-auth-provider.tsx
@@ -1,0 +1,106 @@
+import { createContext, createMemo, createSignal, onCleanup, onMount, useContext, type Accessor, type ParentProps } from "solid-js";
+import { clearDenSession, createDenClient, DenApiError, readDenSettings, type DenUser } from "../lib/den";
+import { denSessionUpdatedEvent, denSettingsChangedEvent } from "../lib/den-session-events";
+
+type DenAuthStatus = "checking" | "signed_in" | "signed_out";
+
+type DenAuthStore = {
+  status: Accessor<DenAuthStatus>;
+  user: Accessor<DenUser | null>;
+  error: Accessor<string | null>;
+  isSignedIn: Accessor<boolean>;
+  refresh: () => Promise<void>;
+};
+
+const DenAuthContext = createContext<DenAuthStore>();
+
+export function DenAuthProvider(props: ParentProps) {
+  const [status, setStatus] = createSignal<DenAuthStatus>("checking");
+  const [user, setUser] = createSignal<DenUser | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  let refreshToken = 0;
+
+  const refresh = async () => {
+    const currentRun = ++refreshToken;
+    const settings = readDenSettings();
+    const token = settings.authToken?.trim() ?? "";
+
+    if (!token) {
+      setUser(null);
+      setError(null);
+      setStatus("signed_out");
+      return;
+    }
+
+    setStatus("checking");
+
+    try {
+      const nextUser = await createDenClient({
+        baseUrl: settings.baseUrl,
+        apiBaseUrl: settings.apiBaseUrl,
+        token,
+      }).getSession();
+
+      if (currentRun !== refreshToken) {
+        return;
+      }
+
+      setUser(nextUser);
+      setError(null);
+      setStatus("signed_in");
+    } catch (nextError) {
+      if (currentRun !== refreshToken) {
+        return;
+      }
+
+      if (nextError instanceof DenApiError && nextError.status === 401) {
+        clearDenSession();
+      }
+
+      setUser(null);
+      setError(nextError instanceof Error ? nextError.message : "Failed to restore OpenWork Cloud session.");
+      setStatus("signed_out");
+    }
+  };
+
+  onMount(() => {
+    void refresh();
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleSessionUpdated = () => {
+      void refresh();
+    };
+
+    window.addEventListener(denSessionUpdatedEvent, handleSessionUpdated);
+    window.addEventListener(denSettingsChangedEvent, handleSessionUpdated);
+    onCleanup(() => {
+      window.removeEventListener(denSessionUpdatedEvent, handleSessionUpdated);
+      window.removeEventListener(denSettingsChangedEvent, handleSessionUpdated);
+    });
+  });
+
+  const store: DenAuthStore = {
+    status,
+    user,
+    error,
+    isSignedIn: createMemo(() => status() === "signed_in"),
+    refresh,
+  };
+
+  return (
+    <DenAuthContext.Provider value={store}>
+      {props.children}
+    </DenAuthContext.Provider>
+  );
+}
+
+export function useDenAuth() {
+  const context = useContext(DenAuthContext);
+  if (!context) {
+    throw new Error("useDenAuth must be used within a DenAuthProvider");
+  }
+  return context;
+}

--- a/apps/app/src/app/cloud/den-auth-provider.tsx
+++ b/apps/app/src/app/cloud/den-auth-provider.tsx
@@ -1,6 +1,6 @@
 import { createContext, createMemo, createSignal, onCleanup, onMount, useContext, type Accessor, type ParentProps } from "solid-js";
-import { clearDenSession, createDenClient, DenApiError, readDenSettings, type DenUser } from "../lib/den";
-import { denSessionUpdatedEvent, denSettingsChangedEvent } from "../lib/den-session-events";
+import { clearDenSession, createDenClient, DenApiError, ensureDenActiveOrganization, readDenSettings, type DenUser } from "../lib/den";
+import { denSessionUpdatedEvent } from "../lib/den-session-events";
 
 type DenAuthStatus = "checking" | "signed_in" | "signed_out";
 
@@ -45,6 +45,16 @@ export function DenAuthProvider(props: ParentProps) {
         return;
       }
 
+      await ensureDenActiveOrganization({
+        forceServerSync:
+          !settings.activeOrgId?.trim() ||
+          !settings.activeOrgSlug?.trim(),
+      }).catch(() => null);
+
+      if (currentRun !== refreshToken) {
+        return;
+      }
+
       setUser(nextUser);
       setError(null);
       setStatus("signed_in");
@@ -75,10 +85,8 @@ export function DenAuthProvider(props: ParentProps) {
     };
 
     window.addEventListener(denSessionUpdatedEvent, handleSessionUpdated);
-    window.addEventListener(denSettingsChangedEvent, handleSessionUpdated);
     onCleanup(() => {
       window.removeEventListener(denSessionUpdatedEvent, handleSessionUpdated);
-      window.removeEventListener(denSettingsChangedEvent, handleSessionUpdated);
     });
   });
 

--- a/apps/app/src/app/cloud/den-signin-surface.tsx
+++ b/apps/app/src/app/cloud/den-signin-surface.tsx
@@ -1,0 +1,200 @@
+import { ArrowUpRight, Cloud } from "lucide-solid";
+import { Show } from "solid-js";
+import { currentLocale, t } from "../../i18n";
+import { DEFAULT_DEN_BASE_URL } from "../lib/den";
+import Button from "../components/button";
+import TextInput from "../components/text-input";
+
+type DenSignInSurfaceProps = {
+  variant?: "panel" | "fullscreen";
+  developerMode: boolean;
+  baseUrl: string;
+  baseUrlDraft: string;
+  baseUrlError: string | null;
+  statusMessage: string | null;
+  authError: string | null;
+  authBusy: boolean;
+  baseUrlBusy: boolean;
+  sessionBusy: boolean;
+  manualAuthOpen: boolean;
+  manualAuthInput: string;
+  onBaseUrlDraftInput: (value: string) => void;
+  onResetBaseUrl: () => void;
+  onApplyBaseUrl: () => void;
+  onOpenControlPlane: () => void;
+  onOpenBrowserAuth: (mode: "sign-in" | "sign-up") => void;
+  onToggleManualAuth: () => void;
+  onManualAuthInput: (value: string) => void;
+  onSubmitManualAuth: () => void;
+};
+
+export default function DenSignInSurface(props: DenSignInSurfaceProps) {
+  const tr = (key: string) => t(key, currentLocale());
+  const variant = () => props.variant ?? "panel";
+  const settingsPanelClass = "ow-soft-card rounded-[28px] p-5 md:p-6";
+  const settingsPanelSoftClass = "ow-soft-card-quiet rounded-2xl p-4";
+  const headerBadgeClass =
+    "inline-flex min-h-8 items-center gap-2 rounded-xl border border-dls-border bg-dls-hover px-3 text-[13px] font-medium text-dls-text shadow-sm";
+  const softNoticeClass =
+    "rounded-xl border border-dls-border bg-dls-hover px-3 py-2 text-xs text-dls-secondary";
+
+  const content = (
+    <div class={`${settingsPanelClass} space-y-4`}>
+      <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div class="space-y-2">
+          <div class={headerBadgeClass}>
+            <Cloud size={13} class="text-dls-secondary" />
+            {tr("den.cloud_section_title")}
+          </div>
+          <div>
+            <div class="text-sm font-medium text-dls-text">
+              {tr("den.signin_title")}
+            </div>
+            <div class="mt-1 max-w-[60ch] text-xs text-dls-secondary">
+              {tr("den.cloud_sleep_hint")}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Show when={props.developerMode}>
+        <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+          <TextInput
+            label={tr("den.cloud_control_plane_url_label")}
+            value={props.baseUrlDraft}
+            onInput={(event) => props.onBaseUrlDraftInput(event.currentTarget.value)}
+            placeholder={DEFAULT_DEN_BASE_URL}
+            hint={tr("den.cloud_control_plane_url_hint")}
+            disabled={props.authBusy || props.baseUrlBusy || props.sessionBusy}
+          />
+          <div class="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              class="h-9 px-3 text-xs"
+            onClick={props.onResetBaseUrl}
+              disabled={props.authBusy || props.baseUrlBusy || props.sessionBusy}
+            >
+              {tr("den.cloud_control_plane_reset")}
+            </Button>
+            <Button
+              variant="secondary"
+              class="h-9 px-3 text-xs"
+              onClick={props.onApplyBaseUrl}
+              disabled={props.authBusy || props.baseUrlBusy || props.sessionBusy}
+            >
+              {tr("den.cloud_control_plane_save")}
+            </Button>
+            <Button
+              variant="outline"
+              class="h-9 px-3 text-xs"
+              onClick={props.onOpenControlPlane}
+            >
+              {tr("den.cloud_control_plane_open")}
+              <ArrowUpRight size={13} />
+            </Button>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={props.baseUrlError}>
+        {(value) => (
+          <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
+            {value()}
+          </div>
+        )}
+      </Show>
+
+      <Show when={props.statusMessage && !props.authError}>
+        {(value) => <div class={softNoticeClass}>{value()}</div>}
+      </Show>
+
+      <div class="space-y-2">
+        <div class="max-w-[54ch] text-sm text-dls-secondary">
+          {tr("den.auto_reconnect_hint")}
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <Button variant="secondary" onClick={() => props.onOpenBrowserAuth("sign-in")}>
+          {tr("den.signin_button")}
+          <ArrowUpRight size={13} />
+        </Button>
+        <Button
+          variant="outline"
+          class="h-9 px-3 text-xs"
+          onClick={() => props.onOpenBrowserAuth("sign-up")}
+        >
+          {tr("den.create_account")}
+          <ArrowUpRight size={13} />
+        </Button>
+        <Button
+          variant="outline"
+          class="h-9 px-3 text-xs"
+          onClick={props.onToggleManualAuth}
+          disabled={props.authBusy || props.sessionBusy}
+        >
+          {props.manualAuthOpen ? tr("den.hide_signin_code") : tr("den.paste_signin_code")}
+        </Button>
+      </div>
+
+      <Show when={props.manualAuthOpen}>
+        <div class={`${settingsPanelSoftClass} space-y-3`}>
+          <TextInput
+            label={tr("den.signin_link_label")}
+            value={props.manualAuthInput}
+            onInput={(event) => props.onManualAuthInput(event.currentTarget.value)}
+            placeholder={tr("den.signin_link_placeholder")}
+            disabled={props.authBusy || props.sessionBusy}
+            hint={tr("den.signin_link_hint")}
+          />
+          <div class="flex flex-wrap items-center gap-2">
+            <Button
+              variant="secondary"
+              class="h-9 px-3 text-xs"
+              onClick={props.onSubmitManualAuth}
+              disabled={props.authBusy || props.sessionBusy || !props.manualAuthInput.trim()}
+            >
+              {props.authBusy ? tr("den.finishing") : tr("den.finish_signin")}
+            </Button>
+            <div class="text-[11px] text-dls-secondary">
+              {tr("den.signin_code_note")}
+            </div>
+          </div>
+        </div>
+      </Show>
+
+      <Show when={props.authError}>
+        {(value) => (
+          <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
+            {value()}
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+
+  if (variant() === "fullscreen") {
+    return (
+      <div class="min-h-screen bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.12),transparent_42%),linear-gradient(180deg,rgba(248,250,252,1),rgba(241,245,249,0.92))] px-6 py-10 text-dls-text">
+        <div class="mx-auto flex min-h-[calc(100vh-5rem)] max-w-3xl items-center justify-center">
+          <div class="w-full space-y-4">
+            <div class="space-y-2 text-center">
+              <div class="text-[11px] font-semibold uppercase tracking-[0.22em] text-dls-secondary">
+                OpenWork Cloud
+              </div>
+              <h1 class="text-3xl font-semibold tracking-tight text-dls-text md:text-4xl">
+                {tr("den.signin_title")}
+              </h1>
+              <p class="mx-auto max-w-2xl text-sm text-dls-secondary md:text-base">
+                {tr("den.cloud_section_desc")}
+              </p>
+            </div>
+            {content}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return content;
+}

--- a/apps/app/src/app/cloud/den-signin-surface.tsx
+++ b/apps/app/src/app/cloud/den-signin-surface.tsx
@@ -50,9 +50,6 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
             <div class="text-sm font-medium text-dls-text">
               {tr("den.signin_title")}
             </div>
-            <div class="mt-1 max-w-[60ch] text-xs text-dls-secondary">
-              {tr("den.cloud_sleep_hint")}
-            </div>
           </div>
         </div>
       </div>
@@ -62,7 +59,9 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
           <TextInput
             label={tr("den.cloud_control_plane_url_label")}
             value={props.baseUrlDraft}
-            onInput={(event) => props.onBaseUrlDraftInput(event.currentTarget.value)}
+            onInput={(event) =>
+              props.onBaseUrlDraftInput(event.currentTarget.value)
+            }
             placeholder={DEFAULT_DEN_BASE_URL}
             hint={tr("den.cloud_control_plane_url_hint")}
             disabled={props.authBusy || props.baseUrlBusy || props.sessionBusy}
@@ -71,8 +70,10 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
             <Button
               variant="outline"
               class="h-9 px-3 text-xs"
-            onClick={props.onResetBaseUrl}
-              disabled={props.authBusy || props.baseUrlBusy || props.sessionBusy}
+              onClick={props.onResetBaseUrl}
+              disabled={
+                props.authBusy || props.baseUrlBusy || props.sessionBusy
+              }
             >
               {tr("den.cloud_control_plane_reset")}
             </Button>
@@ -80,7 +81,9 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
               variant="secondary"
               class="h-9 px-3 text-xs"
               onClick={props.onApplyBaseUrl}
-              disabled={props.authBusy || props.baseUrlBusy || props.sessionBusy}
+              disabled={
+                props.authBusy || props.baseUrlBusy || props.sessionBusy
+              }
             >
               {tr("den.cloud_control_plane_save")}
             </Button>
@@ -115,7 +118,10 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
       </div>
 
       <div class="flex flex-wrap items-center gap-2">
-        <Button variant="secondary" onClick={() => props.onOpenBrowserAuth("sign-in")}>
+        <Button
+          variant="secondary"
+          onClick={() => props.onOpenBrowserAuth("sign-in")}
+        >
           {tr("den.signin_button")}
           <ArrowUpRight size={13} />
         </Button>
@@ -133,7 +139,9 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
           onClick={props.onToggleManualAuth}
           disabled={props.authBusy || props.sessionBusy}
         >
-          {props.manualAuthOpen ? tr("den.hide_signin_code") : tr("den.paste_signin_code")}
+          {props.manualAuthOpen
+            ? tr("den.hide_signin_code")
+            : tr("den.paste_signin_code")}
         </Button>
       </div>
 
@@ -142,7 +150,9 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
           <TextInput
             label={tr("den.signin_link_label")}
             value={props.manualAuthInput}
-            onInput={(event) => props.onManualAuthInput(event.currentTarget.value)}
+            onInput={(event) =>
+              props.onManualAuthInput(event.currentTarget.value)
+            }
             placeholder={tr("den.signin_link_placeholder")}
             disabled={props.authBusy || props.sessionBusy}
             hint={tr("den.signin_link_hint")}
@@ -152,7 +162,11 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
               variant="secondary"
               class="h-9 px-3 text-xs"
               onClick={props.onSubmitManualAuth}
-              disabled={props.authBusy || props.sessionBusy || !props.manualAuthInput.trim()}
+              disabled={
+                props.authBusy ||
+                props.sessionBusy ||
+                !props.manualAuthInput.trim()
+              }
             >
               {props.authBusy ? tr("den.finishing") : tr("den.finish_signin")}
             </Button>
@@ -177,20 +191,7 @@ export default function DenSignInSurface(props: DenSignInSurfaceProps) {
     return (
       <div class="min-h-screen bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.12),transparent_42%),linear-gradient(180deg,rgba(248,250,252,1),rgba(241,245,249,0.92))] px-6 py-10 text-dls-text">
         <div class="mx-auto flex min-h-[calc(100vh-5rem)] max-w-3xl items-center justify-center">
-          <div class="w-full space-y-4">
-            <div class="space-y-2 text-center">
-              <div class="text-[11px] font-semibold uppercase tracking-[0.22em] text-dls-secondary">
-                OpenWork Cloud
-              </div>
-              <h1 class="text-3xl font-semibold tracking-tight text-dls-text md:text-4xl">
-                {tr("den.signin_title")}
-              </h1>
-              <p class="mx-auto max-w-2xl text-sm text-dls-secondary md:text-base">
-                {tr("den.cloud_section_desc")}
-              </p>
-            </div>
-            {content}
-          </div>
+          <div class="w-full space-y-4">{content}</div>
         </div>
       </div>
     );

--- a/apps/app/src/app/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/app/cloud/desktop-config-provider.tsx
@@ -1,0 +1,166 @@
+import { createContext, createEffect, createSignal, onCleanup, onMount, useContext, type Accessor, type ParentProps } from "solid-js";
+import { createDenClient, type DenDesktopConfig, readDenSettings } from "../lib/den";
+import { denSessionUpdatedEvent, denSettingsChangedEvent } from "../lib/den-session-events";
+import { useDenAuth } from "./den-auth-provider";
+
+type DesktopConfigStore = {
+  config: Accessor<DenDesktopConfig>;
+  loading: Accessor<boolean>;
+  refresh: () => Promise<void>;
+};
+
+const DesktopConfigContext = createContext<DesktopConfigStore>();
+
+const DEFAULT_DESKTOP_CONFIG: DenDesktopConfig = {};
+const DESKTOP_CONFIG_REFRESH_MS = 60 * 60 * 1000;
+const DESKTOP_CONFIG_CACHE_PREFIX = "openwork.den.desktopConfig:";
+
+function getDesktopConfigCacheKey() {
+  const settings = readDenSettings();
+  const baseUrl = settings.baseUrl.trim();
+  const activeOrgId = settings.activeOrgId?.trim() ?? "";
+  if (!baseUrl) return "";
+  return `${DESKTOP_CONFIG_CACHE_PREFIX}${baseUrl}::${activeOrgId}`;
+}
+
+function readCachedDesktopConfig(key: string): DenDesktopConfig | null {
+  if (typeof window === "undefined" || !key) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as DenDesktopConfig;
+    return typeof parsed === "object" && parsed !== null ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedDesktopConfig(key: string, config: DenDesktopConfig) {
+  if (typeof window === "undefined" || !key) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, JSON.stringify(config));
+  } catch {
+    // ignore
+  }
+}
+
+export function DesktopConfigProvider(props: ParentProps) {
+  const denAuth = useDenAuth();
+  const [config, setConfig] = createSignal<DenDesktopConfig>(DEFAULT_DESKTOP_CONFIG);
+  const [loading, setLoading] = createSignal(false);
+  const [settingsVersion, setSettingsVersion] = createSignal(0);
+  let refreshRunId = 0;
+
+  const refresh = async () => {
+    const currentRun = ++refreshRunId;
+    const settings = readDenSettings();
+    const token = settings.authToken?.trim() ?? "";
+    const cacheKey = getDesktopConfigCacheKey();
+
+    if (!denAuth.isSignedIn() || !token) {
+      setConfig(DEFAULT_DESKTOP_CONFIG);
+      setLoading(false);
+      return;
+    }
+
+    const cached = readCachedDesktopConfig(cacheKey);
+    if (!cached) {
+      setLoading(true);
+    }
+
+    try {
+      const nextConfig = await createDenClient({
+        baseUrl: settings.baseUrl,
+        apiBaseUrl: settings.apiBaseUrl,
+        token,
+      }).getDesktopConfig();
+
+      if (currentRun !== refreshRunId) {
+        return;
+      }
+
+      writeCachedDesktopConfig(cacheKey, nextConfig);
+      setConfig(nextConfig);
+    } catch {
+      if (currentRun !== refreshRunId) {
+        return;
+      }
+
+      setConfig(cached ?? DEFAULT_DESKTOP_CONFIG);
+    } finally {
+      if (currentRun === refreshRunId) {
+        setLoading(false);
+      }
+    }
+  };
+
+  createEffect(() => {
+    settingsVersion();
+
+    if (!denAuth.isSignedIn()) {
+      setConfig(DEFAULT_DESKTOP_CONFIG);
+      setLoading(false);
+      return;
+    }
+
+    const cacheKey = getDesktopConfigCacheKey();
+    const cached = readCachedDesktopConfig(cacheKey);
+    setConfig(cached ?? DEFAULT_DESKTOP_CONFIG);
+    setLoading(!cached);
+    void refresh();
+  });
+
+  onMount(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleSettingsChanged = () => {
+      setSettingsVersion((value) => value + 1);
+    };
+
+    window.addEventListener(denSessionUpdatedEvent, handleSettingsChanged);
+    window.addEventListener(denSettingsChangedEvent, handleSettingsChanged);
+
+    const interval = window.setInterval(() => {
+      if (!denAuth.isSignedIn()) {
+        return;
+      }
+      void refresh();
+    }, DESKTOP_CONFIG_REFRESH_MS);
+
+    onCleanup(() => {
+      window.removeEventListener(denSessionUpdatedEvent, handleSettingsChanged);
+      window.removeEventListener(denSettingsChangedEvent, handleSettingsChanged);
+      window.clearInterval(interval);
+    });
+  });
+
+  const store: DesktopConfigStore = {
+    config,
+    loading,
+    refresh,
+  };
+
+  return (
+    <DesktopConfigContext.Provider value={store}>
+      {props.children}
+    </DesktopConfigContext.Provider>
+  );
+}
+
+export function useDesktopConfig() {
+  const context = useContext(DesktopConfigContext);
+  if (!context) {
+    throw new Error("useDesktopConfig must be used within a DesktopConfigProvider");
+  }
+  return context;
+}

--- a/apps/app/src/app/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/app/cloud/desktop-config-provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, createEffect, createSignal, onCleanup, onMount, useContext, type Accessor, type ParentProps } from "solid-js";
-import { createDenClient, type DenDesktopConfig, normalizeDenDesktopConfig, readDenSettings } from "../lib/den";
+import { createDenClient, DenApiError, ensureDenActiveOrganization, type DenDesktopConfig, normalizeDenDesktopConfig, readDenSettings } from "../lib/den";
 import { denSessionUpdatedEvent, denSettingsChangedEvent } from "../lib/den-session-events";
 import { useDenAuth } from "./den-auth-provider";
 
@@ -64,7 +64,7 @@ export function DesktopConfigProvider(props: ParentProps) {
     const token = settings.authToken?.trim() ?? "";
     const cacheKey = getDesktopConfigCacheKey();
 
-    if (!denAuth.isSignedIn() || !token) {
+    if (!denAuth.isSignedIn() || !token || !settings.activeOrgId?.trim()) {
       setConfig(DEFAULT_DESKTOP_CONFIG);
       setLoading(false);
       return;
@@ -88,9 +88,17 @@ export function DesktopConfigProvider(props: ParentProps) {
 
       writeCachedDesktopConfig(cacheKey, nextConfig);
       setConfig(nextConfig);
-    } catch {
+    } catch (error) {
       if (currentRun !== refreshRunId) {
         return;
+      }
+
+      if (
+        error instanceof DenApiError &&
+        error.status === 404 &&
+        error.code === "organization_not_found"
+      ) {
+        await ensureDenActiveOrganization({ forceServerSync: true }).catch(() => null);
       }
 
       setConfig(cached ?? DEFAULT_DESKTOP_CONFIG);

--- a/apps/app/src/app/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/app/cloud/desktop-config-provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, createEffect, createSignal, onCleanup, onMount, useContext, type Accessor, type ParentProps } from "solid-js";
-import { createDenClient, type DenDesktopConfig, readDenSettings } from "../lib/den";
+import { createDenClient, type DenDesktopConfig, normalizeDenDesktopConfig, readDenSettings } from "../lib/den";
 import { denSessionUpdatedEvent, denSettingsChangedEvent } from "../lib/den-session-events";
 import { useDenAuth } from "./den-auth-provider";
 
@@ -33,8 +33,7 @@ function readCachedDesktopConfig(key: string): DenDesktopConfig | null {
     if (!raw) {
       return null;
     }
-    const parsed = JSON.parse(raw) as DenDesktopConfig;
-    return typeof parsed === "object" && parsed !== null ? parsed : null;
+    return normalizeDenDesktopConfig(JSON.parse(raw));
   } catch {
     return null;
   }
@@ -46,7 +45,7 @@ function writeCachedDesktopConfig(key: string, config: DenDesktopConfig) {
   }
 
   try {
-    window.localStorage.setItem(key, JSON.stringify(config));
+    window.localStorage.setItem(key, JSON.stringify(normalizeDenDesktopConfig(config)));
   } catch {
     // ignore
   }

--- a/apps/app/src/app/cloud/forced-signin-page.tsx
+++ b/apps/app/src/app/cloud/forced-signin-page.tsx
@@ -1,0 +1,243 @@
+import { createSignal, onCleanup, onMount } from "solid-js";
+import DenSignInSurface from "./den-signin-surface";
+import { useDenAuth } from "./den-auth-provider";
+import { useDesktopConfig } from "./desktop-config-provider";
+import { usePlatform } from "../context/platform";
+import { currentLocale, t } from "../../i18n";
+import {
+  buildDenAuthUrl,
+  clearDenSession,
+  createDenClient,
+  DEFAULT_DEN_BASE_URL,
+  normalizeDenBaseUrl,
+  readDenBootstrapConfig,
+  readDenSettings,
+  resolveDenBaseUrls,
+  setDenBootstrapConfig,
+  writeDenSettings,
+} from "../lib/den";
+import { denSessionUpdatedEvent, dispatchDenSessionUpdated, type DenSessionUpdatedDetail } from "../lib/den-session-events";
+
+type ForcedSigninPageProps = {
+  developerMode: boolean;
+};
+
+export default function ForcedSigninPage(props: ForcedSigninPageProps) {
+  const platform = usePlatform();
+  const denAuth = useDenAuth();
+  const desktopConfig = useDesktopConfig();
+  const initial = readDenSettings();
+  const initialBaseUrl = initial.baseUrl || DEFAULT_DEN_BASE_URL;
+
+  const [baseUrl, setBaseUrl] = createSignal(initialBaseUrl);
+  const [baseUrlDraft, setBaseUrlDraft] = createSignal(initialBaseUrl);
+  const [baseUrlError, setBaseUrlError] = createSignal<string | null>(null);
+  const [authBusy, setAuthBusy] = createSignal(false);
+  const [baseUrlBusy, setBaseUrlBusy] = createSignal(false);
+  const [manualAuthOpen, setManualAuthOpen] = createSignal(false);
+  const [manualAuthInput, setManualAuthInput] = createSignal("");
+  const [authError, setAuthError] = createSignal<string | null>(null);
+  const [statusMessage, setStatusMessage] = createSignal<string | null>(null);
+
+  const openControlPlane = () => {
+    platform.openLink(resolveDenBaseUrls(baseUrl()).baseUrl);
+  };
+
+  const openBrowserAuth = (mode: "sign-in" | "sign-up") => {
+    platform.openLink(buildDenAuthUrl(baseUrl(), mode));
+    setStatusMessage(
+      mode === "sign-up"
+        ? t("den.status_browser_signup", currentLocale())
+        : t("den.status_browser_signin", currentLocale()),
+    );
+    setAuthError(null);
+  };
+
+  const parseManualAuthInput = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+
+    try {
+      const url = new URL(trimmed);
+      const protocol = url.protocol.toLowerCase();
+      const routeHost = url.hostname.toLowerCase();
+      const routePath = url.pathname.replace(/^\/+/, "").toLowerCase();
+      const routeSegments = routePath.split("/").filter(Boolean);
+      const routeTail = routeSegments[routeSegments.length - 1] ?? "";
+      if (
+        (protocol === "openwork:" || protocol === "openwork-dev:") &&
+        (routeHost === "den-auth" || routePath === "den-auth" || routeTail === "den-auth")
+      ) {
+        const grant = url.searchParams.get("grant")?.trim() ?? "";
+        const nextBaseUrl =
+          normalizeDenBaseUrl(url.searchParams.get("denBaseUrl")?.trim() ?? "") ?? undefined;
+        return grant ? { grant, baseUrl: nextBaseUrl } : null;
+      }
+    } catch {
+      // treat non-URL input as a raw handoff grant
+    }
+
+    return trimmed.length >= 12 ? { grant: trimmed } : null;
+  };
+
+  const submitManualAuth = async () => {
+    const parsed = parseManualAuthInput(manualAuthInput());
+    if (!parsed || authBusy()) {
+      if (!parsed) {
+        setAuthError(t("den.error_paste_valid_code", currentLocale()));
+      }
+      return;
+    }
+
+    const nextBaseUrl = parsed.baseUrl ?? baseUrl();
+
+    setAuthBusy(true);
+    setAuthError(null);
+    setStatusMessage(t("den.signing_in", currentLocale()));
+
+    try {
+      const result = await createDenClient({ baseUrl: nextBaseUrl }).exchangeDesktopHandoff(parsed.grant);
+      if (!result.token) {
+        throw new Error(t("den.error_no_token", currentLocale()));
+      }
+
+      if (props.developerMode) {
+        setBaseUrl(nextBaseUrl);
+        setBaseUrlDraft(nextBaseUrl);
+      }
+
+      writeDenSettings({
+        baseUrl: nextBaseUrl,
+        authToken: result.token,
+        activeOrgId: null,
+        activeOrgSlug: null,
+        activeOrgName: null,
+      });
+
+      setManualAuthInput("");
+      setManualAuthOpen(false);
+      dispatchDenSessionUpdated({
+        status: "success",
+        baseUrl: nextBaseUrl,
+        token: result.token,
+        user: result.user,
+        email: result.user?.email ?? null,
+      });
+    } catch (error) {
+      dispatchDenSessionUpdated({
+        status: "error",
+        message: error instanceof Error ? error.message : t("den.error_signin_failed", currentLocale()),
+      });
+    } finally {
+      setAuthBusy(false);
+    }
+  };
+
+  const applyBaseUrl = async () => {
+    const normalized = normalizeDenBaseUrl(baseUrlDraft());
+    if (!normalized) {
+      setBaseUrlError(t("den.error_base_url", currentLocale()));
+      return;
+    }
+
+    const resolved = resolveDenBaseUrls(normalized);
+    setBaseUrlBusy(true);
+
+    try {
+      await setDenBootstrapConfig({
+        baseUrl: resolved.baseUrl,
+        apiBaseUrl: resolved.apiBaseUrl,
+        requireSignin: readDenBootstrapConfig().requireSignin,
+      });
+      setBaseUrlError(null);
+      setBaseUrl(resolved.baseUrl);
+      setBaseUrlDraft(resolved.baseUrl);
+      clearDenSession({ includeBaseUrls: !props.developerMode });
+      writeDenSettings({
+        baseUrl: resolved.baseUrl,
+        apiBaseUrl: resolved.apiBaseUrl,
+        authToken: null,
+        activeOrgId: null,
+        activeOrgSlug: null,
+        activeOrgName: null,
+      }, { persistBootstrap: false });
+      setAuthError(null);
+      setStatusMessage(t("den.status_base_url_updated", currentLocale()));
+      void desktopConfig.refresh();
+      void denAuth.refresh();
+    } catch (error) {
+      setBaseUrlError(
+        error instanceof Error ? error.message : t("den.error_base_url", currentLocale()),
+      );
+    } finally {
+      setBaseUrlBusy(false);
+    }
+  };
+
+  onMount(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handler = (event: Event) => {
+      const customEvent = event as CustomEvent<DenSessionUpdatedDetail>;
+      const nextSettings = readDenSettings();
+      const nextBaseUrl =
+        customEvent.detail?.baseUrl?.trim() ||
+        nextSettings.baseUrl ||
+        DEFAULT_DEN_BASE_URL;
+      setBaseUrl(nextBaseUrl);
+      setBaseUrlDraft(nextBaseUrl);
+      if (customEvent.detail?.status === "success") {
+        setAuthError(null);
+        setStatusMessage(
+          customEvent.detail.email?.trim()
+            ? t("den.status_cloud_signed_in_as", currentLocale(), { email: customEvent.detail.email.trim() })
+            : t("den.status_cloud_signin_done", currentLocale()),
+        );
+      } else if (customEvent.detail?.status === "error") {
+        setAuthError(
+          customEvent.detail.message?.trim() ||
+            t("den.error_signin_failed", currentLocale()),
+        );
+      }
+    };
+
+    window.addEventListener(denSessionUpdatedEvent, handler as EventListener);
+    onCleanup(() => {
+      window.removeEventListener(denSessionUpdatedEvent, handler as EventListener);
+    });
+  });
+
+  return (
+    <DenSignInSurface
+      variant="fullscreen"
+      developerMode={props.developerMode}
+      baseUrl={baseUrl()}
+      baseUrlDraft={baseUrlDraft()}
+      baseUrlError={baseUrlError()}
+      statusMessage={statusMessage()}
+      authError={authError() ?? denAuth.error()}
+      authBusy={authBusy()}
+      baseUrlBusy={baseUrlBusy()}
+      sessionBusy={denAuth.status() === "checking"}
+      manualAuthOpen={manualAuthOpen()}
+      manualAuthInput={manualAuthInput()}
+      onBaseUrlDraftInput={setBaseUrlDraft}
+      onResetBaseUrl={() => setBaseUrlDraft(baseUrl())}
+      onApplyBaseUrl={() => {
+        void applyBaseUrl();
+      }}
+      onOpenControlPlane={openControlPlane}
+      onOpenBrowserAuth={openBrowserAuth}
+      onToggleManualAuth={() => {
+        setManualAuthOpen((value) => !value);
+        setAuthError(null);
+      }}
+      onManualAuthInput={setManualAuthInput}
+      onSubmitManualAuth={() => {
+        void submitManualAuth();
+      }}
+    />
+  );
+}

--- a/apps/app/src/app/components/den-settings-panel.tsx
+++ b/apps/app/src/app/components/den-settings-panel.tsx
@@ -24,6 +24,7 @@ import {
 import type { DenOrgSkillCard } from "../types";
 import type { CloudImportedProvider, CloudImportedSkill, CloudImportedSkillHub } from "../cloud/import-state";
 import {
+  denSettingsChangedEvent,
   denSessionUpdatedEvent,
   dispatchDenSessionUpdated,
   type DenSessionUpdatedDetail,
@@ -154,7 +155,7 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     name: string | null;
   } | null>(null);
   const [orgs, setOrgs] = createSignal<
-    Array<{ id: string; name: string; slug: string; role: "owner" | "member" }>
+    Array<{ id: string; name: string; slug: string; role: "owner" | "admin" | "member" }>
   >([]);
   const [workers, setWorkers] = createSignal<
     Array<{
@@ -546,6 +547,11 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
       const fallback = response.defaultOrgId ?? response.orgs[0]?.id ?? "";
       const next = response.orgs.some((org) => org.id === current) ? current : fallback;
       const nextOrg = response.orgs.find((org) => org.id === next) ?? null;
+
+      if (nextOrg && response.activeOrgId !== nextOrg.id) {
+        await client().setActiveOrganization({ organizationId: nextOrg.id });
+      }
+
       setActiveOrgId(next);
       writeDenSettings({
         baseUrl: baseUrl(),
@@ -858,6 +864,23 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     return () =>
       window.removeEventListener(
         denSessionUpdatedEvent,
+        handler as EventListener,
+      );
+  });
+
+  createEffect(() => {
+    const handler = () => {
+      const nextSettings = readDenSettings();
+      setBaseUrl(nextSettings.baseUrl || DEFAULT_DEN_BASE_URL);
+      setBaseUrlDraft(nextSettings.baseUrl || DEFAULT_DEN_BASE_URL);
+      setAuthToken(nextSettings.authToken?.trim() || "");
+      setActiveOrgId(nextSettings.activeOrgId?.trim() || "");
+    };
+
+    window.addEventListener(denSettingsChangedEvent, handler as EventListener);
+    return () =>
+      window.removeEventListener(
+        denSettingsChangedEvent,
         handler as EventListener,
       );
   });

--- a/apps/app/src/app/components/den-settings-panel.tsx
+++ b/apps/app/src/app/components/den-settings-panel.tsx
@@ -3,6 +3,7 @@ import { ArrowUpRight, Boxes, Brain, Cloud, KeyRound, LogOut, Package, RefreshCc
 
 import Button from "./button";
 import TextInput from "./text-input";
+import DenSignInSurface from "../cloud/den-signin-surface";
 import { currentLocale, t } from "../../i18n";
 import {
   buildDenAuthUrl,
@@ -14,8 +15,10 @@ import {
   type DenTemplate,
   createDenClient,
   normalizeDenBaseUrl,
+  readDenBootstrapConfig,
   readDenSettings,
   resolveDenBaseUrls,
+  setDenBootstrapConfig,
   writeDenSettings,
 } from "../lib/den";
 import type { DenOrgSkillCard } from "../types";
@@ -134,6 +137,7 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
   const [baseUrl, setBaseUrl] = createSignal(initialBaseUrl);
   const [baseUrlDraft, setBaseUrlDraft] = createSignal(initialBaseUrl);
   const [baseUrlError, setBaseUrlError] = createSignal<string | null>(null);
+  const [baseUrlBusy, setBaseUrlBusy] = createSignal(false);
   const [authToken, setAuthToken] = createSignal(initial.authToken?.trim() || "");
   const [activeOrgId, setActiveOrgId] = createSignal(initial.activeOrgId?.trim() || "");
   const [authBusy, setAuthBusy] = createSignal(false);
@@ -183,7 +187,11 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
 
   const activeOrg = createMemo(() => orgs().find((org) => org.id === activeOrgId()) ?? null);
   const client = createMemo(() =>
-    createDenClient({ baseUrl: baseUrl(), token: authToken() }),
+    createDenClient({
+      baseUrl: baseUrl(),
+      apiBaseUrl: readDenSettings().apiBaseUrl,
+      token: authToken(),
+    }),
   );
   const isSignedIn = createMemo(() => Boolean(user() && authToken().trim()));
   const activeOrgName = createMemo(() => activeOrg()?.name || tr("den.no_org_selected"));
@@ -403,7 +411,10 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     setStatusMessage(tr("den.signing_in"));
 
     try {
-      const result = await createDenClient({ baseUrl: nextBaseUrl }).exchangeDesktopHandoff(parsed.grant);
+      const result = await createDenClient({
+        baseUrl: nextBaseUrl,
+        apiBaseUrl: readDenSettings().apiBaseUrl,
+      }).exchangeDesktopHandoff(parsed.grant);
       if (!result.token) {
         throw new Error(tr("den.error_no_token"));
       }
@@ -460,10 +471,9 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
   const clearSignedInState = (message?: string | null) => {
     clearDenSession({ includeBaseUrls: !props.developerMode });
     clearDenTemplateCache();
-    if (!props.developerMode) {
-      setBaseUrl(DEFAULT_DEN_BASE_URL);
-      setBaseUrlDraft(DEFAULT_DEN_BASE_URL);
-    }
+    const nextBaseUrl = readDenSettings().baseUrl || DEFAULT_DEN_BASE_URL;
+    setBaseUrl(nextBaseUrl);
+    setBaseUrlDraft(nextBaseUrl);
     setAuthToken("");
     setOpeningWorkerId(null);
     setOpeningTemplateId(null);
@@ -477,7 +487,7 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     setStatusMessage(message ?? null);
   };
 
-  const applyBaseUrl = () => {
+  const applyBaseUrl = async () => {
     const normalized = normalizeDenBaseUrl(baseUrlDraft());
     if (!normalized) {
       setBaseUrlError(tr("den.error_base_url"));
@@ -485,15 +495,38 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     }
 
     const resolved = resolveDenBaseUrls(normalized);
-    setBaseUrlError(null);
-    if (resolved.baseUrl === baseUrl()) {
-      setBaseUrlDraft(resolved.baseUrl);
-      return;
-    }
+    setBaseUrlBusy(true);
 
-    setBaseUrl(resolved.baseUrl);
-    setBaseUrlDraft(resolved.baseUrl);
-    clearSignedInState(tr("den.status_base_url_updated"));
+    try {
+      await setDenBootstrapConfig({
+        baseUrl: resolved.baseUrl,
+        apiBaseUrl: resolved.apiBaseUrl,
+        requireSignin: readDenBootstrapConfig().requireSignin,
+      });
+      setBaseUrlError(null);
+      if (resolved.baseUrl === baseUrl()) {
+        setBaseUrlDraft(resolved.baseUrl);
+        return;
+      }
+
+      setBaseUrl(resolved.baseUrl);
+      setBaseUrlDraft(resolved.baseUrl);
+      writeDenSettings({
+        baseUrl: resolved.baseUrl,
+        apiBaseUrl: resolved.apiBaseUrl,
+        authToken: null,
+        activeOrgId: null,
+        activeOrgSlug: null,
+        activeOrgName: null,
+      }, { persistBootstrap: false });
+      clearSignedInState(tr("den.status_base_url_updated"));
+    } catch (error) {
+      setBaseUrlError(
+        error instanceof Error ? error.message : tr("den.error_base_url"),
+      );
+    } finally {
+      setBaseUrlBusy(false);
+    }
   };
 
   const refreshOrgs = async (quiet = false) => {
@@ -721,7 +754,11 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
     setSessionBusy(true);
     setAuthError(null);
 
-    void createDenClient({ baseUrl: currentBaseUrl, token })
+    void createDenClient({
+      baseUrl: currentBaseUrl,
+      apiBaseUrl: readDenSettings().apiBaseUrl,
+      token,
+    })
       .getSession()
       .then((nextUser) => {
         if (cancelled) return;
@@ -1127,150 +1164,71 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
 
   return (
     <div class="space-y-6">
-      <div class={`${settingsPanelClass} space-y-4`}>
-        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div class="space-y-2">
-            <div class={headerBadgeClass}>
-              <Cloud size={13} class="text-dls-secondary" />
-              {tr("den.cloud_section_title")}
-            </div>
-            <div>
-              <div class="text-sm font-medium text-dls-text">
-                {tr("den.cloud_section_desc")}
-              </div>
-              <div class="mt-1 max-w-[60ch] text-xs text-dls-secondary">
-                {tr("den.cloud_sleep_hint")}
-              </div>
-            </div>
-          </div>
-          <div class={headerStatusBadgeClass}>
-            <span
-              class={`h-2 w-2 rounded-full ${summaryTone() === "ready" ? "bg-green-500" : summaryTone() === "warning" ? "bg-amber-500" : summaryTone() === "error" ? "bg-red-500" : "bg-gray-400"}`}
-            />
-            {summaryLabel()}
-          </div>
-        </div>
-
-        <Show when={props.developerMode}>
-          <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
-            <TextInput
-              label={tr("den.cloud_control_plane_url_label")}
-              value={baseUrlDraft()}
-              onInput={(event) => setBaseUrlDraft(event.currentTarget.value)}
-              placeholder={DEFAULT_DEN_BASE_URL}
-              hint={tr("den.cloud_control_plane_url_hint")}
-              disabled={authBusy() || sessionBusy()}
-            />
-            <div class="flex flex-wrap items-center gap-2">
-              <Button
-                variant="outline"
-                class="h-9 px-3 text-xs"
-                onClick={() => setBaseUrlDraft(baseUrl())}
-                disabled={authBusy() || sessionBusy()}
-              >
-                {tr("den.cloud_control_plane_reset")}
-              </Button>
-              <Button
-                variant="secondary"
-                class="h-9 px-3 text-xs"
-                onClick={applyBaseUrl}
-                disabled={authBusy() || sessionBusy()}
-              >
-                {tr("den.cloud_control_plane_save")}
-              </Button>
-              <Button
-                variant="outline"
-                class="h-9 px-3 text-xs"
-                onClick={openControlPlane}
-              >
-                {tr("den.cloud_control_plane_open")}
-                <ArrowUpRight size={13} />
-              </Button>
-            </div>
-          </div>
-        </Show>
-
-        <Show when={baseUrlError()}>
-          {(value) => (
-            <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
-              {value()}
-            </div>
-          )}
-        </Show>
-
-        <Show when={statusMessage() && !authError() && !workersError() && !orgsError() && !templatesError()}>
-          {(value) => (
-            <div class={softNoticeClass}>
-              {value()}
-            </div>
-          )}
-        </Show>
-      </div>
-
-      <Show when={!isSignedIn()}>
+      <Show when={!isSignedIn()} fallback={
         <div class={`${settingsPanelClass} space-y-4`}>
+          <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div class="space-y-2">
-              <div class="text-sm font-medium text-dls-text">
-                {tr("den.signin_title")}
+              <div class={headerBadgeClass}>
+                <Cloud size={13} class="text-dls-secondary" />
+                {tr("den.cloud_section_title")}
               </div>
-              <div class="max-w-[54ch] text-sm text-dls-secondary">
-                {tr("den.cloud_sleep_hint")}
+              <div>
+                <div class="text-sm font-medium text-dls-text">
+                  {tr("den.cloud_section_desc")}
+                </div>
+                <div class="mt-1 max-w-[60ch] text-xs text-dls-secondary">
+                  {tr("den.cloud_sleep_hint")}
+                </div>
               </div>
             </div>
-
-          <div class="flex flex-wrap items-center gap-2">
-            <Button variant="secondary" onClick={() => openBrowserAuth("sign-in")}>
-              {tr("den.signin_button")}
-              <ArrowUpRight size={13} />
-            </Button>
-            <Button
-              variant="outline"
-              class="text-xs h-9 px-3"
-              onClick={() => openBrowserAuth("sign-up")}
-            >
-              {tr("den.create_account")}
-              <ArrowUpRight size={13} />
-            </Button>
-            <Button
-              variant="outline"
-              class="text-xs h-9 px-3"
-              onClick={() => {
-                setManualAuthOpen((value) => !value);
-                setAuthError(null);
-              }}
-              disabled={authBusy() || sessionBusy()}
-            >
-              {manualAuthOpen() ? tr("den.hide_signin_code") : tr("den.paste_signin_code")}
-            </Button>
+            <div class={headerStatusBadgeClass}>
+              <span
+                class={`h-2 w-2 rounded-full ${summaryTone() === "ready" ? "bg-green-500" : summaryTone() === "warning" ? "bg-amber-500" : summaryTone() === "error" ? "bg-red-500" : "bg-gray-400"}`}
+              />
+              {summaryLabel()}
+            </div>
           </div>
 
-          <Show when={manualAuthOpen()}>
-            <div class={`${settingsPanelSoftClass} space-y-3`}>
+          <Show when={props.developerMode}>
+            <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
               <TextInput
-                label={tr("den.signin_link_label")}
-                value={manualAuthInput()}
-                onInput={(event) => setManualAuthInput(event.currentTarget.value)}
-                placeholder={tr("den.signin_link_placeholder")}
+                label={tr("den.cloud_control_plane_url_label")}
+                value={baseUrlDraft()}
+                onInput={(event) => setBaseUrlDraft(event.currentTarget.value)}
+                placeholder={DEFAULT_DEN_BASE_URL}
+                hint={tr("den.cloud_control_plane_url_hint")}
                 disabled={authBusy() || sessionBusy()}
-                hint={tr("den.signin_link_hint")}
               />
               <div class="flex flex-wrap items-center gap-2">
                 <Button
-                  variant="secondary"
-                  class="text-xs h-9 px-3"
-                  onClick={() => void submitManualAuth()}
-                  disabled={authBusy() || sessionBusy() || !manualAuthInput().trim()}
+                  variant="outline"
+                  class="h-9 px-3 text-xs"
+                  onClick={() => setBaseUrlDraft(baseUrl())}
+                  disabled={authBusy() || sessionBusy()}
                 >
-                  {authBusy() ? tr("den.finishing") : tr("den.finish_signin")}
+                  {tr("den.cloud_control_plane_reset")}
                 </Button>
-                <div class="text-[11px] text-dls-secondary">
-                  {tr("den.signin_code_note")}
-                </div>
+                <Button
+                  variant="secondary"
+                  class="h-9 px-3 text-xs"
+                  onClick={applyBaseUrl}
+                  disabled={authBusy() || sessionBusy()}
+                >
+                  {tr("den.cloud_control_plane_save")}
+                </Button>
+                <Button
+                  variant="outline"
+                  class="h-9 px-3 text-xs"
+                  onClick={openControlPlane}
+                >
+                  {tr("den.cloud_control_plane_open")}
+                  <ArrowUpRight size={13} />
+                </Button>
               </div>
             </div>
           </Show>
 
-          <Show when={authError()}>
+          <Show when={baseUrlError()}>
             {(value) => (
               <div class="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
                 {value()}
@@ -1278,10 +1236,41 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
             )}
           </Show>
 
-          <div class={`${settingsPanelSoftClass} text-sm text-gray-10`}>
-            {tr("den.auto_reconnect_hint")}
-          </div>
+          <Show when={statusMessage() && !authError() && !workersError() && !orgsError() && !templatesError()}>
+            {(value) => (
+              <div class={softNoticeClass}>
+                {value()}
+              </div>
+            )}
+          </Show>
         </div>
+      }>
+        <DenSignInSurface
+          developerMode={props.developerMode}
+          baseUrl={baseUrl()}
+          baseUrlDraft={baseUrlDraft()}
+          baseUrlError={baseUrlError()}
+          statusMessage={statusMessage() && !workersError() && !orgsError() && !templatesError() ? statusMessage() : null}
+          authError={authError()}
+          authBusy={authBusy()}
+          baseUrlBusy={baseUrlBusy()}
+          sessionBusy={sessionBusy()}
+          manualAuthOpen={manualAuthOpen()}
+          manualAuthInput={manualAuthInput()}
+          onBaseUrlDraftInput={setBaseUrlDraft}
+          onResetBaseUrl={() => setBaseUrlDraft(baseUrl())}
+          onApplyBaseUrl={() => {
+            void applyBaseUrl();
+          }}
+          onOpenControlPlane={openControlPlane}
+          onOpenBrowserAuth={openBrowserAuth}
+          onToggleManualAuth={() => {
+            setManualAuthOpen((value) => !value);
+            setAuthError(null);
+          }}
+          onManualAuthInput={setManualAuthInput}
+          onSubmitManualAuth={() => void submitManualAuth()}
+        />
       </Show>
 
       <Show when={isSignedIn()}>

--- a/apps/app/src/app/context/extensions.ts
+++ b/apps/app/src/app/context/extensions.ts
@@ -715,7 +715,7 @@ export function createExtensionsStore(options: {
         return;
       }
 
-      const client = createDenClient({ baseUrl: settings.baseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
       const catalog = await fetchDenOrgSkillsCatalog(client, orgId);
       if (refreshCloudOrgSkillsAborted) return;
       setCloudOrgSkills(catalog);
@@ -767,7 +767,7 @@ export function createExtensionsStore(options: {
         return;
       }
 
-      const client = createDenClient({ baseUrl: settings.baseUrl, token });
+      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
       const hubs = await client.listOrgSkillHubs(orgId);
       if (refreshCloudOrgSkillHubsAborted) return;
       setCloudOrgSkillHubs(hubs);

--- a/apps/app/src/app/entry.tsx
+++ b/apps/app/src/app/entry.tsx
@@ -1,4 +1,6 @@
 import App from "./app";
+import { DenAuthProvider } from "./cloud/den-auth-provider";
+import { DesktopConfigProvider } from "./cloud/desktop-config-provider";
 import { GlobalSDKProvider } from "./context/global-sdk";
 import { GlobalSyncProvider } from "./context/global-sync";
 import { LocalProvider } from "./context/local";
@@ -37,13 +39,17 @@ export default function AppEntry() {
 
   return (
     <ServerProvider defaultUrl={defaultUrl}>
-      <GlobalSDKProvider>
-        <GlobalSyncProvider>
-          <LocalProvider>
-            <App />
-          </LocalProvider>
-        </GlobalSyncProvider>
-      </GlobalSDKProvider>
+      <DenAuthProvider>
+        <DesktopConfigProvider>
+          <GlobalSDKProvider>
+            <GlobalSyncProvider>
+              <LocalProvider>
+                <App />
+              </LocalProvider>
+            </GlobalSyncProvider>
+          </GlobalSDKProvider>
+        </DesktopConfigProvider>
+      </DenAuthProvider>
     </ServerProvider>
   );
 }

--- a/apps/app/src/app/lib/den-session-events.ts
+++ b/apps/app/src/app/lib/den-session-events.ts
@@ -1,6 +1,7 @@
-import type { DenUser } from "./den";
+import type { DenSettings, DenUser } from "./den";
 
 export const denSessionUpdatedEvent = "openwork-den-session-updated";
+export const denSettingsChangedEvent = "openwork-den-settings-changed";
 
 export type DenSessionUpdatedDetail = {
   status?: "success" | "error";
@@ -18,6 +19,22 @@ export function dispatchDenSessionUpdated(detail: DenSessionUpdatedDetail) {
 
   window.dispatchEvent(
     new CustomEvent<DenSessionUpdatedDetail>(denSessionUpdatedEvent, {
+      detail,
+    }),
+  );
+}
+
+export type DenSettingsChangedDetail = {
+  settings: DenSettings;
+};
+
+export function dispatchDenSettingsChanged(detail: DenSettingsChangedDetail) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<DenSettingsChangedDetail>(denSettingsChangedEvent, {
       detail,
     }),
   );

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1,4 +1,5 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions as DenDesktopConfig } from "@openwork/types/den/desktop-app-restrictions";
 import { isDesktopDeployment } from "./openwork-deployment";
 import {
   dispatchDenSettingsChanged,
@@ -180,13 +181,6 @@ export type DenDesktopHandoffExchange = {
   token: string | null;
 };
 
-export type DenDesktopConfig = {
-  models?: {
-    allowConfig?: boolean;
-    removeZen?: boolean;
-  };
-};
-
 const defaultBootstrapBaseUrls = resolveDenBaseUrls({
   baseUrl: BUILD_DEN_BASE_URL,
   apiBaseUrl: BUILD_DEN_API_BASE_URL,
@@ -240,25 +234,8 @@ function getDenAppVersionMetadata(payload: unknown): DenAppVersionMetadata | nul
   };
 }
 
-function getDenDesktopConfig(payload: unknown): DenDesktopConfig {
-  if (!isRecord(payload)) {
-    return {};
-  }
-
-  const models = isRecord(payload.models)
-    ? {
-        ...(typeof payload.models.allowConfig === "boolean"
-          ? { allowConfig: payload.models.allowConfig }
-          : {}),
-        ...(typeof payload.models.removeZen === "boolean"
-          ? { removeZen: payload.models.removeZen }
-          : {}),
-      }
-    : null;
-
-  return {
-    ...(models && Object.keys(models).length > 0 ? { models } : {}),
-  };
+export function normalizeDenDesktopConfig(payload: unknown): DenDesktopConfig {
+  return normalizeDesktopAppRestrictions(payload);
 }
 
 export function normalizeDenBaseUrl(input: string | null | undefined): string | null {
@@ -1159,7 +1136,7 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         method: "GET",
         token,
       });
-      return getDenDesktopConfig(payload);
+      return normalizeDenDesktopConfig(payload);
     },
 
     async exchangeDesktopHandoff(grant: string): Promise<DenDesktopHandoffExchange> {

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -64,7 +64,7 @@ export type DenOrgSummary = {
   id: string;
   name: string;
   slug: string;
-  role: "owner" | "member";
+  role: "owner" | "admin" | "member";
 };
 
 export type DenWorkerSummary = {
@@ -502,6 +502,17 @@ export function writeDenSettings(next: DenSettings, options?: { persistBootstrap
   const activeOrgSlug = next.activeOrgSlug?.trim() ?? "";
   const activeOrgName = next.activeOrgName?.trim() ?? "";
 
+  if (
+    previous.baseUrl === baseUrl &&
+    (previous.apiBaseUrl ?? "") === apiBaseUrl &&
+    (previous.authToken ?? "") === authToken &&
+    (previous.activeOrgId ?? "") === activeOrgId &&
+    (previous.activeOrgSlug ?? "") === activeOrgSlug &&
+    (previous.activeOrgName ?? "") === activeOrgName
+  ) {
+    return;
+  }
+
   window.localStorage.setItem(STORAGE_BASE_URL, baseUrl);
   window.localStorage.setItem(STORAGE_API_BASE_URL, apiBaseUrl);
   if (authToken) {
@@ -567,6 +578,53 @@ export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
   });
 }
 
+export async function ensureDenActiveOrganization(options?: { forceServerSync?: boolean }) {
+  const settings = readDenSettings();
+  const token = settings.authToken?.trim() ?? "";
+  if (!token) {
+    return null;
+  }
+
+  const client = createDenClient({
+    baseUrl: settings.baseUrl,
+    apiBaseUrl: settings.apiBaseUrl,
+    token,
+  });
+
+  const response = await client.listOrgs();
+  const targetOrg =
+    response.orgs.find((org) => org.id === response.activeOrgId) ??
+    response.orgs.find((org) => org.slug === response.activeOrgSlug) ??
+    response.orgs[0] ??
+    null;
+
+  if (!targetOrg) {
+    writeDenSettings({
+      ...settings,
+      activeOrgId: null,
+      activeOrgSlug: null,
+      activeOrgName: null,
+    }, { persistBootstrap: false });
+    return null;
+  }
+
+  if (
+    options?.forceServerSync &&
+    (!response.activeOrgId || response.activeOrgId !== targetOrg.id)
+  ) {
+    await client.setActiveOrganization({ organizationId: targetOrg.id });
+  }
+
+  writeDenSettings({
+    ...settings,
+    activeOrgId: targetOrg.id,
+    activeOrgSlug: targetOrg.slug,
+    activeOrgName: targetOrg.name,
+  }, { persistBootstrap: false });
+
+  return targetOrg;
+}
+
 function getErrorMessage(payload: unknown, fallback: string): string {
   if (typeof payload === "string" && payload.trim()) {
     return payload.trim();
@@ -623,7 +681,7 @@ function getOrgList(payload: unknown): DenOrgSummary[] {
         typeof entry.id !== "string" ||
         typeof entry.name !== "string" ||
         typeof entry.slug !== "string" ||
-        (entry.role !== "owner" && entry.role !== "member")
+        (entry.role !== "owner" && entry.role !== "admin" && entry.role !== "member")
       ) {
         return null;
       }

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1,5 +1,13 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { isDesktopDeployment } from "./openwork-deployment";
+import {
+  dispatchDenSettingsChanged,
+} from "./den-session-events";
+import {
+  getDesktopBootstrapConfig as getDesktopBootstrapConfigFromShell,
+  setDesktopBootstrapConfig as setDesktopBootstrapConfigInShell,
+  type DesktopBootstrapConfig as ShellDesktopBootstrapConfig,
+} from "./tauri";
 import { isTauriRuntime } from "../utils";
 import type { DenOrgSkillCard } from "../types";
 
@@ -12,10 +20,20 @@ const STORAGE_ACTIVE_ORG_NAME = "openwork.den.activeOrgName";
 const DEFAULT_DEN_TIMEOUT_MS = 12_000;
 
 export const DEFAULT_DEN_AUTH_NAME = "OpenWork User";
-export const DEFAULT_DEN_BASE_URL =
+const BUILD_DEN_BASE_URL =
   (typeof import.meta !== "undefined" && typeof import.meta.env?.VITE_DEN_BASE_URL === "string"
     ? import.meta.env.VITE_DEN_BASE_URL
     : "").trim() || "https://app.openworklabs.com";
+const BUILD_DEN_API_BASE_URL =
+  (typeof import.meta !== "undefined" && typeof import.meta.env?.VITE_DEN_API_BASE_URL === "string"
+    ? import.meta.env.VITE_DEN_API_BASE_URL
+    : "").trim() || undefined;
+const BUILD_DEN_REQUIRE_SIGNIN =
+  (typeof import.meta !== "undefined" && typeof import.meta.env?.VITE_DEN_REQUIRE_SIGNIN === "string"
+    ? /^(1|true|yes|on)$/i.test(import.meta.env.VITE_DEN_REQUIRE_SIGNIN.trim())
+    : false);
+
+export const DEFAULT_DEN_BASE_URL = BUILD_DEN_BASE_URL;
 
 export type DenSettings = {
   baseUrl: string;
@@ -29,6 +47,10 @@ export type DenSettings = {
 type DenBaseUrls = {
   baseUrl: string;
   apiBaseUrl: string;
+};
+
+export type DenBootstrapConfig = DenBaseUrls & {
+  requireSignin: boolean;
 };
 
 export type DenUser = {
@@ -158,6 +180,23 @@ export type DenDesktopHandoffExchange = {
   token: string | null;
 };
 
+export type DenDesktopConfig = {
+  models?: {
+    allowConfig?: boolean;
+    removeZen?: boolean;
+  };
+};
+
+const defaultBootstrapBaseUrls = resolveDenBaseUrls({
+  baseUrl: BUILD_DEN_BASE_URL,
+  apiBaseUrl: BUILD_DEN_API_BASE_URL,
+});
+
+let desktopBootstrapConfig: DenBootstrapConfig = {
+  ...defaultBootstrapBaseUrls,
+  requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
+};
+
 export type DenAppVersionMetadata = {
   minAppVersion: string;
   latestAppVersion: string;
@@ -198,6 +237,27 @@ function getDenAppVersionMetadata(payload: unknown): DenAppVersionMetadata | nul
     minAppVersion:
       typeof payload.minAppVersion === "string" ? payload.minAppVersion.trim() : "",
     latestAppVersion,
+  };
+}
+
+function getDenDesktopConfig(payload: unknown): DenDesktopConfig {
+  if (!isRecord(payload)) {
+    return {};
+  }
+
+  const models = isRecord(payload.models)
+    ? {
+        ...(typeof payload.models.allowConfig === "boolean"
+          ? { allowConfig: payload.models.allowConfig }
+          : {}),
+        ...(typeof payload.models.removeZen === "boolean"
+          ? { removeZen: payload.models.removeZen }
+          : {}),
+      }
+    : null;
+
+  return {
+    ...(models && Object.keys(models).length > 0 ? { models } : {}),
   };
 }
 
@@ -318,6 +378,94 @@ export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?
   };
 }
 
+function resolveDenBootstrapConfig(
+  input: { baseUrl: string; apiBaseUrl?: string | null; requireSignin?: boolean | null },
+): DenBootstrapConfig {
+  return {
+    ...resolveDenBaseUrls(input),
+    requireSignin: input.requireSignin === true,
+  };
+}
+
+function syncBootstrapSettingsToLocalStorage(config: DenBootstrapConfig) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_BASE_URL, config.baseUrl);
+  window.localStorage.setItem(STORAGE_API_BASE_URL, config.apiBaseUrl);
+}
+
+function getPendingBootstrapConfig(next: DenSettings): DenBootstrapConfig | null {
+  if (next.baseUrl === undefined && next.apiBaseUrl === undefined) {
+    return null;
+  }
+
+  const previous = readDenBootstrapConfig();
+  return resolveDenBootstrapConfig({
+    baseUrl: next.baseUrl ?? previous.baseUrl,
+    apiBaseUrl: next.apiBaseUrl ?? previous.apiBaseUrl,
+    requireSignin: previous.requireSignin,
+  });
+}
+
+function applyDesktopBootstrapConfig(config: DenBootstrapConfig) {
+  desktopBootstrapConfig = config;
+  syncBootstrapSettingsToLocalStorage(config);
+}
+
+export function readDenBootstrapConfig(): DenBootstrapConfig {
+  return desktopBootstrapConfig;
+}
+
+export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig> {
+  if (!isTauriRuntime()) {
+    desktopBootstrapConfig = resolveDenBootstrapConfig({
+      baseUrl: BUILD_DEN_BASE_URL,
+      apiBaseUrl: BUILD_DEN_API_BASE_URL,
+      requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
+    });
+    return desktopBootstrapConfig;
+  }
+
+  try {
+    const bootstrap = await getDesktopBootstrapConfigFromShell();
+    applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
+  } catch {
+    desktopBootstrapConfig = resolveDenBootstrapConfig({
+      baseUrl: BUILD_DEN_BASE_URL,
+      apiBaseUrl: BUILD_DEN_API_BASE_URL,
+      requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
+    });
+    syncBootstrapSettingsToLocalStorage(desktopBootstrapConfig);
+  }
+
+  return desktopBootstrapConfig;
+}
+
+export async function setDenBootstrapConfig(
+  next: ShellDesktopBootstrapConfig,
+): Promise<DenBootstrapConfig> {
+  const normalized = resolveDenBootstrapConfig(next);
+
+  if (isTauriRuntime()) {
+    const persisted = await setDesktopBootstrapConfigInShell({
+      baseUrl: normalized.baseUrl,
+      apiBaseUrl: normalized.apiBaseUrl,
+      requireSignin: normalized.requireSignin,
+    });
+    applyDesktopBootstrapConfig(resolveDenBootstrapConfig(persisted));
+  } else {
+    applyDesktopBootstrapConfig(normalized);
+  }
+
+  dispatchDenSettingsChanged({
+    settings: readDenSettings(),
+  });
+
+  return readDenBootstrapConfig();
+}
+
 export function buildDenAuthUrl(baseUrl: string, mode: "sign-in" | "sign-up"): string {
   const target = new URL(resolveDenBaseUrls(baseUrl).baseUrl);
   target.searchParams.set("mode", mode);
@@ -334,12 +482,18 @@ function resolveRequestBaseUrl(baseUrls: DenBaseUrls, path: string): string {
 
 export function readDenSettings(): DenSettings {
   if (typeof window === "undefined") {
-    return resolveDenBaseUrls(DEFAULT_DEN_BASE_URL);
+    return {
+      ...readDenBootstrapConfig(),
+      authToken: null,
+      activeOrgId: null,
+      activeOrgSlug: null,
+      activeOrgName: null,
+    };
   }
 
   const baseUrls = resolveDenBaseUrls({
-    baseUrl: window.localStorage.getItem(STORAGE_BASE_URL) ?? "",
-    apiBaseUrl: window.localStorage.getItem(STORAGE_API_BASE_URL) ?? "",
+    baseUrl: window.localStorage.getItem(STORAGE_BASE_URL) ?? readDenBootstrapConfig().baseUrl,
+    apiBaseUrl: window.localStorage.getItem(STORAGE_API_BASE_URL) ?? readDenBootstrapConfig().apiBaseUrl,
   });
 
   return {
@@ -351,12 +505,21 @@ export function readDenSettings(): DenSettings {
   };
 }
 
-export function writeDenSettings(next: DenSettings) {
+export function writeDenSettings(next: DenSettings, options?: { persistBootstrap?: boolean }) {
   if (typeof window === "undefined") {
     return;
   }
 
-  const { baseUrl, apiBaseUrl } = resolveDenBaseUrls(next);
+  const pendingBootstrap = getPendingBootstrapConfig(next);
+  const previous = readDenSettings();
+  const resolved = resolveDenBaseUrls(next);
+  const previousResolved = resolveDenBaseUrls(previous);
+  const baseUrl = resolved.baseUrl;
+  const apiBaseUrl = next.apiBaseUrl !== undefined
+    ? resolved.apiBaseUrl
+    : previousResolved.baseUrl === resolved.baseUrl
+      ? previous.apiBaseUrl ?? resolved.apiBaseUrl
+      : resolved.apiBaseUrl;
   const authToken = next.authToken?.trim() ?? "";
   const activeOrgId = next.activeOrgId?.trim() ?? "";
   const activeOrgSlug = next.activeOrgSlug?.trim() ?? "";
@@ -387,6 +550,24 @@ export function writeDenSettings(next: DenSettings) {
   } else {
     window.localStorage.removeItem(STORAGE_ACTIVE_ORG_NAME);
   }
+
+  if (options?.persistBootstrap !== false && pendingBootstrap) {
+    const currentBootstrap = readDenBootstrapConfig();
+    if (
+      pendingBootstrap.baseUrl !== currentBootstrap.baseUrl ||
+      pendingBootstrap.apiBaseUrl !== currentBootstrap.apiBaseUrl
+    ) {
+      void setDenBootstrapConfig({
+        baseUrl: pendingBootstrap.baseUrl,
+        apiBaseUrl: pendingBootstrap.apiBaseUrl,
+        requireSignin: currentBootstrap.requireSignin,
+      }).catch(() => undefined);
+    }
+  }
+
+  dispatchDenSettingsChanged({
+    settings: readDenSettings(),
+  });
 }
 
 export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
@@ -403,6 +584,10 @@ export function clearDenSession(options?: { includeBaseUrls?: boolean }) {
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_ID);
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_SLUG);
   window.localStorage.removeItem(STORAGE_ACTIVE_ORG_NAME);
+
+  dispatchDenSettingsChanged({
+    settings: readDenSettings(),
+  });
 }
 
 function getErrorMessage(payload: unknown, fallback: string): string {
@@ -903,8 +1088,11 @@ async function ensureActiveOrganization(
   });
 }
 
-export function createDenClient(options: { baseUrl: string; token?: string | null }) {
-  const baseUrls = resolveDenBaseUrls(options.baseUrl);
+export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string | null; token?: string | null }) {
+  const baseUrls = resolveDenBaseUrls({
+    baseUrl: options.baseUrl,
+    apiBaseUrl: options.apiBaseUrl,
+  });
   const token = options.token?.trim() ?? null;
 
   return {
@@ -964,6 +1152,14 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         throw new DenApiError(500, "invalid_app_version_payload", "App version response was missing version details.");
       }
       return appVersionMetadata;
+    },
+
+    async getDesktopConfig(): Promise<DenDesktopConfig> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/me/desktop-config", {
+        method: "GET",
+        token,
+      });
+      return getDenDesktopConfig(payload);
     },
 
     async exchangeDesktopHandoff(grant: string): Promise<DenDesktopHandoffExchange> {

--- a/apps/app/src/app/lib/tauri.ts
+++ b/apps/app/src/app/lib/tauri.ts
@@ -427,8 +427,24 @@ export type AppBuildInfo = {
   openworkDevMode?: boolean;
 };
 
+export type DesktopBootstrapConfig = {
+  baseUrl: string;
+  apiBaseUrl?: string | null;
+  requireSignin: boolean;
+};
+
 export async function appBuildInfo(): Promise<AppBuildInfo> {
   return invoke<AppBuildInfo>("app_build_info");
+}
+
+export async function getDesktopBootstrapConfig(): Promise<DesktopBootstrapConfig> {
+  return invoke<DesktopBootstrapConfig>("get_desktop_bootstrap_config");
+}
+
+export async function setDesktopBootstrapConfig(
+  config: DesktopBootstrapConfig,
+): Promise<DesktopBootstrapConfig> {
+  return invoke<DesktopBootstrapConfig>("set_desktop_bootstrap_config", { config });
 }
 
 export async function nukeOpenworkAndOpencodeConfigAndExit(): Promise<void> {

--- a/apps/app/src/app/pages/skills.tsx
+++ b/apps/app/src/app/pages/skills.tsx
@@ -212,7 +212,7 @@ export default function SkillsView(props: SkillsViewProps) {
         if (!token) return;
 
         let orgId = settings.activeOrgId?.trim() ?? "";
-        const client = createDenClient({ baseUrl: settings.baseUrl, token });
+        const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
         if (!orgId) {
           const res = await client.listOrgs();
           orgId = res.orgs[0]?.id ?? "";

--- a/apps/app/src/app/system-state.ts
+++ b/apps/app/src/app/system-state.ts
@@ -135,7 +135,7 @@ function compareVersions(left: string, right: string): number | null {
 async function isUpdateSupportedByDen(updateVersion: string) {
   try {
     const settings = readDenSettings();
-    const client = createDenClient({ baseUrl: settings.baseUrl });
+    const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl });
     const metadata = await client.getAppVersionMetadata();
     const comparison = compareVersions(updateVersion, metadata.latestAppVersion);
     return comparison !== null && comparison <= 0;

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -150,7 +150,7 @@ export type SessionCompactionState = {
   messageID: string | null;
 };
 
-export type View = "settings" | "session";
+export type View = "settings" | "session" | "signin";
 
 export type StartupPreference = "local" | "server";
 

--- a/apps/app/src/app/workspace/create-workspace-modal.tsx
+++ b/apps/app/src/app/workspace/create-workspace-modal.tsx
@@ -132,7 +132,11 @@ export default function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
   const remoteError = createMemo(() => (props.remoteError ?? "").trim() || null);
   const isSignedIn = createMemo(() => Boolean(cloudSettings().authToken?.trim()));
   const denClient = createMemo(
-    () => createDenClient({ baseUrl: cloudSettings().baseUrl, token: cloudSettings().authToken ?? "" }),
+    () => createDenClient({
+      baseUrl: cloudSettings().baseUrl,
+      apiBaseUrl: cloudSettings().apiBaseUrl,
+      token: cloudSettings().authToken ?? "",
+    }),
   );
   const templateCacheSnapshot = createMemo(() =>
     readDenTemplateCacheSnapshot({

--- a/apps/app/src/index.tsx
+++ b/apps/app/src/index.tsx
@@ -6,6 +6,7 @@ import { bootstrapTheme } from "./app/theme";
 import "./app/index.css";
 import AppEntry from "./app/entry";
 import { PlatformProvider, type Platform } from "./app/context/platform";
+import { initializeDenBootstrapConfig } from "./app/lib/den";
 import { nativeDeepLinkEvent, pushPendingDeepLinks } from "./app/lib/deep-link-bridge";
 import { getOpenWorkDeployment } from "./app/lib/openwork-deployment";
 import { isTauriRuntime } from "./app/utils";
@@ -75,6 +76,8 @@ startDeepLinkBridge();
 if (import.meta.env.DEV) {
   await import("./solid-devtools-dev");
 }
+
+await initializeDenBootstrapConfig();
 
 const RouterComponent = isTauriRuntime() ? HashRouter : Router;
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2780,6 +2780,7 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 name = "openwork"
 version = "0.11.207"
 dependencies = [
+ "dirs",
  "gethostname",
  "json5",
  "local-ip-address",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ json5 = "0.4"
 notify = "6.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+dirs = "6"
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2"
 sha2 = "0.10"

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -8,6 +8,7 @@ use std::os::unix::fs::PermissionsExt;
 
 fn main() {
     emit_build_info();
+    emit_desktop_bootstrap_seed();
     ensure_opencode_sidecar();
     ensure_openwork_server_sidecar();
     ensure_opencode_router_sidecar();
@@ -142,6 +143,46 @@ fn emit_build_info() {
 
     if let Some(value) = build_epoch {
         println!("cargo:rustc-env=OPENWORK_BUILD_EPOCH={}", value);
+    }
+}
+
+fn emit_desktop_bootstrap_seed() {
+    for key in [
+        "OPENWORK_DESKTOP_DEN_BASE_URL",
+        "OPENWORK_DESKTOP_DEN_API_BASE_URL",
+        "OPENWORK_DESKTOP_DEN_REQUIRE_SIGNIN",
+        "VITE_DEN_BASE_URL",
+        "VITE_DEN_API_BASE_URL",
+        "VITE_DEN_REQUIRE_SIGNIN",
+    ] {
+        println!("cargo:rerun-if-env-changed={key}");
+    }
+
+    if let Some(value) = env::var("OPENWORK_DESKTOP_DEN_BASE_URL")
+        .ok()
+        .or_else(|| env::var("VITE_DEN_BASE_URL").ok())
+        .map(|entry| entry.trim().to_string())
+        .filter(|entry| !entry.is_empty())
+    {
+        println!("cargo:rustc-env=OPENWORK_DESKTOP_DEN_BASE_URL={value}");
+    }
+
+    if let Some(value) = env::var("OPENWORK_DESKTOP_DEN_API_BASE_URL")
+        .ok()
+        .or_else(|| env::var("VITE_DEN_API_BASE_URL").ok())
+        .map(|entry| entry.trim().to_string())
+        .filter(|entry| !entry.is_empty())
+    {
+        println!("cargo:rustc-env=OPENWORK_DESKTOP_DEN_API_BASE_URL={value}");
+    }
+
+    if let Some(value) = env::var("OPENWORK_DESKTOP_DEN_REQUIRE_SIGNIN")
+        .ok()
+        .or_else(|| env::var("VITE_DEN_REQUIRE_SIGNIN").ok())
+        .map(|entry| entry.trim().to_string())
+        .filter(|entry| !entry.is_empty())
+    {
+        println!("cargo:rustc-env=OPENWORK_DESKTOP_DEN_REQUIRE_SIGNIN={value}");
     }
 }
 

--- a/apps/desktop/src-tauri/src/commands/desktop_bootstrap.rs
+++ b/apps/desktop/src-tauri/src/commands/desktop_bootstrap.rs
@@ -1,0 +1,16 @@
+use crate::desktop_bootstrap::{
+    read_or_init_desktop_bootstrap_config, save_desktop_bootstrap_config,
+};
+use crate::types::DesktopBootstrapConfig;
+
+#[tauri::command]
+pub fn get_desktop_bootstrap_config() -> Result<DesktopBootstrapConfig, String> {
+    read_or_init_desktop_bootstrap_config()
+}
+
+#[tauri::command]
+pub fn set_desktop_bootstrap_config(
+    config: DesktopBootstrapConfig,
+) -> Result<DesktopBootstrapConfig, String> {
+    save_desktop_bootstrap_config(&config)
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod command_files;
 pub mod config;
+pub mod desktop_bootstrap;
 pub mod engine;
 pub mod misc;
 pub mod opencode_router;

--- a/apps/desktop/src-tauri/src/desktop_bootstrap.rs
+++ b/apps/desktop/src-tauri/src/desktop_bootstrap.rs
@@ -1,0 +1,151 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::types::DesktopBootstrapConfig;
+
+const DESKTOP_BOOTSTRAP_FILE_NAME: &str = "desktop-bootstrap.json";
+const DESKTOP_BOOTSTRAP_PATH_ENV: &str = "OPENWORK_DESKTOP_BOOTSTRAP_PATH";
+const DEFAULT_DEN_BASE_URL: &str = "https://app.openworklabs.com";
+
+fn trim_to_option(value: Option<&'static str>) -> Option<String> {
+    value.and_then(|entry| {
+        let trimmed = entry.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn env_truthy(value: Option<&'static str>) -> bool {
+    matches!(
+        value.map(|entry| entry.trim().to_ascii_lowercase()),
+        Some(value) if matches!(value.as_str(), "1" | "true" | "yes" | "on")
+    )
+}
+
+fn normalize_desktop_bootstrap_config(
+    config: &DesktopBootstrapConfig,
+) -> Result<DesktopBootstrapConfig, String> {
+    let base_url = config.base_url.trim().to_string();
+    if base_url.is_empty() {
+        return Err("baseUrl is required".to_string());
+    }
+
+    Ok(DesktopBootstrapConfig {
+        base_url,
+        api_base_url: config
+            .api_base_url
+            .as_ref()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        require_signin: config.require_signin,
+    })
+}
+
+fn default_desktop_bootstrap_config() -> DesktopBootstrapConfig {
+    DesktopBootstrapConfig {
+        base_url: DEFAULT_DEN_BASE_URL.to_string(),
+        api_base_url: None,
+        require_signin: false,
+    }
+}
+
+fn seed_desktop_bootstrap_config() -> Result<DesktopBootstrapConfig, String> {
+    normalize_desktop_bootstrap_config(&DesktopBootstrapConfig {
+        base_url: trim_to_option(
+            option_env!("OPENWORK_DESKTOP_DEN_BASE_URL").or(option_env!("VITE_DEN_BASE_URL")),
+        )
+        .unwrap_or_else(|| DEFAULT_DEN_BASE_URL.to_string()),
+        api_base_url: trim_to_option(
+            option_env!("OPENWORK_DESKTOP_DEN_API_BASE_URL")
+                .or(option_env!("VITE_DEN_API_BASE_URL")),
+        ),
+        require_signin: env_truthy(
+            option_env!("OPENWORK_DESKTOP_DEN_REQUIRE_SIGNIN")
+                .or(option_env!("VITE_DEN_REQUIRE_SIGNIN")),
+        ),
+    })
+}
+
+fn is_non_default_seed(config: &DesktopBootstrapConfig) -> bool {
+    let default_config = default_desktop_bootstrap_config();
+    config.base_url != default_config.base_url
+        || config.api_base_url != default_config.api_base_url
+        || config.require_signin != default_config.require_signin
+}
+
+fn desktop_bootstrap_path() -> Result<PathBuf, String> {
+    if let Some(explicit) = env::var_os(DESKTOP_BOOTSTRAP_PATH_ENV) {
+        let path = PathBuf::from(explicit);
+        if !path.as_os_str().is_empty() {
+            return Ok(path);
+        }
+    }
+
+    let config_root = dirs::config_dir()
+        .ok_or_else(|| "Failed to resolve a desktop bootstrap config directory".to_string())?;
+    Ok(config_root
+        .join("OpenWork")
+        .join(DESKTOP_BOOTSTRAP_FILE_NAME))
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<(), String> {
+    let Some(parent) = path.parent() else {
+        return Err(format!(
+            "Bootstrap path {} has no parent directory",
+            path.display()
+        ));
+    };
+
+    fs::create_dir_all(parent).map_err(|e| format!("Failed to create {}: {e}", parent.display()))
+}
+
+pub fn load_desktop_bootstrap_config() -> Result<Option<DesktopBootstrapConfig>, String> {
+    let path = desktop_bootstrap_path()?;
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw =
+        fs::read_to_string(&path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    let parsed = serde_json::from_str::<DesktopBootstrapConfig>(&raw)
+        .map_err(|e| format!("Failed to parse {}: {e}", path.display()))?;
+    Ok(Some(normalize_desktop_bootstrap_config(&parsed)?))
+}
+
+pub fn save_desktop_bootstrap_config(
+    config: &DesktopBootstrapConfig,
+) -> Result<DesktopBootstrapConfig, String> {
+    let path = desktop_bootstrap_path()?;
+    ensure_parent_dir(&path)?;
+
+    let normalized = normalize_desktop_bootstrap_config(config)?;
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&normalized).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| format!("Failed to write {}: {e}", path.display()))?;
+
+    Ok(normalized)
+}
+
+pub fn read_or_init_desktop_bootstrap_config() -> Result<DesktopBootstrapConfig, String> {
+    let seeded = seed_desktop_bootstrap_config()?;
+    let existing = load_desktop_bootstrap_config()?;
+
+    if is_non_default_seed(&seeded) {
+        if existing.as_ref() != Some(&seeded) {
+            save_desktop_bootstrap_config(&seeded)?;
+        }
+        return Ok(seeded);
+    }
+
+    if let Some(config) = existing {
+        return Ok(config);
+    }
+
+    Ok(seeded)
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod bun_env;
 mod commands;
 mod config;
+mod desktop_bootstrap;
 mod engine;
 mod fs;
 mod opencode_router;
@@ -19,6 +20,7 @@ use commands::command_files::{
     opencode_command_delete, opencode_command_list, opencode_command_write,
 };
 use commands::config::{read_opencode_config, write_opencode_config};
+use commands::desktop_bootstrap::{get_desktop_bootstrap_config, set_desktop_bootstrap_config};
 use commands::engine::{
     engine_doctor, engine_info, engine_install, engine_restart, engine_start, engine_stop,
 };
@@ -203,6 +205,8 @@ pub fn run() {
             write_local_skill,
             read_opencode_config,
             write_opencode_config,
+            get_desktop_bootstrap_config,
+            set_desktop_bootstrap_config,
             updater_environment,
             app_build_info,
             nuke_openwork_and_opencode_config_and_exit,

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -237,6 +237,16 @@ pub struct UpdaterEnvironment {
     pub app_bundle_path: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DesktopBootstrapConfig {
+    pub base_url: String,
+    #[serde(default)]
+    pub api_base_url: Option<String>,
+    #[serde(default)]
+    pub require_signin: bool,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ScheduledJobRun {

--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -15,6 +15,7 @@
     "@hono/node-server": "^1.13.8",
     "@hono/standard-validator": "^0.2.2",
     "@hono/swagger-ui": "^0.6.1",
+    "@openwork/types": "workspace:*",
     "@openwork-ee/den-db": "workspace:*",
     "@openwork-ee/utils": "workspace:*",
     "@standard-community/standard-json": "^0.3.5",

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -8,7 +8,7 @@ import type { RequestIdVariables } from "hono/request-id"
 import { requestId } from "hono/request-id"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
 import { z } from "zod"
-import { env } from "./env.js"
+import { desktopConfigSchema, env } from "./env.js"
 import type { MemberTeamsContext, OrganizationContextVariables, UserOrganizationsContext } from "./middleware/index.js"
 import { buildOperationId, emptyResponse, htmlResponse, jsonResponse } from "./openapi.js"
 import { registerAdminRoutes } from "./routes/admin/index.js"
@@ -27,6 +27,18 @@ const healthResponseSchema = z.object({
   ok: z.literal(true),
   service: z.literal("den-api"),
 }).meta({ ref: "DenApiHealthResponse" })
+
+const desktopConfigResponseSchema = desktopConfigSchema.meta({
+  ref: "DenApiDesktopConfigResponse",
+  description: "Desktop app configuration published by den-api via API_DESKTOP_CONFIG.",
+  examples: [{
+    requireSignin: false,
+    models: {
+      allowConfig: true,
+      removeZen: false,
+    },
+  }],
+})
 
 const openApiDocumentSchema = z.object({
   openapi: z.string(),
@@ -101,6 +113,21 @@ app.get(
   }),
   (c) => {
     return c.json({ ok: true, service: "den-api" })
+  },
+)
+
+app.get(
+  "/desktop-config",
+  describeRoute({
+    tags: ["System"],
+    summary: "Get desktop config",
+    description: "Returns the desktop configuration payload derived from the API_DESKTOP_CONFIG environment variable so desktop clients can toggle sign-in and model behavior without another config store.",
+    responses: {
+      200: jsonResponse("Desktop configuration returned successfully.", desktopConfigResponseSchema),
+    },
+  }),
+  (c) => {
+    return c.json(env.desktopConfig)
   },
 )
 

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -8,7 +8,7 @@ import type { RequestIdVariables } from "hono/request-id"
 import { requestId } from "hono/request-id"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
 import { z } from "zod"
-import { desktopConfigSchema, env } from "./env.js"
+import { env } from "./env.js"
 import type { MemberTeamsContext, OrganizationContextVariables, UserOrganizationsContext } from "./middleware/index.js"
 import { buildOperationId, emptyResponse, htmlResponse, jsonResponse } from "./openapi.js"
 import { registerAdminRoutes } from "./routes/admin/index.js"
@@ -27,18 +27,6 @@ const healthResponseSchema = z.object({
   ok: z.literal(true),
   service: z.literal("den-api"),
 }).meta({ ref: "DenApiHealthResponse" })
-
-const desktopConfigResponseSchema = desktopConfigSchema.meta({
-  ref: "DenApiDesktopConfigResponse",
-  description: "Desktop app configuration published by den-api via API_DESKTOP_CONFIG.",
-  examples: [{
-    requireSignin: false,
-    models: {
-      allowConfig: true,
-      removeZen: false,
-    },
-  }],
-})
 
 const openApiDocumentSchema = z.object({
   openapi: z.string(),
@@ -113,21 +101,6 @@ app.get(
   }),
   (c) => {
     return c.json({ ok: true, service: "den-api" })
-  },
-)
-
-app.get(
-  "/desktop-config",
-  describeRoute({
-    tags: ["System"],
-    summary: "Get desktop config",
-    description: "Returns the desktop configuration payload derived from the API_DESKTOP_CONFIG environment variable so desktop clients can toggle sign-in and model behavior without another config store.",
-    responses: {
-      200: jsonResponse("Desktop configuration returned successfully.", desktopConfigResponseSchema),
-    },
-  }),
-  (c) => {
-    return c.json(env.desktopConfig)
   },
 )
 

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -10,7 +10,6 @@ const EnvSchema = z.object({
   DB_MODE: z.enum(["mysql", "planetscale"]).optional(),
   BETTER_AUTH_SECRET: z.string().min(32),
   BETTER_AUTH_URL: z.string().min(1),
-  API_DESKTOP_CONFIG: z.string().optional(),
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
   GITHUB_CLIENT_ID: z.string().optional(),
   GITHUB_CLIENT_SECRET: z.string().optional(),
@@ -112,16 +111,6 @@ const EnvSchema = z.object({
 
 const parsed = EnvSchema.parse(process.env)
 
-export const desktopConfigSchema = z.object({
-  requireSignin: z.boolean().optional(),
-  models: z.object({
-    allowConfig: z.boolean().optional(),
-    removeZen: z.boolean().optional(),
-  }).optional(),
-}).meta({ ref: "DenApiDesktopConfig" })
-
-const defaultDesktopConfig = desktopConfigSchema.parse({})
-
 function splitCsv(value: string | undefined) {
   return (value ?? "")
     .split(",")
@@ -132,24 +121,6 @@ function splitCsv(value: string | undefined) {
 function optionalString(value: string | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed : undefined
-}
-
-function parseDesktopConfig(value: string | undefined) {
-  const trimmed = value?.trim()
-  if (!trimmed) {
-    return defaultDesktopConfig
-  }
-
-  let parsedValue: unknown
-  try {
-    parsedValue = JSON.parse(trimmed)
-  } catch (error) {
-    throw new Error(
-      `API_DESKTOP_CONFIG must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
-    )
-  }
-
-  return desktopConfigSchema.parse(parsedValue)
 }
 
 function normalizeOrigin(origin: string) {
@@ -183,7 +154,6 @@ export const env = {
   databaseUrl: parsed.DATABASE_URL,
   dbEncryptionKey: optionalString(parsed.DEN_DB_ENCRYPTION_KEY),
   dbMode: parsed.DB_MODE ?? (parsed.DATABASE_URL ? "mysql" : "planetscale"),
-  desktopConfig: parseDesktopConfig(parsed.API_DESKTOP_CONFIG),
   planetscale: planetscaleCredentials,
   betterAuthSecret: parsed.BETTER_AUTH_SECRET,
   betterAuthUrl: normalizeOrigin(parsed.BETTER_AUTH_URL),

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -10,6 +10,7 @@ const EnvSchema = z.object({
   DB_MODE: z.enum(["mysql", "planetscale"]).optional(),
   BETTER_AUTH_SECRET: z.string().min(32),
   BETTER_AUTH_URL: z.string().min(1),
+  API_DESKTOP_CONFIG: z.string().optional(),
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
   GITHUB_CLIENT_ID: z.string().optional(),
   GITHUB_CLIENT_SECRET: z.string().optional(),
@@ -111,6 +112,16 @@ const EnvSchema = z.object({
 
 const parsed = EnvSchema.parse(process.env)
 
+export const desktopConfigSchema = z.object({
+  requireSignin: z.boolean().optional(),
+  models: z.object({
+    allowConfig: z.boolean().optional(),
+    removeZen: z.boolean().optional(),
+  }).optional(),
+}).meta({ ref: "DenApiDesktopConfig" })
+
+const defaultDesktopConfig = desktopConfigSchema.parse({})
+
 function splitCsv(value: string | undefined) {
   return (value ?? "")
     .split(",")
@@ -121,6 +132,24 @@ function splitCsv(value: string | undefined) {
 function optionalString(value: string | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed : undefined
+}
+
+function parseDesktopConfig(value: string | undefined) {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return defaultDesktopConfig
+  }
+
+  let parsedValue: unknown
+  try {
+    parsedValue = JSON.parse(trimmed)
+  } catch (error) {
+    throw new Error(
+      `API_DESKTOP_CONFIG must be valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  return desktopConfigSchema.parse(parsedValue)
 }
 
 function normalizeOrigin(origin: string) {
@@ -154,6 +183,7 @@ export const env = {
   databaseUrl: parsed.DATABASE_URL,
   dbEncryptionKey: optionalString(parsed.DEN_DB_ENCRYPTION_KEY),
   dbMode: parsed.DB_MODE ?? (parsed.DATABASE_URL ? "mysql" : "planetscale"),
+  desktopConfig: parseDesktopConfig(parsed.API_DESKTOP_CONFIG),
   planetscale: planetscaleCredentials,
   betterAuthSecret: parsed.BETTER_AUTH_SECRET,
   betterAuthUrl: normalizeOrigin(parsed.BETTER_AUTH_URL),

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -9,6 +9,7 @@ import {
   TeamMemberTable,
   TeamTable,
 } from "@openwork-ee/den-db/schema"
+import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
 import { DEFAULT_ORGANIZATION_LIMITS, serializeOrganizationMetadata } from "./organization-limits.js"
@@ -61,6 +62,7 @@ export type OrganizationContext = {
     slug: string
     logo: string | null
     allowedEmailDomains: AllowedEmailDomains
+    desktopAppRestrictions: DesktopAppRestrictions
     metadata: string | null
     createdAt: Date
     updatedAt: Date
@@ -608,6 +610,7 @@ export async function updateOrganizationSettings(input: {
   organizationId: OrgId
   name?: string
   allowedEmailDomains?: readonly string[] | null
+  desktopAppRestrictions?: DesktopAppRestrictions
 }) {
   const nextName = typeof input.name === "string" ? input.name.trim() : null
   if (typeof input.name === "string" && !nextName) {
@@ -620,6 +623,9 @@ export async function updateOrganizationSettings(input: {
   }
   if (input.allowedEmailDomains !== undefined) {
     updates.allowedEmailDomains = normalizeAllowedEmailDomains(input.allowedEmailDomains).domains
+  }
+  if (input.desktopAppRestrictions !== undefined) {
+    updates.desktopAppRestrictions = normalizeDesktopAppRestrictions(input.desktopAppRestrictions)
   }
 
   if (Object.keys(updates).length === 0) {
@@ -662,6 +668,7 @@ export async function listUserOrgs(userId: UserId) {
         slug: OrganizationTable.slug,
         logo: OrganizationTable.logo,
         allowedEmailDomains: OrganizationTable.allowedEmailDomains,
+        desktopAppRestrictions: OrganizationTable.desktopAppRestrictions,
         metadata: OrganizationTable.metadata,
         createdAt: OrganizationTable.createdAt,
         updatedAt: OrganizationTable.updatedAt,
@@ -678,6 +685,7 @@ export async function listUserOrgs(userId: UserId) {
       slug: row.organization.slug,
       logo: row.organization.logo,
       allowedEmailDomains: normalizeStoredAllowedEmailDomains(row.organization.allowedEmailDomains),
+      desktopAppRestrictions: normalizeDesktopAppRestrictions(row.organization.desktopAppRestrictions),
       metadata: serializeOrganizationMetadata(row.organization.metadata),
     role: row.role,
     orgMemberId: row.membershipId,
@@ -796,6 +804,7 @@ export async function getOrganizationContextForUser(input: {
         slug: organization.slug,
         logo: organization.logo,
         allowedEmailDomains: normalizeStoredAllowedEmailDomains(organization.allowedEmailDomains),
+        desktopAppRestrictions: normalizeDesktopAppRestrictions(organization.desktopAppRestrictions),
         metadata: serializeOrganizationMetadata(organization.metadata),
         createdAt: organization.createdAt,
         updatedAt: organization.updatedAt,

--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
+import { desktopConfigSchema, env } from "../../env.js"
 import { requireUserMiddleware, resolveUserOrganizationsMiddleware, type UserOrganizationsContext } from "../../middleware/index.js"
 import { denTypeIdSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
@@ -18,6 +19,10 @@ const meOrganizationsResponseSchema = z.object({
   activeOrgId: denTypeIdSchema("organization").nullable(),
   activeOrgSlug: z.string().nullable(),
 }).meta({ ref: "CurrentUserOrganizationsResponse" })
+
+const meDesktopConfigResponseSchema = desktopConfigSchema.meta({
+  ref: "CurrentUserDesktopConfigResponse",
+})
 
 export function registerMeRoutes<T extends { Variables: AuthContextVariables & Partial<UserOrganizationsContext> }>(app: Hono<T>) {
   app.get(
@@ -62,6 +67,23 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
       activeOrgId: c.get("activeOrganizationId") ?? null,
       activeOrgSlug: c.get("activeOrganizationSlug") ?? null,
     })
+    },
+  )
+
+  app.get(
+    "/v1/me/desktop-config",
+    describeRoute({
+      tags: ["Users"],
+      summary: "Get current user's desktop config",
+      description: "Returns the authenticated desktop config payload for the current user session. Today this is backed by Den API config and will later resolve org-specific desktop settings.",
+      responses: {
+        200: jsonResponse("Current user desktop config returned successfully.", meDesktopConfigResponseSchema),
+        401: jsonResponse("The caller must be signed in to read desktop config.", unauthorizedSchema),
+      },
+    }),
+    requireUserMiddleware,
+    (c) => {
+      return c.json(env.desktopConfig)
     },
   )
 }

--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -1,8 +1,8 @@
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
+import { desktopAppRestrictionsSchema } from "@openwork/types/den/desktop-app-restrictions"
 import { z } from "zod"
-import { desktopConfigSchema, env } from "../../env.js"
-import { requireUserMiddleware, resolveUserOrganizationsMiddleware, type UserOrganizationsContext } from "../../middleware/index.js"
+import { requireUserMiddleware, resolveOrganizationContextMiddleware, resolveUserOrganizationsMiddleware, type OrganizationContextVariables, type UserOrganizationsContext } from "../../middleware/index.js"
 import { denTypeIdSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 
@@ -20,11 +20,11 @@ const meOrganizationsResponseSchema = z.object({
   activeOrgSlug: z.string().nullable(),
 }).meta({ ref: "CurrentUserOrganizationsResponse" })
 
-const meDesktopConfigResponseSchema = desktopConfigSchema.meta({
+const meDesktopConfigResponseSchema = desktopAppRestrictionsSchema.meta({
   ref: "CurrentUserDesktopConfigResponse",
 })
 
-export function registerMeRoutes<T extends { Variables: AuthContextVariables & Partial<UserOrganizationsContext> }>(app: Hono<T>) {
+export function registerMeRoutes<T extends { Variables: AuthContextVariables & Partial<UserOrganizationsContext> & Partial<OrganizationContextVariables> }>(app: Hono<T>) {
   app.get(
     "/v1/me",
     describeRoute({
@@ -75,15 +75,16 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
     describeRoute({
       tags: ["Users"],
       summary: "Get current user's desktop config",
-      description: "Returns the authenticated desktop config payload for the current user session. Today this is backed by Den API config and will later resolve org-specific desktop settings.",
+      description: "Returns the authenticated desktop app restrictions for the caller's active organization.",
       responses: {
         200: jsonResponse("Current user desktop config returned successfully.", meDesktopConfigResponseSchema),
         401: jsonResponse("The caller must be signed in to read desktop config.", unauthorizedSchema),
       },
     }),
     requireUserMiddleware,
+    resolveOrganizationContextMiddleware,
     (c) => {
-      return c.json(env.desktopConfig)
+      return c.json(c.get("organizationContext").organization.desktopAppRestrictions)
     },
   )
 }

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -1,5 +1,6 @@
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable } from "@openwork-ee/den-db/schema"
+import { desktopAppRestrictionsSchema } from "@openwork/types/den/desktop-app-restrictions"
 import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
@@ -30,7 +31,8 @@ const createOrganizationSchema = z.object({
 const updateOrganizationSchema = z.object({
   name: z.string().trim().min(2).max(120).optional(),
   allowedEmailDomains: z.array(z.string().trim().min(1).max(255)).max(100).nullable().optional(),
-}).refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined, {
+  desktopAppRestrictions: desktopAppRestrictionsSchema.optional(),
+}).refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined || value.desktopAppRestrictions !== undefined, {
   message: "Provide at least one organization field to update.",
 })
 
@@ -303,7 +305,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     describeRoute({
       tags: ["Organizations"],
       summary: "Update organization",
-      description: "Updates organization fields that workspace owners are allowed to change, including the display name and allowed invitation email domains. The slug is immutable to avoid breaking dashboard URLs.",
+      description: "Updates organization fields that workspace owners are allowed to change, including the display name, allowed invitation email domains, and desktop app restrictions. The slug is immutable to avoid breaking dashboard URLs.",
       responses: {
         200: jsonResponse("Organization updated successfully.", organizationResponseSchema),
         400: jsonResponse("The organization update request body was invalid or contained malformed email domains.", invalidEmailDomainSchema),
@@ -340,6 +342,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         organizationId: payload.organization.id,
         name: input.name,
         allowedEmailDomains: normalizedDomains.domains,
+        desktopAppRestrictions: input.desktopAppRestrictions,
       })
 
       if (!updated) {

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -1,3 +1,7 @@
+import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions";
+
+export type DenDesktopAppRestrictions = DesktopAppRestrictions;
+
 export type DenOrgSummary = {
   id: string;
   name: string;
@@ -108,6 +112,7 @@ export type DenOrgContext = {
     slug: string;
     logo: string | null;
     allowedEmailDomains: string[] | null;
+    desktopAppRestrictions: DenDesktopAppRestrictions;
     metadata: string | null;
     createdAt: string | null;
     updatedAt: string | null;
@@ -165,6 +170,10 @@ function asStringArray(value: unknown): string[] | null {
   }
 
   return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function asDesktopAppRestrictions(value: unknown): DenDesktopAppRestrictions {
+  return normalizeDesktopAppRestrictions(value);
 }
 
 function parsePermissionRecord(value: unknown): Record<string, string[]> {
@@ -520,6 +529,7 @@ export function parseOrgContextPayload(payload: unknown): DenOrgContext | null {
       slug: organizationSlug,
       logo: asString(organization.logo),
       allowedEmailDomains: asStringArray(organization.allowedEmailDomains),
+      desktopAppRestrictions: asDesktopAppRestrictions(organization.desktopAppRestrictions),
       metadata: asString(organization.metadata),
       createdAt: asIsoString(organization.createdAt),
       updatedAt: asIsoString(organization.updatedAt),

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
@@ -23,10 +23,12 @@ function normalizeAllowedEmailDomainsInput(value: string): string[] | null {
 }
 
 function SettingsToggle({
+  label,
   checked,
   disabled,
   onChange,
 }: {
+  label: string;
   checked: boolean;
   disabled?: boolean;
   onChange: (nextValue: boolean) => void;
@@ -36,7 +38,7 @@ function SettingsToggle({
       type="button"
       role="switch"
       aria-checked={checked}
-      aria-label="Restrict allowed email domains"
+      aria-label={label}
       disabled={disabled}
       onClick={() => onChange(!checked)}
       className={[
@@ -71,6 +73,9 @@ export function OrgSettingsScreen() {
   const [allowedDomainsDraft, setAllowedDomainsDraft] = useState("");
   const [domainRestrictionsEnabled, setDomainRestrictionsEnabled] =
     useState(false);
+  const [allowNonCloudModelsEnabled, setAllowNonCloudModelsEnabled] = useState(true);
+  const [allowZenModelEnabled, setAllowZenModelEnabled] = useState(true);
+  const [allowMultipleWorkspacesEnabled, setAllowMultipleWorkspacesEnabled] = useState(true);
   const [domainEditModeEnabled, setDomainEditModeEnabled] = useState(false);
   const [pageError, setPageError] = useState<string | null>(null);
   const [pageSuccess, setPageSuccess] = useState<string | null>(null);
@@ -78,6 +83,8 @@ export function OrgSettingsScreen() {
 
   const currentAllowedDomains =
     orgContext?.organization.allowedEmailDomains ?? null;
+  const currentDesktopAppRestrictions =
+    orgContext?.organization.desktopAppRestrictions ?? {};
   const isOwner = orgContext?.currentMember.isOwner ?? false;
   const draftAllowedDomains = useMemo(
     () => normalizeAllowedEmailDomainsInput(allowedDomainsDraft),
@@ -96,6 +103,15 @@ export function OrgSettingsScreen() {
     );
     setDomainRestrictionsEnabled(
       (orgContext.organization.allowedEmailDomains?.length ?? 0) > 0,
+    );
+    setAllowNonCloudModelsEnabled(
+      orgContext.organization.desktopAppRestrictions.disallowNonCloudModels !== true,
+    );
+    setAllowZenModelEnabled(
+      orgContext.organization.desktopAppRestrictions.blockZenModel !== true,
+    );
+    setAllowMultipleWorkspacesEnabled(
+      orgContext.organization.desktopAppRestrictions.blockMultipleWorkspaces !== true,
     );
     setDomainEditModeEnabled(false);
   }, [orgContext]);
@@ -170,6 +186,11 @@ export function OrgSettingsScreen() {
         allowedEmailDomains: domainRestrictionsEnabled
           ? draftAllowedDomains
           : null,
+        desktopAppRestrictions: {
+          ...(!allowNonCloudModelsEnabled ? { disallowNonCloudModels: true } : {}),
+          ...(!allowZenModelEnabled ? { blockZenModel: true } : {}),
+          ...(!allowMultipleWorkspacesEnabled ? { blockMultipleWorkspaces: true } : {}),
+        },
       });
       setDomainEditModeEnabled(false);
       setPageSuccess("Workspace settings updated.");
@@ -268,6 +289,7 @@ export function OrgSettingsScreen() {
                 {domainRestrictionsEnabled ? "On" : "Off"}
               </span>
               <SettingsToggle
+                label="Restrict allowed email domains"
                 checked={domainRestrictionsEnabled}
                 disabled={
                   !isOwner || (domainRestrictionsEnabled && hasDraftDomains)
@@ -332,6 +354,79 @@ export function OrgSettingsScreen() {
               </div>
             </div>
           ) : null}
+        </DenCard>
+
+        <DenCard size="spacious" className="grid gap-6">
+          <div className="grid gap-2">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+              Desktop app
+            </p>
+            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
+              Desktop restrictions
+            </h2>
+            <p className="text-[14px] text-gray-500">
+              Control which desktop-only options remain available after people sign in to this workspace.
+            </p>
+          </div>
+
+          <div className="grid gap-4">
+            <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
+              <div className="grid gap-1 pr-4">
+                <p className="text-[15px] font-medium text-gray-900">
+                  Allow non-cloud deployed models
+                </p>
+                <p className="text-[13px] text-gray-500">
+                  Let signed-in desktop users access models that are not deployed through OpenWork Cloud.
+                </p>
+              </div>
+              <SettingsToggle
+                label="Allow non-cloud deployed models"
+                checked={allowNonCloudModelsEnabled}
+                disabled={!isOwner}
+                onChange={setAllowNonCloudModelsEnabled}
+              />
+            </div>
+
+            <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
+              <div className="grid gap-1 pr-4">
+                <p className="text-[15px] font-medium text-gray-900">
+                  Allow usage of OpenCode Zen model
+                </p>
+                <p className="text-[13px] text-gray-500">
+                  Let signed-in desktop users access the OpenCode Zen model in the desktop app.
+                </p>
+              </div>
+              <SettingsToggle
+                label="Allow usage of OpenCode Zen model"
+                checked={allowZenModelEnabled}
+                disabled={!isOwner}
+                onChange={setAllowZenModelEnabled}
+              />
+            </div>
+
+            <div className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
+              <div className="grid gap-1 pr-4">
+                <p className="text-[15px] font-medium text-gray-900">
+                  Allow users to configure multiple workspaces
+                </p>
+                <p className="text-[13px] text-gray-500">
+                  Let signed-in desktop users create or manage more than one workspace on their machine.
+                </p>
+              </div>
+              <SettingsToggle
+                label="Allow users to configure multiple workspaces"
+                checked={allowMultipleWorkspacesEnabled}
+                disabled={!isOwner}
+                onChange={setAllowMultipleWorkspacesEnabled}
+              />
+            </div>
+
+            {Object.keys(currentDesktopAppRestrictions).length === 0 ? (
+              <p className="text-[13px] text-gray-500">
+                No desktop restrictions are configured yet. Leaving every toggle on stores an empty config object and keeps the desktop defaults.
+              </p>
+            ) : null}
+          </div>
         </DenCard>
 
         <div className="flex flex-wrap items-center justify-between gap-3">

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
@@ -11,6 +11,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useDenFlow } from "../../../../_providers/den-flow-provider";
 import { getErrorMessage, getOrgLimitError, requestJson } from "../../../../_lib/den-flow";
 import {
+  type DenDesktopAppRestrictions,
   type DenOrgContext,
   type DenOrgSummary,
   getOrgDashboardRoute,
@@ -30,7 +31,7 @@ type OrgDashboardContextValue = {
   refreshOrgData: () => Promise<void>;
   createOrganization: (name: string) => Promise<void>;
   updateOrganizationName: (name: string) => Promise<void>;
-  updateOrganizationSettings: (input: { name?: string; allowedEmailDomains?: string[] | null }) => Promise<void>;
+  updateOrganizationSettings: (input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions }) => Promise<void>;
   switchOrganization: (slug: string) => void;
   inviteMember: (input: { email: string; role: string }) => Promise<void>;
   cancelInvitation: (invitationId: string) => Promise<void>;
@@ -250,8 +251,8 @@ export function OrgDashboardProvider({
     await updateOrganizationSettings({ name: trimmed });
   }
 
-  async function updateOrganizationSettings(input: { name?: string; allowedEmailDomains?: string[] | null }) {
-    const body: { name?: string; allowedEmailDomains?: string[] | null } = {};
+  async function updateOrganizationSettings(input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions }) {
+    const body: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions } = {};
     if (typeof input.name === "string") {
       const trimmed = input.name.trim();
       if (!trimmed) {
@@ -261,6 +262,9 @@ export function OrgDashboardProvider({
     }
     if (input.allowedEmailDomains !== undefined) {
       body.allowedEmailDomains = input.allowedEmailDomains;
+    }
+    if (input.desktopAppRestrictions !== undefined) {
+      body.desktopAppRestrictions = input.desktopAppRestrictions;
     }
 
     await runMutation("update-organization-name", async () => {

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@openwork/types": "workspace:*",
     "@openwork-ee/utils": "workspace:*",
     "@openwork/ui": "workspace:*",
     "@paper-design/shaders-react": "0.0.72",

--- a/ee/packages/den-db/drizzle/0013_desktop_app_restrictions.sql
+++ b/ee/packages/den-db/drizzle/0013_desktop_app_restrictions.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `organization`
+ADD COLUMN `desktop_app_restrictions` json NOT NULL DEFAULT (json_object());

--- a/ee/packages/den-db/drizzle/meta/_journal.json
+++ b/ee/packages/den-db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776628833797,
       "tag": "0012_allowed_email_domains",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "5",
+      "when": 1776632400000,
+      "tag": "0013_desktop_app_restrictions",
+      "breakpoints": true
     }
   ]
 }

--- a/ee/packages/den-db/package.json
+++ b/ee/packages/den-db/package.json
@@ -60,6 +60,7 @@
     "db:push": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts"
   },
   "dependencies": {
+    "@openwork/types": "workspace:*",
     "@openwork-ee/utils": "workspace:*",
     "@planetscale/database": "^1.19.0",
     "drizzle-orm": "^0.45.1",

--- a/ee/packages/den-db/src/schema/org.ts
+++ b/ee/packages/den-db/src/schema/org.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from "drizzle-orm"
 import { index, json, mysqlTable, text, timestamp, uniqueIndex, varchar } from "drizzle-orm/mysql-core"
+import type { DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions"
 import { denTypeIdColumn } from "../columns"
 
 export const DesktopHandoffGrantTable = mysqlTable(
@@ -26,6 +27,7 @@ export const OrganizationTable = mysqlTable(
     slug: varchar("slug", { length: 255 }).notNull(),
     logo: varchar("logo", { length: 2048 }),
     allowedEmailDomains: json("allowed_email_domains").$type<string[] | null>(),
+    desktopAppRestrictions: json("desktop_app_restrictions").$type<DesktopAppRestrictions>().notNull().default(sql`(json_object())`),
     metadata: json("metadata").$type<Record<string, unknown> | null>(),
     createdAt: timestamp("created_at", { fsp: 3 }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { fsp: 3 })

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@openwork/types",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "development": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./den/desktop-app-restrictions": {
+      "types": "./src/den/desktop-app-restrictions.ts",
+      "development": "./src/den/desktop-app-restrictions.ts",
+      "default": "./src/den/desktop-app-restrictions.ts"
+    }
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/types/src/den/desktop-app-restrictions.ts
+++ b/packages/types/src/den/desktop-app-restrictions.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+
+export const desktopAppRestrictionsSchema = z.object({
+  disallowNonCloudModels: z.boolean().optional(),
+  blockZenModel: z.boolean().optional(),
+  blockMultipleWorkspaces: z.boolean().optional(),
+}).meta({ ref: "DenDesktopAppRestrictions" })
+
+export type DesktopAppRestrictions = z.infer<typeof desktopAppRestrictionsSchema>
+
+export function normalizeDesktopAppRestrictions(value: unknown): DesktopAppRestrictions {
+  const parsed = desktopAppRestrictionsSchema.safeParse(value)
+  if (parsed.success) {
+    return {
+      ...(parsed.data.disallowNonCloudModels === true ? { disallowNonCloudModels: true } : {}),
+      ...(parsed.data.blockZenModel === true ? { blockZenModel: true } : {}),
+      ...(parsed.data.blockMultipleWorkspaces === true ? { blockMultipleWorkspaces: true } : {}),
+    }
+  }
+
+  const legacy = value as {
+    models?: {
+      removeZen?: unknown
+    }
+  } | null
+
+  return {
+    ...(legacy?.models?.removeZen === true ? { blockZenModel: true } : {}),
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./den/desktop-app-restrictions"

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    "den/desktop-app-restrictions": "src/den/desktop-app-restrictions.ts",
+  },
+  tsconfig: "./tsconfig.json",
+  format: ["esm"],
+  dts: {
+    tsconfig: "./tsconfig.json",
+  },
+  clean: true,
+  target: "es2022",
+  platform: "neutral",
+  sourcemap: false,
+  splitting: false,
+  treeshake: true,
+  external: ["zod"],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.4.9
         version: 1.4.9
+      '@openwork/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@openwork/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -483,6 +486,9 @@ importers:
       '@openwork-ee/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@openwork/types':
+        specifier: workspace:*
+        version: link:../../../packages/types
       '@standard-community/standard-json':
         specifier: ^0.3.5
         version: 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod@4.3.6)
@@ -532,6 +538,9 @@ importers:
       '@openwork-ee/utils':
         specifier: workspace:*
         version: link:../../packages/utils
+      '@openwork/types':
+        specifier: workspace:*
+        version: link:../../../packages/types
       '@openwork/ui':
         specifier: workspace:*
         version: link:../../../packages/ui
@@ -661,6 +670,9 @@ importers:
       '@openwork-ee/utils':
         specifier: workspace:*
         version: link:../utils
+      '@openwork/types':
+        specifier: workspace:*
+        version: link:../../../packages/types
       '@planetscale/database':
         specifier: ^1.19.0
         version: 1.19.0
@@ -724,6 +736,19 @@ importers:
       '@hey-api/openapi-ts':
         specifier: 0.95.0
         version: 0.95.0(typescript@5.9.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  packages/types:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3

--- a/prds/openwork-desktop-bootstrap-config/desktop-bootstrap-and-org-runtime-config.md
+++ b/prds/openwork-desktop-bootstrap-config/desktop-bootstrap-and-org-runtime-config.md
@@ -1,0 +1,296 @@
+# OpenWork Desktop Bootstrap And Org Runtime Config
+
+## Goal
+
+Support three desktop distribution modes while still allowing all of them to update from the default app build:
+
+1. Default build pointing at the default OpenWork server with no forced sign-in.
+2. Custom build pointing at the default OpenWork server with forced sign-in.
+3. Custom build pointing at a client-specific server with forced sign-in.
+
+After install, the desktop app should preserve its initial server/sign-in behavior across app updates, then fetch org-specific runtime config from the server after the user signs in.
+
+## Non-Goals
+
+- No server-wide default desktop config.
+- No anonymous org config fetch before sign-in.
+- No attempt to make the web build own persisted bootstrap state.
+
+## Product Decision
+
+Use two config layers only:
+
+1. `bootstrap config`
+2. `org runtime config`
+
+### Bootstrap config
+
+Bootstrap config is install-level configuration. It is set by the app build, then persisted locally by the desktop app so it survives future updates.
+
+It contains only:
+
+- `server.baseUrl`
+- `server.apiBaseUrl` if needed
+- `requireSignin`
+
+Bootstrap config decides startup behavior before normal app UI renders.
+
+### Current `apps/app` locations
+
+Today, the main Den bootstrap URL logic in `apps/app` lives in:
+
+- `_repos/openwork/_worktrees/Desktop-config-den-endpoint/apps/app/src/app/lib/den.ts`
+
+Specifically:
+
+- `DEFAULT_DEN_BASE_URL` is sourced from `import.meta.env.VITE_DEN_BASE_URL`
+- the stored Den API URL is tracked as `apiBaseUrl`
+- `resolveDenBaseUrls(...)` derives or resolves both the user-facing Den base URL and the API base URL
+- `readDenSettings()` and `writeDenSettings()` are the current read/write path for persisted Den URL state
+
+This PRD assumes that the future bootstrap-config implementation will either extend this location or replace it with a more durable desktop-owned persisted config source, while keeping `apps/app` as the consumer of that state.
+
+## Ownership model
+
+For the update-safe version of this system, `apps/app` should not be the source of truth for bootstrap config.
+
+Instead:
+
+- the desktop shell owns persisted bootstrap config
+- `apps/app` consumes resolved bootstrap config
+- build-time env values are only used to seed first launch
+
+This means `apps/app` should stop treating `VITE_DEN_BASE_URL` or browser-side persisted URL state as authoritative in desktop mode after bootstrap config has been created.
+
+## How config should be passed into `apps/app`
+
+Recommended flow:
+
+1. The desktop shell starts first.
+2. It loads persisted bootstrap config from desktop app data.
+3. If no persisted bootstrap config exists yet, it seeds one from build-time defaults.
+4. The desktop shell passes the resolved bootstrap config into `apps/app` before normal UI startup completes.
+5. `apps/app` uses that resolved config for Den base URL, API base URL, and `requireSignin`.
+
+Recommended interface:
+
+- `getBootstrapConfig()`
+- `setBootstrapConfig()` if editing is allowed
+
+This can be implemented with a Tauri command, a shell-injected bootstrap object, or another desktop-owned bridge. The important part is that the desktop shell is the owner and `apps/app` is the consumer.
+
+## Build-time environment variables
+
+The desktop app supports build-time bootstrap seeding for custom distributions.
+
+Preferred desktop build variables:
+
+- `OPENWORK_DESKTOP_DEN_BASE_URL`
+- `OPENWORK_DESKTOP_DEN_API_BASE_URL`
+- `OPENWORK_DESKTOP_DEN_REQUIRE_SIGNIN`
+
+Fallback variables currently recognized by the app and desktop build:
+
+- `VITE_DEN_BASE_URL`
+- `VITE_DEN_API_BASE_URL`
+- `VITE_DEN_REQUIRE_SIGNIN`
+
+These values are baked into the desktop build as the initial bootstrap seed. After launch, the desktop shell resolves the effective bootstrap config using the external bootstrap file and any persisted bootstrap state.
+
+### Example
+
+```bash
+OPENWORK_DESKTOP_DEN_BASE_URL="https://client.example.com" \
+OPENWORK_DESKTOP_DEN_API_BASE_URL="https://client.example.com/api/den" \
+OPENWORK_DESKTOP_DEN_REQUIRE_SIGNIN="1" \
+pnpm --filter @openwork/desktop build
+```
+
+### Accepted boolean values
+
+`OPENWORK_DESKTOP_DEN_REQUIRE_SIGNIN` and `VITE_DEN_REQUIRE_SIGNIN` are treated as enabled when set to one of:
+
+- `1`
+- `true`
+- `yes`
+- `on`
+
+## Update-safe bootstrap behavior
+
+To preserve custom builds across updates:
+
+1. A one-time custom build ships with seed values such as server URL and `requireSignin`.
+2. On first launch, the desktop shell copies those seed values into persisted desktop app data.
+3. Future app updates may install the default build artifacts.
+4. On next launch, the desktop shell reads the previously persisted bootstrap config instead of reusing the default build values.
+5. `apps/app` receives the persisted bootstrap config and starts with the correct URLs and sign-in behavior.
+
+This ensures that updates do not silently reset a client build back to the default server or disable forced sign-in.
+
+## Storage boundary
+
+Bootstrap config should live outside the bundled web app and outside browser-only storage.
+
+Recommended location:
+
+- Tauri-side persisted store or app-data file
+
+For the current external bootstrap-file approach, the desktop shell should look for `desktop-bootstrap.json` in the host config directory under `OpenWork/`, unless an explicit override path is provided with `OPENWORK_DESKTOP_BOOTSTRAP_PATH`.
+
+Expected default locations:
+
+- macOS: `~/Library/Application Support/OpenWork/desktop-bootstrap.json`
+- Linux: `~/.config/OpenWork/desktop-bootstrap.json`
+- Windows: `%AppData%\OpenWork\desktop-bootstrap.json`
+
+Avoid using browser `localStorage` as the long-term source of truth for install identity in desktop mode.
+
+`localStorage` may still be used as a compatibility layer or temporary cache inside `apps/app`, but the authoritative desktop bootstrap config should live in shell-owned persisted storage.
+
+## Desktop startup contract
+
+In desktop mode, startup should behave like this:
+
+1. shell loads bootstrap config
+2. shell returns bootstrap config to `apps/app`
+3. `apps/app` initializes URL resolution from shell-provided values
+4. `apps/app` applies `requireSignin` before rendering normal UI
+5. signed-in flows then fetch org runtime config
+
+In web mode, `apps/app` can continue using its existing env-based defaults because there is no desktop shell layer.
+
+### Org runtime config
+
+Org runtime config is authenticated, org-specific configuration fetched from the server after sign-in.
+
+Initial examples:
+
+- `disallowNonCloudModels`
+- `blockZenModel`
+- `blockMultipleWorkspaces`
+
+Org runtime config should use sparse negative restriction keys. An empty object means the desktop app keeps its normal default behavior.
+
+In the cloud admin UI, these restrictions may be presented as positive capability toggles for clarity. For example, the UI can show `Allow non-cloud deployed models`, while the stored config saves `disallowNonCloudModels: true` only when that capability is turned off.
+
+This config is cached locally, applied in memory while the app runs, and refreshed from the server over time.
+
+## Why this split exists
+
+Builds 2 and 3 will only be built once, but later update using artifacts from build 1. That means any important startup behavior cannot live only in the bundled web app or binary defaults.
+
+So:
+
+- build-time config seeds the first launch
+- the desktop shell persists bootstrap config locally
+- later updates read that persisted bootstrap config instead of replacing it
+
+This preserves custom server targeting and forced sign-in across updates.
+
+## Required behavior
+
+### Startup
+
+On desktop app start:
+
+1. Load persisted bootstrap config.
+2. Use it to resolve the Den server / API base.
+3. If `requireSignin` is true and there is no valid signed-in session, show a blocking full-screen sign-in screen before rendering normal app UI.
+4. If the user is signed in, load cached org runtime config immediately.
+5. Fetch fresh org runtime config from the server.
+6. Apply fresh config in memory when it arrives.
+
+### Refresh triggers for org runtime config
+
+The app should download org runtime config:
+
+- on every successful sign-in
+- on every app start when the user is already signed in
+- every 1 hour while the app is running
+
+### Update behavior
+
+App updates must not overwrite persisted bootstrap config.
+
+The app should continue using the locally persisted bootstrap config after updating, even if the new binary is the default build.
+
+## Suggested storage model
+
+### Persisted desktop storage
+
+Store these values in desktop app data, not just in browser `localStorage`:
+
+- bootstrap config
+- last known org runtime config
+- metadata for the cached org config if needed, such as fetched time or org id
+
+### In-memory runtime state
+
+During app execution, maintain the current effective config in memory.
+
+Recommended merge order:
+
+1. bootstrap config
+2. cached org runtime config
+3. freshly fetched org runtime config
+
+Bootstrap config should only contain startup-critical fields. Org runtime config should control ongoing product behavior.
+
+## Server contract
+
+Server config is org-specific and authenticated.
+
+Recommended endpoint:
+
+- `GET /v1/me/desktop-config`
+
+Example response:
+
+```json
+{
+  "blockZenModel": true,
+  "blockMultipleWorkspaces": true
+}
+```
+
+`requireSignin` should not be part of this runtime payload. It belongs in bootstrap config.
+
+## Distribution modes
+
+### 1. Default build
+
+- `server.baseUrl`: default OpenWork server
+- `requireSignin`: `false`
+
+### 2. Custom build against default server
+
+- `server.baseUrl`: default OpenWork server
+- `requireSignin`: `true`
+
+### 3. Custom build against client server
+
+- `server.baseUrl`: client-specific server
+- `requireSignin`: `true`
+
+For modes 2 and 3, the build is only used to seed first launch. After that, the persisted bootstrap config is the source of truth.
+
+## UX requirements
+
+- Forced sign-in must block normal app UI until a valid session exists.
+- Manual navigation to other routes while forced sign-in is active should redirect back to the sign-in screen.
+- Once signed in, the app can load and apply org runtime config.
+- If cached org runtime config exists, the app may use it immediately while refreshing in the background.
+
+## Open implementation notes
+
+- Prefer a Tauri-side persisted store or app-data file for bootstrap config instead of relying on web storage alone.
+- The desktop shell should own persisted bootstrap state; the web UI should consume it.
+- If org changes matter for config, the cache key should include org identity.
+- If the org runtime config fetch fails, keep using the last known cached config when available.
+
+## Success criteria
+
+- A custom build can point at a custom server, update from the default release artifacts, and still keep its server target and forced sign-in behavior.
+- Forced sign-in works before normal UI renders.
+- Org runtime config is refreshed on sign-in, startup, and hourly.
+- Model-related config can change over time without rebuilding the app.


### PR DESCRIPTION
## Summary
- persist desktop bootstrap config outside the app bundle so Den base URLs and forced sign-in survive relaunches, default-build updates, and externally managed `desktop-bootstrap.json` deployment
- add authenticated org-owned desktop app restrictions stored on `organization.desktop_app_restrictions`, expose them from `GET /v1/me/desktop-config`, and manage them from the cloud org settings UI with positive capability toggles
- stabilize desktop cloud sign-in and org selection by auto-recovering missing active org state after sign-in/session restore and preventing the repeated org-refresh loop in the Cloud settings panel

## Testing
- `pnpm --filter @openwork/types build`
- `pnpm --filter @openwork-ee/den-api build`
- `pnpm --filter @openwork/app build`
- `cargo check` (in `apps/desktop/src-tauri`)
- Chrome DevTools MCP verification against the local Den Docker stack: sign-up, create org, toggle desktop restrictions in Org Settings, verify `GET /api/den/v1/me/desktop-config`, and confirm MySQL persisted `desktop_app_restrictions`
- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit`

## Notes
- `packages/types/src/den/desktop-app-restrictions.ts` is now the shared contract source for den-api, den-db, den-web, and the desktop app.
- External bootstrap file locations default to the host config directory (for example `~/Library/Application Support/OpenWork/desktop-bootstrap.json` on macOS) and can be overridden with `OPENWORK_DESKTOP_BOOTSTRAP_PATH`.
- `ee/apps/den-web/next-env.d.ts` remains intentionally uncommitted because it is generated by local Next dev.