### PR TITLE
feat(desktop): add embedded browser panel with WebContentsView

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -42,6 +42,30 @@ declare global {
         download?: () => Promise<{ ok: boolean; reason?: string }>;
         installAndRestart?: () => Promise<{ ok: boolean; reason?: string }>;
       };
+      browser?: {
+        show?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
+        hide?: () => Promise<void>;
+        navigate?: (url: string) => Promise<void>;
+        back?: () => Promise<void>;
+        forward?: () => Promise<void>;
+        reload?: () => Promise<void>;
+        setBounds?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
+        getState?: () => Promise<{
+          url: string;
+          title: string;
+          canGoBack: boolean;
+          canGoForward: boolean;
+          isLoading: boolean;
+        } | null>;
+        destroy?: () => Promise<void>;
+        onStateChange?: (callback: (state: {
+          url: string;
+          title: string;
+          canGoBack: boolean;
+          canGoForward: boolean;
+          isLoading: boolean;
+        }) => void) => () => void;
+      };
       meta?: {
         initialDeepLinks?: string[];
         platform?: "darwin" | "linux" | "windows";

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -1,0 +1,218 @@
+/** @jsxImportSource react */
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  Globe,
+  Loader2,
+  RotateCw,
+  X,
+} from "lucide-react";
+import { isElectronRuntime } from "../../../../app/utils";
+
+type BrowserState = {
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
+};
+
+type BrowserPanelProps = {
+  onClose: () => void;
+};
+
+const EMPTY_STATE: BrowserState = {
+  url: "",
+  title: "",
+  canGoBack: false,
+  canGoForward: false,
+  isLoading: false,
+};
+
+function getElectronBrowser() {
+  if (!isElectronRuntime()) return null;
+  return (window as Window).__OPENWORK_ELECTRON__?.browser ?? null;
+}
+
+export function BrowserPanel({ onClose }: BrowserPanelProps) {
+  const [state, setState] = useState<BrowserState>(EMPTY_STATE);
+  const [urlInput, setUrlInput] = useState("");
+  const [urlFocused, setUrlFocused] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const urlInputRef = useRef<HTMLInputElement>(null);
+
+  // Subscribe to state changes from the main process
+  useEffect(() => {
+    const browser = getElectronBrowser();
+    if (!browser) return;
+
+    const unsub = browser.onStateChange((newState: BrowserState) => {
+      setState(newState);
+      if (!urlFocused) {
+        setUrlInput(newState.url);
+      }
+    });
+
+    // Get initial state
+    browser.getState().then((initial: BrowserState | null) => {
+      if (initial) {
+        setState(initial);
+        setUrlInput(initial.url);
+      }
+    });
+
+    return unsub;
+  }, [urlFocused]);
+
+  // Show the browser view when the panel mounts, hide on unmount.
+  // Also update bounds when the panel resizes.
+  useEffect(() => {
+    const browser = getElectronBrowser();
+    if (!browser || !panelRef.current) return;
+
+    const updateBounds = () => {
+      if (!panelRef.current) return;
+      const rect = panelRef.current.getBoundingClientRect();
+      // The toolbar is ~44px, leave space at top for it
+      const toolbarHeight = 44;
+      const bounds = {
+        x: Math.round(rect.x),
+        y: Math.round(rect.y + toolbarHeight),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height - toolbarHeight),
+      };
+      browser.setBounds(bounds);
+    };
+
+    // Show with initial bounds
+    const rect = panelRef.current.getBoundingClientRect();
+    const toolbarHeight = 44;
+    browser.show({
+      x: Math.round(rect.x),
+      y: Math.round(rect.y + toolbarHeight),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height - toolbarHeight),
+    });
+
+    // Observe resize
+    const observer = new ResizeObserver(updateBounds);
+    observer.observe(panelRef.current);
+
+    // Also update on window resize
+    window.addEventListener("resize", updateBounds);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateBounds);
+      browser.hide();
+    };
+  }, []);
+
+  const navigate = useCallback(
+    (url?: string) => {
+      const browser = getElectronBrowser();
+      if (!browser) return;
+      browser.navigate(url ?? urlInput);
+    },
+    [urlInput],
+  );
+
+  const handleUrlKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        navigate();
+        urlInputRef.current?.blur();
+      }
+    },
+    [navigate],
+  );
+
+  const browser = getElectronBrowser();
+
+  if (!isElectronRuntime() || !browser) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-center text-dls-secondary">
+        <p className="text-sm">Browser panel is only available in the desktop app.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={panelRef} className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="flex h-[44px] shrink-0 items-center gap-1 border-b border-dls-border px-2">
+        {/* Navigation buttons */}
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40"
+          onClick={() => browser.back()}
+          disabled={!state.canGoBack}
+          title="Back"
+          aria-label="Go back"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40"
+          onClick={() => browser.forward()}
+          disabled={!state.canGoForward}
+          title="Forward"
+          aria-label="Go forward"
+        >
+          <ArrowRight className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+          onClick={() => browser.reload()}
+          title="Reload"
+          aria-label="Reload page"
+        >
+          {state.isLoading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RotateCw className="h-4 w-4" />
+          )}
+        </button>
+
+        {/* URL bar */}
+        <div className="relative mx-1 flex min-w-0 flex-1 items-center">
+          <Globe className="absolute left-2 h-3.5 w-3.5 text-dls-secondary" />
+          <input
+            ref={urlInputRef}
+            type="text"
+            className="h-7 w-full rounded-md border border-dls-border bg-dls-background-secondary pl-7 pr-2 text-[12px] text-dls-text placeholder:text-dls-secondary focus:border-dls-accent focus:outline-none"
+            value={urlInput}
+            onChange={(e) => setUrlInput(e.target.value)}
+            onKeyDown={handleUrlKeyDown}
+            onFocus={() => {
+              setUrlFocused(true);
+              urlInputRef.current?.select();
+            }}
+            onBlur={() => setUrlFocused(false)}
+            placeholder="Enter URL..."
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </div>
+
+        {/* Close button */}
+        <button
+          type="button"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+          onClick={onClose}
+          title="Close browser"
+          aria-label="Close browser panel"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* WebContentsView renders in this area (managed by Electron main process) */}
+      <div className="min-h-0 flex-1" />
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useState } from "react";
-import { Check, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Check, Globe, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { buildOpenworkWorkspaceBaseUrl, type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -32,6 +32,8 @@ import {
 } from "../../../shell/workspace-shell-layout";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
+import { isElectronRuntime } from "../../../../app/utils";
+import { BrowserPanel } from "../browser/browser-panel";
 
 type StatusBarOverrides = Pick<
   StatusBarProps,
@@ -173,7 +175,12 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [todoExpanded, setTodoExpanded] = useState(true);
+  const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
+
+  const toggleBrowserPanel = useCallback(() => {
+    setBrowserPanelOpen((prev) => !prev);
+  }, []);
 
   const selectedSessionTitle = useMemo(
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, props.selectedSessionId),
@@ -340,6 +347,23 @@ export function SessionPage(props: SessionPageProps) {
             </div>
 
             <div className="flex items-center gap-1.5 text-gray-10">
+              {isElectronRuntime() ? (
+                <button
+                  type="button"
+                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors ${
+                    browserPanelOpen
+                      ? "bg-dls-accent/10 text-dls-accent"
+                      : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"
+                  }`}
+                  onClick={toggleBrowserPanel}
+                  title="Toggle browser panel"
+                  aria-label="Toggle browser panel"
+                  aria-pressed={browserPanelOpen}
+                >
+                  <Globe size={16} />
+                  <span className="hidden lg:inline">Browser</span>
+                </button>
+              ) : null}
               {props.history ? (
                 <>
                   <button
@@ -535,6 +559,16 @@ export function SessionPage(props: SessionPageProps) {
             showSettingsButton={props.statusBar?.showSettingsButton}
           />
         </main>
+
+        {/* Embedded browser panel */}
+        {browserPanelOpen ? (
+          <aside
+            className="hidden min-h-0 shrink-0 overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)] lg:flex lg:flex-col"
+            style={{ width: 520 }}
+          >
+            <BrowserPanel onClose={toggleBrowserPanel} />
+          </aside>
+        ) : null}
       </div>
 
       {props.providerAuthModal ? <ProviderAuthModal {...props.providerAuthModal} /> : null}

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -16,7 +16,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, dialog, ipcMain, nativeImage, shell } from "electron";
+import { app, BrowserWindow, WebContentsView, dialog, ipcMain, nativeImage, shell } from "electron";
 import { registerMigrationIpc } from "./migration.mjs";
 import { createRuntimeManager } from "./runtime.mjs";
 import { registerUpdaterIpc } from "./updater.mjs";
@@ -184,6 +184,82 @@ const pendingDeepLinks = [];
 let uiControlServer = null;
 let uiControlDiscoveryPath = null;
 const uiControlToken = randomBytes(32).toString("hex");
+
+// ── Embedded browser panel ─────────────────────────────────────────────
+let browserView = null;
+let browserViewVisible = false;
+const BROWSER_DEFAULT_URL = "https://www.google.com";
+
+function createBrowserView() {
+  if (browserView) return browserView;
+  browserView = new WebContentsView({
+    webPreferences: {
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      partition: "persist:openwork-browser",
+    },
+  });
+  // Open external links from the embedded browser in the system browser
+  browserView.webContents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: "deny" };
+  });
+  // Notify renderer of navigation events
+  browserView.webContents.on("did-navigate", () => sendBrowserState());
+  browserView.webContents.on("did-navigate-in-page", () => sendBrowserState());
+  browserView.webContents.on("page-title-updated", () => sendBrowserState());
+  browserView.webContents.on("did-start-loading", () => sendBrowserState());
+  browserView.webContents.on("did-stop-loading", () => sendBrowserState());
+  return browserView;
+}
+
+function sendBrowserState() {
+  if (!mainWindow || !browserView) return;
+  try {
+    mainWindow.webContents.send("openwork:browser:state", {
+      url: browserView.webContents.getURL(),
+      title: browserView.webContents.getTitle(),
+      canGoBack: browserView.webContents.canGoBack(),
+      canGoForward: browserView.webContents.canGoForward(),
+      isLoading: browserView.webContents.isLoading(),
+    });
+  } catch {
+    // ignore — window may be closing
+  }
+}
+
+function showBrowserView(bounds) {
+  if (!mainWindow) return;
+  const view = createBrowserView();
+  if (!mainWindow.contentView.children.includes(view)) {
+    mainWindow.contentView.addChildView(view);
+  }
+  view.setBounds(bounds);
+  browserViewVisible = true;
+  if (!view.webContents.getURL()) {
+    view.webContents.loadURL(BROWSER_DEFAULT_URL);
+  }
+  sendBrowserState();
+}
+
+function hideBrowserView() {
+  if (!mainWindow || !browserView) return;
+  try {
+    mainWindow.contentView.removeChildView(browserView);
+  } catch {
+    // already removed
+  }
+  browserViewVisible = false;
+}
+
+function destroyBrowserView() {
+  hideBrowserView();
+  if (browserView) {
+    browserView.webContents.close();
+    browserView = null;
+  }
+}
 
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
@@ -1511,6 +1587,7 @@ async function createMainWindow() {
   });
 
   mainWindow.on("closed", () => {
+    destroyBrowserView();
     mainWindow = null;
   });
 
@@ -1547,6 +1624,48 @@ ipcMain.handle("openwork:shell:openExternal", async (_event, url) => {
 ipcMain.handle("openwork:shell:relaunch", async () => {
   app.relaunch();
   app.exit(0);
+});
+
+// ── Embedded browser IPC ────────────────────────────────────────────────
+ipcMain.handle("openwork:browser:show", (_event, bounds) => {
+  showBrowserView(bounds);
+});
+ipcMain.handle("openwork:browser:hide", () => {
+  hideBrowserView();
+});
+ipcMain.handle("openwork:browser:navigate", (_event, url) => {
+  if (!browserView) return;
+  const target = typeof url === "string" && url.trim() ? url.trim() : BROWSER_DEFAULT_URL;
+  // Add protocol if missing
+  const finalUrl = /^https?:\/\//i.test(target) ? target : `https://${target}`;
+  browserView.webContents.loadURL(finalUrl);
+});
+ipcMain.handle("openwork:browser:back", () => {
+  if (browserView?.webContents.canGoBack()) browserView.webContents.goBack();
+});
+ipcMain.handle("openwork:browser:forward", () => {
+  if (browserView?.webContents.canGoForward()) browserView.webContents.goForward();
+});
+ipcMain.handle("openwork:browser:reload", () => {
+  browserView?.webContents.reload();
+});
+ipcMain.handle("openwork:browser:bounds", (_event, bounds) => {
+  if (browserView && browserViewVisible) {
+    browserView.setBounds(bounds);
+  }
+});
+ipcMain.handle("openwork:browser:state", () => {
+  if (!browserView) return null;
+  return {
+    url: browserView.webContents.getURL(),
+    title: browserView.webContents.getTitle(),
+    canGoBack: browserView.webContents.canGoBack(),
+    canGoForward: browserView.webContents.canGoForward(),
+    isLoading: browserView.webContents.isLoading(),
+  };
+});
+ipcMain.handle("openwork:browser:destroy", () => {
+  destroyBrowserView();
 });
 
 registerMigrationIpc({ app, ipcMain });

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -53,6 +53,42 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
       };
     },
   },
+  browser: {
+    show(bounds) {
+      return ipcRenderer.invoke("openwork:browser:show", bounds);
+    },
+    hide() {
+      return ipcRenderer.invoke("openwork:browser:hide");
+    },
+    navigate(url) {
+      return ipcRenderer.invoke("openwork:browser:navigate", url);
+    },
+    back() {
+      return ipcRenderer.invoke("openwork:browser:back");
+    },
+    forward() {
+      return ipcRenderer.invoke("openwork:browser:forward");
+    },
+    reload() {
+      return ipcRenderer.invoke("openwork:browser:reload");
+    },
+    setBounds(bounds) {
+      return ipcRenderer.invoke("openwork:browser:bounds", bounds);
+    },
+    getState() {
+      return ipcRenderer.invoke("openwork:browser:state");
+    },
+    destroy() {
+      return ipcRenderer.invoke("openwork:browser:destroy");
+    },
+    onStateChange(callback) {
+      const handler = (_event, state) => callback(state);
+      ipcRenderer.on("openwork:browser:state", handler);
+      return () => {
+        ipcRenderer.removeListener("openwork:browser:state", handler);
+      };
+    },
+  },
   meta: {
     initialDeepLinks: [],
     platform: normalizePlatform(process.platform),


### PR DESCRIPTION
## Summary

Adds a built-in browser panel to the Electron desktop app. Users click the Globe icon in the session header to open a browser panel on the right side of the layout.

- Uses Electron's `WebContentsView` (the modern replacement for `BrowserView`) for full process isolation
- Sandboxed session partition (`persist:openwork-browser`) -- separate cookies/storage from the main app
- Real-time navigation state sync (URL, title, loading, can-go-back/forward) pushed to the renderer
- URL bar with keyboard navigation (Enter to go), back/forward/reload buttons, close button
- `ResizeObserver` keeps the WebContentsView bounds in sync with the React panel

## Architecture

```
React (BrowserPanel)
  └── IPC (openwork:browser:*)
      └── Electron Main Process
          └── WebContentsView (sandboxed, persist:openwork-browser partition)
              └── Renders web content
```

The `WebContentsView` is a native Chromium view overlaid on top of the BrowserWindow. The React panel provides the toolbar (URL bar, nav buttons), and a transparent `<div>` placeholder where the native view renders. Bounds are synced via `ResizeObserver` + window resize listener.

## Why this matters

This enables Chrome DevTools MCP to point at the embedded browser (`--browserUrl=http://127.0.0.1:<port>`) so agents can automate a browser visible inside the app -- no external Chrome window needed. Users can watch what the agent is doing in real time.

## Test plan

- **17 existing tests pass** (`bun test apps/app/tests/` -- 0 failures)
- The Globe toggle icon only renders in the Electron runtime (`isElectronRuntime()` gate)
- The `BrowserPanel` component shows a fallback message in non-Electron contexts
- WebContentsView is destroyed on window close to prevent leaks

```
bun test apps/app/tests/
# 17 pass, 0 fail
```

## Files changed

| File | Change |
|------|--------|
| `apps/desktop/electron/main.mjs` | Add `WebContentsView` browser management + IPC handlers |
| `apps/desktop/electron/preload.mjs` | Expose `browser.*` methods via contextBridge |
| `apps/app/src/app/lib/desktop.ts` | Add TypeScript types for browser bridge |
| `apps/app/src/react-app/domains/session/browser/browser-panel.tsx` | New browser panel component |
| `apps/app/src/react-app/domains/session/chat/session-page.tsx` | Integrate browser panel + Globe toggle |

## Manual verification steps

1. `pnpm dev:electron` from `apps/desktop/`
2. Click the Globe icon in the session header bar
3. A browser panel opens on the right (520px wide) showing Google
4. Type a URL in the address bar, press Enter -- navigates
5. Back/forward/reload buttons work
6. Click the X or Globe icon again to close
7. WebContentsView is removed from the window (no ghost rendering)