### PR TITLE
fix(app): keep localServerRef fresh inside refreshRouteState

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -626,6 +626,10 @@ export function SessionRoute() {
       const { normalizedBaseUrl, resolvedToken, resolvedHostToken, hostInfo } = await resolveOpenworkConnection();
       setOpenworkServerHostInfoState(hostInfo);
       if (!normalizedBaseUrl || !resolvedToken) {
+        // Keep `localServerRef` in lockstep with the disconnected state.
+        // Otherwise a previously-cached baseUrl/token would still resolve a
+        // (now invalid) endpoint for any callback that consults the ref.
+        localServerRef.current = { baseUrl: "", token: "" };
         setClient(null);
         setBaseUrl("");
         setToken("");
@@ -635,6 +639,16 @@ export function SessionRoute() {
         setLegacySelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "");
         return;
       }
+
+      // Update the local-server ref synchronously, BEFORE we kick off any
+      // workspace-scoped requests below. `endpointForWorkspace` reads from
+      // this ref synchronously; the `useEffect` that mirrors `[baseUrl,
+      // token]` into the ref doesn't run until after the next React commit,
+      // which is too late for the `activateWorkspace` and
+      // `loadWorkspaceSessionsInBackground` calls that fire later in this
+      // function. Stale ref => `resolveWorkspaceEndpoint` returns null for
+      // local workspaces => sidebar gets stuck in "loading" forever.
+      localServerRef.current = { baseUrl: normalizedBaseUrl, token: resolvedToken };
 
       const openworkClient = createOpenworkServerClient({
         baseUrl: normalizedBaseUrl,


### PR DESCRIPTION
## Summary

After #1702 was merged, local workspaces broke on initial app load:

- The session list stayed in a loading state for a really long time (in practice: forever) for every local workspace.
- Sending a message just stayed on \"Thinking\" — the agent never replied.

Both symptoms had the same root cause: a stale-ref race introduced when we swapped \`endpointForWorkspace\` to read from \`localServerRef.current\`.

## Root cause

#1702 made \`endpointForWorkspace\` a stable callback (deps \`[]\`) that reads \`localServerRef.current\` synchronously, with a \`useEffect\` mirroring \`[baseUrl, token]\` into the ref:

\`\`\`ts
const localServerRef = useRef<{ baseUrl: string; token: string }>({ baseUrl: \"\", token: \"\" });
useEffect(() => {
  localServerRef.current = { baseUrl, token };
}, [baseUrl, token]);
const endpointForWorkspace = useCallback(
  (workspace) => resolveWorkspaceEndpoint(workspace, localServerRef.current),
  [],
);
\`\`\`

Inside \`refreshRouteState\` we then synchronously call those endpoint-consuming functions immediately after the state setters:

\`\`\`ts
setClient(openworkClient);
setBaseUrl(normalizedBaseUrl);
setToken(resolvedToken);
// ...
const nextEndpoint = endpointForWorkspace(nextWorkspace);
if (nextEndpoint) void nextEndpoint.client.activateWorkspace(...);
// ...
void loadWorkspaceSessionsInBackground(orderedWorkspaces);
\`\`\`

But the \`useEffect\` that updates the ref doesn't run until after the next React commit. So when \`endpointForWorkspace\` evaluates synchronously here, \`localServerRef.current\` is still \`{ baseUrl: \"\", token: \"\" }\`. \`resolveWorkspaceEndpoint\` for **local** workspaces requires a non-empty local \`baseUrl\` and returns \`null\`.

Consequences for local workspaces on first refresh:

- \`activateWorkspace\` never fires, but the id is still added to \`launchActivatedWorkspaceIdsRef\`, so it never retries. OpenCode runtime is never bound to the workspace → messages submit but no events stream → UI stays on \"Thinking\" forever.
- \`loadWorkspaceSessionsInBackground\` returns at the \`if (!endpoint) return;\` guard before clearing \`retryingWorkspaceIds\` → the sidebar's per-workspace status stays \`\"loading\"\` forever.

Remote workspaces weren't affected because \`resolveWorkspaceEndpoint\` for remote uses the workspace's own \`baseUrl\`, not \`localServerRef\`.

## Fix

Update \`localServerRef.current\` synchronously inside \`refreshRouteState\` both on the disconnected and connected paths, before any synchronous \`endpointForWorkspace\` use. The \`useEffect\` mirror is still there as a safety net for state changes that don't go through \`refreshRouteState\`.

\`\`\`ts
localServerRef.current = { baseUrl: normalizedBaseUrl, token: resolvedToken };

const openworkClient = createOpenworkServerClient({ ... });
\`\`\`

## Evidence

Verified end-to-end via Chrome MCP against the local dev renderer (\`localhost:5173\`) on a local workspace (\`ws_86921c7eb25a\`).

**Before fix** — only \`/events?since=0\` polling, no \`listSessions\`, no \`activate\`:
\`\`\`
GET http://127.0.0.1:54544/workspace/ws_86921c7eb25a/events?since=0 [200]
GET http://127.0.0.1:54544/workspace/ws_86921c7eb25a/events?since=0 [200]
... (no sessions endpoint hit)
\`\`\`
Sidebar showed empty loading skeletons under the workspace; new-session message never returned.

**After fix** — full route activates and session list loads:
\`\`\`
POST http://127.0.0.1:54544/workspaces/ws_86921c7eb25a/activate [200]
GET  http://127.0.0.1:54544/workspace/ws_86921c7eb25a/sessions?limit=200 [200]
GET  http://127.0.0.1:54544/workspace/ws_86921c7eb25a/sessions/ses_.../snapshot?limit=140 [200]
GET  http://127.0.0.1:54544/workspace/ws_86921c7eb25a/events [200]
\`\`\`
Sidebar populated with 2 real sessions. Sent a fresh prompt; session went through \"Thinking\" and the agent streamed back: _\"Cats have 32 muscles in each ear, allowing them to rotate 180 degrees independently.\"_

## Test instructions

1. Pull the branch, \`pnpm install\`.
2. Boot the desktop app fresh (or just reload the renderer).
3. Open a local workspace.
4. Sidebar should populate with sessions within seconds (instead of staying in loading skeletons).
5. Open a session, send a prompt — the reply should stream back.