### PR TITLE
fix(server): verify built binary embeds compiled openwork-server

### DIFF
--- a/apps/server/script/build.ts
+++ b/apps/server/script/build.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const bunRuntime = (globalThis as typeof globalThis & {
@@ -88,6 +88,43 @@ function outputName(filename: string, target?: string) {
   return `${filename}${suffix}${ext}`;
 }
 
+function targetMatchesHost(target?: string): boolean {
+  if (!target) return true;
+  const isWindowsTarget = target.includes("windows");
+  const isLinuxTarget = target.includes("linux");
+  const isDarwinTarget = target.includes("darwin");
+  if (process.platform === "win32") return isWindowsTarget;
+  if (process.platform === "linux") return isLinuxTarget;
+  if (process.platform === "darwin") return isDarwinTarget;
+  return false;
+}
+
+function readPackageVersion(): string | null {
+  try {
+    const pkg = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function verifyBuiltBinary(outfile: string, expectedVersion: string | null) {
+  if (!expectedVersion) return;
+  const result = spawnSync(outfile, ["--version"], { encoding: "utf8" });
+  const stdout = (result.stdout ?? "").trim();
+  if (result.status === 0 && stdout === expectedVersion) return;
+  console.error(
+    [
+      `openwork-server build verification failed for ${outfile}.`,
+      `  expected --version: ${expectedVersion}`,
+      `  actual exit status: ${result.status ?? "unknown"}`,
+      `  actual stdout:      ${stdout || "(empty)"}`,
+      "  the binary may be a bare Bun runtime instead of a compiled openwork-server.",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
 async function buildOnce(entrypoint: string, outdir: string, filename: string, target?: string) {
   mkdirSync(outdir, { recursive: true });
   const outfile = join(outdir, outputName(filename, target));
@@ -100,6 +137,10 @@ async function buildOnce(entrypoint: string, outdir: string, filename: string, t
   const result = spawnSync("bun", args, { stdio: "inherit" });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
+  }
+
+  if (targetMatchesHost(target)) {
+    verifyBuiltBinary(outfile, readPackageVersion());
   }
 }
 


### PR DESCRIPTION
Closes #1229

## Summary
- Run the produced `openwork-server` binary with `--version` immediately after `bun build --compile` and confirm the output matches the package version.
- Fail the build loudly when the produced binary is a bare Bun runtime (or anything else that does not respond with the expected version), so a stub binary cannot ship in a desktop `.deb` and propagate to AUR.
- Skip the verification step for cross-target builds where the host cannot execute the produced binary.

## Verification
- `pnpm --filter openwork-server typecheck` clean.
- `bun ./script/build.ts --outdir /tmp/owork-server-test --filename openwork-server` produces a working binary; `/tmp/owork-server-test/openwork-server --version` prints the package version.
- Replacing the produced binary with a copy of the host `bun` and re-running the verification logic exits non-zero with `expected --version: 0.13.3` / `actual stdout: 1.3.6`, matching the symptom in the issue.

## Notes
- Out of scope: changing the `build:bin` shorthand in `apps/server/package.json` (developer convenience path) and the equivalent server-v2 build script. The release path that feeds Tauri `externalBin` and the `.deb` asset goes through `apps/desktop/scripts/prepare-sidecar.mjs` -> `apps/server/script/build.ts`, which is what this PR hardens.