### PR TITLE
fix(app): route remote workspaces through a single endpoint helper

### DIFF
--- a/apps/app/scripts/remote-workspace-diagnostics.test.ts
+++ b/apps/app/scripts/remote-workspace-diagnostics.test.ts
@@ -79,7 +79,7 @@ function serverError(status: number, code: string, message: string) {
 }
 
 describe("resolveRemoteWorkspaceConnectionTarget", () => {
-  test("builds a workspace-scoped OpenWork target from saved worker credentials", () => {
+  test("builds a host-scoped OpenWork target from saved worker credentials", () => {
     const target = resolveRemoteWorkspaceConnectionTarget(
       workspace({
         openworkHostUrl: "https://worker.example.com",
@@ -89,7 +89,7 @@ describe("resolveRemoteWorkspaceConnectionTarget", () => {
 
     expect(target.ok).toBe(true);
     if (!target.ok) return;
-    expect(target.target.baseUrl).toBe("https://worker.example.com/w/ws_remote");
+    expect(target.target.baseUrl).toBe("https://worker.example.com");
     expect(target.target.workspaceId).toBe("ws_remote");
     expect(target.target.token).toBe("ow-token");
   });
@@ -100,7 +100,7 @@ describe("resolveRemoteWorkspaceConnectionTarget", () => {
     expect(target.ok).toBe(true);
     if (!target.ok) return;
     expect(target.target.workspaceId).toBe("ws_remote");
-    expect(target.target.baseUrl).toBe("https://worker.example.com/w/ws_remote");
+    expect(target.target.baseUrl).toBe("https://worker.example.com");
   });
 
   test("fails fast when a remote worker has no endpoint", () => {
@@ -185,6 +185,8 @@ describe("testRemoteWorkspaceConnection", () => {
     expect(result.ok).toBe(false);
     expect(result.state.status).toBe("error");
     expect(result.state.message).toContain("Token is missing");
+    expect(result.state.message).toContain("Upgrade the OpenWork host");
+    expect(result.state.message).toContain("team@openworklabs.com");
   });
 
   test("reports unhealthy health responses as endpoint failures", async () => {
@@ -198,6 +200,8 @@ describe("testRemoteWorkspaceConnection", () => {
     expect(result.ok).toBe(false);
     expect(result.state.status).toBe("error");
     expect(result.state.message).toContain("unhealthy response");
+    expect(result.state.message).toContain("Upgrade the OpenWork host");
+    expect(result.state.message).toContain("team@openworklabs.com");
   });
 
   test("uses fallback OpenWork tokens saved on older workspace records", async () => {
@@ -230,14 +234,16 @@ describe("testRemoteWorkspaceConnection", () => {
     expect(result.ok).toBe(false);
     expect(result.state.status).toBe("error");
     expect(result.state.message).toContain("Token was rejected by worker.example.com");
+    expect(result.state.message).toContain("Upgrade the OpenWork host");
+    expect(result.state.message).toContain("team@openworklabs.com");
   });
 
   test("reports a missing workspace separately from a dead worker", async () => {
     const result = await testRemoteWorkspaceConnection(workspace(), {
       createClient: () =>
         client({
-          status: async () => {
-            throw serverError(404, "workspace_not_found", "Workspace not found");
+          listWorkspaces: async () => {
+            return { items: [], activeId: null };
           },
         }),
     });
@@ -245,6 +251,8 @@ describe("testRemoteWorkspaceConnection", () => {
     expect(result.ok).toBe(false);
     expect(result.state.status).toBe("error");
     expect(result.state.message).toContain("Workspace ws_remote was not found");
+    expect(result.state.message).toContain("Upgrade the OpenWork host");
+    expect(result.state.message).toContain("team@openworklabs.com");
   });
 
   test("uses workspace list when the saved remote target is not workspace-scoped", async () => {
@@ -291,13 +299,15 @@ describe("testRemoteWorkspaceConnection", () => {
     expect(result.ok).toBe(false);
     expect(result.state.status).toBe("error");
     expect(result.state.message).toContain("Token was rejected by worker.example.com");
+    expect(result.state.message).toContain("Upgrade the OpenWork host");
+    expect(result.state.message).toContain("team@openworklabs.com");
   });
 
   test("reports unauthorized workspace status separately from bad credentials", async () => {
     const result = await testRemoteWorkspaceConnection(workspace(), {
       createClient: () =>
         client({
-          status: async () => {
+          listWorkspaces: async () => {
             throw serverError(403, "forbidden", "Forbidden");
           },
         }),
@@ -306,6 +316,8 @@ describe("testRemoteWorkspaceConnection", () => {
     expect(result.ok).toBe(false);
     expect(result.state.status).toBe("error");
     expect(result.state.message).toContain("is not authorized");
+    expect(result.state.message).toContain("Upgrade the OpenWork host");
+    expect(result.state.message).toContain("team@openworklabs.com");
   });
 
   test("reports endpoint reachability failures from the health probe", async () => {
@@ -321,6 +333,8 @@ describe("testRemoteWorkspaceConnection", () => {
     expect(result.ok).toBe(false);
     expect(result.state.status).toBe("error");
     expect(result.state.message).toContain("Cannot reach worker.example.com");
+    expect(result.state.message).toContain("Upgrade the OpenWork host");
+    expect(result.state.message).toContain("team@openworklabs.com");
   });
 
   test("redacts token-like values from diagnostic error messages", async () => {

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -152,28 +152,56 @@ function isLoopbackUrl(input: RequestInfo | URL): boolean {
   }
 }
 
-export const desktopFetch: typeof globalThis.fetch = (input, init) => {
+export const desktopFetch: typeof globalThis.fetch = async (input, init) => {
   if (isLoopbackUrl(input)) {
     return globalThis.fetch(input, init);
   }
 
-  return invokeElectronHelper<{
+  // Extract method/headers/body from either a Request object or the (input, init)
+  // pair. The OpenCode SDK calls fetch(request) (no init), so reading these only
+  // from `init` would silently drop the Authorization header and the POST body
+  // — the remote would then reject every request with "Invalid bearer token".
+  let url: string;
+  let method: string | undefined;
+  let headers: Record<string, string> | undefined;
+  let body: string | undefined;
+
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    url = input.url;
+    method = init?.method ?? input.method;
+    const headersSource = init?.headers ? new Headers(init.headers) : input.headers;
+    headers = Object.fromEntries(headersSource.entries());
+    if (typeof init?.body === "string") {
+      body = init.body;
+    } else if (input.body) {
+      // Request body is a stream — buffer to text so it survives the IPC hop
+      // to the Electron main process.
+      body = await input.clone().text();
+    }
+  } else {
+    url = typeof input === "string" ? input : input.toString();
+    method = init?.method;
+    headers = init?.headers ? Object.fromEntries(new Headers(init.headers).entries()) : undefined;
+    body = typeof init?.body === "string" ? init.body : undefined;
+  }
+
+  const result = await invokeElectronHelper<{
     status: number;
     statusText: string;
     headers: [string, string][];
     body: string;
-  }>("__fetch", typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url, {
-    method: init?.method,
-    headers: init?.headers ? Object.fromEntries(new Headers(init.headers).entries()) : undefined,
-    body: typeof init?.body === "string" ? init.body : undefined,
-  }).then(
-    (result) =>
-      new Response(result.body, {
-        status: result.status,
-        statusText: result.statusText,
-        headers: result.headers,
-      }),
-  );
+  }>("__fetch", url, { method, headers, body });
+
+  // Response constructor rejects bodies for null-body status codes, so we
+  // must pass null instead of an empty string for those.
+  const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+  const responseBody = NULL_BODY_STATUSES.has(result.status) ? null : result.body;
+
+  return new Response(responseBody, {
+    status: result.status,
+    statusText: result.statusText,
+    headers: result.headers,
+  });
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/app/src/app/lib/workspace-endpoint.ts
+++ b/apps/app/src/app/lib/workspace-endpoint.ts
@@ -1,0 +1,158 @@
+/**
+ * Single source of truth for "where does a workspace's server live?".
+ *
+ * Every workspace-scoped API call in the app must route to the OpenWork server
+ * that actually owns that workspace. For local workspaces that's the user's
+ * local OpenWork server. For workspaces hosted on a remote OpenWork worker
+ * (`id` starts with `rem_` and `workspaceType === "remote"`), it's the
+ * `baseUrl`/`openworkHostUrl` and `openworkToken` saved on the workspace
+ * record, with the workspace addressed by its server-side id (the `rem_`
+ * prefix is stripped, or `openworkWorkspaceId` is used when present).
+ *
+ * Always go through {@link resolveWorkspaceEndpoint} when you need:
+ *   - an `OpenworkServerClient` for a workspace
+ *   - a mounted `/workspace/<id>` URL prefix
+ *   - the `/opencode` URL for the OpenCode SDK
+ *
+ * Don't compose `<baseUrl>/workspace/<id>` by hand — that pattern is what
+ * caused this whole class of "remote workspace API calls hit the local
+ * server" bugs.
+ */
+
+import type { WorkspaceInfo } from "./desktop";
+import {
+  buildOpenworkWorkspaceBaseUrl,
+  createOpenworkServerClient,
+  type OpenworkServerClient,
+} from "./openwork-server";
+
+export type ResolvedWorkspaceEndpoint = {
+  /** Host URL of the OpenWork server that owns this workspace (no `/workspace` mount). */
+  baseUrl: string;
+  /** Auth token for that server. May be empty for unauthenticated local servers. */
+  token: string;
+  /** Workspace id as the owning server expects it in URL paths. No `rem_` prefix. */
+  workspaceId: string;
+  /** True when the workspace lives on a remote OpenWork worker, not the user's local server. */
+  isRemote: boolean;
+  /** OpenworkServerClient bound to {@link baseUrl}/{@link token}. */
+  client: OpenworkServerClient;
+  /** Mounted base url: `<baseUrl>/workspace/<workspaceId>`. No trailing slash. */
+  mountedBaseUrl: string;
+  /** OpenCode SDK base url: `<mountedBaseUrl>/opencode`. */
+  opencodeBaseUrl: string;
+};
+
+export type LocalServerHandle = {
+  baseUrl: string | null | undefined;
+  token: string | null | undefined;
+};
+
+type WorkspaceEndpointInput = Pick<
+  WorkspaceInfo,
+  | "id"
+  | "workspaceType"
+  | "baseUrl"
+  | "openworkHostUrl"
+  | "openworkToken"
+  | "openworkClientToken"
+  | "openworkHostToken"
+  | "openworkWorkspaceId"
+> | null | undefined;
+
+/**
+ * Cheap predicate. Use this instead of duplicating the `id.startsWith("rem_")`
+ * check inline.
+ */
+export function isRemoteWorkspace(workspace: WorkspaceEndpointInput): boolean {
+  if (!workspace) return false;
+  return (
+    workspace.id.trim().startsWith("rem_") &&
+    workspace.workspaceType === "remote"
+  );
+}
+
+/**
+ * Returns the server-side workspace id (no `rem_` prefix) for any workspace.
+ * For local workspaces, returns the id as-is.
+ */
+export function workspaceServerId(workspace: WorkspaceEndpointInput): string {
+  if (!workspace) return "";
+  const id = workspace.id.trim();
+  if (!isRemoteWorkspace(workspace)) return id;
+  const explicit = workspace.openworkWorkspaceId?.trim();
+  if (explicit) return explicit;
+  return id.startsWith("rem_") ? id.slice("rem_".length) : id;
+}
+
+function pickRemoteBaseUrl(workspace: WorkspaceEndpointInput): string {
+  if (!workspace) return "";
+  return (workspace.baseUrl ?? workspace.openworkHostUrl ?? "").trim();
+}
+
+function pickRemoteToken(workspace: WorkspaceEndpointInput): string {
+  if (!workspace) return "";
+  return (
+    workspace.openworkToken ??
+    workspace.openworkClientToken ??
+    workspace.openworkHostToken ??
+    ""
+  ).trim();
+}
+
+/**
+ * Resolve the right server endpoint for a workspace. Returns null when the
+ * workspace can't be reached (remote with no baseUrl, or local with no local
+ * server connected yet). The returned object's `client`, `mountedBaseUrl`, and
+ * `opencodeBaseUrl` are ready to use for any workspace-scoped API call.
+ */
+export function resolveWorkspaceEndpoint(
+  workspace: WorkspaceEndpointInput,
+  localServer: LocalServerHandle,
+): ResolvedWorkspaceEndpoint | null {
+  if (!workspace) return null;
+
+  if (isRemoteWorkspace(workspace)) {
+    const baseUrl = pickRemoteBaseUrl(workspace);
+    if (!baseUrl) return null;
+    const token = pickRemoteToken(workspace);
+    const workspaceId = workspaceServerId(workspace);
+    const client = createOpenworkServerClient({
+      baseUrl,
+      token: token || undefined,
+    });
+    const mountedBaseUrl = (
+      buildOpenworkWorkspaceBaseUrl(baseUrl, workspaceId) ?? baseUrl
+    ).replace(/\/+$/, "");
+    return {
+      baseUrl,
+      token,
+      workspaceId,
+      isRemote: true,
+      client,
+      mountedBaseUrl,
+      opencodeBaseUrl: `${mountedBaseUrl}/opencode`,
+    };
+  }
+
+  const localBaseUrl = (localServer.baseUrl ?? "").trim();
+  if (!localBaseUrl) return null;
+  const localToken = (localServer.token ?? "").trim();
+  const workspaceId = workspace.id.trim();
+  const client = createOpenworkServerClient({
+    baseUrl: localBaseUrl,
+    token: localToken || undefined,
+  });
+  const mountedBaseUrl = (
+    buildOpenworkWorkspaceBaseUrl(localBaseUrl, workspaceId) ?? localBaseUrl
+  ).replace(/\/+$/, "");
+  return {
+    baseUrl: localBaseUrl,
+    token: localToken,
+    workspaceId,
+    isRemote: false,
+    client,
+    mountedBaseUrl,
+    opencodeBaseUrl: `${mountedBaseUrl}/opencode`,
+  };
+}

--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -333,6 +333,20 @@ export function isSandboxWorkspace(workspace: WorkspaceInfo) {
   );
 }
 
+export function isRemoteConnectionWorkspace(workspace: WorkspaceInfo) {
+  return workspace.id.trim().startsWith("rem_");
+}
+
+export function isRemoteConnectionErrorMessage(message?: string | null) {
+  const value = message?.trim().toLowerCase() ?? "";
+  return (
+    value.includes("remote worker") ||
+    value.includes("cannot reach ") ||
+    value.includes("health check failed") ||
+    value.includes("worker connection failed")
+  );
+}
+
 export function redactTokenLikeText(value: string): string {
   return value
     .replace(/([?&](?:access_token|api_key|key|password|token)=)[^&\s]+/gi, "$1[redacted]")

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Check, Globe, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
-import { buildOpenworkWorkspaceBaseUrl, type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
+import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
@@ -98,7 +98,14 @@ export type SessionPageProps = {
     workspaceType?: WorkspaceInfo["workspaceType"];
   };
   selectedWorkspaceRoot: string;
+  selectedWorkspaceError?: string | null;
   runtimeWorkspaceId: string | null;
+  /**
+   * Pre-built OpenCode SDK base URL for the selected workspace's owning
+   * server. The parent route resolves this through `resolveWorkspaceEndpoint`
+   * so we never compose `<baseUrl>/workspace/<id>/opencode` here.
+   */
+  opencodeBaseUrl?: string | null;
   workspaces: WorkspaceInfo[];
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
@@ -229,16 +236,34 @@ export function SessionPage(props: SessionPageProps) {
     [todos],
   );
   const sidebarInitialLoading = useMemo(() => getSidebarInitialLoading(props.sidebar), [props.sidebar]);
+  // Derive the main-pane error from the same data the sidebar uses so the two
+  // panes can never disagree. We check (in priority order):
+  // 1. selectedWorkspaceError (errorsByWorkspaceId[selectedWorkspaceId])
+  // 2. workspaceConnectionStateById[selectedWorkspaceId].message (covers test/recover paths)
+  // 3. group.error from workspaceSessionGroups (the same source the sidebar reads)
+  const selectedWorkspaceConnectionMessage = (() => {
+    const state = props.sidebar.workspaceConnectionStateById[props.selectedWorkspaceId];
+    if (state?.status === "error") return state.message?.trim() ?? "";
+    return "";
+  })();
+  const selectedWorkspaceGroupError = (() => {
+    const group = props.sidebar.workspaceSessionGroups.find(
+      (item) => item.workspace.id === props.selectedWorkspaceId,
+    );
+    return group?.error?.trim() ?? "";
+  })();
+  const selectedWorkspaceErrorMessage =
+    props.selectedWorkspaceError?.trim() ||
+    selectedWorkspaceConnectionMessage ||
+    selectedWorkspaceGroupError ||
+    "";
+  const showSelectedWorkspaceError = Boolean(selectedWorkspaceErrorMessage);
 
-  const reactSessionBaseUrl = useMemo(() => {
-    const workspaceId = props.runtimeWorkspaceId?.trim() ?? "";
-    const baseUrl = props.openworkServerClient?.baseUrl?.trim() ?? "";
-    if (!workspaceId || !baseUrl) return "";
-    const mounted = buildOpenworkWorkspaceBaseUrl(baseUrl, workspaceId) ?? baseUrl;
-    return `${mounted.replace(/\/+$/, "")}/opencode`;
-  }, [props.openworkServerClient?.baseUrl, props.runtimeWorkspaceId]);
-
-  const reactSessionToken = props.openworkServerClient?.token?.trim() || props.openworkServerToken?.trim() || "";
+  const reactSessionBaseUrl = props.opencodeBaseUrl?.trim() ?? "";
+  const reactSessionToken =
+    props.openworkServerToken?.trim() ||
+    props.openworkServerClient?.token?.trim() ||
+    "";
   const canRenderReactSurface = Boolean(
     props.selectedSessionId &&
       props.runtimeWorkspaceId &&
@@ -467,12 +492,18 @@ export function SessionPage(props: SessionPageProps) {
 
               {!showDelayedSessionLoadingState && canRenderReactSurface ? (
                 <SessionSurface
+                  // Spread `surface` first so the explicit per-workspace
+                  // routing props below CAN'T be silently overridden by
+                  // anything that leaks into `surface`. SessionSurface's
+                  // server target (client/workspaceId/sessionId/opencodeBaseUrl/openworkToken)
+                  // must come from the resolved workspace endpoint passed by
+                  // SessionRoute, not from anything in `surface`.
+                  {...props.surface!}
                   client={props.openworkServerClient!}
                   workspaceId={props.runtimeWorkspaceId!}
                   sessionId={props.selectedSessionId!}
                   opencodeBaseUrl={reactSessionBaseUrl}
                   openworkToken={reactSessionToken}
-                  {...props.surface!}
                 />
               ) : null}
 
@@ -498,6 +529,40 @@ export function SessionPage(props: SessionPageProps) {
                       </div>
                       <div className="flex justify-center">
                         <Button onClick={props.sidebar.onOpenCreateWorkspace}>{t("workspace.create_workspace")}</Button>
+                      </div>
+                    </div>
+                  ) : showSelectedWorkspaceError ? (
+                    <div className="px-6 py-16">
+                      <div className="mx-auto max-w-lg rounded-2xl border border-red-7/35 bg-red-1/40 px-5 py-5 text-left shadow-[var(--dls-card-shadow)]">
+                        <div className="text-sm font-medium text-red-11">Remote workspace unavailable</div>
+                        <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-red-11/90">
+                          {selectedWorkspaceErrorMessage}
+                        </p>
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          <Button
+                            variant="outline"
+                            className="px-3 py-1.5 text-xs"
+                            onClick={() => void Promise.resolve(props.sidebar.onTestWorkspaceConnection(props.selectedWorkspaceId))}
+                          >
+                            {t("workspace_list.test_connection")}
+                          </Button>
+                          <Button
+                            variant="outline"
+                            className="px-3 py-1.5 text-xs"
+                            onClick={() => props.sidebar.onEditWorkspaceConnection(props.selectedWorkspaceId)}
+                          >
+                            {t("workspace_list.edit_connection")}
+                          </Button>
+                          {props.sidebar.workspaceConnectionStateById[props.selectedWorkspaceId]?.status === "error" ? (
+                            <Button
+                              variant="outline"
+                              className="px-3 py-1.5 text-xs"
+                              onClick={() => void Promise.resolve(props.sidebar.onRecoverWorkspace(props.selectedWorkspaceId))}
+                            >
+                              {t("workspace_list.recover")}
+                            </Button>
+                          ) : null}
+                        </div>
                       </div>
                     </div>
                   ) : (

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
 
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
+import { OpenWorkDenHelpLink } from "../../workspace/openwork-den-help-link";
 import type {
   WorkspaceConnectionState,
   WorkspaceSessionGroup,
@@ -274,6 +275,7 @@ function RemoteConnectionIssueCard(props: {
             >
               {props.message}
             </div>
+            <OpenWorkDenHelpLink />
             <div className="mt-2 flex flex-wrap gap-1.5">
               {props.canRecover ? (
                 <Button

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import * as React from "react";
 import {
+  AlertCircle,
   ChevronRight,
   Loader2,
   MoreHorizontal,
@@ -9,6 +10,7 @@ import {
   Share2,
   Trash2,
   RefreshCw,
+  RotateCcw,
   Settings,
   FolderOpen,
 } from "lucide-react";
@@ -20,7 +22,9 @@ import type {
   WorkspaceSessionGroup,
 } from "../../../../app/types";
 import {
+  isRemoteConnectionErrorMessage,
   getWorkspaceTaskLoadErrorDisplay,
+  isRemoteConnectionWorkspace,
   isWindowsPlatform,
 } from "../../../../app/utils";
 import { t } from "../../../../i18n";
@@ -227,6 +231,90 @@ function WorkspaceActionsMenu({ workspace, isConnectionActionBusy, canRecover, c
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function RemoteConnectionIssueCard(props: {
+  message: string;
+  tone: "error" | "offline";
+  canRecover: boolean;
+  busy: boolean;
+  onRecover: () => void;
+  onTest: () => void;
+  onEdit: () => void;
+}) {
+  const isOffline = props.tone === "offline";
+  const shellClass = isOffline
+    ? "border-amber-7/35 bg-amber-2/45"
+    : "border-red-7/35 bg-red-1/40";
+  const iconClass = isOffline
+    ? "bg-amber-3/60 text-amber-11"
+    : "bg-red-3/60 text-red-11";
+  const detailClass = isOffline
+    ? "border-amber-7/25 bg-amber-1/40 text-amber-11"
+    : "border-red-7/25 bg-red-1/40 text-red-11";
+
+  return (
+    <SidebarMenuSubItem>
+      <div className={`w-full rounded-[15px] border px-3 py-3 text-left ${shellClass}`}>
+        <div className="flex items-start gap-2.5">
+          <div className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${iconClass}`}>
+            <AlertCircle size={14} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[12px] font-medium text-dls-text">
+              {t("workspace_list.remote_worker_unavailable")}
+            </div>
+            <div className="mt-1 text-[11px] leading-5 text-gray-10">
+              {t("workspace_list.remote_worker_unavailable_hint")}
+            </div>
+            <div
+              className={`mt-2 rounded-lg border px-2 py-1.5 text-[11px] leading-4 ${detailClass}`}
+              title={props.message}
+            >
+              {props.message}
+            </div>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {props.canRecover ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1.5 rounded-lg px-2 text-[11px]"
+                  onClick={props.onRecover}
+                  disabled={props.busy}
+                >
+                  <RotateCcw size={12} />
+                  {t("workspace_list.recover")}
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 rounded-lg px-2 text-[11px]"
+                onClick={props.onTest}
+                disabled={props.busy}
+              >
+                <RefreshCw size={12} />
+                {t("workspace_list.test_connection")}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 rounded-lg px-2 text-[11px]"
+                onClick={props.onEdit}
+                disabled={props.busy}
+              >
+                <Settings size={12} />
+                {t("common.edit")}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </SidebarMenuSubItem>
   );
 }
 
@@ -525,12 +613,22 @@ function WorkspaceSidebarGroup({
     message: null,
   };
   const isConnectionActionBusy = isConnecting || connectionState.status === "connecting";
-  const canRecover = workspace.workspaceType === "remote" && connectionState.status === "error";
+  const isRemoteWorkspace = isRemoteConnectionWorkspace(workspace);
+  const canRecover = isRemoteWorkspace && connectionState.status === "error";
   const taskLoadError = getWorkspaceTaskLoadErrorDisplay(workspace, group.error);
+  const connectionIssueMessage = connectionState.status === "error"
+    ? connectionState.message?.trim() || taskLoadError.message
+    : group.error?.trim() || taskLoadError.message;
+  const showRemoteConnectionIssue =
+    (isRemoteWorkspace || isRemoteConnectionErrorMessage(connectionIssueMessage)) &&
+    Boolean(connectionIssueMessage) &&
+    (connectionState.status === "error" || group.status === "error");
   const isExpanded = ctx.expandedWorkspaceIds.has(workspace.id);
   const isSelected = ctx.selectedWorkspaceId === workspace.id;
 
   const statusLabel = (() => {
+    if (showRemoteConnectionIssue) return t("workspace_list.unavailable");
+    if (connectionState.status === "error") return connectionState.message?.trim() || taskLoadError.message;
     if (group.status === "error") return taskLoadError.label;
     if (isConnectionActionBusy) return t("workspace_list.connecting");
     if (!ctx.developerMode) return "";
@@ -599,7 +697,23 @@ function WorkspaceSidebarGroup({
 
             <CollapsibleContent className="pt-1">
               <SidebarMenuSub>
-                {showInitialLoading ? (
+                {showRemoteConnectionIssue ? (
+                  <RemoteConnectionIssueCard
+                    message={connectionIssueMessage}
+                    tone={taskLoadError.tone}
+                    canRecover={canRecover}
+                    busy={isConnectionActionBusy}
+                    onRecover={() => {
+                      void Promise.resolve(ctx.onRecoverWorkspace(workspace.id));
+                    }}
+                    onTest={() => {
+                      void Promise.resolve(ctx.onTestWorkspaceConnection(workspace.id));
+                    }}
+                    onEdit={() => {
+                      ctx.onEditWorkspaceConnection(workspace.id);
+                    }}
+                  />
+                ) : showInitialLoading ? (
                   <>
                     {[0, 1, 2].map((idx) => (
                       <SidebarMenuSubItem key={`skeleton-${idx}`}>

--- a/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
@@ -20,6 +20,8 @@ import type {
 } from "../../../../app/types";
 import {
   getWorkspaceTaskLoadErrorDisplay,
+  isRemoteConnectionErrorMessage,
+  isRemoteConnectionWorkspace,
   isSandboxWorkspace,
   isWindowsPlatform,
 } from "../../../../app/utils";
@@ -547,16 +549,16 @@ export function WorkspaceSessionList(props: Props) {
             };
             const isConnectionActionBusy =
               isConnecting || connectionState.status === "connecting";
-            const canRecover =
-              workspace.workspaceType === "remote" && connectionState.status === "error";
+            const isRemoteWorkspace = isRemoteConnectionWorkspace(workspace);
+            const canRecover = isRemoteWorkspace && connectionState.status === "error";
             const isMenuOpen = workspaceMenuId === workspace.id;
             const taskLoadError = getWorkspaceTaskLoadErrorDisplay(workspace, group.error);
             const connectionIssueMessage =
               connectionState.status === "error"
                 ? connectionState.message?.trim() || taskLoadError.message
-                : taskLoadError.message;
+                : group.error?.trim() || taskLoadError.message;
             const showRemoteConnectionIssue =
-              workspace.workspaceType === "remote" &&
+              (isRemoteWorkspace || isRemoteConnectionErrorMessage(connectionIssueMessage)) &&
               Boolean(connectionIssueMessage) &&
               (connectionState.status === "error" || group.status === "error");
             const statusLabel = (() => {
@@ -798,8 +800,7 @@ export function WorkspaceSessionList(props: Props) {
                             props.onEditWorkspaceConnection(workspace.id);
                           }}
                         />
-                      ) : null}
-                      {props.showInitialLoading ? (
+                      ) : props.showInitialLoading ? (
                         <div className="space-y-2">
                           {[0, 1, 2].map((idx) => (
                             <div
@@ -845,7 +846,7 @@ export function WorkspaceSessionList(props: Props) {
                             </button>
                           ) : null}
                         </>
-                      ) : showRemoteConnectionIssue ? null : group.status === "error" ? (
+                      ) : group.status === "error" ? (
                         <div
                           className={`w-full rounded-[15px] border px-3 py-2.5 text-left text-[11px] ${
                             taskLoadError.tone === "offline"

--- a/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
@@ -14,6 +14,7 @@ import {
 
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
+import { OpenWorkDenHelpLink } from "../../workspace/openwork-den-help-link";
 import type {
   WorkspaceConnectionState,
   WorkspaceSessionGroup,
@@ -216,6 +217,7 @@ function RemoteConnectionIssueCard(props: {
           >
             {props.message}
           </div>
+          <OpenWorkDenHelpLink />
           <div className="mt-2 flex flex-wrap gap-1.5">
             {props.canRecover ? (
               <button

--- a/apps/app/src/react-app/domains/workspace/openwork-den-help-link.tsx
+++ b/apps/app/src/react-app/domains/workspace/openwork-den-help-link.tsx
@@ -1,0 +1,88 @@
+/** @jsxImportSource react */
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+const SUPPORT_EMAIL = "team@openworklabs.com";
+const SUPPORT_MAILTO = `mailto:${SUPPORT_EMAIL}?subject=OpenWork%20Den%20remote%20worker%20upgrade`;
+
+/**
+ * Small inline link rendered inside the remote-worker error card. When clicked,
+ * it opens a dialog explaining the OpenWork Den upgrade situation and how to
+ * reach support.
+ */
+export function OpenWorkDenHelpLink() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="mt-2 inline-flex items-center text-[11px] font-medium text-blue-11 underline-offset-2 hover:underline"
+        onClick={() => setOpen(true)}
+      >
+        Using OpenWork Den Remote Workers? Click here
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>OpenWork Den remote workers</DialogTitle>
+            <DialogDescription>
+              We recently upgraded our servers. If your remote worker was
+              provisioned before that upgrade, it may no longer be compatible
+              with the current OpenWork app.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3 text-[13px] leading-5 text-gray-11">
+            <p>To get back online, you have two options:</p>
+            <ul className="ml-4 list-disc space-y-2">
+              <li>
+                Email{" "}
+                <a
+                  href={SUPPORT_MAILTO}
+                  className="font-medium text-blue-11 hover:underline"
+                >
+                  {SUPPORT_EMAIL}
+                </a>{" "}
+                and ask us to upgrade your worker.
+              </li>
+              <li>
+                Use the in-app{" "}
+                <span className="font-medium text-dls-text">Feedback</span>{" "}
+                button to send us a note — we&apos;ll pick it up from there.
+              </li>
+            </ul>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Close
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                window.location.href = SUPPORT_MAILTO;
+              }}
+            >
+              Email support
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/app/src/react-app/domains/workspace/remote-workspace-diagnostics.ts
+++ b/apps/app/src/react-app/domains/workspace/remote-workspace-diagnostics.ts
@@ -1,7 +1,6 @@
 import type { WorkspaceConnectionState } from "../../../app/types";
 import type { WorkspaceInfo } from "../../../app/lib/desktop";
 import {
-  buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
   normalizeOpenworkServerUrl,
   parseOpenworkWorkspaceIdFromUrl,
@@ -60,6 +59,24 @@ function endpointLabel(baseUrl: string) {
   }
 }
 
+function stripOpenworkWorkspaceMount(baseUrl: string) {
+  try {
+    const url = new URL(baseUrl);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const workspaceIndex = segments.indexOf("workspace");
+    const legacyIndex = segments.indexOf("w");
+    const mountIndex = workspaceIndex >= 0 ? workspaceIndex : legacyIndex;
+    if (mountIndex >= 0 && segments[mountIndex + 1]) {
+      const prefix = segments.slice(0, mountIndex).join("/");
+      url.pathname = prefix ? `/${prefix}` : "/";
+      return url.toString().replace(/\/+$/, "");
+    }
+  } catch {
+    // Fall through to the already-normalized value below.
+  }
+  return baseUrl.replace(/\/+$/, "");
+}
+
 function isValidHttpEndpoint(baseUrl: string) {
   try {
     const url = new URL(baseUrl);
@@ -83,7 +100,11 @@ function isServerErrorStatus(error: unknown, status: number | number[]) {
 }
 
 function rejectedTokenMessage(target: RemoteWorkspaceConnectionTarget) {
-  return `Token was rejected by ${target.endpointLabel}. Edit connection and reconnect the worker.`;
+  return remoteSupportMessage(`Token was rejected by ${target.endpointLabel}. Edit connection and reconnect the worker.`);
+}
+
+function remoteSupportMessage(message: string) {
+  return `${message} Upgrade the OpenWork host and try again. If this continues, contact team@openworklabs.com.`;
 }
 
 export function redactRemoteDiagnosticText(value: string): string {
@@ -156,7 +177,7 @@ export function resolveRemoteWorkspaceConnectionTarget(workspace: WorkspaceInfo)
       ok: false,
       state: {
         status: "error",
-        message: "Remote worker URL is missing. Edit connection and add a server URL.",
+        message: remoteSupportMessage("Remote worker URL is missing. Edit connection and add a server URL."),
         checkedAt: Date.now(),
       },
     };
@@ -168,7 +189,7 @@ export function resolveRemoteWorkspaceConnectionTarget(workspace: WorkspaceInfo)
       ok: false,
       state: {
         status: "error",
-        message: "Remote worker URL is invalid. Edit connection and use an http:// or https:// URL.",
+        message: remoteSupportMessage("Remote worker URL is invalid. Edit connection and use an http:// or https:// URL."),
         checkedAt: Date.now(),
       },
     };
@@ -179,9 +200,7 @@ export function resolveRemoteWorkspaceConnectionTarget(workspace: WorkspaceInfo)
     parseOpenworkWorkspaceIdFromUrl(normalizedHostUrl) ||
     parseOpenworkWorkspaceIdFromUrl(trim(workspace.baseUrl)) ||
     null;
-  const baseUrl = workspaceId
-    ? buildOpenworkWorkspaceBaseUrl(normalizedHostUrl, workspaceId) ?? normalizedHostUrl
-    : normalizedHostUrl;
+  const hostBaseUrl = stripOpenworkWorkspaceMount(normalizedHostUrl);
   const token =
     trim(workspace.openworkToken) ||
     trim(workspace.openworkClientToken) ||
@@ -191,8 +210,8 @@ export function resolveRemoteWorkspaceConnectionTarget(workspace: WorkspaceInfo)
     ok: true,
     target: {
       kind: "openwork",
-      baseUrl,
-      endpointLabel: endpointLabel(baseUrl),
+      baseUrl: hostBaseUrl,
+      endpointLabel: endpointLabel(hostBaseUrl),
       token,
       workspaceId,
     },
@@ -222,20 +241,20 @@ export async function testRemoteWorkspaceConnection(
     const health = await client.health();
     if (!health?.ok) {
       return fail(
-        `Cannot reach ${target.endpointLabel}. Health check returned an unhealthy response.`,
+        remoteSupportMessage(`Cannot reach ${target.endpointLabel}. Health check returned an unhealthy response.`),
         checkedAt,
       );
     }
   } catch (error) {
     return fail(
-      `Cannot reach ${target.endpointLabel}. Health check failed: ${describeUnknownError(error)}`,
+      remoteSupportMessage(`Cannot reach ${target.endpointLabel}. Health check failed: ${describeUnknownError(error)}`),
       checkedAt,
     );
   }
 
   if (!target.token) {
     return fail(
-      `Token is missing for ${target.endpointLabel}. Edit connection and paste a valid OpenWork token.`,
+      remoteSupportMessage(`Token is missing for ${target.endpointLabel}. Edit connection and paste a valid OpenWork token.`),
       checkedAt,
     );
   }
@@ -247,15 +266,22 @@ export async function testRemoteWorkspaceConnection(
       return fail(rejectedTokenMessage(target), checkedAt);
     }
     return fail(
-      `Connected to ${target.endpointLabel}, but capabilities failed: ${describeUnknownError(error)}`,
+      remoteSupportMessage(`Connected to ${target.endpointLabel}, but capabilities failed: ${describeUnknownError(error)}`),
       checkedAt,
     );
   }
 
   if (target.workspaceId) {
     try {
-      const status = await client.status();
-      const name = displayWorkspaceName(status.workspace) || target.workspaceId;
+      const list = await client.listWorkspaces();
+      const workspace = list.items.find((item) => item.id === target.workspaceId) ?? null;
+      if (!workspace) {
+        return fail(
+          remoteSupportMessage(`Workspace ${target.workspaceId} was not found on ${target.endpointLabel}. Reconnect the worker.`),
+          checkedAt,
+        );
+      }
+      const name = displayWorkspaceName(workspace) || target.workspaceId;
       return {
         ok: true,
         target,
@@ -266,20 +292,14 @@ export async function testRemoteWorkspaceConnection(
         },
       };
     } catch (error) {
-      if (isServerErrorStatus(error, 404)) {
-        return fail(
-          `Workspace ${target.workspaceId} was not found on ${target.endpointLabel}. Reconnect the worker.`,
-          checkedAt,
-        );
-      }
       if (isServerErrorStatus(error, 403)) {
         return fail(
-          `Workspace ${target.workspaceId} is not authorized on ${target.endpointLabel}. Check the token or server access rules.`,
+          remoteSupportMessage(`Workspace ${target.workspaceId} is not authorized on ${target.endpointLabel}. Check the token or server access rules.`),
           checkedAt,
         );
       }
       return fail(
-        `Connected to ${target.endpointLabel}, but workspace status failed: ${describeUnknownError(error)}`,
+        remoteSupportMessage(`Connected to ${target.endpointLabel}, but workspace list failed: ${describeUnknownError(error)}`),
         checkedAt,
       );
     }
@@ -306,7 +326,7 @@ export async function testRemoteWorkspaceConnection(
       return fail(rejectedTokenMessage(target), checkedAt);
     }
     return fail(
-      `Connected to ${target.endpointLabel}, but workspace list failed: ${describeUnknownError(error)}`,
+      remoteSupportMessage(`Connected to ${target.endpointLabel}, but workspace list failed: ${describeUnknownError(error)}`),
       checkedAt,
     );
   }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -12,12 +12,15 @@ import type {
 import { createClient, unwrap } from "../../app/lib/opencode";
 import { listCommands, shellInSession } from "../../app/lib/opencode-session";
 import {
-  buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
   readOpenworkServerSettings,
   type OpenworkServerClient,
   type OpenworkWorkspaceInfo,
 } from "../../app/lib/openwork-server";
+import {
+  resolveWorkspaceEndpoint,
+  type ResolvedWorkspaceEndpoint,
+} from "../../app/lib/workspace-endpoint";
 import { buildOpenworkEnvRuntimeKey } from "../../app/lib/openwork-env-runtime";
 import {
   engineInfo,
@@ -220,10 +223,26 @@ function mergeRouteWorkspaces(
       .filter(([path]) => path.length > 0),
   );
 
-  const mergedServer = serverWorkspaces.map((workspace) => {
+  // If a server workspace's id matches a desktop workspace marked as remote,
+  // skip the server's view entirely. The local OpenWork server may have stale
+  // registrations from earlier (buggy) activate calls that show up here as
+  // `workspaceType: "local"`, which would otherwise clobber the desktop's
+  // remote routing fields and send workspace-scoped requests back to the
+  // local server.
+  const remoteDesktopIds = new Set(
+    desktopWorkspaces
+      .filter((workspace) => workspace.workspaceType === "remote")
+      .map((workspace) => workspace.id),
+  );
+  const filteredServer = serverWorkspaces.filter((workspace) => !remoteDesktopIds.has(workspace.id));
+
+  const mergedServer = filteredServer.map((workspace) => {
     const match =
       desktopById.get(workspace.id) ??
       desktopByPath.get(normalizeDirectoryPath(workspace.path ?? ""));
+    // For local workspaces, prefer the server's view (which knows things like
+    // `path` and per-workspace runtime fields) and only fall back to the
+    // desktop's display name when the server doesn't provide one.
     const merged = match
       ? {
           ...workspace,
@@ -273,6 +292,10 @@ function toSessionGroups(
     error: errorsByWorkspaceId[workspace.id],
   }));
 }
+
+// All workspace-scoped server URLs/clients/tokens come from
+// `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
+// Don't compose `<baseUrl>/workspace/<id>` here.
 
 function isActiveSessionStatus(status: unknown) {
   return status === "running" || status === "retry" || status === "busy";
@@ -379,6 +402,28 @@ export function SessionRoute() {
   const [routeError, setRouteError] = useState<string | null>(null);
   const [legacySelectedWorkspaceId, setLegacySelectedWorkspaceId] = useState<string>(() => readActiveWorkspaceId() ?? "");
   const selectedWorkspaceId = routeWorkspaceId || legacySelectedWorkspaceId;
+  const selectedWorkspace = useMemo(
+    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? (selectedWorkspaceId ? null : workspaces[0] ?? null),
+    [selectedWorkspaceId, workspaces],
+  );
+  // Workspace-scoped API calls (sessions, events, activate, opencode/*) must
+  // hit the worker that owns the workspace, not the user's local server. The
+  // single source of truth for that routing is `resolveWorkspaceEndpoint`.
+  //
+  // We read the latest local server's baseUrl/token through a ref so the
+  // `endpointForWorkspace` callback stays permanently stable. Otherwise it
+  // would change on every `setBaseUrl`/`setToken`, which used to cascade up
+  // through `loadWorkspaceSessionsInBackground` and `refreshRouteState` and
+  // produce a tight render-refresh-setWorkspaces loop.
+  const localServerRef = useRef<{ baseUrl: string; token: string }>({ baseUrl: "", token: "" });
+  useEffect(() => {
+    localServerRef.current = { baseUrl, token };
+  }, [baseUrl, token]);
+  const endpointForWorkspace = useCallback(
+    (workspace: RouteWorkspace | null | undefined): ResolvedWorkspaceEndpoint | null =>
+      resolveWorkspaceEndpoint(workspace, localServerRef.current),
+    [],
+  );
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   // One-way latch for "a refreshRouteState is currently running"; prevents
   // overlapping route refreshes from queueing up when the user clicks fast.
@@ -461,17 +506,19 @@ export function SessionRoute() {
 
   const backgroundSessionLoadInFlight = useRef<Map<string, number>>(new Map());
   const loadWorkspaceSessionsInBackground = useCallback(
-    async (openworkClient: OpenworkServerClient, workspaces: RouteWorkspace[]) => {
+    async (workspaces: RouteWorkspace[]) => {
       const MAX_ATTEMPTS = 6;
       const backoffMs = (attempt: number) => Math.min(500 * Math.pow(2, attempt), 4_000);
 
       const fetchOnce = async (workspace: RouteWorkspace, attempt: number): Promise<void> => {
+        const endpoint = endpointForWorkspace(workspace);
+        if (!endpoint) return;
         const startedAt = backgroundSessionLoadInFlight.current.get(workspace.id) ?? 0;
         if (startedAt && Date.now() - startedAt < 5_000) return;
         const requestStartedAt = Date.now();
         backgroundSessionLoadInFlight.current.set(workspace.id, requestStartedAt);
         try {
-          const response = await openworkClient.listSessions(workspace.id, { limit: 200 });
+          const response = await endpoint.client.listSessions(endpoint.workspaceId, { limit: 200 });
           const workspaceRoot = normalizeDirectoryPath(workspace.path ?? "");
           const items = workspaceRoot
             ? (response.items ?? []).filter((session: any) =>
@@ -544,7 +591,7 @@ export function SessionRoute() {
 
       await Promise.all(workspaces.map((workspace) => fetchOnce(workspace, 0)));
     },
-    [],
+    [endpointForWorkspace],
   );
 
   const refreshRouteState = useCallback(async () => {
@@ -652,7 +699,11 @@ export function SessionRoute() {
       // transport failure is non-fatal. See issue #870.
       if (nextWorkspaceId && !launchActivatedWorkspaceIdsRef.current.has(nextWorkspaceId)) {
         launchActivatedWorkspaceIdsRef.current.add(nextWorkspaceId);
-        void openworkClient.activateWorkspace(nextWorkspaceId).catch(() => undefined);
+        const nextWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId) ?? null;
+        const nextEndpoint = endpointForWorkspace(nextWorkspace);
+        if (nextEndpoint) {
+          void nextEndpoint.client.activateWorkspace(nextEndpoint.workspaceId).catch(() => undefined);
+        }
       }
       recordInspectorEvent("route.refresh.complete", {
         workspaces: nextWorkspaces.length,
@@ -672,7 +723,7 @@ export function SessionRoute() {
         const orderedWorkspaces = selectedWorkspace
           ? [selectedWorkspace, ...backgroundWorkspaces.filter((workspace) => workspace.id !== selectedWorkspace.id)]
           : backgroundWorkspaces;
-        void loadWorkspaceSessionsInBackground(openworkClient, orderedWorkspaces);
+        void loadWorkspaceSessionsInBackground(orderedWorkspaces);
       }
     } catch (error) {
       const message = describeRouteError(error);
@@ -712,7 +763,12 @@ export function SessionRoute() {
       setRouteError(t("app.error_connect_first"));
       return false;
     }
-    await client.reloadEngine(selectedWorkspaceId);
+    const endpoint = endpointForWorkspace(selectedWorkspace);
+    if (!endpoint) {
+      setRouteError(t("app.error_connect_first"));
+      return false;
+    }
+    await endpoint.client.reloadEngine(endpoint.workspaceId);
     setEngineReloadVersion((v) => v + 1);
     try {
       window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
@@ -721,7 +777,7 @@ export function SessionRoute() {
     }
     await refreshRouteState();
     return true;
-  }, [client, refreshRouteState, selectedWorkspaceId]);
+  }, [client, endpointForWorkspace, refreshRouteState, selectedWorkspace, selectedWorkspaceId]);
 
   useEffect(() => {
     return reloadCoordinator.registerWorkspaceReloadControls({
@@ -733,13 +789,15 @@ export function SessionRoute() {
 
   useEffect(() => {
     if (!client || !selectedWorkspaceId) return;
+    const endpoint = endpointForWorkspace(selectedWorkspace);
+    if (!endpoint) return;
     let cancelled = false;
 
     const pollReloadEvents = async () => {
       const currentCursor = reloadEventCursorByWorkspaceRef.current[selectedWorkspaceId];
       try {
-        const response = await client.listReloadEvents(
-          selectedWorkspaceId,
+        const response = await endpoint.client.listReloadEvents(
+          endpoint.workspaceId,
           typeof currentCursor === "number" ? { since: currentCursor } : undefined,
         );
         if (cancelled) return;
@@ -767,15 +825,17 @@ export function SessionRoute() {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [client, reloadCoordinator, selectedWorkspaceId]);
+  }, [client, endpointForWorkspace, reloadCoordinator, selectedWorkspace, selectedWorkspaceId]);
 
   useEffect(() => {
     if (!client || !selectedWorkspaceId || !selectedSessionId) return;
+    const endpoint = endpointForWorkspace(selectedWorkspace);
+    if (!endpoint) return;
     let cancelled = false;
 
     const refreshSelectedSessionTitle = async () => {
       try {
-        const response = await client.getSession(selectedWorkspaceId, selectedSessionId);
+        const response = await endpoint.client.getSession(endpoint.workspaceId, selectedSessionId);
         if (cancelled || !response.item) return;
         setSessionsByWorkspaceId((current) => {
           const list = current[selectedWorkspaceId] ?? [];
@@ -798,7 +858,7 @@ export function SessionRoute() {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [client, selectedSessionId, selectedWorkspaceId]);
+  }, [client, endpointForWorkspace, selectedSessionId, selectedWorkspace, selectedWorkspaceId]);
 
   useEffect(() => {
     workspacesRef.current = workspaces;
@@ -960,6 +1020,15 @@ export function SessionRoute() {
   // restore the last session the user opened in the active workspace.
   useEffect(() => {
     if (loading) return;
+    if (routeWorkspaceId && workspaces.length > 0 && !workspaces.some((workspace) => workspace.id === routeWorkspaceId)) {
+      const fallbackWorkspaceId = workspaces.some((workspace) => workspace.id === legacySelectedWorkspaceId)
+        ? legacySelectedWorkspaceId
+        : workspaces[0]?.id || "";
+      if (fallbackWorkspaceId) {
+        navigateToWorkspaceSession(fallbackWorkspaceId, selectedSessionId, { replace: true });
+      }
+      return;
+    }
     if (!routeWorkspaceId && selectedWorkspaceId) {
       navigateToWorkspaceSession(selectedWorkspaceId, selectedSessionId, { replace: true });
       return;
@@ -973,11 +1042,13 @@ export function SessionRoute() {
     navigateToWorkspaceSession(selectedWorkspaceId, remembered, { replace: true });
   }, [
     loading,
+    legacySelectedWorkspaceId,
     navigateToWorkspaceSession,
     routeWorkspaceId,
     selectedSessionId,
     selectedWorkspaceId,
     sessionsByWorkspaceId,
+    workspaces,
   ]);
 
   // Redirect to /welcome when no workspaces exist and the user hasn't
@@ -1014,10 +1085,6 @@ export function SessionRoute() {
     return selectedWorkspaceId;
   }, [selectedSessionId, selectedWorkspaceId, workspaceSessionGroups]);
 
-  const selectedWorkspace = useMemo(
-    () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? (selectedWorkspaceId ? null : workspaces[0] ?? null),
-    [selectedWorkspaceId, workspaces],
-  );
   const workspaceConnectionStateById = useMemo(() => {
     const next: Record<string, WorkspaceConnectionState> = { ...workspaceConnectionOverrides };
     for (const workspace of workspaces) {
@@ -1056,11 +1123,15 @@ export function SessionRoute() {
   }, [client, loading, selectedWorkspace, workspaces]);
 
   const selectedWorkspaceRoot = selectedWorkspace?.path?.trim() || "";
-  const opencodeBaseUrl = useMemo(() => {
-    if (!selectedWorkspaceId || !baseUrl) return "";
-    const mounted = buildOpenworkWorkspaceBaseUrl(baseUrl, selectedWorkspaceId) ?? baseUrl;
-    return `${mounted.replace(/\/+$|\/+$/g, "")}/opencode`;
-  }, [baseUrl, selectedWorkspaceId]);
+  // Single source of truth for the selected workspace's server URL/token/id.
+  // For remote workspaces this is the worker that owns the workspace; for
+  // local workspaces it's the user's local OpenWork server.
+  const selectedWorkspaceEndpoint = useMemo(
+    () => resolveWorkspaceEndpoint(selectedWorkspace, { baseUrl, token }),
+    [baseUrl, selectedWorkspace, token],
+  );
+  const selectedWorkspaceServerToken = selectedWorkspaceEndpoint?.token ?? "";
+  const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
   const selectedWorkspaceIsLoading = retryingWorkspaceIds.includes(selectedWorkspaceId);
   const selectedWorkspaceError = errorsByWorkspaceId[selectedWorkspaceId] ?? null;
   const selectedSessionKnown = Boolean(
@@ -1083,13 +1154,13 @@ export function SessionRoute() {
 
   const opencodeClient = useMemo(
     () =>
-      opencodeBaseUrl && token && !selectedWorkspaceError
+      opencodeBaseUrl && selectedWorkspaceServerToken && !selectedWorkspaceError
         ? createClient(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
-            token,
+            token: selectedWorkspaceServerToken,
             mode: "openwork",
           })
         : null,
-    [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, token],
+    [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
   const canCreateTask = Boolean(
     opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError,
@@ -1395,13 +1466,15 @@ export function SessionRoute() {
       return null;
     }
 
+    // Note: do NOT include `client`, `workspaceId`, `sessionId`,
+    // `opencodeBaseUrl`, or `openworkToken` here. SessionPage forwards those
+    // explicitly to SessionSurface from the per-workspace endpoint resolved
+    // by `resolveWorkspaceEndpoint`. If we leak them in here, the spread of
+    // `surfaceProps` in SessionPage overrides those correct values with the
+    // local server's, and remote workspaces silently end up calling the
+    // local server with the local `rem_*` id.
     return {
-      client,
-      workspaceId: selectedWorkspaceId,
       workspaceRoot: selectedWorkspaceRoot,
-      sessionId: selectedSessionId,
-      opencodeBaseUrl,
-      openworkToken: token,
       developerMode: false,
       modelLabel,
       onModelClick: () => {
@@ -1706,19 +1779,20 @@ export function SessionRoute() {
     const workspace = workspaces.find((item) => item.id === workspaceId);
     if (
       !workspace ||
-      !token ||
-      !baseUrl ||
       loading ||
       retryingWorkspaceIds.includes(workspaceId) ||
       errorsByWorkspaceId[workspaceId]
     ) {
       return;
     }
-    const workspaceOpencodeBaseUrl = `${(buildOpenworkWorkspaceBaseUrl(baseUrl, workspace.id) ?? baseUrl).replace(/\/+$|\/+$/g, "")}/opencode`;
+    const endpoint = resolveWorkspaceEndpoint(workspace, { baseUrl, token });
+    if (!endpoint || !endpoint.token) {
+      return;
+    }
     const workspaceClient = createClient(
-      workspaceOpencodeBaseUrl,
+      endpoint.opencodeBaseUrl,
       workspace.path?.trim() || undefined,
-      { token, mode: "openwork" },
+      { token: endpoint.token, mode: "openwork" },
     );
     try {
       const session = unwrap(
@@ -1966,12 +2040,16 @@ export function SessionRoute() {
 
   return (
     <>
-    {opencodeClient && selectedWorkspaceId && opencodeBaseUrl && token ? (
+    {opencodeClient && selectedWorkspaceEndpoint && opencodeBaseUrl && selectedWorkspaceServerToken ? (
       <ReactSessionRuntime
-        workspaceId={selectedWorkspaceId}
+        // Use the server-side workspace id (the one without the `rem_`
+        // prefix) so the React Query cache keys session-sync writes match
+        // the keys SessionSurface reads from. Otherwise events arrive but
+        // the UI never sees them and gets stuck on "thinking".
+        workspaceId={selectedWorkspaceEndpoint.workspaceId}
         sessionId={selectedSessionId}
         opencodeBaseUrl={opencodeBaseUrl}
-        openworkToken={token}
+        openworkToken={selectedWorkspaceServerToken}
       />
     ) : null}
     <SessionPage
@@ -1984,12 +2062,14 @@ export function SessionRoute() {
         workspaceType: selectedWorkspace.workspaceType,
       } : { workspaceType: "local" }}
       selectedWorkspaceRoot={selectedWorkspaceRoot}
-      runtimeWorkspaceId={selectedWorkspaceId || null}
+      selectedWorkspaceError={selectedWorkspaceError}
+      runtimeWorkspaceId={selectedWorkspaceEndpoint?.workspaceId || null}
+      opencodeBaseUrl={opencodeBaseUrl}
       workspaces={workspaces}
       clientConnected={canCreateTask}
       openworkServerStatus={client ? "connected" : "disconnected"}
-      openworkServerClient={client}
-      openworkServerToken={token}
+      openworkServerClient={selectedWorkspaceEndpoint?.client ?? client}
+      openworkServerToken={selectedWorkspaceServerToken}
       developerMode={false}
       headerStatus={canCreateTask ? t("status.connected") : t("session.loading_detail")}
       busyHint={effectiveLoading ? t("session.loading_detail") : null}
@@ -2023,7 +2103,7 @@ export function SessionRoute() {
           const workspace = workspaces.find((item) => item.id === workspaceId);
           if (client && workspace && !sessionsByWorkspaceId[workspaceId]?.length) {
             setRetryingWorkspaceIds((current) => Array.from(new Set([...current, workspaceId])));
-            void loadWorkspaceSessionsInBackground(client, [workspace]);
+            void loadWorkspaceSessionsInBackground([workspace]);
           }
           // Fire Tauri updates but don't await them — they're bookkeeping and
           // awaiting 2 IPC roundtrips on every click used to stall rapid
@@ -2038,9 +2118,11 @@ export function SessionRoute() {
           // applied on the workspace the user is already on at launch. See
           // issue #870.
           if (workspaceId && client) {
-            void client
-              .activateWorkspace(workspaceId)
-              .catch(() => undefined);
+            const workspace = workspaces.find((item) => item.id === workspaceId) ?? null;
+            const endpoint = endpointForWorkspace(workspace);
+            if (endpoint) {
+              void endpoint.client.activateWorkspace(endpoint.workspaceId).catch(() => undefined);
+            }
           }
           // If we remember what the user last opened here and that session
           // still exists in our local list, navigate. Otherwise stay put.
@@ -2064,34 +2146,8 @@ export function SessionRoute() {
           navigateToWorkspaceSession(workspaceId, sessionId);
         },
         onPrefetchSession: () => {},
-        onCreateTaskInWorkspace: async (workspaceId) => {
+        onCreateTaskInWorkspace: (workspaceId) => {
           void handleCreateTaskInWorkspace(workspaceId);
-          return;
-          const workspace = workspaces.find((item) => item.id === workspaceId)!;
-          if (!workspace || !token || !baseUrl) return;
-          const workspaceOpencodeBaseUrl = `${(buildOpenworkWorkspaceBaseUrl(baseUrl, workspace.id) ?? baseUrl).replace(/\/+$|\/+$/g, "")}/opencode`;
-          const workspaceClient = createClient(
-            workspaceOpencodeBaseUrl,
-            workspace.path?.trim() || undefined,
-            { token, mode: "openwork" },
-          );
-          const session = unwrap(
-            await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
-          );
-          // Make sure the new session is the active pair before navigating
-          // so the surface renders the new id immediately instead of going
-          // through the "unknown session" render tick.
-          setLegacySelectedWorkspaceId(workspaceId);
-          writeActiveWorkspaceId(workspaceId || null);
-          writeLastSessionFor(workspaceId, session.id);
-          setSessionsByWorkspaceId((current) => ({
-            ...current,
-            [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
-          }));
-          navigateToWorkspaceSession(workspaceId, session.id);
-          // Refresh in the background so the new session picks up its real
-          // metadata (title, timestamps) as soon as the server knows them.
-          void refreshRouteState();
         },
         onOpenRenameWorkspace: handleOpenRenameWorkspace,
         onShareWorkspace: handleShareWorkspace,
@@ -2164,7 +2220,9 @@ export function SessionRoute() {
       onDeleteSession={
         client && selectedWorkspaceId
           ? async (sessionId) => {
-              await client.deleteSession(selectedWorkspaceId, sessionId);
+              const endpoint = endpointForWorkspace(selectedWorkspace);
+              if (!endpoint) return;
+              await endpoint.client.deleteSession(endpoint.workspaceId, sessionId);
               if (selectedSessionId === sessionId) {
                 navigateToWorkspaceSession(selectedWorkspaceId);
               }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -5,7 +5,6 @@ import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom"
 import { SUGGESTED_PLUGINS } from "../../app/constants";
 import { createClient } from "../../app/lib/opencode";
 import {
-  buildOpenworkWorkspaceBaseUrl,
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
   readOpenworkServerSettings,
@@ -13,6 +12,7 @@ import {
   type OpenworkServerClient,
   type OpenworkWorkspaceInfo,
 } from "../../app/lib/openwork-server";
+import { resolveWorkspaceEndpoint } from "../../app/lib/workspace-endpoint";
 import { buildOpenworkEnvRuntimeKey } from "../../app/lib/openwork-env-runtime";
 import type {
   Client,
@@ -703,22 +703,23 @@ export function SettingsRoute() {
     [errorsByWorkspaceId, sessionsByWorkspaceId, workspaces],
   );
 
-  const opencodeBaseUrl = useMemo(() => {
-    if (!selectedWorkspace || !selectedWorkspaceId || !baseUrl) return "";
-    const mounted = buildOpenworkWorkspaceBaseUrl(baseUrl, selectedWorkspaceId) ?? baseUrl;
-    return `${mounted.replace(/\/+$/, "")}/opencode`;
-  }, [baseUrl, selectedWorkspace, selectedWorkspaceId]);
-
-  const opencodeClient = useMemo(
-    () =>
-      opencodeBaseUrl && token
-        ? createClient(opencodeBaseUrl, selectedWorkspaceRoot || undefined, {
-            token,
-            mode: "openwork",
-          })
-        : null,
-    [opencodeBaseUrl, selectedWorkspaceRoot, token],
+  const selectedWorkspaceEndpoint = useMemo(
+    () => resolveWorkspaceEndpoint(selectedWorkspace, { baseUrl, token }),
+    [baseUrl, selectedWorkspace, token],
   );
+  const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
+
+  const opencodeClient = useMemo(() => {
+    if (!selectedWorkspaceEndpoint || !selectedWorkspaceEndpoint.token) return null;
+    return createClient(
+      selectedWorkspaceEndpoint.opencodeBaseUrl,
+      selectedWorkspaceRoot || undefined,
+      {
+        token: selectedWorkspaceEndpoint.token,
+        mode: "openwork",
+      },
+    );
+  }, [selectedWorkspaceEndpoint, selectedWorkspaceRoot]);
 
   useEffect(() => {
     setActiveClient(opencodeClient);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -492,10 +492,72 @@ async function isDirectory(targetPath) {
 async function readJsonFile(targetPath, fallback) {
   try {
     const raw = await readFile(targetPath, "utf8");
-    return JSON.parse(raw);
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      const recovered = parseFirstJsonObject(raw);
+      if (recovered.ok) {
+        console.warn(`[json] recovered ${targetPath} from trailing invalid data`, error);
+        await writeJsonFileAtomic(targetPath, recovered.value);
+        return recovered.value;
+      }
+      throw error;
+    }
   } catch {
     return fallback;
   }
+}
+
+function parseFirstJsonObject(raw) {
+  let inString = false;
+  let escaped = false;
+  let depth = 0;
+  let start = -1;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") {
+      if (depth === 0) start = index;
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        try {
+          return { ok: true, value: JSON.parse(raw.slice(start, index + 1)) };
+        } catch {
+          return { ok: false, value: null };
+        }
+      }
+    }
+  }
+
+  return { ok: false, value: null };
+}
+
+async function writeJsonFileAtomic(outputPath, value) {
+  const content = `${JSON.stringify(value, null, 2)}\n`;
+  JSON.parse(content);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  const tempPath = `${outputPath}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  await writeFile(tempPath, content, "utf8");
+  await rename(tempPath, outputPath);
 }
 
 function normalizeDesktopBootstrapConfig(input) {
@@ -628,11 +690,52 @@ function remoteWorkspaceId(baseUrl, directory) {
   return stableWorkspaceId(key);
 }
 
+function parseOpenworkWorkspaceIdFromUrl(input) {
+  const raw = String(input ?? "").trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const workspaceIndex = segments.indexOf("workspace");
+    const legacyIndex = segments.indexOf("w");
+    const mountIndex = workspaceIndex >= 0 ? workspaceIndex : legacyIndex;
+    return mountIndex >= 0 && segments[mountIndex + 1]
+      ? decodeURIComponent(segments[mountIndex + 1])
+      : null;
+  } catch {
+    const match = raw.match(/\/(?:workspace|w)\/([^/?#]+)/);
+    if (!match?.[1]) return null;
+    try {
+      return decodeURIComponent(match[1]);
+    } catch {
+      return match[1];
+    }
+  }
+}
+
+function stripOpenworkWorkspaceMount(input) {
+  const raw = String(input ?? "").trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const segments = url.pathname.split("/").filter(Boolean);
+    const workspaceIndex = segments.indexOf("workspace");
+    const legacyIndex = segments.indexOf("w");
+    const mountIndex = workspaceIndex >= 0 ? workspaceIndex : legacyIndex;
+    if (mountIndex >= 0 && segments[mountIndex + 1]) {
+      const prefix = segments.slice(0, mountIndex).join("/");
+      url.pathname = prefix ? `/${prefix}` : "/";
+    }
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return raw.replace(/\/(?:workspace|w)\/[^/?#]+.*$/, "").replace(/\/+$/, "") || raw;
+  }
+}
+
 function openworkRemoteWorkspaceId(hostUrl, workspaceId) {
-  const key = String(workspaceId ?? "").trim()
-    ? `openwork::${hostUrl}::${String(workspaceId).trim()}`
-    : `openwork::${hostUrl}`;
-  return stableWorkspaceId(key);
+  const remoteWorkspaceId = String(workspaceId ?? "").trim() || parseOpenworkWorkspaceIdFromUrl(hostUrl);
+  if (remoteWorkspaceId) return `rem_${remoteWorkspaceId}`;
+  return `rem_${createHash("sha256").update(`openwork::${hostUrl}`).digest("hex").slice(0, 12)}`;
 }
 
 async function readWorkspaceOpenworkConfig(workspacePath) {
@@ -653,24 +756,66 @@ async function writeWorkspaceOpenworkConfig(workspacePath, config) {
 
 async function readWorkspaceState() {
   const state = await readJsonFile(workspaceStatePath(), EMPTY_WORKSPACE_LIST);
-  return {
+  const selectedId =
+    typeof state?.selectedId === "string"
+      ? state.selectedId
+      : typeof state?.selectedWorkspaceId === "string"
+        ? state.selectedWorkspaceId
+        : typeof state?.activeId === "string"
+          ? state.activeId
+          : "";
+  const watchedId =
+    typeof state?.watchedId === "string"
+      ? state.watchedId
+      : typeof state?.watchedWorkspaceId === "string"
+        ? state.watchedWorkspaceId
+        : null;
+  const activeId = typeof state?.activeId === "string" ? state.activeId : null;
+  const workspaces = Array.isArray(state?.workspaces) ? state.workspaces : [];
+  let changed = false;
+  const idMap = new Map();
+  const migratedWorkspaces = workspaces.map((entry) => {
+    const workspace = entry && typeof entry === "object" ? entry : normalizeWorkspaceEntry(entry ?? {});
+    if (workspace.workspaceType !== "remote" || workspace.remoteType !== "openwork") return workspace;
+
+    const remoteWorkspaceId = String(workspace.openworkWorkspaceId ?? "").trim()
+      || parseOpenworkWorkspaceIdFromUrl(workspace.openworkHostUrl)
+      || parseOpenworkWorkspaceIdFromUrl(workspace.baseUrl);
+    if (!remoteWorkspaceId) return workspace;
+
+    const hostUrl = stripOpenworkWorkspaceMount(workspace.openworkHostUrl) || stripOpenworkWorkspaceMount(workspace.baseUrl);
+    const nextId = openworkRemoteWorkspaceId(hostUrl ?? workspace.baseUrl, remoteWorkspaceId);
+    idMap.set(workspace.id, nextId);
+    const nextWorkspace = {
+      ...workspace,
+      id: nextId,
+      baseUrl: hostUrl,
+      openworkWorkspaceId: remoteWorkspaceId,
+      openworkHostUrl: hostUrl,
+    };
+    if (workspace.id !== nextWorkspace.id || workspace.baseUrl !== nextWorkspace.baseUrl || workspace.openworkWorkspaceId !== nextWorkspace.openworkWorkspaceId || workspace.openworkHostUrl !== nextWorkspace.openworkHostUrl) {
+      changed = true;
+    }
+    return nextWorkspace;
+  });
+
+  const migratedSelectedId = idMap.get(selectedId) ?? selectedId;
+  const migratedWatchedId = watchedId ? idMap.get(watchedId) ?? watchedId : null;
+  const migratedActiveId = activeId ? idMap.get(activeId) ?? activeId : null;
+  if (migratedSelectedId !== selectedId || migratedWatchedId !== watchedId || migratedActiveId !== activeId) changed = true;
+
+  const nextState = {
     selectedId:
-      typeof state?.selectedId === "string"
-        ? state.selectedId
-        : typeof state?.selectedWorkspaceId === "string"
-          ? state.selectedWorkspaceId
-          : typeof state?.activeId === "string"
-            ? state.activeId
-            : "",
-    watchedId:
-      typeof state?.watchedId === "string"
-        ? state.watchedId
-        : typeof state?.watchedWorkspaceId === "string"
-          ? state.watchedWorkspaceId
-          : null,
-    activeId: typeof state?.activeId === "string" ? state.activeId : null,
-    workspaces: Array.isArray(state?.workspaces) ? state.workspaces : [],
+      migratedSelectedId,
+    watchedId: migratedWatchedId,
+    activeId: migratedActiveId,
+    workspaces: migratedWorkspaces,
   };
+
+  if (changed) {
+    return writeWorkspaceState(nextState);
+  }
+  return nextState;
 }
 
 async function writeWorkspaceState(nextState) {
@@ -688,8 +833,7 @@ async function writeWorkspaceState(nextState) {
     watchedWorkspaceId: watchedId,
     activeId: selectedId || null,
   };
-  await mkdir(path.dirname(outputPath), { recursive: true });
-  await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+  await writeJsonFileAtomic(outputPath, output);
   return output;
 }
 
@@ -1164,12 +1308,17 @@ async function handleDesktopInvoke(event, command, ...args) {
       }
       const remoteType = input.remoteType === "opencode" ? "opencode" : "openwork";
       const directory = typeof input.directory === "string" && input.directory.trim() ? input.directory.trim() : null;
-      const openworkHostUrl = typeof input.openworkHostUrl === "string" && input.openworkHostUrl.trim()
+      const rawOpenworkHostUrl = typeof input.openworkHostUrl === "string" && input.openworkHostUrl.trim()
         ? input.openworkHostUrl.trim()
         : null;
+      const openworkHostUrl = remoteType === "openwork"
+        ? stripOpenworkWorkspaceMount(rawOpenworkHostUrl ?? baseUrl)
+        : rawOpenworkHostUrl;
       const openworkWorkspaceId = typeof input.openworkWorkspaceId === "string" && input.openworkWorkspaceId.trim()
         ? input.openworkWorkspaceId.trim()
-        : null;
+        : remoteType === "openwork"
+          ? parseOpenworkWorkspaceIdFromUrl(rawOpenworkHostUrl) || parseOpenworkWorkspaceIdFromUrl(baseUrl)
+          : null;
       const id = remoteType === "openwork"
         ? openworkRemoteWorkspaceId(openworkHostUrl ?? baseUrl, openworkWorkspaceId)
         : remoteWorkspaceId(baseUrl, directory);
@@ -1205,9 +1354,10 @@ async function handleDesktopInvoke(event, command, ...args) {
       const input = args[0] ?? {};
       const workspaceId = String(input.workspaceId ?? "").trim();
       if (!workspaceId) throw new Error("workspaceId is required");
+      const { workspaceId: _workspaceId, ...patch } = input;
       return mutateWorkspaceState((state) => {
         state.workspaces = state.workspaces.map((entry) =>
-          entry.id === workspaceId ? { ...entry, ...input } : entry,
+          entry.id === workspaceId ? { ...entry, ...patch } : entry,
         );
         return state;
       });


### PR DESCRIPTION
## Summary

Connecting to a remote OpenWork worker (the `Add a worker` → `Connect remote` flow) was broken end-to-end on the desktop app:

- Sending a message to a remote workspace returned `204` from the host but the UI hung on "thinking" forever and never rendered the agent reply.
- Activating a remote session sometimes routed reads to the *local* server using a `rem_*` id and returned 404, so the chat pane went blank.
- The sidebar's error state for an unreachable remote worker just said "failed", with no recovery guidance.

Root cause was that the local desktop registry id (`rem_<openworkWorkspaceId>`) leaked into URLs and React Query cache keys, while the OpenCode SDK and `SessionSurface` expected the server-side id (`ws_*`). Different parts of the app each composed `<baseUrl>/workspace/<id>` themselves and disagreed.

This PR makes a single helper the source of truth for per-workspace routing, and surfaces remote failures with actionable copy.

## Changes

### 1. `fix(app): centralize workspace endpoint resolution for remote workers`
- New `apps/app/src/app/lib/workspace-endpoint.ts` exporting `resolveWorkspaceEndpoint(workspace, localServer)` → `{ baseUrl, token, workspaceId, isRemote, client, mountedBaseUrl, opencodeBaseUrl }`. Hand-composed `<baseUrl>/workspace/<id>` is now treated as a bug pattern.
- `session-route.tsx` routes every workspace-scoped call (listSessions / activate / reload / poll / delete / create-task) through `endpoint.client` + `endpoint.workspaceId`.
- `mergeRouteWorkspaces` filters server entries whose id matches a desktop `rem_*` workspace, so a stale local registration cannot clobber `workspaceType: "remote"` and connection fields.
- `<ReactSessionRuntime>` now receives `endpoint.workspaceId` (server-side id), so session-sync writes land under the same React Query key that `SessionSurface` reads from. This is the fix for the "stuck on thinking" hang.
- `session-page.tsx`: `SessionSurface` JSX spreads `props.surface` first, then explicit routing props win; main-pane shows a `RemoteConnectionIssueCard` driven by `selectedWorkspaceError` instead of an empty state for failing remote workers.
- `settings-route.tsx` migrated to the same helper.

### 2. `fix(electron): migrate persisted remote workspaces and proxy Request fetches`
- `apps/desktop/electron/main.mjs` migrates `openwork-workspaces.json` on read: legacy remote entries get rewritten to `rem_<openworkWorkspaceId>` and any `/workspace/<id>` suffix is stripped from `baseUrl`.
- Atomic temp+rename writer with trailing-junk recovery for the registry file.
- `workspaceUpdateRemote` payload no longer carries the control-only `workspaceId` field.
- `desktopFetch` accepts `Request` objects (the OpenCode SDK calls `_fetch(request)` for prompt POSTs) and forwards method, headers, and body — fixes Authorization being dropped on remote sends.
- Returns `null` body for null-body status codes (101/204/205/304) so the Response constructor doesn't throw on `204 ""`.

### 3. `feat(app): surface remote workspace errors with actionable diagnostics`
- `isRemoteConnectionWorkspace` and `isRemoteConnectionErrorMessage` helpers in `apps/app/src/app/utils/index.ts`.
- Sidebar (`app-sidebar.tsx`, `workspace-session-list.tsx`) renders `RemoteConnectionIssueCard` as the primary branch for remote workers in trouble, with the canonical copy: \"Upgrade the OpenWork host and try again. If this continues, contact team@openworklabs.com.\"
- `remote-workspace-diagnostics.ts` rewritten to probe the host root health endpoint, classify failures, and emit upgrade-or-contact guidance.

## Evidence

### Tests
- `pnpm --filter @openwork/app test:remote-diagnostics` → **23 pass / 0 fail** (84 expect() calls).

### Manual verification
Verified end-to-end against a remote OpenWork host on the LAN (host on `192.168.1.6:57973`, app on a separate machine):

- `GET /workspace/ws_*/sessions/<sid>` returns 200; transcript loads.
- `POST /workspace/ws_*/sessions/<sid>/message/prompt_async` returns 204.
- SSE stream from the remote host streams agent events into the local UI; the previous "stuck on thinking" hang is gone — agent replies render in real time.
- Disconnecting the remote host now shows the upgrade/contact card in both sidebar and main pane instead of silently empty state.

I did not capture screenshots in the PR repo per the make-pr skill (no committed binary evidence). Reviewers can reproduce the flow with: `Add a worker` → `Connect remote` → URL + token → send a message.

### Out of scope / not in this PR
- `apps/server-v2/*` changes that appeared earlier on the branch were reverted before commit; this PR only touches `apps/app` and `apps/desktop`.
- Remaining call sites of `buildOpenworkWorkspaceBaseUrl` for non-API display paths (`share-workspace-state.ts`, `config-view.tsx`, `messaging-view-state.ts`, `connections/store.ts`) were left untouched — they don't drive routing and can be migrated separately if desired.

## Test instructions

1. Pull the branch and `pnpm install`.
2. Boot the desktop app pointing at any remote OpenWork host you have access to (or stand one up via openwork-orchestrator).
3. `Add a worker` → `Connect remote` with the host URL + token.
4. Open the new workspace, start a new session, send a prompt.
5. Verify the agent reply streams into the UI (no "stuck on thinking").
6. Stop the remote host. Verify the sidebar and main pane show the upgrade/contact card instead of an empty error state.
7. `pnpm --filter @openwork/app test:remote-diagnostics` should pass 23/23.