### PR TITLE
fix(app): clear small React Doctor leftovers

### DIFF
--- a/apps/app/src/react-app/design-system/button.tsx
+++ b/apps/app/src/react-app/design-system/button.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
-import { forwardRef, type ButtonHTMLAttributes } from "react";
+import type { ComponentProps } from "react";
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+export type ButtonProps = ComponentProps<"button"> & {
   variant?: "primary" | "secondary" | "ghost" | "outline" | "danger";
 };
 
@@ -20,18 +20,16 @@ const variants: Record<NonNullable<ButtonProps["variant"]>, string> = {
   danger: "bg-red-3 text-red-11 hover:bg-red-4 border border-red-6",
 };
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  function Button({ variant, className, type, disabled, ...rest }, ref) {
-    const effectiveVariant = variant ?? "primary";
-    return (
-      <button
-        ref={ref}
-        type={type ?? "button"}
-        disabled={disabled}
-        aria-disabled={disabled}
-        className={`${base} ${variants[effectiveVariant]} ${className ?? ""}`.trim()}
-        {...rest}
-      />
-    );
-  },
-);
+export function Button({ variant, className, type, disabled, ref, ...rest }: ButtonProps) {
+  const effectiveVariant = variant ?? "primary";
+  return (
+    <button
+      ref={ref}
+      type={type ?? "button"}
+      disabled={disabled}
+      aria-disabled={disabled}
+      className={`${base} ${variants[effectiveVariant]} ${className ?? ""}`.trim()}
+      {...rest}
+    />
+  );
+}

--- a/apps/app/src/react-app/design-system/text-input.tsx
+++ b/apps/app/src/react-app/design-system/text-input.tsx
@@ -1,31 +1,29 @@
 /** @jsxImportSource react */
-import { forwardRef, type InputHTMLAttributes } from "react";
+import type { ComponentProps } from "react";
 
-export type TextInputProps = InputHTMLAttributes<HTMLInputElement> & {
+export type TextInputProps = ComponentProps<"input"> & {
   label?: string;
   hint?: string;
 };
 
-export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
-  function TextInput({ label, hint, className, ...rest }, ref) {
-    return (
-      <label className="block">
-        {label ? (
-          <div className="mb-1 text-xs font-medium text-dls-secondary">
-            {label}
-          </div>
-        ) : null}
-        <input
-          ref={ref}
-          className={`w-full rounded-lg bg-dls-surface px-3 py-2 text-sm text-dls-text placeholder:text-dls-secondary border border-dls-border shadow-sm focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] ${
-            className ?? ""
-          }`.trim()}
-          {...rest}
-        />
-        {hint ? (
-          <div className="mt-1 text-xs text-dls-secondary">{hint}</div>
-        ) : null}
-      </label>
-    );
-  },
-);
+export function TextInput({ label, hint, className, ref, ...rest }: TextInputProps) {
+  return (
+    <label className="block">
+      {label ? (
+        <div className="mb-1 text-xs font-medium text-dls-secondary">
+          {label}
+        </div>
+      ) : null}
+      <input
+        ref={ref}
+        className={`w-full rounded-lg bg-dls-surface px-3 py-2 text-sm text-dls-text placeholder:text-dls-secondary border border-dls-border shadow-sm focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] ${
+          className ?? ""
+        }`.trim()}
+        {...rest}
+      />
+      {hint ? (
+        <div className="mt-1 text-xs text-dls-secondary">{hint}</div>
+      ) : null}
+    </label>
+  );
+}

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -48,7 +48,6 @@ function ProviderIcon({
 export type ModelPickerModalProps = {
   open: boolean;
   options: ModelOption[];
-  filteredOptions: ModelOption[];
   query: string;
   setQuery: (value: string) => void;
   target: "default" | "session";
@@ -73,13 +72,24 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   const optionRefs = useRef<HTMLDivElement[]>([]);
   const [activeIndex, setActiveIndex] = useState(0);
 
+  const filteredOptions = useMemo(() => {
+    const q = props.query.trim().toLowerCase();
+    if (!q) return props.options;
+    return props.options.filter(
+      (opt) =>
+        opt.title.toLowerCase().includes(q) ||
+        opt.providerID.toLowerCase().includes(q) ||
+        opt.modelID.toLowerCase().includes(q),
+    );
+  }, [props.options, props.query]);
+
   const otherProviderLinks = useMemo(() => {
     const seen = new Set<string>();
     const items: { providerID: string; title: string; matchCount: number }[] =
       [];
     const counts = new Map<string, number>();
 
-    for (const opt of props.filteredOptions) {
+    for (const opt of filteredOptions) {
       if (opt.isConnected) continue;
       counts.set(opt.providerID, (counts.get(opt.providerID) ?? 0) + 1);
       if (seen.has(opt.providerID)) continue;
@@ -95,10 +105,10 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
       ...item,
       matchCount: counts.get(item.providerID) ?? 1,
     }));
-  }, [props.filteredOptions]);
+  }, [filteredOptions]);
 
   const renderedItems = useMemo<RenderedItem[]>(() => {
-    const models = props.filteredOptions.filter((opt) => opt.isConnected);
+    const models = filteredOptions.filter((opt) => opt.isConnected);
     const recommended = models.filter((opt) => opt.isRecommended);
     const others = models.filter((opt) => !opt.isRecommended);
     return [
@@ -109,7 +119,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         ...item,
       })),
     ];
-  }, [otherProviderLinks, props.filteredOptions]);
+  }, [otherProviderLinks, filteredOptions]);
 
   const activeModelIndex = useMemo(
     () =>
@@ -510,7 +520,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
             {props.query.trim() ? (
               <div className="mt-2 text-xs text-dls-secondary">
                 {t("settings.showing_models", {
-                  count: props.filteredOptions.length,
+                  count: filteredOptions.length,
                   total: props.options.length,
                 })}
               </div>

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -14,7 +14,7 @@ import {
   Settings,
   FolderOpen,
 } from "lucide-react";
-import { motion, Reorder, useDragControls } from "motion/react";
+import { LazyMotion, Reorder, domMax, m, useDragControls } from "motion/react";
 
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { WorkspaceInfo } from "../../../../app/lib/desktop";
@@ -492,31 +492,33 @@ export function AppSidebar(props: AppSidebarProps) {
         className="mac:**:data-[sidebar=sidebar]:bg-transparent"
       >
         <div className="hidden h-14 mac:block mac:titlebar-drag"/>
-        <motion.div
-          layoutScroll
-          data-slot="sidebar-content"
-          data-sidebar="content"
-          className="no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden"
-        >
-          <Reorder.Group
-            as="div"
-            axis="y"
-            values={props.workspaceSessionGroups.map((group) => group.workspace.id)}
-            onReorder={(workspaceIds) => props.onReorderWorkspaces?.(workspaceIds)}
-            className="flex flex-col gap-2"
+        <LazyMotion features={domMax}>
+          <m.div
+            layoutScroll
+            data-slot="sidebar-content"
+            data-sidebar="content"
+            className="no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden"
           >
-            {props.workspaceSessionGroups.map((group, index) => (
-              <WorkspaceReorderItem
-                key={group.workspace.id}
-                group={group}
-                className={cn(index === 0 && "mac:pt-0")}
-                showInitialLoading={props.showInitialLoading}
-                previewCount={previewCount(group.workspace.id)}
-                showMoreSessions={showMoreSessions}
-              />
-            ))}
-          </Reorder.Group>
-        </motion.div>
+            <Reorder.Group
+              as="div"
+              axis="y"
+              values={props.workspaceSessionGroups.map((group) => group.workspace.id)}
+              onReorder={(workspaceIds) => props.onReorderWorkspaces?.(workspaceIds)}
+              className="flex flex-col gap-2"
+            >
+              {props.workspaceSessionGroups.map((group, index) => (
+                <WorkspaceReorderItem
+                  key={group.workspace.id}
+                  group={group}
+                  className={cn(index === 0 && "mac:pt-0")}
+                  showInitialLoading={props.showInitialLoading}
+                  previewCount={previewCount(group.workspace.id)}
+                  showMoreSessions={showMoreSessions}
+                />
+              ))}
+            </Reorder.Group>
+          </m.div>
+        </LazyMotion>
 
         <SidebarFooter>
           <SidebarMenu>

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -387,12 +387,8 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
             </div>
           ) : null}
 
-          <form
+          <div
             className="flex items-center gap-2 border-t border-gray-5/60 bg-gray-2/60 p-2"
-            onSubmit={(event) => {
-              event.preventDefault();
-              void addAuthorizedFolder();
-            }}
           >
             <div className="relative flex-1">
               <input
@@ -401,6 +397,11 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                 onChange={(event) => setAuthorizedFolderDraft(event.currentTarget.value)}
                 onPaste={(event) => {
                   event.preventDefault();
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && authorizedFolderDraft.trim()) {
+                    void addAuthorizedFolder();
+                  }
                 }}
                 placeholder={t("context_panel.input_placeholder")}
                 disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canWriteConfig}
@@ -421,9 +422,10 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
             ) : null}
 
             <Button
-              type="submit"
+              type="button"
               variant="outline"
               className="h-8 border border-gray-5/60 bg-gray-3 px-3 text-xs text-gray-12 hover:bg-gray-4"
+              onClick={() => void addAuthorizedFolder()}
               disabled={
                 authorizedFoldersLoading ||
                 authorizedFoldersSaving ||
@@ -433,7 +435,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
             >
               {authorizedFoldersSaving ? t("context_panel.adding_button") : t("context_panel.add_button")}
             </Button>
-          </form>
+          </div>
         </div>
       )}
     </div>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2372,15 +2372,6 @@ export function SessionRoute() {
     <ModelPickerModal
       open={modelPickerOpen}
       options={allowedModelOptions}
-      filteredOptions={allowedModelOptions.filter((opt) => {
-        const q = modelPickerQuery.trim().toLowerCase();
-        if (!q) return true;
-        return (
-          opt.title.toLowerCase().includes(q) ||
-          opt.providerID.toLowerCase().includes(q) ||
-          opt.modelID.toLowerCase().includes(q)
-        );
-      })}
       query={modelPickerQuery}
       setQuery={setModelPickerQuery}
       target="default"

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1878,15 +1878,6 @@ export function SettingsRoute() {
       <ModelPickerModal
         open={modelPickerOpen}
         options={modelOptions}
-        filteredOptions={modelOptions.filter((opt) => {
-          const q = modelPickerQuery.trim().toLowerCase();
-          if (!q) return true;
-          return (
-            opt.title.toLowerCase().includes(q) ||
-            opt.providerID.toLowerCase().includes(q) ||
-            opt.modelID.toLowerCase().includes(q)
-          );
-        })}
         query={modelPickerQuery}
         setQuery={setModelPickerQuery}
         target="default"


### PR DESCRIPTION
## Summary

- Removes React 19 `forwardRef` usage from the design-system button and text input while keeping `ref` as a normal React 19 prop.
- Derives model picker filtered options inside the modal to avoid passing duplicate option arrays.
- Uses LazyMotion with `domMax` for the sidebar Reorder flow and replaces the add-folder submit form with button/key handling.

## Evidence

### React Doctor
- Baseline app scan from fresh branch: `@openwork/app` 124 diagnostics.
- Target counts cleared: `no-react19-deprecated-apis` 2 -> 0, `server-dedup-props` 2 -> 0, `use-lazy-motion` 1 -> 0, `no-prevent-default` 1 -> 0.
- `no-secrets-in-client-code` was intentionally untouched.

### Build verification
- `pnpm install` passed.
- `pnpm build` passed.
- `pnpm typecheck` failed on existing baseline TypeScript issues unrelated to this PR, including unknown Tauri invoke result typing and missing OpenCode Router exports.

### API verification
- No API changes.

### UI verification
- No runtime UI stack was started; this is a source-level React Doctor cleanup verified by static scan and production build.

## Test instructions

1. `pnpm install`
2. `pnpm dlx react-doctor . --full --json --offline --fail-on none`
3. `pnpm build`
4. `pnpm typecheck` to reproduce the current baseline typecheck failures.