### PR TITLE
fix(desktop): quit on main window close + refocus on dock reopen (mac)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -114,12 +114,6 @@ fn show_main_window(app_handle: &AppHandle) {
     }
 }
 
-fn hide_main_window(app_handle: &AppHandle) {
-    if let Some(window) = app_handle.get_webview_window("main") {
-        let _ = window.hide();
-    }
-}
-
 fn stop_managed_services(app_handle: &tauri::AppHandle) {
     if let Ok(mut engine) = app_handle.state::<EngineManager>().inner.lock() {
         EngineManager::stop_locked(&mut engine);
@@ -227,14 +221,16 @@ pub fn run() {
     // orchestrator/opencode/openwork-server processes and stale ports.
     app.run(|app_handle, event| match event {
         RunEvent::ExitRequested { .. } | RunEvent::Exit => stop_managed_services(&app_handle),
+        // On macOS the default behavior is to keep the process alive after the
+        // last window closes. We want parity with Windows/Linux: closing the
+        // main window quits the app.
         #[cfg(target_os = "macos")]
         RunEvent::WindowEvent {
             label,
-            event: WindowEvent::CloseRequested { api, .. },
+            event: WindowEvent::CloseRequested { .. },
             ..
         } if label == "main" => {
-            api.prevent_close();
-            hide_main_window(&app_handle);
+            app_handle.exit(0);
         }
         #[cfg(target_os = "macos")]
         RunEvent::Opened { urls } => {
@@ -245,14 +241,11 @@ pub fn run() {
             show_main_window(&app_handle);
             emit_native_deep_links(&app_handle, urls);
         }
+        // Always raise/refocus the main window on dock-icon clicks, even if
+        // it's already visible but behind other apps or on another Space.
         #[cfg(target_os = "macos")]
-        RunEvent::Reopen {
-            has_visible_windows,
-            ..
-        } => {
-            if !has_visible_windows {
-                show_main_window(&app_handle);
-            }
+        RunEvent::Reopen { .. } => {
+            show_main_window(&app_handle);
         }
         _ => {}
     });


### PR DESCRIPTION
## Summary

Reapplies #1489, which was reverted in `08603fbb` after a suspected test failure on macOS.

### What the change does
- Quits the app when the main window is closed on macOS (parity with Windows/Linux), instead of calling `api.prevent_close()` and hiding the window.
- Always calls `show_main_window` on `RunEvent::Reopen` (dock-icon click), even when `has_visible_windows` is true — so the window is raised/refocused if it's behind another app or on another Space.
- Removes the now-unused `hide_main_window` helper.

### Why the previous merge was reverted
The macOS e2e test failed on PR #1489. **That failure was unrelated to this change** — it was a flaky `opencode serve` migration race:
- `apps/app/scripts/e2e.mjs` spawns an `opencode serve` subprocess and exercises its HTTP API. It does not load the Tauri code touched here.
- `waitForHealthy` returned `{healthy: true}` while stderr still showed `Performing one time database migration…`. The next call (`path.get`) then failed with `fetch failed`.
- The identical commit passed macos-14 CI when it ran post-merge on `dev` (run 24621620198).

If the flake reappears, the right fix is to harden `waitForHealthy` (or the `opencode serve` readiness probe) to wait for migration to finish — that's separate from this change.

## Test plan

- [ ] CI macOS e2e tests pass
- [ ] Manual: close main window on macOS → app exits (process no longer lingers)
- [ ] Manual: minimize / send to back, then click dock icon → main window is raised and focused
- [ ] Manual: Windows/Linux behavior unchanged