### PR TITLE
Update landing downloads for Electron builds

### DIFF
--- a/ee/apps/landing/app/download/page.tsx
+++ b/ee/apps/landing/app/download/page.tsx
@@ -29,7 +29,7 @@ const downloadSchema = {
 export const metadata = {
   title: "Download OpenWork — macOS, Windows, Linux",
   description:
-    "Download OpenWork desktop for macOS, Windows, and Linux. Includes AUR install instructions and direct package downloads.",
+    "Download OpenWork desktop for macOS, Windows, and Linux. Direct Electron build downloads are resolved from the latest GitHub release.",
   alternates: {
     canonical: "/download"
   },
@@ -92,14 +92,14 @@ export default async function Download() {
               className="feature-card border-violet-100 bg-violet-50/50 transition hover:border-violet-200"
             >
               <span className="mb-2 block text-[16px] font-semibold text-gray-900">Windows</span>
-              <p className="text-[14px] text-gray-700">x64 MSI installer</p>
+              <p className="text-[14px] text-gray-700">x64 NSIS installer</p>
             </a>
             <a
               href="#linux"
               className="feature-card border-emerald-100 bg-emerald-50/60 transition hover:border-emerald-200"
             >
               <span className="mb-2 block text-[16px] font-semibold text-gray-900">Linux</span>
-              <p className="text-[14px] text-gray-700">AUR, .deb, and .rpm options</p>
+              <p className="text-[14px] text-gray-700">AppImage and tarball builds</p>
             </a>
           </div>
 
@@ -143,7 +143,7 @@ export default async function Download() {
           <section id="windows" className="py-6">
             <h2 className="mb-2 text-2xl font-bold md:text-3xl">Windows</h2>
             <p className="mb-6 text-[15px] text-gray-700">
-              OpenWork for Windows is available as an x64 MSI installer.
+              OpenWork for Windows is available as an x64 Electron installer.
             </p>
             <a
               href={github.installers.windows.x64}
@@ -151,7 +151,7 @@ export default async function Download() {
               rel="noreferrer"
               target="_blank"
             >
-              Download Windows x64 (.msi)
+              Download Windows x64 (.exe)
             </a>
           </section>
 
@@ -160,78 +160,56 @@ export default async function Download() {
           <section id="linux" className="py-6">
             <h2 className="mb-2 text-2xl font-bold md:text-3xl">Linux</h2>
             <p className="mb-8 text-[15px] text-gray-700">
-              Install from AUR on Arch-based distributions, or download packages
-              directly for Ubuntu/Debian and Fedora/RHEL/openSUSE.
+              Download Electron builds directly for x64 and arm64 Linux systems.
             </p>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              <div className="feature-card border-emerald-100 bg-white/90 ring-1 ring-emerald-100/60">
-                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">Arch Linux (AUR)</h3>
-                <p className="mb-4 text-[14px] text-gray-600">
-                  Install and keep OpenWork updated via the Arch User Repository.
-                </p>
-                <pre className="mono overflow-x-auto rounded-lg bg-gray-950 px-4 py-3 text-[13px] text-gray-100">
-                  <code>yay -S openwork</code>
-                </pre>
-                <p className="mt-3 text-[13px] text-gray-600">
-                  Prefer paru? <span className="mono">paru -S openwork</span>
-                </p>
-                <a
-                  href={github.installers.linux.aur}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mt-4 inline-flex text-[13px] font-semibold text-gray-700 underline decoration-gray-300 underline-offset-4 transition hover:text-black"
-                >
-                  View package on AUR
-                </a>
-              </div>
-
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div className="feature-card border-amber-100 bg-white/90 ring-1 ring-amber-100/60">
-                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">Ubuntu / Debian (.deb)</h3>
+                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">AppImage</h3>
                 <p className="mb-4 text-[14px] text-gray-600">
-                  Download the package for your architecture.
+                  Portable desktop builds for most Linux distributions.
                 </p>
                 <div className="flex flex-wrap gap-3">
                   <a
-                    href={github.installers.linux.debX64}
+                    href={github.installers.linux.appImageX64}
                     target="_blank"
                     rel="noreferrer"
                     className="doc-button"
                   >
-                    x64 .deb
+                    x64 AppImage
                   </a>
                   <a
-                    href={github.installers.linux.debArm64}
+                    href={github.installers.linux.appImageArm64}
                     target="_blank"
                     rel="noreferrer"
                     className="doc-button"
                   >
-                    arm64 .deb
+                    arm64 AppImage
                   </a>
                 </div>
               </div>
 
               <div className="feature-card border-sky-100 bg-white/90 ring-1 ring-sky-100/60">
-                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">Fedora / RHEL / openSUSE (.rpm)</h3>
+                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">Tarball</h3>
                 <p className="mb-4 text-[14px] text-gray-600">
-                  Download an RPM package for x64 or arm64 systems.
+                  Compressed Electron builds for manual installation.
                 </p>
                 <div className="flex flex-wrap gap-3">
                   <a
-                    href={github.installers.linux.rpmX64}
+                    href={github.installers.linux.tarX64}
                     target="_blank"
                     rel="noreferrer"
                     className="doc-button"
                   >
-                    x64 .rpm
+                    x64 .tar.gz
                   </a>
                   <a
-                    href={github.installers.linux.rpmArm64}
+                    href={github.installers.linux.tarArm64}
                     target="_blank"
                     rel="noreferrer"
                     className="doc-button"
                   >
-                    arm64 .rpm
+                    arm64 .tar.gz
                   </a>
                 </div>
               </div>

--- a/ee/apps/landing/components/webmcp-provider.tsx
+++ b/ee/apps/landing/components/webmcp-provider.tsx
@@ -73,16 +73,15 @@ const downloadLinks = {
   platforms: {
     macos: {
       page: "https://openworklabs.com/download#macos",
-      note: "Apple Silicon (.dmg) and Intel (.dmg) builds resolved from the latest GitHub release.",
+      note: "Electron Apple Silicon (.dmg) and Intel (.dmg) builds resolved from the latest GitHub release.",
     },
     windows: {
       page: "https://openworklabs.com/download#windows",
-      note: "x64 MSI installer resolved from the latest GitHub release.",
+      note: "Electron x64 .exe installer resolved from the latest GitHub release.",
     },
     linux: {
       page: "https://openworklabs.com/download#linux",
-      aur: "yay -S openwork",
-      note: "AUR plus .deb and .rpm packages for x64 and arm64.",
+      note: "Electron AppImage and tar.gz builds for x64 and arm64.",
     },
   },
 }

--- a/ee/apps/landing/lib/agent-markdown.ts
+++ b/ee/apps/landing/lib/agent-markdown.ts
@@ -94,13 +94,12 @@ const download = `# Download OpenWork
 
 ## Windows
 
-- **x64** — MSI installer
+- **x64** — Electron ".exe" installer
 
 ## Linux
 
-- **Arch / AUR** — \`yay -S openwork\` (or \`paru -S openwork\`)
-- **Ubuntu / Debian** — \`.deb\` for x64 and arm64
-- **Fedora / RHEL / openSUSE** — \`.rpm\` for x64 and arm64
+- **AppImage** — Electron build for x64 and arm64
+- **Tarball** — Electron \`.tar.gz\` build for x64 and arm64
 
 Direct download URLs resolve from the latest GitHub release. Browse all assets at [github.com/openworklabs/openwork/releases/latest](https://github.com/openworklabs/openwork/releases/latest).
 

--- a/ee/apps/landing/lib/github.ts
+++ b/ee/apps/landing/lib/github.ts
@@ -48,6 +48,7 @@ const selectAsset = (
     matches.find((asset) => asset.name?.toLowerCase().includes("adhoc")) ||
     matches.find((asset) => asset.name?.toLowerCase().includes("universal")) ||
     matches.find((asset) => asset.name?.toLowerCase().includes("aarch64")) ||
+    matches.find((asset) => asset.name?.toLowerCase().includes("arm64")) ||
     matches[0]
   );
 };
@@ -86,11 +87,16 @@ export const getGithubData = async () => {
     const assets = Array.isArray(release?.assets) ? release.assets : [];
     return assets.some((asset) => asset?.browser_download_url);
   };
+  const isElectronDesktopAsset = (name: string) =>
+    name.startsWith("openwork-mac-") ||
+    name.startsWith("openwork-win-") ||
+    name.startsWith("openwork-linux-");
+
   const hasWindowsDesktopAsset = (release: Release) => {
     const assets = Array.isArray(release?.assets) ? release.assets : [];
     return assets.some((asset) => {
       const name = String(asset?.name || "").toLowerCase();
-      return name.startsWith("openwork-desktop-windows-") && (name.endsWith(".msi") || name.endsWith(".exe"));
+      return name.startsWith("openwork-win-x64-") && name.endsWith(".exe");
     });
   };
 
@@ -101,7 +107,7 @@ export const getGithubData = async () => {
     const assets = Array.isArray(release.assets) ? release.assets : [];
     return assets.some((asset) => {
       const name = String(asset?.name || "").toLowerCase();
-      return name.startsWith("openwork-desktop-");
+      return isElectronDesktopAsset(name);
     });
   };
 
@@ -117,19 +123,19 @@ export const getGithubData = async () => {
   const releaseUrl = pick?.html_url || FALLBACK_RELEASE;
   const windowsAssets = Array.isArray(windowsPick?.assets) ? windowsPick.assets : assets;
   const windowsReleaseUrl = windowsPick?.html_url || releaseUrl;
-  const dmg = selectAsset(assets, [".dmg"]);
-  const exe = selectAsset(windowsAssets, [".exe", ".msi"], ["win", "windows"]);
-  const appImage = selectAsset(assets, [".appimage"], ["linux"]);
-
-  const macosApple = selectAsset(assets, [".dmg"], ["darwin-aarch64"]);
-  const macosIntel = selectAsset(assets, [".dmg"], ["darwin-x64"]);
+  const dmg = selectAsset(assets, [".dmg"], ["openwork-mac-"]);
+  const exe = selectAsset(windowsAssets, [".exe"], ["openwork-win-"]);
+  const macosApple = selectAsset(assets, [".dmg"], ["mac-arm64"]);
+  const macosIntel = selectAsset(assets, [".dmg"], ["mac-x64"]);
   const windowsX64 =
-    selectAsset(windowsAssets, [".msi", ".exe"], ["windows-x64"]) || exe;
+    selectAsset(windowsAssets, [".exe"], ["win-x64"]) || exe;
 
-  const linuxDebX64 = selectAsset(assets, [".deb"], ["linux-amd64", "linux-x64"]);
-  const linuxDebArm64 = selectAsset(assets, [".deb"], ["linux-arm64", "linux-aarch64"]);
-  const linuxRpmX64 = selectAsset(assets, [".rpm"], ["linux-x86_64", "linux-amd64"]);
-  const linuxRpmArm64 = selectAsset(assets, [".rpm"], ["linux-aarch64", "linux-arm64"]);
+  const linuxAppImageX64 =
+    selectAsset(assets, [".appimage"], ["linux-x86_64"]) ||
+    selectAsset(assets, [".appimage"], ["linux-x64"]);
+  const linuxAppImageArm64 = selectAsset(assets, [".appimage"], ["linux-arm64"]);
+  const linuxTarX64 = selectAsset(assets, [".tar.gz"], ["linux-x64"]);
+  const linuxTarArm64 = selectAsset(assets, [".tar.gz"], ["linux-arm64"]);
 
   return {
     stars,
@@ -139,9 +145,8 @@ export const getGithubData = async () => {
       macos: dmg?.browser_download_url || FALLBACK_RELEASE,
       windows: exe?.browser_download_url || FALLBACK_RELEASE,
       linux:
-        appImage?.browser_download_url ||
-        linuxDebX64?.browser_download_url ||
-        linuxRpmX64?.browser_download_url ||
+        linuxAppImageX64?.browser_download_url ||
+        linuxTarX64?.browser_download_url ||
         FALLBACK_RELEASE
     },
     installers: {
@@ -153,12 +158,10 @@ export const getGithubData = async () => {
         x64: windowsX64?.browser_download_url || windowsReleaseUrl
       },
       linux: {
-        aur: "https://aur.archlinux.org/packages/openwork",
-        debX64: linuxDebX64?.browser_download_url || releaseUrl,
-        debArm64: linuxDebArm64?.browser_download_url || releaseUrl,
-        rpmX64: linuxRpmX64?.browser_download_url || releaseUrl,
-        rpmArm64: linuxRpmArm64?.browser_download_url || releaseUrl,
-        appImage: appImage?.browser_download_url || releaseUrl
+        appImageX64: linuxAppImageX64?.browser_download_url || releaseUrl,
+        appImageArm64: linuxAppImageArm64?.browser_download_url || releaseUrl,
+        tarX64: linuxTarX64?.browser_download_url || releaseUrl,
+        tarArm64: linuxTarArm64?.browser_download_url || releaseUrl
       }
     }
   };


### PR DESCRIPTION
## Summary
- Update landing page release asset selection to prefer Electron build filenames for macOS, Windows, and Linux.
- Replace Tauri package copy and buttons with Electron installer formats across the download page, WebMCP metadata, and agent markdown.

## Verification
- Confirmed the latest GitHub release includes Electron assets named `openwork-mac-*`, `openwork-win-*`, and `openwork-linux-*`.
- Searched `ee/apps/landing` to verify old Tauri package selectors/copy (`openwork-desktop-*`, `.msi`, `.deb`, `.rpm`, AUR) were removed.
- `pnpm --dir ee/apps/landing lint` did not run locally because this fresh worktree is missing `node_modules` (`next: command not found`).