### PR TITLE
fix(test): isolate opencode e2e server state

### DIFF
--- a/apps/app/scripts/_util.mjs
+++ b/apps/app/scripts/_util.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
+import { mkdtempSync, realpathSync, rmSync, statSync } from "node:fs";
 import net from "node:net";
-import { realpathSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
@@ -52,7 +54,8 @@ export async function spawnOpencodeServe({
   assert.ok(Number.isInteger(port) && port > 0, "port must be a positive integer");
 
   const cwd = realpathSync(directory);
-  const args = ["serve", "--hostname", hostname, "--port", String(port)];
+  const state = mkdtempSync(path.join(os.tmpdir(), "openwork-opencode-e2e-"));
+  const args = ["serve", "--hostname", hostname, "--port", String(port), "--pure"];
   for (const origin of corsOrigins) {
     args.push("--cors", origin);
   }
@@ -64,6 +67,10 @@ export async function spawnOpencodeServe({
       ...process.env,
       // Make it explicit we're a non-TUI client.
       OPENCODE_CLIENT: "openwork-test",
+      HOME: state,
+      XDG_CONFIG_HOME: path.join(state, ".config"),
+      XDG_STATE_HOME: path.join(state, ".local", "state"),
+      XDG_DATA_HOME: path.join(state, ".local", "share"),
     },
   });
 
@@ -99,6 +106,7 @@ export async function spawnOpencodeServe({
       }
 
       const exited = await waitForExit(2500);
+      rmSync(state, { recursive: true, force: true });
       if (exited) {
         return;
       }
@@ -111,6 +119,7 @@ export async function spawnOpencodeServe({
       }
 
       await waitForExit(2500);
+      rmSync(state, { recursive: true, force: true });
     },
     getStderr() {
       return stderr;


### PR DESCRIPTION
## Summary
- run the app e2e helper against an isolated temporary OpenCode home/data/config directory instead of inheriting runner state
- start the spawned OpenCode test server with `--pure` so global plugins or user-level config cannot interfere with the `path.get` smoke step
- clean up the temporary OpenCode state directory after each test server exits to keep repeated runs deterministic

## Why
The merged desktop/org restrictions PR triggered a macOS CI failure in `pnpm --filter @openwork/app test:e2e` where `path.get` hung and eventually reported `fetch failed` after `health` succeeded on OpenCode `1.4.9`. Reproducing the script with a clean temporary home and the pinned release binary passed consistently, which points to inherited runner/global OpenCode state rather than the app code itself.

## Testing
- `PATH="/tmp/opencode-149/extract:$PATH" pnpm --filter @openwork/app test:e2e`