### PR TITLE
raise text contrast to WCAG AA

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -13,7 +13,7 @@
   --dls-accent-hover: #000000;
   --dls-accent-rgb: 1 22 39;
   --dls-text-primary: #111827;
-  --dls-text-secondary: #6b7280;
+  --dls-text-secondary: #4b5563;
   --dls-hover: #f3f4f6;
   --dls-active: #eef2f7;
   --dls-radius: 16px;
@@ -28,11 +28,11 @@
   --dls-sidebar: #1a1a1a;
   --dls-app-bg: #161616;
   --dls-border: #262626;
-  --dls-accent: #3b82f6;
-  --dls-accent-hover: #2563eb;
-  --dls-accent-rgb: 59 130 246;
+  --dls-accent: #2563eb;
+  --dls-accent-hover: #1d4ed8;
+  --dls-accent-rgb: 37 99 235;
   --dls-text-primary: #ededed;
-  --dls-text-secondary: #9ca3af;
+  --dls-text-secondary: #c9c9c9;
   --dls-hover: #1f1f1f;
   --dls-active: #2d2d2d;
   --dls-shell-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);

--- a/apps/app/src/react-app/domains/bundles/import-modal.tsx
+++ b/apps/app/src/react-app/domains/bundles/import-modal.tsx
@@ -72,7 +72,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
                 <h3 className="text-lg font-semibold text-gray-12">
                   {props.title}
                 </h3>
-                <p className="mt-1 text-sm leading-relaxed text-gray-10">
+                <p className="mt-1 text-sm leading-relaxed text-gray-11">
                   {props.description}
                 </p>
               </div>
@@ -81,7 +81,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
               type="button"
               onClick={props.onClose}
               disabled={busy}
-              className="rounded-full p-1 text-gray-10 transition hover:bg-gray-4 hover:text-gray-12 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-full p-1 text-gray-11 transition hover:bg-gray-4 hover:text-gray-12 disabled:cursor-not-allowed disabled:opacity-50"
               aria-label="Close"
             >
               <X size={18} />
@@ -128,7 +128,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
                 <div className="text-sm font-semibold text-gray-12">
                   Create new worker
                 </div>
-                <div className="mt-1 text-sm text-gray-10">
+                <div className="mt-1 text-sm text-gray-11">
                   Open the existing new worker flow, then import this bundle into
                   it.
                 </div>
@@ -149,21 +149,21 @@ export function BundleImportModal(props: BundleImportModalProps) {
                 <div className="text-sm font-semibold text-gray-12">
                   Add to existing worker
                 </div>
-                <div className="mt-1 text-sm text-gray-10">
+                <div className="mt-1 text-sm text-gray-11">
                   Pick an existing worker and import this bundle there.
                 </div>
               </div>
               {showWorkers ? (
-                <ChevronDown size={18} className="text-gray-10" />
+                <ChevronDown size={18} className="text-gray-11" />
               ) : (
-                <ChevronRight size={18} className="text-gray-10" />
+                <ChevronRight size={18} className="text-gray-11" />
               )}
             </button>
 
             {showWorkers ? (
               <div className="space-y-3 border-t border-gray-6 px-4 py-4">
                 {props.workers.length === 0 ? (
-                  <div className="rounded-xl border border-dashed border-gray-6 px-4 py-5 text-sm text-gray-10">
+                  <div className="rounded-xl border border-dashed border-gray-6 px-4 py-5 text-sm text-gray-11">
                     No configured workers are available yet. Create a new worker
                     to import this bundle.
                   </div>
@@ -185,7 +185,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
                               <span className="text-sm font-semibold text-gray-12">
                                 {worker.label}
                               </span>
-                              <span className="rounded-full border border-gray-6 bg-gray-3 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-gray-10">
+                              <span className="rounded-full border border-gray-6 bg-gray-3 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-gray-11">
                                 {worker.badge}
                               </span>
                               {worker.current ? (
@@ -194,7 +194,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
                                 </span>
                               ) : null}
                             </div>
-                            <div className="mt-1 truncate text-sm text-gray-10">
+                            <div className="mt-1 truncate text-sm text-gray-11">
                               {worker.detail}
                             </div>
                             {disabledReason ? (
@@ -205,7 +205,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
                           </div>
                           <ChevronRight
                             size={18}
-                            className="mt-0.5 shrink-0 text-gray-10"
+                            className="mt-0.5 shrink-0 text-gray-11"
                           />
                         </div>
                       </button>

--- a/apps/app/src/react-app/domains/bundles/skill-destination-modal.tsx
+++ b/apps/app/src/react-app/domains/bundles/skill-destination-modal.tsx
@@ -124,7 +124,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
         <div className="border-b border-gray-6 bg-gray-1 px-6 py-5">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 space-y-3">
-              <div className="inline-flex items-center gap-2 rounded-full border border-gray-6 bg-gray-2 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-10">
+              <div className="inline-flex items-center gap-2 rounded-full border border-gray-6 bg-gray-2 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-11">
                 <Sparkles size={12} />
                 {translate("share_skill_destination.skill_label")}
               </div>
@@ -134,7 +134,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                     <Sparkles size={17} />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-9">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-11">
                       {translate("share_skill_destination.skill_label")}
                     </div>
                     <h3 className="mt-1 text-lg font-semibold text-gray-12 break-words">
@@ -142,12 +142,12 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                         translate("share_skill_destination.fallback_skill_name")}
                     </h3>
                     {props.skill?.description?.trim() ? (
-                      <p className="mt-1 text-sm leading-relaxed text-gray-10 break-words">
+                      <p className="mt-1 text-sm leading-relaxed text-gray-11 break-words">
                         {props.skill.description.trim()}
                       </p>
                     ) : null}
                     {props.skill?.trigger?.trim() ? (
-                      <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-gray-6 bg-gray-1 px-3 py-1 text-[11px] text-gray-10">
+                      <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-gray-6 bg-gray-1 px-3 py-1 text-[11px] text-gray-11">
                         <span className="font-semibold text-gray-12">
                           {translate("share_skill_destination.trigger_label")}
                         </span>
@@ -163,7 +163,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                 <h4 className="text-sm font-medium text-gray-12">
                   {translate("share_skill_destination.title")}
                 </h4>
-                <p className="mt-1 text-sm leading-relaxed text-gray-10">
+                <p className="mt-1 text-sm leading-relaxed text-gray-11">
                   {translate("share_skill_destination.subtitle")}
                 </p>
               </div>
@@ -172,7 +172,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
             <button
               onClick={props.onClose}
               disabled={footerBusy}
-              className={`rounded-full p-2 text-gray-9 transition hover:bg-gray-2 hover:text-gray-12 ${
+              className={`rounded-full p-2 text-gray-11 transition hover:bg-gray-2 hover:text-gray-12 ${
                 footerBusy ? "cursor-not-allowed opacity-50" : ""
               }`.trim()}
               aria-label={translate("common.close")}
@@ -189,14 +189,14 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                 {translate("share_skill_destination.existing_workers")}
               </div>
               {props.workspaces.length > 0 ? (
-                <span className="text-[11px] uppercase tracking-[0.18em] text-gray-9">
+                <span className="text-[11px] uppercase tracking-[0.18em] text-gray-11">
                   {props.workspaces.length}
                 </span>
               ) : null}
             </div>
 
             {props.workspaces.length === 0 ? (
-              <div className="rounded-xl border border-dashed border-gray-6 bg-gray-2/20 px-4 py-5 text-sm leading-relaxed text-gray-10">
+              <div className="rounded-xl border border-dashed border-gray-6 bg-gray-2/20 px-4 py-5 text-sm leading-relaxed text-gray-11">
                 {translate("share_skill_destination.no_workers")}
               </div>
             ) : (
@@ -255,7 +255,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                             ) : null}
                           </div>
 
-                          <div className="mt-1 text-[11px] font-mono break-all text-gray-8/80">
+                          <div className="mt-1 text-[11px] font-mono break-all text-gray-11/80">
                             {subtitle(workspace)}
                           </div>
                           {isSelected ? (
@@ -267,14 +267,14 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                           ) : null}
                         </div>
 
-                        <div className="shrink-0 pt-0.5 text-gray-9">
+                        <div className="shrink-0 pt-0.5 text-gray-11">
                           {isBusy ? (
                             <Loader2 size={16} className="animate-spin" />
                           ) : (
                             <CheckCircle2
                               size={16}
                               className={
-                                isSelected ? "text-indigo-11" : "text-gray-7"
+                                isSelected ? "text-indigo-11" : "text-gray-11"
                               }
                             />
                           )}
@@ -310,7 +310,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                         <div className="text-sm font-semibold text-gray-12">
                           {translate("share_skill_destination.create_worker")}
                         </div>
-                        <div className="mt-1 text-sm text-gray-10">
+                        <div className="mt-1 text-sm text-gray-11">
                           {translate(
                             "share_skill_destination.create_worker_hint",
                           )}
@@ -337,7 +337,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                         <div className="text-sm font-semibold text-gray-12">
                           {translate("share_skill_destination.connect_remote")}
                         </div>
-                        <div className="mt-1 text-sm text-gray-10">
+                        <div className="mt-1 text-sm text-gray-11">
                           {translate(
                             "share_skill_destination.connect_remote_hint",
                           )}
@@ -354,11 +354,11 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
         <div className="border-t border-gray-6 bg-gray-1 px-6 py-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             {selectedWorkspace ? (
-              <div className="min-w-0 text-sm text-gray-10">
+              <div className="min-w-0 text-sm text-gray-11">
                 <span className="font-medium text-gray-12">
                   {displayName(selectedWorkspace, "Worker")}
                 </span>
-                <span className="mx-2 text-gray-8">·</span>
+                <span className="mx-2 text-gray-11">·</span>
                 <span className="truncate align-middle">
                   {subtitle(selectedWorkspace)}
                 </span>

--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -629,10 +629,10 @@ export function McpAuthModal(props: McpAuthModalProps) {
               </div>
               <div className="space-y-2">
                 <p className="text-sm font-medium text-gray-12">{translate("mcp.auth.waiting_authorization")}</p>
-                <p className="text-xs text-gray-10">{translate("mcp.auth.follow_browser_steps")}</p>
+                <p className="text-xs text-gray-11">{translate("mcp.auth.follow_browser_steps")}</p>
                 <button
                   type="button"
-                  className="text-xs text-gray-10 underline underline-offset-2 transition-colors hover:text-gray-11"
+                  className="text-xs text-gray-11 underline underline-offset-2 transition-colors hover:text-gray-11"
                   onClick={handleRetry}
                 >
                   {translate("mcp.auth.reopen_browser_link")}
@@ -652,7 +652,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                     ? translate("mcp.auth.waiting_for_conversation_title")
                     : translate("mcp.auth.applying_changes_title")}
                 </p>
-                <p className="text-xs text-gray-10">
+                <p className="text-xs text-gray-11">
                   {props.reloadBlocked
                     ? translate("mcp.auth.waiting_for_conversation_body")
                     : translate("mcp.auth.applying_changes_body")}
@@ -698,7 +698,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                   </p>
                 </div>
               </div>
-              <p className="text-xs text-gray-10">{translate("mcp.auth.configured_previously")}</p>
+              <p className="text-xs text-gray-11">{translate("mcp.auth.configured_previously")}</p>
             </div>
           ) : null}
 
@@ -782,10 +782,10 @@ export function McpAuthModal(props: McpAuthModalProps) {
           {!isBusy && authorizationUrl && props.isRemoteWorkspace && !alreadyConnected ? (
             <div className="space-y-3 rounded-xl border border-gray-6/60 bg-gray-1/40 p-4">
               <div className="text-xs font-medium text-gray-12">{translate("mcp.auth.manual_finish_title")}</div>
-              <div className="text-xs text-gray-10">{translate("mcp.auth.manual_finish_hint")}</div>
+              <div className="text-xs text-gray-11">{translate("mcp.auth.manual_finish_hint")}</div>
               <div className="flex items-center gap-3 rounded-xl border border-gray-6/70 bg-gray-2/40 px-3 py-2">
                 <div className="min-w-0 flex-1">
-                  <div className="text-[10px] uppercase tracking-wide text-gray-8">
+                  <div className="text-[10px] uppercase tracking-wide text-gray-11">
                     {translate("mcp.auth.authorization_link")}
                   </div>
                   <div className="truncate font-mono text-[11px] text-gray-11">{authorizationUrl}</div>
@@ -800,7 +800,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                 value={callbackInput}
                 onChange={(event) => setCallbackInput(event.currentTarget.value)}
               />
-              <div className="text-[11px] text-gray-9">{translate("mcp.auth.port_forward_hint")}</div>
+              <div className="text-[11px] text-gray-11">{translate("mcp.auth.port_forward_hint")}</div>
               <div className="flex justify-end">
                 <Button
                   variant="secondary"
@@ -823,7 +823,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                   </div>
                   <div>
                     <p className="text-sm font-medium text-gray-12">{translate("mcp.auth.step1_title")}</p>
-                    <p className="mt-1 text-xs text-gray-10">
+                    <p className="mt-1 text-xs text-gray-11">
                       {translate("mcp.auth.step1_description", { server: serverName })}
                     </p>
                   </div>
@@ -835,7 +835,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                   </div>
                   <div>
                     <p className="text-sm font-medium text-gray-12">{translate("mcp.auth.step2_title")}</p>
-                    <p className="mt-1 text-xs text-gray-10">{translate("mcp.auth.step2_description")}</p>
+                    <p className="mt-1 text-xs text-gray-11">{translate("mcp.auth.step2_description")}</p>
                   </div>
                 </div>
 
@@ -845,7 +845,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                   </div>
                   <div>
                     <p className="text-sm font-medium text-gray-12">{translate("mcp.auth.step3_title")}</p>
-                    <p className="mt-1 text-xs text-gray-10">{translate("mcp.auth.step3_description")}</p>
+                    <p className="mt-1 text-xs text-gray-11">{translate("mcp.auth.step3_description")}</p>
                   </div>
                 </div>
               </div>
@@ -853,10 +853,10 @@ export function McpAuthModal(props: McpAuthModalProps) {
               <div className="rounded-xl border border-gray-6/60 bg-gray-1/40 p-4 text-sm text-gray-11">
                 <div className="space-y-3">
                   <p>{translate("mcp.auth.waiting_authorization")}</p>
-                  <p className="text-xs text-gray-10">{translate("mcp.auth.follow_browser_steps")}</p>
+                  <p className="text-xs text-gray-11">{translate("mcp.auth.follow_browser_steps")}</p>
                   <button
                     type="button"
-                    className="text-left text-xs text-gray-10 underline underline-offset-2 transition-colors hover:text-gray-11"
+                    className="text-left text-xs text-gray-11 underline underline-offset-2 transition-colors hover:text-gray-11"
                     onClick={handleRetry}
                   >
                     {translate("mcp.auth.reopen_browser_link")}

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -662,7 +662,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                 {errorMessage}
               </div>
             ) : props.loading ? (
-              <div className="rounded-xl border border-gray-6 bg-gray-1/60 px-4 py-3 text-sm text-gray-10 animate-pulse">
+              <div className="rounded-xl border border-gray-6 bg-gray-1/60 px-4 py-3 text-sm text-gray-11 animate-pulse">
                 Loading providers...
               </div>
             ) : null}
@@ -673,7 +673,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
               {resolvedView === "list" ? (
                 <div className="space-y-3" onKeyDown={handleListKeyDown}>
                   <div className="relative flex items-center mb-1">
-                    <Search size={16} className="absolute left-3 text-gray-9" />
+                    <Search size={16} className="absolute left-3 text-gray-11" />
                     <input
                       ref={searchInputRef}
                       type="text"
@@ -721,14 +721,14 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                                   Connected
                                 </div>
                               ) : (
-                                <div className="text-[12px] font-medium text-gray-9 group-hover:text-gray-12 transition-colors flex items-center gap-0.5 opacity-80 group-hover:opacity-100">
+                                <div className="text-[12px] font-medium text-gray-11 group-hover:text-gray-12 transition-colors flex items-center gap-0.5 opacity-80 group-hover:opacity-100">
                                   Connect
                                   <ChevronRight size={14} className="opacity-0 -ml-2 group-hover:opacity-100 group-hover:ml-0 transition-all duration-200" />
                                 </div>
                               )}
                             </div>
                           </div>
-                          <div className="text-[11px] text-gray-9 font-mono truncate mt-0.5 opacity-60 group-hover:opacity-80 transition-opacity">
+                          <div className="text-[11px] text-gray-11 font-mono truncate mt-0.5 opacity-60 group-hover:opacity-80 transition-opacity">
                             {entry.id}
                           </div>
 
@@ -752,12 +752,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       </button>
                     ))
                   ) : (
-                    <div className="text-sm text-gray-10 pt-2">
+                    <div className="text-sm text-gray-11 pt-2">
                       {entries.length ? "No providers match your search." : "No providers available."}
                     </div>
                   )}
 
-                  <div className="text-[11px] text-gray-9">Arrow keys to navigate, Enter to select.</div>
+                  <div className="text-[11px] text-gray-11">Arrow keys to navigate, Enter to select.</div>
                 </div>
               ) : null}
 
@@ -766,7 +766,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="flex items-center justify-between gap-4">
                     <div>
                       <div className="text-sm font-medium text-gray-12">{selectedEntry.name}</div>
-                      <div className="text-xs text-gray-10 mt-1">Choose how you'd like to connect.</div>
+                      <div className="text-xs text-gray-11 mt-1">Choose how you'd like to connect.</div>
                     </div>
                     <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
                       Back
@@ -786,7 +786,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                         disabled={actionDisabled}
                       >
                         <div className="text-sm font-medium text-gray-12">{methodLabel(method)}</div>
-                        <div className="mt-1 text-xs text-gray-10">{methodDescription(selectedEntry, method)}</div>
+                        <div className="mt-1 text-xs text-gray-11">{methodDescription(selectedEntry, method)}</div>
                       </button>
                     ))}
                   </div>
@@ -798,7 +798,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="flex items-center justify-between gap-4">
                     <div>
                       <div className="text-sm font-medium text-gray-12">{selectedEntry.name}</div>
-                      <div className="text-xs text-gray-10 mt-1">Paste your API key to connect.</div>
+                      <div className="text-xs text-gray-11 mt-1">Paste your API key to connect.</div>
                     </div>
                     <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
                       Back
@@ -819,12 +819,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     disabled={actionDisabled}
                   />
                   {selectedEntry.env.length > 0 ? (
-                    <div className="text-[11px] text-gray-9">
+                    <div className="text-[11px] text-gray-11">
                       Env vars: <span className="font-mono">{selectedEntry.env.join(", ")}</span>
                     </div>
                   ) : null}
                   <div className="flex items-center justify-between gap-3">
-                    <div className="text-[11px] text-gray-9">Keys are stored locally by OpenCode.</div>
+                    <div className="text-[11px] text-gray-11">Keys are stored locally by OpenCode.</div>
                     <Button
                       variant="secondary"
                       onClick={handleApiSubmit}
@@ -841,27 +841,27 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="flex items-center justify-between gap-4">
                     <div>
                       <div className="text-sm font-medium text-gray-12">{selectedEntry.name}</div>
-                      <div className="text-xs text-gray-10 mt-1">Connect with the provider managed by your organization.</div>
+                      <div className="text-xs text-gray-11 mt-1">Connect with the provider managed by your organization.</div>
                     </div>
                     <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
                       Back
                     </Button>
                   </div>
-                  <div className="text-xs text-gray-9">
+                  <div className="text-xs text-gray-11">
                     {selectedCloudMethod.description ?? "Use the provider and credential managed by your organization."}
                   </div>
                   {(selectedCloudMethod.modelCount ?? 0) > 0 ? (
-                    <div className="rounded-lg border border-gray-6/60 bg-gray-1/60 px-3 py-2 text-[11px] text-gray-9">
+                    <div className="rounded-lg border border-gray-6/60 bg-gray-1/60 px-3 py-2 text-[11px] text-gray-11">
                       {(selectedCloudMethod.modelCount ?? 0)} curated model{(selectedCloudMethod.modelCount ?? 0) === 1 ? "" : "s"} will be added to this workspace.
                     </div>
                   ) : null}
                   {(selectedCloudMethod.env?.length ?? 0) > 0 ? (
-                    <div className="text-[11px] text-gray-9">
+                    <div className="text-[11px] text-gray-11">
                       Env vars: <span className="font-mono">{selectedCloudMethod.env?.join(", ")}</span>
                     </div>
                   ) : null}
                   <div className="flex items-center justify-between gap-3">
-                    <div className="text-[11px] text-gray-9">
+                    <div className="text-[11px] text-gray-11">
                       OpenWork will install the provider config and use the credential stored for your org.
                     </div>
                     <Button variant="secondary" onClick={handleCloudSubmit} disabled={actionDisabled}>
@@ -876,17 +876,17 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="flex items-center justify-between gap-4">
                     <div>
                       <div className="text-sm font-medium text-gray-12">{selectedEntry.name}</div>
-                      <div className="text-xs text-gray-10 mt-1">Finish OAuth by pasting the authorization code.</div>
+                      <div className="text-xs text-gray-11 mt-1">Finish OAuth by pasting the authorization code.</div>
                     </div>
                     <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
                       Back
                     </Button>
                   </div>
-                  <div className="text-xs text-gray-9">
+                  <div className="text-xs text-gray-11">
                     Complete sign-in in your browser, then paste the code here.
                   </div>
                   {oauthInstructions ? (
-                    <div className="rounded-lg border border-gray-6/60 bg-gray-1/60 px-3 py-2 text-[11px] text-gray-9 font-mono break-all">
+                    <div className="rounded-lg border border-gray-6/60 bg-gray-1/60 px-3 py-2 text-[11px] text-gray-11 font-mono break-all">
                       {oauthInstructions}
                     </div>
                   ) : null}
@@ -934,28 +934,28 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="flex items-center justify-between gap-4">
                     <div>
                       <div className="text-sm font-medium text-gray-12">{selectedEntry.name}</div>
-                      <div className="text-xs text-gray-10 mt-1">Waiting for browser confirmation.</div>
+                      <div className="text-xs text-gray-11 mt-1">Waiting for browser confirmation.</div>
                     </div>
                     <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
                       Back
                     </Button>
                   </div>
                   {isOpenAiHeadlessSession ? (
-                    <div className="space-y-2 text-xs text-gray-9">
+                    <div className="space-y-2 text-xs text-gray-11">
                       <div>You'll need to sign in to your OpenAI account and provide the code below.</div>
                       <div>The first time you do this you'll need to enable Device auth in your account settings.</div>
                       <div>ChatGPT &gt; Account Settings &gt; Security &gt; Enable device code authorization</div>
                       <div>When you're ready, copy the code below, and click &quot;Open Browser&quot;.</div>
                     </div>
                   ) : (
-                    <div className="text-xs text-gray-9">
+                    <div className="text-xs text-gray-11">
                       Sign in in the browser tab we just opened. We will complete the connection automatically.
                     </div>
                   )}
                   {oauthDisplayCode ? (
                     <div className="rounded-xl border border-gray-6/70 bg-gray-2/40 px-3 py-3 flex items-center gap-3">
                       <div className="flex-1 min-w-0">
-                        <div className="text-[10px] uppercase tracking-wide text-gray-8">Confirmation code</div>
+                        <div className="text-[10px] uppercase tracking-wide text-gray-11">Confirmation code</div>
                         <div className="text-sm text-gray-12 font-mono break-all">{oauthDisplayCode}</div>
                       </div>
                       <Button variant="ghost" className="text-xs shrink-0" onClick={() => void copyOauthDisplayCode()}>
@@ -964,11 +964,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     </div>
                   ) : null}
                   {isOpenAiHeadlessSession && !oauthBrowserOpened ? (
-                    <div className="flex items-center gap-2 text-xs text-gray-9">
+                    <div className="flex items-center gap-2 text-xs text-gray-11">
                       <span>Authorization checks will start after you click Open Browser.</span>
                     </div>
                   ) : (
-                    <div className="flex items-center gap-2 text-xs text-gray-9">
+                    <div className="flex items-center gap-2 text-xs text-gray-11">
                       <Loader2 size={14} className={props.submitting || pollingBusy || oauthAutoBusy ? "animate-spin" : ""} />
                       <span>Checking connection status automatically...</span>
                     </div>
@@ -986,7 +986,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                           : "Open Browser"
                         : "Open browser again"}
                     </Button>
-                    <div className="text-[11px] text-gray-9 text-right">
+                    <div className="text-[11px] text-gray-11 text-right">
                       This window will close once the provider is connected.
                     </div>
                   </div>
@@ -997,7 +997,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
         </div>
 
         <div className="px-6 pt-4 pb-6 border-t border-gray-6/50 flex flex-col gap-3">
-          <div className="min-h-[16px] text-xs text-gray-10">
+          <div className="min-h-[16px] text-xs text-gray-11">
             {props.submitting ? submittingLabel() : null}
           </div>
           <Button variant="ghost" onClick={handleClose} disabled={actionDisabled}>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -383,12 +383,12 @@ export function SessionPage(props: SessionPageProps) {
               ) : null}
             </div>
 
-            <div className="flex items-center gap-1.5 text-gray-10">
+            <div className="flex items-center gap-1.5 text-gray-11">
               {props.history ? (
                 <>
                   <button
                     type="button"
-                    className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
+                    className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-11 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
                     onClick={() => void props.history?.onUndo()}
                     disabled={!props.history.canUndo || props.history.busyAction !== null}
                     title={t("session.undo_title")}
@@ -403,7 +403,7 @@ export function SessionPage(props: SessionPageProps) {
                   </button>
                   <button
                     type="button"
-                    className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
+                    className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-gray-11 transition-colors hover:bg-gray-2/70 hover:text-dls-text disabled:cursor-not-allowed disabled:opacity-60"
                     onClick={() => void props.history?.onRedo()}
                     disabled={!props.history.canRedo || props.history.busyAction !== null}
                     title={t("session.redo_title")}
@@ -511,13 +511,13 @@ export function SessionPage(props: SessionPageProps) {
               <div className="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
                 <button
                   type="button"
-                  className="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
+                  className="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-11 transition-colors hover:bg-gray-2/50"
                   onClick={() => setTodoExpanded((current) => !current)}
                 >
                   <div className="flex items-center gap-2">
                     <span className="text-gray-11 font-medium">{todoLabel}</span>
                   </div>
-                  <Minimize2 size={12} className={`text-gray-8 transition-transform ${todoExpanded ? "" : "rotate-180"}`} />
+                  <Minimize2 size={12} className={`text-gray-11 transition-transform ${todoExpanded ? "" : "rotate-180"}`} />
                 </button>
                 {todoExpanded ? (
                   <div className="max-h-60 space-y-2.5 overflow-auto border-t border-dls-border px-4 pb-3">
@@ -535,15 +535,15 @@ export function SessionPage(props: SessionPageProps) {
                                   : active
                                     ? "border-amber-6 bg-amber-2 text-amber-11"
                                     : cancelled
-                                      ? "border-gray-6 bg-gray-2 text-gray-8"
-                                      : "border-gray-6 bg-gray-1 text-gray-8"
+                                      ? "border-gray-6 bg-gray-2 text-gray-11"
+                                      : "border-gray-6 bg-gray-1 text-gray-11"
                               }`}
                             >
                               {done ? <Check size={10} /> : active ? <span className="h-1.5 w-1.5 rounded-full bg-amber-9" /> : null}
                             </div>
                           </div>
-                          <div className={`flex-1 text-sm leading-relaxed ${cancelled ? "text-gray-9 line-through" : "text-gray-12"}`}>
-                            <span className="mr-1.5 text-gray-9">{index + 1}.</span>
+                          <div className={`flex-1 text-sm leading-relaxed ${cancelled ? "text-gray-11 line-through" : "text-gray-12"}`}>
+                            <span className="mr-1.5 text-gray-11">{index + 1}.</span>
                             {todo.content}
                           </div>
                         </div>
@@ -626,7 +626,7 @@ export function SessionPage(props: SessionPageProps) {
               </div>
 
               <div className="mb-6 rounded-xl border border-gray-6 bg-gray-1/50 p-4">
-                <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-10">
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-11">
                   {t("session.permission_label")}
                 </div>
                 <div className="font-mono text-sm text-gray-12">{permissionPresentation.permissionLabel}</div>
@@ -635,7 +635,7 @@ export function SessionPage(props: SessionPageProps) {
                   <p className="mt-2 text-sm text-gray-11">{permissionPresentation.note}</p>
                 ) : null}
 
-                <div className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-gray-10">
+                <div className="mb-2 mt-4 text-xs font-semibold uppercase tracking-wider text-gray-11">
                   {permissionPresentation.scopeLabel}
                 </div>
                 <div className="flex items-center gap-2 rounded border border-amber-7/20 bg-amber-1/30 px-2 py-1 font-mono text-sm text-amber-12">

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -284,7 +284,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             ? "bg-gray-3 text-gray-12"
             : isKeyboardActive
               ? "bg-gray-2 text-gray-12"
-              : "text-gray-10 hover:bg-gray-1/70 hover:text-gray-11",
+              : "text-gray-11 hover:bg-gray-1/70 hover:text-gray-11",
         ].join(" ")}
         onMouseEnter={() => setActiveIndex(index)}
         onClick={() =>
@@ -311,7 +311,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               "mt-[1px] shrink-0 transition-colors",
               active
                 ? "text-gray-12"
-                : "text-gray-10 group-hover:text-gray-11",
+                : "text-gray-11 group-hover:text-gray-11",
             ].join(" ")}
           />
           <div className="flex-1 min-w-0">
@@ -327,8 +327,8 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               className={[
                 "mt-0.5 flex items-center gap-3 text-[11px]",
                 active
-                  ? "text-gray-10"
-                  : "text-gray-9 group-hover:text-gray-10",
+                  ? "text-gray-11"
+                  : "text-gray-11 group-hover:text-gray-11",
               ].join(" ")}
             >
               <span className="truncate">
@@ -343,8 +343,8 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
                 className={[
                   "text-[11px] mt-1",
                   active
-                    ? "text-gray-10"
-                    : "text-gray-8 group-hover:text-gray-9",
+                    ? "text-gray-11"
+                    : "text-gray-11 group-hover:text-gray-11",
                 ].join(" ")}
               >
                 {opt.footer}
@@ -355,7 +355,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
                 className="mt-3 flex items-center gap-2"
                 onKeyDown={(event) => event.stopPropagation()}
               >
-                <span className="text-[11px] font-medium text-gray-10 mr-1">
+                <span className="text-[11px] font-medium text-gray-11 mr-1">
                   {opt.behaviorTitle}:
                 </span>
                 <div
@@ -370,7 +370,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
                         "text-[11px] transition-colors",
                         opt.behaviorValue === option.value
                           ? "text-gray-12 font-semibold"
-                          : "text-gray-10 hover:text-gray-12",
+                          : "text-gray-11 hover:text-gray-12",
                       ].join(" ")}
                       onClick={(event) => {
                         event.preventDefault();
@@ -413,7 +413,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
           "group w-full text-left rounded-xl px-3 py-2.5 transition-colors cursor-pointer",
           isKeyboardActive
             ? "bg-gray-2 text-gray-12"
-            : "text-gray-10 hover:bg-gray-1/70 hover:text-gray-11",
+            : "text-gray-11 hover:bg-gray-1/70 hover:text-gray-11",
         ].join(" ")}
         onMouseEnter={() => setActiveIndex(provider.index)}
         onClick={() => {
@@ -436,7 +436,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               "mt-[1px] shrink-0 transition-colors",
               isKeyboardActive
                 ? "text-gray-12"
-                : "text-gray-10 group-hover:text-gray-11",
+                : "text-gray-11 group-hover:text-gray-11",
             ].join(" ")}
           />
           <div className="flex-1 min-w-0">
@@ -447,8 +447,8 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               className={[
                 "mt-0.5 flex items-center gap-3 text-[11px]",
                 isKeyboardActive
-                  ? "text-gray-10"
-                  : "text-gray-9 group-hover:text-gray-10",
+                  ? "text-gray-11"
+                  : "text-gray-11 group-hover:text-gray-11",
               ].join(" ")}
             >
               <span className="truncate">
@@ -492,7 +492,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             </div>
             <button
               type="button"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-10 transition-colors hover:bg-[var(--dls-hover)]"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-11 transition-colors hover:bg-[var(--dls-hover)]"
               onClick={() => props.onClose()}
             >
               <X size={16} />
@@ -527,7 +527,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
           <div className="mt-4 space-y-4 overflow-y-auto pr-1 -mr-1 min-h-0">
             {recommendedOptions.length > 0 ? (
               <section className="space-y-2">
-                <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-9">
+                <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-11">
                   {translate("model_picker.recommended")}
                 </div>
                 {recommendedOptions.map(({ opt, index }) =>
@@ -538,7 +538,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
 
             {otherEnabledOptions.length > 0 ? (
               <section className="space-y-2">
-                <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-9">
+                <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-11">
                   {translate("model_picker.other_connected_models")}
                 </div>
                 {otherEnabledOptions.map(({ opt, index }) =>
@@ -549,7 +549,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
 
             {otherOptions.length > 0 ? (
               <section className="space-y-2">
-                <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-9">
+                <div className="px-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-11">
                   {translate("model_picker.more_providers")}
                 </div>
                 {otherOptions.map(renderProviderLink)}
@@ -557,7 +557,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             ) : null}
 
             {renderedItems.length === 0 ? (
-              <div className="rounded-2xl border border-gray-6/70 bg-gray-1/40 px-4 py-6 text-sm text-gray-10">
+              <div className="rounded-2xl border border-gray-6/70 bg-gray-1/40 px-4 py-6 text-sm text-gray-11">
                 {translate("model_picker.no_results")}
               </div>
             ) : null}

--- a/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
@@ -345,7 +345,7 @@ export function WorkspaceSessionList(props: Props) {
           className={`group flex min-h-9 w-full items-center justify-between rounded-xl px-3 py-1.5 text-left text-[13px] transition-colors ${
             isSelected
               ? "bg-gray-3 text-gray-12"
-              : "text-gray-10 hover:bg-gray-1/70 hover:text-gray-11"
+              : "text-gray-11 hover:bg-gray-1/70 hover:text-gray-11"
           }`}
           style={{ marginLeft: `${Math.min(row.depth, 4) * 16}px` }}
           onPointerEnter={prefetchSession}
@@ -362,7 +362,7 @@ export function WorkspaceSessionList(props: Props) {
             {hasChildren ? (
               <button
                 type="button"
-                className="-ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
+                className="-ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-gray-11 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
                 aria-label={isExpanded ? t("workspace_list.hide_child_sessions") : t("workspace_list.show_child_sessions")}
                 onClick={(event) => {
                   event.preventDefault();
@@ -391,7 +391,7 @@ export function WorkspaceSessionList(props: Props) {
             {canManageSession ? (
               <button
                 type="button"
-                className="flex h-7 w-7 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-gray-11 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
                 aria-label={t("workspace_list.session_actions")}
                 onClick={(event) => {
                   event.preventDefault();
@@ -476,7 +476,7 @@ export function WorkspaceSessionList(props: Props) {
               ? taskLoadError.tone === "offline"
                 ? "text-amber-11"
                 : "text-red-11"
-              : "text-gray-9";
+              : "text-gray-11";
             const rootSessions = getRootSessions(group.sessions);
             const sessionRows = flattenSessionRows(
               group.sessions,
@@ -495,7 +495,7 @@ export function WorkspaceSessionList(props: Props) {
                     className={`w-full flex items-center justify-between rounded-xl px-3.5 py-2.5 text-left text-[13px] transition-colors ${
                       props.selectedWorkspaceId === workspace.id
                         ? "bg-gray-2/70 text-gray-12"
-                        : "text-gray-10 hover:bg-gray-1/70 hover:text-gray-12"
+                        : "text-gray-11 hover:bg-gray-1/70 hover:text-gray-12"
                     } ${isConnecting ? "opacity-75" : ""}`}
                     onClick={() => {
                       expandWorkspace(workspace.id);
@@ -528,7 +528,7 @@ export function WorkspaceSessionList(props: Props) {
 
                     <div className="ml-4 flex shrink-0 items-center gap-1.5">
                       {group.status === "loading" || isConnecting ? (
-                        <Loader2 size={14} className="animate-spin text-gray-9" />
+                        <Loader2 size={14} className="animate-spin text-gray-11" />
                       ) : null}
 
                       <div
@@ -540,7 +540,7 @@ export function WorkspaceSessionList(props: Props) {
                       >
                         <button
                           type="button"
-                          className="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
+                          className="rounded-md p-1 text-gray-11 hover:bg-gray-3/80 hover:text-gray-11"
                           onClick={(event) => {
                             event.stopPropagation();
                             props.onCreateTaskInWorkspace(workspace.id);
@@ -553,7 +553,7 @@ export function WorkspaceSessionList(props: Props) {
 
                         <button
                           type="button"
-                          className="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
+                          className="rounded-md p-1 text-gray-11 hover:bg-gray-3/80 hover:text-gray-11"
                           onClick={(event) => {
                             event.stopPropagation();
                             setWorkspaceMenuId((current) => (current === workspace.id ? null : workspace.id));
@@ -566,7 +566,7 @@ export function WorkspaceSessionList(props: Props) {
 
                       <button
                         type="button"
-                        className="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
+                        className="rounded-md p-1 text-gray-11 hover:bg-gray-3/80 hover:text-gray-11"
                         aria-label={
                           expandedWorkspaceIds.has(workspace.id)
                             ? t("sidebar.collapse")
@@ -695,7 +695,7 @@ export function WorkspaceSessionList(props: Props) {
                           ))}
                         </div>
                       ) : group.status === "loading" && group.sessions.length === 0 ? (
-                        <div className="w-full rounded-[15px] px-3 py-2.5 text-left text-[11px] text-gray-10">
+                        <div className="w-full rounded-[15px] px-3 py-2.5 text-left text-[11px] text-gray-11">
                           {t("workspace.loading_tasks")}
                         </div>
                       ) : group.sessions.length > 0 ? (
@@ -705,7 +705,7 @@ export function WorkspaceSessionList(props: Props) {
                           {group.sessions.length === 0 && group.status === "ready" ? (
                             <button
                               type="button"
-                              className="group/empty w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
+                              className="group/empty w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-11 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
                               onClick={() => props.onCreateTaskInWorkspace(workspace.id)}
                               disabled={props.newTaskDisabled}
                             >
@@ -719,7 +719,7 @@ export function WorkspaceSessionList(props: Props) {
                           {rootSessions.length > previewCount(workspace.id) ? (
                             <button
                               type="button"
-                              className="w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
+                              className="w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-11 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
                               onClick={() => showMoreSessions(workspace.id, rootSessions.length)}
                             >
                               {showMoreLabel(workspace.id, rootSessions.length)}
@@ -740,7 +740,7 @@ export function WorkspaceSessionList(props: Props) {
                       ) : (
                         <button
                           type="button"
-                          className="group/empty w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-10 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
+                          className="group/empty w-full rounded-[15px] border border-transparent px-3 py-2.5 text-left text-[11px] text-gray-11 transition-colors hover:bg-gray-2/60 hover:text-gray-11"
                           onClick={() => props.onCreateTaskInWorkspace(workspace.id)}
                           disabled={props.newTaskDisabled}
                         >

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -663,7 +663,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                     onMouseEnter={() => setMenuIndex(index)}
                     onClick={() => applyCommandSelection(command)}
                   >
-                    <Terminal size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                    <Terminal size={14} className="mt-0.5 shrink-0 text-gray-11" />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center justify-between gap-3">
                         <div className="truncate text-xs font-semibold">/{command.name}</div>
@@ -673,13 +673,13 @@ export function ReactSessionComposer(props: ComposerProps) {
                           </span>
                         ) : null}
                       </div>
-                      {command.description ? <div className="truncate text-xs text-gray-10">{command.description}</div> : null}
+                      {command.description ? <div className="truncate text-xs text-gray-11">{command.description}</div> : null}
                     </div>
                   </button>
                 ))}
               </div>
             ) : (
-              <div className="px-3 py-2 text-xs text-gray-10">
+              <div className="px-3 py-2 text-xs text-gray-11">
                 {commandsLoading ? t("composer.loading_commands", locale) : t("composer.no_commands", locale)}
               </div>
             )}
@@ -714,13 +714,13 @@ export function ReactSessionComposer(props: ComposerProps) {
                   }}
                 >
                   {item.kind === "agent" ? (
-                    <Zap size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                    <Zap size={14} className="mt-0.5 shrink-0 text-gray-11" />
                   ) : (
-                    <FileText size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                    <FileText size={14} className="mt-0.5 shrink-0 text-gray-11" />
                   )}
                   <div className="min-w-0">
                     <div className="truncate text-xs font-semibold">@{item.label}</div>
-                    <div className="truncate text-xs text-gray-10">
+                    <div className="truncate text-xs text-gray-11">
                       {item.kind === "agent"
                         ? t("composer.agent_label", locale)
                         : t("composer.file_kind", locale)}
@@ -761,17 +761,17 @@ export function ReactSessionComposer(props: ComposerProps) {
           {props.attachments.length > 0 ? (
             <div className="mx-5 mt-5 flex flex-wrap gap-2 md:mx-6">
               {props.attachments.map((attachment) => (
-                <div key={attachment.id} className="flex items-center gap-2 rounded-2xl border border-gray-6 bg-gray-2 px-3 py-2 text-xs text-gray-10">
+                <div key={attachment.id} className="flex items-center gap-2 rounded-2xl border border-gray-6 bg-gray-2 px-3 py-2 text-xs text-gray-11">
                   {isImageAttachment(attachment) && attachment.previewUrl ? (
                     <div className="h-10 w-10 overflow-hidden rounded-xl border border-gray-6 bg-gray-1">
                       <img src={attachment.previewUrl} alt={attachment.name} decoding="async" className="h-full w-full object-cover" />
                     </div>
                   ) : (
-                    <FileText size={14} className="text-gray-9" />
+                    <FileText size={14} className="text-gray-11" />
                   )}
                   <div className="max-w-[160px] min-w-0">
                     <div className="truncate text-[12px] font-medium text-gray-11">{attachment.name}</div>
-                    <div className="flex items-center gap-1.5 text-[11px] text-gray-10">
+                    <div className="flex items-center gap-1.5 text-[11px] text-gray-11">
                       <span>{isImageAttachment(attachment) ? t("composer.image_kind", locale) : t("composer.file_kind", locale)}</span>
                       <span>·</span>
                       <span>{formatBytes(attachment.size)}</span>
@@ -779,7 +779,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                   </div>
                   <button
                     type="button"
-                    className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+                    className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
                     onClick={() => props.onRemoveAttachment(attachment.id)}
                     title={t("action.remove", locale)}
                   >
@@ -908,7 +908,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                 />
                 <button
                   type="button"
-                  className={`inline-flex h-9 max-h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 ${
+                  className={`inline-flex h-9 max-h-9 w-9 items-center justify-center rounded-md text-gray-11 transition-colors hover:bg-gray-3 ${
                     !props.attachmentsEnabled ? "cursor-not-allowed opacity-60" : ""
                   }`}
                   onClick={() => {
@@ -923,7 +923,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                 <div ref={toolMenuRef} className="relative">
                   <button
                     type="button"
-                    className={`inline-flex h-9 max-h-9 w-9 items-center justify-center rounded-md transition-colors ${toolMenuOpen ? "bg-gray-3 text-gray-12" : "text-gray-10 hover:bg-gray-3"}`}
+                    className={`inline-flex h-9 max-h-9 w-9 items-center justify-center rounded-md transition-colors ${toolMenuOpen ? "bg-gray-3 text-gray-12" : "text-gray-11 hover:bg-gray-3"}`}
                     onClick={() => {
                       setMentionOpen(false);
                       setMentionItems([]);
@@ -952,7 +952,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                               onClick={() => setToolMenuSection(section)}
                             >
                               <span className="truncate">{label}</span>
-                              <ChevronRight size={14} className="shrink-0 text-gray-9" />
+                              <ChevronRight size={14} className="shrink-0 text-gray-11" />
                             </button>
                           ))}
                         </div>
@@ -980,16 +980,16 @@ export function ReactSessionComposer(props: ComposerProps) {
                                     className="flex w-full items-start gap-3 rounded-[16px] px-3 py-2.5 text-left text-gray-11 transition-colors hover:bg-gray-2/70"
                                     onClick={() => applyCommandSelection(command)}
                                   >
-                                    <Terminal size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                                    <Terminal size={14} className="mt-0.5 shrink-0 text-gray-11" />
                                     <div className="min-w-0">
                                       <div className="truncate text-xs font-semibold text-gray-11">/{command.name}</div>
-                                      {command.description ? <div className="truncate text-xs text-gray-10">{command.description}</div> : null}
+                                      {command.description ? <div className="truncate text-xs text-gray-11">{command.description}</div> : null}
                                     </div>
                                   </button>
                                 ))}
                               </div>
                             ) : (
-                              <div className="px-3 py-2 text-xs text-gray-10">
+                              <div className="px-3 py-2 text-xs text-gray-11">
                                 {commandsLoading ? t("composer.loading_commands", locale) : t("composer.no_commands", locale)}
                               </div>
                             )
@@ -1004,16 +1004,16 @@ export function ReactSessionComposer(props: ComposerProps) {
                                     className="flex w-full items-start gap-3 rounded-[16px] px-3 py-2.5 text-left text-gray-11 transition-colors hover:bg-gray-2/70"
                                     onClick={() => applyCommandSelection(command)}
                                   >
-                                    <Zap size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                                    <Zap size={14} className="mt-0.5 shrink-0 text-gray-11" />
                                     <div className="min-w-0">
                                       <div className="truncate text-xs font-semibold text-gray-11">/{command.name}</div>
-                                      {command.description ? <div className="truncate text-xs text-gray-10">{command.description}</div> : null}
+                                      {command.description ? <div className="truncate text-xs text-gray-11">{command.description}</div> : null}
                                     </div>
                                   </button>
                                 ))}
                               </div>
                             ) : (
-                              <div className="px-3 py-2 text-xs text-gray-10">
+                              <div className="px-3 py-2 text-xs text-gray-11">
                                 {skillsLoading || commandsLoading ? t("composer.loading_commands", locale) : t("context_panel.no_skills", locale)}
                               </div>
                             )
@@ -1023,7 +1023,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                               <div className="grid gap-1">
                                 {activeMcpItems.map(({ entry, status }) => (
                                   <div key={entry.name} className="flex items-start gap-3 rounded-[16px] px-3 py-2.5 text-gray-11">
-                                    <Plug size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                                    <Plug size={14} className="mt-0.5 shrink-0 text-gray-11" />
                                     <div className="min-w-0 flex-1">
                                       <div className="flex items-center justify-between gap-3">
                                         <div className="truncate text-xs font-semibold text-gray-11">{entry.name}</div>
@@ -1031,13 +1031,13 @@ export function ReactSessionComposer(props: ComposerProps) {
                                           {formatMcpStatusLabel(status, locale)}
                                         </span>
                                       </div>
-                                      <div className="truncate text-xs text-gray-10">{entry.config.type === "remote" ? entry.config.url ?? entry.config.command?.join(" ") ?? "Remote MCP" : entry.config.command?.join(" ") ?? "Local MCP"}</div>
+                                      <div className="truncate text-xs text-gray-11">{entry.config.type === "remote" ? entry.config.url ?? entry.config.command?.join(" ") ?? "Remote MCP" : entry.config.command?.join(" ") ?? "Local MCP"}</div>
                                     </div>
                                   </div>
                                 ))}
                               </div>
                             ) : (
-                              <div className="px-3 py-2 text-xs text-gray-10">
+                              <div className="px-3 py-2 text-xs text-gray-11">
                                 {mcpLoading ? t("composer.loading_commands", locale) : (mcpStatus ?? t("context_panel.no_mcp", locale))}
                               </div>
                             )
@@ -1076,7 +1076,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                     disabled={props.disabled || !canSend}
                     className={`inline-flex h-9 max-h-9 items-center gap-2 rounded-full px-4 text-[13px] font-medium transition-colors ${
                       !canSend || props.disabled
-                        ? "bg-gray-4 text-gray-10"
+                        ? "bg-gray-4 text-gray-11"
                         : "bg-[var(--dls-accent)] text-white hover:bg-[var(--dls-accent-hover)]"
                     }`}
                     title={props.busy ? t("composer.run_task", locale) : t("composer.run_task", locale)}
@@ -1092,11 +1092,11 @@ export function ReactSessionComposer(props: ComposerProps) {
 
         {/* Below-panel control strip: agent + model + behavior variant */}
         <div className="mt-1 flex items-center justify-between px-1">
-          <div className="flex flex-wrap items-center gap-1.5 text-gray-10 sm:gap-2.5">
+          <div className="flex flex-wrap items-center gap-1.5 text-gray-11 sm:gap-2.5">
             <div ref={agentMenuRef} className="relative">
               <button
                 type="button"
-                className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+                className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
                 onClick={() => setAgentMenuOpen((value) => !value)}
                 disabled={props.busy}
                 aria-expanded={agentMenuOpen}
@@ -1107,7 +1107,7 @@ export function ReactSessionComposer(props: ComposerProps) {
               </button>
               {agentMenuOpen ? (
                 <div className="absolute left-0 bottom-full z-40 mb-2 w-64 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
-                  <div className="border-b border-dls-border px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10">
+                  <div className="border-b border-dls-border px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-11">
                     {t("composer.agent_label", locale)}
                   </div>
                   <div
@@ -1128,7 +1128,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                       }}
                     >
                       <span>{t("composer.default_agent", locale)}</span>
-                      {!props.selectedAgent ? <Check size={14} className="text-gray-10" /> : null}
+                      {!props.selectedAgent ? <Check size={14} className="text-gray-11" /> : null}
                     </button>
                     {agents.map((agent, index) => {
                       const active = props.selectedAgent === agent.name;
@@ -1148,7 +1148,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                           }}
                         >
                           <span className="truncate">{agent.name.charAt(0).toUpperCase() + agent.name.slice(1)}</span>
-                          {active ? <Check size={14} className="text-gray-10" /> : null}
+                          {active ? <Check size={14} className="text-gray-11" /> : null}
                         </button>
                       );
                     })}
@@ -1159,7 +1159,7 @@ export function ReactSessionComposer(props: ComposerProps) {
 
             <button
               type="button"
-              className="flex min-w-0 items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+              className="flex min-w-0 items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
               onClick={props.onModelClick}
               disabled={props.busy}
             >
@@ -1171,7 +1171,7 @@ export function ReactSessionComposer(props: ComposerProps) {
               <div ref={variantMenuRef} className="relative">
                 <button
                   type="button"
-                  className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
+                  className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium text-gray-11 transition-colors hover:bg-gray-3 hover:text-gray-12"
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -1192,7 +1192,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                 </button>
                 {variantMenuOpen ? (
                   <div className="absolute left-0 bottom-full z-40 mb-2 w-48 overflow-hidden rounded-[18px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
-                    <div className="border-b border-dls-border px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-10">
+                    <div className="border-b border-dls-border px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-11">
                       {t("composer.behavior_label", locale)}
                     </div>
                     <div className="space-y-1 p-2">
@@ -1219,7 +1219,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                             }}
                           >
                             <span>{option.label}</span>
-                            {isActive ? <Check size={14} className="text-gray-10" /> : null}
+                            {isActive ? <Check size={14} className="text-gray-11" /> : null}
                           </button>
                         );
                       })}

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -431,7 +431,7 @@ function FileCard(props: {
       ) : (
         <div
           className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${
-            props.tone === "user" ? "bg-gray-3/60 text-gray-11" : "bg-gray-2/60 text-gray-10"
+            props.tone === "user" ? "bg-gray-3/60 text-gray-11" : "bg-gray-2/60 text-gray-11"
           }`}
         >
           <FileIcon size={20} />
@@ -440,7 +440,7 @@ function FileCard(props: {
       <div className="min-w-0 flex-1">
         <div className="truncate text-[13px] font-medium leading-snug text-gray-12">{title}</div>
         {badge ? (
-          <div className="mt-1 inline-flex rounded-md bg-gray-3/50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-10">
+          <div className="mt-1 inline-flex rounded-md bg-gray-3/50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-11">
             {badge}
           </div>
         ) : null}
@@ -450,7 +450,7 @@ function FileCard(props: {
         <div className="relative">
           <button
             type="button"
-            className="flex h-8 w-8 items-center justify-center rounded-xl text-gray-9 opacity-0 transition-all hover:bg-gray-3/60 hover:text-gray-12 group-hover:opacity-100"
+            className="flex h-8 w-8 items-center justify-center rounded-xl text-gray-11 opacity-0 transition-all hover:bg-gray-3/60 hover:text-gray-12 group-hover:opacity-100"
             onClick={() => setMenuOpen((value) => !value)}
             title="File actions"
           >
@@ -525,14 +525,14 @@ function StepRow(props: {
       ? (props.part as { text: string }).text
       : "";
     return (
-      <div className="text-[14px] leading-[1.7] text-gray-9 whitespace-pre-wrap">
+      <div className="text-[14px] leading-[1.7] text-gray-11 whitespace-pre-wrap">
         <div className="max-w-[720px]">{cleanReasoningPreview(raw) || headline}</div>
       </div>
     );
   }
 
   return (
-    <div className="text-[14px] text-gray-9">
+    <div className="text-[14px] text-gray-11">
       <button
         type="button"
         className="w-full text-left transition-colors hover:text-dls-text disabled:cursor-default"
@@ -548,7 +548,7 @@ function StepRow(props: {
           {expandable ? (
             <ChevronDown
               size={14}
-              className={`mt-[2px] shrink-0 text-gray-8 transition-transform ${
+              className={`mt-[2px] shrink-0 text-gray-11 transition-transform ${
                 props.expanded ? "" : "-rotate-90"
               }`}
             />
@@ -559,16 +559,16 @@ function StepRow(props: {
         <div className="mt-3 ml-[22px] space-y-3">
           {hasStructuredValue(toolInput) ? (
             <div>
-              <div className="mb-1 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-8">Request</div>
-              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-10">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-11">Request</div>
+              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-11">
                 {formatStructuredValue(toolInput)}
               </pre>
             </div>
           ) : null}
           {hasStructuredValue(toolOutput) ? (
             <div>
-              <div className="mb-1 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-8">Result</div>
-              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-10">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-11">Result</div>
+              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-11">
                 {formatStructuredValue(toolOutput)}
               </pre>
             </div>

--- a/apps/app/src/react-app/domains/session/surface/tool-call.tsx
+++ b/apps/app/src/react-app/domains/session/surface/tool-call.tsx
@@ -87,7 +87,7 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
   const expandable = hasStructuredValue(input) || hasStructuredValue(output) || Boolean(diff) || Boolean(error);
 
   return (
-    <div className="grid gap-3 text-[14px] text-gray-9">
+    <div className="grid gap-3 text-[14px] text-gray-11">
       <button
         type="button"
         className="w-full text-left transition-colors hover:text-dls-text disabled:cursor-default"
@@ -150,7 +150,7 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
           {hasStructuredValue(input) ? (
             <div>
               <div className="mb-1 flex items-center justify-between gap-2">
-                <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-gray-8">Tool request</div>
+                <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-gray-11">Tool request</div>
                 <button
                   type="button"
                   className="rounded-full border border-dls-border bg-dls-surface px-2 py-1 text-[11px] font-medium text-dls-text transition-colors hover:bg-dls-hover"
@@ -159,7 +159,7 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
                   Copy
                 </button>
               </div>
-              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-10">
+              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-11">
                 {formatStructuredValue(input)}
               </pre>
             </div>
@@ -168,7 +168,7 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
           {hasStructuredValue(output) && normalizeToolText(output) !== normalizeToolText(diff) ? (
             <div>
               <div className="mb-1 flex items-center justify-between gap-2">
-                <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-gray-8">Tool result</div>
+                <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-gray-11">Tool result</div>
                 <button
                   type="button"
                   className="rounded-full border border-dls-border bg-dls-surface px-2 py-1 text-[11px] font-medium text-dls-text transition-colors hover:bg-dls-hover"
@@ -177,7 +177,7 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
                   Copy
                 </button>
               </div>
-              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-10">
+              <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-11">
                 {formatStructuredValue(output)}
               </pre>
             </div>
@@ -186,7 +186,7 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
           {error ? <div className="rounded-lg bg-red-1/40 p-2 text-xs text-red-12">{error}</div> : null}
 
           {props.developerMode && !expandable ? (
-            <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-10">
+            <pre className="overflow-x-auto rounded-[16px] border border-dls-border/70 bg-dls-surface px-4 py-3 text-[12px] leading-6 text-gray-11">
               {safeStringify({ input, output, error, state: props.part.state })}
             </pre>
           ) : null}

--- a/apps/app/src/react-app/domains/settings/modals/reset-modal.tsx
+++ b/apps/app/src/react-app/domains/settings/modals/reset-modal.tsx
@@ -12,7 +12,7 @@ const buttonBaseClass =
 const outlineButtonClass = `${buttonBaseClass} border border-dls-border bg-dls-surface text-dls-text hover:bg-[var(--dls-hover)]`;
 const dangerButtonClass = `${buttonBaseClass} bg-red-9 text-white hover:bg-red-10`;
 const ghostIconButtonClass =
-  "inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-10 transition-colors hover:bg-[var(--dls-hover)] disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-11 transition-colors hover:bg-[var(--dls-hover)] disabled:cursor-not-allowed disabled:opacity-60";
 
 export type ResetModalProps = {
   open: boolean;

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -56,7 +56,7 @@ function RuntimeStatusCard(props: RuntimeStatusCardProps) {
         </div>
         <div>
           <div className="text-sm font-medium text-gray-12">{props.title}</div>
-          <div className="text-xs text-gray-9">{props.description}</div>
+          <div className="text-xs text-gray-11">{props.description}</div>
         </div>
       </div>
       <div
@@ -200,7 +200,7 @@ export function AdvancedView(props: AdvancedViewProps) {
       <div className={`${settingsPanelClass} space-y-4`}>
         <div>
           <div className="text-sm font-medium text-gray-12">{t("settings.runtime_title")}</div>
-          <div className="text-xs text-gray-9">{t("settings.runtime_desc")}</div>
+          <div className="text-xs text-gray-11">{t("settings.runtime_desc")}</div>
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2">
@@ -226,13 +226,13 @@ export function AdvancedView(props: AdvancedViewProps) {
       <div className={`${settingsPanelClass} space-y-3`}>
         <div>
           <div className="text-sm font-medium text-gray-12">{t("settings.opencode_section_label")}</div>
-          <div className="text-xs text-gray-9">{t("settings.opencode_runtime_desc")}</div>
+          <div className="text-xs text-gray-11">{t("settings.opencode_runtime_desc")}</div>
         </div>
 
         <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
           <div className="min-w-0">
             <div className="text-sm text-gray-12">{t("settings.enable_exa")}</div>
-            <div className="text-xs text-gray-7">{t("settings.enable_exa_desc")}</div>
+            <div className="text-xs text-gray-11">{t("settings.enable_exa_desc")}</div>
           </div>
           <Button
             variant="outline"
@@ -244,13 +244,13 @@ export function AdvancedView(props: AdvancedViewProps) {
           </Button>
         </div>
 
-        <div className="text-[11px] text-gray-7">{t("settings.exa_restart_hint")}</div>
+        <div className="text-[11px] text-gray-11">{t("settings.exa_restart_hint")}</div>
       </div>
 
       <div className={`${settingsPanelClass} space-y-3`}>
         <div>
           <div className="text-sm font-medium text-gray-12">Feature flags</div>
-          <div className="text-xs text-gray-9">
+          <div className="text-xs text-gray-11">
             Experimental controls for sandbox and workspace behaviors.
           </div>
         </div>
@@ -258,7 +258,7 @@ export function AdvancedView(props: AdvancedViewProps) {
         <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
           <div className="min-w-0">
             <div className="text-sm text-gray-12">Create Sandbox uses microsandbox image</div>
-            <div className="text-xs text-gray-7">
+            <div className="text-xs text-gray-11">
               When enabled, Create Sandbox launches the detached worker with the microsandbox image
               flow instead of the default Docker image flow.
             </div>
@@ -276,7 +276,7 @@ export function AdvancedView(props: AdvancedViewProps) {
 
       <div className={`${settingsPanelClass} space-y-3`}>
         <div className="text-sm font-medium text-gray-12">{t("settings.developer_mode_title")}</div>
-        <div className="text-xs text-gray-9">{t("settings.developer_mode_desc")}</div>
+        <div className="text-xs text-gray-11">{t("settings.developer_mode_desc")}</div>
         <div className="flex flex-wrap items-center gap-3 pt-1">
           <button
             type="button"
@@ -292,7 +292,7 @@ export function AdvancedView(props: AdvancedViewProps) {
               ? t("settings.disable_developer_mode")
               : t("settings.enable_developer_mode")}
           </button>
-          <div className="text-xs text-gray-10">
+          <div className="text-xs text-gray-11">
             {props.developerMode
               ? t("settings.developer_panel_enabled")
               : t("settings.developer_panel_disabled")}
@@ -304,7 +304,7 @@ export function AdvancedView(props: AdvancedViewProps) {
             <div className="flex items-start justify-between gap-3">
               <div>
                 <div className="text-sm font-medium text-gray-12">{t("settings.open_deeplink_title")}</div>
-                <div className="text-xs text-gray-9">{t("settings.open_deeplink_desc")}</div>
+                <div className="text-xs text-gray-11">{t("settings.open_deeplink_desc")}</div>
               </div>
               <button
                 type="button"
@@ -337,20 +337,20 @@ export function AdvancedView(props: AdvancedViewProps) {
                   >
                     {debugDeepLinkBusy ? t("settings.opening") : t("settings.open_deeplink_action")}
                   </Button>
-                  <div className="text-[11px] text-gray-8">{t("settings.deeplink_hint")}</div>
+                  <div className="text-[11px] text-gray-11">{t("settings.deeplink_hint")}</div>
                 </div>
               </div>
             ) : null}
 
-            {debugDeepLinkStatus ? <div className="text-xs text-gray-10">{debugDeepLinkStatus}</div> : null}
+            {debugDeepLinkStatus ? <div className="text-xs text-gray-11">{debugDeepLinkStatus}</div> : null}
           </div>
         ) : null}
       </div>
 
       <div className={`${settingsPanelClass} space-y-3`}>
         <div className="text-sm font-medium text-gray-12">{t("settings.connection_title")}</div>
-        <div className="text-xs text-gray-9">{props.headerStatus}</div>
-        <div className="break-all font-mono text-xs text-gray-8">{props.baseUrl}</div>
+        <div className="text-xs text-gray-11">{props.headerStatus}</div>
+        <div className="break-all font-mono text-xs text-gray-11">{props.baseUrl}</div>
         <div className="flex flex-wrap gap-2 pt-2">
           <button
             type="button"
@@ -398,9 +398,9 @@ export function AdvancedView(props: AdvancedViewProps) {
           ) : null}
         </div>
 
-        {openworkReconnectStatus ? <div className="text-xs text-gray-10">{openworkReconnectStatus}</div> : null}
+        {openworkReconnectStatus ? <div className="text-xs text-gray-11">{openworkReconnectStatus}</div> : null}
         {openworkReconnectError ? <div className="text-xs text-red-11">{openworkReconnectError}</div> : null}
-        {openworkRestartStatus ? <div className="text-xs text-gray-10">{openworkRestartStatus}</div> : null}
+        {openworkRestartStatus ? <div className="text-xs text-gray-11">{openworkRestartStatus}</div> : null}
         {openworkRestartError ? <div className="text-xs text-red-11">{openworkRestartError}</div> : null}
       </div>
 

--- a/apps/app/src/react-app/domains/settings/pages/appearance-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/appearance-view.tsx
@@ -21,7 +21,7 @@ export function AppearanceView(props: AppearanceViewProps) {
       <div className={`${settingsPanelClass} space-y-4`}>
         <div>
           <div className="text-sm font-medium text-gray-12">{t("settings.appearance_title")}</div>
-          <div className="text-xs text-gray-9">{t("settings.appearance_hint")}</div>
+          <div className="text-xs text-gray-11">{t("settings.appearance_hint")}</div>
         </div>
 
         <div className="flex flex-wrap gap-2">
@@ -53,7 +53,7 @@ export function AppearanceView(props: AppearanceViewProps) {
 
         <div className="space-y-2">
           <div className="text-xs font-medium text-gray-11">{t("settings.language")}</div>
-          <div className="text-xs text-gray-9">{t("settings.language.description")}</div>
+          <div className="text-xs text-gray-11">{t("settings.language.description")}</div>
           <div className="flex flex-wrap gap-2">
             {LANGUAGE_OPTIONS.map((option) => (
               <Button
@@ -69,20 +69,20 @@ export function AppearanceView(props: AppearanceViewProps) {
           </div>
         </div>
 
-        <div className="text-xs text-gray-8">{t("settings.theme_system_hint")}</div>
+        <div className="text-xs text-gray-11">{t("settings.theme_system_hint")}</div>
       </div>
 
       {isDesktopRuntime() ? (
         <div className="space-y-3 rounded-2xl border border-gray-6/50 bg-gray-2/30 p-5">
           <div>
             <div className="text-sm font-medium text-gray-12">{t("settings.appearance_title")}</div>
-            <div className="text-xs text-gray-10">{t("settings.window_appearance_desc")}</div>
+            <div className="text-xs text-gray-11">{t("settings.window_appearance_desc")}</div>
           </div>
 
           <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
             <div className="min-w-0">
               <div className="text-sm text-gray-12">{t("settings.hide_titlebar")}</div>
-              <div className="text-xs text-gray-7">{t("settings.hide_titlebar_desc")}</div>
+              <div className="text-xs text-gray-11">{t("settings.hide_titlebar_desc")}</div>
             </div>
             <Button
               variant="outline"

--- a/apps/app/src/react-app/domains/settings/pages/config-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/config-view.tsx
@@ -273,10 +273,10 @@ export function ConfigView(props: ConfigViewProps) {
     <div className="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
       <div className="min-w-0">
         <div className="text-xs font-medium text-gray-11">{label}</div>
-        <div className="text-xs text-gray-7 font-mono truncate">
+        <div className="text-xs text-gray-11 font-mono truncate">
           {visible ? tokenValue || "—" : tokenValue ? "••••••••••••" : "—"}
         </div>
-        <div className="text-[11px] text-gray-8 mt-1">{hint}</div>
+        <div className="text-[11px] text-gray-11 mt-1">{hint}</div>
       </div>
       <div className="flex items-center gap-2 shrink-0">
         <Button
@@ -305,11 +305,11 @@ export function ConfigView(props: ConfigViewProps) {
         <div className="text-sm font-medium text-gray-12">
           {t("config.workspace_config_title")}
         </div>
-        <div className="text-xs text-gray-10">
+        <div className="text-xs text-gray-11">
           {t("config.workspace_config_desc")}
         </div>
         {props.runtimeWorkspaceId ? (
-          <div className="text-[11px] text-gray-7 font-mono truncate">
+          <div className="text-[11px] text-gray-11 font-mono truncate">
             {t("config.workspace_id_prefix")}
             {props.runtimeWorkspaceId}
           </div>
@@ -321,7 +321,7 @@ export function ConfigView(props: ConfigViewProps) {
           <div className="text-sm font-medium text-gray-12">
             {t("config.engine_reload_title")}
           </div>
-          <div className="text-xs text-gray-10">
+          <div className="text-xs text-gray-11">
             {t("config.engine_reload_desc")}
           </div>
         </div>
@@ -331,7 +331,7 @@ export function ConfigView(props: ConfigViewProps) {
             <div className="text-sm text-gray-12">
               {t("config.reload_now_title")}
             </div>
-            <div className="text-xs text-gray-7">
+            <div className="text-xs text-gray-11">
               {t("config.reload_now_desc")}
             </div>
             {props.anyActiveRuns ? (
@@ -343,7 +343,7 @@ export function ConfigView(props: ConfigViewProps) {
               <div className="text-[11px] text-red-11">{props.reloadError}</div>
             ) : null}
             {reloadAvailabilityReason ? (
-              <div className="text-[11px] text-gray-9">
+              <div className="text-[11px] text-gray-11">
                 {reloadAvailabilityReason}
               </div>
             ) : null}
@@ -370,7 +370,7 @@ export function ConfigView(props: ConfigViewProps) {
               <div className="text-sm font-medium text-gray-12">
                 {t("config.diagnostics_title")}
               </div>
-              <div className="text-xs text-gray-10">
+              <div className="text-xs text-gray-11">
                 {t("config.diagnostics_desc")}
               </div>
             </div>
@@ -400,7 +400,7 @@ export function ConfigView(props: ConfigViewProps) {
               <div className="text-sm font-medium text-gray-12">
                 {t("config.server_sharing_title")}
               </div>
-              <div className="text-xs text-gray-10">
+              <div className="text-xs text-gray-11">
                 {t("config.server_sharing_desc")}
               </div>
             </div>
@@ -417,11 +417,11 @@ export function ConfigView(props: ConfigViewProps) {
                 <div className="text-xs font-medium text-gray-11">
                   {t("config.server_url_label")}
                 </div>
-                <div className="text-xs text-gray-7 font-mono truncate">
+                <div className="text-xs text-gray-11 font-mono truncate">
                   {hostConnectUrl || t("config.starting_server")}
                 </div>
                 {hostConnectUrl ? (
-                  <div className="text-[11px] text-gray-8 mt-1">
+                  <div className="text-[11px] text-gray-11 mt-1">
                     {!hostRemoteAccessEnabled
                       ? t("config.remote_access_off_hint")
                       : hostConnectUrlUsesMdns
@@ -474,7 +474,7 @@ export function ConfigView(props: ConfigViewProps) {
             )}
           </div>
 
-          <div className="text-xs text-gray-9">
+          <div className="text-xs text-gray-11">
             {t("config.server_sharing_menu_hint")}
           </div>
         </div>
@@ -486,7 +486,7 @@ export function ConfigView(props: ConfigViewProps) {
             <div className="text-sm font-medium text-gray-12">
               {t("config.server_section_title")}
             </div>
-            <div className="text-xs text-gray-10">
+            <div className="text-xs text-gray-11">
               {t("config.server_section_desc")}
             </div>
           </div>
@@ -529,18 +529,18 @@ export function ConfigView(props: ConfigViewProps) {
                 {openworkTokenVisible ? t("common.hide") : t("common.show")}
               </Button>
             </div>
-            <div className="mt-1 text-xs text-gray-10">
+            <div className="mt-1 text-xs text-gray-11">
               {t("config.token_hint")}
             </div>
           </label>
         </div>
 
         <div className="space-y-1">
-          <div className="text-[11px] text-gray-7 font-mono truncate">
+          <div className="text-[11px] text-gray-11 font-mono truncate">
             {t("config.resolved_worker_url")}
             {resolvedWorkspaceUrl || t("config.not_set")}
           </div>
-          <div className="text-[11px] text-gray-8 font-mono truncate">
+          <div className="text-[11px] text-gray-11 font-mono truncate">
             {t("config.worker_id")}
             {resolvedWorkspaceId || t("config.unavailable")}
           </div>
@@ -581,7 +581,7 @@ export function ConfigView(props: ConfigViewProps) {
                 ? "text-green-11"
                 : openworkTestState === "error"
                   ? "text-red-11"
-                  : "text-gray-9"
+                  : "text-gray-11"
             }`}
             role="status"
             aria-live="polite"
@@ -593,7 +593,7 @@ export function ConfigView(props: ConfigViewProps) {
         ) : null}
 
         {openworkStatusLabel !== t("config.status_connected") ? (
-          <div className="text-xs text-gray-9">
+          <div className="text-xs text-gray-11">
             {t("config.server_needed_hint")}
           </div>
         ) : null}
@@ -603,13 +603,13 @@ export function ConfigView(props: ConfigViewProps) {
         <div className="text-sm font-medium text-gray-12">
           {t("config.messaging_identities_title")}
         </div>
-        <div className="text-xs text-gray-10">
+        <div className="text-xs text-gray-11">
           {t("config.messaging_identities_desc")}
         </div>
       </div>
 
       {!isDesktopRuntime() ? (
-        <div className="text-xs text-gray-9">
+        <div className="text-xs text-gray-11">
           {t("config.desktop_only_hint")}
         </div>
       ) : null}

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -164,7 +164,7 @@ function formatUptime(ms: number) {
 
 function renderLines(lines: string[]) {
   return lines.map((line, index) => (
-    <div key={`${line}-${index}`} className="text-[11px] font-mono text-gray-7 truncate">
+    <div key={`${line}-${index}`} className="text-[11px] font-mono text-gray-11 truncate">
       {line}
     </div>
   ));
@@ -193,7 +193,7 @@ export function DebugView(props: DebugViewProps) {
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="text-sm font-medium text-gray-12">{t("settings.runtime_debug_title")}</div>
-              <div className="text-xs text-gray-10">{t("settings.runtime_debug_desc")}</div>
+              <div className="text-xs text-gray-11">{t("settings.runtime_debug_desc")}</div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
               <Button variant="outline" className="h-8 px-3 py-0 text-xs" onClick={() => void props.onCopyRuntimeDebugReport()}>
@@ -227,14 +227,14 @@ export function DebugView(props: DebugViewProps) {
             </div>
           </div>
           <pre className={settingsMonoPreClass}>{props.runtimeDebugReportJson}</pre>
-          {props.runtimeDebugStatus ? <div className="text-xs text-gray-10">{props.runtimeDebugStatus}</div> : null}
+          {props.runtimeDebugStatus ? <div className="text-xs text-gray-11">{props.runtimeDebugStatus}</div> : null}
         </div>
 
         <div className={settingsCardClass}>
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="text-sm font-medium text-gray-12">Developer log stream</div>
-              <div className="text-xs text-gray-10">
+              <div className="text-xs text-gray-11">
                 Captures dev-mode app, workspace, session, and perf logs while Developer Mode is enabled.
               </div>
             </div>
@@ -252,18 +252,18 @@ export function DebugView(props: DebugViewProps) {
               </Button>
             </div>
           </div>
-          <div className="text-[11px] text-gray-8">
+          <div className="text-[11px] text-gray-11">
             Showing the latest {props.developerLogRecordCount} retained records.
           </div>
           <pre className={settingsMonoPreClass}>{props.developerLogText || "No developer logs captured yet."}</pre>
-          {props.developerLogStatus ? <div className="text-xs text-gray-10">{props.developerLogStatus}</div> : null}
+          {props.developerLogStatus ? <div className="text-xs text-gray-11">{props.developerLogStatus}</div> : null}
         </div>
 
         <div className={settingsCardClass}>
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="text-sm font-medium text-gray-12">{t("settings.sandbox_probe_title")}</div>
-              <div className="text-xs text-gray-10">{t("settings.sandbox_probe_desc")}</div>
+              <div className="text-xs text-gray-11">{t("settings.sandbox_probe_desc")}</div>
             </div>
             <Button
               variant="secondary"
@@ -288,8 +288,8 @@ export function DebugView(props: DebugViewProps) {
               ) : null}
             </div>
           ) : null}
-          {props.sandboxProbeStatus ? <div className="text-xs text-gray-10">{props.sandboxProbeStatus}</div> : null}
-          <div className="text-[11px] text-gray-7">{t("settings.sandbox_export_hint")}</div>
+          {props.sandboxProbeStatus ? <div className="text-xs text-gray-11">{props.sandboxProbeStatus}</div> : null}
+          <div className="text-[11px] text-gray-11">{t("settings.sandbox_export_hint")}</div>
         </div>
 
         <div className={settingsCardClass}>
@@ -321,14 +321,14 @@ export function DebugView(props: DebugViewProps) {
             <RefreshCcw size={14} className="opacity-80 transition-transform group-hover:rotate-180" />
           </Button>
 
-          <p className="text-xs text-gray-7">{t("settings.startup_reset_hint")}</p>
+          <p className="text-xs text-gray-11">{t("settings.startup_reset_hint")}</p>
         </div>
 
         {isDesktop && (isLocalPreference || props.developerMode) ? (
           <div className={settingsCardClass}>
             <div>
               <div className="text-sm font-medium text-gray-12">{t("settings.engine_title")}</div>
-              <div className="text-xs text-gray-10">{t("settings.engine_desc")}</div>
+              <div className="text-xs text-gray-11">{t("settings.engine_desc")}</div>
             </div>
 
             {!isLocalPreference ? (
@@ -338,7 +338,7 @@ export function DebugView(props: DebugViewProps) {
             ) : null}
 
             <div className="space-y-3">
-              <div className="text-xs text-gray-10">{t("settings.engine_source_debug")}</div>
+              <div className="text-xs text-gray-11">{t("settings.engine_source_debug")}</div>
               <div className={props.developerMode ? "grid grid-cols-3 gap-2" : "grid grid-cols-2 gap-2"}>
                 <Button
                   variant={props.engineSource === "sidecar" ? "secondary" : "outline"}
@@ -364,15 +364,15 @@ export function DebugView(props: DebugViewProps) {
                   </Button>
                 ) : null}
               </div>
-              <div className="text-[11px] text-gray-7">{t("settings.engine_bundled_hint")}</div>
+              <div className="text-[11px] text-gray-11">{t("settings.engine_bundled_hint")}</div>
             </div>
 
             {props.developerMode && props.engineSource === "custom" ? (
               <div className="space-y-2">
-                <div className="text-xs text-gray-10">{t("settings.custom_binary_label")}</div>
+                <div className="text-xs text-gray-11">{t("settings.custom_binary_label")}</div>
                 <div className="flex items-center gap-2">
                   <div
-                    className="min-w-0 flex-1 truncate rounded-xl border border-gray-6 bg-gray-1 p-3 font-mono text-[11px] text-gray-7"
+                    className="min-w-0 flex-1 truncate rounded-xl border border-gray-6 bg-gray-1 p-3 font-mono text-[11px] text-gray-11"
                     title={props.engineCustomBinPathLabel}
                   >
                     {props.engineCustomBinPathLabel}
@@ -395,13 +395,13 @@ export function DebugView(props: DebugViewProps) {
                     {t("settings.clear")}
                   </Button>
                 </div>
-                <div className="text-[11px] text-gray-7">{t("settings.custom_binary_hint")}</div>
+                <div className="text-[11px] text-gray-11">{t("settings.custom_binary_hint")}</div>
               </div>
             ) : null}
 
             {props.developerMode ? (
               <div className="space-y-3">
-                <div className="text-xs text-gray-10">{t("settings.engine_runtime_label")}</div>
+                <div className="text-xs text-gray-11">{t("settings.engine_runtime_label")}</div>
                 <div className="grid grid-cols-2 gap-2">
                   <Button
                     variant={props.engineRuntime === "direct" ? "secondary" : "outline"}
@@ -418,7 +418,7 @@ export function DebugView(props: DebugViewProps) {
                     {t("settings.runtime_orchestrator")}
                   </Button>
                 </div>
-                <div className="text-[11px] text-gray-7">{t("settings.runtime_applies_hint")}</div>
+                <div className="text-[11px] text-gray-11">{t("settings.runtime_applies_hint")}</div>
               </div>
             ) : null}
           </div>
@@ -427,13 +427,13 @@ export function DebugView(props: DebugViewProps) {
         <div className={settingsCardClass}>
           <div>
             <div className="text-sm font-medium text-gray-12">{t("settings.reset_recovery_title")}</div>
-            <div className="text-xs text-gray-10">{t("settings.reset_recovery_desc")}</div>
+            <div className="text-xs text-gray-11">{t("settings.reset_recovery_desc")}</div>
           </div>
 
           <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
             <div className="min-w-0">
               <div className="text-sm text-gray-12">{t("settings.reset_onboarding_title")}</div>
-              <div className="text-xs text-gray-7">{t("settings.reset_onboarding_description")}</div>
+              <div className="text-xs text-gray-11">{t("settings.reset_onboarding_description")}</div>
             </div>
             <Button
               variant="outline"
@@ -449,7 +449,7 @@ export function DebugView(props: DebugViewProps) {
           <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
             <div className="min-w-0">
               <div className="text-sm text-gray-12">{t("settings.reset_app_data_title")}</div>
-              <div className="text-xs text-gray-7">{t("settings.reset_app_data_description")}</div>
+              <div className="text-xs text-gray-11">{t("settings.reset_app_data_description")}</div>
             </div>
             <Button
               variant="danger"
@@ -462,19 +462,19 @@ export function DebugView(props: DebugViewProps) {
             </Button>
           </div>
 
-          <div className="text-xs text-gray-7">{t("settings.reset_requires_confirm")}</div>
+          <div className="text-xs text-gray-11">{t("settings.reset_requires_confirm")}</div>
         </div>
 
         <div className={settingsCardClass}>
           <div>
             <div className="text-sm font-medium text-gray-12">{t("settings.devtools_title")}</div>
-            <div className="text-xs text-gray-10">{t("settings.devtools_desc")}</div>
+            <div className="text-xs text-gray-11">{t("settings.devtools_desc")}</div>
           </div>
 
           <div className={`${settingsSoftCardClass} space-y-3`}>
             <div>
               <div className="text-sm font-medium text-gray-12">{t("settings.service_restarts_title")}</div>
-              <div className="text-xs text-gray-10">{t("settings.service_restarts_desc")}</div>
+              <div className="text-xs text-gray-11">{t("settings.service_restarts_desc")}</div>
             </div>
             <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
               <Button
@@ -530,7 +530,7 @@ export function DebugView(props: DebugViewProps) {
             <div className={`${settingsSoftCardClass} space-y-3`}>
               <div>
                 <div className="text-sm font-medium text-gray-12">{t("settings.versions_title")}</div>
-                <div className="text-xs text-gray-10">{t("settings.versions_desc")}</div>
+                <div className="text-xs text-gray-11">{t("settings.versions_desc")}</div>
               </div>
               <div className="space-y-1">{renderLines([
                 t("settings.debug_desktop_app", undefined, { version: props.runtimeSummary.appVersionLabel }),
@@ -546,7 +546,7 @@ export function DebugView(props: DebugViewProps) {
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-medium text-gray-12">{t("settings.opencode_engine_sidecar")}</div>
-                  <div className="text-xs text-gray-10">{t("settings.opencode_engine_sidecar_desc")}</div>
+                  <div className="text-xs text-gray-11">{t("settings.opencode_engine_sidecar_desc")}</div>
                 </div>
                 <div className={`rounded-full border px-2 py-1 text-xs ${props.engineCard.className}`}>
                   {props.engineCard.label}
@@ -555,11 +555,11 @@ export function DebugView(props: DebugViewProps) {
               <div className="space-y-1">{renderLines(props.engineCard.lines)}</div>
               <div className="grid gap-2">
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_stdout")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_stdout")}</div>
                   <pre className={settingsMiniPreClass}>{props.engineCard.stdout || "—"}</pre>
                 </div>
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_stderr")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_stderr")}</div>
                   <pre className={settingsMiniPreClass}>{props.engineCard.stderr || "—"}</pre>
                 </div>
               </div>
@@ -569,7 +569,7 @@ export function DebugView(props: DebugViewProps) {
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-medium text-gray-12">{t("settings.orchestrator_daemon_title")}</div>
-                  <div className="text-xs text-gray-10">{t("settings.orchestrator_daemon_layer_desc")}</div>
+                  <div className="text-xs text-gray-11">{t("settings.orchestrator_daemon_layer_desc")}</div>
                 </div>
                 <div className={`rounded-full border px-2 py-1 text-xs ${props.orchestratorCard.className}`}>
                   {props.orchestratorCard.label}
@@ -578,7 +578,7 @@ export function DebugView(props: DebugViewProps) {
               <div className="space-y-1">{renderLines(props.orchestratorCard.lines)}</div>
               {props.orchestratorCard.error ? (
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_error")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_error")}</div>
                   <pre className={settingsMiniPreClass}>{props.orchestratorCard.error}</pre>
                 </div>
               ) : null}
@@ -588,7 +588,7 @@ export function DebugView(props: DebugViewProps) {
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-medium text-gray-12">{t("settings.opencode_sdk_title")}</div>
-                  <div className="text-xs text-gray-10">{t("settings.opencode_sdk_desc")}</div>
+                  <div className="text-xs text-gray-11">{t("settings.opencode_sdk_desc")}</div>
                 </div>
                 <div className={`rounded-full border px-2 py-1 text-xs ${props.opencodeConnectCard.className}`}>
                   {props.opencodeConnectCard.label}
@@ -602,7 +602,7 @@ export function DebugView(props: DebugViewProps) {
               ) : null}
               {props.opencodeConnectCard.error ? (
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_error")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_error")}</div>
                   <pre className={settingsMiniPreClass}>{props.opencodeConnectCard.error}</pre>
                 </div>
               ) : null}
@@ -612,7 +612,7 @@ export function DebugView(props: DebugViewProps) {
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-medium text-gray-12">{t("settings.openwork_server_label")}</div>
-                  <div className="text-xs text-gray-10">{t("settings.openwork_config_sidecar_desc")}</div>
+                  <div className="text-xs text-gray-11">{t("settings.openwork_config_sidecar_desc")}</div>
                 </div>
                 <div className={`rounded-full border px-2 py-1 text-xs ${props.openworkCard.className}`}>
                   {props.openworkCard.label}
@@ -621,11 +621,11 @@ export function DebugView(props: DebugViewProps) {
               <div className="space-y-1">{renderLines(props.openworkCard.lines)}</div>
               <div className="grid gap-2">
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_stdout")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_stdout")}</div>
                   <pre className={settingsMiniPreClass}>{props.openworkCard.stdout || "—"}</pre>
                 </div>
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_stderr")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_stderr")}</div>
                   <pre className={settingsMiniPreClass}>{props.openworkCard.stderr || "—"}</pre>
                 </div>
               </div>
@@ -635,7 +635,7 @@ export function DebugView(props: DebugViewProps) {
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-sm font-medium text-gray-12">{t("settings.opencode_router_sidecar")}</div>
-                  <div className="text-xs text-gray-10">{t("settings.messaging_bridge_service")}</div>
+                  <div className="text-xs text-gray-11">{t("settings.messaging_bridge_service")}</div>
                 </div>
                 <div className={`rounded-full border px-2 py-1 text-xs ${props.opencodeRouterCard.className}`}>
                   {props.opencodeRouterCard.label}
@@ -670,11 +670,11 @@ export function DebugView(props: DebugViewProps) {
               ) : null}
               <div className="grid gap-2">
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_stdout")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_stdout")}</div>
                   <pre className={settingsMiniPreClass}>{props.opencodeRouterCard.stdout || "—"}</pre>
                 </div>
                 <div>
-                  <div className="mb-1 text-[11px] text-gray-9">{t("settings.last_stderr")}</div>
+                  <div className="mb-1 text-[11px] text-gray-11">{t("settings.last_stderr")}</div>
                   <pre className={settingsMiniPreClass}>{props.opencodeRouterCard.stderr || "—"}</pre>
                 </div>
               </div>
@@ -684,7 +684,7 @@ export function DebugView(props: DebugViewProps) {
           <div className={`${settingsSoftCardClass} space-y-3`}>
             <div className="flex items-center justify-between gap-3">
               <div className="text-sm font-medium text-gray-12">{t("settings.openwork_diagnostics_title")}</div>
-              <div className="truncate font-mono text-[11px] text-gray-8">
+              <div className="truncate font-mono text-[11px] text-gray-11">
                 {props.openworkServerDiagnostics?.version ?? "—"}
               </div>
             </div>
@@ -730,14 +730,14 @@ export function DebugView(props: DebugViewProps) {
                 </div>
               </div>
             ) : (
-              <div className="text-xs text-gray-9">{t("settings.diagnostics_unavailable")}</div>
+              <div className="text-xs text-gray-11">{t("settings.diagnostics_unavailable")}</div>
             )}
           </div>
 
           <div className={`${settingsSoftCardClass} space-y-3`}>
             <div className="flex items-center justify-between gap-3">
               <div className="text-sm font-medium text-gray-12">{t("settings.capabilities_title")}</div>
-              <div className="truncate font-mono text-[11px] text-gray-8">
+              <div className="truncate font-mono text-[11px] text-gray-11">
                 {props.runtimeWorkspaceId
                   ? t("settings.worker_id_label", undefined, { id: props.runtimeWorkspaceId })
                   : t("settings.worker_unresolved")}
@@ -787,19 +787,19 @@ export function DebugView(props: DebugViewProps) {
                 </div>
               </div>
             ) : (
-              <div className="text-xs text-gray-9">{t("settings.capabilities_unavailable")}</div>
+              <div className="text-xs text-gray-11">{t("settings.capabilities_unavailable")}</div>
             )}
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">
             <div className={settingsSoftCardClass}>
-              <div className="mb-2 text-xs text-gray-10">{t("settings.pending_permissions")}</div>
+              <div className="mb-2 text-xs text-gray-11">{t("settings.pending_permissions")}</div>
               <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs text-gray-12">
                 {props.safeStringify(props.pendingPermissions)}
               </pre>
             </div>
             <div className={settingsSoftCardClass}>
-              <div className="mb-2 text-xs text-gray-10">{t("settings.recent_events")}</div>
+              <div className="mb-2 text-xs text-gray-11">{t("settings.recent_events")}</div>
               <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs text-gray-12">
                 {props.safeStringify(props.events)}
               </pre>
@@ -808,7 +808,7 @@ export function DebugView(props: DebugViewProps) {
 
           <div className={settingsSoftCardClass}>
             <div className="mb-2 flex items-center justify-between gap-3">
-              <div className="text-xs text-gray-10">{t("settings.workspace_debug_events_label")}</div>
+              <div className="text-xs text-gray-11">{t("settings.workspace_debug_events_label")}</div>
               <Button
                 variant="outline"
                 className="h-7 shrink-0 px-2 py-0 text-xs"
@@ -837,18 +837,18 @@ export function DebugView(props: DebugViewProps) {
                   <div key={entry.id} className="flex items-start justify-between gap-4 py-2">
                     <div className="min-w-0">
                       <div className="truncate text-sm text-gray-12">{entry.summary}</div>
-                      <div className="truncate text-[11px] text-gray-9">
+                      <div className="truncate text-[11px] text-gray-11">
                         {entry.action} · {entry.target} · {formatActor(entry)}
                       </div>
                     </div>
-                    <div className="whitespace-nowrap text-[11px] text-gray-9">
+                    <div className="whitespace-nowrap text-[11px] text-gray-11">
                       {entry.timestamp ? formatRelativeTime(entry.timestamp) : "—"}
                     </div>
                   </div>
                 ))}
               </div>
             ) : (
-              <div className="text-xs text-gray-9">{t("settings.no_audit_entries")}</div>
+              <div className="text-xs text-gray-11">{t("settings.no_audit_entries")}</div>
             )}
           </div>
         </div>
@@ -858,7 +858,7 @@ export function DebugView(props: DebugViewProps) {
             <div className="flex items-start justify-between gap-3">
               <div>
                 <div className="text-sm font-medium text-gray-12">{t("settings.reset_openwork_title")}</div>
-                <div className="text-xs text-gray-10">
+                <div className="text-xs text-gray-11">
                   {props.opencodeDevModeEnabled
                     ? t("settings.reset_openwork_desc_dev")
                     : t("settings.reset_openwork_desc_prod")}
@@ -868,7 +868,7 @@ export function DebugView(props: DebugViewProps) {
                 className={`shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium ${
                   props.opencodeDevModeEnabled
                     ? "border-blue-7/35 bg-blue-3/25 text-blue-11"
-                    : "border-gray-6 bg-gray-2 text-gray-10"
+                    : "border-gray-6 bg-gray-2 text-gray-11"
                 }`}
               >
                 {props.opencodeDevModeEnabled
@@ -877,7 +877,7 @@ export function DebugView(props: DebugViewProps) {
               </div>
             </div>
 
-            <div className="text-[11px] text-gray-8">{t("settings.quit_hint")}</div>
+            <div className="text-[11px] text-gray-11">{t("settings.quit_hint")}</div>
 
             <div className="flex flex-wrap items-center gap-3">
               <button
@@ -891,7 +891,7 @@ export function DebugView(props: DebugViewProps) {
                   ? t("settings.removing_local_state")
                   : t("settings.delete_local_config")}
               </button>
-              <div className="text-xs text-gray-10">{t("settings.nuke_hint")}</div>
+              <div className="text-xs text-gray-11">{t("settings.nuke_hint")}</div>
             </div>
 
             {props.nukeConfigStatus ? <div className="text-xs text-red-11">{props.nukeConfigStatus}</div> : null}

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -75,7 +75,7 @@ export function ExtensionsView(props: ExtensionsViewProps) {
     `px-3 py-1 rounded-full text-xs font-medium border transition-colors flex items-center gap-2 ${
       active
         ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
-        : "text-gray-10 border-gray-6 hover:text-gray-12"
+        : "text-gray-11 border-gray-6 hover:text-gray-12"
     }`;
 
   return (

--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -70,7 +70,7 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
                 {t("settings.providers_title")}
               </div>
             </div>
-            <div className="mt-1 text-xs text-gray-9">{t("settings.providers_desc")}</div>
+            <div className="mt-1 text-xs text-gray-11">{t("settings.providers_desc")}</div>
           </div>
           <div className={`rounded-full border px-2 py-1 text-xs ${props.providerStatusStyle}`}>
             {props.providerStatusLabel}
@@ -87,7 +87,7 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
               ? t("settings.loading_providers")
               : t("settings.connect_provider")}
           </Button>
-          <div className="text-xs text-gray-10">{props.providerSummary}</div>
+          <div className="text-xs text-gray-11">{props.providerSummary}</div>
         </div>
 
         {props.connectedProviders.length > 0 ? (
@@ -101,9 +101,9 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
                   <ProviderIcon providerId={provider.id} size={18} className="text-gray-12" />
                   <div className="min-w-0">
                     <div className="truncate text-sm font-medium text-gray-12">{provider.name}</div>
-                    <div className="truncate font-mono text-[11px] text-gray-8">{provider.id}</div>
+                    <div className="truncate font-mono text-[11px] text-gray-11">{provider.id}</div>
                     {providerSourceLabel(provider.source) ? (
-                      <div className="mt-1 truncate text-[11px] text-gray-9">
+                      <div className="mt-1 truncate text-[11px] text-gray-11">
                         {providerSourceLabel(provider.source)}
                       </div>
                     ) : null}
@@ -137,7 +137,7 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
           </div>
         ) : null}
         {props.providerDisconnectStatus ? (
-          <div className={`${settingsPanelSoftClass} px-3 py-2 text-xs text-gray-10`}>
+          <div className={`${settingsPanelSoftClass} px-3 py-2 text-xs text-gray-11`}>
             {props.providerDisconnectStatus}
           </div>
         ) : null}
@@ -147,19 +147,19 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
           </div>
         ) : null}
 
-        <div className="text-[11px] text-gray-9">{t("settings.api_keys_info")}</div>
+        <div className="text-[11px] text-gray-11">{t("settings.api_keys_info")}</div>
       </div>
 
       <div className={`${settingsPanelClass} space-y-4`}>
         <div>
           <div className="text-sm font-medium text-gray-12">{t("settings.model_title")}</div>
-          <div className="text-xs text-gray-10">{t("settings.model_section_desc")}</div>
+          <div className="text-xs text-gray-11">{t("settings.model_section_desc")}</div>
         </div>
 
         <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
           <div className="min-w-0">
             <div className="truncate text-sm text-gray-12">{props.defaultModelLabel}</div>
-            <div className="truncate font-mono text-xs text-gray-7">{props.defaultModelRef}</div>
+            <div className="truncate font-mono text-xs text-gray-11">{props.defaultModelRef}</div>
           </div>
           <Button
             variant="outline"
@@ -174,7 +174,7 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
         <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
           <div className="min-w-0">
             <div className="text-sm text-gray-12">{t("settings.show_model_reasoning")}</div>
-            <div className="text-xs text-gray-7">{t("settings.show_model_reasoning_desc")}</div>
+            <div className="text-xs text-gray-11">{t("settings.show_model_reasoning_desc")}</div>
           </div>
           <Button
             variant="outline"
@@ -189,8 +189,8 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
         <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
           <div className="min-w-0">
             <div className="text-sm text-gray-12">{t("settings.model_behavior")}</div>
-            <div className="truncate text-xs text-gray-7">{t("settings.model_behavior_desc")}</div>
-            <div className="mt-1 truncate text-xs font-medium text-gray-8">
+            <div className="truncate text-xs text-gray-11">{t("settings.model_behavior_desc")}</div>
+            <div className="mt-1 truncate text-xs font-medium text-gray-11">
               {props.defaultModelVariantLabel}
             </div>
           </div>
@@ -207,7 +207,7 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
         <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
           <div className="min-w-0">
             <div className="text-sm text-gray-12">{t("settings.auto_compact")}</div>
-            <div className="text-xs text-gray-7">{t("settings.auto_compact_desc")}</div>
+            <div className="text-xs text-gray-11">{t("settings.auto_compact_desc")}</div>
           </div>
           <Button
             variant="outline"
@@ -226,18 +226,18 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
 
         <div className="relative space-y-4">
           <div className="space-y-2">
-            <div className="inline-flex items-center gap-1.5 rounded-full border border-blue-7/35 bg-blue-4/25 px-2.5 py-1 text-[11px] font-medium text-blue-11">
+            <div className="inline-flex items-center gap-1.5 rounded-full border border-blue-7/35 bg-blue-4/25 px-2.5 py-1 text-[11px] font-medium text-blue-12">
               <LifeBuoy size={12} />
               {t("settings.feedback_badge")}
             </div>
             <div className="text-sm font-semibold text-gray-12">{t("settings.feedback_title")}</div>
-            <div className="max-w-[58ch] text-xs text-gray-10">{t("settings.feedback_desc")}</div>
+            <div className="max-w-[58ch] text-xs text-gray-11">{t("settings.feedback_desc")}</div>
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              className="inline-flex h-9 items-center justify-center gap-2 rounded-xl border border-transparent bg-blue-9 px-4 text-xs font-semibold text-blue-1 transition-colors duration-150 active:scale-[0.98] hover:bg-blue-10 focus:outline-none focus:ring-2 focus:ring-blue-7/30"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-xl border border-transparent bg-dls-accent px-4 text-xs font-semibold text-white transition-colors duration-150 active:scale-[0.98] hover:bg-[var(--dls-accent-hover)] focus:outline-none focus:ring-2 focus:ring-blue-7/30"
               onClick={props.onSendFeedback}
             >
               <MessageCircle size={14} />
@@ -256,7 +256,7 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
 
             <button
               type="button"
-              className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-gray-7/60 bg-gray-1/70 px-3 text-xs font-medium text-gray-10 transition-colors hover:border-gray-7/80 hover:text-gray-12 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-7/40"
+              className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-gray-7/60 bg-gray-1/70 px-3 text-xs font-medium text-gray-11 transition-colors hover:border-gray-7/80 hover:text-gray-12 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-7/40"
               onClick={props.onReportIssue}
             >
               {t("settings.report_issue")}

--- a/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
@@ -154,8 +154,8 @@ function SlackIcon({ size = 20 }: { size?: number }) {
 function StatusPill(props: { label: string; value: string; ok: boolean }) {
   return (
     <div className="flex-1 rounded-lg border border-gray-4 bg-gray-1 px-3.5 py-2.5">
-      <div className="mb-0.5 text-[11px] text-gray-9">{props.label}</div>
-      <div className={`text-[13px] font-semibold ${props.ok ? "text-gray-12" : "text-gray-8"}`}>
+      <div className="mb-0.5 text-[11px] text-gray-11">{props.label}</div>
+      <div className={`text-[13px] font-semibold ${props.ok ? "text-gray-12" : "text-gray-11"}`}>
         {props.value}
       </div>
     </div>
@@ -233,22 +233,22 @@ export function MessagingView(props: MessagingViewProps) {
         </div>
 
         {props.showHeader !== false ? (
-          <p className="text-sm leading-relaxed text-gray-9">{t("identities.subtitle")}</p>
+          <p className="text-sm leading-relaxed text-gray-11">{t("identities.subtitle")}</p>
         ) : null}
 
-        <div className="mt-1.5 break-all font-mono text-[11px] text-gray-8">
+        <div className="mt-1.5 break-all font-mono text-[11px] text-gray-11">
           {t("identities.workspace_scope_prefix")} {workspaceScopeLabel}
         </div>
-        {props.reconnectStatus ? <div className="mt-1 text-[11px] text-gray-9">{props.reconnectStatus}</div> : null}
+        {props.reconnectStatus ? <div className="mt-1 text-[11px] text-gray-11">{props.reconnectStatus}</div> : null}
         {props.reconnectError ? <div className="mt-1 text-[11px] text-red-12">{props.reconnectError}</div> : null}
-        {props.messagingStatus ? <div className="mt-1 text-[11px] text-gray-9">{props.messagingStatus}</div> : null}
+        {props.messagingStatus ? <div className="mt-1 text-[11px] text-gray-11">{props.messagingStatus}</div> : null}
         {props.messagingError ? <div className="mt-1 text-[11px] text-red-12">{props.messagingError}</div> : null}
       </div>
 
       {!serverReady ? (
         <div className="rounded-xl border border-gray-4 bg-gray-1 p-5">
           <div className="text-sm font-semibold text-gray-12">{t("identities.connect_server_title")}</div>
-          <div className="mt-1 text-xs text-gray-10">{t("identities.connect_server_desc")}</div>
+          <div className="mt-1 text-xs text-gray-11">{t("identities.connect_server_desc")}</div>
         </div>
       ) : null}
 
@@ -266,7 +266,7 @@ export function MessagingView(props: MessagingViewProps) {
                 <button
                   type="button"
                   className={`flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
-                    props.activeTab === "general" ? "bg-gray-12 text-gray-1" : "text-gray-10 hover:bg-gray-2"
+                    props.activeTab === "general" ? "bg-gray-12 text-gray-1" : "text-gray-11 hover:bg-gray-2"
                   }`}
                   onClick={() => props.onSelectTab("general")}
                 >
@@ -275,7 +275,7 @@ export function MessagingView(props: MessagingViewProps) {
                 <button
                   type="button"
                   className={`flex-1 rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${
-                    props.activeTab === "advanced" ? "bg-gray-12 text-gray-1" : "text-gray-10 hover:bg-gray-2"
+                    props.activeTab === "advanced" ? "bg-gray-12 text-gray-1" : "text-gray-11 hover:bg-gray-2"
                   }`}
                   onClick={() => props.onSelectTab("advanced")}
                 >
@@ -296,8 +296,8 @@ export function MessagingView(props: MessagingViewProps) {
           {!props.messagingEnabled ? (
             <div className="space-y-3 rounded-xl border border-gray-4 bg-gray-1 px-4 py-4">
               <div className="text-sm font-semibold text-gray-12">{t("identities.messaging_disabled_title")}</div>
-              <p className="text-xs leading-relaxed text-gray-10">{t("identities.messaging_disabled_risk")}</p>
-              <p className="text-xs leading-relaxed text-gray-10">{t("identities.messaging_disabled_hint")}</p>
+              <p className="text-xs leading-relaxed text-gray-11">{t("identities.messaging_disabled_risk")}</p>
+              <p className="text-xs leading-relaxed text-gray-11">{t("identities.messaging_disabled_hint")}</p>
               <div className="flex flex-wrap items-center gap-2">
                 <Button
                   variant="primary"
@@ -314,7 +314,7 @@ export function MessagingView(props: MessagingViewProps) {
           {props.activeTab === "general" && props.messagingEnabled ? (
             <>
               {props.messagingRestartRequired ? (
-                <div className="rounded-xl border border-gray-4 bg-gray-1 px-4 py-3 text-xs leading-relaxed text-gray-10">
+                <div className="rounded-xl border border-gray-4 bg-gray-1 px-4 py-3 text-xs leading-relaxed text-gray-11">
                   {t("identities.messaging_sidecar_not_running")}
                   <div className="mt-3">
                     <Button
@@ -384,7 +384,7 @@ export function MessagingView(props: MessagingViewProps) {
               </div>
 
               <div>
-                <div className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-gray-9">
+                <div className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-gray-11">
                   {t("identities.available_channels")}
                 </div>
 
@@ -409,11 +409,11 @@ export function MessagingView(props: MessagingViewProps) {
                             </span>
                           ) : null}
                         </div>
-                        <div className="mt-0.5 text-[13px] leading-snug text-gray-9">{t("identities.telegram_desc")}</div>
+                        <div className="mt-0.5 text-[13px] leading-snug text-gray-11">{t("identities.telegram_desc")}</div>
                       </div>
                       <ChevronRight
                         size={16}
-                        className={`shrink-0 text-gray-8 transition-transform ${
+                        className={`shrink-0 text-gray-11 transition-transform ${
                           props.expandedChannel === "telegram" ? "rotate-90" : ""
                         }`}
                       />
@@ -444,7 +444,7 @@ export function MessagingView(props: MessagingViewProps) {
                                         <span className="font-mono text-[12px]">{item.id}</span>
                                       </span>
                                     </div>
-                                    <div className="mt-0.5 pl-3.5 text-[11px] text-gray-9">
+                                    <div className="mt-0.5 pl-3.5 text-[11px] text-gray-11">
                                       {item.enabled ? t("identities.enabled_label") : t("identities.disabled_label")} · {item.running ? t("identities.running_label") : t("identities.stopped_label")} · {item.access === "private" ? t("identities.private_label") : t("identities.public_label")}
                                     </div>
                                   </div>
@@ -462,7 +462,7 @@ export function MessagingView(props: MessagingViewProps) {
 
                             <div className="flex gap-2.5">
                               <div className="flex-1 rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2.5">
-                                <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.status_label")}</div>
+                                <div className="mb-0.5 text-[11px] text-gray-11">{t("identities.status_label")}</div>
                                 <div className="flex items-center gap-1.5">
                                   <div
                                     className={`h-1.5 w-1.5 rounded-full ${
@@ -473,7 +473,7 @@ export function MessagingView(props: MessagingViewProps) {
                                     className={`text-[13px] font-semibold ${
                                       props.telegram.identities.some((item) => item.running)
                                         ? "text-emerald-11"
-                                        : "text-gray-10"
+                                        : "text-gray-11"
                                     }`}
                                   >
                                     {props.telegram.identities.some((item) => item.running)
@@ -483,20 +483,20 @@ export function MessagingView(props: MessagingViewProps) {
                                 </div>
                               </div>
                               <div className="flex-1 rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2.5">
-                                <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.identities_label")}</div>
+                                <div className="mb-0.5 text-[11px] text-gray-11">{t("identities.identities_label")}</div>
                                 <div className="text-[13px] font-semibold text-gray-12">
                                   {props.telegram.identities.length} {t("identities.configured_suffix")}
                                 </div>
                               </div>
                               <div className="flex-1 rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2.5">
-                                <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.channel_label")}</div>
+                                <div className="mb-0.5 text-[11px] text-gray-11">{t("identities.channel_label")}</div>
                                 <div className="text-[13px] font-semibold text-gray-12">
                                   {props.health?.channels.telegram ? t("common.on") : t("common.off")}
                                 </div>
                               </div>
                             </div>
 
-                            {props.telegram.status ? <div className="text-[11px] text-gray-9">{props.telegram.status}</div> : null}
+                            {props.telegram.status ? <div className="text-[11px] text-gray-11">{props.telegram.status}</div> : null}
                             {props.telegram.error ? <div className="text-[11px] text-red-12">{props.telegram.error}</div> : null}
                           </>
                         ) : null}
@@ -505,7 +505,7 @@ export function MessagingView(props: MessagingViewProps) {
                           {props.telegram.identities.length === 0 ? (
                             <div className="space-y-2.5 rounded-xl border border-gray-4 bg-gray-2/60 px-3.5 py-3">
                               <div className="text-[12px] font-semibold text-gray-12">{t("identities.quick_setup")}</div>
-                              <ol className="space-y-2 text-[12px] leading-relaxed text-gray-10">
+                              <ol className="space-y-2 text-[12px] leading-relaxed text-gray-11">
                                 <li className="flex items-start gap-2">
                                   <span className="mt-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-gray-4 text-[10px] font-semibold text-gray-11">1</span>
                                   <span>
@@ -551,7 +551,7 @@ export function MessagingView(props: MessagingViewProps) {
                             {t("identities.enabled_label")}
                           </label>
 
-                          <div className="rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2 text-[11px] leading-relaxed text-gray-10">
+                          <div className="rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2 text-[11px] leading-relaxed text-gray-11">
                             {t("identities.telegram_bot_access_desc")}
                           </div>
 
@@ -562,7 +562,7 @@ export function MessagingView(props: MessagingViewProps) {
                               disabled={props.telegram.saving || !scopedWorkspaceReady || !props.telegram.token.trim()}
                               className={`flex items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-semibold transition-colors ${
                                 props.telegram.saving || !scopedWorkspaceReady || !props.telegram.token.trim()
-                                  ? "cursor-not-allowed border-gray-5 bg-gray-3 text-gray-8"
+                                  ? "cursor-not-allowed border-gray-5 bg-gray-3 text-gray-11"
                                   : "cursor-pointer border-gray-6 bg-gray-12 text-gray-1 hover:bg-gray-11"
                               }`}
                             >
@@ -632,7 +632,7 @@ export function MessagingView(props: MessagingViewProps) {
                           ) : null}
 
                           {props.telegram.identities.length === 0 && props.telegram.status ? (
-                            <div className="text-[11px] text-gray-9">{props.telegram.status}</div>
+                            <div className="text-[11px] text-gray-11">{props.telegram.status}</div>
                           ) : null}
                           {props.telegram.identities.length === 0 && props.telegram.error ? (
                             <div className="text-[11px] text-red-12">{props.telegram.error}</div>
@@ -662,11 +662,11 @@ export function MessagingView(props: MessagingViewProps) {
                             </span>
                           ) : null}
                         </div>
-                        <div className="mt-0.5 text-[13px] leading-snug text-gray-9">{t("identities.slack_desc")}</div>
+                        <div className="mt-0.5 text-[13px] leading-snug text-gray-11">{t("identities.slack_desc")}</div>
                       </div>
                       <ChevronRight
                         size={16}
-                        className={`shrink-0 text-gray-8 transition-transform ${
+                        className={`shrink-0 text-gray-11 transition-transform ${
                           props.expandedChannel === "slack" ? "rotate-90" : ""
                         }`}
                       />
@@ -697,7 +697,7 @@ export function MessagingView(props: MessagingViewProps) {
                                         <span className="font-mono text-[12px]">{item.id}</span>
                                       </span>
                                     </div>
-                                    <div className="mt-0.5 pl-3.5 text-[11px] text-gray-9">
+                                    <div className="mt-0.5 pl-3.5 text-[11px] text-gray-11">
                                       {item.enabled ? t("identities.enabled_label") : t("identities.disabled_label")} · {item.running ? t("identities.running_label") : t("identities.stopped_label")}
                                     </div>
                                   </div>
@@ -715,7 +715,7 @@ export function MessagingView(props: MessagingViewProps) {
 
                             <div className="flex gap-2.5">
                               <div className="flex-1 rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2.5">
-                                <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.status_label")}</div>
+                                <div className="mb-0.5 text-[11px] text-gray-11">{t("identities.status_label")}</div>
                                 <div className="flex items-center gap-1.5">
                                   <div
                                     className={`h-1.5 w-1.5 rounded-full ${
@@ -726,7 +726,7 @@ export function MessagingView(props: MessagingViewProps) {
                                     className={`text-[13px] font-semibold ${
                                       props.slack.identities.some((item) => item.running)
                                         ? "text-emerald-11"
-                                        : "text-gray-10"
+                                        : "text-gray-11"
                                     }`}
                                   >
                                     {props.slack.identities.some((item) => item.running)
@@ -736,27 +736,27 @@ export function MessagingView(props: MessagingViewProps) {
                                 </div>
                               </div>
                               <div className="flex-1 rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2.5">
-                                <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.identities_label")}</div>
+                                <div className="mb-0.5 text-[11px] text-gray-11">{t("identities.identities_label")}</div>
                                 <div className="text-[13px] font-semibold text-gray-12">
                                   {props.slack.identities.length} {t("identities.configured_suffix")}
                                 </div>
                               </div>
                               <div className="flex-1 rounded-lg border border-gray-4 bg-gray-2/50 px-3 py-2.5">
-                                <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.channel_label")}</div>
+                                <div className="mb-0.5 text-[11px] text-gray-11">{t("identities.channel_label")}</div>
                                 <div className="text-[13px] font-semibold text-gray-12">
                                   {props.health?.channels.slack ? t("common.on") : t("common.off")}
                                 </div>
                               </div>
                             </div>
 
-                            {props.slack.status ? <div className="text-[11px] text-gray-9">{props.slack.status}</div> : null}
+                            {props.slack.status ? <div className="text-[11px] text-gray-11">{props.slack.status}</div> : null}
                             {props.slack.error ? <div className="text-[11px] text-red-12">{props.slack.error}</div> : null}
                           </>
                         ) : null}
 
                         <div className="space-y-2.5">
                           {props.slack.identities.length === 0 ? (
-                            <p className="text-[13px] leading-relaxed text-gray-10">{t("identities.slack_intro")}</p>
+                            <p className="text-[13px] leading-relaxed text-gray-11">{t("identities.slack_intro")}</p>
                           ) : null}
 
                           <div className="space-y-2">
@@ -807,7 +807,7 @@ export function MessagingView(props: MessagingViewProps) {
                           </button>
 
                           {props.slack.identities.length === 0 && props.slack.status ? (
-                            <div className="text-[11px] text-gray-9">{props.slack.status}</div>
+                            <div className="text-[11px] text-gray-11">{props.slack.status}</div>
                           ) : null}
                           {props.slack.identities.length === 0 && props.slack.error ? (
                             <div className="text-[11px] text-red-12">{props.slack.error}</div>
@@ -824,28 +824,28 @@ export function MessagingView(props: MessagingViewProps) {
           {props.activeTab === "advanced" && props.messagingEnabled ? (
             <>
               <div>
-                <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-gray-9">
+                <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-gray-11">
                   {t("identities.message_routing_title")}
                 </div>
-                <p className="mb-3 text-[13px] leading-relaxed text-gray-9">{t("identities.message_routing_desc")}</p>
+                <p className="mb-3 text-[13px] leading-relaxed text-gray-11">{t("identities.message_routing_desc")}</p>
 
                 <div className="space-y-3 rounded-xl border border-gray-4 bg-gray-2/50 px-4 py-3.5">
                   <div className="flex items-center gap-2">
-                    <Shield size={16} className="text-gray-9" />
+                    <Shield size={16} className="text-gray-11" />
                     <span className="text-[13px] font-medium text-gray-11">{t("identities.default_routing")}</span>
                   </div>
                   <div className="flex items-center gap-2 pl-6">
                     <span className="rounded-md bg-gray-4 px-2.5 py-1 text-[12px] font-medium text-gray-11">
                       {t("identities.all_channels")}
                     </span>
-                    <ArrowRight size={14} className="text-gray-8" />
+                    <ArrowRight size={14} className="text-gray-11" />
                     <span className="rounded-md bg-dls-accent/10 px-2.5 py-1 text-[12px] font-medium text-dls-accent">
                       {defaultRoutingDirectory}
                     </span>
                   </div>
                 </div>
 
-                <div className="mt-2.5 text-xs text-gray-10">
+                <div className="mt-2.5 text-xs text-gray-11">
                   {t("identities.routing_override_prefix")}{" "}
                   <code className="rounded bg-gray-3 px-1 py-0.5 font-mono text-[11px]">/dir &lt;path&gt;</code>{" "}
                   {t("identities.routing_override_suffix")}
@@ -856,15 +856,15 @@ export function MessagingView(props: MessagingViewProps) {
                 <div className="flex items-center justify-between gap-2">
                   <div>
                     <div className="text-[13px] font-semibold text-gray-12">{t("identities.agent_behavior_title")}</div>
-                    <div className="mt-0.5 text-[12px] text-gray-9">{t("identities.agent_behavior_desc")}</div>
+                    <div className="mt-0.5 text-[12px] text-gray-11">{t("identities.agent_behavior_desc")}</div>
                   </div>
-                  <span className="rounded-md border border-gray-4 bg-gray-2/50 px-2 py-1 text-[11px] font-mono text-gray-10">
+                  <span className="rounded-md border border-gray-4 bg-gray-2/50 px-2 py-1 text-[11px] font-mono text-gray-11">
                     {agentFilePath}
                   </span>
                 </div>
 
                 {props.health?.agent ? (
-                  <div className="rounded-lg border border-gray-4 bg-gray-2/40 px-3 py-2 text-[11px] text-gray-10">
+                  <div className="rounded-lg border border-gray-4 bg-gray-2/40 px-3 py-2 text-[11px] text-gray-11">
                     {t("identities.agent_scope_status", undefined, {
                       status: props.health.agent.loaded ? t("identities.agent_status_loaded") : t("identities.agent_status_missing"),
                       agent: props.health.agent.selected || t("identities.agent_none"),
@@ -872,7 +872,7 @@ export function MessagingView(props: MessagingViewProps) {
                   </div>
                 ) : null}
 
-                {props.agent.loading ? <div className="text-[11px] text-gray-9">{t("identities.agent_loading")}</div> : null}
+                {props.agent.loading ? <div className="text-[11px] text-gray-11">{t("identities.agent_loading")}</div> : null}
 
                 {!props.agent.exists && !props.agent.loading ? (
                   <div className="rounded-lg border border-amber-7/20 bg-amber-1/30 px-3 py-2 text-xs text-amber-12">
@@ -915,23 +915,23 @@ export function MessagingView(props: MessagingViewProps) {
                     {props.agent.saving ? t("identities.saving") : t("identities.save_behavior")}
                   </Button>
                   {agentDirty && !props.agent.saving ? (
-                    <span className="text-[11px] text-gray-9">{t("identities.unsaved_changes")}</span>
+                    <span className="text-[11px] text-gray-11">{t("identities.unsaved_changes")}</span>
                   ) : null}
                 </div>
 
-                {props.agent.status ? <div className="text-[11px] text-gray-9">{props.agent.status}</div> : null}
+                {props.agent.status ? <div className="text-[11px] text-gray-11">{props.agent.status}</div> : null}
                 {props.agent.error ? <div className="text-[11px] text-red-12">{props.agent.error}</div> : null}
               </div>
 
               <div className="space-y-3 rounded-xl border border-gray-4 bg-gray-1 p-4">
                 <div>
                   <div className="text-[13px] font-semibold text-gray-12">{t("identities.send_test_title")}</div>
-                  <div className="mt-0.5 text-[12px] text-gray-9">{t("identities.send_test_desc")}</div>
+                  <div className="mt-0.5 text-[12px] text-gray-11">{t("identities.send_test_desc")}</div>
                 </div>
 
                 <div className="grid gap-2 sm:grid-cols-2">
                   <div>
-                    <label className="mb-1 block text-[12px] text-gray-9">{t("identities.channel_label")}</label>
+                    <label className="mb-1 block text-[12px] text-gray-11">{t("identities.channel_label")}</label>
                     <select
                       className="w-full rounded-lg border border-gray-4 bg-gray-1 px-3 py-2 text-sm text-gray-12"
                       value={props.sendTest.channel}
@@ -975,7 +975,7 @@ export function MessagingView(props: MessagingViewProps) {
                 </div>
 
                 <div>
-                  <label className="mb-1 block text-[12px] text-gray-9">{t("identities.message_label")}</label>
+                  <label className="mb-1 block text-[12px] text-gray-11">{t("identities.message_label")}</label>
                   <textarea
                     className="min-h-[90px] w-full rounded-lg border border-gray-4 bg-gray-1 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-8"
                     placeholder={t("identities.send_test_button")}
@@ -993,12 +993,12 @@ export function MessagingView(props: MessagingViewProps) {
                   >
                     {props.sendTest.busy ? t("identities.sending") : t("identities.send_test_button")}
                   </Button>
-                  {props.sendTest.status ? <span className="text-[11px] text-gray-9">{props.sendTest.status}</span> : null}
+                  {props.sendTest.status ? <span className="text-[11px] text-gray-11">{props.sendTest.status}</span> : null}
                 </div>
 
                 {props.sendTest.error ? <div className="text-[11px] text-red-12">{props.sendTest.error}</div> : null}
                 {props.sendTest.result ? (
-                  <div className="space-y-1 rounded-lg border border-gray-4 bg-gray-2/40 px-3 py-2 font-mono text-[11px] text-gray-10">
+                  <div className="space-y-1 rounded-lg border border-gray-4 bg-gray-2/40 px-3 py-2 font-mono text-[11px] text-gray-11">
                     <div>
                       sent={props.sendTest.result.sent} attempted={props.sendTest.result.attempted}
                       {props.sendTest.result.failures?.length ? ` failures=${props.sendTest.result.failures.length}` : ""}

--- a/apps/app/src/react-app/domains/settings/pages/plugins-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/plugins-view.tsx
@@ -64,7 +64,7 @@ export function PluginsView(props: PluginsViewProps) {
             <div className="text-sm font-medium text-gray-12">
               {t("plugins.title")}
             </div>
-            <div className="text-xs text-gray-10">{t("plugins.desc")}</div>
+            <div className="text-xs text-gray-11">{t("plugins.desc")}</div>
           </div>
           <div className="flex items-center gap-2">
             <button
@@ -72,7 +72,7 @@ export function PluginsView(props: PluginsViewProps) {
               className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
                 scope === "project"
                   ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
-                  : "text-gray-10 border-gray-6 hover:text-gray-12"
+                  : "text-gray-11 border-gray-6 hover:text-gray-12"
               }`}
               onClick={() => {
                 extensions.setPluginScope("project");
@@ -87,10 +87,10 @@ export function PluginsView(props: PluginsViewProps) {
               className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
                 scope === "global"
                   ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
-                  : "text-gray-10 border-gray-6 hover:text-gray-12"
+                  : "text-gray-11 border-gray-6 hover:text-gray-12"
               } ${
                 !props.canUseGlobalScope
-                  ? "opacity-40 cursor-not-allowed hover:text-gray-10"
+                  ? "opacity-40 cursor-not-allowed hover:text-gray-11"
                   : ""
               }`}
               onClick={() => {
@@ -110,15 +110,15 @@ export function PluginsView(props: PluginsViewProps) {
           </div>
         </div>
 
-        <div className="flex flex-col gap-1 text-xs text-gray-10">
+        <div className="flex flex-col gap-1 text-xs text-gray-11">
           <div>{t("plugins.config_label")}</div>
-          <div className="text-gray-7 font-mono truncate">
+          <div className="text-gray-11 font-mono truncate">
             {extensions.pluginConfigPath() ??
               extensions.pluginConfig()?.path ??
               t("plugins.not_loaded_yet")}
           </div>
           {props.accessHint ? (
-            <div className="text-gray-9">{props.accessHint}</div>
+            <div className="text-gray-11">{props.accessHint}</div>
           ) : null}
         </div>
 
@@ -146,11 +146,11 @@ export function PluginsView(props: PluginsViewProps) {
                       <div className="text-sm font-medium text-gray-12 font-mono">
                         {plugin.name}
                       </div>
-                      <div className="text-xs text-gray-10 mt-1">
+                      <div className="text-xs text-gray-11 mt-1">
                         {plugin.description}
                       </div>
                       {plugin.packageName !== plugin.name ? (
-                        <div className="text-xs text-gray-7 font-mono mt-1">
+                        <div className="text-xs text-gray-11 font-mono mt-1">
                           {plugin.packageName}
                         </div>
                       ) : null}
@@ -202,7 +202,7 @@ export function PluginsView(props: PluginsViewProps) {
                           <div className="text-xs font-medium text-gray-11">
                             {idx + 1}. {step.title}
                           </div>
-                          <div className="text-xs text-gray-10">
+                          <div className="text-xs text-gray-11">
                             {step.description}
                           </div>
                           {step.command ? (
@@ -211,12 +211,12 @@ export function PluginsView(props: PluginsViewProps) {
                             </div>
                           ) : null}
                           {step.note ? (
-                            <div className="text-xs text-gray-10">
+                            <div className="text-xs text-gray-11">
                               {step.note}
                             </div>
                           ) : null}
                           {step.url ? (
-                            <div className="text-xs text-gray-10">
+                            <div className="text-xs text-gray-11">
                               Open:{" "}
                               <span className="font-mono text-gray-11">
                                 {step.url}
@@ -224,7 +224,7 @@ export function PluginsView(props: PluginsViewProps) {
                             </div>
                           ) : null}
                           {step.path ? (
-                            <div className="text-xs text-gray-10">
+                            <div className="text-xs text-gray-11">
                               Path:{" "}
                               <span className="font-mono text-gray-11">
                                 {step.path}
@@ -242,7 +242,7 @@ export function PluginsView(props: PluginsViewProps) {
         </div>
 
         {extensions.pluginList().length === 0 ? (
-          <div className="rounded-xl border border-gray-6/60 bg-gray-1/40 p-4 text-sm text-gray-10">
+          <div className="rounded-xl border border-gray-6/60 bg-gray-1/40 p-4 text-sm text-gray-11">
             {t("plugins.empty")}
           </div>
         ) : (
@@ -253,11 +253,11 @@ export function PluginsView(props: PluginsViewProps) {
                 className="flex items-center justify-between rounded-xl border border-gray-6/60 bg-gray-1/40 px-4 py-2.5"
               >
                 <div className="text-sm text-gray-12 font-mono flex items-center gap-2">
-                  <Cpu size={14} className="text-gray-10" />
+                  <Cpu size={14} className="text-gray-11" />
                   {pluginName}
                 </div>
                 <div className="flex items-center gap-2">
-                  <div className="text-[10px] uppercase tracking-wide text-gray-10">
+                  <div className="text-[10px] uppercase tracking-wide text-gray-11">
                     {t("plugins.enabled")}
                   </div>
                   <Button
@@ -301,7 +301,7 @@ export function PluginsView(props: PluginsViewProps) {
             </Button>
           </div>
           {extensions.pluginStatus() ? (
-            <div className="text-xs text-gray-10">
+            <div className="text-xs text-gray-11">
               {extensions.pluginStatus()}
             </div>
           ) : null}

--- a/apps/app/src/react-app/domains/settings/pages/recovery-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/recovery-view.tsx
@@ -28,8 +28,8 @@ export function RecoveryView(props: RecoveryViewProps) {
     <div className="space-y-6">
       <div className={`${settingsPanelClass} space-y-3`}>
         <div className="text-sm font-medium text-gray-12">{t("settings.workspace_config_title")}</div>
-        <div className="text-xs text-gray-10">{t("settings.workspace_config_desc")}</div>
-        <div className="break-all font-mono text-[11px] text-gray-7">
+        <div className="text-xs text-gray-11">{t("settings.workspace_config_desc")}</div>
+        <div className="break-all font-mono text-[11px] text-gray-11">
           {props.workspaceConfigPath || t("settings.no_active_workspace")}
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -54,14 +54,14 @@ export function RecoveryView(props: RecoveryViewProps) {
           </Button>
         </div>
         {props.configActionStatus ? (
-          <div className="text-xs text-gray-10">{props.configActionStatus}</div>
+          <div className="text-xs text-gray-11">{props.configActionStatus}</div>
         ) : null}
       </div>
 
       <div className="flex flex-col gap-4 rounded-2xl border border-gray-6/50 bg-gray-2/30 p-4 md:flex-row md:items-center md:justify-between">
         <div className="min-w-0">
           <div className="text-sm text-gray-12">{t("settings.opencode_cache")}</div>
-          <div className="text-xs text-gray-7">{t("settings.opencode_cache_description")}</div>
+          <div className="text-xs text-gray-11">{t("settings.opencode_cache_description")}</div>
           {props.cacheRepairResult ? (
             <div className="mt-2 text-xs text-gray-11">{props.cacheRepairResult}</div>
           ) : null}
@@ -80,7 +80,7 @@ export function RecoveryView(props: RecoveryViewProps) {
       <div className="flex flex-col gap-4 rounded-2xl border border-gray-6/50 bg-gray-2/30 p-4 md:flex-row md:items-center md:justify-between">
         <div className="min-w-0">
           <div className="text-sm text-gray-12">{t("settings.docker_containers_title")}</div>
-          <div className="text-xs text-gray-7">{t("settings.docker_containers_desc")}</div>
+          <div className="text-xs text-gray-11">{t("settings.docker_containers_desc")}</div>
           {props.dockerCleanupResult ? (
             <div className="mt-2 text-xs text-gray-11">{props.dockerCleanupResult}</div>
           ) : null}

--- a/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
@@ -66,9 +66,9 @@ export function UpdatesView(props: UpdatesViewProps) {
         <div className="flex items-start justify-between gap-4">
           <div>
             <div className="text-sm font-medium text-gray-12">{t("settings.updates_title")}</div>
-            <div className="text-xs text-gray-10">{t("settings.updates_desc")}</div>
+            <div className="text-xs text-gray-11">{t("settings.updates_desc")}</div>
           </div>
-          <div className="font-mono text-xs text-gray-7">{props.appVersion ? `v${props.appVersion}` : ""}</div>
+          <div className="font-mono text-xs text-gray-11">{props.appVersion ? `v${props.appVersion}` : ""}</div>
         </div>
 
         {props.webDeployment ? (
@@ -85,7 +85,7 @@ export function UpdatesView(props: UpdatesViewProps) {
               <div className="flex items-center justify-between rounded-xl border border-gray-6 bg-gray-1 p-3">
                 <div className="space-y-0.5">
                   <div className="text-sm text-gray-12">Release channel</div>
-                  <div className="text-xs text-gray-7">
+                  <div className="text-xs text-gray-11">
                     Stable is the default. Alpha auto-updates from every merge to{" "}
                     <code className="rounded bg-gray-2 px-1 py-0.5 text-[11px]">dev</code>{" "}
                     (macOS only).
@@ -101,7 +101,7 @@ export function UpdatesView(props: UpdatesViewProps) {
                         className={`rounded-full px-3 py-1 font-medium transition-colors ${
                           active
                             ? "bg-gray-12/12 text-gray-12 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)]"
-                            : "text-gray-10 hover:bg-gray-2/70 hover:text-gray-12"
+                            : "text-gray-11 hover:bg-gray-2/70 hover:text-gray-12"
                         } ${!props.onReleaseChannelChange ? "cursor-default opacity-70" : ""}`}
                         onClick={() => props.onReleaseChannelChange?.(value)}
                         disabled={!props.onReleaseChannelChange}
@@ -116,14 +116,14 @@ export function UpdatesView(props: UpdatesViewProps) {
             <div className="flex items-center justify-between rounded-xl border border-gray-6 bg-gray-1 p-3">
               <div className="space-y-0.5">
                 <div className="text-sm text-gray-12">{t("settings.background_checks_title")}</div>
-                <div className="text-xs text-gray-7">{t("settings.background_checks_desc")}</div>
+                <div className="text-xs text-gray-11">{t("settings.background_checks_desc")}</div>
               </div>
               <button
                 type="button"
                 className={`min-w-[70px] rounded-full border px-4 py-1.5 text-xs font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition-colors ${
                   props.updateAutoCheck
                     ? "border-gray-6/30 bg-gray-12/12 text-gray-12"
-                    : "border-gray-6/60 bg-gray-1/70 text-gray-10 hover:bg-gray-2/70 hover:text-gray-12"
+                    : "border-gray-6/60 bg-gray-1/70 text-gray-11 hover:bg-gray-2/70 hover:text-gray-12"
                 }`}
                 onClick={props.toggleUpdateAutoCheck}
               >
@@ -134,14 +134,14 @@ export function UpdatesView(props: UpdatesViewProps) {
             <div className="flex items-center justify-between rounded-xl border border-gray-6 bg-gray-1 p-3">
               <div className="space-y-0.5">
                 <div className="text-sm text-gray-12">{t("settings.auto_update_title")}</div>
-                <div className="text-xs text-gray-7">{t("settings.auto_update_desc")}</div>
+                <div className="text-xs text-gray-11">{t("settings.auto_update_desc")}</div>
               </div>
               <button
                 type="button"
                 className={`min-w-[70px] rounded-full border px-4 py-1.5 text-xs font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition-colors ${
                   props.updateAutoDownload
                     ? "border-gray-6/30 bg-gray-12/12 text-gray-12"
-                    : "border-gray-6/60 bg-gray-1/70 text-gray-10 hover:bg-gray-2/70 hover:text-gray-12"
+                    : "border-gray-6/60 bg-gray-1/70 text-gray-11 hover:bg-gray-2/70 hover:text-gray-12"
                 }`}
                 onClick={props.toggleUpdateAutoDownload}
               >
@@ -167,7 +167,7 @@ export function UpdatesView(props: UpdatesViewProps) {
                   </div>
 
                   {updateState === "idle" && updateLastCheckedAt ? (
-                    <div className="text-xs text-gray-7">
+                    <div className="text-xs text-gray-11">
                       {t("settings.update_last_checked", undefined, {
                         time: formatRelativeTime(updateLastCheckedAt),
                       })}
@@ -175,13 +175,13 @@ export function UpdatesView(props: UpdatesViewProps) {
                   ) : null}
 
                   {updateState === "available" && updateDate ? (
-                    <div className="text-xs text-gray-7">
+                    <div className="text-xs text-gray-11">
                       {t("settings.update_published", undefined, { date: updateDate })}
                     </div>
                   ) : null}
 
                   {updateState === "downloading" ? (
-                    <div className="text-xs text-gray-7">
+                    <div className="text-xs text-gray-11">
                       {formatBytes(updateDownloadedBytes ?? 0)}
                       {updateTotalBytes != null ? ` / ${formatBytes(updateTotalBytes)}` : ""}
                     </div>

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -297,22 +297,22 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
     <div className={`${panelClass} space-y-4`}>
       <div className="space-y-1">
         <div className="flex items-center gap-2 text-sm font-semibold text-gray-12">
-          <FolderLock size={16} className="text-gray-10" />
+          <FolderLock size={16} className="text-gray-11" />
           {t("context_panel.authorized_folders")}
         </div>
-        <div className="max-w-[65ch] text-xs leading-relaxed text-gray-9">
+        <div className="max-w-[65ch] text-xs leading-relaxed text-gray-11">
           {t("context_panel.authorized_folders_desc")}
         </div>
       </div>
 
       {!canReadConfig ? (
-        <div className={`${softPanelClass} px-3 py-3 text-xs text-gray-10`}>
+        <div className={`${softPanelClass} px-3 py-3 text-xs text-gray-11`}>
           {authorizedFoldersHint ?? t("context_panel.authorized_folders_no_access")}
         </div>
       ) : (
         <div className="flex flex-col overflow-hidden rounded-xl border border-gray-5/60 bg-gray-1/50 shadow-sm">
           {authorizedFoldersHint ? (
-            <div className="border-b border-gray-5/40 bg-gray-2/60 px-3 py-2 text-[11px] text-gray-10">
+            <div className="border-b border-gray-5/40 bg-gray-2/60 px-3 py-2 text-[11px] text-gray-11">
               {authorizedFoldersHint}
             </div>
           ) : null}
@@ -342,7 +342,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                             </span>
                           ) : null}
                         </div>
-                        <span className="truncate font-mono text-[10px] text-gray-8">{folder}</span>
+                        <span className="truncate font-mono text-[10px] text-gray-11">{folder}</span>
                       </div>
                     </div>
                     {!isWorkspaceRoot ? (
@@ -356,7 +356,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                         <X size={16} className="text-current" />
                       </Button>
                     ) : (
-                      <span className="shrink-0 text-[10px] font-medium text-gray-8">
+                      <span className="shrink-0 text-[10px] font-medium text-gray-11">
                         {t("context_panel.always_available")}
                       </span>
                     )}
@@ -370,7 +370,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                 <Folder size={20} />
               </div>
               <div className="text-sm font-medium text-gray-11">{t("context_panel.no_external_folders")}</div>
-              <div className="mt-1 max-w-[40ch] text-[11px] text-gray-9">
+              <div className="mt-1 max-w-[40ch] text-[11px] text-gray-11">
                 {t("context_panel.add_folder_hint")}
               </div>
             </div>

--- a/apps/app/src/react-app/domains/settings/panels/den-settings-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/den-settings-panel.tsx
@@ -1377,7 +1377,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
 
           {authError ? <div className={errorBannerClass}>{authError}</div> : null}
 
-          <div className={`${settingsPanelSoftClass} text-sm text-gray-10`}>
+          <div className={`${settingsPanelSoftClass} text-sm text-gray-11`}>
             {tr("den.auto_reconnect_hint")}
           </div>
         </div>

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -97,7 +97,7 @@ export function SettingsPage(props: SettingsPageProps) {
     <section className="space-y-6 md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-8 md:space-y-0">
       <aside className="space-y-6 md:sticky md:top-4 md:self-start">
         <div className={settingsRailClass}>
-          <div className="mb-2 px-2 text-[11px] font-medium uppercase tracking-[0.18em] text-gray-8">
+          <div className="mb-2 px-2 text-[11px] font-medium uppercase tracking-[0.18em] text-gray-11">
             {t("settings.group_workspace")}
           </div>
           <div className="space-y-1">
@@ -108,7 +108,7 @@ export function SettingsPage(props: SettingsPageProps) {
                 className={`flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-[13px] font-medium transition-colors ${
                   props.activeTab === tab
                     ? "bg-dls-surface text-dls-text shadow-sm"
-                    : "text-gray-10 hover:bg-dls-surface/50 hover:text-dls-text"
+                    : "text-gray-11 hover:bg-dls-surface/50 hover:text-dls-text"
                 }`}
                 onClick={() => props.onSelectTab(tab)}
               >
@@ -119,7 +119,7 @@ export function SettingsPage(props: SettingsPageProps) {
         </div>
 
         <div className={settingsRailClass}>
-          <div className="mb-2 px-2 text-[11px] font-medium uppercase tracking-[0.18em] text-gray-8">
+          <div className="mb-2 px-2 text-[11px] font-medium uppercase tracking-[0.18em] text-gray-11">
             {t("settings.group_global")}
           </div>
           <div className="space-y-1">
@@ -130,7 +130,7 @@ export function SettingsPage(props: SettingsPageProps) {
                 className={`flex w-full items-center justify-between rounded-xl px-3 py-2.5 text-left text-[13px] font-medium transition-colors ${
                   props.activeTab === tab
                     ? "bg-dls-surface text-dls-text shadow-sm"
-                    : "text-gray-10 hover:bg-dls-surface/50 hover:text-dls-text"
+                    : "text-gray-11 hover:bg-dls-surface/50 hover:text-dls-text"
                 }`}
                 onClick={() => props.onSelectTab(tab)}
               >
@@ -147,7 +147,7 @@ export function SettingsPage(props: SettingsPageProps) {
             <h2 className="text-lg font-semibold tracking-tight text-gray-12">
               {getSettingsTabLabel(props.activeTab)}
             </h2>
-            <p className="text-sm text-gray-9">
+            <p className="text-sm text-gray-11">
               {getSettingsTabDescription(props.activeTab)}
             </p>
           </div>

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -69,10 +69,10 @@ export function SettingsShell(props: SettingsShellProps) {
                   </span>
                 ) : null}
               </div>
-              <div className="flex items-center text-gray-10">
+              <div className="flex items-center text-gray-11">
                 <button
                   type="button"
-                  className="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
+                  className="flex h-9 w-9 items-center justify-center rounded-md text-gray-11 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
                   onClick={props.onClose}
                   title={t("dashboard.close_settings")}
                   aria-label={t("dashboard.close_settings")}

--- a/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
@@ -115,7 +115,7 @@ export function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
               </div>
 
               {bodyHasContent ? (
-                <div className="mt-1 space-y-1 text-sm leading-relaxed text-gray-10">
+                <div className="mt-1 space-y-1 text-sm leading-relaxed text-gray-11">
                   <div>
                     {props.hasActiveRuns ? (
                       <span className="font-medium text-amber-11">
@@ -136,7 +136,7 @@ export function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
                     </div>
                   ) : null}
                   {props.blockedReason ? (
-                    <div className="text-xs text-gray-9">
+                    <div className="text-xs text-gray-11">
                       Blocked: {props.blockedReason}
                     </div>
                   ) : null}
@@ -147,7 +147,7 @@ export function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
             <button
               type="button"
               onClick={() => props.onDismiss()}
-              className="rounded-full p-1 text-gray-9 transition hover:bg-gray-3 hover:text-gray-12"
+              className="rounded-full p-1 text-gray-11 transition hover:bg-gray-3 hover:text-gray-12"
               aria-label={props.dismissLabel}
             >
               <X size={16} />

--- a/apps/app/src/react-app/domains/shell-feedback/status-toast.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/status-toast.tsx
@@ -50,7 +50,7 @@ export function StatusToast(props: StatusToastProps) {
                 {props.title}
               </div>
               {props.description?.trim() ? (
-                <p className="mt-1 text-sm leading-relaxed text-gray-10">
+                <p className="mt-1 text-sm leading-relaxed text-gray-11">
                   {props.description}
                 </p>
               ) : null}
@@ -59,7 +59,7 @@ export function StatusToast(props: StatusToastProps) {
             <button
               type="button"
               onClick={props.onDismiss}
-              className="rounded-full p-1 text-gray-9 transition hover:bg-gray-3 hover:text-gray-12"
+              className="rounded-full p-1 text-gray-11 transition hover:bg-gray-3 hover:text-gray-12"
               aria-label={props.dismissLabel ?? "Dismiss"}
             >
               <X size={16} />

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -302,7 +302,7 @@ function applyThemeMode(mode: PersistedThemeMode) {
 
 function PlaceholderSettingsView(props: { title: string; detail: string }) {
   return (
-    <div className="rounded-[28px] border border-dls-border bg-dls-surface p-5 text-sm text-gray-10 md:p-6">
+    <div className="rounded-[28px] border border-dls-border bg-dls-surface p-5 text-sm text-gray-11 md:p-6">
       <div className="font-medium text-gray-12">{props.title}</div>
       <div className="mt-2 leading-relaxed">{props.detail}</div>
     </div>


### PR DESCRIPTION
## Summary
Raise text contrast across the app so agents and humans can both read it.

Agents drive OpenWork through screenshots and vision models; text that's borderline for a person is often unreadable to OCR. Most of the failures share one root cause: Radix gray steps 7–10 are designed for solid fills and borders, not text, and they're used as text in 363 spots across 28 files.

### Contrast of `text-gray-N` as body text (AA floor = 4.5:1)

| Token | Light / surface | Light / sidebar | Dark / surface | Dark / sidebar |
|---|---|---|---|---|
| `text-gray-7` | 1.57 ❌ | 1.51 ❌ | 2.05 ❌ | 1.90 ❌ |
| `text-gray-8` | 1.92 ❌ | 1.84 ❌ | 2.98 ❌ | 2.77 ❌ |
| `text-gray-9` | 3.32 ❌ | 3.18 ❌ | 3.67 ❌ | 3.41 ❌ |
| `text-gray-10` | 3.79 ❌ | 3.63 ❌ | 4.43 ❌ | 4.11 ❌ |
| `text-gray-11` | 5.92 ✅ | 5.66 ✅ | 9.04 ✅ | 8.39 ✅ |

## Changes
- Sweep `text-gray-(7|8|9|10)` → `text-gray-11` across `apps/app/src` (363 occurrences, 28 files). `placeholder:text-gray-*` preserved.
- `apps/app/src/app/index.css` token values:
  - Light `--dls-text-secondary`: `#6b7280` → `#4b5563` (lifts `text-dls-secondary` above AA on `bg-dls-hover`/`bg-dls-active`, which were 4.39:1 / 4.30:1).
  - Dark `--dls-text-secondary`: `#9ca3af` → `#c9c9c9` (7.38 → 11.31).
  - Dark `--dls-accent`: `#3b82f6` → `#2563eb` and `--dls-accent-hover`: `#2563eb` → `#1d4ed8` (white-on-primary-button 3.68 → 5.17).
- `settings/pages/general-view.tsx` feedback card: "Send feedback" button `bg-blue-9 text-blue-1` → `bg-dls-accent text-white` (3.20 → 18.33 in light mode; Radix blue-9/10 can't hit AA with light text in light mode). "We read every message" badge `text-blue-11` → `text-blue-12`.

## Testing
`pnpm --filter @openwork/app typecheck` clean. Automated contrast scan across 7 settings pages × both themes: 0 AA failures.