### PR TITLE
Fix Electron alpha updater manifest lookup

### DIFF
--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -81,7 +81,6 @@ async function applyElectronUpdaterFeed(app, updater) {
   const channel = await readElectronUpdaterChannel(app);
   const state = updaterChannelState(app, channel);
   updater.allowPrerelease = state.channel === "alpha";
-  updater.channel = state.channel;
   if (updater?.setFeedURL) {
     updater.setFeedURL({ provider: "generic", url: state.feedUrl });
   }


### PR DESCRIPTION
## Summary
- Stop setting `autoUpdater.channel` to `alpha` for the generic alpha feed.
- Keep the alpha feed URL pointed at `alpha-macos-latest` while allowing Electron to request the existing `latest-mac.yml` manifest.

## Root Cause
`autoUpdater.channel = \"alpha\"` makes electron-updater request `alpha-mac.yml`. The alpha release publishes `latest-mac.yml`, so update checks 404 even though the release assets exist.

## Verification
- `node --check apps/desktop/electron/updater.mjs`
- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm --filter @openwork/app typecheck`
- Confirmed `https://github.com/different-ai/openwork/releases/download/alpha-macos-latest/latest-mac.yml` returns the alpha manifest.
- Confirmed `alpha-macos-latest` release contains `latest-mac.yml` via `gh release view`.