### PR TITLE
feat(app): add sidebar resize support and improve light mode vibrancy

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource react */
+import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Check, Globe, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
 
@@ -35,6 +36,8 @@ import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
+import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
+import { cn } from "@/lib/utils";
 
 type StatusBarOverrides = Pick<
   StatusBarProps,
@@ -189,6 +192,12 @@ export function SessionPage(props: SessionPageProps) {
     const unsubClose = browser.onPanelClosed?.(() => setBrowserPanelOpen(false));
     return () => { unsubOpen?.(); unsubClose?.(); };
   }, []);
+  const { leftSidebarResizing, leftSidebarWidth, startLeftSidebarResize } = useWorkspaceShellLayout({
+    expandedRightWidth: 520,
+  });
+  const sidebarProviderStyle: CSSProperties & Record<"--sidebar-width", string> = {
+    "--sidebar-width": `${leftSidebarWidth}px`,
+  };
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
   const selectedSessionTitle = useMemo(
@@ -297,7 +306,14 @@ export function SessionPage(props: SessionPageProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text mac:bg-transparent">
-      <SidebarProvider className="relative min-h-0 flex-1 mac:bg-transparent">
+      <SidebarProvider
+        className={cn(
+          "relative min-h-0 flex-1 mac:bg-transparent",
+          leftSidebarResizing &&
+            "**:data-[slot=sidebar-container]:transition-none **:data-[slot=sidebar-gap]:transition-none",
+        )}
+        style={sidebarProviderStyle}
+      >
         <AppSidebar
           workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
           selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
@@ -326,6 +342,7 @@ export function SessionPage(props: SessionPageProps) {
           onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
           onForgetWorkspace={props.sidebar.onForgetWorkspace}
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
+          onStartResize={startLeftSidebarResize}
         />
         <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28 flex flex-row">
           <main className="flex min-w-0 flex-1 flex-col overflow-hidden border-r border-border">

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -39,6 +39,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  SidebarRail,
 } from "@/components/ui/sidebar";
 import {
   Collapsible,
@@ -255,6 +256,7 @@ export type AppSidebarProps = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
+  onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
 };
 
 function useSessionTree(
@@ -420,6 +422,14 @@ export function AppSidebar(props: AppSidebarProps) {
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarFooter>
+        <SidebarRail
+          aria-label={props.onStartResize ? t("session.resize_workspace_column") : undefined}
+          title={props.onStartResize ? t("session.resize_workspace_column") : undefined}
+          onClick={props.onStartResize ? (event) => {
+            event.preventDefault();
+          } : undefined}
+          onPointerDown={props.onStartResize}
+        />
       </Sidebar>
     </SidebarContext.Provider>
   );

--- a/apps/app/src/react-app/shell/workspace-shell-layout.ts
+++ b/apps/app/src/react-app/shell/workspace-shell-layout.ts
@@ -67,6 +67,7 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
   }, []);
 
   const [leftSidebarWidth, setLeftSidebarWidth] = useState(readLeftSidebarWidth);
+  const [leftSidebarResizing, setLeftSidebarResizing] = useState(false);
   const [rightSidebarExpanded, setRightSidebarExpanded] = useState(readRightSidebarExpanded);
   const dragCleanupRef = useRef<(() => void) | null>(null);
 
@@ -89,6 +90,7 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
   const stopLeftSidebarResize = useCallback(() => {
     dragCleanupRef.current?.();
     dragCleanupRef.current = null;
+    setLeftSidebarResizing(false);
     if (typeof document === "undefined") return;
     document.body.style.removeProperty("cursor");
     document.body.style.removeProperty("user-select");
@@ -99,6 +101,7 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
       if (event.button !== 0 || typeof window === "undefined") return;
 
       stopLeftSidebarResize();
+      setLeftSidebarResizing(true);
       const initialX = event.clientX;
       const initialWidth = leftSidebarWidth;
 
@@ -142,6 +145,7 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
 
   return {
     leftSidebarWidth,
+    leftSidebarResizing,
     rightSidebarExpanded,
     rightSidebarWidth,
     setRightSidebarExpanded,

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1090,15 +1090,18 @@ function activeWindowFromEvent(event) {
   return BrowserWindow.fromWebContents(event.sender) ?? mainWindow ?? undefined;
 }
 
+function macosVibrancyForCurrentTheme() {
+  return nativeTheme.shouldUseDarkColors ? "under-window" : "sidebar";
+}
+
 function applyNativeTheme(mode) {
   nativeTheme.themeSource = mode;
 
   if (process.platform !== "darwin") {
     return true;
   }
-  // const isDark = nativeTheme.shouldUseDarkColors;
 
-  mainWindow?.setVibrancy("under-window");
+  mainWindow?.setVibrancy(macosVibrancyForCurrentTheme());
   mainWindow?.setBackgroundColor("#00000001");
 
   return true;
@@ -1705,7 +1708,7 @@ async function createMainWindow() {
     Object.assign(windowAppearanceOptions, {
       backgroundColor: "#00000001",
       titleBarStyle: "hiddenInset",
-      vibrancy: "under-window",
+      vibrancy: macosVibrancyForCurrentTheme(),
       visualEffectState: "active",
     });
   }


### PR DESCRIPTION
## Summary

- Adds resizable workspace sidebar support to the session page using the existing `useWorkspaceShellLayout` hook.
- Passes the computed sidebar width through `--sidebar-width` so the shared sidebar layout follows the saved/resized width.
- Tracks active sidebar resizing and disables sidebar transition classes while dragging for smoother resizing.
- Adds a `SidebarRail` resize handle to `AppSidebar`, wired to the session page resize handler.
- Extends `useWorkspaceShellLayout` to expose `leftSidebarResizing`.
- Updates macOS Electron vibrancy to use `sidebar` in light mode and `under-window` in dark mode, both on startup and when the native theme changes.