### PR TITLE
docs: update enterprise schedule link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 OpenWork is designed around the idea that you can easily ship your agentic workflows for your team as a repeatable, productized process.
 
 > [!TIP]
-> **Looking for an [Enterprise Plan](https://openworklabs.com/enterprise)?** [Speak with our Sales Team today](https://cal.com/team/openwork/enterprise)
+> **Looking for an [Enterprise Plan](https://openworklabs.com/enterprise)?** [Speak with our Sales Team today](https://calendar.app.google/86QpCENvhfEzDFLu5)
 >
 > Get enhanced capabilities including feature prioritization, SSO, SLA support, LTS versions, and more.
 

--- a/packages/docs/cloud/enterprise.mdx
+++ b/packages/docs/cloud/enterprise.mdx
@@ -7,8 +7,8 @@ Want to run OpenWork on your own infra? We'll help you get there.
 
 OpenWork can be deployed inside your VPC or on-prem, with SSO, audit logs, and controls over which models and tools your team can use. If you're exploring a self-hosted or private-cloud rollout, talk to us.
 
-<Card title="Book a call with our team" icon="calendar" href="https://cal.com/team/openwork/enterprise">
-  Schedule a 30-minute intro at [cal.com/team/openwork/enterprise](https://cal.com/team/openwork/enterprise) to scope your deployment.
+<Card title="Book a call with our team" icon="calendar" href="https://calendar.app.google/86QpCENvhfEzDFLu5">
+  Schedule a 30-minute intro at [calendar.app.google/86QpCENvhfEzDFLu5](https://calendar.app.google/86QpCENvhfEzDFLu5) to scope your deployment.
 </Card>
 
 ## What we'll cover

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -5,7 +5,7 @@ description: "Run OpenWork on your own server with openwork-orchestrator."
 
 Most users just use the [desktop app](https://openworklabs.com/download). This guide covers self-hosting OpenWork via the CLI so you can run tasks on your own server and connect the desktop app to it remotely.
 
-Want hosted workspaces, team skill hubs, or shared providers without running infra? Use [OpenWork Cloud](/cloud/get-started) instead. Rolling this out across a company? [Book a call](https://cal.com/team/openwork/enterprise) about [Enterprise](/cloud/enterprise).
+Want hosted workspaces, team skill hubs, or shared providers without running infra? Use [OpenWork Cloud](/cloud/get-started) instead. Rolling this out across a company? [Book a call](https://calendar.app.google/86QpCENvhfEzDFLu5) about [Enterprise](/cloud/enterprise).
 
 ## Step 1: Install on your server
 
@@ -66,5 +66,4 @@ At that scale our customers typically want:
 - **VPC / on-prem deployment** with your own networking and compliance constraints
 - **Support and rollout help** from our team and custom deployment, not just in GitHub.
 
-You can check the [**Enterprise**](/cloud/enterprise) page or [book a 30-minute call](https://cal.com/team/openwork/enterprise).
-
+You can check the [**Enterprise**](/cloud/enterprise) page or [book a 30-minute call](https://calendar.app.google/86QpCENvhfEzDFLu5).


### PR DESCRIPTION
## Summary
- Replace the enterprise Cal.com scheduling URL with the new Google Calendar appointment link.
- Update the README, enterprise docs page, and self-host docs references.

## Verification
- Confirmed no remaining `cal.com/team/openwork/enterprise` references in the repo.