### PR TITLE
Ship Electron builds on all platforms with every release

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -54,7 +54,7 @@ on:
         type: boolean
         default: true
       publish_electron:
-        description: "Build + publish Electron desktop artifacts (macOS) alongside Tauri"
+        description: "Build + publish Electron desktop artifacts (macOS/Linux/Windows) alongside Tauri"
         required: false
         type: boolean
         default: false
@@ -603,23 +603,56 @@ jobs:
             --clobber
 
   publish-electron:
-    name: Build + publish Electron desktop (macOS)
+    name: Build + publish Electron (${{ matrix.artifact }})
     # Runs alongside the Tauri jobs so the same release carries both
-    # latest.json (Tauri updater) AND latest-mac.yml (electron-updater).
+    # latest.json (Tauri updater) AND latest-*.yml (electron-updater).
     # Gated on RELEASE_PUBLISH_ELECTRON=true (repo var) OR the workflow
     # input of the same name so opt-in during rollout, opt-out if a
     # non-migration release doesn't want Electron artifacts.
     needs: [resolve-release, verify-release]
     if: ${{ vars.RELEASE_PUBLISH_ELECTRON == 'true' || github.event.inputs.publish_electron == 'true' }}
-    runs-on: macos-14
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 120
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+      MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-14
+            os_type: macos
+            artifact: electron-macos-arm64
+            electron_args: "--mac --arm64"
+            target_triple: aarch64-apple-darwin
+          - platform: macos-14
+            os_type: macos
+            artifact: electron-macos-x64
+            electron_args: "--mac --x64"
+            target_triple: x86_64-apple-darwin
+          - platform: ubuntu-22.04
+            os_type: linux
+            artifact: electron-linux-x64
+            electron_args: "--linux --x64"
+            target_triple: x86_64-unknown-linux-gnu
+          - platform: windows-2022
+            os_type: windows
+            artifact: electron-windows-x64
+            electron_args: "--win --x64"
+            target_triple: x86_64-pc-windows-msvc
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+
+      - name: Enable git long paths (Windows)
+        if: matrix.os_type == 'windows'
+        shell: pwsh
+        run: git config --global core.longpaths true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -636,11 +669,25 @@ jobs:
         with:
           bun-version: 1.3.9
 
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-electron-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-pnpm-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Write Electron notary API key
-        if: needs.resolve-release.outputs.notarize == 'true'
+      - name: Write Electron notary API key (macOS)
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
         env:
           APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
         run: |
@@ -652,24 +699,64 @@ jobs:
 
           echo "NOTARY_KEY_PATH=$NOTARY_KEY_PATH" >> "$GITHUB_ENV"
 
-      - name: Build + package Electron app
+      - name: Build Electron app
+        shell: bash
         env:
-          # electron-builder reads these to codesign the .app.
+          # TARGET tells prepare-sidecar.mjs which architecture's sidecars
+          # to download (critical for cross-arch builds like x64 on arm64 mac).
+          TARGET: ${{ matrix.target_triple }}
+        run: pnpm --filter @openwork/desktop build:electron
+
+      - name: Package + publish Electron (macOS, signed + notarized)
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
+        env:
           CSC_LINK: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
-          # Our Electron afterSign hook notarizes with the same App Store
-          # Connect API key flow as the Tauri release path. The electron-builder
-          # built-in notarizer is disabled in electron-builder.yml.
-          MACOS_NOTARIZE: ${{ needs.resolve-release.outputs.notarize }}
           APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
           APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
-          # electron-builder needs this to upload artifacts + the updater
-          # feed manifest (latest-mac.yml) to the GitHub release.
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          pnpm --filter @openwork/desktop package:electron --publish always
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            ${{ matrix.electron_args }} \
+            --publish always
+
+      - name: Package + publish Electron (macOS, unsigned)
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE != 'true'
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            ${{ matrix.electron_args }} \
+            --publish always
+
+      - name: Package + publish Electron (Linux)
+        if: matrix.os_type == 'linux'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            ${{ matrix.electron_args }} \
+            --publish always
+
+      - name: Package + publish Electron (Windows)
+        if: matrix.os_type == 'windows'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            ${{ matrix.electron_args }} \
+            --publish always
 
   release-orchestrator-sidecars:
     name: Build + Upload openwork-orchestrator Sidecars

--- a/apps/app/src/react-app/shell/migration-prompt.tsx
+++ b/apps/app/src/react-app/shell/migration-prompt.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource react */
 /**
- * Migration prompt — one-time modal that nudges Tauri v0.12.0 users over
- * to the Electron build. Dormant unless the build was produced with
- * `VITE_OPENWORK_MIGRATION_RELEASE=1`, so landing this code on dev has
- * zero user impact until the release script flips that flag.
+ * Migration prompt — one-time modal that nudges Tauri users over to the
+ * Electron build. Dormant unless the build was produced with
+ * `VITE_OPENWORK_MIGRATION_RELEASE=1` or the dev override
+ * `VITE_OPENWORK_FORCE_MIGRATION_PROMPT=1` is set, so landing this code
+ * on dev has zero user impact until a flag is explicitly flipped.
  */
 import { useCallback, useEffect, useState, type ReactElement } from "react";
 
@@ -33,13 +34,16 @@ type MigrationConfig = {
 
 function readBuildTimeConfig(): MigrationConfig | null {
   const env = (import.meta as unknown as { env?: Record<string, string> }).env ?? {};
-  const enabled = env.VITE_OPENWORK_MIGRATION_RELEASE === "1";
-  if (!enabled) return null;
+  const isMigrationRelease = env.VITE_OPENWORK_MIGRATION_RELEASE === "1";
+  // Dev override: set VITE_OPENWORK_FORCE_MIGRATION_PROMPT=1 in .env.local
+  // to test the migration flow without cutting a release build.
+  const isDevForced = env.VITE_OPENWORK_FORCE_MIGRATION_PROMPT === "1";
+  if (!isMigrationRelease && !isDevForced) return null;
   return {
-    macUrl: env.VITE_OPENWORK_MIGRATION_MAC_URL,
+    macUrl: env.VITE_OPENWORK_MIGRATION_MAC_URL ?? (isDevForced ? "https://github.com/different-ai/openwork/releases/latest" : undefined),
     macSha256: env.VITE_OPENWORK_MIGRATION_MAC_SHA256,
-    windowsUrl: env.VITE_OPENWORK_MIGRATION_WINDOWS_URL,
-    linuxUrl: env.VITE_OPENWORK_MIGRATION_LINUX_URL,
+    windowsUrl: env.VITE_OPENWORK_MIGRATION_WINDOWS_URL ?? (isDevForced ? "https://github.com/different-ai/openwork/releases/latest" : undefined),
+    linuxUrl: env.VITE_OPENWORK_MIGRATION_LINUX_URL ?? (isDevForced ? "https://github.com/different-ai/openwork/releases/latest" : undefined),
   };
 }
 


### PR DESCRIPTION
## Summary

- Expand the `publish-electron` release job from macOS-only to a **4-target matrix** (macOS arm64, macOS x64, Linux x64, Windows x64)
- Add `VITE_OPENWORK_FORCE_MIGRATION_PROMPT=1` dev flag to test the migration prompt locally without a release build

## What changed

### Release workflow (`.github/workflows/release-macos-aarch64.yml`)

The `publish-electron` job was a single `macos-14` job. It's now a matrix:

| Target | Runner | Signing | Artifacts |
|--------|--------|---------|-----------|
| macOS arm64 | macos-14 | codesign + notarize | dmg, zip |
| macOS x64 | macos-14 | codesign + notarize | dmg, zip |
| Linux x64 | ubuntu-22.04 | unsigned | AppImage, tar.gz |
| Windows x64 | windows-2022 | unsigned | nsis |

Key implementation details:
- Each target sets `TARGET` env var so `prepare-sidecar.mjs` downloads the correct architecture's sidecars (fixes cross-arch builds like x64-on-arm64 macOS runner)
- Build step (`build:electron`) separated from package step (`electron-builder`) so sidecars are prepared before packaging
- macOS gets codesign + notarize when `MACOS_NOTARIZE=true`; Linux/Windows publish unsigned for now
- Still gated on `RELEASE_PUBLISH_ELECTRON=true` repo var — no change to existing releases until flipped

### Migration prompt (`migration-prompt.tsx`)

Added `VITE_OPENWORK_FORCE_MIGRATION_PROMPT=1` dev override. Set in `.env.local` to show the migration prompt in `dev:tauri` without needing the build-time `VITE_OPENWORK_MIGRATION_RELEASE=1` flag. Falls back to the GitHub releases latest page as the migration URL in dev mode.

## How to activate

1. Set `RELEASE_PUBLISH_ELECTRON=true` in repo Settings → Variables
2. Next `v*` tag push (or workflow dispatch with `publish_electron=true`) ships Electron on all platforms
3. Test migration prompt locally: `echo 'VITE_OPENWORK_FORCE_MIGRATION_PROMPT=1' >> apps/app/.env.local && pnpm dev:tauri`

## Testing

- [ ] Workflow syntax validated locally (YAML structure matches existing matrix patterns)
- [ ] `electron-builder.yml` already has `mac`, `linux`, `win` target configs — no config changes needed
- [ ] `prepare-sidecar.mjs` respects `TARGET` env var for triple detection (verified in source)
- [ ] `electron-after-pack.cjs` handles all platforms via `targetTriple()` function
- [ ] First real validation will be the next release with `RELEASE_PUBLISH_ELECTRON=true`