### PR TITLE
fix(server): normalize Windows opencode directory paths

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -3336,9 +3336,20 @@ async function readOpenworkConfig(workspaceRoot: string): Promise<Record<string,
 
 function resolveOpencodeDirectory(workspace: WorkspaceInfo): string | null {
   const explicit = workspace.directory?.trim() ?? "";
-  if (explicit) return explicit;
-  if (workspace.workspaceType === "local") return workspace.path;
+  if (explicit) return normalizeOpencodeDirectory(explicit);
+  if (workspace.workspaceType === "local") return normalizeOpencodeDirectory(workspace.path);
   return null;
+}
+
+function normalizeOpencodeDirectory(directory: string): string {
+  // OpenCode stores/list-filters Windows sessions by regular drive paths
+  // (`C:\Users\...`). Electron can persist local workspaces as extended-length
+  // paths (`\\?\C:\Users\...`); passing those through as the directory query
+  // makes OpenCode return an empty session list even though the sessions exist.
+  if (process.platform === "win32") {
+    return directory.replace(/^\\\\\?\\/, "").replace(/^\/\/\?\//, "");
+  }
+  return directory;
 }
 
 function buildOpencodeReloadUrl(baseUrl: string, directory?: string | null): string {


### PR DESCRIPTION
## Summary
-

## Why
-

## Issue
- Closes #

## Scope
-

## Out of scope
-

## Testing
### Ran
- `...`

### Result
- pass/fail:
- if fail, exact files/errors:

## CI status
- pass:
- code-related failures:
- external/env/auth blockers:

## Manual verification
1.
2.
3.

## Evidence
- video/screenshot link, or `N/A (docs-only)`

## Risk
-

## Rollback
-
