### PR TITLE
fix(desktop): restore workspace visibility and package in-process server for Electron

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -297,7 +297,7 @@ export function SessionPage(props: SessionPageProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text mac:bg-transparent">
-      <SidebarProvider className="relative min-h-0 flex-1 mac:bg-transparent" persistence>
+      <SidebarProvider className="relative min-h-0 flex-1 mac:bg-transparent">
         <AppSidebar
           workspaceSessionGroups={props.sidebar.workspaceSessionGroups}
           selectedWorkspaceId={props.sidebar.selectedWorkspaceId}

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -11,6 +11,11 @@ directories:
   output: dist-electron
 files:
   - electron/**/*
+  - from: ../server
+    to: server
+    filter:
+      - dist/**/*
+      - package.json
   - package.json
 extraResources:
   - from: ../app/dist

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -5,6 +5,10 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
+
+const __runtimeDir = path.dirname(fileURLToPath(import.meta.url));
 
 const DIRECT_RUNTIME = "direct";
 const ORCHESTRATOR_RUNTIME = "openwork-orchestrator";
@@ -1001,7 +1005,12 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     Object.assign(process.env, serverEnv);
 
     // One call: resolve config, spawn managed OpenCode, start HTTP server.
-    const { startEmbeddedServer } = await import("../../server/dist/embedded.js");
+    // Packaged: server/dist is a sibling of electron/ inside app.asar (../server/dist)
+    // Dev: server lives at ../../server/dist relative to apps/desktop/electron
+    const packagedPath = path.resolve(__runtimeDir, "..", "server", "dist", "embedded.js");
+    const devPath = path.resolve(__runtimeDir, "..", "..", "server", "dist", "embedded.js");
+    const embeddedPath = existsSync(packagedPath) ? packagedPath : devPath;
+    const { startEmbeddedServer } = await import(pathToFileURL(embeddedPath).href);
     const handle = await startEmbeddedServer({
       host,
       port,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -25,8 +25,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "better-sqlite3": "^11.10.0",
     "chrome-devtools-mcp": "0.17.0",
-    "electron-updater": "^6.3.9"
+    "electron-updater": "^6.3.9",
+    "jsonc-parser": "^3.2.1",
+    "minimatch": "^10.0.1",
+    "yaml": "^2.6.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "electron": "^35.0.0",

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { copyFileSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -33,6 +33,20 @@ run(pnpmCmd, ["--filter", "openwork-server", "build"], repoRoot);
 run(pnpmCmd, ["--filter", "@openwork/app", "build"], repoRoot, {
   OPENWORK_ELECTRON_BUILD: "1",
 });
+// Copy constants.json next to server dist so the packaged asar can resolve it.
+// Also patch the compiled import path so it works from both dev and packaged layouts.
+const serverDistDir = resolve(repoRoot, "apps", "server", "dist");
+const constantsSrc = resolve(repoRoot, "constants.json");
+copyFileSync(constantsSrc, resolve(serverDistDir, "constants.json"));
+const serverJsPath = resolve(serverDistDir, "server.js");
+const serverJsSrc = readFileSync(serverJsPath, "utf8");
+const patched = serverJsSrc.replace(
+  /from\s+["']\.\.\/\.\.\/\.\.\/constants\.json["']/,
+  'from "./constants.json"',
+);
+if (patched !== serverJsSrc) {
+  writeFileSync(serverJsPath, patched, "utf8");
+}
 for (const fileName of readdirSync(electronRoot).filter((name) => name.endsWith(".mjs")).sort()) {
   run(nodeCmd, ["--check", resolve(electronRoot, fileName)], repoRoot);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,12 +152,27 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
       chrome-devtools-mcp:
         specifier: 0.17.0
         version: 0.17.0
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
+      jsonc-parser:
+        specifier: ^3.2.1
+        version: 3.3.1
+      minimatch:
+        specifier: ^10.0.1
+        version: 10.1.1
+      yaml:
+        specifier: ^2.6.1
+        version: 2.8.2
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       electron:
         specifier: ^35.0.0


### PR DESCRIPTION
## Summary
- **Fixes workspace sidebar disappearing** on alpha builds .717+ (reported by Omar)
- **Fixes packaged .app failing to start** the in-process server (preload crash, missing server assets)

## Root cause
The sidebar redesign (#1679) introduced `<SidebarProvider persistence>` which saves collapsed/expanded state to a cookie. If the cookie was `false`, the entire workspace sidebar (including "Add workspace") was hidden on launch — matching the report of "existing workspaces don't show, can't add new".

Separately, the in-process server migration (#1675) assumed `server/dist` would be available via relative imports from inside `app.asar`, but electron-builder was not packaging it.

## Changes
| File | What |
|---|---|
| `session-page.tsx` | Remove `persistence` from workspace `SidebarProvider` |
| `preload.mjs` | Guard `document.documentElement` access (null in packaged asar) |
| `runtime.mjs` | Dynamic import path for embedded server (dev vs packaged) |
| `electron-builder.yml` | Include `server/dist` + `package.json` in asar |
| `desktop/package.json` | Add server runtime deps (better-sqlite3, zod, yaml, etc.) |
| `electron-build.mjs` | Copy + patch `constants.json` import for asar compatibility |

## Verification
Built packaged `.app` via `package:electron:dir`, launched, confirmed:
- Workspace sidebar visible with existing workspaces
- "Add workspace" button present
- In-process server starts (`OpenWork Ready`)
- Session content renders correctly

Regression window: `.714` (good) → `.717` (bad), commits `95ef2d68`, `d58d79ae`, `4633c173`