### PR TITLE
feat: added collapse side bar feature

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useMemo, useState } from "react";
-import { Check, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
+import { Check, ChevronRight, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { buildOpenworkWorkspaceBaseUrl, type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -28,6 +28,7 @@ import { ShareWorkspaceModal } from "../../workspace/share-workspace-modal";
 import { StatusBar, type StatusBarProps } from "./status-bar";
 import {
   DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
+  WORKSPACE_LEFT_SIDEBAR_WIDTH_TRANSITION,
   useWorkspaceShellLayout,
 } from "../../../shell/workspace-shell-layout";
 import { OwDotTicker } from "../../../shell/dot-ticker";
@@ -153,7 +154,13 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 }
 
 export function SessionPage(props: SessionPageProps) {
-  const { leftSidebarWidth, startLeftSidebarResize } = useWorkspaceShellLayout({
+  const {
+    effectiveLeftSidebarWidth,
+    leftSidebarCollapsed,
+    leftSidebarResizeActive,
+    toggleLeftSidebar,
+    startLeftSidebarResize,
+  } = useWorkspaceShellLayout({
     defaultLeftWidth: DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
     expandedRightWidth: 280,
   });
@@ -276,43 +283,72 @@ export function SessionPage(props: SessionPageProps) {
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text">
       <div className="flex min-h-0 flex-1 gap-4 p-3 md:p-4">
         <aside
-          className="relative hidden min-h-0 shrink-0 overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar shadow-[var(--dls-shell-shadow)] lg:flex lg:flex-col"
-          style={{ width: leftSidebarWidth }}
+          className={`relative hidden min-h-0 shrink-0 overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar shadow-[var(--dls-shell-shadow)] lg:grid lg:grid-cols-1 lg:grid-rows-1 ${
+            leftSidebarResizeActive ? "transition-none" : WORKSPACE_LEFT_SIDEBAR_WIDTH_TRANSITION
+          }`}
+          style={{ width: effectiveLeftSidebarWidth }}
         >
-          <div className="flex min-h-0 flex-1">
-            <WorkspaceSessionList
-              workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
-              selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
-              developerMode={props.sidebar.developerMode}
-              selectedSessionId={props.sidebar.selectedSessionId}
-              showInitialLoading={sidebarInitialLoading}
-              showSessionActions={Boolean(props.onRenameSession || props.onDeleteSession)}
-              sessionStatusById={props.sidebar.sessionStatusById}
-              connectingWorkspaceId={props.sidebar.connectingWorkspaceId}
-              workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
-              newTaskDisabled={props.sidebar.newTaskDisabled}
-              onSelectWorkspace={props.sidebar.onSelectWorkspace}
-              onOpenSession={props.sidebar.onOpenSession}
-              onPrefetchSession={props.sidebar.onPrefetchSession}
-              onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
-              onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
-              onOpenDeleteSession={props.onDeleteSession ? () => setDeleteOpen(true) : undefined}
-              onOpenRenameWorkspace={props.sidebar.onOpenRenameWorkspace}
-              onShareWorkspace={props.sidebar.onShareWorkspace}
-              onRevealWorkspace={props.sidebar.onRevealWorkspace}
-              onRecoverWorkspace={props.sidebar.onRecoverWorkspace}
-              onTestWorkspaceConnection={props.sidebar.onTestWorkspaceConnection}
-              onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
-              onForgetWorkspace={props.sidebar.onForgetWorkspace}
-              onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
+          <div
+            className={`relative col-start-1 row-start-1 flex min-h-0 flex-col transition-[opacity,transform] duration-200 ease-out motion-reduce:transform-none motion-reduce:transition-none motion-reduce:opacity-100 ${
+              leftSidebarCollapsed ? "pointer-events-none z-0 -translate-x-2 opacity-0" : "z-10 translate-x-0 opacity-100"
+            }`}
+            aria-hidden={leftSidebarCollapsed}
+          >
+            <div className="flex min-h-0 flex-1">
+              <WorkspaceSessionList
+                onToggleSidebarCollapse={toggleLeftSidebar}
+                workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
+                selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
+                developerMode={props.sidebar.developerMode}
+                selectedSessionId={props.sidebar.selectedSessionId}
+                showInitialLoading={sidebarInitialLoading}
+                showSessionActions={Boolean(props.onRenameSession || props.onDeleteSession)}
+                sessionStatusById={props.sidebar.sessionStatusById}
+                connectingWorkspaceId={props.sidebar.connectingWorkspaceId}
+                workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
+                newTaskDisabled={props.sidebar.newTaskDisabled}
+                onSelectWorkspace={props.sidebar.onSelectWorkspace}
+                onOpenSession={props.sidebar.onOpenSession}
+                onPrefetchSession={props.sidebar.onPrefetchSession}
+                onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
+                onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
+                onOpenDeleteSession={props.onDeleteSession ? () => setDeleteOpen(true) : undefined}
+                onOpenRenameWorkspace={props.sidebar.onOpenRenameWorkspace}
+                onShareWorkspace={props.sidebar.onShareWorkspace}
+                onRevealWorkspace={props.sidebar.onRevealWorkspace}
+                onRecoverWorkspace={props.sidebar.onRecoverWorkspace}
+                onTestWorkspaceConnection={props.sidebar.onTestWorkspaceConnection}
+                onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
+                onForgetWorkspace={props.sidebar.onForgetWorkspace}
+                onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
+              />
+            </div>
+            <div
+              className="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 lg:block"
+              onPointerDown={startLeftSidebarResize}
+              title={t("session.resize_workspace_column")}
+              aria-label={t("session.resize_workspace_column")}
             />
           </div>
+
           <div
-            className="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 lg:block"
-            onPointerDown={startLeftSidebarResize}
-            title={t("session.resize_workspace_column")}
-            aria-label={t("session.resize_workspace_column")}
-          />
+            className={`col-start-1 row-start-1 flex min-h-0 flex-col items-center px-1 pt-3 transition-[opacity,transform] duration-200 ease-out motion-reduce:transform-none motion-reduce:transition-none motion-reduce:opacity-100 lg:justify-center lg:pt-0 ${
+              leftSidebarCollapsed
+                ? "z-10 translate-x-0 opacity-100"
+                : "pointer-events-none z-0 translate-x-2 opacity-0"
+            }`}
+            aria-hidden={!leftSidebarCollapsed}
+          >
+            <button
+              type="button"
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-gray-10 transition-colors duration-200 hover:bg-gray-2/80 hover:text-dls-text active:scale-95 motion-reduce:active:scale-100"
+              onClick={toggleLeftSidebar}
+              title={t("workspace_sidebar.expand_sidebar")}
+              aria-label={t("workspace_sidebar.expand_sidebar")}
+            >
+              <ChevronRight size={18} className="transition-transform duration-200 ease-out" />
+            </button>
+          </div>
         </aside>
 
         <main className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">

--- a/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Loader2, MoreHorizontal, Plus } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, Loader2, MoreHorizontal, Plus } from "lucide-react";
 
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
@@ -40,6 +40,8 @@ type Props = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
+  /** Pinned inline with workspace row actions (+ / ⋯); fallback row when no selection. */
+  onToggleSidebarCollapse?: () => void;
 };
 
 const MAX_SESSIONS_PREVIEW = 6;
@@ -166,9 +168,6 @@ const workspaceSwatchColor = (seed: string) => {
 };
 
 export function WorkspaceSessionList(props: Props) {
-  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = useState<Set<string>>(
-    () => new Set(),
-  );
   const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = useState<Record<string, number>>({});
   const [workspaceMenuId, setWorkspaceMenuId] = useState<string | null>(null);
   const [sessionMenuOpen, setSessionMenuOpen] = useState(false);
@@ -182,45 +181,10 @@ export function WorkspaceSessionList(props: Props) {
     ? t("workspace_list.reveal_explorer")
     : t("workspace_list.reveal_finder");
 
-  const expandWorkspace = (workspaceId: string) => {
-    const id = workspaceId.trim();
-    if (!id) return;
-    setExpandedWorkspaceIds((previous) => {
-      if (previous.has(id)) return previous;
-      const next = new Set(previous);
-      next.add(id);
-      return next;
-    });
-  };
-
-  const toggleWorkspaceExpanded = (workspaceId: string) => {
-    const id = workspaceId.trim();
-    if (!id) return;
-    setExpandedWorkspaceIds((previous) => {
-      const next = new Set(previous);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  };
-
-  useEffect(() => {
-    const id = props.selectedWorkspaceId.trim();
-    if (!id) return;
-    // Keep the selected workspace visible without collapsing other workspaces.
-    // Collapsing the previous workspace on every cross-workspace session click
-    // makes the sidebar feel jumpy and hides the context the user just left.
-    expandWorkspace(id);
-  }, [props.selectedWorkspaceId]);
-
   const previewCount = (workspaceId: string) =>
     previewCountByWorkspaceId[workspaceId] ?? MAX_SESSIONS_PREVIEW;
 
   const showMoreSessions = (workspaceId: string, totalRoots: number) => {
-    expandWorkspace(workspaceId);
     setPreviewCountByWorkspaceId((current) => {
       const next = { ...current };
       const existing = next[workspaceId] ?? MAX_SESSIONS_PREVIEW;
@@ -446,6 +410,21 @@ export function WorkspaceSessionList(props: Props) {
     <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
       <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto pr-1">
         <div className="space-y-2 pb-3">
+          {props.onToggleSidebarCollapse &&
+          (!props.selectedWorkspaceId.trim() ||
+            !props.workspaceSessionGroups.some((g) => g.workspace.id === props.selectedWorkspaceId)) ? (
+            <div className="flex items-center justify-end rounded-xl px-3.5 py-2.5">
+              <button
+                type="button"
+                className="rounded-md p-1 text-gray-9 transition-colors duration-200 hover:bg-gray-3/80 hover:text-gray-11 active:scale-95 motion-reduce:active:scale-100"
+                onClick={() => props.onToggleSidebarCollapse?.()}
+                title={t("workspace_sidebar.collapse_sidebar")}
+                aria-label={t("workspace_sidebar.collapse_sidebar")}
+              >
+                <ChevronLeft size={14} className="transition-transform duration-200 ease-out" />
+              </button>
+            </div>
+          ) : null}
           {props.workspaceSessionGroups.map((group) => {
             const tree = buildSessionTreeState(group.sessions, props.sessionStatusById);
             const forcedExpandedSessionIds = new Set(
@@ -498,14 +477,12 @@ export function WorkspaceSessionList(props: Props) {
                         : "text-gray-10 hover:bg-gray-1/70 hover:text-gray-12"
                     } ${isConnecting ? "opacity-75" : ""}`}
                     onClick={() => {
-                      expandWorkspace(workspace.id);
                       void Promise.resolve(props.onSelectWorkspace(workspace.id));
                     }}
                     onKeyDown={(event) => {
                       if (event.key !== "Enter" && event.key !== " ") return;
                       if (event.nativeEvent.isComposing || event.keyCode === 229) return;
                       event.preventDefault();
-                      expandWorkspace(workspace.id);
                       void Promise.resolve(props.onSelectWorkspace(workspace.id));
                     }}
                   >
@@ -562,27 +539,22 @@ export function WorkspaceSessionList(props: Props) {
                         >
                           <MoreHorizontal size={14} />
                         </button>
+                        {props.onToggleSidebarCollapse && props.selectedWorkspaceId === workspace.id ? (
+                          <button
+                            type="button"
+                            className="rounded-md p-1 text-gray-9 transition-colors duration-200 hover:bg-gray-3/80 hover:text-gray-11 active:scale-95 motion-reduce:active:scale-100"
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              props.onToggleSidebarCollapse?.();
+                            }}
+                            title={t("workspace_sidebar.collapse_sidebar")}
+                            aria-label={t("workspace_sidebar.collapse_sidebar")}
+                          >
+                            <ChevronLeft size={14} className="transition-transform duration-200 ease-out" />
+                          </button>
+                        ) : null}
                       </div>
-
-                      <button
-                        type="button"
-                        className="rounded-md p-1 text-gray-9 hover:bg-gray-3/80 hover:text-gray-11"
-                        aria-label={
-                          expandedWorkspaceIds.has(workspace.id)
-                            ? t("sidebar.collapse")
-                            : t("sidebar.expand")
-                        }
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          toggleWorkspaceExpanded(workspace.id);
-                        }}
-                      >
-                        {expandedWorkspaceIds.has(workspace.id) ? (
-                          <ChevronDown size={14} />
-                        ) : (
-                          <ChevronRight size={14} />
-                        )}
-                      </button>
                     </div>
                   </div>
 
@@ -677,8 +649,7 @@ export function WorkspaceSessionList(props: Props) {
                   ) : null}
                 </div>
 
-                {expandedWorkspaceIds.has(workspace.id) ? (
-                  <div className="mt-3 px-1 pb-1">
+                <div className="mt-3 px-1 pb-1">
                     <div className="relative flex flex-col gap-1 pl-2.5 before:absolute before:bottom-2 before:left-0 before:top-2 before:w-[2px] before:bg-gray-3 before:content-['']">
                       {props.showInitialLoading ? (
                         <div className="space-y-2">
@@ -752,7 +723,6 @@ export function WorkspaceSessionList(props: Props) {
                       )}
                     </div>
                   </div>
-                ) : null}
               </div>
             );
           })}

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource react */
 import type { ComponentProps, PointerEventHandler, ReactNode } from "react";
-import { X } from "lucide-react";
+import { ChevronRight, X } from "lucide-react";
 
 import { t } from "../../../../i18n";
+import { WORKSPACE_LEFT_SIDEBAR_WIDTH_TRANSITION } from "../../../shell/workspace-shell-layout";
 import { SettingsPage, getSettingsTabLabel } from "./settings-page";
 import { WorkspaceSessionList } from "../../session/sidebar/workspace-session-list";
 
@@ -14,6 +15,10 @@ export type SettingsShellProps = SettingsPageChromeProps & {
   busyHint?: string | null;
   workspaceSessionListProps: ComponentProps<typeof WorkspaceSessionList>;
   onClose: () => void;
+  sidebarCollapsed?: boolean;
+  onToggleSidebarCollapsed?: () => void;
+  /** When true, width transition is disabled (user is dragging the resize handle). */
+  sidebarResizeActive?: boolean;
   sidebarTopSlot?: ReactNode;
   headerLeadingSlot?: ReactNode;
   sidebarWidth?: number;
@@ -27,26 +32,61 @@ export type SettingsShellProps = SettingsPageChromeProps & {
 
 export function SettingsShell(props: SettingsShellProps) {
   const title = getSettingsTabLabel(props.activeTab);
+  const sidebarCollapsed = Boolean(props.sidebarCollapsed);
+  const sidebarWidthPx = props.sidebarWidth;
+  const sidebarResizeActive = Boolean(props.sidebarResizeActive);
 
   return (
     <div className="h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 text-gray-12 md:p-4">
       <div className="flex h-full w-full gap-3 md:gap-4">
         <aside
-          className="relative hidden shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5 lg:flex"
-          style={props.sidebarWidth ? { width: `${props.sidebarWidth}px`, minWidth: `${props.sidebarWidth}px` } : undefined}
+          className={`relative hidden shrink-0 overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar lg:grid lg:grid-cols-1 lg:grid-rows-1 ${
+            sidebarResizeActive ? "transition-none" : WORKSPACE_LEFT_SIDEBAR_WIDTH_TRANSITION
+          }`}
+          style={
+            sidebarWidthPx != null
+              ? { width: `${sidebarWidthPx}px`, minWidth: `${sidebarWidthPx}px` }
+              : undefined
+          }
         >
-          {props.sidebarTopSlot ? <div className="shrink-0">{props.sidebarTopSlot}</div> : null}
-          <div className="flex min-h-0 flex-1">
-            <WorkspaceSessionList {...props.workspaceSessionListProps} />
+          <div
+            className={`relative col-start-1 row-start-1 flex h-full min-h-0 flex-col p-2.5 transition-[opacity,transform] duration-200 ease-out motion-reduce:transform-none motion-reduce:transition-none motion-reduce:opacity-100 ${
+              sidebarCollapsed
+                ? "pointer-events-none z-0 -translate-x-2 opacity-0"
+                : "z-10 translate-x-0 opacity-100"
+            }`}
+            aria-hidden={sidebarCollapsed}
+          >
+            {props.sidebarTopSlot ? <div className="shrink-0">{props.sidebarTopSlot}</div> : null}
+            <div className="flex min-h-0 flex-1">
+              <WorkspaceSessionList {...props.workspaceSessionListProps} />
+            </div>
+            {props.onSidebarResizeStart ? (
+              <div
+                className="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 md:block"
+                onPointerDown={props.onSidebarResizeStart}
+                title={t("session.resize_workspace_column")}
+                aria-label={t("session.resize_workspace_column")}
+              />
+            ) : null}
           </div>
-          {props.onSidebarResizeStart ? (
-            <div
-              className="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 md:block"
-              onPointerDown={props.onSidebarResizeStart}
-              title={t("session.resize_workspace_column")}
-              aria-label={t("session.resize_workspace_column")}
-            />
-          ) : null}
+
+          <div
+            className={`col-start-1 row-start-1 flex min-h-0 flex-col items-center justify-start px-1 pt-3 transition-[opacity,transform] duration-200 ease-out motion-reduce:transform-none motion-reduce:transition-none motion-reduce:opacity-100 lg:justify-center lg:pt-0 ${
+              sidebarCollapsed ? "z-10 translate-x-0 opacity-100" : "pointer-events-none z-0 translate-x-2 opacity-0"
+            }`}
+            aria-hidden={!sidebarCollapsed}
+          >
+            <button
+              type="button"
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-gray-10 transition-colors duration-200 hover:bg-gray-2/80 hover:text-dls-text active:scale-95 motion-reduce:active:scale-100"
+              onClick={() => props.onToggleSidebarCollapsed?.()}
+              title={t("workspace_sidebar.expand_sidebar")}
+              aria-label={t("workspace_sidebar.expand_sidebar")}
+            >
+              <ChevronRight size={18} className="transition-transform duration-200 ease-out" />
+            </button>
+          </div>
         </aside>
 
         <main className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">

--- a/apps/app/src/react-app/kernel/system-state.ts
+++ b/apps/app/src/react-app/kernel/system-state.ts
@@ -77,7 +77,9 @@ export function useSystemState(
   const [reloadLastTriggeredAt, setReloadLastTriggeredAt] = useState<
     number | null
   >(null);
-  const [reloadTrigger, setReloadTrigger] = useState<ReloadTrigger | null>(null);
+  const [reloadTrigger, setReloadTrigger] = useState<ReloadTrigger | null>(
+    null,
+  );
   const [reloadBusy, setReloadBusy] = useState(false);
   const [reloadError, setReloadError] = useState<string | null>(null);
 
@@ -164,7 +166,8 @@ export function useSystemState(
       await options.onReloadComplete?.();
       clearReloadRequired();
     } catch (error) {
-      const message = error instanceof Error ? error.message : safeStringify(error);
+      const message =
+        error instanceof Error ? error.message : safeStringify(error);
       setReloadError(message || t("system.reload_failed"));
     } finally {
       setReloadBusy(false);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1358,9 +1358,13 @@ export function SettingsRoute() {
           onEditWorkspaceConnection: () => {},
           onForgetWorkspace: () => {},
           onOpenCreateWorkspace: handleOpenCreateWorkspace,
+          onToggleSidebarCollapse: shellLayout.toggleLeftSidebar,
         }}
         onClose={() => navigate("/session")}
-        sidebarWidth={shellLayout.leftSidebarWidth}
+        sidebarCollapsed={shellLayout.leftSidebarCollapsed}
+        onToggleSidebarCollapsed={shellLayout.toggleLeftSidebar}
+        sidebarResizeActive={shellLayout.leftSidebarResizeActive}
+        sidebarWidth={shellLayout.effectiveLeftSidebarWidth}
         onSidebarResizeStart={shellLayout.startLeftSidebarResize}
         error={routeError}
       >

--- a/apps/app/src/react-app/shell/workspace-shell-layout.ts
+++ b/apps/app/src/react-app/shell/workspace-shell-layout.ts
@@ -2,12 +2,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const LEFT_SIDEBAR_WIDTH_KEY = "openwork.workspace-shell.left-width.v1";
+const LEFT_SIDEBAR_COLLAPSED_KEY = "openwork.workspace-shell.left-collapsed.v1";
 const RIGHT_SIDEBAR_EXPANDED_KEY = "openwork.workspace-shell.right-expanded.v3";
 
 export const DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH = 260;
 export const MIN_WORKSPACE_LEFT_SIDEBAR_WIDTH = 220;
 export const MAX_WORKSPACE_LEFT_SIDEBAR_WIDTH = 420;
+export const COLLAPSED_WORKSPACE_LEFT_SIDEBAR_WIDTH = 48;
 export const DEFAULT_WORKSPACE_RIGHT_SIDEBAR_COLLAPSED_WIDTH = 72;
+
+/** Tailwind classes: width eases on collapse/expand; omitted while drag-resizing. */
+export const WORKSPACE_LEFT_SIDEBAR_WIDTH_TRANSITION =
+  "transition-[width] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none";
 
 type WorkspaceShellLayoutOptions = {
   defaultLeftWidth?: number;
@@ -66,8 +72,16 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
     return raw === "1";
   }, []);
 
+  const readLeftSidebarCollapsed = useCallback(() => {
+    const raw = readStorage(LEFT_SIDEBAR_COLLAPSED_KEY);
+    if (raw == null) return false;
+    return raw === "1";
+  }, []);
+
   const [leftSidebarWidth, setLeftSidebarWidth] = useState(readLeftSidebarWidth);
+  const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(readLeftSidebarCollapsed);
   const [rightSidebarExpanded, setRightSidebarExpanded] = useState(readRightSidebarExpanded);
+  const [leftSidebarResizeActive, setLeftSidebarResizeActive] = useState(false);
   const dragCleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
@@ -81,6 +95,15 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
     writeStorage(RIGHT_SIDEBAR_EXPANDED_KEY, rightSidebarExpanded ? "1" : "0");
   }, [rightSidebarExpanded]);
 
+  useEffect(() => {
+    writeStorage(LEFT_SIDEBAR_COLLAPSED_KEY, leftSidebarCollapsed ? "1" : "0");
+  }, [leftSidebarCollapsed]);
+
+  const effectiveLeftSidebarWidth = useMemo(
+    () => (leftSidebarCollapsed ? COLLAPSED_WORKSPACE_LEFT_SIDEBAR_WIDTH : leftSidebarWidth),
+    [leftSidebarCollapsed, leftSidebarWidth],
+  );
+
   const rightSidebarWidth = useMemo(
     () => (rightSidebarExpanded ? expandedRightWidth : collapsedRightWidth),
     [collapsedRightWidth, expandedRightWidth, rightSidebarExpanded],
@@ -89,6 +112,7 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
   const stopLeftSidebarResize = useCallback(() => {
     dragCleanupRef.current?.();
     dragCleanupRef.current = null;
+    setLeftSidebarResizeActive(false);
     if (typeof document === "undefined") return;
     document.body.style.removeProperty("cursor");
     document.body.style.removeProperty("user-select");
@@ -99,6 +123,7 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
       if (event.button !== 0 || typeof window === "undefined") return;
 
       stopLeftSidebarResize();
+      setLeftSidebarResizeActive(true);
       const initialX = event.clientX;
       const initialWidth = leftSidebarWidth;
 
@@ -134,6 +159,10 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
     setRightSidebarExpanded((current) => !current);
   }, []);
 
+  const toggleLeftSidebar = useCallback(() => {
+    setLeftSidebarCollapsed((current) => !current);
+  }, []);
+
   useEffect(() => {
     return () => {
       stopLeftSidebarResize();
@@ -142,10 +171,15 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
 
   return {
     leftSidebarWidth,
+    effectiveLeftSidebarWidth,
+    leftSidebarCollapsed,
+    leftSidebarResizeActive,
     rightSidebarExpanded,
     rightSidebarWidth,
+    setLeftSidebarCollapsed,
     setRightSidebarExpanded,
     startLeftSidebarResize,
+    toggleLeftSidebar,
     toggleRightSidebar,
   };
 }


### PR DESCRIPTION
## Summary
- Persisted **left sidebar collapse** (narrow strip + expand chevron) alongside existing **width resize**; state in `localStorage` with width transition disabled while drag-resizing.
- **Animations**: width easing + stacked crossfade/slide hints on collapse/expand; respects `prefers-reduced-motion`.
- **Workspace list**: removed per-workspace “fold sessions only” chevron; **sessions stay visible** under each workspace.
- **Collapse control** lives in the **same action strip** as workspace `+` / `⋯` (selected row), with fallback row when selection is missing; session + settings sidebars wired the same via `onToggleSidebarCollapse`.
## Why
- Collapsing only inner session lists wasted space without gaining a wider **main** surface; collapsing the whole rail matches user expectation and frees room for chat/session UI.
- Aligning the chevron with existing row controls keeps chrome consistent with the workspace row pattern and reduces visual noise.
## Issue
- Closes #1620
## Scope
- `apps/app/src/react-app/shell/workspace-shell-layout.ts` — `leftSidebarCollapsed`, `effectiveLeftSidebarWidth`, `toggleLeftSidebar`, `leftSidebarResizeActive`, `WORKSPACE_LEFT_SIDEBAR_WIDTH_TRANSITION`, persisted keys.
- `apps/app/src/react-app/domains/session/chat/session-page.tsx` — aside layout, animations, passes `onToggleSidebarCollapse`.
- `apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx` — optional `onToggleSidebarCollapse`; inline control on selected workspace row + fallback strip.
- `apps/app/src/react-app/domains/settings/shell/settings-shell.tsx` + `apps/app/src/react-app/shell/settings-route.tsx` — same collapse/animation contract and list prop wiring.
## Out of scope
- OpenCode/engine APIs (pure client shell + layout persistence).
- Right-hand panels / todos / main session surface behavior beyond flex reflow when the rail narrows.
## Testing
### Ran
- `pnpm dev`
### Result
- pass/fail: **pass**
- if fail, exact files/errors: N/A
## CI status
- pass: N/A
- code-related failures: N/A
- external/env/auth blockers: N/A
## Manual verification
- Open and close side bar
## Evidence
https://github.com/user-attachments/assets/a1887b0f-3587-4503-bc7c-7e4637b56030
## Risk
- **Low** simple UI change
## Rollback
- Revert the PR