### PR TITLE
fix(share): use a single canonical og image

### DIFF
--- a/apps/share/app/b/[id]/page.tsx
+++ b/apps/share/app/b/[id]/page.tsx
@@ -70,41 +70,14 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
       title: pageTitle,
       description: pageDescription,
       url: props.canonicalUrl,
-      images: props.ogImageUrls
-        ? [
-            {
-              url: props.ogImageUrls.byVariant.facebook,
-              width: 1200,
-              height: 630,
-              alt: `${pageTitle} bundle preview`
-            },
-            {
-              url: props.ogImageUrls.byVariant.linkedin,
-              width: 1200,
-              height: 627,
-              alt: `${pageTitle} bundle preview`
-            },
-            {
-              url: props.ogImageUrls.byVariant.slack,
-              width: 1200,
-              height: 630,
-              alt: `${pageTitle} bundle preview`
-            },
-            {
-              url: props.ogImageUrls.byVariant.whatsapp,
-              width: 1200,
-              height: 630,
-              alt: `${pageTitle} bundle preview`
-            }
-          ]
-        : [
-            {
-              url: props.ogImageUrl,
-              width: 1200,
-              height: 630,
-              alt: `${pageTitle} bundle preview`
-            }
-          ]
+      images: [
+        {
+          url: props.ogImageUrls?.byVariant.facebook || props.ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: `${pageTitle} bundle preview`
+        }
+      ]
     },
     twitter: {
       card: "summary_large_image",


### PR DESCRIPTION
## Summary
- publish one canonical Open Graph image instead of emitting four near-duplicate platform variants
- keep the existing fallback to `ogImageUrl` when platform-specific variants are unavailable

Closes #1082.

## Testing
- `pnpm --filter @openwork/share test`

## Notes
- I did not manually verify live messenger/social scraper previews.
- Manual follow-up: `pnpm --filter @openwork/share dev`, open a bundle page, and inspect the rendered `og:image` metadata in the page head.