### PR TITLE
fix session error display and slash command backspace

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
@@ -759,7 +759,7 @@ export function WorkspaceSessionList(props: Props) {
         </div>
       </div>
 
-      <div className="relative mt-auto border-t border-dls-border/80 bg-dls-sidebar pt-3">
+      <div className="relative mt-auto border-t border-dls-border/80 bg-dls-sidebar px-3 pt-3 pb-4">
         <button
           type="button"
           className="w-full flex items-center justify-center gap-2 rounded-[18px] border border-dls-border bg-dls-surface px-3.5 py-2.5 text-[12px] font-medium text-gray-11 shadow-[var(--dls-card-shadow)] transition-colors hover:bg-gray-2"

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -955,6 +955,7 @@ export function ReactSessionComposer(props: ComposerProps) {
               placeholder={t("composer.placeholder", locale)}
               onChange={props.onDraftChange}
               onSubmit={props.onSend}
+              onPasteText={props.onPasteText}
               onPaste={(event) => {
                 // Paste policy:
                 // 1. Actual files on the clipboard -> attach them.
@@ -986,6 +987,19 @@ export function ReactSessionComposer(props: ComposerProps) {
                 }
 
                 const text = event.clipboardData?.getData("text/plain") ?? "";
+
+                // Collapse long pastes into an inline chip. The threshold
+                // is 3+ lines or 200+ characters — short pastes still go
+                // straight into the editor as plain text.
+                const PASTE_CHIP_LINE_THRESHOLD = 3;
+                const PASTE_CHIP_CHAR_THRESHOLD = 200;
+                const lineCount = text.split(/\r?\n/).length;
+                if (text.trim() && (lineCount >= PASTE_CHIP_LINE_THRESHOLD || text.length >= PASTE_CHIP_CHAR_THRESHOLD)) {
+                  event.preventDefault();
+                  props.onPasteText(text);
+                  return;
+                }
+
                 if (
                   text.trim() &&
                   (props.isRemoteWorkspace || props.isSandboxWorkspace) &&

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1244,15 +1244,13 @@ export function ReactSessionComposer(props: ComposerProps) {
               </div>
 
               {/*
-                Send is ALWAYS reachable — even during streaming — so the
-                user can queue a follow-up prompt without stopping the run.
-                When busy AND the draft is empty, only Stop is visible (the
-                Send button would be a no-op). When busy AND there's a
-                draft, both buttons show so the user can either queue the
-                next turn or cancel the current one.
+                Single action button that toggles between Stop and Run task.
+                When busy with no draft: Stop (cancels current run).
+                When busy with a draft: Run task (queues a follow-up).
+                When idle: Run task.
               */}
               <div className="ml-auto flex shrink-0 items-end gap-1.5">
-                {props.busy ? (
+                {props.busy && !canSend ? (
                   <button
                     type="button"
                     onClick={props.onStop}
@@ -1262,23 +1260,22 @@ export function ReactSessionComposer(props: ComposerProps) {
                     <Square size={12} fill="currentColor" />
                     <span>{t("composer.stop", locale)}</span>
                   </button>
-                ) : null}
-                {!props.busy || canSend ? (
+                ) : (
                   <button
                     type="button"
-                    onClick={props.onSend}
-                    disabled={props.disabled || !canSend}
+                    onClick={canSend ? props.onSend : props.busy ? props.onStop : undefined}
+                    disabled={props.disabled || (!canSend && !props.busy)}
                     className={`inline-flex h-9 max-h-9 items-center gap-2 rounded-full px-4 text-[13px] font-medium transition-colors ${
                       !canSend || props.disabled
                         ? "bg-gray-4 text-gray-10"
                         : "bg-[var(--dls-accent)] text-white hover:bg-[var(--dls-accent-hover)]"
                     }`}
-                    title={props.busy ? t("composer.run_task", locale) : t("composer.run_task", locale)}
+                    title={t("composer.run_task", locale)}
                   >
                     <ArrowUp size={15} />
                     <span>{t("composer.run_task", locale)}</span>
                   </button>
-                ) : null}
+                )}
               </div>
             </div>
           </div>

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1421,9 +1421,7 @@ export function ReactSessionComposer(props: ComposerProps) {
             ) : null}
           </div>
 
-          {props.statusLabel ? (
-            <div className="ml-3 hidden text-[11px] text-dls-secondary sm:block">{props.statusLabel}</div>
-          ) : null}
+          {/* Status label removed — redundant with the footer bar */}
         </div>
       </div>
     </div>

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -18,11 +18,13 @@ import {
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
+  COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_HIGH,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_BACKSPACE_COMMAND,
   KEY_ENTER_COMMAND,
+  PASTE_COMMAND,
   type SerializedTextNode,
   type Spread,
   TextNode,
@@ -40,6 +42,7 @@ type EditorProps = {
   onChange: (value: string) => void;
   onSubmit: () => void | Promise<void>;
   onPaste?: React.ClipboardEventHandler<HTMLDivElement>;
+  onPasteText?: (text: string) => void;
   onDrop?: React.DragEventHandler<HTMLDivElement>;
   onDragOver?: React.DragEventHandler<HTMLDivElement>;
   onDragLeave?: React.DragEventHandler<HTMLDivElement>;
@@ -450,6 +453,43 @@ function SubmitPlugin(props: { onSubmit: () => void | Promise<void>; disabled: b
   return null;
 }
 
+const PASTE_CHIP_LINE_THRESHOLD = 3;
+const PASTE_CHIP_CHAR_THRESHOLD = 200;
+
+function PasteChipPlugin(props: { onPasteText?: (text: string) => void }) {
+  const [editor] = useLexicalComposerContext();
+  const onPasteTextRef = useRef(props.onPasteText);
+
+  useEffect(() => {
+    onPasteTextRef.current = props.onPasteText;
+  }, [props.onPasteText]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      PASTE_COMMAND,
+      (event: ClipboardEvent) => {
+        if (!onPasteTextRef.current) return false;
+        // Only handle plain-text pastes; files are handled in the React onPaste.
+        const files = event.clipboardData?.files;
+        if (files && files.length > 0) return false;
+        const text = event.clipboardData?.getData("text/plain") ?? "";
+        if (!text.trim()) return false;
+        const lineCount = text.split(/\r?\n/).length;
+        if (lineCount < PASTE_CHIP_LINE_THRESHOLD && text.length < PASTE_CHIP_CHAR_THRESHOLD) {
+          return false;
+        }
+        // Collapse into a paste chip.
+        event.preventDefault();
+        onPasteTextRef.current(text);
+        return true;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+  }, [editor]);
+
+  return null;
+}
+
 function MentionChipNavigationPlugin() {
   const [editor] = useLexicalComposerContext();
 
@@ -638,6 +678,7 @@ export function LexicalPromptEditor(props: EditorProps) {
         <HistoryPlugin />
         <SyncPlugin value={props.value} mentions={props.mentions} pastedText={props.pastedText} disabled={props.disabled} />
         <SubmitPlugin onSubmit={props.onSubmit} disabled={props.disabled} />
+        <PasteChipPlugin onPasteText={props.onPasteText} />
         <MentionChipNavigationPlugin />
       </div>
     </LexicalComposer>

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -461,9 +461,39 @@ function MentionChipNavigationPlugin() {
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
         const anchorNode = selection.anchor.getNode();
 
+        // --- Slash command chip: atomic delete ---
+        // When cursor is in the text node right after a slash chip,
+        // remove the chip (and any trailing whitespace text) in one action.
+        if ($isTextNode(anchorNode)) {
+          const previous = anchorNode.getPreviousSibling();
+          if (previous instanceof ComposerSlashCommandNode) {
+            // At offset 0: cursor is right after the chip -> remove chip
+            // At offset > 0 but text is only whitespace: also remove chip
+            const textBefore = anchorNode.getTextContent().slice(0, selection.anchor.offset);
+            if (selection.anchor.offset === 0 || textBefore.trim() === "") {
+              previous.remove();
+              // Also remove the whitespace-only prefix
+              if (selection.anchor.offset > 0) {
+                const remaining = anchorNode.getTextContent().slice(selection.anchor.offset);
+                if (remaining) {
+                  anchorNode.setTextContent(remaining);
+                  const sel = $createRangeSelection();
+                  sel.anchor.set(anchorNode.getKey(), 0, "text");
+                  sel.focus.set(anchorNode.getKey(), 0, "text");
+                  $setSelection(sel);
+                } else {
+                  anchorNode.remove();
+                }
+              }
+              return true;
+            }
+          }
+        }
+
+        // --- Mention / pasted-text chips: atomic delete (same as before) ---
         if ($isTextNode(anchorNode) && selection.anchor.offset === 0) {
           const previous = anchorNode.getPreviousSibling();
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSlashCommandNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerMentionNode || previous instanceof ComposerPastedTextNode) {
             previous.remove();
             return true;
           }
@@ -471,7 +501,7 @@ function MentionChipNavigationPlugin() {
 
         if ($isElementNode(anchorNode)) {
           const previous = anchorNode.getChildAtIndex(selection.anchor.offset - 1);
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerSlashCommandNode || previous instanceof ComposerMentionNode || previous instanceof ComposerPastedTextNode) {
             previous.remove();
             return true;
           }

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -379,10 +379,81 @@ function CopyButton(props: { getText: () => string }) {
   );
 }
 
+/** Expandable chip for collapsed pasted text in sent messages. */
+function PastedTextChip(props: { label: string; text: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const lineCount = props.text.split(/\r?\n/).length;
+
+  return (
+    <span className="inline">
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 rounded-full border border-amber-6/35 bg-amber-3/15 px-2.5 py-0.5 text-xs font-medium text-amber-11 transition-colors hover:bg-amber-3/30"
+        onClick={() => setExpanded((v) => !v)}
+        title={expanded ? "Collapse pasted text" : "Expand pasted text"}
+      >
+        <ChevronDown
+          size={12}
+          className={`shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
+        />
+        <span>Pasted · {lineCount} line{lineCount === 1 ? "" : "s"}</span>
+      </button>
+      {expanded ? (
+        <div className="mt-1.5 mb-1.5 rounded-xl border border-amber-6/20 bg-amber-3/10 px-4 py-3 text-xs leading-5 text-dls-text">
+          <pre className="whitespace-pre-wrap break-words font-mono">{props.text}</pre>
+        </div>
+      ) : null}
+    </span>
+  );
+}
+
+/** Collapsible block for long user messages. Shows a chip with line count
+ *  that expands on click to reveal the full text. */
+function CollapsibleUserText(props: {
+  text: string;
+  lineCount: number;
+  highlightQuery?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const previewLines = 3;
+  const preview = props.text.split(/\r?\n/).slice(0, previewLines).join("\n");
+
+  return (
+    <div>
+      {expanded ? (
+        <HighlightedPlainText
+          text={props.text}
+          className="whitespace-pre-wrap break-words text-gray-12"
+          highlightQuery={props.highlightQuery}
+        />
+      ) : (
+        <div className="whitespace-pre-wrap break-words text-gray-12">
+          {preview}{props.lineCount > previewLines ? "..." : ""}
+        </div>
+      )}
+      <button
+        type="button"
+        className="mt-1.5 inline-flex items-center gap-1 rounded-full border border-amber-6/35 bg-amber-3/15 px-2.5 py-0.5 text-xs font-medium text-amber-11 transition-colors hover:bg-amber-3/30"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <ChevronDown
+          size={12}
+          className={`shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
+        />
+        <span>{expanded ? "Collapse" : `${props.lineCount} lines · expand`}</span>
+      </button>
+    </div>
+  );
+}
+
+const PASTE_TOKEN_RE = /(\[pasted text [^\]]+\])/;
+
 function HighlightedPlainText(props: {
   text: string;
   className: string;
   highlightQuery?: string;
+  /** Map of paste label -> full text for expandable chips */
+  pastedTextMap?: Map<string, string>;
 }) {
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -396,9 +467,29 @@ function HighlightedPlainText(props: {
     });
   }, [props.highlightQuery, props.text]);
 
+  // If no paste tokens present, render as plain text (fast path).
+  if (!props.pastedTextMap?.size || !PASTE_TOKEN_RE.test(props.text)) {
+    return (
+      <div ref={rootRef} className={props.className}>
+        {props.text}
+      </div>
+    );
+  }
+
+  // Split on paste tokens and render chips inline.
+  const segments = props.text.split(PASTE_TOKEN_RE);
   return (
     <div ref={rootRef} className={props.className}>
-      {props.text}
+      {segments.map((segment, index) => {
+        const match = segment.match(/^\[pasted text (.+)\]$/);
+        if (match?.[1]) {
+          const pastedBody = props.pastedTextMap?.get(match[1]);
+          if (pastedBody) {
+            return <PastedTextChip key={index} label={match[1]} text={pastedBody} />;
+          }
+        }
+        return <span key={index}>{segment}</span>;
+      })}
     </div>
   );
 }
@@ -1009,7 +1100,15 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
 
                   const text = partToText(group.part);
                   if (block.isUser) {
-                    return (
+                    const lineCount = text.split(/\r?\n/).length;
+                    const isLong = lineCount >= 6 || text.length >= 400;
+                    return isLong ? (
+                      <CollapsibleUserText
+                        text={text}
+                        lineCount={lineCount}
+                        highlightQuery={highlightQuery}
+                      />
+                    ) : (
                       <HighlightedPlainText
                         text={text}
                         className="whitespace-pre-wrap break-words text-gray-12"

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -407,45 +407,6 @@ function PastedTextChip(props: { label: string; text: string }) {
   );
 }
 
-/** Collapsible block for long user messages. Shows a chip with line count
- *  that expands on click to reveal the full text. */
-function CollapsibleUserText(props: {
-  text: string;
-  lineCount: number;
-  highlightQuery?: string;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const previewLines = 3;
-  const preview = props.text.split(/\r?\n/).slice(0, previewLines).join("\n");
-
-  return (
-    <div>
-      {expanded ? (
-        <HighlightedPlainText
-          text={props.text}
-          className="whitespace-pre-wrap break-words text-gray-12"
-          highlightQuery={props.highlightQuery}
-        />
-      ) : (
-        <div className="whitespace-pre-wrap break-words text-gray-12">
-          {preview}{props.lineCount > previewLines ? "..." : ""}
-        </div>
-      )}
-      <button
-        type="button"
-        className="mt-1.5 inline-flex items-center gap-1 rounded-full border border-amber-6/35 bg-amber-3/15 px-2.5 py-0.5 text-xs font-medium text-amber-11 transition-colors hover:bg-amber-3/30"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <ChevronDown
-          size={12}
-          className={`shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
-        />
-        <span>{expanded ? "Collapse" : `${props.lineCount} lines · expand`}</span>
-      </button>
-    </div>
-  );
-}
-
 const PASTE_TOKEN_RE = /(\[pasted text [^\]]+\])/;
 
 function HighlightedPlainText(props: {
@@ -1100,15 +1061,7 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
 
                   const text = partToText(group.part);
                   if (block.isUser) {
-                    const lineCount = text.split(/\r?\n/).length;
-                    const isLong = lineCount >= 6 || text.length >= 400;
-                    return isLong ? (
-                      <CollapsibleUserText
-                        text={text}
-                        lineCount={lineCount}
-                        highlightQuery={highlightQuery}
-                      />
-                    ) : (
+                    return (
                       <HighlightedPlainText
                         text={text}
                         className="whitespace-pre-wrap break-words text-gray-12"

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -43,6 +43,15 @@ import {
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
 
+type SessionError = {
+  message: string;
+  kind?: "model-not-found" | "generic";
+  /** For model-not-found: the model that failed. */
+  failedModel?: { providerID: string; modelID: string };
+  /** For model-not-found: suggested replacements from the backend. */
+  suggestions?: Array<{ providerID: string; modelID: string }>;
+};
+
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
   workspaceId: string;
@@ -70,6 +79,7 @@ export type SessionSurfaceProps = {
   searchFiles: (query: string) => Promise<string[]>;
   isRemoteWorkspace: boolean;
   isSandboxWorkspace: boolean;
+  onChangeModel?: (model: { providerID: string; modelID: string }) => void;
   onUploadInboxFiles?: ((files: File[], options?: { notify?: boolean }) => void | Promise<unknown>) | null;
   onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins") => void) | undefined;
 };
@@ -134,6 +144,87 @@ function AssistantWaitingCard() {
   );
 }
 
+function parseSessionError(thrown: unknown): SessionError {
+  const raw = thrown instanceof Error ? thrown.message : String(thrown);
+  // Try to detect ProviderModelNotFoundError from the SDK error shape.
+  // The error message may be a JSON string from our serializer in session-route.
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed?.name === "ProviderModelNotFoundError" && parsed?.data) {
+      const { providerID, modelID, suggestions } = parsed.data;
+      return {
+        message: `Model ${providerID}/${modelID} is not available.`,
+        kind: "model-not-found",
+        failedModel: { providerID, modelID },
+        suggestions: Array.isArray(suggestions) ? suggestions : [],
+      };
+    }
+  } catch {
+    // Not JSON — fall through to plain message
+  }
+  // Check if the raw string mentions model-not-found patterns
+  if (/ProviderModelNotFoundError/i.test(raw) || /model.*not found/i.test(raw)) {
+    return { message: raw, kind: "model-not-found" };
+  }
+  return { message: raw || "Failed to send prompt." };
+}
+
+function SessionErrorCard({ error, onDismiss, onChangeModel, onOpenModelPicker }: {
+  error: SessionError;
+  onDismiss: () => void;
+  onChangeModel?: (model: { providerID: string; modelID: string }) => void;
+  onOpenModelPicker?: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-[720px] px-3 py-3 sm:px-5">
+      <div className="rounded-2xl border border-red-6/30 bg-red-3/15 px-5 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium text-red-11">{error.message}</div>
+            {error.kind === "model-not-found" ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {error.suggestions && error.suggestions.length > 0 ? (
+                  error.suggestions.map((s) => (
+                    <button
+                      key={`${s.providerID}/${s.modelID}`}
+                      type="button"
+                      className="rounded-full border border-dls-border bg-dls-surface px-3 py-1.5 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover"
+                      onClick={() => {
+                        onChangeModel?.(s);
+                        onDismiss();
+                      }}
+                    >
+                      Use {s.providerID}/{s.modelID}
+                    </button>
+                  ))
+                ) : null}
+                <button
+                  type="button"
+                  className="rounded-full border border-dls-border bg-dls-surface px-3 py-1.5 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover"
+                  onClick={() => {
+                    onOpenModelPicker?.();
+                    onDismiss();
+                  }}
+                >
+                  Change model
+                </button>
+              </div>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            className="shrink-0 rounded-full p-1 text-red-10 transition-colors hover:bg-red-3 hover:text-red-11"
+            onClick={onDismiss}
+            aria-label="Dismiss error"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M3.5 3.5l7 7M10.5 3.5l-7 7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" /></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }) {
   if (!attachment.previewUrl) return;
   URL.revokeObjectURL(attachment.previewUrl);
@@ -145,7 +236,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [mentions, setMentions] = useState<Record<string, "agent" | "file">>({});
   const [pasteParts, setPasteParts] = useState<Array<{ id: string; label: string; text: string; lines: number }>>([]);
   const [notice, setNotice] = useState<ReactComposerNotice | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<SessionError | null>(null);
   const [sending, setSending] = useState(false);
   const [showDelayedLoading, setShowDelayedLoading] = useState(false);
   const [awaitingAssistantBaseline, setAwaitingAssistantBaseline] = useState<number | null>(null);
@@ -372,7 +463,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     try {
       await navigator.clipboard.writeText(transcriptToText(renderedMessages));
     } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : "Failed to copy transcript.");
+      setError({ message: nextError instanceof Error ? nextError.message : "Failed to copy transcript." });
     }
   };
 
@@ -396,7 +487,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
       props.onDraftChange(buildDraft("", []));
       setSending(false);
     } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : "Failed to send prompt.");
+      const parsed = parseSessionError(nextError);
+      setError(parsed);
+      setDraft("");
       setAwaitingAssistantBaseline(null);
       setSending(false);
     }
@@ -409,7 +502,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       await abortSessionSafe(opencodeClient, props.sessionId);
       await snapshotQuery.refetch();
     } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : "Failed to stop run.");
+      setError({ message: nextError instanceof Error ? nextError.message : "Failed to stop run." });
     }
   };
 
@@ -615,17 +708,33 @@ export function SessionSurface(props: SessionSurfaceProps) {
                 </div>
               </div>
             ) : (snapshotQuery.isError || error) && !snapshot && renderedMessages.length === 0 ? (
-              <div className="px-6 py-16">
-                <div className="mx-auto max-w-xl rounded-3xl border border-red-6/40 bg-red-3/20 px-6 py-5 text-sm text-red-11">
-                  {error || (snapshotQuery.error instanceof Error ? snapshotQuery.error.message : "Failed to load session.")}
-                </div>
+              <div className="px-6 py-8">
+                {error ? (
+                  <SessionErrorCard
+                    error={error}
+                    onDismiss={() => setError(null)}
+                    onChangeModel={props.onChangeModel}
+                    onOpenModelPicker={props.onModelClick}
+                  />
+                ) : (
+                  <div className="mx-auto max-w-xl rounded-3xl border border-red-6/40 bg-red-3/20 px-6 py-5 text-sm text-red-11">
+                    {snapshotQuery.error instanceof Error ? snapshotQuery.error.message : "Failed to load session."}
+                  </div>
+                )}
               </div>
             ) : renderedMessages.length === 0 && showAssistantWaitState ? (
               <div className="px-6 py-12">
                 <AssistantWaitingCard />
               </div>
             ) : renderedMessages.length === 0 && snapshot && snapshot.messages.length === 0 ? (
-              null
+              error ? (
+                <SessionErrorCard
+                  error={error}
+                  onDismiss={() => setError(null)}
+                  onChangeModel={props.onChangeModel}
+                  onOpenModelPicker={props.onModelClick}
+                />
+              ) : null
             ) : (
               <DevProfiler id="SessionTranscript">
                 <>
@@ -635,6 +744,14 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     developerMode={props.developerMode}
                     scrollElement={() => scrollRef.current}
                   />
+                  {error ? (
+                    <SessionErrorCard
+                      error={error}
+                      onDismiss={() => setError(null)}
+                      onChangeModel={props.onChangeModel}
+                      onOpenModelPicker={props.onModelClick}
+                    />
+                  ) : null}
                   {showAssistantWaitState ? <AssistantWaitingCard /> : null}
                 </>
               </DevProfiler>
@@ -723,11 +840,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         />
         </DevProfiler>
       </div>
-      {error ? (
-        <div className="mx-auto w-full max-w-[800px] px-4">
-          <div className="rounded-b-[20px] border border-t-0 border-red-6/30 px-4 py-3 text-sm text-red-11">{error}</div>
-        </div>
-      ) : null}
+      {/* Error display moved inline into the session conversation area */}
       {props.developerMode ? <SessionDebugPanel model={model} snapshot={snapshot} /> : null}
     </div>
     </DevProfiler>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -449,12 +449,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
       }
       return [{ type: "text", text: segment } satisfies ComposerDraft["parts"][number]];
     });
+    // Expand paste placeholders in resolvedText so the model receives
+    // the actual pasted content instead of "[pasted text <label>]".
+    let resolved = text;
+    for (const part of pasteParts) {
+      resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
+    }
     return {
       mode: "prompt",
       parts,
       attachments: nextAttachments,
       text,
-      resolvedText: text,
+      resolvedText: resolved,
       command: slashMatch ? { name: slashMatch[1] ?? "", arguments: slashMatch[2] ?? "" } : undefined,
     };
   }, [mentions, pasteParts]);

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -136,7 +136,7 @@ function messageHasVisibleAssistantOutput(message: UIMessage) {
 function AssistantWaitingCard() {
   return (
     <div className="flex justify-start py-2" role="status" aria-live="polite">
-      <div className="inline-flex items-center gap-3 rounded-full border border-dls-border bg-dls-surface px-3 py-1.5 text-[12px] text-dls-secondary">
+      <div className="inline-flex items-center gap-3 rounded-full px-3 py-1.5 text-[12px] text-dls-secondary">
         <OwDotTicker size="sm" />
         <span>Thinking</span>
       </div>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -366,6 +366,7 @@ export function SessionRoute() {
     modelPickerOpen,
   });
   const [openworkServerSettingsVersion, setOpenworkServerSettingsVersion] = useState(0);
+  const [engineReloadVersion, setEngineReloadVersion] = useState(0);
   const [routeEngineInfo, setRouteEngineInfo] = useState<EngineInfo | null>(null);
   const reconnectAttemptedWorkspaceIdRef = useRef("");
 
@@ -604,6 +605,7 @@ export function SessionRoute() {
       return false;
     }
     await client.reloadEngine(selectedWorkspaceId);
+    setEngineReloadVersion((v) => v + 1);
     try {
       window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
     } catch {
@@ -1086,9 +1088,13 @@ export function SessionRoute() {
   }, [checkDesktopRestriction, modelOptions]);
 
   const listSlashCommands = useCallback(async (): Promise<SlashCommandOption[]> => {
+    // engineReloadVersion is included so the callback identity changes after
+    // an engine reload, which invalidates the composer's command list cache
+    // and causes it to re-fetch (picking up newly created skills).
+    void engineReloadVersion;
     if (!opencodeClient) return [];
     return listCommands(opencodeClient, selectedWorkspaceRoot || undefined);
-  }, [opencodeClient, selectedWorkspaceRoot]);
+  }, [engineReloadVersion, opencodeClient, selectedWorkspaceRoot]);
 
   const surfaceProps = useMemo(() => {
     if (!client || !selectedWorkspaceId || !selectedSessionId || !opencodeBaseUrl || !token || !opencodeClient) {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -100,6 +100,26 @@ function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
   };
 }
 
+/**
+ * Serialize an SDK error value into a string that parseSessionError can parse.
+ * Preserves the original shape (name, data, message) as JSON when possible,
+ * so the session surface can detect ProviderModelNotFoundError and offer
+ * recovery actions like "Change model".
+ */
+function serializeSDKError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      const msg = (error as Record<string, unknown>).message;
+      return typeof msg === "string" ? msg : String(error);
+    }
+  }
+  return String(error);
+}
+
 function folderNameFromPath(path: string) {
   const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
   const parts = normalized.split("/").filter(Boolean);
@@ -1125,7 +1145,7 @@ export function SessionRoute() {
             arguments: draft.command.arguments,
           });
           if (result.error) {
-            throw new Error(result.error instanceof Error ? result.error.message : String(result.error));
+            throw new Error(serializeSDKError(result.error));
           }
           return;
         }
@@ -1139,7 +1159,7 @@ export function SessionRoute() {
           ...(local.prefs.modelVariant ? { variant: local.prefs.modelVariant } : {}),
         });
         if (result.error) {
-          throw new Error(result.error instanceof Error ? result.error.message : String(result.error));
+          throw new Error(serializeSDKError(result.error));
         }
       },
       onDraftChange: () => {
@@ -1177,6 +1197,9 @@ export function SessionRoute() {
       },
       isRemoteWorkspace: selectedWorkspace?.workspaceType === "remote",
       isSandboxWorkspace: selectedWorkspace ? isSandboxWorkspace(selectedWorkspace) : false,
+      onChangeModel: (model: { providerID: string; modelID: string }) => {
+        local.setPrefs((previous) => ({ ...previous, defaultModel: model }));
+      },
     };
   }, [
     client,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1052,7 +1052,10 @@ export function SettingsRoute() {
             accessHint={isRemoteWorkspace ? t("app.skills_hint_readonly") : null}
             extensions={extensionsStore}
             onOpenLink={(url) => platform.openLink(url)}
-            createSessionAndOpen={async () => undefined}
+            createSessionAndOpen={async (_command?: string): Promise<string | undefined> => {
+              navigate("/session");
+              return undefined;
+            }}
           />
         );
       case "extensions":

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -337,6 +337,164 @@ runner. Key differences:
 - For Flow 1 streaming, don't insist on exact assistant text. Confirm the
   assistant bubble becomes non-empty and status returns to `Ready`.
 
+---
+
+## Flow 13 — Slash command selection and backspace
+
+**Why**: The slash menu used to cause render churn and RAM growth from
+unstable regex dependencies and uncached command fetches.
+
+Steps:
+1. Create a new session.
+2. Type `/rev` in the composer.
+3. Expect: slash menu opens with `/review` as the top fuzzy match.
+4. Click `/review`.
+5. Expect: composer shows `/review` chip (purple pill) + trailing space;
+   slash menu closes.
+6. Press Backspace once.
+7. Expect: the entire `/review` chip is removed atomically (not one char at
+   a time). Composer is empty.
+
+Pass criteria:
+- Menu items don't flicker or reset while typing.
+- One backspace removes the chip + space together.
+- No console errors or `react.render_loop_suspected` watchdog warnings.
+
+---
+
+## Flow 14 — Slash command error with model recovery
+
+**Why**: When a slash command fails (e.g. model not found), the error must
+show inline in the session area with a recovery action — not as raw
+`[object Object]` below the composer.
+
+Steps:
+1. Create a new session.
+2. Type `/init`, select it, click Run task.
+3. If the command's configured model is unavailable, expect: an inline error
+   card appears in the session area with a human-readable message like
+   "Model openai/gpt-5.2-codex is not available."
+4. Expect: a "Change model" button is visible on the error card.
+5. Click "Change model".
+6. Expect: the model picker opens. Select a valid model.
+7. Composer should be cleared and editable (not stuck readonly).
+
+Pass criteria:
+- Error renders inline in the session (not below the composer).
+- Error message is human-readable (no `[object Object]`).
+- "Change model" opens the picker (not sets the failed model as default).
+- Composer resets on error.
+
+---
+
+## Flow 15 — Paste chip collapse
+
+**Why**: Pasting large text (3+ lines or 200+ chars) should collapse into an
+inline amber chip in the composer instead of flooding the editor.
+
+Steps:
+1. Create a new session.
+2. Copy a multi-line code snippet (10+ lines) to the system clipboard.
+3. Paste into the composer (Cmd+V).
+4. Expect: an amber "Pasted · N lines" chip appears inline in the composer
+   instead of the raw text.
+5. Type `explain this code:` before the chip.
+6. Click Run task.
+7. Expect: the user message in the transcript shows the full expanded text
+   (not the `[pasted text ...]` placeholder).
+8. The assistant response should reference the pasted code correctly.
+
+Pass criteria:
+- Text over threshold collapses into a chip in the composer.
+- Short pastes (< 3 lines, < 200 chars) go in as plain text.
+- `resolvedText` sent to the model contains the full pasted content.
+- User message in the transcript shows the full text, not the placeholder.
+
+Note: CDP `Meta+V` does not trigger real clipboard events in Electron; use
+osascript (`pbcopy` + `keystroke "v" using command down`) to test paste.
+
+---
+
+## Flow 16 — User message display
+
+**Why**: Hand-typed user messages must never be truncated in the transcript.
+Only pasted chip placeholders should render as collapsible.
+
+Steps:
+1. Send a long message (10+ lines of hand-typed text).
+2. Expect: the full message renders in the user bubble without truncation or
+   "expand" chips.
+
+Pass criteria:
+- No `CollapsibleUserText` or "N lines · expand" button on hand-typed text.
+- The full message is visible immediately without clicking.
+
+---
+
+## Flow 17 — Stop / Run task single button
+
+**Why**: The composer should have a single action button that toggles between
+"Run task" (idle or has draft while busy) and "Stop" (busy with no draft).
+
+Steps:
+1. Send a message that triggers a long response.
+2. Expect: the button label changes from "Run task" to "Stop" while
+   the assistant is streaming.
+3. Once the response finishes, expect: button returns to "Run task".
+4. While streaming, type text into the composer.
+5. Expect: button shows "Run task" (to queue the follow-up), not "Stop".
+
+Pass criteria:
+- Only one button visible at any time (no side-by-side Stop + Run task).
+- Button label toggles based on busy state and draft content.
+
+---
+
+## Flow 18 — Skill lifecycle (create, verify, use)
+
+**Why**: Skills should be createable from the UI, appear on disk, and be
+usable in new sessions after reload.
+
+Steps:
+1. Go to Settings → Skills.
+2. Click "Create skill in chat".
+3. Expect: navigates to a new session.
+4. Type `/skill-creator create a skill about weather alerts`.
+5. Select the command and run it.
+6. Expect: the assistant creates `.opencode/skills/weather-alerts/SKILL.md`
+   (requires a model with tool-use capability).
+7. Verify the file exists on disk.
+8. Reload the app (or trigger config reload).
+9. Create a new session and check that `/weather-alerts` appears in the
+   slash command list.
+10. Run `/weather-alerts` and expect the skill template is used.
+
+Pass criteria:
+- "Create skill in chat" navigates away from settings to a session.
+- The skill command actually writes files to `.opencode/skills/`.
+- After reload, the new skill appears in the slash menu.
+- Running the new skill uses its template as the user message.
+
+Note: requires a model with tool-use support (e.g. Claude, GPT-4). Free-tier
+models may describe what they would do without actually calling tools.
+
+---
+
+## Flow 19 — Add workspace button placement
+
+**Why**: The "Add workspace" button must not clip against the Tauri/Electron
+window bottom corners.
+
+Steps:
+1. Look at the sidebar bottom.
+2. Expect: the "Add workspace" button has visible padding below it, above the
+   footer bar.
+
+Pass criteria:
+- At least 16px gap between the button bottom edge and the window edge.
+
+---
+
 ## Change log
 
 - 2026-04-16 — initial doc after the React port cutover fixed streaming,
@@ -345,3 +503,6 @@ runner. Key differences:
   palette), Flow 12 (workspace options menu). Also added the desktop-runtime
   boot hook and restored 17 missing i18n keys that were leaking as raw
   identifiers in the UI.
+- 2026-04-28 — added Flows 13-19: slash command stability, error recovery
+  with model change, paste chip collapse, user message display, single action
+  button, skill lifecycle, and workspace button placement.


### PR DESCRIPTION
## Summary
- Move error display from below-composer to inline in the session conversation area
- Parse `ProviderModelNotFoundError` from SDK and show a human-readable message with a "Change model" button that opens the model picker
- Fix `[object Object]` error rendering by properly serializing SDK error objects
- Reset composer draft on error so the user isn't stuck with a readonly editor
- Make slash command chip backspace atomic: one backspace removes the whole `/command` chip + trailing space

## Verification
- `pnpm --filter @openwork/app typecheck` (pass)
- Tested via Chrome MCP on Electron dev app:
  - `/init` command error shows inline with "Change model" recovery
  - "Change model" opens model picker (not sets wrong model)
  - Slash command backspace deletes chip atomically
  - Multiple slash commands in sequence work without stale state
  - Workspace create/options menus render correctly

## Notes
- Mention (`@`) char-by-char editing on backspace was explored but reverted: it needs coordination between Lexical nodes and the external React mentions map. The SyncPlugin re-chipifies text immediately. Filed as a follow-up.