### PR TITLE
feat(app): key cloud providers by cloud id

### DIFF
--- a/apps/app/src/app/cloud/import-state.ts
+++ b/apps/app/src/app/cloud/import-state.ts
@@ -19,6 +19,7 @@ export type CloudImportedSkill = {
 export type CloudImportedProvider = {
   cloudProviderId: string;
   providerId: string;
+  sourceProviderId: string;
   name: string;
   source: string | null;
   updatedAt: string | null;
@@ -76,11 +77,15 @@ export function readWorkspaceCloudImports(value: unknown): WorkspaceCloudImports
           ? entry.cloudProviderId.trim()
           : key.trim();
         const providerId = typeof entry.providerId === "string" ? entry.providerId.trim() : "";
+        const sourceProviderId = typeof entry.sourceProviderId === "string"
+          ? entry.sourceProviderId.trim()
+          : providerId;
         const name = typeof entry.name === "string" ? entry.name.trim() : providerId || cloudProviderId;
-        if (!cloudProviderId || !providerId || !name) return null;
+        if (!cloudProviderId || !providerId || !sourceProviderId || !name) return null;
         const imported = {
           cloudProviderId,
           providerId,
+          sourceProviderId,
           name,
           source: typeof entry.source === "string" ? entry.source.trim() || null : null,
           updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt.trim() || null : null,

--- a/apps/app/src/app/components/den-settings-panel.tsx
+++ b/apps/app/src/app/components/den-settings-panel.tsx
@@ -301,7 +301,7 @@ export default function DenSettingsPanel(props: DenSettingsPanelProps) {
       const importedProvider = imported[provider.id] ?? null;
       const status = !importedProvider
         ? "available"
-        : importedProvider.providerId !== provider.providerId ||
+        : importedProvider.sourceProviderId !== provider.providerId ||
             (importedProvider.source ?? null) !== provider.source ||
             (importedProvider.updatedAt ?? null) !== (provider.updatedAt ?? null) ||
             !sameStringList(importedProvider.modelIds, sortStrings(provider.models.map((model) => model.id)))

--- a/apps/app/src/app/components/model-picker-modal.tsx
+++ b/apps/app/src/app/components/model-picker-modal.tsx
@@ -223,7 +223,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
         }}
       >
         <div class="flex items-start gap-3">
-          <ProviderIcon providerId={opt.providerID} size={16} class={`mt-[1px] shrink-0 transition-colors ${active() ? 'text-gray-12' : 'text-gray-10 group-hover:text-gray-11'}`} />
+          <ProviderIcon providerId={opt.providerID} providerName={opt.description} size={16} class={`mt-[1px] shrink-0 transition-colors ${active() ? 'text-gray-12' : 'text-gray-10 group-hover:text-gray-11'}`} />
           <div class="flex-1 min-w-0">
             <div class={`text-[13px] flex items-center justify-between gap-2 ${active() ? 'font-medium text-gray-12' : 'text-current'}`}>
               <span class="truncate">{opt.title}</span>
@@ -300,7 +300,7 @@ export default function ModelPickerModal(props: ModelPickerModalProps) {
       }}
     >
       <div class="flex items-start gap-3">
-        <ProviderIcon providerId={provider.providerID} size={16} class={`mt-[1px] shrink-0 transition-colors ${index === activeIndex() ? 'text-gray-12' : 'text-gray-10 group-hover:text-gray-11'}`} />
+        <ProviderIcon providerId={provider.providerID} providerName={provider.title} size={16} class={`mt-[1px] shrink-0 transition-colors ${index === activeIndex() ? 'text-gray-12' : 'text-gray-10 group-hover:text-gray-11'}`} />
         <div class="flex-1 min-w-0">
           <div class={`text-[13px] flex items-center justify-between gap-2 text-current`}>
             <span class="truncate">{provider.title}</span>

--- a/apps/app/src/app/components/provider-icon.tsx
+++ b/apps/app/src/app/components/provider-icon.tsx
@@ -2,6 +2,7 @@ import { JSX } from "solid-js";
 
 type ProviderIconProps = {
   providerId?: string | null;
+  providerName?: string | null;
   class?: string;
   size?: number;
 };
@@ -9,10 +10,16 @@ type ProviderIconProps = {
 export default function ProviderIcon(props: ProviderIconProps) {
   const size = () => props.size ?? 16;
   const normalizedId = () => props.providerId?.trim().toLowerCase() ?? "";
+  const normalizedName = () => props.providerName?.trim().toLowerCase() ?? "";
+  const hasProviderFamily = (family: string) => {
+    const id = normalizedId();
+    const name = normalizedName();
+    return id === family || name.includes(family);
+  };
 
-  const isAnthropic = () => normalizedId() === "anthropic";
-  const isOpenAI = () => normalizedId() === "openai";
-  const isOpenCode = () => normalizedId() === "opencode";
+  const isAnthropic = () => hasProviderFamily("anthropic");
+  const isOpenAI = () => hasProviderFamily("openai");
+  const isOpenCode = () => hasProviderFamily("opencode");
 
   const fallbackLetters = () => {
     const id = normalizedId();

--- a/apps/app/src/app/context/model-config.ts
+++ b/apps/app/src/app/context/model-config.ts
@@ -617,12 +617,14 @@ export function createModelConfigStore(options: {
   };
 
   const sanitizeModelVariantForRef = (ref: ModelRef, value: string | null) => {
+    const provider = options.providers().find((entry) => entry.id === ref.providerID) ?? null;
     const modelInfo = findProviderModel(ref);
     if (!modelInfo) return normalizeModelBehaviorValue(value);
-    return sanitizeModelBehaviorValue(ref.providerID, modelInfo, value);
+    return sanitizeModelBehaviorValue(ref.providerID, modelInfo, value, provider?.name);
   };
 
   const getModelBehaviorCopy = (ref: ModelRef, value: string | null) => {
+    const provider = options.providers().find((entry) => entry.id === ref.providerID) ?? null;
     const modelInfo = findProviderModel(ref);
     if (!modelInfo) {
       return {
@@ -632,7 +634,7 @@ export function createModelConfigStore(options: {
         options: [],
       };
     }
-    return getModelBehaviorSummary(ref.providerID, modelInfo, value);
+    return getModelBehaviorSummary(ref.providerID, modelInfo, value, provider?.name);
   };
 
   const selectedSessionModelLabel = createMemo(() =>
@@ -710,8 +712,8 @@ export function createModelConfigStore(options: {
           modelPickerTarget() === "session" && modelEquals(ref, selectedSessionModel())
             ? modelVariant()
             : getWorkspaceVariantFor(ref);
-        const behavior = getModelBehaviorSummary(provider.id, model, activeVariant);
-        const behaviorValue = sanitizeModelBehaviorValue(provider.id, model, activeVariant);
+        const behavior = getModelBehaviorSummary(provider.id, model, activeVariant, provider.name);
+        const behaviorValue = sanitizeModelBehaviorValue(provider.id, model, activeVariant, provider.name);
         const footerBits: string[] = [];
         if (defaultModelID === model.id || isDefault) {
           footerBits.push(t("settings.model_default", currentLocale()));

--- a/apps/app/src/app/context/providers/provider-auth-modal.tsx
+++ b/apps/app/src/app/context/providers/provider-auth-modal.tsx
@@ -99,7 +99,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const isOpenAiProvider = (id: string, fallbackName?: string) => {
     const normalizedId = id.trim().toLowerCase();
     const normalizedName = fallbackName?.trim().toLowerCase() ?? "";
-    return normalizedId === "openai" || normalizedName === "openai";
+    return normalizedId === "openai" || normalizedName.includes("openai");
   };
 
   // TODO: remove once we upgrade to opencode 1.3.0 — the Claude Pro/Max OAuth
@@ -107,7 +107,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const isAnthropicProvider = (id: string, fallbackName?: string) => {
     const normalizedId = id.trim().toLowerCase();
     const normalizedName = fallbackName?.trim().toLowerCase() ?? "";
-    return normalizedId === "anthropic" || normalizedName === "anthropic";
+    return normalizedId === "anthropic" || normalizedName.includes("anthropic");
   };
 
   const isClaudeProMaxMethod = (method: ProviderAuthMethod) => {
@@ -743,7 +743,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                               onClick={() => handleEntrySelect(entry)}
                             >
                               <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-5/60 bg-gray-2 shadow-sm overflow-hidden">
-                                <ProviderIcon providerId={entry.id} size={18} class="text-gray-12" />
+                                <ProviderIcon providerId={entry.id} providerName={entry.name} size={18} class="text-gray-12" />
                               </div>
 
                               <div class="flex-1 min-w-0">

--- a/apps/app/src/app/context/providers/store.ts
+++ b/apps/app/src/app/context/providers/store.ts
@@ -120,6 +120,10 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
     modelCount: provider.models.length,
   });
 
+  const getCloudManagedProviderId = (provider: Pick<DenOrgLlmProvider, "id" | "providerId">) => {
+    return provider.id.trim();
+  };
+
   const buildCloudProviderConfig = (
     provider: DenOrgLlmProviderConnection,
   ): ProviderConfig => {
@@ -422,13 +426,14 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
 
   const addCloudProviderComment = (
     raw: string,
-    provider: Pick<DenOrgLlmProvider, "id" | "name" | "providerId">,
+    provider: Pick<DenOrgLlmProvider, "id" | "name">,
+    localProviderId: string,
   ) => {
-    const withoutExisting = removeCloudProviderComment(raw, provider.providerId);
-    const propertyPattern = new RegExp(`^([ \t]*)"${escapeRegExp(provider.providerId)}":`, "m");
+    const withoutExisting = removeCloudProviderComment(raw, localProviderId);
+    const propertyPattern = new RegExp(`^([ \t]*)"${escapeRegExp(localProviderId)}":`, "m");
     return withoutExisting.replace(
       propertyPattern,
-      `$1${cloudProviderComment(provider)}\n$1"${provider.providerId}":`,
+      `$1${cloudProviderComment(provider)}\n$1"${localProviderId}":`,
     );
   };
 
@@ -447,6 +452,7 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
   const formatConfigWithCloudProvider = (
     raw: string,
     provider: DenOrgLlmProviderConnection,
+    localProviderId: string,
     previousProviderId?: string | null,
   ) => {
     const nextProviderConfig = buildCloudProviderConfig(provider) as unknown as Record<string, unknown>;
@@ -460,13 +466,13 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
       updated = applyEdits(updated, previousEdits);
     }
 
-    const providerEdits = modify(updated, ["provider", provider.providerId], nextProviderConfig, {
+    const providerEdits = modify(updated, ["provider", localProviderId], nextProviderConfig, {
       formattingOptions: { insertSpaces: true, tabSize: 2 },
     });
     updated = applyEdits(updated, providerEdits);
-    updated = addCloudProviderComment(updated, provider);
+    updated = addCloudProviderComment(updated, provider, localProviderId);
 
-    const disabledToRemove = new Set([provider.providerId, previousProviderId ?? ""]);
+    const disabledToRemove = new Set([localProviderId, previousProviderId ?? ""]);
     const currentDisabled = options.disabledProviders();
     if (currentDisabled.some((id) => disabledToRemove.has(id))) {
       const nextDisabled = currentDisabled.filter((id) => !disabledToRemove.has(id));
@@ -496,18 +502,23 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
   };
 
   const assertCloudProviderImportSafe = async (provider: DenOrgLlmProviderConnection) => {
-    const existingImported = Object.values(importedCloudProviders()).find(
-      (entry) => entry.providerId === provider.providerId,
-    );
-    if (existingImported && existingImported.cloudProviderId !== provider.id) {
+    const localProviderId = getCloudManagedProviderId(provider);
+    const existingImported = importedCloudProviders()[provider.id] ?? null;
+    if (
+      existingImported &&
+      existingImported.providerId !== localProviderId &&
+      Object.values(importedCloudProviders()).some(
+        (entry) => entry.providerId === localProviderId && entry.cloudProviderId !== provider.id,
+      )
+    ) {
       throw new Error(
-        `${provider.providerId} is already imported from ${existingImported.name}. Remove it before importing a different cloud provider.`,
+        `${localProviderId} is already imported from another cloud provider. Remove it before importing this one.`,
       );
     }
 
-    if (!existingImported && options.providerConnectedIds().includes(provider.providerId)) {
+    if (!existingImported && options.providerConnectedIds().includes(localProviderId)) {
       throw new Error(
-        `${provider.providerId} is already connected in this workspace. Disconnect it before importing the cloud-managed version.`,
+        `${localProviderId} is already connected in this workspace. Disconnect it before importing the cloud-managed version.`,
       );
     }
 
@@ -525,10 +536,10 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
       providerSection &&
       typeof providerSection === "object" &&
       !Array.isArray(providerSection) &&
-      provider.providerId in (providerSection as Record<string, unknown>)
+      localProviderId in (providerSection as Record<string, unknown>)
     ) {
       throw new Error(
-        `${provider.providerId} already has a provider block in opencode.jsonc. Remove it before importing the cloud-managed version.`,
+        `${localProviderId} already has a provider block in opencode.jsonc. Remove it before importing the cloud-managed version.`,
       );
     }
   };
@@ -608,7 +619,8 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
     provider: DenOrgLlmProvider,
     importedProvider: CloudImportedProvider,
   ) =>
-    importedProvider.providerId !== provider.providerId ||
+    importedProvider.providerId !== getCloudManagedProviderId(provider) ||
+    importedProvider.sourceProviderId !== provider.providerId ||
     (importedProvider.source ?? null) !== provider.source ||
     (importedProvider.updatedAt ?? null) !== (provider.updatedAt ?? null) ||
     !sameStringList(importedProvider.modelIds, sortStrings(provider.models.map((model) => model.id)));
@@ -901,7 +913,7 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
       const provider = availableProviders.find((item) => item.id === id);
       const normalizedId = id.trim().toLowerCase();
       const normalizedName = provider?.name?.trim().toLowerCase() ?? "";
-      const isOpenAiProvider = normalizedId === "openai" || normalizedName === "openai";
+      const isOpenAiProvider = normalizedId === "openai" || normalizedName.includes("openai");
       if (!isOpenAiProvider) continue;
       merged[id] = providerMethods.filter((method) => {
         if (method.type !== "oauth") return true;
@@ -1180,6 +1192,7 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
         throw new Error(`${provider.name} is blocked by your organization desktop policy.`);
       }
       const existingImported = importedCloudProviders()[cloudProviderId] ?? null;
+      const localProviderId = getCloudManagedProviderId(provider);
       const apiKey = provider.apiKey?.trim() ?? "";
       const env = getCloudProviderEnv(provider.providerConfig);
       if (!apiKey && env.length > 0) {
@@ -1190,7 +1203,7 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
 
       if (apiKey) {
         await c.auth.set({
-          providerID: provider.providerId,
+          providerID: localProviderId,
           auth: {
             type: "api",
             key: apiKey,
@@ -1208,7 +1221,7 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
         }
       }
       const updatedConfig = await updateProjectConfigFile((raw) =>
-        formatConfigWithCloudProvider(raw, provider, existingImported?.providerId ?? null),
+        formatConfigWithCloudProvider(raw, provider, localProviderId, existingImported?.providerId ?? null),
       );
       if (!updatedConfig) {
         throw new Error("Could not update opencode.jsonc for this workspace.");
@@ -1218,7 +1231,8 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
         ...importedCloudProviders(),
         [provider.id]: {
           cloudProviderId: provider.id,
-          providerId: provider.providerId,
+          providerId: localProviderId,
+          sourceProviderId: provider.providerId,
           name: provider.name,
           source: provider.source,
           updatedAt: provider.updatedAt ?? null,
@@ -1229,7 +1243,7 @@ export function createProvidersStore(options: CreateProvidersStoreOptions) {
       await persistImportedCloudProviders(nextImportedProviders);
 
       const nextDisabledProviders = options.disabledProviders().filter(
-        (id) => id !== provider.providerId && id !== existingImported?.providerId,
+        (id) => id !== localProviderId && id !== existingImported?.providerId,
       );
       options.setDisabledProviders(nextDisabledProviders);
       options.markOpencodeConfigReloadRequired();

--- a/apps/app/src/app/lib/model-behavior.ts
+++ b/apps/app/src/app/lib/model-behavior.ts
@@ -70,13 +70,33 @@ const sortVariantKeys = (keys: string[]) =>
     return a.localeCompare(b);
   });
 
-const getBehaviorTitle = (providerID: string, model: ProviderModel, variantKeys: string[]) => {
+const providerFamily = (providerID: string, providerName?: string | null) => {
+  const normalizedId = providerID.trim().toLowerCase();
+  if (["anthropic", "openai", "google", "opencode"].includes(normalizedId)) {
+    return normalizedId;
+  }
+
+  const normalizedName = providerName?.trim().toLowerCase() ?? "";
+  if (normalizedName.includes("anthropic")) return "anthropic";
+  if (normalizedName.includes("openai")) return "openai";
+  if (normalizedName.includes("google")) return "google";
+  if (normalizedName.includes("opencode")) return "opencode";
+  return normalizedId;
+};
+
+const getBehaviorTitle = (
+  providerID: string,
+  model: ProviderModel,
+  variantKeys: string[],
+  providerName?: string | null,
+) => {
+  const family = providerFamily(providerID, providerName);
   if (variantKeys.length > 0) {
-    if (providerID === "anthropic") return t("model_behavior.title_extended_thinking");
-    if (providerID === "google") return t("model_behavior.title_reasoning_budget");
+    if (family === "anthropic") return t("model_behavior.title_extended_thinking");
+    if (family === "google") return t("model_behavior.title_reasoning_budget");
     if (
-      providerID === "openai" ||
-      providerID === "opencode" ||
+      family === "openai" ||
+      family === "opencode" ||
       variantKeys.some((key) => ["none", "minimal", "low", "medium", "high", "xhigh"].includes(key))
     ) {
       return t("model_behavior.title_reasoning_effort");
@@ -87,12 +107,13 @@ const getBehaviorTitle = (providerID: string, model: ProviderModel, variantKeys:
   return t("model_behavior.title_standard_generation");
 };
 
-const getVariantLabel = (providerID: string, key: string) => {
+const getVariantLabel = (providerID: string, key: string, providerName?: string | null) => {
+  const family = providerFamily(providerID, providerName);
   if (key === "none") return t("model_behavior.label_fast");
   if (key === "minimal") return t("model_behavior.label_quick");
   if (key === "low") return t("model_behavior.label_light");
   if (key === "medium") return t("model_behavior.label_balanced");
-  if (key === "high") return providerID === "anthropic" ? t("model_behavior.label_extended") : t("model_behavior.label_deep");
+  if (key === "high") return family === "anthropic" ? t("model_behavior.label_extended") : t("model_behavior.label_deep");
   if (key === "xhigh" || key === "max") return t("model_behavior.label_maximum");
   return humanize(key);
 };
@@ -103,17 +124,23 @@ export const formatGenericBehaviorLabel = (value: string | null) => {
   return getVariantLabel("generic", normalized);
 };
 
-const getVariantDescription = (providerID: string, key: string, label: string) => {
+const getVariantDescription = (
+  providerID: string,
+  key: string,
+  label: string,
+  providerName?: string | null,
+) => {
+  const family = providerFamily(providerID, providerName);
   if (key === "none") return t("model_behavior.desc_none");
   if (key === "minimal") return t("model_behavior.desc_minimal");
-  if (key === "low") return providerID === "google"
+  if (key === "low") return family === "google"
     ? t("model_behavior.desc_low_google")
     : t("model_behavior.desc_low");
   if (key === "medium") return t("model_behavior.desc_medium");
-  if (key === "high") return providerID === "anthropic"
+  if (key === "high") return family === "anthropic"
     ? t("model_behavior.desc_high_anthropic")
     : t("model_behavior.desc_high");
-  if (key === "xhigh" || key === "max") return providerID === "anthropic"
+  if (key === "xhigh" || key === "max") return family === "anthropic"
     ? t("model_behavior.desc_max_anthropic")
     : t("model_behavior.desc_max");
   return t("model_behavior.desc_generic", undefined, { label: label.toLowerCase() });
@@ -122,17 +149,18 @@ const getVariantDescription = (providerID: string, key: string, label: string) =
 export const getModelBehaviorOptions = (
   providerID: string,
   model: ProviderModel,
+  providerName?: string | null,
 ): ModelBehaviorOption[] => {
   const variantKeys = sortVariantKeys(getVariantKeys(model));
   if (!variantKeys.length) return [];
   return [
     defaultBehaviorOption(),
     ...variantKeys.map((key) => {
-      const label = getVariantLabel(providerID, key);
+      const label = getVariantLabel(providerID, key, providerName);
       return {
         value: key,
         label,
-        description: getVariantDescription(providerID, key, label),
+        description: getVariantDescription(providerID, key, label, providerName),
       };
     }),
   ];
@@ -142,10 +170,11 @@ export const sanitizeModelBehaviorValue = (
   providerID: string,
   model: ProviderModel,
   value: string | null,
+  providerName?: string | null,
 ) => {
   const normalized = normalizeModelBehaviorValue(value);
   if (!normalized) return null;
-  return getModelBehaviorOptions(providerID, model).some((option) => option.value === normalized)
+  return getModelBehaviorOptions(providerID, model, providerName).some((option) => option.value === normalized)
     ? normalized
     : null;
 };
@@ -154,11 +183,12 @@ export const getModelBehaviorSummary = (
   providerID: string,
   model: ProviderModel,
   value: string | null,
+  providerName?: string | null,
 ) => {
-  const options = getModelBehaviorOptions(providerID, model);
-  const sanitized = sanitizeModelBehaviorValue(providerID, model, value);
+  const options = getModelBehaviorOptions(providerID, model, providerName);
+  const sanitized = sanitizeModelBehaviorValue(providerID, model, value, providerName);
   const selected = options.find((option) => option.value === sanitized) ?? options[0] ?? null;
-  const title = getBehaviorTitle(providerID, model, getVariantKeys(model));
+  const title = getBehaviorTitle(providerID, model, getVariantKeys(model), providerName);
 
   if (options.length > 0) {
     return {

--- a/apps/app/src/app/pages/session.tsx
+++ b/apps/app/src/app/pages/session.tsx
@@ -2863,7 +2863,12 @@ export default function SessionView(props: SessionViewProps) {
   };
 
   const hasOpenAiProviderConnected = createMemo(() =>
-    (props.providerConnectedIds ?? []).some((id) => id.trim().toLowerCase() === "openai")
+    (props.providerConnectedIds ?? []).some((id) => {
+      const provider = props.providers.find((entry) => entry.id === id) ?? null;
+      const normalizedId = id.trim().toLowerCase();
+      const normalizedName = provider?.name?.trim().toLowerCase() ?? "";
+      return normalizedId === "openai" || normalizedName.includes("openai");
+    })
   );
   const showNewSessionProviderCta = createMemo(() => !hasOpenAiProviderConnected());
   const emptyStatePreset = createMemo(

--- a/apps/app/src/app/pages/settings.tsx
+++ b/apps/app/src/app/pages/settings.tsx
@@ -1529,7 +1529,7 @@ export default function SettingsView(props: SettingsViewProps) {
                     {(provider) => (
                       <div class={`${settingsPanelSoftClass} flex flex-wrap items-center justify-between gap-3 px-3 py-2`}>
                         <div class="min-w-0 flex items-center gap-3">
-                          <ProviderIcon providerId={provider.id} size={18} class="text-gray-12" />
+                          <ProviderIcon providerId={provider.id} providerName={provider.name} size={18} class="text-gray-12" />
                           <div class="min-w-0">
                             <div class="text-sm font-medium text-gray-12 truncate">
                               {provider.name}


### PR DESCRIPTION
## Summary
- key imported cloud-managed providers and auth entries by the raw cloud provider id so install, update, and delete reconciliation use the same local identifier
- keep the canonical provider family in cloud import metadata and switch UI heuristics to use provider names/source metadata where Anthropic/OpenAI/OpenCode behavior still matters
- preserve cloud settings status checks while making provider removal operate against the same id stored in `opencode.jsonc` and auth storage

## Verification
- pnpm install
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app build

## Notes
- I did not run the live cloud deletion flow through Docker + Chrome MCP because this needs a signed-in org with managed providers and real credentials.