### PR TITLE
feat(provider-auth): allow signing in to OpenCode Zen

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -40,7 +40,7 @@ type ProviderOAuthSession = ProviderOAuthStartResult & {
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
-  opencode: "OpenCode",
+  opencode: "OpenCode Zen",
   openai: "OpenAI",
   anthropic: "Anthropic",
   google: "Google",
@@ -134,6 +134,19 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     const normalizedId = id.trim().toLowerCase();
     const normalizedName = fallbackName?.trim().toLowerCase() ?? "";
     return normalizedId === "anthropic" || normalizedName === "anthropic";
+  };
+
+  const isOpencodeZenProvider = (id: string) => id.trim().toLowerCase() === "opencode";
+
+  const OPENCODE_ZEN_KEY_URL = "https://opencode.ai/auth";
+
+  const openExternalUrl = async (url: string) => {
+    if (!url) return;
+    if (isDesktopRuntime()) {
+      await openDesktopUrl(url);
+      return;
+    }
+    window.open(url, "_blank", "noopener,noreferrer");
   };
 
   const isClaudeProMaxMethod = (method: ProviderAuthMethod) => {
@@ -635,6 +648,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     if (method.type === "cloud") {
       return method.description ?? "Use the provider and credential managed by your organization.";
     }
+    if (isOpencodeZenProvider(entry.id)) {
+      return "Sign in to OpenCode Zen with an API key to unlock paid models alongside the free tier.";
+    }
     return "Paste a secret key that OpenWork stores locally on this device.";
   };
 
@@ -798,16 +814,34 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                   <div className="flex items-center justify-between gap-4">
                     <div>
                       <div className="text-sm font-medium text-gray-12">{selectedEntry.name}</div>
-                      <div className="text-xs text-gray-10 mt-1">Paste your API key to connect.</div>
+                      <div className="text-xs text-gray-10 mt-1">
+                        {isOpencodeZenProvider(selectedEntry.id)
+                          ? "Sign in to OpenCode Zen with an API key from opencode.ai/auth."
+                          : "Paste your API key to connect."}
+                      </div>
                     </div>
                     <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
                       Back
                     </Button>
                   </div>
+                  {isOpencodeZenProvider(selectedEntry.id) ? (
+                    <div className="rounded-lg border border-indigo-5/30 bg-indigo-3/15 px-3 py-2.5 text-xs text-gray-11 space-y-1.5">
+                      <div>
+                        OpenCode Zen gives you access to the best coding models. Free models keep working without a key.
+                      </div>
+                      <button
+                        type="button"
+                        className="text-indigo-11 hover:text-indigo-12 underline underline-offset-2 font-medium"
+                        onClick={() => void openExternalUrl(OPENCODE_ZEN_KEY_URL)}
+                      >
+                        Get an API key →
+                      </button>
+                    </div>
+                  ) : null}
                   <TextInput
                     label="API key"
                     type="password"
-                    placeholder="sk-..."
+                    placeholder={isOpencodeZenProvider(selectedEntry.id) ? "ock_..." : "sk-..."}
                     value={apiKeyInput}
                     onChange={(event) => {
                       setApiKeyInput(event.currentTarget.value);

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -852,7 +852,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     for (const provider of availableProviders ?? []) {
       const id = provider.id?.trim();
-      if (!id || id === "opencode") continue;
+      if (!id) continue;
       if (!Array.isArray(provider.env) || provider.env.length === 0) continue;
       const existing = merged[id] ?? [];
       if (existing.some((method) => method.type === "api")) continue;

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1761,6 +1761,9 @@ export function SettingsRoute() {
         // Hide any provider the org blocks at the desktop layer so users
         // can't connect a forbidden one (dev #1505). Same helper covers
         // opencode-provider gating via the `blockZenModel` restriction.
+        // We also strip the matching key from `authMethods` because the
+        // modal builds its entry list from `Object.keys(authMethods)`,
+        // not from `providers`.
         providers={providerAuthSnapshot.providerAuthProviders.filter(
           (provider) =>
             !isDesktopProviderBlocked({
@@ -1769,7 +1772,15 @@ export function SettingsRoute() {
             }),
         )}
         connectedProviderIds={providerConnectedIds}
-        authMethods={providerAuthSnapshot.providerAuthMethods}
+        authMethods={Object.fromEntries(
+          Object.entries(providerAuthSnapshot.providerAuthMethods).filter(
+            ([providerId]) =>
+              !isDesktopProviderBlocked({
+                providerId,
+                checkRestriction: checkDesktopRestriction,
+              }),
+          ),
+        )}
         onSelect={providerAuthStore.startProviderAuth}
         onSubmitApiKey={providerAuthStore.submitProviderApiKey}
         onConnectCloudProvider={providerAuthStore.connectCloudProvider}


### PR DESCRIPTION
## Summary

- Expose **OpenCode Zen** in the Provider Auth modal so users can paste an API key from `https://opencode.ai/auth` and unlock the paid Zen models alongside the free public-tier models that already work without auth.
- Honor the `blockZenModel` org policy by also stripping blocked provider IDs from `authMethods` (not just `providers`) at the modal call site.
- Add Zen-branded copy + a "Get an API key →" link in the API key view.

## Why it was missing

Two layered bugs:

1. `apps/app/src/react-app/domains/connections/provider-auth/store.ts:855` — `buildProviderAuthMethods` had an explicit \`if (id === "opencode") continue;\` that prevented an \`{ type: "api" }\` method from ever being registered for the opencode provider. The modal builds entries from \`Object.keys(authMethods).filter(entry => entry.methods.length > 0)\`, so opencode was always filtered out.
2. \`apps/app/src/react-app/shell/settings-route.tsx:1764\` — the \`isDesktopProviderBlocked\` filter was only applied to \`providers\`, not \`authMethods\`. The comment claimed it covered the zen restriction, but it only worked because step 1 was independently hiding opencode entirely. Removing the skip would have leaked opencode to orgs that disabled it via \`blockZenModel\`.

## Changes

| File | Change |
|---|---|
| \`store.ts\` | Drop the \`id === "opencode"\` early-continue. Opencode now gets an "API key" method like every other env-keyed provider (env: \`OPENCODE_API_KEY\`). |
| \`settings-route.tsx\` | Also filter \`authMethods\` (not just \`providers\`) through \`isDesktopProviderBlocked\`. This is what actually enforces \`blockZenModel\` on the modal. |
| \`provider-auth-modal.tsx\` | Default fallback label \`"OpenCode" → "OpenCode Zen"\`. Added Zen-branded blurb + clickable "Get an API key →" link to \`https://opencode.ai/auth\` (uses \`openDesktopUrl\` in Tauri, \`window.open\` in web). Friendlier method-selection description. Placeholder hint \`ock_...\` for opencode. |

## Org policy still respected

When the org sets \`blockZenModel: true\`:
- \`isDesktopProviderBlocked({ providerId: "opencode", ... })\` → \`true\`
- Both \`providers\` and \`authMethods\` are stripped of \`opencode\` at the call site → modal never sees it
- \`runDesktopAppRestrictionSyncEffects\` continues to disable the provider in \`opencode.json\` server-side (unchanged)

## Evidence

### Build verification

- \`pnpm --filter @openwork/app build\` — **passed** (vite, 2843 modules, 2.65s)
- \`pnpm typecheck\` — **no new errors** (208 pre-existing baseline errors before/after, none in the files I touched)

### UI verification

Not yet captured. Did **not** boot the desktop app or run Chrome MCP in this session — happy to follow up with screenshots if needed. The change is small and the submit path (\`c.auth.set({ providerID: "opencode", auth: { type: "api", key } })\`) is byte-for-byte the same call upstream's TUI makes (\`_repos/opencode/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx:230-236\`).

### Reference

- Upstream zen sign-in: \`_repos/opencode/packages/opencode/src/cli/cmd/auth.ts:347-369\` — opencode CLI prompts for an API key from \`https://opencode.ai/auth\`. No OAuth, just paste-the-key.
- Upstream provider loader: \`_repos/opencode/packages/opencode/src/provider/provider.ts:104-125\` — without a key, \`opencode\` provider auto-loads with \`apiKey: "public"\` so free models still work. With a key, paid models become available.

## Test instructions

1. Boot the desktop app dev stack.
2. Open **Settings → General → Connect provider**.
3. Verify **OpenCode Zen** now appears in the provider list.
4. Click it → API key view should show:
   - Description: "Sign in to OpenCode Zen with an API key from opencode.ai/auth."
   - "Get an API key →" link that opens \`https://opencode.ai/auth\`.
   - Placeholder \`ock_...\`.
5. Paste a valid Zen API key, click **Save key**. The opencode server writes it to its \`auth.json\`. Provider list refreshes, paid Zen models become available in the model picker.
6. As an org admin, toggle **Allow usage of OpenCode Zen model** off in Den web → re-open the modal in the desktop app → **OpenCode Zen** should disappear from the list.