### PR TITLE
Prepare safe Electron preview migration

### DIFF
--- a/.github/workflows/build-electron-desktop.yml
+++ b/.github/workflows/build-electron-desktop.yml
@@ -1,40 +1,50 @@
-name: Build Electron Desktop
+name: Build Electron Desktop Preview
 
 on:
   workflow_dispatch:
   push:
     branches:
+      - "**"
+  pull_request:
+    branches:
       - dev
-    paths:
-      - apps/app/**
-      - apps/desktop/**
-      - packages/ui/**
-      - constants.json
-      - pnpm-lock.yaml
-      - package.json
-      - .github/workflows/build-electron-desktop.yml
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   build-electron:
+    name: Build Electron (${{ matrix.artifact }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            artifact: macos
-          - os: ubuntu-latest
-            artifact: linux
+          - os: macos-14
+            artifact: mac-arm64
+            target_triple: aarch64-apple-darwin
+            builder_args: --mac --arm64
+          - os: macos-13
+            artifact: mac-x64
+            target_triple: x86_64-apple-darwin
+            builder_args: --mac --x64
+          - os: ubuntu-24.04
+            artifact: linux-x64
+            target_triple: x86_64-unknown-linux-gnu
+            builder_args: --linux --x64
           - os: windows-latest
-            artifact: windows
+            artifact: windows-x64
+            target_triple: x86_64-pc-windows-msvc
+            builder_args: --win --x64
     runs-on: ${{ matrix.os }}
+    env:
+      TAURI_ENV_TARGET_TRIPLE: ${{ matrix.target_triple }}
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      # pnpm must be installed BEFORE setup-node so setup-node can find the
-      # pnpm binary on PATH. Matches the pattern in build-desktop.yml so
-      # the two workflows share the same bootstrap story.
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -50,14 +60,110 @@ jobs:
         with:
           bun-version: 1.3.9
 
+      - name: Install Linux packaging dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libarchive-tools rpm
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Package Electron desktop (unpacked)
-        run: pnpm --filter @openwork/desktop package:electron:dir
+      - name: Build Electron renderer and sidecars
+        shell: bash
+        run: pnpm --filter @openwork/desktop build:electron
 
-      - name: Upload Electron artifacts
+      - name: Package Electron desktop installer
+        shell: bash
+        run: pnpm --filter @openwork/desktop exec electron-builder --config electron-builder.yml ${{ matrix.builder_args }} --publish never
+
+      - name: Upload Electron preview artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: openwork-electron-${{ matrix.artifact }}
-          path: apps/desktop/dist-electron/**
+          name: openwork-electron-${{ matrix.artifact }}-${{ github.sha }}
+          if-no-files-found: error
+          path: |
+            apps/desktop/dist-electron/*.dmg
+            apps/desktop/dist-electron/*.zip
+            apps/desktop/dist-electron/*.AppImage
+            apps/desktop/dist-electron/*.tar.gz
+            apps/desktop/dist-electron/*.exe
+            apps/desktop/dist-electron/latest*.yml
+            apps/desktop/dist-electron/*.blockmap
+
+  publish-preview-release:
+    name: Publish rolling Electron preview release
+    needs: build-electron
+    if: >-
+      github.event_name == 'push' &&
+      github.repository == 'different-ai/openwork' &&
+      (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PREVIEW_TAG: electron-preview-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download Electron artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: preview-artifacts
+          pattern: openwork-electron-*
+          merge-multiple: true
+
+      - name: Create or update preview release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          notes_file="$RUNNER_TEMP/electron-preview-notes.md"
+          cat > "$notes_file" <<EOF
+          Rolling Electron preview build for commit $GITHUB_SHA.
+
+          Safety notes:
+          - This is a preview download bucket, not the stable Tauri updater channel.
+          - Tauri remains the main desktop build until a separate migration release is cut.
+          - The debug migration control in Tauri requires an explicit artifact URL and confirmation before any install handoff.
+          EOF
+
+          if gh release view "$PREVIEW_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$PREVIEW_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Electron Preview Latest" \
+              --notes-file "$notes_file" \
+              --prerelease
+          else
+            if ! git ls-remote --exit-code --tags origin "$PREVIEW_TAG" >/dev/null 2>&1; then
+              git tag "$PREVIEW_TAG" "$GITHUB_SHA"
+              git push origin "refs/tags/$PREVIEW_TAG"
+            fi
+            gh release create "$PREVIEW_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "Electron Preview Latest" \
+              --notes-file "$notes_file" \
+              --prerelease \
+              --latest=false
+          fi
+
+          gh release view "$PREVIEW_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' \
+            | while IFS= read -r asset; do
+                [ -z "$asset" ] && continue
+                gh release delete-asset "$PREVIEW_TAG" "$asset" --repo "$GITHUB_REPOSITORY" -y
+              done
+
+          mapfile -d '' files < <(find preview-artifacts -type f -print0)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No Electron preview artifacts found" >&2
+            exit 1
+          fi
+
+          gh release upload "$PREVIEW_TAG" "${files[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+          echo "Electron preview release: https://github.com/$GITHUB_REPOSITORY/releases/tag/$PREVIEW_TAG"

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -3,6 +3,7 @@ import {
   CircleAlert,
   Copy,
   Download,
+  ExternalLink,
   HardDrive,
   RefreshCcw,
   Smartphone,
@@ -86,6 +87,17 @@ export type DebugViewProps = {
   onClearDeveloperLog: () => void | Promise<void>;
   onCopyDeveloperLog: () => void | Promise<void>;
   onExportDeveloperLog: () => void | Promise<void>;
+  electronMigrationAvailable: boolean;
+  electronMigrationUrl: string;
+  electronMigrationSha256: string;
+  electronMigrationBusy: boolean;
+  electronMigrationStatus: string | null;
+  electronPreviewReleaseUrl: string;
+  onSetElectronMigrationUrl: (value: string) => void;
+  onSetElectronMigrationSha256: (value: string) => void;
+  onOpenElectronPreviewRelease: () => void | Promise<void>;
+  onPrepareElectronMigrationSnapshot: () => void | Promise<void>;
+  onInstallElectronPreviewFromTauri: () => void | Promise<void>;
   sandboxProbeBusy: boolean;
   sandboxProbeResult: SandboxDebugProbeResult | null;
   sandboxProbeStatus: string | null;
@@ -258,6 +270,83 @@ export function DebugView(props: DebugViewProps) {
           <pre className={settingsMonoPreClass}>{props.developerLogText || "No developer logs captured yet."}</pre>
           {props.developerLogStatus ? <div className="text-xs text-gray-10">{props.developerLogStatus}</div> : null}
         </div>
+
+        {props.electronMigrationAvailable ? (
+          <div className={settingsCardClass}>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-gray-12">Electron preview migration</div>
+                <div className="text-xs text-gray-10">
+                  Debug-only Tauri controls. Preparing migration data is non-destructive; installing requires a URL and two confirmations.
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                className="h-8 shrink-0 px-3 py-0 text-xs"
+                onClick={() => void props.onOpenElectronPreviewRelease()}
+              >
+                <ExternalLink size={13} className="mr-1.5" />
+                Preview release
+              </Button>
+            </div>
+
+            <div className="rounded-xl border border-green-7/25 bg-green-3/10 px-3 py-2 text-xs leading-relaxed text-green-11">
+              Safe default: use <strong>Prepare migration data</strong> first. It writes the Electron snapshot only and does not replace, quit, or delete the Tauri app.
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
+              <label className="space-y-1 text-xs text-gray-10">
+                <span>Electron artifact URL</span>
+                <input
+                  type="url"
+                  value={props.electronMigrationUrl}
+                  onChange={(event) => props.onSetElectronMigrationUrl(event.currentTarget.value)}
+                  placeholder="Paste a trusted Electron .zip/.exe/AppImage URL"
+                  className="h-10 w-full rounded-xl border border-gray-6 bg-gray-1 px-3 font-mono text-xs text-gray-12 outline-none transition-colors placeholder:text-gray-7 focus:border-gray-8"
+                />
+              </label>
+              <label className="space-y-1 text-xs text-gray-10">
+                <span>sha256 (optional)</span>
+                <input
+                  type="text"
+                  value={props.electronMigrationSha256}
+                  onChange={(event) => props.onSetElectronMigrationSha256(event.currentTarget.value)}
+                  placeholder="recommended"
+                  className="h-10 w-full rounded-xl border border-gray-6 bg-gray-1 px-3 font-mono text-xs text-gray-12 outline-none transition-colors placeholder:text-gray-7 focus:border-gray-8"
+                />
+              </label>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="secondary"
+                className="h-9 px-3 py-0 text-xs"
+                onClick={() => void props.onPrepareElectronMigrationSnapshot()}
+                disabled={props.electronMigrationBusy}
+              >
+                {props.electronMigrationBusy ? "Preparing…" : "Prepare migration data"}
+              </Button>
+              <Button
+                variant="outline"
+                className="h-9 border-amber-7/50 px-3 py-0 text-xs text-amber-11 hover:bg-amber-3/40"
+                onClick={() => void props.onInstallElectronPreviewFromTauri()}
+                disabled={props.electronMigrationBusy || !props.electronMigrationUrl.trim()}
+                title="Requires a trusted artifact URL. macOS keeps OpenWork.app.migrate-bak for rollback."
+              >
+                Start install handoff…
+              </Button>
+              <div className="text-[11px] text-gray-7">
+                Release page: <span className="font-mono">{props.electronPreviewReleaseUrl}</span>
+              </div>
+            </div>
+
+            {props.electronMigrationStatus ? (
+              <div className="rounded-lg border border-gray-6 bg-gray-1/60 px-3 py-2 text-xs text-gray-11">
+                {props.electronMigrationStatus}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
 
         <div className={settingsCardClass}>
           <div className="flex items-start justify-between gap-3">

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -6,6 +6,7 @@ import {
   engineInfo as engineInfoCmd,
   engineStart as engineStartCmd,
   nukeOpenworkAndOpencodeConfigAndExit,
+  openDesktopUrl,
   openworkServerInfo as openworkServerInfoCmd,
   openworkServerRestart as openworkServerRestartCmd,
   opencodeRouterInfo as opencodeRouterInfoCmd,
@@ -24,11 +25,16 @@ import {
   type SandboxDebugProbeResult,
 } from "../../../../app/lib/desktop";
 import {
+  migrateToElectron,
+  writeMigrationSnapshotFromTauri,
+} from "../../../../app/lib/migration";
+import {
   writeOpenworkServerSettings,
 } from "../../../../app/lib/openwork-server";
 import {
   clearStartupPreference,
   isDesktopRuntime,
+  isTauriRuntime,
   safeStringify,
 } from "../../../../app/utils";
 import { t } from "../../../../i18n";
@@ -40,6 +46,8 @@ const ENGINE_SOURCE_KEY = "openwork.engineSource";
 const ENGINE_RUNTIME_KEY = "openwork.engineRuntime";
 const ENGINE_CUSTOM_BIN_KEY = "openwork.engineCustomBinPath";
 const OPENCODE_ENABLE_EXA_KEY = "openwork.opencodeEnableExa";
+const ELECTRON_PREVIEW_RELEASE_URL = "https://github.com/different-ai/openwork/releases/tag/electron-preview-latest";
+const ELECTRON_INSTALL_CONFIRM_PHRASE = "install electron preview";
 
 type ResetModalMode = "onboarding" | "all";
 
@@ -271,6 +279,10 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
   );
   const [developerLog, setDeveloperLog] = useState<string[]>([]);
   const [developerLogStatus, setDeveloperLogStatus] = useState<string | null>(null);
+  const [electronMigrationUrl, setElectronMigrationUrl] = useState("");
+  const [electronMigrationSha256, setElectronMigrationSha256] = useState("");
+  const [electronMigrationBusy, setElectronMigrationBusy] = useState(false);
+  const [electronMigrationStatus, setElectronMigrationStatus] = useState<string | null>(null);
 
   const refreshEngineInfo = useCallback(async () => {
     if (!isDesktopRuntime()) return;
@@ -437,6 +449,98 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       setDeveloperLogStatus(error instanceof Error ? error.message : safeStringify(error));
     }
   }, [developerLog]);
+
+  const onOpenElectronPreviewRelease = useCallback(async () => {
+    try {
+      await openDesktopUrl(ELECTRON_PREVIEW_RELEASE_URL);
+      setElectronMigrationStatus("Opened the rolling Electron preview release. Download links live there after dev/main push builds finish.");
+    } catch (error) {
+      setElectronMigrationStatus(error instanceof Error ? error.message : safeStringify(error));
+    }
+  }, []);
+
+  const onPrepareElectronMigrationSnapshot = useCallback(async () => {
+    if (!isTauriRuntime()) {
+      setElectronMigrationStatus("Migration snapshot export is only available in the Tauri desktop app.");
+      return;
+    }
+    setElectronMigrationBusy(true);
+    setElectronMigrationStatus(null);
+    try {
+      const result = await writeMigrationSnapshotFromTauri();
+      if (!result.ok) {
+        throw new Error(result.reason ?? "Failed to write migration snapshot.");
+      }
+      setElectronMigrationStatus(
+        `Prepared Electron migration data (${result.keyCount} localStorage key${result.keyCount === 1 ? "" : "s"}). This did not replace or quit Tauri.`,
+      );
+      pushDeveloperLog(`prepared Electron migration snapshot keyCount=${result.keyCount}`);
+    } catch (error) {
+      setElectronMigrationStatus(error instanceof Error ? error.message : safeStringify(error));
+    } finally {
+      setElectronMigrationBusy(false);
+    }
+  }, [pushDeveloperLog]);
+
+  const onInstallElectronPreviewFromTauri = useCallback(async () => {
+    if (!isTauriRuntime()) {
+      setElectronMigrationStatus("Electron install handoff is only available in the Tauri desktop app.");
+      return;
+    }
+
+    const url = electronMigrationUrl.trim();
+    if (!url) {
+      setElectronMigrationStatus("Paste a trusted Electron artifact URL before starting the install handoff.");
+      return;
+    }
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== "https:") {
+        setElectronMigrationStatus("Electron artifact URLs must use https://.");
+        return;
+      }
+    } catch {
+      setElectronMigrationStatus("Paste a valid https:// Electron artifact URL before starting the install handoff.");
+      return;
+    }
+
+    const confirmed =
+      typeof window === "undefined" ||
+      window.confirm(
+        "This debug-only migration action first writes a migration snapshot, then starts the Tauri → Electron handoff. On macOS, the installer swaps OpenWork.app in place and keeps OpenWork.app.migrate-bak for rollback. Tauri stable updates remain unchanged. Continue?",
+      );
+    if (!confirmed) return;
+
+    const phrase =
+      typeof window === "undefined"
+        ? ELECTRON_INSTALL_CONFIRM_PHRASE
+        : window.prompt(`Type \"${ELECTRON_INSTALL_CONFIRM_PHRASE}\" to start the Electron preview install handoff.`);
+    if (phrase !== ELECTRON_INSTALL_CONFIRM_PHRASE) {
+      setElectronMigrationStatus("Install handoff cancelled before any app replacement step.");
+      return;
+    }
+
+    setElectronMigrationBusy(true);
+    setElectronMigrationStatus(null);
+    try {
+      const snapshot = await writeMigrationSnapshotFromTauri();
+      if (!snapshot.ok) {
+        throw new Error(snapshot.reason ?? "Failed to write migration snapshot.");
+      }
+      pushDeveloperLog(`prepared Electron migration snapshot before install keyCount=${snapshot.keyCount}`);
+      const result = await migrateToElectron({
+        url,
+        sha256: electronMigrationSha256.trim() || undefined,
+      });
+      if (!result.ok) {
+        throw new Error(result.reason ?? "Electron install handoff failed.");
+      }
+      setElectronMigrationStatus("Electron install handoff started. Tauri will quit if the native handoff accepted the request.");
+    } catch (error) {
+      setElectronMigrationStatus(error instanceof Error ? error.message : safeStringify(error));
+      setElectronMigrationBusy(false);
+    }
+  }, [electronMigrationSha256, electronMigrationUrl, pushDeveloperLog]);
 
   const onRunSandboxDebugProbe = useCallback(async () => {
     if (!isDesktopRuntime()) return;
@@ -726,6 +830,17 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       onClearDeveloperLog,
       onCopyDeveloperLog,
       onExportDeveloperLog,
+      electronMigrationAvailable: isTauriRuntime(),
+      electronMigrationUrl,
+      electronMigrationSha256,
+      electronMigrationBusy,
+      electronMigrationStatus,
+      electronPreviewReleaseUrl: ELECTRON_PREVIEW_RELEASE_URL,
+      onSetElectronMigrationUrl: setElectronMigrationUrl,
+      onSetElectronMigrationSha256: setElectronMigrationSha256,
+      onOpenElectronPreviewRelease,
+      onPrepareElectronMigrationSnapshot,
+      onInstallElectronPreviewFromTauri,
       sandboxProbeBusy,
       sandboxProbeResult,
       sandboxProbeStatus,
@@ -781,6 +896,10 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       developerLog,
       developerLogStatus,
       developerMode,
+      electronMigrationBusy,
+      electronMigrationSha256,
+      electronMigrationStatus,
+      electronMigrationUrl,
       engineCard,
       engineCustomBinPath,
       engineRuntime,
@@ -794,8 +913,11 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       onCopyRuntimeDebugReport,
       onExportDeveloperLog,
       onExportRuntimeDebugReport,
+      onInstallElectronPreviewFromTauri,
       onNukeOpenworkAndOpencodeConfig,
+      onOpenElectronPreviewRelease,
       onOpenResetModal,
+      onPrepareElectronMigrationSnapshot,
       onPickEngineBinary,
       onResetStartupPreference,
       onRestartLocalServer,

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -17,6 +17,40 @@ scripts/migration/03-post-migration-cleanup.mjs  # delete src-tauri, flip defaul
 | 02   | Right after the workflow finishes | Dogfood validation — no user effect |
 | 03   | After 1-2 weeks of stable Electron telemetry | Dev repo is Electron-only; no user effect |
 
+## Current safe-prep rollout
+
+The next release is intentionally **non-destructive**:
+
+- Tauri remains the main/stable desktop build and keeps using the existing
+  Tauri updater feed (`latest.json`).
+- Electron is built as a preview artifact on every push by
+  `.github/workflows/build-electron-desktop.yml`.
+- Pushes to `dev` or `main` refresh the rolling prerelease bucket at
+  <https://github.com/different-ai/openwork/releases/tag/electron-preview-latest>.
+- The Debug settings migration controls are Tauri-only and developer-mode only.
+  The default action, **Prepare migration data**, only writes
+  `migration-snapshot.v1.json`; it does not quit, replace, or delete Tauri.
+- The install handoff requires a pasted Electron artifact URL plus two explicit
+  confirmations. On macOS the native handoff keeps the previous bundle at
+  `OpenWork.app.migrate-bak` for rollback.
+
+Use this safe-prep release to test migration data capture and preview downloads
+before enabling any user-facing migration prompt.
+
+### Sharing Electron preview downloads
+
+1. Wait for `Build Electron Desktop Preview` to finish on the target commit.
+2. Share the rolling preview release page:
+   <https://github.com/different-ai/openwork/releases/tag/electron-preview-latest>
+3. Ask testers to download the matching platform artifact:
+   - macOS Apple Silicon: `openwork-mac-arm64-*.dmg` or `.zip`
+   - macOS Intel: `openwork-mac-x64-*.dmg` or `.zip`
+   - Windows: `openwork-win-x64-*.exe`
+   - Linux: `openwork-linux-x64-*.AppImage` or `.tar.gz`
+
+Do not point stable Tauri users at these preview assets as an automatic update
+until the explicit migration release is cut and validated.
+
 ## 01 — cut-migration-release.mjs
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a Tauri-only, Developer Mode debug card for safe Electron migration prep: snapshot-only by default, HTTPS artifact URL guard, two explicit confirmations before install handoff.
- Expands Electron preview CI to build macOS arm64/x64, Windows x64, and Linux x64 installers on pushes/PRs, with dev/main pushes refreshing a rolling prerelease bucket.
- Documents the non-destructive rollout and tester download flow while keeping Tauri as the stable/main updater path.

## Safety notes
- The default debug action only writes `migration-snapshot.v1.json`; it does not quit, replace, or delete the Tauri app.
- The install handoff is still debug-only, Tauri-only, requires `https://`, and requires both a confirmation dialog and typing `install electron preview`.
- Electron preview assets publish to `electron-preview-latest`; this does not replace the Tauri `latest.json` stable updater feed.

## Verification
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/desktop build:electron`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-electron-desktop.yml"); puts "yaml-ok"'`
- `pnpm --filter @openwork/app build`

## Notes
- The working tree had pre-existing unstaged changes before this branch; only the four files in this PR were staged and committed.