### PR TITLE
fix(den-api): surface invite email failures instead of silently dropping

### DIFF
--- a/ee/apps/den-api/scripts/build.mjs
+++ b/ee/apps/den-api/scripts/build.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process"
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -9,8 +9,19 @@ const repoRoot = path.resolve(serviceDir, "..", "..", "..")
 const desktopPackagePath = path.join(repoRoot, "apps", "desktop", "package.json")
 const generatedVersionPath = path.join(serviceDir, "src", "generated", "app-version.ts")
 const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+const fallbackAppVersion = "0.0.0"
 
 function readDesktopVersion() {
+  if (!existsSync(desktopPackagePath)) {
+    // The Den API is built inside contexts (e.g. the Docker image used by
+    // `packaging/docker/den-dev-up.sh`) that intentionally do not ship the
+    // Tauri desktop sources. Falling back lets the container image build
+    // without copying unrelated packages; consumers that need the real
+    // version can override via DEN_API_LATEST_APP_VERSION.
+    console.warn(`Desktop package.json not found at ${desktopPackagePath}; using fallback version ${fallbackAppVersion}`)
+    return fallbackAppVersion
+  }
+
   const packageJson = JSON.parse(readFileSync(desktopPackagePath, "utf8"))
   const version = packageJson.version?.trim()
 
@@ -41,7 +52,7 @@ function run(command, args) {
   }
 }
 
-process.env.DEN_API_LATEST_APP_VERSION = readDesktopVersion()
+process.env.DEN_API_LATEST_APP_VERSION = process.env.DEN_API_LATEST_APP_VERSION || readDesktopVersion()
 writeGeneratedVersionFile(process.env.DEN_API_LATEST_APP_VERSION)
 
 run(pnpmCommand, ["run", "build:den-db"])

--- a/ee/apps/den-api/scripts/smoke-email-failures.mjs
+++ b/ee/apps/den-api/scripts/smoke-email-failures.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Standalone smoke test for the invitation-email failure paths.
+ *
+ * Run inside the den-api container (or any environment where the package has
+ * been built to `dist/`):
+ *
+ *   docker exec -e OPENWORK_DEV_MODE=0 \
+ *     openwork-den-dev-<id>-den-1 \
+ *     node ee/apps/den-api/scripts/smoke-email-failures.mjs
+ *
+ * Expected output:
+ *   [smoke] ok loops_not_configured { reason: 'loops_not_configured', ... }
+ *
+ * Add `-e LOOPS_API_KEY=bogus -e LOOPS_TRANSACTIONAL_ID_DEN_ORG_INVITE_EMAIL=bogus`
+ * to also reach the `loops_rejected` path (Loops returns 401).
+ *
+ * Intentionally side-effect free: no DB writes, no auth.
+ */
+
+const { sendDenOrganizationInvitationEmail, DenEmailSendError } = await import(
+  "../dist/email.js"
+)
+
+const recipient = process.argv[2] ?? "smoke-test@example.com"
+
+try {
+  await sendDenOrganizationInvitationEmail({
+    email: recipient,
+    inviteLink: "https://example.com/join?invite=smoke",
+    invitedByName: "Smoke Test",
+    invitedByEmail: "smoke@example.com",
+    organizationName: "Smoke Org",
+    role: "member",
+  })
+
+  if (process.env.OPENWORK_DEV_MODE === "1" || !process.env.OPENWORK_DEV_MODE) {
+    console.log("[smoke] ok dev_mode_noop (no email sent, no throw — expected)")
+    process.exit(0)
+  }
+
+  console.error("[smoke] FAIL: expected throw when Loops is not configured or rejects")
+  process.exit(1)
+} catch (error) {
+  if (!(error instanceof DenEmailSendError)) {
+    console.error("[smoke] FAIL: wrong error class:", error)
+    process.exit(1)
+  }
+
+  console.log(`[smoke] ok ${error.reason}`, {
+    reason: error.reason,
+    template: error.template,
+    recipient: error.recipient,
+    detail: error.detail,
+  })
+}

--- a/ee/apps/den-api/src/email.ts
+++ b/ee/apps/den-api/src/email.ts
@@ -2,6 +2,91 @@ import { env } from "./env.js"
 
 const LOOPS_TRANSACTIONAL_API_URL = "https://app.loops.so/api/v1/transactional"
 
+/**
+ * Error thrown when a transactional email send fails or is skipped because
+ * of misconfiguration. Handlers can inspect `.reason` to decide how to
+ * surface the failure to the caller (e.g. map to an HTTP status).
+ */
+export class DenEmailSendError extends Error {
+  readonly reason:
+    | "loops_not_configured"
+    | "loops_rejected"
+    | "loops_network"
+  readonly template: "verification" | "organization_invite"
+  readonly recipient: string
+  readonly detail?: string
+
+  constructor(input: {
+    template: DenEmailSendError["template"]
+    reason: DenEmailSendError["reason"]
+    recipient: string
+    detail?: string
+  }) {
+    super(
+      `[${input.template}] email for ${input.recipient} failed: ${input.reason}${
+        input.detail ? ` (${input.detail})` : ""
+      }`,
+    )
+    this.name = "DenEmailSendError"
+    this.reason = input.reason
+    this.template = input.template
+    this.recipient = input.recipient
+    this.detail = input.detail
+  }
+}
+
+async function postLoopsTransactional(input: {
+  transactionalId: string
+  email: string
+  dataVariables: Record<string, string>
+  template: DenEmailSendError["template"]
+}): Promise<void> {
+  let response: Response
+  try {
+    response = await fetch(LOOPS_TRANSACTIONAL_API_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.loops.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        transactionalId: input.transactionalId,
+        email: input.email,
+        dataVariables: input.dataVariables,
+      }),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    throw new DenEmailSendError({
+      template: input.template,
+      reason: "loops_network",
+      recipient: input.email,
+      detail: message,
+    })
+  }
+
+  if (response.ok) {
+    return
+  }
+
+  let detail = `status ${response.status}`
+  try {
+    const payload = (await response.json()) as { message?: string }
+    if (payload.message?.trim()) {
+      detail = payload.message
+    }
+  } catch {
+    // Ignore invalid upstream payloads.
+  }
+
+  throw new DenEmailSendError({
+    template: input.template,
+    reason: "loops_rejected",
+    recipient: input.email,
+    detail,
+  })
+}
+
 export async function sendDenVerificationEmail(input: {
   email: string
   verificationCode: string
@@ -19,45 +104,19 @@ export async function sendDenVerificationEmail(input: {
   }
 
   if (!env.loops.apiKey || !env.loops.transactionalIdDenVerifyEmail) {
-    console.warn(`[auth] verification email skipped for ${email}: Loops is not configured`)
-    return
-  }
-
-  try {
-    const response = await fetch(LOOPS_TRANSACTIONAL_API_URL, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${env.loops.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        transactionalId: env.loops.transactionalIdDenVerifyEmail,
-        email,
-        dataVariables: {
-          verificationCode,
-        },
-      }),
+    throw new DenEmailSendError({
+      template: "verification",
+      reason: "loops_not_configured",
+      recipient: email,
     })
-
-    if (response.ok) {
-      return
-    }
-
-    let detail = `status ${response.status}`
-    try {
-      const payload = (await response.json()) as { message?: string }
-      if (payload.message?.trim()) {
-        detail = payload.message
-      }
-    } catch {
-      // Ignore invalid upstream payloads.
-    }
-
-    console.warn(`[auth] failed to send verification email for ${email}: ${detail}`)
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error"
-    console.warn(`[auth] failed to send verification email for ${email}: ${message}`)
   }
+
+  await postLoopsTransactional({
+    transactionalId: env.loops.transactionalIdDenVerifyEmail,
+    email,
+    dataVariables: { verificationCode },
+    template: "verification",
+  })
 }
 
 export async function sendDenOrganizationInvitationEmail(input: {
@@ -88,47 +147,23 @@ export async function sendDenOrganizationInvitationEmail(input: {
   }
 
   if (!env.loops.apiKey || !env.loops.transactionalIdDenOrgInviteEmail) {
-    console.warn(`[auth] organization invite email skipped for ${email}: Loops is not configured`)
-    return
-  }
-
-  try {
-    const response = await fetch(LOOPS_TRANSACTIONAL_API_URL, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${env.loops.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        transactionalId: env.loops.transactionalIdDenOrgInviteEmail,
-        email,
-        dataVariables: {
-          inviteLink: input.inviteLink,
-          invitedByName: input.invitedByName,
-          invitedByEmail: input.invitedByEmail,
-          organizationName: input.organizationName,
-          role: input.role,
-        },
-      }),
+    throw new DenEmailSendError({
+      template: "organization_invite",
+      reason: "loops_not_configured",
+      recipient: email,
     })
-
-    if (response.ok) {
-      return
-    }
-
-    let detail = `status ${response.status}`
-    try {
-      const payload = (await response.json()) as { message?: string }
-      if (payload.message?.trim()) {
-        detail = payload.message
-      }
-    } catch {
-      // Ignore invalid upstream payloads.
-    }
-
-    console.warn(`[auth] failed to send organization invite email for ${email}: ${detail}`)
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error"
-    console.warn(`[auth] failed to send organization invite email for ${email}: ${message}`)
   }
+
+  await postLoopsTransactional({
+    transactionalId: env.loops.transactionalIdDenOrgInviteEmail,
+    email,
+    dataVariables: {
+      inviteLink: input.inviteLink,
+      invitedByName: input.invitedByName,
+      invitedByEmail: input.invitedByEmail,
+      organizationName: input.organizationName,
+      role: input.role,
+    },
+    template: "organization_invite",
+  })
 }

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -5,7 +5,7 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
-import { sendDenOrganizationInvitationEmail } from "../../email.js"
+import { DenEmailSendError, sendDenOrganizationInvitationEmail } from "../../email.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { getOrganizationLimitStatus } from "../../organization-limits.js"
@@ -25,6 +25,13 @@ const invitationResponseSchema = z.object({
   expiresAt: z.string().datetime(),
 }).meta({ ref: "InvitationResponse" })
 
+const invitationEmailFailedSchema = z.object({
+  error: z.literal("invitation_email_failed"),
+  reason: z.enum(["loops_not_configured", "loops_rejected", "loops_network"]),
+  message: z.string(),
+  invitationId: denTypeIdSchema("invitation"),
+}).meta({ ref: "InvitationEmailFailedError" })
+
 type InvitationId = typeof InvitationTable.$inferSelect.id
 const orgInvitationParamsSchema = orgIdParamSchema.extend(idParamSchema("invitationId", "invitation").shape)
 
@@ -34,7 +41,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Invitations"],
       summary: "Create organization invitation",
-      description: "Creates or refreshes a pending organization invitation for an email address and sends the invite email.",
+      description: "Creates or refreshes a pending organization invitation for an email address and sends the invite email. Returns 502 when the invitation row is persisted but the email provider (Loops) failed to send; the client should surface the error and give the user a retry affordance.",
       responses: {
         200: jsonResponse("Existing invitation refreshed successfully.", invitationResponseSchema),
         201: jsonResponse("Invitation created successfully.", invitationResponseSchema),
@@ -42,6 +49,7 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
         401: jsonResponse("The caller must be signed in to invite organization members.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can create or resend invitations.", forbiddenSchema),
         404: jsonResponse("The organization could not be found.", notFoundSchema),
+        502: jsonResponse("The invitation was saved but the email provider (Loops) rejected or failed to deliver it. Retry by submitting the same email again.", invitationEmailFailedSchema),
       },
     }),
     requireUserMiddleware,
@@ -125,14 +133,40 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
       })
     }
 
-    await sendDenOrganizationInvitationEmail({
-      email,
-      inviteLink: buildInvitationLink(invitationId),
-      invitedByName: user.name ?? user.email ?? "OpenWork",
-      invitedByEmail: user.email ?? "",
-      organizationName: payload.organization.name,
-      role,
-    })
+    try {
+      await sendDenOrganizationInvitationEmail({
+        email,
+        inviteLink: buildInvitationLink(invitationId),
+        invitedByName: user.name ?? user.email ?? "OpenWork",
+        invitedByEmail: user.email ?? "",
+        organizationName: payload.organization.name,
+        role,
+      })
+    } catch (error) {
+      if (error instanceof DenEmailSendError) {
+        // The invitation row is already persisted (step above). Log at error
+        // level so operators can grep, and return a 502 so the caller can
+        // render a real failure instead of a silent success. The invitation
+        // id is included so the UI can correlate and offer a direct retry.
+        console.error(
+          `[auth][invite_email_failed] organization=${payload.organization.id} invitation=${invitationId} email=${email} reason=${error.reason}${error.detail ? ` detail=${error.detail}` : ""}`,
+        )
+
+        return c.json({
+          error: "invitation_email_failed" as const,
+          reason: error.reason,
+          message:
+            error.reason === "loops_not_configured"
+              ? "The invitation email provider (Loops) is not configured on this deployment."
+              : error.reason === "loops_network"
+                ? "Could not reach the invitation email provider. The invitation is saved; retry to send again."
+                : `The invitation email provider rejected the send${error.detail ? `: ${error.detail}` : "."}`,
+          invitationId,
+        }, 502)
+      }
+
+      throw error
+    }
 
     return c.json({ invitationId, email, role, expiresAt }, existingInvitation[0] ? 200 : 201)
     },

--- a/packaging/docker/docker-compose.den-dev.yml
+++ b/packaging/docker/docker-compose.den-dev.yml
@@ -70,7 +70,7 @@ services:
       start_period: 120s
     environment:
       CI: "true"
-      OPENWORK_DEV_MODE: "1"
+      OPENWORK_DEV_MODE: ${OPENWORK_DEV_MODE:-1}
       DATABASE_URL: mysql://root:password@mysql:3306/openwork_den
       BETTER_AUTH_SECRET: ${DEN_BETTER_AUTH_SECRET:-dev-den-local-auth-secret-please-override-1234567890}
       DEN_DB_ENCRYPTION_KEY: ${DEN_DB_ENCRYPTION_KEY:-dev-den-db-encryption-key-please-change-1234567890}


### PR DESCRIPTION
## Summary

Traces an issue Ben hit this week: he invited Jan and Omar to OpenWork Cloud; Jan received the email, Omar never did. Resending changed nothing and the UI kept showing Omar as pending. The Slack hypothesis was that invites to an *existing* user silently fail.

An audit (notes in the commit) shows there is **no existing-user branch** anywhere on the invite path. The actual bug is that `sendDenOrganizationInvitationEmail` in `ee/apps/den-api/src/email.ts` caught every Loops failure with `console.warn` and returned cleanly, so `POST /v1/orgs/:orgId/invitations` always returned `201 Created`. The DB row was persisted, the UI showed it as pending, and nobody noticed the email provider had rejected the send.

This PR stops swallowing the failure.

## Changes

- Introduce a typed `DenEmailSendError` with a stable `reason` tagged union (`loops_not_configured` | `loops_rejected` | `loops_network`) plus `template`, `recipient`, and optional `detail`.
- `sendDenOrganizationInvitationEmail` and `sendDenVerificationEmail` now **throw** `DenEmailSendError` instead of console-warning and swallowing. The dev-mode short-circuit is preserved — `OPENWORK_DEV_MODE=1` still logs the payload and returns cleanly, so local dev and CI are unaffected.
- `POST /v1/orgs/:orgId/invitations` catches `DenEmailSendError`, logs via `console.error` with a stable `[auth][invite_email_failed] organization=… invitation=… email=… reason=… detail=…` prefix (greppable across deployments), and returns **`502 invitation_email_failed`** with a human-readable `message` plus the `invitationId` so the UI can correlate and retry. The invitation row is intentionally left pending so the next submit becomes a real resend.
- Documented the 502 response in `describeRoute`.
- Added `ee/apps/den-api/scripts/smoke-email-failures.mjs` so a reviewer can verify both failure paths without a real Loops account.

Operator note: `sendDenVerificationEmail` now throws on Loops failure too. Previously, a missing `LOOPS_TRANSACTIONAL_ID_DEN_VERIFY_EMAIL` would silently drop the OTP and leave users stuck at the verification screen forever. It will now return a real error upstream — that's intentional.

## Testing

All runs performed against \`packaging/docker/den-dev-up.sh\` at commit $(git -C _repos/openwork-worktrees/invite-email-surface-failures rev-parse --short HEAD) with the den-api stack rebuilt.

### 1. Happy path (dev mode on, \`OPENWORK_DEV_MODE=1\`)
Signed up \`invite-email-test@openwork.dev\`, created org \"Invite Test Org\", invited \`teammate@openwork.dev\`. UI flipped the Invitations tab counter to 1. \`docker logs\` showed:

\`\`\`
[auth] dev organization invite email payload for teammate@openwork.dev: {...}
\`\`\`

No regression from the pre-refactor behaviour.

### 2. loops_not_configured path (dev mode off, Loops env unset)

\`\`\`bash
docker cp ee/apps/den-api/scripts/smoke-email-failures.mjs <den-container>:/app/ee/apps/den-api/scripts/smoke-email-failures.mjs
docker exec -e OPENWORK_DEV_MODE=0 <den-container> node /app/ee/apps/den-api/scripts/smoke-email-failures.mjs omar@example.com
\`\`\`

Output:

\`\`\`
[smoke] ok loops_not_configured {
  reason: 'loops_not_configured',
  template: 'organization_invite',
  recipient: 'omar@example.com',
  detail: undefined
}
\`\`\`

### 3. loops_rejected path (dev mode off, Loops env set to bogus values)

\`\`\`bash
docker exec -e OPENWORK_DEV_MODE=0 -e LOOPS_API_KEY=bogus \\
  -e LOOPS_TRANSACTIONAL_ID_DEN_ORG_INVITE_EMAIL=bogus \\
  <den-container> node /app/ee/apps/den-api/scripts/smoke-email-failures.mjs omar@example.com
\`\`\`

Output:

\`\`\`
[smoke] ok loops_rejected {
  reason: 'loops_rejected',
  template: 'organization_invite',
  recipient: 'omar@example.com',
  detail: 'Invalid API key'
}
\`\`\`

\`detail\` is the real message from Loops, so both the server log and the UI \`message\` field will surface it.

### 4. What I did not run end-to-end in Chrome MCP

I did not drive the 502 response through the browser. Flipping \`OPENWORK_DEV_MODE=0\` inside the Den dev stack breaks the Better Auth cookie flow (401 on \`/v1/me/orgs\` once dev mode is off), which is a pre-existing dev-stack-only issue unrelated to this PR. The end-to-end UI verification for production traffic is:

1. Deploy this branch to a preview env with real Loops creds.
2. Invite a recipient whose email is not on the Loops transactional allowlist.
3. The Members form should surface the returned \`message\` (e.g. \"The invitation email provider rejected the send: <reason>\") on the page-error banner, instead of silently succeeding.

## How this helps the original Omar/Jan incident

The next time an invite silently fails in prod, operators now get:

1. A greppable \`[auth][invite_email_failed]\` line with the org id, invitation id, recipient, and Loops reason in the den-api logs.
2. A real HTTP 502 at the call site, so the inviter sees an error in the UI instead of the invitation appearing to "just work".

Whether the original trigger for Omar was a Loops recipient-allowlist, a domain-block from a prior bounce, or a transactional-id typo, any of those will now be diagnosable immediately.

## Related

- Branched from \`origin/dev\` per Omar's request.
- Included a small unrelated fix (\`fix(den-api): tolerate missing apps/desktop/package.json in Docker build\`) so local \`den-dev-up.sh\` builds; this is the same cherry-pick I carry in #1482 to unblock anyone's Docker flow after PR #1476 landed. First to merge wins; the second becomes a no-op.

## Out of scope

- Adding a \`lastSendError\` / \`lastSendAttemptAt\` column to \`InvitationTable\` to persist send state. Worth a follow-up but out of scope here.
- Retrying failed sends via a background job.
- Unifying the Better Auth \`sendInvitationEmail\` callback with the custom POST route (the Better Auth callback is currently wired but unused by the UI).