### PR TITLE
Fix alpha update version ceiling

### DIFF
--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -63,6 +63,10 @@ function comparePrereleaseIdentifiers(left: string[], right: string[]): number {
   return 0;
 }
 
+function releasePart(value: string): number[] | null {
+  return parseComparableVersion(value)?.release ?? null;
+}
+
 /**
  * Compare two version strings. Returns -1 / 0 / 1 as usual, or null if
  * either side fails to parse. Accepts an optional leading `v` and handles
@@ -103,6 +107,72 @@ export function isUpdateAllowedByDesktopConfig(
   );
 }
 
+function maxAllowedDesktopVersion(desktopConfig: DenDesktopConfig | null | undefined): string | null {
+  if (!Array.isArray(desktopConfig?.allowedDesktopVersions)) {
+    return null;
+  }
+
+  let maxVersion: string | null = null;
+  for (const version of desktopConfig.allowedDesktopVersions) {
+    if (parseComparableVersion(version) === null) continue;
+    if (maxVersion === null) {
+      maxVersion = version;
+      continue;
+    }
+    const comparison = compareVersions(version, maxVersion);
+    if (comparison !== null && comparison > 0) {
+      maxVersion = version;
+    }
+  }
+  return maxVersion;
+}
+
+function effectiveMaxDesktopVersion(
+  denLatestAppVersion: string,
+  desktopConfig: DenDesktopConfig | null | undefined,
+): string {
+  const orgMaxVersion = maxAllowedDesktopVersion(desktopConfig);
+  if (!orgMaxVersion) return denLatestAppVersion;
+  const comparison = compareVersions(orgMaxVersion, denLatestAppVersion);
+  return comparison !== null && comparison < 0 ? orgMaxVersion : denLatestAppVersion;
+}
+
+function isWithinOnePatchAhead(updateVersion: string, maxVersion: string): boolean {
+  const directComparison = compareVersions(updateVersion, maxVersion);
+  if (directComparison !== null && directComparison <= 0) {
+    return true;
+  }
+
+  const updateRelease = releasePart(updateVersion);
+  const maxRelease = releasePart(maxVersion);
+  if (!updateRelease || !maxRelease) return false;
+
+  const updateMajor = updateRelease[0] ?? 0;
+  const updateMinor = updateRelease[1] ?? 0;
+  const updatePatch = updateRelease[2] ?? 0;
+  const maxMajor = maxRelease[0] ?? 0;
+  const maxMinor = maxRelease[1] ?? 0;
+  const maxPatch = maxRelease[2] ?? 0;
+
+  return updateMajor === maxMajor && updateMinor === maxMinor && updatePatch <= maxPatch + 1;
+}
+
+async function readDenLatestAppVersion(): Promise<string | null> {
+  try {
+    const settings = readDenSettings();
+    const token = settings.authToken?.trim() ?? "";
+    const client = createDenClient({
+      baseUrl: settings.baseUrl,
+      apiBaseUrl: settings.apiBaseUrl,
+      ...(token ? { token } : {}),
+    });
+    const metadata = await client.getAppVersionMetadata();
+    return metadata.latestAppVersion;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Ask Den for the currently-supported latest app version (dev #1476) and
  * return true only when the candidate update version is the latest
@@ -114,20 +184,25 @@ export function isUpdateAllowedByDesktopConfig(
  * will omit the token when none is persisted.
  */
 export async function isUpdateSupportedByDen(updateVersion: string): Promise<boolean> {
-  try {
-    const settings = readDenSettings();
-    const token = settings.authToken?.trim() ?? "";
-    const client = createDenClient({
-      baseUrl: settings.baseUrl,
-      apiBaseUrl: settings.apiBaseUrl,
-      ...(token ? { token } : {}),
-    });
-    const metadata = await client.getAppVersionMetadata();
-    const comparison = compareVersions(updateVersion, metadata.latestAppVersion);
-    return comparison !== null && comparison <= 0;
-  } catch {
-    return false;
-  }
+  const latestAppVersion = await readDenLatestAppVersion();
+  if (!latestAppVersion) return false;
+  const comparison = compareVersions(updateVersion, latestAppVersion);
+  return comparison !== null && comparison <= 0;
+}
+
+/**
+ * Alpha channel builds may run one patch ahead of the current Den/org maximum
+ * (e.g. Den allows 0.13.3, alpha 0.13.4-alpha.N is allowed). Larger jumps are
+ * still blocked so alpha cannot bypass staged rollout ceilings entirely.
+ */
+export async function isAlphaUpdateAllowed(
+  updateVersion: string,
+  desktopConfig: DenDesktopConfig | null | undefined,
+): Promise<boolean> {
+  const latestAppVersion = await readDenLatestAppVersion();
+  if (!latestAppVersion) return false;
+  const effectiveMaxVersion = effectiveMaxDesktopVersion(latestAppVersion, desktopConfig);
+  return isWithinOnePatchAhead(updateVersion, effectiveMaxVersion);
 }
 
 /**

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { DenDesktopConfig } from "../../../../app/lib/den";
-import { isUpdateAllowed } from "../../../../app/lib/version-gate";
+import { isAlphaUpdateAllowed, isUpdateAllowed } from "../../../../app/lib/version-gate";
 import type { ReleaseChannel } from "../../../../app/types";
 import { isElectronRuntime, isTauriRuntime, safeStringify } from "../../../../app/utils";
 
@@ -138,7 +138,12 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         setUpdateStatus({ state: "idle", lastCheckedAt: Date.now() });
         return;
       }
-      if (releaseChannel !== "alpha" && update.version && !(await isUpdateAllowed(update.version, desktopConfig))) {
+      const allowed = update.version
+        ? releaseChannel === "alpha"
+          ? await isAlphaUpdateAllowed(update.version, desktopConfig)
+          : await isUpdateAllowed(update.version, desktopConfig)
+        : true;
+      if (!allowed) {
         tauriUpdateRef.current = null;
         setUpdateStatus({ state: "idle", lastCheckedAt: Date.now() });
         return;
@@ -220,9 +225,11 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       try {
         const { check } = await import("@tauri-apps/plugin-updater");
         const update = (await check()) as TauriUpdate | null;
-        const allowed = releaseChannel === "alpha" || !update?.version
+        const allowed = !update?.version
           ? true
-          : await isUpdateAllowed(update.version, desktopConfig);
+          : releaseChannel === "alpha"
+            ? await isAlphaUpdateAllowed(update.version, desktopConfig)
+            : await isUpdateAllowed(update.version, desktopConfig);
         if (!allowed) {
           tauriUpdateRef.current = null;
           setUpdateStatus({ state: "idle", lastCheckedAt: Date.now() });
@@ -275,11 +282,11 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         return;
       }
 
-      const availableAllowed = releaseChannel === "alpha"
-        ? result.available
-        : result.available && result.latestVersion
-          ? await isUpdateAllowed(result.latestVersion, desktopConfig)
-          : result.available;
+      const availableAllowed = result.available && result.latestVersion
+        ? releaseChannel === "alpha"
+          ? await isAlphaUpdateAllowed(result.latestVersion, desktopConfig)
+          : await isUpdateAllowed(result.latestVersion, desktopConfig)
+        : result.available;
       const nextStatus: Exclude<SettingsUpdateStatus, null> = availableAllowed
         ? {
             state: "available",

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -138,7 +138,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         setUpdateStatus({ state: "idle", lastCheckedAt: Date.now() });
         return;
       }
-      if (update.version && !(await isUpdateAllowed(update.version, desktopConfig))) {
+      if (releaseChannel !== "alpha" && update.version && !(await isUpdateAllowed(update.version, desktopConfig))) {
         tauriUpdateRef.current = null;
         setUpdateStatus({ state: "idle", lastCheckedAt: Date.now() });
         return;
@@ -212,7 +212,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     } finally {
       unsubProgress?.();
     }
-  }, [desktopConfig, setError]);
+  }, [desktopConfig, releaseChannel, setError]);
 
   const checkForUpdates = useCallback(async () => {
     if (isTauriRuntime()) {
@@ -220,9 +220,9 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       try {
         const { check } = await import("@tauri-apps/plugin-updater");
         const update = (await check()) as TauriUpdate | null;
-        const allowed = update?.version
-          ? await isUpdateAllowed(update.version, desktopConfig)
-          : true;
+        const allowed = releaseChannel === "alpha" || !update?.version
+          ? true
+          : await isUpdateAllowed(update.version, desktopConfig);
         if (!allowed) {
           tauriUpdateRef.current = null;
           setUpdateStatus({ state: "idle", lastCheckedAt: Date.now() });
@@ -275,9 +275,11 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         return;
       }
 
-      const availableAllowed = result.available && result.latestVersion
-        ? await isUpdateAllowed(result.latestVersion, desktopConfig)
-        : result.available;
+      const availableAllowed = releaseChannel === "alpha"
+        ? result.available
+        : result.available && result.latestVersion
+          ? await isUpdateAllowed(result.latestVersion, desktopConfig)
+          : result.available;
       const nextStatus: Exclude<SettingsUpdateStatus, null> = availableAllowed
         ? {
             state: "available",


### PR DESCRIPTION
## Summary
- Keep alpha updates gated by Den/org desktop version policy instead of bypassing it.
- Allow alpha-channel updates only when the candidate is at most one patch above the effective maximum allowed version.
- Preserve stable-channel behavior: stable updates still require exact org allow-list membership, when configured, and Den latest-version support.

## Behavior
- If Den latest is `0.13.3`, `0.13.4-alpha.666` is allowed on the alpha channel.
- If an org allow-list is present, its highest valid version also constrains the effective maximum.
- Larger jumps, different minor versions, or invalid metadata remain blocked.

## Root Cause
The alpha manifest correctly advertises `0.13.4-alpha.666`, but the existing stable update gate only allowed versions at or below Den's stable latest version. Alpha needs a bounded one-patch-ahead allowance, not a full bypass.

## Verification
- Fetched `https://github.com/different-ai/openwork/releases/download/alpha-macos-latest/latest-mac.yml` and confirmed it advertises `0.13.4-alpha.666`.
- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm --filter @openwork/app typecheck`