### PR TITLE
fix(app): reduce React Doctor structure warnings

### DIFF
--- a/apps/app/src/components/ui/field.tsx
+++ b/apps/app/src/components/ui/field.tsx
@@ -179,32 +179,36 @@ function FieldError({
 }: React.ComponentProps<"div"> & {
   errors?: Array<{ message?: string } | undefined>
 }) {
-  const content = React.useMemo(() => {
-    if (children) {
-      return children
-    }
-
-    if (!errors?.length) {
-      return null
-    }
-
-    const uniqueErrors = [
-      ...new Map(errors.map((error) => [error?.message, error])).values(),
-    ]
-
-    if (uniqueErrors?.length == 1) {
-      return uniqueErrors[0]?.message
-    }
-
+  if (children) {
     return (
-      <ul className="ms-4 flex list-disc flex-col gap-1">
-        {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
-        )}
-      </ul>
+      <div
+        role="alert"
+        data-slot="field-error"
+        className={cn("text-sm font-normal text-destructive", className)}
+        {...props}
+      >
+        {children}
+      </div>
     )
-  }, [children, errors])
+  }
+
+  const uniqueErrors = [
+    ...new Map(errors?.map((error) => [error?.message, error]) ?? []).values(),
+  ].filter((error): error is { message: string } => !!error?.message)
+
+  if (!uniqueErrors.length) {
+    return null
+  }
+
+  const content = uniqueErrors.length === 1
+    ? uniqueErrors[0]?.message
+    : (
+        <ul className="ms-4 flex list-disc flex-col gap-1">
+          {uniqueErrors.map((error) => (
+            <li key={error.message}>{error.message}</li>
+          ))}
+        </ul>
+      )
 
   if (!content) {
     return null

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -88,12 +88,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const [oauthAutoBusy, setOauthAutoBusy] = useState(false);
   const [oauthCodeCopied, setOauthCodeCopied] = useState(false);
   const [oauthBrowserOpened, setOauthBrowserOpened] = useState(false);
-  const [autoOpenedPreferredProviderId, setAutoOpenedPreferredProviderId] = useState<string | null>(null);
 
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const providerPollRef = useRef<number | null>(null);
   const oauthAutoPollRef = useRef<number | null>(null);
   const oauthCodeCopiedResetRef = useRef<number | null>(null);
+  const autoOpenedPreferredProviderIdRef = useRef<string | null>(null);
 
   const formatProviderName = (id: string, fallback?: string) => {
     const named = fallback?.trim();
@@ -268,7 +268,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
   useEffect(() => {
     if (!props.open) {
-      setAutoOpenedPreferredProviderId(null);
+      autoOpenedPreferredProviderIdRef.current = null;
       resetState();
     }
   }, [props.open]);
@@ -292,17 +292,16 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     if (!props.open || props.loading || resolvedView !== "list") return;
 
     const preferredId = props.preferredProviderId?.trim().toLowerCase() ?? "";
-    if (!preferredId || autoOpenedPreferredProviderId === preferredId) return;
+    if (!preferredId || autoOpenedPreferredProviderIdRef.current === preferredId) return;
 
     const entry = entries.find((item) => item.id.trim().toLowerCase() === preferredId);
     if (!entry) return;
 
-    setAutoOpenedPreferredProviderId(preferredId);
+    autoOpenedPreferredProviderIdRef.current = preferredId;
     queueMicrotask(() => {
       handleEntrySelect(entry);
     });
   }, [
-    autoOpenedPreferredProviderId,
     entries,
     props.loading,
     props.open,


### PR DESCRIPTION
## Summary

- Remove memoized JSX from `FieldError` and key deduped error list items by message.
- Convert the provider-auth preferred-provider auto-open guard from state to a ref so it does not schedule an extra render.

## Evidence

### React Doctor
- Baseline: `pnpm dlx react-doctor@latest --project @openwork/app --full --json --json-compact --fail-on none` -- score 79, 165 warnings
- After: `pnpm dlx react-doctor@latest --project @openwork/app --full --json --json-compact --fail-on none` -- score 80, 162 warnings
- Target deltas: `rerender-memo-before-early-return` 1 -> 0, `no-array-index-as-key` 10 -> 9, `rerender-state-only-in-handlers` 6 -> 5, `no-render-in-render` 7 -> 7

### Build verification
- `pnpm install --frozen-lockfile` -- passed
- `pnpm --filter @openwork/app build` -- passed
- `pnpm --filter @openwork/app typecheck` -- failed on existing unrelated app-wide type errors; none are in `apps/app/src/components/ui/field.tsx` or `apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx`

### API verification
- No API changes.

### UI verification
- No behavior changes intended; verified with build and React Doctor scan.

## Test instructions

1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @openwork/app build`
3. `pnpm dlx react-doctor@latest --project @openwork/app --full --json --json-compact --fail-on none`