### PR TITLE
Fix/mac app closing onclose

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -114,12 +114,6 @@ fn show_main_window(app_handle: &AppHandle) {
     }
 }
 
-fn hide_main_window(app_handle: &AppHandle) {
-    if let Some(window) = app_handle.get_webview_window("main") {
-        let _ = window.hide();
-    }
-}
-
 fn stop_managed_services(app_handle: &tauri::AppHandle) {
     if let Ok(mut engine) = app_handle.state::<EngineManager>().inner.lock() {
         EngineManager::stop_locked(&mut engine);
@@ -227,14 +221,16 @@ pub fn run() {
     // orchestrator/opencode/openwork-server processes and stale ports.
     app.run(|app_handle, event| match event {
         RunEvent::ExitRequested { .. } | RunEvent::Exit => stop_managed_services(&app_handle),
+        // On macOS the default behavior is to keep the process alive after the
+        // last window closes. We want parity with Windows/Linux: closing the
+        // main window quits the app.
         #[cfg(target_os = "macos")]
         RunEvent::WindowEvent {
             label,
-            event: WindowEvent::CloseRequested { api, .. },
+            event: WindowEvent::CloseRequested { .. },
             ..
         } if label == "main" => {
-            api.prevent_close();
-            hide_main_window(&app_handle);
+            app_handle.exit(0);
         }
         #[cfg(target_os = "macos")]
         RunEvent::Opened { urls } => {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -241,14 +241,11 @@ pub fn run() {
             show_main_window(&app_handle);
             emit_native_deep_links(&app_handle, urls);
         }
+        // Always raise/refocus the main window on dock-icon clicks, even if
+        // it's already visible but behind other apps or on another Space.
         #[cfg(target_os = "macos")]
-        RunEvent::Reopen {
-            has_visible_windows,
-            ..
-        } => {
-            if !has_visible_windows {
-                show_main_window(&app_handle);
-            }
+        RunEvent::Reopen { .. } => {
+            show_main_window(&app_handle);
         }
         _ => {}
     });


### PR DESCRIPTION
## Summary
Previously, on macOS the main window's close button was intercepted to hide the window instead of closing, while Windows and Linux fell through to Tauri's default close. This created inconsistent behavior across platforms.

Desktop: unify window close behavior across platforms
Previously macOS intercepted the main window's close button and hid the window instead of closing, while Windows/Linux quit normally.

Changes (`apps/desktop/src-tauri/src/lib.rs`)
Close = quit on macOS: replaced the prevent_close + hide hack with app_handle.exit(0) on CloseRequested for the main window. Sidecar cleanup still runs via the existing ExitRequested → stop_managed_services path.
Dock click always raises: dropped the has_visible_windows guard in Reopen so clicking the dock icon always shows/unminimizes/focuses the main window, even if it's behind other apps or on another Space.
Removed the now-unused hide_main_window helper.