### PR TITLE
chore: initialize oxlint across monorepo

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "off",
+    "suspicious": "off",
+    "perf": "off",
+    "restriction": "off",
+    "pedantic": "off",
+    "style": "off",
+    "nursery": "off"
+  },
+  "rules": {
+    "no-debugger": "error"
+  },
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.turbo/**",
+    "**/.tauri/**",
+    "**/target/**",
+    "**/coverage/**",
+    "**/out/**",
+    "vendor/**",
+    "patches/**",
+    "translated_readmes/**",
+    "**/*.generated.ts",
+    "**/*.gen.ts",
+    "packages/openwork-server-sdk/src/**",
+    "apps/server-v2/openapi.json",
+    "pnpm-lock.yaml",
+    "package-lock.json"
+  ]
+}

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -32,7 +32,8 @@
     "bump:patch": "node scripts/bump-version.mjs patch",
     "bump:minor": "node scripts/bump-version.mjs minor",
     "bump:major": "node scripts/bump-version.mjs major",
-    "bump:set": "node scripts/bump-version.mjs --set"
+    "bump:set": "node scripts/bump-version.mjs --set",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.148",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,7 +21,8 @@
     "electron": "pnpm exec electron ./electron/main.mjs",
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
-    "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs"
+    "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "electron-updater": "^6.3.9"

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -41,7 +41,8 @@
     "test:unit": "pnpm build && bun test test/*.test.js",
     "test:smoke": "bun scripts/smoke.mjs",
     "test:cli": "pnpm build && bun scripts/test-cli.mjs",
-    "test:npx": "bun scripts/test-npx.mjs"
+    "test:npx": "bun scripts/test-npx.mjs",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.4.9",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "test:router": "pnpm build && node scripts/router.mjs",
     "test:files": "pnpm build && node scripts/files-session.mjs",
-    "prepublishOnly": "node -e \"console.error('openwork-orchestrator is published via apps/orchestrator/scripts/publish-npm.mjs (meta + platform packages)'); process.exit(1);\""
+    "prepublishOnly": "node -e \"console.error('openwork-orchestrator is published via apps/orchestrator/scripts/publish-npm.mjs (meta + platform packages)'); process.exit(1);\"",
+    "lint:oxlint": "oxlint ."
   },
   "files": [
     "dist",

--- a/apps/server-v2/package.json
+++ b/apps/server-v2/package.json
@@ -19,7 +19,8 @@
     "build:bin:embedded:windows": "bun ./script/build.ts --outdir dist/bin --filename openwork-server-v2 --embed-runtime --target bun-windows-x64",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --filename openwork-server-v2 --target bun-darwin-arm64 --target bun-darwin-x64-baseline --target bun-linux-x64-baseline --target bun-linux-arm64 --target bun-windows-x64",
     "build:bin:embedded:all": "bun ./script/build.ts --outdir dist/bin --filename openwork-server-v2 --embed-runtime --target bun-darwin-arm64 --target bun-darwin-x64-baseline --target bun-linux-x64-baseline --target bun-linux-arm64 --target bun-windows-x64",
-    "prepublishOnly": "pnpm openapi:generate && pnpm build:bin"
+    "prepublishOnly": "pnpm openapi:generate && pnpm build:bin",
+    "lint:oxlint": "oxlint ."
   },
   "files": [
     "bin",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -14,7 +14,8 @@
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",
     "start": "bun dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "prepublishOnly": "pnpm build:bin"
+    "prepublishOnly": "pnpm build:bin",
+    "lint:oxlint": "oxlint ."
   },
   "files": [
     "bin",

--- a/apps/share/package.json
+++ b/apps/share/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
     "test": "node --test server/b/render-bundle-page.test.ts server/_lib/package-openwork-files.test.ts server/_lib/publish-security.test.ts server/_lib/render-og-image.test.ts server/_lib/share-utils.test.ts",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@vercel/blob": "^0.27.0",

--- a/apps/story-book/package.json
+++ b/apps/story-book/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint:oxlint": "oxlint ."
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/ui-demo/package.json
+++ b/apps/ui-demo/package.json
@@ -7,7 +7,8 @@
     "dev": "pnpm --dir ../../packages/ui build && vite --host 0.0.0.0 --port 3333 --strictPort",
     "build": "pnpm --dir ../../packages/ui build && vite build",
     "preview": "vite preview --host 0.0.0.0 --port 3333 --strictPort",
-    "typecheck": "pnpm --dir ../../packages/ui build && tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm --dir ../../packages/ui build && tsc -p tsconfig.json --noEmit",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@openwork/ui": "workspace:*",

--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -7,7 +7,8 @@
     "dev:local": "sh -lc 'OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/server.ts'",
     "build": "node ./scripts/build.mjs",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@better-auth/api-key": "^1.5.6",

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -8,7 +8,8 @@
     "prebuild": "pnpm --dir ../../../packages/ui build && pnpm --dir ../../packages/utils build",
     "build": "next build",
     "start": "next start --hostname 0.0.0.0 --port 3005",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@openwork/types": "workspace:*",

--- a/ee/apps/den-worker-proxy/package.json
+++ b/ee/apps/den-worker-proxy/package.json
@@ -7,7 +7,8 @@
     "dev:local": "sh -lc 'NODE_OPTIONS=--conditions=development OPENWORK_DEV_MODE=1 PORT=${DEN_WORKER_PROXY_PORT:-8789} tsx watch src/server.ts'",
     "build": "npm run build:den-db && tsc -p tsconfig.json",
     "build:den-db": "pnpm --filter @openwork-ee/den-db build",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@openwork-ee/den-db": "workspace:*",

--- a/ee/apps/landing/package.json
+++ b/ee/apps/landing/package.json
@@ -7,7 +7,8 @@
     "prebuild": "pnpm --dir ../../../packages/ui build",
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@openwork/ui": "workspace:*",

--- a/ee/packages/den-db/package.json
+++ b/ee/packages/den-db/package.json
@@ -57,7 +57,8 @@
     "build:utils": "pnpm --dir ../utils run build",
     "db:generate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs generate --config drizzle.config.ts",
     "db:migrate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs migrate --config drizzle.config.ts",
-    "db:push": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts"
+    "db:push": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@openwork/types": "workspace:*",

--- a/ee/packages/utils/package.json
+++ b/ee/packages/utils/package.json
@@ -18,7 +18,8 @@
     }
   },
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "luxon": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -46,9 +46,12 @@
     "release:prepare:dry": "node scripts/release/prepare.mjs --dry-run",
     "release:ship": "node scripts/release/ship.mjs",
     "release:ship:watch": "node scripts/release/ship.mjs --watch",
-    "tauri": "pnpm --filter @openwork/desktop exec tauri"
+    "tauri": "pnpm --filter @openwork/desktop exec tauri",
+    "lint": "turbo run lint:oxlint",
+    "lint:fix": "turbo run lint:oxlint -- --fix"
   },
   "devDependencies": {
+    "oxlint": "^1.62.0",
     "turbo": "^2.5.5"
   },
   "pnpm": {

--- a/packages/openwork-server-sdk/package.json
+++ b/packages/openwork-server-sdk/package.json
@@ -18,7 +18,8 @@
     "generate": "pnpm exec openapi-ts -f openapi-ts.config.ts",
     "watch": "node ./scripts/watch.mjs",
     "pretypecheck": "pnpm --dir ../.. run sdk:generate",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@hey-api/client-fetch": "0.13.1"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,7 +19,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "zod": "^4.3.6"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,7 +20,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup --config tsup.config.react.ts && tsup --config tsup.config.solid.ts"
+    "build": "tsup --config tsup.config.react.ts && tsup --config tsup.config.solid.ts",
+    "lint:oxlint": "oxlint ."
   },
   "dependencies": {
     "@paper-design/shaders": "0.0.72",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     devDependencies:
+      oxlint:
+        specifier: ^1.62.0
+        version: 1.62.0
       turbo:
         specifier: ^2.5.5
         version: 2.8.20
@@ -2673,6 +2676,120 @@ packages:
     resolution: {integrity: sha512-JY+hUbXVV+XCk6bC8dvcwawWCEmC3Gid6GDs23AJWBgHZ3TU2kRKrgwTdltm45DOq2cZXrYCt690/yE8bP+Gxg==}
     peerDependencies:
       solid-js: 1.9.9
+
+  '@oxlint/binding-android-arm-eabi@1.62.0':
+    resolution: {integrity: sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.62.0':
+    resolution: {integrity: sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.62.0':
+    resolution: {integrity: sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.62.0':
+    resolution: {integrity: sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.62.0':
+    resolution: {integrity: sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.62.0':
+    resolution: {integrity: sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.62.0':
+    resolution: {integrity: sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.62.0':
+    resolution: {integrity: sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-musl@1.62.0':
+    resolution: {integrity: sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.62.0':
+    resolution: {integrity: sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.62.0':
+    resolution: {integrity: sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.62.0':
+    resolution: {integrity: sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.62.0':
+    resolution: {integrity: sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.62.0':
+    resolution: {integrity: sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-musl@1.62.0':
+    resolution: {integrity: sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-openharmony-arm64@1.62.0':
+    resolution: {integrity: sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.62.0':
+    resolution: {integrity: sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.62.0':
+    resolution: {integrity: sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.62.0':
+    resolution: {integrity: sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@paper-design/shaders-react@0.0.72':
     resolution: {integrity: sha512-q6KwquL93ZVNcuSM7pqzW0z/VLjnDVb/NSpYyGJBxf7MEHHCXx37E+zw/Px6RZLt3SGCUerIDDCGCMT385oW0w==}
@@ -6105,6 +6222,16 @@ packages:
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
+
+  oxlint@1.62.0:
+    resolution: {integrity: sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.18.0'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -9810,6 +9937,63 @@ snapshots:
       - supports-color
       - typescript
       - web-tree-sitter
+
+  '@oxlint/binding-android-arm-eabi@1.62.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.62.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.62.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.62.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.62.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.62.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.62.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.62.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.62.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.62.0':
+    optional: true
 
   '@paper-design/shaders-react@0.0.72(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
@@ -13670,6 +13854,28 @@ snapshots:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+
+  oxlint@1.62.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.62.0
+      '@oxlint/binding-android-arm64': 1.62.0
+      '@oxlint/binding-darwin-arm64': 1.62.0
+      '@oxlint/binding-darwin-x64': 1.62.0
+      '@oxlint/binding-freebsd-x64': 1.62.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.62.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.62.0
+      '@oxlint/binding-linux-arm64-gnu': 1.62.0
+      '@oxlint/binding-linux-arm64-musl': 1.62.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.62.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.62.0
+      '@oxlint/binding-linux-riscv64-musl': 1.62.0
+      '@oxlint/binding-linux-s390x-gnu': 1.62.0
+      '@oxlint/binding-linux-x64-gnu': 1.62.0
+      '@oxlint/binding-linux-x64-musl': 1.62.0
+      '@oxlint/binding-openharmony-arm64': 1.62.0
+      '@oxlint/binding-win32-arm64-msvc': 1.62.0
+      '@oxlint/binding-win32-ia32-msvc': 1.62.0
+      '@oxlint/binding-win32-x64-msvc': 1.62.0
 
   p-cancelable@2.1.1: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,14 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**"]
+    },
+    "lint:oxlint": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "../../.oxlintrc.json",
+        "../../../.oxlintrc.json"
+      ],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds [`oxlint`](https://oxc.rs) as the repo-wide linter, wired through turbo
- Per-package `lint:oxlint` script in all 18 workspaces; root `pnpm lint` runs them via `turbo run lint:oxlint`
- **Minimal config on purpose**: only `no-debugger` is active; all rule categories are off so the first pass exits clean. Stricter rules ship as follow-up PRs.

### Changes

- `package.json` — `oxlint@^1.62.0` devDep, `lint` / `lint:fix` scripts
- `.oxlintrc.json` — root config (single source of truth, oxlint walks up from each package)
- `turbo.json` — `lint:oxlint` task with root-config-aware inputs for cache invalidation
- 18 workspace `package.json` — `lint:oxlint` script
- Next.js apps (`ee/apps/den-web`, `ee/apps/landing`) keep their existing `next lint` untouched

### Why minimal

The repo had no linter at all. Goal of this PR is wiring, not enforcement — flipping rules on now would surface a wall of findings to triage in the same PR. Once this lands, follow-ups can enable `correctness` → `error` and triage package by package.

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm lint` cold run: 18/18 packages pass, 0 warnings, 0 errors (~2.7s)
- [x] `pnpm lint` second run: `>>> FULL TURBO` (33ms cached)
- [ ] CI green