### PR TITLE
feat(app): default updateAutoDownload to true for new and unconfigured users

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -403,7 +403,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     readStoredBoolean(SETTINGS_UPDATE_AUTO_CHECK_KEY, true),
   );
   const [updateAutoDownload, setUpdateAutoDownload] = useState(() =>
-    readStoredBoolean(SETTINGS_UPDATE_AUTO_DOWNLOAD_KEY, false),
+    readStoredBoolean(SETTINGS_UPDATE_AUTO_DOWNLOAD_KEY, true),
   );
   const [configActionStatus, setConfigActionStatus] = useState<string | null>(null);
   const [revealConfigBusy, setRevealConfigBusy] = useState(false);


### PR DESCRIPTION
Refs #1095

## Summary
- Flip the React Settings auto-download default from `false` to `true` so a fresh install opts in to downloading updates as soon as auto-check finds them.
- Use the same flip to migrate existing users who never opened the Updates toggle: `readStoredBoolean(KEY, true)` returns `true` only when no value has ever been written, so anyone who explicitly toggled the switch off keeps their stored `"0"` and stays opted out.
- Auto-check (already `true` by default) and the manual check / install flows remain unchanged.

## Verification
- `pnpm --filter @openwork/app typecheck` currently fails on pre-existing `origin/dev` errors in `settings-route.tsx` lines 1324-1557 (automations and messaging tabs in flight) and `messaging-view-state.ts`; this branch only touches line 367.
- `git diff --check` clean.

## Notes
- Out of scope: the pill-like updates presentation, the visible upgrade banner, and the backend-gated required-update path described on the issue. They depend on design and backend coordination and are better landed separately.
- Existing users who installed the app, never visited Settings > Updates, and stayed on default `false` will move to `true` on first run after this lands; this matches the issue's "existing users where safe" wording since auto-check was already on for them and only the download step changes.