### PR TITLE
Fix feedback app version source

### DIFF
--- a/apps/app/src/app/lib/feedback.ts
+++ b/apps/app/src/app/lib/feedback.ts
@@ -1,4 +1,5 @@
 const ENV_FEEDBACK_URL = String(import.meta.env.VITE_OPENWORK_FEEDBACK_URL ?? "").trim();
+const ENV_APP_VERSION = String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
 
 export const DEFAULT_FEEDBACK_URL =
   ENV_FEEDBACK_URL || "https://openworklabs.com/feedback";
@@ -89,7 +90,7 @@ export function buildFeedbackUrl(options: FeedbackUrlOptions): string {
 
   const entries = {
     deployment: options.deployment?.trim() ?? "",
-    appVersion: options.appVersion?.trim() ?? "",
+    appVersion: options.appVersion?.trim() || ENV_APP_VERSION,
     openworkServerVersion: options.openworkServerVersion?.trim() ?? "",
     opencodeVersion: options.opencodeVersion?.trim() ?? "",
     orchestratorVersion: options.orchestratorVersion?.trim() ?? "",

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1586,7 +1586,6 @@ export function SessionRoute() {
         platform.openLink(
           buildFeedbackUrl({
             entrypoint: "status-bar",
-            appVersion: "0.11.207",
           }),
         );
       }}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -65,6 +65,7 @@ import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { abortSessionSafe } from "../../app/lib/opencode-session";
 import { useReloadCoordinator } from "./reload-coordinator";
+import { buildFeedbackUrl } from "../../app/lib/feedback";
 
 type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
@@ -1037,7 +1038,7 @@ export function SettingsRoute() {
             onToggleAutoCompactContext={() => {
               setRouteError("Auto-compact controls are not wired into the React settings route yet.");
             }}
-            onSendFeedback={() => platform.openLink("https://openworklabs.com/docs")}
+            onSendFeedback={() => platform.openLink(buildFeedbackUrl({ entrypoint: "settings" }))}
             onJoinDiscord={() => platform.openLink("https://discord.gg/VEhNQXxYMB")}
             onReportIssue={() => platform.openLink("https://github.com/different-ai/openwork/issues/new?template=bug.yml")}
           />

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -26,6 +26,21 @@ if (shortHostname && shortHostname !== hostname) {
   addHost(shortHostname);
 }
 const appRoot = resolve(fileURLToPath(new URL(".", import.meta.url)));
+const appPackagePath = resolve(appRoot, "package.json");
+const desktopPackagePath = resolve(appRoot, "..", "desktop", "package.json");
+
+function readPackageVersion(packagePath: string): string | null {
+  if (!existsSync(packagePath)) return null;
+
+  const parsed = JSON.parse(readFileSync(packagePath, "utf8")) as { version?: string };
+  return parsed.version?.trim() || null;
+}
+
+const buildAppVersion =
+  process.env.VITE_OPENWORK_APP_VERSION?.trim() ||
+  readPackageVersion(desktopPackagePath) ||
+  readPackageVersion(appPackagePath) ||
+  "0.0.0";
 
 // Load the Tauri → Electron migration-release fragment if present. Written
 // by scripts/migration/01-cut-migration-release.mjs for the specific
@@ -57,12 +72,15 @@ const isElectronPackagedBuild = process.env.OPENWORK_ELECTRON_BUILD === "1";
 
 export default defineConfig({
   base: isElectronPackagedBuild ? "./" : "/",
-  define: Object.fromEntries(
-    Object.entries(migrationReleaseEnv).map(([k, v]) => [
-      `import.meta.env.${k}`,
-      JSON.stringify(v),
-    ]),
-  ),
+  define: {
+    ...Object.fromEntries(
+      Object.entries(migrationReleaseEnv).map(([k, v]) => [
+        `import.meta.env.${k}`,
+        JSON.stringify(v),
+      ]),
+    ),
+    "import.meta.env.VITE_OPENWORK_APP_VERSION": JSON.stringify(buildAppVersion),
+  },
   plugins: [
     {
       name: "openwork-dev-server-id",


### PR DESCRIPTION
## Summary
- Inject the desktop app version into the Vite app build as `VITE_OPENWORK_APP_VERSION`.
- Use the injected version as the feedback URL app version fallback instead of a stale hardcoded value.
- Route the settings feedback button to the feedback form instead of docs.

## Tests
- `pnpm install`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app build`
- Verified built app JS contains `0.12.4` and does not contain `0.11.207`.