### PR TITLE
feat(app): add resizable browser panel

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -63,6 +63,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",
+    "react-resizable-panels": "^4.11.0",
     "react-router-dom": "^7.14.1",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.6.0",

--- a/apps/app/src/components/ui/resizable.tsx
+++ b/apps/app/src/components/ui/resizable.tsx
@@ -1,0 +1,48 @@
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: ResizablePrimitive.GroupProps) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full aria-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: ResizablePrimitive.SeparatorProps & {
+  withHandle?: boolean
+}) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "relative flex w-px items-center justify-center bg-border ring-offset-background after:absolute after:inset-y-0 after:start-1/2 after:w-1 after:-translate-x-1/2 rtl:after:translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:start-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 rtl:aria-[orientation=horizontal]:after:-translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="z-10 flex h-6 w-1 shrink-0 rounded-lg bg-border" />
+      )}
+    </ResizablePrimitive.Separator>
+  )
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -39,6 +39,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const urlInputRef = useRef<HTMLInputElement>(null);
   const shownRef = useRef(false);
+  const boundsFrameRef = useRef<number | null>(null);
 
   // Subscribe to state changes from the main process
   useEffect(() => {
@@ -61,7 +62,8 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     const panel = panelRef.current;
     const toolbar = toolbarRef.current;
 
-    const tryShow = () => {
+    const syncBounds = () => {
+      boundsFrameRef.current = null;
       const bounds = computeBounds(panel, toolbar);
       if (bounds.width < 1 || bounds.height < 1) return; // not laid out yet
       if (!shownRef.current) {
@@ -71,18 +73,26 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
         browser.setBounds?.(bounds);
       }
     };
+    const scheduleSyncBounds = () => {
+      if (boundsFrameRef.current != null) return;
+      boundsFrameRef.current = window.requestAnimationFrame(syncBounds);
+    };
 
     // Initial show (may be zero-dimension if layout hasn't settled)
-    tryShow();
+    syncBounds();
 
-    const observer = new ResizeObserver(tryShow);
+    const observer = new ResizeObserver(scheduleSyncBounds);
     observer.observe(panel);
     observer.observe(toolbar);
-    window.addEventListener("resize", tryShow);
+    window.addEventListener("resize", scheduleSyncBounds);
 
     return () => {
       observer.disconnect();
-      window.removeEventListener("resize", tryShow);
+      window.removeEventListener("resize", scheduleSyncBounds);
+      if (boundsFrameRef.current != null) {
+        window.cancelAnimationFrame(boundsFrameRef.current);
+        boundsFrameRef.current = null;
+      }
       browser.hide?.();
       shownRef.current = false;
     };

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -216,12 +216,17 @@ export function SessionPage(props: SessionPageProps) {
     expandedRightWidth: 520,
     minRightWidth: 320,
   });
+  const [browserPanelDefaultWidth, setBrowserPanelDefaultWidth] = useState(browserPanelWidth);
   const sidebarProviderStyle: CSSProperties & Record<"--sidebar-width", string> = {
     "--sidebar-width": `${leftSidebarWidth}px`,
   };
+  useEffect(() => {
+    if (browserPanelOpen) return;
+    setBrowserPanelDefaultWidth(browserPanelWidth);
+  }, [browserPanelOpen, browserPanelWidth]);
   const commitBrowserPanelWidth = useCallback(() => {
     const size = browserPanelRef.current?.getSize();
-    if (size) setBrowserPanelWidth(size.inPixels);
+    if (size?.inPixels) setBrowserPanelWidth(Math.round(size.inPixels));
   }, [browserPanelRef, setBrowserPanelWidth]);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
@@ -673,7 +678,7 @@ export function SessionPage(props: SessionPageProps) {
                 <ResizableHandle withHandle className="hidden lg:flex" />
                 <ResizablePanel
                   panelRef={browserPanelRef}
-                  defaultSize={`${browserPanelWidth}px`}
+                  defaultSize={`${browserPanelDefaultWidth}px`}
                   minSize="320px"
                   maxSize="70%"
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePanelRef } from "react-resizable-panels";
 import { Check, Globe, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
@@ -30,6 +31,11 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
 import { ShareWorkspaceModal } from "../../workspace/share-workspace-modal";
 import { StatusBar, type StatusBarProps } from "./status-bar";
 import { OwDotTicker } from "../../../shell/dot-ticker";
@@ -184,6 +190,7 @@ export function SessionPage(props: SessionPageProps) {
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
   const [todoExpanded, setTodoExpanded] = useState(true);
   const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
+  const browserPanelRef = usePanelRef();
   const toggleBrowserPanel = useCallback(() => setBrowserPanelOpen((p) => !p), []);
 
   // Sync browser panel state with Electron main process IPC events.
@@ -199,12 +206,23 @@ export function SessionPage(props: SessionPageProps) {
     const unsubClose = browser.onPanelClosed?.(() => setBrowserPanelOpen(false));
     return () => { unsubOpen?.(); unsubClose?.(); };
   }, []);
-  const { leftSidebarResizing, leftSidebarWidth, startLeftSidebarResize } = useWorkspaceShellLayout({
+  const {
+    leftSidebarResizing,
+    leftSidebarWidth,
+    rightSidebarExpandedWidth: browserPanelWidth,
+    setRightSidebarExpandedWidth: setBrowserPanelWidth,
+    startLeftSidebarResize,
+  } = useWorkspaceShellLayout({
     expandedRightWidth: 520,
+    minRightWidth: 320,
   });
   const sidebarProviderStyle: CSSProperties & Record<"--sidebar-width", string> = {
     "--sidebar-width": `${leftSidebarWidth}px`,
   };
+  const commitBrowserPanelWidth = useCallback(() => {
+    const size = browserPanelRef.current?.getSize();
+    if (size) setBrowserPanelWidth(size.inPixels);
+  }, [browserPanelRef, setBrowserPanelWidth]);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
   const selectedSessionTitle = useMemo(
@@ -369,8 +387,14 @@ export function SessionPage(props: SessionPageProps) {
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
           onStartResize={startLeftSidebarResize}
         />
-        <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28 flex flex-row">
-          <main className="flex min-w-0 flex-1 flex-col overflow-hidden border-r border-border">
+        <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28">
+          <ResizablePanelGroup
+            orientation="horizontal"
+            onLayoutChanged={browserPanelOpen ? commitBrowserPanelWidth : undefined}
+            className="min-h-0"
+          >
+            <ResizablePanel minSize="360px" className="min-w-0">
+              <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
           <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
               <SidebarTrigger className="mac:hidden" />
@@ -642,15 +666,23 @@ export function SessionPage(props: SessionPageProps) {
             statusPulse={props.statusBar?.statusPulse}
             showSettingsButton={props.statusBar?.showSettingsButton}
           />
-          </main>
-          {browserPanelOpen ? (
-            <aside
-              className="hidden min-h-0 shrink-0 overflow-hidden lg:flex lg:flex-col"
-              style={{ width: 520 }}
-            >
-              <BrowserPanel onClose={toggleBrowserPanel} />
-            </aside>
-          ) : null}
+              </main>
+            </ResizablePanel>
+            {browserPanelOpen ? (
+              <>
+                <ResizableHandle withHandle className="hidden lg:flex" />
+                <ResizablePanel
+                  panelRef={browserPanelRef}
+                  defaultSize={`${browserPanelWidth}px`}
+                  minSize="320px"
+                  maxSize="70%"
+                  className="min-h-0 overflow-hidden lg:flex lg:flex-col"
+                >
+                  <BrowserPanel onClose={toggleBrowserPanel} />
+                </ResizablePanel>
+              </>
+            ) : null}
+          </ResizablePanelGroup>
         </SidebarInset>
         <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" />
       </SidebarProvider>

--- a/apps/app/src/react-app/shell/workspace-shell-layout.ts
+++ b/apps/app/src/react-app/shell/workspace-shell-layout.ts
@@ -3,11 +3,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const LEFT_SIDEBAR_WIDTH_KEY = "openwork.workspace-shell.left-width.v1";
 const RIGHT_SIDEBAR_EXPANDED_KEY = "openwork.workspace-shell.right-expanded.v3";
+const RIGHT_SIDEBAR_WIDTH_KEY = "openwork.workspace-shell.right-width.v1";
 
 export const DEFAULT_WORKSPACE_LEFT_SIDEBAR_WIDTH = 260;
 export const MIN_WORKSPACE_LEFT_SIDEBAR_WIDTH = 220;
 export const MAX_WORKSPACE_LEFT_SIDEBAR_WIDTH = 420;
 export const DEFAULT_WORKSPACE_RIGHT_SIDEBAR_COLLAPSED_WIDTH = 72;
+export const MIN_WORKSPACE_RIGHT_SIDEBAR_WIDTH = 320;
+export const MAX_WORKSPACE_RIGHT_SIDEBAR_WIDTH = 960;
 
 type WorkspaceShellLayoutOptions = {
   defaultLeftWidth?: number;
@@ -15,6 +18,8 @@ type WorkspaceShellLayoutOptions = {
   maxLeftWidth?: number;
   collapsedRightWidth?: number;
   expandedRightWidth: number;
+  minRightWidth?: number;
+  maxRightWidth?: number;
 };
 
 function readStorage(key: string): string | null {
@@ -52,6 +57,9 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
     options.collapsedRightWidth ?? DEFAULT_WORKSPACE_RIGHT_SIDEBAR_COLLAPSED_WIDTH,
   );
   const expandedRightWidth = Math.max(collapsedRightWidth, options.expandedRightWidth);
+  const minRightWidth = Math.max(collapsedRightWidth, options.minRightWidth ?? MIN_WORKSPACE_RIGHT_SIDEBAR_WIDTH);
+  const maxRightWidth = Math.max(minRightWidth, options.maxRightWidth ?? MAX_WORKSPACE_RIGHT_SIDEBAR_WIDTH);
+  const defaultRightWidth = clampNumber(expandedRightWidth, minRightWidth, maxRightWidth);
 
   const readLeftSidebarWidth = useCallback(() => {
     const raw = readStorage(LEFT_SIDEBAR_WIDTH_KEY);
@@ -66,9 +74,17 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
     return raw === "1";
   }, []);
 
+  const readRightSidebarExpandedWidth = useCallback(() => {
+    const raw = readStorage(RIGHT_SIDEBAR_WIDTH_KEY);
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return defaultRightWidth;
+    return clampNumber(parsed, minRightWidth, maxRightWidth);
+  }, [defaultRightWidth, maxRightWidth, minRightWidth]);
+
   const [leftSidebarWidth, setLeftSidebarWidth] = useState(readLeftSidebarWidth);
   const [leftSidebarResizing, setLeftSidebarResizing] = useState(false);
   const [rightSidebarExpanded, setRightSidebarExpanded] = useState(readRightSidebarExpanded);
+  const [rightSidebarExpandedWidth, setRightSidebarExpandedWidthState] = useState(readRightSidebarExpandedWidth);
   const dragCleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
@@ -82,9 +98,23 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
     writeStorage(RIGHT_SIDEBAR_EXPANDED_KEY, rightSidebarExpanded ? "1" : "0");
   }, [rightSidebarExpanded]);
 
+  useEffect(() => {
+    writeStorage(
+      RIGHT_SIDEBAR_WIDTH_KEY,
+      String(clampNumber(rightSidebarExpandedWidth, minRightWidth, maxRightWidth)),
+    );
+  }, [maxRightWidth, minRightWidth, rightSidebarExpandedWidth]);
+
   const rightSidebarWidth = useMemo(
-    () => (rightSidebarExpanded ? expandedRightWidth : collapsedRightWidth),
-    [collapsedRightWidth, expandedRightWidth, rightSidebarExpanded],
+    () => (rightSidebarExpanded ? rightSidebarExpandedWidth : collapsedRightWidth),
+    [collapsedRightWidth, rightSidebarExpanded, rightSidebarExpandedWidth],
+  );
+
+  const setRightSidebarExpandedWidth = useCallback(
+    (width: number) => {
+      setRightSidebarExpandedWidthState(clampNumber(width, minRightWidth, maxRightWidth));
+    },
+    [maxRightWidth, minRightWidth],
   );
 
   const stopLeftSidebarResize = useCallback(() => {
@@ -147,8 +177,10 @@ export function useWorkspaceShellLayout(options: WorkspaceShellLayoutOptions) {
     leftSidebarWidth,
     leftSidebarResizing,
     rightSidebarExpanded,
+    rightSidebarExpandedWidth,
     rightSidebarWidth,
     setRightSidebarExpanded,
+    setRightSidebarExpandedWidth,
     startLeftSidebarResize,
     toggleRightSidebar,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      react-resizable-panels:
+        specifier: ^4.11.0
+        version: 4.11.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-router-dom:
         specifier: ^7.14.1
         version: 7.14.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6924,6 +6927,12 @@ packages:
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
+
+  react-resizable-panels@4.11.0:
+    resolution: {integrity: sha512-LPk/AkFDGkg7SsbOyL93ojrE6E7lhrxxDwnYNjfmnSeI6BE7Sje6dB24PXgZk8DeugdeXNk1LO+ohRqIjhxiLw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-router-dom@7.14.1:
     resolution: {integrity: sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==}
@@ -15189,6 +15198,11 @@ snapshots:
       - supports-color
 
   react-refresh@0.18.0: {}
+
+  react-resizable-panels@4.11.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-router-dom@7.14.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
- Adds a shared `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle` wrapper around `react-resizable-panels`.
- Makes the browser side panel in the session page horizontally resizable instead of fixed at `520px`.
- Persists the resized browser panel width in workspace shell layout state/local storage, with min/max width clamping.
- Updates browser webview bounds syncing to batch resize updates with `requestAnimationFrame`, so Electron bounds stay in sync while resizing.
- Adds `react-resizable-panels` to the app dependencies and lockfile.
