### PR TITLE
feat: add workspace import previews

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -202,6 +202,25 @@ export type OpenworkWorkspaceExport = {
   files?: Array<{ path: string; content: string }>;
 };
 
+export type OpenworkWorkspaceImportChange = {
+  kind: "opencode" | "openwork" | "skill" | "command" | "file";
+  action: "create" | "update" | "replace" | "delete" | "unchanged";
+  label: string;
+  path: string;
+};
+
+export type OpenworkWorkspaceImportPreview = {
+  summary: {
+    total: number;
+    create: number;
+    update: number;
+    replace: number;
+    delete: number;
+    unchanged: number;
+  };
+  changes: OpenworkWorkspaceImportChange[];
+};
+
 export type OpenworkWorkspaceExportSensitiveMode = "auto" | "include" | "exclude";
 
 export type OpenworkWorkspaceExportWarning = {
@@ -859,13 +878,25 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
       });
     },
     importWorkspace: (workspaceId: string, payload: Record<string, unknown>) =>
-      requestJson<{ ok: boolean }>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/import`, {
+      requestJson<{ ok: boolean; preview?: OpenworkWorkspaceImportPreview }>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/import`, {
         token,
         hostToken,
         method: "POST",
         body: payload,
         timeoutMs: timeouts.workspaceImport,
       }),
+    previewWorkspaceImport: (workspaceId: string, payload: Record<string, unknown>) =>
+      requestJson<OpenworkWorkspaceImportPreview>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/import/preview`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: payload,
+          timeoutMs: timeouts.workspaceImport,
+        },
+      ),
     materializeBlueprintSessions: (workspaceId: string) =>
       requestJson<OpenworkBlueprintSessionsMaterializeResult>(
         baseUrl,

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -210,6 +210,7 @@ export type OpenworkWorkspaceImportChange = {
 };
 
 export type OpenworkWorkspaceImportPreview = {
+  fingerprint: string;
   summary: {
     total: number;
     create: number;

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -99,6 +99,7 @@ Sandbox advertisement (for capability discovery):
 - `DELETE /workspace/:id/commands/:name`
 - `GET /workspace/:id/audit`
 - `GET /workspace/:id/export`
+- `POST /workspace/:id/import/preview`
 - `POST /workspace/:id/import`
 
 Token management (host/owner auth):

--- a/apps/server/src/commands.ts
+++ b/apps/server/src/commands.ts
@@ -65,10 +65,16 @@ export async function listCommands(workspaceRoot: string, scope: "workspace" | "
   return listCommandsInDir(projectCommandsDir(workspaceRoot), "workspace");
 }
 
-export async function upsertCommand(
-  workspaceRoot: string,
-  payload: { name: string; description?: string; template: string; agent?: string; model?: string | null; subtask?: boolean },
-): Promise<string> {
+export type UpsertCommandPayload = {
+  name: string;
+  description?: string;
+  template: string;
+  agent?: string;
+  model?: string | null;
+  subtask?: boolean;
+};
+
+export function buildCommandContent(payload: UpsertCommandPayload): { name: string; content: string } {
   if (!payload.template || payload.template.trim().length === 0) {
     throw new ApiError(400, "invalid_command_template", "Command template is required");
   }
@@ -82,10 +88,18 @@ export async function upsertCommand(
     subtask: payload.subtask ?? false,
   }));
   const content = frontmatter + "\n" + payload.template.trim() + "\n";
+  return { name: sanitized, content };
+}
+
+export async function upsertCommand(
+  workspaceRoot: string,
+  payload: UpsertCommandPayload,
+): Promise<string> {
+  const command = buildCommandContent(payload);
   const dir = projectCommandsDir(workspaceRoot);
   await mkdir(dir, { recursive: true });
-  const path = join(dir, `${sanitized}.md`);
-  await writeFile(path, content, "utf8");
+  const path = join(dir, `${command.name}.md`);
+  await writeFile(path, command.content, "utf8");
   return path;
 }
 

--- a/apps/server/src/portable-files.ts
+++ b/apps/server/src/portable-files.ts
@@ -114,6 +114,23 @@ async function walkPortableFiles(root: string, currentPath: string, output: Port
   }
 }
 
+async function walkPortableFilePaths(root: string, currentPath: string, output: string[]): Promise<void> {
+  const entries = await readdir(currentPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const absolutePath = join(currentPath, entry.name);
+    if (entry.isDirectory()) {
+      await walkPortableFilePaths(root, absolutePath, output);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+
+    const relativePath = normalizePortablePath(absolutePath.slice(root.length + 1));
+    if (!isAllowedPortableFilePath(relativePath)) continue;
+    output.push(relativePath);
+  }
+}
+
 export async function listPortableFiles(workspaceRoot: string): Promise<PortableFile[]> {
   const root = resolve(workspaceRoot);
   const portableRoot = join(root, ".opencode");
@@ -122,6 +139,17 @@ export async function listPortableFiles(workspaceRoot: string): Promise<Portable
   const output: PortableFile[] = [];
   await walkPortableFiles(root, portableRoot, output);
   output.sort((a, b) => a.path.localeCompare(b.path));
+  return output;
+}
+
+export async function listPortableFilePaths(workspaceRoot: string): Promise<string[]> {
+  const root = resolve(workspaceRoot);
+  const portableRoot = join(root, ".opencode");
+  if (!(await exists(portableRoot))) return [];
+
+  const output: string[] = [];
+  await walkPortableFilePaths(root, portableRoot, output);
+  output.sort((a, b) => a.localeCompare(b));
   return output;
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3428,6 +3428,11 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
   }
 
   if (input.skills.length > 0) {
+    for (const skill of input.skills) {
+      const path = workspaceImportRelativePath(workspace, join(projectSkillsDir(workspace.path), skill.name, "SKILL.md"));
+      if (!changedPath("skill", path)) continue;
+      await upsertSkill(workspace.path, skill);
+    }
     if (input.modes.skills === "replace") {
       for (const change of preview.changes) {
         if (change.kind === "skill" && change.action === "delete") {
@@ -3435,14 +3440,14 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
         }
       }
     }
-    for (const skill of input.skills) {
-      const path = workspaceImportRelativePath(workspace, join(projectSkillsDir(workspace.path), skill.name, "SKILL.md"));
-      if (!changedPath("skill", path)) continue;
-      await upsertSkill(workspace.path, skill);
-    }
   }
 
   if (input.commands.length > 0) {
+    for (const command of input.commands) {
+      const path = workspaceImportRelativePath(workspace, join(projectCommandsDir(workspace.path), `${command.name}.md`));
+      if (!changedPath("command", path)) continue;
+      await upsertCommand(workspace.path, command);
+    }
     if (input.modes.commands === "replace") {
       for (const change of preview.changes) {
         if (change.kind === "command" && change.action === "delete") {
@@ -3450,26 +3455,21 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
         }
       }
     }
-    for (const command of input.commands) {
-      const path = workspaceImportRelativePath(workspace, join(projectCommandsDir(workspace.path), `${command.name}.md`));
-      if (!changedPath("command", path)) continue;
-      await upsertCommand(workspace.path, command);
-    }
   }
 
   if (input.files.length > 0) {
+    for (const file of input.files) {
+      if (!changedPath("file", file.path)) continue;
+      const path = join(workspace.path, file.path);
+      await ensureDir(dirname(path));
+      await writeFile(path, file.content, "utf8");
+    }
     if (input.modes.files === "replace") {
       for (const change of preview.changes) {
         if (change.kind === "file" && change.action === "delete") {
           await rm(change.absolutePath, { force: true });
         }
       }
-    }
-    for (const file of input.files) {
-      if (!changedPath("file", file.path)) continue;
-      const path = join(workspace.path, file.path);
-      await ensureDir(dirname(path));
-      await writeFile(path, file.content, "utf8");
     }
   }
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2821,8 +2821,19 @@ function createRoutes(
     requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
-    const preview = await buildWorkspaceImportPreview(workspace.path, body);
     const expectedFingerprint = parseWorkspaceImportPreviewFingerprint(body);
+    const preview = await buildWorkspaceImportPreview(workspace.path, body);
+    if (expectedFingerprint && expectedFingerprint !== preview.fingerprint) {
+      return jsonResponse(
+        {
+          ok: false,
+          code: "workspace_import_preview_stale",
+          message: "Workspace changed after this import was previewed. Review the latest preview before importing.",
+          preview: publicWorkspaceImportPreview(preview),
+        },
+        409,
+      );
+    }
     const approvalPaths = workspaceImportPreviewApprovalPaths(preview);
     if (approvalPaths.length === 0) {
       return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(preview) });
@@ -2838,35 +2849,36 @@ function createRoutes(
         409,
       );
     }
-    if (expectedFingerprint !== preview.fingerprint) {
-      return jsonResponse(
-        {
-          ok: false,
-          code: "workspace_import_preview_stale",
-          message: "Workspace changed after this import was previewed. Review the latest preview before importing.",
-          preview: publicWorkspaceImportPreview(preview),
-        },
-        409,
-      );
-    }
     await requireApproval(ctx, {
       workspaceId: workspace.id,
       action: "config.import",
       summary: summarizeWorkspaceImportPreview(preview),
       paths: approvalPaths,
     });
-    await importWorkspace(workspace, body, preview);
+    const latestPreview = await buildWorkspaceImportPreview(workspace.path, body);
+    if (latestPreview.fingerprint !== expectedFingerprint) {
+      return jsonResponse(
+        {
+          ok: false,
+          code: "workspace_import_preview_stale",
+          message: "Workspace changed after this import was previewed. Review the latest preview before importing.",
+          preview: publicWorkspaceImportPreview(latestPreview),
+        },
+        409,
+      );
+    }
+    await importWorkspace(workspace, body, latestPreview);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
       actor: ctx.actor ?? { type: "remote" },
       action: "config.import",
       target: "workspace",
-      summary: summarizeWorkspaceImportApplied(preview),
+      summary: summarizeWorkspaceImportApplied(latestPreview),
       timestamp: Date.now(),
     });
     emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
-    return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(preview) });
+    return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(latestPreview) });
   });
 
   addRoute(routes, "POST", "/workspace/:id/blueprint/sessions/materialize", "client", async (ctx) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2822,9 +2822,32 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const preview = await buildWorkspaceImportPreview(workspace.path, body);
+    const expectedFingerprint = parseWorkspaceImportPreviewFingerprint(body);
     const approvalPaths = workspaceImportPreviewApprovalPaths(preview);
     if (approvalPaths.length === 0) {
       return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(preview) });
+    }
+    if (!expectedFingerprint) {
+      return jsonResponse(
+        {
+          ok: false,
+          code: "workspace_import_preview_required",
+          message: "Review this import preview before applying workspace changes.",
+          preview: publicWorkspaceImportPreview(preview),
+        },
+        409,
+      );
+    }
+    if (expectedFingerprint !== preview.fingerprint) {
+      return jsonResponse(
+        {
+          ok: false,
+          code: "workspace_import_preview_stale",
+          message: "Workspace changed after this import was previewed. Review the latest preview before importing.",
+          preview: publicWorkspaceImportPreview(preview),
+        },
+        409,
+      );
     }
     await requireApproval(ctx, {
       workspaceId: workspace.id,
@@ -3392,6 +3415,19 @@ function parseWorkspaceExportSensitiveMode(input: string | null): WorkspaceExpor
   throw new ApiError(400, "invalid_workspace_export_sensitive_mode", `Invalid workspace export sensitive mode: ${trimmed}`);
 }
 
+function parseWorkspaceImportPreviewFingerprint(payload: Record<string, unknown>): string | null {
+  const value = payload.previewFingerprint;
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") {
+    throw new ApiError(
+      400,
+      "invalid_workspace_import_preview_fingerprint",
+      "Workspace import preview fingerprint must be a string",
+    );
+  }
+  return value;
+}
+
 function workspaceImportRelativePath(workspace: WorkspaceInfo, path: string): string {
   return relative(workspace.path, path).replaceAll("\\", "/");
 }
@@ -3427,7 +3463,7 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
     }
   }
 
-  if (input.skills.length > 0) {
+  if (input.sections.skills) {
     for (const skill of input.skills) {
       const path = workspaceImportRelativePath(workspace, join(projectSkillsDir(workspace.path), skill.name, "SKILL.md"));
       if (!changedPath("skill", path)) continue;
@@ -3442,7 +3478,7 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
     }
   }
 
-  if (input.commands.length > 0) {
+  if (input.sections.commands) {
     for (const command of input.commands) {
       const path = workspaceImportRelativePath(workspace, join(projectCommandsDir(workspace.path), `${command.name}.md`));
       if (!changedPath("command", path)) continue;
@@ -3457,7 +3493,7 @@ async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string,
     }
   }
 
-  if (input.files.length > 0) {
+  if (input.sections.files) {
     for (const file of input.files) {
       if (!changedPath("file", file.path)) continue;
       const path = join(workspace.path, file.path);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -15,7 +15,6 @@ import { readJsoncFile, updateJsoncPath, updateJsoncTopLevel, writeJsoncFile } f
 import { recordAudit, readAuditEntries, readLastAudit } from "./audit.js";
 import { ReloadEventStore } from "./events.js";
 import { startReloadWatchers } from "./reload-watcher.js";
-import { parseFrontmatter } from "./frontmatter.js";
 import { opencodeConfigPath, openworkConfigPath, projectCommandsDir, projectSkillsDir } from "./workspace-files.js";
 import { ensureDir, exists, hashToken, shortId } from "./utils.js";
 import { workspaceIdForPath } from "./workspaces.js";
@@ -34,7 +33,15 @@ import {
 import { inheritWorkspaceOpencodeConnection, resolveWorkspaceOpencodeConnection } from "./opencode-connection.js";
 import { fetchSharedBundle, publishSharedBundle } from "./share-bundles.js";
 import { seedOpencodeSessionMessages } from "./opencode-db.js";
-import { listPortableFiles, planPortableFiles, writePortableFiles } from "./portable-files.js";
+import { listPortableFiles } from "./portable-files.js";
+import {
+  buildWorkspaceImportPreview,
+  normalizeWorkspaceImportPayload,
+  publicWorkspaceImportPreview,
+  summarizeWorkspaceImportPreview,
+  type WorkspaceImportPlan,
+  workspaceImportPreviewApprovalPaths,
+} from "./workspace-import-preview.js";
 import { buildSession, buildSessionList, buildSessionMessages, buildSessionSnapshot, buildSessionStatuses, buildSessionTodos } from "./session-read-model.js";
 import {
   collectWorkspaceExportWarnings,
@@ -2800,34 +2807,42 @@ function createRoutes(
     return jsonResponse(exportPayload);
   });
 
+  addRoute(routes, "POST", "/workspace/:id/import/preview", "client", async (ctx) => {
+    requireClientScope(ctx, "viewer");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const preview = await buildWorkspaceImportPreview(workspace.path, body);
+    return jsonResponse(publicWorkspaceImportPreview(preview));
+  });
+
   addRoute(routes, "POST", "/workspace/:id/import", "client", async (ctx) => {
     ensureWritable(config);
     requireClientScope(ctx, "collaborator");
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
-    const portableFiles = planPortableFiles(workspace.path, body.files);
+    const preview = await buildWorkspaceImportPreview(workspace.path, body);
+    const approvalPaths = workspaceImportPreviewApprovalPaths(preview);
+    if (approvalPaths.length === 0) {
+      return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(preview) });
+    }
     await requireApproval(ctx, {
       workspaceId: workspace.id,
       action: "config.import",
-      summary: "Import workspace config",
-      paths: [
-        opencodeConfigPath(workspace.path),
-        openworkConfigPath(workspace.path),
-        ...portableFiles.map((file) => file.absolutePath),
-      ],
+      summary: summarizeWorkspaceImportPreview(preview),
+      paths: approvalPaths,
     });
-    await importWorkspace(workspace, body);
+    await importWorkspace(workspace, body, preview);
     await recordAudit(workspace.path, {
       id: shortId(),
       workspaceId: workspace.id,
       actor: ctx.actor ?? { type: "remote" },
       action: "config.import",
       target: "workspace",
-      summary: "Imported workspace config",
+      summary: summarizeWorkspaceImportPreview(preview).replace(/^Import/, "Imported"),
       timestamp: Date.now(),
     });
     emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));
-    return jsonResponse({ ok: true });
+    return jsonResponse({ ok: true, preview: publicWorkspaceImportPreview(preview) });
   });
 
   addRoute(routes, "POST", "/workspace/:id/blueprint/sessions/materialize", "client", async (ctx) => {
@@ -3376,79 +3391,85 @@ function parseWorkspaceExportSensitiveMode(input: string | null): WorkspaceExpor
   throw new ApiError(400, "invalid_workspace_export_sensitive_mode", `Invalid workspace export sensitive mode: ${trimmed}`);
 }
 
-async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string, unknown>): Promise<void> {
-  const modes = (payload.mode as Record<string, string> | undefined) ?? {};
-  const opencode = payload.opencode as Record<string, unknown> | undefined;
-  const openwork = payload.openwork as Record<string, unknown> | undefined;
-  const skills = (payload.skills as { name: string; content: string; description?: string }[] | undefined) ?? [];
-  const commands = (payload.commands as { name: string; content?: string; description?: string; template?: string; agent?: string; model?: string | null; subtask?: boolean }[] | undefined) ?? [];
-  const files = payload.files;
+function workspaceImportRelativePath(workspace: WorkspaceInfo, path: string): string {
+  return relative(workspace.path, path).replaceAll("\\", "/");
+}
 
-  if (opencode) {
-    const sanitizedOpencode = sanitizePortableOpencodeConfig(opencode);
-    if (modes.opencode === "replace") {
-      await writeJsoncFile(opencodeConfigPath(workspace.path), sanitizedOpencode);
+async function importWorkspace(workspace: WorkspaceInfo, payload: Record<string, unknown>, preview: WorkspaceImportPlan): Promise<void> {
+  const input = normalizeWorkspaceImportPayload(workspace.path, payload);
+  const changed = new Set(
+    preview.changes
+      .filter((change) => change.action !== "unchanged")
+      .map((change) => `${change.kind}:${change.path}`),
+  );
+  const changedPath = (kind: string, path: string) => changed.has(`${kind}:${path}`);
+
+  if (
+    input.opencode !== undefined &&
+    changedPath("opencode", workspaceImportRelativePath(workspace, opencodeConfigPath(workspace.path)))
+  ) {
+    if (input.modes.opencode === "replace") {
+      await writeJsoncFile(opencodeConfigPath(workspace.path), input.opencode);
     } else {
-      await updateJsoncTopLevel(opencodeConfigPath(workspace.path), sanitizedOpencode);
+      await updateJsoncTopLevel(opencodeConfigPath(workspace.path), input.opencode);
     }
   }
 
-  if (openwork) {
-    const sanitizedOpenwork = sanitizeOpenworkTemplateConfig(openwork);
-    if (modes.openwork === "replace") {
-      await writeOpenworkConfig(workspace.path, sanitizedOpenwork, false);
+  if (
+    input.openwork !== undefined &&
+    changedPath("openwork", workspaceImportRelativePath(workspace, openworkConfigPath(workspace.path)))
+  ) {
+    if (input.modes.openwork === "replace") {
+      await writeOpenworkConfig(workspace.path, input.openwork, false);
     } else {
-      await writeOpenworkConfig(workspace.path, sanitizedOpenwork, true);
+      await writeOpenworkConfig(workspace.path, input.openwork, true);
     }
   }
 
-  if (skills.length > 0) {
-    if (modes.skills === "replace") {
-      await rm(projectSkillsDir(workspace.path), { recursive: true, force: true });
+  if (input.skills.length > 0) {
+    if (input.modes.skills === "replace") {
+      for (const change of preview.changes) {
+        if (change.kind === "skill" && change.action === "delete") {
+          await rm(change.absolutePath, { recursive: true, force: true });
+        }
+      }
     }
-    for (const skill of skills) {
+    for (const skill of input.skills) {
+      const path = workspaceImportRelativePath(workspace, join(projectSkillsDir(workspace.path), skill.name, "SKILL.md"));
+      if (!changedPath("skill", path)) continue;
       await upsertSkill(workspace.path, skill);
     }
   }
 
-  if (commands.length > 0) {
-    if (modes.commands === "replace") {
-      await rm(projectCommandsDir(workspace.path), { recursive: true, force: true });
-    }
-    for (const command of commands) {
-      if (command.content) {
-        const parsed = parseFrontmatter(command.content);
-        const name = command.name || (typeof parsed.data.name === "string" ? parsed.data.name : "");
-        const description = command.description || (typeof parsed.data.description === "string" ? parsed.data.description : undefined);
-        if (!name) {
-          throw new ApiError(400, "invalid_command", "Command name is required");
+  if (input.commands.length > 0) {
+    if (input.modes.commands === "replace") {
+      for (const change of preview.changes) {
+        if (change.kind === "command" && change.action === "delete") {
+          await rm(change.absolutePath, { force: true });
         }
-        const template = parsed.body.trim();
-        await upsertCommand(workspace.path, {
-          name,
-          description,
-          template,
-          agent: typeof parsed.data.agent === "string" ? parsed.data.agent : undefined,
-          model: typeof parsed.data.model === "string" ? parsed.data.model : undefined,
-          subtask: typeof parsed.data.subtask === "boolean" ? parsed.data.subtask : undefined,
-        });
-      } else {
-        const name = command.name ?? "";
-        const template = command.template ?? "";
-        await upsertCommand(workspace.path, {
-          name,
-          description: command.description,
-          template,
-          agent: command.agent,
-          model: command.model,
-          subtask: command.subtask,
-        });
       }
+    }
+    for (const command of input.commands) {
+      const path = workspaceImportRelativePath(workspace, join(projectCommandsDir(workspace.path), `${command.name}.md`));
+      if (!changedPath("command", path)) continue;
+      await upsertCommand(workspace.path, command);
     }
   }
 
-  if (Array.isArray(files) && files.length > 0) {
-    await writePortableFiles(workspace.path, files, { replace: modes.files === "replace" });
+  if (input.files.length > 0) {
+    if (input.modes.files === "replace") {
+      for (const change of preview.changes) {
+        if (change.kind === "file" && change.action === "delete") {
+          await rm(change.absolutePath, { force: true });
+        }
+      }
+    }
+    for (const file of input.files) {
+      if (!changedPath("file", file.path)) continue;
+      const path = join(workspace.path, file.path);
+      await ensureDir(dirname(path));
+      await writeFile(path, file.content, "utf8");
+    }
   }
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -38,6 +38,7 @@ import {
   buildWorkspaceImportPreview,
   normalizeWorkspaceImportPayload,
   publicWorkspaceImportPreview,
+  summarizeWorkspaceImportApplied,
   summarizeWorkspaceImportPreview,
   type WorkspaceImportPlan,
   workspaceImportPreviewApprovalPaths,
@@ -2838,7 +2839,7 @@ function createRoutes(
       actor: ctx.actor ?? { type: "remote" },
       action: "config.import",
       target: "workspace",
-      summary: summarizeWorkspaceImportPreview(preview).replace(/^Import/, "Imported"),
+      summary: summarizeWorkspaceImportApplied(preview),
       timestamp: Date.now(),
     });
     emitReloadEvent(ctx.reloadEvents, workspace, "config", buildConfigTrigger(opencodeConfigPath(workspace.path)));

--- a/apps/server/src/skills.ts
+++ b/apps/server/src/skills.ts
@@ -145,10 +145,13 @@ export async function listSkills(workspaceRoot: string, includeGlobal: boolean):
   });
 }
 
-export async function upsertSkill(
-  workspaceRoot: string,
-  payload: { name: string; content: string; description?: string },
-): Promise<{ path: string; action: "added" | "updated" }> {
+export type UpsertSkillPayload = {
+  name: string;
+  content: string;
+  description?: string;
+};
+
+export function buildSkillContent(payload: UpsertSkillPayload): { name: string; content: string } {
   const name = payload.name.trim();
   validateSkillName(name);
   if (!payload.content) {
@@ -177,12 +180,24 @@ export async function upsertSkill(
     content = frontmatter + payload.content.replace(/^\n/, "");
   }
 
+  return {
+    name,
+    content: content.endsWith("\n") ? content : content + "\n",
+  };
+}
+
+export async function upsertSkill(
+  workspaceRoot: string,
+  payload: UpsertSkillPayload,
+): Promise<{ path: string; action: "added" | "updated" }> {
+  const skill = buildSkillContent(payload);
+
   const baseDir = projectSkillsDir(workspaceRoot);
-  const skillDir = join(baseDir, name);
+  const skillDir = join(baseDir, skill.name);
   await mkdir(skillDir, { recursive: true });
   const skillPath = join(skillDir, "SKILL.md");
   const existed = await exists(skillPath);
-  await writeFile(skillPath, content.endsWith("\n") ? content : content + "\n", "utf8");
+  await writeFile(skillPath, skill.content, "utf8");
   return { path: skillPath, action: existed ? "updated" : "added" };
 }
 

--- a/apps/server/src/workspace-import-preview.test.ts
+++ b/apps/server/src/workspace-import-preview.test.ts
@@ -11,6 +11,7 @@ import type { ServerConfig } from "./types.js";
 import {
   buildWorkspaceImportPreview,
   publicWorkspaceImportPreview,
+  summarizeWorkspaceImportApplied,
   summarizeWorkspaceImportPreview,
   workspaceImportPreviewApprovalPaths,
 } from "./workspace-import-preview.js";
@@ -199,6 +200,7 @@ describe("workspace import preview", () => {
       path: "opencode.jsonc",
     });
     expect(summarizeWorkspaceImportPreview(preview)).toBe("Import workspace config (update 1)");
+    expect(summarizeWorkspaceImportApplied(preview)).toBe("Imported workspace config (update 1)");
   });
 
   test("rejects unsafe portable file paths before import", async () => {
@@ -297,6 +299,79 @@ describe("workspace import preview", () => {
       expect(await readFile(join(workspace, ".opencode", "skills", "demo", "SKILL.md"), "utf8")).toContain("Demo skill");
       expect(await readFile(join(workspace, ".opencode", "agents", "demo.md"), "utf8")).toBe("Demo agent\n");
       expect(await readFile(auditLogPath("workspace"), "utf8")).toContain("Imported workspace config");
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("replace import route removes extra skills, commands, and portable files", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+
+    const keepSkill = {
+      name: "keep",
+      description: "Keep skill",
+      content: "Use this skill for stable setup.",
+    };
+    const keepCommand = {
+      name: "keep-command",
+      description: "Keep command",
+      template: "run stable setup",
+    };
+    const keepSkillContent = buildSkillContent(keepSkill).content;
+    const keepCommandContent = buildCommandContent(keepCommand).content;
+
+    await mkdir(join(workspace, ".opencode", "skills", "keep"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "skills", "remove-me"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "commands"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "tools"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "skills", "keep", "SKILL.md"), keepSkillContent, "utf8");
+    await writeFile(join(workspace, ".opencode", "skills", "remove-me", "SKILL.md"), "legacy skill\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "commands", "keep-command.md"), keepCommandContent, "utf8");
+    await writeFile(join(workspace, ".opencode", "commands", "remove-me.md"), "legacy command\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "tools", "shared.ts"), "shared tool\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "tools", "remove-me.ts"), "legacy tool\n", "utf8");
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          mode: { skills: "replace", commands: "replace", files: "replace" },
+          skills: [keepSkill],
+          commands: [keepCommand],
+          files: [{ path: ".opencode/tools/shared.ts", content: "shared tool\n" }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as {
+        preview: { summary: { delete: number; unchanged: number } };
+      };
+      expect(body.preview.summary.delete).toBe(3);
+      expect(body.preview.summary.unchanged).toBe(3);
+      expect(await pathExists(join(workspace, ".opencode", "skills", "remove-me"))).toBe(false);
+      expect(await pathExists(join(workspace, ".opencode", "commands", "remove-me.md"))).toBe(false);
+      expect(await pathExists(join(workspace, ".opencode", "tools", "remove-me.ts"))).toBe(false);
+      expect(await readFile(join(workspace, ".opencode", "skills", "keep", "SKILL.md"), "utf8")).toBe(keepSkillContent);
+      expect(await readFile(join(workspace, ".opencode", "commands", "keep-command.md"), "utf8")).toBe(keepCommandContent);
+      expect(await readFile(join(workspace, ".opencode", "tools", "shared.ts"), "utf8")).toBe("shared tool\n");
+      expect(await readFile(auditLogPath("workspace"), "utf8")).toContain("Imported workspace config (remove 3)");
     } finally {
       server.stop(true);
       if (originalDataDir === undefined) {

--- a/apps/server/src/workspace-import-preview.test.ts
+++ b/apps/server/src/workspace-import-preview.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { auditLogPath } from "./audit.js";
+import { buildCommandContent } from "./commands.js";
+import { startServer } from "./server.js";
+import { buildSkillContent } from "./skills.js";
+import type { ServerConfig } from "./types.js";
+import {
+  buildWorkspaceImportPreview,
+  publicWorkspaceImportPreview,
+  summarizeWorkspaceImportPreview,
+  workspaceImportPreviewApprovalPaths,
+} from "./workspace-import-preview.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeWorkspace(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "openwork-import-preview-"));
+  tempDirs.push(dir);
+  await mkdir(join(dir, ".opencode"), { recursive: true });
+  return dir;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeServerConfig(workspace: string, dataDir: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "test-token",
+    hostToken: "host-token",
+    configPath: join(dataDir, "config.json"),
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: [],
+    workspaces: [
+      {
+        id: "workspace",
+        name: "workspace",
+        path: workspace,
+        preset: "default",
+        workspaceType: "local",
+      },
+    ],
+    authorizedRoots: [workspace],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+describe("workspace import preview", () => {
+  test("summarizes workspace import changes without writing files", async () => {
+    const workspace = await makeWorkspace();
+    await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["old-plugin"] }\n', "utf8");
+    await mkdir(join(workspace, ".opencode", "skills", "demo"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "skills", "demo", "SKILL.md"), "old skill\n", "utf8");
+    await mkdir(join(workspace, ".opencode", "commands"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "commands", "old.md"), "old command\n", "utf8");
+    await mkdir(join(workspace, ".opencode", "tools"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "plugins"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "tools", "existing.ts"), "old tool\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "plugins", "removed.ts"), "removed plugin\n", "utf8");
+
+    const preview = await buildWorkspaceImportPreview(workspace, {
+      mode: { skills: "replace", commands: "replace", files: "replace" },
+      opencode: {
+        plugin: ["old-plugin", "new-plugin"],
+      },
+      openwork: {
+        blueprint: {
+          materialized: {
+            sessions: { items: [{ templateId: "old", sessionId: "ses_123" }] },
+          },
+        },
+      },
+      skills: [
+        { name: "demo", description: "Demo skill", content: "---\nname: demo\ndescription: Demo skill\n---\nupdated\n" },
+        { name: "new-skill", description: "New skill", content: "---\nname: new-skill\ndescription: New skill\n---\nbody\n" },
+      ],
+      commands: [
+        { content: "---\nname: old\ndescription: Old command\n---\nupdated command\n" },
+        { name: "new-command", template: "run new command" },
+      ],
+      files: [
+        { path: ".opencode/tools/existing.ts", content: "new tool\n" },
+        { path: ".opencode/agents/new.md", content: "new agent\n" },
+      ],
+    });
+
+    expect(preview.summary).toEqual({
+      total: 9,
+      create: 4,
+      update: 4,
+      replace: 0,
+      delete: 1,
+      unchanged: 0,
+    });
+    expect(preview.changes.map((change) => [change.kind, change.action, change.path])).toEqual([
+      ["opencode", "update", "opencode.jsonc"],
+      ["openwork", "create", ".opencode/openwork.json"],
+      ["skill", "update", ".opencode/skills/demo/SKILL.md"],
+      ["skill", "create", ".opencode/skills/new-skill/SKILL.md"],
+      ["command", "update", ".opencode/commands/old.md"],
+      ["command", "create", ".opencode/commands/new-command.md"],
+      ["file", "update", ".opencode/tools/existing.ts"],
+      ["file", "create", ".opencode/agents/new.md"],
+      ["file", "delete", ".opencode/plugins/removed.ts"],
+    ]);
+
+    expect(await readFile(join(workspace, ".opencode", "tools", "existing.ts"), "utf8")).toBe("old tool\n");
+  });
+
+  test("marks identical config as unchanged and excludes it from approval paths", async () => {
+    const workspace = await makeWorkspace();
+    await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["demo"] }\n', "utf8");
+
+    const preview = await buildWorkspaceImportPreview(workspace, {
+      opencode: { plugin: ["demo"] },
+    });
+
+    expect(preview.summary).toEqual({
+      total: 1,
+      create: 0,
+      update: 0,
+      replace: 0,
+      delete: 0,
+      unchanged: 1,
+    });
+    expect(preview.changes[0]?.action).toBe("unchanged");
+    expect(workspaceImportPreviewApprovalPaths(preview)).toEqual([]);
+    expect(summarizeWorkspaceImportPreview(preview)).toBe("Import workspace config (no changes)");
+  });
+
+  test("marks identical skills and commands unchanged", async () => {
+    const workspace = await makeWorkspace();
+    const skill = {
+      name: "demo",
+      description: "Demo skill",
+      content: "---\nname: demo\ndescription: Demo skill\n---\nbody\n",
+    };
+    const command = {
+      name: "demo-command",
+      description: "Demo command",
+      template: "do the thing",
+    };
+    const skillContent = buildSkillContent(skill);
+    const commandContent = buildCommandContent(command);
+    await mkdir(join(workspace, ".opencode", "skills", "demo"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "commands"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "skills", "demo", "SKILL.md"), skillContent.content, "utf8");
+    await writeFile(join(workspace, ".opencode", "commands", "demo-command.md"), commandContent.content, "utf8");
+
+    const preview = await buildWorkspaceImportPreview(workspace, {
+      skills: [skill],
+      commands: [command],
+    });
+
+    expect(preview.changes.map((change) => [change.kind, change.action, change.path])).toEqual([
+      ["skill", "unchanged", ".opencode/skills/demo/SKILL.md"],
+      ["command", "unchanged", ".opencode/commands/demo-command.md"],
+    ]);
+    expect(workspaceImportPreviewApprovalPaths(preview)).toEqual([]);
+    expect(publicWorkspaceImportPreview(preview).changes[0]).not.toHaveProperty("absolutePath");
+  });
+
+  test("uses replace action for config replacement", async () => {
+    const workspace = await makeWorkspace();
+    await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["old"] }\n', "utf8");
+
+    const preview = await buildWorkspaceImportPreview(workspace, {
+      mode: { opencode: "replace" },
+      opencode: { plugin: ["new"] },
+    });
+
+    expect(preview.changes[0]).toMatchObject({
+      kind: "opencode",
+      action: "replace",
+      path: "opencode.jsonc",
+    });
+    expect(summarizeWorkspaceImportPreview(preview)).toBe("Import workspace config (update 1)");
+  });
+
+  test("rejects unsafe portable file paths before import", async () => {
+    const workspace = await makeWorkspace();
+
+    await expect(
+      buildWorkspaceImportPreview(workspace, {
+        files: [{ path: ".opencode/.env", content: "SECRET=value\n" }],
+      }),
+    ).rejects.toThrow(/Portable file path is not allowed/i);
+  });
+
+  test("preview route returns public changes and no-op import does not audit", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+    await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["demo"] }\n', "utf8");
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      };
+      const body = JSON.stringify({ opencode: { plugin: ["demo"] } });
+
+      const previewResponse = await fetch(`${baseUrl}/workspace/workspace/import/preview`, {
+        method: "POST",
+        headers,
+        body,
+      });
+      expect(previewResponse.status).toBe(200);
+      const preview = await previewResponse.json() as Record<string, unknown>;
+      expect((preview.changes as Array<Record<string, unknown>>)[0]).not.toHaveProperty("absolutePath");
+
+      const importResponse = await fetch(`${baseUrl}/workspace/workspace/import`, {
+        method: "POST",
+        headers,
+        body,
+      });
+      expect(importResponse.status).toBe(200);
+      const imported = await importResponse.json() as Record<string, unknown>;
+      expect(imported.preview).toEqual(preview);
+      expect(await pathExists(auditLogPath("workspace"))).toBe(false);
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("import route writes changed items and records audit", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          opencode: { plugin: ["demo"] },
+          skills: [
+            {
+              name: "demo",
+              description: "Demo skill",
+              content: "Use this skill for demo work.",
+            },
+          ],
+          files: [{ path: ".opencode/agents/demo.md", content: "Demo agent\n" }],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { preview: { summary: { create: number } } };
+      expect(body.preview.summary.create).toBe(3);
+      expect(await readFile(join(workspace, "opencode.jsonc"), "utf8")).toContain('"plugin"');
+      expect(await readFile(join(workspace, ".opencode", "skills", "demo", "SKILL.md"), "utf8")).toContain("Demo skill");
+      expect(await readFile(join(workspace, ".opencode", "agents", "demo.md"), "utf8")).toBe("Demo agent\n");
+      expect(await readFile(auditLogPath("workspace"), "utf8")).toContain("Imported workspace config");
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+});

--- a/apps/server/src/workspace-import-preview.test.ts
+++ b/apps/server/src/workspace-import-preview.test.ts
@@ -105,6 +105,20 @@ async function requestWorkspaceImportWithPreview(
   });
 }
 
+async function waitForPendingApproval(baseUrl: string): Promise<string> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const response = await fetch(`${baseUrl}/approvals`, {
+      headers: { "X-OpenWork-Host-Token": "host-token" },
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json() as { items: Array<{ id: string }> };
+    const approval = body.items[0];
+    if (approval) return approval.id;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for approval request");
+}
+
 describe("workspace import preview", () => {
   test("summarizes workspace import changes without writing files", async () => {
     const workspace = await makeWorkspace();
@@ -315,6 +329,45 @@ describe("workspace import preview", () => {
       expect(importResponse.status).toBe(200);
       const imported = await importResponse.json() as Record<string, unknown>;
       expect(imported.preview).toEqual(preview);
+      expect(await pathExists(auditLogPath("workspace"))).toBe(false);
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("no-op import validates preview fingerprint shape", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+    await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["demo"] }\n', "utf8");
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          opencode: { plugin: ["demo"] },
+          previewFingerprint: 123,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      const body = await response.json() as { code: string };
+      expect(body.code).toBe("invalid_workspace_import_preview_fingerprint");
       expect(await pathExists(auditLogPath("workspace"))).toBe(false);
     } finally {
       server.stop(true);
@@ -578,6 +631,67 @@ describe("workspace import preview", () => {
       expect(rejected.code).toBe("workspace_import_preview_stale");
       expect(rejected.preview.fingerprint).not.toBe(preview.fingerprint);
       expect(await readFile(join(workspace, "opencode.jsonc"), "utf8")).toContain("changed-after-preview");
+      expect(await pathExists(auditLogPath("workspace"))).toBe(false);
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("import route revalidates the preview after approval", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+    await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["old"] }\n', "utf8");
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const serverConfig = makeServerConfig(workspace, dataDir);
+    serverConfig.approval = { mode: "manual", timeoutMs: 5000 };
+    const server = startServer(serverConfig) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      };
+      const payload = { opencode: { plugin: ["new"] } };
+      const preview = await requestWorkspaceImportPreview(baseUrl, headers, payload);
+
+      const importPromise = fetch(`${baseUrl}/workspace/workspace/import`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ ...payload, previewFingerprint: preview.fingerprint }),
+      });
+
+      const approvalId = await waitForPendingApproval(baseUrl);
+      await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["changed-during-approval"] }\n', "utf8");
+      const approvalResponse = await fetch(`${baseUrl}/approvals/${approvalId}`, {
+        method: "POST",
+        headers: {
+          "X-OpenWork-Host-Token": "host-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ reply: "allow" }),
+      });
+      expect(approvalResponse.status).toBe(200);
+
+      const importResponse = await importPromise;
+      expect(importResponse.status).toBe(409);
+      const rejected = await importResponse.json() as {
+        code: string;
+        preview: { fingerprint: string };
+      };
+      expect(rejected.code).toBe("workspace_import_preview_stale");
+      expect(rejected.preview.fingerprint).not.toBe(preview.fingerprint);
+      expect(await readFile(join(workspace, "opencode.jsonc"), "utf8")).toContain("changed-during-approval");
       expect(await pathExists(auditLogPath("workspace"))).toBe(false);
     } finally {
       server.stop(true);

--- a/apps/server/src/workspace-import-preview.test.ts
+++ b/apps/server/src/workspace-import-preview.test.ts
@@ -70,6 +70,41 @@ function makeServerConfig(workspace: string, dataDir: string): ServerConfig {
   };
 }
 
+type TestHeaders = {
+  Authorization: string;
+  "Content-Type": string;
+};
+
+async function requestWorkspaceImportPreview(
+  baseUrl: string,
+  headers: TestHeaders,
+  payload: Record<string, unknown>,
+): Promise<{ fingerprint: string; summary: { create: number; update: number; delete: number; unchanged: number } }> {
+  const response = await fetch(`${baseUrl}/workspace/workspace/import/preview`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  });
+  expect(response.status).toBe(200);
+  return await response.json() as {
+    fingerprint: string;
+    summary: { create: number; update: number; delete: number; unchanged: number };
+  };
+}
+
+async function requestWorkspaceImportWithPreview(
+  baseUrl: string,
+  headers: TestHeaders,
+  payload: Record<string, unknown>,
+): Promise<Response> {
+  const preview = await requestWorkspaceImportPreview(baseUrl, headers, payload);
+  return await fetch(`${baseUrl}/workspace/workspace/import`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ ...payload, previewFingerprint: preview.fingerprint }),
+  });
+}
+
 describe("workspace import preview", () => {
   test("summarizes workspace import changes without writing files", async () => {
     const workspace = await makeWorkspace();
@@ -183,6 +218,7 @@ describe("workspace import preview", () => {
     ]);
     expect(workspaceImportPreviewApprovalPaths(preview)).toEqual([]);
     expect(publicWorkspaceImportPreview(preview).changes[0]).not.toHaveProperty("absolutePath");
+    expect(publicWorkspaceImportPreview(preview).changes[0]).not.toHaveProperty("beforeDigest");
   });
 
   test("uses replace action for config replacement", async () => {
@@ -213,6 +249,33 @@ describe("workspace import preview", () => {
     ).rejects.toThrow(/Portable file path is not allowed/i);
   });
 
+  test("replace preview treats empty sections as delete all", async () => {
+    const workspace = await makeWorkspace();
+    await mkdir(join(workspace, ".opencode", "skills", "old-skill"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "commands"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "agents"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "skills", "old-skill", "SKILL.md"), "old skill\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "commands", "old-command.md"), "old command\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "agents", "old.md"), "old agent\n", "utf8");
+
+    const preview = await buildWorkspaceImportPreview(workspace, {
+      mode: { skills: "replace", commands: "replace", files: "replace" },
+      skills: [],
+      commands: [],
+      files: [],
+    });
+
+    expect(preview.summary).toMatchObject({
+      total: 3,
+      delete: 3,
+    });
+    expect(preview.changes.map((change) => [change.kind, change.action, change.path])).toEqual([
+      ["skill", "delete", ".opencode/skills/old-skill"],
+      ["command", "delete", ".opencode/commands/old-command.md"],
+      ["file", "delete", ".opencode/agents/old.md"],
+    ]);
+  });
+
   test("preview route returns public changes and no-op import does not audit", async () => {
     const workspace = await makeWorkspace();
     const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
@@ -240,7 +303,9 @@ describe("workspace import preview", () => {
       });
       expect(previewResponse.status).toBe(200);
       const preview = await previewResponse.json() as Record<string, unknown>;
+      expect(typeof preview.fingerprint).toBe("string");
       expect((preview.changes as Array<Record<string, unknown>>)[0]).not.toHaveProperty("absolutePath");
+      expect((preview.changes as Array<Record<string, unknown>>)[0]).not.toHaveProperty("beforeDigest");
 
       const importResponse = await fetch(`${baseUrl}/workspace/workspace/import`, {
         method: "POST",
@@ -250,6 +315,49 @@ describe("workspace import preview", () => {
       expect(importResponse.status).toBe(200);
       const imported = await importResponse.json() as Record<string, unknown>;
       expect(imported.preview).toEqual(preview);
+      expect(await pathExists(auditLogPath("workspace"))).toBe(false);
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("changed import requires a reviewed preview fingerprint", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          opencode: { plugin: ["demo"] },
+        }),
+      });
+
+      expect(response.status).toBe(409);
+      const body = await response.json() as {
+        code: string;
+        preview: { fingerprint: string; summary: { create: number } };
+      };
+      expect(body.code).toBe("workspace_import_preview_required");
+      expect(typeof body.preview.fingerprint).toBe("string");
+      expect(body.preview.summary.create).toBe(1);
+      expect(await pathExists(join(workspace, "opencode.jsonc"))).toBe(false);
       expect(await pathExists(auditLogPath("workspace"))).toBe(false);
     } finally {
       server.stop(true);
@@ -273,23 +381,21 @@ describe("workspace import preview", () => {
       stop: (force?: boolean) => void;
     };
     try {
-      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
-        method: "POST",
-        headers: {
-          Authorization: "Bearer test-token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          opencode: { plugin: ["demo"] },
-          skills: [
-            {
-              name: "demo",
-              description: "Demo skill",
-              content: "Use this skill for demo work.",
-            },
-          ],
-          files: [{ path: ".opencode/agents/demo.md", content: "Demo agent\n" }],
-        }),
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      };
+      const response = await requestWorkspaceImportWithPreview(baseUrl, headers, {
+        opencode: { plugin: ["demo"] },
+        skills: [
+          {
+            name: "demo",
+            description: "Demo skill",
+            content: "Use this skill for demo work.",
+          },
+        ],
+        files: [{ path: ".opencode/agents/demo.md", content: "Demo agent\n" }],
       });
 
       expect(response.status).toBe(200);
@@ -345,18 +451,16 @@ describe("workspace import preview", () => {
       stop: (force?: boolean) => void;
     };
     try {
-      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
-        method: "POST",
-        headers: {
-          Authorization: "Bearer test-token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          mode: { skills: "replace", commands: "replace", files: "replace" },
-          skills: [keepSkill],
-          commands: [keepCommand],
-          files: [{ path: ".opencode/tools/shared.ts", content: "shared tool\n" }],
-        }),
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      };
+      const response = await requestWorkspaceImportWithPreview(baseUrl, headers, {
+        mode: { skills: "replace", commands: "replace", files: "replace" },
+        skills: [keepSkill],
+        commands: [keepCommand],
+        files: [{ path: ".opencode/tools/shared.ts", content: "shared tool\n" }],
       });
 
       expect(response.status).toBe(200);
@@ -372,6 +476,146 @@ describe("workspace import preview", () => {
       expect(await readFile(join(workspace, ".opencode", "commands", "keep-command.md"), "utf8")).toBe(keepCommandContent);
       expect(await readFile(join(workspace, ".opencode", "tools", "shared.ts"), "utf8")).toBe("shared tool\n");
       expect(await readFile(auditLogPath("workspace"), "utf8")).toContain("Imported workspace config (remove 3)");
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("replace import route honors empty sections", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+
+    await mkdir(join(workspace, ".opencode", "skills", "old-skill"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "commands"), { recursive: true });
+    await mkdir(join(workspace, ".opencode", "agents"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "skills", "old-skill", "SKILL.md"), "old skill\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "commands", "old-command.md"), "old command\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "agents", "old.md"), "old agent\n", "utf8");
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      };
+      const response = await requestWorkspaceImportWithPreview(baseUrl, headers, {
+        mode: { skills: "replace", commands: "replace", files: "replace" },
+        skills: [],
+        commands: [],
+        files: [],
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as {
+        preview: { summary: { delete: number } };
+      };
+      expect(body.preview.summary.delete).toBe(3);
+      expect(await pathExists(join(workspace, ".opencode", "skills", "old-skill"))).toBe(false);
+      expect(await pathExists(join(workspace, ".opencode", "commands", "old-command.md"))).toBe(false);
+      expect(await pathExists(join(workspace, ".opencode", "agents", "old.md"))).toBe(false);
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("import route rejects a stale reviewed preview", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+    await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["old"] }\n', "utf8");
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      };
+      const payload = { opencode: { plugin: ["new"] } };
+
+      const previewResponse = await fetch(`${baseUrl}/workspace/workspace/import/preview`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      });
+      expect(previewResponse.status).toBe(200);
+      const preview = await previewResponse.json() as { fingerprint: string };
+
+      await writeFile(join(workspace, "opencode.jsonc"), '{ "plugin": ["changed-after-preview"] }\n', "utf8");
+
+      const importResponse = await fetch(`${baseUrl}/workspace/workspace/import`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ ...payload, previewFingerprint: preview.fingerprint }),
+      });
+      expect(importResponse.status).toBe(409);
+      const rejected = await importResponse.json() as {
+        code: string;
+        preview: { fingerprint: string };
+      };
+      expect(rejected.code).toBe("workspace_import_preview_stale");
+      expect(rejected.preview.fingerprint).not.toBe(preview.fingerprint);
+      expect(await readFile(join(workspace, "opencode.jsonc"), "utf8")).toContain("changed-after-preview");
+      expect(await pathExists(auditLogPath("workspace"))).toBe(false);
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+
+  test("import route validates preview fingerprint shape", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          opencode: { plugin: ["demo"] },
+          previewFingerprint: 123,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      const body = await response.json() as { code: string };
+      expect(body.code).toBe("invalid_workspace_import_preview_fingerprint");
     } finally {
       server.stop(true);
       if (originalDataDir === undefined) {
@@ -398,22 +642,20 @@ describe("workspace import preview", () => {
       stop: (force?: boolean) => void;
     };
     try {
-      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
-        method: "POST",
-        headers: {
-          Authorization: "Bearer test-token",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          mode: { skills: "replace" },
-          skills: [
-            {
-              name: "new",
-              description: "New skill",
-              content: "new skill\n",
-            },
-          ],
-        }),
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      };
+      const response = await requestWorkspaceImportWithPreview(baseUrl, headers, {
+        mode: { skills: "replace" },
+        skills: [
+          {
+            name: "new",
+            description: "New skill",
+            content: "new skill\n",
+          },
+        ],
       });
 
       expect(response.ok).toBe(false);

--- a/apps/server/src/workspace-import-preview.test.ts
+++ b/apps/server/src/workspace-import-preview.test.ts
@@ -105,6 +105,19 @@ async function requestWorkspaceImportWithPreview(
   });
 }
 
+async function silenceExpectedServerError<T>(run: () => Promise<T>): Promise<T> {
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    if (args[0] === "[openwork-server] Unhandled error:") return;
+    originalError(...args);
+  };
+  try {
+    return await run();
+  } finally {
+    console.error = originalError;
+  }
+}
+
 async function waitForPendingApproval(baseUrl: string): Promise<string> {
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const response = await fetch(`${baseUrl}/approvals`, {
@@ -761,18 +774,21 @@ describe("workspace import preview", () => {
         Authorization: "Bearer test-token",
         "Content-Type": "application/json",
       };
-      const response = await requestWorkspaceImportWithPreview(baseUrl, headers, {
-        mode: { skills: "replace" },
-        skills: [
-          {
-            name: "new",
-            description: "New skill",
-            content: "new skill\n",
-          },
-        ],
-      });
+      const response = await silenceExpectedServerError(() =>
+        requestWorkspaceImportWithPreview(baseUrl, headers, {
+          mode: { skills: "replace" },
+          skills: [
+            {
+              name: "new",
+              description: "New skill",
+              content: "new skill\n",
+            },
+          ],
+        }),
+      );
 
       expect(response.ok).toBe(false);
+      expect(response.status).toBe(500);
       expect(await readFile(join(workspace, ".opencode", "skills", "old", "SKILL.md"), "utf8")).toBe("old skill\n");
       expect(await readFile(join(workspace, ".opencode", "skills", "new"), "utf8")).toBe(
         "blocks new skill directory\n",

--- a/apps/server/src/workspace-import-preview.test.ts
+++ b/apps/server/src/workspace-import-preview.test.ts
@@ -381,4 +381,53 @@ describe("workspace import preview", () => {
       }
     }
   });
+
+  test("replace import keeps existing items when an incoming write fails", async () => {
+    const workspace = await makeWorkspace();
+    const dataDir = await mkdtemp(join(tmpdir(), "openwork-import-preview-data-"));
+    tempDirs.push(dataDir);
+
+    await mkdir(join(workspace, ".opencode", "skills", "old"), { recursive: true });
+    await writeFile(join(workspace, ".opencode", "skills", "old", "SKILL.md"), "old skill\n", "utf8");
+    await writeFile(join(workspace, ".opencode", "skills", "new"), "blocks new skill directory\n", "utf8");
+
+    const originalDataDir = process.env.OPENWORK_DATA_DIR;
+    process.env.OPENWORK_DATA_DIR = dataDir;
+    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+      port: number;
+      stop: (force?: boolean) => void;
+    };
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/workspace/workspace/import`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          mode: { skills: "replace" },
+          skills: [
+            {
+              name: "new",
+              description: "New skill",
+              content: "new skill\n",
+            },
+          ],
+        }),
+      });
+
+      expect(response.ok).toBe(false);
+      expect(await readFile(join(workspace, ".opencode", "skills", "old", "SKILL.md"), "utf8")).toBe("old skill\n");
+      expect(await readFile(join(workspace, ".opencode", "skills", "new"), "utf8")).toBe(
+        "blocks new skill directory\n",
+      );
+    } finally {
+      server.stop(true);
+      if (originalDataDir === undefined) {
+        delete process.env.OPENWORK_DATA_DIR;
+      } else {
+        process.env.OPENWORK_DATA_DIR = originalDataDir;
+      }
+    }
+  });
 });

--- a/apps/server/src/workspace-import-preview.ts
+++ b/apps/server/src/workspace-import-preview.ts
@@ -6,7 +6,7 @@ import { buildCommandContent } from "./commands.js";
 import { ApiError } from "./errors.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import { readJsoncFile } from "./jsonc.js";
-import { planPortableFiles, listPortableFiles, type PortableFile } from "./portable-files.js";
+import { planPortableFiles, listPortableFilePaths, type PortableFile } from "./portable-files.js";
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { buildSkillContent } from "./skills.js";
 import { exists } from "./utils.js";
@@ -370,14 +370,14 @@ export async function buildWorkspaceImportPreview(
       });
     }
     if (input.modes.files === "replace") {
-      for (const file of await listPortableFiles(workspaceRoot)) {
-        if (incoming.has(file.path)) continue;
-        const path = join(workspaceRoot, file.path);
+      for (const filePath of await listPortableFilePaths(workspaceRoot)) {
+        if (incoming.has(filePath)) continue;
+        const path = join(workspaceRoot, filePath);
         changes.push({
           kind: "file",
           action: "delete",
-          label: file.path,
-          path: file.path,
+          label: filePath,
+          path: filePath,
           absolutePath: path,
         });
       }
@@ -412,12 +412,20 @@ function countLabel(verb: string, count: number): string | null {
   return `${verb} ${count}`;
 }
 
-export function summarizeWorkspaceImportPreview(preview: WorkspaceImportPreview): string {
+function summarizeWorkspaceImport(prefix: "Import" | "Imported", preview: WorkspaceImportPreview): string {
   const parts = [
     countLabel("add", preview.summary.create),
     countLabel("update", preview.summary.update + preview.summary.replace),
     countLabel("remove", preview.summary.delete),
   ].filter((part): part is string => Boolean(part));
 
-  return parts.length ? `Import workspace config (${parts.join(", ")})` : "Import workspace config (no changes)";
+  return parts.length ? `${prefix} workspace config (${parts.join(", ")})` : `${prefix} workspace config (no changes)`;
+}
+
+export function summarizeWorkspaceImportPreview(preview: WorkspaceImportPreview): string {
+  return summarizeWorkspaceImport("Import", preview);
+}
+
+export function summarizeWorkspaceImportApplied(preview: WorkspaceImportPreview): string {
+  return summarizeWorkspaceImport("Imported", preview);
 }

--- a/apps/server/src/workspace-import-preview.ts
+++ b/apps/server/src/workspace-import-preview.ts
@@ -1,0 +1,423 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+import { sanitizeOpenworkTemplateConfig } from "./blueprint-sessions.js";
+import { buildCommandContent } from "./commands.js";
+import { ApiError } from "./errors.js";
+import { parseFrontmatter } from "./frontmatter.js";
+import { readJsoncFile } from "./jsonc.js";
+import { planPortableFiles, listPortableFiles, type PortableFile } from "./portable-files.js";
+import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
+import { buildSkillContent } from "./skills.js";
+import { exists } from "./utils.js";
+import { sanitizeCommandName, validateCommandName, validateSkillName } from "./validators.js";
+import {
+  opencodeConfigPath,
+  openworkConfigPath,
+  projectCommandsDir,
+  projectSkillsDir,
+} from "./workspace-files.js";
+
+export type WorkspaceImportMode = "merge" | "replace";
+export type WorkspaceImportChangeKind = "opencode" | "openwork" | "skill" | "command" | "file";
+export type WorkspaceImportChangeAction = "create" | "update" | "replace" | "delete" | "unchanged";
+
+export type WorkspaceImportChange = {
+  kind: WorkspaceImportChangeKind;
+  action: WorkspaceImportChangeAction;
+  label: string;
+  path: string;
+};
+
+type WorkspaceImportPlannedChange = WorkspaceImportChange & {
+  absolutePath: string;
+};
+
+export type WorkspaceImportPreview = {
+  summary: {
+    total: number;
+    create: number;
+    update: number;
+    replace: number;
+    delete: number;
+    unchanged: number;
+  };
+  changes: WorkspaceImportChange[];
+};
+
+export type WorkspaceImportPlan = Omit<WorkspaceImportPreview, "changes"> & {
+  changes: WorkspaceImportPlannedChange[];
+};
+
+export type NormalizedWorkspaceImport = {
+  modes: Record<string, WorkspaceImportMode>;
+  opencode?: Record<string, unknown>;
+  openwork?: Record<string, unknown>;
+  skills: Array<{ name: string; content: string; description?: string }>;
+  commands: Array<{
+    name: string;
+    template: string;
+    description?: string;
+    agent?: string;
+    model?: string | null;
+    subtask?: boolean;
+  }>;
+  files: PortableFile[];
+};
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readMode(value: unknown): WorkspaceImportMode {
+  return value === "replace" ? "replace" : "merge";
+}
+
+function normalizeModes(value: unknown): Record<string, WorkspaceImportMode> {
+  const record = readRecord(value) ?? {};
+  return {
+    opencode: readMode(record.opencode),
+    openwork: readMode(record.openwork),
+    skills: readMode(record.skills),
+    commands: readMode(record.commands),
+    files: readMode(record.files),
+  };
+}
+
+function readArray(value: unknown, label: string): Record<string, unknown>[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new ApiError(400, "invalid_workspace_import_payload", `${label} must be an array`);
+  }
+  return value.map((item, index) => {
+    const record = readRecord(item);
+    if (!record) {
+      throw new ApiError(400, "invalid_workspace_import_payload", `${label}[${index}] must be an object`);
+    }
+    return record;
+  });
+}
+
+function normalizeSkills(value: unknown): NormalizedWorkspaceImport["skills"] {
+  return readArray(value, "skills").map((skill) => {
+    const name = String(skill.name ?? "").trim();
+    const content = typeof skill.content === "string" ? skill.content : "";
+    validateSkillName(name);
+    if (!content) {
+      throw new ApiError(400, "invalid_skill_content", "Skill content is required");
+    }
+    return {
+      name,
+      content,
+      description: typeof skill.description === "string" ? skill.description : undefined,
+    };
+  });
+}
+
+function normalizeCommands(value: unknown): NormalizedWorkspaceImport["commands"] {
+  return readArray(value, "commands").map((command) => {
+    if (typeof command.content === "string" && command.content.trim()) {
+      const parsed = parseFrontmatter(command.content);
+      const name = sanitizeCommandName(
+        String(command.name || (typeof parsed.data.name === "string" ? parsed.data.name : "")),
+      );
+      validateCommandName(name);
+      const template = parsed.body.trim();
+      if (!template) {
+        throw new ApiError(400, "invalid_command_template", "Command template is required");
+      }
+      return {
+        name,
+        template,
+        description:
+          typeof command.description === "string"
+            ? command.description
+            : typeof parsed.data.description === "string"
+              ? parsed.data.description
+              : undefined,
+        agent: typeof parsed.data.agent === "string" ? parsed.data.agent : undefined,
+        model: typeof parsed.data.model === "string" ? parsed.data.model : undefined,
+        subtask: typeof parsed.data.subtask === "boolean" ? parsed.data.subtask : undefined,
+      };
+    }
+
+    const name = sanitizeCommandName(String(command.name ?? ""));
+    validateCommandName(name);
+    const template = typeof command.template === "string" ? command.template : "";
+    if (!template.trim()) {
+      throw new ApiError(400, "invalid_command_template", "Command template is required");
+    }
+    return {
+      name,
+      template,
+      description: typeof command.description === "string" ? command.description : undefined,
+      agent: typeof command.agent === "string" ? command.agent : undefined,
+      model: typeof command.model === "string" ? command.model : null,
+      subtask: typeof command.subtask === "boolean" ? command.subtask : undefined,
+    };
+  });
+}
+
+export function normalizeWorkspaceImportPayload(
+  workspaceRoot: string,
+  payload: Record<string, unknown>,
+): NormalizedWorkspaceImport {
+  return {
+    modes: normalizeModes(payload.mode),
+    ...(payload.opencode !== undefined
+      ? { opencode: sanitizePortableOpencodeConfig(readRecord(payload.opencode)) }
+      : {}),
+    ...(payload.openwork !== undefined
+      ? { openwork: sanitizeOpenworkTemplateConfig(readRecord(payload.openwork)) }
+      : {}),
+    skills: normalizeSkills(payload.skills),
+    commands: normalizeCommands(payload.commands),
+    files: planPortableFiles(workspaceRoot, payload.files).map((file) => ({
+      path: file.path,
+      content: file.content,
+    })),
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function actionForTarget(
+  existsBefore: boolean,
+  changed: boolean,
+  mode: WorkspaceImportMode,
+): WorkspaceImportChangeAction {
+  if (!existsBefore) return "create";
+  if (!changed) return "unchanged";
+  return mode === "replace" ? "replace" : "update";
+}
+
+function rel(workspaceRoot: string, absolutePath: string): string {
+  return relative(workspaceRoot, absolutePath).replaceAll("\\", "/");
+}
+
+function countSummary(changes: WorkspaceImportChange[]): WorkspaceImportPreview["summary"] {
+  return changes.reduce(
+    (summary, change) => {
+      summary.total += 1;
+      summary[change.action] += 1;
+      return summary;
+    },
+    { total: 0, create: 0, update: 0, replace: 0, delete: 0, unchanged: 0 },
+  );
+}
+
+async function readOpenworkConfig(path: string): Promise<Record<string, unknown>> {
+  if (!(await exists(path))) return {};
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+  } catch {
+    throw new ApiError(422, "invalid_json", "Failed to parse openwork.json");
+  }
+}
+
+async function listProjectSkillNames(workspaceRoot: string): Promise<string[]> {
+  const dir = projectSkillsDir(workspaceRoot);
+  if (!(await exists(dir))) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (await exists(join(dir, entry.name, "SKILL.md"))) {
+      names.push(entry.name);
+    }
+  }
+  return names.sort();
+}
+
+async function listProjectCommandNames(workspaceRoot: string): Promise<string[]> {
+  const dir = projectCommandsDir(workspaceRoot);
+  if (!(await exists(dir))) return [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name.replace(/\.md$/, ""))
+    .sort();
+}
+
+export async function buildWorkspaceImportPreview(
+  workspaceRoot: string,
+  payload: Record<string, unknown>,
+): Promise<WorkspaceImportPlan> {
+  const input = normalizeWorkspaceImportPayload(workspaceRoot, payload);
+  const changes: WorkspaceImportPlannedChange[] = [];
+
+  if (input.opencode !== undefined) {
+    const path = opencodeConfigPath(workspaceRoot);
+    const before = await readJsoncFile(path, {} as Record<string, unknown>);
+    const after = input.modes.opencode === "replace" ? input.opencode : { ...before.data, ...input.opencode };
+    changes.push({
+      kind: "opencode",
+      action: actionForTarget(Boolean(before.raw), !sameJson(before.data, after), input.modes.opencode),
+      label: "OpenCode config",
+      path: rel(workspaceRoot, path),
+      absolutePath: path,
+    });
+  }
+
+  if (input.openwork !== undefined) {
+    const path = openworkConfigPath(workspaceRoot);
+    const existsBefore = await exists(path);
+    const before = await readOpenworkConfig(path);
+    const after = input.modes.openwork === "replace" ? input.openwork : { ...before, ...input.openwork };
+    changes.push({
+      kind: "openwork",
+      action: actionForTarget(existsBefore, !sameJson(before, after), input.modes.openwork),
+      label: "OpenWork config",
+      path: rel(workspaceRoot, path),
+      absolutePath: path,
+    });
+  }
+
+  if (input.skills.length > 0) {
+    const existing = new Set(await listProjectSkillNames(workspaceRoot));
+    const incoming = new Set<string>();
+    for (const skill of input.skills) {
+      incoming.add(skill.name);
+      const path = join(projectSkillsDir(workspaceRoot), skill.name, "SKILL.md");
+      const existsBefore = existing.has(skill.name);
+      const before = existsBefore ? await readFile(path, "utf8") : "";
+      const next = buildSkillContent(skill);
+      changes.push({
+        kind: "skill",
+        action: actionForTarget(existsBefore, before !== next.content, "merge"),
+        label: skill.name,
+        path: rel(workspaceRoot, path),
+        absolutePath: path,
+      });
+    }
+    if (input.modes.skills === "replace") {
+      for (const name of existing) {
+        if (incoming.has(name)) continue;
+        const path = join(projectSkillsDir(workspaceRoot), name);
+        changes.push({
+          kind: "skill",
+          action: "delete",
+          label: name,
+          path: rel(workspaceRoot, path),
+          absolutePath: path,
+        });
+      }
+    }
+  }
+
+  if (input.commands.length > 0) {
+    const existing = new Set(await listProjectCommandNames(workspaceRoot));
+    const incoming = new Set<string>();
+    for (const command of input.commands) {
+      incoming.add(command.name);
+      const path = join(projectCommandsDir(workspaceRoot), `${command.name}.md`);
+      const existsBefore = existing.has(command.name);
+      const before = existsBefore ? await readFile(path, "utf8") : "";
+      const next = buildCommandContent(command);
+      changes.push({
+        kind: "command",
+        action: actionForTarget(existsBefore, before !== next.content, "merge"),
+        label: command.name,
+        path: rel(workspaceRoot, path),
+        absolutePath: path,
+      });
+    }
+    if (input.modes.commands === "replace") {
+      for (const name of existing) {
+        if (incoming.has(name)) continue;
+        const path = join(projectCommandsDir(workspaceRoot), `${name}.md`);
+        changes.push({
+          kind: "command",
+          action: "delete",
+          label: name,
+          path: rel(workspaceRoot, path),
+          absolutePath: path,
+        });
+      }
+    }
+  }
+
+  if (input.files.length > 0) {
+    const incoming = new Set<string>();
+    for (const file of input.files) {
+      incoming.add(file.path);
+      const path = join(workspaceRoot, file.path);
+      const existsBefore = await exists(path);
+      const before = existsBefore ? await readFile(path, "utf8") : "";
+      changes.push({
+        kind: "file",
+        action: actionForTarget(existsBefore, before !== file.content, "merge"),
+        label: file.path,
+        path: file.path,
+        absolutePath: path,
+      });
+    }
+    if (input.modes.files === "replace") {
+      for (const file of await listPortableFiles(workspaceRoot)) {
+        if (incoming.has(file.path)) continue;
+        const path = join(workspaceRoot, file.path);
+        changes.push({
+          kind: "file",
+          action: "delete",
+          label: file.path,
+          path: file.path,
+          absolutePath: path,
+        });
+      }
+    }
+  }
+
+  return {
+    summary: countSummary(changes),
+    changes,
+  };
+}
+
+export function publicWorkspaceImportPreview(preview: WorkspaceImportPlan): WorkspaceImportPreview {
+  return {
+    summary: preview.summary,
+    changes: preview.changes.map(({ absolutePath: _absolutePath, ...change }) => change),
+  };
+}
+
+export function workspaceImportPreviewApprovalPaths(preview: WorkspaceImportPlan): string[] {
+  return Array.from(
+    new Set(
+      preview.changes
+        .filter((change) => change.action !== "unchanged")
+        .map((change) => change.absolutePath),
+    ),
+  );
+}
+
+function countLabel(verb: string, count: number): string | null {
+  if (count <= 0) return null;
+  return `${verb} ${count}`;
+}
+
+export function summarizeWorkspaceImportPreview(preview: WorkspaceImportPreview): string {
+  const parts = [
+    countLabel("add", preview.summary.create),
+    countLabel("update", preview.summary.update + preview.summary.replace),
+    countLabel("remove", preview.summary.delete),
+  ].filter((part): part is string => Boolean(part));
+
+  return parts.length ? `Import workspace config (${parts.join(", ")})` : "Import workspace config (no changes)";
+}

--- a/apps/server/src/workspace-import-preview.ts
+++ b/apps/server/src/workspace-import-preview.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readdir, readFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 
@@ -31,9 +32,12 @@ export type WorkspaceImportChange = {
 
 type WorkspaceImportPlannedChange = WorkspaceImportChange & {
   absolutePath: string;
+  beforeDigest: string;
+  afterDigest: string;
 };
 
 export type WorkspaceImportPreview = {
+  fingerprint: string;
   summary: {
     total: number;
     create: number;
@@ -49,8 +53,11 @@ export type WorkspaceImportPlan = Omit<WorkspaceImportPreview, "changes"> & {
   changes: WorkspaceImportPlannedChange[];
 };
 
+type WorkspaceImportSection = "opencode" | "openwork" | "skills" | "commands" | "files";
+
 export type NormalizedWorkspaceImport = {
   modes: Record<string, WorkspaceImportMode>;
+  sections: Record<WorkspaceImportSection, boolean>;
   opencode?: Record<string, unknown>;
   openwork?: Record<string, unknown>;
   skills: Array<{ name: string; content: string; description?: string }>;
@@ -166,6 +173,13 @@ export function normalizeWorkspaceImportPayload(
 ): NormalizedWorkspaceImport {
   return {
     modes: normalizeModes(payload.mode),
+    sections: {
+      opencode: payload.opencode !== undefined,
+      openwork: payload.openwork !== undefined,
+      skills: payload.skills !== undefined,
+      commands: payload.commands !== undefined,
+      files: payload.files !== undefined,
+    },
     ...(payload.opencode !== undefined
       ? { opencode: sanitizePortableOpencodeConfig(readRecord(payload.opencode)) }
       : {}),
@@ -191,7 +205,19 @@ function stableStringify(value: unknown): string {
       .map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`);
     return `{${entries.join(",")}}`;
   }
-  return JSON.stringify(value);
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(stableStringify(value)).digest("hex");
+}
+
+function textDigest(content: string | null): string {
+  return digest(content === null ? { type: "missing" } : { type: "text", content });
+}
+
+function jsonDigest(value: unknown): string {
+  return digest({ type: "json", value });
 }
 
 function sameJson(left: unknown, right: unknown): boolean {
@@ -220,6 +246,18 @@ function countSummary(changes: WorkspaceImportChange[]): WorkspaceImportPreview[
       return summary;
     },
     { total: 0, create: 0, update: 0, replace: 0, delete: 0, unchanged: 0 },
+  );
+}
+
+function fingerprintWorkspaceImportChanges(changes: WorkspaceImportPlannedChange[]): string {
+  return digest(
+    changes.map((change) => ({
+      kind: change.kind,
+      action: change.action,
+      path: change.path,
+      beforeDigest: change.beforeDigest,
+      afterDigest: change.afterDigest,
+    })),
   );
 }
 
@@ -273,6 +311,8 @@ export async function buildWorkspaceImportPreview(
       label: "OpenCode config",
       path: rel(workspaceRoot, path),
       absolutePath: path,
+      beforeDigest: jsonDigest(before.data),
+      afterDigest: jsonDigest(after),
     });
   }
 
@@ -287,10 +327,12 @@ export async function buildWorkspaceImportPreview(
       label: "OpenWork config",
       path: rel(workspaceRoot, path),
       absolutePath: path,
+      beforeDigest: existsBefore ? jsonDigest(before) : textDigest(null),
+      afterDigest: jsonDigest(after),
     });
   }
 
-  if (input.skills.length > 0) {
+  if (input.sections.skills) {
     const existing = new Set(await listProjectSkillNames(workspaceRoot));
     const incoming = new Set<string>();
     for (const skill of input.skills) {
@@ -305,24 +347,29 @@ export async function buildWorkspaceImportPreview(
         label: skill.name,
         path: rel(workspaceRoot, path),
         absolutePath: path,
+        beforeDigest: existsBefore ? textDigest(before) : textDigest(null),
+        afterDigest: textDigest(next.content),
       });
     }
     if (input.modes.skills === "replace") {
       for (const name of existing) {
         if (incoming.has(name)) continue;
         const path = join(projectSkillsDir(workspaceRoot), name);
+        const skillFile = join(path, "SKILL.md");
         changes.push({
           kind: "skill",
           action: "delete",
           label: name,
           path: rel(workspaceRoot, path),
           absolutePath: path,
+          beforeDigest: textDigest(await readFile(skillFile, "utf8")),
+          afterDigest: textDigest(null),
         });
       }
     }
   }
 
-  if (input.commands.length > 0) {
+  if (input.sections.commands) {
     const existing = new Set(await listProjectCommandNames(workspaceRoot));
     const incoming = new Set<string>();
     for (const command of input.commands) {
@@ -337,6 +384,8 @@ export async function buildWorkspaceImportPreview(
         label: command.name,
         path: rel(workspaceRoot, path),
         absolutePath: path,
+        beforeDigest: existsBefore ? textDigest(before) : textDigest(null),
+        afterDigest: textDigest(next.content),
       });
     }
     if (input.modes.commands === "replace") {
@@ -349,12 +398,14 @@ export async function buildWorkspaceImportPreview(
           label: name,
           path: rel(workspaceRoot, path),
           absolutePath: path,
+          beforeDigest: textDigest(await readFile(path, "utf8")),
+          afterDigest: textDigest(null),
         });
       }
     }
   }
 
-  if (input.files.length > 0) {
+  if (input.sections.files) {
     const incoming = new Set<string>();
     for (const file of input.files) {
       incoming.add(file.path);
@@ -367,6 +418,8 @@ export async function buildWorkspaceImportPreview(
         label: file.path,
         path: file.path,
         absolutePath: path,
+        beforeDigest: existsBefore ? textDigest(before) : textDigest(null),
+        afterDigest: textDigest(file.content),
       });
     }
     if (input.modes.files === "replace") {
@@ -379,21 +432,28 @@ export async function buildWorkspaceImportPreview(
           label: filePath,
           path: filePath,
           absolutePath: path,
+          beforeDigest: textDigest(await readFile(path, "utf8")),
+          afterDigest: textDigest(null),
         });
       }
     }
   }
 
+  const summary = countSummary(changes);
   return {
-    summary: countSummary(changes),
+    fingerprint: fingerprintWorkspaceImportChanges(changes),
+    summary,
     changes,
   };
 }
 
 export function publicWorkspaceImportPreview(preview: WorkspaceImportPlan): WorkspaceImportPreview {
   return {
+    fingerprint: preview.fingerprint,
     summary: preview.summary,
-    changes: preview.changes.map(({ absolutePath: _absolutePath, ...change }) => change),
+    changes: preview.changes.map(
+      ({ absolutePath: _absolutePath, beforeDigest: _beforeDigest, afterDigest: _afterDigest, ...change }) => change,
+    ),
   };
 }
 

--- a/apps/server/src/workspace-import-preview.ts
+++ b/apps/server/src/workspace-import-preview.ts
@@ -238,6 +238,19 @@ function rel(workspaceRoot: string, absolutePath: string): string {
   return relative(workspaceRoot, absolutePath).replaceAll("\\", "/");
 }
 
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
+}
+
+async function readTextIfPresent(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isMissingFileError(error)) return null;
+    throw error;
+  }
+}
+
 function countSummary(changes: WorkspaceImportChange[]): WorkspaceImportPreview["summary"] {
   return changes.reduce(
     (summary, change) => {
@@ -262,9 +275,10 @@ function fingerprintWorkspaceImportChanges(changes: WorkspaceImportPlannedChange
 }
 
 async function readOpenworkConfig(path: string): Promise<Record<string, unknown>> {
-  if (!(await exists(path))) return {};
+  const raw = await readTextIfPresent(path);
+  if (raw === null) return {};
   try {
-    return JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    return JSON.parse(raw) as Record<string, unknown>;
   } catch {
     throw new ApiError(422, "invalid_json", "Failed to parse openwork.json");
   }
@@ -339,15 +353,15 @@ export async function buildWorkspaceImportPreview(
       incoming.add(skill.name);
       const path = join(projectSkillsDir(workspaceRoot), skill.name, "SKILL.md");
       const existsBefore = existing.has(skill.name);
-      const before = existsBefore ? await readFile(path, "utf8") : "";
+      const before = existsBefore ? await readTextIfPresent(path) : null;
       const next = buildSkillContent(skill);
       changes.push({
         kind: "skill",
-        action: actionForTarget(existsBefore, before !== next.content, "merge"),
+        action: actionForTarget(before !== null, before !== next.content, "merge"),
         label: skill.name,
         path: rel(workspaceRoot, path),
         absolutePath: path,
-        beforeDigest: existsBefore ? textDigest(before) : textDigest(null),
+        beforeDigest: before !== null ? textDigest(before) : textDigest(null),
         afterDigest: textDigest(next.content),
       });
     }
@@ -356,13 +370,15 @@ export async function buildWorkspaceImportPreview(
         if (incoming.has(name)) continue;
         const path = join(projectSkillsDir(workspaceRoot), name);
         const skillFile = join(path, "SKILL.md");
+        const before = await readTextIfPresent(skillFile);
+        if (before === null) continue;
         changes.push({
           kind: "skill",
           action: "delete",
           label: name,
           path: rel(workspaceRoot, path),
           absolutePath: path,
-          beforeDigest: textDigest(await readFile(skillFile, "utf8")),
+          beforeDigest: textDigest(before),
           afterDigest: textDigest(null),
         });
       }
@@ -376,15 +392,15 @@ export async function buildWorkspaceImportPreview(
       incoming.add(command.name);
       const path = join(projectCommandsDir(workspaceRoot), `${command.name}.md`);
       const existsBefore = existing.has(command.name);
-      const before = existsBefore ? await readFile(path, "utf8") : "";
+      const before = existsBefore ? await readTextIfPresent(path) : null;
       const next = buildCommandContent(command);
       changes.push({
         kind: "command",
-        action: actionForTarget(existsBefore, before !== next.content, "merge"),
+        action: actionForTarget(before !== null, before !== next.content, "merge"),
         label: command.name,
         path: rel(workspaceRoot, path),
         absolutePath: path,
-        beforeDigest: existsBefore ? textDigest(before) : textDigest(null),
+        beforeDigest: before !== null ? textDigest(before) : textDigest(null),
         afterDigest: textDigest(next.content),
       });
     }
@@ -392,13 +408,15 @@ export async function buildWorkspaceImportPreview(
       for (const name of existing) {
         if (incoming.has(name)) continue;
         const path = join(projectCommandsDir(workspaceRoot), `${name}.md`);
+        const before = await readTextIfPresent(path);
+        if (before === null) continue;
         changes.push({
           kind: "command",
           action: "delete",
           label: name,
           path: rel(workspaceRoot, path),
           absolutePath: path,
-          beforeDigest: textDigest(await readFile(path, "utf8")),
+          beforeDigest: textDigest(before),
           afterDigest: textDigest(null),
         });
       }
@@ -411,14 +429,14 @@ export async function buildWorkspaceImportPreview(
       incoming.add(file.path);
       const path = join(workspaceRoot, file.path);
       const existsBefore = await exists(path);
-      const before = existsBefore ? await readFile(path, "utf8") : "";
+      const before = existsBefore ? await readTextIfPresent(path) : null;
       changes.push({
         kind: "file",
-        action: actionForTarget(existsBefore, before !== file.content, "merge"),
+        action: actionForTarget(before !== null, before !== file.content, "merge"),
         label: file.path,
         path: file.path,
         absolutePath: path,
-        beforeDigest: existsBefore ? textDigest(before) : textDigest(null),
+        beforeDigest: before !== null ? textDigest(before) : textDigest(null),
         afterDigest: textDigest(file.content),
       });
     }
@@ -426,13 +444,15 @@ export async function buildWorkspaceImportPreview(
       for (const filePath of await listPortableFilePaths(workspaceRoot)) {
         if (incoming.has(filePath)) continue;
         const path = join(workspaceRoot, filePath);
+        const before = await readTextIfPresent(path);
+        if (before === null) continue;
         changes.push({
           kind: "file",
           action: "delete",
           label: filePath,
           path: filePath,
           absolutePath: path,
-          beforeDigest: textDigest(await readFile(path, "utf8")),
+          beforeDigest: textDigest(before),
           afterDigest: textDigest(null),
         });
       }


### PR DESCRIPTION
## Why
Workspace/template imports can change `.opencode` config, skills, commands, and portable files. Without a preview, users are approving a write they cannot inspect, and replace mode can remove existing setup with no server-side proof that the reviewed state still matches the workspace.

This adds the server primitive for safe imports: preview first, then apply only if the workspace still matches that preview.

## What changed
- Add `POST /workspace/:id/import/preview` with a public diff and preview fingerprint.
- Require changed `POST /workspace/:id/import` calls to include a matching `previewFingerprint`; stale previews return 409 with the latest preview.
- Make replace mode honor empty `skills`, `commands`, and `files` arrays, so "replace with none" removes existing items.
- Share skill/command content builders so preview and write use the same formatting rules.

## Test plan
- `pnpm --filter openwork-server exec bun test src/workspace-import-preview.test.ts`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwork-server build:bin`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`
- `git diff --check`

## Notes
No app UI in this revision. The older team-template UI this branch originally targeted was removed from `dev` in #1593, so this keeps the server/API import safety primitive without bringing that surface back.