### PR TITLE
fix(desktop): respect opencode jsonc on Electron startup

### DIFF
--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -936,11 +936,12 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function ensureOpencodeConfig(projectDir) {
-    const configPath = path.join(projectDir, "opencode.json");
-    if (await fileExists(configPath)) return;
+    const jsoncPath = path.join(projectDir, "opencode.jsonc");
+    const jsonPath = path.join(projectDir, "opencode.json");
+    if ((await fileExists(jsoncPath)) || (await fileExists(jsonPath))) return;
     await mkdir(projectDir, { recursive: true });
     await writeFile(
-      configPath,
+      jsoncPath,
       `${JSON.stringify({ $schema: "https://opencode.ai/config.json" }, null, 2)}\n`,
       "utf8",
     );


### PR DESCRIPTION
## Summary
- Update Electron startup config bootstrap to respect an existing `opencode.jsonc` before creating config.
- Create `opencode.jsonc` when neither `opencode.jsonc` nor `opencode.json` exists, matching the rest of the app config preference.

## Verification
- `node --check apps/desktop/electron/runtime.mjs`
- `pnpm --filter @openwork/desktop check:electron`