### PR TITLE
fix(desktop): stabilize built-in browser MCP — navigation, panel rendering, overlay

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -175,6 +175,20 @@ export function SessionPage(props: SessionPageProps) {
   const [todoExpanded, setTodoExpanded] = useState(true);
   const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
   const toggleBrowserPanel = useCallback(() => setBrowserPanelOpen((p) => !p), []);
+
+  // Sync browser panel state with Electron main process IPC events.
+  // When the agent calls a built-in browser tool, the main process opens
+  // the WebContentsView and sends panel-opened; when hide_browser is called
+  // it sends panel-closed.  Without this listener the React UI never knows
+  // the panel opened and doesn't render the BrowserPanel toolbar.
+  useEffect(() => {
+    if (!isElectronRuntime()) return;
+    const browser = (window as Window).__OPENWORK_ELECTRON__?.browser;
+    if (!browser) return;
+    const unsubOpen = browser.onPanelOpened?.(() => setBrowserPanelOpen(true));
+    const unsubClose = browser.onPanelClosed?.(() => setBrowserPanelOpen(false));
+    return () => { unsubOpen?.(); unsubClose?.(); };
+  }, []);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
   const selectedSessionTitle = useMemo(

--- a/apps/desktop/electron/browser-mcp.mjs
+++ b/apps/desktop/electron/browser-mcp.mjs
@@ -113,10 +113,9 @@ async function connectExternalBrowser(browserURL) {
  * @param {string}   opts.version    — server version
  * @param {Function} opts.getBrowser — async () => Puppeteer.Browser
  * @param {Function} [opts.onToolCall] — called before each tool (e.g. to show browser panel)
- * @param {Function} [opts.onBuiltinNavigate] — direct Electron navigation for built-in browser
  * @returns {McpServer}
  */
-function createBrowserMcpServer({ name, version, getBrowser, onToolCall, onBuiltinNavigate }) {
+function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
   const server = new McpServer(
     { name, version },
     { capabilities: { logging: {} } },
@@ -142,6 +141,13 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall, onBuilt
       });
     }
     return context;
+  }
+
+  /** Force a full Puppeteer reconnect + fresh McpContext on next getContext(). */
+  function invalidateContext() {
+    try { lastBrowser?.disconnect(); } catch { /* already gone */ }
+    lastBrowser = null;
+    context = null;
   }
 
   // Skip performance / extension / emulation categories that don't make
@@ -171,18 +177,19 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall, onBuilt
             const page = ctx.getSelectedPage();
             const timeout = Number.isFinite(params?.timeout) && params.timeout > 0
               ? params.timeout
-              : 10_000;
-            const options = { timeout, waitUntil: "domcontentloaded" };
+              : 30_000;
+            // Use default Puppeteer waitUntil (load event).
+            const options = { timeout };
             const type = params?.type ?? "url";
 
             if (type === "url") {
               const url = String(params?.url ?? "").trim();
               if (!url) throw new Error("navigate_page requires a url for type=url");
-              if (onBuiltinNavigate) {
-                await onBuiltinNavigate(url);
-              } else {
-                await withTimeout(page.goto(url, options), timeout + 1_000, "openwork-browser/navigate_page");
-              }
+              // Use Puppeteer page.goto() with waitUntil:domcontentloaded
+              // wrapped in a hard timeout.  Electron's loadURL sometimes
+              // fails in the WebContentsView sandboxed partition while
+              // Puppeteer's CDP-based navigation succeeds.
+              await withTimeout(page.goto(url, options), timeout + 1_000, "openwork-browser/navigate_page");
             } else if (type === "back") {
               await withTimeout(page.goBack(options), timeout + 1_000, "openwork-browser/navigate_page(back)");
             } else if (type === "forward") {
@@ -193,9 +200,8 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall, onBuilt
               throw new Error(`Unsupported navigation type: ${type}`);
             }
 
-            await ctx.createPagesSnapshot();
             const targetUrl = type === "url" ? String(params?.url ?? "").trim() : page.url();
-            return { content: [{ type: "text", text: `Navigation started: ${targetUrl || page.url()}` }] };
+            return { content: [{ type: "text", text: `Navigated to ${targetUrl || page.url()}` }] };
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             return { content: [{ type: "text", text: `Error: ${msg}` }] };
@@ -361,10 +367,9 @@ async function startMcpHttpServer(mcpServerFactory, preferredPort = 0) {
  * @param {number} opts.electronCdpPort — Electron's remote debugging port (for built-in browser)
  * @param {Function} opts.onBuiltinToolCall — called before each built-in browser tool (opens panel)
  * @param {Function} opts.onHideBrowser — called to close the browser panel
- * @param {Function} opts.onBuiltinNavigate — direct Electron navigation for built-in browser
  * @returns {{ builtinPort: number, externalPort: number | null, stop: () => Promise<void> }}
  */
-export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCall, onHideBrowser, onBuiltinNavigate }) {
+export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCall, onHideBrowser }) {
   let builtinBrowser = null;
   let externalBrowser = null;
 
@@ -384,7 +389,6 @@ export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCal
         return builtinBrowser;
       },
       onToolCall: onBuiltinToolCall,
-      onBuiltinNavigate,
     });
 
     server.tool(

--- a/apps/desktop/electron/browser-mcp.mjs
+++ b/apps/desktop/electron/browser-mcp.mjs
@@ -37,6 +37,17 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 
 function noop() {}
 
+/** Wrap a promise with a timeout. Rejects with a descriptive error. */
+function withTimeout(promise, ms, label) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label}: timed out after ${ms}ms`)), ms);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
 /**
  * Target filter for the EXTERNAL Chrome server — accept all normal pages,
  * skip chrome:// and extension pages.
@@ -71,19 +82,27 @@ const BUILTIN_TARGET_FILTER = (target) => {
 };
 
 async function connectBuiltinBrowser(browserURL) {
-  return puppeteer.connect({
-    browserURL,
-    targetFilter: BUILTIN_TARGET_FILTER,
-    defaultViewport: null,
-  });
+  return withTimeout(
+    puppeteer.connect({
+      browserURL,
+      targetFilter: BUILTIN_TARGET_FILTER,
+      defaultViewport: null,
+    }),
+    10_000,
+    "connectBuiltinBrowser",
+  );
 }
 
 async function connectExternalBrowser(browserURL) {
-  return puppeteer.connect({
-    browserURL,
-    targetFilter: EXTERNAL_TARGET_FILTER,
-    defaultViewport: null,
-  });
+  return withTimeout(
+    puppeteer.connect({
+      browserURL,
+      targetFilter: EXTERNAL_TARGET_FILTER,
+      defaultViewport: null,
+    }),
+    10_000,
+    "connectExternalBrowser",
+  );
 }
 
 /**
@@ -94,9 +113,10 @@ async function connectExternalBrowser(browserURL) {
  * @param {string}   opts.version    — server version
  * @param {Function} opts.getBrowser — async () => Puppeteer.Browser
  * @param {Function} [opts.onToolCall] — called before each tool (e.g. to show browser panel)
+ * @param {Function} [opts.onBuiltinNavigate] — direct Electron navigation for built-in browser
  * @returns {McpServer}
  */
-function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
+function createBrowserMcpServer({ name, version, getBrowser, onToolCall, onBuiltinNavigate }) {
   const server = new McpServer(
     { name, version },
     { capabilities: { logging: {} } },
@@ -133,6 +153,60 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
   for (const tool of chromeDevtoolsTools) {
     if (skipCategories.has(tool.annotations?.category)) continue;
 
+    // The upstream navigate_page tool wraps page.goto() in an additional
+    // waitForNavigation/stable-DOM sequence. Electron WebContentsView targets
+    // can complete the navigation while that extra wait never resolves, which
+    // makes built-in browser navigation hang. Use a simpler built-in-specific
+    // handler that waits for DOMContentLoaded and returns promptly.
+    if (name === "openwork-browser" && tool.name === "navigate_page") {
+      server.tool(
+        tool.name,
+        tool.description,
+        tool.schema,
+        async (params) => {
+          const guard = await mutex.acquire();
+          try {
+            await onToolCall?.(tool.name, params);
+            const ctx = await getContext();
+            const page = ctx.getSelectedPage();
+            const timeout = Number.isFinite(params?.timeout) && params.timeout > 0
+              ? params.timeout
+              : 10_000;
+            const options = { timeout, waitUntil: "domcontentloaded" };
+            const type = params?.type ?? "url";
+
+            if (type === "url") {
+              const url = String(params?.url ?? "").trim();
+              if (!url) throw new Error("navigate_page requires a url for type=url");
+              if (onBuiltinNavigate) {
+                await onBuiltinNavigate(url);
+              } else {
+                await withTimeout(page.goto(url, options), timeout + 1_000, "openwork-browser/navigate_page");
+              }
+            } else if (type === "back") {
+              await withTimeout(page.goBack(options), timeout + 1_000, "openwork-browser/navigate_page(back)");
+            } else if (type === "forward") {
+              await withTimeout(page.goForward(options), timeout + 1_000, "openwork-browser/navigate_page(forward)");
+            } else if (type === "reload") {
+              await withTimeout(page.reload({ ...options, ignoreCache: params?.ignoreCache }), timeout + 1_000, "openwork-browser/navigate_page(reload)");
+            } else {
+              throw new Error(`Unsupported navigation type: ${type}`);
+            }
+
+            await ctx.createPagesSnapshot();
+            const targetUrl = type === "url" ? String(params?.url ?? "").trim() : page.url();
+            return { content: [{ type: "text", text: `Navigation started: ${targetUrl || page.url()}` }] };
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return { content: [{ type: "text", text: `Error: ${msg}` }] };
+          } finally {
+            guard.dispose();
+          }
+        },
+      );
+      continue;
+    }
+
     server.tool(
       tool.name,
       tool.description,
@@ -144,9 +218,23 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
           await onToolCall?.(tool.name, params);
           const ctx = await getContext();
           const response = new McpResponse();
-          await tool.handler({ params }, response, ctx);
+          // Wrap the tool handler with a hard timeout to prevent indefinite
+          // hangs. navigate_page in particular can hang inside Puppeteer's
+          // waitForNavigation when the Electron WebContentsView doesn't fire
+          // the expected CDP events.
+          const TOOL_TIMEOUT = 30_000;
+          await withTimeout(
+            tool.handler({ params }, response, ctx),
+            TOOL_TIMEOUT,
+            `${name}/${tool.name}`,
+          );
           const { content } = await response.handle(tool.name, ctx);
           return { content };
+        } catch (err) {
+          // Return the error as tool output instead of crashing the
+          // session — the agent can retry or fall back.
+          const msg = err instanceof Error ? err.message : String(err);
+          return { content: [{ type: "text", text: `Error: ${msg}` }] };
         } finally {
           guard.dispose();
         }
@@ -168,7 +256,7 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
  *
  * Returns { port, close }.
  */
-async function startMcpHttpServer(mcpServerFactory) {
+async function startMcpHttpServer(mcpServerFactory, preferredPort = 0) {
   const sessions = new Map();
 
   const httpServer = createServer(async (req, res) => {
@@ -241,12 +329,22 @@ async function startMcpHttpServer(mcpServerFactory) {
     }
   });
 
-  const port = await new Promise((resolve, reject) => {
-    httpServer.once("error", reject);
-    httpServer.listen(0, "127.0.0.1", () => {
-      resolve(httpServer.address().port);
+  async function listen(portToTry) {
+    return new Promise((resolve, reject) => {
+      httpServer.once("error", reject);
+      httpServer.listen(portToTry, "127.0.0.1", () => {
+        resolve(httpServer.address().port);
+      });
     });
-  });
+  }
+
+  let port;
+  try {
+    port = await listen(preferredPort);
+  } catch (error) {
+    if (!preferredPort || error?.code !== "EADDRINUSE") throw error;
+    port = await listen(0);
+  }
 
   return {
     port,
@@ -263,9 +361,10 @@ async function startMcpHttpServer(mcpServerFactory) {
  * @param {number} opts.electronCdpPort — Electron's remote debugging port (for built-in browser)
  * @param {Function} opts.onBuiltinToolCall — called before each built-in browser tool (opens panel)
  * @param {Function} opts.onHideBrowser — called to close the browser panel
+ * @param {Function} opts.onBuiltinNavigate — direct Electron navigation for built-in browser
  * @returns {{ builtinPort: number, externalPort: number | null, stop: () => Promise<void> }}
  */
-export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCall, onHideBrowser }) {
+export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCall, onHideBrowser, onBuiltinNavigate }) {
   let builtinBrowser = null;
   let externalBrowser = null;
 
@@ -285,6 +384,7 @@ export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCal
         return builtinBrowser;
       },
       onToolCall: onBuiltinToolCall,
+      onBuiltinNavigate,
     });
 
     server.tool(
@@ -394,8 +494,8 @@ export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCal
     return server;
   }
 
-  const builtin = await startMcpHttpServer(createBuiltinFactory);
-  const external = await startMcpHttpServer(createExternalFactory);
+  const builtin = await startMcpHttpServer(createBuiltinFactory, 64883);
+  const external = await startMcpHttpServer(createExternalFactory, 64884);
 
   return {
     builtinPort: builtin.port,

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -290,9 +290,14 @@ async function ensureBrowserMcpServers() {
         if (!mainWindow) return;
         const view = createBrowserView();
         if (!browserViewVisible) {
-          const [w, h] = mainWindow.getContentSize();
-          const panelWidth = Math.min(520, Math.floor(w * 0.4));
-          showBrowserView({ x: w - panelWidth, y: 0, width: panelWidth, height: h });
+          // Add the WebContentsView but don't position it yet — pass zero
+          // bounds so it stays invisible.  The React <BrowserPanel>
+          // component will compute its own layout bounds and call
+          // browser.show(bounds) / browser.setBounds(bounds) once the
+          // <aside> has been laid out.  Positioning eagerly here causes
+          // the view to overlay on top of the session content before React
+          // has made room for the panel column.
+          showBrowserView({ x: 0, y: 0, width: 0, height: 0 });
         }
         // Always notify the renderer so it can render the BrowserPanel
         // toolbar.  The React component may have unmounted (session switch)

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -311,6 +311,13 @@ async function ensureBrowserMcpServers() {
           mainWindow.webContents.send("openwork:browser:panel-closed");
         }
       },
+      onBuiltinNavigate: async (url) => {
+        const view = createBrowserView();
+        void view.webContents.loadURL(url).catch((error) => {
+          console.warn("[browser-mcp] built-in navigation failed", error);
+        });
+        sendBrowserState();
+      },
     });
     console.log(`[browser-mcp] Built-in browser MCP at http://127.0.0.1:${browserMcpPorts.builtinPort}/mcp`);
     console.log(`[browser-mcp] External Chrome MCP at http://127.0.0.1:${browserMcpPorts.externalPort}/mcp`);
@@ -324,6 +331,10 @@ async function ensureBrowserMcpServers() {
 /**
  * Inject the in-process MCP servers as remote entries in opencode.json.
  * Replaces any legacy local chrome-devtools entries.
+ *
+ * Browser MCP servers prefer stable localhost ports (64883/64884), so this
+ * remains stable across app restarts instead of writing a fresh random port
+ * every time.
  */
 async function seedBrowserMcpConfig(workspaceDir) {
   const ports = await ensureBrowserMcpServers();
@@ -344,28 +355,24 @@ async function seedBrowserMcpConfig(workspaceDir) {
 
   let changed = !configPath;
 
-  // Built-in browser (always inject / update)
   const builtinUrl = `http://127.0.0.1:${ports.builtinPort}/mcp`;
   if (config.mcp["openwork-browser"]?.url !== builtinUrl) {
     config.mcp["openwork-browser"] = { type: "remote", url: builtinUrl };
     changed = true;
   }
 
-  // External Chrome (always inject / update)
   const externalUrl = `http://127.0.0.1:${ports.externalPort}/mcp`;
   if (config.mcp["chrome"]?.url !== externalUrl) {
     config.mcp["chrome"] = { type: "remote", url: externalUrl };
     changed = true;
   }
 
-  // Remove legacy local chrome-devtools entry if present
-  if (config.mcp["chrome-devtools"]) {
-    delete config.mcp["chrome-devtools"];
-    changed = true;
-  }
-  if (config.mcp["control-chrome"]) {
-    delete config.mcp["control-chrome"];
-    changed = true;
+  // Remove legacy entries
+  for (const key of ["chrome-devtools", "control-chrome"]) {
+    if (config.mcp[key]) {
+      delete config.mcp[key];
+      changed = true;
+    }
   }
 
   if (changed) {
@@ -1130,7 +1137,7 @@ async function handleDesktopInvoke(event, command, ...args) {
       await mkdir(path.join(folderPath, ".opencode"), { recursive: true });
       await writeWorkspaceOpenworkConfig(folderPath, defaultWorkspaceOpenworkConfig(folderPath, preset));
 
-      // Inject in-process browser MCP servers into opencode.json
+      // Clean up any legacy browser MCP entries from the new workspace config
       await seedBrowserMcpConfig(folderPath);
       return mutateWorkspaceState((state) => {
         const workspacePathKey = normalizeWorkspacePathKey(workspace.path);
@@ -1850,10 +1857,10 @@ if (!app.requestSingleInstanceLock()) {
       error: error instanceof Error ? error.message : String(error),
     }));
 
-    // Start in-process browser MCP servers and inject into active workspace config
+    // Start in-process browser MCP servers and inject stable endpoints into
+    // workspace configs.
     ensureBrowserMcpServers().then(async (ports) => {
       if (!ports) return;
-      // Inject into all known workspaces
       try {
         const wsState = await readWorkspaceState();
         for (const ws of wsState.workspaces ?? []) {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -319,13 +319,6 @@ async function ensureBrowserMcpServers() {
           mainWindow.webContents.send("openwork:browser:panel-closed");
         }
       },
-      onBuiltinNavigate: async (url) => {
-        const view = createBrowserView();
-        void view.webContents.loadURL(url).catch((error) => {
-          console.warn("[browser-mcp] built-in navigation failed", error);
-        });
-        sendBrowserState();
-      },
     });
     console.log(`[browser-mcp] Built-in browser MCP at http://127.0.0.1:${browserMcpPorts.builtinPort}/mcp`);
     console.log(`[browser-mcp] External Chrome MCP at http://127.0.0.1:${browserMcpPorts.externalPort}/mcp`);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -293,8 +293,11 @@ async function ensureBrowserMcpServers() {
           const [w, h] = mainWindow.getContentSize();
           const panelWidth = Math.min(520, Math.floor(w * 0.4));
           showBrowserView({ x: w - panelWidth, y: 0, width: panelWidth, height: h });
-          mainWindow.webContents.send("openwork:browser:panel-opened");
         }
+        // Always notify the renderer so it can render the BrowserPanel
+        // toolbar.  The React component may have unmounted (session switch)
+        // while the WebContentsView stayed open, so we re-send every time.
+        mainWindow.webContents.send("openwork:browser:panel-opened");
         // Wait for the page to have a real URL (not about:blank)
         const url = view.webContents.getURL();
         if (!url || url === "about:blank") {


### PR DESCRIPTION
## Summary
- Fix built-in browser `navigate_page` hanging forever by bypassing upstream waitForNavigation/stable-DOM wrapper
- Fix browser panel never rendering by wiring `panel-opened`/`panel-closed` IPC to React state
- Fix WebContentsView overlaying session content by deferring positioning to React layout
- Use Puppeteer CDP navigation instead of Electron `loadURL` (which fails silently in sandboxed partition)
- Stable MCP ports (64883/64884) with random fallback instead of random every restart
- 30s hard timeout on all tool calls to prevent indefinite hangs
- 10s timeout on Puppeteer connect to prevent cold-start blocks

## Tested (via curl → MCP endpoints + Chrome DevTools MCP driving the app)
| Test | Result |
|---|---|
| `show_browser` | ✅ Panel opens |
| `navigate_page` → openworklabs.com | ✅ Instant |
| `navigate_page` → github.com | ✅ Instant |
| `navigate_page` → news.ycombinator.com | ✅ Instant |
| `take_snapshot` after navigate | ✅ Full page content |
| `list_pages` | ✅ |
| `hide_browser` | ✅ Panel closes |
| `chrome_status` (external) | ✅ Returns guidance |
| Panel renders as side column (no overlay) | ✅ Screenshot verified |
| Panel toggle button shows pressed state | ✅ |