### PR TITLE
fix(den): gate billing at shared workspace launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ User mental model:
 * The server is the execution/control API layer.
 * A worker is a remote runtime destination.
 * Connecting to a worker happens through `Add worker` -> `Connect remote` using URL + token (or deep link).
+* Billing gates belong to shared cloud workspace launch, not base Den sign-up or organization creation.
 
 Read `ARCHITECTURE.md` for runtime flow, server-vs-shell ownership, and architecture behavior. Read `INFRASTRUCTURE.md` for deployment and control-plane details.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -350,10 +350,11 @@ This is intentional for now: predictable scoping beats clever cross-root auto-ro
 ## Cloud Worker Connect Flow (Canonical)
 
 1. Authenticate in OpenWork Cloud control surface.
-2. Launch worker (with checkout/paywall when needed).
-3. Wait for provisioning and health.
-4. Generate/retrieve connect credentials.
-5. Connect in OpenWork app via deep link or manual URL + token.
+2. Create or select a Den organization without billing gates.
+3. Launch a shared cloud workspace/worker (with checkout/paywall when the hosted shared-workspace gate is enabled).
+4. Wait for provisioning and health.
+5. Generate/retrieve connect credentials.
+6. Connect in OpenWork app via deep link or manual URL + token.
 
 Technical note:
 

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -6,9 +6,7 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth } from "../../auth.js"
-import { requireCloudWorkerAccess } from "../../billing/polar.js"
 import { db } from "../../db.js"
-import { env } from "../../env.js"
 import { jsonValidator, queryValidator, requireUserMiddleware, resolveMemberTeamsMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import {
@@ -56,16 +54,6 @@ const organizationOwnerSchema = z.object({
   email: z.string().email().nullable(),
   image: z.string().nullable().optional(),
 }).meta({ ref: "OrganizationOwner" })
-
-const paymentRequiredSchema = z.object({
-  error: z.literal("payment_required"),
-  message: z.string(),
-  polar: z.object({
-    checkoutUrl: z.string().nullable(),
-    productId: z.string().nullable().optional(),
-    benefitId: z.string().nullable().optional(),
-  }).passthrough(),
-}).meta({ ref: "PaymentRequiredError" })
 
 const invitationPreviewResponseSchema = z.object({}).passthrough().meta({ ref: "InvitationPreviewResponse" })
 
@@ -141,12 +129,11 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
       tags: ["Organizations"],
       hide: true,
       summary: "Create organization",
-      description: "Creates a new organization for the signed-in user after verifying that their account can provision OpenWork Cloud workspaces.",
+      description: "Creates a new organization for the signed-in user. Billing is enforced only when launching shared cloud workspaces.",
       responses: {
         201: jsonResponse("Organization created successfully.", organizationResponseSchema),
         400: jsonResponse("The organization creation request body was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to create an organization.", unauthorizedSchema),
-        402: jsonResponse("The caller needs an active cloud plan before creating an organization.", paymentRequiredSchema),
         403: jsonResponse("API keys cannot create organizations.", forbiddenSchema),
       },
     }),
@@ -162,29 +149,6 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
 
     const user = c.get("user")
     const input = c.req.valid("json")
-    const email = getRequiredUserEmail(user)
-
-    if (!email) {
-      return c.json({ error: "user_email_required" }, 400)
-    }
-
-    const access = await requireCloudWorkerAccess({
-      userId: normalizeDenTypeId("user", user.id),
-      email,
-      name: user.name ?? user.email ?? "OpenWork User",
-    })
-
-    if (!access.allowed) {
-      return c.json({
-        error: "payment_required",
-        message: "Creating a workspace requires an active OpenWork Cloud plan.",
-        polar: {
-          checkoutUrl: access.checkoutUrl,
-          productId: env.polar.productId,
-          benefitId: env.polar.benefitId,
-        },
-      }, 402)
-    }
 
     const organizationId = await createOrganizationForUser({
       userId: normalizeDenTypeId("user", user.id),

--- a/ee/apps/den-api/src/routes/workers/core.ts
+++ b/ee/apps/den-api/src/routes/workers/core.ts
@@ -1,13 +1,15 @@
 import { desc, eq } from "@openwork-ee/den-db/drizzle"
 import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
-import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { db } from "../../db.js"
+import { env } from "../../env.js"
 import { jsonValidator, paramValidator, queryValidator, requireUserMiddleware, resolveUserOrganizationsMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { getOrganizationLimitStatus } from "../../organization-limits.js"
+import { getRequiredUserEmail } from "../../user.js"
 import type { WorkerRouteVariables } from "./shared.js"
 import {
   continueCloudProvisioning,
@@ -18,6 +20,7 @@ import {
   getWorkerTokensAndConnect,
   listWorkersQuerySchema,
   parseWorkerIdParam,
+  requireCloudAccessOrPayment,
   toInstanceResponse,
   toWorkerResponse,
   token,
@@ -105,6 +108,20 @@ const orgLimitReachedSchema = z.object({
   message: z.string(),
 }).meta({ ref: "WorkerOrgLimitReachedError" })
 
+const paymentRequiredSchema = z.object({
+  error: z.literal("payment_required"),
+  message: z.string(),
+  polar: z.object({
+    checkoutUrl: z.string().nullable(),
+    productId: z.string().nullable().optional(),
+    benefitId: z.string().nullable().optional(),
+  }).passthrough(),
+}).meta({ ref: "WorkerPaymentRequiredError" })
+
+const userEmailRequiredSchema = z.object({
+  error: z.literal("user_email_required"),
+}).meta({ ref: "WorkerUserEmailRequiredError" })
+
 const workerRuntimeUnavailableSchema = z.object({
   error: z.literal("worker_tokens_unavailable"),
   message: z.string(),
@@ -164,12 +181,13 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
     describeRoute({
       tags: ["Workers"],
       summary: "Create worker",
-      description: "Creates a local or cloud worker for the active organization and returns the initial tokens needed to connect to it.",
+      description: "Creates a local worker or shared cloud workspace for the active organization and returns the initial tokens needed to connect to it.",
       responses: {
         201: jsonResponse("Local worker created successfully.", workerCreateResponseSchema),
         202: jsonResponse("Cloud worker creation started successfully.", workerCreateResponseSchema),
-        400: jsonResponse("The worker creation payload was invalid.", z.union([invalidRequestSchema, organizationUnavailableSchema, workspacePathRequiredSchema])),
+        400: jsonResponse("The worker creation payload was invalid.", z.union([invalidRequestSchema, organizationUnavailableSchema, workspacePathRequiredSchema, userEmailRequiredSchema])),
         401: jsonResponse("The caller must be signed in to create workers.", unauthorizedSchema),
+        402: jsonResponse("The caller needs an active cloud plan before launching a shared workspace.", paymentRequiredSchema),
         409: jsonResponse("The organization has reached its worker limit.", orgLimitReachedSchema),
       },
     }),
@@ -190,6 +208,29 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
     }
 
     if (input.destination === "cloud") {
+      const email = getRequiredUserEmail(user)
+      if (!email) {
+        return c.json({ error: "user_email_required" }, 400)
+      }
+
+      const access = await requireCloudAccessOrPayment({
+        userId: normalizeDenTypeId("user", user.id),
+        email,
+        name: user.name ?? user.email ?? "OpenWork User",
+      })
+
+      if (!access.allowed) {
+        return c.json({
+          error: "payment_required",
+          message: "Launching a shared workspace requires an active OpenWork Cloud plan.",
+          polar: {
+            checkoutUrl: access.checkoutUrl,
+            productId: env.polar.productId,
+            benefitId: env.polar.benefitId,
+          },
+        }, 402)
+      }
+
       const workerLimit = await getOrganizationLimitStatus(orgId, "workers")
       if (workerLimit.exceeded) {
         return c.json({

--- a/ee/apps/den-web/README.md
+++ b/ee/apps/den-web/README.md
@@ -7,7 +7,7 @@ Frontend for `app.openworklabs.com`.
 - Signs up / signs in users against Den service auth.
 - Handles invited-org signup flows where the invited email stays locked and the user verifies access before joining.
 - Launches cloud workers via `POST /v1/workers`.
-- Handles paywall responses (`402 payment_required`), routes users through Polar checkout, and only enables worker launch after purchase.
+- Handles shared workspace paywall responses (`402 payment_required`) from cloud worker launch and routes users through Polar checkout.
 - Offers desktop handoff actions so users can open the generated worker directly in OpenWork or copy the connect credentials manually.
 - Uses a Next.js proxy route (`/api/den/*`) to reach `api.openworklabs.com` without browser CORS issues.
 - Uses a same-origin auth proxy (`/api/auth/*`) so GitHub OAuth callbacks can land on `app.openworklabs.com`.
@@ -15,9 +15,10 @@ Frontend for `app.openworklabs.com`.
 ## Current hosted user flow
 
 1. Sign in with a standard provider or accept an org invite.
-2. If the org requires billing, complete checkout before launching a worker.
-3. Launch the worker from the cloud dashboard.
-4. Open the worker in the desktop app with the provided deep link, or copy the URL/token into `Connect remote` manually.
+2. Create or select an organization without a billing gate.
+3. If the shared workspace launch requires billing, complete checkout before launching the hosted worker.
+4. Launch the worker from the cloud dashboard.
+5. Open the worker in the desktop app with the provided deep link, or copy the URL/token into `Connect remote` manually.
 
 ## Local development
 

--- a/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
@@ -197,9 +197,9 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
         <div className="flex flex-col gap-4 lg:max-w-3xl">
           <div className="grid gap-3">
             <p className="den-eyebrow">OpenWork Cloud</p>
-            <h1 className="den-title-xl max-w-[14ch]">Purchase a plan before creating your workspace.</h1>
+            <h1 className="den-title-xl max-w-[14ch]">Purchase a plan before launching a shared workspace.</h1>
             <p className="den-copy max-w-2xl">
-              Start with one workspace plan for $50/month. Each plan includes up to 5 members and 1 hosted worker.
+              Den is free for solo setup. Shared cloud workspaces require a workspace plan with up to 5 members and 1 hosted worker.
             </p>
           </div>
 
@@ -218,8 +218,8 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
                 Refresh purchase link
               </button>
             )}
-            <a href="https://openworklabs.com/download" className="den-button-secondary w-full sm:w-auto">
-              Use desktop only
+            <a href="https://github.com/different-ai/openwork/releases/latest" target="_blank" rel="noreferrer" className="den-button-secondary w-full sm:w-auto">
+              Download desktop app
             </a>
           </div>
 
@@ -290,8 +290,8 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
               </div>
 
               <div className="mt-auto pt-2">
-                <a href="https://openworklabs.com/download" className="den-button-secondary w-full sm:w-auto">
-                  Use desktop only
+                <a href="https://github.com/different-ai/openwork/releases/latest" target="_blank" rel="noreferrer" className="den-button-secondary w-full sm:w-auto">
+                  Download desktop app
                 </a>
               </div>
             </article>
@@ -302,7 +302,7 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
               <p className="den-eyebrow">Billing status</p>
               <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{subscriptionStatus}</h2>
               <p className="den-copy text-sm">
-                {billingSummary.hasActivePlan ? "Your workspace plan is active." : "Purchase a plan to create your first workspace."}
+                {billingSummary.hasActivePlan ? "Your workspace plan is active." : "Purchase a plan to launch shared workspaces."}
               </p>
             </div>
 

--- a/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
@@ -558,7 +558,7 @@ export function DashboardScreen({ showSidebar = true }: { showSidebar?: boolean 
                     {billingSummary?.featureGateEnabled
                       ? billingSummary.hasActivePlan
                         ? "Your account has active worker billing."
-                        : "Workers stay disabled until you purchase one for $50/month."
+                        : "Shared workspace launches require a workspace plan."
                       : "Billing gates are disabled in this environment."}
                   </p>
                   <Link
@@ -575,12 +575,12 @@ export function DashboardScreen({ showSidebar = true }: { showSidebar?: boolean 
           <div className="rounded-[24px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-8">
             <div className="mx-auto max-w-[30rem] text-center">
               <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">No workers yet</h2>
-              <p className="mt-3 text-sm leading-6 text-[var(--dls-text-secondary)]">Purchase your first worker to unlock connection details and runtime controls.</p>
+              <p className="mt-3 text-sm leading-6 text-[var(--dls-text-secondary)]">Launch a shared workspace to unlock connection details and runtime controls.</p>
               <Link
                 href="/checkout"
                 className="mt-5 inline-flex rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)]"
               >
-                Purchase worker billing
+                Open shared workspace billing
               </Link>
             </div>
           </div>
@@ -659,7 +659,7 @@ export function DashboardScreen({ showSidebar = true }: { showSidebar?: boolean 
 
             {workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">Loading workers...</p> : null}
             {workersError ? <p className="text-xs font-medium text-rose-600">{workersError}</p> : null}
-            {workers.length === 0 && !workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">No workers yet. Purchase one to get started.</p> : null}
+            {workers.length === 0 && !workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">No shared workspaces yet.</p> : null}
           </div>
 
             <div className="text-xs text-[var(--dls-text-secondary)] md:text-sm">

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -9,55 +9,9 @@ import { useDenFlow } from "../_providers/den-flow-provider";
 
 type SettingsTab = "profile" | "organizations";
 
-const PENDING_ORG_DRAFT_STORAGE_KEY = "openwork-den-pending-org-draft";
-
-function readPendingOrgDraft(userEmail: string | null | undefined) {
-  if (typeof window === "undefined" || !userEmail) {
-    return null;
-  }
-
-  const raw = window.localStorage.getItem(PENDING_ORG_DRAFT_STORAGE_KEY);
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as { name?: unknown; email?: unknown };
-    if (typeof parsed.name !== "string" || typeof parsed.email !== "string") {
-      return null;
-    }
-
-    return parsed.email === userEmail ? parsed.name.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
-function writePendingOrgDraft(name: string, userEmail: string | null | undefined) {
-  if (typeof window === "undefined" || !userEmail) {
-    return;
-  }
-
-  window.localStorage.setItem(
-    PENDING_ORG_DRAFT_STORAGE_KEY,
-    JSON.stringify({
-      name,
-      email: userEmail,
-    }),
-  );
-}
-
-function clearPendingOrgDraft() {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  window.localStorage.removeItem(PENDING_ORG_DRAFT_STORAGE_KEY);
-}
-
 export function OrganizationScreen() {
   const router = useRouter();
-  const { user, sessionHydrated, signOut, billingSummary } = useDenFlow();
+  const { user, sessionHydrated, signOut } = useDenFlow();
   const [orgs, setOrgs] = useState<DenOrgSummary[]>([]);
   const [busy, setBusy] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -66,7 +20,6 @@ export function OrganizationScreen() {
   const [createName, setCreateName] = useState("");
   const [createBusy, setCreateBusy] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
-  const [hasPendingOrgDraft, setHasPendingOrgDraft] = useState(false);
 
   const userDisplayName = useMemo(() => {
     const trimmedName = user?.name?.trim();
@@ -82,8 +35,6 @@ export function OrganizationScreen() {
 
   const activeOrg = useMemo(() => orgs.find((org) => org.isActive) ?? null, [orgs]);
   const showDirectCreateFlow = orgs.length === 0;
-  const returningToSavedDraft = showDirectCreateFlow && hasPendingOrgDraft;
-  const draftReadyAfterCheckout = returningToSavedDraft && Boolean(billingSummary?.hasActivePlan);
 
   useEffect(() => {
     if (!sessionHydrated) return;
@@ -123,28 +74,6 @@ export function OrganizationScreen() {
     };
   }, [sessionHydrated, user, router]);
 
-  useEffect(() => {
-    if (!user?.email) {
-      setHasPendingOrgDraft(false);
-      return;
-    }
-
-    if (!showDirectCreateFlow) {
-      clearPendingOrgDraft();
-      setHasPendingOrgDraft(false);
-      return;
-    }
-
-    const savedName = readPendingOrgDraft(user.email);
-    if (!savedName) {
-      setHasPendingOrgDraft(false);
-      return;
-    }
-
-    setCreateName((current) => current || savedName);
-    setHasPendingOrgDraft(true);
-  }, [showDirectCreateFlow, user?.email]);
-
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = createName.trim();
@@ -159,13 +88,6 @@ export function OrganizationScreen() {
       });
 
       if (!response.ok) {
-        if (response.status === 402) {
-          writePendingOrgDraft(trimmed, user?.email);
-          setHasPendingOrgDraft(true);
-          setCreateBusy(false);
-          router.push("/checkout");
-          return;
-        }
         throw new Error(getErrorMessage(payload, "Failed to create organization."));
       }
 
@@ -179,8 +101,6 @@ export function OrganizationScreen() {
         throw new Error("Organization was created, but no slug was returned.");
       }
 
-      clearPendingOrgDraft();
-      setHasPendingOrgDraft(false);
       router.push(getOrgDashboardRoute(nextSlug));
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : "Failed to create organization.");
@@ -229,14 +149,10 @@ export function OrganizationScreen() {
                 <div className="min-w-0">
                   <p className="text-sm font-medium uppercase tracking-[0.18em] text-gray-400">OpenWork Cloud</p>
                   <h1 className="mt-2 text-3xl font-semibold tracking-[-0.03em] text-gray-950">
-                    {returningToSavedDraft ? "Finish creating your organization." : "Create your first organization."}
+                    Create your first organization.
                   </h1>
                   <p className="mt-3 max-w-xl text-sm leading-6 text-gray-500">
-                    {draftReadyAfterCheckout
-                      ? "Your plan is ready. Confirm the workspace name below and create the workspace to finish setup."
-                      : returningToSavedDraft
-                        ? "We saved your workspace name so you can pick up right where you left off."
-                        : "Name the workspace you want to set up for your team. If billing is enabled, the plan step comes right after this."}
+                    Name the workspace you want to set up. Billing only appears when you launch a shared cloud workspace.
                   </p>
                 </div>
               </div>
@@ -269,7 +185,7 @@ export function OrganizationScreen() {
                     disabled={createBusy || !createName.trim()}
                     className="rounded-2xl bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
                   >
-                    {createBusy ? "Creating..." : returningToSavedDraft ? "Create organization" : "Continue"}
+                    {createBusy ? "Creating..." : "Continue"}
                   </button>
                   <p className="text-sm text-gray-500">Signed in as {user?.email ?? "your account"}</p>
                 </div>

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/dashboard-overview-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/dashboard-overview-screen.tsx
@@ -338,8 +338,8 @@ export function DashboardOverviewScreen() {
           <p className="text-[14px] font-medium text-white">Download OpenWork</p>
           <p className="mt-1 max-w-[480px] text-[13px] leading-[1.55] text-white/60">Run locally for free. Keep data on your machine and move to shared workflows when ready.</p>
         </div>
-        <a href="https://openworklabs.com/download" className="inline-flex shrink-0 items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-[12px] font-medium text-white transition-colors hover:bg-white/10">
-          <Download className="h-3.5 w-3.5" />Download
+        <a href="https://github.com/different-ai/openwork/releases/latest" target="_blank" rel="noreferrer" className="inline-flex shrink-0 items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-[12px] font-medium text-white transition-colors hover:bg-white/10">
+          <Download className="h-3.5 w-3.5" />Download desktop app
         </a>
       </div>
     </div>

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_providers/org-dashboard-provider.tsx
@@ -188,10 +188,6 @@ export function OrgDashboardProvider({
       );
 
       if (!response.ok) {
-        if (response.status === 402) {
-          router.push("/checkout");
-          return;
-        }
         throw new Error(getErrorMessage(payload, `Failed to create organization (${response.status}).`));
       }
 

--- a/ee/apps/landing/app/download/page.tsx
+++ b/ee/apps/landing/app/download/page.tsx
@@ -4,14 +4,16 @@ import { StructuredData } from "../../components/structured-data";
 import { getGithubData } from "../../lib/github";
 import { baseOpenGraph } from "../../lib/seo";
 
+const CLOUD_SIGNUP_URL = "https://app.openworklabs.com?mode=sign-up";
+
 const downloadSchema = {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   name: "OpenWork",
   description:
-    "Open source Claude Cowork alternative. Desktop app for macOS, Windows, and Linux that lets teams use 50+ LLMs with their own provider keys.",
+    "Open source Claude Cowork alternative. Sign up for OpenWork Cloud to get access to the desktop app for macOS, Windows, and Linux.",
   url: "https://openworklabs.com/download",
-  downloadUrl: "https://github.com/different-ai/openwork/releases/latest",
+  downloadUrl: CLOUD_SIGNUP_URL,
   applicationCategory: "BusinessApplication",
   operatingSystem: "macOS, Windows, Linux",
   offers: {
@@ -27,9 +29,9 @@ const downloadSchema = {
 };
 
 export const metadata = {
-  title: "Download OpenWork — macOS, Windows, Linux",
+  title: "Get Started with OpenWork — macOS, Windows, Linux",
   description:
-    "Download OpenWork desktop for macOS, Windows, and Linux. Direct Electron build downloads are resolved from the latest GitHub release.",
+    "Create a free OpenWork Cloud account to get access to the OpenWork desktop app for macOS, Windows, and Linux.",
   alternates: {
     canonical: "/download"
   },
@@ -41,8 +43,6 @@ export const metadata = {
 
 export default async function Download() {
   const github = await getGithubData();
-  const releaseLabel = github.releaseTag || "latest";
-  const releaseUrl = github.releaseUrl;
 
   return (
     <div className="min-h-screen">
@@ -55,178 +55,40 @@ export default async function Download() {
 
       <main className="pb-24 pt-20">
         <div className="content-max-width px-6">
-          <div className="animate-fade-up">
+          <div className="animate-fade-up max-w-3xl">
             <div className="mb-3 text-[12px] font-bold uppercase tracking-wider text-gray-500">
               OpenWork desktop
             </div>
             <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">
-              Download OpenWork
+              Get Started with OpenWork
             </h1>
-            <p className="mb-4 max-w-3xl text-[17px] leading-relaxed text-gray-700">
-              Install OpenWork on macOS, Windows, or Linux. Pick the package that
-              matches your distro and architecture.
-            </p>
-            <p className="mb-10 text-[14px] text-gray-600">
-              Latest stable release: 
-              <a
-                href={releaseUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="font-semibold text-gray-900 underline decoration-gray-300 underline-offset-4 transition hover:decoration-gray-700"
-              >
-                {releaseLabel}
-              </a>
-            </p>
-          </div>
-
-          <div className="mb-10 grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <a
-              href="#macos"
-              className="feature-card border-sky-100 bg-sky-50/60 transition hover:border-sky-200"
-            >
-              <span className="mb-2 block text-[16px] font-semibold text-gray-900">macOS</span>
-              <p className="text-[14px] text-gray-700">Apple Silicon and Intel builds</p>
-            </a>
-            <a
-              href="#windows"
-              className="feature-card border-violet-100 bg-violet-50/50 transition hover:border-violet-200"
-            >
-              <span className="mb-2 block text-[16px] font-semibold text-gray-900">Windows</span>
-              <p className="text-[14px] text-gray-700">x64 NSIS installer</p>
-            </a>
-            <a
-              href="#linux"
-              className="feature-card border-emerald-100 bg-emerald-50/60 transition hover:border-emerald-200"
-            >
-              <span className="mb-2 block text-[16px] font-semibold text-gray-900">Linux</span>
-              <p className="text-[14px] text-gray-700">AppImage and tarball builds</p>
-            </a>
-          </div>
-
-          <section id="macos" className="py-6">
-            <h2 className="mb-2 text-2xl font-bold md:text-3xl">macOS</h2>
-            <p className="mb-8 text-[15px] text-gray-700">
-              Download the DMG that matches your Mac.
-            </p>
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div className="feature-card bg-white/90">
-                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">Apple Silicon (M-series)</h3>
-                <p className="mb-4 text-[14px] text-gray-600">Recommended for M1, M2, M3, and M4 chips.</p>
-                <a
-                  href={github.installers.macos.appleSilicon}
-                  className="doc-button"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  Download .dmg
-                </a>
-              </div>
-
-              <div className="feature-card bg-white/90">
-                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">Intel (x64)</h3>
-                <p className="mb-4 text-[14px] text-gray-600">For Intel-based Macs.</p>
-                <a
-                  href={github.installers.macos.intel}
-                  className="doc-button"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  Download .dmg
-                </a>
-              </div>
-            </div>
-          </section>
-
-          <hr />
-
-          <section id="windows" className="py-6">
-            <h2 className="mb-2 text-2xl font-bold md:text-3xl">Windows</h2>
-            <p className="mb-6 text-[15px] text-gray-700">
-              OpenWork for Windows is available as an x64 Electron installer.
+            <p className="mb-6 text-[17px] leading-relaxed text-gray-700">
+              Create a free OpenWork Cloud account first. After signup, we guide
+              you to the desktop app and connect it to your cloud workspace.
             </p>
             <a
-              href={github.installers.windows.x64}
-              className="doc-button"
-              rel="noreferrer"
+              href={CLOUD_SIGNUP_URL}
               target="_blank"
+              rel="noreferrer"
+              className="doc-button inline-flex"
             >
-              Download Windows x64 (.exe)
+              Get Started for free
             </a>
-          </section>
+          </div>
 
-          <hr />
-
-          <section id="linux" className="py-6">
-            <h2 className="mb-2 text-2xl font-bold md:text-3xl">Linux</h2>
-            <p className="mb-8 text-[15px] text-gray-700">
-              Download Electron builds directly for x64 and arm64 Linux systems.
-            </p>
-
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <div className="feature-card border-amber-100 bg-white/90 ring-1 ring-amber-100/60">
-                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">AppImage</h3>
-                <p className="mb-4 text-[14px] text-gray-600">
-                  Portable desktop builds for most Linux distributions.
-                </p>
-                <div className="flex flex-wrap gap-3">
-                  <a
-                    href={github.installers.linux.appImageX64}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="doc-button"
-                  >
-                    x64 AppImage
-                  </a>
-                  <a
-                    href={github.installers.linux.appImageArm64}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="doc-button"
-                  >
-                    arm64 AppImage
-                  </a>
-                </div>
-              </div>
-
-              <div className="feature-card border-sky-100 bg-white/90 ring-1 ring-sky-100/60">
-                <h3 className="mb-2 text-[16px] font-semibold text-gray-900">Tarball</h3>
-                <p className="mb-4 text-[14px] text-gray-600">
-                  Compressed Electron builds for manual installation.
-                </p>
-                <div className="flex flex-wrap gap-3">
-                  <a
-                    href={github.installers.linux.tarX64}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="doc-button"
-                  >
-                    x64 .tar.gz
-                  </a>
-                  <a
-                    href={github.installers.linux.tarArm64}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="doc-button"
-                  >
-                    arm64 .tar.gz
-                  </a>
-                </div>
-              </div>
+          <section className="my-12 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="feature-card border-sky-100 bg-sky-50/60">
+              <span className="mb-2 block text-[16px] font-semibold text-gray-900">1. Sign up</span>
+              <p className="text-[14px] text-gray-700">Create your free OpenWork Cloud account.</p>
             </div>
-
-            <p className="mt-8 text-[14px] text-gray-600">
-              Need another format? 
-              <a
-                href={releaseUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="font-semibold text-gray-900 underline decoration-gray-300 underline-offset-4 transition hover:decoration-gray-700"
-              >
-                Browse all release assets
-              </a>
-              .
-            </p>
+            <div className="feature-card border-violet-100 bg-violet-50/50">
+              <span className="mb-2 block text-[16px] font-semibold text-gray-900">2. Create a workspace</span>
+              <p className="text-[14px] text-gray-700">Set up your personal or team workspace before installing.</p>
+            </div>
+            <div className="feature-card border-emerald-100 bg-emerald-50/60">
+              <span className="mb-2 block text-[16px] font-semibold text-gray-900">3. Open the app</span>
+              <p className="text-[14px] text-gray-700">Use the guided desktop app access flow from Cloud.</p>
+            </div>
           </section>
 
           <SiteFooter />

--- a/ee/apps/landing/app/pricing/page.tsx
+++ b/ee/apps/landing/app/pricing/page.tsx
@@ -19,7 +19,7 @@ const pricingSchema = {
       name: "Solo",
       price: "0",
       priceCurrency: "USD",
-      url: "https://openworklabs.com/download",
+      url: "https://app.openworklabs.com?mode=sign-up",
       availability: "https://schema.org/InStock",
       description: "Free forever. Open source desktop app with bring-your-own-keys."
     },

--- a/ee/apps/landing/components/landing-home.tsx
+++ b/ee/apps/landing/components/landing-home.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { AnimatePresence, motion, useInView } from "framer-motion";
-import { Download, Users } from "lucide-react";
+import { ArrowRight, Users } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
 import { LandingAppDemoPanel } from "./landing-app-demo-panel";
@@ -28,6 +28,8 @@ const externalLinkProps = (href: string) =>
     ? { rel: "noreferrer", target: "_blank" as const }
     : {};
 
+const CLOUD_SIGNUP_URL = "https://app.openworklabs.com?mode=sign-up";
+
 export function LandingHome(props: Props) {
   const [activeDemoId, setActiveDemoId] = useState(defaultLandingDemoFlowId);
   const [activeUseCase, setActiveUseCase] = useState(0);
@@ -43,15 +45,9 @@ export function LandingHome(props: Props) {
   );
 
   const callLinkProps = externalLinkProps(props.callHref);
-  const primaryCtaHref = props.isMobileVisitor
-    ? "https://app.openworklabs.com"
-    : "/download";
-  const primaryCtaLabel = props.isMobileVisitor
-    ? "Open the app"
-    : "Download for free";
-  const primaryCtaLinkProps = props.isMobileVisitor
-    ? {}
-    : externalLinkProps(primaryCtaHref);
+  const primaryCtaHref = CLOUD_SIGNUP_URL;
+  const primaryCtaLabel = "Get Started for free";
+  const primaryCtaLinkProps = externalLinkProps(primaryCtaHref);
 
   return (
     <div className="relative min-h-screen overflow-hidden text-[#011627]">
@@ -63,8 +59,8 @@ export function LandingHome(props: Props) {
             stars={props.stars}
             downloadHref={props.downloadHref}
             callUrl={props.callHref}
-            mobilePrimaryHref="https://app.openworklabs.com"
-            mobilePrimaryLabel="Open app"
+            mobilePrimaryHref={CLOUD_SIGNUP_URL}
+            mobilePrimaryLabel="Get Started for free"
             active="home"
           />
         </div>
@@ -86,7 +82,7 @@ export function LandingHome(props: Props) {
                   className="doc-button inline-flex items-center gap-2"
                   {...primaryCtaLinkProps}
                 >
-                  {primaryCtaLabel} <Download size={18} />
+                  {primaryCtaLabel} <ArrowRight size={18} />
                 </a>
                 <a
                   href={props.callHref}

--- a/ee/apps/landing/components/pricing-grid.tsx
+++ b/ee/apps/landing/components/pricing-grid.tsx
@@ -24,6 +24,8 @@ type PricingCard = {
   isCustomPricing?: boolean;
 };
 
+const CLOUD_SIGNUP_URL = "https://app.openworklabs.com?mode=sign-up";
+
 function PricingCardView({ card }: { card: PricingCard }) {
   return (
     <div className="flex h-full flex-col relative group">
@@ -109,8 +111,9 @@ export function PricingGrid(props: PricingGridProps) {
       title: "Solo",
       price: "$0",
       priceSub: "open source",
-      ctaLabel: "Download free",
-      href: "/download",
+      ctaLabel: "Get Started for free",
+      href: CLOUD_SIGNUP_URL,
+      external: true,
       features: [
         { text: "Open source desktop app", icon: Download },
         { text: "macOS and Linux downloads", icon: Download },

--- a/ee/apps/landing/components/site-nav.tsx
+++ b/ee/apps/landing/components/site-nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Download, Menu, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { OpenWorkMark } from "./openwork-mark";
 
@@ -25,10 +25,9 @@ export function SiteNav(props: Props) {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
   const callHref = props.callUrl || "/enterprise#book";
-  const downloadHref = props.downloadHref || "/download";
-  const downloadPageHref = "/download";
-  const mobilePrimaryHref = props.mobilePrimaryHref || downloadHref;
-  const mobilePrimaryLabel = props.mobilePrimaryLabel || "Desktop";
+  const cloudSignupHref = "https://app.openworklabs.com?mode=sign-up";
+  const mobilePrimaryHref = props.mobilePrimaryHref || cloudSignupHref;
+  const mobilePrimaryLabel = props.mobilePrimaryLabel || "Get Started for free";
   const callExternal = /^https?:\/\//.test(callHref);
   const mobilePrimaryExternal = /^https?:\/\//.test(mobilePrimaryHref);
   const navItems = [
@@ -93,12 +92,14 @@ export function SiteNav(props: Props) {
               </svg>
               {props.stars}
             </a>
-            <Link
-              href={downloadPageHref}
+            <a
+              href={cloudSignupHref}
               className="doc-button !hidden items-center gap-2 md:!inline-flex"
+              rel="noreferrer"
+              target="_blank"
             >
-              Desktop <Download size={16} />
-            </Link>
+              Get Started for free
+            </a>
             <button
               type="button"
               className="rounded-full p-2 text-[#011627] transition-colors hover:bg-white/70 md:hidden"

--- a/ee/apps/landing/components/webmcp-provider.tsx
+++ b/ee/apps/landing/components/webmcp-provider.tsx
@@ -15,7 +15,7 @@ type Tool = {
 
 const destinations: Record<string, string> = {
   home: "/",
-  download: "/download",
+  download: "https://app.openworklabs.com?mode=sign-up",
   pricing: "/pricing",
   enterprise: "/enterprise",
   cloud: "https://app.openworklabs.com",
@@ -36,7 +36,7 @@ const pricingSummary = {
         "macOS, Windows, Linux downloads",
         "Bring your own provider keys",
       ],
-      cta: { label: "Download", href: "/download" },
+      cta: { label: "Get Started for free", href: "https://app.openworklabs.com?mode=sign-up" },
     },
     {
       id: "team-starter",
@@ -68,20 +68,19 @@ const pricingSummary = {
 }
 
 const downloadLinks = {
-  page: "https://openworklabs.com/download",
-  githubReleases: "https://github.com/different-ai/openwork/releases/latest",
+  page: "https://app.openworklabs.com?mode=sign-up",
   platforms: {
     macos: {
-      page: "https://openworklabs.com/download#macos",
-      note: "Electron Apple Silicon (.dmg) and Intel (.dmg) builds resolved from the latest GitHub release.",
+      page: "https://app.openworklabs.com?mode=sign-up",
+      note: "Sign up for OpenWork Cloud first, then use the guided desktop app access flow.",
     },
     windows: {
-      page: "https://openworklabs.com/download#windows",
-      note: "Electron x64 .exe installer resolved from the latest GitHub release.",
+      page: "https://app.openworklabs.com?mode=sign-up",
+      note: "Sign up for OpenWork Cloud first, then use the guided desktop app access flow.",
     },
     linux: {
-      page: "https://openworklabs.com/download#linux",
-      note: "Electron AppImage and tar.gz builds for x64 and arm64.",
+      page: "https://app.openworklabs.com?mode=sign-up",
+      note: "Sign up for OpenWork Cloud first, then use the guided desktop app access flow.",
     },
   },
 }
@@ -145,7 +144,7 @@ const tools: Tool[] = [
   {
     name: "get_download_links",
     description:
-      "Return the canonical download page URLs per platform plus the GitHub releases URL. Use this to tell the user where to get the desktop app. Read-only; does not navigate.",
+      "Return the canonical cloud signup URL users should visit before getting desktop app access. Read-only; does not navigate.",
     inputSchema: {
       type: "object",
       properties: {},

--- a/ee/apps/landing/lib/agent-markdown.ts
+++ b/ee/apps/landing/lib/agent-markdown.ts
@@ -12,7 +12,7 @@ const home = `# OpenWork
 
 ## Primary calls-to-action
 
-- **Try it free** — [Download the desktop app](https://openworklabs.com/download)
+- **Try it free** — [Get Started for free](https://app.openworklabs.com?mode=sign-up)
 - **Hosted cloud workers** — [Pricing](https://openworklabs.com/pricing) (\\$50/mo per worker)
 - **Sign in to the hosted workspace** — [Cloud](https://app.openworklabs.com)
 - **SSO / audit / procurement** — [Enterprise](https://openworklabs.com/enterprise)
@@ -38,7 +38,7 @@ const pricing = `# OpenWork pricing — free, team, and enterprise
 - macOS, Windows, Linux downloads
 - Bring your own provider keys
 - Free forever
-- CTA: [Download](https://openworklabs.com/download)
+- CTA: [Get Started for free](https://app.openworklabs.com?mode=sign-up)
 
 ## Team Starter — \\$50 / month
 
@@ -83,27 +83,23 @@ const enterprise = `# A privacy-first alternative to Claude Cowork for your orga
 - See [Pricing](https://openworklabs.com/pricing) for tier comparison
 `
 
-const download = `# Download OpenWork
+const download = `# Get Started with OpenWork
 
-> Desktop app for macOS, Windows, and Linux. Latest release published on GitHub.
+> Create a free OpenWork Cloud account first, then use the guided desktop app access flow.
 
-## macOS
+## Start here
 
-- **Apple Silicon (M-series)** — recommended for M1/M2/M3/M4. \`.dmg\`
-- **Intel (x64)** — for Intel-based Macs. \`.dmg\`
+- [Get Started for free](https://app.openworklabs.com?mode=sign-up)
+- Create or select your workspace.
+- Follow the Cloud app's desktop app access flow.
 
-## Windows
+## Supported platforms
 
-- **x64** — Electron ".exe" installer
+- macOS
+- Windows
+- Linux
 
-## Linux
-
-- **AppImage** — Electron build for x64 and arm64
-- **Tarball** — Electron \`.tar.gz\` build for x64 and arm64
-
-Direct download URLs resolve from the latest GitHub release. Browse all assets at [github.com/openworklabs/openwork/releases/latest](https://github.com/openworklabs/openwork/releases/latest).
-
-## After installing
+## After signing up
 
 Once the desktop app is running, use the [workspace-guide skill](https://openworklabs.com/.well-known/agent-skills/workspace-guide/SKILL.md) for first-run orientation.
 `


### PR DESCRIPTION
## Summary

- Move the Den billing gate from organization creation to shared cloud workspace launch.
- Route public free/get-started CTAs through OpenWork Cloud signup instead of direct installer downloads.
- Keep signed-in desktop download links available from Den while updating docs and architecture notes for the new billing model.

## Evidence

### Screenshots

0x0.st uploads are currently disabled, so these screenshots are hosted on the 24h Litterbox fallback.

![Landing home CTA](https://litter.catbox.moe/czq7k7.png)
![Landing pricing CTA](https://litter.catbox.moe/iuoi6q.png)
![Get started page](https://litter.catbox.moe/q1elge.png)
![Den cloud signup](https://litter.catbox.moe/cme27r.png)
![Shared workspace checkout](https://litter.catbox.moe/dwdcor.png)

### Build verification

- `pnpm install --frozen-lockfile` passed
- `pnpm --filter @openwork-ee/landing build` passed
- `pnpm --filter @openwork-ee/den-web build` passed
- `DEN_API_LATEST_APP_VERSION=0.11.212 pnpm --filter @openwork-ee/den-api build` passed
- `git diff --check --cached` passed before commit

### API verification

- `bun test ee/apps/den-api/test/org-invitations.test.ts ee/apps/den-api/test/plugin-system-access.test.ts` passed: 8 tests, 0 failures
- Live curl verification was not rerun after rebasing onto `origin/dev`; the API build and Den API route tests passed on the final branch.

### UI verification

- Verified landing and Den screens locally with Chrome-channel Playwright screenshots.
- Chrome MCP was unavailable in this environment, so screenshots were captured with Playwright instead of MCP.

## Test instructions

1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @openwork-ee/landing build`
3. `pnpm --filter @openwork-ee/den-web build`
4. `DEN_API_LATEST_APP_VERSION=0.11.212 pnpm --filter @openwork-ee/den-api build`
5. `bun test ee/apps/den-api/test/org-invitations.test.ts ee/apps/den-api/test/plugin-system-access.test.ts`
6. Open the landing page and verify free CTAs say `Get Started for free` and route to `https://app.openworklabs.com?mode=sign-up`.
7. In Den, verify organization creation does not redirect to checkout and launching a shared cloud workspace still routes unpaid users to checkout.