### PR TITLE
fix(electron): stabilize sharing runtime part 1

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -360,7 +360,7 @@ function handleEventChunk(
 export function createOpenworkChatTransport(options: TransportOptions): ChatTransport<UIMessage> {
   return {
     async sendMessages({ messages, abortSignal }) {
-      const client = createClient(options.baseUrl, {
+      const client = createClient(options.baseUrl, undefined, {
         token: options.openworkToken,
         mode: "openwork",
       });

--- a/apps/app/src/react-app/domains/workspace/remote-access-restart.ts
+++ b/apps/app/src/react-app/domains/workspace/remote-access-restart.ts
@@ -37,7 +37,18 @@ export function useRemoteAccessRestart(options: UseRemoteAccessRestartOptions) {
 
       try {
         const info = await openworkServerRestart({ remoteAccessEnabled: enabled });
+        writeOpenworkServerSettings({
+          urlOverride: info.baseUrl?.trim() || undefined,
+          token:
+            info.ownerToken?.trim() ||
+            info.clientToken?.trim() ||
+            undefined,
+          hostToken: info.hostToken?.trim() || undefined,
+          portOverride: info.port ?? undefined,
+          remoteAccessEnabled: info.remoteAccessEnabled === true,
+        });
         options.onHostInfo(info);
+        options.onSettingsChanged();
         setPhase("idle");
       } catch (caught) {
         writeOpenworkServerSettings(previous);

--- a/apps/app/src/react-app/domains/workspace/share-workspace-state.ts
+++ b/apps/app/src/react-app/domains/workspace/share-workspace-state.ts
@@ -140,8 +140,9 @@ export function useShareWorkspaceState(options: UseShareWorkspaceStateOptions) {
         ? buildOpenworkWorkspaceBaseUrl(hostUrl, shareLocalOpenworkWorkspaceId)
         : null;
       const url = mountedUrl || hostUrl;
-      const ownerToken = options.openworkServerHostInfo?.ownerToken?.trim() || "";
       const collaboratorToken = options.openworkServerHostInfo?.clientToken?.trim() || "";
+      const ownerToken =
+        collaboratorToken || options.openworkServerHostInfo?.ownerToken?.trim() || "";
       return [
         {
           label: t("session.share_worker_url"),

--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -117,6 +117,7 @@ export function useDesktopRuntimeBoot() {
               baseUrl?: string | null;
               ownerToken?: string | null;
               clientToken?: string | null;
+              hostToken?: string | null;
               port?: number | null;
               remoteAccessEnabled?: boolean;
             };
@@ -137,6 +138,16 @@ export function useDesktopRuntimeBoot() {
           }
           const serverInfo = boot.openworkServer;
           if (serverInfo?.baseUrl) {
+            writeOpenworkServerSettings({
+              urlOverride: serverInfo.baseUrl,
+              token:
+                serverInfo.ownerToken?.trim() ||
+                serverInfo.clientToken?.trim() ||
+                undefined,
+              hostToken: serverInfo.hostToken?.trim() || undefined,
+              portOverride: serverInfo.port ?? undefined,
+              remoteAccessEnabled: serverInfo.remoteAccessEnabled === true,
+            });
             try {
               window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
             } catch {

--- a/apps/app/src/react-app/shell/openwork-connection.ts
+++ b/apps/app/src/react-app/shell/openwork-connection.ts
@@ -35,7 +35,7 @@ export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConne
     try {
       const info = await openworkServerInfo();
       const normalizedBaseUrl =
-        normalizeOpenworkServerUrl(info.connectUrl ?? info.baseUrl ?? info.lanUrl ?? info.mdnsUrl ?? "") ??
+        normalizeOpenworkServerUrl(info.baseUrl ?? info.connectUrl ?? info.lanUrl ?? info.mdnsUrl ?? "") ??
         "";
       const resolvedToken = info.ownerToken?.trim() || info.clientToken?.trim() || "";
       if (info.running === true && hasUsableConnection(normalizedBaseUrl, resolvedToken)) {

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -564,9 +564,10 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
   }
 
   async function resolveOpenworkPort(host, workspaceKey) {
-    // Use a fresh port every boot. Persisted preferred ports made prod starts
-    // fragile when an old sidecar held the previous port or shutdown was
-    // unclean; Electron publishes the chosen URL to React after boot.
+    const preferredPort = await readPreferredOpenworkPort(workspaceKey);
+    if (preferredPort && (await portAvailable(host, preferredPort))) {
+      return preferredPort;
+    }
     return findFreePort(host);
   }
 
@@ -1034,14 +1035,25 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     openworkServerState.lanUrl = connectUrls.lanUrl;
 
     // No health check needed -- startServer() resolves only after the listener is bound.
-    const ownerToken = await issueOwnerToken(baseUrl, tokens.hostToken);
+    let workspaceList = null;
+    let ownerToken = tokens.ownerToken?.trim() || null;
+    if (ownerToken) {
+      try {
+        workspaceList = await fetchJson(`${baseUrl}/workspaces`, {
+          headers: { Authorization: `Bearer ${ownerToken}` },
+        }, 5000);
+      } catch {
+        ownerToken = null;
+      }
+    }
+    ownerToken ||= await issueOwnerToken(baseUrl, tokens.hostToken);
     openworkServerState.ownerToken = ownerToken;
     if (ownerToken) {
       await persistWorkspaceOwnerToken(activeWorkspace, ownerToken);
     }
     if (ownerToken) {
       try {
-        const list = await fetchJson(`${baseUrl}/workspaces`, {
+        const list = workspaceList ?? await fetchJson(`${baseUrl}/workspaces`, {
           headers: { Authorization: `Bearer ${ownerToken}` },
         }, 5000);
         const first = Array.isArray(list?.items) ? list.items[0] : undefined;
@@ -1310,12 +1322,17 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
 
   async function openworkServerRestart(options = {}) {
     const workspacePaths = (await listLocalWorkspacePaths()).filter(Boolean);
+    const shouldManageOpencode = Boolean(
+      openworkServerState.managedOpencodeBinPath || engineState.opencodeBinPath,
+    );
     return startOpenworkServer({
       workspacePaths,
-      opencodeBaseUrl: engineState.baseUrl,
-      opencodeUsername: engineState.opencodeUsername,
-      opencodePassword: engineState.opencodePassword,
+      opencodeBaseUrl: shouldManageOpencode ? null : engineState.baseUrl,
+      opencodeUsername: shouldManageOpencode ? null : engineState.opencodeUsername,
+      opencodePassword: shouldManageOpencode ? null : engineState.opencodePassword,
       remoteAccessEnabled: options.remoteAccessEnabled === true,
+      manageOpencode: shouldManageOpencode,
+      opencodeBinPath: engineState.opencodeBinPath ?? openworkServerState.managedOpencodeBinPath,
     });
   }
 


### PR DESCRIPTION
## Summary

- Reuse persisted Electron OpenWork server ports and stable tokens for shared workspaces.
- Keep remote-access restart state in sync with renderer settings and preserve managed OpenCode when toggling sharing.
- Fix OpenWork chat auth wiring and an Electron bridge duplicate key that blocked Electron typecheck.

## Evidence

### Build verification
- `pnpm --filter @openwork/desktop check:electron` -- passed
- `pnpm --filter @openwork/desktop typecheck:electron` -- passed
- `pnpm --filter @openwork/app build` -- passed

### API verification
- No API schema changes. Verified Electron runtime code path by typecheck and bridge check.

### UI verification
- Manual user flow improved during local iteration: sharing values remain stable across restarts and chat auth no longer uses the wrong SDK argument position.
- Full Chrome MCP screenshot/video verification was not run for this part.

## Test instructions

1. Start the Electron desktop app from this branch.
2. Open a local workspace and enable sharing.
3. Confirm the displayed URL port and token stay stable across host restart.
4. Toggle sharing enabled/disabled, then send a chat message without fully restarting the app.
5. From another machine, verify `GET /health` and authenticated session listing with `GET /workspace/<workspace-id>/sessions?limit=200`.