### PR TITLE
fix(openwork): use workspace opencode proxy path

### DIFF
--- a/apps/app/src/app/lib/opencode.ts
+++ b/apps/app/src/app/lib/opencode.ts
@@ -139,9 +139,11 @@ async function postSessionRequest<T>(
 function resolveOpenworkWorkspaceMount(baseUrl: string): { baseUrl: string; workspaceId: string } | null {
   try {
     const url = new URL(baseUrl);
-    const match = url.pathname.replace(/\/+$/, "").match(/^(.*\/w\/([^/]+))\/opencode$/);
-    if (!match?.[1] || !match[2]) return null;
-    url.pathname = match[1];
+    const match = url.pathname
+      .replace(/\/+$/, "")
+      .match(/^(.*)\/(?:w|workspace)\/([^/]+)\/opencode$/);
+    if (!match || match[1] === undefined || !match[2]) return null;
+    url.pathname = match[1] || "/";
     url.search = "";
     return {
       baseUrl: url.toString().replace(/\/+$/, ""),

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -336,12 +336,17 @@ export function parseOpenworkWorkspaceIdFromUrl(input: string) {
   try {
     const url = new URL(normalized);
     const segments = url.pathname.split("/").filter(Boolean);
-    const last = segments[segments.length - 1] ?? "";
-    const prev = segments[segments.length - 2] ?? "";
-    if (prev !== "w" || !last) return null;
-    return decodeURIComponent(last);
+    const legacyIndex = segments.indexOf("w");
+    if (legacyIndex >= 0 && segments[legacyIndex + 1]) {
+      return decodeURIComponent(segments[legacyIndex + 1]);
+    }
+    const workspaceIndex = segments.indexOf("workspace");
+    if (workspaceIndex >= 0 && segments[workspaceIndex + 1]) {
+      return decodeURIComponent(segments[workspaceIndex + 1]);
+    }
+    return null;
   } catch {
-    const match = normalized.match(/\/w\/([^/?#]+)/);
+    const match = normalized.match(/\/(?:w|workspace)\/([^/?#]+)/);
     if (!match?.[1]) return null;
     try {
       return decodeURIComponent(match[1]);
@@ -358,10 +363,14 @@ export function buildOpenworkWorkspaceBaseUrl(hostUrl: string, workspaceId?: str
   try {
     const url = new URL(normalized);
     const segments = url.pathname.split("/").filter(Boolean);
-    const last = segments[segments.length - 1] ?? "";
-    const prev = segments[segments.length - 2] ?? "";
-    const alreadyMounted = prev === "w" && Boolean(last);
-    if (alreadyMounted) {
+    const workspaceIndex = segments.indexOf("workspace");
+    const legacyIndex = segments.indexOf("w");
+    const mountIndex = workspaceIndex >= 0 ? workspaceIndex : legacyIndex;
+    if (mountIndex >= 0 && segments[mountIndex + 1]) {
+      const prefix = segments.slice(0, mountIndex).join("/");
+      url.pathname = `${prefix ? `/${prefix}` : ""}/workspace/${encodeURIComponent(
+        decodeURIComponent(segments[mountIndex + 1]),
+      )}`;
       return url.toString().replace(/\/+$/, "");
     }
 
@@ -369,12 +378,12 @@ export function buildOpenworkWorkspaceBaseUrl(hostUrl: string, workspaceId?: str
     if (!id) return url.toString().replace(/\/+$/, "");
 
     const basePath = url.pathname.replace(/\/+$/, "");
-    url.pathname = `${basePath}/w/${encodeURIComponent(id)}`;
+    url.pathname = `${basePath}/workspace/${encodeURIComponent(id)}`;
     return url.toString().replace(/\/+$/, "");
   } catch {
     const id = (workspaceId ?? "").trim();
     if (!id) return normalized;
-    return `${normalized.replace(/\/+$/, "")}/w/${encodeURIComponent(id)}`;
+    return `${normalized.replace(/\/+$/, "")}/workspace/${encodeURIComponent(id)}`;
   }
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -170,6 +170,19 @@ function parseWorkspaceMount(pathname: string): { workspaceId: string; restPath:
   return { workspaceId: decodeURIComponent(workspaceId), restPath };
 }
 
+function parseWorkspaceOpencodeMount(pathname: string): { workspaceId: string; restPath: string } | null {
+  if (!pathname.startsWith("/workspace/")) return null;
+  const remainder = pathname.slice("/workspace/".length);
+  if (!remainder) return null;
+  const slash = remainder.indexOf("/");
+  if (slash === -1) return null;
+  const workspaceId = remainder.slice(0, slash);
+  const restPath = remainder.slice(slash) || "/";
+  if (!workspaceId.trim()) return null;
+  if (restPath !== "/opencode" && !restPath.startsWith("/opencode/")) return null;
+  return { workspaceId: decodeURIComponent(workspaceId), restPath };
+}
+
 function normalizeOpencodeProxyPath(proxyPath: string): string {
   const raw = (proxyPath ?? "").trim() || "/";
   const withoutPrefix = raw.startsWith("/opencode") ? raw.slice("/opencode".length) : raw;
@@ -263,12 +276,7 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
         return wrapped;
       };
 
-      if (request.method === "OPTIONS") {
-        return finalize(new Response(null, { status: 204 }));
-      }
-
-      const mount = parseWorkspaceMount(url.pathname);
-      if (mount && (mount.restPath === "/opencode" || mount.restPath.startsWith("/opencode/"))) {
+      const proxyWorkspaceOpencodeMount = async (mount: { workspaceId: string; restPath: string }) => {
         authMode = "client";
         try {
           const actor = await requireClient(request, config, tokens);
@@ -285,6 +293,20 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
           errorMessage = apiError.message;
           return finalize(jsonResponse(formatError(apiError), apiError.status));
         }
+      };
+
+      if (request.method === "OPTIONS") {
+        return finalize(new Response(null, { status: 204 }));
+      }
+
+      const canonicalOpencodeMount = parseWorkspaceOpencodeMount(url.pathname);
+      if (canonicalOpencodeMount) {
+        return proxyWorkspaceOpencodeMount(canonicalOpencodeMount);
+      }
+
+      const mount = parseWorkspaceMount(url.pathname);
+      if (mount && (mount.restPath === "/opencode" || mount.restPath.startsWith("/opencode/"))) {
+        return proxyWorkspaceOpencodeMount(mount);
       }
 
       // Allow clients to use a mounted base URL (e.g. http://host:8787/w/<id>) while

--- a/apps/server/src/session-read-model.e2e.test.ts
+++ b/apps/server/src/session-read-model.e2e.test.ts
@@ -266,7 +266,7 @@ describe("workspace session read APIs", () => {
     });
 
     const response = await Promise.race([
-      fetch(`http://127.0.0.1:${openwork.server.port}/w/ws_1/opencode/session/ses_1/command`, {
+      fetch(`http://127.0.0.1:${openwork.server.port}/workspace/ws_1/opencode/session/ses_1/command`, {
         method: "POST",
         headers: { ...auth(openwork.token), "Content-Type": "application/json" },
         body: JSON.stringify({ command: "review", arguments: "" }),
@@ -280,6 +280,24 @@ describe("workspace session read APIs", () => {
     const sawCommand = await waitUntil(() => mock.requests.some((request) => request.pathname === "/session/ses_1/command"));
     command.resolve();
     expect(sawCommand).toBe(true);
+  });
+
+  test("keeps legacy /w workspace opencode proxy alias", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenworkServer({
+      workspaceRoot,
+      opencodeBaseUrl: `http://127.0.0.1:${mock.server.port}`,
+    });
+
+    const response = await fetch(`http://127.0.0.1:${openwork.server.port}/w/ws_1/opencode/session`, {
+      headers: auth(openwork.token),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(mock.requests.some((request) => request.pathname === "/session")).toBe(true);
   });
 
   test("returns 502 when OpenCode returns an invalid session list payload", async () => {


### PR DESCRIPTION
## Summary

- Add canonical `/workspace/:id/opencode/*` proxy handling for OpenCode-compatible workspace calls.
- Keep `/w/:id/opencode/*` as a legacy compatibility alias.
- Update the React app URL helper/parser so generated client paths use `/workspace/:id` while still accepting old `/w/:id` URLs.

## Evidence

### Build verification
- `bun test apps/server/src/session-read-model.e2e.test.ts` -- passed
- `pnpm --filter openwork-server build` -- passed
- `pnpm --filter @openwork/app build` -- passed

### API verification
- Server regression test covers canonical `/workspace/:id/opencode/session/:sessionId/command` proxy behavior.
- Server regression test covers legacy `/w/:id/opencode/session` alias behavior.

### UI verification
- Full Chrome MCP UI verification was not run for this path-level API/client routing change.

## Test instructions

1. Start the OpenWork desktop app from this branch.
2. Share a local workspace.
3. Confirm the app logs OpenCode SDK traffic under `/workspace/<workspace-id>/opencode/*` rather than `/w/<workspace-id>/opencode/*`.
4. Confirm old shared `/w/<workspace-id>/opencode/*` URLs still proxy successfully.