### PR TITLE
fix desktop bootstrap config startup

### DIFF
--- a/apps/app/src/index.react.tsx
+++ b/apps/app/src/index.react.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, HashRouter } from "react-router-dom";
 
+import { initializeDenBootstrapConfig } from "./app/lib/den";
 import { getOpenWorkDeployment } from "./app/lib/openwork-deployment";
 import { bootstrapTheme } from "./app/theme";
 import { isDesktopRuntime } from "./app/utils";
@@ -21,6 +22,7 @@ import "./app/index.css";
 bootstrapTheme();
 initLocale();
 startDeepLinkBridge();
+await initializeDenBootstrapConfig();
 
 const root = document.getElementById("root");
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -204,7 +204,10 @@ function flushPendingDeepLinks() {
 }
 
 function desktopBootstrapPath() {
-  return path.join(app.getPath("userData"), "desktop-bootstrap.json");
+  if (process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH?.trim()) {
+    return process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH.trim();
+  }
+  return path.join(os.homedir(), ".config", "openwork", "desktop-bootstrap.json");
 }
 
 function workspaceStatePath() {

--- a/apps/desktop/src-tauri/src/desktop_bootstrap.rs
+++ b/apps/desktop/src-tauri/src/desktop_bootstrap.rs
@@ -85,11 +85,11 @@ fn desktop_bootstrap_path() -> Result<PathBuf, String> {
         }
     }
 
-    let config_root = dirs::config_dir()
-        .ok_or_else(|| "Failed to resolve a desktop bootstrap config directory".to_string())?;
-    Ok(config_root
-        .join("OpenWork")
-        .join(DESKTOP_BOOTSTRAP_FILE_NAME))
+    let config_root = dirs::home_dir()
+        .ok_or_else(|| "Failed to resolve a desktop bootstrap config directory".to_string())?
+        .join(".config")
+        .join("openwork");
+    Ok(config_root.join(DESKTOP_BOOTSTRAP_FILE_NAME))
 }
 
 fn ensure_parent_dir(path: &Path) -> Result<(), String> {

--- a/prds/openwork-desktop-bootstrap-config/desktop-bootstrap-and-org-runtime-config.md
+++ b/prds/openwork-desktop-bootstrap-config/desktop-bootstrap-and-org-runtime-config.md
@@ -135,13 +135,11 @@ Recommended location:
 
 - Tauri-side persisted store or app-data file
 
-For the current external bootstrap-file approach, the desktop shell should look for `desktop-bootstrap.json` in the host config directory under `OpenWork/`, unless an explicit override path is provided with `OPENWORK_DESKTOP_BOOTSTRAP_PATH`.
+For the current external bootstrap-file approach, the desktop shell should look for `desktop-bootstrap.json` in the shared OpenWork config directory, unless an explicit override path is provided with `OPENWORK_DESKTOP_BOOTSTRAP_PATH`.
 
 Expected default locations:
 
-- macOS: `~/Library/Application Support/OpenWork/desktop-bootstrap.json`
-- Linux: `~/.config/OpenWork/desktop-bootstrap.json`
-- Windows: `%AppData%\OpenWork\desktop-bootstrap.json`
+- All platforms: `~/.config/openwork/desktop-bootstrap.json`
 
 Avoid using browser `localStorage` as the long-term source of truth for install identity in desktop mode.
 


### PR DESCRIPTION
## Summary
- Load the desktop bootstrap config before React renders so persisted Den bootstrap settings apply at startup.
- Move the default desktop bootstrap file to the shared OpenWork config path: ~/.config/openwork/desktop-bootstrap.json.
- Keep OPENWORK_DESKTOP_BOOTSTRAP_PATH as an explicit override and document the new default path.

## Verification
- pnpm --filter @openwork/app typecheck
- cargo fmt --check
- cargo check