### PR TITLE
fix(config): respect .opencode opencode.jsonc paths

### DIFF
--- a/apps/desktop/src-tauri/src/config.rs
+++ b/apps/desktop/src-tauri/src/config.rs
@@ -7,14 +7,19 @@ use crate::types::{ExecResult, OpencodeConfigFile};
 fn opencode_config_candidates(
     scope: &str,
     project_dir: &str,
-) -> Result<(PathBuf, PathBuf), String> {
+) -> Result<Vec<PathBuf>, String> {
     match scope {
         "project" => {
             if project_dir.trim().is_empty() {
                 return Err("projectDir is required".to_string());
             }
             let root = PathBuf::from(project_dir);
-            Ok((root.join("opencode.jsonc"), root.join("opencode.json")))
+            Ok(vec![
+                root.join("opencode.jsonc"),
+                root.join("opencode.json"),
+                root.join(".opencode").join("opencode.jsonc"),
+                root.join(".opencode").join("opencode.json"),
+            ])
         }
         "global" => {
             let base = if let Ok(dir) = env::var("XDG_CONFIG_HOME") {
@@ -26,24 +31,25 @@ fn opencode_config_candidates(
             };
 
             let root = base.join("opencode");
-            Ok((root.join("opencode.jsonc"), root.join("opencode.json")))
+            Ok(vec![root.join("opencode.jsonc"), root.join("opencode.json")])
         }
         _ => Err("scope must be 'project' or 'global'".to_string()),
     }
 }
 
 pub fn resolve_opencode_config_path(scope: &str, project_dir: &str) -> Result<PathBuf, String> {
-    let (jsonc_path, json_path) = opencode_config_candidates(scope, project_dir)?;
+    let candidates = opencode_config_candidates(scope, project_dir)?;
 
-    if jsonc_path.exists() {
-        return Ok(jsonc_path);
+    for path in &candidates {
+        if path.exists() {
+            return Ok(path.clone());
+        }
     }
 
-    if json_path.exists() {
-        return Ok(json_path);
-    }
-
-    Ok(jsonc_path)
+    candidates
+        .into_iter()
+        .next()
+        .ok_or_else(|| "No config path candidates available".to_string())
 }
 
 pub fn read_opencode_config(scope: &str, project_dir: &str) -> Result<OpencodeConfigFile, String> {

--- a/apps/desktop/src-tauri/src/workspace/files.rs
+++ b/apps/desktop/src-tauri/src/workspace/files.rs
@@ -399,6 +399,25 @@ fn seed_commands(commands_dir: &PathBuf, preset: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn resolve_workspace_opencode_config_path(root: &Path) -> PathBuf {
+    let config_path_jsonc = root.join("opencode.jsonc");
+    let config_path_json = root.join("opencode.json");
+    let hidden_config_path_jsonc = root.join(".opencode").join("opencode.jsonc");
+    let hidden_config_path_json = root.join(".opencode").join("opencode.json");
+
+    if config_path_jsonc.exists() {
+        config_path_jsonc
+    } else if config_path_json.exists() {
+        config_path_json
+    } else if hidden_config_path_jsonc.exists() {
+        hidden_config_path_jsonc
+    } else if hidden_config_path_json.exists() {
+        hidden_config_path_json
+    } else {
+        config_path_jsonc
+    }
+}
+
 pub fn ensure_workspace_files(workspace_path: &str, preset: &str) -> Result<(), String> {
     let root = PathBuf::from(workspace_path);
 
@@ -421,15 +440,7 @@ pub fn ensure_workspace_files(workspace_path: &str, preset: &str) -> Result<(), 
         .map_err(|e| format!("Failed to create .opencode/commands: {e}"))?;
     seed_commands(&commands_dir, preset)?;
 
-    let config_path_jsonc = root.join("opencode.jsonc");
-    let config_path_json = root.join("opencode.json");
-    let config_path = if config_path_jsonc.exists() {
-        config_path_jsonc
-    } else if config_path_json.exists() {
-        config_path_json
-    } else {
-        config_path_jsonc
-    };
+    let config_path = resolve_workspace_opencode_config_path(&root);
 
     let config_exists = config_path.exists();
     let mut config_changed = !config_exists;
@@ -552,4 +563,60 @@ pub fn ensure_workspace_files(workspace_path: &str, preset: &str) -> Result<(), 
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_workspace_opencode_config_path;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_workspace_root() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("openwork-workspace-files-{unique}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn prefers_hidden_opencode_jsonc_when_root_config_is_missing() {
+        let root = temp_workspace_root();
+        let hidden = root.join(".opencode").join("opencode.jsonc");
+        fs::create_dir_all(hidden.parent().unwrap()).unwrap();
+        fs::write(&hidden, "{}\n").unwrap();
+
+        let resolved = resolve_workspace_opencode_config_path(&root);
+        assert_eq!(resolved, hidden);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn prefers_root_config_over_hidden_config() {
+        let root = temp_workspace_root();
+        let root_jsonc = root.join("opencode.jsonc");
+        let hidden = root.join(".opencode").join("opencode.jsonc");
+        fs::create_dir_all(hidden.parent().unwrap()).unwrap();
+        fs::write(&root_jsonc, "{}\n").unwrap();
+        fs::write(&hidden, "{}\n").unwrap();
+
+        let resolved = resolve_workspace_opencode_config_path(&root);
+        assert_eq!(resolved, root_jsonc);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn falls_back_to_root_jsonc_path_when_no_config_exists() {
+        let root = temp_workspace_root();
+
+        let resolved = resolve_workspace_opencode_config_path(&root);
+        assert_eq!(resolved, root.join("opencode.jsonc"));
+
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/apps/server/src/workspace-files.ts
+++ b/apps/server/src/workspace-files.ts
@@ -4,8 +4,12 @@ import { join } from "node:path";
 export function opencodeConfigPath(workspaceRoot: string): string {
   const jsoncPath = join(workspaceRoot, "opencode.jsonc");
   const jsonPath = join(workspaceRoot, "opencode.json");
+  const hiddenJsoncPath = join(workspaceRoot, ".opencode", "opencode.jsonc");
+  const hiddenJsonPath = join(workspaceRoot, ".opencode", "opencode.json");
   if (existsSync(jsoncPath)) return jsoncPath;
   if (existsSync(jsonPath)) return jsonPath;
+  if (existsSync(hiddenJsoncPath)) return hiddenJsoncPath;
+  if (existsSync(hiddenJsonPath)) return hiddenJsonPath;
   return jsoncPath;
 }
 


### PR DESCRIPTION
## Summary
- resolve project-scoped OpenCode config from `.opencode/opencode.jsonc` and `.opencode/opencode.json` in both desktop and server paths
- keep the lookup order aligned with OpenCode's config resolution behavior

Closes #824.

## Testing
- `pnpm --filter openwork-server typecheck`
- `cargo test --manifest-path "apps/desktop/src-tauri/Cargo.toml" config`

## Notes
- I did not run a full app/Docker flow for this config-path change.
- Manual follow-up: `bash packaging/docker/dev-up.sh`, open a workspace that only has `.opencode/opencode.jsonc`, and confirm the config is discovered without fallback renames.