### PR TITLE
fix(app): normalize escaped newlines in release notes

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -65,14 +65,18 @@ function describeError(error: unknown) {
   return serialized && serialized !== "{}" ? serialized : String(error);
 }
 
+function normalizeReleaseNotes(value: string): string {
+  return value.replace(/\\r\\n|\\n/g, "\n");
+}
+
 function releaseNotesToText(value: unknown): string | undefined {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") return normalizeReleaseNotes(value);
   if (Array.isArray(value)) {
     return value
       .flatMap((entry) => {
-        if (typeof entry === "string") return entry;
+        if (typeof entry === "string") return normalizeReleaseNotes(entry);
         if (entry && typeof entry === "object" && "note" in entry) {
-          const note = String((entry as { note?: unknown }).note ?? "");
+          const note = normalizeReleaseNotes(String((entry as { note?: unknown }).note ?? ""));
           return note ? [note] : [];
         }
         return [];


### PR DESCRIPTION
Refs #1095 (does not close it; only addresses the rescoped sub-comment about escaped newlines).

## Summary
- Convert literal `\n` and `\r\n` escape sequences to real newlines in release notes before they reach the Settings updates view.
- Apply the same normalization to both the string and array shapes returned by `electron-updater`, so notes built from `releaseNotes` arrays render with intended line breaks.
- Keep the existing `whitespace-pre-wrap` rendering path unchanged; this only fixes the source string when the upstream payload is double-escaped.

## Verification
- `git diff --check` clean.
- `pnpm --filter @openwork/app typecheck` currently fails on unrelated `origin/dev` TypeScript errors in `messaging-view-state.ts`, `command-palette.tsx`, and `settings-route.tsx`; this branch does not touch those files.

## Notes
- The broader "updates active by default" piece from the original issue body is split out into #1663 (default flip plus explicit-opt-out-respecting migration).
- Still out of scope: the pill-like updates presentation and the required-update / backend-gated escalation path described on the issue.
