### PR TITLE
fix(app): reduce React Doctor state warnings

### DIFF
--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { ArrowLeft, ArrowRight, Globe, Loader2, RotateCw, X } from "lucide-react";
 import { isElectronRuntime } from "../../../../app/utils";
 
@@ -11,9 +11,33 @@ type BrowserState = {
   isLoading: boolean;
 };
 
+type BrowserPanelState = {
+  browserState: BrowserState;
+  urlInput: string;
+};
+
+type BrowserPanelAction =
+  | { type: "browserStateChanged"; browserState: BrowserState; syncUrlInput: boolean }
+  | { type: "urlInputChanged"; value: string };
+
 type BrowserPanelProps = { onClose: () => void };
 
 const EMPTY_STATE: BrowserState = { url: "", title: "", canGoBack: false, canGoForward: false, isLoading: false };
+
+function browserPanelReducer(
+  state: BrowserPanelState,
+  action: BrowserPanelAction,
+): BrowserPanelState {
+  switch (action.type) {
+    case "browserStateChanged":
+      return {
+        browserState: action.browserState,
+        urlInput: action.syncUrlInput ? action.browserState.url : state.urlInput,
+      };
+    case "urlInputChanged":
+      return { ...state, urlInput: action.value };
+  }
+}
 
 function getElectronBrowser() {
   if (!isElectronRuntime()) return null;
@@ -32,9 +56,11 @@ function computeBounds(el: HTMLElement, toolbar: HTMLElement) {
 }
 
 export function BrowserPanel({ onClose }: BrowserPanelProps) {
-  const [state, setState] = useState<BrowserState>(EMPTY_STATE);
-  const [urlInput, setUrlInput] = useState("");
-  const [urlFocused, setUrlFocused] = useState(false);
+  const [state, dispatch] = useReducer(browserPanelReducer, {
+    browserState: EMPTY_STATE,
+    urlInput: "",
+  });
+  const urlFocusedRef = useRef(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const urlInputRef = useRef<HTMLInputElement>(null);
@@ -46,14 +72,23 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     const browser = getElectronBrowser();
     if (!browser) return;
     const unsub = browser.onStateChange?.((s: BrowserState) => {
-      setState(s);
-      if (!urlFocused) setUrlInput(s.url);
+      dispatch({
+        type: "browserStateChanged",
+        browserState: s,
+        syncUrlInput: !urlFocusedRef.current,
+      });
     });
     browser.getState?.().then((s: BrowserState | null) => {
-      if (s) { setState(s); setUrlInput(s.url); }
+      if (s) {
+        dispatch({
+          type: "browserStateChanged",
+          browserState: s,
+          syncUrlInput: true,
+        });
+      }
     });
     return unsub;
-  }, [urlFocused]);
+  }, []);
 
   // Show the browser view when the panel mounts, keep bounds in sync, hide on unmount.
   useEffect(() => {
@@ -99,8 +134,8 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
   }, []);
 
   const navigate = useCallback((url?: string) => {
-    getElectronBrowser()?.navigate?.(url ?? urlInput);
-  }, [urlInput]);
+    getElectronBrowser()?.navigate?.(url ?? state.urlInput);
+  }, [state.urlInput]);
 
   const handleUrlKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -122,14 +157,14 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
   return (
     <div ref={panelRef} className="flex h-full flex-col">
       <div ref={toolbarRef} className="flex h-10 shrink-0 items-center gap-1 border-b border-border px-2">
-        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.back?.()} disabled={!state.canGoBack} title="Back" aria-label="Go back">
+        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.back?.()} disabled={!state.browserState.canGoBack} title="Back" aria-label="Go back">
           <ArrowLeft className="size-4" />
         </button>
-        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.forward?.()} disabled={!state.canGoForward} title="Forward" aria-label="Go forward">
+        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.forward?.()} disabled={!state.browserState.canGoForward} title="Forward" aria-label="Go forward">
           <ArrowRight className="size-4" />
         </button>
         <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text" onClick={() => browser.reload?.()} title="Reload" aria-label="Reload page">
-          {state.isLoading ? <Loader2 className="size-4 animate-spin" /> : <RotateCw className="size-4" />}
+          {state.browserState.isLoading ? <Loader2 className="size-4 animate-spin" /> : <RotateCw className="size-4" />}
         </button>
         <div className="relative mx-1 flex min-w-0 flex-1 items-center">
           <Globe className="absolute left-2 size-3.5 text-dls-secondary" />
@@ -137,11 +172,13 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
             ref={urlInputRef}
             type="text"
             className="h-7 w-full rounded-md border border-dls-border bg-dls-background-secondary pl-7 pr-2 text-[12px] text-dls-text placeholder:text-dls-secondary focus:border-dls-accent focus:outline-none"
-            value={urlInput}
-            onChange={(e) => setUrlInput(e.target.value)}
+            value={state.urlInput}
+            onChange={(e) =>
+              dispatch({ type: "urlInputChanged", value: e.target.value })
+            }
             onKeyDown={handleUrlKeyDown}
-            onFocus={() => { setUrlFocused(true); urlInputRef.current?.select(); }}
-            onBlur={() => setUrlFocused(false)}
+            onFocus={() => { urlFocusedRef.current = true; urlInputRef.current?.select(); }}
+            onBlur={() => { urlFocusedRef.current = false; }}
             placeholder="Enter URL..."
             spellCheck={false}
             autoComplete="off"

--- a/apps/app/src/react-app/domains/session/modals/question-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/question-modal.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 import type { QuestionInfo } from "@opencode-ai/sdk/v2/client";
 import { Check, ChevronRight, HelpCircle } from "lucide-react";
 
@@ -13,73 +13,124 @@ export type QuestionModalProps = {
   onReply: (answers: string[][]) => void;
 };
 
+type QuestionState = {
+  currentIndex: number;
+  answers: string[][];
+  currentSelection: string[];
+  customInput: string;
+  focusedOptionIndex: number;
+};
+
+type QuestionAction =
+  | { type: "reset"; questionCount: number }
+  | { type: "setCustomInput"; value: string }
+  | { type: "setFocusedOptionIndex"; value: number }
+  | { type: "moveFocusedOption"; direction: 1 | -1; optionsCount: number }
+  | { type: "toggleMultipleOption"; option: string }
+  | { type: "selectOption"; option: string }
+  | { type: "advance"; answers: string[][] }
+  | { type: "setAnswers"; answers: string[][] };
+
+const initialQuestionState: QuestionState = {
+  currentIndex: 0,
+  answers: [],
+  currentSelection: [],
+  customInput: "",
+  focusedOptionIndex: 0,
+};
+
+function questionReducer(state: QuestionState, action: QuestionAction): QuestionState {
+  switch (action.type) {
+    case "reset":
+      return {
+        currentIndex: 0,
+        answers: new Array(action.questionCount).fill([]),
+        currentSelection: [],
+        customInput: "",
+        focusedOptionIndex: 0,
+      };
+    case "setCustomInput":
+      return { ...state, customInput: action.value };
+    case "setFocusedOptionIndex":
+      return { ...state, focusedOptionIndex: action.value };
+    case "moveFocusedOption":
+      return {
+        ...state,
+        focusedOptionIndex:
+          (state.focusedOptionIndex + action.direction + action.optionsCount) %
+          action.optionsCount,
+      };
+    case "toggleMultipleOption": {
+      const selected = state.currentSelection.includes(action.option)
+        ? state.currentSelection.filter((option) => option !== action.option)
+        : [...state.currentSelection, action.option];
+      return { ...state, currentSelection: selected };
+    }
+    case "selectOption":
+      return { ...state, currentSelection: [action.option] };
+    case "advance":
+      return {
+        ...state,
+        answers: action.answers,
+        currentIndex: state.currentIndex + 1,
+        currentSelection: [],
+        customInput: "",
+        focusedOptionIndex: 0,
+      };
+    case "setAnswers":
+      return { ...state, answers: action.answers };
+  }
+}
+
 export function QuestionModal(props: QuestionModalProps) {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [answers, setAnswers] = useState<string[][]>([]);
-  const [currentSelection, setCurrentSelection] = useState<string[]>([]);
-  const [customInput, setCustomInput] = useState("");
-  const [focusedOptionIndex, setFocusedOptionIndex] = useState(0);
+  const [state, dispatch] = useReducer(questionReducer, initialQuestionState);
 
   useEffect(() => {
     if (!props.open) return;
-    setCurrentIndex(0);
-    setAnswers(new Array(props.questions.length).fill([]));
-    setCurrentSelection([]);
-    setCustomInput("");
-    setFocusedOptionIndex(0);
+    dispatch({ type: "reset", questionCount: props.questions.length });
   }, [props.open, props.questions.length]);
 
-  const currentQuestion = props.questions[currentIndex];
-  const isLastQuestion = currentIndex === props.questions.length - 1;
+  const currentQuestion = props.questions[state.currentIndex];
+  const isLastQuestion = state.currentIndex === props.questions.length - 1;
   const canProceed = (() => {
     if (!currentQuestion) return false;
-    if (currentQuestion.custom && customInput.trim().length > 0) return true;
-    return currentSelection.length > 0;
+    if (currentQuestion.custom && state.customInput.trim().length > 0) return true;
+    return state.currentSelection.length > 0;
   })();
 
   const handleNext = () => {
     if (!canProceed || !currentQuestion) return;
-    const nextAnswer = [...currentSelection];
-    if (currentQuestion.custom && customInput.trim()) {
-      nextAnswer.push(customInput.trim());
+    const nextAnswer = [...state.currentSelection];
+    if (currentQuestion.custom && state.customInput.trim()) {
+      nextAnswer.push(state.customInput.trim());
     }
-    const newAnswers = [...answers];
-    newAnswers[currentIndex] = nextAnswer;
-    setAnswers(newAnswers);
+    const newAnswers = [...state.answers];
+    newAnswers[state.currentIndex] = nextAnswer;
     if (isLastQuestion) {
+      dispatch({ type: "setAnswers", answers: newAnswers });
       props.onReply(newAnswers);
     } else {
-      setCurrentIndex((i) => i + 1);
-      setCurrentSelection([]);
-      setCustomInput("");
-      setFocusedOptionIndex(0);
+      dispatch({ type: "advance", answers: newAnswers });
     }
   };
 
   const toggleOption = (option: string) => {
     if (!currentQuestion) return;
     if (currentQuestion.multiple) {
-      setCurrentSelection((prev) =>
-        prev.includes(option) ? prev.filter((o) => o !== option) : [...prev, option],
-      );
+      dispatch({ type: "toggleMultipleOption", option });
       return;
     }
-    setCurrentSelection([option]);
+    dispatch({ type: "selectOption", option });
     if (!currentQuestion.custom) {
       setTimeout(() => {
-        setAnswers((prevAnswers) => {
-          const newAnswers = [...prevAnswers];
-          newAnswers[currentIndex] = [option];
-          if (isLastQuestion) {
-            props.onReply(newAnswers);
-          } else {
-            setCurrentIndex((i) => i + 1);
-            setCurrentSelection([]);
-            setCustomInput("");
-            setFocusedOptionIndex(0);
-          }
-          return newAnswers;
-        });
+        const newAnswers = [...state.answers];
+        newAnswers[state.currentIndex] = [option];
+        if (isLastQuestion) {
+          dispatch({ type: "setAnswers", answers: newAnswers });
+          props.onReply(newAnswers);
+        } else {
+          dispatch({ type: "advance", answers: newAnswers });
+        }
       }, 150);
     }
   };
@@ -92,12 +143,10 @@ export function QuestionModal(props: QuestionModalProps) {
 
       if (event.key === "ArrowDown") {
         event.preventDefault();
-        setFocusedOptionIndex((prev) => (prev + 1) % optionsCount);
+        dispatch({ type: "moveFocusedOption", direction: 1, optionsCount });
       } else if (event.key === "ArrowUp") {
         event.preventDefault();
-        setFocusedOptionIndex(
-          (prev) => (prev - 1 + optionsCount) % optionsCount,
-        );
+        dispatch({ type: "moveFocusedOption", direction: -1, optionsCount });
       } else if (event.key === "Enter") {
         if (event.isComposing || event.keyCode === 229) return;
         event.preventDefault();
@@ -108,7 +157,7 @@ export function QuestionModal(props: QuestionModalProps) {
           handleNext();
           return;
         }
-        const option = currentQuestion.options[focusedOptionIndex]?.description;
+        const option = currentQuestion.options[state.focusedOptionIndex]?.description;
         if (option) toggleOption(option);
       }
     };
@@ -116,7 +165,7 @@ export function QuestionModal(props: QuestionModalProps) {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.open, currentQuestion, focusedOptionIndex]);
+  }, [props.open, currentQuestion, state.focusedOptionIndex]);
 
   if (!props.open || !currentQuestion) return null;
 
@@ -134,7 +183,7 @@ export function QuestionModal(props: QuestionModalProps) {
               </h3>
               <div className="text-xs text-gray-11 font-medium">
                 {t("question_modal.question_counter", undefined, {
-                  current: currentIndex + 1,
+                  current: state.currentIndex + 1,
                   total: props.questions.length,
                 })}
               </div>
@@ -148,8 +197,8 @@ export function QuestionModal(props: QuestionModalProps) {
         <div className="p-6 overflow-y-auto min-h-0 flex-1">
           <div className="space-y-2">
             {currentQuestion.options.map((opt, idx) => {
-              const isSelected = currentSelection.includes(opt.description);
-              const isFocused = focusedOptionIndex === idx;
+              const isSelected = state.currentSelection.includes(opt.description);
+              const isFocused = state.focusedOptionIndex === idx;
               return (
                 <button
                   key={opt.description}
@@ -163,7 +212,7 @@ export function QuestionModal(props: QuestionModalProps) {
                         ${isFocused ? "ring-2 ring-blue-9/20 border-blue-9/40 bg-gray-3" : ""}
                       `}
                   onClick={() => {
-                    setFocusedOptionIndex(idx);
+                    dispatch({ type: "setFocusedOptionIndex", value: idx });
                     toggleOption(opt.description);
                   }}
                 >
@@ -185,8 +234,13 @@ export function QuestionModal(props: QuestionModalProps) {
               </label>
               <input
                 type="text"
-                value={customInput}
-                onChange={(event) => setCustomInput(event.currentTarget.value)}
+                value={state.customInput}
+                onChange={(event) =>
+                  dispatch({
+                    type: "setCustomInput",
+                    value: event.currentTarget.value,
+                  })
+                }
                 className="w-full px-4 py-3 rounded-xl bg-dls-surface border border-dls-border focus:border-dls-accent focus:ring-4 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] focus:outline-none text-sm text-dls-text placeholder:text-dls-secondary transition-shadow"
                 placeholder={t("question_modal.custom_answer_placeholder")}
                 onKeyDown={(event) => {

--- a/apps/app/src/react-app/domains/session/surface/tool-call.tsx
+++ b/apps/app/src/react-app/domains/session/surface/tool-call.tsx
@@ -42,6 +42,15 @@ function extractDiff(output: unknown) {
   return null;
 }
 
+function toKeyedLines(value: string) {
+  let offset = 0;
+  return value.split("\n").map((line) => {
+    const key = `${offset}:${line}`;
+    offset += line.length + 1;
+    return { key, line };
+  });
+}
+
 async function copyText(text: string) {
   await navigator.clipboard.writeText(text);
 }
@@ -83,7 +92,7 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
   const output = props.part.state === "output-available" ? props.part.output : undefined;
   const error = props.part.state === "output-error" ? props.part.errorText : "";
   const diff = extractDiff(output);
-  const diffLines = diff ? normalizeToolText(diff).split("\n") : [];
+  const diffLines = diff ? toKeyedLines(normalizeToolText(diff)) : [];
   const expandable = hasStructuredValue(input) || hasStructuredValue(output) || Boolean(diff) || Boolean(error);
 
   return (
@@ -135,9 +144,9 @@ export function ToolCallView(props: { part: DynamicToolUIPart; developerMode: bo
                 </button>
               </div>
               <div className="mt-2 grid gap-1 overflow-hidden rounded-md">
-                {diffLines.map((line, index) => (
+                {diffLines.map(({ key, line }) => (
                   <div
-                    key={`${props.part.toolCallId}-diff-${index}`}
+                    key={`${props.part.toolCallId}-diff-${key}`}
                     className={`whitespace-pre-wrap break-words px-2 py-0.5 font-mono text-[11px] leading-relaxed ${diffLineClass(line)}`}
                   >
                     {line || " "}

--- a/apps/app/src/react-app/domains/settings/modals/reset-modal.tsx
+++ b/apps/app/src/react-app/domains/settings/modals/reset-modal.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource react */
-import type { ReactNode } from "react";
 import { X } from "lucide-react";
 
 import { t } from "../../../../i18n";
@@ -27,22 +26,18 @@ export type ResetModalProps = {
 };
 
 export function ResetModal(props: ResetModalProps) {
-  const resetConfirmationHint = (): ReactNode => {
+  const resetConfirmationHint = () => {
     const template = t("settings.reset_confirmation_hint");
     const parts = template.split(RESET_CONFIRM_PLACEHOLDER);
     if (parts.length === 1) return template;
-    const nodes: ReactNode[] = [];
-    parts.forEach((part, index) => {
-      nodes.push(<span key={`part-${index}`}>{part}</span>);
-      if (index < parts.length - 1) {
-        nodes.push(
-          <span key={`word-${index}`} className="font-mono">
-            {RESET_CONFIRM_WORD}
-          </span>,
-        );
-      }
-    });
-    return nodes;
+    const [beforeReset, afterReset] = parts;
+    return (
+      <>
+        {beforeReset}
+        <span className="font-mono">{RESET_CONFIRM_WORD}</span>
+        {afterReset}
+      </>
+    );
   };
 
   if (!props.open) return null;

--- a/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-local-panel.tsx
@@ -71,6 +71,15 @@ function stepIcon(status: CreateWorkspaceProgressStep["status"]) {
   return <div className="size-4 rounded-full border-2 border-dls-border" />;
 }
 
+function toKeyedLines(lines: string[]) {
+  let offset = 0;
+  return lines.map((line) => {
+    const key = `${offset}:${line}`;
+    offset += line.length + 1;
+    return { key, line };
+  });
+}
+
 function stepTextClass(status: CreateWorkspaceProgressStep["status"]) {
   if (status === "done") return "text-dls-text font-medium";
   if (status === "active") return "text-dls-text font-semibold";
@@ -210,9 +219,9 @@ export function CreateWorkspaceLocalPanel(
                   Live logs
                 </div>
                 <div className="max-h-[120px] space-y-0.5 overflow-y-auto">
-                  {progress.logs.slice(-10).map((line, index) => (
+                  {toKeyedLines(progress.logs.slice(-10)).map(({ key, line }) => (
                     <div
-                      key={`${progress.runId}-log-${index}`}
+                      key={`${progress.runId}-log-${key}`}
                       className="break-all font-mono text-[10px] leading-tight text-dls-text"
                     >
                       {line}
@@ -264,8 +273,8 @@ export function CreateWorkspaceLocalPanel(
                   Docker debug details
                 </summary>
                 <div className="mt-2 space-y-1 break-words font-mono">
-                  {props.workerDebugLines.map((line, index) => (
-                    <div key={`docker-line-${index}`}>{line}</div>
+                  {toKeyedLines(props.workerDebugLines).map(({ key, line }) => (
+                    <div key={`docker-line-${key}`}>{line}</div>
                   ))}
                 </div>
               </details>

--- a/apps/app/src/react-app/domains/workspace/share-workspace-access-panel.tsx
+++ b/apps/app/src/react-app/domains/workspace/share-workspace-access-panel.tsx
@@ -32,6 +32,63 @@ const displayFieldLabel = (field: ShareField) => {
   return field.label;
 };
 
+type CredentialFieldProps = {
+  field: ShareField;
+  fieldKey: string;
+  copiedKey: string | null;
+  revealedByKey: Record<string, boolean>;
+  onCopy: (value: string, key: string) => void;
+  onToggleReveal: (key: string) => void;
+};
+
+function CredentialField(props: CredentialFieldProps) {
+  const isSecret = Boolean(props.field.secret);
+  const revealed = Boolean(props.revealedByKey[props.fieldKey]);
+
+  return (
+    <div>
+      <label className="mb-1.5 block text-[13px] font-medium text-dls-text">
+        {displayFieldLabel(props.field)}
+      </label>
+      <div className="relative flex items-center gap-2">
+        <input
+          type={isSecret && !revealed ? "password" : "text"}
+          readOnly
+          value={props.field.value || props.field.placeholder || ""}
+          className={`${inputClass} font-mono text-[12px]`}
+        />
+        {isSecret ? (
+          <button
+            type="button"
+            onClick={() => props.onToggleReveal(props.fieldKey)}
+            disabled={!props.field.value}
+            className={pillSecondaryClass}
+            title={revealed ? "Hide password" : "Reveal password"}
+          >
+            {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={() => props.onCopy(props.field.value, props.fieldKey)}
+          disabled={!props.field.value}
+          className={pillSecondaryClass}
+          title="Copy"
+        >
+          {props.copiedKey === props.fieldKey ? (
+            <Check size={14} className="text-emerald-600" />
+          ) : (
+            <Copy size={14} />
+          )}
+        </button>
+      </div>
+      {props.field.hint?.trim() ? (
+        <p className="mt-1.5 text-[12px] text-dls-secondary">{props.field.hint}</p>
+      ) : null}
+    </div>
+  );
+}
+
 export type ShareWorkspaceAccessPanelProps = {
   fields: ShareField[];
   copiedKey: string | null;
@@ -78,59 +135,6 @@ export function ShareWorkspaceAccessPanel(
       : props.remoteAccess?.enabled === false && props.remoteAccessEnabled
         ? "Save & restart worker"
         : "Save";
-
-  const renderCredentialField = (
-    field: ShareField,
-    index: number,
-    keyPrefix: string,
-  ) => {
-    const key = `${keyPrefix}:${field.label}:${index}`;
-    const isSecret = Boolean(field.secret);
-    const revealed = Boolean(props.revealedByKey[key]);
-
-    return (
-      <div>
-        <label className="mb-1.5 block text-[13px] font-medium text-dls-text">
-          {displayFieldLabel(field)}
-        </label>
-        <div className="relative flex items-center gap-2">
-          <input
-            type={isSecret && !revealed ? "password" : "text"}
-            readOnly
-            value={field.value || field.placeholder || ""}
-            className={`${inputClass} font-mono text-[12px]`}
-          />
-          {isSecret ? (
-            <button
-              type="button"
-              onClick={() => props.onToggleReveal(key)}
-              disabled={!field.value}
-              className={pillSecondaryClass}
-              title={revealed ? "Hide password" : "Reveal password"}
-            >
-              {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
-            </button>
-          ) : null}
-          <button
-            type="button"
-            onClick={() => props.onCopy(field.value, key)}
-            disabled={!field.value}
-            className={pillSecondaryClass}
-            title="Copy"
-          >
-            {props.copiedKey === key ? (
-              <Check size={14} className="text-emerald-600" />
-            ) : (
-              <Copy size={14} />
-            )}
-          </button>
-        </div>
-        {field.hint?.trim() ? (
-          <p className="mt-1.5 text-[12px] text-dls-secondary">{field.hint}</p>
-        ) : null}
-      </div>
-    );
-  };
 
   return (
     <div className="space-y-5 pt-2 animate-in fade-in slide-in-from-right-4 duration-300">
@@ -205,9 +209,16 @@ export function ShareWorkspaceAccessPanel(
             Connection details
           </div>
           <div className="space-y-4">
-            {primaryAccessFields.map((field, index) => (
-              <div key={`${field.label}-${index}`}>
-                {renderCredentialField(field, index, "primary")}
+            {primaryAccessFields.map((field) => (
+              <div key={field.label}>
+                <CredentialField
+                  field={field}
+                  fieldKey={`primary:${field.label}`}
+                  copiedKey={props.copiedKey}
+                  revealedByKey={props.revealedByKey}
+                  onCopy={props.onCopy}
+                  onToggleReveal={props.onToggleReveal}
+                />
               </div>
             ))}
           </div>
@@ -242,7 +253,14 @@ export function ShareWorkspaceAccessPanel(
               <div className="mb-3 text-[12px] text-dls-secondary">
                 Routine access without permission approvals.
               </div>
-              {renderCredentialField(collaboratorField, 0, "collaborator")}
+              <CredentialField
+                field={collaboratorField}
+                fieldKey={`collaborator:${collaboratorField.label}`}
+                copiedKey={props.copiedKey}
+                revealedByKey={props.revealedByKey}
+                onCopy={props.onCopy}
+                onToggleReveal={props.onToggleReveal}
+              />
             </div>
           ) : null}
         </div>

--- a/apps/app/src/react-app/domains/workspace/share-workspace-modal.tsx
+++ b/apps/app/src/react-app/domains/workspace/share-workspace-modal.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer } from "react";
 import { ArrowLeft, MonitorUp, X } from "lucide-react";
 
 import { t } from "../../../i18n";
@@ -16,14 +16,83 @@ import { WorkspaceOptionCard } from "./option-card";
 import { ShareWorkspaceAccessPanel } from "./share-workspace-access-panel";
 import type { ShareView, ShareWorkspaceModalProps } from "./types";
 
+type ShareWorkspaceModalState = {
+  activeView: ShareView;
+  revealedByKey: Record<string, boolean>;
+  copiedKey: string | null;
+  collaboratorExpanded: boolean;
+  remoteAccessEnabled: boolean;
+};
+
+type ShareWorkspaceModalAction =
+  | { type: "reset"; remoteAccessEnabled: boolean }
+  | { type: "setActiveView"; view: ShareView }
+  | { type: "toggleReveal"; key: string }
+  | { type: "setCopiedKey"; key: string | null }
+  | { type: "clearCopiedKey"; key: string }
+  | { type: "toggleCollaboratorExpanded" }
+  | { type: "setRemoteAccessEnabled"; enabled: boolean };
+
+const initialShareWorkspaceModalState: ShareWorkspaceModalState = {
+  activeView: "chooser",
+  revealedByKey: {},
+  copiedKey: null,
+  collaboratorExpanded: false,
+  remoteAccessEnabled: false,
+};
+
+function shareWorkspaceModalReducer(
+  state: ShareWorkspaceModalState,
+  action: ShareWorkspaceModalAction,
+): ShareWorkspaceModalState {
+  switch (action.type) {
+    case "reset":
+      return {
+        activeView: "chooser",
+        revealedByKey: {},
+        copiedKey: null,
+        collaboratorExpanded: false,
+        remoteAccessEnabled: action.remoteAccessEnabled,
+      };
+    case "setActiveView":
+      return { ...state, activeView: action.view };
+    case "toggleReveal":
+      return {
+        ...state,
+        revealedByKey: {
+          ...state.revealedByKey,
+          [action.key]: !state.revealedByKey[action.key],
+        },
+      };
+    case "setCopiedKey":
+      return { ...state, copiedKey: action.key };
+    case "clearCopiedKey":
+      return {
+        ...state,
+        copiedKey: state.copiedKey === action.key ? null : state.copiedKey,
+      };
+    case "toggleCollaboratorExpanded":
+      return {
+        ...state,
+        collaboratorExpanded: !state.collaboratorExpanded,
+      };
+    case "setRemoteAccessEnabled":
+      return { ...state, remoteAccessEnabled: action.enabled };
+  }
+}
+
 export function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
-  const [activeView, setActiveView] = useState<ShareView>("chooser");
-  const [revealedByKey, setRevealedByKey] = useState<Record<string, boolean>>(
-    {},
+  const [state, dispatch] = useReducer(
+    shareWorkspaceModalReducer,
+    initialShareWorkspaceModalState,
   );
-  const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const [collaboratorExpanded, setCollaboratorExpanded] = useState(false);
-  const [remoteAccessEnabled, setRemoteAccessEnabled] = useState(false);
+  const {
+    activeView,
+    revealedByKey,
+    copiedKey,
+    collaboratorExpanded,
+    remoteAccessEnabled,
+  } = state;
 
   const title = props.title ?? t("share.title");
   const workspaceBadge = useMemo(() => {
@@ -35,18 +104,11 @@ export function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
   // Reset state whenever the modal opens.
   useEffect(() => {
     if (!props.open) return;
-    setActiveView("chooser");
-    setRevealedByKey({});
-    setCopiedKey(null);
-    setCollaboratorExpanded(false);
-    setRemoteAccessEnabled(props.remoteAccess?.enabled === true);
+    dispatch({
+      type: "reset",
+      remoteAccessEnabled: props.remoteAccess?.enabled === true,
+    });
   }, [props.open, props.remoteAccess?.enabled, props.workspaceName]);
-
-  // Mirror remote-access-enabled changes from the parent while open.
-  useEffect(() => {
-    if (!props.open) return;
-    setRemoteAccessEnabled(props.remoteAccess?.enabled === true);
-  }, [props.open, props.remoteAccess?.enabled]);
 
   // Escape key handling: chooser closes the modal, sub-views step back.
   useEffect(() => {
@@ -54,20 +116,18 @@ export function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
-      setActiveView((view) => {
-        if (view === "chooser") {
-          props.onClose();
-          return view;
-        }
-        return "chooser";
-      });
+      if (activeView === "chooser") {
+        props.onClose();
+        return;
+      }
+      dispatch({ type: "setActiveView", view: "chooser" });
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [props]);
+  }, [activeView, props]);
 
   const goBack = useCallback(() => {
-    setActiveView("chooser");
+    dispatch({ type: "setActiveView", view: "chooser" });
   }, []);
 
   const handleCopy = useCallback(async (value: string, key: string) => {
@@ -75,9 +135,9 @@ export function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
     if (!text) return;
     try {
       await navigator.clipboard.writeText(text);
-      setCopiedKey(key);
+      dispatch({ type: "setCopiedKey", key });
       window.setTimeout(() => {
-        setCopiedKey((current) => (current === key ? null : current));
+        dispatch({ type: "clearCopiedKey", key });
       }, 2000);
     } catch {
       // ignore clipboard failures
@@ -149,7 +209,7 @@ export function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
                 title={t("share.option_access_title")}
                 description={t("share.option_access_desc")}
                 icon={MonitorUp}
-                onClick={() => setActiveView("access")}
+                onClick={() => dispatch({ type: "setActiveView", view: "access" })}
               />
             </div>
           ) : null}
@@ -160,19 +220,16 @@ export function ShareWorkspaceModal(props: ShareWorkspaceModalProps) {
               copiedKey={copiedKey}
               onCopy={(value, key) => void handleCopy(value, key)}
               revealedByKey={revealedByKey}
-              onToggleReveal={(key) =>
-                setRevealedByKey((prev) => ({
-                  ...prev,
-                  [key]: !prev[key],
-                }))
-              }
+              onToggleReveal={(key) => dispatch({ type: "toggleReveal", key })}
               collaboratorExpanded={collaboratorExpanded}
               onToggleCollaboratorExpanded={() =>
-                setCollaboratorExpanded((value) => !value)
+                dispatch({ type: "toggleCollaboratorExpanded" })
               }
               remoteAccess={props.remoteAccess}
               remoteAccessEnabled={remoteAccessEnabled}
-              onRemoteAccessEnabledChange={setRemoteAccessEnabled}
+              onRemoteAccessEnabledChange={(enabled) =>
+                dispatch({ type: "setRemoteAccessEnabled", enabled })
+              }
               note={props.note}
             />
           ) : null}

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useReducer, type ReactNode } from "react";
 
 import { isDesktopRuntime } from "../../app/utils";
 import { useBootState } from "./boot-state";
@@ -20,6 +20,27 @@ type ArchitectureMismatchGateProps = {
   children: ReactNode;
 };
 
+type ArchitectureGateState = {
+  info: ArchitectureInfo | null;
+  checked: boolean;
+};
+
+type ArchitectureGateAction =
+  | { type: "checked" }
+  | { type: "resolved"; info: ArchitectureInfo };
+
+function architectureGateReducer(
+  state: ArchitectureGateState,
+  action: ArchitectureGateAction,
+): ArchitectureGateState {
+  switch (action.type) {
+    case "checked":
+      return { ...state, checked: true };
+    case "resolved":
+      return { info: action.info, checked: true };
+  }
+}
+
 function platformLabel(platform: ArchitectureInfo["platform"]): string {
   if (platform === "darwin") return "macOS";
   if (platform === "windows") return "Windows";
@@ -28,27 +49,29 @@ function platformLabel(platform: ArchitectureInfo["platform"]): string {
 
 export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateProps) {
   const { markRouteReady } = useBootState();
-  const [info, setInfo] = useState<ArchitectureInfo | null>(null);
-  const [checked, setChecked] = useState(!isDesktopRuntime());
+  const [state, dispatch] = useReducer(architectureGateReducer, {
+    info: null,
+    checked: !isDesktopRuntime(),
+  });
+  const { info, checked } = state;
 
   useEffect(() => {
     let cancelled = false;
     const bridge = window.__OPENWORK_ELECTRON__?.system?.getArchitectureInfo;
     if (!bridge) {
-      setChecked(true);
+      dispatch({ type: "checked" });
       return;
     }
 
     void bridge()
       .then((nextInfo) => {
         if (cancelled) return;
-        setInfo(nextInfo);
+        dispatch({ type: "resolved", info: nextInfo });
       })
       .catch((error) => {
+        if (cancelled) return;
         console.warn("[architecture-gate] failed to resolve runtime architecture", error);
-      })
-      .finally(() => {
-        if (!cancelled) setChecked(true);
+        dispatch({ type: "checked" });
       });
 
     return () => {


### PR DESCRIPTION
## Summary
- Consolidates related modal/panel state with reducers to reduce React Doctor cascading state and prefer-useReducer findings.
- Extracts credential rendering into a named child component and replaces several index keys with stable content-derived keys.
- Keeps the riskiest giant route/session files out of scope where fixes would require larger behavior-sensitive refactors.

## React Doctor Target Counts
Before: no-cascading-set-state 29, prefer-useReducer 22, no-giant-component 21, no-render-in-render 9, rerender-state-only-in-handlers 9, no-array-index-as-key 16.
After: no-cascading-set-state 25, prefer-useReducer 20, no-giant-component 21, no-render-in-render 7, rerender-state-only-in-handlers 7, no-array-index-as-key 10.

## Verification
- `npx react-doctor@latest . --verbose` from `apps/app`: completed, 308 total issues, target counts above.
- `pnpm install --frozen-lockfile`: passed.
- `pnpm --filter @openwork/app build`: passed.
- `pnpm --filter @openwork/app typecheck`: failed on existing unrelated TypeScript errors outside changed files, primarily unknown IPC return typings and missing messaging API exports.

No screenshots: changes are structural React cleanup/key stability changes and are not meaningfully UI-visible without app-stack behavioral flows.