### PR TITLE
fix(den): persist active org for legacy proxy requests

### DIFF
--- a/ee/apps/den-api/src/middleware/organization-context.ts
+++ b/ee/apps/den-api/src/middleware/organization-context.ts
@@ -18,7 +18,9 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
   }
 
   const apiKey = c.get("apiKey")
-  const scopedOrganizationId = getApiKeyScopedOrganizationId(apiKey) ?? getLegacyProxyOrganizationId(c.req.raw.headers)
+  const apiKeyScopedOrganizationId = getApiKeyScopedOrganizationId(apiKey)
+  const legacyProxyOrganizationId = getLegacyProxyOrganizationId(c.req.raw.headers)
+  const scopedOrganizationId = apiKeyScopedOrganizationId ?? legacyProxyOrganizationId
 
   let organizationId = c.get("activeOrganizationId") ?? null
   let organizationSlug = c.get("activeOrganizationSlug") ?? null
@@ -38,7 +40,7 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
     organizationSlug = scopedOrganizationId ? scopedOrgs[0]?.slug ?? null : resolved.activeOrgSlug
 
     if (shouldHydrateSessionActiveOrganization({
-      scopedOrganizationId,
+      scopedOrganizationId: apiKeyScopedOrganizationId,
       sessionActiveOrganizationId: session?.activeOrganizationId,
       resolvedActiveOrganizationId: organizationId,
     })) {

--- a/ee/apps/den-api/src/middleware/user-organizations.ts
+++ b/ee/apps/den-api/src/middleware/user-organizations.ts
@@ -59,7 +59,9 @@ export const resolveUserOrganizationsMiddleware: MiddlewareHandler<{
 
   const session = c.get("session")
   const apiKey = c.get("apiKey")
-  const scopedOrganizationId = getApiKeyScopedOrganizationId(apiKey) ?? getLegacyProxyOrganizationId(c.req.raw.headers)
+  const apiKeyScopedOrganizationId = getApiKeyScopedOrganizationId(apiKey)
+  const legacyProxyOrganizationId = getLegacyProxyOrganizationId(c.req.raw.headers)
+  const scopedOrganizationId = apiKeyScopedOrganizationId ?? legacyProxyOrganizationId
   const resolved = await resolveUserOrganizations({
     activeOrganizationId: scopedOrganizationId ?? session?.activeOrganizationId ?? null,
     userId: normalizeDenTypeId("user", user.id),
@@ -75,7 +77,7 @@ export const resolveUserOrganizationsMiddleware: MiddlewareHandler<{
     : resolved.activeOrgSlug
 
   if (shouldHydrateSessionActiveOrganization({
-    scopedOrganizationId,
+    scopedOrganizationId: apiKeyScopedOrganizationId,
     sessionActiveOrganizationId: session?.activeOrganizationId,
     resolvedActiveOrganizationId: activeOrganizationId,
   })) {


### PR DESCRIPTION
## Summary
- follow up on #1502 by separating legacy org-path forwarding from API-key scoping when resolving the active organization
- persist `activeOrganizationId` back onto the session for legacy `/v1/orgs/:orgId/*` requests so older clients fully recover after the path migration
- keep API-key-scoped behavior unchanged while fixing missing-session hydration for proxied user requests

## Testing
- `pnpm install`
- `pnpm --filter @openwork-ee/utils build && pnpm --filter @openwork-ee/den-db build`
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit`
- `bun test ee/apps/den-api/test/org-invitations.test.ts`
- local Den stack live check of `GET /api/den/v1/orgs/:orgId/api-keys` and `GET /api/den/v1/api-keys` with the session `active_organization_id` manually nulled before each request; both returned `200` and rehydrated the session org