### PR TITLE
feat: add MiniMax-M2.7 provider support

### DIFF
--- a/apps/app/src/app/utils/providers.ts
+++ b/apps/app/src/app/utils/providers.ts
@@ -1,6 +1,6 @@
 import type { Provider as ConfigProvider, ProviderListResponse } from "@opencode-ai/sdk/v2/client";
 
-const PINNED_PROVIDER_ORDER = ["opencode", "openai", "anthropic"] as const;
+const PINNED_PROVIDER_ORDER = ["opencode", "openai", "anthropic", "minimax"] as const;
 
 export const providerPriorityRank = (id: string) => {
   const normalized = id.trim().toLowerCase();

--- a/apps/app/src/react-app/design-system/provider-icon.tsx
+++ b/apps/app/src/react-app/design-system/provider-icon.tsx
@@ -28,6 +28,7 @@ export function ProviderIcon(props: ProviderIconProps) {
     if (normalizedId === "openrouter") return "OR";
     if (normalizedId === "deepseek") return "DS";
     if (normalizedId === "google") return "GO";
+    if (normalizedId === "minimax") return "MM";
     if (normalizedId.length >= 2) return normalizedId.substring(0, 2).toUpperCase();
     return "AI";
   })();

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -76,7 +76,7 @@ Pass criteria:
 - Sidebar shows a new **"New session"** entry above existing sessions.
 - Main area renders the composer with **"No transcript yet."**.
 - Composer model label is whatever is saved as default (e.g.
-  `opencode/minimax-m2.5-free`).
+  `opencode/minimax-m2.7`).
 
 Known regressions this catches:
 - `onCreateTaskInWorkspace` silently failing because the route has no
@@ -151,7 +151,7 @@ Known regressions this catches:
 Steps:
 1. On the General tab click **Change** (under "Model").
 2. In the picker, search or scroll to a model in an already-connected
-   provider (e.g. `opencode/minimax-m2.5-free`).
+   provider (e.g. `opencode/minimax-m2.7`).
 3. Click the model card.
 
 Pass criteria:


### PR DESCRIPTION
## Summary

- Pin minimax in the provider sort order (PINNED_PROVIDER_ORDER) so it appears featured in the Connections UI alongside opencode, openai, and anthropic
- Add MM abbreviation in ProviderIcon for the minimax provider ID (the generic substring fallback produced MI instead of MM)
- Update eval examples from opencode/minimax-m2.5-free to opencode/minimax-m2.7

## Test plan

- [ ] Open Connections tab: MiniMax appears before unlisted providers
- [ ] Connected MiniMax provider shows MM badge in provider icon
- [ ] Flows 2 and 6 in evals/react-session-flows.md work with opencode/minimax-m2.7