### PR TITLE
Revert over-eager "security: harden release workflows against secret leakage (#1480)"

### DIFF
--- a/.github/workflows/aur-validate.yml
+++ b/.github/workflows/aur-validate.yml
@@ -414,13 +414,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin dev --no-tags
-          publish_sha="$(git rev-parse HEAD)"
-          if ! git merge-base --is-ancestor "$publish_sha" origin/dev; then
-            echo "Ref ${publish_sha} is not reachable from origin/dev; refusing AUR publish." >&2
-            exit 1
-          fi
-
           if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ]; then
             echo "AUR_SSH_PRIVATE_KEY not set; cannot push to AUR." >&2
             exit 1

--- a/.github/workflows/deploy-den.yml
+++ b/.github/workflows/deploy-den.yml
@@ -7,11 +7,6 @@ on:
         description: "Daytona snapshot name to promote into Render"
         required: true
         type: string
-    secrets:
-      RENDER_API_KEY:
-        required: true
-      RENDER_DEN_CONTROL_PLANE_SERVICE_ID:
-        required: true
   workflow_dispatch:
     inputs:
       daytona_snapshot:

--- a/.github/workflows/opencode-agents.yml
+++ b/.github/workflows/opencode-agents.yml
@@ -1,0 +1,96 @@
+name: Opencode Agents
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  triage-issue:
+    if: github.event_name == 'issues'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install opencode
+        run: |
+          version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$version" --no-modify-path
+
+      - name: Triage issue
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          cat > /tmp/issue_prompt.txt <<'PROMPT_EOF'
+          The following issue was just opened, triage it:
+          PROMPT_EOF
+          printf '\nTitle: %s\n\n%s\n' "$ISSUE_TITLE" "$ISSUE_BODY" >> /tmp/issue_prompt.txt
+          opencode run --agent triage "$(cat /tmp/issue_prompt.txt)"
+
+  duplicate-prs:
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'opencode-agent[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install opencode
+        run: |
+          version="$(node -e "const fs=require('fs'); const parsed=JSON.parse(fs.readFileSync('constants.json','utf8')); process.stdout.write(String(parsed.opencodeVersion||'').trim().replace(/^v/,''));")"
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$version" --no-modify-path
+
+      - name: Build prompt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo "Check for duplicate PRs related to this new PR:"
+            echo ""
+            echo "CURRENT_PR_NUMBER: $PR_NUMBER"
+            echo ""
+            echo "Title: $(gh pr view \"$PR_NUMBER\" --json title --jq .title)"
+            echo ""
+            echo "Description:"
+            gh pr view "$PR_NUMBER" --json body --jq .body
+          } > pr_info.txt
+
+      - name: Check for duplicate PRs
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          opencode run --agent duplicate-pr "$(cat pr_info.txt)" > /tmp/comment_output.txt
+
+          {
+            echo "_The following comment was made by an LLM, it may be inaccurate:_"
+            echo ""
+            cat /tmp/comment_output.txt
+          } > /tmp/comment_body.txt
+          gh pr comment "$PR_NUMBER" --body-file /tmp/comment_body.txt

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - feat/windows-sidecar
 
 permissions:
   contents: write
@@ -299,8 +300,8 @@ jobs:
           args: ${{ matrix.args }}
           retryAttempts: 3
 
-      - name: Build + upload (macOS signed, no notarization)
-        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE != 'true'
+      - name: Build + upload
+        if: matrix.os_type != 'macos' || env.MACOS_NOTARIZE != 'true'
         uses: tauri-apps/tauri-action@v0.5.17
         env:
           CI: true
@@ -314,27 +315,6 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
-        with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: ${{ env.RELEASE_NAME }}
-          releaseBody: ${{ env.RELEASE_BODY }}
-          prerelease: true
-          releaseDraft: false
-          projectPath: apps/desktop
-          tauriScript: pnpm exec tauri -vvv
-          args: ${{ matrix.args }}
-          retryAttempts: 3
-
-      - name: Build + upload (non-macOS)
-        if: matrix.os_type != 'macos'
-        uses: tauri-apps/tauri-action@v0.5.17
-        env:
-          CI: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # Tauri updater signing
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: ${{ env.RELEASE_NAME }}

--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -20,13 +20,6 @@ on:
         description: "Optional Daytona region override for snapshot push"
         required: false
         type: string
-    secrets:
-      DAYTONA_API_KEY:
-        required: true
-      RENDER_API_KEY:
-        required: false
-      RENDER_DEN_CONTROL_PLANE_SERVICE_ID:
-        required: false
   workflow_dispatch:
     inputs:
       tag:
@@ -105,22 +98,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.resolve.outputs.release_tag }}
 
-      - name: Ensure tag commit is on a trusted branch
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          tag_commit="$(git rev-parse HEAD)"
-          git fetch origin dev --no-tags
-
-          if git merge-base --is-ancestor "$tag_commit" origin/dev; then
-            echo "Trusted release tag commit verified: $tag_commit"
-            exit 0
-          fi
-
-          echo "Release tag ${{ steps.resolve.outputs.release_tag }} points to commit $tag_commit, which is not reachable from origin/dev." >&2
-          exit 1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -192,6 +169,4 @@ jobs:
     uses: ./.github/workflows/deploy-den.yml
     with:
       daytona_snapshot: ${{ needs.publish-daytona-snapshot.outputs.snapshot_name }}
-    secrets:
-      RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-      RENDER_DEN_CONTROL_PLANE_SERVICE_ID: ${{ secrets.RENDER_DEN_CONTROL_PLANE_SERVICE_ID }}
+    secrets: inherit

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -214,38 +214,9 @@ jobs:
             --notes-file "$BODY_FILE" \
             $DRAFT_FLAG $PRERELEASE_FLAG
 
-  verify-trusted-release-tag:
-    name: Verify Trusted Release Tag
-    needs: resolve-release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    env:
-      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
-    steps:
-      - name: Checkout tagged release source
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ env.RELEASE_TAG }}
-          fetch-depth: 0
-
-      - name: Ensure tag commit is on a trusted branch
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          tag_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
-          git fetch origin dev --no-tags
-
-          if git merge-base --is-ancestor "$tag_commit" origin/dev; then
-            echo "Trusted release tag commit verified: $tag_commit"
-            exit 0
-          fi
-
-          echo "Release tag $RELEASE_TAG points to commit $tag_commit, which is not reachable from origin/dev." >&2
-          exit 1
-
   verify-release:
     name: Verify Release Versions
-    needs: [resolve-release, verify-trusted-release-tag]
+    needs: resolve-release
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -529,8 +500,8 @@ jobs:
           updaterJsonPreferNsis: true
           releaseAssetNamePattern: openwork-desktop-[platform]-[arch][ext]
 
-      - name: Build + upload (macOS signed, no notarization)
-        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE != 'true'
+      - name: Build + upload
+        if: matrix.os_type != 'macos' || env.MACOS_NOTARIZE != 'true'
         uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
         env:
           CI: true
@@ -544,30 +515,6 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
-        with:
-          tagName: ${{ env.RELEASE_TAG }}
-          releaseName: ${{ env.RELEASE_NAME }}
-          releaseBody: ${{ env.RELEASE_BODY }}
-          releaseDraft: ${{ env.RELEASE_DRAFT == 'true' }}
-          prerelease: ${{ env.RELEASE_PRERELEASE == 'true' }}
-          projectPath: apps/desktop
-          tauriScript: pnpm exec tauri -vvv
-          args: ${{ matrix.args }}
-          retryAttempts: 3
-          uploadUpdaterJson: false
-          updaterJsonPreferNsis: true
-          releaseAssetNamePattern: openwork-desktop-[platform]-[arch][ext]
-
-      - name: Build + upload (non-macOS)
-        if: matrix.os_type != 'macos'
-        uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a
-        env:
-          CI: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # Tauri updater signing
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ env.RELEASE_TAG }}
           releaseName: ${{ env.RELEASE_NAME }}
@@ -918,10 +865,7 @@ jobs:
     uses: ./.github/workflows/release-daytona-snapshot.yml
     with:
       tag: ${{ needs.resolve-release.outputs.release_tag }}
-    secrets:
-      DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-      RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-      RENDER_DEN_CONTROL_PLANE_SERVICE_ID: ${{ secrets.RENDER_DEN_CONTROL_PLANE_SERVICE_ID }}
+    secrets: inherit
 
   aur-publish:
     name: Publish AUR

--- a/.github/workflows/windows-signed-artifacts.yml
+++ b/.github/workflows/windows-signed-artifacts.yml
@@ -12,59 +12,19 @@ permissions:
   contents: read
 
 jobs:
-  resolve-trusted-ref:
-    name: Resolve trusted ref
-    runs-on: ubuntu-22.04
-    outputs:
-      trusted_sha: ${{ steps.resolve.outputs.trusted_sha }}
-    steps:
-      - name: Checkout repository metadata
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Resolve and verify trusted ref
-        id: resolve
-        shell: bash
-        env:
-          INPUT_REF: ${{ github.event.inputs.ref }}
-        run: |
-          set -euo pipefail
-
-          requested_ref="${INPUT_REF:-${GITHUB_REF_NAME}}"
-
-          git fetch origin --force --tags dev
-
-          if git show-ref --verify --quiet "refs/remotes/origin/${requested_ref}"; then
-            candidate_sha="$(git rev-parse "refs/remotes/origin/${requested_ref}")"
-          elif git show-ref --verify --quiet "refs/tags/${requested_ref}"; then
-            candidate_sha="$(git rev-list -n 1 "refs/tags/${requested_ref}")"
-          else
-            git fetch origin "${requested_ref}" --depth=1
-            candidate_sha="$(git rev-parse FETCH_HEAD)"
-          fi
-
-          if git merge-base --is-ancestor "$candidate_sha" origin/dev; then
-            echo "trusted_sha=$candidate_sha" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Requested ref ${requested_ref} resolves to ${candidate_sha}, which is not reachable from origin/dev." >&2
-          exit 1
-
   build-and-sign-windows:
     name: Build and sign Windows artifacts
-    needs: resolve-trusted-ref
     runs-on: windows-latest
     env:
       TAURI_TARGET: x86_64-pc-windows-msvc
       BUN_TARGET: bun-windows-x64
+      WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+      WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.resolve-trusted-ref.outputs.trusted_sha }}
-          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -96,7 +56,6 @@ jobs:
         shell: pwsh
         env:
           WINDOWS_CERT_PFX_BASE64: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
-          WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
         run: |
           if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERT_PFX_BASE64)) {
             throw "WINDOWS_CERT_PFX_BASE64 is required for Windows signing."
@@ -111,9 +70,6 @@ jobs:
 
       - name: Sign bundled Windows sidecars
         shell: pwsh
-        env:
-          WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
-          WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
         run: |
           $targets = @(
             "apps/desktop/src-tauri/sidecars/opencode-$env:TAURI_TARGET.exe",
@@ -133,9 +89,6 @@ jobs:
 
       - name: Sign Server V2 executable
         shell: pwsh
-        env:
-          WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
-          WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
         run: |
           $serverPath = "apps/server-v2/dist/bin/openwork-server-v2-$env:BUN_TARGET.exe"
           if (!(Test-Path $serverPath)) {
@@ -149,9 +102,6 @@ jobs:
 
       - name: Sign desktop Windows artifacts
         shell: pwsh
-        env:
-          WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
-          WINDOWS_TIMESTAMP_URL: ${{ secrets.WINDOWS_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
         run: |
           $artifacts = Get-ChildItem -Path "apps/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle" -Recurse -Include *.exe,*.msi
           if ($artifacts.Count -eq 0) {


### PR DESCRIPTION
## Summary
- revert `security: harden release workflows against secret leakage (#1480)` from `dev`
- restore the prior GitHub Actions workflow behavior, including the deleted `opencode-agents` workflow
- isolate the rollback so the release workflow hardening can be revisited separately without blocking current workflow behavior