### PR TITLE
fix command invocation timeout

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -64,6 +64,7 @@ export type OpencodeAuth = {
 const DEFAULT_OPENCODE_REQUEST_TIMEOUT_MS = 10_000;
 const OAUTH_OPENCODE_REQUEST_TIMEOUT_MS = 5 * 60_000;
 const MCP_AUTH_OPENCODE_REQUEST_TIMEOUT_MS = 90_000;
+const SESSION_COMMAND_URL_RE = /\/session\/[^/?#]+\/command(?:[?#]|$)/;
 
 function getRequestUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;
@@ -74,6 +75,9 @@ function getRequestUrl(input: RequestInfo | URL): string {
 
 function resolveRequestTimeoutMs(input: RequestInfo | URL, fallbackMs: number): number {
   const url = getRequestUrl(input);
+  if (SESSION_COMMAND_URL_RE.test(url)) {
+    return 0;
+  }
   if (/\/provider\/oauth\//.test(url) || /\/mcp\/auth\/callback\b/.test(url)) {
     return Math.max(fallbackMs, OAUTH_OPENCODE_REQUEST_TIMEOUT_MS);
   }

--- a/apps/server-v2/src/services/workspace-session-service.ts
+++ b/apps/server-v2/src/services/workspace-session-service.ts
@@ -145,13 +145,40 @@ export function createWorkspaceSessionService(input: {
     }
   }
 
+  async function runAsyncMutation(workspaceId: string, operation: (backend: SessionBackend) => Promise<unknown>) {
+    const workspace = getWorkspaceOrThrow(workspaceId);
+    let backend: SessionBackend;
+    try {
+      backend = resolveBackend(workspace);
+    } catch (error) {
+      remapBackendError(error);
+      throw error;
+    }
+
+    void operation(backend)
+      .then(() => recordSuccess(input.repositories, workspace, { refresh: true, sync: true }))
+      .catch((error) => {
+        const remapped = (() => {
+          try {
+            remapBackendError(error);
+          } catch (next) {
+            return next;
+          }
+          return error;
+        })();
+        recordError(input.repositories, workspace, remapped as Error);
+      });
+
+    return { accepted: true };
+  }
+
   return {
     abortSession(workspaceId: string, sessionId: string) {
       return runMutation(workspaceId, (backend) => backend.abortSession(sessionId));
     },
 
     command(workspaceId: string, sessionId: string, body: Record<string, unknown>) {
-      return runMutation(workspaceId, (backend) => backend.command(sessionId, body));
+      return runAsyncMutation(workspaceId, (backend) => backend.command(sessionId, body));
     },
 
     createSession(workspaceId: string, body: Record<string, unknown>) {

--- a/apps/server-v2/src/sessions.test.ts
+++ b/apps/server-v2/src/sessions.test.ts
@@ -54,14 +54,14 @@ function withMockOpencodeBaseUrl(dependencies: ReturnType<typeof createAppDepend
   });
 }
 
-function startMockOpencode(options?: { expectBearer?: string; mountPrefix?: string }) {
+function startMockOpencode(options?: { expectBearer?: string; holdCommand?: Promise<void>; mountPrefix?: string }) {
   const requests: Array<{ method: string; pathname: string; authorization: string | null; body: unknown }> = [];
   const prefix = options?.mountPrefix?.replace(/\/+$/, "") ?? "";
 
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch(request) {
+    async fetch(request) {
       const url = new URL(request.url);
       const pathname = prefix && url.pathname.startsWith(prefix) ? url.pathname.slice(prefix.length) || "/" : url.pathname;
       const authorization = request.headers.get("authorization");
@@ -183,6 +183,7 @@ function startMockOpencode(options?: { expectBearer?: string; mountPrefix?: stri
       }
 
       if (pathname === "/session/ses_1/command" && request.method === "POST") {
+        await options?.holdCommand;
         return Response.json({ ok: true });
       }
 
@@ -213,6 +214,14 @@ function startMockOpencode(options?: { expectBearer?: string; mountPrefix?: stri
     requests,
     url: `http://127.0.0.1:${server.port}`,
   };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
 }
 
 describe("workspace session routes", () => {
@@ -277,7 +286,8 @@ describe("workspace session routes", () => {
   });
 
   test("routes remote workspace sessions through the mounted remote backend", async () => {
-    const remote = startMockOpencode({ expectBearer: "secret", mountPrefix: "/w/alpha/opencode" });
+    const command = deferred();
+    const remote = startMockOpencode({ expectBearer: "secret", holdCommand: command.promise, mountPrefix: "/w/alpha/opencode" });
     const { app, dependencies } = createTestApp();
     const workspace = dependencies.persistence.registry.importRemoteWorkspace({
       baseUrl: `${remote.url}/w/alpha/opencode`,
@@ -297,11 +307,17 @@ describe("workspace session routes", () => {
     expect(listResponse.status).toBe(200);
     expect((await listResponse.json()).data.items[0].id).toBe("ses_1");
 
-    const commandResponse = await app.request(`http://openwork.local/workspaces/${workspace.id}/sessions/ses_1/command`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ command: "review" }),
-    });
+    const commandResponse = await Promise.race([
+      app.request(`http://openwork.local/workspaces/${workspace.id}/sessions/ses_1/command`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ command: "review" }),
+      }),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
+    ]);
+    expect(commandResponse).not.toBe("timeout");
+    command.resolve();
+    if (!(commandResponse instanceof Response)) throw new Error("Command response timed out");
     expect(commandResponse.status).toBe(200);
     expect((await commandResponse.json()).data.accepted).toBe(true);
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -182,6 +182,10 @@ function assertOpencodeProxyAllowed(actor: Actor, method: string, proxyPath: str
   }
 }
 
+function isSessionCommandProxyRequest(method: string, proxyPath: string) {
+  return method === "POST" && /^\/session\/[^/]+\/command$/.test(normalizeOpencodeProxyPath(proxyPath));
+}
+
 interface Route {
   method: string;
   regex: RegExp;
@@ -489,6 +493,17 @@ async function proxyOpencodeRequest(input: {
 
   const method = input.request.method.toUpperCase();
   const body = method === "GET" || method === "HEAD" ? undefined : input.request.body;
+  if (isSessionCommandProxyRequest(method, proxyPath)) {
+    const bufferedBody = body ? await input.request.arrayBuffer() : undefined;
+    void fetch(targetUrl, {
+      method,
+      headers,
+      body: bufferedBody,
+    }).catch(() => {
+      // Command failures are surfaced through the OpenCode event stream.
+    });
+    return jsonResponse({ ok: true, accepted: true });
+  }
   const response = await fetch(targetUrl, {
     method,
     headers,

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -34,12 +34,12 @@ function auth(token: string) {
   return { Authorization: `Bearer ${token}` };
 }
 
-function startMockOpencode(input?: { invalidList?: boolean }) {
+function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promise<void> }) {
   const requests: Array<{ pathname: string; search: string; directory: string | null }> = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch(request) {
+    async fetch(request) {
       const url = new URL(request.url);
       requests.push({
         pathname: url.pathname,
@@ -108,6 +108,11 @@ function startMockOpencode(input?: { invalidList?: boolean }) {
         ]);
       }
 
+      if (url.pathname === "/session/ses_1/command" && request.method === "POST") {
+        await input?.holdCommand;
+        return Response.json({ ok: true });
+      }
+
       return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
     },
   }) as Served;
@@ -144,6 +149,22 @@ function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: st
   const server = startServer(config) as Served;
   stops.push(() => server.stop(true));
   return { server, token: config.token };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+async function waitUntil(predicate: () => boolean) {
+  for (let index = 0; index < 20; index++) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return predicate();
 }
 
 describe("workspace session read APIs", () => {
@@ -233,6 +254,32 @@ describe("workspace session read APIs", () => {
       message: "Session not found",
     });
 
+  });
+
+  test("acknowledges proxied session commands before upstream completion", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const command = deferred();
+    const mock = startMockOpencode({ holdCommand: command.promise });
+    const openwork = startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    });
+
+    const response = await Promise.race([
+      fetch(`http://127.0.0.1:${openwork.server.port}/w/ws_1/opencode/session/ses_1/command`, {
+        method: "POST",
+        headers: { ...auth(openwork.token), "Content-Type": "application/json" },
+        body: JSON.stringify({ command: "review", arguments: "" }),
+      }),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
+    ]);
+
+    expect(response).not.toBe("timeout");
+    expect(response instanceof Response ? response.status : 0).toBe(200);
+    await expect(response instanceof Response ? response.json() : null).resolves.toMatchObject({ accepted: true });
+    const sawCommand = await waitUntil(() => mock.requests.some((request) => request.pathname === "/session/ses_1/command"));
+    command.resolve();
+    expect(sawCommand).toBe(true);
   });
 
   test("returns 502 when OpenCode returns an invalid session list payload", async () => {


### PR DESCRIPTION
## Summary
- Return immediately for desktop proxied session command requests while OpenCode continues work in the background.
- Match server-v2 command handling to async prompt behavior so command streaming is not tied to the POST response lifetime.
- Add regression coverage for legacy proxy and server-v2 command paths.

## Verification
- `pnpm --filter openwork-server test -- src/session-read-model.e2e.test.ts`
- `pnpm --filter openwork-server-v2 test -- src/sessions.test.ts`
- `pnpm --filter openwork-server typecheck`
- `pnpm --filter openwork-server-v2 typecheck`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server build:bin`