### PR TITLE
fix(den): proxy legacy org-scoped routes

### DIFF
--- a/ee/apps/den-api/src/middleware/organization-context.ts
+++ b/ee/apps/den-api/src/middleware/organization-context.ts
@@ -3,7 +3,7 @@ import type { MiddlewareHandler } from "hono"
 import { getApiKeyScopedOrganizationId, isScopedApiKeyForOrganization } from "../api-keys.js"
 import { getOrganizationContextForUser, resolveUserOrganizations, type OrganizationContext } from "../orgs.js"
 import type { AuthContextVariables } from "../session.js"
-import type { UserOrganizationsContext } from "./user-organizations.js"
+import { hydrateSessionActiveOrganization, shouldHydrateSessionActiveOrganization, type UserOrganizationsContext } from "./user-organizations.js"
 
 export type OrganizationContextVariables = {
   organizationContext: OrganizationContext
@@ -24,8 +24,9 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
   let organizationSlug = c.get("activeOrganizationSlug") ?? null
 
   if (!organizationId) {
+    const session = c.get("session")
     const resolved = await resolveUserOrganizations({
-      activeOrganizationId: scopedOrganizationId ?? c.get("session")?.activeOrganizationId ?? null,
+      activeOrganizationId: scopedOrganizationId ?? session?.activeOrganizationId ?? null,
       userId: normalizeDenTypeId("user", user.id),
     })
 
@@ -35,6 +36,17 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
 
     organizationId = scopedOrganizationId ? scopedOrgs[0]?.id ?? null : resolved.activeOrgId
     organizationSlug = scopedOrganizationId ? scopedOrgs[0]?.slug ?? null : resolved.activeOrgSlug
+
+    if (shouldHydrateSessionActiveOrganization({
+      scopedOrganizationId,
+      sessionActiveOrganizationId: session?.activeOrganizationId,
+      resolvedActiveOrganizationId: organizationId,
+    })) {
+      await hydrateSessionActiveOrganization(session, organizationId)
+      if (session) {
+        c.set("session", { ...session, activeOrganizationId: organizationId })
+      }
+    }
 
     c.set("userOrganizations", scopedOrgs)
     c.set("activeOrganizationId", organizationId)

--- a/ee/apps/den-api/src/middleware/organization-context.ts
+++ b/ee/apps/den-api/src/middleware/organization-context.ts
@@ -3,7 +3,7 @@ import type { MiddlewareHandler } from "hono"
 import { getApiKeyScopedOrganizationId, isScopedApiKeyForOrganization } from "../api-keys.js"
 import { getOrganizationContextForUser, resolveUserOrganizations, type OrganizationContext } from "../orgs.js"
 import type { AuthContextVariables } from "../session.js"
-import { hydrateSessionActiveOrganization, shouldHydrateSessionActiveOrganization, type UserOrganizationsContext } from "./user-organizations.js"
+import { getLegacyProxyOrganizationId, hydrateSessionActiveOrganization, shouldHydrateSessionActiveOrganization, type UserOrganizationsContext } from "./user-organizations.js"
 
 export type OrganizationContextVariables = {
   organizationContext: OrganizationContext
@@ -18,7 +18,7 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
   }
 
   const apiKey = c.get("apiKey")
-  const scopedOrganizationId = getApiKeyScopedOrganizationId(apiKey)
+  const scopedOrganizationId = getApiKeyScopedOrganizationId(apiKey) ?? getLegacyProxyOrganizationId(c.req.raw.headers)
 
   let organizationId = c.get("activeOrganizationId") ?? null
   let organizationSlug = c.get("activeOrganizationSlug") ?? null

--- a/ee/apps/den-api/src/middleware/user-organizations.ts
+++ b/ee/apps/den-api/src/middleware/user-organizations.ts
@@ -4,6 +4,8 @@ import { getApiKeyScopedOrganizationId } from "../api-keys.js"
 import { resolveUserOrganizations, setSessionActiveOrganization, type UserOrgSummary } from "../orgs.js"
 import type { AuthContextVariables } from "../session.js"
 
+export const LEGACY_ORG_PROXY_HEADER = "x-openwork-legacy-org-id"
+
 export type UserOrganizationsContext = {
   userOrganizations: UserOrgSummary[]
   activeOrganizationId: string | null
@@ -11,6 +13,19 @@ export type UserOrganizationsContext = {
 }
 
 type SessionLike = AuthContextVariables["session"]
+
+export function getLegacyProxyOrganizationId(headers: Headers) {
+  const rawOrganizationId = headers.get(LEGACY_ORG_PROXY_HEADER)?.trim()
+  if (!rawOrganizationId) {
+    return null
+  }
+
+  try {
+    return normalizeDenTypeId("organization", rawOrganizationId)
+  } catch {
+    return null
+  }
+}
 
 export function shouldHydrateSessionActiveOrganization(input: {
   resolvedActiveOrganizationId: string | null
@@ -44,7 +59,7 @@ export const resolveUserOrganizationsMiddleware: MiddlewareHandler<{
 
   const session = c.get("session")
   const apiKey = c.get("apiKey")
-  const scopedOrganizationId = getApiKeyScopedOrganizationId(apiKey)
+  const scopedOrganizationId = getApiKeyScopedOrganizationId(apiKey) ?? getLegacyProxyOrganizationId(c.req.raw.headers)
   const resolved = await resolveUserOrganizations({
     activeOrganizationId: scopedOrganizationId ?? session?.activeOrganizationId ?? null,
     userId: normalizeDenTypeId("user", user.id),

--- a/ee/apps/den-api/src/middleware/user-organizations.ts
+++ b/ee/apps/den-api/src/middleware/user-organizations.ts
@@ -1,13 +1,37 @@
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { MiddlewareHandler } from "hono"
 import { getApiKeyScopedOrganizationId } from "../api-keys.js"
-import { resolveUserOrganizations, type UserOrgSummary } from "../orgs.js"
+import { resolveUserOrganizations, setSessionActiveOrganization, type UserOrgSummary } from "../orgs.js"
 import type { AuthContextVariables } from "../session.js"
 
 export type UserOrganizationsContext = {
   userOrganizations: UserOrgSummary[]
   activeOrganizationId: string | null
   activeOrganizationSlug: string | null
+}
+
+type SessionLike = AuthContextVariables["session"]
+
+export function shouldHydrateSessionActiveOrganization(input: {
+  resolvedActiveOrganizationId: string | null
+  scopedOrganizationId: string | null
+  sessionActiveOrganizationId?: string | null
+}) {
+  return !input.scopedOrganizationId && !input.sessionActiveOrganizationId && !!input.resolvedActiveOrganizationId
+}
+
+export async function hydrateSessionActiveOrganization(session: SessionLike, organizationId: string | null) {
+  if (!session?.id || !organizationId || session.activeOrganizationId === organizationId) {
+    return
+  }
+
+  try {
+    const sessionId = normalizeDenTypeId("session", session.id)
+    const normalizedOrganizationId = normalizeDenTypeId("organization", organizationId)
+    await setSessionActiveOrganization(sessionId, normalizedOrganizationId)
+  } catch {
+    return
+  }
 }
 
 export const resolveUserOrganizationsMiddleware: MiddlewareHandler<{
@@ -34,6 +58,17 @@ export const resolveUserOrganizationsMiddleware: MiddlewareHandler<{
   const activeOrganizationSlug = scopedOrganizationId
     ? scopedOrgs[0]?.slug ?? null
     : resolved.activeOrgSlug
+
+  if (shouldHydrateSessionActiveOrganization({
+    scopedOrganizationId,
+    sessionActiveOrganizationId: session?.activeOrganizationId,
+    resolvedActiveOrganizationId: activeOrganizationId,
+  })) {
+    await hydrateSessionActiveOrganization(session, activeOrganizationId)
+    if (session) {
+      c.set("session", { ...session, activeOrganizationId })
+    }
+  }
 
   c.set("userOrganizations", scopedOrgs)
   c.set("activeOrganizationId", activeOrganizationId)

--- a/ee/apps/den-api/src/routes/org/index.ts
+++ b/ee/apps/den-api/src/routes/org/index.ts
@@ -1,5 +1,6 @@
 import type { Hono } from "hono"
 import { registerOrgApiKeyRoutes } from "./api-keys.js"
+import { LEGACY_ORG_PROXY_HEADER } from "../../middleware/user-organizations.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { registerOrgCoreRoutes } from "./core.js"
 import { registerOrgInvitationRoutes } from "./invitations.js"
@@ -10,6 +11,32 @@ import { registerOrgRoleRoutes } from "./roles.js"
 import { registerOrgSkillRoutes } from "./skills.js"
 import { registerOrgTeamRoutes } from "./teams.js"
 import { registerOrgTemplateRoutes } from "./templates.js"
+
+const LEGACY_ORG_PATH_PREFIX = "/v1/orgs/"
+
+function extractLegacyOrgProxyTarget(pathname: string) {
+  if (!pathname.startsWith(LEGACY_ORG_PATH_PREFIX)) {
+    return null
+  }
+
+  const remainder = pathname.slice(LEGACY_ORG_PATH_PREFIX.length)
+  const slashIndex = remainder.indexOf("/")
+  if (slashIndex <= 0) {
+    return null
+  }
+
+  const organizationId = remainder.slice(0, slashIndex)
+  if (!organizationId.startsWith("org_")) {
+    return null
+  }
+
+  const targetPath = `/v1${remainder.slice(slashIndex)}`
+  if (targetPath === pathname) {
+    return null
+  }
+
+  return { organizationId, targetPath }
+}
 
 export function registerOrgRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
   registerOrgCoreRoutes(app)
@@ -22,4 +49,22 @@ export function registerOrgRoutes<T extends { Variables: OrgRouteVariables }>(ap
   registerOrgSkillRoutes(app)
   registerOrgTeamRoutes(app)
   registerOrgTemplateRoutes(app)
+
+  app.all("/v1/orgs/:orgId/*", async (c) => {
+    const url = new URL(c.req.raw.url)
+    const target = extractLegacyOrgProxyTarget(url.pathname)
+    if (!target) {
+      return c.json({ error: "not_found" }, 404)
+    }
+
+    const proxiedUrl = new URL(url)
+    proxiedUrl.pathname = target.targetPath
+
+    const headers = new Headers(c.req.raw.headers)
+    headers.set(LEGACY_ORG_PROXY_HEADER, target.organizationId)
+
+    const proxiedRequest = new Request(new Request(proxiedUrl, c.req.raw), { headers })
+
+    return app.fetch(proxiedRequest, c.env)
+  })
 }

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -1,13 +1,12 @@
 import { and, eq, gt } from "@openwork-ee/den-db/drizzle"
 import { AuthUserTable, InvitationTable, MemberTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
-import type { Context, Hono, MiddlewareHandler } from "hono"
+import type { Context, Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
 import { DenEmailSendError, sendDenOrganizationInvitationEmail } from "../../email.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
-import { hydrateSessionActiveOrganization } from "../../middleware/user-organizations.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { getOrganizationLimitStatus } from "../../organization-limits.js"
 import { isEmailAllowedForOrganization, listAssignableRoles } from "../../orgs.js"
@@ -44,8 +43,6 @@ type InvitationId = typeof InvitationTable.$inferSelect.id
 type OrgContext = Context<{ Variables: OrgRouteVariables }>
 
 const orgInvitationParamsSchema = idParamSchema("invitationId", "invitation")
-const legacyOrgParamsSchema = idParamSchema("orgId", "organization")
-const legacyOrgInvitationParamsSchema = legacyOrgParamsSchema.extend(orgInvitationParamsSchema.shape)
 
 function validRequestPart<T>(c: OrgContext, target: "json" | "param") {
   return (c.req as unknown as { valid: (part: typeof target) => unknown }).valid(target) as T
@@ -75,21 +72,6 @@ function getRequiredOrganizationContext(c: OrgContext) {
   }
 
   return payload
-}
-
-const bindLegacyOrganizationParamMiddleware: MiddlewareHandler<{ Variables: OrgRouteVariables }> = async (c, next) => {
-  const params = validParam<z.infer<typeof legacyOrgParamsSchema> | z.infer<typeof legacyOrgInvitationParamsSchema>>(c as OrgContext)
-  const session = c.get("session")
-
-  if (!session?.activeOrganizationId) {
-    await hydrateSessionActiveOrganization(session, params.orgId)
-    if (session) {
-      c.set("session", { ...session, activeOrganizationId: params.orgId })
-    }
-  }
-
-  c.set("activeOrganizationId", params.orgId)
-  await next()
 }
 
 async function handleCreateInvitation(c: OrgContext) {
@@ -223,7 +205,7 @@ async function handleCancelInvitation(c: OrgContext) {
   }
 
   const payload = getRequiredOrganizationContext(c)
-  const params = validParam<z.infer<typeof orgInvitationParamsSchema> | z.infer<typeof legacyOrgInvitationParamsSchema>>(c)
+  const params = validParam<z.infer<typeof orgInvitationParamsSchema>>(c)
   let invitationId: InvitationId
   try {
     invitationId = normalizeDenTypeId("invitation", params.invitationId)
@@ -270,32 +252,6 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
   )
 
   app.post(
-    "/v1/orgs/:orgId/invitations",
-    describeRoute({
-      hide: true,
-      tags: ["Invitations"],
-      summary: "Legacy create organization invitation",
-      description: "Accepts legacy org-scoped invitation URLs and routes them through the active invitation handler.",
-      responses: {
-        200: jsonResponse("Existing invitation refreshed successfully.", invitationResponseSchema),
-        201: jsonResponse("Invitation created successfully.", invitationResponseSchema),
-        400: jsonResponse("The invitation request body or path parameters were invalid.", invalidRequestSchema),
-        401: jsonResponse("The caller must be signed in to invite organization members.", unauthorizedSchema),
-        403: jsonResponse("Only workspace owners and admins can create or resend invitations.", forbiddenSchema),
-        404: jsonResponse("The organization could not be found.", notFoundSchema),
-        409: jsonResponse("The email address is outside this workspace's allowed domains.", inviteEmailDomainNotAllowedSchema),
-        502: jsonResponse("The invitation was saved but the email provider (Loops) rejected or failed to deliver it. Retry by submitting the same email again.", invitationEmailFailedSchema),
-      },
-    }),
-    requireUserMiddleware,
-    paramValidator(legacyOrgParamsSchema),
-    bindLegacyOrganizationParamMiddleware,
-    resolveOrganizationContextMiddleware,
-    jsonValidator(inviteMemberSchema),
-    handleCreateInvitation,
-  )
-
-  app.post(
     "/v1/invitations/:invitationId/cancel",
     describeRoute({
       tags: ["Invitations"],
@@ -311,28 +267,6 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     }),
     requireUserMiddleware,
     paramValidator(orgInvitationParamsSchema),
-    resolveOrganizationContextMiddleware,
-    handleCancelInvitation,
-  )
-
-  app.post(
-    "/v1/orgs/:orgId/invitations/:invitationId/cancel",
-    describeRoute({
-      hide: true,
-      tags: ["Invitations"],
-      summary: "Legacy cancel organization invitation",
-      description: "Accepts legacy org-scoped invitation cancel URLs and routes them through the active invitation handler.",
-      responses: {
-        200: jsonResponse("Invitation cancelled successfully.", successSchema),
-        400: jsonResponse("The invitation cancellation path parameters were invalid.", invalidRequestSchema),
-        401: jsonResponse("The caller must be signed in to cancel invitations.", unauthorizedSchema),
-        403: jsonResponse("Only workspace owners and admins can cancel invitations.", forbiddenSchema),
-        404: jsonResponse("The invitation or organization could not be found.", notFoundSchema),
-      },
-    }),
-    requireUserMiddleware,
-    paramValidator(legacyOrgInvitationParamsSchema),
-    bindLegacyOrganizationParamMiddleware,
     resolveOrganizationContextMiddleware,
     handleCancelInvitation,
   )

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -1,7 +1,7 @@
 import { and, eq, gt } from "@openwork-ee/den-db/drizzle"
 import { AuthUserTable, InvitationTable, MemberTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
-import type { Context, Hono } from "hono"
+import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
@@ -40,192 +40,8 @@ const inviteEmailDomainNotAllowedSchema = z.object({
 }).meta({ ref: "InviteEmailDomainNotAllowedError" })
 
 type InvitationId = typeof InvitationTable.$inferSelect.id
-type OrgContext = Context<{ Variables: OrgRouteVariables }>
 
 const orgInvitationParamsSchema = idParamSchema("invitationId", "invitation")
-
-function validRequestPart<T>(c: OrgContext, target: "json" | "param") {
-  return (c.req as unknown as { valid: (part: typeof target) => unknown }).valid(target) as T
-}
-
-function validJson<T>(c: OrgContext) {
-  return validRequestPart<T>(c, "json")
-}
-
-function validParam<T>(c: OrgContext) {
-  return validRequestPart<T>(c, "param")
-}
-
-function getRequiredInvitationUser(c: OrgContext) {
-  const user = c.get("user")
-  if (!user) {
-    throw new Error("Invitation routes require an authenticated user.")
-  }
-
-  return user
-}
-
-function getRequiredOrganizationContext(c: OrgContext) {
-  const payload = c.get("organizationContext")
-  if (!payload) {
-    throw new Error("Invitation routes require an organization context.")
-  }
-
-  return payload
-}
-
-async function handleCreateInvitation(c: OrgContext) {
-  const permission = ensureInviteManager(c)
-  if (!permission.ok) {
-    return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
-  }
-
-  const payload = getRequiredOrganizationContext(c)
-  const user = getRequiredInvitationUser(c)
-  const input = validJson<z.infer<typeof inviteMemberSchema>>(c)
-
-  const email = input.email.trim().toLowerCase()
-  if (!isEmailAllowedForOrganization(payload.organization.allowedEmailDomains, email)) {
-    const emailDomain = email.includes("@") ? email.slice(email.lastIndexOf("@") + 1) : null
-    return c.json({
-      error: "invite_email_domain_not_allowed",
-      message:
-        payload.organization.allowedEmailDomains && payload.organization.allowedEmailDomains.length === 1
-          ? `This workspace only allows ${payload.organization.allowedEmailDomains[0]} email addresses.`
-          : `This workspace only allows email addresses from these domains: ${(payload.organization.allowedEmailDomains ?? []).join(", ")}.`,
-      emailDomain,
-      allowedEmailDomains: payload.organization.allowedEmailDomains ?? [],
-    }, 409)
-  }
-
-  const availableRoles = await listAssignableRoles(payload.organization.id)
-  const role = normalizeRoleName(input.role)
-  if (!availableRoles.has(role)) {
-    return c.json({ error: "invalid_role", message: "Choose one of the existing organization roles." }, 400)
-  }
-
-  const existingMembers = await db
-    .select({ id: MemberTable.id })
-    .from(MemberTable)
-    .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-    .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email)))
-    .limit(1)
-
-  if (existingMembers[0]) {
-    return c.json({
-      error: "member_exists",
-      message: "That email address is already a member of this organization.",
-    }, 409)
-  }
-
-  const existingInvitation = await db
-    .select()
-    .from(InvitationTable)
-    .where(
-      and(
-        eq(InvitationTable.organizationId, payload.organization.id),
-        eq(InvitationTable.email, email),
-        eq(InvitationTable.status, "pending"),
-        gt(InvitationTable.expiresAt, new Date()),
-      ),
-    )
-    .limit(1)
-
-  if (!existingInvitation[0]) {
-    const memberLimit = await getOrganizationLimitStatus(payload.organization.id, "members")
-    if (memberLimit.exceeded) {
-      return c.json({
-        error: "org_limit_reached",
-        limitType: "members",
-        limit: memberLimit.limit,
-        currentCount: memberLimit.currentCount,
-        message: `This workspace currently supports up to ${memberLimit.limit} members. Contact support to increase the limit.`,
-      }, 409)
-    }
-  }
-
-  const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7)
-  const invitationId = existingInvitation[0]?.id ?? createInvitationId()
-
-  if (existingInvitation[0]) {
-    await db
-      .update(InvitationTable)
-      .set({ role, inviterId: normalizeDenTypeId("user", user.id), expiresAt })
-      .where(eq(InvitationTable.id, existingInvitation[0].id))
-  } else {
-    await db.insert(InvitationTable).values({
-      id: invitationId,
-      organizationId: payload.organization.id,
-      email,
-      role,
-      status: "pending",
-      inviterId: normalizeDenTypeId("user", user.id),
-      expiresAt,
-    })
-  }
-
-  try {
-    await sendDenOrganizationInvitationEmail({
-      email,
-      inviteLink: buildInvitationLink(invitationId),
-      invitedByName: user.name ?? user.email ?? "OpenWork",
-      invitedByEmail: user.email ?? "",
-      organizationName: payload.organization.name,
-      role,
-    })
-  } catch (error) {
-    if (error instanceof DenEmailSendError) {
-      console.error(
-        `[auth][invite_email_failed] organization=${payload.organization.id} invitation=${invitationId} email=${email} reason=${error.reason}${error.detail ? ` detail=${error.detail}` : ""}`,
-      )
-
-      return c.json({
-        error: "invitation_email_failed" as const,
-        reason: error.reason,
-        message:
-          error.reason === "loops_not_configured"
-            ? "The invitation email provider (Loops) is not configured on this deployment."
-            : error.reason === "loops_network"
-              ? "Could not reach the invitation email provider. The invitation is saved; retry to send again."
-              : `The invitation email provider rejected the send${error.detail ? `: ${error.detail}` : "."}`,
-        invitationId,
-      }, 502)
-    }
-
-    throw error
-  }
-
-  return c.json({ invitationId, email, role, expiresAt }, existingInvitation[0] ? 200 : 201)
-}
-
-async function handleCancelInvitation(c: OrgContext) {
-  const permission = ensureInviteManager(c)
-  if (!permission.ok) {
-    return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
-  }
-
-  const payload = getRequiredOrganizationContext(c)
-  const params = validParam<z.infer<typeof orgInvitationParamsSchema>>(c)
-  let invitationId: InvitationId
-  try {
-    invitationId = normalizeDenTypeId("invitation", params.invitationId)
-  } catch {
-    return c.json({ error: "invitation_not_found" }, 404)
-  }
-
-  const invitationRows = await db
-    .select({ id: InvitationTable.id })
-    .from(InvitationTable)
-    .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
-    .limit(1)
-
-  if (!invitationRows[0]) {
-    return c.json({ error: "invitation_not_found" }, 404)
-  }
-
-  await db.update(InvitationTable).set({ status: "canceled" }).where(eq(InvitationTable.id, invitationId))
-  return c.json({ success: true })
-}
 
 export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
   app.post(
@@ -248,7 +64,133 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     requireUserMiddleware,
     resolveOrganizationContextMiddleware,
     jsonValidator(inviteMemberSchema),
-    handleCreateInvitation,
+    async (c) => {
+    const permission = ensureInviteManager(c)
+    if (!permission.ok) {
+      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
+    }
+
+    const payload = c.get("organizationContext")
+    const user = c.get("user")
+    const input = c.req.valid("json")
+
+    const email = input.email.trim().toLowerCase()
+    if (!isEmailAllowedForOrganization(payload.organization.allowedEmailDomains, email)) {
+      const emailDomain = email.includes("@") ? email.slice(email.lastIndexOf("@") + 1) : null
+      return c.json({
+        error: "invite_email_domain_not_allowed",
+        message:
+          payload.organization.allowedEmailDomains && payload.organization.allowedEmailDomains.length === 1
+            ? `This workspace only allows ${payload.organization.allowedEmailDomains[0]} email addresses.`
+            : `This workspace only allows email addresses from these domains: ${(payload.organization.allowedEmailDomains ?? []).join(", ")}.`,
+        emailDomain,
+        allowedEmailDomains: payload.organization.allowedEmailDomains ?? [],
+      }, 409)
+    }
+
+    const availableRoles = await listAssignableRoles(payload.organization.id)
+    const role = normalizeRoleName(input.role)
+    if (!availableRoles.has(role)) {
+      return c.json({ error: "invalid_role", message: "Choose one of the existing organization roles." }, 400)
+    }
+
+    const existingMembers = await db
+      .select({ id: MemberTable.id })
+      .from(MemberTable)
+      .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+      .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email)))
+      .limit(1)
+
+    if (existingMembers[0]) {
+      return c.json({
+        error: "member_exists",
+        message: "That email address is already a member of this organization.",
+      }, 409)
+    }
+
+    const existingInvitation = await db
+      .select()
+      .from(InvitationTable)
+      .where(
+        and(
+          eq(InvitationTable.organizationId, payload.organization.id),
+          eq(InvitationTable.email, email),
+          eq(InvitationTable.status, "pending"),
+          gt(InvitationTable.expiresAt, new Date()),
+        ),
+      )
+      .limit(1)
+
+    if (!existingInvitation[0]) {
+      const memberLimit = await getOrganizationLimitStatus(payload.organization.id, "members")
+      if (memberLimit.exceeded) {
+        return c.json({
+          error: "org_limit_reached",
+          limitType: "members",
+          limit: memberLimit.limit,
+          currentCount: memberLimit.currentCount,
+          message: `This workspace currently supports up to ${memberLimit.limit} members. Contact support to increase the limit.`,
+        }, 409)
+      }
+    }
+
+    const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7)
+    const invitationId = existingInvitation[0]?.id ?? createInvitationId()
+
+    if (existingInvitation[0]) {
+      await db
+        .update(InvitationTable)
+        .set({ role, inviterId: normalizeDenTypeId("user", user.id), expiresAt })
+        .where(eq(InvitationTable.id, existingInvitation[0].id))
+    } else {
+      await db.insert(InvitationTable).values({
+        id: invitationId,
+        organizationId: payload.organization.id,
+        email,
+        role,
+        status: "pending",
+        inviterId: normalizeDenTypeId("user", user.id),
+        expiresAt,
+      })
+    }
+
+    try {
+      await sendDenOrganizationInvitationEmail({
+        email,
+        inviteLink: buildInvitationLink(invitationId),
+        invitedByName: user.name ?? user.email ?? "OpenWork",
+        invitedByEmail: user.email ?? "",
+        organizationName: payload.organization.name,
+        role,
+      })
+    } catch (error) {
+      if (error instanceof DenEmailSendError) {
+        // The invitation row is already persisted (step above). Log at error
+        // level so operators can grep, and return a 502 so the caller can
+        // render a real failure instead of a silent success. The invitation
+        // id is included so the UI can correlate and offer a direct retry.
+        console.error(
+          `[auth][invite_email_failed] organization=${payload.organization.id} invitation=${invitationId} email=${email} reason=${error.reason}${error.detail ? ` detail=${error.detail}` : ""}`,
+        )
+
+        return c.json({
+          error: "invitation_email_failed" as const,
+          reason: error.reason,
+          message:
+            error.reason === "loops_not_configured"
+              ? "The invitation email provider (Loops) is not configured on this deployment."
+              : error.reason === "loops_network"
+                ? "Could not reach the invitation email provider. The invitation is saved; retry to send again."
+                : `The invitation email provider rejected the send${error.detail ? `: ${error.detail}` : "."}`,
+          invitationId,
+        }, 502)
+      }
+
+      throw error
+    }
+
+    return c.json({ invitationId, email, role, expiresAt }, existingInvitation[0] ? 200 : 201)
+    },
   )
 
   app.post(
@@ -268,6 +210,33 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     requireUserMiddleware,
     paramValidator(orgInvitationParamsSchema),
     resolveOrganizationContextMiddleware,
-    handleCancelInvitation,
+    async (c) => {
+    const permission = ensureInviteManager(c)
+    if (!permission.ok) {
+      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
+    }
+
+    const payload = c.get("organizationContext")
+    const params = c.req.valid("param")
+    let invitationId: InvitationId
+    try {
+      invitationId = normalizeDenTypeId("invitation", params.invitationId)
+    } catch {
+      return c.json({ error: "invitation_not_found" }, 404)
+    }
+
+    const invitationRows = await db
+      .select({ id: InvitationTable.id })
+      .from(InvitationTable)
+      .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
+      .limit(1)
+
+    if (!invitationRows[0]) {
+      return c.json({ error: "invitation_not_found" }, 404)
+    }
+
+    await db.update(InvitationTable).set({ status: "canceled" }).where(eq(InvitationTable.id, invitationId))
+    return c.json({ success: true })
+    },
   )
 }

--- a/ee/apps/den-api/src/routes/org/invitations.ts
+++ b/ee/apps/den-api/src/routes/org/invitations.ts
@@ -1,12 +1,13 @@
 import { and, eq, gt } from "@openwork-ee/den-db/drizzle"
 import { AuthUserTable, InvitationTable, MemberTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
-import type { Hono } from "hono"
+import type { Context, Hono, MiddlewareHandler } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
 import { DenEmailSendError, sendDenOrganizationInvitationEmail } from "../../email.js"
 import { jsonValidator, paramValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
+import { hydrateSessionActiveOrganization } from "../../middleware/user-organizations.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, successSchema, unauthorizedSchema } from "../../openapi.js"
 import { getOrganizationLimitStatus } from "../../organization-limits.js"
 import { isEmailAllowedForOrganization, listAssignableRoles } from "../../orgs.js"
@@ -40,7 +41,209 @@ const inviteEmailDomainNotAllowedSchema = z.object({
 }).meta({ ref: "InviteEmailDomainNotAllowedError" })
 
 type InvitationId = typeof InvitationTable.$inferSelect.id
+type OrgContext = Context<{ Variables: OrgRouteVariables }>
+
 const orgInvitationParamsSchema = idParamSchema("invitationId", "invitation")
+const legacyOrgParamsSchema = idParamSchema("orgId", "organization")
+const legacyOrgInvitationParamsSchema = legacyOrgParamsSchema.extend(orgInvitationParamsSchema.shape)
+
+function validRequestPart<T>(c: OrgContext, target: "json" | "param") {
+  return (c.req as unknown as { valid: (part: typeof target) => unknown }).valid(target) as T
+}
+
+function validJson<T>(c: OrgContext) {
+  return validRequestPart<T>(c, "json")
+}
+
+function validParam<T>(c: OrgContext) {
+  return validRequestPart<T>(c, "param")
+}
+
+function getRequiredInvitationUser(c: OrgContext) {
+  const user = c.get("user")
+  if (!user) {
+    throw new Error("Invitation routes require an authenticated user.")
+  }
+
+  return user
+}
+
+function getRequiredOrganizationContext(c: OrgContext) {
+  const payload = c.get("organizationContext")
+  if (!payload) {
+    throw new Error("Invitation routes require an organization context.")
+  }
+
+  return payload
+}
+
+const bindLegacyOrganizationParamMiddleware: MiddlewareHandler<{ Variables: OrgRouteVariables }> = async (c, next) => {
+  const params = validParam<z.infer<typeof legacyOrgParamsSchema> | z.infer<typeof legacyOrgInvitationParamsSchema>>(c as OrgContext)
+  const session = c.get("session")
+
+  if (!session?.activeOrganizationId) {
+    await hydrateSessionActiveOrganization(session, params.orgId)
+    if (session) {
+      c.set("session", { ...session, activeOrganizationId: params.orgId })
+    }
+  }
+
+  c.set("activeOrganizationId", params.orgId)
+  await next()
+}
+
+async function handleCreateInvitation(c: OrgContext) {
+  const permission = ensureInviteManager(c)
+  if (!permission.ok) {
+    return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
+  }
+
+  const payload = getRequiredOrganizationContext(c)
+  const user = getRequiredInvitationUser(c)
+  const input = validJson<z.infer<typeof inviteMemberSchema>>(c)
+
+  const email = input.email.trim().toLowerCase()
+  if (!isEmailAllowedForOrganization(payload.organization.allowedEmailDomains, email)) {
+    const emailDomain = email.includes("@") ? email.slice(email.lastIndexOf("@") + 1) : null
+    return c.json({
+      error: "invite_email_domain_not_allowed",
+      message:
+        payload.organization.allowedEmailDomains && payload.organization.allowedEmailDomains.length === 1
+          ? `This workspace only allows ${payload.organization.allowedEmailDomains[0]} email addresses.`
+          : `This workspace only allows email addresses from these domains: ${(payload.organization.allowedEmailDomains ?? []).join(", ")}.`,
+      emailDomain,
+      allowedEmailDomains: payload.organization.allowedEmailDomains ?? [],
+    }, 409)
+  }
+
+  const availableRoles = await listAssignableRoles(payload.organization.id)
+  const role = normalizeRoleName(input.role)
+  if (!availableRoles.has(role)) {
+    return c.json({ error: "invalid_role", message: "Choose one of the existing organization roles." }, 400)
+  }
+
+  const existingMembers = await db
+    .select({ id: MemberTable.id })
+    .from(MemberTable)
+    .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
+    .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email)))
+    .limit(1)
+
+  if (existingMembers[0]) {
+    return c.json({
+      error: "member_exists",
+      message: "That email address is already a member of this organization.",
+    }, 409)
+  }
+
+  const existingInvitation = await db
+    .select()
+    .from(InvitationTable)
+    .where(
+      and(
+        eq(InvitationTable.organizationId, payload.organization.id),
+        eq(InvitationTable.email, email),
+        eq(InvitationTable.status, "pending"),
+        gt(InvitationTable.expiresAt, new Date()),
+      ),
+    )
+    .limit(1)
+
+  if (!existingInvitation[0]) {
+    const memberLimit = await getOrganizationLimitStatus(payload.organization.id, "members")
+    if (memberLimit.exceeded) {
+      return c.json({
+        error: "org_limit_reached",
+        limitType: "members",
+        limit: memberLimit.limit,
+        currentCount: memberLimit.currentCount,
+        message: `This workspace currently supports up to ${memberLimit.limit} members. Contact support to increase the limit.`,
+      }, 409)
+    }
+  }
+
+  const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7)
+  const invitationId = existingInvitation[0]?.id ?? createInvitationId()
+
+  if (existingInvitation[0]) {
+    await db
+      .update(InvitationTable)
+      .set({ role, inviterId: normalizeDenTypeId("user", user.id), expiresAt })
+      .where(eq(InvitationTable.id, existingInvitation[0].id))
+  } else {
+    await db.insert(InvitationTable).values({
+      id: invitationId,
+      organizationId: payload.organization.id,
+      email,
+      role,
+      status: "pending",
+      inviterId: normalizeDenTypeId("user", user.id),
+      expiresAt,
+    })
+  }
+
+  try {
+    await sendDenOrganizationInvitationEmail({
+      email,
+      inviteLink: buildInvitationLink(invitationId),
+      invitedByName: user.name ?? user.email ?? "OpenWork",
+      invitedByEmail: user.email ?? "",
+      organizationName: payload.organization.name,
+      role,
+    })
+  } catch (error) {
+    if (error instanceof DenEmailSendError) {
+      console.error(
+        `[auth][invite_email_failed] organization=${payload.organization.id} invitation=${invitationId} email=${email} reason=${error.reason}${error.detail ? ` detail=${error.detail}` : ""}`,
+      )
+
+      return c.json({
+        error: "invitation_email_failed" as const,
+        reason: error.reason,
+        message:
+          error.reason === "loops_not_configured"
+            ? "The invitation email provider (Loops) is not configured on this deployment."
+            : error.reason === "loops_network"
+              ? "Could not reach the invitation email provider. The invitation is saved; retry to send again."
+              : `The invitation email provider rejected the send${error.detail ? `: ${error.detail}` : "."}`,
+        invitationId,
+      }, 502)
+    }
+
+    throw error
+  }
+
+  return c.json({ invitationId, email, role, expiresAt }, existingInvitation[0] ? 200 : 201)
+}
+
+async function handleCancelInvitation(c: OrgContext) {
+  const permission = ensureInviteManager(c)
+  if (!permission.ok) {
+    return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
+  }
+
+  const payload = getRequiredOrganizationContext(c)
+  const params = validParam<z.infer<typeof orgInvitationParamsSchema> | z.infer<typeof legacyOrgInvitationParamsSchema>>(c)
+  let invitationId: InvitationId
+  try {
+    invitationId = normalizeDenTypeId("invitation", params.invitationId)
+  } catch {
+    return c.json({ error: "invitation_not_found" }, 404)
+  }
+
+  const invitationRows = await db
+    .select({ id: InvitationTable.id })
+    .from(InvitationTable)
+    .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
+    .limit(1)
+
+  if (!invitationRows[0]) {
+    return c.json({ error: "invitation_not_found" }, 404)
+  }
+
+  await db.update(InvitationTable).set({ status: "canceled" }).where(eq(InvitationTable.id, invitationId))
+  return c.json({ success: true })
+}
 
 export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVariables }>(app: Hono<T>) {
   app.post(
@@ -63,133 +266,33 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     requireUserMiddleware,
     resolveOrganizationContextMiddleware,
     jsonValidator(inviteMemberSchema),
-    async (c) => {
-    const permission = ensureInviteManager(c)
-    if (!permission.ok) {
-      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
-    }
+    handleCreateInvitation,
+  )
 
-    const payload = c.get("organizationContext")
-    const user = c.get("user")
-    const input = c.req.valid("json")
-
-    const email = input.email.trim().toLowerCase()
-    if (!isEmailAllowedForOrganization(payload.organization.allowedEmailDomains, email)) {
-      const emailDomain = email.includes("@") ? email.slice(email.lastIndexOf("@") + 1) : null
-      return c.json({
-        error: "invite_email_domain_not_allowed",
-        message:
-          payload.organization.allowedEmailDomains && payload.organization.allowedEmailDomains.length === 1
-            ? `This workspace only allows ${payload.organization.allowedEmailDomains[0]} email addresses.`
-            : `This workspace only allows email addresses from these domains: ${(payload.organization.allowedEmailDomains ?? []).join(", ")}.`,
-        emailDomain,
-        allowedEmailDomains: payload.organization.allowedEmailDomains ?? [],
-      }, 409)
-    }
-
-    const availableRoles = await listAssignableRoles(payload.organization.id)
-    const role = normalizeRoleName(input.role)
-    if (!availableRoles.has(role)) {
-      return c.json({ error: "invalid_role", message: "Choose one of the existing organization roles." }, 400)
-    }
-
-    const existingMembers = await db
-      .select({ id: MemberTable.id })
-      .from(MemberTable)
-      .innerJoin(AuthUserTable, eq(MemberTable.userId, AuthUserTable.id))
-      .where(and(eq(MemberTable.organizationId, payload.organization.id), eq(AuthUserTable.email, email)))
-      .limit(1)
-
-    if (existingMembers[0]) {
-      return c.json({
-        error: "member_exists",
-        message: "That email address is already a member of this organization.",
-      }, 409)
-    }
-
-    const existingInvitation = await db
-      .select()
-      .from(InvitationTable)
-      .where(
-        and(
-          eq(InvitationTable.organizationId, payload.organization.id),
-          eq(InvitationTable.email, email),
-          eq(InvitationTable.status, "pending"),
-          gt(InvitationTable.expiresAt, new Date()),
-        ),
-      )
-      .limit(1)
-
-    if (!existingInvitation[0]) {
-      const memberLimit = await getOrganizationLimitStatus(payload.organization.id, "members")
-      if (memberLimit.exceeded) {
-        return c.json({
-          error: "org_limit_reached",
-          limitType: "members",
-          limit: memberLimit.limit,
-          currentCount: memberLimit.currentCount,
-          message: `This workspace currently supports up to ${memberLimit.limit} members. Contact support to increase the limit.`,
-        }, 409)
-      }
-    }
-
-    const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7)
-    const invitationId = existingInvitation[0]?.id ?? createInvitationId()
-
-    if (existingInvitation[0]) {
-      await db
-        .update(InvitationTable)
-        .set({ role, inviterId: normalizeDenTypeId("user", user.id), expiresAt })
-        .where(eq(InvitationTable.id, existingInvitation[0].id))
-    } else {
-      await db.insert(InvitationTable).values({
-        id: invitationId,
-        organizationId: payload.organization.id,
-        email,
-        role,
-        status: "pending",
-        inviterId: normalizeDenTypeId("user", user.id),
-        expiresAt,
-      })
-    }
-
-    try {
-      await sendDenOrganizationInvitationEmail({
-        email,
-        inviteLink: buildInvitationLink(invitationId),
-        invitedByName: user.name ?? user.email ?? "OpenWork",
-        invitedByEmail: user.email ?? "",
-        organizationName: payload.organization.name,
-        role,
-      })
-    } catch (error) {
-      if (error instanceof DenEmailSendError) {
-        // The invitation row is already persisted (step above). Log at error
-        // level so operators can grep, and return a 502 so the caller can
-        // render a real failure instead of a silent success. The invitation
-        // id is included so the UI can correlate and offer a direct retry.
-        console.error(
-          `[auth][invite_email_failed] organization=${payload.organization.id} invitation=${invitationId} email=${email} reason=${error.reason}${error.detail ? ` detail=${error.detail}` : ""}`,
-        )
-
-        return c.json({
-          error: "invitation_email_failed" as const,
-          reason: error.reason,
-          message:
-            error.reason === "loops_not_configured"
-              ? "The invitation email provider (Loops) is not configured on this deployment."
-              : error.reason === "loops_network"
-                ? "Could not reach the invitation email provider. The invitation is saved; retry to send again."
-                : `The invitation email provider rejected the send${error.detail ? `: ${error.detail}` : "."}`,
-          invitationId,
-        }, 502)
-      }
-
-      throw error
-    }
-
-    return c.json({ invitationId, email, role, expiresAt }, existingInvitation[0] ? 200 : 201)
-    },
+  app.post(
+    "/v1/orgs/:orgId/invitations",
+    describeRoute({
+      hide: true,
+      tags: ["Invitations"],
+      summary: "Legacy create organization invitation",
+      description: "Accepts legacy org-scoped invitation URLs and routes them through the active invitation handler.",
+      responses: {
+        200: jsonResponse("Existing invitation refreshed successfully.", invitationResponseSchema),
+        201: jsonResponse("Invitation created successfully.", invitationResponseSchema),
+        400: jsonResponse("The invitation request body or path parameters were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to invite organization members.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can create or resend invitations.", forbiddenSchema),
+        404: jsonResponse("The organization could not be found.", notFoundSchema),
+        409: jsonResponse("The email address is outside this workspace's allowed domains.", inviteEmailDomainNotAllowedSchema),
+        502: jsonResponse("The invitation was saved but the email provider (Loops) rejected or failed to deliver it. Retry by submitting the same email again.", invitationEmailFailedSchema),
+      },
+    }),
+    requireUserMiddleware,
+    paramValidator(legacyOrgParamsSchema),
+    bindLegacyOrganizationParamMiddleware,
+    resolveOrganizationContextMiddleware,
+    jsonValidator(inviteMemberSchema),
+    handleCreateInvitation,
   )
 
   app.post(
@@ -209,33 +312,28 @@ export function registerOrgInvitationRoutes<T extends { Variables: OrgRouteVaria
     requireUserMiddleware,
     paramValidator(orgInvitationParamsSchema),
     resolveOrganizationContextMiddleware,
-    async (c) => {
-    const permission = ensureInviteManager(c)
-    if (!permission.ok) {
-      return c.json(permission.response, permission.response.error === "forbidden" ? 403 : 404)
-    }
+    handleCancelInvitation,
+  )
 
-    const payload = c.get("organizationContext")
-    const params = c.req.valid("param")
-    let invitationId: InvitationId
-    try {
-      invitationId = normalizeDenTypeId("invitation", params.invitationId)
-    } catch {
-      return c.json({ error: "invitation_not_found" }, 404)
-    }
-
-    const invitationRows = await db
-      .select({ id: InvitationTable.id })
-      .from(InvitationTable)
-      .where(and(eq(InvitationTable.id, invitationId), eq(InvitationTable.organizationId, payload.organization.id)))
-      .limit(1)
-
-    if (!invitationRows[0]) {
-      return c.json({ error: "invitation_not_found" }, 404)
-    }
-
-    await db.update(InvitationTable).set({ status: "canceled" }).where(eq(InvitationTable.id, invitationId))
-    return c.json({ success: true })
-    },
+  app.post(
+    "/v1/orgs/:orgId/invitations/:invitationId/cancel",
+    describeRoute({
+      hide: true,
+      tags: ["Invitations"],
+      summary: "Legacy cancel organization invitation",
+      description: "Accepts legacy org-scoped invitation cancel URLs and routes them through the active invitation handler.",
+      responses: {
+        200: jsonResponse("Invitation cancelled successfully.", successSchema),
+        400: jsonResponse("The invitation cancellation path parameters were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to cancel invitations.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can cancel invitations.", forbiddenSchema),
+        404: jsonResponse("The invitation or organization could not be found.", notFoundSchema),
+      },
+    }),
+    requireUserMiddleware,
+    paramValidator(legacyOrgInvitationParamsSchema),
+    bindLegacyOrganizationParamMiddleware,
+    resolveOrganizationContextMiddleware,
+    handleCancelInvitation,
   )
 }

--- a/ee/apps/den-api/test/org-invitations.test.ts
+++ b/ee/apps/den-api/test/org-invitations.test.ts
@@ -6,25 +6,28 @@ function seedRequiredEnv() {
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
 }
 
 let invitationModule: typeof import("../src/routes/org/invitations.js")
+let orgRoutesModule: typeof import("../src/routes/org/index.js")
 let userOrganizationsModule: typeof import("../src/middleware/user-organizations.js")
 
 beforeAll(async () => {
   seedRequiredEnv()
   invitationModule = await import("../src/routes/org/invitations.js")
+  orgRoutesModule = await import("../src/routes/org/index.js")
   userOrganizationsModule = await import("../src/middleware/user-organizations.js")
 })
 
-function createInvitationApp() {
+function createOrgApp() {
   const app = new Hono()
-  invitationModule.registerOrgInvitationRoutes(app)
+  orgRoutesModule.registerOrgRoutes(app)
   return app
 }
 
-test("legacy org-scoped invitation create path is still registered", async () => {
-  const app = createInvitationApp()
+test("legacy org-scoped paths proxy into the unscoped handlers", async () => {
+  const app = createOrgApp()
   const response = await app.request("http://den.local/v1/orgs/org_123/invitations", {
     body: JSON.stringify({ email: "teammate@example.com", role: "admin" }),
     headers: {
@@ -37,9 +40,33 @@ test("legacy org-scoped invitation create path is still registered", async () =>
   await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
 })
 
-test("legacy org-scoped invitation cancel path is still registered", async () => {
-  const app = createInvitationApp()
-  const response = await app.request("http://den.local/v1/orgs/org_123/invitations/invitation_123/cancel", {
+test("legacy org-scoped proxy also reaches non-invitation org resources", async () => {
+  const app = createOrgApp()
+  const response = await app.request("http://den.local/v1/orgs/org_123/teams", {
+    body: JSON.stringify({ memberIds: [], name: "Legacy Team" }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
+})
+
+test("current org endpoints are not swallowed by the legacy proxy", async () => {
+  const app = createOrgApp()
+  const response = await app.request("http://den.local/v1/orgs/invitations/preview?id=bad", {
+    method: "GET",
+  })
+
+  expect(response.status).toBe(400)
+})
+
+test("invitation cancel still validates against the unscoped handler", async () => {
+  const app = new Hono()
+  invitationModule.registerOrgInvitationRoutes(app)
+  const response = await app.request("http://den.local/v1/invitations/invitation_123/cancel", {
     method: "POST",
   })
 

--- a/ee/apps/den-api/test/org-invitations.test.ts
+++ b/ee/apps/den-api/test/org-invitations.test.ts
@@ -1,0 +1,68 @@
+import { beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+let invitationModule: typeof import("../src/routes/org/invitations.js")
+let userOrganizationsModule: typeof import("../src/middleware/user-organizations.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  invitationModule = await import("../src/routes/org/invitations.js")
+  userOrganizationsModule = await import("../src/middleware/user-organizations.js")
+})
+
+function createInvitationApp() {
+  const app = new Hono()
+  invitationModule.registerOrgInvitationRoutes(app)
+  return app
+}
+
+test("legacy org-scoped invitation create path is still registered", async () => {
+  const app = createInvitationApp()
+  const response = await app.request("http://den.local/v1/orgs/org_123/invitations", {
+    body: JSON.stringify({ email: "teammate@example.com", role: "admin" }),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
+})
+
+test("legacy org-scoped invitation cancel path is still registered", async () => {
+  const app = createInvitationApp()
+  const response = await app.request("http://den.local/v1/orgs/org_123/invitations/invitation_123/cancel", {
+    method: "POST",
+  })
+
+  expect(response.status).toBe(401)
+  await expect(response.json()).resolves.toEqual({ error: "unauthorized" })
+})
+
+test("session hydration only runs when a user session is missing an active organization", () => {
+  expect(userOrganizationsModule.shouldHydrateSessionActiveOrganization({
+    scopedOrganizationId: null,
+    sessionActiveOrganizationId: null,
+    resolvedActiveOrganizationId: "organization_first",
+  })).toBe(true)
+
+  expect(userOrganizationsModule.shouldHydrateSessionActiveOrganization({
+    scopedOrganizationId: null,
+    sessionActiveOrganizationId: "organization_existing",
+    resolvedActiveOrganizationId: "organization_existing",
+  })).toBe(false)
+
+  expect(userOrganizationsModule.shouldHydrateSessionActiveOrganization({
+    scopedOrganizationId: "organization_scoped",
+    sessionActiveOrganizationId: null,
+    resolvedActiveOrganizationId: "organization_scoped",
+  })).toBe(false)
+})

--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -7,12 +7,14 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 COPY .npmrc /app/.npmrc
 COPY patches /app/patches
+COPY packages/types/package.json /app/packages/types/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/packages/den-db/package.json /app/ee/packages/den-db/package.json
 COPY ee/apps/den-api/package.json /app/ee/apps/den-api/package.json
 
 RUN pnpm install --frozen-lockfile
 
+COPY packages/types /app/packages/types
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/packages/den-db /app/ee/packages/den-db
 COPY ee/apps/den-api /app/ee/apps/den-api

--- a/packaging/docker/Dockerfile.den-web
+++ b/packaging/docker/Dockerfile.den-web
@@ -7,12 +7,14 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 COPY .npmrc /app/.npmrc
 COPY patches /app/patches
+COPY packages/types/package.json /app/packages/types/package.json
 COPY packages/ui/package.json /app/packages/ui/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/apps/den-web/package.json /app/ee/apps/den-web/package.json
 
 RUN pnpm install --frozen-lockfile --filter @openwork-ee/den-web...
 
+COPY packages/types /app/packages/types
 COPY packages/ui /app/packages/ui
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/apps/den-web /app/ee/apps/den-web

--- a/packaging/docker/Dockerfile.den-worker-proxy
+++ b/packaging/docker/Dockerfile.den-worker-proxy
@@ -7,12 +7,14 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 COPY .npmrc /app/.npmrc
 COPY patches /app/patches
+COPY packages/types/package.json /app/packages/types/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/packages/den-db/package.json /app/ee/packages/den-db/package.json
 COPY ee/apps/den-worker-proxy/package.json /app/ee/apps/den-worker-proxy/package.json
 
 RUN pnpm install --frozen-lockfile
 
+COPY packages/types /app/packages/types
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/packages/den-db /app/ee/packages/den-db
 COPY ee/apps/den-worker-proxy /app/ee/apps/den-worker-proxy


### PR DESCRIPTION
## Summary
- proxy legacy `/v1/orgs/:orgId/*` requests into the new unscoped `/v1/*` handlers instead of only aliasing invitation routes
- preserve the existing `/v1/orgs/...` endpoints by keeping the generic proxy behind the current explicit org routes and only forwarding valid `org_` ids
- carry the legacy org id through middleware so old clients still resolve the intended workspace context, and keep the Den Docker image fixes needed for local verification

## Testing
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit`
- `bun test ee/apps/den-api/test/org-invitations.test.ts`
- `bash packaging/docker/den-dev-up.sh`
- verified in the browser that sign-up/org creation worked, the legacy invitation create route returned `201`, the legacy cancel route returned `200`, and the session `active_organization_id` was rehydrated from membership