### PR TITLE
Add cloud plugin marketplace import

### DIFF
--- a/apps/app/src/app/cloud/import-state.ts
+++ b/apps/app/src/app/cloud/import-state.ts
@@ -27,10 +27,30 @@ export type CloudImportedProvider = {
   importedAt: number | null;
 };
 
+export type CloudImportedPluginFile = {
+  configObjectId: string;
+  versionId: string | null;
+  objectType: string;
+  title: string;
+  path: string;
+  updatedAt: string | null;
+};
+
+export type CloudImportedPlugin = {
+  pluginId: string;
+  marketplaceId: string | null;
+  name: string;
+  description: string | null;
+  updatedAt: string | null;
+  files: CloudImportedPluginFile[];
+  importedAt: number | null;
+};
+
 export type WorkspaceCloudImports = {
   skillHubs: Record<string, CloudImportedSkillHub>;
   skills: Record<string, CloudImportedSkill>;
   providers: Record<string, CloudImportedProvider>;
+  plugins: Record<string, CloudImportedPlugin>;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -47,6 +67,7 @@ export function readWorkspaceCloudImports(value: unknown): WorkspaceCloudImports
   const rawSkillHubs = isRecord(cloudImports.skillHubs) ? cloudImports.skillHubs : {};
   const rawSkills = isRecord(cloudImports.skills) ? cloudImports.skills : {};
   const rawProviders = isRecord(cloudImports.providers) ? cloudImports.providers : {};
+  const rawPlugins = isRecord(cloudImports.plugins) ? cloudImports.plugins : {};
 
   const skillHubs = Object.fromEntries(
     Object.entries(rawSkillHubs)
@@ -125,7 +146,50 @@ export function readWorkspaceCloudImports(value: unknown): WorkspaceCloudImports
       .filter((entry): entry is readonly [string, CloudImportedSkill] => Boolean(entry)),
   );
 
-  return { skillHubs, skills, providers };
+  const plugins = Object.fromEntries(
+    Object.entries(rawPlugins)
+      .map(([key, entry]) => {
+        if (!isRecord(entry)) return null;
+        const pluginId = typeof entry.pluginId === "string" ? entry.pluginId.trim() : key.trim();
+        const name = typeof entry.name === "string" ? entry.name.trim() : pluginId;
+        if (!pluginId || !name) return null;
+        const files = Array.isArray(entry.files)
+          ? entry.files
+              .map((file): CloudImportedPluginFile | null => {
+                if (!isRecord(file)) return null;
+                const configObjectId = typeof file.configObjectId === "string" ? file.configObjectId.trim() : "";
+                const objectType = typeof file.objectType === "string" ? file.objectType.trim() : "";
+                const title = typeof file.title === "string" ? file.title.trim() : configObjectId;
+                const path = typeof file.path === "string" ? file.path.trim() : "";
+                if (!configObjectId || !objectType || !title || !path) return null;
+                return {
+                  configObjectId,
+                  versionId: typeof file.versionId === "string" ? file.versionId.trim() || null : null,
+                  objectType,
+                  title,
+                  path,
+                  updatedAt: typeof file.updatedAt === "string" ? file.updatedAt.trim() || null : null,
+                };
+              })
+              .filter((file): file is CloudImportedPluginFile => file !== null)
+          : [];
+        const imported = {
+          pluginId,
+          marketplaceId: typeof entry.marketplaceId === "string" ? entry.marketplaceId.trim() || null : null,
+          name,
+          description: typeof entry.description === "string" ? entry.description.trim() || null : null,
+          updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt.trim() || null : null,
+          files,
+          importedAt: typeof entry.importedAt === "number" && Number.isFinite(entry.importedAt)
+            ? entry.importedAt
+            : null,
+        } satisfies CloudImportedPlugin;
+        return [pluginId, imported] as const;
+      })
+      .filter((entry): entry is readonly [string, CloudImportedPlugin] => Boolean(entry)),
+  );
+
+  return { skillHubs, skills, providers, plugins };
 }
 
 export function withWorkspaceCloudImports(
@@ -138,6 +202,7 @@ export function withWorkspaceCloudImports(
       skillHubs: cloudImports.skillHubs,
       skills: cloudImports.skills,
       providers: cloudImports.providers,
+      plugins: cloudImports.plugins,
     },
   };
 }

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -121,6 +121,65 @@ export type DenOrgLlmProviderConnection = DenOrgLlmProvider & {
   apiKey: string | null;
 };
 
+export type DenPluginConfigObjectType = "skill" | "agent" | "command" | "tool" | "mcp" | "hook" | "context" | "custom";
+
+export type DenPluginConfigObjectVersion = {
+  id: string;
+  rawSourceText: string | null;
+  normalizedPayloadJson: Record<string, unknown> | null;
+  sourceRevisionRef: string | null;
+  createdAt: string | null;
+};
+
+export type DenPluginConfigObject = {
+  id: string;
+  objectType: DenPluginConfigObjectType;
+  title: string;
+  description: string | null;
+  currentFileName: string | null;
+  currentFileExtension: string | null;
+  currentRelativePath: string | null;
+  status: string;
+  updatedAt: string | null;
+  latestVersion: DenPluginConfigObjectVersion | null;
+};
+
+export type DenPluginMembership = {
+  id: string;
+  pluginId: string;
+  configObjectId: string;
+  configObject?: DenPluginConfigObject;
+};
+
+export type DenOrgPlugin = {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  memberCount: number;
+  updatedAt: string | null;
+  componentCounts: Record<string, number>;
+};
+
+export type DenOrgMarketplace = {
+  id: string;
+  name: string;
+  description: string | null;
+  status: string;
+  pluginCount: number;
+  updatedAt: string | null;
+};
+
+export type DenOrgMarketplaceResolved = {
+  marketplace: DenOrgMarketplace;
+  plugins: DenOrgPlugin[];
+};
+
+export type DenOrgPluginResolved = {
+  plugin: DenOrgPlugin;
+  memberships: DenPluginMembership[];
+};
+
 export type DenBillingPrice = {
   amount: number | null;
   currency: string | null;
@@ -846,6 +905,109 @@ function getDenOrgLlmProviderConnection(payload: unknown): DenOrgLlmProviderConn
   };
 }
 
+function parsePluginConfigObjectType(value: unknown): DenPluginConfigObjectType | null {
+  return value === "skill" || value === "agent" || value === "command" || value === "tool" ||
+    value === "mcp" || value === "hook" || value === "context" || value === "custom"
+    ? value
+    : null;
+}
+
+function parsePluginConfigObjectVersion(value: unknown): DenPluginConfigObjectVersion | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  return {
+    id: value.id,
+    rawSourceText: typeof value.rawSourceText === "string" ? value.rawSourceText : null,
+    normalizedPayloadJson: isRecord(value.normalizedPayloadJson) ? value.normalizedPayloadJson : null,
+    sourceRevisionRef: typeof value.sourceRevisionRef === "string" ? value.sourceRevisionRef : null,
+    createdAt: typeof value.createdAt === "string" ? value.createdAt : null,
+  };
+}
+
+function parsePluginConfigObject(value: unknown): DenPluginConfigObject | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.title !== "string") return null;
+  const objectType = parsePluginConfigObjectType(value.objectType);
+  if (!objectType) return null;
+  return {
+    id: value.id,
+    objectType,
+    title: value.title,
+    description: typeof value.description === "string" ? value.description : null,
+    currentFileName: typeof value.currentFileName === "string" ? value.currentFileName : null,
+    currentFileExtension: typeof value.currentFileExtension === "string" ? value.currentFileExtension : null,
+    currentRelativePath: typeof value.currentRelativePath === "string" ? value.currentRelativePath : null,
+    status: typeof value.status === "string" ? value.status : "active",
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : null,
+    latestVersion: parsePluginConfigObjectVersion(value.latestVersion),
+  };
+}
+
+function parseOrgPlugin(value: unknown): DenOrgPlugin | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") return null;
+  const counts = isRecord(value.componentCounts)
+    ? Object.fromEntries(
+        Object.entries(value.componentCounts).filter((entry): entry is [string, number] =>
+          typeof entry[0] === "string" && typeof entry[1] === "number" && Number.isFinite(entry[1]) && entry[1] >= 0,
+        ),
+      )
+    : {};
+  return {
+    id: value.id,
+    name: value.name,
+    description: typeof value.description === "string" ? value.description : null,
+    status: typeof value.status === "string" ? value.status : "active",
+    memberCount: typeof value.memberCount === "number" && Number.isFinite(value.memberCount) ? value.memberCount : 0,
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : null,
+    componentCounts: counts,
+  };
+}
+
+function parseOrgMarketplace(value: unknown): DenOrgMarketplace | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.name !== "string") return null;
+  return {
+    id: value.id,
+    name: value.name,
+    description: typeof value.description === "string" ? value.description : null,
+    status: typeof value.status === "string" ? value.status : "active",
+    pluginCount: typeof value.pluginCount === "number" && Number.isFinite(value.pluginCount) ? value.pluginCount : 0,
+    updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : null,
+  };
+}
+
+function parsePluginMembership(value: unknown): DenPluginMembership | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.pluginId !== "string" || typeof value.configObjectId !== "string") {
+    return null;
+  }
+  const configObject = parsePluginConfigObject(value.configObject);
+  return {
+    id: value.id,
+    pluginId: value.pluginId,
+    configObjectId: value.configObjectId,
+    ...(configObject ? { configObject } : {}),
+  };
+}
+
+function getOrgMarketplaces(payload: unknown): DenOrgMarketplace[] {
+  if (!isRecord(payload) || !Array.isArray(payload.items)) return [];
+  return payload.items.map(parseOrgMarketplace).filter((entry): entry is DenOrgMarketplace => entry !== null);
+}
+
+function getOrgMarketplaceResolved(payload: unknown): DenOrgMarketplaceResolved | null {
+  if (!isRecord(payload) || !isRecord(payload.item)) return null;
+  const marketplace = parseOrgMarketplace(payload.item.marketplace);
+  if (!marketplace || !Array.isArray(payload.item.plugins)) return null;
+  return {
+    marketplace,
+    plugins: payload.item.plugins.map(parseOrgPlugin).filter((entry): entry is DenOrgPlugin => entry !== null),
+  };
+}
+
+function getOrgPluginResolved(plugin: DenOrgPlugin, payload: unknown): DenOrgPluginResolved {
+  const memberships = isRecord(payload) && Array.isArray(payload.items)
+    ? payload.items.map(parsePluginMembership).filter((entry): entry is DenPluginMembership => entry !== null)
+    : [];
+  return { plugin, memberships };
+}
+
 function getBillingPrice(value: unknown): DenBillingPrice | null {
   if (!isRecord(value)) {
     return null;
@@ -1262,6 +1424,37 @@ export function createDenClient(options: { baseUrl: string; apiBaseUrl?: string 
         throw new DenApiError(500, "invalid_llm_provider_payload", "LLM provider response was missing connection details.");
       }
       return provider;
+    },
+
+    async listOrgMarketplaces(orgId: string): Promise<DenOrgMarketplace[]> {
+      const payload = await requestJson<unknown>(
+        baseUrls,
+        `/v1/marketplaces?status=active&limit=100`,
+        { method: "GET", token },
+      );
+      return getOrgMarketplaces(payload);
+    },
+
+    async getOrgMarketplaceResolved(orgId: string, marketplaceId: string): Promise<DenOrgMarketplaceResolved> {
+      const payload = await requestJson<unknown>(
+        baseUrls,
+        `/v1/marketplaces/${encodeURIComponent(marketplaceId)}/resolved`,
+        { method: "GET", token },
+      );
+      const resolved = getOrgMarketplaceResolved(payload);
+      if (!resolved) {
+        throw new DenApiError(500, "invalid_marketplace_payload", "Marketplace response was missing plugin details.");
+      }
+      return resolved;
+    },
+
+    async getOrgPluginResolved(orgId: string, plugin: DenOrgPlugin): Promise<DenOrgPluginResolved> {
+      const payload = await requestJson<unknown>(
+        baseUrls,
+        `/v1/plugins/${encodeURIComponent(plugin.id)}/resolved`,
+        { method: "GET", token },
+      );
+      return getOrgPluginResolved(plugin, payload);
     },
 
     async getBillingStatus(options: { includeCheckout?: boolean; includePortal?: boolean; includeInvoices?: boolean } = {}): Promise<DenBillingSummary> {

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
 import { ArrowUp, Check, ChevronDown, ChevronRight, FileText, Paperclip, Plug, Settings, Square, Terminal, X, Zap } from "lucide-react";
 import fuzzysort from "fuzzysort";
+import type { CloudImportedPlugin, CloudImportedPluginFile } from "../../../../../app/cloud/import-state";
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, SkillCard, SlashCommandOption } from "../../../../../app/types";
 import { currentLocale, t, type Language } from "../../../../../i18n";
 import { LexicalPromptEditor } from "./editor";
@@ -25,7 +26,8 @@ type PastedTextChip = {
   lines: number;
 };
 
-type ToolMenuSection = "commands" | "skills" | "mcps";
+type ToolMenuSettingsSection = "commands" | "skills" | "mcps" | "plugins";
+type ToolMenuSection = "commands" | "skills" | "mcps" | `plugin:${string}`;
 
 type ComposerProps = {
   draft: string;
@@ -58,7 +60,9 @@ type ComposerProps = {
   mcpServers?: McpServerEntry[];
   mcpStatus?: string | null;
   mcpStatuses?: McpStatusMap;
-  onOpenSettingsSection?: (section: ToolMenuSection) => void;
+  listImportedPlugins?: () => Promise<CloudImportedPlugin[]>;
+  importedPlugins?: CloudImportedPlugin[];
+  onOpenSettingsSection?: (section: ToolMenuSettingsSection) => void;
   recentFiles: string[];
   searchFiles: (query: string) => Promise<string[]>;
   onInsertMention: (kind: "agent" | "file", value: string) => void;
@@ -219,6 +223,26 @@ function mcpStatusBadgeClass(status: McpServerStatus) {
   }
 }
 
+function formatPluginObjectType(type: string) {
+  const normalized = type.trim().toLowerCase();
+  if (!normalized) return "File";
+  if (normalized === "mcp") return "MCP";
+  return `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`;
+}
+
+function pluginSlashCommandName(file: CloudImportedPluginFile) {
+  const path = file.path.trim();
+  if (file.objectType === "command") {
+    const command = path.match(/^\.opencode\/(?:command|commands)\/(.+)\.md$/i)?.[1];
+    return command?.trim() || null;
+  }
+  if (file.objectType === "skill") {
+    const skill = path.match(/^\.opencode\/(?:skill|skills)\/(?:[^/]+\/)?([^/]+)\/SKILL\.md$/i)?.[1];
+    return skill?.trim() || null;
+  }
+  return null;
+}
+
 export function ReactSessionComposer(props: ComposerProps) {
   let fileInput: HTMLInputElement | undefined;
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -232,6 +256,8 @@ export function ReactSessionComposer(props: ComposerProps) {
   const [mcpServers, setMcpServers] = useState<McpServerEntry[]>(props.mcpServers ?? []);
   const [mcpStatus, setMcpStatus] = useState<string | null>(props.mcpStatus ?? null);
   const [mcpStatuses, setMcpStatuses] = useState<McpStatusMap>(props.mcpStatuses ?? {});
+  const [importedPlugins, setImportedPlugins] = useState<CloudImportedPlugin[]>(props.importedPlugins ?? []);
+  const [pluginsLoading, setPluginsLoading] = useState(false);
   const [slashOpen, setSlashOpen] = useState(false);
   const [toolMenuOpen, setToolMenuOpen] = useState(false);
   const [toolMenuSection, setToolMenuSection] = useState<ToolMenuSection>("commands");
@@ -286,6 +312,10 @@ export function ReactSessionComposer(props: ComposerProps) {
     setMcpStatus(props.mcpStatus ?? null);
     setMcpStatuses(props.mcpStatuses ?? {});
   }, [props.mcpServers, props.mcpStatus, props.mcpStatuses]);
+
+  useEffect(() => {
+    setImportedPlugins(props.importedPlugins ?? []);
+  }, [props.importedPlugins]);
 
   useEffect(() => {
     setAgentMenuIndex(0);
@@ -379,6 +409,28 @@ export function ReactSessionComposer(props: ComposerProps) {
 
   useEffect(() => {
     if (!toolMenuOpen) return;
+    if (props.listImportedPlugins) {
+      let cancelled = false;
+      setPluginsLoading(true);
+      void props.listImportedPlugins()
+        .then((next) => {
+          if (!cancelled) setImportedPlugins(next);
+        })
+        .catch(() => {
+          if (!cancelled) setImportedPlugins([]);
+        })
+        .finally(() => {
+          if (!cancelled) setPluginsLoading(false);
+        });
+      return () => {
+        cancelled = true;
+      };
+    }
+    return undefined;
+  }, [toolMenuOpen, props.listImportedPlugins]);
+
+  useEffect(() => {
+    if (!toolMenuOpen) return;
     if (toolMenuSection === "skills" && props.listSkills) {
       let cancelled = false;
       setSkillsLoading(true);
@@ -437,7 +489,20 @@ export function ReactSessionComposer(props: ComposerProps) {
   const toolCommandItems = commands.filter((command) => !command.source || command.source === "command");
   const toolSkillItems = commands.filter((command) => command.source === "skill");
   const toolMcpItems = commands.filter((command) => command.source === "mcp");
+  void toolMcpItems;
+  const pluginSections = importedPlugins
+    .filter((plugin) => plugin.files.length > 0)
+    .map((plugin) => ({ section: `plugin:${plugin.pluginId}` as const, plugin }));
+  const activePlugin = toolMenuSection.startsWith("plugin:")
+    ? pluginSections.find((entry) => entry.section === toolMenuSection)?.plugin ?? null
+    : null;
   const canSend = props.draft.trim().length > 0 || props.attachments.length > 0;
+
+  useEffect(() => {
+    if (!toolMenuSection.startsWith("plugin:")) return;
+    if (activePlugin) return;
+    setToolMenuSection("commands");
+  }, [activePlugin, toolMenuSection]);
 
   useEffect(() => {
     if (!activeItems.length) {
@@ -456,6 +521,27 @@ export function ReactSessionComposer(props: ComposerProps) {
     props.onDraftChange(`/${command.name} `);
     setSlashOpen(false);
     setToolMenuOpen(false);
+  };
+
+  const applyPluginFileSelection = (file: CloudImportedPluginFile) => {
+    const commandName = pluginSlashCommandName(file);
+    if (commandName) {
+      applyCommandSelection({
+        id: `plugin:${file.configObjectId}`,
+        name: commandName,
+        source: file.objectType === "skill" ? "skill" : "command",
+      });
+      return;
+    }
+    props.onInsertMention("file", file.path);
+    setToolMenuOpen(false);
+  };
+
+  const openToolMenuSettings = () => {
+    const section: ToolMenuSettingsSection = toolMenuSection === "commands" || toolMenuSection === "skills" || toolMenuSection === "mcps"
+      ? toolMenuSection
+      : "plugins";
+    props.onOpenSettingsSection?.(section);
   };
 
   const acceptActiveItem = () => {
@@ -955,6 +1041,18 @@ export function ReactSessionComposer(props: ComposerProps) {
                               <ChevronRight size={14} className="shrink-0 text-gray-9" />
                             </button>
                           ))}
+                          {pluginSections.length > 0 ? <div className="my-2 border-t border-dls-border" /> : null}
+                          {pluginSections.map(({ section, plugin }) => (
+                            <button
+                              key={plugin.pluginId}
+                              type="button"
+                              className={`mb-1 flex w-full items-center justify-between rounded-[16px] px-3 py-2.5 text-left text-sm transition-colors ${toolMenuSection === section ? "bg-gray-3 text-gray-12" : "text-gray-11 hover:bg-gray-2"}`}
+                              onClick={() => setToolMenuSection(section)}
+                            >
+                              <span className="truncate">{plugin.name}</span>
+                              <ChevronRight size={14} className="shrink-0 text-gray-9" />
+                            </button>
+                          ))}
                         </div>
                         <div className="max-h-72 overflow-y-auto p-2">
                           <div className="mb-2 flex justify-end border-b border-dls-border px-1 pb-2">
@@ -963,7 +1061,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                               className="inline-flex items-center gap-1.5 rounded-full border border-dls-border px-3 py-1.5 text-[12px] font-medium text-gray-11 transition-colors hover:bg-gray-2"
                               onClick={() => {
                                 setToolMenuOpen(false);
-                                props.onOpenSettingsSection?.(toolMenuSection);
+                                openToolMenuSettings();
                               }}
                             >
                               <Settings size={12} />
@@ -1041,6 +1139,36 @@ export function ReactSessionComposer(props: ComposerProps) {
                                 {mcpLoading ? t("composer.loading_commands", locale) : (mcpStatus ?? t("context_panel.no_mcp", locale))}
                               </div>
                             )
+                          ) : null}
+                          {activePlugin ? (
+                            activePlugin.files.length > 0 ? (
+                              <div className="grid gap-1">
+                                {activePlugin.files.map((file) => (
+                                  <button
+                                    key={`${file.configObjectId}:${file.path}`}
+                                    type="button"
+                                    className="flex w-full items-start gap-3 rounded-[16px] px-3 py-2.5 text-left text-gray-11 transition-colors hover:bg-gray-2/70"
+                                    onClick={() => applyPluginFileSelection(file)}
+                                  >
+                                    <FileText size={14} className="mt-0.5 shrink-0 text-gray-9" />
+                                    <div className="min-w-0 flex-1">
+                                      <div className="flex items-center justify-between gap-3">
+                                        <div className="truncate text-xs font-semibold text-gray-11">{file.title}</div>
+                                        <span className="shrink-0 rounded-full bg-gray-3 px-2 py-0.5 text-[10px] font-medium text-gray-11">
+                                          {formatPluginObjectType(file.objectType)}
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </button>
+                                ))}
+                              </div>
+                            ) : (
+                              <div className="px-3 py-2 text-xs text-gray-10">No plugin files imported yet.</div>
+                            )
+                          ) : toolMenuSection.startsWith("plugin:") ? (
+                            <div className="px-3 py-2 text-xs text-gray-10">
+                              {pluginsLoading ? t("composer.loading_commands", locale) : "Plugin files are unavailable."}
+                            </div>
                           ) : null}
                         </div>
                       </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { createClient, unwrap } from "../../../../app/lib/opencode";
 import { abortSessionSafe } from "../../../../app/lib/opencode-session";
+import { readWorkspaceCloudImports, type CloudImportedPlugin } from "../../../../app/cloud/import-state";
 import type {
   OpenworkServerClient,
   OpenworkSessionSnapshot,
@@ -67,7 +68,7 @@ export type SessionSurfaceProps = {
   isRemoteWorkspace: boolean;
   isSandboxWorkspace: boolean;
   onUploadInboxFiles?: ((files: File[], options?: { notify?: boolean }) => void | Promise<unknown>) | null;
-  onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps") => void) | undefined;
+  onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins") => void) | undefined;
 };
 
 function transcriptToText(messages: UIMessage[]) {
@@ -147,6 +148,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolMcpServers, setToolMcpServers] = useState<McpServerEntry[]>([]);
   const [toolMcpStatus, setToolMcpStatus] = useState<string | null>(null);
   const [toolMcpStatuses, setToolMcpStatuses] = useState<McpStatusMap>({});
+  const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
   const hydratedKeyRef = useRef<string | null>(null);
   const attachmentsRef = useRef<ComposerAttachment[]>([]);
   attachmentsRef.current = attachments;
@@ -536,6 +538,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
     return { servers, statuses, status };
   };
 
+  const listImportedPlugins = async (): Promise<CloudImportedPlugin[]> => {
+    const response = await props.client.getConfig(props.workspaceId);
+    const plugins = Object.values(readWorkspaceCloudImports(response.openwork).plugins)
+      .sort((left, right) => left.name.localeCompare(right.name));
+    setToolImportedPlugins(plugins);
+    return plugins;
+  };
+
   const handleUploadInboxFiles = async (files: File[], options?: { notify?: boolean }) => {
     const input = files.filter(Boolean);
     if (!input.length) return;
@@ -697,6 +707,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
         mcpServers={toolMcpServers}
         mcpStatus={toolMcpStatus}
         mcpStatuses={toolMcpStatuses}
+        listImportedPlugins={listImportedPlugins}
+        importedPlugins={toolImportedPlugins}
         onOpenSettingsSection={props.onOpenSettingsSection}
         recentFiles={props.recentFiles}
         searchFiles={props.searchFiles}

--- a/apps/app/src/react-app/domains/settings/panels/den-settings-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/den-settings-panel.tsx
@@ -20,6 +20,8 @@ import {
   DEFAULT_DEN_BASE_URL,
   DenApiError,
   type DenOrgLlmProvider,
+  type DenOrgMarketplaceResolved,
+  type DenOrgPlugin,
   type DenOrgSkillHub,
   type DenUser,
   createDenClient,
@@ -34,7 +36,7 @@ import {
   dispatchDenSessionUpdated,
   type DenSessionUpdatedDetail,
 } from "../../../../app/lib/den-session-events";
-import type { CloudImportedProvider, CloudImportedSkill, CloudImportedSkillHub } from "../../../../app/cloud/import-state";
+import type { CloudImportedPlugin, CloudImportedProvider, CloudImportedSkill, CloudImportedSkillHub } from "../../../../app/cloud/import-state";
 import type { DenOrgSkillCard, SkillCard } from "../../../../app/types";
 import { Button } from "../../../design-system/button";
 import { TextInput } from "../../../design-system/text-input";
@@ -69,6 +71,13 @@ type CloudSkillRow = {
   installedName: string | null;
 };
 
+type CloudPluginRow = {
+  marketplaceId: string;
+  plugin: DenOrgPlugin;
+  imported: CloudImportedPlugin | null;
+  status: "available" | "imported" | "out_of_sync";
+};
+
 type AsyncResult = { ok: boolean; message: string };
 
 export type DenSettingsExtensionsStore = {
@@ -87,6 +96,11 @@ export type DenSettingsExtensionsStore = {
   importCloudOrgSkillHub: (hub: DenOrgSkillHub) => Promise<AsyncResult>;
   removeCloudOrgSkillHub: (hubId: string) => Promise<AsyncResult>;
   syncCloudOrgSkillHub: (hub: DenOrgSkillHub) => Promise<AsyncResult>;
+  cloudOrgMarketplaces: () => DenOrgMarketplaceResolved[];
+  cloudOrgMarketplacesStatus: () => string | null;
+  importedCloudPlugins: () => Record<string, CloudImportedPlugin>;
+  refreshCloudOrgMarketplaces: (options?: { force?: boolean }) => Promise<unknown>;
+  importCloudOrgPlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => Promise<AsyncResult>;
 };
 
 export type DenSettingsPanelProps = {
@@ -238,6 +252,10 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
   const [skillActionId, setSkillActionId] = useState<string | null>(null);
   const [skillActionKind, setSkillActionKind] = useState<"import" | "remove" | "sync" | null>(null);
   const [skillActionError, setSkillActionError] = useState<string | null>(null);
+  const [marketplacesBusy, setMarketplacesBusy] = useState(false);
+  const [activeMarketplaceId, setActiveMarketplaceId] = useState<string | null>(null);
+  const [pluginActionId, setPluginActionId] = useState<string | null>(null);
+  const [pluginActionError, setPluginActionError] = useState<string | null>(null);
   const [providersBusy, setProvidersBusy] = useState(false);
   const [providerActionId, setProviderActionId] = useState<string | null>(null);
   const [providerActionKind, setProviderActionKind] = useState<"import" | "remove" | "sync" | null>(null);
@@ -264,6 +282,8 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
   const liveSkillHubs = props.extensions.cloudOrgSkillHubs();
   const liveSkills = props.extensions.cloudOrgSkills();
   const importedSkills = props.extensions.importedCloudSkills();
+  const liveMarketplaces = props.extensions.cloudOrgMarketplaces();
+  const importedPlugins = props.extensions.importedCloudPlugins();
 
   const skillHubRows = useMemo<CloudSkillHubRow[]>(() => {
     const rows: CloudSkillHubRow[] = liveSkillHubs.map((hub) => {
@@ -383,12 +403,34 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
     return rows;
   }, [props.cloudOrgProviders, props.importedCloudProviders]);
 
+  const marketplacePluginRows = useMemo<Record<string, CloudPluginRow[]>>(() => {
+    const next: Record<string, CloudPluginRow[]> = {};
+    for (const marketplace of liveMarketplaces) {
+      next[marketplace.marketplace.id] = marketplace.plugins.map((plugin) => {
+        const imported = importedPlugins[plugin.id] ?? null;
+        const status = !imported
+          ? "available"
+          : imported.updatedAt !== plugin.updatedAt || imported.files.length !== plugin.memberCount
+            ? "out_of_sync"
+            : "imported";
+        return { marketplaceId: marketplace.marketplace.id, plugin, imported, status };
+      });
+    }
+    return next;
+  }, [importedPlugins, liveMarketplaces]);
+
+  const selectedMarketplace = useMemo(() => {
+    if (liveMarketplaces.length === 0) return null;
+    return liveMarketplaces.find((entry) => entry.marketplace.id === activeMarketplaceId) ?? liveMarketplaces[0];
+  }, [activeMarketplaceId, liveMarketplaces]);
+
   const summaryTone = useMemo(() => {
     if (
       authError ||
       workersError ||
       orgsError ||
       skillActionError ||
+      pluginActionError ||
       providerActionError ||
       skillHubActionError
     ) {
@@ -399,6 +441,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
       orgsBusy ||
       workersBusy ||
       skillsBusy ||
+      marketplacesBusy ||
       providersBusy ||
       skillHubsBusy
     ) {
@@ -412,7 +455,9 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
     orgsBusy,
     orgsError,
     providerActionError,
+    pluginActionError,
     providersBusy,
+    marketplacesBusy,
     sessionBusy,
     skillActionError,
     skillHubActionError,
@@ -437,6 +482,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
     setOrgsError(null);
     setWorkersError(null);
     setSkillHubActionError(null);
+    setPluginActionError(null);
     setProviderActionError(null);
     setSkillHubActionKind(null);
     setProviderActionKind(null);
@@ -452,6 +498,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
       setAuthToken("");
       setOpeningWorkerId(null);
       setSkillHubActionId(null);
+      setPluginActionId(null);
       setProviderActionId(null);
       setSkillHubActionKind(null);
       setProviderActionKind(null);
@@ -693,6 +740,35 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
     [activeOrg, activeOrgId, authToken, props, tr],
   );
 
+  const refreshMarketplaces = useCallback(
+    async (quiet = false) => {
+      const orgId = activeOrgId.trim();
+      if (!authToken.trim() || !orgId) return;
+
+      setMarketplacesBusy(true);
+      if (!quiet) setPluginActionError(null);
+
+      try {
+        await props.extensions.refreshCloudOrgMarketplaces({ force: true });
+        if (!quiet) {
+          const count = props.extensions.cloudOrgMarketplaces().length;
+          setStatusMessage(
+            count > 0
+              ? `Loaded ${count} marketplace${count === 1 ? "" : "s"} for ${activeOrg?.name ?? tr("den.active_org_title")}.`
+              : `No marketplaces are available for ${activeOrg?.name ?? tr("den.active_org_title")}.`,
+          );
+        }
+      } catch (error) {
+        if (!quiet) {
+          setPluginActionError(error instanceof Error ? error.message : "Failed to load marketplaces.");
+        }
+      } finally {
+        setMarketplacesBusy(false);
+      }
+    },
+    [activeOrg, activeOrgId, authToken, props.extensions, tr],
+  );
+
   useEffect(() => {
     const token = authToken.trim();
     if (!token) {
@@ -750,6 +826,11 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
     if (!user || !activeOrgId.trim()) return;
     void refreshSkills(true);
   }, [activeOrgId, refreshSkills, user]);
+
+  useEffect(() => {
+    if (!user || !activeOrgId.trim()) return;
+    void refreshMarketplaces(true);
+  }, [activeOrgId, refreshMarketplaces, user]);
 
   useEffect(() => {
     if (!user || !activeOrgId.trim()) return;
@@ -1040,6 +1121,26 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
       }
     },
     [props.extensions, skillActionId, tr, tx],
+  );
+
+  const handleImportPlugin = useCallback(
+    async (marketplaceId: string | null, plugin: DenOrgPlugin) => {
+      if (pluginActionId) return;
+
+      setPluginActionId(plugin.id);
+      setPluginActionError(null);
+
+      try {
+        const result = await props.extensions.importCloudOrgPlugin(marketplaceId, plugin);
+        if (!result.ok) throw new Error(result.message);
+        setStatusMessage(`${result.message} ${tr("den.reload_workspace")}`);
+      } catch (error) {
+        setPluginActionError(error instanceof Error ? error.message : `Failed to import ${plugin.name}.`);
+      } finally {
+        setPluginActionId(null);
+      }
+    },
+    [pluginActionId, props.extensions, tr],
   );
 
   const handleImportProvider = useCallback(
@@ -1333,6 +1434,119 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
             <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
               <div>
                 <div className="flex items-center gap-2 text-sm font-medium text-dls-text">
+                  <Boxes size={15} className="text-dls-secondary" />
+                  Marketplaces & Plugins
+                </div>
+                <div className="mt-1 text-xs text-dls-secondary">
+                  Browse organization marketplaces and import plugin files into this workspace.
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <div className={sectionPillClass}>
+                  <Users size={12} />
+                  {activeOrgName}
+                </div>
+                <Button
+                  variant="outline"
+                  className="h-8 px-3 text-xs"
+                  onClick={() => void refreshMarketplaces()}
+                  disabled={marketplacesBusy || !activeOrgId.trim()}
+                >
+                  <RefreshCcw size={13} className={marketplacesBusy ? "animate-spin" : ""} />
+                  {tr("den.refresh")}
+                </Button>
+              </div>
+            </div>
+
+            {pluginActionError || props.extensions.cloudOrgMarketplacesStatus() ? (
+              <div className={errorBannerClass}>{pluginActionError || props.extensions.cloudOrgMarketplacesStatus()}</div>
+            ) : null}
+
+            {!marketplacesBusy && liveMarketplaces.length === 0 ? (
+              <div className={`${settingsPanelSoftClass} border-dashed py-6 text-center text-sm text-dls-secondary`}>
+                {activeOrgId.trim() ? "No marketplaces are available yet." : "Choose an organization to view marketplaces."}
+              </div>
+            ) : null}
+
+            {liveMarketplaces.length > 0 ? (
+              <div className="space-y-3">
+                <div className="flex gap-2 overflow-x-auto pb-1">
+                  {liveMarketplaces.map((entry) => {
+                    const selected = selectedMarketplace?.marketplace.id === entry.marketplace.id;
+                    return (
+                      <button
+                        key={entry.marketplace.id}
+                        type="button"
+                        onClick={() => setActiveMarketplaceId(entry.marketplace.id)}
+                        className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                          selected
+                            ? "border-dls-border bg-dls-hover text-dls-text shadow-sm"
+                            : "border-dls-border bg-dls-hover text-dls-secondary hover:text-dls-text"
+                        }`}
+                      >
+                        {entry.marketplace.name}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {selectedMarketplace ? (
+                  <div className="space-y-1">
+                    {(marketplacePluginRows[selectedMarketplace.marketplace.id] ?? []).map((row) => {
+                      const actionBusy = pluginActionId === row.plugin.id;
+                      const counts = Object.entries(row.plugin.componentCounts)
+                        .filter(([, count]) => count > 0)
+                        .map(([type, count]) => `${count} ${type}${count === 1 ? "" : "s"}`);
+                      return (
+                        <div
+                          key={row.plugin.id}
+                          className="flex flex-col gap-3 rounded-xl px-3 py-3 text-left text-[13px] transition-colors hover:bg-dls-hover sm:flex-row sm:items-center sm:justify-between"
+                        >
+                          <div className="min-w-0 pr-4">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="truncate font-medium text-dls-text">{row.plugin.name}</span>
+                              {row.status !== "available" ? (
+                                <span className={sectionPillClass}>
+                                  {row.status === "imported" ? tr("den.imported_badge") : tr("den.out_of_sync_badge")}
+                                </span>
+                              ) : null}
+                              {counts.length > 0 ? counts.map((label) => <span key={label} className={sectionPillClass}>{label}</span>) : null}
+                            </div>
+                            <div className="mt-0.5 text-[11px] text-dls-secondary">
+                              {row.plugin.description || "No description provided."}
+                            </div>
+                            {row.imported?.files.length ? (
+                              <div className="mt-1 truncate text-[11px] text-dls-secondary">
+                                Installed files: {row.imported.files.map((file) => file.path).join(", ")}
+                              </div>
+                            ) : null}
+                          </div>
+                          <Button
+                            variant={row.status === "available" ? "secondary" : "outline"}
+                            className="h-8 shrink-0 px-4 text-xs"
+                            onClick={() => void handleImportPlugin(row.marketplaceId, row.plugin)}
+                            disabled={pluginActionId !== null}
+                          >
+                            {actionBusy ? tr("den.importing") : row.status === "available" ? "Import plugin" : "Sync plugin"}
+                          </Button>
+                        </div>
+                      );
+                    })}
+                    {(marketplacePluginRows[selectedMarketplace.marketplace.id] ?? []).length === 0 ? (
+                      <div className={`${settingsPanelSoftClass} border-dashed py-6 text-center text-sm text-dls-secondary`}>
+                        This marketplace does not have plugins yet.
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
+          <div className={`${settingsPanelClass} space-y-4`}>
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div>
+                <div className="flex items-center gap-2 text-sm font-medium text-dls-text">
                   <Package size={15} className="text-dls-secondary" />
                   {tr("den.cloud_skills_title")}
                 </div>
@@ -1379,7 +1593,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
                 return (
                   <div
                     key={row.key}
-                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-[#f8fafc]"
+                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-dls-hover"
                   >
                     <div className="min-w-0 pr-4">
                       <div className="flex flex-wrap items-center gap-2">
@@ -1484,7 +1698,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
                 return (
                   <div
                     key={worker.workerId}
-                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-[#f8fafc]"
+                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-dls-hover"
                   >
                     <div className="min-w-0 pr-4">
                       <div className="flex flex-wrap items-center gap-2">
@@ -1566,7 +1780,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
                 return (
                   <div
                     key={row.key}
-                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-[#f8fafc]"
+                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-dls-hover"
                   >
                     <div className="min-w-0 pr-4">
                       <div className="flex flex-wrap items-center gap-2">
@@ -1680,7 +1894,7 @@ export function DenSettingsPanel(props: DenSettingsPanelProps) {
                 return (
                   <div
                     key={row.key}
-                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-[#f8fafc]"
+                    className="flex items-center justify-between rounded-xl px-3 py-2 text-left text-[13px] transition-colors hover:bg-dls-hover"
                   >
                     <div className="min-w-0 pr-4">
                       <div className="flex flex-wrap items-center gap-2">

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -43,11 +43,16 @@ import {
   createDenClient,
   fetchDenOrgSkillsCatalog,
   readDenSettings,
+  type DenOrgMarketplaceResolved,
+  type DenOrgPlugin,
+  type DenOrgPluginResolved,
   type DenOrgSkillHub,
 } from "../../../../app/lib/den";
 import {
   readWorkspaceCloudImports,
   withWorkspaceCloudImports,
+  type CloudImportedPlugin,
+  type CloudImportedPluginFile,
   type CloudImportedSkill,
   type CloudImportedSkillHub,
 } from "../../../../app/cloud/import-state";
@@ -75,6 +80,9 @@ export type ExtensionsStoreSnapshot = {
   cloudOrgSkillHubs: DenOrgSkillHub[];
   cloudOrgSkillHubsStatus: string | null;
   importedCloudSkillHubs: Record<string, CloudImportedSkillHub>;
+  cloudOrgMarketplaces: DenOrgMarketplaceResolved[];
+  cloudOrgMarketplacesStatus: string | null;
+  importedCloudPlugins: Record<string, CloudImportedPlugin>;
   hubRepo: HubSkillRepo | null;
   hubRepos: HubSkillRepo[];
   pluginScope: PluginScope;
@@ -107,6 +115,9 @@ type MutableState = {
   cloudOrgSkillHubs: DenOrgSkillHub[];
   cloudOrgSkillHubsStatus: string | null;
   importedCloudSkillHubs: Record<string, CloudImportedSkillHub>;
+  cloudOrgMarketplaces: DenOrgMarketplaceResolved[];
+  cloudOrgMarketplacesStatus: string | null;
+  importedCloudPlugins: Record<string, CloudImportedPlugin>;
   hubRepo: HubSkillRepo | null;
   hubRepos: HubSkillRepo[];
   pluginScope: PluginScope;
@@ -185,19 +196,23 @@ export function createExtensionsStore(options: {
   let refreshHubSkillsInFlight = false;
   let refreshCloudOrgSkillsInFlight = false;
   let refreshCloudOrgSkillHubsInFlight = false;
+  let refreshCloudOrgMarketplacesInFlight = false;
   let refreshSkillsAborted = false;
   let refreshPluginsAborted = false;
   let refreshHubSkillsAborted = false;
   let refreshCloudOrgSkillsAborted = false;
   let refreshCloudOrgSkillHubsAborted = false;
+  let refreshCloudOrgMarketplacesAborted = false;
   let skillsLoaded = false;
   let hubSkillsLoaded = false;
   let cloudOrgSkillsLoaded = false;
   let cloudOrgSkillHubsLoaded = false;
+  let cloudOrgMarketplacesLoaded = false;
   let skillsRoot = "";
   let hubSkillsLoadKey = "";
   let cloudOrgSkillsLoadKey = "";
   let cloudOrgSkillHubsLoadKey = "";
+  let cloudOrgMarketplacesLoadKey = "";
 
   let state: MutableState = {
     skillsContextKey: "",
@@ -214,6 +229,9 @@ export function createExtensionsStore(options: {
     cloudOrgSkillHubs: [],
     cloudOrgSkillHubsStatus: null,
     importedCloudSkillHubs: {},
+    cloudOrgMarketplaces: [],
+    cloudOrgMarketplacesStatus: null,
+    importedCloudPlugins: {},
     hubRepo: DEFAULT_HUB_REPO,
     hubRepos: [DEFAULT_HUB_REPO],
     pluginScope: "project",
@@ -254,6 +272,9 @@ export function createExtensionsStore(options: {
       cloudOrgSkillHubs: state.cloudOrgSkillHubs,
       cloudOrgSkillHubsStatus: state.cloudOrgSkillHubsStatus,
       importedCloudSkillHubs: state.importedCloudSkillHubs,
+      cloudOrgMarketplaces: state.cloudOrgMarketplaces,
+      cloudOrgMarketplacesStatus: state.cloudOrgMarketplacesStatus,
+      importedCloudPlugins: state.importedCloudPlugins,
       hubRepo: state.hubRepo,
       hubRepos: state.hubRepos,
       pluginScope: state.pluginScope,
@@ -397,6 +418,18 @@ export function createExtensionsStore(options: {
     }
   };
 
+  const refreshImportedCloudPlugins = async () => {
+    try {
+      const config = await readWorkspaceOpenworkConfigRecord();
+      const cloudImports = readWorkspaceCloudImports(config);
+      setStateField("importedCloudPlugins", cloudImports.plugins);
+      return cloudImports.plugins;
+    } catch {
+      setStateField("importedCloudPlugins", {});
+      return {};
+    }
+  };
+
   const persistImportedCloudSkillHubs = async (nextSkillHubs: Record<string, CloudImportedSkillHub>) => {
     const config = await readWorkspaceOpenworkConfigRecord();
     const cloudImports = readWorkspaceCloudImports(config);
@@ -423,6 +456,20 @@ export function createExtensionsStore(options: {
       throw new Error("OpenWork server unavailable. Connect to manage imported cloud skills.");
     }
     setStateField("importedCloudSkills", nextSkills);
+  };
+
+  const persistImportedCloudPlugins = async (nextPlugins: Record<string, CloudImportedPlugin>) => {
+    const config = await readWorkspaceOpenworkConfigRecord();
+    const cloudImports = readWorkspaceCloudImports(config);
+    const nextConfig = withWorkspaceCloudImports(config, {
+      ...cloudImports,
+      plugins: nextPlugins,
+    });
+    const persisted = await writeWorkspaceOpenworkConfigRecord(nextConfig);
+    if (!persisted) {
+      throw new Error("OpenWork server unavailable. Connect to manage imported cloud plugins.");
+    }
+    setStateField("importedCloudPlugins", nextPlugins);
   };
 
   const buildCloudSkillContent = (name: string, description: string, body: string) => {
@@ -590,6 +637,161 @@ export function createExtensionsStore(options: {
     return { nextSkillNames, nextSkillIds, removedSkillNames };
   };
 
+  const slugifyConfigObjectName = (title: string, fallback: string) => {
+    const slug = slugifyOpencodeSkillName(title || fallback);
+    return slug === "skill" && fallback ? slugifyOpencodeSkillName(fallback) : slug;
+  };
+
+  const pluginNamespace = (pluginName: string, pluginId: string) => {
+    const base = slugifyConfigObjectName(pluginName, pluginId);
+    return `${base.replace(/-plugin$/, "")}-plugin`;
+  };
+
+  const normalizePluginSourcePath = (path: string, objectType: string, namespace: string) => {
+    const parts = path.trim().replace(/^\/+/, "").split("/").filter(Boolean);
+    if (parts.length === 0 || parts.some((part) => part === ".." || part === ".")) return "";
+
+    const folderByType: Record<string, string> = {
+      agent: "agents",
+      command: "commands",
+      context: "context",
+      hook: "hooks",
+      mcp: "mcps",
+      skill: "skills",
+      tool: "tools",
+    };
+    const folder = folderByType[objectType];
+    if (!folder) return "";
+    const opencodeIndex = parts.findIndex((part) => part === ".opencode");
+    const searchParts = opencodeIndex >= 0 ? parts.slice(opencodeIndex + 1) : parts;
+    const folderIndex = searchParts.findIndex((part) => part === folder);
+    if (folderIndex < 0 || folderIndex === searchParts.length - 1) return "";
+    const rest = searchParts.slice(folderIndex + 1);
+    if (rest[0] === namespace) return [".opencode", folder, ...rest].join("/");
+    return [".opencode", folder, namespace, ...rest].join("/");
+  };
+
+  const getPluginObjectInstallPath = (
+    object: NonNullable<DenOrgPluginResolved["memberships"][number]["configObject"]>,
+    namespace: string,
+  ) => {
+    const existing = normalizePluginSourcePath(object.currentRelativePath ?? "", object.objectType, namespace);
+    if (existing) {
+      if (object.objectType === "skill" && !/\/SKILL\.md$/i.test(existing)) {
+        const skillName = existing.split("/").filter(Boolean).at(-1) ?? slugifyConfigObjectName(object.title, object.id);
+        return `.opencode/skills/${namespace}/${skillName}/SKILL.md`;
+      }
+      return existing;
+    }
+    const name = slugifyConfigObjectName(object.title, object.id);
+    switch (object.objectType) {
+      case "skill":
+        return `.opencode/skills/${namespace}/${name}/SKILL.md`;
+      case "agent":
+        return `.opencode/agents/${namespace}/${name}.md`;
+      case "command":
+        return `.opencode/commands/${namespace}/${name}.md`;
+      case "mcp":
+        return `.opencode/mcps/${namespace}/${name}.json`;
+      case "hook":
+        return `.opencode/hooks/${namespace}/${name}.json`;
+      case "tool":
+        return `.opencode/tools/${namespace}/${name}.ts`;
+      case "context":
+        return `.opencode/context/${namespace}/${name}.md`;
+      default:
+        return `.opencode/plugins/${namespace}/${name}.txt`;
+    }
+  };
+
+  const pluginReloadReason = (objectType: string): ReloadReason => {
+    switch (objectType) {
+      case "skill":
+        return "skills";
+      case "agent":
+        return "agents";
+      case "command":
+        return "commands";
+      case "mcp":
+        return "mcp";
+      default:
+        return "config";
+    }
+  };
+
+  const writePluginWorkspaceFile = async (path: string, content: string) => {
+    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkClient = openworkSnapshot.openworkServerClient;
+    const openworkWorkspaceId = options.runtimeWorkspaceId();
+    if (
+      openworkSnapshot.openworkServerStatus === "connected" &&
+      openworkClient &&
+      openworkWorkspaceId &&
+      typeof openworkClient.writeWorkspaceFile === "function"
+    ) {
+      await openworkClient.writeWorkspaceFile(openworkWorkspaceId, { path, content, force: true });
+      return;
+    }
+    throw new Error("OpenWork server unavailable. Connect to import plugin files into this workspace.");
+  };
+
+  const applyCloudOrgPluginImport = async (
+    marketplaceId: string | null,
+    resolved: DenOrgPluginResolved,
+  ): Promise<CloudImportedPluginFile[]> => {
+    const files: CloudImportedPluginFile[] = [];
+    const existing = snapshot.importedCloudPlugins[resolved.plugin.id];
+    const namespace = pluginNamespace(resolved.plugin.name, resolved.plugin.id);
+
+    for (const membership of resolved.memberships) {
+      const object = membership.configObject;
+      const version = object?.latestVersion ?? null;
+      if (!object || object.status !== "active" || version?.rawSourceText == null) continue;
+
+      const path = getPluginObjectInstallPath(object, namespace);
+      let content = version.rawSourceText;
+      if (object.objectType === "skill") {
+        const rawDesc = (object.description?.trim() || object.title).trim();
+        const description = rawDesc.slice(0, 1024) || object.title.slice(0, 1024) || "Skill";
+        const installName = path.match(/^\.opencode\/skills\/[^/]+\/([^/]+)\/SKILL\.md$/)?.[1] ?? slugifyConfigObjectName(object.title, object.id);
+        content = buildCloudSkillContent(installName, description, extractSkillBodyMarkdown(content));
+      }
+      await writePluginWorkspaceFile(path, content);
+
+      files.push({
+        configObjectId: object.id,
+        versionId: version.id,
+        objectType: object.objectType,
+        title: object.title,
+        path,
+        updatedAt: object.updatedAt,
+      });
+      options.markReloadRequired?.(pluginReloadReason(object.objectType), {
+        type:
+          object.objectType === "skill" || object.objectType === "agent" || object.objectType === "command" || object.objectType === "mcp"
+            ? object.objectType
+            : "config",
+        name: object.title,
+        action: existing ? "updated" : "added",
+      });
+    }
+
+    const nextPlugins = {
+      ...snapshot.importedCloudPlugins,
+      [resolved.plugin.id]: {
+        pluginId: resolved.plugin.id,
+        marketplaceId,
+        name: resolved.plugin.name,
+        description: resolved.plugin.description,
+        updatedAt: resolved.plugin.updatedAt,
+        files,
+        importedAt: existing?.importedAt ?? Date.now(),
+      },
+    } satisfies Record<string, CloudImportedPlugin>;
+    await persistImportedCloudPlugins(nextPlugins);
+    return files;
+  };
+
   const persistHubRepos = () => {
     if (typeof window === "undefined") return;
     try {
@@ -607,10 +809,12 @@ export function createExtensionsStore(options: {
     hubSkillsLoaded = false;
     cloudOrgSkillsLoaded = false;
     cloudOrgSkillHubsLoaded = false;
+    cloudOrgMarketplacesLoaded = false;
     skillsRoot = "";
     hubSkillsLoadKey = "";
     cloudOrgSkillsLoadKey = "";
     cloudOrgSkillHubsLoadKey = "";
+    cloudOrgMarketplacesLoadKey = "";
   };
 
   const touch = () => {
@@ -853,6 +1057,100 @@ export function createExtensionsStore(options: {
       }));
     } finally {
       refreshCloudOrgSkillHubsInFlight = false;
+    }
+  }
+
+  async function refreshCloudOrgMarketplaces(optionsOverride?: { force?: boolean }) {
+    const wk = getWorkspaceContextKey();
+    const settings = readDenSettings();
+    const token = settings.authToken?.trim() ?? "";
+    const orgId = settings.activeOrgId?.trim() ?? "";
+    const loadKey = `${wk}::${orgId}`;
+
+    if (loadKey !== cloudOrgMarketplacesLoadKey) {
+      cloudOrgMarketplacesLoaded = false;
+    }
+
+    if (!optionsOverride?.force && cloudOrgMarketplacesLoaded) {
+      await refreshImportedCloudPlugins();
+      return;
+    }
+    if (refreshCloudOrgMarketplacesInFlight) return;
+
+    refreshCloudOrgMarketplacesInFlight = true;
+    refreshCloudOrgMarketplacesAborted = false;
+
+    try {
+      setStateField("cloudOrgMarketplacesStatus", null);
+
+      if (!token || !orgId) {
+        mutateState((current) => ({
+          ...current,
+          cloudOrgMarketplaces: [],
+          cloudOrgMarketplacesStatus: null,
+        }));
+        cloudOrgMarketplacesLoaded = true;
+        cloudOrgMarketplacesLoadKey = loadKey;
+        await refreshImportedCloudPlugins();
+        return;
+      }
+
+      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const marketplaces = await client.listOrgMarketplaces(orgId);
+      const resolved = await Promise.all(
+        marketplaces.map((marketplace) => client.getOrgMarketplaceResolved(orgId, marketplace.id)),
+      );
+      if (refreshCloudOrgMarketplacesAborted) return;
+      mutateState((current) => ({
+        ...current,
+        cloudOrgMarketplaces: resolved,
+        cloudOrgMarketplacesStatus: resolved.length ? null : "No organization marketplaces are available yet.",
+      }));
+      cloudOrgMarketplacesLoaded = true;
+      cloudOrgMarketplacesLoadKey = loadKey;
+      await refreshImportedCloudPlugins();
+    } catch (error) {
+      if (refreshCloudOrgMarketplacesAborted) return;
+      mutateState((current) => ({
+        ...current,
+        cloudOrgMarketplaces: [],
+        cloudOrgMarketplacesStatus:
+          error instanceof Error ? error.message : "Failed to load organization marketplaces.",
+      }));
+    } finally {
+      refreshCloudOrgMarketplacesInFlight = false;
+    }
+  }
+
+  async function importCloudOrgPlugin(
+    marketplaceId: string | null,
+    plugin: DenOrgPlugin,
+  ): Promise<{ ok: boolean; message: string; files: CloudImportedPluginFile[] }> {
+    options.setBusy(true);
+    options.setError(null);
+    setStateField("cloudOrgMarketplacesStatus", null);
+
+    try {
+      const settings = readDenSettings();
+      const token = settings.authToken?.trim() ?? "";
+      const orgId = settings.activeOrgId?.trim() ?? "";
+      if (!token || !orgId) throw new Error("Sign in to OpenWork Cloud and choose an organization first.");
+      const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
+      const resolved = await client.getOrgPluginResolved(orgId, plugin);
+      const files = await applyCloudOrgPluginImport(marketplaceId, resolved);
+      await refreshSkills({ force: true });
+      await refreshCloudOrgMarketplaces({ force: true });
+      return {
+        ok: true,
+        message: `Imported ${plugin.name} with ${files.length} file${files.length === 1 ? "" : "s"}.`,
+        files,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : translate("skills.unknown_error");
+      options.setError(addOpencodeCacheHint(message));
+      return { ok: false, message, files: [] };
+    } finally {
+      options.setBusy(false);
     }
   }
 
@@ -1917,6 +2215,7 @@ export function createExtensionsStore(options: {
     refreshHubSkillsAborted = true;
     refreshCloudOrgSkillsAborted = true;
     refreshCloudOrgSkillHubsAborted = true;
+    refreshCloudOrgMarketplacesAborted = true;
   }
 
   function ensureSkillsFresh() {
@@ -2025,6 +2324,7 @@ export function createExtensionsStore(options: {
       const onDenSessionUpdated = () => {
         cloudOrgSkillsLoaded = false;
         cloudOrgSkillHubsLoaded = false;
+        cloudOrgMarketplacesLoaded = false;
         mutateState((current) => ({ ...current, cloudOrgSkillsContextKey: "" }));
       };
       window.addEventListener("openwork-den-session-updated", onDenSessionUpdated);
@@ -2062,6 +2362,7 @@ export function createExtensionsStore(options: {
     void refreshPlugins();
     void refreshImportedCloudSkills();
     void refreshImportedCloudSkillHubs();
+    void refreshImportedCloudPlugins();
   };
 
   refreshSnapshot();
@@ -2091,6 +2392,9 @@ export function createExtensionsStore(options: {
     cloudOrgSkillHubs: () => snapshot.cloudOrgSkillHubs,
     cloudOrgSkillHubsStatus: () => snapshot.cloudOrgSkillHubsStatus,
     importedCloudSkillHubs: () => snapshot.importedCloudSkillHubs,
+    cloudOrgMarketplaces: () => snapshot.cloudOrgMarketplaces,
+    cloudOrgMarketplacesStatus: () => snapshot.cloudOrgMarketplacesStatus,
+    importedCloudPlugins: () => snapshot.importedCloudPlugins,
     hubRepo: () => snapshot.hubRepo,
     hubRepos: () => snapshot.hubRepos,
     get pluginScope() {
@@ -2126,6 +2430,7 @@ export function createExtensionsStore(options: {
     refreshHubSkills,
     refreshCloudOrgSkills,
     refreshCloudOrgSkillHubs,
+    refreshCloudOrgMarketplaces,
     setHubRepo,
     addHubRepo,
     removeHubRepo,
@@ -2141,6 +2446,7 @@ export function createExtensionsStore(options: {
     importCloudOrgSkillHub,
     syncCloudOrgSkillHub,
     removeCloudOrgSkillHub,
+    importCloudOrgPlugin,
     revealSkillsFolder,
     uninstallSkill,
     readSkill,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1101,8 +1101,8 @@ export function SessionRoute() {
         setModelPickerQuery("");
         setModelPickerOpen(true);
       },
-      onOpenSettingsSection: (section: "commands" | "skills" | "mcps") => {
-        navigate(section === "skills" ? "/settings/skills" : section === "mcps" ? "/settings/mcp" : "/settings/general");
+      onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins") => {
+        navigate(section === "skills" ? "/settings/skills" : section === "mcps" ? "/settings/mcp" : section === "plugins" ? "/settings/den" : "/settings/general");
       },
       onSendDraft: async (draft: ComposerDraft) => {
         const text = (draft.resolvedText ?? draft.text).trim();


### PR DESCRIPTION
## Summary
- Add OpenWork Cloud marketplace and plugin import support in Cloud settings.
- Persist imported plugin manifests and install plugin files under namespaced `.opencode` paths.
- Surface imported plugins as browsable composer tool sections, with plugin commands and skills applying as slash-command pills.

## Verification
- `pnpm --filter @openwork/app typecheck`
- `git diff --check`

## Notes
- Full end-to-end Cloud marketplace verification requires a signed-in org with marketplace/plugin data.