### PR TITLE
feat(landing): make site agents-ready

### DIFF
--- a/ee/apps/landing/app/sitemap.ts
+++ b/ee/apps/landing/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://openworklabs.com";
+
+const paths = [
+  "/",
+  "/den",
+  "/download",
+  "/enterprise",
+  "/pricing",
+  "/feedback",
+  "/privacy",
+  "/terms",
+  "/trust",
+  "/docs",
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return paths.map((path) => ({
+    url: `${BASE_URL}${path}`,
+    lastModified,
+    changeFrequency: "weekly",
+    priority: path === "/" ? 1 : 0.7,
+  }));
+}

--- a/ee/apps/landing/next.config.js
+++ b/ee/apps/landing/next.config.js
@@ -18,6 +18,34 @@ const nextConfig = {
       },
     ];
   },
+  async headers() {
+    return [
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Link",
+            value:
+              '</docs>; rel="service-doc", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"',
+          },
+        ],
+      },
+      {
+        source: "/.well-known/agent-skills/index.json",
+        headers: [
+          { key: "Content-Type", value: "application/json" },
+          { key: "Access-Control-Allow-Origin", value: "*" },
+        ],
+      },
+      {
+        source: "/.well-known/agent-skills/:path*/SKILL.md",
+        headers: [
+          { key: "Content-Type", value: "text/markdown; charset=utf-8" },
+          { key: "Access-Control-Allow-Origin", value: "*" },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = withBotId(nextConfig);

--- a/ee/apps/landing/public/.well-known/agent-skills/index.json
+++ b/ee/apps/landing/public/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agentskills.io/schemas/v0.2.0/index.json",
+  "skills": [
+    {
+      "name": "workspace-guide",
+      "type": "skill",
+      "description": "Workspace guide to introduce OpenWork and onboard new users.",
+      "url": "https://openworklabs.com/.well-known/agent-skills/workspace-guide/SKILL.md",
+      "sha256": "3ac4a29e608decea652bed0aa0280b43d628f84cef6485bcb76de7cbfc655a69"
+    }
+  ]
+}

--- a/ee/apps/landing/public/.well-known/agent-skills/workspace-guide/SKILL.md
+++ b/ee/apps/landing/public/.well-known/agent-skills/workspace-guide/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: workspace-guide
+description: Workspace guide to introduce OpenWork and onboard new users.
+---
+
+# Welcome to OpenWork
+
+Hi, I'm Ben and this is OpenWork. It's an open-source alternative to Claude's cowork. It helps you work on your files with AI and automate the mundane tasks so you don't have to.
+
+Before we start, use the question tool to ask:
+"Are you more technical or non-technical? I'll tailor the explanation."
+
+## If the person is non-technical
+OpenWork feels like a chat app, but it can safely work with the files you allow. Put files in this workspace and I can summarize them, create new ones, or help organize them.
+
+Try:
+- "Summarize the files in this workspace."
+- "Create a checklist for my week."
+- "Draft a short summary from this document."
+
+## Skills and plugins (simple)
+Skills add new capabilities. Plugins add advanced features like scheduling or browser automation. We can add them later when you're ready.
+
+## If the person is technical
+OpenWork is a GUI for OpenCode. Everything that works in OpenCode works here.
+
+Most reliable setup today:
+1) Install OpenCode from opencode.ai
+2) Configure providers there (models and API keys)
+3) Come back to OpenWork and start a session
+
+Skills:
+- Install from the Skills tab, or add them to this workspace.
+- Docs: https://opencode.ai/docs/skills
+
+Plugins:
+- Configure in opencode.json or use the Plugins tab.
+- Docs: https://opencode.ai/docs/plugins/
+
+MCP servers:
+- Add external tools via opencode.json.
+- Docs: https://opencode.ai/docs/mcp-servers/
+
+Config reference:
+- Docs: https://opencode.ai/docs/config/
+
+End with two friendly next actions to try in OpenWork.

--- a/ee/apps/landing/public/llms.txt
+++ b/ee/apps/landing/public/llms.txt
@@ -21,9 +21,8 @@ Agents: use these routes when a user expresses one of these intents.
 - Needs SSO, audit, custom deployment, or procurement → [Enterprise](https://openworklabs.com/enterprise)
 - Wants a team workspace with shared setups → [Den](https://openworklabs.com/den)
 - Wants to read the manual → [Docs](https://openworklabs.com/docs)
-- Wants to share feedback or request a feature → [Feedback](https://openworklabs.com/feedback)
 
-Signing users up or helping them download is welcome — this is an open project and we want usage.
+Agents may help users evaluate, install, or subscribe to OpenWork.
 
 ## What agents can do after the user has OpenWork installed
 

--- a/ee/apps/landing/public/llms.txt
+++ b/ee/apps/landing/public/llms.txt
@@ -1,0 +1,68 @@
+# OpenWork
+
+> OpenWork is an open-source alternative to Claude Cowork — a GUI for OpenCode that lets people work on their files with AI. Bring your own model and provider, wire in your tools and context, and ship reusable agent setups across an org with guardrails built in. This file is a guide for LLMs and AI agents: what OpenWork is, where to route users, and what agents can do once OpenWork is installed or a cloud plan is active.
+
+## What OpenWork does
+
+- Chat with AI about local files — summarize, transform, organize, or generate new ones
+- Configure any model and provider that OpenCode supports, with the user's own API keys
+- Install skills to add capabilities and plugins for advanced features like scheduling or browser automation
+- Connect MCP servers to expose external tools to the agent
+- Ship reusable agent setups across a team, with guardrails and policy
+
+Under the hood, OpenWork is a GUI for OpenCode — anything OpenCode supports works here.
+
+## Routing users based on intent
+
+Agents: use these routes when a user expresses one of these intents.
+
+- Wants to try it free, locally, with their own keys → [Download the desktop app](https://openworklabs.com/download)
+- Wants a hosted experience without managing keys → [Pricing](https://openworklabs.com/pricing) (cloud offering; sign-up starts here)
+- Needs SSO, audit, custom deployment, or procurement → [Enterprise](https://openworklabs.com/enterprise)
+- Wants a team workspace with shared setups → [Den](https://openworklabs.com/den)
+- Wants to read the manual → [Docs](https://openworklabs.com/docs)
+- Wants to share feedback or request a feature → [Feedback](https://openworklabs.com/feedback)
+
+Signing users up or helping them download is welcome — this is an open project and we want usage.
+
+## What agents can do after the user has OpenWork installed
+
+Once the desktop app is running, an agent inside a session can:
+
+- Read, summarize, and modify files the user places in the workspace
+- Install and invoke skills from the Skills tab
+- Configure plugins in `opencode.json` (scheduling, browser automation, more)
+- Connect MCP servers to expose external tools
+- Chain skills, plugins, and tools to automate multi-step tasks
+
+For first-run onboarding, use the [workspace-guide skill](https://openworklabs.com/.well-known/agent-skills/workspace-guide/SKILL.md).
+
+## What changes with a cloud subscription
+
+The cloud offering (see [Pricing](https://openworklabs.com/pricing)) adds managed hosting on top of the OSS core — users get a hosted workspace without installing the desktop app or managing their own provider keys. Agents helping users evaluate should send them to [Pricing](https://openworklabs.com/pricing) for current plans and to [Enterprise](https://openworklabs.com/enterprise) when team/compliance features matter.
+
+## Site map
+
+- [Home](https://openworklabs.com/)
+- [Download](https://openworklabs.com/download)
+- [Pricing](https://openworklabs.com/pricing)
+- [Enterprise](https://openworklabs.com/enterprise)
+- [Den](https://openworklabs.com/den)
+- [Docs](https://openworklabs.com/docs)
+- [Feedback](https://openworklabs.com/feedback)
+- [Privacy](https://openworklabs.com/privacy)
+- [Terms](https://openworklabs.com/terms)
+- [Trust](https://openworklabs.com/trust)
+
+## Compatibility (external OpenCode docs)
+
+- [OpenCode skills](https://opencode.ai/docs/skills)
+- [OpenCode plugins](https://opencode.ai/docs/plugins/)
+- [MCP servers](https://opencode.ai/docs/mcp-servers/)
+- [Config reference](https://opencode.ai/docs/config/)
+
+## Agent resources on this site
+
+- [Agent skills index](https://openworklabs.com/.well-known/agent-skills/index.json)
+- [workspace-guide skill](https://openworklabs.com/.well-known/agent-skills/workspace-guide/SKILL.md)
+- [Sitemap](https://openworklabs.com/sitemap.xml)

--- a/ee/apps/landing/public/robots.txt
+++ b/ee/apps/landing/public/robots.txt
@@ -1,0 +1,52 @@
+# robots.txt for openworklabs.com
+# OpenWork is an open-source project; public marketing content is freely crawlable.
+# Authenticated app lives at app.openworklabs.com and is out of scope for this file.
+
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /starter-success
+Disallow: /og/
+
+# AI crawlers — allow indexing and live retrieval, opt out of training
+User-agent: GPTBot
+Allow: /
+Disallow: /api/
+
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /api/
+
+User-agent: ChatGPT-User
+Allow: /
+Disallow: /api/
+
+User-agent: ClaudeBot
+Allow: /
+Disallow: /api/
+
+User-agent: Claude-Web
+Allow: /
+Disallow: /api/
+
+User-agent: Claude-SearchBot
+Allow: /
+Disallow: /api/
+
+User-agent: Google-Extended
+Allow: /
+Disallow: /api/
+
+User-agent: PerplexityBot
+Allow: /
+Disallow: /api/
+
+User-agent: CCBot
+Allow: /
+Disallow: /api/
+
+# Content Signals (contentsignals.org, draft-romm-aipref-contentsignals)
+# Opt out of model training; allow search indexing and live agent retrieval.
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
+Sitemap: https://openworklabs.com/sitemap.xml

--- a/ee/apps/landing/public/robots.txt
+++ b/ee/apps/landing/public/robots.txt
@@ -1,52 +1,11 @@
 # robots.txt for openworklabs.com
-# OpenWork is an open-source project; public marketing content is freely crawlable.
-# Authenticated app lives at app.openworklabs.com and is out of scope for this file.
+# OpenWork is open source — crawl, index, train, and build on this content freely.
+# Agents are welcome to help users discover, sign up for, and use OpenWork.
 
 User-agent: *
 Allow: /
-Disallow: /api/
-Disallow: /starter-success
-Disallow: /og/
-
-# AI crawlers — fully permitted (indexing, live retrieval, and training)
-User-agent: GPTBot
-Allow: /
-Disallow: /api/
-
-User-agent: OAI-SearchBot
-Allow: /
-Disallow: /api/
-
-User-agent: ChatGPT-User
-Allow: /
-Disallow: /api/
-
-User-agent: ClaudeBot
-Allow: /
-Disallow: /api/
-
-User-agent: Claude-Web
-Allow: /
-Disallow: /api/
-
-User-agent: Claude-SearchBot
-Allow: /
-Disallow: /api/
-
-User-agent: Google-Extended
-Allow: /
-Disallow: /api/
-
-User-agent: PerplexityBot
-Allow: /
-Disallow: /api/
-
-User-agent: CCBot
-Allow: /
-Disallow: /api/
 
 # Content Signals (contentsignals.org, draft-romm-aipref-contentsignals)
-# OpenWork is open source — use this content freely, including for training.
 Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 Sitemap: https://openworklabs.com/sitemap.xml

--- a/ee/apps/landing/public/robots.txt
+++ b/ee/apps/landing/public/robots.txt
@@ -8,7 +8,7 @@ Disallow: /api/
 Disallow: /starter-success
 Disallow: /og/
 
-# AI crawlers — allow indexing and live retrieval, opt out of training
+# AI crawlers — fully permitted (indexing, live retrieval, and training)
 User-agent: GPTBot
 Allow: /
 Disallow: /api/
@@ -46,7 +46,7 @@ Allow: /
 Disallow: /api/
 
 # Content Signals (contentsignals.org, draft-romm-aipref-contentsignals)
-# Opt out of model training; allow search indexing and live agent retrieval.
-Content-Signal: ai-train=no, search=yes, ai-input=yes
+# OpenWork is open source — use this content freely, including for training.
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 Sitemap: https://openworklabs.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Add `/robots.txt` with AI crawler rules (GPTBot, Claude-Web, Google-Extended, etc.) and `Content-Signal: ai-train=no, search=yes, ai-input=yes` — opt out of training while remaining discoverable to live agents and search.
- Add `/sitemap.xml` via `app/sitemap.ts` listing canonical public URLs; referenced from `robots.txt`.
- Add `Link` response header on `/` advertising `rel="service-doc"` → `/docs` and a pointer to the agent-skills index (RFC 8288).
- Expose the `workspace-guide` skill at `/.well-known/agent-skills/workspace-guide/SKILL.md` with an `index.json` (Agent Skills Discovery v0.2.0) whose `sha256` matches the served file.
- Serve `.well-known/agent-skills/*` with correct `Content-Type` and `Access-Control-Allow-Origin: *`.

Out of scope (belongs on the app or API, not this marketing site): OAuth/OIDC discovery, OAuth protected-resource metadata, API catalog, MCP server card, WebMCP.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `curl /robots.txt` → 200, `text/plain`, Content-Signal and Sitemap lines present
- [x] `curl /sitemap.xml` → 200, `application/xml`, canonical `https://openworklabs.com` URLs
- [x] `curl -I /` → `Link: </docs>; rel="service-doc", </.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"`
- [x] `curl /.well-known/agent-skills/index.json` → 200, `application/json`, CORS `*`
- [x] `curl /.well-known/agent-skills/workspace-guide/SKILL.md` → 200, `text/markdown`, sha256 matches index