### PR TITLE
feat(app): enforce desktop restriction policies

### DIFF
--- a/apps/app/src/app/app.tsx
+++ b/apps/app/src/app/app.tsx
@@ -21,6 +21,12 @@ import SkillDestinationModal from "./bundles/skill-destination-modal";
 import BundleImportModal from "./bundles/import-modal";
 import BundleStartModal from "./bundles/start-modal";
 import { useDenAuth } from "./cloud/den-auth-provider";
+import { useDesktopConfig } from "./cloud/desktop-config-provider";
+import {
+  isDesktopProviderBlocked,
+  runDesktopAppRestrictionSyncEffects,
+} from "./cloud/desktop-app-restrictions";
+import RestrictionNoticeModal from "./components/restriction-notice-modal";
 import ForcedSigninPage from "./cloud/forced-signin-page";
 import RenameWorkspaceModal from "./components/rename-workspace-modal";
 import ConnectionsModals from "./connections/modals";
@@ -154,9 +160,15 @@ type PendingInitialSessionSelection = {
   readyAt: number;
 };
 
+type RestrictionNotice = {
+  title: string;
+  message: string;
+};
+
 const STARTUP_SESSION_SNAPSHOT_KEY = "openwork.startupSessionSnapshot.v1";
 const STARTUP_SESSION_SNAPSHOT_VERSION = 1;
 const STARTUP_SESSION_SNAPSHOT_MAX_PER_WORKSPACE = 12;
+const PROVIDER_RESTRICTION_MESSAGE = "Your administrator has restricted which providers and models are allowed. Please reach out to them to add new providers and models.";
 
 type StartupSessionSnapshotEntry = {
   id: string;
@@ -177,6 +189,7 @@ type StartupSessionSnapshot = {
 
 export default function App() {
   const denAuth = useDenAuth();
+  const desktopConfig = useDesktopConfig();
   const { resetSessionDisplayPreferences } = useSessionDisplayPreferences();
   const { microsandboxCreateSandboxEnabled } = useFeatureFlagsPreferences();
   const envOpenworkWorkspaceId =
@@ -202,6 +215,7 @@ export default function App() {
   const [settingsTab, setSettingsTabState] = createSignal<SettingsTab>("general");
   const [pendingInitialSessionSelection, setPendingInitialSessionSelection] =
     createSignal<PendingInitialSessionSelection | null>(null);
+  const [restrictionNotice, setRestrictionNotice] = createSignal<RestrictionNotice | null>(null);
 
   const goToSettings = (nextTab: SettingsTab, options?: { replace?: boolean }) => {
     setSettingsTabState(nextTab);
@@ -215,6 +229,22 @@ export default function App() {
     }
     setSettingsTabState(nextTab);
   };
+
+  const openCreateWorkspace = () => {
+    if (desktopConfig.checkRestriction({ restriction: "blockMultipleWorkspaces" })) {
+      setRestrictionNotice({
+        title: "Additional workspaces are restricted",
+        message: "Your organization administrator has restricted access to adding additional workspaces.",
+      });
+      return;
+    }
+
+    workspaceStore.setCreateWorkspaceOpen(true);
+  };
+
+  const providerConnectionsRestricted = createMemo(() =>
+    desktopConfig.checkRestriction({ restriction: "disallowNonCloudModels" }),
+  );
 
   const setView = (next: View, sessionId?: string) => {
     if (next === "signin") {
@@ -476,6 +506,25 @@ export default function App() {
   const providers = createMemo(() => globalSync.data.provider.all ?? []);
   const providerDefaults = createMemo(() => globalSync.data.provider.default ?? {});
   const providerConnectedIds = createMemo(() => globalSync.data.provider.connected ?? []);
+  const connectedProviderIdSet = createMemo(
+    () => new Set(providerConnectedIds().map((providerId) => providerId.trim())),
+  );
+  const visibleProviders = createMemo(() =>
+    providers().filter((provider) =>
+      !isDesktopProviderBlocked({
+        providerId: provider.id,
+        checkRestriction: desktopConfig.checkRestriction,
+      }) &&
+      (!providerConnectionsRestricted() || connectedProviderIdSet().has(provider.id.trim())),
+    ),
+  );
+  const visibleProviderConnectedIds = createMemo(() =>
+    providerConnectedIds().filter((providerId) =>
+      !isDesktopProviderBlocked({
+        providerId,
+        checkRestriction: desktopConfig.checkRestriction,
+      })),
+  );
   const setProviders = (value: ProviderListItem[]) => {
     globalSync.set("provider", "all", value);
   };
@@ -505,6 +554,7 @@ export default function App() {
     openworkServerStatus: () => openworkServerStore?.openworkServerStatus?.() ?? "disconnected",
     openworkServerCapabilities: () => openworkServerStore?.openworkServerCapabilities?.() ?? null,
     runtimeWorkspaceId: () => workspaceStore?.runtimeWorkspaceId?.() ?? null,
+    checkDesktopAppRestriction: desktopConfig.checkRestriction,
     focusSessionPromptSoon: () => focusSessionPromptSoon(),
     setError,
     setLastKnownConfigSnapshot,
@@ -929,7 +979,8 @@ export default function App() {
     connectCloudProvider,
     removeCloudProvider,
     disconnectProvider,
-    openProviderAuthModal,
+    ensureProjectProviderDisabledState,
+    openProviderAuthModal: openProviderAuthModalInternal,
     closeProviderAuthModal,
   } = createProvidersStore({
     client,
@@ -940,6 +991,7 @@ export default function App() {
     selectedWorkspaceDisplay: () => workspaceStore.selectedWorkspaceDisplay(),
     selectedWorkspaceRoot: () => workspaceStore.selectedWorkspaceRoot(),
     runtimeWorkspaceId: () => workspaceStore.runtimeWorkspaceId(),
+    checkDesktopAppRestriction: desktopConfig.checkRestriction,
     openworkServer: openworkServerStore,
     setProviders,
     setProviderDefaults,
@@ -947,6 +999,67 @@ export default function App() {
     setDisabledProviders: (value) => globalSync.set("config", "disabled_providers", value),
     markOpencodeConfigReloadRequired: () => markOpencodeConfigReloadRequired(),
     focusPromptSoon: focusSessionPromptSoon,
+  });
+
+  const openProviderAuthModal = async (optionsArg?: {
+    returnFocusTarget?: "none" | "composer";
+    preferredProviderId?: string;
+  }) => {
+    if (providerConnectionsRestricted()) {
+      setRestrictionNotice({
+        title: "Provider connections are restricted",
+        message: PROVIDER_RESTRICTION_MESSAGE,
+      });
+      return;
+    }
+
+    await openProviderAuthModalInternal(optionsArg);
+  };
+
+  let desktopRestrictionSyncKey = "";
+  let desktopRestrictionSyncRunId = 0;
+
+  createEffect(() => {
+    const workspaceId = workspaceStore.selectedWorkspaceId().trim();
+    if (!workspaceId) {
+      desktopRestrictionSyncKey = "";
+      return;
+    }
+
+    const workspacePath = workspaceStore.selectedWorkspacePath().trim();
+    const restrictionSnapshot = JSON.stringify(desktopConfig.config());
+    const providerSnapshot = providers().map((provider) => provider.id).join(",");
+    const connectedSnapshot = providerConnectedIds().join(",");
+    const defaultModelSnapshot = modelConfig.defaultModelRef();
+    const hasClient = Boolean(client());
+    const nextKey = [
+      workspaceId,
+      workspacePath,
+      restrictionSnapshot,
+      providerSnapshot,
+      connectedSnapshot,
+      defaultModelSnapshot,
+      hasClient ? "client" : "no-client",
+    ].join("::");
+
+    if (nextKey === desktopRestrictionSyncKey) {
+      return;
+    }
+
+    desktopRestrictionSyncKey = nextKey;
+    const currentRun = ++desktopRestrictionSyncRunId;
+
+    void runDesktopAppRestrictionSyncEffects({
+      checkRestriction: desktopConfig.checkRestriction,
+      reconcileRestrictedModels: modelConfig.reconcileRestrictedModels,
+      ensureProjectProviderDisabledState,
+      onError: (error, details) => {
+        if (currentRun !== desktopRestrictionSyncRunId) {
+          return;
+        }
+        console.warn("[desktop-app-restrictions] effect failed", details, error);
+      },
+    });
   });
 
   const runtimeWorkspaceId = createMemo(() => workspaceStore.runtimeWorkspaceId());
@@ -2065,8 +2178,8 @@ export default function App() {
     return {
       settingsTab: settingsTab(),
       setSettingsTab,
-      providers: providers(),
-      providerConnectedIds: providerConnectedIds(),
+      providers: visibleProviders(),
+      providerConnectedIds: visibleProviderConnectedIds(),
       providerAuthBusy: providerAuthBusy(),
       providerAuthModalOpen: providerAuthModalOpen(),
       providerAuthError: providerAuthError(),
@@ -2134,7 +2247,7 @@ export default function App() {
       switchWorkspace: workspaceStore.switchWorkspace,
       testWorkspaceConnection: workspaceStore.testWorkspaceConnection,
       recoverWorkspace: workspaceStore.recoverWorkspace,
-      openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
+      openCreateWorkspace,
       connectRemoteWorkspace: workspaceStore.createRemoteWorkspaceFlow,
       openTeamBundle: bundlesStore.openTeamBundle,
       exportWorkspaceConfig: workspaceStore.exportWorkspaceConfig,
@@ -2242,7 +2355,7 @@ export default function App() {
     recoverWorkspace: workspaceStore.recoverWorkspace,
     editWorkspaceConnection: workspaceStore.openWorkspaceConnectionSettings,
     forgetWorkspace: workspaceStore.forgetWorkspace,
-    openCreateWorkspace: () => workspaceStore.setCreateWorkspaceOpen(true),
+    openCreateWorkspace,
     exportWorkspaceConfig: workspaceStore.exportWorkspaceConfig,
     exportWorkspaceBusy: workspaceStore.exportingWorkspaceConfig(),
     clientConnected: Boolean(client()),
@@ -2310,8 +2423,8 @@ export default function App() {
     providerAuthMethods: providerAuthMethods(),
     providerAuthProviders: providerAuthProviders(),
     providerAuthPreferredProviderId: providerAuthPreferredProviderId(),
-    providers: providers(),
-    providerConnectedIds: providerConnectedIds(),
+    providers: visibleProviders(),
+    providerConnectedIds: visibleProviderConnectedIds(),
     sessionStatusById: activeSessionStatusById(),
     hasEarlierMessages: selectedSessionHasEarlierMessages(),
     loadingEarlierMessages: selectedSessionLoadingEarlierMessages(),
@@ -2673,6 +2786,13 @@ export default function App() {
           return busy() && busyLabel() === "status.creating_workspace";
         })()}
         submittingProgress={workspaceStore.sandboxCreateProgress?.() ?? null}
+      />
+
+      <RestrictionNoticeModal
+        open={Boolean(restrictionNotice())}
+        onClose={() => setRestrictionNotice(null)}
+        title={restrictionNotice()?.title ?? "Restriction"}
+        message={restrictionNotice()?.message ?? ""}
       />
 
       <SkillDestinationModal

--- a/apps/app/src/app/cloud/desktop-app-restrictions.ts
+++ b/apps/app/src/app/cloud/desktop-app-restrictions.ts
@@ -1,0 +1,78 @@
+import type { DesktopAppRestrictions as DenDesktopConfig } from "@openwork/types/den/desktop-app-restrictions";
+import type { ModelRef } from "../types";
+
+export type DesktopAppRestrictionKey = keyof DenDesktopConfig;
+
+export type DesktopAppRestrictionChecker = (input: {
+  restriction: DesktopAppRestrictionKey;
+}) => boolean;
+
+export const DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID = "opencode";
+
+export function checkDesktopAppRestriction(input: {
+  config: DenDesktopConfig | null | undefined;
+  restriction: DesktopAppRestrictionKey;
+}) {
+  return input.config?.[input.restriction] === true;
+}
+
+export function isDesktopProviderBlocked(input: {
+  providerId: string;
+  checkRestriction: DesktopAppRestrictionChecker;
+}) {
+  const providerId = input.providerId.trim().toLowerCase();
+  if (!providerId) return false;
+
+  if (providerId === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
+    return input.checkRestriction({ restriction: "blockZenModel" });
+  }
+
+  return false;
+}
+
+export function isDesktopModelBlocked(input: {
+  model: ModelRef;
+  checkRestriction: DesktopAppRestrictionChecker;
+}) {
+  return isDesktopProviderBlocked({
+    providerId: input.model.providerID,
+    checkRestriction: input.checkRestriction,
+  });
+}
+
+type DesktopAppRestrictionSyncContext = {
+  checkRestriction: DesktopAppRestrictionChecker;
+  reconcileRestrictedModels?: () => void;
+  ensureProjectProviderDisabledState?: (providerId: string, disabled: boolean) => Promise<unknown>;
+  onError?: (error: Error, details: {
+    restriction: DesktopAppRestrictionKey;
+    action: string;
+    providerId?: string;
+  }) => void;
+};
+
+export async function runDesktopAppRestrictionSyncEffects(
+  input: DesktopAppRestrictionSyncContext,
+) {
+  const shouldDisableOpencodeProvider = input.checkRestriction({ restriction: "blockZenModel" });
+
+  input.reconcileRestrictedModels?.();
+
+  if (input.ensureProjectProviderDisabledState) {
+    try {
+      await input.ensureProjectProviderDisabledState(
+        DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
+        shouldDisableOpencodeProvider,
+      );
+    } catch (error) {
+      input.onError?.(
+        error instanceof Error ? error : new Error(String(error ?? "Desktop restriction effect failed.")),
+        {
+          restriction: "blockZenModel",
+          action: "ensureProjectProviderDisabledState",
+          providerId: DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
+        },
+      );
+    }
+  }
+}

--- a/apps/app/src/app/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/app/cloud/desktop-config-provider.tsx
@@ -2,11 +2,13 @@ import { createContext, createEffect, createSignal, onCleanup, onMount, useConte
 import { createDenClient, DenApiError, ensureDenActiveOrganization, type DenDesktopConfig, normalizeDenDesktopConfig, readDenSettings } from "../lib/den";
 import { denSessionUpdatedEvent, denSettingsChangedEvent } from "../lib/den-session-events";
 import { useDenAuth } from "./den-auth-provider";
+import { checkDesktopAppRestriction, type DesktopAppRestrictionChecker } from "./desktop-app-restrictions";
 
 type DesktopConfigStore = {
   config: Accessor<DenDesktopConfig>;
   loading: Accessor<boolean>;
   refresh: () => Promise<void>;
+  checkRestriction: DesktopAppRestrictionChecker;
 };
 
 const DesktopConfigContext = createContext<DesktopConfigStore>();
@@ -155,6 +157,12 @@ export function DesktopConfigProvider(props: ParentProps) {
     config,
     loading,
     refresh,
+    checkRestriction(input) {
+      return checkDesktopAppRestriction({
+        config: config(),
+        restriction: input.restriction,
+      });
+    },
   };
 
   return (

--- a/apps/app/src/app/components/restriction-notice-modal.tsx
+++ b/apps/app/src/app/components/restriction-notice-modal.tsx
@@ -1,0 +1,45 @@
+import { Show } from "solid-js";
+import { X } from "lucide-solid";
+
+import { currentLocale, t } from "../../i18n";
+import Button from "./button";
+
+export type RestrictionNoticeModalProps = {
+  open: boolean;
+  title: string;
+  message: string;
+  onClose: () => void;
+};
+
+export default function RestrictionNoticeModal(props: RestrictionNoticeModalProps) {
+  return (
+    <Show when={props.open}>
+      <div class="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm">
+        <div class="flex w-full max-w-[480px] flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
+          <div class="flex items-start justify-between gap-4 border-b border-dls-border px-6 py-5">
+            <div class="min-w-0">
+              <h2 class="text-[20px] font-semibold tracking-[-0.3px] text-dls-text">{props.title}</h2>
+            </div>
+            <button
+              type="button"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-full text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+              aria-label={t("common.close", currentLocale())}
+              onClick={props.onClose}
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          <div class="px-6 py-6">
+            <p class="text-[14px] leading-6 text-dls-secondary">{props.message}</p>
+            <div class="mt-6 flex justify-end">
+              <Button variant="primary" onClick={props.onClose}>
+                {t("common.close", currentLocale())}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/apps/app/src/app/context/model-config.ts
+++ b/apps/app/src/app/context/model-config.ts
@@ -4,6 +4,10 @@ import { parse } from "jsonc-parser";
 
 import { currentLocale, t } from "../../i18n";
 import { DEFAULT_MODEL, MODEL_PREF_KEY, SESSION_MODEL_PREF_KEY, VARIANT_PREF_KEY } from "../constants";
+import {
+  isDesktopModelBlocked,
+  type DesktopAppRestrictionChecker,
+} from "../cloud/desktop-app-restrictions";
 import { readOpencodeConfig, writeOpencodeConfig } from "../lib/tauri";
 import {
   formatGenericBehaviorLabel,
@@ -332,6 +336,7 @@ export function createModelConfigStore(options: {
   openworkServerStatus: Accessor<OpenworkServerStatus>;
   openworkServerCapabilities: Accessor<OpenworkServerCapabilities | null>;
   runtimeWorkspaceId: Accessor<string | null>;
+  checkDesktopAppRestriction: DesktopAppRestrictionChecker;
   focusSessionPromptSoon: () => void;
   setError: (value: string | null) => void;
   setLastKnownConfigSnapshot: (value: string) => void;
@@ -489,6 +494,71 @@ export function createModelConfigStore(options: {
   const getWorkspaceVariantFor = (ref: ModelRef) =>
     workspaceVariantMap()[formatModelRef(ref)] ?? null;
 
+  const isBlockedModelRef = (ref: ModelRef) =>
+    isDesktopModelBlocked({
+      model: ref,
+      checkRestriction: options.checkDesktopAppRestriction,
+    });
+
+  const restrictToInstalledModels = () =>
+    options.checkDesktopAppRestriction({ restriction: "disallowNonCloudModels" });
+
+  const isInstalledProvider = (providerId: string) =>
+    options.providerConnectedIds().some((id) => id.trim() === providerId.trim());
+
+  const isRestrictedModelRef = (ref: ModelRef) => {
+    if (isBlockedModelRef(ref)) {
+      return true;
+    }
+
+    if (restrictToInstalledModels() && !isInstalledProvider(ref.providerID)) {
+      return true;
+    }
+
+    return false;
+  };
+
+  const listAllowedModelRefs = () => {
+    const sortedProviders = options.providers().slice().sort(compareProviders);
+    const next: ModelRef[] = [];
+
+    for (const provider of sortedProviders) {
+      const providerId = provider.id?.trim();
+      if (!providerId) continue;
+      if (restrictToInstalledModels() && !isInstalledProvider(providerId)) continue;
+
+      const models = Object.values(provider.models ?? {})
+        .filter((model) => model.status !== "deprecated")
+        .sort((a, b) => {
+          const aFree = a.cost?.input === 0 && a.cost?.output === 0;
+          const bFree = b.cost?.input === 0 && b.cost?.output === 0;
+          if (aFree !== bFree) return aFree ? -1 : 1;
+          return (a.name ?? a.id).localeCompare(b.name ?? b.id);
+        });
+
+      for (const model of models) {
+        const ref = { providerID: providerId, modelID: model.id };
+        if (isRestrictedModelRef(ref)) continue;
+        next.push(ref);
+      }
+    }
+
+    return next;
+  };
+
+  const resolveAllowedModelFallback = () => {
+    if (!isRestrictedModelRef(defaultModel())) {
+      return defaultModel();
+    }
+
+    const allowed = listAllowedModelRefs();
+    if (allowed.length > 0) {
+      return allowed[0];
+    }
+
+    return isRestrictedModelRef(DEFAULT_MODEL) ? null : DEFAULT_MODEL;
+  };
+
   const getVariantFor = (ref: ModelRef, sessionId?: string | null) => {
     if (sessionId) {
       const choice = sessionChoiceOverrideById()[sessionId];
@@ -508,16 +578,21 @@ export function createModelConfigStore(options: {
   const selectedSessionModel = createMemo<ModelRef>(() => {
     const id = options.selectedSessionId();
     const pendingChoice = pendingSessionChoice();
-    if (!id) return pendingChoice?.model ?? defaultModel();
+    if (!id) {
+      if (pendingChoice?.model && !isRestrictedModelRef(pendingChoice.model)) {
+        return pendingChoice.model;
+      }
+      return defaultModel();
+    }
 
     const override = sessionChoiceOverrideById()[id]?.model;
-    if (override) return override;
+    if (override && !isRestrictedModelRef(override)) return override;
 
     const known = sessionModelById()[id];
-    if (known) return known;
+    if (known && !isRestrictedModelRef(known)) return known;
 
     const fromMessages = lastUserModelFromMessages(options.messages());
-    if (fromMessages) return fromMessages;
+    if (fromMessages && !isRestrictedModelRef(fromMessages)) return fromMessages;
 
     return defaultModel();
   });
@@ -615,6 +690,7 @@ export function createModelConfigStore(options: {
     for (const provider of sortedProviders) {
       const defaultModelID = defaults[provider.id];
       const isConnected = options.providerConnectedIds().includes(provider.id);
+      if (restrictToInstalledModels() && !isConnected) continue;
       const models = Object.values(provider.models ?? {}).filter((m) => m.status !== "deprecated");
 
       models.sort((a, b) => {
@@ -629,6 +705,7 @@ export function createModelConfigStore(options: {
         const isDefault =
           provider.id === currentDefault.providerID && model.id === currentDefault.modelID;
         const ref = { providerID: provider.id, modelID: model.id };
+        if (isRestrictedModelRef(ref)) continue;
         const activeVariant =
           modelPickerTarget() === "session" && modelEquals(ref, selectedSessionModel())
             ? modelVariant()
@@ -843,6 +920,68 @@ export function createModelConfigStore(options: {
     setSessionModelById({});
     setWorkspaceVariantMap({});
     closeModelPicker({ restorePromptFocus: false });
+  };
+
+  const reconcileRestrictedModels = () => {
+    const isRestrictedChoice = (model: ModelRef | null | undefined) => {
+      if (!model) return false;
+      return isRestrictedModelRef(model);
+    };
+
+    const fallback = resolveAllowedModelFallback();
+
+    if (isRestrictedChoice(defaultModel()) && fallback && !modelEquals(defaultModel(), fallback)) {
+      applyDefaultModelChoice(fallback);
+    }
+
+    setPendingSessionChoice((current) => {
+      if (!current?.model || !isRestrictedChoice(current.model)) {
+        return current;
+      }
+
+      return hasOwn(current, "variant")
+        ? { variant: current.variant ?? null }
+        : null;
+    });
+
+    setSessionChoiceOverrideById((current) => {
+      const next: Record<string, SessionChoiceOverride> = {};
+      let changed = false;
+
+      for (const [sessionId, choice] of Object.entries(current)) {
+        if (!choice.model || !isRestrictedChoice(choice.model)) {
+          next[sessionId] = choice;
+          continue;
+        }
+
+        changed = true;
+        const stripped = normalizeSessionChoice(
+          hasOwn(choice, "variant") ? { variant: choice.variant ?? null } : null,
+        );
+        if (stripped) {
+          next[sessionId] = stripped;
+        }
+      }
+
+      return changed ? next : current;
+    });
+
+    setSessionModelById((current) => {
+      const next = Object.fromEntries(
+        Object.entries(current).filter(([, model]) => !isRestrictedChoice(model)),
+      );
+      return Object.keys(next).length === Object.keys(current).length ? current : next;
+    });
+
+    setWorkspaceVariantMap((current) => {
+      const next = Object.fromEntries(
+        Object.entries(current).filter(([ref]) => {
+          const parsed = parseModelRef(ref);
+          return !parsed || !isRestrictedChoice(parsed);
+        }),
+      );
+      return Object.keys(next).length === Object.keys(current).length ? current : next;
+    });
   };
 
   createEffect(() => {
@@ -1284,6 +1423,7 @@ export function createModelConfigStore(options: {
     closeModelPicker,
     applyModelSelection,
     setModelPickerBehavior,
+    reconcileRestrictedModels,
     autoCompactContext,
     toggleAutoCompactContext,
     autoCompactContextSaving,

--- a/apps/app/src/app/context/providers/provider-auth-modal.tsx
+++ b/apps/app/src/app/context/providers/provider-auth-modal.tsx
@@ -6,6 +6,7 @@ import { compareProviders } from "../../utils/providers";
 import Button from "../../components/button";
 import ProviderIcon from "../../components/provider-icon";
 import TextInput from "../../components/text-input";
+import { useDesktopConfig } from "../../cloud/desktop-config-provider";
 import type { ProviderAuthMethod, ProviderAuthProvider, ProviderOAuthStartResult } from "./store";
 
 type ProviderAuthEntry = {
@@ -34,6 +35,8 @@ export type ProviderAuthModalProps = {
   loading: boolean;
   submitting: boolean;
   error: string | null;
+  restricted?: boolean;
+  restrictedMessage?: string | null;
   preferredProviderId?: string | null;
   workerType?: "local" | "remote";
   providers: ProviderAuthProvider[];
@@ -52,8 +55,17 @@ export type ProviderAuthModalProps = {
 };
 
 export default function ProviderAuthModal(props: ProviderAuthModalProps) {
+  const desktopConfig = useDesktopConfig();
   const workerType = createMemo(() => (props.workerType === "remote" ? "remote" : "local"));
   const isRemoteWorker = createMemo(() => workerType() === "remote");
+  const restricted = createMemo(() =>
+    props.restricted ?? desktopConfig.checkRestriction({ restriction: "disallowNonCloudModels" }),
+  );
+  const restrictionMessage = createMemo(
+    () =>
+      props.restrictedMessage?.trim() ||
+      "Your administrator has restricted which providers and models are allowed. Please reach out to them to add new providers and models.",
+  );
 
   const formatProviderName = (id: string, fallback?: string) => {
     const named = fallback?.trim();
@@ -658,9 +670,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
           <div class="px-6 py-4 flex flex-col gap-4 min-h-0">
             <div class="min-h-[36px]">
               <Show
-                when={errorMessage()}
+                when={!restricted() && errorMessage()}
                 fallback={
-                  <Show when={props.loading}>
+                  <Show when={!restricted() && props.loading}>
                     <div class="rounded-xl border border-gray-6 bg-gray-1/60 px-4 py-3 text-sm text-gray-10 animate-pulse">
                       Loading providers...
                     </div>
@@ -673,7 +685,18 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
               </Show>
             </div>
 
-            <Show when={!props.loading}>
+            <Show when={restricted()}>
+              <div class="rounded-xl border border-gray-6/50 bg-gray-2/50 p-5">
+                <p class="text-sm leading-6 text-gray-11">{restrictionMessage()}</p>
+                <div class="mt-5 flex justify-end">
+                  <Button variant="primary" onClick={handleClose}>
+                    Close
+                  </Button>
+                </div>
+              </div>
+            </Show>
+
+            <Show when={!restricted() && !props.loading}>
               <div class="flex-1 space-y-2 overflow-y-auto pr-1 -mr-1">
                 <Show when={resolvedView() === "list"}>
                   <div class="space-y-3" onKeyDown={handleListKeyDown}>

--- a/apps/app/src/app/context/providers/store.ts
+++ b/apps/app/src/app/context/providers/store.ts
@@ -1190,40 +1190,13 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
       provider?.source === "config" || provider?.source === "custom";
 
     const disableProvider = async () => {
-      const config = unwrap(await c.config.get());
-      const disabledProviders = Array.isArray(config.disabled_providers)
-        ? config.disabled_providers
-        : [];
-      if (disabledProviders.includes(resolved)) {
-        return false;
-      }
-
-      const next = [...disabledProviders, resolved];
-      options.setDisabledProviders(next);
-      try {
-        const result = await c.config.update({
-          config: {
-            ...config,
-            disabled_providers: next,
-          },
-        });
-        assertNoClientError(result);
-        options.markOpencodeConfigReloadRequired();
-      } catch (error) {
-        options.setDisabledProviders(disabledProviders);
-        throw error;
-      }
-      return true;
+      return await ensureProjectProviderDisabledState(resolved, true);
     };
 
     try {
       await removeProviderAuthCredentials(resolved);
       let updated = await refreshProviders({ dispose: true });
-      if (
-        canDisableProvider &&
-        Array.isArray(updated?.connected) &&
-        updated.connected.includes(resolved)
-      ) {
+      if (canDisableProvider) {
         const disabled = await disableProvider();
         if (disabled && updated) {
           updated = filterProviderList(updated, options.disabledProviders() ?? []);

--- a/apps/app/src/app/context/providers/store.ts
+++ b/apps/app/src/app/context/providers/store.ts
@@ -4,6 +4,10 @@ import { applyEdits, modify, parse } from "jsonc-parser";
 import type { ProviderAuthAuthorization, ProviderConfig, ProviderListResponse } from "@opencode-ai/sdk/v2/client";
 
 import { t } from "../../../i18n";
+import {
+  isDesktopProviderBlocked,
+  type DesktopAppRestrictionChecker,
+} from "../../cloud/desktop-app-restrictions";
 import { createDenClient, readDenSettings, type DenOrgLlmProvider, type DenOrgLlmProviderConnection } from "../../lib/den";
 import { unwrap, waitForHealthy } from "../../lib/opencode";
 import {
@@ -54,6 +58,7 @@ type CreateProvidersStoreOptions = {
   selectedWorkspaceDisplay: Accessor<WorkspaceDisplay>;
   selectedWorkspaceRoot: Accessor<string>;
   runtimeWorkspaceId: Accessor<string | null>;
+  checkDesktopAppRestriction: DesktopAppRestrictionChecker;
   openworkServer: OpenworkServerStore;
   setProviders: (value: ProviderListItem[]) => void;
   setProviderDefaults: (value: Record<string, string>) => void;
@@ -326,6 +331,66 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
     return true;
   };
 
+  const normalizeDisabledProviders = (value: unknown) =>
+    Array.isArray(value)
+      ? [...new Set(value.filter((entry): entry is string => typeof entry === "string").map((entry) => entry.trim()).filter(Boolean))]
+      : [];
+
+  const formatConfigWithProviderDisabledState = (raw: string, providerId: string, disabled: boolean) => {
+    const resolvedProviderId = providerId.trim();
+    let updated = raw.trim() ? raw : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
+    const parsed = parse(updated) as Record<string, unknown> | undefined;
+    const currentDisabled = normalizeDisabledProviders(parsed?.disabled_providers);
+    const nextDisabled = disabled
+      ? [...currentDisabled.filter((entry) => entry !== resolvedProviderId), resolvedProviderId]
+      : currentDisabled.filter((entry) => entry !== resolvedProviderId);
+    const disabledEdits = modify(updated, ["disabled_providers"], nextDisabled.length ? nextDisabled : undefined, {
+      formattingOptions: { insertSpaces: true, tabSize: 2 },
+    });
+    updated = applyEdits(updated, disabledEdits);
+    return updated.endsWith("\n") ? updated : `${updated}\n`;
+  };
+
+  const ensureProjectProviderDisabledState = async (providerId: string, disabled: boolean) => {
+    const resolvedProviderId = providerId.trim();
+    if (!resolvedProviderId) {
+      throw new Error(t("providers.provider_id_required"));
+    }
+
+    const currentDisabled = normalizeDisabledProviders(options.disabledProviders());
+    const nextDisabled = disabled
+      ? [...currentDisabled.filter((entry) => entry !== resolvedProviderId), resolvedProviderId]
+      : currentDisabled.filter((entry) => entry !== resolvedProviderId);
+
+    if (
+      nextDisabled.length === currentDisabled.length &&
+      nextDisabled.every((entry, index) => entry === currentDisabled[index])
+    ) {
+      return false;
+    }
+
+    const updatedConfig = await updateProjectConfigFile(
+      (raw) => formatConfigWithProviderDisabledState(raw, resolvedProviderId, disabled),
+      (config) => {
+        const nextConfig = { ...config };
+        if (nextDisabled.length) {
+          nextConfig.disabled_providers = nextDisabled;
+        } else {
+          delete nextConfig.disabled_providers;
+        }
+        return nextConfig;
+      },
+    );
+
+    if (!updatedConfig) {
+      throw new Error("Could not update opencode.jsonc for this workspace.");
+    }
+
+    options.setDisabledProviders(nextDisabled);
+    options.markOpencodeConfigReloadRequired();
+    return true;
+  };
+
   const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
   const cloudProviderComment = (provider: Pick<DenOrgLlmProvider, "id" | "name">) =>
@@ -457,6 +522,9 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
     for (const provider of options.providers()) {
       const id = provider.id?.trim();
       if (!id) continue;
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) {
+        continue;
+      }
       merged.set(id, {
         id,
         name: provider.name?.trim() || id,
@@ -467,6 +535,9 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
     for (const provider of cloudOrgProviders()) {
       const id = provider.providerId.trim();
       if (!id || merged.has(id)) continue;
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) {
+        continue;
+      }
       merged.set(id, {
         id,
         name: provider.name.trim() || id,
@@ -714,6 +785,10 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
       merged[id] = [...existing, { type: "api", label: t("providers.api_key_label") }];
     }
     for (const [id, providerMethods] of Object.entries(merged)) {
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) {
+        delete merged[id];
+        continue;
+      }
       const provider = availableProviders.find((item) => item.id === id);
       const normalizedId = id.trim().toLowerCase();
       const normalizedName = provider?.name?.trim().toLowerCase() ?? "";
@@ -730,6 +805,9 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
     for (const provider of cloudProviders) {
       const id = provider.providerId.trim();
       if (!id) continue;
+      if (isDesktopProviderBlocked({ providerId: id, checkRestriction: options.checkDesktopAppRestriction })) {
+        continue;
+      }
       const existing = merged[id] ?? [];
       if (existing.some((method) => method.type === "cloud" && method.cloudProviderId === provider.id)) {
         continue;
@@ -984,6 +1062,9 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
         token,
       });
       const provider = await den.getOrgLlmProviderConnection(orgId, cloudProviderId);
+      if (isDesktopProviderBlocked({ providerId: provider.providerId, checkRestriction: options.checkDesktopAppRestriction })) {
+        throw new Error(`${provider.name} is blocked by your organization desktop policy.`);
+      }
       const existingImported = importedCloudProviders()[cloudProviderId] ?? null;
       const apiKey = provider.apiKey?.trim() ?? "";
       const env = getCloudProviderEnv(provider.providerConfig);
@@ -1221,6 +1302,7 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
     connectCloudProvider,
     removeCloudProvider,
     disconnectProvider,
+    ensureProjectProviderDisabledState,
     openProviderAuthModal,
     closeProviderAuthModal,
   };

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -1,5 +1,5 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
-import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions as DenDesktopConfig } from "@openwork/types/den/desktop-app-restrictions";
+import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions";
 import { isDesktopDeployment } from "./openwork-deployment";
 import {
   dispatchDenSettingsChanged,
@@ -53,6 +53,8 @@ type DenBaseUrls = {
 export type DenBootstrapConfig = DenBaseUrls & {
   requireSignin: boolean;
 };
+
+export type DenDesktopConfig = DesktopAppRestrictions;
 
 export type DenUser = {
   id: string;

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
@@ -73,9 +73,11 @@ export function OrgSettingsScreen() {
   const [allowedDomainsDraft, setAllowedDomainsDraft] = useState("");
   const [domainRestrictionsEnabled, setDomainRestrictionsEnabled] =
     useState(false);
-  const [allowNonCloudModelsEnabled, setAllowNonCloudModelsEnabled] = useState(true);
+  const [allowNonCloudModelsEnabled, setAllowNonCloudModelsEnabled] =
+    useState(true);
   const [allowZenModelEnabled, setAllowZenModelEnabled] = useState(true);
-  const [allowMultipleWorkspacesEnabled, setAllowMultipleWorkspacesEnabled] = useState(true);
+  const [allowMultipleWorkspacesEnabled, setAllowMultipleWorkspacesEnabled] =
+    useState(true);
   const [domainEditModeEnabled, setDomainEditModeEnabled] = useState(false);
   const [pageError, setPageError] = useState<string | null>(null);
   const [pageSuccess, setPageSuccess] = useState<string | null>(null);
@@ -105,13 +107,15 @@ export function OrgSettingsScreen() {
       (orgContext.organization.allowedEmailDomains?.length ?? 0) > 0,
     );
     setAllowNonCloudModelsEnabled(
-      orgContext.organization.desktopAppRestrictions.disallowNonCloudModels !== true,
+      orgContext.organization.desktopAppRestrictions.disallowNonCloudModels !==
+        true,
     );
     setAllowZenModelEnabled(
       orgContext.organization.desktopAppRestrictions.blockZenModel !== true,
     );
     setAllowMultipleWorkspacesEnabled(
-      orgContext.organization.desktopAppRestrictions.blockMultipleWorkspaces !== true,
+      orgContext.organization.desktopAppRestrictions.blockMultipleWorkspaces !==
+        true,
     );
     setDomainEditModeEnabled(false);
   }, [orgContext]);
@@ -187,9 +191,13 @@ export function OrgSettingsScreen() {
           ? draftAllowedDomains
           : null,
         desktopAppRestrictions: {
-          ...(!allowNonCloudModelsEnabled ? { disallowNonCloudModels: true } : {}),
+          ...(!allowNonCloudModelsEnabled
+            ? { disallowNonCloudModels: true }
+            : {}),
           ...(!allowZenModelEnabled ? { blockZenModel: true } : {}),
-          ...(!allowMultipleWorkspacesEnabled ? { blockMultipleWorkspaces: true } : {}),
+          ...(!allowMultipleWorkspacesEnabled
+            ? { blockMultipleWorkspaces: true }
+            : {}),
         },
       });
       setDomainEditModeEnabled(false);
@@ -365,7 +373,8 @@ export function OrgSettingsScreen() {
               Desktop restrictions
             </h2>
             <p className="text-[14px] text-gray-500">
-              Control which desktop-only options remain available after people sign in to this workspace.
+              Control which desktop-only options remain available after people
+              sign in to this workspace.
             </p>
           </div>
 
@@ -376,7 +385,8 @@ export function OrgSettingsScreen() {
                   Allow non-cloud deployed models
                 </p>
                 <p className="text-[13px] text-gray-500">
-                  Let signed-in desktop users access models that are not deployed through OpenWork Cloud.
+                  Let signed-in desktop users access models that are not
+                  deployed through OpenWork Cloud.
                 </p>
               </div>
               <SettingsToggle
@@ -393,7 +403,8 @@ export function OrgSettingsScreen() {
                   Allow usage of OpenCode Zen model
                 </p>
                 <p className="text-[13px] text-gray-500">
-                  Let signed-in desktop users access the OpenCode Zen model in the desktop app.
+                  Let signed-in desktop users access the OpenCode Zen model in
+                  the desktop app.
                 </p>
               </div>
               <SettingsToggle
@@ -410,7 +421,8 @@ export function OrgSettingsScreen() {
                   Allow users to configure multiple workspaces
                 </p>
                 <p className="text-[13px] text-gray-500">
-                  Let signed-in desktop users create or manage more than one workspace on their machine.
+                  Let signed-in desktop users create or manage more than one
+                  workspace on their machine.
                 </p>
               </div>
               <SettingsToggle
@@ -420,12 +432,6 @@ export function OrgSettingsScreen() {
                 onChange={setAllowMultipleWorkspacesEnabled}
               />
             </div>
-
-            {Object.keys(currentDesktopAppRestrictions).length === 0 ? (
-              <p className="text-[13px] text-gray-500">
-                No desktop restrictions are configured yet. Leaving every toggle on stores an empty config object and keeps the desktop defaults.
-              </p>
-            ) : null}
           </div>
         </DenCard>
 

--- a/ee/apps/den-web/next-env.d.ts
+++ b/ee/apps/den-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add shared desktop restriction checks and sync effects so the desktop app can enforce org restriction flags consistently
- block workspace creation and provider expansion flows when org policy disallows them, and filter model/provider pickers down to allowed installed options
- keep workspace `opencode.jsonc` `disabled_providers` in sync for Zen restrictions and config-backed provider disconnects

## Testing
- `pnpm --filter @openwork/app typecheck`
- `git diff --check`

## Notes
- I did not run the full Docker + Chrome MCP end-to-end flow for this branch
- I did not capture screenshots or video for the PR