### PR TITLE
fix(desktop): buffer native deep links until web bridge is ready

### DIFF
--- a/apps/app/src/app/lib/desktop-tauri.ts
+++ b/apps/app/src/app/lib/desktop-tauri.ts
@@ -51,30 +51,41 @@ export async function setDesktopZoomFactor(value: number): Promise<boolean> {
 export async function subscribeDesktopDeepLinks(
   handler: (urls: string[]) => void,
 ): Promise<() => void> {
-  const [{ getCurrent, onOpenUrl }, { listen }] = await Promise.all([
+  const [{ getCurrent, onOpenUrl }, { listen }, { invoke }] = await Promise.all([
     import("@tauri-apps/plugin-deep-link"),
     import("@tauri-apps/api/event"),
+    import("@tauri-apps/api/core"),
   ]);
 
-  const startUrls = await getCurrent().catch(() => null);
-  if (Array.isArray(startUrls)) {
-    handler(startUrls);
-  }
-
-  const deepLinkUnlisten = await onOpenUrl((urls) => {
-    handler(urls);
-  }).catch(() => () => undefined);
-
-  const eventUnlisten = await listen<string[]>(nativeDeepLinkEvent, (event) => {
-    if (Array.isArray(event.payload)) {
-      handler(event.payload);
+  let deepLinkUnlisten: (() => void) | undefined;
+  let eventUnlisten: (() => void) | undefined;
+  try {
+    const startUrls = await getCurrent().catch(() => null);
+    if (Array.isArray(startUrls)) {
+      handler(startUrls);
     }
-  }).catch(() => () => undefined);
 
-  return () => {
-    void deepLinkUnlisten();
-    void eventUnlisten();
-  };
+    deepLinkUnlisten = await onOpenUrl((urls) => {
+      handler(urls);
+    }).catch(() => () => undefined);
+
+    eventUnlisten = await listen<string[]>(nativeDeepLinkEvent, (event) => {
+      if (Array.isArray(event.payload)) {
+        handler(event.payload);
+      }
+    }).catch(() => () => undefined);
+
+    return () => {
+      void deepLinkUnlisten?.();
+      void eventUnlisten?.();
+    };
+  } finally {
+    try {
+      await invoke("set_native_deep_link_bridge_ready");
+    } catch {
+      // Best-effort: the shell still delivers URLs via the deep-link plugin after this.
+    }
+  }
 }
 
 export type EngineInfo = {

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "Default OpenWork capability (UI permissions)",
   "windows": ["*"],
   "permissions": [
+    "openwork:allow-set-native-deep-link-bridge-ready",
     "core:default",
     "core:webview:allow-set-webview-zoom",
     "deep-link:default",

--- a/apps/desktop/src-tauri/permissions/allow-set-native-deep-link-bridge-ready.toml
+++ b/apps/desktop/src-tauri/permissions/allow-set-native-deep-link-bridge-ready.toml
@@ -1,0 +1,6 @@
+[[permission]]
+identifier = "allow-set-native-deep-link-bridge-ready"
+description = "Enables the front-end to flush native OpenWork handoff deep links that arrived before the web deep-link bridge subscribed."
+commands.allow = [
+  "set_native_deep_link_bridge_ready",
+]

--- a/apps/desktop/src-tauri/src/commands/deep_link.rs
+++ b/apps/desktop/src-tauri/src/commands/deep_link.rs
@@ -1,0 +1,33 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter};
+
+const NATIVE_DEEP_LINK_EVENT: &str = "openwork:deep-link-native";
+
+static NATIVE_DEEPLINK_WEB_READY: AtomicBool = AtomicBool::new(false);
+static PENDING_NATIVE_DEEPLINKS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+pub fn emit_native(app: &AppHandle, urls: Vec<String>) {
+    if urls.is_empty() {
+        return;
+    }
+    if NATIVE_DEEPLINK_WEB_READY.load(Ordering::SeqCst) {
+        let _ = app.emit(NATIVE_DEEP_LINK_EVENT, urls);
+        return;
+    }
+    if let Ok(mut list) = PENDING_NATIVE_DEEPLINKS.lock() {
+        list.extend(urls);
+    }
+}
+
+#[tauri::command]
+pub fn set_native_deep_link_bridge_ready(app: AppHandle) {
+    NATIVE_DEEPLINK_WEB_READY.store(true, Ordering::SeqCst);
+    let mut flush: Vec<String> = Vec::new();
+    if let Ok(mut list) = PENDING_NATIVE_DEEPLINKS.lock() {
+        std::mem::swap(&mut flush, &mut *list);
+    }
+    if !flush.is_empty() {
+        let _ = app.emit(NATIVE_DEEP_LINK_EVENT, flush);
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod command_files;
 pub mod config;
+pub mod deep_link;
 pub mod desktop_bootstrap;
 pub mod engine;
 pub mod migration;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ use commands::command_files::{
     opencode_command_delete, opencode_command_list, opencode_command_write,
 };
 use commands::config::{read_opencode_config, write_opencode_config};
+use commands::deep_link;
 use commands::desktop_bootstrap::{get_desktop_bootstrap_config, set_desktop_bootstrap_config};
 use commands::engine::{
     engine_doctor, engine_info, engine_install, engine_restart, engine_start, engine_stop,
@@ -56,10 +57,8 @@ use engine::manager::EngineManager;
 use opencode_router::manager::OpenCodeRouterManager;
 use openwork_server::manager::OpenworkServerManager;
 use orchestrator::manager::OrchestratorManager;
-use tauri::{AppHandle, Emitter, Manager, RunEvent, WindowEvent};
+use tauri::{AppHandle, Manager, RunEvent, WindowEvent};
 use workspace::watch::WorkspaceWatchState;
-
-const NATIVE_DEEP_LINK_EVENT: &str = "openwork:deep-link-native";
 
 #[cfg(target_os = "macos")]
 fn set_dev_app_name() {
@@ -96,17 +95,10 @@ fn forwarded_deep_links(args: &[String]) -> Vec<String> {
         .collect()
 }
 
-fn emit_native_deep_links(app_handle: &AppHandle, urls: Vec<String>) {
-    if urls.is_empty() {
-        return;
-    }
-
-    let _ = app_handle.emit(NATIVE_DEEP_LINK_EVENT, urls);
-}
 
 fn emit_forwarded_deep_links(app_handle: &AppHandle, args: &[String]) {
     let urls = forwarded_deep_links(args);
-    emit_native_deep_links(app_handle, urls);
+    deep_link::emit_native(app_handle, urls);
 }
 
 fn show_main_window(app_handle: &AppHandle) {
@@ -160,6 +152,7 @@ pub fn run() {
         .manage(OpenCodeRouterManager::default())
         .manage(WorkspaceWatchState::default())
         .invoke_handler(tauri::generate_handler![
+            deep_link::set_native_deep_link_bridge_ready,
             engine_start,
             engine_stop,
             engine_info,
@@ -246,7 +239,7 @@ pub fn run() {
                 .map(|url| url.to_string())
                 .collect::<Vec<_>>();
             show_main_window(&app_handle);
-            emit_native_deep_links(&app_handle, urls);
+            deep_link::emit_native(&app_handle, urls);
         }
         // Always raise/refocus the main window on dock-icon clicks, even if
         // it's already visible but behind other apps or on another Space.


### PR DESCRIPTION
### summary

- Fix first-install cloud sign-in: native openwork:// handoff was emitted before the webview listened; buffer until the bridge is ready, then flush.

### Why
- Event could be dropped; restart often worked.

### Issue
Closes : #1467

### Scope
- Tauri: queue + set_native_deep_link_bridge_ready, emit wiring, one permission.
- desktop-tauri.ts: invoke in subscribeDesktopDeepLinks finally.


### Manual verification
- Fresh install / signed out, sign in to cloud, finish OAuth.
- App shows signed in without relaunch.

### Risk
- Low; wrong ACL could block invoke (check local cargo tauri build).