### PR TITLE
fix(electron): keep preload bridge available

### DIFF
--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -2,21 +2,30 @@ import { contextBridge, ipcRenderer } from "electron";
 
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 
-document.documentElement.dataset.openworkShell = "electron";
-document.documentElement.classList.add("openwork-electron");
-
-if (process.platform === "darwin") {
-  document.documentElement.classList.add("openwork-platform-mac");
-} else if (process.platform === "win32") {
-  document.documentElement.classList.add("openwork-platform-windows");
-} else if (process.platform === "linux") {
-  document.documentElement.classList.add("openwork-platform-linux");
-}
-
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
   if (value === "win32") return "windows";
   return "linux";
+}
+
+function applyShellDocumentMarkers() {
+  try {
+    const root = document?.documentElement;
+    if (!root) return false;
+
+    root.dataset.openworkShell = "electron";
+    root.classList.add("openwork-electron");
+    if (process.platform === "darwin") {
+      root.classList.add("openwork-platform-mac");
+    } else if (process.platform === "win32") {
+      root.classList.add("openwork-platform-windows");
+    } else if (process.platform === "linux") {
+      root.classList.add("openwork-platform-linux");
+    }
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
@@ -101,3 +110,7 @@ ipcRenderer.on(NATIVE_DEEP_LINK_EVENT, (_event, urls) => {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent(NATIVE_DEEP_LINK_EVENT, { detail: urls }));
 });
+
+if (!applyShellDocumentMarkers() && typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", applyShellDocumentMarkers, { once: true });
+}


### PR DESCRIPTION
## Summary

- Exposes `window.__OPENWORK_ELECTRON__` before any cosmetic DOM setup in the Electron preload script.
- Wraps Electron/mac platform document markers in a best-effort helper with a `DOMContentLoaded` retry so styling setup cannot abort desktop bridge exposure.

## Evidence

### Build verification
- `node --check apps/desktop/electron/preload.mjs` -- passed
- `pnpm --filter @openwork/desktop check:electron` -- passed
- `pnpm --filter @openwork/desktop build` -- blocked in this worktree because dependencies are not installed: `preload not found "@opentui/solid/preload"`; pnpm also reported `node_modules missing`

### API verification
- No API changes.

### UI verification
- No screenshot captured. This is an Electron preload hardening patch for alpha startup; direct packaged alpha verification should confirm DevTools reports `window.__OPENWORK_ELECTRON__` as defined and workspaces load from the desktop bridge.

## Test instructions

1. Install dependencies if needed: `pnpm install`.
2. Run `pnpm --filter @openwork/desktop build`.
3. Build/install an alpha Electron app from this branch.
4. Open DevTools and verify `window.__OPENWORK_ELECTRON__` is defined.
5. Verify the app loads an existing `/workspace/:workspaceId/session` route without showing `Workspace or session not found`.