### PR TITLE
Fix cloud plugin import server writes

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -38,7 +38,12 @@ import {
   writeOpencodeConfig,
   type OpencodeConfigFile,
 } from "../../../../app/lib/desktop";
-import type { OpenworkHubRepo, OpenworkServerClient } from "../../../../app/lib/openwork-server";
+import type {
+  OpenworkHubRepo,
+  OpenworkServerCapabilities,
+  OpenworkServerClient,
+  OpenworkServerStatus,
+} from "../../../../app/lib/openwork-server";
 import {
   createDenClient,
   fetchDenOrgSkillsCatalog,
@@ -174,6 +179,11 @@ export function createExtensionsStore(options: {
   selectedWorkspaceRoot: () => string;
   workspaceType: () => "local" | "remote";
   openworkServer: OpenworkServerStore;
+  openworkServerConnection?: () => {
+    openworkServerClient: OpenworkServerClient | null;
+    openworkServerStatus: OpenworkServerStatus;
+    openworkServerCapabilities: OpenworkServerCapabilities | null;
+  };
   runtimeWorkspaceId: () => string | null;
   setBusy: (value: boolean) => void;
   setBusyLabel: (value: string | null) => void;
@@ -255,6 +265,18 @@ export function createExtensionsStore(options: {
     const runtimeWorkspaceId = (options.runtimeWorkspaceId() ?? "").trim();
     const workspaceType = options.workspaceType();
     return `${workspaceType}:${workspaceId}:${root}:${runtimeWorkspaceId}`;
+  };
+
+  const getOpenworkServerSnapshot = () => {
+    const snapshot = options.openworkServer.getSnapshot();
+    const connection = options.openworkServerConnection?.();
+    if (!connection?.openworkServerClient) return snapshot;
+    return {
+      ...snapshot,
+      openworkServerClient: connection.openworkServerClient,
+      openworkServerStatus: connection.openworkServerStatus,
+      openworkServerCapabilities: connection.openworkServerCapabilities,
+    };
   };
 
   const refreshSnapshot = () => {
@@ -342,7 +364,7 @@ export function createExtensionsStore(options: {
   const readWorkspaceOpenworkConfigRecord = async (): Promise<Record<string, unknown>> => {
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -366,7 +388,7 @@ export function createExtensionsStore(options: {
   const writeWorkspaceOpenworkConfigRecord = async (config: Record<string, unknown>) => {
     const root = options.selectedWorkspaceRoot().trim();
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -494,7 +516,7 @@ export function createExtensionsStore(options: {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
     const root = options.selectedWorkspaceRoot().trim();
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -568,7 +590,7 @@ export function createExtensionsStore(options: {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
     const root = options.selectedWorkspaceRoot().trim();
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -720,7 +742,7 @@ export function createExtensionsStore(options: {
   };
 
   const writePluginWorkspaceFile = async (path: string, content: string) => {
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     if (
@@ -826,7 +848,7 @@ export function createExtensionsStore(options: {
     const root = options.selectedWorkspaceRoot().trim();
     const repo = snapshot.hubRepo;
     const loadKey = `${root}::${repo ? hubRepoKey(repo) : "none"}`;
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const canUseOpenworkServer =
       openworkSnapshot.openworkServerStatus === "connected" &&
@@ -1270,7 +1292,7 @@ export function createExtensionsStore(options: {
     if (!repo) return { ok: false, message: "Select a hub repo before installing skills." };
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -1403,7 +1425,7 @@ export function createExtensionsStore(options: {
     const root = options.selectedWorkspaceRoot().trim();
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -1561,7 +1583,7 @@ export function createExtensionsStore(options: {
   async function refreshPlugins(scopeOverride?: PluginScope) {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -1732,7 +1754,7 @@ export function createExtensionsStore(options: {
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -1821,7 +1843,7 @@ export function createExtensionsStore(options: {
     const triggerName = stripPluginVersion(name);
 
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -1934,7 +1956,7 @@ export function createExtensionsStore(options: {
   async function installSkillCreator(): Promise<{ ok: boolean; message: string }> {
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -2091,7 +2113,7 @@ export function createExtensionsStore(options: {
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =
@@ -2145,7 +2167,7 @@ export function createExtensionsStore(options: {
 
     const isRemoteWorkspace = options.workspaceType() === "remote";
     const isLocalWorkspace = options.workspaceType() === "local";
-    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const openworkSnapshot = getOpenworkServerSnapshot();
     const openworkClient = openworkSnapshot.openworkServerClient;
     const openworkWorkspaceId = options.runtimeWorkspaceId();
     const canUseOpenworkServer =

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -75,6 +75,14 @@ type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
 };
 
+const ROUTE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
+  skills: { read: true, write: true, source: "openwork" },
+  plugins: { read: true, write: true },
+  mcp: { read: true, write: true },
+  commands: { read: true, write: true },
+  config: { read: true, write: true },
+};
+
 function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
   return {
     ...workspace,
@@ -373,6 +381,9 @@ export function SettingsRoute() {
     selectedWorkspaceRoot: "",
     selectedWorkspaceType: "local" as "local" | "remote",
     runtimeWorkspaceId: null as string | null,
+    openworkServerClient: null as OpenworkServerClient | null,
+    openworkServerStatus: "disconnected" as "connected" | "disconnected",
+    openworkServerCapabilities: null as OpenworkServerCapabilities | null,
     selectedWorkspaceDisplay: emptyWorkspaceDisplay as WorkspaceDisplay,
     providerItems: [] as ProviderListItem[],
     providerDefaults: {} as Record<string, string>,
@@ -408,6 +419,9 @@ export function SettingsRoute() {
     selectedWorkspaceRoot,
     selectedWorkspaceType: selectedWorkspace?.workspaceType ?? "local",
     runtimeWorkspaceId: selectedWorkspace?.id ?? null,
+    openworkServerClient: openworkClient,
+    openworkServerStatus: openworkClient ? "connected" : "disconnected",
+    openworkServerCapabilities: openworkClient ? ROUTE_OPENWORK_CAPABILITIES : null,
     selectedWorkspaceDisplay,
     providerItems: providers,
     providerDefaults,
@@ -557,6 +571,11 @@ export function SettingsRoute() {
         selectedWorkspaceRoot: () => routeStateRef.current.selectedWorkspaceRoot,
         workspaceType: () => routeStateRef.current.selectedWorkspaceType,
         openworkServer: openworkServerStore,
+        openworkServerConnection: () => ({
+          openworkServerClient: routeStateRef.current.openworkServerClient,
+          openworkServerStatus: routeStateRef.current.openworkServerStatus,
+          openworkServerCapabilities: routeStateRef.current.openworkServerCapabilities,
+        }),
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
         setBusy,
         setBusyLabel,
@@ -911,13 +930,7 @@ export function SettingsRoute() {
   const mcpConnectedAppsCount = connectionsSnapshot.mcpServers.length;
   const routeOpenworkStatus = openworkClient ? "connected" : "disconnected";
   const routeOpenworkCapabilities: OpenworkServerCapabilities | null = openworkClient
-    ? {
-        skills: { read: true, write: true, source: "openwork" },
-        plugins: { read: true, write: true },
-        mcp: { read: true, write: true },
-        commands: { read: true, write: true },
-        config: { read: true, write: true },
-      }
+    ? ROUTE_OPENWORK_CAPABILITIES
     : null;
   const environmentRuntimeKey = buildOpenworkEnvRuntimeKey({
     baseUrl: openworkServerSnapshot.openworkServerBaseUrl || openworkServerSnapshot.openworkServerUrl,

--- a/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
+++ b/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeWorkspaceRelativePath } from "./server.js";
+import { isSupportedWorkspaceTextFilePath, normalizeWorkspaceRelativePath } from "./server.js";
 
 describe("normalizeWorkspaceRelativePath", () => {
   test("accepts a plain workspace-relative path", () => {
@@ -32,5 +32,17 @@ describe("normalizeWorkspaceRelativePath", () => {
   test("treats workspace/ with no file as invalid", () => {
     expect(() => normalizeWorkspaceRelativePath("workspace/", { allowSubdirs: true })).toThrow();
     expect(() => normalizeWorkspaceRelativePath("/workspace/", { allowSubdirs: true })).toThrow();
+  });
+});
+
+describe("isSupportedWorkspaceTextFilePath", () => {
+  test("accepts plugin import text file extensions", () => {
+    expect(isSupportedWorkspaceTextFilePath(".opencode/tools/cloud.ts")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath(".opencode/mcps/cloud.json")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath(".opencode/plugins/cloud.txt")).toBe(true);
+  });
+
+  test("rejects unsupported binary-like extensions", () => {
+    expect(isSupportedWorkspaceTextFilePath(".opencode/plugins/cloud.bin")).toBe(false);
   });
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -741,6 +741,13 @@ export function normalizeWorkspaceRelativePath(input: string, options: { allowSu
   return parts.join("/");
 }
 
+export function isSupportedWorkspaceTextFilePath(relativePath: string): boolean {
+  const lowered = relativePath.toLowerCase();
+  return [".md", ".mdx", ".markdown", ".json", ".jsonc", ".ts", ".js", ".mjs", ".cjs", ".txt"].some((ext) =>
+    lowered.endsWith(ext),
+  );
+}
+
 function resolveSafeChildPath(root: string, child: string): string {
   const rootResolved = resolve(root);
   const candidate = resolve(rootResolved, child);
@@ -2203,10 +2210,8 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const requested = (ctx.url.searchParams.get("path") ?? "").trim();
     const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
-    const lowered = relativePath.toLowerCase();
-    const isMarkdown = lowered.endsWith(".md") || lowered.endsWith(".mdx") || lowered.endsWith(".markdown");
-    if (!isMarkdown) {
-      throw new ApiError(400, "invalid_path", "Only markdown files are supported");
+    if (!isSupportedWorkspaceTextFilePath(relativePath)) {
+      throw new ApiError(400, "invalid_path", "Only Markdown and OpenCode plugin text files are supported");
     }
 
     const absPath = resolveSafeChildPath(workspace.path, relativePath);
@@ -2235,10 +2240,8 @@ function createRoutes(
 
     const requestedPath = String(body.path ?? "");
     const relativePath = normalizeWorkspaceRelativePath(requestedPath, { allowSubdirs: true });
-    const lowered = relativePath.toLowerCase();
-    const isMarkdown = lowered.endsWith(".md") || lowered.endsWith(".mdx") || lowered.endsWith(".markdown");
-    if (!isMarkdown) {
-      throw new ApiError(400, "invalid_path", "Only markdown files are supported");
+    if (!isSupportedWorkspaceTextFilePath(relativePath)) {
+      throw new ApiError(400, "invalid_path", "Only Markdown and OpenCode plugin text files are supported");
     }
 
     if (typeof body.content !== "string") {


### PR DESCRIPTION
## Summary
- Route cloud plugin imports through the settings route's resolved OpenWork server connection instead of a possibly stale health-poll snapshot.
- Allow the OpenWork server file content endpoint to write OpenCode plugin text file types used by cloud imports.
- Add coverage for supported plugin import text file extensions.

## Tests
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-server typecheck
- pnpm --filter openwork-server test
- git diff --check

## Not Run
- Authenticated Electron cloud import click-through; requires an active signed-in Cloud session.