### PR TITLE
fix: the user-message copy button hover behavior

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -949,10 +949,10 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
     return (
       <div
         key={`message-${block.messageId}`}
-        className={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
+        className={`relative flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
         data-message-role={block.isUser ? "user" : "assistant"}
         data-message-id={block.messageId}
-        style={{ contain: "layout style paint", ...blockPerfStyle(blockIndex) }}
+        style={{ contain: block.isUser ? "layout style" : "layout style paint", ...blockPerfStyle(blockIndex) }}
       >
         <div
           className={`${
@@ -1046,12 +1046,20 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
             );
           })}
 
-          {!isNestedVariant ? (
+          {!isNestedVariant && !block.isUser ? (
             <div className="absolute bottom-2 right-2 flex justify-end opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto md:group-focus-within:opacity-100 md:group-focus-within:pointer-events-auto transition-opacity select-none">
               <CopyButton text={messageToText(block.message)} />
             </div>
           ) : null}
         </div>
+
+        {!isNestedVariant && block.isUser ? (
+          <div className="absolute inset-x-0 top-full z-10 h-4 opacity-100 pointer-events-auto md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 transition-opacity select-none">
+            <div className="absolute right-0 top-1 flex justify-end">
+              <CopyButton text={messageToText(block.message)} />
+            </div>
+          </div>
+        ) : null}
       </div>
     );
   };


### PR DESCRIPTION

https://github.com/user-attachments/assets/7681df81-74f5-4e7d-9aa9-0729bca78df6

Fixed the user-message copy button hover behavior.

The copy button used to sit inside the message bubble, so on longer user messages it could overlap the text and make the bubble look messy. I moved the copy action outside the bubble, positioned at the bottom-right on hover, so the message content keeps its full readable space.

I also added an invisible hover area across the existing gap between the user message and the assistant reply. That keeps the copy button reachable without adding extra vertical spacing or shifting the transcript layout.

/closes #1586 