### PR TITLE
fix(app): style and gate reasoning messages, fix streaming classification

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -579,7 +579,7 @@ function StepRow(props: {
     return (
       <div
         data-reasoning="true"
-        className="font-mono text-[12px] leading-[1.7] text-gray-8 whitespace-pre-wrap"
+        className="font-mono text-[13px] leading-[1.7] text-gray-8 whitespace-pre-wrap"
       >
         <div className="max-w-[720px]">{cleanReasoningPreview(raw) || headline}</div>
       </div>

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -577,7 +577,10 @@ function StepRow(props: {
       ? (props.part as { text: string }).text
       : "";
     return (
-      <div className="text-[14px] leading-[1.7] text-gray-9 whitespace-pre-wrap">
+      <div
+        data-reasoning="true"
+        className="font-mono text-[12px] leading-[1.7] text-gray-8 whitespace-pre-wrap"
+      >
         <div className="max-w-[720px]">{cleanReasoningPreview(raw) || headline}</div>
       </div>
     );

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -33,6 +33,7 @@ import type { ReactComposerNotice } from "./composer/notice";
 import { SessionDebugPanel } from "./debug-panel";
 import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
 import { SessionTranscript } from "./message-list";
+import { useLocal } from "../../../kernel/local-provider";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import {
@@ -246,6 +247,8 @@ function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }
 }
 
 export function SessionSurface(props: SessionSurfaceProps) {
+  const local = useLocal();
+  const showThinking = local.prefs.showThinking;
   const [draft, setDraft] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [mentions, setMentions] = useState<Record<string, "agent" | "file">>({});
@@ -890,6 +893,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     messages={renderedMessages}
                     isStreaming={chatStreaming}
                     developerMode={props.developerMode}
+                    showThinking={showThinking}
                     scrollElement={() => scrollRef.current}
                   />
                   {error ? (

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -369,10 +369,34 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const mapped = toUIPart(part);
     if (!mapped) return;
     const pending = entry.pendingDeltas.get(part.id);
+    // Seed the new part with any deltas that arrived before this
+    // declaration. We deliberately ignore `pending.reasoning` — it
+    // can't be trusted because opencode emits `field: "text"` for
+    // both text and reasoning streams. The part's actual kind
+    // (`mapped.type`) is the source of truth.
+    //
+    // Both `pending.text` and `mapped.text` are cumulative views of the
+    // same stream, so we keep whichever is longer instead of
+    // concatenating (concatenation double-counts the bytes that landed
+    // in both). Without this, reasoning text shows up duplicated in the
+    // streaming UI.
     const seededPart =
-      pending && ((mapped.type === "text" && !pending.reasoning) || (mapped.type === "reasoning" && pending.reasoning))
-        ? { ...mapped, text: `${mapped.text}${pending.text}`, state: "streaming" as const }
+      pending && (mapped.type === "text" || mapped.type === "reasoning")
+        ? {
+            ...mapped,
+            text: pending.text.length > mapped.text.length ? pending.text : mapped.text,
+            state: "streaming" as const,
+          }
         : mapped;
+    // Drop any deltas for this partID still queued in the rAF flush
+    // buffer — they've already been incorporated into `mapped.text`.
+    // Without this, the rAF flush would re-append them on top of the
+    // cumulative text we just wrote, duplicating bytes mid-stream.
+    if (entry.deltaFlushBuffer.length > 0) {
+      entry.deltaFlushBuffer = entry.deltaFlushBuffer.filter(
+        (item) => item.partId !== part.id,
+      );
+    }
     queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, part.sessionID), (current = []) => {
       // If we already have this message, keep its role; otherwise infer
       // from the alternation pattern. Only the newly-stubbed case needs
@@ -398,13 +422,17 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     };
     if (!props.sessionID || !props.messageID || !props.partID || !props.delta) return;
     if (!isTrackedSession(entry, props.sessionID)) return;
-    // Buffer this delta and let the frame flusher apply all queued deltas
-    // for this entry in a single setQueryData call per affected session.
+    // Note: we do NOT trust `props.field` to disambiguate reasoning vs
+    // text. Opencode emits `field: "text"` for both kinds; the actual
+    // distinction lives on the part's `type`, which we only see via
+    // `message.part.updated`. The flusher resolves the kind at apply
+    // time, falling back to `pendingDeltas` if the part hasn't been
+    // declared yet.
     entry.deltaFlushBuffer.push({
       sessionId: props.sessionID!,
       messageId: props.messageID!,
       partId: props.partID!,
-      reasoning: props.field === "reasoning",
+      reasoning: false,
       delta: props.delta!,
     });
     scheduleDeltaFlush(entry, workspaceId);
@@ -467,15 +495,22 @@ function flushDeltas(entry: SyncEntry, workspaceId: string) {
             next = upsertMessage(next, { id: item.messageId, role, parts: [] });
             ensuredMessageIds.add(item.messageId);
           }
-          next = appendDelta(next, item.messageId, item.partId, item.delta, item.reasoning);
-          // If the delta landed on a synthetic "no matching part" case, keep
-          // the text so a later message.part.updated event can stitch it.
-          const message = next.find((m) => m.id === item.messageId);
-          const matched = message?.parts.some((part) =>
+          // Resolve the part kind from the transcript instead of trusting
+          // the inbound delta event (opencode emits `field: "text"` for
+          // both text and reasoning parts). If the part hasn't been
+          // declared yet via `message.part.updated`, defer the delta into
+          // `entry.pendingDeltas` so the part can be created with the
+          // correct kind later. Without this, every delta lands as a text
+          // part — and reasoning content leaks into the response markdown
+          // until the next reload reconstructs the transcript from the
+          // snapshot.
+          const ownerMessage = next.find((m) => m.id === item.messageId);
+          const ownerPart = ownerMessage?.parts.find((part) =>
             (part.type === "dynamic-tool" && part.toolCallId === item.partId) ||
               getPartMetadataId(part) === item.partId,
           );
-          if (!matched) {
+
+          if (!ownerPart) {
             const existing = entry.pendingDeltas.get(item.partId) ?? {
               messageId: item.messageId,
               reasoning: item.reasoning,
@@ -483,7 +518,11 @@ function flushDeltas(entry: SyncEntry, workspaceId: string) {
             };
             existing.text += item.delta;
             entry.pendingDeltas.set(item.partId, existing);
+            continue;
           }
+
+          const reasoning = ownerPart.type === "reasoning";
+          next = appendDelta(next, item.messageId, item.partId, item.delta, reasoning);
         }
         return next;
       },


### PR DESCRIPTION
## Summary

- Reasoning messages now render in their own monospaced div (13px, lighter gray `text-gray-8`), visually distinct from regular response text (15px, primary). Marked with `data-reasoning="true"` for downstream styling.
- Wired the existing **Settings → General → Show model reasoning** preference into the chat surface. Previously the toggle persisted to `localStorage` but `<SessionTranscript>` never read it, so reasoning was always hidden for normal users (developer mode only).
- Fixed a streaming bug where reasoning content would leak into the response markdown block until a reload. Root cause was in `session-sync.ts`: `field === "reasoning"` never matches because opencode emits `field: "text"` for both kinds; every delta was being appended as a text part. Fix resolves the kind from the actual cached part type, defers pre-declaration deltas via `pendingDeltas`, drops already-incorporated deltas from the rAF flush buffer, and seeds with the longer of pending/mapped to avoid double-counting.

## Evidence

### Screenshots

**Toggle ON — reasoning visible, monospaced + smaller + lighter gray, separate from response:**
![reasoning on](https://litter.catbox.moe/rtq622.png)

**Toggle OFF — reasoning hidden:**
![reasoning off](https://litter.catbox.moe/kikgih.png)

**Streaming with toggle ON (post-fix) — clean separation, no duplication, no leak into response markdown:**
![streaming clean](https://litter.catbox.moe/700mqk.png)

### Build verification
- `pnpm --filter @openwork/app build` — passed (built in 2.73s)
- Typecheck status unchanged from `origin/dev` baseline (208 pre-existing errors in `settings-route.tsx` / `welcome-route.tsx`, none introduced by this PR)

### UI verification (Chrome MCP)
Verified all four streaming-state combinations in the running desktop app, sampled DOM at 100–250ms intervals during streams:

| Toggle | State | Result |
|---|---|---|
| ON | post-reload | reasoning rendered in its own `[data-reasoning="true"]` block, response in markdown block, no overlap |
| ON | streaming live | same — reasoning streams in styled, response separate |
| OFF | post-reload | no reasoning blocks in DOM, response only |
| OFF | streaming live | no reasoning blocks in DOM, response streams clean |

Computed style on rendered reasoning element:
```json
{ "fontSize": "13px", "fontFamily": "ui-monospace", "color": "rgb(96, 96, 96)" }
```
Compared to response markdown body: `{ "fontSize": "15px", "fontFamily": "IBM Plex Sans, ...", "color": "rgb(238, 238, 238)" }`.

- Console errors: none
- Failed network requests: none related to this change

## Test instructions

1. From `_repos/openwork`: `pnpm dev`
2. Open a session and ensure `Settings → General → Show model reasoning` is **Off** — send a prompt to a reasoning-capable model (e.g. `opencode/big-pickle`). Confirm reasoning is hidden during and after streaming.
3. Toggle the setting **On** and reload. Send another prompt. Confirm reasoning appears in monospace, smaller, lighter gray than response, with no duplication or leak into the response block during streaming.
4. Optionally inspect: any reasoning element should have `data-reasoning="true"` and no overlap with `.markdown-content` siblings.