### PR TITLE
fix(desktop): bundle embedded server in Electron app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _worktrees/
 
 # Desktop sidecars
 apps/desktop/resources/sidecars/
+apps/desktop/server/
 
 # Env
 .env

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -11,11 +11,7 @@ directories:
   output: dist-electron
 files:
   - electron/**/*
-  - from: ../server
-    to: server
-    filter:
-      - dist/**/*
-      - package.json
+  - server/**/*
   - package.json
 extraResources:
   - from: ../app/dist

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -1005,11 +1005,20 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     Object.assign(process.env, serverEnv);
 
     // One call: resolve config, spawn managed OpenCode, start HTTP server.
-    // Packaged: server/dist is a sibling of electron/ inside app.asar (../server/dist)
-    // Dev: server lives at ../../server/dist relative to apps/desktop/electron
-    const packagedPath = path.resolve(__runtimeDir, "..", "server", "dist", "embedded.js");
+    // Dev must prefer apps/server/dist; build output also stages a packaged
+    // copy under apps/desktop/server for electron-builder.
     const devPath = path.resolve(__runtimeDir, "..", "..", "server", "dist", "embedded.js");
-    const embeddedPath = existsSync(packagedPath) ? packagedPath : devPath;
+    const packagedPaths = [
+      path.resolve(__runtimeDir, "..", "server", "dist", "embedded.js"),
+      ...(process.resourcesPath ? [path.resolve(process.resourcesPath, "server", "dist", "embedded.js")] : []),
+    ];
+    const candidates = process.env.OPENWORK_DEV_MODE === "1"
+      ? [devPath, ...packagedPaths]
+      : [...packagedPaths, devPath];
+    const embeddedPath = candidates.find((candidate) => existsSync(candidate));
+    if (!embeddedPath) {
+      throw new Error(`Cannot find OpenWork embedded server bundle. Checked: ${candidates.join(", ")}`);
+    }
     const { startEmbeddedServer } = await import(pathToFileURL(embeddedPath).href);
     const handle = await startEmbeddedServer({
       host,

--- a/apps/desktop/scripts/electron-build.mjs
+++ b/apps/desktop/scripts/electron-build.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { copyFileSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { copyFileSync, cpSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +8,7 @@ const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "../..");
 const electronSidecarDir = resolve(desktopRoot, "resources", "sidecars");
 const electronRoot = resolve(desktopRoot, "electron");
+const packagedServerRoot = resolve(desktopRoot, "server");
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const nodeCmd = process.execPath;
@@ -47,6 +48,9 @@ const patched = serverJsSrc.replace(
 if (patched !== serverJsSrc) {
   writeFileSync(serverJsPath, patched, "utf8");
 }
+rmSync(packagedServerRoot, { recursive: true, force: true });
+cpSync(serverDistDir, resolve(packagedServerRoot, "dist"), { recursive: true });
+copyFileSync(resolve(repoRoot, "apps", "server", "package.json"), resolve(packagedServerRoot, "package.json"));
 for (const fileName of readdirSync(electronRoot).filter((name) => name.endsWith(".mjs")).sort()) {
   run(nodeCmd, ["--check", resolve(electronRoot, fileName)], repoRoot);
 }


### PR DESCRIPTION
## Summary

- Stage the compiled OpenWork server under `apps/desktop/server` during the Electron build so electron-builder packages a deterministic in-app server bundle.
- Point the Electron package config at the staged server directory instead of reaching outside the desktop package.
- Keep dev mode preferring the live `apps/server/dist` output while packaged builds prefer bundled server paths and report all checked paths if missing.

## Evidence

### Screenshots
No UI changes.

### Build verification
- `node --check apps/desktop/scripts/electron-build.mjs` -- passed
- `node --check apps/desktop/electron/runtime.mjs` -- passed
- `pnpm install --frozen-lockfile` -- passed
- `pnpm --filter @openwork/desktop build:electron` -- passed
- `pnpm --dir apps/desktop exec electron-builder --config electron-builder.yml --dir --publish never` -- passed
- `pnpm dlx @electron/asar list apps/desktop/dist-electron/mac-arm64/OpenWork.app/Contents/Resources/app.asar` -- verified `/server/dist/embedded.js` is present
- Brief packaged app smoke launch -- no missing-module crash appeared in logs

### API verification
No API changes.

### UI verification
No UI changes. This fixes packaged Electron launch-time resource resolution.

## Test instructions

1. Build an alpha macOS Electron artifact from this branch.
2. Install and launch OpenWork.
3. Verify the window no longer shows `Cannot find module ... Resources/server/dist/embedded.js`.
4. Verify the app reaches the normal startup UI.