### PR TITLE
fix slash command composer churn

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
 import { ArrowUp, Check, ChevronDown, ChevronRight, FileText, Paperclip, Plug, Settings, Square, Terminal, X, Zap } from "lucide-react";
 import fuzzysort from "fuzzysort";
@@ -265,6 +265,9 @@ export function ReactSessionComposer(props: ComposerProps) {
   const [mentionOpen, setMentionOpen] = useState(false);
   const [menuIndex, setMenuIndex] = useState(0);
   const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const commandsCacheRef = useRef<SlashCommandOption[] | null>(null);
+  const commandsRequestRef = useRef<Promise<SlashCommandOption[]> | null>(null);
+  const commandsLoadVersionRef = useRef(0);
   const [agentMenuIndex, setAgentMenuIndex] = useState(0);
   const agentItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const [dropzoneActive, setDropzoneActive] = useState(false);
@@ -284,19 +287,21 @@ export function ReactSessionComposer(props: ComposerProps) {
   }, [props.draft]);
 
   const slashMatch = props.draft.match(/^\/(\S*)$/);
+  const slashOpenNext = Boolean(slashMatch);
   const slashQuery = slashMatch?.[1] ?? "";
   const mentionMatch = props.draft.match(/@([^\s@]*)$/);
+  const mentionOpenNext = Boolean(mentionMatch);
   const mentionQuery = mentionMatch?.[1] ?? "";
 
   useEffect(() => {
-    setSlashOpen(Boolean(slashMatch));
+    setSlashOpen(slashOpenNext);
     setMenuIndex(0);
-  }, [slashMatch]);
+  }, [slashOpenNext, slashQuery]);
 
   useEffect(() => {
-    setMentionOpen(Boolean(mentionMatch));
+    setMentionOpen(mentionOpenNext);
     setMenuIndex(0);
-  }, [mentionMatch]);
+  }, [mentionOpenNext, mentionQuery]);
 
   useEffect(() => {
     if (!agentMenuOpen) return;
@@ -327,10 +332,46 @@ export function ReactSessionComposer(props: ComposerProps) {
   }, [agentMenuIndex, agentMenuOpen]);
 
   useEffect(() => {
+    commandsLoadVersionRef.current += 1;
+    commandsCacheRef.current = null;
+    commandsRequestRef.current = null;
+  }, [props.listCommands]);
+
+  const loadCommands = useCallback(() => {
+    if (commandsCacheRef.current !== null) {
+      return Promise.resolve(commandsCacheRef.current);
+    }
+    if (commandsRequestRef.current) {
+      return commandsRequestRef.current;
+    }
+    const version = commandsLoadVersionRef.current;
+    const request = props.listCommands().then((next) => {
+      if (commandsLoadVersionRef.current === version) {
+        commandsCacheRef.current = next;
+      }
+      return next;
+    }).finally(() => {
+      if (commandsLoadVersionRef.current === version) {
+        commandsRequestRef.current = null;
+      }
+    });
+    commandsRequestRef.current = request;
+    return request;
+  }, [props.listCommands]);
+
+  useEffect(() => {
     if (!slashOpen && !toolMenuOpen) return;
     let cancelled = false;
+    const cached = commandsCacheRef.current;
+    if (cached !== null) {
+      setCommands(cached);
+      setCommandsLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
     setCommandsLoading(true);
-    void props.listCommands()
+    void loadCommands()
       .then((next) => {
         if (!cancelled) setCommands(next);
       })
@@ -343,7 +384,7 @@ export function ReactSessionComposer(props: ComposerProps) {
     return () => {
       cancelled = true;
     };
-  }, [slashOpen, toolMenuOpen, props.listCommands]);
+  }, [slashOpen, toolMenuOpen, loadCommands]);
 
   useEffect(() => {
     if (!mentionOpen) return;
@@ -473,16 +514,20 @@ export function ReactSessionComposer(props: ComposerProps) {
     return undefined;
   }, [toolMenuOpen, toolMenuSection, props.listSkills, props.listMcp]);
 
-  const slashFiltered = !slashOpen
-    ? []
-    : slashQuery
-      ? fuzzysort.go(slashQuery, commands, { keys: ["name", "description"] }).map((entry) => entry.obj).slice(0, 8)
-      : commands.slice(0, 8);
-  const mentionFiltered = !mentionOpen
-    ? []
-    : mentionQuery
-      ? fuzzysort.go(mentionQuery, mentionItems, { keys: ["label"] }).map((entry) => entry.obj).slice(0, 8)
-      : mentionItems.slice(0, 8);
+  const slashFiltered = useMemo(() => {
+    if (!slashOpen) return [];
+    if (!slashQuery) return commands.slice(0, 8);
+    return fuzzysort.go(slashQuery, commands, { keys: ["name", "description"], limit: 8 }).map((entry) => entry.obj);
+  }, [commands, slashOpen, slashQuery]);
+  const mentionFiltered = useMemo(() => {
+    if (!mentionOpen) return [];
+    if (!mentionQuery) return mentionItems.slice(0, 8);
+    return fuzzysort.go(mentionQuery, mentionItems, { keys: ["label"], limit: 8 }).map((entry) => entry.obj);
+  }, [mentionItems, mentionOpen, mentionQuery]);
+  const pastedTextTokens = useMemo(
+    () => props.pastedText.map((item) => ({ label: item.label, lines: item.lines })),
+    [props.pastedText],
+  );
 
   const activeMenu = slashOpen ? "slash" : mentionOpen ? "mention" : null;
   const activeItems = activeMenu === "slash" ? slashFiltered : activeMenu === "mention" ? mentionFiltered : [];
@@ -513,6 +558,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   }, [activeItems.length]);
 
   useEffect(() => {
+    menuItemRefs.current.length = activeItems.length;
     const target = menuItemRefs.current[menuIndex];
     target?.scrollIntoView({ block: "nearest" });
   }, [menuIndex, activeItems.length]);
@@ -549,8 +595,7 @@ export function ReactSessionComposer(props: ComposerProps) {
     if (activeMenu === "slash") {
       const command = slashFiltered[menuIndex];
       if (!command) return false;
-      props.onDraftChange(`/${command.name} `);
-      setSlashOpen(false);
+      applyCommandSelection(command);
       return true;
     }
     if (activeMenu === "mention") {
@@ -747,7 +792,14 @@ export function ReactSessionComposer(props: ComposerProps) {
                     type="button"
                     className={`flex w-full items-start gap-3 rounded-[16px] px-3 py-2.5 text-left transition-colors hover:bg-gray-2/70 ${activeMenu === "slash" && slashFiltered[menuIndex]?.id === command.id ? "bg-gray-3 text-gray-12" : "text-gray-11"}`}
                     onMouseEnter={() => setMenuIndex(index)}
-                    onClick={() => applyCommandSelection(command)}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      applyCommandSelection(command);
+                    }}
+                    onClick={(event) => {
+                      if (event.detail === 0) applyCommandSelection(command);
+                    }}
                   >
                     <Terminal size={14} className="mt-0.5 shrink-0 text-gray-9" />
                     <div className="min-w-0 flex-1">
@@ -898,7 +950,7 @@ export function ReactSessionComposer(props: ComposerProps) {
             <LexicalPromptEditor
               value={props.draft}
               mentions={props.mentions}
-              pastedText={props.pastedText.map((item) => ({ label: item.label, lines: item.lines }))}
+              pastedText={pastedTextTokens}
               disabled={props.disabled}
               placeholder={t("composer.placeholder", locale)}
               onChange={props.onDraftChange}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -410,13 +410,18 @@ function SyncPlugin(props: { value: string; mentions: Record<string, "agent" | "
       setPrompt(props.value, props.mentions, props.pastedText);
       $getRoot().selectEnd();
     });
-  }, [editor, props.mentions, props.value]);
+  }, [editor, props.mentions, props.pastedText, props.value]);
 
   return null;
 }
 
 function SubmitPlugin(props: { onSubmit: () => void | Promise<void>; disabled: boolean }) {
   const [editor] = useLexicalComposerContext();
+  const onSubmitRef = useRef(props.onSubmit);
+
+  useEffect(() => {
+    onSubmitRef.current = props.onSubmit;
+  }, [props.onSubmit]);
 
   useEffect(() => {
     return editor.registerCommand(
@@ -435,12 +440,12 @@ function SubmitPlugin(props: { onSubmit: () => void | Promise<void>; disabled: b
         // Plain Enter submits. Cmd/Ctrl+Enter also submits for muscle
         // memory compatibility.
         event?.preventDefault();
-        void props.onSubmit();
+        void onSubmitRef.current();
         return true;
       },
       COMMAND_PRIORITY_HIGH,
     );
-  }, [editor, props.disabled, props.onSubmit]);
+  }, [editor, props.disabled]);
 
   return null;
 }
@@ -533,6 +538,17 @@ function MentionChipNavigationPlugin() {
 }
 
 export function LexicalPromptEditor(props: EditorProps) {
+  const valueRef = useRef(props.value);
+  const onChangeRef = useRef(props.onChange);
+
+  useEffect(() => {
+    valueRef.current = props.value;
+  }, [props.value]);
+
+  useEffect(() => {
+    onChangeRef.current = props.onChange;
+  }, [props.onChange]);
+
   const initialConfig = useMemo(
     () => ({
       namespace: "openwork-react-session-composer",
@@ -551,10 +567,13 @@ export function LexicalPromptEditor(props: EditorProps) {
   const handleChange = useCallback(
     (state: Parameters<NonNullable<React.ComponentProps<typeof OnChangePlugin>["onChange"]>>[0]) => {
       state.read(() => {
-        props.onChange(serializePromptFromRoot());
+        const next = serializePromptFromRoot();
+        if (next === valueRef.current) return;
+        valueRef.current = next;
+        onChangeRef.current(next);
       });
     },
-    [props],
+    [],
   );
 
   return (

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
 
@@ -341,7 +341,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     isError: snapshotQuery.isError || Boolean(error),
   });
 
-  const buildDraft = (text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
+  const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
     const trimmed = text.trim();
     const slashMatch = trimmed.match(/^\/([^\s]+)\s*(.*)$/);
     const parts: ComposerPart[] = text.split(/(\[pasted text [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
@@ -369,7 +369,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       resolvedText: text,
       command: slashMatch ? { name: slashMatch[1] ?? "", arguments: slashMatch[2] ?? "" } : undefined,
     };
-  };
+  }, [mentions, pasteParts]);
 
   const handleCopyTranscript = async () => {
     try {
@@ -424,7 +424,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     props.onDraftChange(buildDraft(draft, attachments));
-  }, [draft, attachments, pasteParts, props]);
+  }, [attachments, buildDraft, draft, props.onDraftChange]);
 
   const handleAttachFiles = (files: File[]) => {
     if (!props.attachmentsEnabled) {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1065,6 +1065,11 @@ export function SessionRoute() {
     });
   }, [checkDesktopRestriction, modelOptions]);
 
+  const listSlashCommands = useCallback(async (): Promise<SlashCommandOption[]> => {
+    if (!opencodeClient) return [];
+    return listCommands(opencodeClient, selectedWorkspaceRoot || undefined);
+  }, [opencodeClient, selectedWorkspaceRoot]);
+
   const surfaceProps = useMemo(() => {
     if (!client || !selectedWorkspaceId || !selectedSessionId || !opencodeBaseUrl || !token || !opencodeClient) {
       return null;
@@ -1155,10 +1160,7 @@ export function SessionRoute() {
         return list.filter((agent) => !agent.hidden && agent.mode !== "subagent");
       },
       onSelectAgent: (agent: string | null) => setSelectedAgent(agent),
-      listCommands: async (): Promise<SlashCommandOption[]> => {
-        const list = await listCommands(opencodeClient, selectedWorkspaceRoot || undefined);
-        return list;
-      },
+      listCommands: listSlashCommands,
       recentFiles: [],
       searchFiles: async (query: string) => {
         const trimmed = query.trim();
@@ -1179,6 +1181,7 @@ export function SessionRoute() {
   }, [
     client,
     local,
+    listSlashCommands,
     modelLabel,
     navigate,
     opencodeBaseUrl,


### PR DESCRIPTION
## Summary
- Stabilize slash and mention menu state so selection does not reset on unrelated renders.
- Cache/dedupe slash command loading while menus are open and bound fuzzy search work to visible results.
- Add Lexical draft equality/ref guards to avoid extra onChange and submit command churn.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`

## Notes
- No screenshot/video captured; this is an interaction stability fix and I verified with typecheck/build rather than a browser recording.