### PR TITLE
fix : Reasoning toggle works properly

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -63,6 +63,7 @@ export type SessionSurfaceProps = {
   opencodeBaseUrl: string;
   openworkToken: string;
   developerMode: boolean;
+  showThinking: boolean;
   modelLabel: string;
   onModelClick: () => void;
   onSendDraft: (draft: ComposerDraft) => void;
@@ -893,7 +894,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                     messages={renderedMessages}
                     isStreaming={chatStreaming}
                     developerMode={props.developerMode}
-                    showThinking={showThinking}
+                    showThinking={props.showThinking}
                     scrollElement={() => scrollRef.current}
                   />
                   {error ? (

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -28,6 +28,7 @@ type SyncEntry = {
   dispose: () => void;
   trackedSessionRefs: Map<string, number>;
   pendingDeltas: Map<string, { messageId: string; reasoning: boolean; text: string }>;
+  partKinds: Map<string, Part["type"]>;
   // Coalesce rapid-fire delta events from the SSE stream into one cache
   // commit per animation frame. Without this, a long response produces a
   // setQueryData per token; each triggers a full transcript re-render
@@ -366,6 +367,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     const part = props.part;
     if (!part?.sessionID || !part.messageID) return;
     if (!isTrackedSession(entry, part.sessionID)) return;
+    entry.partKinds.set(part.id, part.type);
     const mapped = toUIPart(part);
     if (!mapped) return;
     const pending = entry.pendingDeltas.get(part.id);
@@ -428,11 +430,13 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     // `message.part.updated`. The flusher resolves the kind at apply
     // time, falling back to `pendingDeltas` if the part hasn't been
     // declared yet.
+    const knownPartKind = entry.partKinds.get(props.partID);
+    const isReasoningDelta = props.field === "reasoning" || knownPartKind === "reasoning";
     entry.deltaFlushBuffer.push({
       sessionId: props.sessionID!,
       messageId: props.messageID!,
       partId: props.partID!,
-      reasoning: false,
+      reasoning: isReasoningDelta,
       delta: props.delta!,
     });
     scheduleDeltaFlush(entry, workspaceId);
@@ -586,6 +590,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     dispose: () => {},
     trackedSessionRefs: new Map(),
     pendingDeltas: new Map(),
+    partKinds: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,
   });

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1490,6 +1490,7 @@ export function SessionRoute() {
     return {
       workspaceRoot: selectedWorkspaceRoot,
       developerMode: false,
+      showThinking: local.prefs.showThinking,
       modelLabel,
       onModelClick: () => {
         setModelPickerQuery("");


### PR DESCRIPTION
## Summary
- Fixes the session reasoning visibility flow so the `showThinking` preference is correctly wired from route state into the session surface.
- Improves streaming delta classification by tracking part kinds and marking deltas as reasoning when appropriate, even when events arrive out of order.
- Prevents reasoning content from being treated like regular text deltas in the transcript sync path.

## Why
- The reasoning toggle behavior was inconsistent because the `SessionSurface` used a local value instead of the route-provided preference.
- In SSE streams, `message.delta` can arrive before `message.part.added`; without part-type tracking, reasoning deltas were misclassified.
- This led to incorrect rendering behavior for thinking/reasoning output.

## Issue
- Closes #1692

## Scope
- `apps/app/src/react-app/shell/session-route.tsx`
  - Pass `local.prefs.showThinking` into `SessionSurface` props.
- `apps/app/src/react-app/domains/session/surface/session-surface.tsx`
  - Add `showThinking` to `SessionSurfaceProps`.
  - Use `props.showThinking` when rendering transcript/messages.
- `apps/app/src/react-app/domains/session/sync/session-sync.ts`
  - Track part types in `partKinds`.
  - Use known part type + field to classify deltas as reasoning.
  - Initialize and maintain this map in sync state.

## Out of scope
- No changes to model execution, backend protocol, or SSE payload formats.
- No redesign of transcript UI or reasoning presentation.
- No changes to unrelated session preferences.

## Testing
### Ran
- `pnpm typecheck`
- `pnpm test:e2e`
### Result
- pass/fail:
  - `pnpm typecheck`: fail (preexisting repo-wide type errors; none in files changed by this PR)
  - `pnpm test:e2e`: pass
- if fail, exact files/errors:
  - Typecheck failures are in unrelated files (outside this PR scope)

## CI status
- pass: e2e test workflow
- code-related failures: none identified in changed files
- external/env/auth blockers: typecheck job fails due to preexisting unrelated type errors

## Manual verification
1. Opened a session with reasoning-capable output and toggle “Show model reasoning” on/off.
2. Verified reasoning visibility follows the toggle consistently (including while streaming).
3. Verified streamed reasoning deltas render as reasoning (not plain text), including race-order scenarios.

## Evidence
- Thinking mode : off 
<img width="786" height="228" alt="image" src="https://github.com/user-attachments/assets/c00b14a0-3361-498a-8c84-3e6c012c9756" />
-Thinking mode : on 
<img width="1112" height="879" alt="Screenshot 2026-05-08 233012" src="https://github.com/user-attachments/assets/87752668-3319-488b-8d4f-8ba97fca238c" />
- ##Screen Recording :


https://github.com/user-attachments/assets/e17d5355-5fb3-448d-a679-f4fd2da29d3a


## Risk
- Low to medium: touches session streaming sync and transcript rendering classification.
- Mitigated by narrow file scope and no protocol/API changes.

## Rollback
- Revert commit `a2df4688` to restore previous behavior:
  - `git revert a2df4688`