### PR TITLE
fix(updater): prevent architecture mismatch updates

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -281,6 +281,11 @@ jobs:
             artifact: electron-windows-x64
             electron_args: "--win --x64"
             target_triple: x86_64-pc-windows-msvc
+          - platform: windows-2022
+            os_type: windows
+            artifact: electron-windows-arm64
+            electron_args: "--win --arm64"
+            target_triple: aarch64-pc-windows-msvc
 
     steps:
       - name: Checkout
@@ -374,7 +379,7 @@ jobs:
           TARGET: ${{ matrix.target_triple }}
         run: pnpm --filter @openwork/desktop build:electron
 
-      - name: Package + publish Electron (macOS, signed + notarized)
+      - name: Package Electron (macOS, signed + notarized)
         if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
         env:
           CSC_LINK: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
@@ -382,36 +387,75 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
           APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           pnpm --dir apps/desktop exec electron-builder \
             --config electron-builder.yml \
             ${{ matrix.electron_args }} \
-            --publish always
+            --publish never
 
-      - name: Package + publish Electron (Linux)
+      - name: Package Electron (Linux)
         if: matrix.os_type == 'linux'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           pnpm --dir apps/desktop exec electron-builder \
             --config electron-builder.yml \
             ${{ matrix.electron_args }} \
-            --publish always
+            --publish never
 
-      - name: Package + publish Electron (Windows)
+      - name: Package Electron (Windows)
         if: matrix.os_type == 'windows'
-        env:
-          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
           pnpm --dir apps/desktop exec electron-builder \
             --config electron-builder.yml \
             ${{ matrix.electron_args }} \
-            --publish always
+            --publish never
+
+      - name: Upload Electron dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: apps/desktop/dist-electron/**
+          if-no-files-found: error
+
+  publish-electron-assets:
+    name: Publish Electron Assets
+    needs: [resolve-release, verify-release, publish-electron]
+    if: |
+      always() &&
+      needs.resolve-release.outputs.build_electron == 'true' &&
+      needs.resolve-release.result == 'success' &&
+      needs.verify-release.result == 'success' &&
+      needs.publish-electron.result == 'success'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Dispatch-based release recovery uses the workflow ref so fixes to
+          # release asset publishing can run without moving an already-shipped tag.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download Electron dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: electron-*
+          path: ${{ runner.temp }}/electron-dist
+
+      - name: Upload release assets and merged updater manifests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/release/publish-electron-assets.mjs "${{ runner.temp }}/electron-dist" "$RELEASE_TAG"
 
   release-orchestrator-sidecars:
     name: Build + Upload openwork-orchestrator Sidecars
@@ -736,6 +780,7 @@ jobs:
       - resolve-release
       - verify-release
       - publish-electron
+      - publish-electron-assets
       - release-orchestrator-sidecars
       - publish-npm
       - publish-daytona-snapshot
@@ -745,6 +790,7 @@ jobs:
       needs.resolve-release.result == 'success' &&
       needs.verify-release.result == 'success' &&
       (needs.publish-electron.result == 'success' || needs.publish-electron.result == 'skipped') &&
+      (needs.publish-electron-assets.result == 'success' || needs.publish-electron-assets.result == 'skipped') &&
       (needs.release-orchestrator-sidecars.result == 'success' || needs.release-orchestrator-sidecars.result == 'skipped') &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
       (needs.publish-daytona-snapshot.result == 'success' || needs.publish-daytona-snapshot.result == 'skipped')

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -38,6 +38,19 @@ declare global {
         openExternal?: (url: string) => Promise<void>;
         relaunch?: () => Promise<void>;
       };
+      system?: {
+        getArchitectureInfo?: () => Promise<{
+          appArch: string;
+          appArchLabel: string;
+          systemArch: string;
+          systemArchLabel: string;
+          mismatch: boolean;
+          platform: "darwin" | "linux" | "windows";
+          version: string;
+          downloadUrl: string;
+          releaseUrl: string;
+        }>;
+      };
       migration?: {
         readSnapshot?: () => Promise<unknown>;
         ackSnapshot?: () => Promise<{ ok: boolean; moved: boolean }>;

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -1,0 +1,145 @@
+/** @jsxImportSource react */
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+
+import { isDesktopRuntime } from "../../app/utils";
+import { useBootState } from "./boot-state";
+
+type ArchitectureInfo = {
+  appArch: string;
+  appArchLabel: string;
+  systemArch: string;
+  systemArchLabel: string;
+  mismatch: boolean;
+  platform: "darwin" | "linux" | "windows";
+  version: string;
+  downloadUrl: string;
+  releaseUrl: string;
+};
+
+type ArchitectureMismatchGateProps = {
+  children: ReactNode;
+};
+
+function platformLabel(platform: ArchitectureInfo["platform"]): string {
+  if (platform === "darwin") return "macOS";
+  if (platform === "windows") return "Windows";
+  return "Linux";
+}
+
+export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateProps) {
+  const { markRouteReady } = useBootState();
+  const [info, setInfo] = useState<ArchitectureInfo | null>(null);
+  const [checked, setChecked] = useState(!isDesktopRuntime());
+
+  useEffect(() => {
+    let cancelled = false;
+    const bridge = window.__OPENWORK_ELECTRON__?.system?.getArchitectureInfo;
+    if (!bridge) {
+      setChecked(true);
+      return;
+    }
+
+    void bridge()
+      .then((nextInfo) => {
+        if (cancelled) return;
+        setInfo(nextInfo);
+      })
+      .catch((error) => {
+        console.warn("[architecture-gate] failed to resolve runtime architecture", error);
+      })
+      .finally(() => {
+        if (!cancelled) setChecked(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (info?.mismatch) markRouteReady();
+  }, [info?.mismatch, markRouteReady]);
+
+  const openDownload = useCallback(() => {
+    const url = info?.downloadUrl || info?.releaseUrl;
+    if (!url) return;
+    void window.__OPENWORK_ELECTRON__?.shell?.openExternal?.(url);
+  }, [info?.downloadUrl, info?.releaseUrl]);
+
+  const openRelease = useCallback(() => {
+    if (!info?.releaseUrl) return;
+    void window.__OPENWORK_ELECTRON__?.shell?.openExternal?.(info.releaseUrl);
+  }, [info?.releaseUrl]);
+
+  if (!checked) return null;
+  if (!info?.mismatch) return <>{children}</>;
+
+  return (
+    <main className="min-h-screen bg-[#05070c] text-white">
+      <div className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-6 py-12">
+        <section className="w-full overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.04] shadow-2xl shadow-black/40">
+          <div className="grid gap-0 lg:grid-cols-[1.05fr_0.95fr]">
+            <div className="space-y-8 p-8 sm:p-10 lg:p-12">
+              <div className="inline-flex rounded-full border border-amber-300/30 bg-amber-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-amber-100">
+                Architecture mismatch
+              </div>
+              <div className="space-y-4">
+                <h1 className="max-w-2xl text-4xl font-semibold tracking-[-0.04em] text-white sm:text-5xl">
+                  Install the correct OpenWork build
+                </h1>
+                <p className="max-w-2xl text-base leading-7 text-white/72 sm:text-lg">
+                  Your application is running the {info.appArchLabel} version of OpenWork, but this {platformLabel(info.platform)} system is {info.systemArchLabel}. This may cause unpredictable issues.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                  <div className="text-xs uppercase tracking-[0.2em] text-white/40">Running app</div>
+                  <div className="mt-2 text-2xl font-semibold text-white">{info.appArchLabel}</div>
+                  <div className="mt-1 font-mono text-xs text-white/45">{info.appArch}</div>
+                </div>
+                <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-4">
+                  <div className="text-xs uppercase tracking-[0.2em] text-emerald-100/70">Your system</div>
+                  <div className="mt-2 text-2xl font-semibold text-emerald-50">{info.systemArchLabel}</div>
+                  <div className="mt-1 font-mono text-xs text-emerald-100/55">{info.systemArch}</div>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <button
+                  type="button"
+                  onClick={openDownload}
+                  className="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-semibold text-black transition hover:bg-emerald-100"
+                >
+                  Download correct version
+                </button>
+                <button
+                  type="button"
+                  onClick={openRelease}
+                  className="inline-flex items-center justify-center rounded-full border border-white/14 px-5 py-3 text-sm font-semibold text-white/85 transition hover:bg-white/10"
+                >
+                  Open release page
+                </button>
+              </div>
+            </div>
+
+            <aside className="border-t border-white/10 bg-gradient-to-br from-emerald-300/12 via-sky-300/8 to-transparent p-8 sm:p-10 lg:border-l lg:border-t-0 lg:p-12">
+              <div className="space-y-5 rounded-[28px] border border-white/10 bg-black/25 p-6 text-sm leading-6 text-white/68">
+                <div className="text-lg font-semibold text-white">Why OpenWork stopped here</div>
+                <p>
+                  OpenWork blocks startup when the installed app architecture does not match the machine architecture. This prevents runtime sidecars, browser tooling, and update downloads from continuing on the wrong build.
+                </p>
+                <p>
+                  After installing the correct {info.systemArchLabel} build, quit this copy and launch OpenWork again. Your workspaces and settings are kept in the same app data folder.
+                </p>
+                <div className="rounded-2xl bg-white/[0.06] p-4 font-mono text-xs text-white/55">
+                  v{info.version} · {platformLabel(info.platform)} · {info.systemArch}
+                </div>
+              </div>
+            </aside>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -10,6 +10,7 @@ import { RestrictionNoticeProvider } from "../domains/cloud/restriction-notice-p
 import { StatusToastsProvider } from "../domains/shell-feedback/status-toasts";
 import { LocalProvider } from "../kernel/local-provider";
 import { ServerProvider } from "../kernel/server-provider";
+import { ArchitectureMismatchGate } from "./architecture-mismatch-gate";
 import { BootStateProvider } from "./boot-state";
 import { DesktopRuntimeBoot } from "./desktop-runtime-boot";
 import { startDebugLogger, stopDebugLogger } from "./debug-logger";
@@ -61,18 +62,20 @@ export function AppProviders({ children }: AppProvidersProps) {
   return (
     <BootStateProvider>
       <ServerProvider defaultUrl={defaultUrl}>
-        <DesktopRuntimeBoot />
-        <DenAuthProvider>
-          <DesktopConfigProvider>
-            <RestrictionNoticeProvider>
-              <LocalProvider>
-                <StatusToastsProvider>
-                  <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
-                </StatusToastsProvider>
-              </LocalProvider>
-            </RestrictionNoticeProvider>
-          </DesktopConfigProvider>
-        </DenAuthProvider>
+        <ArchitectureMismatchGate>
+          <DesktopRuntimeBoot />
+          <DenAuthProvider>
+            <DesktopConfigProvider>
+              <RestrictionNoticeProvider>
+                <LocalProvider>
+                  <StatusToastsProvider>
+                    <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
+                  </StatusToastsProvider>
+                </LocalProvider>
+              </RestrictionNoticeProvider>
+            </DesktopConfigProvider>
+          </DenAuthProvider>
+        </ArchitectureMismatchGate>
       </ServerProvider>
     </BootStateProvider>
   );

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { createServer } from "node:http";
 import { existsSync } from "node:fs";
 import {
@@ -32,6 +33,7 @@ const DESKTOP_PROTOCOL_SCHEME = "openwork";
 const isDevMode = process.env.OPENWORK_DEV_MODE === "1";
 const APP_NAME = isDevMode ? "OpenWork - Dev" : "OpenWork";
 const APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
+const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
 
 // Production Electron shares the same on-disk state folder as the Tauri shell
 // so in-place migration is a no-op for almost every file. Dev mode uses the
@@ -77,6 +79,78 @@ function resolveAppIconPath() {
     if (candidate && existsSync(candidate)) return candidate;
   }
   return null;
+}
+
+function normalizeRuntimeArch(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (["arm64", "aarch64", "arm64e"].includes(normalized)) return "arm64";
+  if (["x64", "x86_64", "amd64"].includes(normalized)) return "x64";
+  return normalized || "unknown";
+}
+
+function isMacRunningUnderRosetta() {
+  if (process.platform !== "darwin" || process.arch !== "x64") return false;
+  try {
+    return execFileSync("/usr/sbin/sysctl", ["-in", "sysctl.proc_translated"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim() === "1";
+  } catch {
+    return false;
+  }
+}
+
+function resolveSystemArch() {
+  if (process.platform === "darwin" && isMacRunningUnderRosetta()) return "arm64";
+  if (process.platform === "win32") {
+    return normalizeRuntimeArch(
+      process.env.PROCESSOR_ARCHITEW6432 || process.env.PROCESSOR_ARCHITECTURE || os.arch(),
+    );
+  }
+  if (typeof os.machine === "function") return normalizeRuntimeArch(os.machine());
+  return normalizeRuntimeArch(os.arch());
+}
+
+function platformDownloadSlug() {
+  if (process.platform === "darwin") return "mac";
+  if (process.platform === "win32") return "win";
+  return "linux";
+}
+
+function downloadAssetArch(arch) {
+  if (process.platform === "linux" && arch === "x64") return "x86_64";
+  return arch;
+}
+
+function downloadAssetExtension() {
+  if (process.platform === "darwin") return "dmg";
+  if (process.platform === "win32") return "exe";
+  return "AppImage";
+}
+
+function archLabel(arch) {
+  if (arch === "arm64") return "ARM";
+  if (arch === "x64") return "Intel";
+  return arch;
+}
+
+function resolveArchitectureInfo() {
+  const appArch = normalizeRuntimeArch(process.arch);
+  const systemArch = resolveSystemArch();
+  const version = app.getVersion();
+  const targetArch = systemArch === "arm64" || systemArch === "x64" ? systemArch : appArch;
+  const assetName = `openwork-${platformDownloadSlug()}-${downloadAssetArch(targetArch)}-${version}.${downloadAssetExtension()}`;
+  return {
+    appArch,
+    appArchLabel: archLabel(appArch),
+    systemArch,
+    systemArchLabel: archLabel(systemArch),
+    mismatch: appArch !== systemArch && (systemArch === "arm64" || systemArch === "x64"),
+    platform: process.platform === "win32" ? "windows" : process.platform,
+    version,
+    downloadUrl: `${RELEASE_DOWNLOAD_BASE_URL}/${assetName}`,
+    releaseUrl: "https://github.com/different-ai/openwork/releases/latest",
+  };
 }
 
 const APP_ICON_PATH = resolveAppIconPath();
@@ -1923,6 +1997,7 @@ ipcMain.handle("openwork:shell:relaunch", async () => {
   app.relaunch();
   app.exit(0);
 });
+ipcMain.handle("openwork:system:architecture", async () => resolveArchitectureInfo());
 
 // ── Embedded browser IPC ────────────────────────────────────────────────
 ipcMain.handle("openwork:browser:show", (_event, bounds) => attachBrowserView(bounds));

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -34,6 +34,7 @@ const isDevMode = process.env.OPENWORK_DEV_MODE === "1";
 const APP_NAME = isDevMode ? "OpenWork - Dev" : "OpenWork";
 const APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
 const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
+const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
 
 // Production Electron shares the same on-disk state folder as the Tauri shell
 // so in-place migration is a no-op for almost every file. Dev mode uses the
@@ -128,18 +129,76 @@ function downloadAssetExtension() {
   return "AppImage";
 }
 
+function updaterManifestName(arch) {
+  if (process.platform === "darwin") return "latest-mac.yml";
+  if (process.platform === "win32") return "latest.yml";
+  return arch === "arm64" ? "latest-linux-arm64.yml" : "latest-linux.yml";
+}
+
 function archLabel(arch) {
   if (arch === "arm64") return "ARM";
   if (arch === "x64") return "Intel";
   return arch;
 }
 
-function resolveArchitectureInfo() {
+function parseUpdaterManifestFiles(raw) {
+  const files = [];
+  let current = null;
+  for (const line of String(raw || "").split(/\r?\n/)) {
+    const start = line.match(/^\s*-\s+url:\s*(.+?)\s*$/);
+    if (start) {
+      current = { url: start[1].trim().replace(/^['"]|['"]$/g, "") };
+      files.push(current);
+      continue;
+    }
+    const prop = line.match(/^\s{4}([A-Za-z][A-Za-z0-9_-]*):\s*(.+?)\s*$/);
+    if (prop && current) {
+      current[prop[1]] = prop[2].trim().replace(/^['"]|['"]$/g, "");
+    }
+  }
+  return files.filter((file) => file.url);
+}
+
+function selectDownloadFile(files, arch) {
+  const assetArch = downloadAssetArch(arch);
+  const expected = `-${assetArch}-`;
+  const extension = downloadAssetExtension();
+  const matchingArch = files.filter((file) => file.url.includes(expected));
+  return (
+    matchingArch.find((file) => file.url.endsWith(`.${extension}`)) ||
+    matchingArch.find((file) => file.url.endsWith(".zip")) ||
+    matchingArch[0] ||
+    files.find((file) => file.url.endsWith(`.${extension}`)) ||
+    files[0] ||
+    null
+  );
+}
+
+async function resolveCorrectArchitectureDownloadUrl(arch) {
+  const manifestUrl = `${RELEASE_DOWNLOAD_BASE_URL}/${updaterManifestName(arch)}`;
+  try {
+    const response = await fetch(manifestUrl, {
+      headers: { Accept: "text/yaml, text/plain, */*" },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const selected = selectDownloadFile(parseUpdaterManifestFiles(await response.text()), arch);
+    if (!selected?.url) return null;
+    return /^https?:\/\//i.test(selected.url)
+      ? selected.url
+      : new URL(selected.url, `${RELEASE_DOWNLOAD_BASE_URL}/`).toString();
+  } catch (error) {
+    console.warn("[architecture] failed to resolve latest download URL", error);
+    return null;
+  }
+}
+
+async function resolveArchitectureInfo() {
   const appArch = normalizeRuntimeArch(process.arch);
   const systemArch = resolveSystemArch();
   const version = app.getVersion();
   const targetArch = systemArch === "arm64" || systemArch === "x64" ? systemArch : appArch;
   const assetName = `openwork-${platformDownloadSlug()}-${downloadAssetArch(targetArch)}-${version}.${downloadAssetExtension()}`;
+  const latestDownloadUrl = await resolveCorrectArchitectureDownloadUrl(targetArch);
   return {
     appArch,
     appArchLabel: archLabel(appArch),
@@ -148,8 +207,8 @@ function resolveArchitectureInfo() {
     mismatch: appArch !== systemArch && (systemArch === "arm64" || systemArch === "x64"),
     platform: process.platform === "win32" ? "windows" : process.platform,
     version,
-    downloadUrl: `${RELEASE_DOWNLOAD_BASE_URL}/${assetName}`,
-    releaseUrl: "https://github.com/different-ai/openwork/releases/latest",
+    downloadUrl: latestDownloadUrl || `${RELEASE_DOWNLOAD_BASE_URL}/${assetName}`,
+    releaseUrl: RELEASE_PAGE_URL,
   };
 }
 

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -40,6 +40,11 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
       return ipcRenderer.invoke("openwork:shell:relaunch");
     },
   },
+  system: {
+    getArchitectureInfo() {
+      return ipcRenderer.invoke("openwork:system:architecture");
+    },
+  },
   migration: {
     readSnapshot() {
       return ipcRenderer.invoke("openwork:migration:read");

--- a/scripts/release/publish-electron-assets.mjs
+++ b/scripts/release/publish-electron-assets.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
+
+const [, , distRootArg, releaseTag] = process.argv;
+
+if (!distRootArg || !releaseTag) {
+  console.error("Usage: node scripts/release/publish-electron-assets.mjs <dist-root> <release-tag>");
+  process.exit(2);
+}
+
+const repo = process.env.GITHUB_REPOSITORY;
+if (!repo) {
+  console.error("GITHUB_REPOSITORY is required.");
+  process.exit(2);
+}
+
+const distRoot = resolve(distRootArg);
+const outputDir = resolve(process.env.RUNNER_TEMP || ".", "openwork-electron-manifests");
+mkdirSync(outputDir, { recursive: true });
+
+function walk(dir) {
+  const entries = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) entries.push(...walk(path));
+    else if (stat.isFile()) entries.push(path);
+  }
+  return entries;
+}
+
+function isUpdaterManifest(path) {
+  return /^latest.*\.ya?ml$/.test(basename(path));
+}
+
+function isReleaseAsset(path) {
+  if (isUpdaterManifest(path)) return false;
+  if (!basename(path).startsWith("openwork-")) return false;
+  return /\.(AppImage|blockmap|dmg|exe|rpm|zip)$/i.test(path) || /\.tar\.gz$/i.test(path);
+}
+
+function runGh(args) {
+  const result = spawnSync("gh", args, { stdio: "inherit", encoding: "utf8" });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+function parseManifest(path) {
+  const raw = readFileSync(path, "utf8");
+  const parsed = { files: [] };
+  let currentFile = null;
+
+  for (const line of raw.split(/\r?\n/)) {
+    const topLevel = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*?)\s*$/);
+    if (topLevel) {
+      const [, key, value] = topLevel;
+      if (key !== "files") parsed[key] = unquoteYamlScalar(value);
+      currentFile = null;
+      continue;
+    }
+
+    const fileStart = line.match(/^\s*-\s+([A-Za-z][A-Za-z0-9_-]*):\s*(.*?)\s*$/);
+    if (fileStart) {
+      const [, key, value] = fileStart;
+      currentFile = {};
+      currentFile[key] = parseYamlScalar(value);
+      parsed.files.push(currentFile);
+      continue;
+    }
+
+    const fileProp = line.match(/^\s{4}([A-Za-z][A-Za-z0-9_-]*):\s*(.*?)\s*$/);
+    if (fileProp && currentFile) {
+      const [, key, value] = fileProp;
+      currentFile[key] = parseYamlScalar(value);
+    }
+  }
+
+  if (!parsed.version) throw new Error(`Missing version in ${path}`);
+  if (!Array.isArray(parsed.files) || parsed.files.length === 0) {
+    throw new Error(`Missing files in ${path}`);
+  }
+  return parsed;
+}
+
+function unquoteYamlScalar(value) {
+  const trimmed = String(value || "").trim();
+  return trimmed.replace(/^['"]|['"]$/g, "");
+}
+
+function parseYamlScalar(value) {
+  const unquoted = unquoteYamlScalar(value);
+  if (/^\d+$/.test(unquoted)) return Number(unquoted);
+  return unquoted;
+}
+
+function quoteYamlScalar(value) {
+  const string = String(value ?? "");
+  if (!string || /[:#\[\]{}&,*!|>'"%@`\s]/.test(string)) {
+    return `'${string.replace(/'/g, "''")}'`;
+  }
+  return string;
+}
+
+function stringifyManifest(manifest) {
+  const lines = [`version: ${quoteYamlScalar(manifest.version)}`, "files:"];
+  for (const file of manifest.files) {
+    lines.push(`  - url: ${quoteYamlScalar(file.url)}`);
+    for (const [key, value] of Object.entries(file)) {
+      if (key === "url") continue;
+      lines.push(`    ${key}: ${typeof value === "number" ? value : quoteYamlScalar(value)}`);
+    }
+  }
+  if (manifest.releaseDate) lines.push(`releaseDate: ${quoteYamlScalar(manifest.releaseDate)}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function sortFiles(files) {
+  const rank = (url) => {
+    const value = String(url || "");
+    if (value.includes("arm64")) return 0;
+    if (value.includes("x64") || value.includes("x86_64")) return 1;
+    return 2;
+  };
+  return [...files].sort((left, right) => {
+    const byRank = rank(left.url) - rank(right.url);
+    if (byRank !== 0) return byRank;
+    const leftExt = extname(String(left.url || ""));
+    const rightExt = extname(String(right.url || ""));
+    if (leftExt === ".zip" && rightExt !== ".zip") return -1;
+    if (rightExt === ".zip" && leftExt !== ".zip") return 1;
+    return String(left.url || "").localeCompare(String(right.url || ""));
+  });
+}
+
+function mergeManifests(name, paths) {
+  const manifests = paths.map(parseManifest);
+  const version = manifests[0].version;
+  for (const manifest of manifests) {
+    if (manifest.version !== version) {
+      throw new Error(`${name} has mixed versions: ${version} and ${manifest.version}`);
+    }
+  }
+
+  const filesByUrl = new Map();
+  for (const manifest of manifests) {
+    for (const file of manifest.files) {
+      if (!file?.url) throw new Error(`${name} contains a file entry without url.`);
+      filesByUrl.set(file.url, file);
+    }
+  }
+
+  const releaseDates = manifests.map((manifest) => manifest.releaseDate).filter(Boolean).sort();
+  const merged = {
+    version,
+    files: sortFiles([...filesByUrl.values()]),
+  };
+  if (releaseDates.length) merged.releaseDate = releaseDates[releaseDates.length - 1];
+  return merged;
+}
+
+function validateManifest(name, manifest) {
+  const urls = manifest.files.map((file) => String(file.url || ""));
+  if (name === "latest-mac.yml") {
+    for (const arch of ["mac-arm64", "mac-x64"]) {
+      if (!urls.some((url) => url.includes(arch))) {
+        throw new Error(`${name} is missing ${arch} artifacts.`);
+      }
+    }
+  }
+  if (name === "latest-linux.yml" && urls.some((url) => url.includes("arm64"))) {
+    throw new Error(`${name} should remain the Linux x64 feed; arm64 belongs in latest-linux-arm64.yml.`);
+  }
+  if (name === "latest-linux-arm64.yml" && !urls.some((url) => url.includes("arm64"))) {
+    throw new Error(`${name} is missing Linux arm64 artifacts.`);
+  }
+}
+
+const files = walk(distRoot);
+const releaseAssets = files.filter(isReleaseAsset);
+const manifestsByName = new Map();
+
+for (const path of files.filter(isUpdaterManifest)) {
+  const name = basename(path);
+  const current = manifestsByName.get(name) || [];
+  current.push(path);
+  manifestsByName.set(name, current);
+}
+
+if (releaseAssets.length === 0) {
+  console.error(`No Electron release assets found under ${distRoot}`);
+  process.exit(1);
+}
+
+if (manifestsByName.size === 0) {
+  console.error(`No Electron updater manifests found under ${distRoot}`);
+  process.exit(1);
+}
+
+runGh(["release", "upload", releaseTag, ...releaseAssets, "--repo", repo, "--clobber"]);
+
+for (const [name, paths] of [...manifestsByName.entries()].sort()) {
+  const manifest = mergeManifests(name, paths);
+  validateManifest(name, manifest);
+  const outputPath = join(outputDir, name);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, stringifyManifest(manifest), "utf8");
+  runGh(["release", "upload", releaseTag, `${outputPath}#${name}`, "--repo", repo, "--clobber"]);
+}


### PR DESCRIPTION
## Summary

- Prevent Electron release matrix jobs from clobbering updater manifests by publishing packaged artifacts through a single manifest merge job.
- Add Windows arm64 Electron release coverage and validate the merged macOS feed includes both arm64 and x64 artifacts.
- Block app startup when the running Electron app architecture does not match the host architecture, with a direct download CTA for the correct build.

## Evidence

### Screenshots
- Not captured. The new UI only appears on architecture mismatch, which requires running a packaged wrong-architecture build under Rosetta or an equivalent host mismatch.

### Build verification
- `node --check apps/desktop/electron/main.mjs && node --check apps/desktop/electron/preload.mjs && node --check scripts/release/publish-electron-assets.mjs` -- passed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos-aarch64.yml")'` -- passed
- Local mocked manifest merge test -- passed; generated `latest-mac.yml` included both `openwork-mac-arm64-...zip` and `openwork-mac-x64-...zip`
- `pnpm --filter @openwork/app typecheck` -- failed on existing repo-wide TypeScript errors unrelated to this change after dependencies were installed

### API verification
- No API changes.

### UI verification
- Not run through Chrome MCP because the gating condition depends on packaged app/process architecture mismatch rather than a normal browser route.

## Test instructions

1. Trigger `Release App` for a test tag with Electron publishing enabled.
2. Confirm the release upload includes one merged `latest-mac.yml` containing both `openwork-mac-arm64-<version>.zip` and `openwork-mac-x64-<version>.zip`.
3. On Apple Silicon, launch an x64 packaged build under Rosetta and verify the startup gate appears before runtime boot.
4. Click `Download correct version` and verify it opens the latest release asset URL for the system architecture.