### PR TITLE
feat(app): expose Add MCP from the command palette

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -814,6 +814,8 @@ export default {
   "session.cmd_agent_default_detail": "Use the engine's default agent",
   "session.cmd_agents_detail": "Choose which agent runs your prompts",
   "session.cmd_agents_title": "Switch agent",
+  "session.cmd_add_mcp_detail": "Open the Apps & MCP page to connect a new integration",
+  "session.cmd_add_mcp_title": "Add MCP",
   "session.cmd_current_workspace": "Current workspace",
   "session.cmd_new_session_detail": "Start a fresh task in the current workspace",
   "session.cmd_new_session_meta": "Create",

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -286,6 +286,16 @@ export function CommandPalette(props: CommandPaletteProps) {
       },
     },
     {
+      id: "settings-add-mcp",
+      title: t("session.cmd_add_mcp_title"),
+      detail: t("session.cmd_add_mcp_detail"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        props.onOpenSettings("/settings/extensions/mcp");
+      },
+    },
+    {
       id: "settings-appearance",
       title: t("settings.tab_appearance"),
       detail: t("settings.tab_description_appearance"),


### PR DESCRIPTION
Closes #1142

## Summary
- Add a dedicated `Add MCP` row to the React command palette right after the existing `Extensions` shortcut so the primary integration entry point is one Cmd/Ctrl+K stroke away.
- Route the new entry to `/settings/extensions/mcp` so the user lands on the dedicated MCP filter where the existing prominent `+ Add MCP` CTA card is the first thing on screen.
- Add `session.cmd_add_mcp_title` and `session.cmd_add_mcp_detail` to `en.ts` so the row reads in English.

## Verification
- `node scripts/i18n-audit.mjs --ci` passes.
- `pnpm --filter @openwork/app typecheck` currently fails on a pre-existing `origin/dev` error in the same file (`command-palette.tsx:97` — `t()` arity mismatch on `session.cmd_sessions_detail`); this branch does not touch that line.

## Notes
- Existing locales follow the en source on demand (audit confirms 91-94% completeness across non-en locales today); the two new keys will surface in the next translation pass alongside the rest of the gap.
- Out of scope: auto-opening the `AddMcpModal` from the route. The CTA card on the destination page is already the most prominent action, so a single navigation keeps the change surgical.