### PR TITLE
fix session resume render loop

### DIFF
--- a/apps/app/scripts/session-error-recovery.ts
+++ b/apps/app/scripts/session-error-recovery.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
-import { latestSessionErrorTurnTime, shouldResetRunState } from "../src/app/session/run-state";
+import {
+  latestSessionErrorTurnTime,
+  shouldResetRunState,
+} from "../src/react-app/domains/session/sync/run-state";
 
 assert.equal(latestSessionErrorTurnTime([]), null);
 assert.equal(

--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import type { UIMessage } from "ai";
+
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+
+function snapshotWithText(text: string): OpenworkSessionSnapshot {
+  return {
+    session: {
+      id: "ses_test",
+      parentID: undefined,
+      title: "Test session",
+      time: { created: 1, updated: 2 },
+      share: undefined,
+      version: "0",
+    },
+    messages: [
+      {
+        info: {
+          id: "msg_user",
+          role: "user",
+          sessionID: "ses_test",
+          time: { created: 1 },
+        },
+        parts: [
+          {
+            id: "part_text",
+            type: "text",
+            text,
+            sessionID: "ses_test",
+            messageID: "msg_user",
+          },
+        ],
+      },
+    ],
+    todos: [],
+    status: { type: "idle" },
+  } as unknown as OpenworkSessionSnapshot;
+}
+
+describe("deriveRenderedSessionMessages", () => {
+  it("falls back to snapshot messages when transcript cache is empty", () => {
+    const messages = deriveRenderedSessionMessages({
+      transcriptState: [],
+      snapshot: snapshotWithText("still here"),
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "still here",
+    });
+  });
+
+  it("keeps live transcript cache when present", () => {
+    const cached: UIMessage[] = [
+      {
+        id: "msg_live",
+        role: "assistant",
+        parts: [{ type: "text", text: "live text", state: "done" }],
+      },
+    ];
+
+    expect(deriveRenderedSessionMessages({
+      transcriptState: cached,
+      snapshot: snapshotWithText("snapshot text"),
+    })).toBe(cached);
+  });
+
+  it("returns an empty list only when there is no cache or snapshot content", () => {
+    expect(deriveRenderedSessionMessages({
+      transcriptState: [],
+      snapshot: null,
+    })).toEqual([]);
+  });
+});

--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "bun:test";
 import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
-import { deriveRenderedSessionMessages } from "../src/react-app/domains/session/surface/session-render-state";
+import {
+  deriveRenderedSessionMessages,
+  resolveRenderedSessionSnapshot,
+} from "../src/react-app/domains/session/surface/session-render-state";
 
-function snapshotWithText(text: string): OpenworkSessionSnapshot {
+function snapshotWithText(text: string, sessionId = "ses_test"): OpenworkSessionSnapshot {
   return {
     session: {
-      id: "ses_test",
+      id: sessionId,
       parentID: undefined,
       title: "Test session",
       time: { created: 1, updated: 2 },
@@ -19,7 +22,7 @@ function snapshotWithText(text: string): OpenworkSessionSnapshot {
         info: {
           id: "msg_user",
           role: "user",
-          sessionID: "ses_test",
+          sessionID: sessionId,
           time: { created: 1 },
         },
         parts: [
@@ -27,7 +30,7 @@ function snapshotWithText(text: string): OpenworkSessionSnapshot {
             id: "part_text",
             type: "text",
             text,
-            sessionID: "ses_test",
+            sessionID: sessionId,
             messageID: "msg_user",
           },
         ],
@@ -72,5 +75,40 @@ describe("deriveRenderedSessionMessages", () => {
       transcriptState: [],
       snapshot: null,
     })).toEqual([]);
+  });
+
+  it("does not use a cached snapshot from a different session", () => {
+    const snapshot = resolveRenderedSessionSnapshot({
+      sessionId: "ses_next",
+      currentSnapshot: null,
+      cachedRendered: {
+        sessionId: "ses_previous",
+        snapshot: snapshotWithText("previous session", "ses_previous"),
+      },
+    });
+
+    expect(snapshot).toBeNull();
+    expect(deriveRenderedSessionMessages({
+      transcriptState: [],
+      snapshot,
+    })).toEqual([]);
+  });
+
+  it("keeps a cached snapshot for the current session while live cache is empty", () => {
+    const cached = snapshotWithText("current session", "ses_current");
+    const snapshot = resolveRenderedSessionSnapshot({
+      sessionId: "ses_current",
+      currentSnapshot: null,
+      cachedRendered: {
+        sessionId: "ses_current",
+        snapshot: cached,
+      },
+    });
+
+    expect(snapshot).toBe(cached);
+    expect(deriveRenderedSessionMessages({
+      transcriptState: [],
+      snapshot,
+    })[0]?.parts[0]).toMatchObject({ text: "current session" });
   });
 });

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -360,7 +360,7 @@ async function revealFileInFinder(path: string) {
   }
 }
 
-function CopyButton(props: { text: string }) {
+function CopyButton(props: { getText: () => string }) {
   const [copied, setCopied] = useState(false);
 
   return (
@@ -369,7 +369,7 @@ function CopyButton(props: { text: string }) {
       className="inline-flex items-center justify-center rounded-lg border border-dls-border bg-dls-surface p-1.5 text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
       title="Copy message"
       onClick={async () => {
-        await navigator.clipboard.writeText(props.text);
+        await navigator.clipboard.writeText(props.getText());
         setCopied(true);
         window.setTimeout(() => setCopied(false), 1200);
       }}
@@ -1048,7 +1048,7 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
 
           {!isNestedVariant ? (
             <div className="absolute bottom-2 right-2 flex justify-end opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto md:group-focus-within:opacity-100 md:group-focus-within:pointer-events-auto transition-opacity select-none">
-              <CopyButton text={messageToText(block.message)} />
+              <CopyButton getText={() => messageToText(block.message)} />
             </div>
           ) : null}
         </div>

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -3,6 +3,23 @@ import type { UIMessage } from "ai";
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
 
+export function resolveRenderedSessionSnapshot(input: {
+  sessionId: string;
+  currentSnapshot: OpenworkSessionSnapshot | null | undefined;
+  cachedRendered: { sessionId: string; snapshot: OpenworkSessionSnapshot } | null | undefined;
+}) {
+  if (input.currentSnapshot?.session.id === input.sessionId) {
+    return input.currentSnapshot;
+  }
+  if (
+    input.cachedRendered?.sessionId === input.sessionId &&
+    input.cachedRendered.snapshot.session.id === input.sessionId
+  ) {
+    return input.cachedRendered.snapshot;
+  }
+  return null;
+}
+
 export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
   snapshot: OpenworkSessionSnapshot | null | undefined;

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -1,0 +1,17 @@
+import type { UIMessage } from "ai";
+
+import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
+import { snapshotToUIMessages } from "../sync/usechat-adapter";
+
+export function deriveRenderedSessionMessages(input: {
+  transcriptState: UIMessage[] | null | undefined;
+  snapshot: OpenworkSessionSnapshot | null | undefined;
+}) {
+  if (input.transcriptState && input.transcriptState.length > 0) {
+    return input.transcriptState;
+  }
+  if (input.snapshot && input.snapshot.messages.length > 0) {
+    return snapshotToUIMessages(input.snapshot);
+  }
+  return input.transcriptState ?? [];
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
-import type { SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
+import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, unwrap } from "../../../../app/lib/opencode";
 import { abortSessionSafe } from "../../../../app/lib/opencode-session";
@@ -30,19 +30,17 @@ import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import type { ReactComposerNotice } from "./composer/notice";
 import { SessionDebugPanel } from "./debug-panel";
-import { deriveRenderedSessionMessages } from "./session-render-state";
+import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
 import { SessionTranscript } from "./message-list";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import {
   seedSessionState,
   statusKey as reactStatusKey,
-  todoKey as reactTodoKey,
   transcriptKey as reactTranscriptKey,
 } from "../sync/session-sync";
 
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
-const EMPTY_TODOS: Todo[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
 
 export type SessionSurfaceProps = {
@@ -177,11 +175,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
     () => reactStatusKey(props.workspaceId, props.sessionId),
     [props.workspaceId, props.sessionId],
   );
-  const todoQueryKey = useMemo(
-    () => reactTodoKey(props.workspaceId, props.sessionId),
-    [props.workspaceId, props.sessionId],
-  );
-
   const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
     queryKey: snapshotQueryKey,
     queryFn: async () => (await props.client.getSessionSnapshot(props.workspaceId, props.sessionId, { limit: 140 })).item,
@@ -191,7 +184,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const currentSnapshot = snapshotQuery.data?.session.id === props.sessionId ? snapshotQuery.data : null;
   const transcriptState = useSharedQueryState<UIMessage[]>(transcriptQueryKey, EMPTY_TRANSCRIPT);
   const statusState = useSharedQueryState(statusQueryKey, currentSnapshot?.status ?? IDLE_STATUS);
-  useSharedQueryState(todoQueryKey, currentSnapshot?.todos ?? EMPTY_TODOS);
 
   useEffect(() => {
     if (!currentSnapshot) return;
@@ -288,7 +280,11 @@ export function SessionSurface(props: SessionSurfaceProps) {
     seedSessionState(props.workspaceId, currentSnapshot);
   }, [props.sessionId, currentSnapshot, props.workspaceId]);
 
-  const snapshot = currentSnapshot ?? rendered?.snapshot ?? null;
+  const snapshot = resolveRenderedSessionSnapshot({
+    sessionId: props.sessionId,
+    currentSnapshot,
+    cachedRendered: rendered,
+  });
   const liveStatus = statusState ?? snapshot?.status ?? IDLE_STATUS;
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
   const renderedMessages = useMemo(
@@ -336,7 +332,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   const model = deriveSessionRenderModel({
     intendedSessionId: props.sessionId,
-    renderedSessionId: renderedMessages.length > 0 || snapshotQuery.data ? props.sessionId : rendered?.sessionId ?? null,
+    renderedSessionId: renderedMessages.length > 0 || snapshot ? props.sessionId : null,
     hasSnapshot: Boolean(snapshot) || renderedMessages.length > 0,
     isFetching: snapshotQuery.isFetching,
     isError: snapshotQuery.isError || Boolean(error),

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
+import type { SessionStatus, Todo } from "@opencode-ai/sdk/v2/client";
 
 import { createClient, unwrap } from "../../../../app/lib/opencode";
 import { abortSessionSafe } from "../../../../app/lib/opencode-session";
@@ -29,6 +30,7 @@ import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import type { ReactComposerNotice } from "./composer/notice";
 import { SessionDebugPanel } from "./debug-panel";
+import { deriveRenderedSessionMessages } from "./session-render-state";
 import { SessionTranscript } from "./message-list";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
@@ -38,7 +40,10 @@ import {
   todoKey as reactTodoKey,
   transcriptKey as reactTranscriptKey,
 } from "../sync/session-sync";
-import { snapshotToUIMessages } from "../sync/usechat-adapter";
+
+const EMPTY_TRANSCRIPT: UIMessage[] = [];
+const EMPTY_TODOS: Todo[] = [];
+const IDLE_STATUS: SessionStatus = { type: "idle" };
 
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
@@ -102,6 +107,9 @@ function statusLabel(snapshot: OpenworkSessionSnapshot | undefined, busy: boolea
 
 function useSharedQueryState<T>(queryKey: readonly unknown[], fallback: T) {
   const queryClient = getReactQueryClient();
+  // useSyncExternalStore requires getSnapshot to return the same reference
+  // while the external store has not changed. Callers must pass stable
+  // fallbacks for empty cache states.
   return useSyncExternalStore(
     (callback) => queryClient.getQueryCache().subscribe(callback),
     () => (queryClient.getQueryData<T>(queryKey) ?? fallback),
@@ -174,16 +182,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
     [props.workspaceId, props.sessionId],
   );
 
-  useEffect(() => {
-    return () => {
-      const queryClient = getReactQueryClient();
-      queryClient.removeQueries({ queryKey: snapshotQueryKey, exact: true });
-      queryClient.removeQueries({ queryKey: transcriptQueryKey, exact: true });
-      queryClient.removeQueries({ queryKey: statusQueryKey, exact: true });
-      queryClient.removeQueries({ queryKey: todoQueryKey, exact: true });
-    };
-  }, [snapshotQueryKey, transcriptQueryKey, statusQueryKey, todoQueryKey]);
-
   const snapshotQuery = useQuery<OpenworkSessionSnapshot>({
     queryKey: snapshotQueryKey,
     queryFn: async () => (await props.client.getSessionSnapshot(props.workspaceId, props.sessionId, { limit: 140 })).item,
@@ -191,9 +189,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
 
   const currentSnapshot = snapshotQuery.data?.session.id === props.sessionId ? snapshotQuery.data : null;
-  const transcriptState = useSharedQueryState<UIMessage[]>(transcriptQueryKey, []);
-  const statusState = useSharedQueryState(statusQueryKey, currentSnapshot?.status ?? { type: "idle" as const });
-  useSharedQueryState(todoQueryKey, currentSnapshot?.todos ?? []);
+  const transcriptState = useSharedQueryState<UIMessage[]>(transcriptQueryKey, EMPTY_TRANSCRIPT);
+  const statusState = useSharedQueryState(statusQueryKey, currentSnapshot?.status ?? IDLE_STATUS);
+  useSharedQueryState(todoQueryKey, currentSnapshot?.todos ?? EMPTY_TODOS);
 
   useEffect(() => {
     if (!currentSnapshot) return;
@@ -291,9 +289,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [props.sessionId, currentSnapshot, props.workspaceId]);
 
   const snapshot = currentSnapshot ?? rendered?.snapshot ?? null;
-  const liveStatus = statusState ?? snapshot?.status ?? { type: "idle" as const };
+  const liveStatus = statusState ?? snapshot?.status ?? IDLE_STATUS;
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
-  const renderedMessages = transcriptState ?? [];
+  const renderedMessages = useMemo(
+    () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
+    [snapshot, transcriptState],
+  );
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -414,9 +414,23 @@ function startSync(input: SyncOptions) {
   const client = createClient(input.baseUrl, undefined, { token: input.openworkToken, mode: "openwork" });
   const controller = new AbortController();
   const entry = syncs.get(syncKey(input));
+  let disposed = false;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryDelayMs = 1_000;
 
-  void client.event.subscribe(undefined, { signal: controller.signal }).then((sub) => {
-    void (async () => {
+  const scheduleRetry = () => {
+    if (disposed || controller.signal.aborted || retryTimer) return;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void connect();
+    }, retryDelayMs);
+    retryDelayMs = Math.min(retryDelayMs * 2, 10_000);
+  };
+
+  const connect = async () => {
+    try {
+      const sub = await client.event.subscribe(undefined, { signal: controller.signal });
+      retryDelayMs = 1_000;
       for await (const raw of sub.stream) {
         if (controller.signal.aborted) return;
         const event = normalizeEvent(raw);
@@ -424,10 +438,19 @@ function startSync(input: SyncOptions) {
         if (!entry) continue;
         applyEvent(entry, input.workspaceId, event);
       }
-    })();
-  });
+      if (!controller.signal.aborted) scheduleRetry();
+    } catch {
+      if (!controller.signal.aborted) scheduleRetry();
+    }
+  };
 
-  return () => controller.abort();
+  void connect();
+
+  return () => {
+    disposed = true;
+    if (retryTimer) clearTimeout(retryTimer);
+    controller.abort();
+  };
 }
 
 export function ensureWorkspaceSessionSync(input: SyncOptions) {
@@ -530,10 +553,6 @@ export function trackWorkspaceSessionSync(input: SyncOptions, sessionId: string 
       entry.deltaFlushBuffer = entry.deltaFlushBuffer.filter(
         (item) => item.sessionId !== normalizedSessionId,
       );
-      const queryClient = getReactQueryClient();
-      queryClient.removeQueries({ queryKey: transcriptKey(input.workspaceId, normalizedSessionId), exact: true });
-      queryClient.removeQueries({ queryKey: statusKey(input.workspaceId, normalizedSessionId), exact: true });
-      queryClient.removeQueries({ queryKey: todoKey(input.workspaceId, normalizedSessionId), exact: true });
       return;
     }
     entry.trackedSessionRefs.set(normalizedSessionId, current - 1);

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -50,6 +50,22 @@ function syncKey(input: SyncOptions) {
   return `${input.workspaceId}:${input.baseUrl}:${input.openworkToken}`;
 }
 
+function getErrorStatus(error: unknown) {
+  if (!error || typeof error !== "object") return null;
+  const record = error as {
+    status?: unknown;
+    response?: { status?: unknown };
+    cause?: { status?: unknown };
+  };
+  const status = record.status ?? record.response?.status ?? record.cause?.status;
+  return typeof status === "number" ? status : null;
+}
+
+function shouldRetrySyncSubscribe(error: unknown) {
+  const status = getErrorStatus(error);
+  return status !== 401 && status !== 403 && status !== 404;
+}
+
 function isTrackedSession(entry: SyncEntry, sessionId: string) {
   return (entry.trackedSessionRefs.get(sessionId) ?? 0) > 0;
 }
@@ -439,8 +455,8 @@ function startSync(input: SyncOptions) {
         applyEvent(entry, input.workspaceId, event);
       }
       if (!controller.signal.aborted) scheduleRetry();
-    } catch {
-      if (!controller.signal.aborted) scheduleRetry();
+    } catch (error) {
+      if (!controller.signal.aborted && shouldRetrySyncSubscribe(error)) scheduleRetry();
     }
   };
 


### PR DESCRIPTION
## Why
I hit this in the desktop app after leaving a session idle: the transcript could go blank and the renderer would spin, while the OpenWork server and OpenCode stayed healthy. The failure path is in the React session surface, not the runtime.

## What changed
- Keep session cache entries available across surface unmounts instead of clearing transcript/status/todo state immediately.
- Fall back to the server snapshot when the live transcript cache is empty.
- Use stable empty/idle fallbacks for `useSyncExternalStore`, so the session surface does not see a new snapshot every render.
- Reconnect the OpenCode event stream after it ends, and defer message copy serialization until the user clicks copy.

## Test plan
- `bun test apps/app/scripts/session-render-state.test.ts`
- `pnpm --filter @openwork/app test:session-error-recovery`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`
- `git diff --check`

I also ran a 10-minute idle smoke against the same release server/session that reproduced the issue. Before this patch, the renderer hit ~110% CPU and close to 1GB RSS around the 5-minute mark. With this branch, it stayed around 0-0.3% CPU and ~103-121MB RSS, with the title, transcript text, and composer still present.

## Notes
No screenshot attached here. A static screenshot does not really prove an idle render loop is fixed; the smoke metrics above are the useful evidence. This is scoped to the session resume/cache path and does not claim to fix every possible app freeze.
