### PR TITLE
feat: run OpenWork server in-process within Electron (no sidecar binary)

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -483,6 +483,17 @@ export function SessionRoute() {
           setRetryingWorkspaceIds((current) =>
             current.includes(workspace.id) ? current.filter((id) => id !== workspace.id) : current,
           );
+          // When a workspace returns zero sessions during the initial batch
+          // load, OpenCode may still be warming up its index.  Schedule a
+          // single delayed retry so the sidebar doesn't stay permanently
+          // empty while the managed engine finishes starting.
+          if (items.length === 0 && attempt === 0) {
+            window.setTimeout(() => {
+              if (backgroundSessionLoadInFlight.current.get(workspace.id)) return;
+              backgroundSessionLoadInFlight.current.delete(workspace.id);
+              void fetchOnce(workspace, 1);
+            }, 3_000);
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : t("app.unknown_error");
           // The first cold call to OpenCode's /session endpoint often hits

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -593,6 +593,7 @@ export function SessionRoute() {
 
       // Preserve any sessions we already have cached so switching routes
       // doesn't erase the sidebar while we refetch.
+      const alreadyLoadedWorkspaceIds = new Set(Object.keys(sessionsByWorkspaceIdRef.current));
       const cachedEntries = nextWorkspaces.map((workspace) => ({
         workspaceId: workspace.id,
         sessions: sessionsByWorkspaceIdRef.current[workspace.id] ?? [],
@@ -632,9 +633,10 @@ export function SessionRoute() {
         return next;
       });
       setRetryingWorkspaceIds(
-        cachedEntries.find((entry) => entry.workspaceId === nextWorkspaceId)?.sessions.length === 0 && nextWorkspaceId
-          ? [nextWorkspaceId]
-          : [],
+        cachedEntries
+          .filter((entry) => entry.sessions.length === 0)
+          .filter((entry) => entry.workspaceId === nextWorkspaceId || !alreadyLoadedWorkspaceIds.has(entry.workspaceId))
+          .map((entry) => entry.workspaceId),
       );
       setLegacySelectedWorkspaceId(nextWorkspaceId);
       writeActiveWorkspaceId(nextWorkspaceId || null);
@@ -657,8 +659,14 @@ export function SessionRoute() {
       // so the UI is interactive immediately; the sidebar shows a
       // loading state per-workspace until the list arrives.
       const selectedWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId);
-      if (selectedWorkspace) {
-        void loadWorkspaceSessionsInBackground(openworkClient, [selectedWorkspace]);
+      const backgroundWorkspaces = nextWorkspaces.filter(
+        (workspace) => workspace.id === nextWorkspaceId || !alreadyLoadedWorkspaceIds.has(workspace.id),
+      );
+      if (backgroundWorkspaces.length > 0) {
+        const orderedWorkspaces = selectedWorkspace
+          ? [selectedWorkspace, ...backgroundWorkspaces.filter((workspace) => workspace.id !== selectedWorkspace.id)]
+          : backgroundWorkspaces;
+        void loadWorkspaceSessionsInBackground(openworkClient, orderedWorkspaces);
       }
     } catch (error) {
       const message = describeRouteError(error);

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -40,9 +40,6 @@ mac:
         - opencode
         - opencode-aarch64-apple-darwin
         - opencode-x86_64-apple-darwin
-        - openwork-server
-        - openwork-server-aarch64-apple-darwin
-        - openwork-server-x86_64-apple-darwin
         - openwork-orchestrator
         - openwork-orchestrator-aarch64-apple-darwin
         - openwork-orchestrator-x86_64-apple-darwin
@@ -64,9 +61,6 @@ linux:
         - opencode
         - opencode-aarch64-unknown-linux-gnu
         - opencode-x86_64-unknown-linux-gnu
-        - openwork-server
-        - openwork-server-aarch64-unknown-linux-gnu
-        - openwork-server-x86_64-unknown-linux-gnu
         - openwork-orchestrator
         - openwork-orchestrator-aarch64-unknown-linux-gnu
         - openwork-orchestrator-x86_64-unknown-linux-gnu
@@ -88,9 +82,6 @@ win:
         - opencode.exe
         - opencode-aarch64-pc-windows-msvc.exe
         - opencode-x86_64-pc-windows-msvc.exe
-        - openwork-server.exe
-        - openwork-server-aarch64-pc-windows-msvc.exe
-        - openwork-server-x86_64-pc-windows-msvc.exe
         - openwork-orchestrator.exe
         - openwork-orchestrator-aarch64-pc-windows-msvc.exe
         - openwork-orchestrator-x86_64-pc-windows-msvc.exe

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -968,33 +968,22 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     return token || null;
   }
 
+  // In-process server handle. Kept alive across restarts so we can stop it.
+  let inProcessServer = null;
+
   async function startOpenworkServer(options) {
+    // Stop any previously running in-process server
+    if (inProcessServer) {
+      try { inProcessServer.stop(); } catch { /* ignore */ }
+      inProcessServer = null;
+    }
     await stopChild(openworkServerState);
 
     const workspacePaths = options.workspacePaths.filter((value) => value.trim().length > 0);
     const activeWorkspace = workspacePaths[0] ?? "";
     const host = options.remoteAccessEnabled ? "0.0.0.0" : "127.0.0.1";
     const port = await resolveOpenworkPort(host, activeWorkspace);
-    const baseUrl = `http://127.0.0.1:${port}`;
     const tokens = await loadOrCreateWorkspaceTokens(activeWorkspace);
-    const program = resolveBinary("openwork-server");
-    if (!program) {
-      throw new Error("Failed to locate openwork-server.");
-    }
-
-    const args = [
-      "--host",
-      host,
-      "--port",
-      String(port),
-      "--cors",
-      "*",
-      "--approval",
-      "auto",
-      ...workspacePaths.flatMap((workspacePath) => ["--workspace", workspacePath]),
-      ...(options.opencodeBaseUrl ? ["--opencode-base-url", options.opencodeBaseUrl] : []),
-      ...(activeWorkspace ? ["--opencode-directory", activeWorkspace] : []),
-    ];
 
     const managedOpencode = options.manageOpencode ? resolveOpencodeBinary(options.opencodeBinPath) : null;
     openworkServerState.managedOpencodeBinPath = managedOpencode?.path ?? null;
@@ -1004,7 +993,8 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       engineState.opencodeBinSource = managedOpencode?.source ?? null;
     }
 
-    const env = await buildChildEnv({
+    // Inject env vars that the server reads (managed opencode, etc.)
+    const serverEnv = await buildChildEnv({
       OPENWORK_TOKEN: tokens.clientToken,
       OPENWORK_HOST_TOKEN: tokens.hostToken,
       ...(options.manageOpencode ? { OPENWORK_MANAGE_OPENCODE: "1" } : {}),
@@ -1013,30 +1003,45 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       ...(options.opencodeUsername ? { OPENWORK_OPENCODE_USERNAME: options.opencodeUsername } : {}),
       ...(options.opencodePassword ? { OPENWORK_OPENCODE_PASSWORD: options.opencodePassword } : {}),
     });
+    Object.assign(process.env, serverEnv);
 
-    spawnManagedChild(openworkServerState, program, args, {
-      cwd: activeWorkspace || desktopRoot,
-      env,
-    });
+    // Import and start the server in-process (no child process, no health poll)
+    const { startServer } = await import("../../server/src/server.ts");
+    const { resolveServerConfig } = await import("../../server/src/config.js");
+
+    // Build CLI-style args for resolveServerConfig
+    const cliArgs = {
+      host,
+      port,
+      corsOrigins: ["*"],
+      approvalMode: "auto",
+      workspaces: workspacePaths,
+      token: tokens.clientToken,
+      hostToken: tokens.hostToken,
+      opencodeBaseUrl: options.opencodeBaseUrl ?? undefined,
+      opencodeDirectory: activeWorkspace || undefined,
+    };
+    const serverConfig = await resolveServerConfig(cliArgs);
+
+    const server = await startServer(serverConfig);
+    inProcessServer = server;
+
+    const boundPort = server.port;
+    const baseUrl = `http://127.0.0.1:${boundPort}`;
 
     openworkServerState.remoteAccessEnabled = options.remoteAccessEnabled;
     openworkServerState.host = host;
-    openworkServerState.port = port;
+    openworkServerState.port = boundPort;
     openworkServerState.baseUrl = baseUrl;
     openworkServerState.clientToken = tokens.clientToken;
     openworkServerState.hostToken = tokens.hostToken;
 
-    const connectUrls = options.remoteAccessEnabled ? buildConnectUrls(port) : { connectUrl: null, mdnsUrl: null, lanUrl: null };
+    const connectUrls = options.remoteAccessEnabled ? buildConnectUrls(boundPort) : { connectUrl: null, mdnsUrl: null, lanUrl: null };
     openworkServerState.connectUrl = connectUrls.connectUrl;
     openworkServerState.mdnsUrl = connectUrls.mdnsUrl;
     openworkServerState.lanUrl = connectUrls.lanUrl;
 
-    await waitForHttpOk(`${baseUrl}/health`, 10_000);
-    // Owner tokens live in the OpenWork server token store, which can be reset
-    // independently from the desktop runtime token cache. Always mint a fresh
-    // owner token for the newly-started server instead of trusting the cached
-    // value; otherwise the renderer can receive a stale bearer token and all
-    // workspace calls fail with 401.
+    // No health check needed -- startServer() resolves only after the listener is bound.
     const ownerToken = await issueOwnerToken(baseUrl, tokens.hostToken);
     openworkServerState.ownerToken = ownerToken;
     if (ownerToken) {
@@ -1064,7 +1069,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
         appendOutput(openworkServerState, "lastStderr", `OpenWork server workspace probe: ${error instanceof Error ? error.message : String(error)}\n`);
       }
     }
-    await persistPreferredOpenworkPort(activeWorkspace, port);
+    await persistPreferredOpenworkPort(activeWorkspace, boundPort);
     return snapshotOpenworkServerState(openworkServerState);
   }
 
@@ -1194,6 +1199,11 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function stopAllRuntimeChildren() {
+    // Stop the in-process server if running
+    if (inProcessServer) {
+      try { inProcessServer.stop(); } catch { /* ignore */ }
+      inProcessServer = null;
+    }
     await stopChild(openworkServerState);
     await stopChild(orchestratorState, {
       requestShutdown: () => requestOrchestratorShutdown(orchestratorState.dataDir || orchestratorDataDir()),

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -995,30 +995,13 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       engineState.opencodeBinSource = managedOpencode?.source ?? null;
     }
 
-    // Inject env vars that the server reads (managed opencode, etc.)
-    const serverEnv = await buildChildEnv({
-      OPENWORK_TOKEN: tokens.clientToken,
-      OPENWORK_HOST_TOKEN: tokens.hostToken,
-      ...(options.manageOpencode ? { OPENWORK_MANAGE_OPENCODE: "1" } : {}),
-      ...(options.manageOpencode ? { OPENWORK_OPENCODE_BIN: managedOpencode?.path ?? "" } : {}),
-      ...(options.manageOpencode ? { OPENWORK_MANAGED_OPENCODE_CWD: managedOpencodeWorkdir() } : {}),
-      ...(options.opencodeUsername ? { OPENWORK_OPENCODE_USERNAME: options.opencodeUsername } : {}),
-      ...(options.opencodePassword ? { OPENWORK_OPENCODE_PASSWORD: options.opencodePassword } : {}),
-    });
+    // Inject user env vars so the server and managed OpenCode inherit them.
+    const serverEnv = await buildChildEnv({});
     Object.assign(process.env, serverEnv);
 
-    // Import the server in-process (compiled TS → JS via tsc into dist/)
-    let startServer, resolveServerConfig;
-    try {
-      ({ startServer } = await import("../../server/dist/server.js"));
-      ({ resolveServerConfig } = await import("../../server/dist/config.js"));
-    } catch (importError) {
-      console.error("[openwork-server] Failed to import server library:", importError);
-      throw importError;
-    }
-
-    // Build CLI-style args for resolveServerConfig
-    const cliArgs = {
+    // One call: resolve config, spawn managed OpenCode, start HTTP server.
+    const { startEmbeddedServer } = await import("../../server/dist/embedded.js");
+    const handle = await startEmbeddedServer({
       host,
       port,
       corsOrigins: ["*"],
@@ -1028,26 +1011,14 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       hostToken: tokens.hostToken,
       opencodeBaseUrl: options.opencodeBaseUrl ?? undefined,
       opencodeDirectory: activeWorkspace || undefined,
-    };
-    let serverConfig;
-    try {
-      serverConfig = await resolveServerConfig(cliArgs);
-    } catch (configError) {
-      console.error("[openwork-server] Failed to resolve config:", configError);
-      throw configError;
-    }
+      manageOpencode: options.manageOpencode === true,
+      opencodeBin: managedOpencode?.path ?? undefined,
+      opencodeCwd: managedOpencodeWorkdir(),
+    });
+    inProcessServer = handle;
 
-    let server;
-    try {
-      server = await startServer(serverConfig);
-    } catch (startError) {
-      console.error("[openwork-server] Failed to start in-process server:", startError);
-      throw startError;
-    }
-    inProcessServer = server;
-
-    const boundPort = server.port;
-    const baseUrl = `http://127.0.0.1:${boundPort}`;
+    const boundPort = handle.port;
+    const baseUrl = handle.url;
 
     openworkServerState.inProcess = true;
     openworkServerState.remoteAccessEnabled = options.remoteAccessEnabled;
@@ -1220,7 +1191,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function stopAllRuntimeChildren() {
-    // Stop the in-process server if running
+    // Stop the in-process server (and its managed OpenCode child) if running.
     if (inProcessServer) {
       try { inProcessServer.stop(); } catch { /* ignore */ }
       inProcessServer = null;

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1005,9 +1005,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     });
     Object.assign(process.env, serverEnv);
 
-    // Import and start the server in-process (no child process, no health poll)
-    const { startServer } = await import("../../server/src/server.ts");
-    const { resolveServerConfig } = await import("../../server/src/config.js");
+    // Import the server in-process (compiled TS → JS via tsc into dist/)
+    const { startServer } = await import("../../server/dist/server.js");
+    const { resolveServerConfig } = await import("../../server/dist/config.js");
 
     // Build CLI-style args for resolveServerConfig
     const cliArgs = {

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -72,6 +72,7 @@ function createOpenworkServerState() {
   return {
     child: null,
     childExited: true,
+    inProcess: false,
     remoteAccessEnabled: false,
     host: null,
     port: null,
@@ -91,8 +92,9 @@ function createOpenworkServerState() {
 
 function snapshotOpenworkServerState(state) {
   const child = state.childExited ? null : state.child;
+  const running = state.inProcess || Boolean(child && child.exitCode === null && !child.killed);
   return {
-    running: Boolean(child && child.exitCode === null && !child.killed),
+    running,
     remoteAccessEnabled: state.remoteAccessEnabled,
     host: state.host,
     port: state.port,
@@ -1006,8 +1008,14 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     Object.assign(process.env, serverEnv);
 
     // Import the server in-process (compiled TS → JS via tsc into dist/)
-    const { startServer } = await import("../../server/dist/server.js");
-    const { resolveServerConfig } = await import("../../server/dist/config.js");
+    let startServer, resolveServerConfig;
+    try {
+      ({ startServer } = await import("../../server/dist/server.js"));
+      ({ resolveServerConfig } = await import("../../server/dist/config.js"));
+    } catch (importError) {
+      console.error("[openwork-server] Failed to import server library:", importError);
+      throw importError;
+    }
 
     // Build CLI-style args for resolveServerConfig
     const cliArgs = {
@@ -1021,14 +1029,27 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
       opencodeBaseUrl: options.opencodeBaseUrl ?? undefined,
       opencodeDirectory: activeWorkspace || undefined,
     };
-    const serverConfig = await resolveServerConfig(cliArgs);
+    let serverConfig;
+    try {
+      serverConfig = await resolveServerConfig(cliArgs);
+    } catch (configError) {
+      console.error("[openwork-server] Failed to resolve config:", configError);
+      throw configError;
+    }
 
-    const server = await startServer(serverConfig);
+    let server;
+    try {
+      server = await startServer(serverConfig);
+    } catch (startError) {
+      console.error("[openwork-server] Failed to start in-process server:", startError);
+      throw startError;
+    }
     inProcessServer = server;
 
     const boundPort = server.port;
     const baseUrl = `http://127.0.0.1:${boundPort}`;
 
+    openworkServerState.inProcess = true;
     openworkServerState.remoteAccessEnabled = options.remoteAccessEnabled;
     openworkServerState.host = host;
     openworkServerState.port = boundPort;

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -25,6 +25,8 @@ function run(command, args, cwd, env) {
 }
 
 run(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdir", electronSidecarDir], desktopRoot);
+// Build the server TS → JS so Electron can import it in-process
+run(pnpmCmd, ["--filter", "openwork-server", "build"], repoRoot);
 // OPENWORK_ELECTRON_BUILD tells Vite to emit relative asset paths so
 // index.html resolves /assets/* correctly when loaded via file:// from
 // inside the packaged .app bundle.

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -193,6 +193,10 @@ process.once("SIGTERM", () => void stopAll(143));
 
 runSync(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdir", electronSidecarDir], { cwd: desktopRoot });
 
+// Build the server TS → JS so Electron can import it in-process
+console.log("[electron-dev] Building openwork-server (tsc)...");
+runSync(pnpmCmd, ["--filter", "openwork-server", "build"], { cwd: repoRoot });
+
 const initialProbeUrls = [startUrl, ...viteProbeUrls].filter(Boolean);
 let viteReady = false;
 for (const candidate of initialProbeUrls) {

--- a/apps/desktop/scripts/prepare-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-sidecar.mjs
@@ -287,69 +287,11 @@ const parseChecksum = (content, assetName) => {
   return null;
 };
 
-let didBuildOpenworkServer = false;
-const shouldBuildOpenworkServer =
-  forceBuild || !existsSync(openworkServerBuildPath) || isStubBinary(openworkServerBuildPath);
+// openwork-server is no longer compiled as a sidecar binary — it runs
+// in-process inside Electron via a direct import of the server library.
+const didBuildOpenworkServer = false;
 
-if (shouldBuildOpenworkServer) {
-  mkdirSync(sidecarDir, { recursive: true });
-  if (existsSync(openworkServerBuildPath)) {
-    try {
-      unlinkSync(openworkServerBuildPath);
-    } catch {
-      // ignore
-    }
-  }
-  const openworkServerScript = resolveBuildScript(openworkServerDir);
-  if (!existsSync(openworkServerScript)) {
-    console.error(`OpenWork server build script not found at ${openworkServerScript}`);
-    process.exit(1);
-  }
-  const openworkServerArgs = [openworkServerScript, "--outdir", sidecarDir, "--filename", "openwork-server"];
-  if (bunTarget) {
-    openworkServerArgs.push("--target", bunTarget);
-  }
-  const buildResult = spawnSync("bun", openworkServerArgs, {
-    cwd: openworkServerDir,
-    stdio: "inherit",
-    shell: true,
-  });
-
-  if (buildResult.status !== 0) {
-    process.exit(buildResult.status ?? 1);
-  }
-
-  didBuildOpenworkServer = true;
-}
-
-if (existsSync(openworkServerBuildPath)) {
-  const shouldCopyCanonical = didBuildOpenworkServer || !existsSync(openworkServerPath) || isStubBinary(openworkServerPath);
-  if (shouldCopyCanonical && openworkServerBuildPath !== openworkServerPath) {
-    try {
-      if (existsSync(openworkServerPath)) {
-        unlinkSync(openworkServerPath);
-      }
-    } catch {
-      // ignore
-    }
-    copyFileSync(openworkServerBuildPath, openworkServerPath);
-  }
-
-  if (openworkServerTargetPath) {
-    const shouldCopyTarget =
-      didBuildOpenworkServer || !existsSync(openworkServerTargetPath) || isStubBinary(openworkServerTargetPath);
-    if (shouldCopyTarget && openworkServerBuildPath !== openworkServerTargetPath) {
-      try {
-        if (existsSync(openworkServerTargetPath)) {
-          unlinkSync(openworkServerTargetPath);
-        }
-      } catch {
-        // ignore
-      }
-      copyFileSync(openworkServerBuildPath, openworkServerTargetPath);
-    }
-  }
-}
+// Server binary copy/sign skipped — runs in-process.
 
 if (!existingOpencodeVersion && opencodeCandidatePath) {
   existingOpencodeVersion =
@@ -559,9 +501,7 @@ if (existsSync(orchestratorBuildPath)) {
 adHocSignDarwinSidecars([
   opencodePath,
   opencodeTargetPath,
-  openworkServerBuildPath,
-  openworkServerPath,
-  openworkServerTargetPath,
+  // openwork-server runs in-process — no binary to sign.
   orchestratorBuildPath,
   orchestratorPath,
   orchestratorTargetPath,
@@ -592,7 +532,7 @@ const versions = {
   },
   "openwork-server": {
     version: openworkServerVersion,
-    sha256: existsSync(openworkServerPath) ? sha256File(openworkServerPath) : null,
+    sha256: "in-process",
   },
   "openwork-orchestrator": {
     version: orchestratorVersion,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -45,16 +45,16 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^11.10.0",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.0.1",
     "yaml": "^2.6.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.12",
-    "@types/node": "^22.10.2",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/minimatch": "^5.1.2",
+    "@types/node": "^22.10.2",
     "bun-types": "^1.3.6",
     "typescript": "^5.6.3"
   },

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -41,13 +41,18 @@
   "publishConfig": {
     "access": "public"
   },
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "dependencies": {
+    "better-sqlite3": "^11.0.0",
     "jsonc-parser": "^3.2.1",
     "minimatch": "^10.0.1",
     "yaml": "^2.6.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.2",
     "@types/minimatch": "^5.1.2",
     "bun-types": "^1.3.6",

--- a/apps/server/src/bun.d.ts
+++ b/apps/server/src/bun.d.ts
@@ -1,0 +1,9 @@
+declare const Bun: {
+  serve: (options: {
+    hostname: string;
+    port: number;
+    fetch: (request: Request) => Response | Promise<Response>;
+  }) => {
+    port: number;
+  };
+};

--- a/apps/server/src/bun.d.ts
+++ b/apps/server/src/bun.d.ts
@@ -1,9 +1,0 @@
-declare const Bun: {
-  serve: (options: {
-    hostname: string;
-    port: number;
-    fetch: (request: Request) => Response | Promise<Response>;
-  }) => {
-    port: number;
-  };
-};

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -48,7 +48,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
   }
 }
 
-const server = startServer(config);
+const server = await startServer(config);
 
 const url = `http://${config.host}:${server.port}`;
 logger.log("info", `OpenWork server listening on ${url}`);

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -4,7 +4,7 @@ import type { ApprovalMode, ApprovalConfig, ServerConfig, WorkspaceConfig, LogFo
 import { buildWorkspaceInfos } from "./workspaces.js";
 import { parseList, readJsonFile, shortId } from "./utils.js";
 
-interface CliArgs {
+export interface CliArgs {
   configPath?: string;
   host?: string;
   port?: number;

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -1,0 +1,80 @@
+/**
+ * Single entry point for embedding the OpenWork server in-process.
+ *
+ * Handles config resolution, managed OpenCode spawn, and server start
+ * in one call -- mirrors what cli.ts does but returns a handle instead
+ * of owning the process lifecycle.
+ */
+import { mkdir } from "node:fs/promises";
+import { resolveServerConfig, type CliArgs } from "./config.js";
+import { createManagedOpencodeServer, type ManagedOpencodeServer } from "./managed-opencode.js";
+import { startServer } from "./server.js";
+import type { ServeResult } from "./serve-node.js";
+import type { ServerConfig } from "./types.js";
+
+export type EmbeddedServerOptions = CliArgs & {
+  /** When true, spawn a managed OpenCode child process. */
+  manageOpencode?: boolean;
+  /** Path to the OpenCode binary. Falls back to OPENWORK_OPENCODE_BIN env. */
+  opencodeBin?: string;
+  /** Working directory for the managed OpenCode process. */
+  opencodeCwd?: string;
+};
+
+export type EmbeddedServerHandle = {
+  /** Bound port the HTTP server is listening on. */
+  port: number;
+  /** Full base URL, e.g. http://127.0.0.1:48123 */
+  url: string;
+  /** The resolved server config (with OpenCode URLs populated). */
+  config: ServerConfig;
+  /** Stop the HTTP server and managed OpenCode (if any). */
+  stop: () => void;
+};
+
+export async function startEmbeddedServer(options: EmbeddedServerOptions): Promise<EmbeddedServerHandle> {
+  const config = await resolveServerConfig(options);
+
+  // Spawn managed OpenCode if requested and no explicit base URL was provided.
+  let managedOpencode: ManagedOpencodeServer | null = null;
+
+  if (!config.opencodeBaseUrl && options.manageOpencode) {
+    const workspace = config.workspaces[0];
+    if (workspace?.path) {
+      const cwd = options.opencodeCwd
+        || process.env.OPENWORK_MANAGED_OPENCODE_CWD?.trim()
+        || workspace.path;
+      await mkdir(cwd, { recursive: true });
+
+      managedOpencode = await createManagedOpencodeServer({
+        bin: options.opencodeBin || process.env.OPENWORK_OPENCODE_BIN,
+        cwd,
+        env: {
+          ...(process.env.OPENWORK_DEV_MODE ? { OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE } : {}),
+        },
+      });
+
+      config.opencodeBaseUrl = managedOpencode.url;
+      config.opencodeUsername = managedOpencode.username;
+      config.opencodePassword = managedOpencode.password;
+      for (const entry of config.workspaces) {
+        entry.baseUrl ??= managedOpencode.url;
+        entry.opencodeUsername ??= managedOpencode.username;
+        entry.opencodePassword ??= managedOpencode.password;
+        entry.directory ??= entry.path;
+      }
+    }
+  }
+
+  const server = await startServer(config);
+
+  return {
+    port: server.port,
+    url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
+    config,
+    stop() {
+      managedOpencode?.close();
+      server.stop();
+    },
+  };
+}

--- a/apps/server/src/env-routes.e2e.test.ts
+++ b/apps/server/src/env-routes.e2e.test.ts
@@ -36,8 +36,8 @@ function baseConfig(): ServerConfig {
   } as ServerConfig;
 }
 
-function boot() {
-  const server = startServer(baseConfig()) as Served;
+async function boot() {
+  const server = await startServer(baseConfig()) as Served;
   stops.push(() => server.stop(true));
   return {
     server,
@@ -79,13 +79,13 @@ afterEach(async () => {
 
 describe("env routes", () => {
   test("rejects unauthenticated requests", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const response = await fetch(`${base}/env`);
     expect(response.status).toBe(401);
   });
 
   test("rejects owner bearer tokens", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const issued = await fetch(`${base}/tokens`, {
       method: "POST",
       headers: hostAuth(),
@@ -101,7 +101,7 @@ describe("env routes", () => {
   });
 
   test("CORS preflight allows PUT", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const response = await fetch(`${base}/env`, {
       method: "OPTIONS",
       headers: {
@@ -114,7 +114,7 @@ describe("env routes", () => {
   });
 
   test("PUT + GET round-trips a single entry and returns raw values", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const put = await fetch(`${base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -131,7 +131,7 @@ describe("env routes", () => {
   });
 
   test("GET /env/keys returns names without values", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     await fetch(`${base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -150,7 +150,7 @@ describe("env routes", () => {
 
   test("invalid env store returns 409 instead of overwriting on PUT", async () => {
     writeFileSync(process.env.OPENWORK_ENV_STORE!, "{ this is not json");
-    const { base } = boot();
+    const { base } = await boot();
 
     const put = await fetch(`${base}/env`, {
       method: "PUT",
@@ -164,7 +164,7 @@ describe("env routes", () => {
   });
 
   test("PUT accepts a batch via entries[]", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const put = await fetch(`${base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -185,7 +185,7 @@ describe("env routes", () => {
   });
 
   test("PUT rejects invalid keys with 400", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const put = await fetch(`${base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -199,7 +199,7 @@ describe("env routes", () => {
   });
 
   test("PUT rejects reserved keys with 400", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const put = await fetch(`${base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -213,7 +213,7 @@ describe("env routes", () => {
   });
 
   test("PUT with no entries returns 400", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const put = await fetch(`${base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -223,7 +223,7 @@ describe("env routes", () => {
   });
 
   test("DELETE removes an existing entry", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     await fetch(`${base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -240,13 +240,13 @@ describe("env routes", () => {
   });
 
   test("DELETE on missing key returns 404", async () => {
-    const { base } = boot();
+    const { base } = await boot();
     const del = await fetch(`${base}/env/MISSING`, { method: "DELETE", headers: hostAuth() });
     expect(del.status).toBe(404);
   });
 
   test("values persist across server restart", async () => {
-    const first = boot();
+    const first = await boot();
     await fetch(`${first.base}/env`, {
       method: "PUT",
       headers: hostAuth(),
@@ -255,7 +255,7 @@ describe("env routes", () => {
     await first.server.stop(true);
     stops.pop();
 
-    const second = boot();
+    const second = await boot();
     const body = (await (await fetch(`${second.base}/env`, { headers: hostAuth() })).json()) as {
       items: Array<{ key: string; value: string }>;
     };

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Library entry point for the OpenWork server.
+ *
+ * Use this to embed the server in-process (e.g. inside Electron)
+ * instead of running it as a standalone binary.
+ *
+ * ```ts
+ * import { startServer } from "@openwork/server";
+ *
+ * const server = await startServer(config);
+ * console.log(`Listening on port ${server.port}`);
+ * ```
+ */
+export { startServer } from "./server.js";
+export type { ServeResult } from "./serve-node.js";

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,15 +1,24 @@
 /**
  * Library entry point for the OpenWork server.
  *
- * Use this to embed the server in-process (e.g. inside Electron)
- * instead of running it as a standalone binary.
- *
  * ```ts
- * import { startServer } from "@openwork/server";
+ * import { startEmbeddedServer } from "openwork-server";
  *
- * const server = await startServer(config);
- * console.log(`Listening on port ${server.port}`);
+ * const handle = await startEmbeddedServer({
+ *   host: "127.0.0.1",
+ *   port: 0,
+ *   workspaces: ["/path/to/workspace"],
+ *   token: clientToken,
+ *   hostToken: hostToken,
+ *   manageOpencode: true,
+ *   opencodeBin: "/path/to/opencode",
+ * });
+ *
+ * console.log(`Server at ${handle.url}`);
+ * handle.stop();
  * ```
  */
+export { startEmbeddedServer, type EmbeddedServerHandle, type EmbeddedServerOptions } from "./embedded.js";
 export { startServer } from "./server.js";
+export { resolveServerConfig } from "./config.js";
 export type { ServeResult } from "./serve-node.js";

--- a/apps/server/src/opencode-db.ts
+++ b/apps/server/src/opencode-db.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 
-import { Database } from "bun:sqlite";
+import Database from "better-sqlite3";
 
 type SeedMessage = {
   role: "assistant" | "user";
@@ -99,7 +99,7 @@ function findOpencodeSessionDbPath(sessionId: string, inputPath?: string): strin
   for (const dbPath of candidates) {
     const db = new Database(dbPath, { readonly: true });
     try {
-      const session = db.query("select id from session where id = ?1").get(sessionId);
+      const session = db.prepare("select id from session where id = ?1").get(sessionId);
       if (session) return dbPath;
     } catch {
       // ignore non-matching dbs
@@ -157,12 +157,12 @@ export function seedOpencodeSessionMessages(input: {
 
   try {
     const run = db.transaction(() => {
-      const session = db.query("select id from session where id = ?1").get(sessionId);
+      const session = db.prepare("select id from session where id = ?1").get(sessionId);
       if (!session) {
         throw new Error(`OpenCode session not found: ${sessionId}`);
       }
 
-      const existing = db.query("select count(1) as count from message where session_id = ?1").get(sessionId) as { count?: number } | null;
+      const existing = db.prepare("select count(1) as count from message where session_id = ?1").get(sessionId) as { count?: number } | null;
       if ((existing?.count ?? 0) > 0) {
         return { inserted: 0, skipped: true };
       }

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -1,0 +1,136 @@
+/**
+ * Node.js HTTP adapter for the OpenWork server.
+ *
+ * Provides a `serve()` function with the same interface as Bun.serve()
+ * but backed by `node:http`. This allows the server to run in any Node.js
+ * environment (including Electron's main process) without Bun.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+
+export type ServeOptions = {
+  hostname: string;
+  port: number;
+  fetch: (request: Request) => Response | Promise<Response>;
+  idleTimeout?: number;
+};
+
+export type ServeResult = {
+  port: number;
+  stop: () => void;
+};
+
+/**
+ * Convert a Node.js IncomingMessage into a Web API Request.
+ */
+function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number): Request {
+  const url = `http://${hostname}:${port}${nodeReq.url ?? "/"}`;
+  const method = nodeReq.method ?? "GET";
+  const headers = new Headers();
+
+  // Node headers can be string | string[] | undefined
+  for (const [key, value] of Object.entries(nodeReq.headers)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(key, v);
+    } else {
+      headers.set(key, value);
+    }
+  }
+
+  const hasBody = method !== "GET" && method !== "HEAD";
+  const body = hasBody
+    ? (Readable.toWeb(nodeReq) as ReadableStream<Uint8Array>)
+    : null;
+
+  return new Request(url, {
+    method,
+    headers,
+    body,
+    // @ts-expect-error duplex is required for streaming request bodies
+    duplex: hasBody ? "half" : undefined,
+  });
+}
+
+/**
+ * Write a Web API Response to a Node.js ServerResponse.
+ */
+async function writeWebResponse(webRes: Response, nodeRes: ServerResponse): Promise<void> {
+  const headersObj: Record<string, string | string[]> = {};
+  webRes.headers.forEach((value, key) => {
+    const existing = headersObj[key];
+    if (existing) {
+      headersObj[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+    } else {
+      headersObj[key] = value;
+    }
+  });
+
+  nodeRes.writeHead(webRes.status, headersObj);
+
+  if (!webRes.body) {
+    nodeRes.end();
+    return;
+  }
+
+  const reader = webRes.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!nodeRes.write(value)) {
+        await new Promise<void>((resolve) => nodeRes.once("drain", resolve));
+      }
+    }
+  } finally {
+    reader.releaseLock();
+    nodeRes.end();
+  }
+}
+
+/**
+ * Start an HTTP server with a Web-standard fetch handler.
+ *
+ * Interface mirrors Bun.serve() so the caller doesn't need to change.
+ */
+export function serve(options: ServeOptions): Promise<ServeResult> {
+  const { hostname, port, fetch: fetchHandler } = options;
+
+  const server = createServer(async (nodeReq, nodeRes) => {
+    try {
+      const webReq = toWebRequest(nodeReq, hostname, boundPort);
+      const webRes = await fetchHandler(webReq);
+      await writeWebResponse(webRes, nodeRes);
+    } catch (error) {
+      console.error("[serve-node] Unhandled error:", error);
+      if (!nodeRes.headersSent) {
+        nodeRes.writeHead(500, { "Content-Type": "application/json" });
+      }
+      nodeRes.end(JSON.stringify({ error: "internal_error" }));
+    }
+  });
+
+  // Set keep-alive timeout to match Bun's idleTimeout
+  if (options.idleTimeout) {
+    server.keepAliveTimeout = options.idleTimeout * 1000;
+  }
+
+  let boundPort = port;
+
+  return new Promise<ServeResult>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(port, hostname, () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        boundPort = addr.port;
+      }
+      resolve({
+        port: boundPort,
+        stop: () => {
+          server.close();
+          server.closeAllConnections();
+        },
+      });
+    });
+  });
+}

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -39,15 +39,18 @@ function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number):
   }
 
   const hasBody = method !== "GET" && method !== "HEAD";
+
+  // Readable.toWeb() returns a Node stream/web ReadableStream which is structurally
+  // compatible with the global ReadableStream but TypeScript treats them as distinct.
   const body = hasBody
-    ? (Readable.toWeb(nodeReq) as ReadableStream<Uint8Array>)
+    ? (Readable.toWeb(nodeReq) as unknown as ReadableStream<Uint8Array>)
     : null;
 
   return new Request(url, {
     method,
     headers,
     body,
-    // @ts-expect-error duplex is required for streaming request bodies
+    // @ts-expect-error duplex is required for streaming request bodies in Node
     duplex: hasBody ? "half" : undefined,
   });
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -49,6 +49,9 @@ import {
   stripSensitiveWorkspaceExportData,
   type WorkspaceExportSensitiveMode,
 } from "./workspace-export-safety.js";
+import { createReadStream } from "node:fs";
+import { Readable } from "node:stream";
+import { serve, type ServeResult } from "./serve-node.js";
 import pkg from "../package.json" with { type: "json" };
 import constants from "../../../constants.json" with { type: "json" };
 
@@ -215,7 +218,7 @@ interface RequestContext {
   actor?: Actor;
 }
 
-export function startServer(config: ServerConfig) {
+export async function startServer(config: ServerConfig): Promise<ServeResult> {
   const approvals = new ApprovalService(config.approval);
   const reloadEvents = new ReloadEventStore();
   const tokens = new TokenService(config);
@@ -359,9 +362,10 @@ export function startServer(config: ServerConfig) {
     },
   };
 
-  (serverOptions as { idleTimeout?: number }).idleTimeout = 120;
-
-  const server = Bun.serve(serverOptions);
+  const server = await serve({
+    ...serverOptions,
+    idleTimeout: 120,
+  });
 
   return server;
 }
@@ -1792,7 +1796,8 @@ function createRoutes(
     headers.set("Content-Type", "application/octet-stream");
     headers.set("Content-Length", String(info.size));
     headers.set("Content-Disposition", `attachment; filename=\"${basename(relativePath)}\"`);
-    return new Response((Bun as any).file(absPath), { status: 200, headers });
+    const stream = Readable.toWeb(createReadStream(absPath)) as ReadableStream;
+    return new Response(stream, { status: 200, headers });
   });
 
   addRoute(routes, "POST", "/workspace/:id/inbox", "client", async (ctx) => {
@@ -1881,7 +1886,8 @@ function createRoutes(
     headers.set("Content-Type", "application/octet-stream");
     headers.set("Content-Length", String(info.size));
     headers.set("Content-Disposition", `attachment; filename="${basename(relativePath)}"`);
-    return new Response((Bun as any).file(absPath), { status: 200, headers });
+    const stream = Readable.toWeb(createReadStream(absPath)) as ReadableStream;
+    return new Response(stream, { status: 200, headers });
   });
 
   addRoute(routes, "POST", "/workspace/:id/files/sessions", "client", async (ctx) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -506,13 +506,17 @@ async function proxyOpencodeRequest(input: {
   }
 
   const method = input.request.method.toUpperCase();
-  const body = method === "GET" || method === "HEAD" ? undefined : input.request.body;
+  // Buffer the request body so it can be forwarded reliably across Node.js
+  // stream boundaries (Readable.toWeb streams from the HTTP adapter aren't
+  // always accepted directly by Node's global fetch as a body).
+  const body = method === "GET" || method === "HEAD"
+    ? undefined
+    : await input.request.arrayBuffer().then((buf) => (buf.byteLength > 0 ? buf : undefined));
   if (isSessionCommandProxyRequest(method, proxyPath)) {
-    const bufferedBody = body ? await input.request.arrayBuffer() : undefined;
     void fetch(targetUrl, {
       method,
       headers,
-      body: bufferedBody,
+      body,
     }).catch(() => {
       // Command failures are surfaced through the OpenCode event stream.
     });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1796,7 +1796,7 @@ function createRoutes(
     headers.set("Content-Type", "application/octet-stream");
     headers.set("Content-Length", String(info.size));
     headers.set("Content-Disposition", `attachment; filename=\"${basename(relativePath)}\"`);
-    const stream = Readable.toWeb(createReadStream(absPath)) as ReadableStream;
+    const stream = Readable.toWeb(createReadStream(absPath)) as unknown as ReadableStream;
     return new Response(stream, { status: 200, headers });
   });
 
@@ -1886,7 +1886,7 @@ function createRoutes(
     headers.set("Content-Type", "application/octet-stream");
     headers.set("Content-Length", String(info.size));
     headers.set("Content-Disposition", `attachment; filename="${basename(relativePath)}"`);
-    const stream = Readable.toWeb(createReadStream(absPath)) as ReadableStream;
+    const stream = Readable.toWeb(createReadStream(absPath)) as unknown as ReadableStream;
     return new Response(stream, { status: 200, headers });
   });
 

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -120,7 +120,7 @@ function startMockOpencode(input?: { invalidList?: boolean; holdCommand?: Promis
   return { server, requests };
 }
 
-function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: string }) {
+async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: string }) {
   const config: ServerConfig = {
     host: "127.0.0.1",
     port: 0,
@@ -146,7 +146,7 @@ function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: st
     logFormat: "pretty",
     logRequests: false,
   };
-  const server = startServer(config) as Served;
+  const server = await startServer(config) as Served;
   stops.push(() => server.stop(true));
   return { server, token: config.token };
 }
@@ -171,7 +171,7 @@ describe("workspace session read APIs", () => {
   test("lists sessions and returns session details, messages, and snapshot", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();
-    const openwork = startOpenworkServer({
+    const openwork = await startOpenworkServer({
       workspaceRoot,
       opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
     });
@@ -240,7 +240,7 @@ describe("workspace session read APIs", () => {
   test("returns 404 when the upstream session is missing", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();
-    const openwork = startOpenworkServer({
+    const openwork = await startOpenworkServer({
       workspaceRoot,
       opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
     });
@@ -260,7 +260,7 @@ describe("workspace session read APIs", () => {
     const workspaceRoot = await createWorkspaceRoot();
     const command = deferred();
     const mock = startMockOpencode({ holdCommand: command.promise });
-    const openwork = startOpenworkServer({
+    const openwork = await startOpenworkServer({
       workspaceRoot,
       opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
     });
@@ -285,7 +285,7 @@ describe("workspace session read APIs", () => {
   test("returns 502 when OpenCode returns an invalid session list payload", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const mock = startMockOpencode({ invalidList: true });
-    const openwork = startOpenworkServer({
+    const openwork = await startOpenworkServer({
       workspaceRoot,
       opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
     });

--- a/apps/server/src/workspace-activate.e2e.test.ts
+++ b/apps/server/src/workspace-activate.e2e.test.ts
@@ -54,7 +54,7 @@ function startMockOpencode() {
   return { server, requests };
 }
 
-function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: string }) {
+async function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: string }) {
   const config: ServerConfig = {
     host: "127.0.0.1",
     port: 0,
@@ -80,7 +80,7 @@ function startOpenworkServer(input: { workspaceRoot: string; opencodeBaseUrl: st
     logFormat: "pretty",
     logRequests: false,
   };
-  const server = startServer(config) as Served;
+  const server = await startServer(config) as Served;
   stops.push(() => server.stop(true));
   return { server, hostToken: config.hostToken };
 }
@@ -89,7 +89,7 @@ describe("workspace activation", () => {
   test("reloads the bound OpenCode engine on activate", async () => {
     const workspaceRoot = await createWorkspaceRoot();
     const mock = startMockOpencode();
-    const openwork = startOpenworkServer({
+    const openwork = await startOpenworkServer({
       workspaceRoot,
       opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
     });

--- a/apps/server/src/workspace-import-preview.test.ts
+++ b/apps/server/src/workspace-import-preview.test.ts
@@ -311,7 +311,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -361,7 +361,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -399,7 +399,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -442,7 +442,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -512,7 +512,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -566,7 +566,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -609,7 +609,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -665,7 +665,7 @@ describe("workspace import preview", () => {
     process.env.OPENWORK_DATA_DIR = dataDir;
     const serverConfig = makeServerConfig(workspace, dataDir);
     serverConfig.approval = { mode: "manual", timeoutMs: 5000 };
-    const server = startServer(serverConfig) as {
+    const server = await startServer(serverConfig) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -723,7 +723,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };
@@ -764,7 +764,7 @@ describe("workspace import preview", () => {
 
     const originalDataDir = process.env.OPENWORK_DATA_DIR;
     process.env.OPENWORK_DATA_DIR = dataDir;
-    const server = startServer(makeServerConfig(workspace, dataDir)) as {
+    const server = await startServer(makeServerConfig(workspace, dataDir)) as {
       port: number;
       stop: (force?: boolean) => void;
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
 
   apps/server:
     dependencies:
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
       jsonc-parser:
         specifier: ^3.2.1
         version: 3.3.1
@@ -285,6 +288,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/minimatch':
         specifier: ^5.1.2
         version: 5.1.2
@@ -474,10 +480,10 @@ importers:
     dependencies:
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))
       '@better-auth/oauth-provider':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))(better-call@1.3.2(zod@4.3.6))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))(better-call@1.3.2(zod@4.3.6))
       '@daytonaio/sdk':
         specifier: ^0.150.0
         version: 0.150.0(ws@8.19.0)
@@ -516,7 +522,7 @@ importers:
         version: 1.1.0
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)
+        version: 1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)
       better-call:
         specifier: ^1.3.2
         version: 1.3.2(zod@4.3.6)
@@ -694,7 +700,7 @@ importers:
         version: 1.19.0
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4)
+        version: 0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4)
       mysql2:
         specifier: ^3.11.3
         version: 3.17.4
@@ -3650,6 +3656,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -4164,9 +4173,15 @@ packages:
       zod:
         optional: true
 
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -4374,6 +4389,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4787,6 +4805,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -5169,6 +5191,10 @@ packages:
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
@@ -5256,6 +5282,9 @@ packages:
   file-type@16.5.4:
     resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
     engines: {node: '>=10'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
@@ -5425,6 +5454,9 @@ packages:
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
     hasBin: true
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -5665,6 +5697,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -6432,6 +6467,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
@@ -6489,6 +6527,9 @@ packages:
   nanostores@1.2.0:
     resolution: {integrity: sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
@@ -6995,6 +7036,12 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -7081,6 +7128,10 @@ packages:
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -7432,6 +7483,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
@@ -7583,6 +7640,10 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
 
@@ -7671,6 +7732,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
@@ -7811,6 +7875,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.8.20:
     resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
@@ -9140,11 +9207,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))':
+  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)
+      better-auth: 1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)
       zod: 4.3.6
 
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0)':
@@ -9160,12 +9227,12 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4)
 
   '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.15)':
     dependencies:
@@ -9184,12 +9251,12 @@ snapshots:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/oauth-provider@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/oauth-provider@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)
+      better-auth: 1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10)
       better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       zod: 4.3.6
@@ -11635,6 +11702,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -12189,10 +12260,10 @@ snapshots:
 
   baseline-browser-mapping@2.9.14: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10):
+  better-auth@1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))
       '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.15)
       '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
       '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
@@ -12209,8 +12280,9 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
+      better-sqlite3: 11.10.0
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4)
       mysql2: 3.17.4
       next: 16.2.1(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -12229,7 +12301,16 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   bl@4.1.0:
     dependencies:
@@ -12507,6 +12588,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   chownr@2.0.0: {}
 
@@ -12885,6 +12968,8 @@ snapshots:
 
   dedent@1.7.2: {}
 
+  deep-extend@0.6.0: {}
+
   deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
@@ -13002,10 +13087,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4):
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@planetscale/database': 1.19.0
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 11.10.0
       bun-types: 1.3.6
       kysely: 0.28.15
       mysql2: 3.17.4
@@ -13296,6 +13383,8 @@ snapshots:
 
   exif-parser@0.1.12: {}
 
+  expand-template@2.0.3: {}
+
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
@@ -13420,6 +13509,8 @@ snapshots:
       readable-web-to-node-stream: 3.0.4
       strtok3: 6.3.0
       token-types: 4.2.1
+
+  file-uri-to-path@1.0.0: {}
 
   filelist@1.0.6:
     dependencies:
@@ -13606,6 +13697,8 @@ snapshots:
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -13941,6 +14034,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -14834,6 +14929,8 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
@@ -14908,6 +15005,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanostores@1.2.0: {}
+
+  napi-build-utils@2.0.0: {}
 
   negotiator@0.6.4: {}
 
@@ -15406,6 +15505,21 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -15488,6 +15602,13 @@ snapshots:
     dependencies:
       defu: 6.1.4
       destr: 2.0.5
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@18.2.0(react@18.2.0):
     dependencies:
@@ -15976,6 +16097,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.4
@@ -16148,6 +16277,8 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strnum@2.2.0: {}
 
   strtok3@6.3.0:
@@ -16241,6 +16372,13 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
 
   tar-stream@2.2.0:
     dependencies:
@@ -16394,6 +16532,10 @@ snapshots:
       get-tsconfig: 4.13.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo@2.8.20:
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Add a Node.js HTTP adapter (`serve-node.ts`) that replaces `Bun.serve()` with `node:http`
- Replace `bun:sqlite` with `better-sqlite3` (near-identical API, works in Electron/Node.js)
- Replace `Bun.file()` with `fs.createReadStream()` for streaming file responses
- Export `startServer()` as a library entry point (`src/index.ts`)
- Electron's `runtime.mjs` now imports and calls `startServer()` in-process instead of spawning the `openwork-server` sidecar binary

## What this eliminates

| Before | After |
|--------|-------|
| Compile openwork-server to standalone Bun binary | No server binary in desktop builds |
| Spawn child process → poll `/health` → POST `/tokens` | `await startServer(config)` |
| Orphan process cleanup (`ps -Ao pid=`) | In-process, dies with Electron |
| ~10s startup overhead | Instant |
| ~70MB sidecar binary per platform | Zero |

## What stays the same

- The standalone Bun binary build path (`cli.ts`, `build:bin`) is preserved for orchestrator and cloud worker modes
- All routes, auth, workspace logic untouched
- The HTTP API surface is identical -- the React app still `fetch()`es `localhost:{port}`
- OpenCode is still managed as a child process by the server's `managed-opencode.ts`

## Independent of

This PR has no dependency on `deprecate/tauri-shell` ([#1674](https://github.com/different-ai/openwork/pull/1674)). Either can merge first.

## Notes

- The `import("../../server/src/server.ts")` dynamic import in `runtime.mjs` requires TypeScript-capable loading in Electron's main process. If Electron doesn't support `.ts` imports natively, this will need a build step or `tsx` loader -- flagging for review.
- `better-sqlite3` is a native addon and will need to be rebuilt for Electron's Node.js version during packaging (`electron-rebuild` or `@electron/rebuild`).