### PR TITLE
fix(desktop): handle alpha updater versions

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -917,7 +917,7 @@ export default {
   "settings.auto_compact_desc": "Controls OpenCode compaction.auto for this workspace. Reload the engine after changing it.",
   "settings.auto_update_desc": "Download updates automatically (prompts to",
   "settings.auto_update_title": "Auto-update",
-  "settings.background_checks_desc": "OpenWork always checks on launch. Also checks once",
+  "settings.background_checks_desc": "OpenWork checks on launch and when this page opens.",
   "settings.background_checks_title": "Background checks",
   "settings.cache_repair_requires_desktop": "Cache repair requires the desktop app",
   "settings.cap_browser_tools": "Browser tools: {value}",

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -30,6 +30,7 @@ type TauriUpdate = {
 type UseElectronUpdaterStateOptions = {
   releaseChannel: ReleaseChannel;
   onReleaseChannelChange: (next: ReleaseChannel) => void;
+  updateAutoCheck: boolean;
   updateAutoDownload: boolean;
   desktopConfig: DenDesktopConfig | null | undefined;
   setError: (message: string | null) => void;
@@ -75,11 +76,12 @@ function updateProgress(event: unknown): { downloaded?: number; total?: number }
 }
 
 export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions) {
-  const { releaseChannel, onReleaseChannelChange, updateAutoDownload, desktopConfig, setError } = options;
+  const { releaseChannel, onReleaseChannelChange, updateAutoCheck, updateAutoDownload, desktopConfig, setError } = options;
   const [updateStatus, setUpdateStatus] = useState<SettingsUpdateStatus>(null);
   const [appVersion, setAppVersion] = useState<string | null>(null);
   const [updateEnv, setUpdateEnv] = useState<{ supported?: boolean; reason?: string | null } | null>(null);
   const tauriUpdateRef = useRef<TauriUpdate | null>(null);
+  const autoCheckKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (isTauriRuntime()) {
@@ -310,6 +312,14 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       setUpdateStatus({ state: "error", message: describeError(error) });
     }
   }, [desktopConfig, downloadUpdate, onReleaseChannelChange, releaseChannel, setError, updateAutoDownload]);
+
+  useEffect(() => {
+    if (!updateAutoCheck || updateEnv?.supported === false) return;
+    const key = `${releaseChannel}:${appVersion ?? "unknown"}`;
+    if (autoCheckKeyRef.current === key) return;
+    autoCheckKeyRef.current = key;
+    void checkForUpdates();
+  }, [appVersion, checkForUpdates, releaseChannel, updateAutoCheck, updateEnv?.supported]);
 
   const installUpdateAndRestart = useCallback(async () => {
     if (isTauriRuntime()) {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -666,6 +666,7 @@ export function SettingsRoute() {
   const electronUpdaterState = useElectronUpdaterState({
     releaseChannel: local.prefs.releaseChannel ?? "stable",
     onReleaseChannelChange,
+    updateAutoCheck,
     updateAutoDownload,
     desktopConfig: desktopConfig.config,
     setError: setRouteError,

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -68,6 +68,78 @@ function electronUpdaterFeedUrl(channel) {
   return ELECTRON_UPDATER_FEEDS[normalizeElectronUpdaterChannel(channel)];
 }
 
+function parseComparableVersion(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().replace(/^v/i, "");
+  if (!normalized) return null;
+
+  const [versionCore] = normalized.split("+", 1);
+  if (!versionCore) return null;
+
+  const [releasePart, prereleasePart = ""] = versionCore.split("-", 2);
+  const release = releasePart.split(".").map((segment) => Number(segment));
+  if (!release.length || release.some((segment) => !Number.isInteger(segment) || segment < 0)) {
+    return null;
+  }
+
+  const prerelease = prereleasePart
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  return { release, prerelease };
+}
+
+function comparePrereleaseIdentifiers(left, right) {
+  if (!left.length && !right.length) return 0;
+  if (!left.length) return 1;
+  if (!right.length) return -1;
+
+  const count = Math.max(left.length, right.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+
+    const leftNumeric = /^\d+$/.test(leftPart) ? Number(leftPart) : null;
+    const rightNumeric = /^\d+$/.test(rightPart) ? Number(rightPart) : null;
+
+    if (leftNumeric !== null && rightNumeric !== null) {
+      if (leftNumeric !== rightNumeric) return leftNumeric < rightNumeric ? -1 : 1;
+      continue;
+    }
+
+    if (leftNumeric !== null) return -1;
+    if (rightNumeric !== null) return 1;
+
+    const comparison = leftPart.localeCompare(rightPart);
+    if (comparison !== 0) return comparison < 0 ? -1 : 1;
+  }
+
+  return 0;
+}
+
+function compareVersions(left, right) {
+  const parsedLeft = parseComparableVersion(left);
+  const parsedRight = parseComparableVersion(right);
+  if (!parsedLeft || !parsedRight) return null;
+
+  const count = Math.max(parsedLeft.release.length, parsedRight.release.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = parsedLeft.release[index] ?? 0;
+    const rightPart = parsedRight.release[index] ?? 0;
+    if (leftPart !== rightPart) return leftPart < rightPart ? -1 : 1;
+  }
+
+  return comparePrereleaseIdentifiers(parsedLeft.prerelease, parsedRight.prerelease);
+}
+
+function isVersionNewer(candidate, current) {
+  const comparison = compareVersions(candidate, current);
+  return comparison === null ? candidate !== current : comparison > 0;
+}
+
 function updaterChannelState(app, channel) {
   const normalized = normalizeElectronUpdaterChannel(channel);
   return {
@@ -92,6 +164,7 @@ async function applyElectronUpdaterFeed(app, updater) {
 export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
   let autoUpdaterInstance = null;
   let autoUpdaterLoaded = false;
+  let checkedUpdateVersion = null;
 
   function sendToRenderer(channel, data) {
     try {
@@ -144,6 +217,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
 
   ipcMain.handle("openwork:updater:setChannel", async (_event, rawChannel) => {
     const channel = await writeElectronUpdaterChannel(app, rawChannel);
+    checkedUpdateVersion = null;
     const updater = await ensureAutoUpdater();
     if (updater) {
       return applyElectronUpdaterFeed(app, updater);
@@ -160,15 +234,19 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     try {
       const result = await updater.checkForUpdates();
       const info = result?.updateInfo ?? null;
+      const currentVersion = resolveAppVersion(app);
+      const available = Boolean(info?.version && isVersionNewer(info.version, currentVersion));
+      checkedUpdateVersion = available ? info.version : null;
       return {
-        available: Boolean(info && info.version && info.version !== resolveAppVersion(app)),
-        currentVersion: resolveAppVersion(app),
+        available,
+        currentVersion,
         latestVersion: info?.version ?? null,
         releaseDate: info?.releaseDate ?? null,
         releaseNotes: info?.releaseNotes ?? null,
         ...channelState,
       };
     } catch (error) {
+      checkedUpdateVersion = null;
       return { available: false, reason: String(error?.message ?? error), ...channelState };
     }
   });
@@ -177,6 +255,18 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
+      await applyElectronUpdaterFeed(app, updater);
+      const currentVersion = resolveAppVersion(app);
+      if (!checkedUpdateVersion || !isVersionNewer(checkedUpdateVersion, currentVersion)) {
+        const result = await updater.checkForUpdates();
+        const info = result?.updateInfo ?? null;
+        checkedUpdateVersion = info?.version && isVersionNewer(info.version, currentVersion)
+          ? info.version
+          : null;
+      }
+      if (!checkedUpdateVersion) {
+        return { ok: false, reason: "No update available." };
+      }
       await updater.downloadUpdate();
       return { ok: true };
     } catch (error) {


### PR DESCRIPTION
## Summary
- Compare Electron updater versions semver-style so alpha build metadata does not make the current build look outdated.
- Revalidate update availability before download to avoid leaking electron-updater's \"Please check update first\" error.
- Wire Settings background checks to auto-check the active release channel when Updates opens, including alpha.

## Verification
- `pnpm --filter @openwork/desktop check:electron`
- `node -e \"import('./apps/desktop/electron/updater.mjs').then(() => console.log('updater import ok'))\"`

## Not Run
- `pnpm --filter @openwork/app typecheck` (blocked locally because this worktree is missing dependencies: `tsup` / `node_modules`).
- Packaged Electron updater end-to-end flow (requires a packaged build pointed at the release feed).