### PR TITLE
fix(settings): restore debug value interpolation

### DIFF
--- a/apps/app/src/i18n/index.ts
+++ b/apps/app/src/i18n/index.ts
@@ -155,8 +155,19 @@ const resolvePluralKey = (loc: Language, key: string, count: number): string => 
  *   `${key}_one` / `${key}_other` (or `${key}_zero` when count === 0) per
  *   `Intl.PluralRules`, and falls back to the bare key when no variants exist.
  */
-export const t = (key: string, params?: Record<string, string | number> & { lng?: Language }): string => {
-  const loc = params?.lng ?? locale();
+type TranslationParams = Record<string, string | number> & { lng?: Language };
+
+export const t = (
+  key: string,
+  paramsOrLocale?: TranslationParams | Language,
+  legacyParams?: Record<string, string | number>,
+): string => {
+  const params = legacyParams ?? (typeof paramsOrLocale === "string" ? undefined : paramsOrLocale);
+  const loc: Language = typeof paramsOrLocale === "string"
+    ? paramsOrLocale
+    : isLanguage(params?.lng)
+      ? params.lng
+      : locale();
 
   const lookupKey =
     typeof params?.count === "number" ? resolvePluralKey(loc, key, params.count) : key;

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -339,13 +339,13 @@ export function DebugView(props: DebugViewProps) {
           </div>
         </div>
         <div className="grid gap-2 text-[12px] text-dls-secondary md:grid-cols-2">
-          <div>{t("settings.debug_desktop_app", undefined, { version: props.runtimeSummary.appVersionLabel })}</div>
-          <div>{t("settings.debug_commit", undefined, { commit: props.runtimeSummary.appCommitLabel })}</div>
+          <div>{t("settings.debug_desktop_app", { version: props.runtimeSummary.appVersionLabel })}</div>
+          <div>{t("settings.debug_commit", { commit: props.runtimeSummary.appCommitLabel })}</div>
           <div>
-            {t("settings.debug_opencode_version", undefined, { version: props.runtimeSummary.opencodeVersionLabel })}
+            {t("settings.debug_opencode_version", { version: props.runtimeSummary.opencodeVersionLabel })}
           </div>
           <div>
-            {t("settings.debug_openwork_server_version", undefined, {
+            {t("settings.debug_openwork_server_version", {
               version: props.runtimeSummary.openworkServerVersionLabel,
             })}
           </div>
@@ -450,41 +450,41 @@ export function DebugView(props: DebugViewProps) {
 
         {props.openworkServerDiagnostics ? (
           <div className="grid gap-2 text-[12px] text-dls-secondary md:grid-cols-2">
-            <div>{t("settings.diag_started", undefined, { time: formatUptime(props.openworkServerDiagnostics.uptimeMs) })}</div>
+            <div>{t("settings.diag_started", { time: formatUptime(props.openworkServerDiagnostics.uptimeMs) })}</div>
             <div>
-              {t("settings.diag_read_only", undefined, {
+              {t("settings.diag_read_only", {
                 value: props.openworkServerDiagnostics.readOnly ? "true" : "false",
               })}
             </div>
             <div>
-              {t("settings.diag_approval", undefined, {
+              {t("settings.diag_approval", {
                 mode: props.openworkServerDiagnostics.approval.mode,
                 ms: String(props.openworkServerDiagnostics.approval.timeoutMs),
               })}
             </div>
-            <div>{t("settings.diag_workspaces", undefined, { count: String(props.openworkServerDiagnostics.workspaceCount) })}</div>
+            <div>{t("settings.diag_workspaces", { count: String(props.openworkServerDiagnostics.workspaceCount) })}</div>
             <div>
-              {t("settings.diag_selected_workspace", undefined, {
+              {t("settings.diag_selected_workspace", {
                 id: props.openworkServerDiagnostics.selectedWorkspaceId ?? "—",
               })}
             </div>
             <div>
-              {t("settings.diag_runtime_workspace", undefined, {
+              {t("settings.diag_runtime_workspace", {
                 id: props.openworkServerDiagnostics.activeWorkspaceId ?? "—",
               })}
             </div>
             <div>
-              {t("settings.diag_config_path", undefined, {
+              {t("settings.diag_config_path", {
                 path: props.openworkServerDiagnostics.server.configPath ?? t("settings.diag_default"),
               })}
             </div>
             <div>
-              {t("settings.diag_token_source", undefined, {
+              {t("settings.diag_token_source", {
                 source: props.openworkServerDiagnostics.tokenSource.client,
               })}
             </div>
             <div>
-              {t("settings.diag_host_token_source", undefined, {
+              {t("settings.diag_host_token_source", {
                 source: props.openworkServerDiagnostics.tokenSource.host,
               })}
             </div>
@@ -500,19 +500,19 @@ export function DebugView(props: DebugViewProps) {
             </div>
             <div className="truncate font-mono text-[11px] text-dls-secondary">
               {props.runtimeWorkspaceId
-                ? t("settings.worker_id_label", undefined, { id: props.runtimeWorkspaceId })
+                ? t("settings.worker_id_label", { id: props.runtimeWorkspaceId })
                 : t("settings.worker_unresolved")}
             </div>
           </div>
           {props.openworkServerCapabilities ? (
             <div className="grid gap-2 text-[12px] text-dls-secondary md:grid-cols-2">
-              <div>{t("settings.cap_skills", undefined, { value: formatCapability(props.openworkServerCapabilities.skills) })}</div>
-              <div>{t("settings.cap_plugins", undefined, { value: formatCapability(props.openworkServerCapabilities.plugins) })}</div>
-              <div>{t("settings.cap_mcp", undefined, { value: formatCapability(props.openworkServerCapabilities.mcp) })}</div>
-              <div>{t("settings.cap_commands", undefined, { value: formatCapability(props.openworkServerCapabilities.commands) })}</div>
-              <div>{t("settings.cap_config", undefined, { value: formatCapability(props.openworkServerCapabilities.config) })}</div>
+              <div>{t("settings.cap_skills", { value: formatCapability(props.openworkServerCapabilities.skills) })}</div>
+              <div>{t("settings.cap_plugins", { value: formatCapability(props.openworkServerCapabilities.plugins) })}</div>
+              <div>{t("settings.cap_mcp", { value: formatCapability(props.openworkServerCapabilities.mcp) })}</div>
+              <div>{t("settings.cap_commands", { value: formatCapability(props.openworkServerCapabilities.commands) })}</div>
+              <div>{t("settings.cap_config", { value: formatCapability(props.openworkServerCapabilities.config) })}</div>
               <div>
-                {t("settings.cap_browser_tools", undefined, {
+                {t("settings.cap_browser_tools", {
                   value: (() => {
                     const browser = props.openworkServerCapabilities.toolProviders?.browser;
                     if (!browser?.enabled) return t("settings.disabled");
@@ -521,7 +521,7 @@ export function DebugView(props: DebugViewProps) {
                 })}
               </div>
               <div>
-                {t("settings.cap_file_tools", undefined, {
+                {t("settings.cap_file_tools", {
                   value: (() => {
                     const files = props.openworkServerCapabilities.toolProviders?.files;
                     if (!files) return t("config.unavailable");
@@ -533,7 +533,7 @@ export function DebugView(props: DebugViewProps) {
                 })}
               </div>
               <div>
-                {t("settings.cap_sandbox", undefined, {
+                {t("settings.cap_sandbox", {
                   value: props.openworkServerCapabilities.sandbox
                     ? `${props.openworkServerCapabilities.sandbox.backend} (${props.openworkServerCapabilities.sandbox.enabled ? t("settings.on") : t("settings.off")})`
                     : t("config.unavailable"),
@@ -648,7 +648,7 @@ export function DebugView(props: DebugViewProps) {
           </div>
         </div>
         <div className="text-[11px] text-dls-secondary">
-          {t("settings.developer_log_count", undefined, { count: String(props.developerLogRecordCount) })}
+          {t("settings.developer_log_count", { count: String(props.developerLogRecordCount) })}
         </div>
         <pre className={monoPreClass}>{props.developerLogText || t("settings.developer_log_empty")}</pre>
         {props.developerLogStatus ? <StatusBanner tone="info" message={props.developerLogStatus} /> : null}
@@ -681,9 +681,9 @@ export function DebugView(props: DebugViewProps) {
           </div>
           {props.sandboxProbeResult ? (
             <div className="space-y-1 text-[12px] text-dls-secondary">
-              <div>{t("settings.sandbox_run_id", undefined, { id: props.sandboxProbeResult.runId ?? "—" })}</div>
+              <div>{t("settings.sandbox_run_id", { id: props.sandboxProbeResult.runId ?? "—" })}</div>
               <div>
-                {t("settings.sandbox_result", undefined, {
+                {t("settings.sandbox_result", {
                   status: props.sandboxProbeResult.ready ? t("settings.sandbox_ready") : t("settings.sandbox_error"),
                 })}
               </div>

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -157,12 +157,12 @@ function describeEngine(info: EngineInfo | null) {
   return {
     ...statusPill(running),
     lines: [
-      t("settings.debug_base_url", undefined, { url: info?.baseUrl ?? "—" }),
-      t("settings.debug_runtime", undefined, { runtime: info?.runtime ?? "—" }),
-      t("settings.diag_opencode_binary", undefined, { binary: formatOpencodeBinary(info) }),
-      t("settings.debug_pid", undefined, { pid: info?.pid ? String(info.pid) : "—" }),
-      t("settings.debug_hostname", undefined, { hostname: info?.hostname ?? "—" }),
-      t("settings.debug_port", undefined, { port: info?.port ? String(info.port) : "—" }),
+      t("settings.debug_base_url", { url: info?.baseUrl ?? "—" }),
+      t("settings.debug_runtime", { runtime: info?.runtime ?? "—" }),
+      t("settings.diag_opencode_binary", { binary: formatOpencodeBinary(info) }),
+      t("settings.debug_pid", { pid: info?.pid ? String(info.pid) : "—" }),
+      t("settings.debug_hostname", { hostname: info?.hostname ?? "—" }),
+      t("settings.debug_port", { port: info?.port ? String(info.port) : "—" }),
     ],
     stdout: info?.lastStdout ?? null,
     stderr: info?.lastStderr ?? null,
@@ -193,13 +193,13 @@ function describeOpenworkServer(info: OpenworkServerInfo | null) {
   return {
     ...statusPill(running),
     lines: [
-      t("settings.debug_base_url", undefined, { url: info?.baseUrl ?? "—" }),
-      t("settings.diag_opencode_binary", undefined, { binary: formatManagedOpencodeBinary(info) }),
-      t("settings.debug_connect_url", undefined, { url: info?.connectUrl ?? "—" }),
-      t("settings.debug_lan_url", undefined, { url: info?.lanUrl ?? "—" }),
-      t("settings.debug_mdns_url", undefined, { url: info?.mdnsUrl ?? "—" }),
-      t("settings.debug_pid", undefined, { pid: info?.pid ? String(info.pid) : "—" }),
-      t("settings.debug_remote_access", undefined, {
+      t("settings.debug_base_url", { url: info?.baseUrl ?? "—" }),
+      t("settings.diag_opencode_binary", { binary: formatManagedOpencodeBinary(info) }),
+      t("settings.debug_connect_url", { url: info?.connectUrl ?? "—" }),
+      t("settings.debug_lan_url", { url: info?.lanUrl ?? "—" }),
+      t("settings.debug_mdns_url", { url: info?.mdnsUrl ?? "—" }),
+      t("settings.debug_pid", { pid: info?.pid ? String(info.pid) : "—" }),
+      t("settings.debug_remote_access", {
         value: info?.remoteAccessEnabled ? t("settings.on") : t("settings.off"),
       }),
     ],
@@ -214,9 +214,9 @@ function describeOpencodeConnect(engine: EngineInfo | null) {
   return {
     ...statusPill(running),
     lines: [
-      t("settings.debug_base_url", undefined, { url: engine?.baseUrl ?? "—" }),
-      t("settings.debug_project_dir", undefined, { path: engine?.projectDir ?? "—" }),
-      t("settings.debug_runtime", undefined, { runtime: engine?.runtime ?? "—" }),
+      t("settings.debug_base_url", { url: engine?.baseUrl ?? "—" }),
+      t("settings.debug_project_dir", { path: engine?.projectDir ?? "—" }),
+      t("settings.debug_runtime", { runtime: engine?.runtime ?? "—" }),
     ],
     metricsLines: [] as string[],
     error: null as string | null,
@@ -785,14 +785,14 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       await bootFullEngineStack();
       setOpencodeServiceStatus({
         tone: "success",
-        message: t("settings.restart_succeeded_template", undefined, { service: "OpenCode" }),
+        message: t("settings.restart_succeeded_template", { service: "OpenCode" }),
       });
       pushDeveloperLog("Restarted OpenCode via engine_start");
     } catch (error) {
       const message = error instanceof Error ? error.message : safeStringify(error);
       setOpencodeServiceStatus({
         tone: "error",
-        message: `${t("settings.restart_failed_template", undefined, { service: "OpenCode" })} ${message}`,
+        message: `${t("settings.restart_failed_template", { service: "OpenCode" })} ${message}`,
       });
       setServiceRestartError(message);
     } finally {
@@ -811,7 +811,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       });
       setOpenworkServiceStatus({
         tone: "success",
-        message: t("settings.restart_succeeded_template", undefined, { service: "OpenWork server" }),
+        message: t("settings.restart_succeeded_template", { service: "OpenWork server" }),
       });
       pushDeveloperLog("Restarted openwork-server");
       await openworkServerStore.reconnectOpenworkServer();
@@ -819,7 +819,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       const message = error instanceof Error ? error.message : safeStringify(error);
       setOpenworkServiceStatus({
         tone: "error",
-        message: `${t("settings.restart_failed_template", undefined, { service: "OpenWork server" })} ${message}`,
+        message: `${t("settings.restart_failed_template", { service: "OpenWork server" })} ${message}`,
       });
       setServiceRestartError(message);
     } finally {
@@ -851,7 +851,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     }
     try {
       await navigator.clipboard.writeText(text);
-      setOpencodeLogStatus(t("settings.copied_service_logs", undefined, { service: "OpenCode" }));
+      setOpencodeLogStatus(t("settings.copied_service_logs", { service: "OpenCode" }));
     } catch (error) {
       setOpencodeLogStatus(error instanceof Error ? error.message : safeStringify(error));
     }
@@ -884,7 +884,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     }
     try {
       await navigator.clipboard.writeText(text);
-      setOpenworkLogStatus(t("settings.copied_service_logs", undefined, { service: "OpenWork server" }));
+      setOpenworkLogStatus(t("settings.copied_service_logs", { service: "OpenWork server" }));
     } catch (error) {
       setOpenworkLogStatus(error instanceof Error ? error.message : safeStringify(error));
     }


### PR DESCRIPTION
## Summary
- Restore Settings > Debug interpolation so runtime values replace `{version}`, `{url}`, `{count}`, and related placeholders.
- Update Debug page callsites to the current `t(key, params)` signature.
- Add `t()` compatibility for stale old-signature callsites so missed usages do not silently render placeholders.

## Verification
- `git diff --check` passed.
- `pnpm --filter @openwork/app typecheck` was run after `pnpm install`; it still fails on pre-existing unrelated errors in provider auth, OpenCode Router messaging types, automations settings route references, and createClient call signatures. The i18n changes no longer produce type errors.