### PR TITLE
feat(app): redesign sidebar and add window vibrancy on macOS

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -24,7 +24,7 @@
       })();
     </script>
   </head>
-  <body class="bg-dls-surface text-dls-text">
+  <body class="bg-dls-surface text-dls-text mac:bg-transparent">
     <div id="root"></div>
     <script type="module" src="/src/index.react.tsx"></script>
   </body>

--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -12,6 +12,35 @@
 @import "@fontsource-variable/ibm-plex-sans";
 
 @custom-variant dark (&:is(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
+@custom-variant electron {
+  html.openwork-electron & {
+    @slot;
+  }
+}
+@custom-variant windows {
+  html.openwork-electron.openwork-platform-windows & {
+    @slot;
+  }
+}
+@custom-variant mac {
+  html.openwork-electron.openwork-platform-mac & {
+    @slot;
+  }
+}
+@custom-variant linux {
+  html.openwork-electron.openwork-platform-linux & {
+    @slot;
+  }
+}
+
+@utility titlebar-drag {
+  app-region: drag;
+  user-select: none;
+}
+
+@utility titlebar-no-drag {
+  app-region: no-drag;
+}
 
 :root {
   color-scheme: light;
@@ -124,7 +153,6 @@ body {
   font-size: 0.875rem;
   line-height: 1.5;
   color: var(--dls-text-primary);
-  background-color: var(--dls-surface);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/apps/app/src/components/ui/button.tsx
+++ b/apps/app/src/components/ui/button.tsx
@@ -4,19 +4,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-4xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 relative",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-4xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 relative",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80 bg-clip-padding shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+        default: "bg-primary text-primary-foreground hover:bg-primary/80 bg-clip-padding shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)] active:not-aria-[haspopup]:translate-y-px",
         outline:
-          "border-border bg-muted/20 hover:bg-muted hover:border-foreground/20 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-muted/20 dark:hover:bg-input/30 dark:hover:border-input/80 bg-clip-padding shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+          "border-border bg-muted/20 hover:bg-muted hover:border-foreground/20 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-muted/20 dark:hover:bg-input/30 dark:hover:border-input/80 bg-clip-padding shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)] active:not-aria-[haspopup]:translate-y-px",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground active:not-aria-[haspopup]:translate-y-px",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:text-foreground aria-expanded:text-foreground",
         destructive:
-          "border-border text-destructive hover:bg-destructive/10 hover:border-destructive/40 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:border-border dark:hover:bg-destructive/10 dark:border-destructive/40 dark:focus-visible:ring-destructive/40 bg-clip-padding shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+          "border-border text-destructive hover:bg-destructive/10 hover:border-destructive/40 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:border-border dark:hover:bg-destructive/10 dark:border-destructive/40 dark:focus-visible:ring-destructive/40 bg-clip-padding shadow-xs/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)] active:not-aria-[haspopup]:translate-y-px",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/apps/app/src/components/ui/context-menu.tsx
+++ b/apps/app/src/components/ui/context-menu.tsx
@@ -1,0 +1,274 @@
+"use client"
+
+import * as React from "react"
+import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuPortal({ ...props }: ContextMenuPrimitive.Portal.Props) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  )
+}
+
+function ContextMenuTrigger({
+  className,
+  ...props
+}: ContextMenuPrimitive.Trigger.Props) {
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      className={cn("select-none", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuContent({
+  className,
+  align = "start",
+  alignOffset = 4,
+  side = "inline-end",
+  sideOffset = 0,
+  ...props
+}: ContextMenuPrimitive.Popup.Props &
+  Pick<
+    ContextMenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <ContextMenuPrimitive.Popup
+          data-slot="context-menu-content"
+          className={cn(
+                                            "dark z-50 max-h-(--available-height) min-w-48 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-3xl p-1.5 text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-start-2 data-[side=inline-start]:slide-in-from-end-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+                                            className
+                                          )}
+          {...props}
+        />
+      </ContextMenuPrimitive.Positioner>
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuGroup({ ...props }: ContextMenuPrimitive.Group.Props) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: ContextMenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.GroupLabel
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-3 py-2.5 text-xs text-muted-foreground data-inset:ps-9.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: ContextMenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/context-menu-item relative flex cursor-default items-center gap-2.5 rounded-2xl px-3 py-2 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:ps-9.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSub({ ...props }: ContextMenuPrimitive.SubmenuRoot.Props) {
+  return (
+    <ContextMenuPrimitive.SubmenuRoot data-slot="context-menu-sub" {...props} />
+  )
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: ContextMenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.SubmenuTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center rounded-2xl px-3 py-2 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:ps-9.5 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="rtl:rotate-180 ms-auto" />
+    </ContextMenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function ContextMenuSubContent({
+  ...props
+}: React.ComponentProps<typeof ContextMenuContent>) {
+  return (
+    <ContextMenuContent
+      data-slot="context-menu-sub-content"
+      className="dark shadow-lg animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!"
+      side="inline-end"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: ContextMenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2.5 rounded-2xl py-2 pe-8 ps-3 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:ps-9.5 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute end-2">
+        <ContextMenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </ContextMenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  )
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: ContextMenuPrimitive.RadioGroup.Props) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: ContextMenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2.5 rounded-2xl py-2 pe-8 ps-3 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:ps-9.5 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute end-2">
+        <ContextMenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </ContextMenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  )
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: ContextMenuPrimitive.Separator.Props) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1.5 my-1.5 h-px bg-border/50", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ms-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}

--- a/apps/app/src/components/ui/dropdown-menu.tsx
+++ b/apps/app/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,272 @@
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+                                            "dark z-50 max-h-(--available-height) w-(--anchor-width) min-w-48 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-3xl p-1.5 text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-start-2 data-[side=inline-start]:slide-in-from-end-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+                                            className
+                                          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-3 py-2.5 text-xs text-muted-foreground data-inset:ps-9.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-2.5 rounded-2xl px-3 py-2 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:ps-9.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:ps-9.5 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="rtl:rotate-180 ms-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "inline-end",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+                        "dark w-auto min-w-36 rounded-3xl p-1.5 text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+                        className
+                      )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2.5 rounded-2xl py-2 pe-8 ps-3 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:ps-9.5 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute end-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-2.5 rounded-2xl py-2 pe-8 ps-3 text-sm font-medium outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:ps-9.5 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute end-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1.5 my-1.5 h-px bg-border/50", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ms-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -44,6 +44,18 @@ type SidebarContextProps = {
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
 
+function getDefaultOpen(defaultOpen: boolean, persistence: boolean) {
+  if (!persistence) return defaultOpen
+
+  const cookie = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${SIDEBAR_COOKIE_NAME}=`))
+
+  if (!cookie) return defaultOpen
+
+  return cookie.split("=")[1] === "true"
+}
+
 function useSidebar() {
   const context = React.useContext(SidebarContext)
   if (!context) {
@@ -57,6 +69,7 @@ function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
+  persistence = false,
   className,
   style,
   children,
@@ -65,13 +78,14 @@ function SidebarProvider({
   defaultOpen?: boolean
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  persistence?: boolean
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen)
+  const [_open, _setOpen] = React.useState(() => getDefaultOpen(defaultOpen, persistence))
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
@@ -82,10 +96,12 @@ function SidebarProvider({
         _setOpen(openState)
       }
 
-      // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+      if (persistence) {
+        // This sets the cookie to keep the sidebar state.
+        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+      }
     },
-    [setOpenProp, open]
+    [setOpenProp, open, persistence]
   )
 
   // Helper to toggle the sidebar.
@@ -253,7 +269,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon-sm"
-      className={cn(className)}
+      className={cn("border-none", className)}
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()
@@ -281,7 +297,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
         "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
         "in-data-[side=left]:cursor-w-resize rtl:in-data-[side=left]:cursor-e-resize in-data-[side=right]:cursor-e-resize rtl:in-data-[side=right]:cursor-w-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize rtl:[[data-side=left][data-state=collapsed]_&]:cursor-w-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize rtl:[[data-side=right][data-state=collapsed]_&]:cursor-e-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 rtl:group-data-[collapsible=offcanvas]:-translate-x-0 group-data-[collapsible=offcanvas]:after:start-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "group-data-[collapsible=offcanvas]:translate-x-0 rtl:group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:start-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
         "[[data-side=left][data-collapsible=offcanvas]_&]:-end-2",
         "[[data-side=right][data-collapsible=offcanvas]_&]:-start-2",
         className
@@ -467,7 +483,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-xl px-3 py-2 text-start text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pe-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden relative rounded-md px-3 py-2 text-start text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pe-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate mac:hover:bg-black/5 mac:active:bg-black/5 mac:data-active:bg-black/5 dark:mac:hover:bg-white/10 dark:mac:active:bg-white/10 dark:mac:data-active:bg-white/10 ",
   {
     variants: {
       variant: {
@@ -476,7 +492,7 @@ const sidebarMenuButtonVariants = cva(
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
-        default: "h-9 text-sm",
+        default: "h-8 text-sm",
         sm: "h-8 text-xs",
         lg: "h-14 px-3 text-sm group-data-[collapsible=icon]:p-0!",
       },
@@ -633,7 +649,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "mx-3.5 flex min-w-0 translate-x-px rtl:-translate-x-px flex-col gap-1 border-s border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
+        "flex min-w-0 translate-x-px rtl:-translate-x-px flex-col gap-1 group-data-[collapsible=icon]:hidden",
         className
       )}
       {...props}
@@ -671,7 +687,7 @@ function SidebarMenuSubButton({
     props: mergeProps<"a">(
       {
         className: cn(
-          "flex h-7 min-w-0 -translate-x-px rtl:translate-x-px items-center gap-2 overflow-hidden rounded-xl px-3 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+          "flex h-7 ps-10 min-w-0 -translate-x-px rtl:translate-x-px items-center gap-2 overflow-hidden relative rounded-md px-3 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-hover/menu-sub-item:bg-sidebar-accent group-hover/menu-sub-item:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground mac:hover:bg-black/5 mac:group-hover/menu-sub-item:bg-black/5 mac:active:bg-black/5 mac:data-active:bg-black/5 dark:mac:hover:bg-white/10 dark:mac:group-hover/menu-sub-item:bg-white/10 dark:mac:active:bg-white/10 dark:mac:data-active:bg-white/10",
           className
         ),
       },

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -191,6 +191,7 @@ export default {
   "dashboard.chooser_local_desc": "Create a workspace on this device.",
   "dashboard.chooser_remote_desc": "Attach to a self-hosted OpenWork worker using a URL and access token.",
   "dashboard.chooser_shared_desc": "Browse cloud workers shared with your organization and connect in one step.",
+  "dashboard.back_to_app": "Back to app",
   "dashboard.close_settings": "Close settings",
   "dashboard.cloud_worker": "Cloud worker",
   "dashboard.commands": "Commands",

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -14,20 +14,20 @@ type BrowserState = {
 type BrowserPanelProps = { onClose: () => void };
 
 const EMPTY_STATE: BrowserState = { url: "", title: "", canGoBack: false, canGoForward: false, isLoading: false };
-const TOOLBAR_HEIGHT = 44;
 
 function getElectronBrowser() {
   if (!isElectronRuntime()) return null;
   return (window as Window).__OPENWORK_ELECTRON__?.browser ?? null;
 }
 
-function computeBounds(el: HTMLElement) {
+function computeBounds(el: HTMLElement, toolbar: HTMLElement) {
   const rect = el.getBoundingClientRect();
+  const toolbarRect = toolbar.getBoundingClientRect();
   return {
     x: Math.round(rect.x),
-    y: Math.round(rect.y + TOOLBAR_HEIGHT),
+    y: Math.round(rect.y + toolbarRect.height),
     width: Math.round(rect.width),
-    height: Math.round(rect.height - TOOLBAR_HEIGHT),
+    height: Math.round(rect.height - toolbarRect.height),
   };
 }
 
@@ -36,6 +36,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
   const [urlInput, setUrlInput] = useState("");
   const [urlFocused, setUrlFocused] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
   const urlInputRef = useRef<HTMLInputElement>(null);
   const shownRef = useRef(false);
 
@@ -56,11 +57,12 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
   // Show the browser view when the panel mounts, keep bounds in sync, hide on unmount.
   useEffect(() => {
     const browser = getElectronBrowser();
-    if (!browser || !panelRef.current) return;
+    if (!browser || !panelRef.current || !toolbarRef.current) return;
+    const panel = panelRef.current;
+    const toolbar = toolbarRef.current;
 
     const tryShow = () => {
-      if (!panelRef.current) return;
-      const bounds = computeBounds(panelRef.current);
+      const bounds = computeBounds(panel, toolbar);
       if (bounds.width < 1 || bounds.height < 1) return; // not laid out yet
       if (!shownRef.current) {
         browser.show?.(bounds);
@@ -74,7 +76,8 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     tryShow();
 
     const observer = new ResizeObserver(tryShow);
-    observer.observe(panelRef.current);
+    observer.observe(panel);
+    observer.observe(toolbar);
     window.addEventListener("resize", tryShow);
 
     return () => {
@@ -108,7 +111,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
 
   return (
     <div ref={panelRef} className="flex h-full flex-col">
-      <div className="flex h-[44px] shrink-0 items-center gap-1 border-b border-dls-border px-2">
+      <div ref={toolbarRef} className="flex h-10 shrink-0 items-center gap-1 border-b border-border px-2">
         <button type="button" className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.back?.()} disabled={!state.canGoBack} title="Back" aria-label="Go back">
           <ArrowLeft className="h-4 w-4" />
         </button>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -22,14 +22,15 @@ import ProviderAuthModal, { type ProviderAuthModalProps } from "../../connection
 import { PermissionApprovalModal } from "./permission-approval-modal";
 import { QuestionModal } from "../modals/question-modal";
 import { RenameSessionModal } from "../modals/rename-session-modal";
-import { WorkspaceSessionList } from "../sidebar/workspace-session-list";
+import { AppSidebar } from "../sidebar/app-sidebar";
 import { SessionSurface, type SessionSurfaceProps } from "../surface/session-surface";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
 import { ShareWorkspaceModal } from "../../workspace/share-workspace-modal";
 import { StatusBar, type StatusBarProps } from "./status-bar";
-import {
-  DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-  useWorkspaceShellLayout,
-} from "../../../shell/workspace-shell-layout";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { isElectronRuntime } from "../../../../app/utils";
@@ -156,10 +157,6 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 }
 
 export function SessionPage(props: SessionPageProps) {
-  const { leftSidebarWidth, startLeftSidebarResize } = useWorkspaceShellLayout({
-    defaultLeftWidth: DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-    expandedRightWidth: 280,
-  });
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
     selectedWorkspaceId: props.selectedWorkspaceId,
@@ -174,6 +171,7 @@ export function SessionPage(props: SessionPageProps) {
   const [renameBusy, setRenameBusy] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBusy, setDeleteBusy] = useState(false);
+  const [sessionActionId, setSessionActionId] = useState<string | null>(null);
   const [todoExpanded, setTodoExpanded] = useState(true);
   const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
   const toggleBrowserPanel = useCallback(() => setBrowserPanelOpen((p) => !p), []);
@@ -182,6 +180,10 @@ export function SessionPage(props: SessionPageProps) {
   const selectedSessionTitle = useMemo(
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, props.selectedSessionId),
     [props.selectedSessionId, props.sidebar.workspaceSessionGroups],
+  );
+  const sessionActionTitle = useMemo(
+    () => sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionActionId),
+    [props.sidebar.workspaceSessionGroups, sessionActionId],
   );
   const workspaceName =
     props.selectedWorkspaceDisplay.displayName?.trim() ||
@@ -239,18 +241,20 @@ export function SessionPage(props: SessionPageProps) {
     setDeleteOpen(false);
     setRenameBusy(false);
     setDeleteBusy(false);
+    setSessionActionId(null);
   }, [props.selectedSessionId]);
 
-  const openRenameModal = () => {
-    if (!props.selectedSessionId || !props.onRenameSession) return;
-    setRenameTitle(selectedSessionTitle);
+  const openRenameModal = (sessionId: string) => {
+    if (!props.onRenameSession) return;
+    setSessionActionId(sessionId);
+    setRenameTitle(sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId));
     setRenameOpen(true);
   };
 
   const submitRename = async () => {
-    const sessionId = props.selectedSessionId;
+    const sessionId = sessionActionId;
     const nextTitle = renameTitle.trim();
-    if (!sessionId || !props.onRenameSession || !nextTitle || nextTitle === selectedSessionTitle.trim()) return;
+    if (!sessionId || !props.onRenameSession || !nextTitle || nextTitle === sessionActionTitle.trim()) return;
     setRenameBusy(true);
     try {
       await props.onRenameSession(sessionId, nextTitle);
@@ -261,7 +265,7 @@ export function SessionPage(props: SessionPageProps) {
   };
 
   const confirmDelete = async () => {
-    const sessionId = props.selectedSessionId;
+    const sessionId = sessionActionId;
     if (!sessionId || !props.onDeleteSession) return;
     setDeleteBusy(true);
     try {
@@ -274,55 +278,46 @@ export function SessionPage(props: SessionPageProps) {
 
   const todoLabel =
     completedTodos > 0
-      ? t("session.todo_progress_label", undefined, { completed: completedTodos, total: todos.length })
-      : t("session.todo_label", undefined, { count: todos.length });
+      ? t("session.todo_progress_label", { completed: completedTodos, total: todos.length })
+      : t("session.todo_label", { count: todos.length });
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text">
-      <div className="flex min-h-0 flex-1 gap-4 p-3 md:p-4">
-        <aside
-          className="relative hidden min-h-0 shrink-0 overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar shadow-[var(--dls-shell-shadow)] lg:flex lg:flex-col"
-          style={{ width: leftSidebarWidth }}
-        >
-          <div className="flex min-h-0 flex-1">
-            <WorkspaceSessionList
-              workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
-              selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
-              developerMode={props.sidebar.developerMode}
-              selectedSessionId={props.sidebar.selectedSessionId}
-              showInitialLoading={sidebarInitialLoading}
-              showSessionActions={Boolean(props.onRenameSession || props.onDeleteSession)}
-              sessionStatusById={props.sidebar.sessionStatusById}
-              connectingWorkspaceId={props.sidebar.connectingWorkspaceId}
-              workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
-              newTaskDisabled={props.sidebar.newTaskDisabled}
-              onSelectWorkspace={props.sidebar.onSelectWorkspace}
-              onOpenSession={props.sidebar.onOpenSession}
-              onPrefetchSession={props.sidebar.onPrefetchSession}
-              onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
-              onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
-              onOpenDeleteSession={props.onDeleteSession ? () => setDeleteOpen(true) : undefined}
-              onOpenRenameWorkspace={props.sidebar.onOpenRenameWorkspace}
-              onShareWorkspace={props.sidebar.onShareWorkspace}
-              onRevealWorkspace={props.sidebar.onRevealWorkspace}
-              onRecoverWorkspace={props.sidebar.onRecoverWorkspace}
-              onTestWorkspaceConnection={props.sidebar.onTestWorkspaceConnection}
-              onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
-              onForgetWorkspace={props.sidebar.onForgetWorkspace}
-              onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
-            />
-          </div>
-          <div
-            className="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 lg:block"
-            onPointerDown={startLeftSidebarResize}
-            title={t("session.resize_workspace_column")}
-            aria-label={t("session.resize_workspace_column")}
-          />
-        </aside>
-
-        <main className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)]">
-          <header className="z-10 flex h-12 shrink-0 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6">
+    <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text mac:bg-transparent">
+      <SidebarProvider className="relative min-h-0 flex-1 mac:bg-transparent" persistence>
+        <AppSidebar
+          workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
+          selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
+          developerMode={props.sidebar.developerMode}
+          selectedSessionId={props.sidebar.selectedSessionId}
+          showInitialLoading={sidebarInitialLoading}
+          showSessionActions={Boolean(props.onRenameSession || props.onDeleteSession)}
+          sessionStatusById={props.sidebar.sessionStatusById}
+          connectingWorkspaceId={props.sidebar.connectingWorkspaceId}
+          workspaceConnectionStateById={props.sidebar.workspaceConnectionStateById}
+          newTaskDisabled={props.sidebar.newTaskDisabled}
+          onSelectWorkspace={props.sidebar.onSelectWorkspace}
+          onOpenSession={props.sidebar.onOpenSession}
+          onPrefetchSession={props.sidebar.onPrefetchSession}
+          onCreateTaskInWorkspace={props.sidebar.onCreateTaskInWorkspace}
+          onOpenRenameSession={props.onRenameSession ? openRenameModal : undefined}
+          onOpenDeleteSession={props.onDeleteSession ? (sessionId) => {
+            setSessionActionId(sessionId);
+            setDeleteOpen(true);
+          } : undefined}
+          onOpenRenameWorkspace={props.sidebar.onOpenRenameWorkspace}
+          onShareWorkspace={props.sidebar.onShareWorkspace}
+          onRevealWorkspace={props.sidebar.onRevealWorkspace}
+          onRecoverWorkspace={props.sidebar.onRecoverWorkspace}
+          onTestWorkspaceConnection={props.sidebar.onTestWorkspaceConnection}
+          onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
+          onForgetWorkspace={props.sidebar.onForgetWorkspace}
+          onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
+        />
+        <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28 flex flex-row">
+          <main className="flex min-w-0 flex-1 flex-col overflow-hidden border-r border-border">
+          <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
+              <SidebarTrigger className="mac:hidden" />
               <h1 className="truncate text-[15px] font-semibold text-dls-text">
                 {showWorkspaceSetupEmptyState
                   ? t("session.create_or_connect_workspace")
@@ -343,7 +338,7 @@ export function SessionPage(props: SessionPageProps) {
               ) : null}
             </div>
 
-            <div className="flex items-center gap-1.5 text-gray-10">
+            <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {isElectronRuntime() ? (
                 <button
                   type="button"
@@ -354,7 +349,7 @@ export function SessionPage(props: SessionPageProps) {
                   aria-pressed={browserPanelOpen}
                 >
                   <Globe size={16} />
-                  <span className="hidden lg:inline">Browser</span>
+                  <span className="hidden @lg/titlebar:inline">Browser</span>
                 </button>
               ) : null}
               {props.history ? (
@@ -372,7 +367,7 @@ export function SessionPage(props: SessionPageProps) {
                     ) : (
                       <Undo2 size={16} />
                     )}
-                    <span className="hidden lg:inline">{t("session.revert_label")}</span>
+                    <span className="hidden @lg/titlebar:inline">{t("session.revert_label")}</span>
                   </button>
                   <button
                     type="button"
@@ -387,7 +382,7 @@ export function SessionPage(props: SessionPageProps) {
                     ) : (
                       <Redo2 size={16} />
                     )}
-                    <span className="hidden lg:inline">{t("session.redo_label")}</span>
+                    <span className="hidden @lg/titlebar:inline">{t("session.redo_label")}</span>
                   </button>
                 </>
               ) : null}
@@ -395,7 +390,7 @@ export function SessionPage(props: SessionPageProps) {
           </header>
 
           <div className="flex min-h-0 flex-1 overflow-hidden">
-            <div className="relative min-w-0 flex-1 overflow-hidden bg-dls-surface">
+            <div className="relative min-w-0 flex-1 overflow-hidden bg-dls-surface mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
               {showStartupSkeleton ? (
                 <div className="px-6 py-14" role="status" aria-live="polite">
                   <div className="mx-auto max-w-2xl space-y-6">
@@ -551,17 +546,18 @@ export function SessionPage(props: SessionPageProps) {
             statusPulse={props.statusBar?.statusPulse}
             showSettingsButton={props.statusBar?.showSettingsButton}
           />
-        </main>
-
-        {browserPanelOpen ? (
-          <aside
-            className="hidden min-h-0 shrink-0 overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)] lg:flex lg:flex-col"
-            style={{ width: 520 }}
-          >
-            <BrowserPanel onClose={toggleBrowserPanel} />
-          </aside>
-        ) : null}
-      </div>
+          </main>
+          {browserPanelOpen ? (
+            <aside
+              className="hidden min-h-0 shrink-0 overflow-hidden lg:flex lg:flex-col"
+              style={{ width: 520 }}
+            >
+              <BrowserPanel onClose={toggleBrowserPanel} />
+            </aside>
+          ) : null}
+        </SidebarInset>
+        <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" />
+      </SidebarProvider>
 
       {props.providerAuthModal ? <ProviderAuthModal {...props.providerAuthModal} /> : null}
 
@@ -570,7 +566,7 @@ export function SessionPage(props: SessionPageProps) {
           open={renameOpen}
           title={renameTitle}
           busy={renameBusy}
-          canSave={renameTitle.trim().length > 0 && renameTitle.trim() !== selectedSessionTitle.trim()}
+          canSave={renameTitle.trim().length > 0 && renameTitle.trim() !== sessionActionTitle.trim()}
           onClose={() => {
             if (!renameBusy) setRenameOpen(false);
           }}
@@ -584,8 +580,8 @@ export function SessionPage(props: SessionPageProps) {
           open={deleteOpen}
           title={t("session.delete_session_title")}
           message={
-            selectedSessionTitle.trim()
-              ? t("session.delete_named_session_message", undefined, { title: selectedSessionTitle.trim() })
+            sessionActionTitle.trim()
+              ? t("session.delete_named_session_message", { title: sessionActionTitle.trim() })
               : t("session.delete_session_generic")
           }
           confirmLabel={deleteBusy ? t("session.deleting") : t("session.delete")}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource react */
+import * as React from "react";
+import type { WorkspaceConnectionState } from "../../../../app/types";
+
+export type SidebarContextValue = {
+  selectedWorkspaceId: string;
+  selectedSessionId: string | null;
+  developerMode: boolean;
+  showSessionActions?: boolean;
+  sessionStatusById?: Record<string, string>;
+  newTaskDisabled: boolean;
+  connectingWorkspaceId: string | null;
+  workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
+  onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onOpenSession: (workspaceId: string, sessionId: string) => void;
+  onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
+  onCreateTaskInWorkspace: (workspaceId: string) => void;
+  onOpenRenameSession?: (sessionId: string) => void;
+  onOpenDeleteSession?: (sessionId: string) => void;
+  onOpenRenameWorkspace: (workspaceId: string) => void;
+  onShareWorkspace: (workspaceId: string) => void;
+  onRevealWorkspace: (workspaceId: string) => void;
+  onRecoverWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onTestWorkspaceConnection: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onEditWorkspaceConnection: (workspaceId: string) => void;
+  onForgetWorkspace: (workspaceId: string) => void;
+  expandWorkspace: (workspaceId: string) => void;
+  toggleWorkspaceExpanded: (workspaceId: string) => void;
+  toggleSessionExpanded: (sessionId: string) => void;
+  expandedWorkspaceIds: Set<string>;
+  expandedSessionIds: Set<string>;
+};
+
+export const SidebarContext = React.createContext<SidebarContextValue | null>(null);
+
+export function useSidebarContext() {
+  const context = React.useContext(SidebarContext);
+  if (!context) throw new Error("useSidebarContext must be used within SidebarProvider");
+  return context;
+}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1,0 +1,734 @@
+/** @jsxImportSource react */
+import * as React from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Share2,
+  Trash2,
+  RefreshCw,
+  Settings,
+  FolderOpen,
+} from "lucide-react";
+
+import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
+import type { WorkspaceInfo } from "../../../../app/lib/desktop";
+import type {
+  WorkspaceConnectionState,
+  WorkspaceSessionGroup,
+} from "../../../../app/types";
+import {
+  getWorkspaceTaskLoadErrorDisplay,
+  isWindowsPlatform,
+} from "../../../../app/utils";
+import { t } from "../../../../i18n";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from "@/components/ui/sidebar";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+
+import { SidebarContext, useSidebarContext } from "./app-sidebar-provider";
+import type { SidebarContextValue } from "./app-sidebar-provider";
+import {
+  MAX_SESSIONS_PREVIEW,
+  buildSessionTreeState,
+  flattenSessionRows,
+  getRootSessions,
+  workspaceKindLabel,
+  workspaceLabel,
+  workspaceSwatchColor,
+} from "./utils";
+import type { SessionListItem, SessionTreeState } from "./utils";
+import { cn } from "@/lib/utils";
+
+type SessionActionsProps = {
+  className: string;
+  sessionId: string;
+};
+
+function SessionActions({ className, sessionId }: SessionActionsProps) {
+  const ctx = useSidebarContext();
+  const canManage = Boolean(
+    ctx.showSessionActions && (ctx.onOpenRenameSession || ctx.onOpenDeleteSession),
+  );
+
+  if (!canManage) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="size-4"
+        render={
+          <Button variant="ghost" size="icon-sm" className={cn("size-4", className)}>
+            <MoreHorizontal className="size-4" />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" side="bottom" sideOffset={4} alignOffset={-4} className="w-56">
+        {ctx.onOpenRenameSession ? (
+          <DropdownMenuItem onClick={() => ctx.onOpenRenameSession?.(sessionId)}>
+            <Pencil size={14} />
+            {t("workspace_list.rename_session")}
+          </DropdownMenuItem>
+        ) : null}
+        {ctx.onOpenDeleteSession ? (
+          <DropdownMenuItem variant="destructive" onClick={() => ctx.onOpenDeleteSession?.(sessionId)}>
+            <Trash2 size={14} />
+            {t("workspace_list.delete_session")}
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+type SessionContextMenuProps = {
+  children: React.ReactElement;
+  sessionId: string;
+};
+
+function SessionContextMenu({ children, sessionId }: SessionContextMenuProps) {
+  const ctx = useSidebarContext();
+  const canManage = Boolean(
+    ctx.showSessionActions && (ctx.onOpenRenameSession || ctx.onOpenDeleteSession),
+  );
+
+  if (!canManage) return children;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger render={children} />
+      <ContextMenuContent className="w-56">
+        {ctx.onOpenRenameSession ? (
+          <ContextMenuItem onClick={() => ctx.onOpenRenameSession?.(sessionId)}>
+            <Pencil size={14} />
+            {t("workspace_list.rename_session")}
+          </ContextMenuItem>
+        ) : null}
+        {ctx.onOpenDeleteSession ? (
+          <ContextMenuItem variant="destructive" onClick={() => ctx.onOpenDeleteSession?.(sessionId)}>
+            <Trash2 size={14} />
+            {t("workspace_list.delete_session")}
+          </ContextMenuItem>
+        ) : null}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+type WorkspaceActionsMenuProps = {
+  workspace: WorkspaceInfo;
+  isConnectionActionBusy: boolean;
+  canRecover: boolean;
+  className: string;
+};
+
+function WorkspaceActionsMenu({ workspace, isConnectionActionBusy, canRecover, className }: WorkspaceActionsMenuProps) {
+  const ctx = useSidebarContext();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className={className}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            aria-label={t("workspace_list.workspace_options")}
+          >
+            <MoreHorizontal size={14} />
+          </Button>
+        }
+      />
+      <DropdownMenuContent align="end" side="bottom" sideOffset={4} className="w-56">
+        <DropdownMenuItem onClick={() => ctx.onOpenRenameWorkspace(workspace.id)}>
+          <Pencil size={14} />
+          {t("workspace_list.edit_name")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => ctx.onShareWorkspace(workspace.id)}>
+          <Share2 size={14} />
+          {t("workspace_list.share")}
+        </DropdownMenuItem>
+        {workspace.workspaceType === "local" ? (
+          <DropdownMenuItem onClick={() => ctx.onRevealWorkspace(workspace.id)}>
+            <FolderOpen size={14} />
+            {isWindowsPlatform() ? t("workspace_list.reveal_explorer") : t("workspace_list.reveal_finder")}
+          </DropdownMenuItem>
+        ) : null}
+        {workspace.workspaceType === "remote" ? (
+          <>
+            {canRecover ? (
+              <DropdownMenuItem
+                onClick={() => void Promise.resolve(ctx.onRecoverWorkspace(workspace.id))}
+                disabled={isConnectionActionBusy}
+              >
+                <RefreshCw size={14} />
+                {t("workspace_list.recover")}
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuItem
+              onClick={() => void Promise.resolve(ctx.onTestWorkspaceConnection(workspace.id))}
+              disabled={isConnectionActionBusy}
+            >
+              <RefreshCw size={14} />
+              {t("workspace_list.test_connection")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => ctx.onEditWorkspaceConnection(workspace.id)}
+              disabled={isConnectionActionBusy}
+            >
+              <Settings size={14} />
+              {t("workspace_list.edit_connection")}
+            </DropdownMenuItem>
+          </>
+        ) : null}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          onClick={() => ctx.onForgetWorkspace(workspace.id)}
+        >
+          <Trash2 size={14} />
+          {t("workspace_list.remove_workspace")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export type AppSidebarProps = {
+  workspaceSessionGroups: WorkspaceSessionGroup[];
+  showInitialLoading?: boolean;
+  selectedWorkspaceId: string;
+  developerMode: boolean;
+  selectedSessionId: string | null;
+  showSessionActions?: boolean;
+  sessionStatusById?: Record<string, string>;
+  connectingWorkspaceId: string | null;
+  workspaceConnectionStateById: Record<string, WorkspaceConnectionState>;
+  newTaskDisabled: boolean;
+  onSelectWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onOpenSession: (workspaceId: string, sessionId: string) => void;
+  onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
+  onCreateTaskInWorkspace: (workspaceId: string) => void;
+  onOpenRenameSession?: (sessionId: string) => void;
+  onOpenDeleteSession?: (sessionId: string) => void;
+  onOpenRenameWorkspace: (workspaceId: string) => void;
+  onShareWorkspace: (workspaceId: string) => void;
+  onRevealWorkspace: (workspaceId: string) => void;
+  onRecoverWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onTestWorkspaceConnection: (workspaceId: string) => Promise<boolean> | boolean | void;
+  onEditWorkspaceConnection: (workspaceId: string) => void;
+  onForgetWorkspace: (workspaceId: string) => void;
+  onOpenCreateWorkspace: () => void;
+};
+
+function useSessionTree(
+  sessions: WorkspaceSessionGroup["sessions"],
+  sessionStatusById: Record<string, string> | undefined,
+) {
+  return React.useMemo(
+    () => buildSessionTreeState(sessions, sessionStatusById),
+    [sessions, sessionStatusById],
+  );
+}
+
+export function AppSidebar(props: AppSidebarProps) {
+  const [expandedWorkspaceIds, setExpandedWorkspaceIds] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  const [previewCountByWorkspaceId, setPreviewCountByWorkspaceId] = React.useState<Record<string, number>>({});
+  const [expandedSessionIds, setExpandedSessionIds] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const expandWorkspace = React.useCallback((workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((previous) => {
+      if (previous.has(id)) return previous;
+      const next = new Set(previous);
+      next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleWorkspaceExpanded = React.useCallback((workspaceId: string) => {
+    const id = workspaceId.trim();
+    if (!id) return;
+    setExpandedWorkspaceIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSessionExpanded = React.useCallback((sessionId: string) => {
+    const id = sessionId.trim();
+    if (!id) return;
+    setExpandedSessionIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    const id = props.selectedWorkspaceId.trim();
+    if (!id) return;
+    expandWorkspace(id);
+  }, [props.selectedWorkspaceId, expandWorkspace]);
+
+  const previewCount = (workspaceId: string) =>
+    previewCountByWorkspaceId[workspaceId] ?? MAX_SESSIONS_PREVIEW;
+
+  const showMoreSessions = (workspaceId: string, totalRoots: number) => {
+    expandWorkspace(workspaceId);
+    setPreviewCountByWorkspaceId((current) => ({
+      ...current,
+      [workspaceId]: Math.min((current[workspaceId] ?? MAX_SESSIONS_PREVIEW) + MAX_SESSIONS_PREVIEW, totalRoots),
+    }));
+  };
+
+  React.useEffect(() => {
+    const workspaceId = props.selectedWorkspaceId.trim();
+    if (!workspaceId) return;
+
+    const group = props.workspaceSessionGroups.find(
+      (entry) => entry.workspace.id === workspaceId,
+    );
+    if (!group?.sessions.length) return;
+
+    const selectedId = props.selectedSessionId?.trim() ?? "";
+    const selectedIndex = selectedId
+      ? group.sessions.findIndex((session) => session.id === selectedId)
+      : -1;
+    const start = selectedIndex >= 0 ? Math.max(0, selectedIndex - 2) : 0;
+    const end = selectedIndex >= 0
+      ? Math.min(group.sessions.length, selectedIndex + 3)
+      : Math.min(group.sessions.length, 4);
+
+    group.sessions.slice(start, end).forEach((session) => {
+      props.onPrefetchSession?.(workspaceId, session.id);
+    });
+  }, [
+    props.onPrefetchSession,
+    props.selectedSessionId,
+    props.selectedWorkspaceId,
+    props.workspaceSessionGroups,
+  ]);
+
+  const contextValue: SidebarContextValue = {
+    selectedWorkspaceId: props.selectedWorkspaceId,
+    selectedSessionId: props.selectedSessionId,
+    developerMode: props.developerMode,
+    showSessionActions: props.showSessionActions,
+    sessionStatusById: props.sessionStatusById,
+    newTaskDisabled: props.newTaskDisabled,
+    connectingWorkspaceId: props.connectingWorkspaceId,
+    workspaceConnectionStateById: props.workspaceConnectionStateById,
+    onSelectWorkspace: props.onSelectWorkspace,
+    onOpenSession: props.onOpenSession,
+    onPrefetchSession: props.onPrefetchSession,
+    onCreateTaskInWorkspace: props.onCreateTaskInWorkspace,
+    onOpenRenameSession: props.onOpenRenameSession,
+    onOpenDeleteSession: props.onOpenDeleteSession,
+    onOpenRenameWorkspace: props.onOpenRenameWorkspace,
+    onShareWorkspace: props.onShareWorkspace,
+    onRevealWorkspace: props.onRevealWorkspace,
+    onRecoverWorkspace: props.onRecoverWorkspace,
+    onTestWorkspaceConnection: props.onTestWorkspaceConnection,
+    onEditWorkspaceConnection: props.onEditWorkspaceConnection,
+    onForgetWorkspace: props.onForgetWorkspace,
+    expandWorkspace,
+    toggleWorkspaceExpanded,
+    toggleSessionExpanded,
+    expandedWorkspaceIds,
+    expandedSessionIds,
+  };
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <Sidebar
+        collapsible="offcanvas"
+        className="mac:**:data-[sidebar=sidebar]:bg-transparent"
+      >
+        <div className="hidden h-10 mac:block mac:titlebar-drag"/>
+        <SidebarContent>
+          
+          {props.workspaceSessionGroups.map((group) => (
+            <WorkspaceSidebarGroup
+              className="mac:first:pt-0"
+              key={group.workspace.id}
+              group={group}
+              showInitialLoading={props.showInitialLoading}
+              previewCount={previewCount(group.workspace.id)}
+              showMoreSessions={showMoreSessions}
+            />
+          ))}
+        </SidebarContent>
+
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton onClick={props.onOpenCreateWorkspace}>
+                <Plus size={14} />
+                {t("workspace_list.add_workspace")}
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+      </Sidebar>
+    </SidebarContext.Provider>
+  );
+}
+
+type WorkspaceHeaderProps = React.ComponentProps<typeof SidebarMenuButton> & {
+  workspace: WorkspaceInfo;
+  statusLabel: string;
+  isError: boolean;
+  isLoading: boolean;
+};
+
+function WorkspaceHeader({
+  workspace,
+  statusLabel,
+  isError,
+  isLoading,
+  onClick,
+  ...props
+}: WorkspaceHeaderProps) {
+  const ctx = useSidebarContext();
+
+  const handleSelectWorkspace = () => {
+    void Promise.resolve(ctx.onSelectWorkspace(workspace.id));
+  };
+
+  return (
+    <SidebarMenuButton
+      {...props}
+      className="h-8 group-hover/workspace-header:bg-sidebar-accent group-hover/workspace-header:text-sidebar-accent-foreground mac:group-hover/workspace-header:bg-black/5 dark:mac:group-hover/workspace-header:bg-white/10"
+      onClick={(event) => {
+        onClick?.(event);
+        handleSelectWorkspace();
+      }}
+    >
+      <div
+        className="flex size-5 shrink-0 items-center justify-center rounded-full"
+        style={{ backgroundColor: workspaceSwatchColor(workspace.id || workspaceLabel(workspace)) }}
+      />
+      <div className="min-w-0 flex-1">
+        <span className="block truncate font-medium">{workspaceLabel(workspace)}</span>
+        {statusLabel ? (
+          <span className={`block text-xs ${isError ? "text-destructive" : "text-muted-foreground"}`}>
+            {statusLabel}
+          </span>
+        ) : null}
+      </div>
+      <span className="ml-auto flex items-center gap-1 pl-0">
+        {isLoading ? (
+          <Loader2 size={14} className="animate-spin text-muted-foreground" />
+        ) : null}
+        <ChevronRight size={14} className="text-muted-foreground transition-transform duration-200 group-data-open/collapsible:rotate-90 hover:text-foreground" />
+      </span>
+    </SidebarMenuButton>
+  );
+}
+
+type WorkspaceSidebarGroupProps = {
+  className: string;
+  group: WorkspaceSessionGroup;
+  showInitialLoading?: boolean;
+  previewCount: number;
+  showMoreSessions: (workspaceId: string, totalRoots: number) => void;
+};
+
+function WorkspaceSidebarGroup({
+  className,
+  group,
+  showInitialLoading,
+  previewCount,
+  showMoreSessions,
+}: WorkspaceSidebarGroupProps) {
+  const ctx = useSidebarContext();
+  const workspace = group.workspace;
+  const tree = useSessionTree(group.sessions, ctx.sessionStatusById);
+
+  const forcedExpandedSessionIds = React.useMemo(
+    () => new Set(
+      ctx.selectedSessionId
+        ? tree.ancestorIdsBySessionId.get(ctx.selectedSessionId) ?? []
+        : [],
+    ),
+    [ctx.selectedSessionId, tree.ancestorIdsBySessionId],
+  );
+
+  const isConnecting = ctx.connectingWorkspaceId === workspace.id;
+  const connectionState: WorkspaceConnectionState = ctx.workspaceConnectionStateById[workspace.id] ?? {
+    status: "idle",
+    message: null,
+  };
+  const isConnectionActionBusy = isConnecting || connectionState.status === "connecting";
+  const canRecover = workspace.workspaceType === "remote" && connectionState.status === "error";
+  const taskLoadError = getWorkspaceTaskLoadErrorDisplay(workspace, group.error);
+  const isExpanded = ctx.expandedWorkspaceIds.has(workspace.id);
+  const isSelected = ctx.selectedWorkspaceId === workspace.id;
+
+  const statusLabel = (() => {
+    if (group.status === "error") return taskLoadError.label;
+    if (isConnectionActionBusy) return t("workspace_list.connecting");
+    if (!ctx.developerMode) return "";
+    if (isSelected) return t("workspace.selected");
+    return workspaceKindLabel(workspace);
+  })();
+
+  const rootSessions = getRootSessions(group.sessions);
+  const sessionRows = flattenSessionRows(
+    group.sessions,
+    previewCount,
+    tree,
+    ctx.expandedSessionIds,
+    forcedExpandedSessionIds,
+  );
+  const remainingRootSessions = Math.max(0, rootSessions.length - previewCount);
+  const showMoreLabel = remainingRootSessions > 0
+    ? t("workspace_list.show_more", {
+      count: Math.min(MAX_SESSIONS_PREVIEW, remainingRootSessions),
+    })
+    : t("workspace_list.show_more_fallback");
+
+  return (
+    <SidebarGroup className={className}>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <Collapsible
+            render={<SidebarMenuItem />}
+            open={isExpanded}
+            onOpenChange={() => ctx.toggleWorkspaceExpanded(workspace.id)}
+            className="group/collapsible"
+          >
+            <div className="group/workspace-header relative">
+              <CollapsibleTrigger
+                render={
+                  <WorkspaceHeader
+                    workspace={workspace}
+                    statusLabel={statusLabel}
+                    isError={group.status === "error"}
+                    isLoading={group.status === "loading" || isConnecting}
+                  />
+                }
+              />
+              <div className="absolute right-8 top-1 flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-6 text-muted-foreground opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  ctx.onCreateTaskInWorkspace(workspace.id);
+                }}
+                disabled={ctx.newTaskDisabled}
+                aria-label={t("session.new_task")}
+              >
+                <Plus size={14} />
+              </Button>
+              <WorkspaceActionsMenu
+                workspace={workspace}
+                isConnectionActionBusy={isConnectionActionBusy}
+                canRecover={canRecover}
+                className="size-6 text-muted-foreground opacity-0 group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-popup-open:opacity-100"
+              />
+              </div>
+            </div>
+
+            <CollapsibleContent className="pt-1">
+              <SidebarMenuSub>
+                {showInitialLoading ? (
+                  <>
+                    {[0, 1, 2].map((idx) => (
+                      <SidebarMenuSubItem key={`skeleton-${idx}`}>
+                        <SidebarMenuSkeleton showIcon />
+                      </SidebarMenuSubItem>
+                    ))}
+                  </>
+                ) : group.status === "loading" && group.sessions.length === 0 ? (
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton aria-disabled className="text-muted-foreground text-xs">
+                      {t("workspace.loading_tasks")}
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                ) : group.sessions.length > 0 ? (
+                  <>
+                    {sessionRows.map((row) => (
+                      <SessionMenuItem
+                        key={row.session.id}
+                        session={row.session}
+                        tree={tree}
+                        workspaceId={workspace.id}
+                        forcedExpandedSessionIds={forcedExpandedSessionIds}
+                      />
+                    ))}
+                    {rootSessions.length > previewCount ? (
+                      <SidebarMenuSubItem>
+                        <SidebarMenuSubButton
+                          className="text-muted-foreground text-xs"
+                          onClick={() => showMoreSessions(workspace.id, rootSessions.length)}
+                        >
+                          {showMoreLabel}
+                        </SidebarMenuSubButton>
+                      </SidebarMenuSubItem>
+                    ) : null}
+                  </>
+                ) : group.status === "error" ? (
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton
+                      aria-disabled
+                      className={taskLoadError.tone === "offline" ? "text-amber-600" : "text-destructive"}
+                    >
+                      {taskLoadError.message}
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                ) : (
+                  <SidebarMenuSubItem>
+                    <SidebarMenuSubButton
+                      className="text-muted-foreground text-xs"
+                      onClick={() => ctx.onCreateTaskInWorkspace(workspace.id)}
+                      aria-disabled={ctx.newTaskDisabled}
+                    >
+                      {t("workspace.no_tasks")}
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                )}
+              </SidebarMenuSub>
+            </CollapsibleContent>
+          </Collapsible>
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+type SessionMenuItemProps = {
+  session: SessionListItem;
+  tree: SessionTreeState;
+  workspaceId: string;
+  forcedExpandedSessionIds: Set<string>;
+};
+
+function SessionMenuItem({ session, tree, workspaceId, forcedExpandedSessionIds }: SessionMenuItemProps) {
+  const ctx = useSidebarContext();
+  const isSelected = ctx.selectedSessionId === session.id;
+  const displayTitle = getDisplaySessionTitle(session.title);
+  const hasChildren = (tree.descendantCountBySessionId.get(session.id) ?? 0) > 0;
+  const isExpanded = ctx.expandedSessionIds.has(session.id) || forcedExpandedSessionIds.has(session.id);
+  const isSessionActive = tree.activeIds.has(session.id);
+
+  const openSession = () => {
+    ctx.onOpenSession(workspaceId, session.id);
+  };
+
+  const prefetchSession = () => {
+    if (workspaceId !== ctx.selectedWorkspaceId) {
+      return;
+    }
+
+    ctx.onPrefetchSession?.(workspaceId, session.id);
+  };
+
+  if (hasChildren) {
+    return (
+      <Collapsible open={isExpanded} onOpenChange={() => ctx.toggleSessionExpanded(session.id)}>
+        <SidebarMenuSubItem>
+          <div className="flex min-w-0 items-center gap-1">
+            <CollapsibleTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-7 shrink-0"
+                  aria-label={isExpanded ? t("sidebar.collapse") : t("sidebar.expand")}
+                >
+                  {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                </Button>
+              }
+            />
+            <SessionContextMenu sessionId={session.id}>
+              <SidebarMenuSubButton
+                isActive={isSelected}
+                onClick={openSession}
+                onPointerEnter={prefetchSession}
+                onFocus={prefetchSession}
+              >
+                {isSessionActive ? <span className="size-1.5 shrink-0 rounded-full bg-amber-500" /> : null}
+                <span className="truncate" title={displayTitle}>
+                  {displayTitle}
+                </span>
+              </SidebarMenuSubButton>
+            </SessionContextMenu>
+          </div>
+          <SessionActions
+            sessionId={session.id}
+            className="absolute right-3 top-1.5 opacity-0 group-hover/menu-sub-item:opacity-100 data-popup-open:opacity-100"
+          />
+        </SidebarMenuSubItem>
+      </Collapsible>
+    );
+  }
+
+  return (
+    <SidebarMenuSubItem>
+      <SessionContextMenu sessionId={session.id}>
+        <SidebarMenuSubButton isActive={isSelected} onClick={openSession} onPointerEnter={prefetchSession} onFocus={prefetchSession}>
+          {isSessionActive ? <span className="size-1.5 shrink-0 rounded-full bg-amber-500" /> : null}
+          <span className="truncate" title={displayTitle}>{displayTitle}</span>
+        </SidebarMenuSubButton>
+      </SessionContextMenu>
+      <SessionActions
+        sessionId={session.id}
+        className="absolute right-3 top-1.5 opacity-0 group-hover/menu-sub-item:opacity-100 data-popup-open:opacity-100"
+      />
+    </SidebarMenuSubItem>
+  );
+}

--- a/apps/app/src/react-app/domains/session/sidebar/utils.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/utils.ts
@@ -1,0 +1,127 @@
+import type { WorkspaceInfo } from "../../../../app/lib/desktop";
+import type { WorkspaceSessionGroup } from "../../../../app/types";
+import { isSandboxWorkspace } from "../../../../app/utils";
+import { t } from "../../../../i18n";
+
+export const MAX_SESSIONS_PREVIEW = 6;
+
+export type SessionListItem = WorkspaceSessionGroup["sessions"][number];
+export type FlattenedSessionRow = { session: SessionListItem; depth: number };
+export type SessionTreeState = {
+  childrenByParent: Map<string, SessionListItem[]>;
+  ancestorIdsBySessionId: Map<string, string[]>;
+  descendantCountBySessionId: Map<string, number>;
+  activeIds: Set<string>;
+};
+
+const normalizeSessionParentID = (session: SessionListItem) => {
+  const parentID = session.parentID?.trim();
+  return parentID || "";
+};
+
+export const getRootSessions = (sessions: WorkspaceSessionGroup["sessions"]) => {
+  const byID = new Set(sessions.map((session) => session.id));
+  return sessions.filter((session) => {
+    const parentID = normalizeSessionParentID(session);
+    return !parentID || !byID.has(parentID);
+  });
+};
+
+export const buildSessionTreeState = (
+  sessions: WorkspaceSessionGroup["sessions"],
+  sessionStatusById: Record<string, string> | undefined,
+): SessionTreeState => {
+  const childrenByParent = new Map<string, SessionListItem[]>();
+  const ancestorIdsBySessionId = new Map<string, string[]>();
+  const descendantCountBySessionId = new Map<string, number>();
+  const activeIds = new Set<string>();
+  const sessionIds = new Set(sessions.map((session) => session.id));
+
+  sessions.forEach((session) => {
+    const parentID = normalizeSessionParentID(session);
+    if (!parentID || !sessionIds.has(parentID)) return;
+    const siblings = childrenByParent.get(parentID) ?? [];
+    siblings.push(session);
+    childrenByParent.set(parentID, siblings);
+  });
+
+  const walk = (session: SessionListItem, ancestors: string[]) => {
+    ancestorIdsBySessionId.set(session.id, ancestors);
+    const children = childrenByParent.get(session.id) ?? [];
+    let descendantCount = 0;
+    let subtreeActive = (sessionStatusById?.[session.id] ?? "idle") !== "idle";
+
+    children.forEach((child) => {
+      const childState = walk(child, [...ancestors, session.id]);
+      descendantCount += 1 + childState.descendantCount;
+      subtreeActive = subtreeActive || childState.subtreeActive;
+    });
+
+    descendantCountBySessionId.set(session.id, descendantCount);
+    if (subtreeActive) activeIds.add(session.id);
+    return { descendantCount, subtreeActive };
+  };
+
+  getRootSessions(sessions).forEach((session) => {
+    walk(session, []);
+  });
+
+  return {
+    childrenByParent,
+    ancestorIdsBySessionId,
+    descendantCountBySessionId,
+    activeIds,
+  };
+};
+
+export const flattenSessionRows = (
+  sessions: WorkspaceSessionGroup["sessions"],
+  rootLimit: number,
+  tree: SessionTreeState,
+  expandedSessionIds: Set<string>,
+  forcedExpandedSessionIds: Set<string>,
+) => {
+  const roots = getRootSessions(sessions).slice(0, rootLimit);
+  const rows: FlattenedSessionRow[] = [];
+  const visited = new Set<string>();
+
+  const walk = (session: SessionListItem, depth: number) => {
+    if (visited.has(session.id)) return;
+    visited.add(session.id);
+    rows.push({ session, depth });
+    const children = tree.childrenByParent.get(session.id) ?? [];
+    if (!children.length) return;
+    const expanded = expandedSessionIds.has(session.id) || forcedExpandedSessionIds.has(session.id);
+    if (!expanded) return;
+    children.forEach((child) => walk(child, depth + 1));
+  };
+
+  roots.forEach((root) => walk(root, 0));
+  return rows;
+};
+
+export const workspaceLabel = (workspace: WorkspaceInfo) =>
+  workspace.displayName?.trim() ||
+  workspace.openworkWorkspaceName?.trim() ||
+  workspace.name?.trim() ||
+  workspace.path?.trim() ||
+  t("workspace_list.workspace_fallback");
+
+export const workspaceKindLabel = (workspace: WorkspaceInfo) =>
+  workspace.workspaceType === "remote"
+    ? isSandboxWorkspace(workspace)
+      ? t("workspace.sandbox_badge")
+      : t("workspace.remote_badge")
+    : t("workspace.local_badge");
+
+const WORKSPACE_SWATCHES = ["#2563eb", "#5a67d8", "#f97316", "#10b981"];
+
+export const workspaceSwatchColor = (seed: string) => {
+  const value = seed.trim() || "workspace";
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return WORKSPACE_SWATCHES[Math.abs(hash) % WORKSPACE_SWATCHES.length];
+};

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -847,7 +847,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   const panelRoundedClass =
     mentionOpen || slashOpen
       ? "rounded-t-[18px] border-t-transparent"
-      : "shadow-[var(--dls-shell-shadow)]";
+      : "";
 
   const renderSlashMenu = () => {
     if (!slashOpen) return null;

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource react */
 import type * as React from "react";
 import {
+  ArrowLeft,
   Bug,
+  ChevronDown,
   Cloud,
   Cog,
   Paintbrush,
@@ -19,12 +21,17 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
-  SidebarInset,
+  SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarProvider,
 } from "@/components/ui/sidebar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { t } from "../../../../i18n";
 import type { SettingsTab } from "../../../../app/types";
 import {
@@ -141,100 +148,151 @@ type SettingsPageProps = {
   children: React.ReactNode;
 };
 
-export function SettingsPage(props: SettingsPageProps) {
+type SettingsSidebarProps = Pick<SettingsPageProps, "activeTab" | "onSelectTab" | "developerMode"> & {
+  onClose: () => void;
+  selectedWorkspaceId: string;
+  selectedWorkspaceName: string;
+  selectedWorkspaceColor: string;
+  workspaces: Array<{ id: string; name: string; color: string }>;
+  onSelectWorkspace: (workspaceId: string) => void;
+};
+
+export function SettingsSidebar(props: SettingsSidebarProps) {
   const workspaceTabs = getWorkspaceSettingsTabs();
   const globalTabs = getGlobalSettingsTabs(props.developerMode);
 
   return (
-    <SidebarProvider className="relative min-h-full min-w-0">
-        <Sidebar collapsible="none" className="absolute inset-0">
-          <SidebarContent>
-            <SidebarGroup>
-              <SidebarGroupLabel>{t("settings.group_workspace")}</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {workspaceTabs.map((tab) => {
-                    const Icon = getSettingsTabIcon(tab);
-                    return (
-                      <SidebarMenuItem key={tab}>
-                        <SidebarMenuButton
-                          type="button"
-                          isActive={props.activeTab === tab}
-                          onClick={() => props.onSelectTab(tab)}
-                        >
-                          <Icon />
-                          <span>{getSettingsTabLabel(tab)}</span>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-
-            <SidebarGroup>
-              <SidebarGroupLabel>{t("settings.group_global")}</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {globalTabs.map((tab) => {
-                    const Icon = getSettingsTabIcon(tab);
-                    return (
-                      <SidebarMenuItem key={tab}>
-                        <SidebarMenuButton
-                          type="button"
-                          isActive={props.activeTab === tab}
-                          onClick={() => props.onSelectTab(tab)}
-                        >
-                          <Icon />
-                          <span>{getSettingsTabLabel(tab)}</span>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          </SidebarContent>
-        </Sidebar>
-
-        <SidebarInset className="h-full min-w-0 w-full max-w-full overflow-hidden">
-        <SettingsContent>
-          <SettingsPanel>
-            <SettingsPanelHeading>
-              <SettingsPanelTitle>{getSettingsTabLabel(props.activeTab)}</SettingsPanelTitle>
-              <SettingsPanelDescription>{getSettingsTabDescription(props.activeTab)}</SettingsPanelDescription>
-            </SettingsPanelHeading>
-
-            {props.showUpdateToolbar && props.activeTab === "general" ? (
-              <SettingsPanelToolbar>
-                <SettingsPanelToolbarActions>
-                  <SettingsPanelToolbarStatus
-                    tone={props.updateToolbarTone}
-                    title={props.updateToolbarTitle}
-                    spinning={props.updateToolbarSpinning}
+    <Sidebar className="mac:**:data-[sidebar=sidebar]:bg-transparent">
+      <div className="hidden h-10 mac:block mac:titlebar-drag" />
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton type="button" onClick={props.onClose}>
+              <ArrowLeft size={14} />
+              <span>{t("dashboard.back_to_app")}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <SidebarMenuButton type="button">
+                    <span
+                      className="size-4 shrink-0 rounded-full"
+                      style={{ backgroundColor: props.selectedWorkspaceColor }}
+                    />
+                    <span className="truncate">{props.selectedWorkspaceName}</span>
+                    <ChevronDown className="ml-auto" />
+                  </SidebarMenuButton>
+                }
+              />
+              <DropdownMenuContent className="w-(--anchor-width)">
+                {props.workspaces.map((workspace) => (
+                  <DropdownMenuItem
+                    key={workspace.id}
+                    onClick={() => props.onSelectWorkspace(workspace.id)}
+                    disabled={workspace.id === props.selectedWorkspaceId}
                   >
-                    {props.updateToolbarLabel}
-                  </SettingsPanelToolbarStatus>
-                  {props.updateToolbarActionLabel ? (
-                    <SettingsPanelToolbarButton
-                      onClick={props.onUpdateToolbarAction}
-                      disabled={props.updateToolbarDisabled}
-                      title={props.updateRestartBlockedMessage ?? ""}
+                    <span
+                      className="size-4 shrink-0 rounded-full"
+                      style={{ backgroundColor: workspace.color }}
+                    />
+                    <span className="truncate">{workspace.name}</span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>{t("settings.group_workspace")}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {workspaceTabs.map((tab) => {
+                const Icon = getSettingsTabIcon(tab);
+                return (
+                  <SidebarMenuItem key={tab}>
+                    <SidebarMenuButton
+                      type="button"
+                      isActive={props.activeTab === tab}
+                      onClick={() => props.onSelectTab(tab)}
                     >
-                      {props.updateToolbarActionLabel}
-                    </SettingsPanelToolbarButton>
-                  ) : null}
-                </SettingsPanelToolbarActions>
-                {props.updateRestartBlockedMessage ? (
-                  <SettingsPanelToolbarMessage>{props.updateRestartBlockedMessage}</SettingsPanelToolbarMessage>
-                ) : null}
-              </SettingsPanelToolbar>
-            ) : null}
-          </SettingsPanel>
+                      <Icon />
+                      <span>{getSettingsTabLabel(tab)}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
 
-          {props.children}
-        </SettingsContent>
-        </SidebarInset>
-    </SidebarProvider>
+        <SidebarGroup>
+          <SidebarGroupLabel>{t("settings.group_global")}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {globalTabs.map((tab) => {
+                const Icon = getSettingsTabIcon(tab);
+                return (
+                  <SidebarMenuItem key={tab}>
+                    <SidebarMenuButton
+                      type="button"
+                      isActive={props.activeTab === tab}
+                      onClick={() => props.onSelectTab(tab)}
+                    >
+                      <Icon />
+                      <span>{getSettingsTabLabel(tab)}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  );
+}
+
+export function SettingsPage(props: SettingsPageProps) {
+  return (
+    <SettingsContent>
+      <SettingsPanel>
+        <SettingsPanelHeading>
+          <SettingsPanelTitle>{getSettingsTabLabel(props.activeTab)}</SettingsPanelTitle>
+          <SettingsPanelDescription>{getSettingsTabDescription(props.activeTab)}</SettingsPanelDescription>
+        </SettingsPanelHeading>
+
+        {props.showUpdateToolbar && props.activeTab === "general" ? (
+          <SettingsPanelToolbar>
+            <SettingsPanelToolbarActions>
+              <SettingsPanelToolbarStatus
+                tone={props.updateToolbarTone}
+                title={props.updateToolbarTitle}
+                spinning={props.updateToolbarSpinning}
+              >
+                {props.updateToolbarLabel}
+              </SettingsPanelToolbarStatus>
+              {props.updateToolbarActionLabel ? (
+                <SettingsPanelToolbarButton
+                  onClick={props.onUpdateToolbarAction}
+                  disabled={props.updateToolbarDisabled}
+                  title={props.updateRestartBlockedMessage ?? ""}
+                >
+                  {props.updateToolbarActionLabel}
+                </SettingsPanelToolbarButton>
+              ) : null}
+            </SettingsPanelToolbarActions>
+            {props.updateRestartBlockedMessage ? (
+              <SettingsPanelToolbarMessage>{props.updateRestartBlockedMessage}</SettingsPanelToolbarMessage>
+            ) : null}
+          </SettingsPanelToolbar>
+        ) : null}
+      </SettingsPanel>
+
+      {props.children}
+    </SettingsContent>
   );
 }

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -3,22 +3,26 @@ import type * as React from "react";
 import { X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
 import { t } from "../../../../i18n";
-import { SettingsPage, getSettingsTabLabel } from "./settings-page";
-import { WorkspaceSessionList } from "../../session/sidebar/workspace-session-list";
+import { SettingsPage, SettingsSidebar, getSettingsTabLabel } from "./settings-page";
 
 type SettingsPageChromeProps = Omit<React.ComponentProps<typeof SettingsPage>, "children">;
 
 export type SettingsShellProps = SettingsPageChromeProps & {
+  selectedWorkspaceId: string;
   selectedWorkspaceName: string;
+  selectedWorkspaceColor: string;
+  workspaces: Array<{ id: string; name: string; color: string }>;
   headerStatus?: string;
   busyHint?: string | null;
-  workspaceSessionListProps: React.ComponentProps<typeof WorkspaceSessionList>;
+  onSelectWorkspace: (workspaceId: string) => void;
   onClose: () => void;
-  sidebarTopSlot?: React.ReactNode;
   headerLeadingSlot?: React.ReactNode;
-  sidebarWidth?: number;
-  onSidebarResizeStart?: React.PointerEventHandler<HTMLDivElement>;
   children: React.ReactNode;
   error?: string | null;
   errorSlot?: React.ReactNode;
@@ -30,77 +34,73 @@ export function SettingsShell(props: SettingsShellProps) {
   const title = getSettingsTabLabel(props.activeTab);
 
   return (
-    <div className="h-[100dvh] min-h-screen w-full overflow-hidden bg-[var(--dls-app-bg)] p-3 text-gray-12 md:p-4">
-      <div className="flex h-full w-full gap-3 md:gap-4">
-        <aside
-          className="relative hidden shrink-0 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-sidebar p-2.5 lg:flex"
-          style={props.sidebarWidth ? { width: `${props.sidebarWidth}px`, minWidth: `${props.sidebarWidth}px` } : undefined}
-        >
-          {props.sidebarTopSlot ? <div className="shrink-0">{props.sidebarTopSlot}</div> : null}
-          <div className="flex min-h-0 flex-1">
-            <WorkspaceSessionList {...props.workspaceSessionListProps} />
-          </div>
-          {props.onSidebarResizeStart ? (
-            <div
-              className="absolute right-0 top-3 hidden h-[calc(100%-24px)] w-2 translate-x-1/2 cursor-col-resize rounded-full bg-transparent transition-colors hover:bg-gray-6/40 md:block"
-              onPointerDown={props.onSidebarResizeStart}
-              title={t("session.resize_workspace_column")}
-              aria-label={t("session.resize_workspace_column")}
-            />
-          ) : null}
-        </aside>
-
-        <main className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-[24px] border border-dls-border bg-dls-surface">
-          <header className="shrink-0 flex h-12 items-center justify-between border-b border-dls-border bg-dls-surface px-4 md:px-6">
-            <div className="flex min-w-0 items-center gap-3">
-              {props.headerLeadingSlot}
-              <h1 className="truncate text-[15px] font-semibold text-dls-text">{title}</h1>
-              <span className="hidden truncate text-[13px] text-dls-secondary lg:inline">
-                {props.selectedWorkspaceName}
-              </span>
-              {props.developerMode && props.headerStatus ? (
-                <span className="hidden text-[12px] text-dls-secondary lg:inline">
-                  {props.headerStatus}
+    <div className="flex h-dvh min-h-screen w-full overflow-hidden">
+      <SidebarProvider open={true} className="relative min-h-0 flex-1">
+        <SettingsSidebar
+          activeTab={props.activeTab}
+          onSelectTab={props.onSelectTab}
+          developerMode={props.developerMode}
+          onClose={props.onClose}
+          selectedWorkspaceId={props.selectedWorkspaceId}
+          selectedWorkspaceName={props.selectedWorkspaceName}
+          selectedWorkspaceColor={props.selectedWorkspaceColor}
+          workspaces={props.workspaces}
+          onSelectWorkspace={props.onSelectWorkspace}
+        />
+        <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-16 [&_header]:pl-16 md:[&_header]:pl-6">
+          <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            <header className="shrink-0 flex h-10 items-center justify-between border-b border-dls-border px-4 md:px-6">
+              <div className="flex min-w-0 items-center gap-3">
+                <SidebarTrigger className="md:hidden" />
+                {props.headerLeadingSlot}
+                <h1 className="truncate text-[15px] font-semibold text-dls-text">{title}</h1>
+                <span className="hidden truncate text-[13px] text-dls-secondary lg:inline">
+                  {props.selectedWorkspaceName}
                 </span>
-              ) : null}
-              {props.busyHint ? (
-                <span className="hidden text-[12px] text-dls-secondary lg:inline">
-                  {props.busyHint}
-                </span>
-              ) : null}
-            </div>
-            <div className="flex items-center text-gray-10">
-              <Button
-                variant="ghost"
-                type="button"
-                className="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
-                onClick={props.onClose}
-                title={t("dashboard.close_settings")}
-                aria-label={t("dashboard.close_settings")}
-              >
-                <X size={18} />
-              </Button>
-            </div>
-          </header>
-
-          <div className="flex min-h-0 flex-1 flex-col">
-            <SettingsPage {...props}>{props.children}</SettingsPage>
-
-            {props.error ? (
-              <div className="mx-auto max-w-5xl px-6 pb-24 md:px-10 md:pb-10">
-                <div className="flex flex-col gap-y-3 rounded-2xl border border-red-7/20 bg-red-1/40 px-5 py-4 text-sm text-red-12">
-                  <div>{props.error}</div>
-                  {props.errorSlot}
-                </div>
+                {props.developerMode && props.headerStatus ? (
+                  <span className="hidden text-[12px] text-dls-secondary lg:inline">
+                    {props.headerStatus}
+                  </span>
+                ) : null}
+                {props.busyHint ? (
+                  <span className="hidden text-[12px] text-dls-secondary lg:inline">
+                    {props.busyHint}
+                  </span>
+                ) : null}
               </div>
-            ) : null}
+              <div className="flex items-center text-gray-10 md:hidden">
+                <Button
+                  variant="ghost"
+                  type="button"
+                  className="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
+                  onClick={props.onClose}
+                  title={t("dashboard.close_settings")}
+                  aria-label={t("dashboard.close_settings")}
+                >
+                  <X size={18} />
+                </Button>
+              </div>
+            </header>
 
-            {props.modalSlot}
-          </div>
+            <div className="flex min-h-0 flex-1 flex-col">
+              <SettingsPage {...props}>{props.children}</SettingsPage>
 
-          {props.footer}
-        </main>
-      </div>
+              {props.error ? (
+                <div className="mx-auto max-w-5xl px-6 pb-24 md:px-10 md:pb-10">
+                  <div className="flex flex-col gap-y-3 rounded-2xl border border-red-7/20 bg-red-1/40 px-5 py-4 text-sm text-red-12">
+                    <div>{props.error}</div>
+                    {props.errorSlot}
+                  </div>
+                </div>
+              ) : null}
+
+              {props.modalSlot}
+            </div>
+
+            {props.footer}
+          </main>
+        </SidebarInset>
+      </SidebarProvider>
     </div>
   );
 }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -51,12 +51,6 @@ import { createExtensionsStore, useExtensionsStoreSnapshot } from "../domains/se
 import { usePlatform } from "../kernel/platform";
 import { useLocal } from "../kernel/local-provider";
 import {
-  DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-  MAX_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-  MIN_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-  useWorkspaceShellLayout,
-} from "./workspace-shell-layout";
-import {
   openworkServerInfo,
   openworkServerRestart,
   engineStart,
@@ -90,6 +84,7 @@ import {
 } from "../domains/workspace/remote-workspace-diagnostics";
 import { ModelPickerModal } from "../domains/session/modals/model-picker-modal";
 import type { ModelOption, ModelRef } from "../../app/types";
+import { workspaceSwatchColor } from "../domains/session/sidebar/utils";
 import { recordInspectorEvent } from "./app-inspector";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
@@ -563,13 +558,6 @@ export function SettingsRoute() {
     selectedWorkspaceId,
   ]);
 
-  const shellLayout = useWorkspaceShellLayout({
-    expandedRightWidth: 320,
-    defaultLeftWidth: DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-    minLeftWidth: MIN_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-    maxLeftWidth: MAX_WORKSPACE_LEFT_SIDEBAR_WIDTH,
-  });
-
   const openworkServerStore = useMemo(
     () =>
       createOpenworkServerStore({
@@ -788,6 +776,7 @@ export function SettingsRoute() {
 
   useEffect(() => {
     applyThemeMode(themeMode);
+    void window.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setNativeTheme", themeMode);
     if (typeof window !== "undefined") {
       window.localStorage.setItem(SETTINGS_THEME_KEY, themeMode);
     }
@@ -1128,6 +1117,12 @@ export function SettingsRoute() {
   }, [activeClient, connectionsStore, providerAuthStore, selectedWorkspace?.id]);
 
   const selectedWorkspaceName = selectedWorkspace?.displayNameResolved ?? t("session.workspace_fallback");
+  const workspaceOptions = workspaces.map((workspace) => ({
+    id: workspace.id,
+    name: workspace.displayNameResolved,
+    color: workspaceSwatchColor(workspace.id),
+  }));
+  const selectedWorkspaceColor = workspaceSwatchColor(selectedWorkspaceId);
   const workspaceType = selectedWorkspace?.workspaceType ?? "local";
   const isRemoteWorkspace = workspaceType === "remote";
   const canWriteWorkspaceSkills =
@@ -1212,6 +1207,16 @@ export function SettingsRoute() {
     setCreateWorkspaceRemoteError(null);
     setCreateWorkspaceOpen(true);
   };
+
+  const handleSelectSettingsWorkspace = useCallback((workspaceId: string) => {
+    setLegacySelectedWorkspaceId(workspaceId);
+    writeActiveWorkspaceId(workspaceId);
+    if (isDesktopRuntime()) {
+      void workspaceSetSelected(workspaceId).catch(() => undefined);
+      void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
+    }
+    navigate(workspaceSettingsRoute(workspaceId, settingsPathForRoute(route)), { state: location.state });
+  }, [location.state, navigate, route]);
 
   const handleOpenRenameWorkspace = useCallback((workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
@@ -1733,40 +1738,14 @@ export function SettingsRoute() {
         activeTab={route.tab}
         onSelectTab={(tab) => navigate(selectedWorkspaceId ? workspaceSettingsRoute(selectedWorkspaceId, tab) : `/settings/${tab}`)}
         developerMode={developerMode}
+        selectedWorkspaceId={selectedWorkspaceId}
         selectedWorkspaceName={selectedWorkspaceName}
+        selectedWorkspaceColor={selectedWorkspaceColor}
+        workspaces={workspaceOptions}
+        onSelectWorkspace={handleSelectSettingsWorkspace}
         headerStatus={routeOpenworkStatus}
         busyHint={loading ? t("session.loading_detail") : busyLabel}
-        workspaceSessionListProps={{
-          workspaceSessionGroups,
-          selectedWorkspaceId,
-          developerMode,
-          selectedSessionId: null,
-          connectingWorkspaceId: null,
-          workspaceConnectionStateById,
-          newTaskDisabled: !opencodeClient,
-          onSelectWorkspace: async (workspaceId) => {
-            setLegacySelectedWorkspaceId(workspaceId);
-            writeActiveWorkspaceId(workspaceId || null);
-            if (isDesktopRuntime()) {
-              void workspaceSetSelected(workspaceId).catch(() => undefined);
-              void workspaceSetRuntimeActive(workspaceId).catch(() => undefined);
-            }
-            return true;
-          },
-          onOpenSession: (workspaceId, sessionId) => navigate(workspaceSessionRoute(workspaceId, sessionId)),
-          onCreateTaskInWorkspace: (workspaceId) => navigate(workspaceSessionRoute(workspaceId)),
-          onOpenRenameWorkspace: handleOpenRenameWorkspace,
-          onShareWorkspace: shareWorkspaceState.openShareWorkspace,
-          onRevealWorkspace: (id) => void handleRevealWorkspace(id),
-          onRecoverWorkspace: (workspaceId) => runRemoteWorkspaceConnectionCheck(workspaceId, "recover"),
-          onTestWorkspaceConnection: (workspaceId) => runRemoteWorkspaceConnectionCheck(workspaceId, "test"),
-          onEditWorkspaceConnection: remoteWorkspaceConnectionEditor.open,
-          onForgetWorkspace: (id) => void handleForgetWorkspace(id),
-          onOpenCreateWorkspace: handleOpenCreateWorkspace,
-        }}
         onClose={() => navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session")}
-        sidebarWidth={shellLayout.leftSidebarWidth}
-        onSidebarResizeStart={shellLayout.startLeftSidebarResize}
         error={routeError ?? notFoundRouteError}
       >
         {settingsView}

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -17,7 +17,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, WebContentsView, dialog, ipcMain, nativeImage, shell } from "electron";
+import { app, BrowserWindow, WebContentsView, dialog, ipcMain, nativeImage, nativeTheme, shell } from "electron";
 import { registerMigrationIpc } from "./migration.mjs";
 import { createRuntimeManager } from "./runtime.mjs";
 import { registerUpdaterIpc } from "./updater.mjs";
@@ -1041,6 +1041,20 @@ function activeWindowFromEvent(event) {
   return BrowserWindow.fromWebContents(event.sender) ?? mainWindow ?? undefined;
 }
 
+function applyNativeTheme(mode) {
+  nativeTheme.themeSource = mode;
+
+  if (process.platform !== "darwin") {
+    return true;
+  }
+  // const isDark = nativeTheme.shouldUseDarkColors;
+
+  mainWindow?.setVibrancy("under-window");
+  mainWindow?.setBackgroundColor("#00000001");
+
+  return true;
+}
+
 async function handleDesktopInvoke(event, command, ...args) {
   switch (command) {
     case "workspaceBootstrap":
@@ -1482,6 +1496,8 @@ async function handleDesktopInvoke(event, command, ...args) {
       window.webContents.setZoomFactor(factor);
       return true;
     }
+    case "__setNativeTheme":
+      return applyNativeTheme(String(args[0]));
     case "resolveChromeDevtoolsMcpBin":
       return resolveChromeDevtoolsMcpBin();
     default:
@@ -1634,11 +1650,22 @@ async function createMainWindow() {
   if (mainWindow) return mainWindow;
 
   const preloadPath = path.join(__dirname, "preload.mjs");
+  const windowAppearanceOptions = {};
+  if (process.platform === "darwin") {
+    Object.assign(windowAppearanceOptions, {
+      backgroundColor: "#00000001",
+      titleBarStyle: "hiddenInset",
+      vibrancy: "under-window",
+      visualEffectState: "active",
+    });
+  }
+
   mainWindow = new BrowserWindow({
     width: 1180,
     height: 820,
     title: APP_NAME,
     show: false,
+    ...windowAppearanceOptions,
     ...(APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty() ? { icon: APP_ICON_IMAGE } : {}),
     webPreferences: {
       preload: preloadPath,

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -2,6 +2,17 @@ import { contextBridge, ipcRenderer } from "electron";
 
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 
+document.documentElement.dataset.openworkShell = "electron";
+document.documentElement.classList.add("openwork-electron");
+
+if (process.platform === "darwin") {
+  document.documentElement.classList.add("openwork-platform-mac");
+} else if (process.platform === "win32") {
+  document.documentElement.classList.add("openwork-platform-windows");
+} else if (process.platform === "linux") {
+  document.documentElement.classList.add("openwork-platform-linux");
+}
+
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
   if (value === "win32") return "windows";


### PR DESCRIPTION
## Summary
- Adds a redesigned app sidebar for sessions/workspaces using the shared sidebar primitives.
- Replaces the old workspace session list in `SessionPage` with `AppSidebar`, including workspace expansion, nested session threading, “show more” session pagination, active-session indicators, prefetch-on-hover/focus, and session/workspace action menus.
- Adds shared `ContextMenu` and `DropdownMenu` UI components, plus sidebar styling updates for smaller rows, macOS hover states, optional sidebar persistence, and cleaner sidebar trigger styling.
- Redesigns settings shell to use the same sidebar layout, with grouped workspace/global settings tabs, a workspace picker, and a “Back to app” action.
- Updates settings routing to pass workspace picker data into the new settings sidebar and to sync Electron native theme when theme mode changes.
- Adds macOS/Electron platform CSS variants and titlebar drag/no-drag utilities, plus transparent body/background handling for native vibrancy.
- Enables macOS window vibrancy/transparent background in Electron and exposes platform classes from preload.
- Fixes browser panel sizing by measuring the actual toolbar height instead of using a hardcoded `44px` constant.
- Adjusts the browser toolbar from fixed `h-[44px]` to `h-10` and updates its border token.
- Tweaks button variants so active press translation only applies to relevant variants and simplifies ghost hover styling.
- Updates the composer bottom offset slightly for the new layout.
- Adds the English string `dashboard.back_to_app`.

## Evidence

<img width="2808" height="2088" alt="CleanShot 2026-05-06 at 12 31 22@2x" src="https://github.com/user-attachments/assets/a89aade6-c70e-4705-b0d2-774727293a66" />
<img width="2808" height="2088" alt="CleanShot 2026-05-06 at 12 31 43@2x" src="https://github.com/user-attachments/assets/5af09600-ed15-44b2-a57b-f36d3b7cd796" />
<img width="2808" height="2088" alt="CleanShot 2026-05-06 at 12 32 04@2x" src="https://github.com/user-attachments/assets/668897f3-c429-4a89-846d-9903458dd03f" />
<img width="2808" height="2088" alt="CleanShot 2026-05-06 at 12 32 22@2x" src="https://github.com/user-attachments/assets/77605494-d81c-4d64-a813-7139800d99fd" />
<img width="1526" height="2028" alt="CleanShot 2026-05-06 at 12 32 42@2x" src="https://github.com/user-attachments/assets/ddc4b7f8-b64f-4f66-8d9c-f4ae9f2f0a6b" />
