### PR TITLE
feat(app): redesign appearance settings

### DIFF
--- a/apps/app/src/components/ui/switch.tsx
+++ b/apps/app/src/components/ui/switch.tsx
@@ -1,0 +1,30 @@
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border-2 transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-5 data-[size=default]:w-11 data-[size=sm]:h-4 data-[size=sm]:w-7 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-unchecked:border-transparent data-unchecked:bg-input/90 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background shadow-sm ring-0 transition-transform not-dark:bg-clip-padding group-data-[size=default]/switch:h-4 group-data-[size=default]/switch:w-6 group-data-[size=sm]/switch:h-3 group-data-[size=sm]/switch:w-4 data-checked:translate-x-[calc(100%-8px)] rtl:data-checked:-translate-x-[calc(100%-8px)] dark:data-checked:bg-primary-foreground data-unchecked:translate-x-0 rtl:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/apps/app/src/components/ui/toggle-group.tsx
+++ b/apps/app/src/components/ui/toggle-group.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-[spacing=0]:data-[variant=outline]:rounded-3xl data-vertical:flex-col data-vertical:items-stretch",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-3 group-data-[spacing=0]/toggle-group:shadow-none focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pe-2.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:ps-2.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-s-3xl group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-3xl group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-e-3xl group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-3xl data-[state=on]:bg-muted group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-s-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-s group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/apps/app/src/components/ui/toggle.tsx
+++ b/apps/app/src/components/ui/toggle.tsx
@@ -1,0 +1,43 @@
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-3xl text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-9 min-w-9 px-3 has-data-[icon=inline-end]:pe-2.5 has-data-[icon=inline-start]:ps-2.5",
+        sm: "h-8 min-w-8 px-3 has-data-[icon=inline-end]:pe-2 has-data-[icon=inline-start]:ps-2",
+        lg: "h-10 min-w-10 px-4 has-data-[icon=inline-end]:pe-3 has-data-[icon=inline-start]:ps-3",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/apps/app/src/react-app/domains/settings/appearance/language-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/language-section.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource react */
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { LANGUAGE_OPTIONS, t } from "../../../../i18n";
+import type { AppearanceViewProps } from "../pages/appearance-view";
+import {
+  SettingsSection,
+  SettingsSectionHeader,
+  SettingsSectionHeaderContent,
+  SettingsSectionHeaderDescription,
+  SettingsSectionHeaderTitle,
+} from "../settings-section";
+
+interface LanguageSectionProps extends Pick<AppearanceViewProps, "busy" | "language" | "setLanguage"> {}
+
+export function LanguageSection(props: LanguageSectionProps) {
+  return (
+    <SettingsSection>
+      <SettingsSectionHeader>
+        <SettingsSectionHeaderContent>
+          <SettingsSectionHeaderTitle>{t("settings.language")}</SettingsSectionHeaderTitle>
+          <SettingsSectionHeaderDescription>{t("settings.language.description")}</SettingsSectionHeaderDescription>
+        </SettingsSectionHeaderContent>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <div className="w-64 max-w-full">
+            <Select
+              value={props.language}
+              items={LANGUAGE_OPTIONS}
+              onValueChange={(value) => {
+                if (value) props.setLanguage(value);
+              }}
+              disabled={props.busy}
+            >
+              <SelectTrigger className="w-full" aria-label={t("settings.language")}>
+                <SelectValue placeholder={t("settings.language")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {LANGUAGE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.nativeName}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </SettingsSectionHeader>
+    </SettingsSection>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
@@ -1,0 +1,139 @@
+/** @jsxImportSource react */
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+import { t } from "../../../../i18n";
+import type { AppearanceViewProps } from "../pages/appearance-view";
+import {
+  SettingsSection,
+  SettingsSectionHeader,
+  SettingsSectionHeaderContent,
+  SettingsSectionHeaderDescription,
+  SettingsSectionHeaderTitle,
+} from "../settings-section";
+
+type ThemeMode = AppearanceViewProps["themeMode"];
+
+interface ThemeSectionProps
+  extends Pick<AppearanceViewProps, "busy" | "themeMode" | "setThemeMode"> {}
+
+export function ThemeSection(props: ThemeSectionProps) {
+  return (
+    <SettingsSection className="items-center">
+      <SettingsSectionHeader className="w-full">
+        <SettingsSectionHeaderContent>
+          <SettingsSectionHeaderTitle>{t("settings.appearance_title")}</SettingsSectionHeaderTitle>
+          <SettingsSectionHeaderDescription>{t("settings.appearance_hint")}</SettingsSectionHeaderDescription>
+        </SettingsSectionHeaderContent>
+      </SettingsSectionHeader>
+
+      <ThemePicker
+        className="pt-1"
+        busy={props.busy}
+        themeMode={props.themeMode}
+        setThemeMode={props.setThemeMode}
+      />
+
+      <div className="text-xs text-muted-foreground">{t("settings.theme_system_hint")}</div>
+    </SettingsSection>
+  );
+}
+
+interface ThemePickerProps {
+  className?: string;
+  busy: boolean;
+  themeMode: ThemeMode;
+  setThemeMode: (value: ThemeMode) => void;
+}
+
+function ThemePicker(props: ThemePickerProps) {
+  return (
+    <ToggleGroup
+      value={[props.themeMode]}
+      onValueChange={(value) => {
+        if (value[0] === null) {
+          return;
+        }
+
+        props.setThemeMode(value[0] as ThemeMode);
+      }}
+      disabled={props.busy}
+      className={cn("w-full gap-6 max-w-xl", props.className)}
+    >
+      <ThemePickerItem
+        value="system"
+        label={t("settings.theme_system")}
+      >
+        <ThemePreview value="system" />
+        <ThemePickerLabel>{t("settings.theme_system")}</ThemePickerLabel>
+      </ThemePickerItem>
+      <ThemePickerItem
+        value="light"
+        label={t("settings.theme_light")}
+      >
+        <ThemePreview value="light" className="bg-white" />
+        <ThemePickerLabel>{t("settings.theme_light")}</ThemePickerLabel>
+      </ThemePickerItem>
+      <ThemePickerItem
+        value="dark"
+        label={t("settings.theme_dark")}
+      >
+        <ThemePreview value="dark" className="bg-black" />
+        <ThemePickerLabel>{t("settings.theme_dark")}</ThemePickerLabel>
+      </ThemePickerItem>
+    </ToggleGroup>
+  );
+}
+
+interface ThemePickerItemProps {
+  value: ThemeMode;
+  label: string;
+  children: ReactNode;
+}
+
+function ThemePickerItem(props: ThemePickerItemProps) {
+  return (
+    <ToggleGroupItem
+      value={props.value}
+      aria-label={props.label}
+      className="group/theme h-auto flex-1 flex-col gap-3 rounded-sm px-0 py-0 hover:bg-transparent aria-pressed:bg-transparent"
+    >
+      {props.children}
+    </ToggleGroupItem>
+  );
+}
+
+interface ThemePreviewProps {
+  value: ThemeMode;
+  className?: string;
+}
+
+function ThemePreview(props: ThemePreviewProps) {
+  return (
+    <div
+      className={cn(
+        "aspect-4/3 w-full overflow-hidden rounded-md border transition-shadow group-data-pressed/theme:ring-2 group-data-pressed/theme:ring-primary group-data-pressed/theme:ring-offset-2 group-data-pressed/theme:ring-offset-background group-hover/theme:ring-1 group-hover/theme:ring-primary/40 group-hover/theme:ring-offset-2 group-hover/theme:ring-offset-background",
+        props.className,
+      )}
+    >
+      {props.value === "system" && (
+        <div className="flex h-full">
+          <div className="w-1/2 bg-white" />
+          <div className="w-1/2 bg-black" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ThemePickerLabelProps {
+  children: string;
+}
+
+function ThemePickerLabel(props: ThemePickerLabelProps) {
+  return (
+    <span className="text-sm text-muted-foreground group-data-pressed/theme:text-foreground">
+      {props.children}
+    </span>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/appearance/window-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/window-section.tsx
@@ -1,0 +1,45 @@
+/** @jsxImportSource react */
+import { Button } from "@/components/ui/button";
+import { t } from "../../../../i18n";
+import type { AppearanceViewProps } from "../pages/appearance-view";
+import {
+  SettingsInset,
+  SettingsSection,
+  SettingsSectionHeader,
+  SettingsSectionHeaderContent,
+  SettingsSectionHeaderDescription,
+  SettingsSectionHeaderTitle,
+} from "../settings-section";
+
+interface WindowSectionProps
+  extends Pick<AppearanceViewProps, "busy" | "hideTitlebar" | "toggleHideTitlebar"> {}
+
+export function WindowSection(props: WindowSectionProps) {
+  return (
+    <SettingsSection>
+      <SettingsSectionHeader>
+        <SettingsSectionHeaderContent>
+          <SettingsSectionHeaderTitle>{t("settings.appearance_title")}</SettingsSectionHeaderTitle>
+          <SettingsSectionHeaderDescription>{t("settings.window_appearance_desc")}</SettingsSectionHeaderDescription>
+        </SettingsSectionHeaderContent>
+      </SettingsSectionHeader>
+
+      <SettingsInset>
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm text-foreground">{t("settings.hide_titlebar")}</div>
+            <div className="text-xs text-muted-foreground">{t("settings.hide_titlebar_desc")}</div>
+          </div>
+          <Button
+            variant="outline"
+            className="h-8 shrink-0 px-3 py-0 text-xs"
+            onClick={props.toggleHideTitlebar}
+            disabled={props.busy}
+          >
+            {props.hideTitlebar ? t("settings.on") : t("settings.off")}
+          </Button>
+        </div>
+      </SettingsInset>
+    </SettingsSection>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/appearance/window-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/window-section.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { t } from "../../../../i18n";
 import type { AppearanceViewProps } from "../pages/appearance-view";
 import {
@@ -30,14 +30,11 @@ export function WindowSection(props: WindowSectionProps) {
             <div className="text-sm text-foreground">{t("settings.hide_titlebar")}</div>
             <div className="text-xs text-muted-foreground">{t("settings.hide_titlebar_desc")}</div>
           </div>
-          <Button
-            variant="outline"
-            className="h-8 shrink-0 px-3 py-0 text-xs"
-            onClick={props.toggleHideTitlebar}
+          <Switch
+            checked={props.hideTitlebar}
             disabled={props.busy}
-          >
-            {props.hideTitlebar ? t("settings.on") : t("settings.off")}
-          </Button>
+            onCheckedChange={props.toggleHideTitlebar}
+          />
         </div>
       </SettingsInset>
     </SettingsSection>

--- a/apps/app/src/react-app/domains/settings/pages/appearance-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/appearance-view.tsx
@@ -1,9 +1,11 @@
 /** @jsxImportSource react */
-import { LANGUAGE_OPTIONS, t, type Language } from "../../../../i18n";
 import { isDesktopRuntime } from "../../../../app/utils";
-import { Button } from "../../../design-system/button";
-
-const settingsPanelClass = "rounded-[28px] border border-dls-border bg-dls-surface p-5 md:p-6";
+import type { Language } from "../../../../i18n";
+import { Separator } from "@/components/ui/separator";
+import { LanguageSection } from "../appearance/language-section";
+import { ThemeSection } from "../appearance/theme-section";
+import { WindowSection } from "../appearance/window-section";
+import { SettingsStack } from "../settings-section";
 
 export type AppearanceViewProps = {
   busy: boolean;
@@ -17,84 +19,16 @@ export type AppearanceViewProps = {
 
 export function AppearanceView(props: AppearanceViewProps) {
   return (
-    <div className="space-y-6">
-      <div className={`${settingsPanelClass} space-y-4`}>
-        <div>
-          <div className="text-sm font-medium text-gray-12">{t("settings.appearance_title")}</div>
-          <div className="text-xs text-gray-9">{t("settings.appearance_hint")}</div>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Button
-            variant={props.themeMode === "system" ? "secondary" : "outline"}
-            className="h-8 px-3 py-0 text-xs"
-            onClick={() => props.setThemeMode("system")}
-            disabled={props.busy}
-          >
-            {t("settings.theme_system")}
-          </Button>
-          <Button
-            variant={props.themeMode === "light" ? "secondary" : "outline"}
-            className="h-8 px-3 py-0 text-xs"
-            onClick={() => props.setThemeMode("light")}
-            disabled={props.busy}
-          >
-            {t("settings.theme_light")}
-          </Button>
-          <Button
-            variant={props.themeMode === "dark" ? "secondary" : "outline"}
-            className="h-8 px-3 py-0 text-xs"
-            onClick={() => props.setThemeMode("dark")}
-            disabled={props.busy}
-          >
-            {t("settings.theme_dark")}
-          </Button>
-        </div>
-
-        <div className="space-y-2">
-          <div className="text-xs font-medium text-gray-11">{t("settings.language")}</div>
-          <div className="text-xs text-gray-9">{t("settings.language.description")}</div>
-          <div className="flex flex-wrap gap-2">
-            {LANGUAGE_OPTIONS.map((option) => (
-              <Button
-                key={option.value}
-                variant={props.language === option.value ? "secondary" : "outline"}
-                className="h-8 px-3 py-0 text-xs"
-                onClick={() => props.setLanguage(option.value)}
-                disabled={props.busy}
-              >
-                {option.nativeName}
-              </Button>
-            ))}
-          </div>
-        </div>
-
-        <div className="text-xs text-gray-8">{t("settings.theme_system_hint")}</div>
-      </div>
-
+    <SettingsStack>
+      <ThemeSection {...props} />
+      <Separator />
+      <LanguageSection {...props} />
       {isDesktopRuntime() ? (
-        <div className="space-y-3 rounded-2xl border border-gray-6/50 bg-gray-2/30 p-5">
-          <div>
-            <div className="text-sm font-medium text-gray-12">{t("settings.appearance_title")}</div>
-            <div className="text-xs text-gray-10">{t("settings.window_appearance_desc")}</div>
-          </div>
-
-          <div className="flex items-center justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 p-3">
-            <div className="min-w-0">
-              <div className="text-sm text-gray-12">{t("settings.hide_titlebar")}</div>
-              <div className="text-xs text-gray-7">{t("settings.hide_titlebar_desc")}</div>
-            </div>
-            <Button
-              variant="outline"
-              className="h-8 shrink-0 px-3 py-0 text-xs"
-              onClick={props.toggleHideTitlebar}
-              disabled={props.busy}
-            >
-              {props.hideTitlebar ? t("settings.on") : t("settings.off")}
-            </Button>
-          </div>
-        </div>
+        <>
+          <Separator />
+          <WindowSection {...props} />
+        </>
       ) : null}
-    </div>
+    </SettingsStack>
   );
 }

--- a/apps/app/src/react-app/domains/settings/settings-section.tsx
+++ b/apps/app/src/react-app/domains/settings/settings-section.tsx
@@ -61,7 +61,7 @@ export interface SettingsLayoutProps {
 }
 
 export function SettingsStack({ children, className }: SettingsLayoutProps) {
-  return <div className={cn("flex w-full max-w-3xl flex-col gap-y-6", className)}>{children}</div>;
+  return <div className={cn("@container/settings flex w-full max-w-3xl flex-col gap-y-6", className)}>{children}</div>;
 }
 
 export function SettingsSection({ children, className }: SettingsLayoutProps) {


### PR DESCRIPTION
## Summary
- Redesigned Appearance settings into separate Theme, Language, and Window sections.
- Added shared Toggle, ToggleGroup, and Switch UI components for the redesigned controls.
- Replaced the old theme/language button lists with a visual theme selector, language dropdown, and switch-based title bar setting.

## Evidence
<img width="2808" height="2088" alt="CleanShot 2026-05-06 at 10 10 02@2x" src="https://github.com/user-attachments/assets/60cdefe7-f1fe-4d98-88f8-701e481eebdd" />

## Note
- The hide title bar option in settings does not seem to work, but it also appears to already be broken in the production version, at least on my machine.
- Requires graphics for the theme switch at a later stage
