### PR TITLE
fix electron macOS runners

### DIFF
--- a/.github/workflows/build-electron-desktop.yml
+++ b/.github/workflows/build-electron-desktop.yml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
+          - os: macos-26
             artifact: mac-arm64
             target_triple: aarch64-apple-darwin
             builder_args: --mac --arm64
-          - os: macos-13
+          - os: macos-26-intel
             artifact: mac-x64
             target_triple: x86_64-apple-darwin
             builder_args: --mac --x64


### PR DESCRIPTION
## Summary
- Update Electron desktop preview macOS arm64 builds to GitHub's macOS 26 arm64 runner label: `macos-26`.
- Update Electron desktop preview macOS x64 builds to GitHub's macOS 26 Intel runner label: `macos-26-intel`.

## Tests
- `git diff --check -- .github/workflows/build-electron-desktop.yml`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "YAML parses"' ".github/workflows/build-electron-desktop.yml"`

## Notes
- `actionlint` is not installed locally, so workflow linting was limited to whitespace and YAML parsing.