### PR TITLE
fix(app): reduce safe React effect warnings

### DIFF
--- a/apps/app/src/react-app/design-system/select-menu.tsx
+++ b/apps/app/src/react-app/design-system/select-menu.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown } from "lucide-react";
 
 export type SelectMenuOption = {
@@ -37,7 +37,7 @@ export function SelectMenu(props: SelectMenuProps) {
     return props.placeholder?.trim() || "";
   }, [props.options, props.placeholder, props.value]);
 
-  const close = useCallback(() => setOpen(false), []);
+  const close = useEffectEvent(() => setOpen(false));
 
   useEffect(() => {
     if (!open) return;
@@ -50,7 +50,7 @@ export function SelectMenu(props: SelectMenuProps) {
     window.addEventListener("pointerdown", onPointerDown, true);
     return () =>
       window.removeEventListener("pointerdown", onPointerDown, true);
-  }, [close, open]);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -62,7 +62,7 @@ export function SelectMenu(props: SelectMenuProps) {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [close, open]);
+  }, [open]);
 
   return (
     <div ref={rootRef} className="relative w-full">

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -2,6 +2,7 @@
 import {
   useCallback,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -169,27 +170,24 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     [renderedItems.length],
   );
 
-  const scrollActiveIntoView = useCallback((idx: number) => {
+  const scrollActiveIntoView = useEffectEvent((idx: number) => {
     const el = optionRefs.current[idx];
     if (!el) return;
     el.scrollIntoView({ block: "nearest" });
-  }, []);
+  });
 
-  const selectRenderedItem = useCallback(
-    (item: RenderedItem | undefined) => {
-      if (!item) return;
-      if (item.kind === "provider") {
-        props.onClose({ restorePromptFocus: false });
-        props.onOpenSettings();
-        return;
-      }
-      props.onSelect({
-        providerID: item.opt.providerID,
-        modelID: item.opt.modelID,
-      });
-    },
-    [props],
-  );
+  const selectRenderedItem = useEffectEvent((item: RenderedItem | undefined) => {
+    if (!item) return;
+    if (item.kind === "provider") {
+      props.onClose({ restorePromptFocus: false });
+      props.onOpenSettings();
+      return;
+    }
+    props.onSelect({
+      providerID: item.opt.providerID,
+      modelID: item.opt.modelID,
+    });
+  });
 
   // Focus the search input whenever the modal opens.
   useEffect(() => {
@@ -211,7 +209,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     setActiveIndex(clamped);
     const frame = requestAnimationFrame(() => scrollActiveIntoView(clamped));
     return () => cancelAnimationFrame(frame);
-  }, [activeModelIndex, clampIndex, props.open, scrollActiveIntoView]);
+  }, [activeModelIndex, clampIndex, props.open]);
 
   // Window-level key handling.
   useEffect(() => {
@@ -255,7 +253,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [activeIndex, clampIndex, renderedItems, scrollActiveIntoView, selectRenderedItem]);
+  }, [activeIndex, clampIndex, renderedItems]);
 
   if (!props.open) return null;
 

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -447,7 +447,7 @@ export function McpView(props: McpViewProps) {
           </h3>
           {props.mcpLastUpdatedAt ? (
             <span className="tabular-nums text-[11px] text-dls-secondary">
-              {t("mcp.last_synced")} {formatRelativeTime(props.mcpLastUpdatedAt ?? Date.now())}
+              {t("mcp.last_synced")} {formatRelativeTime(props.mcpLastUpdatedAt)}
             </span>
           ) : null}
         </div>

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -106,7 +106,7 @@ export function LocalProvider({ children }: LocalProviderProps) {
       defaultModel: readStoredDefaultModel(),
     };
   });
-  const [ready, setReady] = useState(false);
+  const ready = true;
   const migratedThinkingRef = useRef(false);
 
   useEffect(() => {
@@ -118,11 +118,6 @@ export function LocalProvider({ children }: LocalProviderProps) {
   }, [prefs]);
 
   useEffect(() => {
-    setReady(true);
-  }, []);
-
-  useEffect(() => {
-    if (!ready) return;
     if (typeof window === "undefined") return;
     if (migratedThinkingRef.current) return;
     migratedThinkingRef.current = true;
@@ -144,7 +139,7 @@ export function LocalProvider({ children }: LocalProviderProps) {
     } catch {
       // ignore
     }
-  }, [ready]);
+  }, []);
 
   const setUi = useCallback(
     (updater: (previous: LocalUIState) => LocalUIState) => {

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useSyncExternalStore, type ReactNode } from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
 import { readDenBootstrapConfig } from "../../app/lib/den";
@@ -20,6 +20,16 @@ type DenSigninGateProps = {
   children: ReactNode;
 };
 
+const readRequireSigninSnapshot = () => readDenBootstrapConfig().requireSignin;
+
+const subscribeToRequireSignin = (onStoreChange: () => void) => {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(denSettingsChangedEvent, onStoreChange);
+  return () => {
+    window.removeEventListener(denSettingsChangedEvent, onStoreChange);
+  };
+};
+
 /**
  * Forced-signin gate ported from the Solid shell.
  *
@@ -35,24 +45,11 @@ function DenSigninGate({ children }: DenSigninGateProps) {
   const denAuth = useDenAuth();
   const location = useLocation();
   const navigate = useNavigate();
-  // The bootstrap file is read synchronously; re-read on settings-changed so a
-  // developer-mode override flips the gate live without a reload.
-  const [requireSignin, setRequireSignin] = useState(
-    () => readDenBootstrapConfig().requireSignin,
+  const requireSignin = useSyncExternalStore(
+    subscribeToRequireSignin,
+    readRequireSigninSnapshot,
+    readRequireSigninSnapshot,
   );
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const handler = () => {
-      setRequireSignin(readDenBootstrapConfig().requireSignin);
-    };
-
-    window.addEventListener(denSettingsChangedEvent, handler);
-    return () => {
-      window.removeEventListener(denSettingsChangedEvent, handler);
-    };
-  }, []);
 
   useEffect(() => {
     // Wait for the first auth check so we don't bounce the user between

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -215,16 +215,13 @@ export function CommandPalette(props: CommandPaletteProps) {
   }, [props, query]);
 
   const items = mode === "sessions" ? sessionItems : rootItems;
-
-  useEffect(() => {
-    if (activeIndex >= items.length) setActiveIndex(0);
-  }, [activeIndex, items.length]);
+  const visibleActiveIndex = items.length > 0 ? Math.min(activeIndex, items.length - 1) : 0;
 
   useEffect(() => {
     if (!props.open) return;
-    const target = optionRefs.current[activeIndex];
+    const target = optionRefs.current[visibleActiveIndex];
     target?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex, items.length, props.open]);
+  }, [props.open, visibleActiveIndex]);
 
   const handleKey = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key === "Escape") {
@@ -253,7 +250,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     }
     if (event.key === "Enter") {
       event.preventDefault();
-      const item = items[activeIndex];
+      const item = items[visibleActiveIndex];
       if (item) item.action();
       return;
     }
@@ -340,7 +337,7 @@ export function CommandPalette(props: CommandPaletteProps) {
                     }}
                     type="button"
                     className={`w-full px-4 py-2.5 flex items-start gap-3 text-left transition-colors ${
-                      index === activeIndex
+                      index === visibleActiveIndex
                         ? "bg-dls-hover"
                         : "hover:bg-dls-hover/60"
                     }`}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import type {
   AgentPartInput,
@@ -1876,36 +1876,38 @@ export function SessionRoute() {
   // Global shortcuts:
   //   Cmd/Ctrl+N  -> new task in selected workspace
   //   Cmd/Ctrl+K  -> toggle command palette
+  const handleGlobalShortcut = useEffectEvent((event: KeyboardEvent) => {
+    const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+    const mod = isMac ? event.metaKey : event.ctrlKey;
+    if (!mod) return;
+    if (event.shiftKey || event.altKey) return;
+
+    const target = event.target as HTMLElement | null;
+    const inEditable =
+      !!target &&
+      (target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable);
+
+    const key = event.key?.toLowerCase();
+    if (key === "n" && !inEditable) {
+      event.preventDefault();
+      if (canCreateTask && selectedWorkspaceId) {
+        void handleCreateTaskInWorkspace(selectedWorkspaceId);
+      }
+      return;
+    }
+    if (key === "k") {
+      event.preventDefault();
+      setCommandPaletteOpen((value) => !value);
+    }
+  });
+
   useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
-      const mod = isMac ? event.metaKey : event.ctrlKey;
-      if (!mod) return;
-      if (event.shiftKey || event.altKey) return;
-
-      const target = event.target as HTMLElement | null;
-      const inEditable =
-        !!target &&
-        (target.tagName === "INPUT" ||
-          target.tagName === "TEXTAREA" ||
-          target.isContentEditable);
-
-      const key = event.key?.toLowerCase();
-      if (key === "n" && !inEditable) {
-        event.preventDefault();
-        if (canCreateTask && selectedWorkspaceId) {
-          void handleCreateTaskInWorkspace(selectedWorkspaceId);
-        }
-        return;
-      }
-      if (key === "k") {
-        event.preventDefault();
-        setCommandPaletteOpen((value) => !value);
-      }
-    };
+    const handler = (event: KeyboardEvent) => handleGlobalShortcut(event);
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [canCreateTask, handleCreateTaskInWorkspace, selectedWorkspaceId]);
+  }, []);
 
   const navigateToSessionForControl = useCallback((sessionId: string) => {
     const owner = Object.entries(sessionsByWorkspaceId).find(([, sessions]) =>


### PR DESCRIPTION
## Summary
- Replaced safe listener/timer-only callbacks with `useEffectEvent` so effects stop resubscribing on parent renders.
- Swapped the Den sign-in bootstrap subscription to `useSyncExternalStore` and removed mount-only ready state that caused hydration/no-flicker warnings.
- Kept behavior-sensitive form and server-store effect chains unchanged.

## React Doctor Target Counts
- `react-doctor/prefer-use-effect-event`: 5 -> 0
- `react-doctor/no-effect-chain`: 6 -> 5
- `react-doctor/no-derived-state-effect`: 2 -> 2
- `react-doctor/prefer-use-sync-external-store`: 1 -> 0
- `react-doctor/rendering-hydration-no-flicker`: 1 -> 0
- `react-doctor/rendering-hydration-mismatch-time`: 2 -> 0

## Verification
- `npx react-doctor@latest . --verbose` in `apps/app`: completed, score 72/100, 313 issues total; target counts above.
- `pnpm install --frozen-lockfile`: passed.
- `pnpm --filter @openwork/app build`: passed; Vite reported the existing large chunk warning.
- `pnpm --filter @openwork/app typecheck`: failed on existing unrelated TypeScript errors outside this change, primarily `unknown` Tauri invoke results and missing OpenCode Router exports.

## Skipped Target Warnings
- `react-doctor/no-effect-chain`: skipped remaining `settings-route`, `config-view`, and `create-workspace-modal` chains because they coordinate external stores, form resets, or remote workspace refresh lifecycles.
- `react-doctor/no-derived-state-effect`: skipped remaining `settings-route` and `config-view` derived/reset warnings because replacing them would change active client or editable form synchronization behavior.