### PR TITLE
server: harden MCP config validation

### DIFF
--- a/apps/server/src/validators.test.ts
+++ b/apps/server/src/validators.test.ts
@@ -123,6 +123,9 @@ describe("validateMcpConfig", () => {
 
   test("rejects remote with invalid or non-http url", () => {
     expect(() => validateMcpConfig({ type: "remote", url: "notaurl" })).toThrow();
+    expect(() => validateMcpConfig({ type: "remote", url: "https:example.com" })).toThrow();
+    expect(() => validateMcpConfig({ type: "remote", url: " https://example.com" })).toThrow();
+    expect(() => validateMcpConfig({ type: "remote", url: "https://example.com " })).toThrow();
     expect(() => validateMcpConfig({ type: "remote", url: "file:///tmp/mcp" })).toThrow();
     expect(() => validateMcpConfig({ type: "remote", url: "javascript:alert(1)" })).toThrow();
   });

--- a/apps/server/src/validators.test.ts
+++ b/apps/server/src/validators.test.ts
@@ -100,6 +100,9 @@ describe("validateMcpConfig", () => {
     expect(() =>
       validateMcpConfig({ type: "remote", url: "https://example.com" }),
     ).not.toThrow();
+    expect(() =>
+      validateMcpConfig({ type: "remote", url: "http://localhost:8080/mcp" }),
+    ).not.toThrow();
   });
 
   test("accepts valid local config", () => {
@@ -114,10 +117,20 @@ describe("validateMcpConfig", () => {
 
   test("rejects remote without url", () => {
     expect(() => validateMcpConfig({ type: "remote" })).toThrow();
+    expect(() => validateMcpConfig({ type: "remote", url: "" })).toThrow();
+    expect(() => validateMcpConfig({ type: "remote", url: "   " })).toThrow();
+  });
+
+  test("rejects remote with invalid or non-http url", () => {
+    expect(() => validateMcpConfig({ type: "remote", url: "notaurl" })).toThrow();
+    expect(() => validateMcpConfig({ type: "remote", url: "file:///tmp/mcp" })).toThrow();
+    expect(() => validateMcpConfig({ type: "remote", url: "javascript:alert(1)" })).toThrow();
   });
 
   test("rejects local without command", () => {
     expect(() => validateMcpConfig({ type: "local" })).toThrow();
     expect(() => validateMcpConfig({ type: "local", command: [] })).toThrow();
+    expect(() => validateMcpConfig({ type: "local", command: ["", "foo"] })).toThrow();
+    expect(() => validateMcpConfig({ type: "local", command: ["npx", 12] })).toThrow();
   });
 });

--- a/apps/server/src/validators.ts
+++ b/apps/server/src/validators.ts
@@ -46,14 +46,27 @@ export function validateMcpConfig(config: Record<string, unknown>): void {
   }
   if (type === "local") {
     const command = config.command;
-    if (!Array.isArray(command) || command.length === 0) {
+    if (
+      !Array.isArray(command) ||
+      command.length === 0 ||
+      command.some((part) => typeof part !== "string" || part.trim().length === 0)
+    ) {
       throw new ApiError(400, "invalid_mcp_config", "Local MCP requires command array");
     }
   }
   if (type === "remote") {
     const url = config.url;
-    if (!url || typeof url !== "string") {
+    if (!url || typeof url !== "string" || url.trim().length === 0) {
       throw new ApiError(400, "invalid_mcp_config", "Remote MCP requires url");
+    }
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new ApiError(400, "invalid_mcp_config", "Remote MCP url must use http(s)");
+      }
+    } catch (error) {
+      if (error instanceof ApiError) throw error;
+      throw new ApiError(400, "invalid_mcp_config", "Remote MCP requires a valid url");
     }
   }
 }

--- a/apps/server/src/validators.ts
+++ b/apps/server/src/validators.ts
@@ -59,8 +59,15 @@ export function validateMcpConfig(config: Record<string, unknown>): void {
     if (!url || typeof url !== "string" || url.trim().length === 0) {
       throw new ApiError(400, "invalid_mcp_config", "Remote MCP requires url");
     }
+    const normalizedUrl = url.trim();
+    if (url !== normalizedUrl) {
+      throw new ApiError(400, "invalid_mcp_config", "Remote MCP url must not include surrounding whitespace");
+    }
+    if (!/^https?:\/\//i.test(normalizedUrl)) {
+      throw new ApiError(400, "invalid_mcp_config", "Remote MCP url must start with http(s)://");
+    }
     try {
-      const parsed = new URL(url);
+      const parsed = new URL(normalizedUrl);
       if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
         throw new ApiError(400, "invalid_mcp_config", "Remote MCP url must use http(s)");
       }


### PR DESCRIPTION
## Summary
- tighten validateMcpConfig for local MCP entries by requiring a non-empty command array of non-empty strings
- tighten remote MCP validation by rejecting blank URLs, malformed URLs, and non-http(s) schemes
- extend validator tests to cover localhost URLs and malformed/non-http URL and command cases

## Why
The server currently accepts malformed MCP configs that can later break MCP runtime behavior (for example, empty command argv entries or invalid remote URLs). This change fails fast at write-time and keeps workspace config clean.

## Testing
- pnpm install --filter openwork-server...
- pnpm --filter openwork-server test
