### PR TITLE
chore: bump bundled opencode to 1.14.38

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -46,7 +46,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@lexical/react": "^0.35.0",
-    "@opencode-ai/sdk": "^1.4.9",
+    "@opencode-ai/sdk": "^1.14.38",
     "@openwork/types": "workspace:*",
     "@openwork/ui": "workspace:*",
     "@radix-ui/colors": "^3.0.0",

--- a/apps/opencode-router/package.json
+++ b/apps/opencode-router/package.json
@@ -44,7 +44,7 @@
     "test:npx": "bun scripts/test-npx.mjs"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.4.9",
+    "@opencode-ai/sdk": "^1.14.38",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.13.0",
     "commander": "^12.1.0",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.4.9",
+    "@opencode-ai/sdk": "^1.14.38",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
     "opencode-router": "0.13.3",

--- a/apps/server-v2/package.json
+++ b/apps/server-v2/package.json
@@ -27,7 +27,7 @@
     "src"
   ],
   "dependencies": {
-    "@opencode-ai/sdk": "1.4.9",
+    "@opencode-ai/sdk": "1.14.38",
     "hono": "4.12.12",
     "hono-openapi": "1.3.0",
     "jsonc-parser": "^3.3.1",

--- a/apps/server-v2/src/runtime/assets.test.ts
+++ b/apps/server-v2/src/runtime/assets.test.ts
@@ -67,7 +67,7 @@ test("release runtime assets use manifest versions without reading repo metadata
   const releaseRoot = makeTempDir("openwork-server-v2-release-assets");
   const opencodePath = path.join(releaseRoot, process.platform === "win32" ? "opencode.exe" : "opencode");
   const routerPath = path.join(releaseRoot, process.platform === "win32" ? "opencode-router.exe" : "opencode-router");
-  writeVersionedBinary(opencodePath, "1.4.9");
+  writeVersionedBinary(opencodePath, "1.14.38");
   writeVersionedBinary(routerPath, "0.11.206");
 
   const manifest: RuntimeManifest = {
@@ -85,7 +85,7 @@ test("release runtime assets use manifest versions without reading repo metadata
     },
     generatedAt: new Date().toISOString(),
     manifestVersion: 1,
-    opencodeVersion: "1.4.9",
+    opencodeVersion: "1.14.38",
     rootDir: releaseRoot,
     routerVersion: "0.11.206",
     serverVersion: "0.0.0-test",
@@ -118,7 +118,7 @@ test("release runtime assets use manifest versions without reading repo metadata
   });
 
   const bundle = await service.resolveRuntimeBundle();
-  expect(bundle.opencode.version).toBe("1.4.9");
+  expect(bundle.opencode.version).toBe("1.14.38");
   expect(bundle.router.version).toBe("0.11.206");
   expect(bundle.manifest.source).toBe("release");
 });
@@ -136,7 +136,7 @@ test("release runtime assets extract into the managed runtime directory and surv
 
   const opencodePath = path.join(bundleRoot, process.platform === "win32" ? "opencode.exe" : "opencode");
   const routerPath = path.join(bundleRoot, process.platform === "win32" ? "opencode-router.exe" : "opencode-router");
-  writeVersionedBinary(opencodePath, "1.4.9");
+  writeVersionedBinary(opencodePath, "1.14.38");
   writeVersionedBinary(routerPath, "0.11.206");
 
   const manifest: RuntimeManifest = {
@@ -154,7 +154,7 @@ test("release runtime assets extract into the managed runtime directory and surv
     },
     generatedAt: new Date().toISOString(),
     manifestVersion: 1,
-    opencodeVersion: "1.4.9",
+    opencodeVersion: "1.14.38",
     rootDir: bundleRoot,
     routerVersion: "0.11.206",
     serverVersion: "0.0.0-test",
@@ -213,7 +213,7 @@ test("release runtime assets can extract from an embedded runtime bundle", async
   const opencodePath = path.join(bundleRoot, process.platform === "win32" ? "opencode.exe" : "opencode");
   const routerPath = path.join(bundleRoot, process.platform === "win32" ? "opencode-router.exe" : "opencode-router");
   const manifestPath = path.join(bundleRoot, "manifest.json");
-  writeVersionedBinary(opencodePath, "1.4.9");
+  writeVersionedBinary(opencodePath, "1.14.38");
   writeVersionedBinary(routerPath, "0.11.206");
 
   const manifest: RuntimeManifest = {
@@ -231,7 +231,7 @@ test("release runtime assets can extract from an embedded runtime bundle", async
     },
     generatedAt: new Date().toISOString(),
     manifestVersion: 1,
-    opencodeVersion: "1.4.9",
+    opencodeVersion: "1.14.38",
     rootDir: bundleRoot,
     routerVersion: "0.11.206",
     serverVersion: "0.0.0-test",

--- a/apps/server-v2/src/services/runtime-service.test.ts
+++ b/apps/server-v2/src/services/runtime-service.test.ts
@@ -71,7 +71,7 @@ async function createFakeAssetService(opencodePath: string, routerPath: string) 
     },
     generatedAt: new Date().toISOString(),
     manifestVersion: 1,
-    opencodeVersion: "1.4.9",
+    opencodeVersion: "1.14.38",
     rootDir: path.dirname(opencodePath),
     routerVersion: "0.11.206",
     serverVersion: "0.0.0-test",
@@ -87,7 +87,7 @@ async function createFakeAssetService(opencodePath: string, routerPath: string) 
     source: "development" as const,
     stagedRoot: path.dirname(opencodePath),
     target,
-    version: "1.4.9",
+    version: "1.14.38",
   };
   const routerBinary = {
     absolutePath: routerPath,
@@ -104,7 +104,7 @@ async function createFakeAssetService(opencodePath: string, routerPath: string) 
     ensureOpencodeBinary: async () => opencodeBinary,
     ensureRouterBinary: async () => routerBinary,
     getDevelopmentRoot: () => path.dirname(opencodePath),
-    getPinnedOpencodeVersion: async () => "1.4.9",
+    getPinnedOpencodeVersion: async () => "1.14.38",
     getReleaseRoot: () => path.dirname(opencodePath),
     getRouterVersion: async () => "0.11.206",
     getSource: () => "development" as const,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -50,8 +50,10 @@ import {
   type WorkspaceExportSensitiveMode,
 } from "./workspace-export-safety.js";
 import pkg from "../package.json" with { type: "json" };
+import constants from "../../../constants.json" with { type: "json" };
 
 const SERVER_VERSION = pkg.version;
+const OPENCODE_VERSION = constants.opencodeVersion.trim().replace(/^v/, "");
 
 const FILE_SESSION_DEFAULT_TTL_MS = 15 * 60 * 1000;
 const FILE_SESSION_MIN_TTL_MS = 30 * 1000;
@@ -626,6 +628,7 @@ function buildCapabilities(config: ServerConfig): Capabilities {
   return {
     schemaVersion,
     serverVersion: SERVER_VERSION,
+    opencodeVersion: OPENCODE_VERSION,
     skills: { read: true, write: writeEnabled, source: "openwork" },
     hub: {
       skills: {
@@ -1094,11 +1097,11 @@ function createRoutes(
   };
 
   addRoute(routes, "GET", "/health", "none", async () => {
-    return jsonResponse({ ok: true, version: SERVER_VERSION, uptimeMs: Date.now() - config.startedAt });
+    return jsonResponse({ ok: true, version: SERVER_VERSION, opencodeVersion: OPENCODE_VERSION, uptimeMs: Date.now() - config.startedAt });
   });
 
   addRoute(routes, "GET", "/w/:id/health", "none", async () => {
-    return jsonResponse({ ok: true, version: SERVER_VERSION, uptimeMs: Date.now() - config.startedAt });
+    return jsonResponse({ ok: true, version: SERVER_VERSION, opencodeVersion: OPENCODE_VERSION, uptimeMs: Date.now() - config.startedAt });
   });
 
   // Dev log sink: append browser console + error events to a file that an
@@ -1188,6 +1191,7 @@ function createRoutes(
     return jsonResponse({
       ok: true,
       version: SERVER_VERSION,
+      opencodeVersion: OPENCODE_VERSION,
       uptimeMs: Date.now() - config.startedAt,
       readOnly: config.readOnly,
       approval: config.approval,
@@ -1222,6 +1226,7 @@ function createRoutes(
     return jsonResponse({
       ok: true,
       version: SERVER_VERSION,
+      opencodeVersion: OPENCODE_VERSION,
       uptimeMs: Date.now() - config.startedAt,
       readOnly: config.readOnly,
       approval: config.approval,

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -96,6 +96,7 @@ export interface ServerConfig {
 export interface Capabilities {
   schemaVersion: number;
   serverVersion: string;
+  opencodeVersion: string;
   skills: { read: boolean; write: boolean; source: "openwork" | "opencode" };
   hub: {
     skills: {

--- a/apps/story-book/package.json
+++ b/apps/story-book/package.json
@@ -23,7 +23,7 @@
     "@codemirror/language": "^6.11.0",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.38.0",
-    "@opencode-ai/sdk": "^1.4.9",
+    "@opencode-ai/sdk": "^1.14.38",
     "@radix-ui/colors": "^3.0.0",
     "@solid-primitives/event-bus": "^1.1.2",
     "@solid-primitives/storage": "^4.3.3",

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,3 @@
 {
-  "opencodeVersion": "v1.4.9"
+  "opencodeVersion": "v1.14.38"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^0.35.0
         version: 0.35.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
       '@opencode-ai/sdk':
-        specifier: ^1.4.9
-        version: 1.4.9
+        specifier: ^1.14.38
+        version: 1.14.38
       '@openwork/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -190,8 +190,8 @@ importers:
   apps/opencode-router:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.4.9
-        version: 1.4.9
+        specifier: ^1.14.38
+        version: 1.14.38
       '@slack/socket-mode':
         specifier: ^2.0.5
         version: 2.0.5
@@ -224,8 +224,8 @@ importers:
   apps/orchestrator:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.4.9
-        version: 1.4.9
+        specifier: ^1.14.38
+        version: 1.14.38
       '@opentui/core':
         specifier: 0.1.77
         version: 0.1.77(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
@@ -298,8 +298,8 @@ importers:
   apps/server-v2:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: 1.4.9
-        version: 1.4.9
+        specifier: 1.14.38
+        version: 1.14.38
       hono:
         specifier: 4.12.12
         version: 4.12.12
@@ -390,8 +390,8 @@ importers:
         specifier: ^6.38.0
         version: 6.39.14
       '@opencode-ai/sdk':
-        specifier: ^1.4.9
-        version: 1.4.9
+        specifier: ^1.14.38
+        version: 1.14.38
       '@radix-ui/colors':
         specifier: ^3.0.0
         version: 3.0.0
@@ -2623,8 +2623,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.4.9':
-    resolution: {integrity: sha512-S8WQLuBFu2WwvSc1wupsV4qskniBA+JN1VaZZs52BPWwiN2zQFTD5/6dMh6oiYOMDtPjKsTFZ6qLFxDvVPNggQ==}
+  '@opencode-ai/sdk@1.14.38':
+    resolution: {integrity: sha512-0BNDR/xQHF4k17ocSVtwk3GM5jHAym0lOnuT25K3Z7XZoHxwQG1zVe+jhJrK459oZH3gUKp2FrCk6G6OB/Fn6A==}
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -10550,7 +10550,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.4.9':
+  '@opencode-ai/sdk@1.14.38':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## Summary
- Bump the bundled OpenCode pin from v1.4.9 to v1.14.38.
- Update @opencode-ai/sdk dependencies and lockfile entries to 1.14.38.
- Expose the pinned OpenCode version from server v1 health/status/capabilities, matching server v2's pinned runtime flow.

## Verification
- pnpm install
- pnpm --filter openwork-server-v2 test
- pnpm --filter openwork-server typecheck
- pnpm --filter openwork-server test
- pnpm --filter openwork-server build