### PR TITLE
fix(den): stabilize redirect loading layout

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -18,17 +18,37 @@ function FeatureCard({ title, body }: { title: string; body: string }) {
   );
 }
 
-function LoadingPanel({ title, body }: { title: string; body: string }) {
+function SessionStatusPanel({ mode }: { mode: "checking" | "redirecting" }) {
+  const status = mode === "checking"
+    ? {
+        title: "Checking account",
+        body: "If you are already signed in, we will open your workspace. Otherwise you can continue here.",
+      }
+    : {
+        title: "Opening workspace",
+        body: "You are signed in. We are taking you to the right Cloud destination.",
+      };
+
   return (
-    <div className="den-frame grid gap-3 p-6 md:p-7">
+    <div className="den-frame flex min-h-[420px] flex-col justify-between gap-8 p-6 md:p-7" role="status" aria-live="polite">
       <div className="grid gap-3">
-        <p className="den-eyebrow">OpenWork Cloud</p>
-        <h2 className="den-title-lg">{title}</h2>
-        <p className="den-copy">{body}</p>
+        <p className="den-eyebrow">Account</p>
+        <div className="rounded-[1.5rem] border border-[var(--dls-border)] bg-[var(--dls-hover)]/60 p-4">
+          <div className="flex items-start gap-3">
+            <span className="relative mt-1 flex h-2.5 w-2.5 shrink-0">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--dls-accent)] opacity-30" />
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--dls-accent)]" />
+            </span>
+            <div className="min-w-0">
+              <p className="m-0 text-[14px] font-medium text-[var(--dls-text-primary)]">{status.title}</p>
+              <p className="mt-1 text-[13px] leading-6 text-[var(--dls-text-secondary)]">{status.body}</p>
+            </div>
+          </div>
+        </div>
       </div>
-      <div className="h-2 overflow-hidden rounded-full bg-[var(--dls-hover)]">
-        <div className="h-full w-1/3 animate-pulse rounded-full bg-[var(--dls-accent)]" />
-      </div>
+      <p className="m-0 text-xs leading-5 text-[var(--dls-text-secondary)]">
+        No action needed.
+      </p>
     </div>
   );
 }
@@ -62,14 +82,6 @@ export function AuthScreen() {
         routingRef.current = false;
       });
   }, [hasResolvedSession, pathname, resolveUserLandingRoute, router]);
-
-  if (!sessionHydrated) {
-    return (
-      <section className="den-page flex w-full items-center py-4 lg:min-h-[calc(100vh-2.5rem)]">
-        <LoadingPanel title="Checking your session." body="Loading your Cloud account state..." />
-      </section>
-    );
-  }
 
   return (
     <section className="den-page flex w-full items-center py-4 lg:min-h-[calc(100vh-2.5rem)]">
@@ -138,11 +150,10 @@ export function AuthScreen() {
         </div>
 
         <div className="order-1 lg:order-2">
-          {hasResolvedSession ? (
-            <LoadingPanel
-              title="Redirecting to your workspace."
-              body="We found your account and are sending you to the right Cloud destination now."
-            />
+          {!sessionHydrated ? (
+            <SessionStatusPanel mode="checking" />
+          ) : hasResolvedSession ? (
+            <SessionStatusPanel mode="redirecting" />
           ) : (
             <AuthPanel />
           )}

--- a/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
@@ -20,12 +20,32 @@ function formatSubscriptionStatus(value: string | null | undefined) {
     .join(" ");
 }
 
-function LoadingPanel({ title, body }: { title: string; body: string }) {
+function CheckoutStatusPanel({ body }: { body: string }) {
   return (
-    <section className="den-page py-4">
-      <div className="den-frame-soft grid max-w-[44rem] gap-4 p-6">
-        <h1 className="text-xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{title}</h1>
-        <p className="text-sm text-[var(--dls-text-secondary)]">{body}</p>
+    <section className="den-page grid gap-6 py-4 lg:py-6">
+      <div className="den-frame grid gap-6 p-6 md:p-8 lg:p-10">
+        <div className="flex flex-col gap-4 lg:max-w-3xl">
+          <div className="grid gap-3">
+            <p className="den-eyebrow">OpenWork Cloud</p>
+            <h1 className="den-title-xl max-w-[14ch]">Shared workspace billing.</h1>
+            <p className="den-copy max-w-2xl">
+              Den is free for solo setup. Billing appears only when launching a shared cloud workspace.
+            </p>
+          </div>
+
+          <div className="rounded-[1.5rem] border border-[var(--dls-border)] bg-[var(--dls-hover)]/60 p-4" role="status" aria-live="polite">
+            <div className="flex items-start gap-3">
+              <span className="relative mt-1 flex h-2.5 w-2.5 shrink-0">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[var(--dls-accent)] opacity-30" />
+                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-[var(--dls-accent)]" />
+              </span>
+              <div className="min-w-0">
+                <p className="m-0 text-[14px] font-medium text-[var(--dls-text-primary)]">Checking access</p>
+                <p className="mt-1 text-[13px] leading-6 text-[var(--dls-text-secondary)]">{body}</p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
   );
@@ -170,15 +190,12 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
 
   if (!sessionHydrated || (!user && !mockMode)) {
     return (
-      <LoadingPanel
-        title="Checking your billing session..."
-        body="Loading your account and billing state before continuing."
-      />
+      <CheckoutStatusPanel body="Checking whether you are signed in before showing workspace billing." />
     );
   }
 
   if (redirectMessage) {
-    return <LoadingPanel title="One moment." body={redirectMessage} />;
+    return <CheckoutStatusPanel body={redirectMessage} />;
   }
 
   const billingPrice = billingSummary?.price ?? null;


### PR DESCRIPTION
## Summary

- Keep the Den auth screen in one stable two-column shell while session state resolves instead of switching to a standalone loading card.
- Replace the oversized progress-card loading state with a quieter inline account status panel.
- Keep checkout redirect/loading states inside the checkout page shell so returning from billing does not jump layouts.

## Evidence

### Build verification

- `pnpm install --frozen-lockfile` passed
- `pnpm --filter @openwork-ee/den-web build` passed

### UI verification

- Code-level verification: the `AuthScreen` no longer has an early `!sessionHydrated` return, so the same auth shell renders before and after session hydration.
- Code-level verification: checkout auth/redirect states now render through `CheckoutStatusPanel`, which uses the same `den-page` and hero shell as the checkout page.
- Browser screenshot evidence was not captured in this turn because the reported state is transient during session/redirect resolution.

### API verification

- No API changes.

## Test instructions

1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @openwork-ee/den-web build`
3. Run Den web locally.
4. Open `/` while signed out and confirm session checking does not jump from a standalone centered card to the auth layout.
5. Sign in from `/` and confirm the redirect state stays in the right-side auth panel slot.
6. Visit `/checkout` while unauthenticated or after checkout return and confirm the status appears within the checkout shell instead of a separate loading layout.