### PR TITLE
fix: enforce cloud worker billing gate

### DIFF
--- a/ee/apps/den-api/src/routes/workers/core.ts
+++ b/ee/apps/den-api/src/routes/workers/core.ts
@@ -5,9 +5,11 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
+import { env } from "../../env.js"
 import { jsonValidator, paramValidator, queryValidator, requireUserMiddleware, resolveUserOrganizationsMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { getOrganizationLimitStatus } from "../../organization-limits.js"
+import { getRequiredUserEmail } from "../../user.js"
 import type { WorkerRouteVariables } from "./shared.js"
 import {
   continueCloudProvisioning,
@@ -17,7 +19,9 @@ import {
   getWorkerByIdForOrg,
   getWorkerTokensAndConnect,
   listWorkersQuerySchema,
+  parseUserId,
   parseWorkerIdParam,
+  requireCloudAccessOrPayment,
   toInstanceResponse,
   toWorkerResponse,
   token,
@@ -105,6 +109,20 @@ const orgLimitReachedSchema = z.object({
   message: z.string(),
 }).meta({ ref: "WorkerOrgLimitReachedError" })
 
+const userEmailRequiredSchema = z.object({
+  error: z.literal("user_email_required"),
+}).meta({ ref: "WorkerUserEmailRequiredError" })
+
+const paymentRequiredSchema = z.object({
+  error: z.literal("payment_required"),
+  message: z.string(),
+  polar: z.object({
+    checkoutUrl: z.string().nullable(),
+    productId: z.string().nullable().optional(),
+    benefitId: z.string().nullable().optional(),
+  }),
+}).meta({ ref: "WorkerPaymentRequiredError" })
+
 const workerRuntimeUnavailableSchema = z.object({
   error: z.literal("worker_tokens_unavailable"),
   message: z.string(),
@@ -168,8 +186,9 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
       responses: {
         201: jsonResponse("Local worker created successfully.", workerCreateResponseSchema),
         202: jsonResponse("Cloud worker creation started successfully.", workerCreateResponseSchema),
-        400: jsonResponse("The worker creation payload was invalid.", z.union([invalidRequestSchema, organizationUnavailableSchema, workspacePathRequiredSchema])),
+        400: jsonResponse("The worker creation payload was invalid.", z.union([invalidRequestSchema, organizationUnavailableSchema, workspacePathRequiredSchema, userEmailRequiredSchema])),
         401: jsonResponse("The caller must be signed in to create workers.", unauthorizedSchema),
+        402: jsonResponse("The caller needs an active cloud plan before creating a cloud worker.", paymentRequiredSchema),
         409: jsonResponse("The organization has reached its worker limit.", orgLimitReachedSchema),
       },
     }),
@@ -190,6 +209,11 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
     }
 
     if (input.destination === "cloud") {
+      const email = getRequiredUserEmail(user)
+      if (!email) {
+        return c.json({ error: "user_email_required" }, 400)
+      }
+
       const workerLimit = await getOrganizationLimitStatus(orgId, "workers")
       if (workerLimit.exceeded) {
         return c.json({
@@ -199,6 +223,24 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
           currentCount: workerLimit.currentCount,
           message: `This workspace currently supports up to ${workerLimit.limit} workers. Contact support to increase the limit.`,
         }, 409)
+      }
+
+      const access = await requireCloudAccessOrPayment({
+        userId: parseUserId(user.id),
+        email,
+        name: user.name ?? user.email ?? "OpenWork User",
+      })
+
+      if (!access.allowed) {
+        return c.json({
+          error: "payment_required",
+          message: "Creating a cloud worker requires an active OpenWork Cloud plan.",
+          polar: {
+            checkoutUrl: access.checkoutUrl,
+            productId: env.polar.productId,
+            benefitId: env.polar.benefitId,
+          },
+        }, 402)
       }
     }
 

--- a/ee/apps/den-api/test/worker-billing-gate.test.ts
+++ b/ee/apps/den-api/test/worker-billing-gate.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeAll, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.POLAR_ACCESS_TOKEN = process.env.POLAR_ACCESS_TOKEN ?? "polar_test_token"
+  process.env.POLAR_PRODUCT_ID = process.env.POLAR_PRODUCT_ID ?? "product_test"
+  process.env.POLAR_BENEFIT_ID = process.env.POLAR_BENEFIT_ID ?? "benefit_test"
+  process.env.POLAR_SUCCESS_URL = process.env.POLAR_SUCCESS_URL ?? "https://app.openworklabs.test/success"
+  process.env.POLAR_RETURN_URL = process.env.POLAR_RETURN_URL ?? "https://app.openworklabs.test/checkout"
+}
+
+const activeOrgId = createDenTypeId("organization")
+const activeUserId = createDenTypeId("user")
+const activeSessionId = createDenTypeId("session")
+
+type AccessResult =
+  | { allowed: true }
+  | { allowed: false; checkoutUrl: string }
+
+const workerRows: Array<Record<string, unknown>> = []
+const tokenRows: Array<Record<string, unknown>> = []
+
+let billingAccess: AccessResult = { allowed: true }
+let workerLimitExceeded = false
+let workerLimitCalls = 0
+
+const requireCloudWorkerAccess = mock(async () => billingAccess)
+const provisionWorker = mock(async (input: { workerId: string }) => ({
+  provider: "daytona",
+  region: "us",
+  url: `https://workers.test/${input.workerId}`,
+  status: "healthy",
+}))
+
+function resetFakes() {
+  workerRows.length = 0
+  tokenRows.length = 0
+  billingAccess = { allowed: true }
+  workerLimitExceeded = false
+  workerLimitCalls = 0
+  requireCloudWorkerAccess.mockClear()
+  provisionWorker.mockClear()
+}
+
+function classifyInsertedValues(values: unknown) {
+  const rows = Array.isArray(values) ? values : [values]
+  const first = rows[0] as Record<string, unknown> | undefined
+
+  if (first?.scope) {
+    tokenRows.push(...rows as Array<Record<string, unknown>>)
+    return
+  }
+
+  if (first?.provider && first?.worker_id) {
+    return
+  }
+
+  if (first?.org_id && first?.destination) {
+    workerRows.push(...rows as Array<Record<string, unknown>>)
+  }
+}
+
+const fakeDb = {
+  insert() {
+    return {
+      values: async (values: unknown) => {
+        classifyInsertedValues(values)
+        return []
+      },
+    }
+  },
+  update() {
+    return {
+      set: () => ({
+        where: async () => {
+          return []
+        },
+      }),
+    }
+  },
+  select() {
+    return {
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: async () => [],
+          }),
+          limit: async () => [],
+        }),
+        orderBy: () => ({
+          limit: async () => [],
+        }),
+        limit: async () => [],
+      }),
+    }
+  },
+}
+
+mock.module("../src/db.js", () => ({
+  db: fakeDb,
+}))
+
+mock.module("../src/orgs.js", () => ({
+  getOrganizationContextForUser: mock(async () => null),
+  listTeamsForMember: mock(async () => []),
+  resolveUserOrganizations: mock(async () => ({
+    activeOrgId,
+    activeOrgSlug: "test-org",
+    orgs: [{ id: activeOrgId, slug: "test-org", name: "Test Org" }],
+  })),
+  setSessionActiveOrganization: mock(async () => undefined),
+}))
+
+mock.module("../src/organization-limits.js", () => ({
+  getOrganizationLimitStatus: mock(async () => {
+    workerLimitCalls += 1
+    return {
+      currentCount: workerLimitExceeded ? 1 : 0,
+      exceeded: workerLimitExceeded,
+      limit: 1,
+      limitType: "workers",
+    }
+  }),
+}))
+
+mock.module("../src/billing/polar.js", () => ({
+  getCloudWorkerBillingStatus: mock(async () => ({})),
+  requireCloudWorkerAccess,
+  setCloudWorkerSubscriptionCancellation: mock(async () => null),
+}))
+
+mock.module("../src/workers/provisioner.js", () => ({
+  deprovisionWorker: mock(async () => undefined),
+  provisionWorker,
+}))
+
+let workerCoreModule: typeof import("../src/routes/workers/core.js")
+let envModule: typeof import("../src/env.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  envModule = await import("../src/env.js")
+  envModule.env.polar.productId = "product_test"
+  envModule.env.polar.benefitId = "benefit_test"
+  workerCoreModule = await import("../src/routes/workers/core.js")
+})
+
+afterEach(() => {
+  resetFakes()
+})
+
+function createWorkerApp(input: { email?: string | null } = {}) {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("user", {
+      id: activeUserId,
+      name: "Test User",
+      email: input.email === undefined ? "test@example.com" : input.email,
+    })
+    c.set("session", {
+      id: activeSessionId,
+      activeOrganizationId: activeOrgId,
+    })
+    await next()
+  })
+  workerCoreModule.registerWorkerCoreRoutes(app)
+  return app
+}
+
+function postWorker(app: Hono, body: Record<string, unknown>) {
+  return app.request("http://den.local/v1/workers", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+test("cloud worker creation returns payment_required before writing rows when billing is missing", async () => {
+  billingAccess = { allowed: false, checkoutUrl: "https://polar.test/checkout/session" }
+  const app = createWorkerApp()
+
+  const response = await postWorker(app, {
+    name: "Cloud Worker",
+    destination: "cloud",
+  })
+
+  expect(response.status).toBe(402)
+  await expect(response.json()).resolves.toEqual({
+    error: "payment_required",
+    message: "Creating a cloud worker requires an active OpenWork Cloud plan.",
+    polar: {
+      checkoutUrl: "https://polar.test/checkout/session",
+      productId: "product_test",
+      benefitId: "benefit_test",
+    },
+  })
+  expect(workerLimitCalls).toBe(1)
+  expect(requireCloudWorkerAccess).toHaveBeenCalledTimes(1)
+  expect(provisionWorker).not.toHaveBeenCalled()
+  expect(workerRows).toHaveLength(0)
+  expect(tokenRows).toHaveLength(0)
+})
+
+test("cloud worker creation stops at the organization worker limit before billing", async () => {
+  workerLimitExceeded = true
+  billingAccess = { allowed: false, checkoutUrl: "https://polar.test/checkout/session" }
+  const app = createWorkerApp()
+
+  const response = await postWorker(app, {
+    name: "Cloud Worker",
+    destination: "cloud",
+  })
+
+  expect(response.status).toBe(409)
+  await expect(response.json()).resolves.toEqual({
+    currentCount: 1,
+    error: "org_limit_reached",
+    limit: 1,
+    limitType: "workers",
+    message: "This workspace currently supports up to 1 workers. Contact support to increase the limit.",
+  })
+  expect(workerLimitCalls).toBe(1)
+  expect(requireCloudWorkerAccess).not.toHaveBeenCalled()
+  expect(provisionWorker).not.toHaveBeenCalled()
+  expect(workerRows).toHaveLength(0)
+  expect(tokenRows).toHaveLength(0)
+})
+
+test("paid cloud worker creation still provisions and returns launch details", async () => {
+  billingAccess = { allowed: true }
+  const app = createWorkerApp()
+
+  const response = await postWorker(app, {
+    name: "Cloud Worker",
+    destination: "cloud",
+  })
+
+  expect(response.status).toBe(202)
+  const payload = await response.json() as { launch?: { mode?: string }; worker?: { destination?: string } }
+  expect(payload.worker?.destination).toBe("cloud")
+  expect(payload.launch?.mode).toBe("async")
+  expect(workerLimitCalls).toBe(1)
+  expect(requireCloudWorkerAccess).toHaveBeenCalledTimes(1)
+  expect(workerRows).toHaveLength(1)
+  expect(tokenRows).toHaveLength(3)
+  expect(provisionWorker).toHaveBeenCalledTimes(1)
+})
+
+test("local worker creation does not require cloud billing", async () => {
+  billingAccess = { allowed: false, checkoutUrl: "https://polar.test/checkout/session" }
+  const app = createWorkerApp()
+
+  const response = await postWorker(app, {
+    name: "Local Worker",
+    destination: "local",
+    workspacePath: "/tmp/openwork",
+  })
+
+  expect(response.status).toBe(201)
+  const payload = await response.json() as { launch?: { mode?: string }; worker?: { destination?: string } }
+  expect(payload.worker?.destination).toBe("local")
+  expect(payload.launch?.mode).toBe("instant")
+  expect(workerLimitCalls).toBe(0)
+  expect(requireCloudWorkerAccess).not.toHaveBeenCalled()
+  expect(workerRows).toHaveLength(1)
+  expect(tokenRows).toHaveLength(3)
+  expect(provisionWorker).not.toHaveBeenCalled()
+})
+
+test("cloud worker creation requires a user email before contacting billing", async () => {
+  const app = createWorkerApp({ email: null })
+
+  const response = await postWorker(app, {
+    name: "Cloud Worker",
+    destination: "cloud",
+  })
+
+  expect(response.status).toBe(400)
+  await expect(response.json()).resolves.toEqual({ error: "user_email_required" })
+  expect(workerLimitCalls).toBe(0)
+  expect(requireCloudWorkerAccess).not.toHaveBeenCalled()
+  expect(workerRows).toHaveLength(0)
+  expect(tokenRows).toHaveLength(0)
+})

--- a/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
@@ -54,14 +54,14 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
 
   const mockMode = MOCK_BILLING && process.env.NODE_ENV !== "production";
 
-  const billingSummary = MOCK_BILLING
+  const billingSummary = mockMode
     ? {
         featureGateEnabled: true,
         hasActivePlan: false,
         checkoutRequired: true,
-              checkoutUrl: MOCK_CHECKOUT_URL,
-              portalUrl: null,
-              price: { amount: 5000, currency: "usd", recurringInterval: "month", recurringIntervalCount: 1 },
+        checkoutUrl: MOCK_CHECKOUT_URL,
+        portalUrl: null,
+        price: { amount: 5000, currency: "usd", recurringInterval: "month", recurringIntervalCount: 1 },
         subscription: null,
         invoices: [],
         productId: null,
@@ -182,8 +182,8 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
   }
 
   const billingPrice = billingSummary?.price ?? null;
-  const showLoading = resuming || (billingBusy && !billingSummary && !MOCK_BILLING);
-  const checkoutHref = effectiveCheckoutUrl ?? MOCK_CHECKOUT_URL ?? null;
+  const showLoading = resuming || (billingBusy && !billingSummary && !mockMode);
+  const checkoutHref = effectiveCheckoutUrl ?? (mockMode ? MOCK_CHECKOUT_URL : null);
   const planAmountLabel =
     billingPrice && billingPrice.amount !== null
       ? `${formatMoneyMinor(billingPrice.amount, billingPrice.currency)}/${billingPrice.recurringInterval}`


### PR DESCRIPTION
## Summary
- Enforces the existing Polar billing gate before cloud worker creation can write tokens or start provisioning.
- Keeps local worker creation unchanged.
- Tightens checkout mock mode so it only affects non-production builds.

## Why
- The cloud worker launch UI already handles `402 payment_required`, but `POST /v1/workers` did not check billing before provisioning.
- That could let an unpaid user create cloud workers directly through the API and consume hosted runtime resources.

## Issue
- No linked issue.

## Scope
- `POST /v1/workers` now checks user email, org worker limit, then cloud billing access before DB writes/provisioning.
- Adds OpenAPI response schemas for `user_email_required` and `payment_required`.
- Adds route tests for unpaid, paid, org-limit, local-worker, and missing-email paths.
- Limits checkout mock data/link fallback to `NODE_ENV !== "production"`.

## Out of scope
- Billing model changes.
- Worker limit changes.
- Checkout UI redesign.

## Testing
### Ran
- `pnpm --filter @openwork-ee/den-api exec bun test test/worker-billing-gate.test.ts`
- `pnpm --filter @openwork-ee/den-api exec sh -lc 'bun test ./test/*.test.ts'`
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit`
- `pnpm --filter @openwork-ee/den-api build`
- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit`
- `pnpm --filter @openwork-ee/den-web build`
- `git diff --check`

### Result
- All passed.

## CI status
- Local checks passed.
- Fork preview deploy may require OpenWork team authorization.

## Manual verification
1. `destination: "cloud"` with no active billing returns `402 payment_required` and does not write worker/token rows.
2. Paid cloud worker creation still returns `202` and provisions.
3. `destination: "local"` still returns `201` and does not call billing.
4. Checkout mock billing is ignored in production builds.

## Evidence
- No screenshot; this is a server-side billing gate and production mock guard. Evidence is the route test coverage and production builds above.

## Risk
- Low. The change only gates cloud worker creation and uses the existing Polar access helper and existing `402 payment_required` frontend path.

## Rollback
- Revert this commit to restore the previous worker creation behavior.
