### PR TITLE
feat(desktop): replace Puppeteer with native Electron APIs for built-in browser

### DIFF
--- a/apps/app/src/app/data/commands/browser-setup.md
+++ b/apps/app/src/app/data/commands/browser-setup.md
@@ -1,14 +1,14 @@
 ---
 name: browser-setup
-description: Try Control Chrome first, then explain setup if Chrome MCP is unavailable
+description: Use the built-in browser first, fall back to Chrome if needed
 ---
 
 Try browser automation in OpenWork right away.
 
 IMPORTANT:
-- Prefer Chrome DevTools MCP / `chrome-devtools_*` tools first.
+- Prefer the built-in OpenWork browser (`openwork-browser_*` tools) first.
 - If those tools are available, use them in your first response to open `https://example.com` and tell the user the page title.
-- If those tools are not available, do not invent substitute tools and do not fall back to Playwright first.
-- Instead, tell the user the shortest exact steps to connect `Control Chrome` from OpenWork's MCP tab, then ask them to retry.
+- If the built-in browser is unavailable, try Chrome DevTools MCP / `chrome-devtools_*` tools.
+- If neither is available, tell the user the shortest exact steps to enable browser control, then ask them to retry.
 
 Keep the response short and action-oriented.

--- a/apps/desktop/electron/browser-mcp.mjs
+++ b/apps/desktop/electron/browser-mcp.mjs
@@ -1,12 +1,10 @@
 /**
  * In-process browser MCP servers.
  *
- * Imports chrome-devtools-mcp tools and runs them inside the Electron main
- * process — no sidecar binary, no npx, no absolute paths.
- *
  * Two servers:
- *   1. "openwork-browser" — controls the embedded WebContentsView
- *   2. "chrome"           — connects to the user's external Chrome via CDP
+ *   1. "openwork-browser" — controls the embedded WebContentsView using
+ *      native Electron webContents APIs (no Puppeteer, no app-level CDP).
+ *   2. "chrome" — connects to the user's external Chrome via Puppeteer/CDP.
  *
  * Both are exposed as HTTP MCP endpoints that OpenCode connects to as
  * remote MCP servers.
@@ -15,7 +13,10 @@
 import { createServer } from "node:http";
 import { randomUUID } from "node:crypto";
 
-// ── Chrome DevTools MCP internals (imported as library, NOT spawned) ──
+// ── Native built-in browser server ────────────────────────────────────
+import { createNativeBuiltinServer } from "./browser-native-tools.mjs";
+
+// ── Chrome DevTools MCP internals (for EXTERNAL Chrome only) ──────────
 // IMPORTANT: never import main.js — it runs parseArguments at module load.
 import "chrome-devtools-mcp/build/src/polyfill.js";
 
@@ -59,40 +60,6 @@ const EXTERNAL_TARGET_FILTER = (target) => {
   return true;
 };
 
-/**
- * Target filter for the BUILT-IN browser server — only accept pages that
- * are NOT the main OpenWork renderer.  The main renderer loads from
- * localhost (dev) or file:// (prod).  The WebContentsView loads real
- * websites (https://, http:// on non-localhost).
- */
-const BUILTIN_TARGET_FILTER = (target) => {
-  const url = target.url();
-  // Skip the main OpenWork renderer
-  if (url.startsWith("file://")) return false;
-  if (url.startsWith("http://localhost")) return false;
-  if (url.startsWith("http://127.0.0.1")) return false;
-  if (url.startsWith("http://[::1]")) return false;
-  // Skip chrome internals
-  if (url.startsWith("chrome://") || url.startsWith("chrome-extension://")) return false;
-  if (url.startsWith("devtools://")) return false;
-  // Skip about:blank (initial empty state before WebContentsView loads)
-  if (url === "about:blank") return false;
-  // Accept everything else — these are real websites in the WebContentsView
-  return true;
-};
-
-async function connectBuiltinBrowser(browserURL) {
-  return withTimeout(
-    puppeteer.connect({
-      browserURL,
-      targetFilter: BUILTIN_TARGET_FILTER,
-      defaultViewport: null,
-    }),
-    10_000,
-    "connectBuiltinBrowser",
-  );
-}
-
 async function connectExternalBrowser(browserURL) {
   return withTimeout(
     puppeteer.connect({
@@ -107,17 +74,11 @@ async function connectExternalBrowser(browserURL) {
 
 /**
  * Create an MCP server backed by chrome-devtools-mcp tools.
- *
- * @param {object}   opts
- * @param {string}   opts.name       — server name (e.g. "openwork-browser")
- * @param {string}   opts.version    — server version
- * @param {Function} opts.getBrowser — async () => Puppeteer.Browser
- * @param {Function} [opts.onToolCall] — called before each tool (e.g. to show browser panel)
- * @returns {McpServer}
+ * Used ONLY for the external Chrome server.
  */
-function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
+function createExternalChromeServer({ getBrowser }) {
   const server = new McpServer(
-    { name, version },
+    { name: "chrome", version: "0.1.0" },
     { capabilities: { logging: {} } },
   );
 
@@ -130,7 +91,7 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
   async function getContext() {
     const browser = await getBrowser();
     if (!browser?.connected) {
-      throw new Error(`Browser not connected for ${name}`);
+      throw new Error("Browser not connected for chrome");
     }
     if (browser !== lastBrowser) {
       lastBrowser = browser;
@@ -143,76 +104,7 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
     return context;
   }
 
-  /** Force a full Puppeteer reconnect + fresh McpContext on next getContext(). */
-  function invalidateContext() {
-    try { lastBrowser?.disconnect(); } catch { /* already gone */ }
-    lastBrowser = null;
-    context = null;
-  }
-
-  // Skip performance / extension / emulation categories that don't make
-  // sense for the built-in browser.  Keep the full set for external Chrome.
-  const skipCategories = name === "openwork-browser"
-    ? new Set(["extensions", "performance"])
-    : new Set();
-
   for (const tool of chromeDevtoolsTools) {
-    if (skipCategories.has(tool.annotations?.category)) continue;
-
-    // The upstream navigate_page tool wraps page.goto() in an additional
-    // waitForNavigation/stable-DOM sequence. Electron WebContentsView targets
-    // can complete the navigation while that extra wait never resolves, which
-    // makes built-in browser navigation hang. Use a simpler built-in-specific
-    // handler that waits for DOMContentLoaded and returns promptly.
-    if (name === "openwork-browser" && tool.name === "navigate_page") {
-      server.tool(
-        tool.name,
-        tool.description,
-        tool.schema,
-        async (params) => {
-          const guard = await mutex.acquire();
-          try {
-            await onToolCall?.(tool.name, params);
-            const ctx = await getContext();
-            const page = ctx.getSelectedPage();
-            const timeout = Number.isFinite(params?.timeout) && params.timeout > 0
-              ? params.timeout
-              : 30_000;
-            // Use default Puppeteer waitUntil (load event).
-            const options = { timeout };
-            const type = params?.type ?? "url";
-
-            if (type === "url") {
-              const url = String(params?.url ?? "").trim();
-              if (!url) throw new Error("navigate_page requires a url for type=url");
-              // Use Puppeteer page.goto() with waitUntil:domcontentloaded
-              // wrapped in a hard timeout.  Electron's loadURL sometimes
-              // fails in the WebContentsView sandboxed partition while
-              // Puppeteer's CDP-based navigation succeeds.
-              await withTimeout(page.goto(url, options), timeout + 1_000, "openwork-browser/navigate_page");
-            } else if (type === "back") {
-              await withTimeout(page.goBack(options), timeout + 1_000, "openwork-browser/navigate_page(back)");
-            } else if (type === "forward") {
-              await withTimeout(page.goForward(options), timeout + 1_000, "openwork-browser/navigate_page(forward)");
-            } else if (type === "reload") {
-              await withTimeout(page.reload({ ...options, ignoreCache: params?.ignoreCache }), timeout + 1_000, "openwork-browser/navigate_page(reload)");
-            } else {
-              throw new Error(`Unsupported navigation type: ${type}`);
-            }
-
-            const targetUrl = type === "url" ? String(params?.url ?? "").trim() : page.url();
-            return { content: [{ type: "text", text: `Navigated to ${targetUrl || page.url()}` }] };
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            return { content: [{ type: "text", text: `Error: ${msg}` }] };
-          } finally {
-            guard.dispose();
-          }
-        },
-      );
-      continue;
-    }
-
     server.tool(
       tool.name,
       tool.description,
@@ -220,25 +112,17 @@ function createBrowserMcpServer({ name, version, getBrowser, onToolCall }) {
       async (params) => {
         const guard = await mutex.acquire();
         try {
-          // onToolCall may be async (e.g. ensuring the WebContentsView is loaded)
-          await onToolCall?.(tool.name, params);
           const ctx = await getContext();
           const response = new McpResponse();
-          // Wrap the tool handler with a hard timeout to prevent indefinite
-          // hangs. navigate_page in particular can hang inside Puppeteer's
-          // waitForNavigation when the Electron WebContentsView doesn't fire
-          // the expected CDP events.
           const TOOL_TIMEOUT = 30_000;
           await withTimeout(
             tool.handler({ params }, response, ctx),
             TOOL_TIMEOUT,
-            `${name}/${tool.name}`,
+            `chrome/${tool.name}`,
           );
           const { content } = await response.handle(tool.name, ctx);
           return { content };
         } catch (err) {
-          // Return the error as tool output instead of crashing the
-          // session — the agent can retry or fall back.
           const msg = err instanceof Error ? err.message : String(err);
           return { content: [{ type: "text", text: `Error: ${msg}` }] };
         } finally {
@@ -363,64 +247,29 @@ async function startMcpHttpServer(mcpServerFactory, preferredPort = 0) {
 /**
  * Boot both MCP servers.
  *
- * @param {object} opts
- * @param {number} opts.electronCdpPort — Electron's remote debugging port (for built-in browser)
+ * @param {object}   opts
+ * @param {Function} opts.getWebContents    — () => WebContents | null (built-in browser view)
  * @param {Function} opts.onBuiltinToolCall — called before each built-in browser tool (opens panel)
- * @param {Function} opts.onHideBrowser — called to close the browser panel
- * @returns {{ builtinPort: number, externalPort: number | null, stop: () => Promise<void> }}
+ * @param {Function} opts.onHideBrowser     — called to close the browser panel
+ * @returns {{ builtinPort: number, externalPort: number, stop: () => Promise<void> }}
  */
-export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCall, onHideBrowser }) {
-  let builtinBrowser = null;
+export async function startBrowserMcpServers({ getWebContents, onBuiltinToolCall, onHideBrowser }) {
   let externalBrowser = null;
 
-  // Factory: each new MCP session gets a fresh server instance.
+  // ── Built-in browser: native Electron APIs ────────────────────────
+  let builtinSnapshotReset = null;
   function createBuiltinFactory() {
-    const server = createBrowserMcpServer({
-      name: "openwork-browser",
-      version: "0.1.0",
-      getBrowser: async () => {
-        // Preserve the Puppeteer browser/context across sequential tool calls.
-        // chrome-devtools-mcp stores the latest accessibility snapshot on the
-        // McpContext; reconnecting for every tool loses that snapshot, making
-        // follow-up fill/click calls fail with "No snapshot found".
-        if (!builtinBrowser?.connected) {
-          builtinBrowser = await connectBuiltinBrowser(`http://127.0.0.1:${electronCdpPort}`);
-        }
-        return builtinBrowser;
-      },
+    const srv = createNativeBuiltinServer({
+      getWebContents,
       onToolCall: onBuiltinToolCall,
+      onHideBrowser,
     });
-
-    server.tool(
-      "show_browser",
-      "Open the built-in browser panel inside the OpenWork app. " +
-      "Called automatically when any browser tool runs, but can also be " +
-      "called explicitly to show the panel before interacting.",
-      {},
-      async () => {
-        await onBuiltinToolCall?.("show_browser");
-        return { content: [{ type: "text", text: "Browser panel opened." }] };
-      },
-    );
-
-    server.tool(
-      "hide_browser",
-      "Close the built-in browser panel. Call when the browsing task is " +
-      "finished and the user no longer needs to see the browser.",
-      {},
-      async () => {
-        onHideBrowser?.();
-        return { content: [{ type: "text", text: "Browser panel closed." }] };
-      },
-    );
-
-    return server;
+    builtinSnapshotReset = srv._snapshotReset;
+    return srv;
   }
 
-  /**
-   * Probe whether an external Chrome is reachable on any known CDP port.
-   * Returns { connected, port } without storing state.
-   */
+  // ── External Chrome: Puppeteer + CDP (unchanged) ──────────────────
+
   async function probeExternalChrome() {
     for (const port of [9222, 9229]) {
       try {
@@ -434,9 +283,7 @@ export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCal
   }
 
   function createExternalFactory() {
-    const server = createBrowserMcpServer({
-      name: "chrome",
-      version: "0.1.0",
+    const server = createExternalChromeServer({
       getBrowser: async () => {
         if (!externalBrowser?.connected) {
           for (const port of [9222, 9229]) {
@@ -504,9 +351,9 @@ export async function startBrowserMcpServers({ electronCdpPort, onBuiltinToolCal
   return {
     builtinPort: builtin.port,
     externalPort: external.port,
+    _snapshotReset: () => builtinSnapshotReset?.(),
     async stop() {
       await Promise.all([builtin.close(), external.close()]);
-      try { builtinBrowser?.disconnect(); } catch {}
       try { externalBrowser?.disconnect(); } catch {}
     },
   };

--- a/apps/desktop/electron/browser-native-tools.mjs
+++ b/apps/desktop/electron/browser-native-tools.mjs
@@ -1,0 +1,829 @@
+/**
+ * Native Electron MCP server for the built-in WebContentsView.
+ *
+ * Replaces Puppeteer-over-CDP with direct webContents APIs.
+ * Minimal CDP is used via webContents.debugger for:
+ *   - Accessibility tree snapshots (Accessibility.getFullAXTree)
+ *   - DOM node resolution for uid-based click/fill (DOM.resolveNode)
+ *   - Input dispatch for drag/key operations (Input.dispatch*)
+ *   - Emulation overrides (Emulation.*)
+ *
+ * Everything else uses Electron's native webContents methods:
+ *   - loadURL(), goBack(), goForward(), reload()
+ *   - capturePage()
+ *   - executeJavaScript()
+ */
+
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Import MCP SDK + zod directly — no chrome-devtools-mcp dependency.
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+// ── Snapshot manager ──────────────────────────────────────────────────
+//
+// Manages the a11y tree snapshot and uid→backendDOMNodeId mapping.
+// Uses webContents.debugger for CDP Accessibility calls (scoped to
+// this single WebContentsView, no app-level --remote-debugging-port).
+
+class NativeSnapshot {
+  #getWebContents;
+  #nodes = new Map(); // uid → node data
+  #snapshotCounter = 0;
+  #stableIdMap = new Map(); // backendDOMNodeId → uid (stable across snapshots)
+  #debuggerReady = false;
+
+  constructor(getWebContents) {
+    this.#getWebContents = getWebContents;
+  }
+
+  #ensureDebugger() {
+    const wc = this.#getWebContents();
+    if (!wc || wc.isDestroyed()) throw new Error("No browser page available.");
+    if (!this.#debuggerReady) {
+      try {
+        wc.debugger.attach("1.3");
+      } catch {
+        // Already attached — fine
+      }
+      this.#debuggerReady = true;
+      wc.once("destroyed", () => { this.#debuggerReady = false; });
+    }
+    return wc;
+  }
+
+  async take(verbose = false) {
+    const wc = this.#ensureDebugger();
+    await wc.debugger.sendCommand("Accessibility.enable");
+    const { nodes: rawNodes } = await wc.debugger.sendCommand(
+      "Accessibility.getFullAXTree",
+    );
+
+    // Build a lookup from CDP nodeId → raw node
+    const cdpById = new Map();
+    for (const n of rawNodes) cdpById.set(n.nodeId, n);
+
+    this.#snapshotCounter++;
+    const sid = this.#snapshotCounter;
+    let counter = 0;
+    this.#nodes.clear();
+    const seenBackendIds = new Set();
+
+    const processNode = (cdpNode) => {
+      const bid = cdpNode.backendDOMNodeId;
+      const bidKey = String(bid ?? "");
+
+      // Re-use stable uid when the same DOM node appears across snapshots
+      let uid;
+      if (bidKey && this.#stableIdMap.has(bidKey)) {
+        uid = this.#stableIdMap.get(bidKey);
+      } else {
+        uid = `${sid}_${counter++}`;
+        if (bidKey) this.#stableIdMap.set(bidKey, uid);
+      }
+      if (bidKey) seenBackendIds.add(bidKey);
+
+      const role = cdpNode.role?.value ?? "";
+      const name = cdpNode.name?.value ?? "";
+      const value = cdpNode.value?.value;
+      const ignored = cdpNode.ignored ?? false;
+
+      // Extract meaningful properties
+      const props = {};
+      for (const p of cdpNode.properties ?? []) {
+        if (p.value?.value !== undefined) props[p.name] = p.value.value;
+      }
+
+      const children = (cdpNode.childIds ?? [])
+        .map((id) => cdpById.get(id))
+        .filter(Boolean)
+        .map(processNode);
+
+      const node = { uid, role, name, value, ignored, backendDOMNodeId: bid, props, children };
+      this.#nodes.set(uid, node);
+      return node;
+    };
+
+    if (!rawNodes[0]) return "Empty page — no accessibility tree.";
+    const root = processNode(rawNodes[0]);
+
+    // Prune stale mappings
+    for (const key of this.#stableIdMap.keys()) {
+      if (!seenBackendIds.has(key)) this.#stableIdMap.delete(key);
+    }
+
+    return this.#format(root, verbose);
+  }
+
+  #format(node, verbose, depth = 0) {
+    if (!node) return "";
+    if ((node.ignored || node.role === "none") && !verbose) {
+      return node.children.map((c) => this.#format(c, verbose, depth)).join("");
+    }
+
+    const indent = "  ".repeat(depth);
+    const parts = [`uid=${node.uid}`];
+    if (node.role) parts.push(node.role === "none" ? "ignored" : node.role);
+    if (node.name) parts.push(`"${node.name}"`);
+    if (node.value !== undefined) parts.push(`value="${node.value}"`);
+
+    for (const [k, v] of Object.entries(node.props)) {
+      if (typeof v === "boolean" && v) parts.push(k);
+      else if (typeof v === "string" || typeof v === "number") parts.push(`${k}="${v}"`);
+    }
+
+    const lines = [indent + parts.join(" ")];
+    for (const child of node.children) {
+      const s = this.#format(child, verbose, depth + 1);
+      if (s) lines.push(s);
+    }
+    return lines.join("\n");
+  }
+
+  /** Resolve a snapshot uid to a CDP RemoteObject objectId. */
+  async resolveElement(uid) {
+    if (!this.#nodes.size) {
+      throw new Error("No snapshot found. Use take_snapshot to capture one.");
+    }
+    const node = this.#nodes.get(uid);
+    if (!node) throw new Error(`No such element found in the snapshot (uid: ${uid}).`);
+    if (!node.backendDOMNodeId) {
+      throw new Error(`Element "${uid}" (${node.role}) has no backing DOM node.`);
+    }
+
+    const wc = this.#ensureDebugger();
+    const { object } = await wc.debugger.sendCommand("DOM.resolveNode", {
+      backendNodeId: node.backendDOMNodeId,
+    });
+    if (!object?.objectId) {
+      throw new Error(`Element "${uid}" no longer exists on the page.`);
+    }
+    return object.objectId;
+  }
+
+  /** Get node data for a uid (used by upload_file for backendDOMNodeId). */
+  getNodeData(uid) {
+    return this.#nodes.get(uid);
+  }
+
+  /** Reset snapshot state. Call when the WebContentsView is destroyed. */
+  reset() {
+    try { this.#getWebContents()?.debugger?.detach(); } catch { /* ok */ }
+    this.#debuggerReady = false;
+    this.#nodes.clear();
+    this.#stableIdMap.clear();
+  }
+}
+
+// ── MCP server factory ────────────────────────────────────────────────
+
+/**
+ * Create an MCP server for the built-in browser using native Electron APIs.
+ *
+ * @param {object}   opts
+ * @param {Function} opts.getWebContents — () => webContents | null
+ * @param {Function} [opts.onToolCall]   — called before each tool
+ * @param {Function} [opts.onHideBrowser] — called to close the browser panel
+ * @returns {McpServer}
+ */
+export function createNativeBuiltinServer({ getWebContents, onToolCall, onHideBrowser }) {
+  const server = new McpServer(
+    { name: "openwork-browser", version: "0.2.0" },
+    { capabilities: { logging: {} } },
+  );
+
+  const snap = new NativeSnapshot(getWebContents);
+
+  // Expose reset so main.mjs can call it when the view is destroyed
+  server._snapshotReset = () => snap.reset();
+
+  function wc() {
+    const c = getWebContents();
+    if (!c || c.isDestroyed()) throw new Error("Built-in browser is not open.");
+    return c;
+  }
+
+  /** Navigate and wait for the page to load. Simple event-based wait —
+   *  the about:blank preload in createBrowserView prevents session-restore races. */
+  function navigateAndWait(webContents, url, timeoutMs = 30_000) {
+    return new Promise((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs);
+      const done = () => { clearTimeout(timer); resolve(); };
+      webContents.once("did-finish-load", done);
+      webContents.once("did-fail-load", done);
+      webContents.loadURL(url);
+    });
+  }
+
+  /** Wait for a navigation action (back/forward/reload) to complete.
+   *  Rejects on timeout so the caller reports the failure honestly. */
+  function waitForNav(webContents, timeoutMs = 30_000) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("Navigation timed out")), timeoutMs);
+      const done = () => { clearTimeout(timer); resolve(); };
+      webContents.once("did-finish-load", done);
+      webContents.once("did-fail-load", done);
+    });
+  }
+
+  // Helper: run a tool body inside an error boundary
+  function defineTool(name, description, schema, handler) {
+    server.tool(name, description, schema, async (params) => {
+      try {
+        await onToolCall?.(name, params);
+        return await handler(params);
+      } catch (err) {
+        return { content: [{ type: "text", text: `Error: ${err.message ?? err}` }] };
+      }
+    });
+  }
+
+  // ── Navigation ────────────────────────────────────────────────────
+
+  defineTool(
+    "navigate_page",
+    "Go to a URL, or back, forward, or reload.",
+    {
+      url: z.string().optional().describe("Target URL (only type=url)"),
+      type: z.enum(["url", "back", "forward", "reload"]).optional()
+        .describe("Navigate by URL, back/forward in history, or reload."),
+      timeout: z.number().int().optional()
+        .describe("Maximum wait time in milliseconds. Default: 30000"),
+      ignoreCache: z.boolean().optional()
+        .describe("Whether to ignore cache on reload."),
+    },
+    async (params) => {
+      const w = wc();
+      const type = params.type ?? "url";
+      const timeout = params.timeout ?? 30_000;
+
+      if (type === "url") {
+        const url = String(params.url ?? "").trim();
+        if (!url) throw new Error("navigate_page requires a url for type=url");
+        await navigateAndWait(w, url, timeout);
+      } else if (type === "back") {
+        if (w.navigationHistory?.canGoBack?.() ?? w.canGoBack()) {
+          const p = waitForNav(w, timeout);
+          w.goBack();
+          await p;
+        }
+      } else if (type === "forward") {
+        if (w.navigationHistory?.canGoForward?.() ?? w.canGoForward()) {
+          const p = waitForNav(w, timeout);
+          w.goForward();
+          await p;
+        }
+      } else if (type === "reload") {
+        const p = waitForNav(w, timeout);
+        params.ignoreCache ? w.reloadIgnoringCache() : w.reload();
+        await p;
+      }
+
+      return { content: [{ type: "text", text: `Navigated to ${w.getURL()}` }] };
+    },
+  );
+
+  // ── Snapshot ──────────────────────────────────────────────────────
+
+  defineTool(
+    "take_snapshot",
+    "Take a text snapshot of the currently selected page based on the a11y tree. " +
+    "The snapshot lists page elements along with a unique identifier (uid). " +
+    "Always use the latest snapshot. Prefer taking a snapshot over taking a screenshot.",
+    {
+      verbose: z.boolean().optional()
+        .describe("Include all possible information in the full a11y tree. Default: false."),
+      filePath: z.string().optional()
+        .describe("Save snapshot to this path instead of returning inline."),
+    },
+    async (params) => {
+      const text = await snap.take(params.verbose ?? false);
+      if (params.filePath) {
+        await writeFile(params.filePath, text, "utf8");
+        return { content: [{ type: "text", text: `Saved snapshot to ${params.filePath}.` }] };
+      }
+      return { content: [{ type: "text", text: "## Latest page snapshot\n" + text }] };
+    },
+  );
+
+  // ── Screenshot ────────────────────────────────────────────────────
+
+  defineTool(
+    "take_screenshot",
+    "Take a screenshot of the page or element.",
+    {
+      format: z.enum(["png", "jpeg", "webp"]).default("png")
+        .describe('Format. Default: "png"'),
+      quality: z.number().min(0).max(100).optional()
+        .describe("JPEG/WebP quality (0-100). Ignored for PNG."),
+      uid: z.string().optional()
+        .describe("Element uid from snapshot. Omit for page screenshot."),
+      fullPage: z.boolean().optional()
+        .describe("Full scrollable page screenshot. Incompatible with uid."),
+      filePath: z.string().optional()
+        .describe("Save screenshot to this path instead of returning inline."),
+    },
+    async (params) => {
+      const w = wc();
+      if (params.uid && params.fullPage) throw new Error('Cannot use both "uid" and "fullPage".');
+
+      let imageBuffer;
+      const fmt = params.format ?? "png";
+
+      if (params.uid) {
+        // Element screenshot via bounding rect — clamp to viewport
+        const objectId = await snap.resolveElement(params.uid);
+        const { result } = await w.debugger.sendCommand("Runtime.callFunctionOn", {
+          objectId,
+          functionDeclaration: `function() {
+            this.scrollIntoViewIfNeeded();
+            const r = this.getBoundingClientRect();
+            return JSON.stringify({
+              x: Math.max(0, Math.round(r.x)),
+              y: Math.max(0, Math.round(r.y)),
+              width: Math.round(Math.min(r.width, window.innerWidth - Math.max(0, r.x))),
+              height: Math.round(Math.min(r.height, window.innerHeight - Math.max(0, r.y)))
+            });
+          }`,
+          returnByValue: true,
+        });
+        const rect = JSON.parse(result.value);
+        if (rect.width > 0 && rect.height > 0) {
+          const img = await w.capturePage(rect);
+          imageBuffer = fmt === "jpeg" ? img.toJPEG(params.quality ?? 80) : img.toPNG();
+        } else {
+          // Element not visible — fall back to viewport screenshot
+          const img = await w.capturePage();
+          imageBuffer = fmt === "jpeg" ? img.toJPEG(params.quality ?? 80) : img.toPNG();
+        }
+      } else {
+        const img = await w.capturePage();
+        imageBuffer = fmt === "jpeg" ? img.toJPEG(params.quality ?? 80) : img.toPNG();
+      }
+
+      if (params.filePath) {
+        await writeFile(params.filePath, imageBuffer);
+        return { content: [{ type: "text", text: `Screenshot saved to ${params.filePath}.` }] };
+      }
+      if (imageBuffer.length >= 2_000_000) {
+        const p = join(tmpdir(), `openwork-ss-${Date.now()}.${fmt}`);
+        await writeFile(p, imageBuffer);
+        return { content: [{ type: "text", text: `Screenshot saved to ${p} (${(imageBuffer.length / 1024) | 0} KB).` }] };
+      }
+      return { content: [{ type: "image", mimeType: `image/${fmt}`, data: imageBuffer.toString("base64") }] };
+    },
+  );
+
+  // ── Click ─────────────────────────────────────────────────────────
+
+  defineTool(
+    "click",
+    "Clicks on the provided element.",
+    {
+      uid: z.string().describe("Element uid from page snapshot"),
+      dblClick: z.boolean().optional().describe("Double click. Default: false."),
+      includeSnapshot: z.boolean().optional().describe("Include snapshot in response. Default: false."),
+    },
+    async (params) => {
+      const objectId = await snap.resolveElement(params.uid);
+      const w = wc();
+      await w.debugger.sendCommand("Runtime.callFunctionOn", {
+        objectId,
+        functionDeclaration: `function(dbl) {
+          this.scrollIntoViewIfNeeded();
+          this.click();
+          if (dbl) this.click();
+        }`,
+        arguments: [{ value: !!params.dblClick }],
+      });
+      const text = params.dblClick ? "Successfully double clicked on the element" : "Successfully clicked on the element";
+      if (params.includeSnapshot) {
+        return { content: [{ type: "text", text }, { type: "text", text: await snap.take(false) }] };
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // ── Hover ─────────────────────────────────────────────────────────
+
+  defineTool(
+    "hover",
+    "Hover over the provided element.",
+    {
+      uid: z.string().describe("Element uid from page snapshot"),
+      includeSnapshot: z.boolean().optional(),
+    },
+    async (params) => {
+      const objectId = await snap.resolveElement(params.uid);
+      const w = wc();
+      await w.debugger.sendCommand("Runtime.callFunctionOn", {
+        objectId,
+        functionDeclaration: `function() {
+          this.scrollIntoViewIfNeeded();
+          this.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+          this.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        }`,
+      });
+      const text = "Successfully hovered over the element";
+      if (params.includeSnapshot) {
+        return { content: [{ type: "text", text }, { type: "text", text: await snap.take(false) }] };
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // ── Fill ──────────────────────────────────────────────────────────
+
+  const FILL_FN = `function(val) {
+    this.scrollIntoViewIfNeeded();
+    this.focus();
+    if (this.tagName === 'SELECT') {
+      const opt = Array.from(this.options).find(o => o.text === val || o.value === val);
+      if (opt) this.value = opt.value; else this.value = val;
+    } else {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+        || Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set;
+      if (setter) setter.call(this, val); else this.value = val;
+    }
+    this.dispatchEvent(new Event('input', { bubbles: true }));
+    this.dispatchEvent(new Event('change', { bubbles: true }));
+  }`;
+
+  defineTool(
+    "fill",
+    "Type text into an input, text area, or select an option from a <select> element.",
+    {
+      uid: z.string().describe("Element uid from page snapshot"),
+      value: z.string().describe("The value to fill in"),
+      includeSnapshot: z.boolean().optional(),
+    },
+    async (params) => {
+      const objectId = await snap.resolveElement(params.uid);
+      await wc().debugger.sendCommand("Runtime.callFunctionOn", {
+        objectId,
+        functionDeclaration: FILL_FN,
+        arguments: [{ value: params.value }],
+      });
+      const text = "Successfully filled out the element";
+      if (params.includeSnapshot) {
+        return { content: [{ type: "text", text }, { type: "text", text: await snap.take(false) }] };
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // ── Fill form ─────────────────────────────────────────────────────
+
+  defineTool(
+    "fill_form",
+    "Fill out multiple form elements at once.",
+    {
+      elements: z.array(z.object({
+        uid: z.string().describe("Element uid to fill out"),
+        value: z.string().describe("Value for the element"),
+      })).describe("Elements from snapshot to fill out."),
+      includeSnapshot: z.boolean().optional(),
+    },
+    async (params) => {
+      for (const el of params.elements) {
+        const objectId = await snap.resolveElement(el.uid);
+        await wc().debugger.sendCommand("Runtime.callFunctionOn", {
+          objectId,
+          functionDeclaration: FILL_FN,
+          arguments: [{ value: el.value }],
+        });
+      }
+      const text = "Successfully filled out the form";
+      if (params.includeSnapshot) {
+        return { content: [{ type: "text", text }, { type: "text", text: await snap.take(false) }] };
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // ── Drag ──────────────────────────────────────────────────────────
+
+  defineTool(
+    "drag",
+    "Drag an element onto another element.",
+    {
+      from_uid: z.string().describe("Element uid to drag"),
+      to_uid: z.string().describe("Element uid to drop into"),
+      includeSnapshot: z.boolean().optional(),
+    },
+    async (params) => {
+      const w = wc();
+      const fromId = await snap.resolveElement(params.from_uid);
+      const toId = await snap.resolveElement(params.to_uid);
+
+      const getCenter = async (objectId) => {
+        const { result } = await w.debugger.sendCommand("Runtime.callFunctionOn", {
+          objectId,
+          functionDeclaration: `function() { this.scrollIntoViewIfNeeded(); const r = this.getBoundingClientRect(); return JSON.stringify({ x: r.x + r.width/2, y: r.y + r.height/2 }); }`,
+          returnByValue: true,
+        });
+        return JSON.parse(result.value);
+      };
+
+      const from = await getCenter(fromId);
+      const to = await getCenter(toId);
+      const steps = 10;
+
+      await w.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mouseMoved", x: from.x, y: from.y });
+      await w.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mousePressed", x: from.x, y: from.y, button: "left", clickCount: 1 });
+      for (let i = 1; i <= steps; i++) {
+        const t = i / steps;
+        await w.debugger.sendCommand("Input.dispatchMouseEvent", {
+          type: "mouseMoved",
+          x: from.x + (to.x - from.x) * t,
+          y: from.y + (to.y - from.y) * t,
+        });
+      }
+      await w.debugger.sendCommand("Input.dispatchMouseEvent", { type: "mouseReleased", x: to.x, y: to.y, button: "left", clickCount: 1 });
+
+      const text = "Successfully dragged an element";
+      if (params.includeSnapshot) {
+        return { content: [{ type: "text", text }, { type: "text", text: await snap.take(false) }] };
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // ── Upload file ───────────────────────────────────────────────────
+
+  defineTool(
+    "upload_file",
+    "Upload a file through a provided element.",
+    {
+      uid: z.string().describe("Element uid of file input or trigger element"),
+      filePath: z.string().describe("Local path of the file to upload"),
+      includeSnapshot: z.boolean().optional(),
+    },
+    async (params) => {
+      const node = snap.getNodeData(params.uid);
+      if (!node?.backendDOMNodeId) throw new Error(`Element "${params.uid}" has no DOM node.`);
+      await wc().debugger.sendCommand("DOM.setFileInputFiles", {
+        files: [params.filePath],
+        backendNodeId: node.backendDOMNodeId,
+      });
+      const text = `File uploaded from ${params.filePath}.`;
+      if (params.includeSnapshot) {
+        return { content: [{ type: "text", text }, { type: "text", text: await snap.take(false) }] };
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // ── Press key ─────────────────────────────────────────────────────
+
+  defineTool(
+    "press_key",
+    'Press a key or key combination (e.g. "Enter", "Control+A", "Control+Shift+R"). Modifiers: Control, Shift, Alt, Meta.',
+    {
+      key: z.string().describe('A key or combination, e.g. "Enter", "Control+A"'),
+      includeSnapshot: z.boolean().optional(),
+    },
+    async (params) => {
+      const w = wc();
+      const tokens = params.key.split("+");
+      const mainKey = tokens.pop();
+      const modifiers = [...tokens]; // defensive copy before reverse
+
+      let flags = 0;
+      for (const m of modifiers) {
+        if (m === "Alt") flags |= 1;
+        if (m === "Control") flags |= 2;
+        if (m === "Meta") flags |= 4;
+        if (m === "Shift") flags |= 8;
+      }
+
+      const dbg = w.debugger;
+      for (const m of modifiers) {
+        await dbg.sendCommand("Input.dispatchKeyEvent", { type: "rawKeyDown", key: m, modifiers: flags });
+      }
+      await dbg.sendCommand("Input.dispatchKeyEvent", { type: "rawKeyDown", key: mainKey, text: mainKey.length === 1 ? mainKey : "", modifiers: flags });
+      if (mainKey.length === 1) {
+        await dbg.sendCommand("Input.dispatchKeyEvent", { type: "char", text: mainKey, modifiers: flags });
+      }
+      await dbg.sendCommand("Input.dispatchKeyEvent", { type: "keyUp", key: mainKey, modifiers: flags });
+      for (const m of [...modifiers].reverse()) {
+        await dbg.sendCommand("Input.dispatchKeyEvent", { type: "keyUp", key: m, modifiers: flags });
+      }
+
+      const text = `Successfully pressed key: ${params.key}`;
+      if (params.includeSnapshot) {
+        return { content: [{ type: "text", text }, { type: "text", text: await snap.take(false) }] };
+      }
+      return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // ── Type text ─────────────────────────────────────────────────────
+
+  defineTool(
+    "type_text",
+    "Type text using keyboard into a previously focused input.",
+    {
+      text: z.string().describe("The text to type"),
+      submitKey: z.string().optional().describe('Optional key to press after typing, e.g. "Enter", "Tab"'),
+    },
+    async (params) => {
+      const dbg = wc().debugger;
+      for (const ch of params.text) {
+        await dbg.sendCommand("Input.dispatchKeyEvent", { type: "char", text: ch });
+      }
+      if (params.submitKey) {
+        await dbg.sendCommand("Input.dispatchKeyEvent", { type: "rawKeyDown", key: params.submitKey });
+        await dbg.sendCommand("Input.dispatchKeyEvent", { type: "keyUp", key: params.submitKey });
+      }
+      return { content: [{ type: "text", text: `Typed "${params.text}"${params.submitKey ? ` and pressed ${params.submitKey}` : ""}` }] };
+    },
+  );
+
+  // ── Evaluate script ───────────────────────────────────────────────
+
+  defineTool(
+    "evaluate_script",
+    "Evaluate a JavaScript function inside the current page. Returns JSON-serializable values.",
+    {
+      function: z.string().describe(
+        'A JavaScript function declaration, e.g. `() => { return document.title }` or `(el) => { return el.innerText; }`',
+      ),
+      args: z.array(z.string()).optional()
+        .describe("Optional list of element uids from the page snapshot to pass as arguments to the function"),
+      dialogAction: z.string().optional()
+        .describe('Handle dialogs during execution: "accept", "dismiss", or prompt response text. Default: accept.'),
+    },
+    async (params) => {
+      const w = wc();
+
+      if (params.args?.length) {
+        const argIds = [];
+        for (const uid of params.args) argIds.push(await snap.resolveElement(uid));
+        const { result } = await w.debugger.sendCommand("Runtime.callFunctionOn", {
+          objectId: argIds[0],
+          functionDeclaration: params.function,
+          arguments: argIds.slice(1).map((id) => ({ objectId: id })),
+          returnByValue: true,
+        });
+        return { content: [{ type: "text", text: JSON.stringify(result?.value, null, 2) ?? "undefined" }] };
+      }
+
+      const result = await w.executeJavaScript(`(${params.function})()`);
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) ?? "undefined" }] };
+    },
+  );
+
+  // ── Wait for ──────────────────────────────────────────────────────
+
+  defineTool(
+    "wait_for",
+    "Wait for the specified text to appear on the selected page.",
+    {
+      text: z.union([z.string(), z.array(z.string()).min(1)])
+        .describe("Non-empty list of texts. Resolves when any value appears on the page."),
+      timeout: z.number().int().optional()
+        .describe("Maximum wait time in milliseconds. Default: 30000"),
+    },
+    async (params) => {
+      const w = wc();
+      const texts = Array.isArray(params.text) ? params.text : [params.text];
+      const deadline = Date.now() + (params.timeout ?? 30_000);
+
+      while (Date.now() < deadline) {
+        for (const t of texts) {
+          const found = await w.executeJavaScript(
+            `document.body?.innerText?.includes(${JSON.stringify(t)}) ?? false`,
+          );
+          if (found) {
+            const snapText = await snap.take(false);
+            return { content: [
+              { type: "text", text: `Element with text "${t}" found.` },
+              { type: "text", text: snapText },
+            ] };
+          }
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+
+      throw new Error(`Timeout: none of [${texts.map(t => `"${t}"`).join(", ")}] appeared within ${params.timeout ?? 30_000}ms.`);
+    },
+  );
+
+  // ── Handle dialog ─────────────────────────────────────────────────
+
+  defineTool(
+    "handle_dialog",
+    "Handle a browser dialog (alert, confirm, prompt).",
+    {
+      action: z.enum(["accept", "dismiss"]).describe("Whether to dismiss or accept the dialog"),
+      promptText: z.string().optional().describe("Optional prompt text to enter"),
+    },
+    async (params) => {
+      await wc().debugger.sendCommand("Page.handleJavaScriptDialog", {
+        accept: params.action === "accept",
+        promptText: params.promptText,
+      });
+      return { content: [{ type: "text", text: `Dialog ${params.action}ed.` }] };
+    },
+  );
+
+  // ── Page management (single-page) ─────────────────────────────────
+
+  defineTool(
+    "list_pages",
+    "Get a list of pages open in the browser.",
+    {},
+    async () => {
+      const w = wc();
+      return { content: [{ type: "text", text: JSON.stringify([{
+        pageId: 1, url: w.getURL(), title: w.getTitle(), selected: true,
+      }]) }] };
+    },
+  );
+
+  defineTool(
+    "select_page",
+    "Select a page as context for future tool calls.",
+    { pageId: z.number().describe("Page ID to select.") },
+    async (params) => {
+      if (params.pageId !== 1) throw new Error("Only page 1 exists in the built-in browser.");
+      return { content: [{ type: "text", text: "Page 1 selected." }] };
+    },
+  );
+
+  // ── Resize ────────────────────────────────────────────────────────
+
+  defineTool(
+    "resize_page",
+    "Resizes the selected page's window so that the page has specified dimension.",
+    {
+      width: z.number().describe("Page width"),
+      height: z.number().describe("Page height"),
+    },
+    async (params) => {
+      return { content: [{ type: "text", text: `Resize requested (${params.width}x${params.height}). Actual size depends on app layout.` }] };
+    },
+  );
+
+  // ── Emulate ───────────────────────────────────────────────────────
+
+  defineTool(
+    "emulate",
+    "Emulates various features on the selected page.",
+    {
+      colorScheme: z.enum(["dark", "light", "auto"]).optional()
+        .describe('Emulate dark or light mode. "auto" to reset.'),
+      userAgent: z.string().optional()
+        .describe("User agent to emulate. Empty string to clear."),
+    },
+    async (params) => {
+      const dbg = wc().debugger;
+      const results = [];
+
+      if (params.colorScheme) {
+        const media = params.colorScheme === "auto" ? "" : params.colorScheme;
+        await dbg.sendCommand("Emulation.setEmulatedMedia", {
+          features: [{ name: "prefers-color-scheme", value: media || "" }],
+        });
+        results.push(`Color scheme: ${params.colorScheme}`);
+      }
+
+      if (params.userAgent !== undefined) {
+        await dbg.sendCommand("Emulation.setUserAgentOverride", {
+          userAgent: params.userAgent || "",
+        });
+        results.push(`User agent: ${params.userAgent || "(cleared)"}`);
+      }
+
+      return { content: [{ type: "text", text: results.length ? results.join("; ") : "No emulation changes applied." }] };
+    },
+  );
+
+  // ── Show / Hide browser ───────────────────────────────────────────
+
+  server.tool(
+    "show_browser",
+    "Open the built-in browser panel inside the OpenWork app. " +
+    "Called automatically when any browser tool runs, but can also be called explicitly.",
+    {},
+    async () => {
+      await onToolCall?.("show_browser");
+      return { content: [{ type: "text", text: "Browser panel opened." }] };
+    },
+  );
+
+  server.tool(
+    "hide_browser",
+    "Close the built-in browser panel. Call when the browsing task is finished.",
+    {},
+    async () => {
+      onHideBrowser?.();
+      return { content: [{ type: "text", text: "Browser panel closed." }] };
+    },
+  );
+
+  return server;
+}

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -86,8 +86,9 @@ if (process.platform === "darwin" && APP_ICON_IMAGE && !APP_ICON_IMAGE.isEmpty()
   app.dock.setIcon(APP_ICON_IMAGE);
 }
 
-// Optional: expose Chrome DevTools Protocol so external tools (chrome-devtools
-// MCP, raw CDP clients, etc.) can attach to this Electron instance.
+// Optional: expose Chrome DevTools Protocol so external tools (raw CDP clients,
+// DevTools front-ends) can attach to this Electron instance for debugging.
+// NOT required for the built-in browser — that uses native webContents APIs.
 // Enable by setting OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=<port> before launch.
 const remoteDebugPort = Number.parseInt(
   process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() ?? "",
@@ -192,6 +193,12 @@ let browserView = null;
 let browserViewVisible = false;
 const BROWSER_DEFAULT_URL = "https://www.google.com";
 
+/** Send an IPC message to the main renderer, guarding against disposed frames. */
+function sendToRenderer(channel, payload) {
+  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return;
+  try { mainWindow.webContents.send(channel, payload); } catch { /* window closing */ }
+}
+
 function createBrowserView() {
   if (browserView) return browserView;
   browserView = new WebContentsView({
@@ -202,6 +209,9 @@ function createBrowserView() {
       partition: "persist:openwork-browser",
     },
   });
+  // Load about:blank immediately to preempt persistent-session restore.
+  // Cookies live on the session object, not the document — they survive this.
+  browserView.webContents.loadURL("about:blank");
   browserView.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
     return { action: "deny" };
@@ -215,21 +225,23 @@ function createBrowserView() {
 }
 
 function sendBrowserState() {
-  if (!mainWindow || !browserView) return;
-  try {
-    mainWindow.webContents.send("openwork:browser:state", {
-      url: browserView.webContents.getURL(),
-      title: browserView.webContents.getTitle(),
-      canGoBack: browserView.webContents.canGoBack(),
-      canGoForward: browserView.webContents.canGoForward(),
-      isLoading: browserView.webContents.isLoading(),
-    });
-  } catch {
-    // window may be closing
-  }
+  if (!browserView) return;
+  sendToRenderer("openwork:browser:state", {
+    url: browserView.webContents.getURL(),
+    title: browserView.webContents.getTitle(),
+    canGoBack: browserView.webContents.canGoBack(),
+    canGoForward: browserView.webContents.canGoForward(),
+    isLoading: browserView.webContents.isLoading(),
+  });
 }
 
-function showBrowserView(bounds) {
+/**
+ * Attach the browser view to the main window.
+ * @param {object} bounds — { x, y, width, height }
+ * @param {object} [opts]
+ * @param {boolean} [opts.preloadDefault=true] — load default URL if the view has no URL
+ */
+function attachBrowserView(bounds, { preloadDefault = true } = {}) {
   if (!mainWindow) return;
   const view = createBrowserView();
   if (!mainWindow.contentView.children.includes(view)) {
@@ -239,7 +251,8 @@ function showBrowserView(bounds) {
     view.setBounds(bounds);
   }
   browserViewVisible = true;
-  if (!view.webContents.getURL()) {
+  const url = view.webContents.getURL();
+  if (preloadDefault && (!url || url === "about:blank")) {
     view.webContents.loadURL(BROWSER_DEFAULT_URL);
   }
   sendBrowserState();
@@ -255,9 +268,12 @@ function hideBrowserView() {
   browserViewVisible = false;
 }
 
+let _snapshotReset = null; // set by ensureBrowserMcpServers
+
 function destroyBrowserView() {
   hideBrowserView();
   if (browserView) {
+    _snapshotReset?.();
     try { browserView.webContents.close(); } catch { /* already destroyed */ }
     browserView = null;
   }
@@ -273,53 +289,27 @@ let browserMcpPorts = null; // { builtinPort, externalPort, stop }
 async function ensureBrowserMcpServers() {
   if (browserMcpPorts) return browserMcpPorts;
 
-  // CDP port for the Electron app itself (WebContentsView is a target on it)
-  const cdpPortRaw = process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() ?? "";
-  const cdpPort = Number.parseInt(cdpPortRaw, 10);
-  if (!Number.isFinite(cdpPort) || cdpPort <= 0) {
-    console.error("[browser-mcp] Cannot start — no Electron CDP port configured (OPENWORK_ELECTRON_REMOTE_DEBUG_PORT)");
-    return null;
-  }
-
   try {
     browserMcpPorts = await startBrowserMcpServers({
-      electronCdpPort: cdpPort,
+      getWebContents: () => browserView?.webContents ?? null,
       onBuiltinToolCall: async (toolName) => {
-        // Every built-in browser tool call ensures the panel is open and
-        // has a loaded page before puppeteer tries to connect.
+        // Ensure the browser panel is open so the agent can interact.
+        // preloadDefault: false — the tool will navigate on its own.
         if (!mainWindow) return;
-        const view = createBrowserView();
         if (!browserViewVisible) {
-          // Add the WebContentsView but don't position it yet — pass zero
-          // bounds so it stays invisible.  The React <BrowserPanel>
-          // component will compute its own layout bounds and call
-          // browser.show(bounds) / browser.setBounds(bounds) once the
-          // <aside> has been laid out.  Positioning eagerly here causes
-          // the view to overlay on top of the session content before React
-          // has made room for the panel column.
-          showBrowserView({ x: 0, y: 0, width: 0, height: 0 });
+          attachBrowserView({ x: 0, y: 0, width: 0, height: 0 }, { preloadDefault: false });
         }
-        // Always notify the renderer so it can render the BrowserPanel
-        // toolbar.  The React component may have unmounted (session switch)
-        // while the WebContentsView stayed open, so we re-send every time.
-        mainWindow.webContents.send("openwork:browser:panel-opened");
-        // Wait for the page to have a real URL (not about:blank)
-        const url = view.webContents.getURL();
-        if (!url || url === "about:blank") {
-          view.webContents.loadURL(BROWSER_DEFAULT_URL);
-          await new Promise((resolve) => {
-            view.webContents.once("did-finish-load", resolve);
-            setTimeout(resolve, 5000);
-          });
-        }
+        sendToRenderer("openwork:browser:panel-opened");
       },
       onHideBrowser: () => {
         hideBrowserView();
-        if (mainWindow) {
-          mainWindow.webContents.send("openwork:browser:panel-closed");
-        }
+        sendToRenderer("openwork:browser:panel-closed");
       },
     });
+    // Wire snapshot reset so destroyBrowserView clears stale uid state
+    if (browserMcpPorts._snapshotReset) {
+      _snapshotReset = browserMcpPorts._snapshotReset;
+    }
     console.log(`[browser-mcp] Built-in browser MCP at http://127.0.0.1:${browserMcpPorts.builtinPort}/mcp`);
     console.log(`[browser-mcp] External Chrome MCP at http://127.0.0.1:${browserMcpPorts.externalPort}/mcp`);
   } catch (err) {
@@ -1935,7 +1925,7 @@ ipcMain.handle("openwork:shell:relaunch", async () => {
 });
 
 // ── Embedded browser IPC ────────────────────────────────────────────────
-ipcMain.handle("openwork:browser:show", (_event, bounds) => showBrowserView(bounds));
+ipcMain.handle("openwork:browser:show", (_event, bounds) => attachBrowserView(bounds));
 ipcMain.handle("openwork:browser:hide", () => hideBrowserView());
 ipcMain.handle("openwork:browser:navigate", (_event, url) => {
   if (!browserView) return;

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -233,11 +233,10 @@ if (!viteReady) {
 
 const resolvedStartUrl = await waitForVite(startUrl);
 
-// Default Electron CDP on a stable dev port so chrome-devtools MCP / raw CDP
-// clients can attach without each launch picking a random port. Override with
-// OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=<port> or set to "0" to disable.
-const defaultCdpPort = "9823";
-const cdpPortRaw = process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() ?? defaultCdpPort;
+// Optional Electron CDP for external debugging / raw CDP clients.
+// NOT required for the built-in browser (uses native webContents APIs).
+// Set OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823 to enable.
+const cdpPortRaw = process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() ?? "";
 const cdpPort = cdpPortRaw === "" || cdpPortRaw === "0" ? "" : cdpPortRaw;
 
 electronChild = run(pnpmCmd, ["exec", "electron", "./electron/main.mjs"], {


### PR DESCRIPTION
## Summary

- Replaces the built-in browser MCP server's Puppeteer-over-CDP roundabout path with direct Electron `webContents` APIs
- The old flow was `Agent → MCP → Puppeteer → CDP HTTP → --remote-debugging-port → back to own WebContentsView`. Now it's `Agent → MCP → webContents.*`
- External Chrome MCP path still uses Puppeteer (correctly — can't access a remote browser's webContents)
- 20 native tool handlers: navigate, snapshot, screenshot, click, fill, hover, drag, press_key, type_text, evaluate_script, wait_for, and more

## What changed

| File | Change |
|------|--------|
| `apps/desktop/electron/browser-native-tools.mjs` | **NEW** — Native MCP server using `webContents.loadURL()`, `.capturePage()`, `.executeJavaScript()`, and per-view `webContents.debugger` for a11y tree |
| `apps/desktop/electron/browser-mcp.mjs` | Built-in path delegates to native server; external Chrome path unchanged |
| `apps/desktop/electron/main.mjs` | `sendToRenderer` helper, `about:blank` preload, `attachBrowserView` with `preloadDefault` option, snapshot reset wiring |
| `apps/desktop/scripts/electron-dev.mjs` | CDP port no longer exposed by default |
| `apps/app/src/app/data/commands/browser-setup.md` | Updated to prefer `openwork-browser_*` tools |

## What this eliminates

| Before | After |
|--------|-------|
| `--remote-debugging-port` required | Not required (truly optional) |
| Puppeteer dependency for built-in | No Puppeteer for built-in |
| Target filtering (6+ URL checks) | Direct webContents handle |
| Puppeteer connection management | None needed |
| `withTimeout` on every operation | Native APIs, no hangs |
| Navigation hang workaround | `webContents.loadURL()` just works |
| Entire app CDP surface exposed | Only per-view debugger |

## Bugs fixed

- `press_key` keyUp missing modifier mask → ghost-pressed modifiers
- `take_screenshot` element rect not clamped → negative coords crash
- `navigate_page` back/forward/reload silently succeeded on timeout → now rejects
- `navigateAndWait` retry storm → replaced with simple event wait
- Dead-renderer IPC sends → `sendToRenderer` with `isDestroyed()` guard
- `emulate.viewport` declared but unimplemented → removed from schema
- `select_page` silently succeeded for invalid pageId → errors on != 1
- `wait_for` didn't accept `string[]` → now matches host schema
- NativeSnapshot stale state after view destroy → `reset()` wired to `destroyBrowserView`
- Persistent session restore race → `about:blank` preload in `createBrowserView`

## Evidence

### E2E verification
Agent session executed: "Go to craigslist.org, find the free stuff section, click on it, and tell me how many listings you see" — agent called `navigate_page → take_snapshot → click → take_snapshot` and reported "200 listings".

![E2E: Craigslist free stuff via native browser tools](https://litter.catbox.moe/iz7y39.png)

### Build verification
- `pnpm --filter @openwork/desktop build` — **passed**
- ESM import resolution — **passed** (both `browser-native-tools.mjs` and `browser-mcp.mjs` load cleanly)
- Syntax check — **passed** (all 3 .mjs files)

## Test instructions

1. `pnpm dev` (from openwork root)
2. Open a session, type "go to craigslist and click on free stuff"
3. Verify the browser panel opens, navigates, and the agent reports results
4. Check no CDP port on 9823 unless `OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9823` is set