### PR TITLE
fix(updater): refresh checks after channel switch

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -126,7 +126,8 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     };
   }, [onReleaseChannelChange, releaseChannel]);
 
-  const downloadUpdate = useCallback(async () => {
+  const downloadUpdate = useCallback(async (channelOverride?: ReleaseChannel) => {
+    const activeReleaseChannel = channelOverride ?? releaseChannel;
     if (isTauriRuntime()) {
       let update = tauriUpdateRef.current;
       if (!update) {
@@ -139,7 +140,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         return;
       }
       const allowed = update.version
-        ? releaseChannel === "alpha"
+        ? activeReleaseChannel === "alpha"
           ? await isAlphaUpdateAllowed(update.version, desktopConfig)
           : await isUpdateAllowed(update.version, desktopConfig)
         : true;
@@ -219,7 +220,8 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     }
   }, [desktopConfig, releaseChannel, setError]);
 
-  const checkForUpdates = useCallback(async () => {
+  const checkForUpdates = useCallback(async (channelOverride?: ReleaseChannel) => {
+    const activeReleaseChannel = channelOverride ?? releaseChannel;
     if (isTauriRuntime()) {
       setUpdateStatus({ state: "checking" });
       try {
@@ -227,7 +229,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         const update = (await check()) as TauriUpdate | null;
         const allowed = !update?.version
           ? true
-          : releaseChannel === "alpha"
+          : activeReleaseChannel === "alpha"
             ? await isAlphaUpdateAllowed(update.version, desktopConfig)
             : await isUpdateAllowed(update.version, desktopConfig);
         if (!allowed) {
@@ -247,7 +249,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
           : { state: "idle", lastCheckedAt: Date.now() };
         setUpdateStatus(nextStatus);
         if (update && updateAutoDownload) {
-          await downloadUpdate();
+          await downloadUpdate(activeReleaseChannel);
         }
       } catch (error) {
         setUpdateStatus({ state: "error", message: describeError(error) });
@@ -282,8 +284,9 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         return;
       }
 
+      const checkedReleaseChannel = result.channel ?? activeReleaseChannel;
       const availableAllowed = result.available && result.latestVersion
-        ? releaseChannel === "alpha"
+        ? checkedReleaseChannel === "alpha"
           ? await isAlphaUpdateAllowed(result.latestVersion, desktopConfig)
           : await isUpdateAllowed(result.latestVersion, desktopConfig)
         : result.available;
@@ -304,7 +307,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
           };
       setUpdateStatus(nextStatus);
       if (availableAllowed && updateAutoDownload) {
-        await downloadUpdate();
+        await downloadUpdate(checkedReleaseChannel);
       }
     } catch (error) {
       setUpdateStatus({ state: "error", message: describeError(error) });
@@ -346,12 +349,12 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         if (state.channel && state.channel !== next) {
           onReleaseChannelChange(state.channel);
         }
-        setUpdateStatus({ state: "idle", lastCheckedAt: null });
+        await checkForUpdates(state.channel ?? next);
       } catch (error) {
         setUpdateStatus({ state: "error", message: describeError(error) });
       }
     },
-    [onReleaseChannelChange],
+    [checkForUpdates, onReleaseChannelChange],
   );
 
   return {

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -81,6 +81,9 @@ async function applyElectronUpdaterFeed(app, updater) {
   const channel = await readElectronUpdaterChannel(app);
   const state = updaterChannelState(app, channel);
   updater.allowPrerelease = state.channel === "alpha";
+  // Moving from alpha back to stable can be a semver downgrade; still show
+  // the latest stable so users can return to the stable channel deliberately.
+  updater.allowDowngrade = state.channel === "stable";
   if (updater?.setFeedURL) {
     updater.setFeedURL({ provider: "generic", url: state.feedUrl });
   }


### PR DESCRIPTION
## Summary
- Re-checks for updates immediately after the desktop release channel is changed.
- Uses the updater bridge's applied channel when gating available updates so checks do not use stale React state.
- Allows stable-channel downgrade checks so users can return from alpha to the latest stable build.

## Verification
- `node --check apps/desktop/electron/updater.mjs`
- `pnpm --filter @openwork/app typecheck` (fails on existing unrelated TypeScript errors in provider auth, messaging, and settings shell code; no errors reported in the updater files changed here)

## Notes
- Full auto-updater validation requires a packaged Electron build because `electron-updater` is packaged-only.