### PR TITLE
fix(composer): prevent double chip creation and fix cursor position after paste

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1065,17 +1065,11 @@ export function ReactSessionComposer(props: ComposerProps) {
 
                 const text = event.clipboardData?.getData("text/plain") ?? "";
 
-                // Collapse long pastes into an inline chip. The threshold
-                // is 3+ lines or 200+ characters — short pastes still go
-                // straight into the editor as plain text.
-                const PASTE_CHIP_LINE_THRESHOLD = 3;
-                const PASTE_CHIP_CHAR_THRESHOLD = 200;
-                const lineCount = text.split(/\r?\n/).length;
-                if (text.trim() && (lineCount >= PASTE_CHIP_LINE_THRESHOLD || text.length >= PASTE_CHIP_CHAR_THRESHOLD)) {
-                  event.preventDefault();
-                  props.onPasteText(text);
-                  return;
-                }
+                // Long pastes (3+ lines / 200+ chars) are collapsed into
+                // an inline chip by PasteChipPlugin inside the Lexical
+                // editor. Do NOT duplicate that here — calling onPasteText
+                // from both the React onPaste handler and the Lexical
+                // PASTE_COMMAND handler causes double chip creation.
 
                 if (
                   text.trim() &&

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -426,7 +426,18 @@ function SyncPlugin(props: { value: string; mentions: Record<string, "agent" | "
       // changed the state between the read above and this callback.
       if (!forceRebuild && serializePromptFromRoot() === props.value) return;
       setPrompt(props.value, props.mentions, props.pastedText);
-      $getRoot().selectEnd();
+      // $getRoot().selectEnd() doesn't work when the last node is a
+      // token (chip) — Lexical can't position a cursor inside a token,
+      // so the selection collapses to position 0. Use element-level
+      // selection instead: place the cursor *after* the last child of
+      // the last paragraph.
+      const lastParagraph = $getRoot().getLastChild();
+      if ($isElementNode(lastParagraph)) {
+        const childCount = lastParagraph.getChildrenSize();
+        lastParagraph.select(childCount, childCount);
+      } else {
+        $getRoot().selectEnd();
+      }
     });
   }, [editor, props.mentions, props.pastedText, props.value]);
 


### PR DESCRIPTION
## Summary

Follow-up to #1669 (which only had the SyncPlugin early-return). This PR fixes the actual bugs:

1. **Double chip creation**: both the React `onPaste` handler and the Lexical `PasteChipPlugin` intercepted multiline paste, each calling `onPasteText` — creating two "Pasted · N lines" chips. Fix: remove the duplicate from `onPaste`; `PasteChipPlugin` already handles it at the Lexical `PASTE_COMMAND` level.

2. **Cursor jumps to position 0**: `$getRoot().selectEnd()` traverses to the last descendant and calls its `selectEnd()`. When the last node is a token (chip with `isToken()=true`), Lexical can't position a cursor inside it and the selection collapses to 0. Fix: use `lastParagraph.select(childCount, childCount)` to place cursor *after* the chip.

## Evidence

### Screenshot (after fix)
![Composer: single chip, cursor after chip](https://litter.catbox.moe/m5mvek.png)

### CDP automated test output
```
Before paste: {"text":"hello ","focusOffset":6}
AFTER PASTE:
  chipCount: 1              ← was 2 (double-fire fixed)
  BUG_CURSOR_AT_START: false ← was true
  absoluteOffset: 22         ← cursor at end
  focusInLastParagraph: true
```

### Build
- `pnpm --filter app build` — passed

## Test instructions

1. `pnpm --filter @openwork/desktop dev:electron`
2. Open a session, type text, paste 3+ lines
3. **Expected**: single chip, cursor right after it
4. **Before fix**: two chips, cursor at position 0