### PR TITLE
fix(app): resolve missing titlebar drag areas

### DIFF
--- a/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
@@ -191,7 +191,8 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
 
   if (variant === "fullscreen") {
     return (
-      <div className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.12),transparent_42%),linear-gradient(180deg,rgba(248,250,252,1),rgba(241,245,249,0.92))] px-6 py-10 text-dls-text">
+      <div className="relative min-h-screen bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.12),transparent_42%),linear-gradient(180deg,rgba(248,250,252,1),rgba(241,245,249,0.92))] px-6 py-10 text-dls-text">
+        <div className="absolute inset-x-0 top-0 h-10 mac:titlebar-drag" />
         <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-3xl items-center justify-center">
           <div className="w-full space-y-4">{content}</div>
         </div>

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -28,7 +28,8 @@ type WelcomePageProps = {
 
 export function WelcomePage({ onGetStarted }: WelcomePageProps) {
   return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-dls-background p-6">
+    <div className="relative flex min-h-screen w-full items-center justify-center bg-dls-background p-6">
+      <div className="absolute inset-x-0 top-0 h-10 mac:titlebar-drag" />
       <div className="mx-auto w-full max-w-[640px] space-y-10">
         {/* Header */}
         <div className="space-y-3 text-center">

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -49,9 +49,9 @@ export function SettingsShell(props: SettingsShellProps) {
         />
         <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-16 [&_header]:pl-16 md:[&_header]:pl-6">
           <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-            <header className="shrink-0 flex h-10 items-center justify-between border-b border-dls-border px-4 md:px-6">
+            <header className="shrink-0 flex h-10 items-center justify-between border-b border-dls-border px-4 md:px-6 mac:titlebar-drag">
               <div className="flex min-w-0 items-center gap-3">
-                <SidebarTrigger className="md:hidden" />
+                <SidebarTrigger className="mac:titlebar-no-drag md:hidden" />
                 {props.headerLeadingSlot}
                 <h1 className="truncate text-[15px] font-semibold text-dls-text">{title}</h1>
                 <span className="hidden truncate text-[13px] text-dls-secondary lg:inline">
@@ -68,7 +68,7 @@ export function SettingsShell(props: SettingsShellProps) {
                   </span>
                 ) : null}
               </div>
-              <div className="flex items-center text-gray-10 md:hidden">
+              <div className="flex items-center text-gray-10 mac:titlebar-no-drag md:hidden">
                 <Button
                   variant="ghost"
                   type="button"


### PR DESCRIPTION
## Summary

- Adds macOS titlebar drag space to the fullscreen Den sign-in surface.
- Adds the same top drag region to the onboarding welcome page.
- Marks the settings shell header as draggable on macOS.
- Excludes interactive settings header controls from the draggable region so the sidebar trigger and close button remain clickable.