### PR TITLE
docs(desktop): explain why we match both ExitRequested and Exit on quit

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -223,8 +223,11 @@ pub fn run() {
     // Best-effort cleanup on app exit. Without this, background sidecars can keep
     // running after the UI quits (especially during dev), leading to multiple
     // orchestrator/opencode/openwork-server processes and stale ports.
+    // Only run on ExitRequested — Exit fires immediately after and would re-run
+    // the same teardown, causing duplicate shutdown HTTP requests against an
+    // already-stopped orchestrator.
     app.run(|app_handle, event| match event {
-        RunEvent::ExitRequested { .. } | RunEvent::Exit => stop_managed_services(&app_handle),
+        RunEvent::ExitRequested { .. } => stop_managed_services(&app_handle),
         // On macOS the default behavior is to keep the process alive after the
         // last window closes. We want parity with Windows/Linux: closing the
         // main window quits the app.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -223,6 +223,12 @@ pub fn run() {
     // Best-effort cleanup on app exit. Without this, background sidecars can keep
     // running after the UI quits (especially during dev), leading to multiple
     // orchestrator/opencode/openwork-server processes and stale ports.
+    //
+    // We intentionally match both ExitRequested AND Exit: on macOS the built-in
+    // Quit menu, Cmd+Q, and dock -> Quit only fire RunEvent::Exit — they don't
+    // fire ExitRequested (tauri-apps/tauri#9198). The red-X path fires both
+    // because we translate WindowEvent::CloseRequested into app_handle.exit(0)
+    // below. stop_managed_services is idempotent, so firing on both is safe.
     app.run(|app_handle, event| match event {
         RunEvent::ExitRequested { .. } | RunEvent::Exit => stop_managed_services(&app_handle),
         // On macOS the default behavior is to keep the process alive after the

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -223,11 +223,8 @@ pub fn run() {
     // Best-effort cleanup on app exit. Without this, background sidecars can keep
     // running after the UI quits (especially during dev), leading to multiple
     // orchestrator/opencode/openwork-server processes and stale ports.
-    // Only run on ExitRequested — Exit fires immediately after and would re-run
-    // the same teardown, causing duplicate shutdown HTTP requests against an
-    // already-stopped orchestrator.
     app.run(|app_handle, event| match event {
-        RunEvent::ExitRequested { .. } => stop_managed_services(&app_handle),
+        RunEvent::ExitRequested { .. } | RunEvent::Exit => stop_managed_services(&app_handle),
         // On macOS the default behavior is to keep the process alive after the
         // last window closes. We want parity with Windows/Linux: closing the
         // main window quits the app.

--- a/apps/desktop/src-tauri/src/orchestrator/manager.rs
+++ b/apps/desktop/src-tauri/src/orchestrator/manager.rs
@@ -20,6 +20,17 @@ pub struct OrchestratorState {
 
 impl OrchestratorManager {
     pub fn stop_locked(state: &mut OrchestratorState) {
+        // Only act if we actually own a daemon process from this session. If we
+        // never spawned one (or already stopped it), the state file's base_url
+        // belongs to a previous run and POSTing to it would just log a spurious
+        // "Connection refused".
+        let Some(child) = state.child.take() else {
+            state.data_dir = None;
+            state.last_stdout = None;
+            state.last_stderr = None;
+            return;
+        };
+
         let data_dir = state
             .data_dir
             .clone()
@@ -33,12 +44,10 @@ impl OrchestratorManager {
             }
         };
 
-        if let Some(child) = state.child.take() {
-            // Prefer daemon-owned graceful shutdown so openwork-orchestrator can
-            // terminate its managed OpenCode child before exiting.
-            if !shutdown_requested {
-                let _ = child.kill();
-            }
+        // Prefer daemon-owned graceful shutdown so openwork-orchestrator can
+        // terminate its managed OpenCode child before exiting.
+        if !shutdown_requested {
+            let _ = child.kill();
         }
 
         orchestrator::clear_orchestrator_auth(&data_dir);

--- a/apps/desktop/src-tauri/src/orchestrator/manager.rs
+++ b/apps/desktop/src-tauri/src/orchestrator/manager.rs
@@ -20,17 +20,6 @@ pub struct OrchestratorState {
 
 impl OrchestratorManager {
     pub fn stop_locked(state: &mut OrchestratorState) {
-        // Only act if we actually own a daemon process from this session. If we
-        // never spawned one (or already stopped it), the state file's base_url
-        // belongs to a previous run and POSTing to it would just log a spurious
-        // "Connection refused".
-        let Some(child) = state.child.take() else {
-            state.data_dir = None;
-            state.last_stdout = None;
-            state.last_stderr = None;
-            return;
-        };
-
         let data_dir = state
             .data_dir
             .clone()
@@ -44,10 +33,12 @@ impl OrchestratorManager {
             }
         };
 
-        // Prefer daemon-owned graceful shutdown so openwork-orchestrator can
-        // terminate its managed OpenCode child before exiting.
-        if !shutdown_requested {
-            let _ = child.kill();
+        if let Some(child) = state.child.take() {
+            // Prefer daemon-owned graceful shutdown so openwork-orchestrator can
+            // terminate its managed OpenCode child before exiting.
+            if !shutdown_requested {
+                let _ = child.kill();
+            }
         }
 
         orchestrator::clear_orchestrator_auth(&data_dir);


### PR DESCRIPTION
## What this PR actually ships (final)

A **6-line inline comment** in `apps/desktop/src-tauri/src/lib.rs` documenting why the cleanup arm matches both `RunEvent::ExitRequested` and `RunEvent::Exit`, pinned to upstream [tauri-apps/tauri#9198](https://github.com/tauri-apps/tauri/issues/9198). No functional code changes.

## Why not the original fix

The PR initially tried two changes to silence a duplicate `[orchestrator] Failed to request shutdown ... Connection refused` log line on macOS red-X close. Both were reverted in this branch after deeper review:

1. **`71670825` — dropping `RunEvent::Exit` from the cleanup arm** (reverted in `15d1f3f4`).
   On macOS, the default menu's Quit, Cmd+Q, and dock → Quit fire only `Exit`, not `ExitRequested` ([tauri#9198](https://github.com/tauri-apps/tauri/issues/9198)). Dropping `Exit` would silently skip cleanup for those quit paths, orphaning orchestrator / opencode / openwork-server sidecars — exactly the failure mode fixed by [#655](https://github.com/different-ai/openwork/pull/655).

2. **`f68ee858` — early-returning from `OrchestratorManager::stop_locked` when `state.child` is `None`** (reverted in `b57642ec`).
   `stop_locked` is intentionally called with `state.child == None` in two places:
   - `engine_start` (`commands/engine.rs:386-389`) calls it before spawning a new daemon, to reap a surviving orchestrator from a crashed previous session.
   - `engine.rs:152` comment: *"The orchestrator can keep running across app relaunches."*
   
   Early-returning there would leave a surviving daemon running while the desktop spawns a second one — the exact orphan-process / memory-leak regression from [#652](https://github.com/different-ai/openwork/issues/652) that [#655](https://github.com/different-ai/openwork/pull/655) fixed.

## Outstanding

The original symptom (a spurious "Connection refused" log line on red-X close when a stale `base_url` is in the state file but no orchestrator is live) is **not fixed by this PR**. It remains cosmetic — no functional impact. A proper follow-up would probe `GET /health` before POSTing `/shutdown` inside `request_orchestrator_shutdown`, so a dead URL returns `Ok(false)` silently instead of logging. That's out of scope here.

## Test plan

- [x] `cargo check --no-default-features` on `apps/desktop/src-tauri` — clean
- [x] `pnpm --filter @openwork/app test:e2e` on macOS — all steps `ok`
- [x] Net diff vs `dev` is comment-only: `apps/desktop/src-tauri/src/lib.rs | 6 ++++++`

## Rollback

```bash
gh pr revert 1497
```

Comment-only change, nothing to migrate.