### PR TITLE
feat(den): allow org desktop version controls

### DIFF
--- a/ee/apps/den-api/src/generated/app-version.ts
+++ b/ee/apps/den-api/src/generated/app-version.ts
@@ -1,1 +1,1 @@
-export const BUILD_LATEST_APP_VERSION = "0.11.207" as const
+export const BUILD_LATEST_APP_VERSION = "0.11.210" as const

--- a/ee/apps/den-api/src/organization-limits.ts
+++ b/ee/apps/den-api/src/organization-limits.ts
@@ -18,6 +18,7 @@ type OrganizationId = typeof OrganizationTable.$inferSelect.id
 
 export type OrganizationMetadata = {
   limits: OrganizationLimits
+  allowedDesktopVersions?: string[]
 } & Record<string, unknown>
 
 type OrganizationMetadataInput = Record<string, unknown> | string | null | undefined
@@ -39,6 +40,38 @@ function normalizePositiveInteger(value: unknown, fallback: number) {
   }
 
   return fallback
+}
+
+function normalizeDesktopVersionString(value: unknown) {
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const normalized = value.trim().replace(/^v/i, "")
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(normalized)
+    ? normalized
+    : null
+}
+
+function normalizeAllowedDesktopVersions(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  const versions = [...new Set(value.map((entry) => normalizeDesktopVersionString(entry)).filter((entry): entry is string => Boolean(entry)))]
+  return versions
+}
+
+function sameStringArray(left: string[] | null, right: string[] | null) {
+  if (left === right) {
+    return true
+  }
+
+  if (!left || !right || left.length !== right.length) {
+    return false
+  }
+
+  return left.every((entry, index) => right[index] === entry)
 }
 
 function parseMetadata(input: OrganizationMetadataInput): Record<string, unknown> {
@@ -64,6 +97,7 @@ export function normalizeOrganizationMetadata(input: OrganizationMetadataInput):
 } {
   const parsed = parseMetadata(input)
   const rawLimits = isRecord(parsed.limits) ? parsed.limits : null
+  const allowedDesktopVersions = normalizeAllowedDesktopVersions(parsed.allowedDesktopVersions)
   const members = normalizePositiveInteger(rawLimits?.members, DEFAULT_ORGANIZATION_LIMITS.members)
   const workers = normalizePositiveInteger(rawLimits?.workers ?? rawLimits?.Workers, DEFAULT_ORGANIZATION_LIMITS.workers)
 
@@ -73,13 +107,23 @@ export function normalizeOrganizationMetadata(input: OrganizationMetadataInput):
       members,
       workers,
     },
+    ...(allowedDesktopVersions !== null ? { allowedDesktopVersions } : {}),
   } as OrganizationMetadata
+
+  if (allowedDesktopVersions === null) {
+    delete metadata.allowedDesktopVersions
+  }
+
+  const rawAllowedDesktopVersions = Array.isArray(parsed.allowedDesktopVersions)
+    ? parsed.allowedDesktopVersions.filter((entry): entry is string => typeof entry === "string")
+    : null
 
   const changed =
     !isRecord(parsed.limits) ||
     Object.keys(parsed).length === 0 ||
     rawLimits?.members !== members ||
-    (rawLimits?.workers ?? rawLimits?.Workers) !== workers
+    (rawLimits?.workers ?? rawLimits?.Workers) !== workers ||
+    !sameStringArray(rawAllowedDesktopVersions, allowedDesktopVersions)
 
   return { metadata, changed }
 }

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -12,7 +12,7 @@ import {
 import { normalizeDesktopAppRestrictions, type DesktopAppRestrictions } from "@openwork/types/den/desktop-app-restrictions"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "./db.js"
-import { DEFAULT_ORGANIZATION_LIMITS, serializeOrganizationMetadata } from "./organization-limits.js"
+import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata, serializeOrganizationMetadata } from "./organization-limits.js"
 import { denDefaultDynamicOrganizationRoles, denOrganizationStaticRoles } from "./organization-access.js"
 
 type UserId = typeof AuthUserTable.$inferSelect.id
@@ -611,6 +611,7 @@ export async function updateOrganizationSettings(input: {
   name?: string
   allowedEmailDomains?: readonly string[] | null
   desktopAppRestrictions?: DesktopAppRestrictions
+  allowedDesktopVersions?: readonly string[] | null
 }) {
   const nextName = typeof input.name === "string" ? input.name.trim() : null
   if (typeof input.name === "string" && !nextName) {
@@ -626,6 +627,30 @@ export async function updateOrganizationSettings(input: {
   }
   if (input.desktopAppRestrictions !== undefined) {
     updates.desktopAppRestrictions = normalizeDesktopAppRestrictions(input.desktopAppRestrictions)
+  }
+  if (input.allowedDesktopVersions !== undefined) {
+    const rows = await db
+      .select({ metadata: OrganizationTable.metadata })
+      .from(OrganizationTable)
+      .where(eq(OrganizationTable.id, input.organizationId))
+      .limit(1)
+
+    const existingOrganization = rows[0]
+    if (!existingOrganization) {
+      return null
+    }
+
+    const nextMetadata = {
+      ...normalizeOrganizationMetadata(existingOrganization.metadata).metadata,
+    } as Record<string, unknown>
+
+    if (input.allowedDesktopVersions === null) {
+      delete nextMetadata.allowedDesktopVersions
+    } else {
+      nextMetadata.allowedDesktopVersions = input.allowedDesktopVersions
+    }
+
+    updates.metadata = normalizeOrganizationMetadata(nextMetadata).metadata
   }
 
   if (Object.keys(updates).length === 0) {

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -32,7 +32,8 @@ const updateOrganizationSchema = z.object({
   name: z.string().trim().min(2).max(120).optional(),
   allowedEmailDomains: z.array(z.string().trim().min(1).max(255)).max(100).nullable().optional(),
   desktopAppRestrictions: desktopAppRestrictionsSchema.optional(),
-}).refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined || value.desktopAppRestrictions !== undefined, {
+  allowedDesktopVersions: z.array(z.string().trim().min(1).max(32)).max(200).nullable().optional(),
+}).refine((value) => value.name !== undefined || value.allowedEmailDomains !== undefined || value.desktopAppRestrictions !== undefined || value.allowedDesktopVersions !== undefined, {
   message: "Provide at least one organization field to update.",
 })
 
@@ -343,6 +344,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         name: input.name,
         allowedEmailDomains: normalizedDomains.domains,
         desktopAppRestrictions: input.desktopAppRestrictions,
+        allowedDesktopVersions: input.allowedDesktopVersions,
       })
 
       if (!updated) {

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -138,6 +138,10 @@ export type DenOrgContext = {
   currentMemberTeams: DenCurrentMemberTeam[];
 };
 
+export type DenOrganizationMetadata = {
+  allowedDesktopVersions?: string[];
+} & Record<string, unknown>;
+
 export const DEN_ROLE_PERMISSION_OPTIONS = {
   organization: ["update", "delete"],
   member: ["create", "update", "delete"],
@@ -170,6 +174,37 @@ function asStringArray(value: unknown): string[] | null {
   }
 
   return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function normalizeDesktopVersionString(value: string): string | null {
+  const normalized = value.trim().replace(/^v/i, "");
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(normalized)
+    ? normalized
+    : null;
+}
+
+export function parseOrganizationMetadata(metadata: string | null): DenOrganizationMetadata | null {
+  if (!metadata) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(metadata) as unknown;
+    return isRecord(parsed) ? (parsed as DenOrganizationMetadata) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getAllowedDesktopVersionsFromMetadata(metadata: string | null): string[] | null {
+  const parsed = parseOrganizationMetadata(metadata);
+  const values = asStringArray(parsed?.allowedDesktopVersions);
+
+  if (!values) {
+    return null;
+  }
+
+  return [...new Set(values.map((entry) => normalizeDesktopVersionString(entry)).filter((entry): entry is string => Boolean(entry)))];
 }
 
 function asDesktopAppRestrictions(value: unknown): DenDesktopAppRestrictions {

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
@@ -2,6 +2,8 @@
 
 import { Check, Copy, Pencil, SlidersHorizontal } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { getErrorMessage, requestJson } from "../../../../_lib/den-flow";
+import { getAllowedDesktopVersionsFromMetadata } from "../../../../_lib/den-org";
 import { DashboardPageTemplate } from "../../../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../../../_components/ui/button";
 import { DenCard } from "../../../../_components/ui/card";
@@ -20,6 +22,88 @@ function normalizeAllowedEmailDomainsInput(value: string): string[] | null {
   ];
 
   return domains.length > 0 ? domains : null;
+}
+
+function normalizeDesktopVersionString(value: string): string | null {
+  const normalized = value.trim().replace(/^v/i, "");
+  return /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : null;
+}
+
+function getDesktopVersionMetadata(payload: unknown): {
+  minAppVersion: string;
+  latestAppVersion: string;
+} | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  const minAppVersion =
+    typeof record.minAppVersion === "string"
+      ? normalizeDesktopVersionString(record.minAppVersion)
+      : null;
+  const latestAppVersion =
+    typeof record.latestAppVersion === "string"
+      ? normalizeDesktopVersionString(record.latestAppVersion)
+      : null;
+
+  if (!minAppVersion || !latestAppVersion) {
+    return null;
+  }
+
+  return { minAppVersion, latestAppVersion };
+}
+
+function buildDesktopVersionOptions(
+  minVersion: string,
+  maxVersion: string,
+): string[] {
+  const minMatch = minVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  const maxMatch = maxVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!minMatch || !maxMatch) {
+    return [...new Set([minVersion, maxVersion])];
+  }
+
+  const minMajor = Number(minMatch[1]);
+  const minMinor = Number(minMatch[2]);
+  const minPatch = Number(minMatch[3]);
+  const maxMajor = Number(maxMatch[1]);
+  const maxMinor = Number(maxMatch[2]);
+  const maxPatch = Number(maxMatch[3]);
+
+  if (minMajor !== maxMajor || minMinor !== maxMinor || minPatch > maxPatch) {
+    return [...new Set([minVersion, maxVersion])];
+  }
+
+  return Array.from(
+    { length: maxPatch - minPatch + 1 },
+    (_, index) => `${minMajor}.${minMinor}.${minPatch + index}`,
+  );
+}
+
+function toggleAllowedDesktopVersion(
+  current: string[],
+  version: string,
+  checked: boolean,
+) {
+  if (checked) {
+    return current.includes(version) ? current : [...current, version];
+  }
+
+  return current.filter((entry) => entry !== version);
+}
+
+function filterAllowedDesktopVersionsToVisibleOptions(
+  storedVersions: string[] | null,
+  visibleOptions: string[],
+) {
+  if (storedVersions === null) {
+    return null;
+  }
+
+  const visibleOptionSet = new Set(visibleOptions);
+  return storedVersions.filter((version) => visibleOptionSet.has(version));
 }
 
 function SettingsToggle({
@@ -79,6 +163,16 @@ export function OrgSettingsScreen() {
   const [allowMultipleWorkspacesEnabled, setAllowMultipleWorkspacesEnabled] =
     useState(true);
   const [domainEditModeEnabled, setDomainEditModeEnabled] = useState(false);
+  const [desktopVersionOptions, setDesktopVersionOptions] = useState<string[]>(
+    [],
+  );
+  const [allowedDesktopVersionsDraft, setAllowedDesktopVersionsDraft] =
+    useState<string[]>([]);
+  const [desktopVersionOptionsBusy, setDesktopVersionOptionsBusy] =
+    useState(false);
+  const [desktopVersionOptionsError, setDesktopVersionOptionsError] = useState<
+    string | null
+  >(null);
   const [pageError, setPageError] = useState<string | null>(null);
   const [pageSuccess, setPageSuccess] = useState<string | null>(null);
   const [copiedOrgId, setCopiedOrgId] = useState(false);
@@ -93,6 +187,23 @@ export function OrgSettingsScreen() {
     [allowedDomainsDraft],
   );
   const hasDraftDomains = (draftAllowedDomains?.length ?? 0) > 0;
+  const visibleAllowedDesktopVersionsDraft = useMemo(
+    () =>
+      filterAllowedDesktopVersionsToVisibleOptions(
+        allowedDesktopVersionsDraft,
+        desktopVersionOptions,
+      ) ?? [],
+    [allowedDesktopVersionsDraft, desktopVersionOptions],
+  );
+  const selectedDesktopVersions = useMemo(
+    () => new Set(visibleAllowedDesktopVersionsDraft),
+    [visibleAllowedDesktopVersionsDraft],
+  );
+  const allDesktopVersionsAllowed =
+    desktopVersionOptions.length > 0 &&
+    desktopVersionOptions.every((version) =>
+      selectedDesktopVersions.has(version),
+    );
 
   useEffect(() => {
     if (!orgContext) {
@@ -119,6 +230,97 @@ export function OrgSettingsScreen() {
     );
     setDomainEditModeEnabled(false);
   }, [orgContext]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadDesktopVersionOptions() {
+      setDesktopVersionOptionsBusy(true);
+      setDesktopVersionOptionsError(null);
+
+      try {
+        const { response, payload } = await requestJson(
+          "/v1/app-version",
+          { method: "GET" },
+          12000,
+        );
+
+        if (!response.ok) {
+          throw new Error(
+            getErrorMessage(
+              payload,
+              `Failed to load desktop version metadata (${response.status}).`,
+            ),
+          );
+        }
+
+        const metadata = getDesktopVersionMetadata(payload);
+        if (!metadata) {
+          throw new Error("Desktop version metadata was incomplete.");
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        setDesktopVersionOptions(
+          buildDesktopVersionOptions(
+            metadata.minAppVersion,
+            metadata.latestAppVersion,
+          ),
+        );
+      } catch (error) {
+        if (!cancelled) {
+          setDesktopVersionOptions([]);
+          setDesktopVersionOptionsError(
+            error instanceof Error
+              ? error.message
+              : "Could not load desktop versions.",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setDesktopVersionOptionsBusy(false);
+        }
+      }
+    }
+
+    void loadDesktopVersionOptions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!orgContext || desktopVersionOptions.length === 0) {
+      return;
+    }
+
+    const storedAllowedDesktopVersions =
+      filterAllowedDesktopVersionsToVisibleOptions(
+        getAllowedDesktopVersionsFromMetadata(orgContext.organization.metadata),
+        desktopVersionOptions,
+      );
+
+    if (storedAllowedDesktopVersions === null) {
+      setAllowedDesktopVersionsDraft(desktopVersionOptions);
+      return;
+    }
+
+    setAllowedDesktopVersionsDraft(storedAllowedDesktopVersions);
+  }, [desktopVersionOptions, orgContext]);
+
+  useEffect(() => {
+    if (
+      visibleAllowedDesktopVersionsDraft.length ===
+      allowedDesktopVersionsDraft.length
+    ) {
+      return;
+    }
+
+    setAllowedDesktopVersionsDraft(visibleAllowedDesktopVersionsDraft);
+  }, [allowedDesktopVersionsDraft.length, visibleAllowedDesktopVersionsDraft]);
 
   useEffect(() => {
     if (!copiedOrgId) {
@@ -199,6 +401,15 @@ export function OrgSettingsScreen() {
             ? { blockMultipleWorkspaces: true }
             : {}),
         },
+        ...(desktopVersionOptions.length > 0
+          ? {
+              allowedDesktopVersions: allDesktopVersionsAllowed
+                ? null
+                : desktopVersionOptions.filter((version) =>
+                    selectedDesktopVersions.has(version),
+                  ),
+            }
+          : {}),
       });
       setDomainEditModeEnabled(false);
       setPageSuccess("Workspace settings updated.");
@@ -435,6 +646,90 @@ export function OrgSettingsScreen() {
           </div>
         </DenCard>
 
+        <DenCard size="spacious" className="grid gap-6">
+          <div className="grid gap-2">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+              Desktop app
+            </p>
+            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
+              Allowed Desktop Versions
+            </h2>
+            <p className="text-[14px] text-gray-500">
+              Choose which supported desktop versions can sign in to this
+              workspace.
+            </p>
+            {desktopVersionOptions.length > 0 ? (
+              <p className="text-[13px] text-gray-500">
+                This server supports desktop versions from
+                {` ${desktopVersionOptions[0]} `}
+                to {desktopVersionOptions[desktopVersionOptions.length - 1]}.
+              </p>
+            ) : null}
+          </div>
+
+          {desktopVersionOptionsBusy ? (
+            <div className="rounded-[24px] border border-dashed border-gray-200 bg-gray-50 px-5 py-4 text-[14px] text-gray-500">
+              Loading desktop versions...
+            </div>
+          ) : null}
+
+          {desktopVersionOptionsError ? (
+            <div className="rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] text-amber-800">
+              {desktopVersionOptionsError}
+            </div>
+          ) : null}
+
+          {!desktopVersionOptionsBusy &&
+          !desktopVersionOptionsError &&
+          desktopVersionOptions.length > 0 ? (
+            <div className="grid gap-4">
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-[24px] border border-gray-200 bg-gray-50 px-5 py-4">
+                <p className="text-[14px] text-gray-600">
+                  {allowedDesktopVersionsDraft.length} of{" "}
+                  {desktopVersionOptions.length} supported versions allowed.
+                </p>
+                <p className="text-[13px] text-gray-500">
+                  All versions are allowed by default.
+                </p>
+              </div>
+
+              <div className="grid gap-3">
+                {desktopVersionOptions.map((version) => {
+                  const checked = selectedDesktopVersions.has(version);
+
+                  return (
+                    <label
+                      key={version}
+                      className="flex items-center justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4"
+                    >
+                      <div className="grid gap-1">
+                        <p className="text-[15px] font-medium text-gray-900">
+                          {version}
+                        </p>
+                      </div>
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={!isOwner}
+                        aria-label={`Allow desktop version ${version}`}
+                        onChange={(event) =>
+                          setAllowedDesktopVersionsDraft((current) =>
+                            toggleAllowedDesktopVersion(
+                              current,
+                              version,
+                              event.target.checked,
+                            ),
+                          )
+                        }
+                      />
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+        </DenCard>
+
         <div className="flex flex-wrap items-center justify-between gap-3">
           <p className="text-[13px] text-gray-500">
             {!isOwner && "Only workspace owners can change these settings."}
@@ -442,7 +737,7 @@ export function OrgSettingsScreen() {
           {isOwner ? (
             <DenButton
               type="submit"
-              loading={mutationBusy === "update-organization-name"}
+              loading={mutationBusy === "update-organization-settings"}
             >
               Save settings
             </DenButton>

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
@@ -659,8 +659,8 @@ export function OrgSettingsScreen() {
               workspace.
             </p>
             {desktopVersionOptions.length > 0 ? (
-              <p className="text-[13px] text-gray-500">
-                This server supports desktop versions from
+              <p className="text-[10px] text-gray-400">
+                This server currently supports desktop
                 {` ${desktopVersionOptions[0]} `}
                 to {desktopVersionOptions[desktopVersionOptions.length - 1]}.
               </p>
@@ -683,16 +683,6 @@ export function OrgSettingsScreen() {
           !desktopVersionOptionsError &&
           desktopVersionOptions.length > 0 ? (
             <div className="grid gap-4">
-              <div className="flex flex-wrap items-center justify-between gap-3 rounded-[24px] border border-gray-200 bg-gray-50 px-5 py-4">
-                <p className="text-[14px] text-gray-600">
-                  {allowedDesktopVersionsDraft.length} of{" "}
-                  {desktopVersionOptions.length} supported versions allowed.
-                </p>
-                <p className="text-[13px] text-gray-500">
-                  All versions are allowed by default.
-                </p>
-              </div>
-
               <div className="grid gap-3">
                 {desktopVersionOptions.map((version) => {
                   const checked = selectedDesktopVersions.has(version);

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
@@ -31,7 +31,7 @@ type OrgDashboardContextValue = {
   refreshOrgData: () => Promise<void>;
   createOrganization: (name: string) => Promise<void>;
   updateOrganizationName: (name: string) => Promise<void>;
-  updateOrganizationSettings: (input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions }) => Promise<void>;
+  updateOrganizationSettings: (input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions; allowedDesktopVersions?: string[] | null }) => Promise<void>;
   switchOrganization: (slug: string) => void;
   inviteMember: (input: { email: string; role: string }) => Promise<void>;
   cancelInvitation: (invitationId: string) => Promise<void>;
@@ -251,8 +251,8 @@ export function OrgDashboardProvider({
     await updateOrganizationSettings({ name: trimmed });
   }
 
-  async function updateOrganizationSettings(input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions }) {
-    const body: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions } = {};
+  async function updateOrganizationSettings(input: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions; allowedDesktopVersions?: string[] | null }) {
+    const body: { name?: string; allowedEmailDomains?: string[] | null; desktopAppRestrictions?: DenDesktopAppRestrictions; allowedDesktopVersions?: string[] | null } = {};
     if (typeof input.name === "string") {
       const trimmed = input.name.trim();
       if (!trimmed) {
@@ -266,8 +266,11 @@ export function OrgDashboardProvider({
     if (input.desktopAppRestrictions !== undefined) {
       body.desktopAppRestrictions = input.desktopAppRestrictions;
     }
+    if (input.allowedDesktopVersions !== undefined) {
+      body.allowedDesktopVersions = input.allowedDesktopVersions;
+    }
 
-    await runMutation("update-organization-name", async () => {
+    await runMutation("update-organization-settings", async () => {
       ensureActiveOrganizationSelected();
       const { response, payload } = await requestJson(
         "/v1/org",


### PR DESCRIPTION
## Summary
- add an org settings allowlist for supported desktop versions derived from the Den API min/max range
- persist custom selections in organization metadata while dropping the override when every supported version is allowed
- ignore out-of-range stored versions in the UI and show the active supported version range to admins

## Testing
- Not run: `pnpm --filter @openwork-ee/den-web exec tsc --noEmit` (worktree is missing installed dependencies like `react`, `next`, and `node_modules`)
- Not run: `pnpm --filter @openwork-ee/den-api build` (worktree is missing installed build dependencies like `tsup`)