### PR TITLE
fix(app): collapse redundant Tailwind axes

### DIFF
--- a/apps/app/src/react-app/design-system/restriction-notice-modal.tsx
+++ b/apps/app/src/react-app/design-system/restriction-notice-modal.tsx
@@ -34,7 +34,7 @@ export function RestrictionNoticeModal(props: RestrictionNoticeModalProps) {
           </div>
           <button
             type="button"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+            className="inline-flex size-9 items-center justify-center rounded-full text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
             aria-label={t("common.close")}
             onClick={props.onClose}
           >
@@ -42,7 +42,7 @@ export function RestrictionNoticeModal(props: RestrictionNoticeModalProps) {
           </button>
         </div>
 
-        <div className="px-6 py-6">
+        <div className="p-6">
           <p className="text-[14px] leading-6 text-dls-secondary">
             {props.message}
           </p>

--- a/apps/app/src/react-app/domains/bundles/import-modal.tsx
+++ b/apps/app/src/react-app/domains/bundles/import-modal.tsx
@@ -65,7 +65,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
         <div className="border-b border-gray-6 bg-gray-1 px-6 py-5">
           <div className="flex items-start justify-between gap-4">
             <div className="flex items-start gap-3">
-              <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-indigo-9/15 text-indigo-11">
+              <div className="flex size-11 items-center justify-center rounded-2xl bg-indigo-9/15 text-indigo-11">
                 <Boxes size={20} />
               </div>
               <div>
@@ -118,10 +118,10 @@ export function BundleImportModal(props: BundleImportModalProps) {
             type="button"
             onClick={props.onCreateNewWorker}
             disabled={busy}
-            className="flex w-full items-center justify-between rounded-2xl border border-indigo-7/30 bg-indigo-9/10 px-4 py-4 text-left transition hover:border-indigo-7/50 hover:bg-indigo-9/15 disabled:cursor-not-allowed disabled:opacity-60"
+            className="flex w-full items-center justify-between rounded-2xl border border-indigo-7/30 bg-indigo-9/10 p-4 text-left transition hover:border-indigo-7/50 hover:bg-indigo-9/15 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-9/20 text-indigo-11">
+              <div className="mt-0.5 flex size-10 items-center justify-center rounded-xl bg-indigo-9/20 text-indigo-11">
                 <Plus size={18} />
               </div>
               <div>
@@ -142,7 +142,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
               type="button"
               onClick={() => setShowWorkers((value) => !value)}
               disabled={busy}
-              className="flex w-full items-center justify-between gap-3 px-4 py-4 text-left transition hover:bg-gray-3/60 disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex w-full items-center justify-between gap-3 p-4 text-left transition hover:bg-gray-3/60 disabled:cursor-not-allowed disabled:opacity-60"
               aria-expanded={showWorkers}
             >
               <div>
@@ -161,7 +161,7 @@ export function BundleImportModal(props: BundleImportModalProps) {
             </button>
 
             {showWorkers ? (
-              <div className="space-y-3 border-t border-gray-6 px-4 py-4">
+              <div className="space-y-3 border-t border-gray-6 p-4">
                 {props.workers.length === 0 ? (
                   <div className="rounded-xl border border-dashed border-gray-6 px-4 py-5 text-sm text-gray-10">
                     No configured workers are available yet. Create a new worker

--- a/apps/app/src/react-app/domains/bundles/skill-destination-modal.tsx
+++ b/apps/app/src/react-app/domains/bundles/skill-destination-modal.tsx
@@ -127,9 +127,9 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                 <Sparkles size={12} />
                 {t("share_skill_destination.skill_label")}
               </div>
-              <div className="rounded-xl border border-gray-6 bg-gray-2/40 px-4 py-4">
+              <div className="rounded-xl border border-gray-6 bg-gray-2/40 p-4">
                 <div className="flex items-start gap-3">
-                  <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-indigo-7/20 bg-indigo-7/10 text-indigo-11">
+                  <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full border border-indigo-7/20 bg-indigo-7/10 text-indigo-11">
                     <Sparkles size={17} />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -220,7 +220,7 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                     >
                       <div className="flex items-start gap-3 px-4 py-3">
                         <div
-                          className={`mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full ${workspaceCircleClass(
+                          className={`mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-full ${workspaceCircleClass(
                             workspace,
                             isSelected,
                           )}`.trim()}
@@ -293,12 +293,12 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                     type="button"
                     onClick={() => props.onCreateWorker?.()}
                     disabled={footerBusy}
-                    className={`rounded-xl border border-indigo-7/30 bg-indigo-7/10 px-4 py-4 text-left transition hover:border-indigo-7/50 hover:bg-indigo-7/15 ${
+                    className={`rounded-xl border border-indigo-7/30 bg-indigo-7/10 p-4 text-left transition hover:border-indigo-7/50 hover:bg-indigo-7/15 ${
                       footerBusy ? "cursor-not-allowed opacity-60" : ""
                     }`.trim()}
                   >
                     <div className="flex items-start gap-3">
-                      <div className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-full border border-indigo-7/30 bg-indigo-7/15 text-indigo-11">
+                      <div className="mt-0.5 flex size-10 items-center justify-center rounded-full border border-indigo-7/30 bg-indigo-7/15 text-indigo-11">
                         <FolderPlus size={17} />
                       </div>
                       <div>
@@ -318,12 +318,12 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
                     type="button"
                     onClick={() => props.onConnectRemote?.()}
                     disabled={footerBusy}
-                    className={`rounded-xl border border-sky-7/30 bg-sky-7/10 px-4 py-4 text-left transition hover:border-sky-7/50 hover:bg-sky-7/15 ${
+                    className={`rounded-xl border border-sky-7/30 bg-sky-7/10 p-4 text-left transition hover:border-sky-7/50 hover:bg-sky-7/15 ${
                       footerBusy ? "cursor-not-allowed opacity-60" : ""
                     }`.trim()}
                   >
                     <div className="flex items-start gap-3">
-                      <div className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-full border border-sky-7/30 bg-sky-7/15 text-sky-11">
+                      <div className="mt-0.5 flex size-10 items-center justify-center rounded-full border border-sky-7/30 bg-sky-7/15 text-sky-11">
                         <Globe size={17} />
                       </div>
                       <div>

--- a/apps/app/src/react-app/domains/bundles/start-modal.tsx
+++ b/apps/app/src/react-app/domains/bundles/start-modal.tsx
@@ -75,7 +75,7 @@ export function BundleStartModal(props: BundleStartModalProps) {
         <div className="border-b border-dls-border px-6 py-5 bg-dls-surface">
           <div className="flex items-start justify-between gap-4">
             <div className="flex min-w-0 items-start gap-3">
-              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-dls-accent/10 text-dls-accent">
+              <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl bg-dls-accent/10 text-dls-accent">
                 <Rocket size={20} />
               </div>
               <div className="min-w-0">
@@ -118,7 +118,7 @@ export function BundleStartModal(props: BundleStartModalProps) {
           ) : null}
         </div>
 
-        <div className="space-y-4 px-6 py-6">
+        <div className="space-y-4 p-6">
           <div className="rounded-2xl border border-dls-border bg-dls-sidebar px-5 py-4">
             <div className="text-[15px] font-semibold text-dls-text">
               Workspace folder

--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -677,7 +677,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
           {!isBusy && alreadyConnected ? (
             <div className="space-y-4 rounded-xl border border-green-7/20 bg-green-7/10 p-5">
               <div className="flex items-center gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-7/20">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-green-7/20">
                   <CheckCircle2 size={24} className="text-green-11" />
                 </div>
                 <div>
@@ -807,7 +807,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
             <>
               <div className="space-y-4">
                 <div className="flex items-start gap-3">
-                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-4 text-xs font-medium text-gray-11">
+                  <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-4 text-xs font-medium text-gray-11">
                     1
                   </div>
                   <div>
@@ -819,7 +819,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                 </div>
 
                 <div className="flex items-start gap-3">
-                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-4 text-xs font-medium text-gray-11">
+                  <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-4 text-xs font-medium text-gray-11">
                     2
                   </div>
                   <div>
@@ -829,7 +829,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
                 </div>
 
                 <div className="flex items-start gap-3">
-                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-4 text-xs font-medium text-gray-11">
+                  <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-gray-4 text-xs font-medium text-gray-11">
                     3
                   </div>
                   <div>

--- a/apps/app/src/react-app/domains/connections/modals/add-mcp-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/add-mcp-modal.tsx
@@ -184,14 +184,14 @@ export function AddMcpModal(props: AddMcpModalProps) {
                 value={url}
                 onChange={(event) => setUrl(event.currentTarget.value)}
               />
-              <div className="rounded-xl border border-dls-border bg-dls-hover/40 px-3 py-3">
+              <div className="rounded-xl border border-dls-border bg-dls-hover/40 p-3">
                 <div className="mb-2 text-xs font-medium text-dls-text">
                   {t("mcp.sign_in_section_label")}
                 </div>
                 <label className="flex items-start gap-2 text-xs text-dls-secondary">
                   <input
                     type="checkbox"
-                    className="mt-0.5 h-4 w-4 rounded border border-dls-border"
+                    className="mt-0.5 size-4 rounded border border-dls-border"
                     checked={oauthRequired}
                     onChange={(event) =>
                       setOauthRequired(event.currentTarget.checked)

--- a/apps/app/src/react-app/domains/connections/modals/chrome-connection-setup-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/chrome-connection-setup-modal.tsx
@@ -107,7 +107,7 @@ export function ChromeConnectionSetupModal(props: ChromeConnectionSetupModalProp
         </div>
 
         {/* Body */}
-        <div className="space-y-5 px-6 py-6 sm:px-7">
+        <div className="space-y-5 p-6 sm:px-7">
           {/* Connection status */}
           <div className={`flex items-center gap-3 rounded-xl border px-4 py-3 ${statusColor}`}>
             {status === "checking" ? (
@@ -133,7 +133,7 @@ export function ChromeConnectionSetupModal(props: ChromeConnectionSetupModalProp
           {/* Step 1: Enable remote debugging */}
           <div className="rounded-2xl border border-gray-6 bg-gray-1/40 p-5">
             <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-blue-3 text-blue-11">
+              <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-xl bg-blue-3 text-blue-11">
                 <span className="text-sm font-bold">1</span>
               </div>
               <div className="min-w-0 flex-1">
@@ -170,7 +170,7 @@ export function ChromeConnectionSetupModal(props: ChromeConnectionSetupModalProp
           {/* Step 2: Test connection */}
           <div className="rounded-2xl border border-gray-6 bg-gray-1/40 p-5">
             <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gray-3 text-gray-11">
+              <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-3 text-gray-11">
                 <span className="text-sm font-bold">2</span>
               </div>
               <div className="min-w-0 flex-1">

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -719,7 +719,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                         onMouseEnter={() => setActiveEntryIndex(index)}
                         onClick={() => handleEntrySelect(entry)}
                       >
-                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-5/60 bg-gray-2 shadow-sm overflow-hidden">
+                        <div className="flex size-8 shrink-0 items-center justify-center rounded-full border border-gray-5/60 bg-gray-2 shadow-sm overflow-hidden">
                           <ProviderIcon providerId={entry.id} size={18} className="text-gray-12" />
                         </div>
 
@@ -987,7 +987,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     </div>
                   )}
                   {oauthDisplayCode ? (
-                    <div className="rounded-xl border border-gray-6/70 bg-gray-2/40 px-3 py-3 flex items-center gap-3">
+                    <div className="rounded-xl border border-gray-6/70 bg-gray-2/40 p-3 flex items-center gap-3">
                       <div className="flex-1 min-w-0">
                         <div className="text-[10px] uppercase tracking-wide text-gray-8">Confirmation code</div>
                         <div className="text-sm text-gray-12 font-mono break-all">{oauthDisplayCode}</div>

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -11,7 +11,7 @@ type CapabilityCardProps = {
 function CapabilityCard({ icon, title, description }: CapabilityCardProps) {
   return (
     <div className="flex flex-col items-center gap-2 rounded-2xl border border-dls-border bg-dls-surface p-5 text-center transition-colors">
-      <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-dls-border bg-dls-hover text-dls-secondary">
+      <div className="flex size-10 items-center justify-center rounded-xl border border-dls-border bg-dls-hover text-dls-secondary">
         {icon}
       </div>
       <div className="text-[14px] font-medium text-dls-text">{title}</div>
@@ -33,7 +33,7 @@ export function WelcomePage({ onGetStarted }: WelcomePageProps) {
       <div className="mx-auto w-full max-w-[640px] space-y-10">
         {/* Header */}
         <div className="space-y-3 text-center">
-          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl border border-dls-border bg-dls-surface shadow-sm">
+          <div className="mx-auto flex size-16 items-center justify-center rounded-3xl border border-dls-border bg-dls-surface shadow-sm">
             <Bot size={28} className="text-dls-accent" />
           </div>
           <h1 className="text-[28px] font-semibold tracking-[-0.5px] text-dls-text">

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -122,17 +122,17 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
   return (
     <div ref={panelRef} className="flex h-full flex-col">
       <div ref={toolbarRef} className="flex h-10 shrink-0 items-center gap-1 border-b border-border px-2">
-        <button type="button" className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.back?.()} disabled={!state.canGoBack} title="Back" aria-label="Go back">
-          <ArrowLeft className="h-4 w-4" />
+        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.back?.()} disabled={!state.canGoBack} title="Back" aria-label="Go back">
+          <ArrowLeft className="size-4" />
         </button>
-        <button type="button" className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.forward?.()} disabled={!state.canGoForward} title="Forward" aria-label="Go forward">
-          <ArrowRight className="h-4 w-4" />
+        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.forward?.()} disabled={!state.canGoForward} title="Forward" aria-label="Go forward">
+          <ArrowRight className="size-4" />
         </button>
-        <button type="button" className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text" onClick={() => browser.reload?.()} title="Reload" aria-label="Reload page">
-          {state.isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCw className="h-4 w-4" />}
+        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text" onClick={() => browser.reload?.()} title="Reload" aria-label="Reload page">
+          {state.isLoading ? <Loader2 className="size-4 animate-spin" /> : <RotateCw className="size-4" />}
         </button>
         <div className="relative mx-1 flex min-w-0 flex-1 items-center">
-          <Globe className="absolute left-2 h-3.5 w-3.5 text-dls-secondary" />
+          <Globe className="absolute left-2 size-3.5 text-dls-secondary" />
           <input
             ref={urlInputRef}
             type="text"
@@ -147,8 +147,8 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
             autoComplete="off"
           />
         </div>
-        <button type="button" className="inline-flex h-7 w-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text" onClick={onClose} title="Close browser" aria-label="Close browser panel">
-          <X className="h-4 w-4" />
+        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text" onClick={onClose} title="Close browser" aria-label="Close browser panel">
+          <X className="size-4" />
         </button>
       </div>
       {/* WebContentsView renders in this area (managed by Electron main process) */}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -549,7 +549,7 @@ export function SessionPage(props: SessionPageProps) {
                     </div>
                   ) : showWorkspaceSetupEmptyState ? (
                     <div className="space-y-6 px-6 text-center">
-                      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl border border-dls-border bg-dls-hover">
+                      <div className="mx-auto flex size-16 items-center justify-center rounded-3xl border border-dls-border bg-dls-hover">
                         <Zap className="text-dls-secondary" />
                       </div>
                       <div className="space-y-2">
@@ -564,7 +564,7 @@ export function SessionPage(props: SessionPageProps) {
                     </div>
                   ) : showSelectedWorkspaceError ? (
                     <div className="px-6 py-16">
-                      <div className="mx-auto max-w-lg rounded-2xl border border-red-7/35 bg-red-1/40 px-5 py-5 text-left shadow-[var(--dls-card-shadow)]">
+                      <div className="mx-auto max-w-lg rounded-2xl border border-red-7/35 bg-red-1/40 p-5 text-left shadow-[var(--dls-card-shadow)]">
                         <div className="text-sm font-medium text-red-11">Remote workspace unavailable</div>
                         <p className="mt-2 whitespace-pre-wrap wrap-anywhere text-sm leading-6 text-red-11/90">
                           {selectedWorkspaceErrorMessage}
@@ -631,7 +631,7 @@ export function SessionPage(props: SessionPageProps) {
                         <div key={`${todo.content}-${index}`} className="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
                           <div className="flex items-center gap-1.5 pt-0.5">
                             <div
-                              className={`flex h-4.5 w-4.5 items-center justify-center rounded-full border ${
+                              className={`flex size-4.5 items-center justify-center rounded-full border ${
                                 done
                                   ? "border-green-6 bg-green-2 text-green-11"
                                   : active
@@ -641,7 +641,7 @@ export function SessionPage(props: SessionPageProps) {
                                       : "border-gray-6 bg-gray-1 text-gray-8"
                               }`}
                             >
-                              {done ? <Check size={10} /> : active ? <span className="h-1.5 w-1.5 rounded-full bg-amber-9" /> : null}
+                              {done ? <Check size={10} /> : active ? <span className="size-1.5 rounded-full bg-amber-9" /> : null}
                             </div>
                           </div>
                           <div className={`flex-1 text-sm leading-relaxed ${cancelled ? "text-gray-9 line-through" : "text-gray-12"}`}>

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -157,14 +157,14 @@ export function StatusBar(props: StatusBarProps) {
     <div className="border-t border-dls-border bg-dls-surface">
       <div className="flex h-12 items-center justify-between gap-3 px-4 md:px-6 text-[12px] text-dls-secondary">
         <div className="flex min-w-0 items-center gap-2.5">
-          <span className="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
+          <span className="relative flex size-2.5 shrink-0 items-center justify-center">
             {statusCopy.pulse ? (
               <span
-                className={`absolute inline-flex h-full w-full rounded-full ${statusCopy.pingClass}`}
+                className={`absolute inline-flex size-full rounded-full ${statusCopy.pingClass}`}
               />
             ) : null}
             <span
-              className={`relative inline-flex h-2.5 w-2.5 rounded-full ${statusCopy.dotClass}`}
+              className={`relative inline-flex size-2.5 rounded-full ${statusCopy.dotClass}`}
             />
           </span>
           <span className="shrink-0 font-medium text-dls-text">
@@ -184,7 +184,7 @@ export function StatusBar(props: StatusBarProps) {
             title={t("status.open_docs")}
             aria-label={t("status.open_docs")}
           >
-            <BookOpen className="h-4 w-4" />
+            <BookOpen className="size-4" />
             <span className="text-[11px] font-medium">{t("status.docs")}</span>
           </button>
           <button
@@ -195,7 +195,7 @@ export function StatusBar(props: StatusBarProps) {
             title={t("status.send_feedback")}
             aria-label={t("status.send_feedback")}
           >
-            <MessageCircle className="h-4 w-4" />
+            <MessageCircle className="size-4" />
             <span className="text-[11px] font-medium">
               {t("status.feedback")}
             </span>
@@ -204,7 +204,7 @@ export function StatusBar(props: StatusBarProps) {
             <button
               ref={settingsButtonRef}
               type="button"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+              className="flex size-8 shrink-0 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
               onClick={props.onOpenSettings}
               title={
                 props.settingsOpen ? t("status.back") : t("status.settings")
@@ -213,7 +213,7 @@ export function StatusBar(props: StatusBarProps) {
                 props.settingsOpen ? t("status.back") : t("status.settings")
               }
             >
-              <Settings className="h-4 w-4" />
+              <Settings className="size-4" />
             </button>
           ) : null}
         </div>

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -486,7 +486,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             </div>
             <button
               type="button"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full text-gray-10 transition-colors hover:bg-[var(--dls-hover)]"
+              className="inline-flex size-8 items-center justify-center rounded-full text-gray-10 transition-colors hover:bg-[var(--dls-hover)]"
               onClick={() => props.onClose()}
             >
               <X size={16} />

--- a/apps/app/src/react-app/domains/session/modals/question-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/question-modal.tsx
@@ -125,7 +125,7 @@ export function QuestionModal(props: QuestionModalProps) {
       <div className="bg-gray-2 border border-gray-6/70 w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden flex flex-col max-h-[85vh]">
         <div className="p-6 border-b border-gray-6/40 bg-gray-2/50">
           <div className="flex items-center gap-3 mb-2">
-            <div className="w-8 h-8 rounded-full bg-blue-9/20 flex items-center justify-center text-blue-9">
+            <div className="size-8 rounded-full bg-blue-9/20 flex items-center justify-center text-blue-9">
               <HelpCircle size={18} />
             </div>
             <div>
@@ -169,7 +169,7 @@ export function QuestionModal(props: QuestionModalProps) {
                 >
                   <span className="font-medium">{opt.description}</span>
                   {isSelected ? (
-                    <div className="w-5 h-5 rounded-full bg-blue-9 flex items-center justify-center shadow-sm">
+                    <div className="size-5 rounded-full bg-blue-9 flex items-center justify-center shadow-sm">
                       <Check size={12} className="text-white" strokeWidth={3} />
                     </div>
                   ) : null}

--- a/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
@@ -199,9 +199,9 @@ function RemoteConnectionIssueCard(props: {
     : "border-red-7/25 bg-red-1/40 text-red-11";
 
   return (
-    <div className={`w-full rounded-[15px] border px-3 py-3 text-left ${shellClass}`}>
+    <div className={`w-full rounded-[15px] border p-3 text-left ${shellClass}`}>
       <div className="flex items-start gap-2.5">
-        <div className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${iconClass}`}>
+        <div className={`mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full ${iconClass}`}>
           <AlertCircle size={14} />
         </div>
         <div className="min-w-0 flex-1">
@@ -452,7 +452,7 @@ export function WorkspaceSessionList(props: Props) {
             {hasChildren ? (
               <button
                 type="button"
-                className="-ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
+                className="-ml-1 flex size-6 shrink-0 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
                 aria-label={isExpanded ? t("workspace_list.hide_child_sessions") : t("workspace_list.show_child_sessions")}
                 onClick={(event) => {
                   event.preventDefault();
@@ -466,7 +466,7 @@ export function WorkspaceSessionList(props: Props) {
               <span className="h-[1px] w-3 shrink-0 rounded-full bg-dls-border" />
             ) : null}
 
-            {isSessionActive ? <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-9" /> : null}
+            {isSessionActive ? <span className="size-1.5 shrink-0 rounded-full bg-amber-9" /> : null}
             <span
               className={`block min-w-0 truncate ${
                 isSelected ? "font-medium text-gray-12" : "font-normal text-current"
@@ -481,7 +481,7 @@ export function WorkspaceSessionList(props: Props) {
             {canManageSession ? (
               <button
                 type="button"
-                className="flex h-7 w-7 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
+                className="flex size-7 items-center justify-center rounded-md text-gray-9 transition-colors hover:bg-gray-3/80 hover:text-gray-11"
                 aria-label={t("workspace_list.session_actions")}
                 onClick={(event) => {
                   event.preventDefault();
@@ -615,7 +615,7 @@ export function WorkspaceSessionList(props: Props) {
                   >
                     <div className="flex min-w-0 items-center gap-3.5">
                       <div
-                        className="flex h-5.5 w-5.5 shrink-0 items-center justify-center rounded-full"
+                        className="flex size-5.5 shrink-0 items-center justify-center rounded-full"
                         style={{
                           backgroundColor: workspaceSwatchColor(workspace.id || workspaceLabel(workspace)),
                         }}

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -477,12 +477,12 @@ function FileCard(props: {
       }`}
     >
       {isImage && props.part.url ? (
-        <div className="h-11 w-11 shrink-0 overflow-hidden rounded-xl border border-dls-border/60 bg-dls-surface">
-          <img src={props.part.url} alt={title} loading="lazy" decoding="async" className="h-full w-full object-cover" />
+        <div className="size-11 shrink-0 overflow-hidden rounded-xl border border-dls-border/60 bg-dls-surface">
+          <img src={props.part.url} alt={title} loading="lazy" decoding="async" className="size-full object-cover" />
         </div>
       ) : (
         <div
-          className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${
+          className={`flex size-11 shrink-0 items-center justify-center rounded-xl ${
             props.tone === "user" ? "bg-gray-3/60 text-gray-11" : "bg-gray-2/60 text-gray-10"
           }`}
         >
@@ -502,7 +502,7 @@ function FileCard(props: {
         <div className="relative">
           <button
             type="button"
-            className="flex h-8 w-8 items-center justify-center rounded-xl text-gray-9 opacity-0 transition-all hover:bg-gray-3/60 hover:text-gray-12 group-hover:opacity-100"
+            className="flex size-8 items-center justify-center rounded-xl text-gray-9 opacity-0 transition-all hover:bg-gray-3/60 hover:text-gray-12 group-hover:opacity-100"
             onClick={() => setMenuOpen((value) => !value)}
             title="File actions"
           >

--- a/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
@@ -96,7 +96,7 @@ function ThemePickerItem(props: ThemePickerItemProps) {
     <ToggleGroupItem
       value={props.value}
       aria-label={props.label}
-      className="group/theme h-auto flex-1 flex-col gap-3 rounded-sm px-0 py-0 hover:bg-transparent aria-pressed:bg-transparent"
+      className="group/theme h-auto flex-1 flex-col gap-3 rounded-sm p-0 hover:bg-transparent aria-pressed:bg-transparent"
     >
       {props.children}
     </ToggleGroupItem>

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -52,7 +52,7 @@ function RuntimeStatusCard(props: RuntimeStatusCardProps) {
   return (
     <div className={`${settingsPanelSoftClass} space-y-3`}>
       <div className="flex items-start gap-3">
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-gray-6/60 bg-gray-1/70 text-gray-12">
+        <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-gray-6/60 bg-gray-1/70 text-gray-12">
           {props.icon}
         </div>
         <div>
@@ -63,7 +63,7 @@ function RuntimeStatusCard(props: RuntimeStatusCardProps) {
       <div
         className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-medium ${props.statusStyle}`}
       >
-        <span className={`h-2 w-2 rounded-full ${props.statusDot}`} />
+        <span className={`size-2 rounded-full ${props.statusDot}`} />
         {props.statusLabel}
       </div>
       {props.detailLines?.length ? (

--- a/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
@@ -15,9 +15,9 @@ import { clearOpenworkEnvSystemContextCache } from "../../session/sync/env-conte
 
 const settingsPanelClass = "rounded-[28px] border border-dls-border bg-dls-surface p-5 md:p-6";
 const rowIconButtonClass =
-  "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-gray-7/80 bg-gray-2 text-gray-11 shadow-sm transition-colors hover:border-gray-8 hover:bg-gray-4 hover:text-gray-12 focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.25)] disabled:cursor-not-allowed disabled:opacity-50";
+  "inline-flex size-8 shrink-0 items-center justify-center rounded-lg border border-gray-7/80 bg-gray-2 text-gray-11 shadow-sm transition-colors hover:border-gray-8 hover:bg-gray-4 hover:text-gray-12 focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.25)] disabled:cursor-not-allowed disabled:opacity-50";
 const rowDangerIconButtonClass =
-  "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-red-7/75 bg-red-3/40 text-red-10 shadow-sm transition-colors hover:border-red-8 hover:bg-red-4/80 hover:text-red-11 focus:outline-none focus:ring-2 focus:ring-red-7/30 disabled:cursor-not-allowed disabled:opacity-50";
+  "inline-flex size-8 shrink-0 items-center justify-center rounded-lg border border-red-7/75 bg-red-3/40 text-red-10 shadow-sm transition-colors hover:border-red-8 hover:bg-red-4/80 hover:text-red-11 focus:outline-none focus:ring-2 focus:ring-red-7/30 disabled:cursor-not-allowed disabled:opacity-50";
 
 const KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const RESERVED_PREFIXES = ["OPENWORK_", "OPENCODE_"] as const;
@@ -266,10 +266,10 @@ export function EnvironmentView(props: EnvironmentViewProps) {
         ) : null}
 
         {pendingChanges && !isRemoteWorkspace ? (
-          <div className="rounded-xl border border-amber-7/50 bg-amber-3/30 px-3 py-3">
+          <div className="rounded-xl border border-amber-7/50 bg-amber-3/30 p-3">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex min-w-0 items-start gap-2.5">
-                <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-amber-4/70 text-amber-11">
+                <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-4/70 text-amber-11">
                   <RefreshCw size={14} />
                 </div>
                 <div className="min-w-0">
@@ -369,7 +369,7 @@ export function EnvironmentView(props: EnvironmentViewProps) {
                         : t("settings.environment.reveal_value")
                       ).replace("{key}", item.key)}
                     >
-                      {isRevealed ? <EyeOff className="h-4 w-4" strokeWidth={2.1} /> : <Eye className="h-4 w-4" strokeWidth={2.1} />}
+                      {isRevealed ? <EyeOff className="size-4" strokeWidth={2.1} /> : <Eye className="size-4" strokeWidth={2.1} />}
                     </button>
                     {canEdit ? (
                       <button
@@ -380,7 +380,7 @@ export function EnvironmentView(props: EnvironmentViewProps) {
                         title={t("settings.environment.delete")}
                         aria-label={t("settings.environment.delete_variable").replace("{key}", item.key)}
                       >
-                        <Trash2 className="h-4 w-4" strokeWidth={2.1} />
+                        <Trash2 className="size-4" strokeWidth={2.1} />
                       </button>
                     ) : null}
                   </div>
@@ -416,7 +416,7 @@ export function EnvironmentView(props: EnvironmentViewProps) {
               </div>
               <Button
                 variant="ghost"
-                className="h-7 w-7 p-0"
+                className="size-7 p-0"
                 onClick={closeEditor}
                 aria-label={t("settings.environment.close_editor")}
                 title={t("settings.environment.close_editor")}

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -97,7 +97,7 @@ export function ExtensionsView(props: ExtensionsViewProps) {
           >
             {props.mcpConnectedAppsCount > 0 ? (
               <div className="inline-flex items-center gap-2 rounded-full bg-green-3 px-3 py-1">
-                <div className="w-2 h-2 rounded-full bg-green-9" />
+                <div className="size-2 rounded-full bg-green-9" />
                 <span className="text-xs font-medium text-green-11">
                   {t("extensions.app_count", { count: props.mcpConnectedAppsCount })}
                 </span>

--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -221,8 +221,8 @@ export function GeneralSettingsView(props: GeneralSettingsViewProps) {
       </div>
 
       <div className="relative overflow-hidden rounded-2xl border border-blue-7/30 bg-gradient-to-br from-blue-3/35 via-gray-1/75 to-cyan-3/30 p-5">
-        <div className="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-blue-6/20 blur-2xl" />
-        <div className="pointer-events-none absolute -bottom-12 left-6 h-24 w-24 rounded-full bg-cyan-6/20 blur-2xl" />
+        <div className="pointer-events-none absolute -right-10 -top-10 size-32 rounded-full bg-blue-6/20 blur-2xl" />
+        <div className="pointer-events-none absolute -bottom-12 left-6 size-24 rounded-full bg-cyan-6/20 blur-2xl" />
 
         <div className="relative space-y-4">
           <div className="space-y-2">

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -316,7 +316,7 @@ export function McpView(props: McpViewProps) {
           <p className="mt-1.5 text-sm text-dls-secondary">{t("mcp.apps_subtitle")}</p>
           {connectedCount > 0 ? (
             <div className="mt-3 inline-flex items-center gap-2 rounded-full bg-green-3 px-3 py-1">
-              <div className="h-2 w-2 rounded-full bg-green-9" />
+              <div className="size-2 rounded-full bg-green-9" />
               <span className="text-xs font-medium text-green-11">
                 {connectedCount} {connectedCount === 1 ? t("mcp.app_connected") : t("mcp.apps_connected")}
               </span>
@@ -333,7 +333,7 @@ export function McpView(props: McpViewProps) {
 
       {/* Connect Chrome card */}
       {isDesktopRuntime() ? (
-        <div className="rounded-2xl border border-amber-6/30 bg-[linear-gradient(180deg,rgba(245,158,11,0.08),rgba(245,158,11,0.03))] px-5 py-5 sm:px-6">
+        <div className="rounded-2xl border border-amber-6/30 bg-[linear-gradient(180deg,rgba(245,158,11,0.08),rgba(245,158,11,0.03))] p-5 sm:px-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="space-y-1">
               <div className="text-base font-semibold text-dls-text">{t("chrome_setup.title")}</div>
@@ -347,7 +347,7 @@ export function McpView(props: McpViewProps) {
         </div>
       ) : null}
 
-      <div className="rounded-2xl border border-blue-6/30 bg-[linear-gradient(180deg,rgba(59,130,246,0.08),rgba(59,130,246,0.03))] px-5 py-5 sm:px-6">
+      <div className="rounded-2xl border border-blue-6/30 bg-[linear-gradient(180deg,rgba(59,130,246,0.08),rgba(59,130,246,0.03))] p-5 sm:px-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <div className="text-base font-semibold text-dls-text">{t("mcp.add_modal_title")}</div>
@@ -392,7 +392,7 @@ export function McpView(props: McpViewProps) {
                 >
                   <div className="flex items-start gap-3">
                     <div
-                      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border ${
+                      className={`flex size-10 shrink-0 items-center justify-center rounded-lg border ${
                         configured ? "border-green-6 bg-green-3" : serviceIconBg(entry.name)
                       }`}
                     >
@@ -482,7 +482,7 @@ export function McpView(props: McpViewProps) {
                   >
                     <div className="flex items-center gap-3">
                       <div
-                        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border ${
+                        className={`flex size-8 shrink-0 items-center justify-center rounded-lg border ${
                           status === "connected"
                             ? "border-green-6 bg-green-3"
                             : serviceIconBg(entry.name)
@@ -501,7 +501,7 @@ export function McpView(props: McpViewProps) {
                         </div>
                       </div>
                       <div className="flex shrink-0 items-center gap-2">
-                        <div className={`h-2 w-2 rounded-full ${statusDot(status)}`} />
+                        <div className={`size-2 rounded-full ${statusDot(status)}`} />
                         <span className="text-[11px] text-dls-secondary">
                           {friendlyStatus(status)}
                         </span>

--- a/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
@@ -294,7 +294,7 @@ export function MessagingView(props: MessagingViewProps) {
           ) : null}
 
           {!props.messagingEnabled ? (
-            <div className="space-y-3 rounded-xl border border-gray-4 bg-gray-1 px-4 py-4">
+            <div className="space-y-3 rounded-xl border border-gray-4 bg-gray-1 p-4">
               <div className="text-sm font-semibold text-gray-12">{t("identities.messaging_disabled_title")}</div>
               <p className="text-xs leading-relaxed text-gray-10">{t("identities.messaging_disabled_risk")}</p>
               <p className="text-xs leading-relaxed text-gray-10">{t("identities.messaging_disabled_hint")}</p>
@@ -333,9 +333,9 @@ export function MessagingView(props: MessagingViewProps) {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2.5">
                     {isWorkerOnline ? (
-                      <div className="h-2.5 w-2.5 rounded-full bg-emerald-9 animate-pulse" />
+                      <div className="size-2.5 rounded-full bg-emerald-9 animate-pulse" />
                     ) : (
-                      <div className="h-2.5 w-2.5 rounded-full bg-gray-8" />
+                      <div className="size-2.5 rounded-full bg-gray-8" />
                     )}
                     <span className="text-[15px] font-semibold text-gray-12">
                       {isWorkerOnline
@@ -420,7 +420,7 @@ export function MessagingView(props: MessagingViewProps) {
                     </button>
 
                     {props.expandedChannel === "telegram" ? (
-                      <div className="space-y-3 border-t border-gray-4 px-4 py-4 animate-[fadeUp_0.2s_ease-out]">
+                      <div className="space-y-3 border-t border-gray-4 p-4 animate-[fadeUp_0.2s_ease-out]">
                         {props.telegram.identitiesError ? (
                           <div className="rounded-lg border border-amber-7/20 bg-amber-1/30 px-3 py-2 text-xs text-amber-12">
                             {props.telegram.identitiesError}
@@ -438,7 +438,7 @@ export function MessagingView(props: MessagingViewProps) {
                                   <div className="min-w-0">
                                     <div className="flex items-center gap-2">
                                       <div
-                                        className={`h-1.5 w-1.5 shrink-0 rounded-full ${item.running ? "bg-emerald-9" : "bg-gray-8"}`}
+                                        className={`size-1.5 shrink-0 rounded-full ${item.running ? "bg-emerald-9" : "bg-gray-8"}`}
                                       />
                                       <span className="truncate text-[13px] font-semibold text-gray-12">
                                         <span className="font-mono text-[12px]">{item.id}</span>
@@ -465,7 +465,7 @@ export function MessagingView(props: MessagingViewProps) {
                                 <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.status_label")}</div>
                                 <div className="flex items-center gap-1.5">
                                   <div
-                                    className={`h-1.5 w-1.5 rounded-full ${
+                                    className={`size-1.5 rounded-full ${
                                       props.telegram.identities.some((item) => item.running) ? "bg-emerald-9" : "bg-gray-8"
                                     }`}
                                   />
@@ -507,7 +507,7 @@ export function MessagingView(props: MessagingViewProps) {
                               <div className="text-[12px] font-semibold text-gray-12">{t("identities.quick_setup")}</div>
                               <ol className="space-y-2 text-[12px] leading-relaxed text-gray-10">
                                 <li className="flex items-start gap-2">
-                                  <span className="mt-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-gray-4 text-[10px] font-semibold text-gray-11">1</span>
+                                  <span className="mt-0.5 flex size-4 items-center justify-center rounded-full bg-gray-4 text-[10px] font-semibold text-gray-11">1</span>
                                   <span>
                                     {t("identities.botfather_step1_open")}{" "}
                                     <a href="https://t.me/BotFather" target="_blank" rel="noreferrer" className="font-medium text-gray-12 underline">
@@ -518,11 +518,11 @@ export function MessagingView(props: MessagingViewProps) {
                                   </span>
                                 </li>
                                 <li className="flex items-start gap-2">
-                                  <span className="mt-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-gray-4 text-[10px] font-semibold text-gray-11">2</span>
+                                  <span className="mt-0.5 flex size-4 items-center justify-center rounded-full bg-gray-4 text-[10px] font-semibold text-gray-11">2</span>
                                   <span>{t("identities.copy_bot_token_hint")}</span>
                                 </li>
                                 <li className="flex items-start gap-2">
-                                  <span className="mt-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-gray-4 text-[10px] font-semibold text-gray-11">3</span>
+                                  <span className="mt-0.5 flex size-4 items-center justify-center rounded-full bg-gray-4 text-[10px] font-semibold text-gray-11">3</span>
                                   <span>
                                     {t("identities.botfather_step3_choose")} <span className="font-medium text-gray-12">{t("identities.botfather_step3_public")}</span>{" "}
                                     {t("identities.botfather_step3_or_private")} <span className="font-medium text-gray-12">{t("identities.botfather_step3_private")}</span>{" "}
@@ -567,7 +567,7 @@ export function MessagingView(props: MessagingViewProps) {
                               }`}
                             >
                               {props.telegram.saving ? (
-                                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                                <div className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
                               ) : (
                                 <Link size={15} />
                               )}
@@ -586,7 +586,7 @@ export function MessagingView(props: MessagingViewProps) {
                               style={{ background: "#229ED9" }}
                             >
                               {props.telegram.saving ? (
-                                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                                <div className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
                               ) : (
                                 <Shield size={15} />
                               )}
@@ -673,7 +673,7 @@ export function MessagingView(props: MessagingViewProps) {
                     </button>
 
                     {props.expandedChannel === "slack" ? (
-                      <div className="space-y-3 border-t border-gray-4 px-4 py-4 animate-[fadeUp_0.2s_ease-out]">
+                      <div className="space-y-3 border-t border-gray-4 p-4 animate-[fadeUp_0.2s_ease-out]">
                         {props.slack.identitiesError ? (
                           <div className="rounded-lg border border-amber-7/20 bg-amber-1/30 px-3 py-2 text-xs text-amber-12">
                             {props.slack.identitiesError}
@@ -691,7 +691,7 @@ export function MessagingView(props: MessagingViewProps) {
                                   <div className="min-w-0">
                                     <div className="flex items-center gap-2">
                                       <div
-                                        className={`h-1.5 w-1.5 shrink-0 rounded-full ${item.running ? "bg-emerald-9" : "bg-gray-8"}`}
+                                        className={`size-1.5 shrink-0 rounded-full ${item.running ? "bg-emerald-9" : "bg-gray-8"}`}
                                       />
                                       <span className="truncate text-[13px] font-semibold text-gray-12">
                                         <span className="font-mono text-[12px]">{item.id}</span>
@@ -718,7 +718,7 @@ export function MessagingView(props: MessagingViewProps) {
                                 <div className="mb-0.5 text-[11px] text-gray-9">{t("identities.status_label")}</div>
                                 <div className="flex items-center gap-1.5">
                                   <div
-                                    className={`h-1.5 w-1.5 rounded-full ${
+                                    className={`size-1.5 rounded-full ${
                                       props.slack.identities.some((item) => item.running) ? "bg-emerald-9" : "bg-gray-8"
                                     }`}
                                   />
@@ -799,7 +799,7 @@ export function MessagingView(props: MessagingViewProps) {
                             style={{ background: "#4A154B" }}
                           >
                             {props.slack.saving ? (
-                              <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                              <div className="size-3.5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
                             ) : (
                               <Link size={15} />
                             )}

--- a/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
@@ -833,7 +833,7 @@ export function SkillsView(props: SkillsViewProps) {
                     onKeyDown={(event) => handleSkillCardKeyDown(event, skill)}
                   >
                     <div className="flex min-w-0 gap-4">
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
                         <Package size={20} className="text-dls-secondary" />
                       </div>
                       <div className="min-w-0 flex-1">
@@ -966,7 +966,7 @@ export function SkillsView(props: SkillsViewProps) {
                       return (
                         <div key={skill.id} className={`${panelCardClass} flex flex-col gap-4 text-left`}>
                           <div className="flex min-w-0 gap-4">
-                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
+                            <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
                               <Cloud size={20} className="text-dls-secondary" />
                             </div>
                             <div className="min-w-0 flex-1">
@@ -1111,7 +1111,7 @@ export function SkillsView(props: SkillsViewProps) {
                 {filteredHubSkills.map((skill) => (
                   <div key={`${skill.source.owner}/${skill.source.repo}/${skill.name}`} className={`${panelCardClass} flex flex-col gap-4 text-left`}>
                     <div className="flex min-w-0 gap-4">
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
                         <Package size={20} className="text-dls-secondary" />
                       </div>
                       <div className="min-w-0 flex-1">

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -306,7 +306,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
       </div>
 
       {!canReadConfig ? (
-        <div className={`${softPanelClass} px-3 py-3 text-xs text-gray-10`}>
+        <div className={`${softPanelClass} p-3 text-xs text-gray-10`}>
           {authorizedFoldersHint ?? t("context_panel.authorized_folders_no_access")}
         </div>
       ) : (
@@ -330,7 +330,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                     }`}
                   >
                     <div className="flex overflow-hidden items-center gap-3">
-                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-3/30 text-blue-11">
+                      <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-blue-3/30 text-blue-11">
                         <Folder size={15} />
                       </div>
                       <div className="flex min-w-0 flex-col">
@@ -348,7 +348,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                     {!isWorkspaceRoot ? (
                       <Button
                         variant="ghost"
-                        className="h-6 w-6 shrink-0 !rounded-full !p-0 border-0 bg-transparent text-red-10 shadow-none hover:bg-red-3/15 hover:text-red-11 focus:ring-red-7/25"
+                        className="size-6 shrink-0 !rounded-full !p-0 border-0 bg-transparent text-red-10 shadow-none hover:bg-red-3/15 hover:text-red-11 focus:ring-red-7/25"
                         onClick={() => void removeAuthorizedFolder(folder)}
                         disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canWriteConfig}
                         aria-label={t("context_panel.remove_folder", undefined, { name: folderName })}
@@ -366,7 +366,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
             </div>
           ) : (
             <div className="flex flex-col items-center justify-center p-6 text-center">
-              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-3/30 text-blue-11">
+              <div className="mb-3 flex size-10 items-center justify-center rounded-full bg-blue-3/30 text-blue-11">
                 <Folder size={20} />
               </div>
               <div className="text-sm font-medium text-gray-11">{t("context_panel.no_external_folders")}</div>

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -72,7 +72,7 @@ export function SettingsShell(props: SettingsShellProps) {
                 <Button
                   variant="ghost"
                   type="button"
-                  className="flex h-9 w-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
+                  className="flex size-9 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-2/70 hover:text-dls-text"
                   onClick={props.onClose}
                   title={t("dashboard.close_settings")}
                   aria-label={t("dashboard.close_settings")}

--- a/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
@@ -86,9 +86,9 @@ export function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
 
   return (
     <div className="w-full max-w-[24rem] overflow-hidden rounded-[1.4rem] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)] backdrop-blur-xl animate-in fade-in slide-in-from-top-4 duration-300">
-      <div className="flex items-start gap-3 px-4 py-4">
+      <div className="flex items-start gap-3 p-4">
         <div
-          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border ${
+          className={`flex size-10 shrink-0 items-center justify-center rounded-2xl border ${
             props.hasActiveRuns
               ? "border-amber-6/40 bg-amber-4/80 text-amber-11"
               : "border-sky-6/40 bg-sky-4/80 text-sky-11"

--- a/apps/app/src/react-app/domains/shell-feedback/status-toast.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/status-toast.tsx
@@ -36,9 +36,9 @@ export function StatusToast(props: StatusToastProps) {
 
   return (
     <div className="w-full max-w-[24rem] overflow-hidden rounded-[1.4rem] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)] backdrop-blur-xl animate-in fade-in slide-in-from-top-4 duration-300">
-      <div className="flex items-start gap-3 px-4 py-4">
+      <div className="flex items-start gap-3 p-4">
         <div
-          className={`mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border ${tileClass}`.trim()}
+          className={`mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-2xl border ${tileClass}`.trim()}
         >
           <Icon size={18} />
         </div>

--- a/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
@@ -68,7 +68,7 @@ function stepIcon(status: CreateWorkspaceProgressStep["status"]) {
   if (status === "active")
     return <Loader2 size={16} className="animate-spin text-dls-accent" />;
   if (status === "error") return <XCircle size={16} className="text-red-10" />;
-  return <div className="h-4 w-4 rounded-full border-2 border-dls-border" />;
+  return <div className="size-4 rounded-full border-2 border-dls-border" />;
 }
 
 function stepTextClass(status: CreateWorkspaceProgressStep["status"]) {
@@ -183,7 +183,7 @@ export function CreateWorkspaceLocalPanel(
             <div className="mt-4 grid gap-2.5">
               {progress.steps.map((step) => (
                 <div key={step.key} className="flex items-center gap-3">
-                  <div className="flex h-5 w-5 shrink-0 items-center justify-center">
+                  <div className="flex size-5 shrink-0 items-center justify-center">
                     {stepIcon(step.status)}
                   </div>
                   <div className="flex min-w-0 flex-1 items-center justify-between gap-2">

--- a/apps/app/src/react-app/domains/workspace/create-workspace-shared-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-shared-panel.tsx
@@ -72,7 +72,7 @@ export function CreateWorkspaceSharedPanel(
           <div
             className={`${surfaceCardClass} w-full max-w-[420px] p-8 text-center`}
           >
-            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-hover text-dls-text">
+            <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-hover text-dls-text">
               <Cloud size={24} />
             </div>
             <div className="mt-5 text-[20px] font-semibold tracking-[-0.3px] text-dls-text">
@@ -200,7 +200,7 @@ export function CreateWorkspaceSharedPanel(
                       <span
                         className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${statusBadgeClass(status.tone)}`.trim()}
                       >
-                        <span className="h-1.5 w-1.5 rounded-full bg-current opacity-80" />
+                        <span className="size-1.5 rounded-full bg-current opacity-80" />
                         {status.label}
                       </span>
                     </div>

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -317,7 +317,7 @@ export function CommandPalette(props: CommandPaletteProps) {
             />
             <button
               type="button"
-              className="h-8 w-8 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors flex items-center justify-center"
+              className="size-8 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors flex items-center justify-center"
               onClick={props.onClose}
               aria-label={t("common.close")}
             >

--- a/apps/app/src/react-app/shell/dev-profiler.tsx
+++ b/apps/app/src/react-app/shell/dev-profiler.tsx
@@ -354,7 +354,7 @@ function DevProfilerOverlayVisible({ onHide }: { onHide: () => void }) {
       {collapsed ? null : (
         <div className="max-h-[50vh] overflow-y-auto">
           {topZones.length === 0 ? (
-            <div className="px-3 py-3 text-dls-secondary">
+            <div className="p-3 text-dls-secondary">
               No profiler data yet. Interact with the app.
             </div>
           ) : (

--- a/apps/app/src/react-app/shell/react-render-watchdog-overlay.tsx
+++ b/apps/app/src/react-app/shell/react-render-watchdog-overlay.tsx
@@ -101,7 +101,7 @@ export function ReactRenderWatchdogOverlay() {
       {collapsed ? null : (
         <div className="max-h-[50vh] overflow-y-auto">
           {hot.length === 0 ? (
-            <div className="px-3 py-3 text-dls-secondary">
+            <div className="p-3 text-dls-secondary">
               No render samples yet. Interact with the app.
             </div>
           ) : (


### PR DESCRIPTION
## Summary

- Collapses matching Tailwind `w-* h-*` pairs to `size-*` in @openwork/app React UI files.
- Collapses matching Tailwind `px-* py-*` pairs to `p-*` where axes are identical.
- Leaves responsive and differing-axis cases untouched.

## Evidence

### React Doctor
- Before: score 67 / 100, 415 warnings across 117 files.
- Before target counts: `react-doctor/design-no-redundant-size-axes` x73, `react-doctor/design-no-redundant-padding-axes` x18.
- After: score 69 / 100, 324 warnings across 108 files.
- After target counts: `react-doctor/design-no-redundant-size-axes` x0, `react-doctor/design-no-redundant-padding-axes` x0.
- After share URL: https://www.react.doctor/share?p=%40openwork%2Fapp&s=69&w=324&f=108

### Build Verification
- `pnpm install --frozen-lockfile` passed to hydrate the fresh worktree.
- `pnpm --filter @openwork/app build` passed.

### Typecheck
- `pnpm --filter @openwork/app typecheck` still fails on unrelated existing TypeScript errors, primarily `unknown` IPC/result typing, missing OpenCode router exports, and existing settings/session route errors.

### UI Verification
- No screenshots captured; this is a mechanical Tailwind class shorthand cleanup with no intended visual behavior change.

### API Verification
- No API changes.

## Test Instructions

1. `cd apps/app`
2. `npx react-doctor@latest . --verbose`
3. Confirm both target rules are absent.
4. From repo root, run `pnpm --filter @openwork/app build`.