### PR TITLE
fix settings session log spam

### DIFF
--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -181,6 +181,22 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     el.scrollIntoView({ block: "nearest" });
   }, []);
 
+  const selectRenderedItem = useCallback(
+    (item: RenderedItem | undefined) => {
+      if (!item) return;
+      if (item.kind === "provider") {
+        props.onClose({ restorePromptFocus: false });
+        props.onOpenSettings();
+        return;
+      }
+      props.onSelect({
+        providerID: item.opt.providerID,
+        modelID: item.opt.modelID,
+      });
+    },
+    [props],
+  );
+
   // Focus the search input whenever the modal opens.
   useEffect(() => {
     if (!props.open) return;
@@ -235,28 +251,17 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
       }
       if (event.key === "Enter") {
         if (event.isComposing || event.keyCode === 229) return;
-        setActiveIndex((current) => {
-          const item = renderedItems[current];
-          if (!item) return current;
-          event.preventDefault();
-          event.stopPropagation();
-          if (item.kind === "provider") {
-            props.onClose({ restorePromptFocus: false });
-            props.onOpenSettings();
-            return current;
-          }
-          props.onSelect({
-            providerID: item.opt.providerID,
-            modelID: item.opt.modelID,
-          });
-          return current;
-        });
+        const item = renderedItems[activeIndex];
+        if (!item) return;
+        event.preventDefault();
+        event.stopPropagation();
+        selectRenderedItem(item);
       }
     };
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [clampIndex, props, renderedItems, scrollActiveIntoView]);
+  }, [activeIndex, clampIndex, renderedItems, scrollActiveIntoView, selectRenderedItem]);
 
   if (!props.open) return null;
 

--- a/apps/app/src/react-app/shell/debug-logger.ts
+++ b/apps/app/src/react-app/shell/debug-logger.ts
@@ -351,10 +351,8 @@ export function startDebugLogger(opts?: { serverUrl?: () => string | Promise<str
     lastHeartbeat = now;
   }, 1000);
 
-  // When the page returns to visibility after being backgrounded, stale
-  // in-flight SSE subscriptions/Query caches can make the UI look frozen
-  // even though JS is fine. Nudge the app to re-resolve its connection and
-  // re-fetch route data.
+  // Track visibility changes for diagnostics only. Route-level code owns any
+  // refresh behavior so the logger does not accidentally fan out network calls.
   if (typeof document !== "undefined") {
     const handleVisibilityChange = () => {
       enqueue({
@@ -362,13 +360,6 @@ export function startDebugLogger(opts?: { serverUrl?: () => string | Promise<str
         message: `visibilitychange: ${document.visibilityState}`,
         extra: { visibility: document.visibilityState },
       });
-      if (document.visibilityState === "visible") {
-        try {
-          window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
-        } catch {
-          // ignore
-        }
-      }
     };
     visibilityHandlerRef = handleVisibilityChange;
     document.addEventListener("visibilitychange", handleVisibilityChange);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -330,6 +330,7 @@ export function SettingsRoute() {
   const [busyLabel, setBusyLabel] = useState<string | null>(null);
   const [routeError, setRouteError] = useState<string | null>(null);
   const workspacesRef = useRef<RouteWorkspace[]>([]);
+  const refreshInFlightRef = useRef(false);
   const reconnectAttemptedWorkspaceIdRef = useRef("");
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
   const [providerDefaults, setProviderDefaults] = useState<Record<string, string>>({});
@@ -682,6 +683,8 @@ export function SettingsRoute() {
 
   const { markRouteReady: markBootRouteReady } = useBootState();
   const refreshRouteState = useMemo(() => async () => {
+    if (refreshInFlightRef.current) return;
+    refreshInFlightRef.current = true;
     setLoading(true);
     setRouteError(null);
     let desktopList = null as Awaited<ReturnType<typeof workspaceBootstrap>> | null;
@@ -717,9 +720,13 @@ export function SettingsRoute() {
 
       const client = createOpenworkServerClient({ baseUrl: normalizedBaseUrl, token: resolvedToken });
       const list = await client.listWorkspaces();
+      const serverWorkspaceIds = new Set(list.items.map((workspace) => workspace.id));
       const nextWorkspaces = mergeRouteWorkspaces(list.items, desktopWorkspaces);
       const sessionEntries = await Promise.all(
         nextWorkspaces.map(async (workspace) => {
+          if (!serverWorkspaceIds.has(workspace.id)) {
+            return { workspaceId: workspace.id, sessions: [], error: null as string | null };
+          }
           try {
             const response = await client.listSessions(workspace.id, { limit: 200 });
             const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
@@ -763,6 +770,7 @@ export function SettingsRoute() {
       }
     } finally {
       setLoading(false);
+      refreshInFlightRef.current = false;
       // Settings can be the first route a user lands on (direct link, deep
       // link, or after reload). Let the boot overlay dismiss once we've
       // completed our first data load.


### PR DESCRIPTION
## Summary
- Stop the debug logger from dispatching settings refresh events on every visibility return.
- Avoid settings-route session fetches for desktop-only workspaces that the server cannot resolve.
- Move model-picker Enter selection out of a state updater to avoid React render-time state update warnings.

## Verification
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app build

## Notes
- The Electron CSP warning is a development-only warning and was not changed here.