### PR TITLE
fix(app): reduce React Doctor async warnings

### DIFF
--- a/apps/app/src/react-app/domains/connections/modals/chrome-connection-setup-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/chrome-connection-setup-modal.tsx
@@ -22,17 +22,17 @@ export type ChromeConnectionSetupModalProps = {
 type ChromeStatus = "unknown" | "checking" | "connected" | "unavailable";
 
 async function checkChromeReachable(): Promise<boolean> {
-  for (const port of [9222, 9229]) {
+  const results = await Promise.all([9222, 9229].map(async (port) => {
     try {
       const response = await fetch(`http://127.0.0.1:${port}/json/version`, {
         signal: AbortSignal.timeout(2000),
       });
-      if (response.ok) return true;
+      return response.ok;
     } catch {
-      // not available on this port
+      return false;
     }
-  }
-  return false;
+  }));
+  return results.some(Boolean);
 }
 
 export function ChromeConnectionSetupModal(props: ChromeConnectionSetupModalProps) {

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1326,8 +1326,10 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return;
     }
 
-    const importedProviders = await refreshImportedCloudProviders();
-    const liveProviders = await refreshCloudOrgProviders({ force: true });
+    const [importedProviders, liveProviders] = await Promise.all([
+      refreshImportedCloudProviders(),
+      refreshCloudOrgProviders({ force: true }),
+    ]);
     const liveProviderMap = new Map(liveProviders.map((provider) => [provider.id, provider]));
     const failures: string[] = [];
     const processedLiveProviderIds = new Set<string>();

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -674,7 +674,7 @@ export function createExtensionsStore(options: {
     const nextSkillNameSet = new Set<string>();
     const nextSkillIds: string[] = [];
 
-    for (const skill of hub.skills) {
+    const skillWrites = hub.skills.map((skill) => {
       const preferredName = importedNameMap.get(skill.id)?.trim() ?? "";
       const installName =
         preferredName && !nextSkillNameSet.has(preferredName)
@@ -689,15 +689,17 @@ export function createExtensionsStore(options: {
       const description = rawDesc.slice(0, 1024) || skill.title.slice(0, 1024) || "Skill";
       const body = extractSkillBodyMarkdown(skill.skillText);
       const content = buildCloudSkillContent(installName, description, body);
-      await upsertWorkspaceSkill(installName, content, description, {
-        overwrite: Boolean(preferredName),
-      });
-    }
+      return { installName, content, description, overwrite: Boolean(preferredName) };
+    });
+
+    await Promise.all(
+      skillWrites.map(({ installName, content, description, overwrite }) =>
+        upsertWorkspaceSkill(installName, content, description, { overwrite }),
+      ),
+    );
 
     const removedSkillNames = (imported?.skillNames ?? []).filter((name) => !nextSkillNameSet.has(name));
-    for (const name of removedSkillNames) {
-      await deleteWorkspaceSkill(name);
-    }
+    await Promise.all(removedSkillNames.map((name) => deleteWorkspaceSkill(name)));
 
     return { nextSkillNames, nextSkillIds, removedSkillNames };
   };
@@ -1241,9 +1243,11 @@ export function createExtensionsStore(options: {
       };
       await persistImportedCloudSkillHubs(nextImports);
       options.markReloadRequired?.("skills", { type: "skill", name: hub.name, action: "added" });
-      await refreshSkills({ force: true });
-      await refreshCloudOrgSkills({ force: true });
-      await refreshCloudOrgSkillHubs({ force: true });
+      await Promise.all([
+        refreshSkills({ force: true }),
+        refreshCloudOrgSkills({ force: true }),
+        refreshCloudOrgSkillHubs({ force: true }),
+      ]);
       return {
         ok: true,
         message: `Imported ${hub.skills.length} skill${hub.skills.length === 1 ? "" : "s"} from ${hub.name}.`,
@@ -1280,9 +1284,11 @@ export function createExtensionsStore(options: {
       };
       await persistImportedCloudSkillHubs(nextImports);
       options.markReloadRequired?.("skills", { type: "skill", name: hub.name, action: "added" });
-      await refreshSkills({ force: true });
-      await refreshCloudOrgSkills({ force: true });
-      await refreshCloudOrgSkillHubs({ force: true });
+      await Promise.all([
+        refreshSkills({ force: true }),
+        refreshCloudOrgSkills({ force: true }),
+        refreshCloudOrgSkillHubs({ force: true }),
+      ]);
       return { ok: true, message: `Synced ${hub.name} from cloud.`, importedNames: applied.nextSkillNames };
     } catch (error) {
       const message = error instanceof Error ? error.message : t("skills.unknown_error");
@@ -1304,17 +1310,19 @@ export function createExtensionsStore(options: {
     setStateField("skillsStatus", null);
 
     try {
+      await Promise.all(imported.skillNames.map((name) => deleteWorkspaceSkill(name)));
       for (const name of imported.skillNames) {
-        await deleteWorkspaceSkill(name);
         options.markReloadRequired?.("skills", { type: "skill", name, action: "removed" });
       }
 
       const nextImports = { ...snapshot.importedCloudSkillHubs };
       delete nextImports[hubId];
       await persistImportedCloudSkillHubs(nextImports);
-      await refreshSkills({ force: true });
-      await refreshCloudOrgSkills({ force: true });
-      await refreshCloudOrgSkillHubs({ force: true });
+      await Promise.all([
+        refreshSkills({ force: true }),
+        refreshCloudOrgSkills({ force: true }),
+        refreshCloudOrgSkillHubs({ force: true }),
+      ]);
       return {
         ok: true,
         message: `Removed ${imported.skillNames.length} imported skill${imported.skillNames.length === 1 ? "" : "s"} from ${imported.name}.`,
@@ -1357,8 +1365,7 @@ export function createExtensionsStore(options: {
     try {
       const repoOverride: OpenworkHubRepo = { owner: repo.owner, repo: repo.repo, ref: repo.ref };
       const result = await openworkClient.installHubSkill(openworkWorkspaceId, trimmed, { repo: repoOverride });
-      await refreshSkills({ force: true });
-      await refreshHubSkills({ force: true });
+      await Promise.all([refreshSkills({ force: true }), refreshHubSkills({ force: true })]);
       if (!result?.ok) return { ok: false, message: "Install failed." };
       return { ok: true, message: `Installed ${trimmed}.` };
     } catch (error) {
@@ -1390,8 +1397,7 @@ export function createExtensionsStore(options: {
       await upsertWorkspaceSkill(installName, content, description, { overwrite: Boolean(existingImport) });
       await persistImportedCloudSkillRecord(skill, installName);
       options.markReloadRequired?.("skills", { type: "skill", name: installName, action });
-      await refreshSkills({ force: true });
-      await refreshCloudOrgSkills({ force: true });
+      await Promise.all([refreshSkills({ force: true }), refreshCloudOrgSkills({ force: true })]);
       return {
         ok: true,
         message: t(existingImport ? "skills.cloud_updated" : "skills.cloud_installed", { name: installName }),
@@ -1427,8 +1433,7 @@ export function createExtensionsStore(options: {
       delete nextImports[cloudSkillId];
       await persistImportedCloudSkills(nextImports);
       options.markReloadRequired?.("skills", { type: "skill", name: imported.installedName, action: "removed" });
-      await refreshSkills({ force: true });
-      await refreshCloudOrgSkills({ force: true });
+      await Promise.all([refreshSkills({ force: true }), refreshCloudOrgSkills({ force: true })]);
       return {
         ok: true,
         message: t("skills.cloud_removed", { name: imported.installedName }),
@@ -2105,9 +2110,11 @@ export function createExtensionsStore(options: {
     }
 
     try {
-      const opencodeSkills = await joinDesktopPath(root, ".opencode", "skills");
-      const claudeSkills = await joinDesktopPath(root, ".claude", "skills");
-      const legacySkills = await joinDesktopPath(root, ".opencode", "skill");
+      const [opencodeSkills, claudeSkills, legacySkills] = await Promise.all([
+        joinDesktopPath(root, ".opencode", "skills"),
+        joinDesktopPath(root, ".claude", "skills"),
+        joinDesktopPath(root, ".opencode", "skill"),
+      ]);
       const tryOpen = async (target: string) => {
         try {
           await openDesktopPath(target);

--- a/apps/app/src/react-app/shell/reload-coordinator.tsx
+++ b/apps/app/src/react-app/shell/reload-coordinator.tsx
@@ -85,10 +85,9 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
 
   const forceStopActiveSessionsAndReload = useCallback(async () => {
     const controls = controlsRef.current;
-    if (controls?.stopSession) {
-      for (const session of activeSessions) {
-        await Promise.resolve(controls.stopSession(session.id)).catch(() => undefined);
-      }
+    const stopSession = controls?.stopSession;
+    if (stopSession) {
+      await Promise.all(activeSessions.map((session) => Promise.resolve(stopSession(session.id)).catch(() => undefined)));
     }
     await systemState.reloadWorkspaceEngine();
   }, [activeSessions, systemState.reloadWorkspaceEngine]);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -382,14 +382,16 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
     }
   }
 
-  for (const attachment of draft.attachments) {
-    parts.push({
-      type: "file",
-      url: await fileToDataUrl(attachment.file),
-      filename: attachment.name,
-      mime: attachment.mimeType,
-    });
-  }
+  parts.push(
+    ...(await Promise.all(
+      draft.attachments.map(async (attachment) => ({
+        type: "file" as const,
+        url: await fileToDataUrl(attachment.file),
+        filename: attachment.name,
+        mime: attachment.mimeType,
+      })),
+    )),
+  );
 
   return parts;
 }


### PR DESCRIPTION
## Summary

- Parallelize independent async app operations flagged by React Doctor while preserving ordered polling, restart, and config mutation semantics.
- Reduce target React Doctor async warnings from `async-await-in-loop` 13 -> 7, `async-parallel` 9 -> 4, and `server-sequential-independent-await` 1 -> 0.

## Evidence

### React Doctor
- Baseline: `npx react-doctor@latest . --verbose` in `apps/app` reported target counts `async-await-in-loop` 13, `async-parallel` 9, `server-sequential-independent-await` 1.
- Final: `npx react-doctor@latest . --verbose` in `apps/app` reported target counts `async-await-in-loop` 7, `async-parallel` 4, `server-sequential-independent-await` 0.

### Build verification
- `pnpm install --frozen-lockfile` -- passed.
- `pnpm --filter @openwork/app build` -- passed.
- `pnpm --filter @openwork/app typecheck` -- failed on existing unrelated baseline TypeScript errors, primarily `unknown` desktop command results and missing OpenCode Router exports. The transient new `reload-coordinator.tsx` narrowing error was fixed and is absent from the final typecheck output.

### API verification
- No API changes.

### UI verification
- No UI flow changes; async cleanup only.

## Skipped Warnings

- Polling/retry loops in server health, MCP reload, provider OAuth, and MCP auth discovery remain sequential because each iteration depends on timeout/status state and delay cadence.
- Restart/reconnect flows in settings remain sequential because reconnect and route refresh depend on server restart completion.
- Provider sync config mutations remain sequential because remove/connect operations mutate shared provider config and should preserve order.
- Plugin import file writes remain sequential because partial failure semantics and reload markers are currently tied to per-file write order.
- Script test steps remain sequential because the tests intentionally report and validate ordered steps.