### PR TITLE
fix(desktop): disable WebKit compositing on Linux to prevent NVIDIA/X…

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(target_os = "linux")]
+    std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+
     openwork::run();
 }


### PR DESCRIPTION
## Summary
- Set `WEBKIT_DISABLE_COMPOSITING_MODE=1` automatically on Linux 
  builds before the Tauri window initializes

## Why
- WebKitGTK attempts to use GPU compositing via GBM on startup
- On systems with NVIDIA proprietary drivers + X11, this fails with
  "Failed to create GBM buffer: Invalid argument" and crashes the app
- Setting this env var tells WebKitGTK to use software compositing
  instead, which works reliably across all Linux GPU/display configs

## Issue
- Closes #1238 

## Scope
- Single line change in `apps/desktop/src-tauri/src/main.rs`
- Linux builds only (guarded by `#[cfg(target_os = "linux")]`)
- No effect on Windows or macOS builds

## Out of scope
- Detecting specific GPU vendors or display servers at runtime
- Any changes to the frontend or WebKit configuration beyond this var

## Testing
### Ran
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `pnpm dev`

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: yes (compilation succeeds, no new warnings introduced)
- code-related failures: none
- external/env/auth blockers: none

## Manual verification
1. On a Linux system with NVIDIA proprietary driver + X11, launch 
   OpenWork without the fix → app crashes with GBM buffer error
2. Apply this fix and relaunch → app starts successfully
3. On Wayland or non-NVIDIA systems, app continues to work normally

Note: I was unable to personally reproduce the crash due to my laptop
running on integrated AMD graphics. The fix is consistent with the
workaround documented in the project README and is the standard
approach used across the Tauri ecosystem for this known WebKitGTK issue.

## Evidence
- N/A (could not reproduce crash on my hardware setup, see note above)

## Risk
- Very low. The env var only affects Linux builds and disables GPU
  compositing in WebKitGTK — there is no user-visible difference in
  rendering quality for a desktop app of this type

## Rollback
- Revert the single line addition in `apps/desktop/src-tauri/src/main.rs`