### PR TITLE
fix(app): scope session routes by workspace

### DIFF
--- a/apps/app/src/react-app/ARCHITECTURE.md
+++ b/apps/app/src/react-app/ARCHITECTURE.md
@@ -94,6 +94,46 @@ Cross-domain imports go through module boundaries, not a shared blob.
 - Feature-specific state that is tightly coupled to one domain lives inside that domain
   (`domains/session/sync/`, `domains/settings/state/`).
 
+## Active workspace and session
+
+Workspace and session identity are route state, not app-global mutable state.
+
+Canonical workspace-scoped routes:
+
+- `/workspace/:workspaceId/session`
+- `/workspace/:workspaceId/session/:sessionId`
+- `/workspace/:workspaceId/settings/:tab`
+- `/workspace/:workspaceId/settings/extensions/:section`
+
+Use `react-app/shell/workspace-routes.ts` to build these paths. Do not hand-build `/session/...`
+or `/settings/...` URLs for workspace-scoped flows.
+
+Rules for agents and future code:
+
+- In session or workspace-scoped settings routes, read the active workspace from the URL
+  `workspaceId` param first.
+- Read the active session from the URL `sessionId` param. A selected session should never imply a
+  different workspace than the URL workspace.
+- The legacy `openwork.react.activeWorkspace` and `openwork.react.sessionByWorkspace` values are
+  only restore/fallback memory. They are not authoritative while a workspace-scoped URL is active.
+- `/session`, `/session/:sessionId`, and `/settings/*` are compatibility entry points. They should
+  redirect to workspace-scoped URLs when the workspace can be resolved.
+- Missing URL resources should not silently fall back to the first workspace. Show a not-found state
+  and let the user pick a workspace/session from the sidebar.
+- Workspace-scoped actions (rename workspace, create session, open MCP/settings tabs, quick actions,
+  commands, delete session) should use the URL-derived workspace/session context or receive explicit
+  workspace/session ids from the caller.
+
+Practical examples:
+
+- From session B in workspace B, opening settings should navigate to
+  `/workspace/B/settings/general`.
+- Opening a session from the command palette should navigate to
+  `/workspace/<owner-workspace-id>/session/<session-id>`, where the owner is found from the session
+  list.
+- Creating a new task in a workspace should navigate to
+  `/workspace/<workspace-id>/session/<new-session-id>`.
+
 ## Framework-agnostic boundary
 
 Anything that is already Solid-free stays under `src/app/` and is re-exported from the React

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -122,6 +122,7 @@ export type SessionPageProps = {
   questionReplyBusy?: boolean;
   respondQuestion?: (requestID: string, answers: string[][]) => void;
   statusBar?: Partial<StatusBarOverrides>;
+  notFoundMessage?: string | null;
   onRenameSession?: (sessionId: string, title: string) => Promise<void> | void;
   onDeleteSession?: (sessionId: string) => Promise<void> | void;
 };
@@ -434,7 +435,14 @@ export function SessionPage(props: SessionPageProps) {
 
               {!showDelayedSessionLoadingState && !canRenderReactSurface && !showStartupSkeleton ? (
                 <div className={`mx-auto max-w-[800px] px-6 ${showWorkspaceSetupEmptyState ? "pt-20" : "pt-10"}`}>
-                  {showWorkspaceSetupEmptyState ? (
+                  {props.notFoundMessage ? (
+                    <div className="px-6 py-16 text-center">
+                      <div className="mx-auto max-w-md rounded-2xl border border-dls-border bg-dls-card px-5 py-6 shadow-[var(--dls-card-shadow)]">
+                        <h3 className="text-base font-medium text-dls-text">Workspace or session not found</h3>
+                        <p className="mt-2 text-sm leading-6 text-dls-secondary">{props.notFoundMessage}</p>
+                      </div>
+                    </div>
+                  ) : showWorkspaceSetupEmptyState ? (
                     <div className="space-y-6 px-6 text-center">
                       <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl border border-dls-border bg-dls-hover">
                         <Zap className="text-dls-secondary" />

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../../app/lib/opencode-session";
 import { finishPerf, perfNow, recordPerfLog } from "../../../../app/lib/perf-log";
 import { toSessionTransportDirectory } from "../../../../app/lib/session-scope";
+import { workspaceSessionRoute } from "../../../shell/workspace-routes";
 import type {
   Client,
   ComposerAttachment,
@@ -423,7 +424,7 @@ export function createSessionActionsStore(options: {
 
       await options.refreshSidebarWorkspaceSessions(id).catch(() => undefined);
 
-      options.navigate(`/session/${session.id}`);
+      options.navigate(workspaceSessionRoute(id, session.id));
 
       finishPerf(perfEnabled, "session.create", "done", startedAt, {
         runId,
@@ -792,8 +793,8 @@ export function createSessionActionsStore(options: {
 
     try {
       const path = options.locationPath().toLowerCase();
-      if (path === `/session/${trimmed.toLowerCase()}`) {
-        options.navigate("/session", { replace: true });
+      if (path === `/session/${trimmed.toLowerCase()}` || path.endsWith(`/session/${trimmed.toLowerCase()}`)) {
+        options.navigate(workspaceSessionRoute(options.selectedWorkspaceId()), { replace: true });
       }
     } catch {
       // ignore

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -130,6 +130,30 @@ export function AppRoot() {
                 }
               />
               <Route
+                path="/workspace/:workspaceId/session"
+                element={
+                  <DevProfiler id="SessionRoute">
+                    <SessionRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
+                path="/workspace/:workspaceId/session/:sessionId"
+                element={
+                  <DevProfiler id="SessionRoute">
+                    <SessionRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
+                path="/workspace/:workspaceId/settings/*"
+                element={
+                  <DevProfiler id="SettingsRoute">
+                    <SettingsRoute />
+                  </DevProfiler>
+                }
+              />
+              <Route
                 path="/settings/*"
                 element={
                   <DevProfiler id="SettingsRoute">

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -108,6 +108,7 @@ import { useReloadCoordinator } from "./reload-coordinator";
 import { getReactQueryClient } from "../infra/query-client";
 import { useStatusToasts } from "../domains/shell-feedback/status-toasts";
 import { useSessionControlActions } from "../domains/session/control/session-control-actions";
+import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 
 type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
@@ -348,8 +349,17 @@ export function SessionRoute() {
   const { showToast } = useStatusToasts();
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const restrictionNotice = useRestrictionNotice();
-  const params = useParams<{ sessionId?: string }>();
+  const params = useParams<{ workspaceId?: string; sessionId?: string }>();
+  const routeWorkspaceId = params.workspaceId?.trim() || "";
   const selectedSessionId = params.sessionId?.trim() || null;
+  const navigateToWorkspaceSession = useCallback((workspaceId: string, sessionId?: string | null, options?: { replace?: boolean }) => {
+    const id = workspaceId.trim();
+    if (!id) {
+      navigate(legacySessionRoute(sessionId), options);
+      return;
+    }
+    navigate(workspaceSessionRoute(id, sessionId), options);
+  }, [navigate]);
 
   const { markRouteReady: markBootRouteReady } = useBootState();
   const [loading, setLoading] = useState(true);
@@ -361,7 +371,8 @@ export function SessionRoute() {
   const [errorsByWorkspaceId, setErrorsByWorkspaceId] = useState<Record<string, string | null>>({});
   const [workspaceConnectionOverrides, setWorkspaceConnectionOverrides] = useState<Record<string, WorkspaceConnectionState>>({});
   const [routeError, setRouteError] = useState<string | null>(null);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>(() => readActiveWorkspaceId() ?? "");
+  const [legacySelectedWorkspaceId, setLegacySelectedWorkspaceId] = useState<string>(() => readActiveWorkspaceId() ?? "");
+  const selectedWorkspaceId = routeWorkspaceId || legacySelectedWorkspaceId;
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   // One-way latch for "a refreshRouteState is currently running"; prevents
   // overlapping route refreshes from queueing up when the user clicks fast.
@@ -557,7 +568,7 @@ export function SessionRoute() {
         setWorkspaces(desktopWorkspaces);
         setSessionsByWorkspaceId({});
         setErrorsByWorkspaceId({});
-        setSelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "");
+        setLegacySelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "");
         return;
       }
 
@@ -580,6 +591,9 @@ export function SessionRoute() {
       // activeId, the server's activeId, then the first known workspace.
       const persistedActiveId = readActiveWorkspaceId();
       let nextWorkspaceId =
+        (routeWorkspaceId && nextWorkspaces.some((w) => w.id === routeWorkspaceId)
+          ? routeWorkspaceId
+          : "") ||
         (persistedActiveId && nextWorkspaces.some((w) => w.id === persistedActiveId)
           ? persistedActiveId
           : "") ||
@@ -611,7 +625,7 @@ export function SessionRoute() {
           ? [nextWorkspaceId]
           : [],
       );
-      setSelectedWorkspaceId(nextWorkspaceId);
+      setLegacySelectedWorkspaceId(nextWorkspaceId);
       writeActiveWorkspaceId(nextWorkspaceId || null);
       // Mark the chosen workspace as active on the server so that the
       // OpenCode engine bound to it re-reads opencode.jsonc and applies
@@ -646,7 +660,7 @@ export function SessionRoute() {
       setRouteError(message);
       if (desktopWorkspaces.length > 0) {
         setWorkspaces(desktopWorkspaces);
-        setSelectedWorkspaceId((current) =>
+        setLegacySelectedWorkspaceId((current) =>
           current || resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "",
         );
       }
@@ -660,7 +674,7 @@ export function SessionRoute() {
         markBootRouteReady();
       }
     }
-  }, [loadWorkspaceSessionsInBackground, markBootRouteReady, selectedSessionId]);
+  }, [loadWorkspaceSessionsInBackground, markBootRouteReady, routeWorkspaceId, selectedSessionId]);
 
   const remoteAccessRestart = useRemoteAccessRestart({
     isEnabled: () => openworkServerSettings.remoteAccessEnabled === true,
@@ -921,14 +935,25 @@ export function SessionRoute() {
   // restore the last session the user opened in the active workspace.
   useEffect(() => {
     if (loading) return;
+    if (!routeWorkspaceId && selectedWorkspaceId) {
+      navigateToWorkspaceSession(selectedWorkspaceId, selectedSessionId, { replace: true });
+      return;
+    }
     if (selectedSessionId) return;
     if (!selectedWorkspaceId) return;
     const remembered = readLastSessionFor(selectedWorkspaceId);
     if (!remembered) return;
     const sessions = sessionsByWorkspaceId[selectedWorkspaceId] ?? [];
     if (!sessions.some((session: any) => session?.id === remembered)) return;
-    navigate(`/session/${remembered}`, { replace: true });
-  }, [loading, navigate, selectedSessionId, selectedWorkspaceId, sessionsByWorkspaceId]);
+    navigateToWorkspaceSession(selectedWorkspaceId, remembered, { replace: true });
+  }, [
+    loading,
+    navigateToWorkspaceSession,
+    routeWorkspaceId,
+    selectedSessionId,
+    selectedWorkspaceId,
+    sessionsByWorkspaceId,
+  ]);
 
   // Redirect to /welcome when no workspaces exist and the user hasn't
   // completed onboarding. This fires after the initial route refresh so
@@ -953,8 +978,19 @@ export function SessionRoute() {
     [errorsByWorkspaceId, retryingWorkspaceIds, sessionsByWorkspaceId, workspaces],
   );
 
+  const sidebarActiveWorkspaceId = useMemo(() => {
+    const sessionId = selectedSessionId?.trim() ?? "";
+    if (sessionId) {
+      const owner = workspaceSessionGroups.find((group) =>
+        group.sessions.some((session: any) => session?.id === sessionId),
+      );
+      if (owner?.workspace.id) return owner.workspace.id;
+    }
+    return selectedWorkspaceId;
+  }, [selectedSessionId, selectedWorkspaceId, workspaceSessionGroups]);
+
   const selectedWorkspace = useMemo(
-    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? workspaces[0] ?? null,
+    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? (selectedWorkspaceId ? null : workspaces[0] ?? null),
     [selectedWorkspaceId, workspaces],
   );
   const workspaceConnectionStateById = useMemo(() => {
@@ -1002,6 +1038,20 @@ export function SessionRoute() {
   }, [baseUrl, selectedWorkspaceId]);
   const selectedWorkspaceIsLoading = retryingWorkspaceIds.includes(selectedWorkspaceId);
   const selectedWorkspaceError = errorsByWorkspaceId[selectedWorkspaceId] ?? null;
+  const selectedSessionKnown = Boolean(
+    selectedSessionId &&
+      (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).some((session: any) => session?.id === selectedSessionId),
+  );
+  const routeNotFoundMessage = (() => {
+    if (loading) return null;
+    if (routeWorkspaceId && !selectedWorkspace) {
+      return "Workspace was not found. Select a new workspace from the sidebar.";
+    }
+    if (selectedSessionId && !selectedWorkspaceIsLoading && !selectedSessionKnown) {
+      return "Session was not found. Select a new session from the sidebar.";
+    }
+    return null;
+  })();
   // Boot-level loading blocks the whole UI. Session-list retries only fill the
   // sidebar; they must not gate the composer/New task.
   const effectiveLoading = loading;
@@ -1289,6 +1339,14 @@ export function SessionRoute() {
     return listCommands(opencodeClient, selectedWorkspaceRoot || undefined);
   }, [engineReloadVersion, opencodeClient, selectedWorkspaceRoot]);
 
+  const handleOpenSettings = useCallback((route = "/settings/general", workspaceId = sidebarActiveWorkspaceId) => {
+    const sessionId = workspaceId === sidebarActiveWorkspaceId ? selectedSessionId : null;
+    const tab = route.replace(/^\/settings\/?/, "").replace(/^\/+|\/+$/g, "") || "general";
+    const target = workspaceId ? workspaceSettingsRoute(workspaceId, tab) : route;
+    writeActiveWorkspaceId(workspaceId || null);
+    navigate(target, { state: { workspaceId, sessionId } });
+  }, [navigate, selectedSessionId, sidebarActiveWorkspaceId]);
+
   const surfaceProps = useMemo(() => {
     if (!client || !selectedWorkspaceId || !selectedSessionId || !opencodeBaseUrl || !token || !opencodeClient) {
       return null;
@@ -1326,7 +1384,7 @@ export function SessionRoute() {
         setModelPickerOpen(true);
       },
       onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins") => {
-        navigate(section === "skills" ? "/settings/skills" : section === "mcps" ? "/settings/mcp" : section === "plugins" ? "/settings/den" : "/settings/general");
+        handleOpenSettings(section === "skills" ? "/settings/skills" : section === "mcps" ? "/settings/extensions/mcp" : section === "plugins" ? "/settings/extensions/plugins" : "/settings/general");
       },
       onSendDraft: async (draft: ComposerDraft) => {
         const text = (draft.resolvedText ?? draft.text).trim();
@@ -1412,6 +1470,7 @@ export function SessionRoute() {
     };
   }, [
     client,
+    handleOpenSettings,
     local,
     listSlashCommands,
     modelLabel,
@@ -1549,9 +1608,9 @@ export function SessionRoute() {
         await client.deleteWorkspace(workspaceId).catch(() => undefined);
       }
       if (selectedWorkspaceId === workspaceId) {
-        setSelectedWorkspaceId("");
+        setLegacySelectedWorkspaceId("");
         writeActiveWorkspaceId(null);
-        navigate("/session");
+        navigate(legacySessionRoute());
       }
       forgetWorkspaceMemory(workspaceId);
       await refreshRouteState();
@@ -1640,14 +1699,14 @@ export function SessionRoute() {
       const session = unwrap(
         await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
       );
-      setSelectedWorkspaceId(workspaceId);
+      setLegacySelectedWorkspaceId(workspaceId);
       writeActiveWorkspaceId(workspaceId || null);
       writeLastSessionFor(workspaceId, session.id);
       setSessionsByWorkspaceId((current) => ({
         ...current,
         [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
       }));
-      navigate(`/session/${session.id}`);
+      navigateToWorkspaceSession(workspaceId, session.id);
       void refreshRouteState();
     } catch (error) {
       const message = describeRouteError(error);
@@ -1663,7 +1722,7 @@ export function SessionRoute() {
         }
       }
     }
-  }, [baseUrl, errorsByWorkspaceId, loading, navigate, refreshRouteState, retryingWorkspaceIds, token, workspaces]);
+  }, [baseUrl, errorsByWorkspaceId, loading, navigateToWorkspaceSession, refreshRouteState, retryingWorkspaceIds, token, workspaces]);
 
   // Global shortcuts:
   //   Cmd/Ctrl+N  -> new task in selected workspace
@@ -1700,12 +1759,15 @@ export function SessionRoute() {
   }, [canCreateTask, handleCreateTaskInWorkspace, selectedWorkspaceId]);
 
   const navigateToSessionForControl = useCallback((sessionId: string) => {
-    navigate(`/session/${sessionId}`);
-  }, [navigate]);
+    const owner = Object.entries(sessionsByWorkspaceId).find(([, sessions]) =>
+      (sessions ?? []).some((session: any) => session?.id === sessionId),
+    )?.[0];
+    navigateToWorkspaceSession(owner || selectedWorkspaceId, sessionId);
+  }, [navigateToWorkspaceSession, selectedWorkspaceId, sessionsByWorkspaceId]);
 
   const navigateToSessionRootForControl = useCallback(() => {
-    navigate("/session");
-  }, [navigate]);
+    navigateToWorkspaceSession(selectedWorkspaceId);
+  }, [navigateToWorkspaceSession, selectedWorkspaceId]);
 
   const openModelPickerForControl = useCallback(() => {
     setModelPickerOpen(true);
@@ -1806,14 +1868,14 @@ export function SessionRoute() {
       local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
       await refreshRouteState();
       if (createdId) {
-        navigate("/settings/general");
+        handleOpenSettings("/settings/general", createdId);
       }
     } catch (error) {
       setCreateWorkspaceError(describeWorkspaceCreateError(error));
     } finally {
       setCreateWorkspaceBusy(false);
     }
-  }, [client, local, navigate, refreshRouteState]);
+  }, [client, handleOpenSettings, local, refreshRouteState]);
 
   const handleCreateRemoteWorkspace = useCallback(async (input: {
     openworkHostUrl?: string | null;
@@ -1892,7 +1954,7 @@ export function SessionRoute() {
           }),
         );
       }}
-      onOpenSettings={() => navigate("/settings/general")}
+      onOpenSettings={() => handleOpenSettings("/settings/general")}
       sidebar={{
         workspaceSessionGroups,
         selectedWorkspaceId,
@@ -1906,7 +1968,7 @@ export function SessionRoute() {
         startupPhase: effectiveLoading ? "nativeInit" : "ready",
         onSelectWorkspace: async (workspaceId) => {
           if (workspaceId === selectedWorkspaceId) return true;
-          setSelectedWorkspaceId(workspaceId);
+          setLegacySelectedWorkspaceId(workspaceId);
           writeActiveWorkspaceId(workspaceId || null);
           const workspace = workspaces.find((item) => item.id === workspaceId);
           if (client && workspace && !sessionsByWorkspaceId[workspaceId]?.length) {
@@ -1936,16 +1998,20 @@ export function SessionRoute() {
           if (remembered && remembered !== selectedSessionId) {
             const known = sessionsByWorkspaceId[workspaceId];
             if (known?.some((session: any) => session?.id === remembered)) {
-              navigate(`/session/${remembered}`);
+              navigateToWorkspaceSession(workspaceId, remembered);
+            } else {
+              navigateToWorkspaceSession(workspaceId);
             }
+          } else {
+            navigateToWorkspaceSession(workspaceId);
           }
           return true;
         },
         onOpenSession: (workspaceId, sessionId) => {
-          setSelectedWorkspaceId(workspaceId);
+          setLegacySelectedWorkspaceId(workspaceId);
           writeActiveWorkspaceId(workspaceId || null);
           writeLastSessionFor(workspaceId, sessionId);
-          navigate(`/session/${sessionId}`);
+          navigateToWorkspaceSession(workspaceId, sessionId);
         },
         onPrefetchSession: () => {},
         onCreateTaskInWorkspace: async (workspaceId) => {
@@ -1965,14 +2031,14 @@ export function SessionRoute() {
           // Make sure the new session is the active pair before navigating
           // so the surface renders the new id immediately instead of going
           // through the "unknown session" render tick.
-          setSelectedWorkspaceId(workspaceId);
+          setLegacySelectedWorkspaceId(workspaceId);
           writeActiveWorkspaceId(workspaceId || null);
           writeLastSessionFor(workspaceId, session.id);
           setSessionsByWorkspaceId((current) => ({
             ...current,
             [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
           }));
-          navigate(`/session/${session.id}`);
+          navigateToWorkspaceSession(workspaceId, session.id);
           // Refresh in the background so the new session picks up its real
           // metadata (title, timestamps) as soon as the server knows them.
           void refreshRouteState();
@@ -2050,7 +2116,7 @@ export function SessionRoute() {
           ? async (sessionId) => {
               await client.deleteSession(selectedWorkspaceId, sessionId);
               if (selectedSessionId === sessionId) {
-                navigate("/session");
+                navigateToWorkspaceSession(selectedWorkspaceId);
               }
               await refreshRouteState();
             }
@@ -2063,6 +2129,7 @@ export function SessionRoute() {
         statusPingClass: "bg-amber-9/35 animate-ping",
         statusPulse: true,
       } : undefined}
+      notFoundMessage={routeNotFoundMessage}
     />
     <CreateWorkspaceModal
       open={createWorkspaceOpen}
@@ -2110,8 +2177,8 @@ export function SessionRoute() {
           void handleCreateTaskInWorkspace(selectedWorkspaceId);
         }
       }}
-      onOpenSession={(_workspaceId, sessionId) => navigate(`/session/${sessionId}`)}
-      onOpenSettings={(route) => navigate(route ?? "/settings/general")}
+      onOpenSession={(workspaceId, sessionId) => navigateToWorkspaceSession(workspaceId, sessionId)}
+      onOpenSettings={(route) => handleOpenSettings(route ?? "/settings/general")}
       sessions={paletteSessionOptions}
     />
     <ModelPickerModal
@@ -2137,7 +2204,7 @@ export function SessionRoute() {
       onBehaviorChange={() => {}}
       onOpenSettings={() => {
         setModelPickerOpen(false);
-        navigate("/settings/general");
+        handleOpenSettings("/settings/general");
       }}
       onClose={() => setModelPickerOpen(false)}
     />

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Navigate, useLocation, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { SUGGESTED_PLUGINS } from "../../app/constants";
 import { createClient } from "../../app/lib/opencode";
@@ -96,6 +96,8 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import { abortSessionSafe } from "../../app/lib/opencode-session";
 import { useReloadCoordinator } from "./reload-coordinator";
 import { buildFeedbackUrl } from "../../app/lib/feedback";
+import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
+import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 
 type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
@@ -266,9 +268,12 @@ function parseSettingsPath(pathname: string): {
   redirectPath: string | null;
   extensionsSection?: "all" | "mcp" | "plugins";
 } {
-  const trimmed = pathname.replace(/^\/settings\/?/, "").replace(/^\/+|\/+$/g, "");
+  const trimmed = pathname
+    .replace(/^\/workspace\/[^/]+\/settings\/?/, "")
+    .replace(/^\/settings\/?/, "")
+    .replace(/^\/+|\/+$/g, "");
   if (!trimmed) {
-    return { tab: "general", redirectPath: "/settings/general" };
+    return { tab: "general", redirectPath: "general" };
   }
 
   const [head, tail] = trimmed.split("/");
@@ -288,7 +293,7 @@ function parseSettingsPath(pathname: string): {
       if (tail === "plugins") return { tab: "extensions", redirectPath: null, extensionsSection: "plugins" };
       return { tab: "extensions", redirectPath: null, extensionsSection: "all" };
     default:
-      return { tab: "general", redirectPath: "/settings/general" };
+      return { tab: "general", redirectPath: "general" };
   }
 }
 
@@ -312,6 +317,34 @@ function writeStoredBoolean(key: string, value: boolean) {
   }
 }
 
+function readNavigationWorkspaceId(state: unknown): string | null {
+  if (!state || typeof state !== "object") return null;
+  const value = (state as { workspaceId?: unknown }).workspaceId;
+  return typeof value === "string" ? value.trim() || null : null;
+}
+
+function readNavigationSessionId(state: unknown): string | null {
+  if (!state || typeof state !== "object") return null;
+  const value = (state as { sessionId?: unknown }).sessionId;
+  return typeof value === "string" ? value.trim() || null : null;
+}
+
+function findSessionWorkspaceId(
+  sessionId: string | null,
+  entries: Array<{ workspaceId: string; sessions: any[] }>,
+) {
+  const id = sessionId?.trim();
+  if (!id) return null;
+  return entries.find((entry) => entry.sessions.some((session: any) => session?.id === id))?.workspaceId ?? null;
+}
+
+function settingsPathForRoute(route: ReturnType<typeof parseSettingsPath>) {
+  if (route.tab === "extensions" && route.extensionsSection && route.extensionsSection !== "all") {
+    return `extensions/${route.extensionsSection}`;
+  }
+  return route.tab;
+}
+
 function readStoredThemeMode(): PersistedThemeMode {
   if (typeof window === "undefined") return "system";
   try {
@@ -332,19 +365,24 @@ function applyThemeMode(mode: PersistedThemeMode) {
 export function SettingsRoute() {
   const navigate = useNavigate();
   const location = useLocation();
+  const params = useParams<{ workspaceId?: string }>();
+  const routeWorkspaceId = params.workspaceId?.trim() || "";
   const local = useLocal();
   const platform = usePlatform();
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const desktopConfig = useDesktopConfig();
   const reloadCoordinator = useReloadCoordinator();
   const route = parseSettingsPath(location.pathname);
+  const navigationWorkspaceId = readNavigationWorkspaceId(location.state);
+  const navigationSessionId = readNavigationSessionId(location.state);
 
   const [loading, setLoading] = useState(true);
   const [workspaces, setWorkspaces] = useState<RouteWorkspace[]>([]);
   const [sessionsByWorkspaceId, setSessionsByWorkspaceId] = useState<Record<string, any[]>>({});
   const [errorsByWorkspaceId, setErrorsByWorkspaceId] = useState<Record<string, string | null>>({});
   const [workspaceConnectionOverrides, setWorkspaceConnectionOverrides] = useState<Record<string, WorkspaceConnectionState>>({});
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState("");
+  const [legacySelectedWorkspaceId, setLegacySelectedWorkspaceId] = useState(() => navigationWorkspaceId ?? readActiveWorkspaceId() ?? "");
+  const selectedWorkspaceId = routeWorkspaceId || legacySelectedWorkspaceId;
   const [baseUrl, setBaseUrl] = useState("");
   const [token, setToken] = useState("");
   const [openworkClient, setOpenworkClient] = useState<OpenworkServerClient | null>(null);
@@ -417,7 +455,7 @@ export function SettingsRoute() {
   });
 
   const selectedWorkspace = useMemo(
-    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? workspaces[0] ?? null,
+    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? (selectedWorkspaceId ? null : workspaces[0] ?? null),
     [selectedWorkspaceId, workspaces],
   );
   const workspaceConnectionStateById = useMemo(() => {
@@ -678,10 +716,10 @@ export function SettingsRoute() {
   );
 
   const opencodeBaseUrl = useMemo(() => {
-    if (!selectedWorkspaceId || !baseUrl) return "";
+    if (!selectedWorkspace || !selectedWorkspaceId || !baseUrl) return "";
     const mounted = buildOpenworkWorkspaceBaseUrl(baseUrl, selectedWorkspaceId) ?? baseUrl;
     return `${mounted.replace(/\/+$/, "")}/opencode`;
-  }, [baseUrl, selectedWorkspaceId]);
+  }, [baseUrl, selectedWorkspace, selectedWorkspaceId]);
 
   const opencodeClient = useMemo(
     () =>
@@ -800,7 +838,11 @@ export function SettingsRoute() {
         setWorkspaces(desktopWorkspaces);
         setSessionsByWorkspaceId({});
         setErrorsByWorkspaceId({});
-        setSelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "");
+        setLegacySelectedWorkspaceId((current) => {
+          const next = current || readActiveWorkspaceId() || resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "";
+          writeActiveWorkspaceId(next || null);
+          return next;
+        });
         return;
       }
 
@@ -869,9 +911,13 @@ export function SettingsRoute() {
         }
         return next;
       });
-      setSelectedWorkspaceId((current) =>
-        reconcileSelectedWorkspaceId(current, list, desktopList, nextWorkspaces),
-      );
+      setLegacySelectedWorkspaceId((current) => {
+        const sessionWorkspaceId = findSessionWorkspaceId(navigationSessionId, sessionEntries);
+        const preferred = routeWorkspaceId || sessionWorkspaceId || navigationWorkspaceId || current || readActiveWorkspaceId() || "";
+        const next = reconcileSelectedWorkspaceId(preferred, list, desktopList, nextWorkspaces);
+        writeActiveWorkspaceId(next || null);
+        return next;
+      });
     } catch (error) {
       const message = describeRouteError(error);
       console.error("[settings-route] refreshRouteState failed", error);
@@ -883,7 +929,11 @@ export function SettingsRoute() {
       setRouteError(message);
       if (desktopWorkspaces.length > 0) {
         setWorkspaces(desktopWorkspaces);
-        setSelectedWorkspaceId((current) => current || resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "");
+        setLegacySelectedWorkspaceId((current) => {
+          const next = current || readActiveWorkspaceId() || resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "";
+          writeActiveWorkspaceId(next || null);
+          return next;
+        });
       }
     } finally {
       setLoading(false);
@@ -893,7 +943,7 @@ export function SettingsRoute() {
       // completed our first data load.
       markBootRouteReady();
     }
-  }, [markBootRouteReady]);
+  }, [markBootRouteReady, navigationSessionId, navigationWorkspaceId, routeWorkspaceId]);
 
   useEffect(() => {
     workspacesRef.current = workspaces;
@@ -1110,6 +1160,9 @@ export function SettingsRoute() {
     }));
   const mcpConnectedAppsCount = connectionsSnapshot.mcpServers.length;
   const routeOpenworkStatus = openworkClient ? "connected" : "disconnected";
+  const notFoundRouteError = !loading && routeWorkspaceId && !selectedWorkspace
+    ? "Workspace was not found. Select a new workspace from the sidebar."
+    : null;
   const routeOpenworkCapabilities: OpenworkServerCapabilities | null = openworkClient
     ? ROUTE_OPENWORK_CAPABILITIES
     : null;
@@ -1231,7 +1284,7 @@ export function SettingsRoute() {
     if (selectedWorkspaceId === workspaceId) {
       const nextWorkspace = workspaces.find((workspace) => workspace.id !== workspaceId);
       const nextId = nextWorkspace?.id ?? "";
-      setSelectedWorkspaceId(nextId);
+      setLegacySelectedWorkspaceId(nextId);
       if (nextId) {
         await workspaceSetSelected(nextId).catch(() => undefined);
       }
@@ -1362,7 +1415,14 @@ export function SettingsRoute() {
   });
 
   if (route.redirectPath) {
-    return <Navigate to={route.redirectPath} replace />;
+    const target = selectedWorkspaceId
+      ? workspaceSettingsRoute(selectedWorkspaceId, route.redirectPath)
+      : `/settings/${route.redirectPath}`;
+    return <Navigate to={target} replace state={location.state} />;
+  }
+
+  if (!routeWorkspaceId && selectedWorkspaceId) {
+    return <Navigate to={workspaceSettingsRoute(selectedWorkspaceId, settingsPathForRoute(route))} replace state={location.state} />;
   }
 
   const settingsView = (() => {
@@ -1452,7 +1512,7 @@ export function SettingsRoute() {
             extensions={extensionsStore}
             onOpenLink={(url) => platform.openLink(url)}
             createSessionAndOpen={async (_command?: string): Promise<string | undefined> => {
-              navigate("/session");
+              navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session");
               return undefined;
             }}
           />
@@ -1470,7 +1530,10 @@ export function SettingsRoute() {
             extensions={extensionsStore}
             mcpConnectedAppsCount={mcpConnectedAppsCount}
             initialSection={route.extensionsSection}
-            setSectionRoute={(section) => navigate(`/settings/extensions/${section}`)}
+            setSectionRoute={(section) => {
+              const path = `extensions/${section}`;
+              navigate(selectedWorkspaceId ? workspaceSettingsRoute(selectedWorkspaceId, path) : `/settings/${path}`);
+            }}
             onRefresh={() => {
               void connectionsStore.refreshMcpServers();
               void extensionsStore.refreshPlugins();
@@ -1668,7 +1731,7 @@ export function SettingsRoute() {
     <>
       <SettingsShell
         activeTab={route.tab}
-        onSelectTab={(tab) => navigate(`/settings/${tab}`)}
+        onSelectTab={(tab) => navigate(selectedWorkspaceId ? workspaceSettingsRoute(selectedWorkspaceId, tab) : `/settings/${tab}`)}
         developerMode={developerMode}
         selectedWorkspaceName={selectedWorkspaceName}
         headerStatus={routeOpenworkStatus}
@@ -1682,11 +1745,16 @@ export function SettingsRoute() {
           workspaceConnectionStateById,
           newTaskDisabled: !opencodeClient,
           onSelectWorkspace: async (workspaceId) => {
-            setSelectedWorkspaceId(workspaceId);
+            setLegacySelectedWorkspaceId(workspaceId);
+            writeActiveWorkspaceId(workspaceId || null);
+            if (isDesktopRuntime()) {
+              void workspaceSetSelected(workspaceId).catch(() => undefined);
+              void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
+            }
             return true;
           },
-          onOpenSession: (_workspaceId, sessionId) => navigate(`/session/${sessionId}`),
-          onCreateTaskInWorkspace: () => navigate("/session"),
+          onOpenSession: (workspaceId, sessionId) => navigate(workspaceSessionRoute(workspaceId, sessionId)),
+          onCreateTaskInWorkspace: (workspaceId) => navigate(workspaceSessionRoute(workspaceId)),
           onOpenRenameWorkspace: handleOpenRenameWorkspace,
           onShareWorkspace: shareWorkspaceState.openShareWorkspace,
           onRevealWorkspace: (id) => void handleRevealWorkspace(id),
@@ -1696,10 +1764,10 @@ export function SettingsRoute() {
           onForgetWorkspace: (id) => void handleForgetWorkspace(id),
           onOpenCreateWorkspace: handleOpenCreateWorkspace,
         }}
-        onClose={() => navigate("/session")}
+        onClose={() => navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session")}
         sidebarWidth={shellLayout.leftSidebarWidth}
         onSidebarResizeStart={shellLayout.startLeftSidebarResize}
-        error={routeError}
+        error={routeError ?? notFoundRouteError}
       >
         {settingsView}
       </SettingsShell>

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -18,6 +18,7 @@ import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-moda
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { createOpenworkServerClient } from "../../app/lib/openwork-server";
 import { writeActiveWorkspaceId } from "./session-memory";
+import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 
 function folderNameFromPath(path: string) {
   const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
@@ -97,7 +98,7 @@ export function WelcomeRoute() {
         }
         markOnboardingComplete();
         setModalOpen(false);
-        navigate("/settings/general", { replace: true });
+        navigate(createdId ? workspaceSettingsRoute(createdId, "general") : "/settings/general", { replace: true });
       } catch (error) {
         setCreateError(
           error instanceof Error ? error.message : "Failed to create workspace.",
@@ -140,7 +141,7 @@ export function WelcomeRoute() {
         }
         markOnboardingComplete();
         setModalOpen(false);
-        navigate("/session", { replace: true });
+        navigate(createdId ? workspaceSessionRoute(createdId) : "/session", { replace: true });
         return true;
       } catch (error) {
         setRemoteError(

--- a/apps/app/src/react-app/shell/workspace-routes.ts
+++ b/apps/app/src/react-app/shell/workspace-routes.ts
@@ -1,0 +1,25 @@
+import type { SettingsTab } from "../../app/types";
+
+export function workspaceSessionRoute(workspaceId: string, sessionId?: string | null) {
+  const workspace = encodeURIComponent(workspaceId.trim());
+  const session = sessionId?.trim();
+  return session
+    ? `/workspace/${workspace}/session/${encodeURIComponent(session)}`
+    : `/workspace/${workspace}/session`;
+}
+
+export function workspaceSettingsRoute(
+  workspaceId: string,
+  tab: SettingsTab | "extensions/mcp" | "extensions/plugins" | string = "general",
+) {
+  return `/workspace/${encodeURIComponent(workspaceId.trim())}/settings/${tab}`;
+}
+
+export function globalSettingsRoute(tab: SettingsTab) {
+  return `/settings/${tab}`;
+}
+
+export function legacySessionRoute(sessionId?: string | null) {
+  const session = sessionId?.trim();
+  return session ? `/session/${encodeURIComponent(session)}` : "/session";
+}


### PR DESCRIPTION
## Summary
- Add canonical workspace-scoped session and settings routes so workspace identity comes from the URL.
- Update session/sidebar/settings/onboarding/session-action navigation to generate `/workspace/:workspaceId/...` URLs while preserving legacy fallbacks.
- Show explicit missing workspace/session states instead of silently falling back to the first workspace.

## Verification
- `git diff --check` passed.
- `pnpm --filter @openwork/app typecheck` was run, but the branch still has existing unrelated TypeScript failures in provider-auth, messaging OpenCode Router types, and settings automations references.