### PR TITLE
Fix release sidecar workflow job

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -662,6 +662,8 @@ jobs:
         run: |
           set -euo pipefail
           pnpm --filter @openwork/desktop package:electron --publish always
+
+  release-orchestrator-sidecars:
     name: Build + Upload openwork-orchestrator Sidecars
     needs: [resolve-release, verify-release]
     if: needs.resolve-release.outputs.publish_sidecars == 'true'


### PR DESCRIPTION
## Summary
- Restores the missing `release-orchestrator-sidecars` job key in the macOS release workflow.
- Fixes GitHub Actions duplicate-key parsing errors for `name`, `needs`, `if`, `runs-on`, `env`, and `steps`.

## Verification
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/release-macos-aarch64.yml\"); puts \"yaml ok\"'`

## Notes
- `actionlint` was not installed locally, so only YAML parsing was run.