### PR TITLE
fix(app): use React 19 context API

### DIFF
--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -57,7 +57,7 @@ function getDefaultOpen(defaultOpen: boolean, persistence: boolean) {
 }
 
 function useSidebar() {
-  const context = React.useContext(SidebarContext)
+  const context = React.use(SidebarContext)
   if (!context) {
     throw new Error("useSidebar must be used within a SidebarProvider.")
   }

--- a/apps/app/src/components/ui/toggle-group.tsx
+++ b/apps/app/src/components/ui/toggle-group.tsx
@@ -63,7 +63,7 @@ function ToggleGroupItem({
   size = "default",
   ...props
 }: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
-  const context = React.useContext(ToggleGroupContext)
+  const context = React.use(ToggleGroupContext)
 
   return (
     <TogglePrimitive

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -196,7 +196,7 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
 }
 
 export function useDenAuth(): DenAuthStore {
-  const context = useContext(DenAuthContext);
+  const context = use(DenAuthContext);
   if (!context) {
     throw new Error("useDenAuth must be used within a DenAuthProvider");
   }

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -211,7 +211,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
 }
 
 export function useDesktopConfig(): DesktopConfigStore {
-  const context = useContext(DesktopConfigContext);
+  const context = use(DesktopConfigContext);
   if (!context) {
     throw new Error("useDesktopConfig must be used within a DesktopConfigProvider");
   }

--- a/apps/app/src/react-app/domains/cloud/restriction-notice-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/restriction-notice-provider.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useMemo,
   useState,
   type ReactNode,
@@ -79,7 +79,7 @@ export function RestrictionNoticeProvider({ children }: RestrictionNoticeProvide
 }
 
 export function useRestrictionNotice(): RestrictionNoticeController {
-  const context = useContext(RestrictionNoticeContext);
+  const context = use(RestrictionNoticeContext);
   if (!context) {
     throw new Error(
       "useRestrictionNotice must be used within a RestrictionNoticeProvider",

--- a/apps/app/src/react-app/domains/connections/openwork-server-provider.tsx
+++ b/apps/app/src/react-app/domains/connections/openwork-server-provider.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import {
   createContext,
-  useContext,
+  use,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -22,7 +22,7 @@ export function OpenworkServerProvider(props: {
 }
 
 export function useOpenworkServer() {
-  const store = useContext(OpenworkServerContext);
+  const store = use(OpenworkServerContext);
   if (!store) {
     throw new Error("useOpenworkServer must be used within an OpenworkServerProvider");
   }

--- a/apps/app/src/react-app/domains/connections/provider-auth/index.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/index.ts
@@ -1,7 +1,7 @@
 import {
   createContext,
   createElement,
-  useContext,
+  use,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -33,7 +33,7 @@ export function ProviderAuthStoreProvider({
 }
 
 export function useProviderAuth() {
-  const store = useContext(ProviderAuthContext);
+  const store = use(ProviderAuthContext);
   if (!store) {
     throw new Error("useProviderAuth must be used within a ProviderAuthStoreProvider");
   }

--- a/apps/app/src/react-app/domains/connections/provider.tsx
+++ b/apps/app/src/react-app/domains/connections/provider.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import {
   createContext,
-  useContext,
+  use,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -22,7 +22,7 @@ export function ConnectionsProvider(props: {
 }
 
 export function useConnections() {
-  const store = useContext(ConnectionsContext);
+  const store = use(ConnectionsContext);
   if (!store) {
     throw new Error("useConnections must be used within a ConnectionsProvider");
   }

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -34,7 +34,7 @@ export type SidebarContextValue = {
 export const SidebarContext = React.createContext<SidebarContextValue | null>(null);
 
 export function useSidebarContext() {
-  const context = React.useContext(SidebarContext);
+  const context = React.use(SidebarContext);
   if (!context) throw new Error("useSidebarContext must be used within SidebarProvider");
   return context;
 }

--- a/apps/app/src/react-app/domains/session/sync/actions-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sync/actions-provider.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { createContext, useContext, useSyncExternalStore, type ReactNode } from "react";
+import { createContext, use, useSyncExternalStore, type ReactNode } from "react";
 
 import type { SessionActionsStore } from "./actions-store";
 
@@ -22,7 +22,7 @@ export function SessionActionsProvider({
 }
 
 export function useSessionActions(): SessionActionsStore {
-  const context = useContext(SessionActionsContext);
+  const context = use(SessionActionsContext);
   if (!context) {
     throw new Error("useSessionActions must be used within a SessionActionsProvider");
   }

--- a/apps/app/src/react-app/domains/settings/state/model-controls-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/state/model-controls-provider.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, use, type ReactNode } from "react";
 
 import type { ModelControlsStore } from "./model-controls-store";
 
@@ -22,7 +22,7 @@ export function ModelControlsProvider({
 }
 
 export function useModelControls(): ModelControlsStore {
-  const context = useContext(ModelControlsContext);
+  const context = use(ModelControlsContext);
   if (!context) {
     throw new Error("useModelControls must be used within a ModelControlsProvider");
   }

--- a/apps/app/src/react-app/domains/shell-feedback/status-toasts.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/status-toasts.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -111,7 +111,7 @@ export function StatusToastsProvider({ children }: StatusToastsProviderProps) {
 }
 
 export function useStatusToasts(): StatusToastsStore {
-  const context = useContext(StatusToastsContext);
+  const context = use(StatusToastsContext);
   if (!context) {
     throw new Error("useStatusToasts must be used within a StatusToastsProvider");
   }

--- a/apps/app/src/react-app/kernel/global-sdk-provider.tsx
+++ b/apps/app/src/react-app/kernel/global-sdk-provider.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import {
   createContext,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -217,7 +217,7 @@ export function GlobalSDKProvider({ children }: GlobalSDKProviderProps) {
 }
 
 export function useGlobalSDK(): GlobalSDKContextValue {
-  const context = useContext(GlobalSDKContext);
+  const context = use(GlobalSDKContext);
   if (!context) {
     throw new Error("Global SDK context is missing");
   }

--- a/apps/app/src/react-app/kernel/global-sync-provider.tsx
+++ b/apps/app/src/react-app/kernel/global-sync-provider.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -397,7 +397,7 @@ export function GlobalSyncProvider({ children }: GlobalSyncProviderProps) {
 }
 
 export function useGlobalSync(): GlobalSyncContextValue {
-  const context = useContext(GlobalSyncContext);
+  const context = use(GlobalSyncContext);
   if (!context) {
     throw new Error("Global sync context is missing");
   }

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -164,7 +164,7 @@ export function LocalProvider({ children }: LocalProviderProps) {
 }
 
 export function useLocal(): LocalContextValue {
-  const context = useContext(LocalContext);
+  const context = use(LocalContext);
   if (!context) {
     throw new Error("Local context is missing");
   }

--- a/apps/app/src/react-app/kernel/platform.tsx
+++ b/apps/app/src/react-app/kernel/platform.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, use, type ReactNode } from "react";
 
 import { openDesktopUrl, relaunchDesktopApp } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
@@ -47,7 +47,7 @@ export function PlatformProvider({ value, children }: PlatformProviderProps) {
 }
 
 export function usePlatform(): Platform {
-  const context = useContext(PlatformContext);
+  const context = use(PlatformContext);
   if (!context) {
     throw new Error("Platform context is missing");
   }

--- a/apps/app/src/react-app/kernel/server-provider.tsx
+++ b/apps/app/src/react-app/kernel/server-provider.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -220,7 +220,7 @@ export function ServerProvider({ children, defaultUrl }: ServerProviderProps) {
 }
 
 export function useServer(): ServerContextValue {
-  const context = useContext(ServerContext);
+  const context = use(ServerContext);
   if (!context) {
     throw new Error("Server context is missing");
   }

--- a/apps/app/src/react-app/shell/boot-state.tsx
+++ b/apps/app/src/react-app/shell/boot-state.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -116,7 +116,7 @@ export function BootStateProvider({ children }: { children: ReactNode }) {
 }
 
 export function useBootState(): BootStateContextValue {
-  const value = useContext(BootStateContext);
+  const value = use(BootStateContext);
   if (!value) {
     throw new Error("useBootState must be used inside <BootStateProvider>");
   }

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -388,7 +388,7 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
 }
 
 export function useOpenworkControl() {
-  return useContext(OpenworkControlContext);
+  return use(OpenworkControlContext);
 }
 
 export function useControlAction(action: OpenworkControlAction | null | false | undefined) {

--- a/apps/app/src/react-app/shell/reload-coordinator.tsx
+++ b/apps/app/src/react-app/shell/reload-coordinator.tsx
@@ -2,7 +2,7 @@
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -143,7 +143,7 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
 }
 
 export function useReloadCoordinator(): ReloadCoordinatorContextValue {
-  const value = useContext(ReloadCoordinatorContext);
+  const value = use(ReloadCoordinatorContext);
   if (!value) {
     throw new Error("useReloadCoordinator must be used inside <ReloadCoordinatorProvider>");
   }


### PR DESCRIPTION
## Summary
- Replaces safe `useContext(Context)` reads with React 19 `use(Context)` across app context hooks.
- Leaves exported `forwardRef` design-system primitives unchanged to avoid broad component API rewrites.

## Evidence

### React Doctor
- Baseline: `npx react-doctor@latest . --verbose` in `apps/app` reported `react-doctor/no-react19-deprecated-apis ×22`, 165 total issues, score 79.
- After: `npx react-doctor@latest . --verbose` in `apps/app` reported `react-doctor/no-react19-deprecated-apis ×2`, 145 total issues, score 79.
- Remaining rule hits: `apps/app/src/react-app/design-system/button.tsx`, `apps/app/src/react-app/design-system/text-input.tsx` (`forwardRef`, skipped because these are exported design-system primitives and changing ref-as-prop would alter public component API shape).

### Build verification
- `pnpm install --frozen-lockfile` passed after the fresh worktree lacked `node_modules`.
- `pnpm --filter @openwork/app build` passed.
- `pnpm --filter @openwork/app typecheck` failed on existing unrelated type errors outside the changed context-hook files, mostly unknown IPC result typing and missing OpenCode Router exports.

### API/UI verification
- No API changes.
- No UI behavior changes beyond mechanical React context reads; no browser flow required.

## Test instructions
1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @openwork/app build`
3. `npx react-doctor@latest . --verbose` from `apps/app`