### PR TITLE
docs: make get started app-first and add missing languages page

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -37,8 +37,19 @@
               "start-here/do-work-with-it/share-your-setup"
             ]
           },
-          "start-here/self-host",
-          "start-here/missing-docs"
+          {
+            "group": "Self-host",
+            "pages": [
+              "start-here/self-host"
+            ]
+          },
+          {
+            "group": "Help improve OpenWork",
+            "pages": [
+              "start-here/missing-docs",
+              "start-here/missing-languages"
+            ]
+          }
         ]
       },
       {

--- a/packages/docs/start-here/get-started.mdx
+++ b/packages/docs/start-here/get-started.mdx
@@ -3,11 +3,11 @@ title: "Get started"
 description: "Privacy-first, open-source alternative to Claude Cowork."
 ---
 
-Our [app](https://openworklabs.com/download) lets you use any LLM, Skill and Plugin and share the setup with your team.
+Most people should start with the [OpenWork app](https://openworklabs.com/download). It lets you use any LLM, skill, and plugin locally, then share that setup when you are ready.
 
 ## Start
 
-Get started by connecting your LLM provider of choice and send your first message:
+Get started by connecting your LLM provider of choice and sending your first message:
 
 <CardGroup cols={3}>
   <Card title="Connect a provider" icon="plug" href="/start-here/connect-your-stack/sign-in-with-chatgpt">
@@ -21,9 +21,16 @@ Get started by connecting your LLM provider of choice and send your first messag
   </Card>
 </CardGroup>
 
-## For teams
+## Choose your setup
 
-[OpenWork Cloud →](/cloud/get-started) shared workspaces, org skill hubs, managed providers, RBAC.
+<CardGroup cols={2}>
+  <Card title="Download OpenWork" icon="download" href="https://openworklabs.com/download">
+    Start with the desktop app if you want to connect providers, add MCP servers, and run tasks right away.
+  </Card>
+  <Card title="OpenWork Cloud" icon="users" href="/cloud/get-started">
+    Use hosted workers, shared workspaces, org skill hubs, managed providers, and RBAC when you need a team setup.
+  </Card>
+</CardGroup>
 
 ## Self-hosting
 
@@ -32,4 +39,4 @@ If you're an enterprise looking for support in a private deployment, check out [
 
 ---
 
-[GitHub](https://github.com/different-ai/openwork) · [Changelog](/changelog) · [Product Roadmap](/roadmap) · [Missing docs](/start-here/missing-docs)
+[GitHub](https://github.com/different-ai/openwork) · [Changelog](/changelog) · [Product Roadmap](/roadmap) · [Missing docs](/start-here/missing-docs) · [Missing languages](/start-here/missing-languages)

--- a/packages/docs/start-here/get-started.mdx
+++ b/packages/docs/start-here/get-started.mdx
@@ -3,7 +3,7 @@ title: "Get started"
 description: "Privacy-first, open-source alternative to Claude Cowork."
 ---
 
-Most people should start with the [OpenWork app](https://openworklabs.com/download). It lets you use any LLM, skill, and plugin locally, then share that setup when you are ready.
+Most people should start with the [OpenWork app](https://openworklabs.com/download). It lets you use any LLM, skill, and plugin locally, then share that setup with your team when you are ready.
 
 ## Start
 
@@ -25,13 +25,13 @@ Get started by connecting your LLM provider of choice and sending your first mes
 
 <CardGroup cols={3}>
   <Card title="Download OpenWork" icon="download" href="https://openworklabs.com/download">
-    Start with the desktop app if you want to connect providers, add MCP servers, and run tasks right away.
+    Start with the desktop app, connect providers, add MCP servers, and run tasks right away.
   </Card>
   <Card title="OpenWork Cloud" icon="users" href="/cloud/get-started">
-    Use hosted workers, shared workspaces, org skill hubs, managed providers, and RBAC when you need a team setup.
+    Meant for teams: Shared workspaces, org skill hubs, hosted workers, and managed LLM providers.
   </Card>
   <Card title="Enterprise" icon="building" href="/cloud/enterprise">
-    Go straight to the enterprise deployment and support path if you need a private rollout or custom requirements.
+    Get support with an enterprise deployment if you need a private rollout or custom requirements.
   </Card>
 </CardGroup>
 

--- a/packages/docs/start-here/get-started.mdx
+++ b/packages/docs/start-here/get-started.mdx
@@ -23,19 +23,17 @@ Get started by connecting your LLM provider of choice and sending your first mes
 
 ## Choose your setup
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Download OpenWork" icon="download" href="https://openworklabs.com/download">
     Start with the desktop app if you want to connect providers, add MCP servers, and run tasks right away.
   </Card>
   <Card title="OpenWork Cloud" icon="users" href="/cloud/get-started">
     Use hosted workers, shared workspaces, org skill hubs, managed providers, and RBAC when you need a team setup.
   </Card>
+  <Card title="Enterprise" icon="building" href="/cloud/enterprise">
+    Go straight to the enterprise deployment and support path if you need a private rollout or custom requirements.
+  </Card>
 </CardGroup>
-
-## Self-hosting
-
-The first step for self-hosting is to [Start the CLI](/start-here/self-host). 
-If you're an enterprise looking for support in a private deployment, check out [Enterprise](/cloud/enterprise) or [book a call directly](https://cal.com/team/openwork/enterprise).
 
 ---
 

--- a/packages/docs/start-here/missing-languages.mdx
+++ b/packages/docs/start-here/missing-languages.mdx
@@ -1,0 +1,37 @@
+---
+title: "Missing languages"
+description: "See which OpenWork languages ship today and help us improve them."
+---
+
+Want to help OpenWork speak more languages? Start here.
+
+<Frame>
+  <iframe
+    width="100%"
+    height="400"
+    src="https://www.youtube.com/embed/orGF117Snu8"
+    title="OpenWork missing languages overview"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</Frame>
+
+## Languages available today
+
+OpenWork currently ships with these app languages:
+
+- English (`en`)
+- Japanese (`ja`)
+- Simplified Chinese (`zh`)
+- Vietnamese (`vi`)
+- Portuguese (Brazil) (`pt-BR`)
+- Thai (`th`)
+- French (`fr`)
+- Catalan (`ca`)
+- Spanish (`es`)
+
+## Help improve it
+
+If you spot a translation issue, want to correct copy, or want to add support for another language, open a [pull request](https://github.com/different-ai/openwork/tree/dev/apps/app/src/i18n) and we will review it.
+
+If you want to follow broader localization work, language requests, or upcoming improvements, check the [i18n roadmap](https://github.com/different-ai/openwork/issues/1385).

--- a/packages/docs/start-here/missing-languages.mdx
+++ b/packages/docs/start-here/missing-languages.mdx
@@ -3,7 +3,7 @@ title: "Missing languages"
 description: "See which OpenWork languages ship today and help us improve them."
 ---
 
-Want to help OpenWork speak more languages? Start here.
+OpenWork already ships with a growing set of languages, and we want to keep expanding that list.
 
 <Frame>
   <iframe
@@ -18,7 +18,7 @@ Want to help OpenWork speak more languages? Start here.
 
 ## Languages available today
 
-OpenWork currently ships with these app languages:
+Watch the video above for a quick overview, then use this list as the current source of truth for languages supported in the app:
 
 - English (`en`)
 - Japanese (`ja`)
@@ -30,8 +30,25 @@ OpenWork currently ships with these app languages:
 - Catalan (`ca`)
 - Spanish (`es`)
 
-## Help improve it
+## Improve current translations
 
-If you spot a translation issue, want to correct copy, or want to add support for another language, open a [pull request](https://github.com/different-ai/openwork/tree/dev/apps/app/src/i18n) and we will review it.
+If you want to improve an existing translation, start in [`apps/app/src/i18n/locales`](https://github.com/different-ai/openwork/tree/dev/apps/app/src/i18n/locales).
+
+Each language lives in its own file, so most fixes are simple copy updates inside one locale file such as `apps/app/src/i18n/locales/fr.ts` or `apps/app/src/i18n/locales/es.ts`.
+
+## Add a new language
+
+If you want to add a new language to OpenWork, the basic file changes are:
+
+- Create a new locale file in `apps/app/src/i18n/locales/<language-code>.ts`.
+- Register that locale in `apps/app/src/i18n/index.ts` by adding the import, language code, language option, and translation map entry.
+- Re-export the locale from `apps/app/src/i18n/locales/index.ts`.
+- Add the new locale code to `scripts/i18n-audit.mjs` so the audit script checks it.
+
+After that, run the audit script to spot missing keys:
+
+```bash
+node scripts/i18n-audit.mjs --missing
+```
 
 If you want to follow broader localization work, language requests, or upcoming improvements, check the [i18n roadmap](https://github.com/different-ai/openwork/issues/1385).


### PR DESCRIPTION
## Summary
- make the Start Here entrypoint app-first so the main OpenWork CTA is clearer and team/cloud guidance no longer leads the page
- move self-host into its own docs navigation group and collect docs-improvement links together
- add a Missing Languages page with the video, current locale list, PR invitation, and i18n roadmap link

## Testing
- `git diff --check`
- `node -e \"JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8')); console.log('docs.json ok')\"`

## Notes
- Docs-only change; no app/runtime flow changed.