### PR TITLE
feat(plugin-system): support OpenAI plugin marketplaces

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-app.ts
@@ -28,6 +28,7 @@ export type GithubConnectorAppConfig = {
 type GithubFetch = typeof fetch
 
 export type GithubManifestKind = "marketplace" | "plugin" | null
+export type GithubManifestStandard = "claude" | "openai" | null
 
 type GithubRepositorySummary = {
   defaultBranch: string | null
@@ -35,9 +36,17 @@ type GithubRepositorySummary = {
   hasPluginManifest?: boolean
   id: number
   manifestKind?: GithubManifestKind
+  manifestStandard?: GithubManifestStandard
   marketplacePluginCount?: number | null
   private: boolean
 }
+
+const SUPPORTED_GITHUB_REPOSITORY_MANIFESTS = [
+  { kind: "marketplace", path: ".claude-plugin/marketplace.json", standard: "claude" },
+  { kind: "marketplace", path: ".agents/plugins/marketplace.json", standard: "openai" },
+  { kind: "plugin", path: ".claude-plugin/plugin.json", standard: "claude" },
+  { kind: "plugin", path: ".codex-plugin/plugin.json", standard: "openai" },
+] as const
 
 export type GithubRepositoryTreeEntry = {
   id: string
@@ -387,6 +396,7 @@ export async function listGithubInstallationRepositories(input: { config: Github
       ...normalized,
       hasPluginManifest: manifest.manifestKind !== null,
       manifestKind: manifest.manifestKind,
+      manifestStandard: manifest.manifestStandard,
       marketplacePluginCount: manifest.marketplacePluginCount,
     })
   }
@@ -396,50 +406,57 @@ export async function listGithubInstallationRepositories(input: { config: Github
 
 async function detectRepositoryManifest(input: { fetchFn?: GithubFetch; ownerAndRepo: string; token: string }): Promise<{
   manifestKind: GithubManifestKind
+  manifestStandard: GithubManifestStandard
   marketplacePluginCount: number | null
 }> {
   const parts = splitRepositoryFullName(input.ownerAndRepo)
   if (!parts) {
-    return { manifestKind: null, marketplacePluginCount: null }
+    return { manifestKind: null, manifestStandard: null, marketplacePluginCount: null }
   }
 
-  const marketplaceResponse = await requestGithubJson<{ content?: string; encoding?: string }>({
-    allowStatuses: [404],
-    fetchFn: input.fetchFn,
-    headers: {
-      Authorization: `Bearer ${input.token}`,
-    },
-    path: `/repos/${encodeURIComponent(parts.owner)}/${encodeURIComponent(parts.repo)}/contents/.claude-plugin/marketplace.json`,
-  })
+  for (const manifest of SUPPORTED_GITHUB_REPOSITORY_MANIFESTS) {
+    const response = await requestGithubJson<{ content?: string; encoding?: string }>({
+      allowStatuses: [404],
+      fetchFn: input.fetchFn,
+      headers: {
+        Authorization: `Bearer ${input.token}`,
+      },
+      path: `/repos/${encodeURIComponent(parts.owner)}/${encodeURIComponent(parts.repo)}/contents/${manifest.path.split("/").map(encodeURIComponent).join("/")}`,
+    })
 
-  if (marketplaceResponse.ok && typeof marketplaceResponse.body?.content === "string" && marketplaceResponse.body.encoding === "base64") {
-    let marketplacePluginCount: number | null = null
-    try {
-      const decoded = Buffer.from(marketplaceResponse.body.content.replace(/\n/g, ""), "base64").toString("utf8")
-      const parsed = JSON.parse(decoded) as unknown
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && Array.isArray((parsed as Record<string, unknown>).plugins)) {
-        marketplacePluginCount = ((parsed as Record<string, unknown>).plugins as unknown[]).length
-      }
-    } catch {
-      marketplacePluginCount = null
+    if (!response.ok) {
+      continue
     }
-    return { manifestKind: "marketplace", marketplacePluginCount }
+
+    if (manifest.kind === "marketplace") {
+      let marketplacePluginCount: number | null = null
+      if (typeof response.body?.content === "string" && response.body.encoding === "base64") {
+        try {
+          const decoded = Buffer.from(response.body.content.replace(/\n/g, ""), "base64").toString("utf8")
+          const parsed = JSON.parse(decoded) as unknown
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && Array.isArray((parsed as Record<string, unknown>).plugins)) {
+            marketplacePluginCount = ((parsed as Record<string, unknown>).plugins as unknown[]).length
+          }
+        } catch {
+          marketplacePluginCount = null
+        }
+      }
+
+      return {
+        manifestKind: manifest.kind,
+        manifestStandard: manifest.standard,
+        marketplacePluginCount,
+      }
+    }
+
+    return {
+      manifestKind: manifest.kind,
+      manifestStandard: manifest.standard,
+      marketplacePluginCount: null,
+    }
   }
 
-  const pluginResponse = await requestGithubJson<unknown>({
-    allowStatuses: [404],
-    fetchFn: input.fetchFn,
-    headers: {
-      Authorization: `Bearer ${input.token}`,
-    },
-    path: `/repos/${encodeURIComponent(parts.owner)}/${encodeURIComponent(parts.repo)}/contents/.claude-plugin/plugin.json`,
-  })
-
-  if (pluginResponse.ok) {
-    return { manifestKind: "plugin", marketplacePluginCount: null }
-  }
-
-  return { manifestKind: null, marketplacePluginCount: null }
+  return { manifestKind: null, manifestStandard: null, marketplacePluginCount: null }
 }
 
 function splitRepositoryFullName(repositoryFullName: string) {

--- a/ee/apps/den-api/src/routes/org/plugin-system/github-discovery.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-discovery.ts
@@ -8,10 +8,12 @@ export type GithubDiscoveryTreeEntry = {
   size: number | null
 }
 
+export type GithubPluginStandard = "claude" | "openai"
+
 export type GithubDiscoveryClassification =
-  | "claude_marketplace_repo"
-  | "claude_multi_plugin_repo"
-  | "claude_single_plugin_repo"
+  | "marketplace_repo"
+  | "multi_plugin_repo"
+  | "single_plugin_repo"
   | "folder_inferred_repo"
   | "unsupported"
 
@@ -51,6 +53,7 @@ export type GithubDiscoveredPlugin = {
   rootPath: string
   selectedByDefault: boolean
   sourceKind: GithubDiscoveredPluginSourceKind
+  standard: GithubPluginStandard
   supported: boolean
   warnings: string[]
 }
@@ -59,6 +62,7 @@ export type GithubMarketplaceInfo = {
   description: string | null
   name: string | null
   owner: string | null
+  standard: GithubPluginStandard
   version: string | null
 }
 
@@ -83,11 +87,56 @@ type MarketplaceEntry = {
 
 type PluginMetadata = {
   description: string | null
+  displayName: string | null
   metadata: Record<string, unknown>
   name: string | null
 }
 
+type ComponentBucket = keyof GithubDiscoveredPlugin["componentPaths"]
+
+type GithubDiscoveryStandardDefinition = {
+  defaultComponentCandidates: (rootPath: string) => Array<{ bucket: ComponentBucket; kind: "directory" | "file"; path: string }>
+  fallbackMetadataPath?: (rootPath: string) => string | null
+  id: GithubPluginStandard
+  label: string
+  marketplaceManifestPath: string
+  pluginManifestPath: string
+}
+
 const KNOWN_COMPONENT_SEGMENTS = ["skills", "commands", "agents"] as const
+
+const DISCOVERY_STANDARDS = [
+  {
+    defaultComponentCandidates: (rootPath) => [
+      { bucket: "skills", kind: "directory", path: joinPath(rootPath, "skills") },
+      { bucket: "skills", kind: "directory", path: joinPath(rootPath, ".claude/skills") },
+      { bucket: "commands", kind: "directory", path: joinPath(rootPath, "commands") },
+      { bucket: "commands", kind: "directory", path: joinPath(rootPath, ".claude/commands") },
+      { bucket: "agents", kind: "directory", path: joinPath(rootPath, "agents") },
+      { bucket: "agents", kind: "directory", path: joinPath(rootPath, ".claude/agents") },
+      { bucket: "hooks", kind: "file", path: joinPath(rootPath, "hooks/hooks.json") },
+      { bucket: "mcpServers", kind: "file", path: joinPath(rootPath, ".mcp.json") },
+      { bucket: "lspServers", kind: "file", path: joinPath(rootPath, ".lsp.json") },
+      { bucket: "monitors", kind: "file", path: joinPath(rootPath, "monitors/monitors.json") },
+      { bucket: "settings", kind: "file", path: joinPath(rootPath, "settings.json") },
+    ],
+    fallbackMetadataPath: (rootPath) => joinPath(rootPath, "plugin.json"),
+    id: "claude",
+    label: "Claude",
+    marketplaceManifestPath: ".claude-plugin/marketplace.json",
+    pluginManifestPath: ".claude-plugin/plugin.json",
+  },
+  {
+    defaultComponentCandidates: (rootPath) => [
+      { bucket: "skills", kind: "directory", path: joinPath(rootPath, "skills") },
+      { bucket: "mcpServers", kind: "file", path: joinPath(rootPath, ".mcp.json") },
+    ],
+    id: "openai",
+    label: "OpenAI",
+    marketplaceManifestPath: ".agents/plugins/marketplace.json",
+    pluginManifestPath: ".codex-plugin/plugin.json",
+  },
+] satisfies GithubDiscoveryStandardDefinition[]
 
 function normalizePath(value: string) {
   return value.trim().replace(/^\.\//, "").replace(/^\/+/, "").replace(/\/+$/, "")
@@ -164,34 +213,48 @@ function readJsonMap(fileTextByPath: Record<string, string | null | undefined>, 
   }
 }
 
-function readPluginMetadata(fileTextByPath: Record<string, string | null | undefined>, rootPath: string, manifestPath?: string | null): PluginMetadata {
-  const manifestCandidate = manifestPath ? normalizePath(manifestPath) : normalizePath(joinPath(rootPath, ".claude-plugin/plugin.json"))
+function readPluginMetadataFromManifest(manifest: Record<string, unknown>): PluginMetadata {
+  const interfaceMetadata = isRecord(manifest.interface) ? manifest.interface : null
+  return {
+    description: asString(interfaceMetadata?.shortDescription)
+      ?? asString(interfaceMetadata?.longDescription)
+      ?? asString(manifest.description),
+    displayName: asString(interfaceMetadata?.displayName) ?? asString(manifest.name),
+    metadata: manifest,
+    name: asString(manifest.name),
+  }
+}
+
+function readPluginMetadata(
+  fileTextByPath: Record<string, string | null | undefined>,
+  rootPath: string,
+  standard: GithubPluginStandard,
+  manifestPath?: string | null,
+): PluginMetadata {
+  const definition = DISCOVERY_STANDARDS.find((entry) => entry.id === standard)
+  const manifestCandidate = manifestPath
+    ? normalizePath(manifestPath)
+    : normalizePath(joinPath(rootPath, definition?.pluginManifestPath ?? ""))
   const explicitManifest = manifestCandidate ? readJsonMap(fileTextByPath, manifestCandidate) : null
   if (isRecord(explicitManifest)) {
-    return {
-      description: asString(explicitManifest.description),
-      metadata: explicitManifest,
-      name: asString(explicitManifest.name),
-    }
+    return readPluginMetadataFromManifest(explicitManifest)
   }
 
-  const fallbackPluginJson = readJsonMap(fileTextByPath, joinPath(rootPath, "plugin.json"))
+  const fallbackPath = definition?.fallbackMetadataPath?.(rootPath)
+  const fallbackPluginJson = fallbackPath ? readJsonMap(fileTextByPath, fallbackPath) : null
   if (isRecord(fallbackPluginJson)) {
-    return {
-      description: asString(fallbackPluginJson.description),
-      metadata: fallbackPluginJson,
-      name: asString(fallbackPluginJson.name),
-    }
+    return readPluginMetadataFromManifest(fallbackPluginJson)
   }
 
   return {
     description: null,
+    displayName: null,
     metadata: {},
     name: null,
   }
 }
 
-function collectComponentPaths(knownPaths: Set<string>, rootPath: string) {
+function collectComponentPaths(knownPaths: Set<string>, rootPath: string, standard: GithubPluginStandard) {
   const componentPaths = {
     agents: [] as string[],
     commands: [] as string[],
@@ -203,38 +266,28 @@ function collectComponentPaths(knownPaths: Set<string>, rootPath: string) {
     skills: [] as string[],
   }
 
-  const candidates: Array<[keyof typeof componentPaths, string]> = [
-    ["skills", joinPath(rootPath, "skills")],
-    ["skills", joinPath(rootPath, ".claude/skills")],
-    ["commands", joinPath(rootPath, "commands")],
-    ["commands", joinPath(rootPath, ".claude/commands")],
-    ["agents", joinPath(rootPath, "agents")],
-    ["agents", joinPath(rootPath, ".claude/agents")],
-    ["hooks", joinPath(rootPath, "hooks/hooks.json")],
-    ["mcpServers", joinPath(rootPath, ".mcp.json")],
-    ["lspServers", joinPath(rootPath, ".lsp.json")],
-    ["monitors", joinPath(rootPath, "monitors/monitors.json")],
-    ["settings", joinPath(rootPath, "settings.json")],
-  ]
+  const definition = DISCOVERY_STANDARDS.find((entry) => entry.id === standard)
+  const candidates = definition?.defaultComponentCandidates(rootPath) ?? []
 
-  for (const [bucket, candidate] of candidates) {
-    if (!candidate) continue
-    if (bucket === "hooks" || bucket === "mcpServers" || bucket === "lspServers" || bucket === "monitors" || bucket === "settings") {
-      if (hasPath(knownPaths, candidate)) {
-        componentPaths[bucket].push(candidate)
-      }
-      continue
-    }
-
-    if (hasDescendant(knownPaths, candidate)) {
-      componentPaths[bucket].push(candidate)
+  for (const candidate of candidates) {
+    if (!candidate.path) continue
+    const matches = candidate.kind === "directory"
+      ? hasDescendant(knownPaths, candidate.path)
+      : hasPath(knownPaths, candidate.path)
+    if (matches) {
+      componentPaths[candidate.bucket].push(candidate.path)
     }
   }
 
   return componentPaths
 }
 
-function readStringArray(value: unknown) {
+function readPathArray(value: unknown) {
+  if (typeof value === "string") {
+    const normalized = asString(value)
+    return normalized ? [normalized] : []
+  }
+
   return Array.isArray(value)
     ? value.flatMap((entry) => {
         const normalized = asString(entry)
@@ -243,34 +296,38 @@ function readStringArray(value: unknown) {
     : []
 }
 
+function resolveDeclaredPaths(input: {
+  knownPaths: Set<string>
+  rootPath: string
+  values: unknown
+} & { directory?: boolean; file?: boolean }) {
+  const paths: string[] = []
+  for (const value of readPathArray(input.values)) {
+    const candidate = joinPath(input.rootPath, value)
+    if (!candidate && !input.rootPath) {
+      continue
+    }
+    if ((input.directory && hasDescendant(input.knownPaths, candidate)) || (input.file && hasPath(input.knownPaths, candidate))) {
+      paths.push(candidate)
+    }
+  }
+  return paths
+}
+
 function declaredComponentPaths(input: {
   declared: Partial<Record<keyof GithubDiscoveredPlugin["componentPaths"], unknown>>
   knownPaths: Set<string>
   rootPath: string
 }) {
-  const collect = (values: unknown, { file, directory }: { file?: boolean; directory?: boolean }) => {
-    const paths: string[] = []
-    for (const value of readStringArray(values)) {
-      const candidate = joinPath(input.rootPath, value)
-      if (!candidate && !input.rootPath) {
-        continue
-      }
-      if ((directory && hasDescendant(input.knownPaths, candidate)) || (file && hasPath(input.knownPaths, candidate))) {
-        paths.push(candidate)
-      }
-    }
-    return paths
-  }
-
   return {
-    agents: collect(input.declared.agents, { directory: true }),
-    commands: collect(input.declared.commands, { directory: true }),
-    hooks: collect(input.declared.hooks, { file: true, directory: true }),
+    agents: resolveDeclaredPaths({ directory: true, knownPaths: input.knownPaths, rootPath: input.rootPath, values: input.declared.agents }),
+    commands: resolveDeclaredPaths({ directory: true, knownPaths: input.knownPaths, rootPath: input.rootPath, values: input.declared.commands }),
+    hooks: resolveDeclaredPaths({ directory: true, file: true, knownPaths: input.knownPaths, rootPath: input.rootPath, values: input.declared.hooks }),
     lspServers: [],
-    mcpServers: collect(input.declared.mcpServers, { file: true }),
+    mcpServers: resolveDeclaredPaths({ file: true, knownPaths: input.knownPaths, rootPath: input.rootPath, values: input.declared.mcpServers }),
     monitors: [],
-    settings: collect(input.declared.settings, { file: true }),
-    skills: collect(input.declared.skills, { directory: true }),
+    settings: resolveDeclaredPaths({ file: true, knownPaths: input.knownPaths, rootPath: input.rootPath, values: input.declared.settings }),
+    skills: resolveDeclaredPaths({ directory: true, knownPaths: input.knownPaths, rootPath: input.rootPath, values: input.declared.skills }),
   } satisfies GithubDiscoveredPlugin["componentPaths"]
 }
 
@@ -306,6 +363,33 @@ function componentKindsFromPaths(componentPaths: GithubDiscoveredPlugin["compone
   return kinds
 }
 
+function pluginManifestWarnings(input: {
+  knownPaths: Set<string>
+  metadata: PluginMetadata
+  rootPath: string
+  standard: GithubPluginStandard
+}) {
+  if (input.standard !== "openai") {
+    return []
+  }
+
+  const appPaths = resolveDeclaredPaths({
+    file: true,
+    knownPaths: input.knownPaths,
+    rootPath: input.rootPath,
+    values: input.metadata.metadata.apps,
+  })
+  if (appPaths.length === 0) {
+    return []
+  }
+
+  return [
+    appPaths.length === 1
+      ? `OpenAI app bundle ${appPaths[0]} is not imported yet. OpenWork will import the plugin's skills and MCP servers only.`
+      : "OpenAI app bundles are not imported yet. OpenWork will import the plugin's skills and MCP servers only.",
+  ]
+}
+
 function buildDiscoveredPlugin(input: {
   componentPathsOverride?: GithubDiscoveredPlugin["componentPaths"] | null
   description?: string | null
@@ -316,21 +400,33 @@ function buildDiscoveredPlugin(input: {
   manifestPath?: string | null
   rootPath: string
   sourceKind: GithubDiscoveredPluginSourceKind
+  standard: GithubPluginStandard
   supported?: boolean
   warnings?: string[]
 }) {
-  const metadata = readPluginMetadata(input.fileTextByPath, input.rootPath, input.manifestPath)
+  const metadata = readPluginMetadata(input.fileTextByPath, input.rootPath, input.standard, input.manifestPath)
   const manifestDeclaredPaths = declaredComponentPaths({
     declared: metadata.metadata,
     knownPaths: input.knownPaths,
     rootPath: input.rootPath,
   })
   const componentPaths = input.componentPathsOverride
-    ?? (hasAnyComponentPaths(manifestDeclaredPaths) ? manifestDeclaredPaths : collectComponentPaths(input.knownPaths, input.rootPath))
-  const displayName = input.displayName?.trim()
+    ?? (hasAnyComponentPaths(manifestDeclaredPaths) ? manifestDeclaredPaths : collectComponentPaths(input.knownPaths, input.rootPath, input.standard))
+  const displayName = metadata.displayName
+    || input.displayName?.trim()
     || metadata.name
     || basename(input.rootPath)
     || "Repository plugin"
+  const derivedWarnings = pluginManifestWarnings({
+    knownPaths: input.knownPaths,
+    metadata,
+    rootPath: input.rootPath,
+    standard: input.standard,
+  })
+  const warnings = [...(input.warnings ?? []), ...derivedWarnings]
+  const supported = input.supported === false
+    ? false
+    : !(warnings.length > 0 && !hasAnyComponentPaths(componentPaths))
 
   return {
     componentKinds: componentKindsFromPaths(componentPaths),
@@ -338,14 +434,23 @@ function buildDiscoveredPlugin(input: {
     description: input.description ?? metadata.description,
     displayName,
     key: input.key,
-    manifestPath: input.manifestPath ? normalizePath(input.manifestPath) : (hasPath(input.knownPaths, joinPath(input.rootPath, ".claude-plugin/plugin.json")) ? joinPath(input.rootPath, ".claude-plugin/plugin.json") : null),
+    manifestPath: input.manifestPath
+      ? normalizePath(input.manifestPath)
+      : (hasPath(input.knownPaths, joinPath(input.rootPath, discoveryDefinition(input.standard).pluginManifestPath))
+          ? joinPath(input.rootPath, discoveryDefinition(input.standard).pluginManifestPath)
+          : null),
     metadata: metadata.metadata,
     rootPath: normalizePath(input.rootPath),
-    selectedByDefault: input.supported !== false,
+    selectedByDefault: supported,
     sourceKind: input.sourceKind,
-    supported: input.supported !== false,
-    warnings: input.warnings ?? [],
+    standard: input.standard,
+    supported,
+    warnings,
   } satisfies GithubDiscoveredPlugin
+}
+
+function discoveryDefinition(standard: GithubPluginStandard) {
+  return DISCOVERY_STANDARDS.find((entry) => entry.id === standard) ?? DISCOVERY_STANDARDS[0]
 }
 
 function localMarketplaceRoot(entry: MarketplaceEntry) {
@@ -357,6 +462,11 @@ function localMarketplaceRoot(entry: MarketplaceEntry) {
     return null
   }
 
+  const sourceType = asString(entry.source.source)
+  if (sourceType && sourceType !== "local") {
+    return null
+  }
+
   if (typeof entry.source.url === "string") {
     return null
   }
@@ -365,11 +475,21 @@ function localMarketplaceRoot(entry: MarketplaceEntry) {
   return localPath ? normalizePath(localPath) : null
 }
 
-function pluginRootsFromManifests(entries: GithubDiscoveryTreeEntry[]) {
+function pluginRootFromManifestPath(path: string, standard: GithubPluginStandard) {
+  const normalizedPath = normalizePath(path)
+  const pluginManifestPath = discoveryDefinition(standard).pluginManifestPath
+  if (normalizedPath === pluginManifestPath) {
+    return ""
+  }
+
+  const suffix = `/${pluginManifestPath}`
+  return normalizedPath.endsWith(suffix) ? normalizedPath.slice(0, -suffix.length) : null
+}
+
+function pluginRootsFromManifests(entries: GithubDiscoveryTreeEntry[], standard: GithubPluginStandard) {
   return entries
-    .map((entry) => normalizePath(entry.path))
-    .filter((path) => path.endsWith(".claude-plugin/plugin.json"))
-    .map((path) => path.slice(0, -"/.claude-plugin/plugin.json".length))
+    .map((entry) => pluginRootFromManifestPath(entry.path, standard))
+    .filter((path): path is string => path !== null)
 }
 
 function inferredRootsFromKnownFolders(entries: GithubDiscoveryTreeEntry[]) {
@@ -395,6 +515,25 @@ function inferredRootsFromKnownFolders(entries: GithubDiscoveryTreeEntry[]) {
   return [...inferred]
 }
 
+function marketplaceInfoFromManifest(manifest: Record<string, unknown>, standard: GithubPluginStandard): GithubMarketplaceInfo {
+  const interfaceMetadata = isRecord(manifest.interface) ? manifest.interface : null
+  return {
+    description: asString(manifest.description)
+      ?? asString(interfaceMetadata?.shortDescription)
+      ?? asString(interfaceMetadata?.longDescription),
+    name: asString(interfaceMetadata?.displayName) ?? asString(manifest.name),
+    owner: isRecord(manifest.owner)
+      ? asString(manifest.owner.name) ?? asString(manifest.owner.login) ?? asString(manifest.owner)
+      : asString(manifest.owner),
+    standard,
+    version: asString(manifest.version),
+  }
+}
+
+function supportedManifestWarning() {
+  return "OpenWork currently supports Claude and OpenAI plugins and marketplaces. Add `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, `.agents/plugins/marketplace.json`, or `.codex-plugin/plugin.json` to this repository."
+}
+
 export function buildGithubRepoDiscovery(input: {
   entries: GithubDiscoveryTreeEntry[]
   fileTextByPath: Record<string, string | null | undefined>
@@ -402,22 +541,27 @@ export function buildGithubRepoDiscovery(input: {
   const knownPaths = buildPathSet(input.entries)
   const warnings: string[] = []
 
-  if (hasPath(knownPaths, ".claude-plugin/marketplace.json")) {
-    const marketplaceJson = readJsonMap(input.fileTextByPath, ".claude-plugin/marketplace.json")
+  const marketplaceDefinitions = DISCOVERY_STANDARDS.filter((definition) => hasPath(knownPaths, definition.marketplaceManifestPath))
+  if (marketplaceDefinitions.length > 0) {
+    const definition = marketplaceDefinitions[0]
+    if (marketplaceDefinitions.length > 1) {
+      warnings.push(`Multiple marketplace manifests were detected. OpenWork is using the ${definition.label} marketplace manifest at ${definition.marketplaceManifestPath}.`)
+    }
+
+    const marketplaceJson = readJsonMap(input.fileTextByPath, definition.marketplaceManifestPath)
     const marketplaceEntries = isRecord(marketplaceJson) && Array.isArray(marketplaceJson.plugins)
       ? marketplaceJson.plugins.filter(isRecord) as MarketplaceEntry[]
       : []
 
-    const marketplaceInfo: GithubMarketplaceInfo = isRecord(marketplaceJson)
-      ? {
-          description: asString(marketplaceJson.description),
-          name: asString(marketplaceJson.name),
-          owner: isRecord(marketplaceJson.owner)
-            ? asString(marketplaceJson.owner.name) ?? asString(marketplaceJson.owner.login) ?? asString(marketplaceJson.owner)
-            : asString(marketplaceJson.owner),
-          version: asString(marketplaceJson.version),
-        }
-      : { description: null, name: null, owner: null, version: null }
+    const marketplaceInfo = isRecord(marketplaceJson)
+      ? marketplaceInfoFromManifest(marketplaceJson, definition.id)
+      : {
+          description: null,
+          name: null,
+          owner: null,
+          standard: definition.id,
+          version: null,
+        } satisfies GithubMarketplaceInfo
 
     const discoveredPlugins = marketplaceEntries.map((entry, index) => {
       const rootPath = localMarketplaceRoot(entry)
@@ -428,11 +572,12 @@ export function buildGithubRepoDiscovery(input: {
           description: asString(entry.description),
           displayName: asString(entry.name) ?? `Marketplace plugin ${index + 1}`,
           fileTextByPath: input.fileTextByPath,
-          key: `marketplace:${asString(entry.name) ?? index}`,
+          key: `${definition.id}:marketplace:${asString(entry.name) ?? index}`,
           knownPaths,
           manifestPath: null,
           rootPath: "",
           sourceKind: "marketplace_entry",
+          standard: definition.id,
           supported: false,
           warnings: [warning],
         })
@@ -446,35 +591,47 @@ export function buildGithubRepoDiscovery(input: {
         description: asString(entry.description),
         displayName: asString(entry.name),
         fileTextByPath: input.fileTextByPath,
-        key: `marketplace:${rootPath}`,
+        key: `${definition.id}:marketplace:${rootPath}`,
         knownPaths,
-        manifestPath: joinPath(rootPath, ".claude-plugin/plugin.json"),
+        manifestPath: joinPath(rootPath, definition.pluginManifestPath),
         rootPath,
         sourceKind: "marketplace_entry",
+        standard: definition.id,
       })
     })
 
     return {
-      classification: "claude_marketplace_repo",
+      classification: "marketplace_repo",
       discoveredPlugins,
       marketplace: marketplaceInfo,
       warnings,
     } satisfies GithubRepoDiscoveryResult
   }
 
-  const manifestRoots = [...new Set(pluginRootsFromManifests(input.entries))]
-  if (manifestRoots.length > 0) {
-    const discoveredPlugins = manifestRoots.map((rootPath) => buildDiscoveredPlugin({
+  const manifestPlugins = [...new Map(
+    DISCOVERY_STANDARDS.flatMap((definition) => pluginRootsFromManifests(input.entries, definition.id).map((rootPath) => [
+      `${definition.id}:${rootPath}`,
+      { rootPath, standard: definition.id },
+    ]))
+  ).values()]
+
+  if (manifestPlugins.length > 0) {
+    if (new Set(manifestPlugins.map((entry) => entry.standard)).size > 1) {
+      warnings.push("Multiple plugin standards were detected. OpenWork will import supported manifests from each standard.")
+    }
+
+    const discoveredPlugins = manifestPlugins.map(({ rootPath, standard }) => buildDiscoveredPlugin({
       fileTextByPath: input.fileTextByPath,
-      key: `manifest:${rootPath || "root"}`,
+      key: `${standard}:manifest:${rootPath || "root"}`,
       knownPaths,
-      manifestPath: joinPath(rootPath, ".claude-plugin/plugin.json"),
+      manifestPath: joinPath(rootPath, discoveryDefinition(standard).pluginManifestPath),
       rootPath,
       sourceKind: "plugin_manifest",
+      standard,
     }))
 
     return {
-      classification: manifestRoots.length === 1 && manifestRoots[0] === "" ? "claude_single_plugin_repo" : "claude_multi_plugin_repo",
+      classification: manifestPlugins.length === 1 ? "single_plugin_repo" : "multi_plugin_repo",
       discoveredPlugins,
       marketplace: null,
       warnings,
@@ -483,7 +640,7 @@ export function buildGithubRepoDiscovery(input: {
 
   // Intentionally disabled for now: directory-based inference can over-classify
   // arbitrary repos as plugins. Until we support a broader compatibility model,
-  // discovery should only accept explicit Claude plugin markers.
+  // discovery should only accept explicit marketplace or plugin manifests.
   // const inferredRoots = inferredRootsFromKnownFolders(input.entries)
   // const standaloneRoot = inferredRoots.includes("") && (
   //   hasDescendant(knownPaths, ".claude/skills")
@@ -499,16 +656,19 @@ export function buildGithubRepoDiscovery(input: {
   //     knownPaths,
   //     rootPath,
   //     sourceKind: standaloneRoot && rootPath === "" ? "standalone_claude" : "folder_inference",
+  //     standard: "claude",
   //   }))
   //
   //   return {
   //     classification: "folder_inferred_repo",
   //     discoveredPlugins,
+  //     marketplace: null,
   //     warnings,
   //   } satisfies GithubRepoDiscoveryResult
   // }
+  void inferredRootsFromKnownFolders
 
-  warnings.push("OpenWork currently only supports Claude-compatible plugins and marketplaces. Add `.claude-plugin/marketplace.json` or `.claude-plugin/plugin.json` to this repository.")
+  warnings.push(supportedManifestWarning())
 
   return {
     classification: "unsupported",

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -777,6 +777,7 @@ export const githubRepositorySchema = z.object({
   defaultBranch: z.string().trim().min(1).nullable(),
   hasPluginManifest: z.boolean().optional(),
   manifestKind: z.enum(["marketplace", "plugin"]).nullable().optional(),
+  manifestStandard: z.enum(["claude", "openai"]).nullable().optional(),
   marketplacePluginCount: z.number().int().nonnegative().nullable().optional(),
   private: z.boolean(),
 }).meta({ ref: "PluginArchGithubRepository" })
@@ -794,6 +795,7 @@ export const githubDiscoveryTreeSummarySchema = z.object({
 export const githubDiscoveredPluginSchema = z.object({
   key: z.string().trim().min(1),
   sourceKind: z.enum(["marketplace_entry", "plugin_manifest", "standalone_claude", "folder_inference"]),
+  standard: z.enum(["claude", "openai"]),
   rootPath: z.string(),
   displayName: z.string().trim().min(1),
   description: nullableStringSchema,
@@ -818,7 +820,7 @@ export const githubConnectorDiscoveryResponseSchema = pluginArchMutationResponse
   "PluginArchGithubConnectorDiscoveryResponse",
   z.object({
     autoImportNewPlugins: z.boolean(),
-    classification: z.enum(["claude_marketplace_repo", "claude_multi_plugin_repo", "claude_single_plugin_repo", "folder_inferred_repo", "unsupported"]),
+    classification: z.enum(["marketplace_repo", "multi_plugin_repo", "single_plugin_repo", "folder_inferred_repo", "unsupported"]),
     connectorInstance: connectorInstanceSchema,
     connectorTarget: connectorTargetSchema,
     discoveredPlugins: z.array(githubDiscoveredPluginSchema),

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -42,6 +42,7 @@ import {
   buildGithubRepoDiscovery,
   type GithubDiscoveredPlugin,
   type GithubDiscoveryClassification,
+  type GithubPluginStandard,
   type GithubMarketplaceInfo,
   type GithubDiscoveryTreeEntry,
 } from "./github-discovery.js"
@@ -159,6 +160,7 @@ type RepositorySummary = {
   hasPluginManifest?: boolean
   id: number
   manifestKind?: "marketplace" | "plugin" | null
+  manifestStandard?: "claude" | "openai" | null
   marketplacePluginCount?: number | null
   private: boolean
 }
@@ -2365,13 +2367,13 @@ function buildGithubConnectorDiscoverySteps(input: {
 }) {
   return [
     discoveryStep("completed", "read_repository_structure", "Read repository structure"),
-    discoveryStep(input.classification === "claude_marketplace_repo" ? "completed" : "warning", "check_marketplace_manifest", "Check for Claude marketplace manifest"),
+    discoveryStep(input.classification === "marketplace_repo" ? "completed" : "warning", "check_marketplace_manifest", "Check for supported marketplace manifests"),
     discoveryStep(
-      input.classification === "claude_single_plugin_repo" || input.classification === "claude_multi_plugin_repo"
+      input.classification === "single_plugin_repo" || input.classification === "multi_plugin_repo"
         ? "completed"
         : "warning",
       "check_plugin_manifests",
-      "Check for plugin manifests",
+      "Check for supported plugin manifests",
     ),
     discoveryStep(input.discoveredPlugins.length > 0 ? "completed" : "warning", "prepare_discovered_plugins", "Prepare discovered plugins"),
   ] satisfies GithubConnectorDiscoveryStep[]
@@ -2388,6 +2390,62 @@ function buildGithubDiscoveryImportPlans(input: { discoveredPlugins: GithubDisco
   ])) satisfies Record<string, GithubDiscoveryImportPlan[]>
 }
 
+function normalizeGithubPluginStandard(value: unknown): GithubPluginStandard | null {
+  return value === "claude" || value === "openai" ? value : null
+}
+
+function inferGithubPluginStandard(input: { key?: string | null; manifestPath?: string | null }) {
+  if (input.key?.startsWith("openai:")) return "openai" satisfies GithubPluginStandard
+  if (input.manifestPath?.includes(".codex-plugin/")) return "openai" satisfies GithubPluginStandard
+  return "claude" satisfies GithubPluginStandard
+}
+
+function normalizeGithubDiscoveryClassification(value: unknown): GithubDiscoveryClassification | null {
+  if (value === "marketplace_repo"
+    || value === "multi_plugin_repo"
+    || value === "single_plugin_repo"
+    || value === "folder_inferred_repo"
+    || value === "unsupported") {
+    return value
+  }
+  if (value === "claude_marketplace_repo") return "marketplace_repo"
+  if (value === "claude_multi_plugin_repo") return "multi_plugin_repo"
+  if (value === "claude_single_plugin_repo") return "single_plugin_repo"
+  return null
+}
+
+function normalizeGithubDiscoveredPlugin(entry: unknown): GithubDiscoveredPlugin | null {
+  if (!isRecord(entry)) {
+    return null
+  }
+
+  const standard = normalizeGithubPluginStandard(entry.standard) ?? inferGithubPluginStandard({
+    key: typeof entry.key === "string" ? entry.key : null,
+    manifestPath: typeof entry.manifestPath === "string" ? entry.manifestPath : null,
+  })
+
+  return {
+    ...entry,
+    standard,
+  } as GithubDiscoveredPlugin
+}
+
+function normalizeGithubMarketplaceInfo(entry: unknown, fallbackStandard: GithubPluginStandard | null) {
+  if (!isRecord(entry)) {
+    return null
+  }
+
+  const standard = normalizeGithubPluginStandard(entry.standard) ?? fallbackStandard
+  if (!standard) {
+    return null
+  }
+
+  return {
+    ...entry,
+    standard,
+  } as GithubMarketplaceInfo
+}
+
 function readGithubDiscoveryCache(config: Record<string, unknown> | null) {
   const cache = config && isRecord(config.githubDiscoveryCache) ? config.githubDiscoveryCache : null
   if (!cache) {
@@ -2398,13 +2456,18 @@ function readGithubDiscoveryCache(config: Record<string, unknown> | null) {
   const branch = typeof cache.branch === "string" ? cache.branch : null
   const ref = typeof cache.ref === "string" ? cache.ref : null
   const sourceRevisionRef = typeof cache.sourceRevisionRef === "string" ? cache.sourceRevisionRef : null
-  const discoveredPlugins = Array.isArray(cache.discoveredPlugins) ? cache.discoveredPlugins as GithubDiscoveredPlugin[] : null
+  const classification = normalizeGithubDiscoveryClassification(cache.classification)
+  const discoveredPlugins = Array.isArray(cache.discoveredPlugins)
+    ? cache.discoveredPlugins.map(normalizeGithubDiscoveredPlugin).filter((entry): entry is GithubDiscoveredPlugin => entry !== null)
+    : null
   const warnings = Array.isArray(cache.warnings) ? cache.warnings.filter((entry): entry is string => typeof entry === "string") : null
   const treeSummary = isRecord(cache.treeSummary) ? cache.treeSummary as GithubConnectorDiscoveryTreeSummary : null
   const importPlansByPluginKey = isRecord(cache.importPlansByPluginKey)
     ? cache.importPlansByPluginKey as Record<string, GithubDiscoveryImportPlan[]>
     : null
-  const classification = typeof cache.classification === "string" ? cache.classification as GithubDiscoveryClassification : null
+  const fallbackStandard = classification === "marketplace_repo" || classification === "single_plugin_repo" || classification === "multi_plugin_repo"
+    ? (discoveredPlugins?.[0]?.standard ?? "claude")
+    : null
 
   if (!repositoryFullName || !branch || !ref || !sourceRevisionRef || !discoveredPlugins || !warnings || !treeSummary || !importPlansByPluginKey || !classification) {
     return null
@@ -2415,7 +2478,7 @@ function readGithubDiscoveryCache(config: Record<string, unknown> | null) {
     classification,
     discoveredPlugins,
     importPlansByPluginKey,
-    marketplace: isRecord(cache.marketplace) || cache.marketplace === null ? cache.marketplace as GithubMarketplaceInfo | null : null,
+    marketplace: cache.marketplace === null ? null : normalizeGithubMarketplaceInfo(cache.marketplace, fallbackStandard),
     ref,
     repositoryFullName,
     sourceRevisionRef,
@@ -2581,12 +2644,19 @@ async function getGithubDiscoveryFileTexts(input: {
   const interestingPaths = new Set<string>()
   const knownPaths = new Set(input.treeEntries.map((entry) => entry.path))
 
-  if (knownPaths.has(".claude-plugin/marketplace.json")) {
-    interestingPaths.add(".claude-plugin/marketplace.json")
+  for (const manifestPath of [".claude-plugin/marketplace.json", ".agents/plugins/marketplace.json"]) {
+    if (knownPaths.has(manifestPath)) {
+      interestingPaths.add(manifestPath)
+    }
   }
 
   for (const entry of input.treeEntries) {
-    if (entry.path.endsWith(".claude-plugin/plugin.json") || entry.path.endsWith("/plugin.json") || entry.path === "plugin.json") {
+    if (
+      entry.path.endsWith(".claude-plugin/plugin.json")
+      || entry.path.endsWith(".codex-plugin/plugin.json")
+      || entry.path.endsWith("/plugin.json")
+      || entry.path === "plugin.json"
+    ) {
       interestingPaths.add(entry.path)
     }
   }
@@ -3379,7 +3449,7 @@ export async function applyGithubConnectorDiscovery(input: { autoImportNewPlugin
   const marketplaceName = marketplaceInfo?.name?.trim() || discovery.cache.repositoryFullName
   const marketplaceDescription = marketplaceInfo?.description?.trim()
     ?? `Imported from GitHub marketplace repository ${discovery.cache.repositoryFullName}.`
-  const createdMarketplace = discovery.cache.classification === "claude_marketplace_repo"
+  const createdMarketplace = discovery.cache.classification === "marketplace_repo"
     ? await ensureDiscoveryMarketplace({
         context: input.context,
         description: marketplaceDescription,
@@ -3481,6 +3551,7 @@ export async function listGithubRepositories(input: { connectorAccountId: Connec
         hasPluginManifest: repository.hasPluginManifest ?? false,
         id: repository.id,
         manifestKind: repository.manifestKind ?? null,
+        manifestStandard: repository.manifestStandard ?? null,
         marketplacePluginCount: repository.marketplacePluginCount ?? null,
         private: repository.private,
       })),
@@ -3501,6 +3572,7 @@ export async function listGithubRepositories(input: { connectorAccountId: Connec
       hasPluginManifest: Boolean(repository.hasPluginManifest),
       id: Number(repository.id),
       manifestKind: repository.manifestKind ?? null,
+      manifestStandard: repository.manifestStandard ?? null,
       marketplacePluginCount: repository.marketplacePluginCount ?? null,
       private: repository.private,
     })),

--- a/ee/apps/den-api/test/github-connector-app.test.ts
+++ b/ee/apps/den-api/test/github-connector-app.test.ts
@@ -57,7 +57,15 @@ describe("github connector app helpers", () => {
           return new Response(JSON.stringify({ message: "not found" }), { status: 404 })
         }
 
+        if (String(url).endsWith("/contents/.agents/plugins/marketplace.json")) {
+          return new Response(JSON.stringify({ message: "not found" }), { status: 404 })
+        }
+
         if (String(url).endsWith("/contents/.claude-plugin/plugin.json")) {
+          return new Response(JSON.stringify({ message: "not found" }), { status: 404 })
+        }
+
+        if (String(url).endsWith("/contents/.codex-plugin/plugin.json")) {
           if (String(url).includes("different-ai/opencode")) {
             return new Response(JSON.stringify({ name: "plugin.json" }), { status: 200 })
           }
@@ -79,11 +87,13 @@ describe("github connector app helpers", () => {
       "https://api.github.com/installation/repositories",
       "https://api.github.com/repos/different-ai/openwork/contents/.claude-plugin/marketplace.json",
       "https://api.github.com/repos/different-ai/opencode/contents/.claude-plugin/marketplace.json",
+      "https://api.github.com/repos/different-ai/opencode/contents/.agents/plugins/marketplace.json",
       "https://api.github.com/repos/different-ai/opencode/contents/.claude-plugin/plugin.json",
+      "https://api.github.com/repos/different-ai/opencode/contents/.codex-plugin/plugin.json",
     ])
     expect(repositories).toEqual([
-      { defaultBranch: "main", fullName: "different-ai/openwork", hasPluginManifest: true, id: 42, manifestKind: "marketplace", marketplacePluginCount: 3, private: true },
-      { defaultBranch: "dev", fullName: "different-ai/opencode", hasPluginManifest: true, id: 99, manifestKind: "plugin", marketplacePluginCount: null, private: false },
+      { defaultBranch: "main", fullName: "different-ai/openwork", hasPluginManifest: true, id: 42, manifestKind: "marketplace", manifestStandard: "claude", marketplacePluginCount: 3, private: true },
+      { defaultBranch: "dev", fullName: "different-ai/opencode", hasPluginManifest: true, id: 99, manifestKind: "plugin", manifestStandard: "openai", marketplacePluginCount: null, private: false },
     ])
   })
 

--- a/ee/apps/den-api/test/github-discovery.test.ts
+++ b/ee/apps/den-api/test/github-discovery.test.ts
@@ -6,7 +6,7 @@ function blob(path: string): GithubDiscoveryTreeEntry {
 }
 
 describe("github discovery", () => {
-  test("classifies marketplace repos and resolves local plugin roots", () => {
+  test("classifies Claude marketplace repos and resolves local plugin roots", () => {
     const result = buildGithubRepoDiscovery({
       entries: [
         blob(".claude-plugin/marketplace.json"),
@@ -27,15 +27,73 @@ describe("github discovery", () => {
       },
     })
 
-    expect(result.classification).toBe("claude_marketplace_repo")
+    expect(result.classification).toBe("marketplace_repo")
     expect(result.discoveredPlugins).toHaveLength(1)
     expect(result.discoveredPlugins[0]).toMatchObject({
       displayName: "sales",
       rootPath: "plugins/sales",
       sourceKind: "marketplace_entry",
+      standard: "claude",
     })
     expect(result.discoveredPlugins[0]?.componentPaths.skills).toEqual(["plugins/sales/skills"])
     expect(result.discoveredPlugins[0]?.componentPaths.commands).toEqual(["plugins/sales/commands"])
+  })
+
+  test("classifies OpenAI marketplace repos and resolves plugin manifests from local entries", () => {
+    const result = buildGithubRepoDiscovery({
+      entries: [
+        blob(".agents/plugins/marketplace.json"),
+        blob("plugins/research/.codex-plugin/plugin.json"),
+        blob("plugins/research/skills/triage/SKILL.md"),
+        blob("plugins/research/.mcp.json"),
+      ],
+      fileTextByPath: {
+        ".agents/plugins/marketplace.json": JSON.stringify({
+          name: "local-example-plugins",
+          interface: { displayName: "Local Example Plugins" },
+          plugins: [
+            {
+              name: "research-helper",
+              source: {
+                source: "local",
+                path: "./plugins/research",
+              },
+              policy: {
+                authentication: "ON_INSTALL",
+                installation: "AVAILABLE",
+              },
+              category: "Productivity",
+            },
+          ],
+        }),
+        "plugins/research/.codex-plugin/plugin.json": JSON.stringify({
+          name: "research-helper",
+          version: "0.1.0",
+          description: "Bundle reusable skills and app integrations.",
+          skills: "./skills/",
+          mcpServers: "./.mcp.json",
+          interface: {
+            displayName: "Research Helper",
+            shortDescription: "Reusable skills and MCP servers",
+          },
+        }),
+      },
+    })
+
+    expect(result.classification).toBe("marketplace_repo")
+    expect(result.marketplace).toMatchObject({
+      name: "Local Example Plugins",
+      standard: "openai",
+    })
+    expect(result.discoveredPlugins).toHaveLength(1)
+    expect(result.discoveredPlugins[0]).toMatchObject({
+      displayName: "Research Helper",
+      rootPath: "plugins/research",
+      sourceKind: "marketplace_entry",
+      standard: "openai",
+    })
+    expect(result.discoveredPlugins[0]?.componentPaths.skills).toEqual(["plugins/research/skills"])
+    expect(result.discoveredPlugins[0]?.componentPaths.mcpServers).toEqual(["plugins/research/.mcp.json"])
   })
 
   test("treats marketplace source './' as the current repo root", () => {
@@ -61,19 +119,47 @@ describe("github discovery", () => {
       },
     })
 
-    expect(result.classification).toBe("claude_marketplace_repo")
+    expect(result.classification).toBe("marketplace_repo")
     expect(result.warnings).toEqual([])
     expect(result.discoveredPlugins).toHaveLength(1)
     expect(result.discoveredPlugins[0]).toMatchObject({
       displayName: "agent-browser",
       rootPath: "",
       sourceKind: "marketplace_entry",
+      standard: "claude",
       supported: true,
     })
     expect(result.discoveredPlugins[0]?.componentPaths.skills).toEqual(["skills/agent-browser"])
   })
 
-  test("treats non-Claude folder-only repos as unsupported", () => {
+  test("warns when an OpenAI plugin only exposes app bundles", () => {
+    const result = buildGithubRepoDiscovery({
+      entries: [
+        blob(".codex-plugin/plugin.json"),
+        blob(".app.json"),
+      ],
+      fileTextByPath: {
+        ".codex-plugin/plugin.json": JSON.stringify({
+          name: "app-only-plugin",
+          apps: "./.app.json",
+          interface: {
+            displayName: "App Only Plugin",
+          },
+        }),
+      },
+    })
+
+    expect(result.classification).toBe("single_plugin_repo")
+    expect(result.discoveredPlugins).toHaveLength(1)
+    expect(result.discoveredPlugins[0]).toMatchObject({
+      displayName: "App Only Plugin",
+      standard: "openai",
+      supported: false,
+    })
+    expect(result.discoveredPlugins[0]?.warnings[0]).toContain("OpenAI app bundle")
+  })
+
+  test("treats folder-only repos as unsupported without supported manifests", () => {
     const result = buildGithubRepoDiscovery({
       entries: [
         blob("Sales/skills/pitch/SKILL.md"),
@@ -88,7 +174,7 @@ describe("github discovery", () => {
 
     expect(result.classification).toBe("unsupported")
     expect(result.discoveredPlugins).toEqual([])
-    expect(result.warnings[0]).toContain("only supports Claude-compatible plugins and marketplaces")
+    expect(result.warnings[0]).toContain("supports Claude and OpenAI plugins and marketplaces")
   })
 
   test("treats standalone .claude directories as unsupported without plugin manifests", () => {
@@ -102,6 +188,6 @@ describe("github discovery", () => {
 
     expect(result.classification).toBe("unsupported")
     expect(result.discoveredPlugins).toEqual([])
-    expect(result.warnings[0]).toContain("only supports Claude-compatible plugins and marketplaces")
+    expect(result.warnings[0]).toContain("supports Claude and OpenAI plugins and marketplaces")
   })
 })

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/github-integration-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/github-integration-screen.tsx
@@ -728,6 +728,7 @@ function GithubConnectedAccountSelectionPhase({ connectorAccountId }: { connecto
                         fullName={repository.fullName}
                         defaultBranch={repository.defaultBranch ?? null}
                         manifestKind={repository.manifestKind ?? null}
+                        manifestStandard={repository.manifestStandard ?? null}
                         marketplacePluginCount={repository.marketplacePluginCount ?? null}
                         configuredInstanceId={configuredInstanceId}
                         configuredHref={configuredInstanceId ? `${getGithubIntegrationRoute(orgSlug)}?connectorInstanceId=${encodeURIComponent(configuredInstanceId)}` : null}
@@ -823,15 +824,20 @@ function GithubConnectedAccountSelectionPhase({ connectorAccountId }: { connecto
   );
 }
 
-function manifestLabel(kind: "marketplace" | "plugin" | null, marketplacePluginCount: number | null): string | null {
+function manifestLabel(
+  kind: "marketplace" | "plugin" | null,
+  standard: "claude" | "openai" | null,
+  marketplacePluginCount: number | null,
+): string | null {
+  const standardLabel = standard === "openai" ? "OpenAI" : standard === "claude" ? "Claude" : "Supported";
   if (kind === "marketplace") {
     if (marketplacePluginCount && marketplacePluginCount > 1) {
-      return `Claude Marketplace · ${marketplacePluginCount} plugins`;
+      return `${standardLabel} Marketplace · ${marketplacePluginCount} plugins`;
     }
-    return "Claude Marketplace Detected";
+    return `${standardLabel} Marketplace Detected`;
   }
   if (kind === "plugin") {
-    return "Claude Plugin Detected";
+    return `${standardLabel} Plugin Detected`;
   }
   return null;
 }
@@ -840,6 +846,7 @@ function RepositoryCard({
   fullName,
   defaultBranch,
   manifestKind,
+  manifestStandard,
   marketplacePluginCount,
   configuredInstanceId,
   configuredHref,
@@ -849,13 +856,14 @@ function RepositoryCard({
   fullName: string;
   defaultBranch: string | null;
   manifestKind: "marketplace" | "plugin" | null;
+  manifestStandard: "claude" | "openai" | null;
   marketplacePluginCount: number | null;
   configuredInstanceId: string | null;
   configuredHref: string | null;
   selected: boolean;
   onSelect: () => void;
 }) {
-  const badge = manifestLabel(manifestKind, marketplacePluginCount);
+  const badge = manifestLabel(manifestKind, manifestStandard, marketplacePluginCount);
   const isConfigured = Boolean(configuredInstanceId);
 
   const innerContent = (
@@ -1073,10 +1081,10 @@ function GithubDiscoveryPhase({ connectorInstanceId, onBack }: { connectorInstan
             ) : (
               <div className="rounded-2xl border border-dashed border-gray-200 bg-white px-5 py-10 text-center">
                 <p className="text-[14px] font-medium tracking-[-0.02em] text-gray-800">
-                  No Claude-compatible plugins detected
+                  No supported plugins detected
                 </p>
                 <p className="mx-auto mt-2 max-w-[440px] text-[13px] leading-6 text-gray-500">
-                  OpenWork currently only supports Claude-compatible plugins and marketplaces. Add <code className="rounded bg-gray-100 px-1 py-0.5 text-[11px]">.claude-plugin/marketplace.json</code> or <code className="rounded bg-gray-100 px-1 py-0.5 text-[11px]">.claude-plugin/plugin.json</code> to this repository.
+                  OpenWork currently supports Claude and OpenAI plugin ecosystems. Add <code className="rounded bg-gray-100 px-1 py-0.5 text-[11px]">.claude-plugin/marketplace.json</code>, <code className="rounded bg-gray-100 px-1 py-0.5 text-[11px]">.claude-plugin/plugin.json</code>, <code className="rounded bg-gray-100 px-1 py-0.5 text-[11px]">.agents/plugins/marketplace.json</code>, or <code className="rounded bg-gray-100 px-1 py-0.5 text-[11px]">.codex-plugin/plugin.json</code> to this repository.
                 </p>
               </div>
             )}
@@ -1121,6 +1129,7 @@ function DiscoveredPluginCard({
     description: string | null;
     rootPath: string;
     sourceKind: string;
+    standard: "claude" | "openai";
     supported: boolean;
     componentKinds: string[];
     warnings: string[];
@@ -1157,6 +1166,9 @@ function DiscoveredPluginCard({
                 <h3 className="truncate text-[15px] font-semibold tracking-[-0.02em] text-gray-900">
                   {plugin.displayName}
                 </h3>
+                <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10.5px] font-medium uppercase tracking-[0.06em] text-gray-600">
+                  {plugin.standard === "openai" ? "OpenAI" : "Claude"}
+                </span>
                 {!plugin.supported ? (
                   <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10.5px] font-medium uppercase tracking-[0.06em] text-amber-700">
                     Unsupported
@@ -1279,7 +1291,7 @@ function DiscoveryLoadingState() {
         Discovering marketplaces and plugins in your repository
       </h2>
       <p className="mt-2 max-w-[460px] text-[13px] leading-[1.6] text-gray-500">
-        OpenWork is scanning the repo for Claude-compatible plugin and marketplace manifests.
+        OpenWork is scanning the repo for Claude and OpenAI plugin and marketplace manifests.
       </p>
     </section>
   );

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/integration-data.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/integration-data.tsx
@@ -19,6 +19,7 @@ export type IntegrationAccount = {
 };
 
 export type IntegrationRepoManifestKind = "marketplace" | "plugin" | null;
+export type IntegrationRepoManifestStandard = "claude" | "openai" | null;
 
 export type IntegrationRepo = {
   connectorInstanceId?: string;
@@ -28,6 +29,7 @@ export type IntegrationRepo = {
   description: string;
   hasPluginManifest?: boolean;
   manifestKind?: IntegrationRepoManifestKind;
+  manifestStandard?: IntegrationRepoManifestStandard;
   marketplacePluginCount?: number | null;
   hasPlugins: boolean;
   defaultBranch?: string | null;
@@ -87,6 +89,7 @@ export type GithubDiscoveredPlugin = {
   rootPath: string;
   selectedByDefault: boolean;
   sourceKind: string;
+  standard: "claude" | "openai";
   supported: boolean;
   warnings: string[];
 };
@@ -201,6 +204,20 @@ function asString(value: unknown): string | null {
 
 function asNullableString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function describeRepositoryManifest(
+  kind: IntegrationRepoManifestKind,
+  standard: IntegrationRepoManifestStandard,
+) {
+  const standardLabel = standard === "openai" ? "OpenAI" : standard === "claude" ? "Claude" : "Supported";
+  if (kind === "marketplace") {
+    return `${standardLabel} marketplace manifest detected.`;
+  }
+  if (kind === "plugin") {
+    return `${standardLabel} plugin manifest detected.`;
+  }
+  return "Repository available to connect.";
 }
 
 function parseGithubConnectorAccounts(payload: unknown) {
@@ -470,18 +487,19 @@ export function useGithubInstallCompletion(input: { installationId: number | nul
             const manifestKind: IntegrationRepoManifestKind = manifestKindValue === "marketplace" || manifestKindValue === "plugin"
               ? manifestKindValue
               : null;
+            const manifestStandardValue = entry.manifestStandard;
+            const manifestStandard: IntegrationRepoManifestStandard = manifestStandardValue === "claude" || manifestStandardValue === "openai"
+              ? manifestStandardValue
+              : null;
             return [{
               defaultBranch: asNullableString(entry.defaultBranch),
-              description: manifestKind === "marketplace"
-                ? "Claude marketplace manifest detected."
-                : manifestKind === "plugin"
-                  ? "Claude plugin manifest detected."
-                  : "Repository available to connect.",
+              description: describeRepositoryManifest(manifestKind, manifestStandard),
               fullName,
               hasPluginManifest: Boolean(entry.hasPluginManifest),
               hasPlugins: Boolean(entry.hasPluginManifest),
               id,
               manifestKind,
+              manifestStandard,
               marketplacePluginCount: typeof entry.marketplacePluginCount === "number" ? entry.marketplacePluginCount : null,
               name: toRepoName(fullName),
               private: Boolean(entry.private),
@@ -536,18 +554,19 @@ export function useGithubAccountRepositories(connectorAccountId: string | null) 
             const manifestKind: IntegrationRepoManifestKind = manifestKindValue === "marketplace" || manifestKindValue === "plugin"
               ? manifestKindValue
               : null;
+            const manifestStandardValue = entry.manifestStandard;
+            const manifestStandard: IntegrationRepoManifestStandard = manifestStandardValue === "claude" || manifestStandardValue === "openai"
+              ? manifestStandardValue
+              : null;
             return [{
               defaultBranch: asNullableString(entry.defaultBranch),
-              description: manifestKind === "marketplace"
-                ? "Claude marketplace manifest detected."
-                : manifestKind === "plugin"
-                  ? "Claude plugin manifest detected."
-                  : "Repository available to connect.",
+              description: describeRepositoryManifest(manifestKind, manifestStandard),
               fullName,
               hasPluginManifest: Boolean(entry.hasPluginManifest),
               hasPlugins: Boolean(entry.hasPluginManifest),
               id,
               manifestKind,
+              manifestStandard,
               marketplacePluginCount: typeof entry.marketplacePluginCount === "number" ? entry.marketplacePluginCount : null,
               name: toRepoName(fullName),
               private: Boolean(entry.private),
@@ -685,6 +704,7 @@ export function useGithubConnectorDiscovery(connectorInstanceId: string | null) 
               rootPath: typeof entry.rootPath === "string" ? entry.rootPath : "",
               selectedByDefault: Boolean(entry.selectedByDefault),
               sourceKind: asString(entry.sourceKind) ?? "folder_inference",
+              standard: entry.standard === "openai" ? "openai" : "claude",
               supported: Boolean(entry.supported),
               warnings: Array.isArray(entry.warnings)
                 ? entry.warnings.flatMap((candidate) => {

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/marketplaces-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/marketplaces-screen.tsx
@@ -31,7 +31,7 @@ export function MarketplacesScreen() {
       icon={Store}
       badgeLabel="Preview"
       title="Marketplaces"
-      description="Marketplaces group plugins imported from a Claude marketplace repository."
+      description="Marketplaces group plugins imported from supported marketplace repositories."
       colors={["#FEF3C7", "#92400E", "#F59E0B", "#FDE68A"]}
     >
       <div className="mb-6">
@@ -54,14 +54,14 @@ export function MarketplacesScreen() {
         <div className="rounded-2xl border border-gray-100 bg-white px-6 py-10 text-[14px] text-gray-500">
           Loading marketplaces…
         </div>
-      ) : !hasAnyIntegration && marketplaces.length === 0 ? (
+      ) : !hasAnyIntegration ? (
         <ConnectIntegrationEmptyState integrationsHref={getIntegrationsRoute(orgSlug)} />
       ) : filtered.length === 0 ? (
         <EmptyState
           title={marketplaces.length === 0 ? "No marketplaces yet" : "No marketplaces match that search"}
           description={
             marketplaces.length === 0
-              ? "Imported marketplaces and connected integration marketplaces will show up here when they are available."
+              ? "Marketplaces show up here when you import a repository that has a supported marketplace manifest like `.claude-plugin/marketplace.json` or `.agents/plugins/marketplace.json`."
               : "Try a different search term or open the plugins tab."
           }
           action={
@@ -147,7 +147,7 @@ function ConnectIntegrationEmptyState({ integrationsHref }: { integrationsHref: 
   return (
     <EmptyState
       title="Connect an integration to discover marketplaces"
-      description="Marketplaces are created when OpenWork finds a `.claude-plugin/marketplace.json` manifest in a connected repository."
+      description="Marketplaces are created when OpenWork finds a supported marketplace manifest in a connected repository."
       action={{ href: integrationsHref, label: "Open Integrations", icon: Cable }}
     />
   );

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/marketplaces-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/marketplaces-screen.tsx
@@ -31,7 +31,7 @@ export function MarketplacesScreen() {
       icon={Store}
       badgeLabel="Preview"
       title="Marketplaces"
-      description="Marketplaces group plugins imported from a Claude marketplace repository."
+      description="Marketplaces group plugins imported from supported marketplace repositories."
       colors={["#FEF3C7", "#92400E", "#F59E0B", "#FDE68A"]}
     >
       <div className="mb-6">
@@ -61,7 +61,7 @@ export function MarketplacesScreen() {
           title={marketplaces.length === 0 ? "No marketplaces yet" : "No marketplaces match that search"}
           description={
             marketplaces.length === 0
-              ? "Marketplaces show up here when you import a repository that has a `.claude-plugin/marketplace.json` manifest."
+              ? "Marketplaces show up here when you import a repository that has a supported marketplace manifest like `.claude-plugin/marketplace.json` or `.agents/plugins/marketplace.json`."
               : "Try a different search term or open the plugins tab."
           }
           action={
@@ -147,7 +147,7 @@ function ConnectIntegrationEmptyState({ integrationsHref }: { integrationsHref: 
   return (
     <EmptyState
       title="Connect an integration to discover marketplaces"
-      description="Marketplaces are created when OpenWork finds a `.claude-plugin/marketplace.json` manifest in a connected repository."
+      description="Marketplaces are created when OpenWork finds a supported marketplace manifest in a connected repository."
       action={{ href: integrationsHref, label: "Open Integrations", icon: Cable }}
     />
   );


### PR DESCRIPTION
## Summary
- generalize GitHub plugin discovery so OpenWork can ingest multiple plugin and marketplace manifest standards instead of remaining Claude-only
- add OpenAI marketplace support via `.agents/plugins/marketplace.json` and OpenAI plugin support via `.codex-plugin/plugin.json`
- update repo detection, discovery UI, and tests so Claude and OpenAI standards are surfaced consistently

## Testing
- `cd ee/apps/den-api && bun test test/github-discovery.test.ts test/github-connector-app.test.ts`

## Not Run
- `packaging/docker/dev-up.sh`
- Chrome MCP end-to-end verification
- full package typecheck/build in this worktree because dependencies are not installed here