### PR TITLE
feat(desktop): bundle chrome-devtools-mcp as dependency, eliminate npx requirement

### DIFF
--- a/apps/app/src/app/mcp.ts
+++ b/apps/app/src/app/mcp.ts
@@ -2,10 +2,42 @@ import { applyEdits, modify, parse, printParseErrorCode } from "jsonc-parser";
 import type { McpServerConfig, McpServerEntry } from "./types";
 import { readOpencodeConfig, writeOpencodeConfig } from "./lib/desktop";
 import { CHROME_DEVTOOLS_MCP_COMMAND, CHROME_DEVTOOLS_MCP_ID } from "./constants";
+import { isElectronRuntime } from "./utils";
 
 type McpConfigValue = Record<string, unknown> | null | undefined;
 
 export const CHROME_DEVTOOLS_AUTO_CONNECT_ARG = "--autoConnect";
+
+/**
+ * Cached result of resolving the bundled chrome-devtools-mcp binary path
+ * from the Electron main process. `undefined` = not yet resolved.
+ */
+let _resolvedBundledCommand: string[] | null | undefined;
+
+/**
+ * Resolve the chrome-devtools-mcp command for the current runtime.
+ *
+ * In Electron, the package is bundled as a dependency of `@openwork/desktop`,
+ * so we ask the main process for the absolute path to the bin and use
+ * `["node", "<path>"]` — no npm/npx required.
+ *
+ * Falls back to the npx-based command for web/remote contexts.
+ */
+export async function resolveChromeDevtoolsMcpCommand(): Promise<string[]> {
+  if (isElectronRuntime() && _resolvedBundledCommand === undefined) {
+    try {
+      const resolved = await (window as Window).__OPENWORK_ELECTRON__!.invokeDesktop(
+        "resolveChromeDevtoolsMcpBin",
+      );
+      _resolvedBundledCommand = Array.isArray(resolved) && resolved.length > 0
+        ? (resolved as string[])
+        : null;
+    } catch {
+      _resolvedBundledCommand = null;
+    }
+  }
+  return _resolvedBundledCommand ?? [...CHROME_DEVTOOLS_MCP_COMMAND];
+}
 
 type McpIdentity = {
   id?: string;
@@ -30,10 +62,14 @@ export function usesChromeDevtoolsAutoConnect(command?: string[]): boolean {
   return Array.isArray(command) && command.includes(CHROME_DEVTOOLS_AUTO_CONNECT_ARG);
 }
 
-export function buildChromeDevtoolsCommand(command: string[] | undefined, useExistingProfile: boolean): string[] {
+export function buildChromeDevtoolsCommand(
+  command: string[] | undefined,
+  useExistingProfile: boolean,
+  resolvedBase?: string[],
+): string[] {
   const base = Array.isArray(command) && command.length
     ? command.filter((part) => part !== CHROME_DEVTOOLS_AUTO_CONNECT_ARG)
-    : [...CHROME_DEVTOOLS_MCP_COMMAND];
+    : resolvedBase ?? [...CHROME_DEVTOOLS_MCP_COMMAND];
   return useExistingProfile ? [...base, CHROME_DEVTOOLS_AUTO_CONNECT_ARG] : base;
 }
 

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -20,6 +20,7 @@ import { toSessionTransportDirectory } from "../../../app/lib/session-scope";
 import {
   parseMcpServersFromContent,
   removeMcpFromConfig,
+  resolveChromeDevtoolsMcpCommand,
   usesChromeDevtoolsAutoConnect,
   validateMcpServerName,
 } from "../../../app/mcp";
@@ -31,7 +32,7 @@ import type {
   ReloadReason,
   ReloadTrigger,
 } from "../../../app/types";
-import { isDesktopRuntime, normalizeDirectoryPath, safeStringify } from "../../../app/utils";
+import { isDesktopRuntime, isElectronRuntime, normalizeDirectoryPath, safeStringify } from "../../../app/utils";
 
 import type { OpenworkServerStore } from "./openwork-server-store";
 
@@ -496,11 +497,23 @@ export function createConnectionsStore(options: {
         if (!entry.command?.length) {
           throw new Error("Missing MCP command.");
         }
-        mcpEntryConfig["command"] = entry.command;
+
+        // For chrome-devtools in Electron, resolve the bundled binary so we
+        // don't need npx/npm at runtime.
+        let resolvedCommand = entry.command;
+        if (slug === CHROME_DEVTOOLS_MCP_ID && isElectronRuntime()) {
+          const bundled = await resolveChromeDevtoolsMcpCommand();
+          // Preserve any extra args (e.g. --autoConnect) from the original
+          const extraArgs = entry.command.filter(
+            (arg) => arg.startsWith("--") || arg.startsWith("-"),
+          );
+          resolvedCommand = [...bundled, ...extraArgs];
+        }
+        mcpEntryConfig["command"] = resolvedCommand;
 
         if (
           slug === CHROME_DEVTOOLS_MCP_ID &&
-          usesChromeDevtoolsAutoConnect(entry.command) &&
+          usesChromeDevtoolsAutoConnect(resolvedCommand) &&
           isDesktopRuntime()
         ) {
           try {

--- a/apps/app/tests/chrome-devtools-mcp-resolution.test.ts
+++ b/apps/app/tests/chrome-devtools-mcp-resolution.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildChromeDevtoolsCommand,
+  CHROME_DEVTOOLS_AUTO_CONNECT_ARG,
+  isChromeDevtoolsMcp,
+  usesChromeDevtoolsAutoConnect,
+} from "../src/app/mcp";
+import { CHROME_DEVTOOLS_MCP_COMMAND } from "../src/app/constants";
+
+describe("chrome-devtools-mcp bundled resolution", () => {
+  describe("buildChromeDevtoolsCommand", () => {
+    test("uses npx fallback when no resolved base is provided", () => {
+      const result = buildChromeDevtoolsCommand(undefined, false);
+      expect(result).toEqual([...CHROME_DEVTOOLS_MCP_COMMAND]);
+    });
+
+    test("uses resolved base when provided and command is undefined", () => {
+      const resolved = ["node", "/abs/path/to/build/src/index.js"];
+      const result = buildChromeDevtoolsCommand(undefined, false, resolved);
+      expect(result).toEqual(resolved);
+    });
+
+    test("uses resolved base when provided and command is empty", () => {
+      const resolved = ["node", "/abs/path/to/build/src/index.js"];
+      const result = buildChromeDevtoolsCommand([], false, resolved);
+      expect(result).toEqual(resolved);
+    });
+
+    test("prefers explicit command over resolved base", () => {
+      const resolved = ["node", "/abs/path/to/build/src/index.js"];
+      const explicit = ["custom-chrome-mcp", "--flag"];
+      const result = buildChromeDevtoolsCommand(explicit, false, resolved);
+      expect(result).toEqual(explicit);
+    });
+
+    test("appends --autoConnect when useExistingProfile is true", () => {
+      const resolved = ["node", "/abs/path/to/build/src/index.js"];
+      const result = buildChromeDevtoolsCommand(undefined, true, resolved);
+      expect(result).toEqual([...resolved, CHROME_DEVTOOLS_AUTO_CONNECT_ARG]);
+    });
+
+    test("strips existing --autoConnect before re-adding", () => {
+      const command = ["node", "/path/index.js", "--autoConnect"];
+      const result = buildChromeDevtoolsCommand(command, true);
+      expect(result).toEqual(["node", "/path/index.js", "--autoConnect"]);
+      // Should not have double --autoConnect
+      expect(result.filter((a) => a === "--autoConnect")).toHaveLength(1);
+    });
+
+    test("strips --autoConnect when useExistingProfile is false", () => {
+      const command = ["node", "/path/index.js", "--autoConnect"];
+      const result = buildChromeDevtoolsCommand(command, false);
+      expect(result).toEqual(["node", "/path/index.js"]);
+    });
+  });
+
+  describe("isChromeDevtoolsMcp", () => {
+    test("returns true for chrome-devtools id", () => {
+      expect(isChromeDevtoolsMcp({ id: "chrome-devtools", name: "Chrome" })).toBe(true);
+    });
+
+    test("returns true for control-chrome slug", () => {
+      expect(isChromeDevtoolsMcp({ name: "Control Chrome" })).toBe(true);
+    });
+
+    test("returns false for other MCPs", () => {
+      expect(isChromeDevtoolsMcp({ name: "Notion" })).toBe(false);
+    });
+
+    test("returns false for null/undefined", () => {
+      expect(isChromeDevtoolsMcp(null)).toBe(false);
+      expect(isChromeDevtoolsMcp(undefined)).toBe(false);
+    });
+  });
+
+  describe("usesChromeDevtoolsAutoConnect", () => {
+    test("returns true when --autoConnect is present", () => {
+      expect(usesChromeDevtoolsAutoConnect(["node", "/path", "--autoConnect"])).toBe(true);
+    });
+
+    test("returns false when --autoConnect is absent", () => {
+      expect(usesChromeDevtoolsAutoConnect(["node", "/path"])).toBe(false);
+    });
+
+    test("returns false for undefined", () => {
+      expect(usesChromeDevtoolsAutoConnect(undefined)).toBe(false);
+    });
+  });
+});
+
+describe("bundled bin path resolution (Electron main process)", () => {
+  test("chrome-devtools-mcp package is installed and bin exists", () => {
+    // This test verifies the dependency is actually installed and the bin
+    // is resolvable — the same resolution the Electron main process does.
+    const path = require("node:path");
+    const fs = require("node:fs");
+    const { createRequire } = require("node:module");
+
+    // Resolve from the desktop package (where the dependency is declared)
+    const desktopDir = path.resolve(__dirname, "../../desktop");
+    const require_ = createRequire(path.join(desktopDir, "package.json"));
+
+    let pkgJsonPath: string;
+    try {
+      pkgJsonPath = require_.resolve("chrome-devtools-mcp/package.json");
+    } catch {
+      // In CI or if node_modules isn't installed, skip gracefully
+      console.log("SKIP: chrome-devtools-mcp not installed (run pnpm install)");
+      return;
+    }
+
+    const binPath = path.join(path.dirname(pkgJsonPath), "build", "src", "index.js");
+    expect(fs.existsSync(binPath)).toBe(true);
+
+    // Verify it has the shebang (it's a CLI entry point)
+    const head = fs.readFileSync(binPath, "utf8").slice(0, 50);
+    expect(head).toContain("#!/usr/bin/env node");
+  });
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -12,6 +12,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1329,6 +1330,21 @@ async function handleDesktopInvoke(event, command, ...args) {
       }
       window.webContents.setZoomFactor(factor);
       return true;
+    }
+    case "resolveChromeDevtoolsMcpBin": {
+      // Resolve the bundled chrome-devtools-mcp bin path so the renderer
+      // can write a command to opencode.json that doesn't require npx.
+      try {
+        const require_ = createRequire(import.meta.url);
+        const pkgJsonPath = require_.resolve("chrome-devtools-mcp/package.json");
+        const binPath = path.join(path.dirname(pkgJsonPath), "build", "src", "index.js");
+        if (existsSync(binPath)) {
+          return [process.execPath, binPath];
+        }
+      } catch {
+        // package not found — fall through to null
+      }
+      return null;
     }
     default:
       throw new Error(`Electron desktop bridge method is not implemented yet: ${command}`);

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,6 +25,7 @@
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs"
   },
   "dependencies": {
+    "chrome-devtools-mcp": "0.17.0",
     "electron-updater": "^6.3.9"
   },
   "devDependencies": {

--- a/apps/desktop/scripts/chrome-devtools-mcp-shim.test.ts
+++ b/apps/desktop/scripts/chrome-devtools-mcp-shim.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+describe("chrome-devtools-mcp-shim resolution", () => {
+  test("resolves bundled chrome-devtools-mcp bin from node_modules", () => {
+    // Replicate the exact resolution logic from the shim
+    const require_ = createRequire(import.meta.url);
+
+    let pkgJsonPath: string;
+    try {
+      pkgJsonPath = require_.resolve("chrome-devtools-mcp/package.json");
+    } catch {
+      console.log("SKIP: chrome-devtools-mcp not installed");
+      return;
+    }
+
+    const binPath = join(dirname(pkgJsonPath), "build", "src", "index.js");
+    expect(existsSync(binPath)).toBe(true);
+  });
+
+  test("resolved bin is a valid node script with shebang", () => {
+    const require_ = createRequire(import.meta.url);
+
+    let pkgJsonPath: string;
+    try {
+      pkgJsonPath = require_.resolve("chrome-devtools-mcp/package.json");
+    } catch {
+      console.log("SKIP: chrome-devtools-mcp not installed");
+      return;
+    }
+
+    const binPath = join(dirname(pkgJsonPath), "build", "src", "index.js");
+    const content = readFileSync(binPath, "utf8");
+    expect(content.startsWith("#!/usr/bin/env node")).toBe(true);
+  });
+
+  test("package.json declares correct bin field", () => {
+    const require_ = createRequire(import.meta.url);
+
+    let pkgJsonPath: string;
+    try {
+      pkgJsonPath = require_.resolve("chrome-devtools-mcp/package.json");
+    } catch {
+      console.log("SKIP: chrome-devtools-mcp not installed");
+      return;
+    }
+
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    // The bin field should point to the index.js entry
+    expect(pkg.bin).toBeDefined();
+    expect(typeof pkg.bin === "string" ? pkg.bin : "").toContain("index.js");
+  });
+
+  test("version matches expected pinned version", () => {
+    const require_ = createRequire(import.meta.url);
+
+    let pkgJsonPath: string;
+    try {
+      pkgJsonPath = require_.resolve("chrome-devtools-mcp/package.json");
+    } catch {
+      console.log("SKIP: chrome-devtools-mcp not installed");
+      return;
+    }
+
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8"));
+    expect(pkg.version).toBe("0.17.0");
+  });
+});

--- a/apps/desktop/scripts/chrome-devtools-mcp-shim.ts
+++ b/apps/desktop/scripts/chrome-devtools-mcp-shim.ts
@@ -1,35 +1,76 @@
 #!/usr/bin/env node
+/**
+ * Chrome DevTools MCP shim — resolves the bundled `chrome-devtools-mcp`
+ * dependency and runs it directly via Node, eliminating the runtime
+ * dependency on npm/npx.
+ *
+ * Fallback: if the bundled package cannot be found (e.g. standalone
+ * sidecar without node_modules), falls back to `npm exec` like before.
+ */
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 
 const packageSpec =
   process.env.OPENWORK_CHROME_DEVTOOLS_MCP_SPEC?.trim() ||
   process.env.CHROME_DEVTOOLS_MCP_SPEC?.trim() ||
   "chrome-devtools-mcp@0.17.0";
 
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-const args = ["exec", "--yes", packageSpec, "--", ...process.argv.slice(2)];
+/**
+ * Try to resolve the chrome-devtools-mcp entry point from node_modules.
+ * The package's `bin` field points at `./build/src/index.js`.
+ */
+function resolveBundledBin(): string | null {
+  try {
+    const require_ = createRequire(import.meta.url);
+    const pkgJsonPath = require_.resolve("chrome-devtools-mcp/package.json");
+    const binPath = join(dirname(pkgJsonPath), "build", "src", "index.js");
+    if (existsSync(binPath)) {
+      return binPath;
+    }
+  } catch {
+    // package not found in node_modules — will fall back to npm exec
+  }
+  return null;
+}
 
-const child = spawn(npmCommand, args, {
-  stdio: "inherit",
-  env: {
-    ...process.env,
-    npm_config_yes: "true",
-  },
-});
+const bundledBin = resolveBundledBin();
 
-child.on("error", (error) => {
+let child: ReturnType<typeof spawn>;
+
+if (bundledBin) {
+  // Direct invocation via Node — no npm/npx needed
+  child = spawn(process.execPath, [bundledBin, ...process.argv.slice(2)], {
+    stdio: "inherit",
+    env: process.env,
+  });
+} else {
+  // Fallback: npm exec (requires npm on PATH)
+  const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+  const args = ["exec", "--yes", packageSpec, "--", ...process.argv.slice(2)];
+  child = spawn(npmCommand, args, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      npm_config_yes: "true",
+    },
+  });
+}
+
+child.on("error", (error: Error) => {
   const message = error instanceof Error ? error.message : String(error);
   if (message.includes("ENOENT")) {
     console.error(
-      "Control Chrome requires npm (Node.js). Install Node.js or configure mcp.chrome-devtools.command to a local chrome-devtools-mcp binary."
+      "Control Chrome requires Node.js. Install Node.js or configure mcp.chrome-devtools.command to a local chrome-devtools-mcp binary."
     );
   } else {
-    console.error(`Failed to start chrome-devtools-mcp via npm exec: ${message}`);
+    console.error(`Failed to start chrome-devtools-mcp: ${message}`);
   }
   process.exit(1);
 });
 
-child.on("exit", (code, signal) => {
+child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
   if (signal) {
     process.kill(process.pid, signal);
     return;

--- a/apps/desktop/scripts/prepare-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-sidecar.mjs
@@ -162,20 +162,14 @@ const orchestratorTargetName = orchestratorTargetTriple
 const orchestratorTargetPath = orchestratorTargetName ? join(sidecarDir, orchestratorTargetName) : null;
 const orchestratorDir = resolve(__dirname, "..", "..", "orchestrator");
 
-// chrome-devtools-mcp shim sidecar
+// chrome-devtools-mcp: now bundled as a node_modules dependency of
+// @openwork/desktop (Electron resolves it directly). The Bun-compiled shim
+// sidecar is no longer built.  These variables are kept only so the
+// versions.json metadata block below can record the pinned version without
+// breaking the build.
 const chromeDevtoolsBaseName = "chrome-devtools-mcp";
 const chromeDevtoolsName = isWindowsTarget ? `${chromeDevtoolsBaseName}.exe` : chromeDevtoolsBaseName;
 const chromeDevtoolsPath = join(sidecarDir, chromeDevtoolsName);
-const chromeDevtoolsBuildName = bunTarget
-  ? `${chromeDevtoolsBaseName}-${bunTarget}${bunTarget.includes("windows") ? ".exe" : ""}`
-  : chromeDevtoolsName;
-const chromeDevtoolsBuildPath = join(sidecarDir, chromeDevtoolsBuildName);
-const chromeDevtoolsTargetTriple = resolvedTargetTriple;
-const chromeDevtoolsTargetName = chromeDevtoolsTargetTriple
-  ? `${chromeDevtoolsBaseName}-${chromeDevtoolsTargetTriple}${chromeDevtoolsTargetTriple.includes("windows") ? ".exe" : ""}`
-  : null;
-const chromeDevtoolsTargetPath = chromeDevtoolsTargetName ? join(sidecarDir, chromeDevtoolsTargetName) : null;
-const chromeDevtoolsShimPath = resolve(__dirname, "chrome-devtools-mcp-shim.ts");
 
 const readHeader = (filePath, length = 256) => {
   const fd = openSync(filePath, "r");
@@ -560,80 +554,7 @@ if (existsSync(orchestratorBuildPath)) {
   }
 }
 
-// Build chrome-devtools-mcp shim sidecar
-let didBuildChromeDevtools = false;
-const shouldBuildChromeDevtools =
-  forceBuild || !existsSync(chromeDevtoolsBuildPath) || isStubBinary(chromeDevtoolsBuildPath);
-if (shouldBuildChromeDevtools) {
-  mkdirSync(sidecarDir, { recursive: true });
-  if (existsSync(chromeDevtoolsBuildPath)) {
-    try {
-      unlinkSync(chromeDevtoolsBuildPath);
-    } catch {
-      // ignore
-    }
-  }
-
-  if (!existsSync(chromeDevtoolsShimPath)) {
-    console.error(`Chrome DevTools MCP shim source not found at ${chromeDevtoolsShimPath}`);
-    process.exit(1);
-  }
-
-  const chromeDevtoolsArgs = [
-    "build",
-    "--compile",
-    chromeDevtoolsShimPath,
-    "--outfile",
-    chromeDevtoolsBuildPath,
-  ];
-  if (bunTarget) {
-    chromeDevtoolsArgs.push("--target", bunTarget);
-  }
-
-  const result = spawnSync("bun", chromeDevtoolsArgs, {
-    cwd: __dirname,
-    stdio: "inherit",
-    shell: true,
-    env: {
-      ...process.env,
-      NODE_ENV: "production",
-      BUN_ENV: "production",
-    },
-  });
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
-
-  didBuildChromeDevtools = true;
-}
-
-if (existsSync(chromeDevtoolsBuildPath)) {
-  const shouldCopyCanonical =
-    didBuildChromeDevtools || !existsSync(chromeDevtoolsPath) || isStubBinary(chromeDevtoolsPath);
-  if (shouldCopyCanonical && chromeDevtoolsBuildPath !== chromeDevtoolsPath) {
-    try {
-      if (existsSync(chromeDevtoolsPath)) unlinkSync(chromeDevtoolsPath);
-    } catch {
-      // ignore
-    }
-    copyFileSync(chromeDevtoolsBuildPath, chromeDevtoolsPath);
-  }
-
-  if (chromeDevtoolsTargetPath) {
-    const shouldCopyTarget =
-      didBuildChromeDevtools ||
-      !existsSync(chromeDevtoolsTargetPath) ||
-      isStubBinary(chromeDevtoolsTargetPath);
-    if (shouldCopyTarget && chromeDevtoolsBuildPath !== chromeDevtoolsTargetPath) {
-      try {
-        if (existsSync(chromeDevtoolsTargetPath)) unlinkSync(chromeDevtoolsTargetPath);
-      } catch {
-        // ignore
-      }
-      copyFileSync(chromeDevtoolsBuildPath, chromeDevtoolsTargetPath);
-    }
-  }
-}
+// chrome-devtools-mcp is now a node_modules dependency — no sidecar build needed.
 
 adHocSignDarwinSidecars([
   opencodePath,
@@ -644,9 +565,6 @@ adHocSignDarwinSidecars([
   orchestratorBuildPath,
   orchestratorPath,
   orchestratorTargetPath,
-  chromeDevtoolsBuildPath,
-  chromeDevtoolsPath,
-  chromeDevtoolsTargetPath,
 ]);
 
 const openworkServerVersion = (() => {
@@ -682,7 +600,8 @@ const versions = {
   },
   "chrome-devtools-mcp": {
     version: chromeDevtoolsMcpVersion,
-    sha256: existsSync(chromeDevtoolsPath) ? sha256File(chromeDevtoolsPath) : null,
+    // No longer a sidecar binary — bundled as a node_modules dependency.
+    sha256: "bundled",
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      chrome-devtools-mcp:
+        specifier: 0.17.0
+        version: 0.17.0
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
@@ -4379,6 +4382,11 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  chrome-devtools-mcp@0.17.0:
+    resolution: {integrity: sha512-vMi2zXq2ph2EG6amyyApcvuKJcEFj4cGK1XQVb6x8vQYHk8D9ZnSxdtFqD0cRnG7SbUOrg3GhjOZEJAD1dZWSQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+    hasBin: true
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
@@ -12503,6 +12511,8 @@ snapshots:
   chownr@2.0.0: {}
 
   chownr@3.0.0: {}
+
+  chrome-devtools-mcp@0.17.0: {}
 
   chromium-pickle-js@0.2.0: {}
 


### PR DESCRIPTION
## Summary

- Bundles `chrome-devtools-mcp@0.17.0` as a direct dependency of `@openwork/desktop`, so the Electron app no longer requires `npm`/`npx` on PATH to run Chrome DevTools MCP.
- In the Electron runtime, the main process resolves the bundled bin path via `createRequire` and exposes it through a new `resolveChromeDevtoolsMcpBin` IPC handler.
- When connecting Chrome DevTools MCP from the UI, the resolved `["node", "<abs-path>"]` command is written to `opencode.json` instead of `["npx", "-y", "chrome-devtools-mcp@latest"]`.
- The Bun-compiled sidecar shim build is removed from `prepare-sidecar.mjs`. The shim script itself is updated to try the bundled package first and fall back to `npm exec` only if unavailable.

## Why

Not every user has `npx` available. Since Electron already ships a full Node.js runtime, we can resolve and run the bundled package directly — zero external tooling required.

## Test plan

- **19 new tests** across 2 test files (all pass):
  - `apps/app/tests/chrome-devtools-mcp-resolution.test.ts` — tests `buildChromeDevtoolsCommand` with resolved base, `isChromeDevtoolsMcp`, `usesChromeDevtoolsAutoConnect`, and verifies the installed package bin is resolvable.
  - `apps/desktop/scripts/chrome-devtools-mcp-shim.test.ts` — verifies the shim resolution logic, bin shebang, package.json `bin` field, and pinned version.
- **All 32 existing tests pass** (`bun test apps/app/tests/` — 0 failures).
- Tauri path is untouched (the `.rs` auto-injection and Tauri sidecar config remain as-is for backwards compatibility).

```
bun test apps/app/tests/
# 32 pass, 0 fail, 48 expect() calls

bun test apps/desktop/scripts/chrome-devtools-mcp-shim.test.ts
# 4 pass, 0 fail, 5 expect() calls
```

## Files changed

| File | Change |
|------|--------|
| `apps/desktop/package.json` | Add `chrome-devtools-mcp@0.17.0` dependency |
| `apps/desktop/electron/main.mjs` | Add `resolveChromeDevtoolsMcpBin` IPC + `createRequire` import |
| `apps/app/src/app/mcp.ts` | Add `resolveChromeDevtoolsMcpCommand()` async resolver |
| `apps/app/src/react-app/domains/connections/store.ts` | Use resolved command for Electron runtime |
| `apps/desktop/scripts/chrome-devtools-mcp-shim.ts` | Rewrite: bundled bin first, npm exec fallback |
| `apps/desktop/scripts/prepare-sidecar.mjs` | Remove Bun-compiled chrome-devtools sidecar build |
| `pnpm-lock.yaml` | Lockfile update |