### PR TITLE
fix(app): open new workspace sessions after creation

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1868,6 +1868,7 @@ export function SessionRoute() {
         preset,
       });
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
+      let targetWorkspaceId = createdId;
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);
         await workspaceSetRuntimeActive(createdId).catch(() => undefined);
@@ -1878,23 +1879,28 @@ export function SessionRoute() {
       // is launched with a fixed --workspace list at boot and the bridge
       // write only updates desktop-side state).
       if (client) {
-        await client
+        const serverList = await client
           .createLocalWorkspace({ folderPath: folder, name: workspaceName, preset })
-          .catch(() => undefined);
+          .catch(() => null);
+        targetWorkspaceId = serverList
+          ? resolveWorkspaceListSelectedId(serverList) || serverList.workspaces[serverList.workspaces.length - 1]?.id || targetWorkspaceId
+          : targetWorkspaceId;
       }
       setCreateWorkspaceOpen(false);
       // Mark onboarding complete so the /welcome redirect never fires again.
       local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
       await refreshRouteState();
-      if (createdId) {
-        handleOpenSettings("/settings/general", createdId);
+      if (targetWorkspaceId) {
+        setLegacySelectedWorkspaceId(targetWorkspaceId);
+        writeActiveWorkspaceId(targetWorkspaceId);
+        navigateToWorkspaceSession(targetWorkspaceId, null, { replace: true });
       }
     } catch (error) {
       setCreateWorkspaceError(describeWorkspaceCreateError(error));
     } finally {
       setCreateWorkspaceBusy(false);
     }
-  }, [client, handleOpenSettings, local, refreshRouteState]);
+  }, [client, local, navigateToWorkspaceSession, refreshRouteState]);
 
   const handleCreateRemoteWorkspace = useCallback(async (input: {
     openworkHostUrl?: string | null;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -192,6 +192,12 @@ function describeWorkspaceCreateError(error: unknown) {
   return message;
 }
 
+function focusPromptSoon() {
+  if (typeof window === "undefined") return;
+  const focus = () => window.dispatchEvent(new Event("openwork:focusPrompt"));
+  [0, 80, 240, 600].forEach((delay) => window.setTimeout(focus, delay));
+}
+
 const emptyPendingPermissions: PendingPermission[] = [];
 
 function useQueryCacheState<T>(queryKey: readonly unknown[] | null, fallback: T): T {
@@ -1726,6 +1732,7 @@ export function SessionRoute() {
         [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
       }));
       navigateToWorkspaceSession(workspaceId, session.id);
+      focusPromptSoon();
       void refreshRouteState();
     } catch (error) {
       const message = describeRouteError(error);
@@ -1911,6 +1918,7 @@ export function SessionRoute() {
           }));
         }
         navigateToWorkspaceSession(targetWorkspaceId, session?.id ?? null, { replace: true });
+        if (session?.id) focusPromptSoon();
       }
     } catch (error) {
       setCreateWorkspaceError(describeWorkspaceCreateError(error));

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1869,6 +1869,7 @@ export function SessionRoute() {
       });
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       let targetWorkspaceId = createdId;
+      let targetWorkspace = list.workspaces.find((workspace) => workspace.id === createdId) ?? null;
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);
         await workspaceSetRuntimeActive(createdId).catch(() => undefined);
@@ -1885,15 +1886,31 @@ export function SessionRoute() {
         targetWorkspaceId = serverList
           ? resolveWorkspaceListSelectedId(serverList) || serverList.workspaces[serverList.workspaces.length - 1]?.id || targetWorkspaceId
           : targetWorkspaceId;
+        targetWorkspace = serverList?.workspaces.find((workspace) => workspace.id === targetWorkspaceId) ?? targetWorkspace;
       }
       setCreateWorkspaceOpen(false);
       // Mark onboarding complete so the /welcome redirect never fires again.
       local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
       await refreshRouteState();
       if (targetWorkspaceId) {
+        const workspacePath = targetWorkspace?.path?.trim() || folder;
+        const session = baseUrl && token
+          ? unwrap(await createClient(
+              `${(buildOpenworkWorkspaceBaseUrl(baseUrl, targetWorkspaceId) ?? baseUrl).replace(/\/+$/, "")}/opencode`,
+              workspacePath || undefined,
+              { token, mode: "openwork" },
+            ).session.create({ directory: workspacePath || undefined }))
+          : null;
         setLegacySelectedWorkspaceId(targetWorkspaceId);
         writeActiveWorkspaceId(targetWorkspaceId);
-        navigateToWorkspaceSession(targetWorkspaceId, null, { replace: true });
+        if (session?.id) {
+          writeLastSessionFor(targetWorkspaceId, session.id);
+          setSessionsByWorkspaceId((current) => ({
+            ...current,
+            [targetWorkspaceId]: [session as any, ...(current[targetWorkspaceId] ?? [])],
+          }));
+        }
+        navigateToWorkspaceSession(targetWorkspaceId, session?.id ?? null, { replace: true });
       }
     } catch (error) {
       setCreateWorkspaceError(describeWorkspaceCreateError(error));

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -18,7 +18,7 @@ import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-moda
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { createOpenworkServerClient } from "../../app/lib/openwork-server";
 import { writeActiveWorkspaceId } from "./session-memory";
-import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
+import { workspaceSessionRoute } from "./workspace-routes";
 
 function folderNameFromPath(path: string) {
   const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
@@ -70,6 +70,7 @@ export function WelcomeRoute() {
           resolveWorkspaceListSelectedId(list) ||
           list.workspaces[list.workspaces.length - 1]?.id ||
           "";
+        let targetWorkspaceId = createdId;
         if (createdId) {
           await workspaceSetSelected(createdId).catch(() => undefined);
           await workspaceSetRuntimeActive(createdId).catch(() => undefined);
@@ -85,20 +86,24 @@ export function WelcomeRoute() {
               token: resolvedToken,
               hostToken: resolvedHostToken || undefined,
             });
-            await openworkClient
+            const serverList = await openworkClient
               .createLocalWorkspace({
                 folderPath: folder,
                 name: workspaceName,
                 preset: "starter",
               })
-              .catch(() => undefined);
+              .catch(() => null);
+            targetWorkspaceId = serverList
+              ? resolveWorkspaceListSelectedId(serverList) || serverList.workspaces[serverList.workspaces.length - 1]?.id || targetWorkspaceId
+              : targetWorkspaceId;
           }
         } catch {
           // Best-effort server registration.
         }
+        if (targetWorkspaceId) writeActiveWorkspaceId(targetWorkspaceId);
         markOnboardingComplete();
         setModalOpen(false);
-        navigate(createdId ? workspaceSettingsRoute(createdId, "general") : "/settings/general", { replace: true });
+        navigate(targetWorkspaceId ? workspaceSessionRoute(targetWorkspaceId) : "/session", { replace: true });
       } catch (error) {
         setCreateError(
           error instanceof Error ? error.message : "Failed to create workspace.",

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -27,6 +27,12 @@ function folderNameFromPath(path: string) {
   return parts[parts.length - 1] ?? "workspace";
 }
 
+function focusPromptSoon() {
+  if (typeof window === "undefined") return;
+  const focus = () => window.dispatchEvent(new Event("openwork:focusPrompt"));
+  [0, 80, 240, 600].forEach((delay) => window.setTimeout(focus, delay));
+}
+
 /**
  * WelcomeRoute: full-screen welcome page shown on first launch when
  * the user has no workspaces and has not completed onboarding.
@@ -120,6 +126,7 @@ export function WelcomeRoute() {
         markOnboardingComplete();
         setModalOpen(false);
         navigate(targetWorkspaceId ? workspaceSessionRoute(targetWorkspaceId, targetSessionId) : "/session", { replace: true });
+        if (targetSessionId) focusPromptSoon();
       } catch (error) {
         setCreateError(
           error instanceof Error ? error.message : "Failed to create workspace.",

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -12,12 +12,13 @@ import {
   workspaceSetSelected,
 } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
+import { createClient, unwrap } from "../../app/lib/opencode";
 import { useLocal } from "../kernel/local-provider";
 import { WelcomePage } from "../domains/onboarding/welcome-page";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
 import { resolveOpenworkConnection } from "./openwork-connection";
-import { createOpenworkServerClient } from "../../app/lib/openwork-server";
-import { writeActiveWorkspaceId } from "./session-memory";
+import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
+import { writeActiveWorkspaceId, writeLastSessionFor } from "./session-memory";
 import { workspaceSessionRoute } from "./workspace-routes";
 
 function folderNameFromPath(path: string) {
@@ -71,6 +72,8 @@ export function WelcomeRoute() {
           list.workspaces[list.workspaces.length - 1]?.id ||
           "";
         let targetWorkspaceId = createdId;
+        let targetWorkspace = list.workspaces.find((workspace) => workspace.id === createdId) ?? null;
+        let targetSessionId: string | null = null;
         if (createdId) {
           await workspaceSetSelected(createdId).catch(() => undefined);
           await workspaceSetRuntimeActive(createdId).catch(() => undefined);
@@ -96,14 +99,27 @@ export function WelcomeRoute() {
             targetWorkspaceId = serverList
               ? resolveWorkspaceListSelectedId(serverList) || serverList.workspaces[serverList.workspaces.length - 1]?.id || targetWorkspaceId
               : targetWorkspaceId;
+            targetWorkspace = serverList?.workspaces.find((workspace) => workspace.id === targetWorkspaceId) ?? targetWorkspace;
+            if (targetWorkspaceId) {
+              const workspacePath = targetWorkspace?.path?.trim() || folder;
+              const session = unwrap(await createClient(
+                `${(buildOpenworkWorkspaceBaseUrl(normalizedBaseUrl, targetWorkspaceId) ?? normalizedBaseUrl).replace(/\/+$/, "")}/opencode`,
+                workspacePath || undefined,
+                { token: resolvedToken, mode: "openwork" },
+              ).session.create({ directory: workspacePath || undefined }));
+              targetSessionId = session.id;
+            }
           }
         } catch {
           // Best-effort server registration.
         }
-        if (targetWorkspaceId) writeActiveWorkspaceId(targetWorkspaceId);
+        if (targetWorkspaceId) {
+          writeActiveWorkspaceId(targetWorkspaceId);
+          if (targetSessionId) writeLastSessionFor(targetWorkspaceId, targetSessionId);
+        }
         markOnboardingComplete();
         setModalOpen(false);
-        navigate(targetWorkspaceId ? workspaceSessionRoute(targetWorkspaceId) : "/session", { replace: true });
+        navigate(targetWorkspaceId ? workspaceSessionRoute(targetWorkspaceId, targetSessionId) : "/session", { replace: true });
       } catch (error) {
         setCreateError(
           error instanceof Error ? error.message : "Failed to create workspace.",

--- a/evals/onboarding-welcome-flows.md
+++ b/evals/onboarding-welcome-flows.md
@@ -114,7 +114,7 @@ Known regressions this catches:
 
 **Why**: The most common first-run path: pick a local folder and
 create a workspace. After creation, onboarding must be marked complete
-and the user lands on `/settings/general`.
+and the user lands in the new workspace session surface.
 
 Steps:
 1. From `/welcome`, click "Get started".
@@ -129,7 +129,8 @@ Steps:
    - "Select folder" button.
 4. Click "Select folder" and choose a folder.
 5. Click "Create Workspace".
-6. Expect: workspace is created; URL changes to `/settings/general`.
+6. Expect: workspace is created; URL changes to
+   `/workspace/<new-workspace-id>/session`.
 7. Navigate to `/welcome`.
 8. Expect: URL redirects back to `/session` (not `/welcome`), because
    `hasCompletedOnboarding` is now true.
@@ -144,13 +145,14 @@ chrome-devtools_take_snapshot
 chrome-devtools_click { uid: <Select folder> }
 -- native picker interaction --
 chrome-devtools_click { uid: <Create Workspace> }
-chrome-devtools_wait_for { text: ["Settings"], timeout: 15000 }
+chrome-devtools_wait_for { text: ["New session"], timeout: 15000 }
 chrome-devtools_take_snapshot
 ```
 
 Pass criteria:
 - Folder explanation (bullets, hint) is visible before picking.
-- After workspace creation, URL is `/settings/general`.
+- After workspace creation, URL contains `/workspace/` and ends with `/session`.
+- Main panel heading is "New session".
 - Navigating to `/welcome` redirects away (onboarding flagged done).
 - `localStorage` contains `hasCompletedOnboarding: true` in
   `openwork.preferences`.

--- a/evals/onboarding-welcome-flows.md
+++ b/evals/onboarding-welcome-flows.md
@@ -130,7 +130,7 @@ Steps:
 4. Click "Select folder" and choose a folder.
 5. Click "Create Workspace".
 6. Expect: workspace is created; URL changes to
-   `/workspace/<new-workspace-id>/session`.
+   `/workspace/<new-workspace-id>/session/<new-session-id>`.
 7. Navigate to `/welcome`.
 8. Expect: URL redirects back to `/session` (not `/welcome`), because
    `hasCompletedOnboarding` is now true.
@@ -151,8 +151,10 @@ chrome-devtools_take_snapshot
 
 Pass criteria:
 - Folder explanation (bullets, hint) is visible before picking.
-- After workspace creation, URL contains `/workspace/` and ends with `/session`.
+- After workspace creation, URL contains `/workspace/` and `/session/ses_`.
 - Main panel heading is "New session".
+- Composer is visible with the "Run task" action.
+- "Select or create a session to get started." is not visible.
 - Navigating to `/welcome` redirects away (onboarding flagged done).
 - `localStorage` contains `hasCompletedOnboarding: true` in
   `openwork.preferences`.

--- a/evals/onboarding-welcome-flows.md
+++ b/evals/onboarding-welcome-flows.md
@@ -154,6 +154,8 @@ Pass criteria:
 - After workspace creation, URL contains `/workspace/` and `/session/ses_`.
 - Main panel heading is "New session".
 - Composer is visible with the "Run task" action.
+- Composer is focused so typing starts in "Describe your task..." without an
+  extra click.
 - "Select or create a session to get started." is not visible.
 - Navigating to `/welcome` redirects away (onboarding flagged done).
 - `localStorage` contains `hasCompletedOnboarding: true` in

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -538,9 +538,9 @@ Steps:
 3. Select or inject a disposable test folder path.
 4. Click "Create Workspace".
 5. Expect: the modal closes and the URL changes to
-   `/workspace/<new-workspace-id>/session`.
+   `/workspace/<new-workspace-id>/session/<new-session-id>`.
 6. Expect: the new workspace is selected in the sidebar.
-7. Expect: the main area shows "New session" for that workspace.
+7. Expect: the main area shows a ready empty chat session for that workspace.
 8. Expect: the app does not navigate to `/settings/general`.
 
 Tool recipe:
@@ -555,13 +555,17 @@ chrome-devtools_take_snapshot
 ```
 
 Pass criteria:
-- URL contains `/workspace/` and ends with `/session`.
+- URL contains `/workspace/` and `/session/ses_`.
 - The selected sidebar workspace name matches the folder name.
 - Main panel heading is "New session".
+- Composer is visible with the "Run task" action.
+- "Select or create a session to get started." is not visible.
 - Settings heading is not visible after creation.
 
 Known regressions this catches:
 - Local workspace creation calling `handleOpenSettings("/settings/general")`.
+- Local workspace creation stopping at the workspace session root instead of
+  creating a ready-to-chat empty session.
 - The selected workspace id being persisted but the route remaining on the
   previous workspace.
 

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -107,6 +107,8 @@ Pass criteria:
 - URL changes to `/session/ses_*`.
 - Sidebar shows a new **"New session"** entry above existing sessions.
 - Main area renders the composer with **"No transcript yet."**.
+- Composer is focused so typing starts in **"Describe your task..."** without
+  an extra click.
 - Composer model label is whatever is saved as default (e.g.
   `opencode/minimax-m2.5-free`).
 
@@ -559,6 +561,8 @@ Pass criteria:
 - The selected sidebar workspace name matches the folder name.
 - Main panel heading is "New session".
 - Composer is visible with the "Run task" action.
+- Composer is focused so typing starts in "Describe your task..." without an
+  extra click.
 - "Select or create a session to get started." is not visible.
 - Settings heading is not visible after creation.
 

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -527,6 +527,46 @@ Pass criteria:
 
 ---
 
+## Flow 20 — Local workspace creation opens a new session
+
+**Why**: Creating a local workspace from the session sidebar is a task-starting
+flow. The user should land in that workspace's session surface, not in settings.
+
+Steps:
+1. From an existing session route, click "Add workspace" in the sidebar.
+2. Click "Local workspace".
+3. Select or inject a disposable test folder path.
+4. Click "Create Workspace".
+5. Expect: the modal closes and the URL changes to
+   `/workspace/<new-workspace-id>/session`.
+6. Expect: the new workspace is selected in the sidebar.
+7. Expect: the main area shows "New session" for that workspace.
+8. Expect: the app does not navigate to `/settings/general`.
+
+Tool recipe:
+```
+chrome-devtools_take_snapshot
+chrome-devtools_click { uid: <Add workspace> }
+chrome-devtools_click { uid: <Local workspace card> }
+-- select a disposable folder, or inject it when the native picker blocks automation --
+chrome-devtools_click { uid: <Create Workspace> }
+chrome-devtools_wait_for { text: ["New session"], timeout: 15000 }
+chrome-devtools_take_snapshot
+```
+
+Pass criteria:
+- URL contains `/workspace/` and ends with `/session`.
+- The selected sidebar workspace name matches the folder name.
+- Main panel heading is "New session".
+- Settings heading is not visible after creation.
+
+Known regressions this catches:
+- Local workspace creation calling `handleOpenSettings("/settings/general")`.
+- The selected workspace id being persisted but the route remaining on the
+  previous workspace.
+
+---
+
 ## Change log
 
 - 2026-04-16 — initial doc after the React port cutover fixed streaming,
@@ -538,3 +578,5 @@ Pass criteria:
 - 2026-04-28 — added Flows 13-19: slash command stability, error recovery
   with model change, paste chip collapse, user message display, single action
   button, skill lifecycle, and workspace button placement.
+- 2026-05-06 — added Flow 20 to ensure local workspace creation opens the
+  new workspace session surface instead of settings.


### PR DESCRIPTION
## Summary

- Route newly created local workspaces to their session surface instead of settings.
- Prefer the server-registered workspace id after local registration so the session route uses live runtime endpoints.
- Create and open an empty chat session immediately so the new workspace is ready to chat.
- Focus the composer after creating a new session so users can type immediately.
- Update UI evals to cover the sidebar Add workspace regression, first-run local workspace destination, and composer focus.

## Evidence

### Screenshots
![New local workspace opens a focused empty chat session](https://litter.catbox.moe/fgtsyu.png)

### Build verification
- `pnpm install --frozen-lockfile` -- passed
- `pnpm --filter @openwork/app build` -- passed
- `pnpm --filter @openwork/app typecheck` -- failed on existing unrelated app-wide TypeScript errors around `unknown` desktop bridge return values and missing messaging exports.

### API verification
- No API changes.
- Runtime requests for newly created workspaces returned 200 for session create, snapshot, events, config, providers, permissions, activate, and sessions endpoints.

### UI verification
Verified via OpenWork Electron devtools against the worktree app on `http://localhost:5273`:
- Added a local workspace from the session sidebar using `/var/folders/8j/hhcc8zs100d3fd654fjkk9580000gn/T/opencode/openwork-focus-regression-2`.
- After creation, URL was `http://localhost:5273/#/workspace/ws_31cec6cb70c8/session/ses_20064686fffex42YH7zIYUoAbE`.
- Main panel showed `New session` and workspace name `openwork-focus-regression-2`.
- Composer was visible with `Describe your task...`, attach/tools controls, and `Run task`.
- `document.activeElement` was the Lexical composer: `contenteditable=true`, `data-lexical-editor=true`, `role=textbox`.
- `Select or create a session to get started.` was not visible after creation.
- App did not navigate to `/settings/general`.
- Console errors/warnings: none after the final flow.

## Test instructions

1. Start the Electron dev app: `PORT=5273 OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 pnpm --filter @openwork/desktop dev:electron`.
2. Open the app through OpenWork devtools and click `Add workspace`.
3. Choose `Local workspace`, select a disposable folder, and click `Create Workspace`.
4. Verify the resulting URL contains `/workspace/` and `/session/ses_`.
5. Verify the main panel shows `New session` with the composer ready for input, not the session-root empty action and not settings.
6. Verify the composer is focused so typing starts immediately without an extra click.