### PR TITLE
fix: session transcript disappears mid-stream when live cache only has the active turn

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -6,8 +6,12 @@ import {
   deriveRenderedSessionMessages,
   resolveRenderedSessionSnapshot,
 } from "../src/react-app/domains/session/surface/session-render-state";
+import { mergeSnapshotIntoCachedMessages } from "../src/react-app/domains/session/sync/message-merge";
 
-function snapshotWithText(text: string, sessionId = "ses_test"): OpenworkSessionSnapshot {
+function snapshotWithMessages(
+  messages: Array<{ id: string; role: "user" | "assistant"; text: string }>,
+  sessionId = "ses_test",
+): OpenworkSessionSnapshot {
   return {
     session: {
       id: sessionId,
@@ -17,29 +21,59 @@ function snapshotWithText(text: string, sessionId = "ses_test"): OpenworkSession
       share: undefined,
       version: "0",
     },
-    messages: [
-      {
-        info: {
-          id: "msg_user",
-          role: "user",
-          sessionID: sessionId,
-          time: { created: 1 },
-        },
-        parts: [
-          {
-            id: "part_text",
-            type: "text",
-            text,
-            sessionID: sessionId,
-            messageID: "msg_user",
-          },
-        ],
+    messages: messages.map((message, index) => ({
+      info: {
+        id: message.id,
+        role: message.role,
+        sessionID: sessionId,
+        time: { created: index + 1 },
       },
-    ],
+      parts: [
+        {
+          id: `part_${message.id}`,
+          type: "text",
+          text: message.text,
+          sessionID: sessionId,
+          messageID: message.id,
+        },
+      ],
+    })),
     todos: [],
     status: { type: "idle" },
   } as unknown as OpenworkSessionSnapshot;
 }
+
+function uiMessage(id: string, role: "user" | "assistant", text: string): UIMessage {
+  return {
+    id,
+    role,
+    parts: [{ type: "text", text, state: "done" }],
+  };
+}
+
+function snapshotWithText(text: string, sessionId = "ses_test"): OpenworkSessionSnapshot {
+  return snapshotWithMessages([{ id: "msg_user", role: "user", text }], sessionId);
+}
+
+describe("mergeSnapshotIntoCachedMessages", () => {
+  it("keeps older cached messages when a busy snapshot only contains the active tail", () => {
+    const merged = mergeSnapshotIntoCachedMessages(
+      [uiMessage("msg_current_user", "user", "latest prompt")],
+      [
+        uiMessage("msg_old_user", "user", "old prompt"),
+        uiMessage("msg_old_assistant", "assistant", "old answer"),
+        uiMessage("msg_current_user", "user", "latest"),
+      ],
+    );
+
+    expect(merged.map((message) => message.id)).toEqual([
+      "msg_old_user",
+      "msg_old_assistant",
+      "msg_current_user",
+    ]);
+    expect(merged[2]?.parts[0]).toMatchObject({ text: "latest prompt" });
+  });
+});
 
 describe("deriveRenderedSessionMessages", () => {
   it("falls back to snapshot messages when transcript cache is empty", () => {
@@ -55,10 +89,10 @@ describe("deriveRenderedSessionMessages", () => {
     });
   });
 
-  it("keeps live transcript cache when present", () => {
+  it("keeps live transcript cache when it covers the snapshot", () => {
     const cached: UIMessage[] = [
       {
-        id: "msg_live",
+        id: "msg_user",
         role: "assistant",
         parts: [{ type: "text", text: "live text", state: "done" }],
       },
@@ -68,6 +102,35 @@ describe("deriveRenderedSessionMessages", () => {
       transcriptState: cached,
       snapshot: snapshotWithText("snapshot text"),
     })).toBe(cached);
+  });
+
+  it("keeps snapshot history visible when the live cache only has the active turn", () => {
+    const messages = deriveRenderedSessionMessages({
+      transcriptState: [
+        {
+          id: "msg_current_user",
+          role: "user",
+          parts: [{ type: "text", text: "latest prompt", state: "done" }],
+        },
+        {
+          id: "msg_current_assistant",
+          role: "assistant",
+          parts: [{ type: "text", text: "streaming answer", state: "streaming" }],
+        },
+      ],
+      snapshot: snapshotWithMessages([
+        { id: "msg_old_user", role: "user", text: "old prompt" },
+        { id: "msg_old_assistant", role: "assistant", text: "old answer" },
+      ]),
+      includeLiveOnlyMessages: true,
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "msg_old_user",
+      "msg_old_assistant",
+      "msg_current_user",
+      "msg_current_assistant",
+    ]);
   });
 
   it("returns an empty list only when there is no cache or snapshot content", () => {

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
+import { mergeSnapshotAndLiveMessages, messageListContainsAll } from "../sync/message-merge";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
 
 export function resolveRenderedSessionSnapshot(input: {
@@ -23,12 +24,23 @@ export function resolveRenderedSessionSnapshot(input: {
 export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
   snapshot: OpenworkSessionSnapshot | null | undefined;
+  includeLiveOnlyMessages?: boolean;
 }) {
-  if (input.transcriptState && input.transcriptState.length > 0) {
-    return input.transcriptState;
+  const liveMessages = input.transcriptState ?? [];
+  const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
+    ? snapshotToUIMessages(input.snapshot)
+    : [];
+
+  if (liveMessages.length > 0 && snapshotMessages.length === 0) return liveMessages;
+  if (liveMessages.length === 0 && snapshotMessages.length > 0) return snapshotMessages;
+  if (liveMessages.length > 0 && snapshotMessages.length > 0) {
+    if (messageListContainsAll(liveMessages, snapshotMessages)) return liveMessages;
+    return mergeSnapshotAndLiveMessages(snapshotMessages, liveMessages, {
+      appendLiveOnlyMessages: input.includeLiveOnlyMessages,
+    });
   }
   if (input.snapshot && input.snapshot.messages.length > 0) {
-    return snapshotToUIMessages(input.snapshot);
+    return snapshotMessages;
   }
   return input.transcriptState ?? [];
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -379,8 +379,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const liveStatus = statusState ?? snapshot?.status ?? IDLE_STATUS;
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
   const renderedMessages = useMemo(
-    () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
-    [snapshot, transcriptState],
+    () => deriveRenderedSessionMessages({ transcriptState, snapshot, includeLiveOnlyMessages: chatStreaming }),
+    [chatStreaming, snapshot, transcriptState],
   );
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {

--- a/apps/app/src/react-app/domains/session/sync/message-merge.ts
+++ b/apps/app/src/react-app/domains/session/sync/message-merge.ts
@@ -1,0 +1,89 @@
+import type { UIMessage } from "ai";
+
+function mergeMessageParts(snapshotMessage: UIMessage, cachedMessage: UIMessage) {
+  const parts = snapshotMessage.parts.map((part, index) => {
+    const cachedPart = cachedMessage.parts[index];
+    if (!cachedPart) return part;
+
+    if (
+      (part.type === "text" || part.type === "reasoning") &&
+      cachedPart.type === part.type &&
+      cachedPart.text.length > part.text.length
+    ) {
+      return { ...part, text: cachedPart.text };
+    }
+
+    return part;
+  });
+
+  if (cachedMessage.parts.length > snapshotMessage.parts.length) {
+    parts.push(...cachedMessage.parts.slice(snapshotMessage.parts.length));
+  }
+
+  return parts;
+}
+
+function mergeSnapshotMessageWithCached(snapshotMessage: UIMessage, cachedMessage: UIMessage): UIMessage {
+  return {
+    ...snapshotMessage,
+    parts: mergeMessageParts(snapshotMessage, cachedMessage),
+  };
+}
+
+export function messageListContainsAll(container: UIMessage[], required: UIMessage[]) {
+  if (required.length === 0) return true;
+  const ids = new Set(container.map((message) => message.id));
+  return required.every((message) => ids.has(message.id));
+}
+
+export function mergeSnapshotAndLiveMessages(
+  snapshotMessages: UIMessage[],
+  liveMessages: UIMessage[],
+  options: { appendLiveOnlyMessages?: boolean } = {},
+) {
+  if (snapshotMessages.length === 0) return liveMessages;
+  if (liveMessages.length === 0) return snapshotMessages;
+
+  const liveById = new Map(liveMessages.map((message) => [message.id, message]));
+  const snapshotIds = new Set(snapshotMessages.map((message) => message.id));
+  const merged = snapshotMessages.map((snapshotMessage) => {
+    const liveMessage = liveById.get(snapshotMessage.id);
+    return liveMessage ? mergeSnapshotMessageWithCached(snapshotMessage, liveMessage) : snapshotMessage;
+  });
+
+  if (options.appendLiveOnlyMessages) {
+    for (const liveMessage of liveMessages) {
+      if (!snapshotIds.has(liveMessage.id)) merged.push(liveMessage);
+    }
+  }
+
+  return merged;
+}
+
+export function mergeSnapshotIntoCachedMessages(snapshotMessages: UIMessage[], cachedMessages: UIMessage[]) {
+  if (snapshotMessages.length === 0) return cachedMessages;
+  if (cachedMessages.length === 0) return snapshotMessages;
+
+  const snapshotById = new Map(snapshotMessages.map((message) => [message.id, message]));
+  const cachedById = new Map(cachedMessages.map((message) => [message.id, message]));
+  const useCachedOrder = cachedMessages.length > snapshotMessages.length;
+  const primary = useCachedOrder ? cachedMessages : snapshotMessages;
+  const secondary = useCachedOrder ? snapshotMessages : cachedMessages;
+  const seen = new Set<string>();
+  const merged = primary.map((message) => {
+    seen.add(message.id);
+    const snapshotMessage = snapshotById.get(message.id);
+    const cachedMessage = cachedById.get(message.id);
+    return snapshotMessage && cachedMessage
+      ? mergeSnapshotMessageWithCached(snapshotMessage, cachedMessage)
+      : message;
+  });
+
+  for (const message of secondary) {
+    if (seen.has(message.id)) continue;
+    seen.add(message.id);
+    merged.push(message);
+  }
+
+  return merged;
+}

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -7,6 +7,7 @@ import { normalizeEvent } from "../../../../app/utils";
 import type { OpencodeEvent, PendingPermission } from "../../../../app/types";
 import { snapshotToUIMessages } from "./usechat-adapter";
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
+import { mergeSnapshotIntoCachedMessages } from "./message-merge";
 
 type SyncOptions = {
   workspaceId: string;
@@ -582,29 +583,7 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
     // for in-progress parts while the cache already accumulated text via
     // deltas.  Merge so we never overwrite longer cached text with shorter
     // server text.
-    const merged = incoming.map((incomingMsg) => {
-      const cachedMsg = existing.find((m) => m.id === incomingMsg.id);
-      if (!cachedMsg) return incomingMsg;
-      const parts = incomingMsg.parts.map((inPart, index) => {
-        const cachedPart = cachedMsg.parts[index];
-        if (!cachedPart) return inPart;
-        if (
-          (inPart.type === "text" || inPart.type === "reasoning") &&
-          (cachedPart.type === "text" || cachedPart.type === "reasoning") &&
-          cachedPart.text.length > inPart.text.length
-        ) {
-          return { ...inPart, text: cachedPart.text };
-        }
-        return inPart;
-      });
-      // Keep any extra cached parts the server doesn't know about yet
-      if (cachedMsg.parts.length > incomingMsg.parts.length) {
-        for (let i = incomingMsg.parts.length; i < cachedMsg.parts.length; i++) {
-          parts.push(cachedMsg.parts[i]);
-        }
-      }
-      return { ...incomingMsg, parts };
-    });
+    const merged = mergeSnapshotIntoCachedMessages(incoming, existing);
     queryClient.setQueryData(key, merged);
   } else {
     queryClient.setQueryData(key, incoming);


### PR DESCRIPTION
## Summary

- **Bug**: during streaming, the session transcript would disappear — only the last user message and the in-progress assistant reply were visible. The full history reappeared once the session went idle.
- **Root cause**: `deriveRenderedSessionMessages` gave absolute priority to the live transcript cache (fed by SSE deltas). When a new turn starts streaming, the cache often only contains the current user+assistant pair while the snapshot still holds the full history. The old logic returned whichever source was non-empty first, dropping the snapshot history.
- **Fix**: extract `message-merge.ts` helpers that union snapshot history with live streaming parts. `deriveRenderedSessionMessages` now detects when the live cache is missing messages the snapshot knows about and merges both, appending live-only messages (the active turn) when streaming. `seedSessionState` reuses the same merge helpers, replacing the inline O(N*M) merge that could also drop older cached messages when a busy snapshot arrived with fewer entries.

## Changes

| File | What |
|------|------|
| `apps/app/src/react-app/domains/session/sync/message-merge.ts` | New: shared merge helpers for snapshot + live message lists |
| `apps/app/src/react-app/domains/session/surface/session-render-state.ts` | Uses merge when live cache is incomplete vs snapshot |
| `apps/app/src/react-app/domains/session/surface/session-surface.tsx` | Passes `includeLiveOnlyMessages` flag during streaming |
| `apps/app/src/react-app/domains/session/sync/session-sync.ts` | `seedSessionState` delegates to shared merge helpers |
| `apps/app/scripts/session-render-state.test.ts` | Regression tests for the disappearing-transcript scenario |

## Verification

- `bun test apps/app/scripts/session-render-state.test.ts` — 7/7 pass
- `pnpm --filter @openwork/app typecheck` — clean
- Docker dev stack started manually (sequential service boot); UI loaded, session created, prompt submitted and rendered in transcript via direct CDP inspection