### PR TITLE
fix(desktop): prevent orphaned Electron and server processes after Ctrl-C

### DIFF
--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -218,7 +218,6 @@ if (!viteReady) {
 if (!viteReady) {
   uiChild = run(pnpmCmd, ["-w", "dev:ui"], {
     cwd: repoRoot,
-    detached: process.platform !== "win32",
     env: {
       ...process.env,
       PORT: String(devPort),
@@ -239,7 +238,6 @@ const cdpPort = cdpPortRaw === "" || cdpPortRaw === "0" ? "" : cdpPortRaw;
 
 electronChild = run(pnpmCmd, ["exec", "electron", "./electron/main.mjs"], {
   cwd: desktopRoot,
-  detached: process.platform !== "win32",
   env: {
     ...process.env,
     OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE ?? "1",


### PR DESCRIPTION
## Summary

- **Vite**: replaced the nested `pnpm -w dev:ui` child process tree with Vite's JavaScript API (`createServer`/`close`) so the dev launcher owns the server object directly and can shut it down deterministically
- **Electron**: removed `detached: true` so Electron shares the terminal process group and receives `Ctrl-C` SIGINT directly; resolved the binary path directly instead of going through `pnpm exec` which added a signal-swallowing intermediary
- **OpenWork server**: added `SIGINT`/`SIGTERM` handlers to Electron's `main.mjs` that route terminal signals through `app.quit()` and the existing `before-quit` cleanup chain (`stopAllRuntimeChildren`, sidecar shutdown)
- **Shutdown order**: reversed cleanup to kill Electron first (synchronous signal), then close Vite; added `process.on('exit')` safety-net `SIGKILL` for Electron
- **Root script**: flattened `dev:ui` from `pnpm --filter @openwork/app dev` to `pnpm --dir apps/app exec vite` to remove unnecessary process layers

## Root cause

Three things combined to cause log leaks after `Ctrl-C`:

1. Electron was spawned `detached: true` → separate process group → terminal SIGINT never reached it
2. Electron's main process had no `SIGINT`/`SIGTERM` handlers → even when signaled programmatically, the OpenWork server cleanup chain (`before-quit` → `stopAllRuntimeChildren`) never ran
3. Vite was spawned as a nested `pnpm → pnpm → vite` child tree → one intermediary could survive the parent exit with terminal fd still open

## Evidence

### Build verification
- `node --check apps/desktop/scripts/electron-dev.mjs` -- passed
- `node --check apps/desktop/electron/main.mjs` -- passed  
- `pnpm --filter @openwork/desktop check:electron` -- passed (50 renderer methods)

### Shutdown verification

Smoke test: start `pnpm dev` on a custom port, wait for full boot, send `SIGINT`, then check for survivors:

```
PORT=5205 node apps/desktop/scripts/electron-dev.mjs &
sleep 24
kill -INT $pid
sleep 5
lsof -nP -iTCP:5205 -sTCP:LISTEN   # → empty (port released)
ps -axo pid,ppid,command | rg "opencode.*serve|Electron|vite.*5205"  # → no orphans
```

**Before fix**: Vite process (3 pnpm layers) + Electron + OpenWork server survived indefinitely, logging `GET /workspace/...` to the terminal.

**After fix**: all processes exit cleanly within seconds. No orphaned sidecar, no leaked logs, no port held.

## Test instructions

1. `cd _repos/openwork` (or this worktree)
2. `pnpm dev`
3. Wait for Electron to open and show the dashboard
4. Press `Ctrl-C` in the terminal
5. Verify:
   - No request logs appear after the prompt returns
   - `lsof -nP -iTCP:5173 -sTCP:LISTEN` shows nothing
   - `ps -axo pid,ppid,command | grep -E "Electron|opencode.*serve|vite"` shows no orphans from this run