### PR TITLE
fix(app): reduce React Doctor state warnings

### DIFF
--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -5,6 +5,7 @@ import {
   use,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
   type ReactNode,
@@ -84,6 +85,11 @@ type DesktopConfigProviderProps = {
   children: ReactNode;
 };
 
+type DesktopConfigState = {
+  config: DenDesktopConfig;
+  loading: boolean;
+};
+
 /**
  * React port of the Solid `DesktopConfigProvider`
  * (`apps/app/src/app/cloud/desktop-config-provider.tsx` on dev).
@@ -96,10 +102,13 @@ type DesktopConfigProviderProps = {
  */
 export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) {
   const denAuth = useDenAuth();
-  const [config, setConfig] = useState<DenDesktopConfig>(DEFAULT_DESKTOP_CONFIG);
-  const [loading, setLoading] = useState(false);
+  const [desktopConfigState, setDesktopConfigState] = useState<DesktopConfigState>({
+    config: DEFAULT_DESKTOP_CONFIG,
+    loading: false,
+  });
+  const { config, loading } = desktopConfigState;
   // Bumped whenever the browser tells us the Den session or settings changed.
-  const [settingsVersion, setSettingsVersion] = useState(0);
+  const [settingsVersion, bumpSettingsVersion] = useReducer((value: number) => value + 1, 0);
   // Monotonic run id — same guard-against-stale-resolution pattern as DenAuthProvider.
   const refreshRunRef = useRef(0);
   const isSignedIn = denAuth.isSignedIn;
@@ -111,13 +120,14 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     const cacheKey = getDesktopConfigCacheKey();
 
     if (!isSignedIn || !token || !settings.activeOrgId?.trim()) {
-      setConfig(DEFAULT_DESKTOP_CONFIG);
-      setLoading(false);
+      setDesktopConfigState({ config: DEFAULT_DESKTOP_CONFIG, loading: false });
       return;
     }
 
     const cached = readCachedDesktopConfig(cacheKey);
-    if (!cached) setLoading(true);
+    if (!cached) {
+      setDesktopConfigState((current) => ({ ...current, loading: true }));
+    }
 
     try {
       const nextConfig = await createDenClient({
@@ -129,7 +139,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       if (currentRun !== refreshRunRef.current) return;
 
       writeCachedDesktopConfig(cacheKey, nextConfig);
-      setConfig(nextConfig);
+      setDesktopConfigState((current) => ({ ...current, config: nextConfig }));
     } catch (error) {
       if (currentRun !== refreshRunRef.current) return;
 
@@ -145,10 +155,13 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
         );
       }
 
-      setConfig(cached ?? DEFAULT_DESKTOP_CONFIG);
+      setDesktopConfigState((current) => ({
+        ...current,
+        config: cached ?? DEFAULT_DESKTOP_CONFIG,
+      }));
     } finally {
       if (currentRun === refreshRunRef.current) {
-        setLoading(false);
+        setDesktopConfigState((current) => ({ ...current, loading: false }));
       }
     }
   }, [isSignedIn]);
@@ -161,15 +174,16 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     void settingsVersion;
 
     if (!isSignedIn) {
-      setConfig(DEFAULT_DESKTOP_CONFIG);
-      setLoading(false);
+      setDesktopConfigState({ config: DEFAULT_DESKTOP_CONFIG, loading: false });
       return;
     }
 
     const cacheKey = getDesktopConfigCacheKey();
     const cached = readCachedDesktopConfig(cacheKey);
-    setConfig(cached ?? DEFAULT_DESKTOP_CONFIG);
-    setLoading(!cached);
+    setDesktopConfigState({
+      config: cached ?? DEFAULT_DESKTOP_CONFIG,
+      loading: !cached,
+    });
     void refresh();
   }, [isSignedIn, refresh, settingsVersion]);
 
@@ -177,7 +191,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     if (typeof window === "undefined") return;
 
     const handleSettingsChanged = () => {
-      setSettingsVersion((value) => value + 1);
+      bumpSettingsVersion();
     };
 
     window.addEventListener(denSessionUpdatedEvent, handleSettingsChanged);

--- a/apps/app/src/react-app/domains/settings/pages/config-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/config-view.tsx
@@ -43,15 +43,26 @@ export type ConfigViewProps = {
 
 type OpenworkTestState = "idle" | "testing" | "success" | "error";
 
+type OpenworkConnectionState = {
+  url: string;
+  token: string;
+  testState: OpenworkTestState;
+  testMessage: string | null;
+};
+
 export function ConfigView(props: ConfigViewProps) {
-  const [openworkUrl, setOpenworkUrl] = useState("");
-  const [openworkToken, setOpenworkToken] = useState("");
+  const [openworkConnection, setOpenworkConnection] =
+    useState<OpenworkConnectionState>({
+      url: "",
+      token: "",
+      testState: "idle",
+      testMessage: null,
+    });
+  const openworkUrl = openworkConnection.url;
+  const openworkToken = openworkConnection.token;
+  const openworkTestState = openworkConnection.testState;
+  const openworkTestMessage = openworkConnection.testMessage;
   const [openworkTokenVisible, setOpenworkTokenVisible] = useState(false);
-  const [openworkTestState, setOpenworkTestState] =
-    useState<OpenworkTestState>("idle");
-  const [openworkTestMessage, setOpenworkTestMessage] = useState<string | null>(
-    null,
-  );
   const [clientTokenVisible, setClientTokenVisible] = useState(false);
   const [ownerTokenVisible, setOwnerTokenVisible] = useState(false);
   const [hostTokenVisible, setHostTokenVisible] = useState(false);
@@ -59,14 +70,13 @@ export function ConfigView(props: ConfigViewProps) {
   const copyTimeoutRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
-    setOpenworkUrl(props.openworkServerSettings.urlOverride ?? "");
-    setOpenworkToken(props.openworkServerSettings.token ?? "");
+    setOpenworkConnection({
+      url: props.openworkServerSettings.urlOverride ?? "",
+      token: props.openworkServerSettings.token ?? "",
+      testState: "idle",
+      testMessage: null,
+    });
   }, [props.openworkServerSettings]);
-
-  useEffect(() => {
-    setOpenworkTestState("idle");
-    setOpenworkTestMessage(null);
-  }, [openworkUrl, openworkToken]);
 
   useEffect(() => {
     return () => {
@@ -244,21 +254,30 @@ export function ConfigView(props: ConfigViewProps) {
     if (openworkTestState === "testing") return;
     const next = buildOpenworkSettings();
     props.updateOpenworkServerSettings(next);
-    setOpenworkTestState("testing");
-    setOpenworkTestMessage(null);
+    setOpenworkConnection((current) => ({
+      ...current,
+      testState: "testing",
+      testMessage: null,
+    }));
     try {
       const ok = await props.testOpenworkServerConnection(next);
-      setOpenworkTestState(ok ? "success" : "error");
-      setOpenworkTestMessage(
-        ok ? t("config.connection_successful") : t("config.connection_failed"),
-      );
+      setOpenworkConnection((current) => ({
+        ...current,
+        testState: ok ? "success" : "error",
+        testMessage: ok
+          ? t("config.connection_successful")
+          : t("config.connection_failed"),
+      }));
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
           : t("config.connection_failed_check");
-      setOpenworkTestState("error");
-      setOpenworkTestMessage(message);
+      setOpenworkConnection((current) => ({
+        ...current,
+        testState: "error",
+        testMessage: message,
+      }));
     }
   };
 
@@ -501,7 +520,14 @@ export function ConfigView(props: ConfigViewProps) {
           <TextInput
             label={t("config.server_url_input_label")}
             value={openworkUrl}
-            onChange={(event) => setOpenworkUrl(event.currentTarget.value)}
+            onChange={(event) =>
+              setOpenworkConnection((current) => ({
+                ...current,
+                url: event.currentTarget.value,
+                testState: "idle",
+                testMessage: null,
+              }))
+            }
             placeholder="http://127.0.0.1:<port>"
             hint={t("config.server_url_hint")}
             disabled={props.busy}
@@ -515,7 +541,14 @@ export function ConfigView(props: ConfigViewProps) {
               <input
                 type={openworkTokenVisible ? "text" : "password"}
                 value={openworkToken}
-                onChange={(event) => setOpenworkToken(event.currentTarget.value)}
+                onChange={(event) =>
+                  setOpenworkConnection((current) => ({
+                    ...current,
+                    token: event.currentTarget.value,
+                    testState: "idle",
+                    testMessage: null,
+                  }))
+                }
                 placeholder={t("config.token_placeholder")}
                 disabled={props.busy}
                 className="w-full rounded-xl bg-gray-2/60 px-3 py-2 text-sm text-gray-12 placeholder:text-gray-10 shadow-[0_0_0_1px_rgba(255,255,255,0.08)] focus:outline-none focus:ring-2 focus:ring-gray-6/20"

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 import type { DenDesktopConfig } from "../../../../app/lib/den";
 import { isAlphaUpdateAllowed, isUpdateAllowed } from "../../../../app/lib/version-gate";
@@ -28,6 +28,30 @@ type UseElectronUpdaterStateOptions = {
   desktopConfig: DenDesktopConfig | null | undefined;
   setError: (message: string | null) => void;
 };
+
+type ElectronUpdaterEnvState = {
+  appVersion: string | null;
+  updateEnv: { supported?: boolean; reason?: string | null } | null;
+};
+
+type ElectronUpdaterEnvAction =
+  | { type: "app-version"; appVersion: string | null }
+  | { type: "unsupported"; reason: string };
+
+function electronUpdaterEnvReducer(
+  state: ElectronUpdaterEnvState,
+  action: ElectronUpdaterEnvAction,
+): ElectronUpdaterEnvState {
+  switch (action.type) {
+    case "app-version":
+      return { ...state, appVersion: action.appVersion };
+    case "unsupported":
+      return {
+        ...state,
+        updateEnv: { supported: false, reason: action.reason },
+      };
+  }
+}
 
 function electronUpdaterBridge(): ElectronUpdaterBridge | null {
   if (typeof window === "undefined") return null;
@@ -71,15 +95,18 @@ function updateProgress(event: unknown): { downloaded?: number; total?: number }
 export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions) {
   const { releaseChannel, onReleaseChannelChange, updateAutoCheck, updateAutoDownload, desktopConfig, setError } = options;
   const [updateStatus, setUpdateStatus] = useState<SettingsUpdateStatus>(null);
-  const [appVersion, setAppVersion] = useState<string | null>(null);
-  const [updateEnv, setUpdateEnv] = useState<{ supported?: boolean; reason?: string | null } | null>(null);
+  const [envState, dispatchEnvState] = useReducer(electronUpdaterEnvReducer, {
+    appVersion: null,
+    updateEnv: null,
+  });
+  const { appVersion, updateEnv } = envState;
   const autoCheckKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!isElectronRuntime()) return;
     const bridge = electronUpdaterBridge();
     if (!bridge?.getChannel) {
-      setUpdateEnv({ supported: false, reason: "Electron updater bridge is unavailable." });
+      dispatchEnvState({ type: "unsupported", reason: "Electron updater bridge is unavailable." });
       return;
     }
     let cancelled = false;
@@ -87,11 +114,11 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       .getChannel()
       .then(async (state) => {
         if (cancelled) return;
-        setAppVersion(state.currentVersion ?? null);
+        dispatchEnvState({ type: "app-version", appVersion: state.currentVersion ?? null });
         if (state.channel && state.channel !== releaseChannel && bridge.setChannel) {
           const nextState = await bridge.setChannel(releaseChannel);
           if (cancelled) return;
-          setAppVersion(nextState.currentVersion ?? null);
+          dispatchEnvState({ type: "app-version", appVersion: nextState.currentVersion ?? null });
           if (nextState.channel && nextState.channel !== releaseChannel) {
             onReleaseChannelChange(nextState.channel);
           }
@@ -99,7 +126,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       })
       .catch(() => {
         if (!cancelled) {
-          setUpdateEnv({ supported: false, reason: "Electron updater bridge is unavailable." });
+          dispatchEnvState({ type: "unsupported", reason: "Electron updater bridge is unavailable." });
         }
       });
     return () => {
@@ -164,7 +191,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     setUpdateStatus({ state: "checking" });
     try {
       const result = await bridge.check();
-      setAppVersion(result.currentVersion ?? null);
+      dispatchEnvState({ type: "app-version", appVersion: result.currentVersion ?? null });
       if (result.channel && result.channel !== releaseChannel) {
         onReleaseChannelChange(result.channel);
       }
@@ -239,7 +266,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       if (!bridge?.setChannel) return;
       try {
         const state = await bridge.setChannel(next);
-        setAppVersion(state.currentVersion ?? null);
+        dispatchEnvState({ type: "app-version", appVersion: state.currentVersion ?? null });
         if (state.channel && state.channel !== next) {
           onReleaseChannelChange(state.channel);
         }

--- a/apps/app/src/react-app/domains/workspace/create-remote-workspace-modal.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-remote-workspace-modal.tsx
@@ -18,16 +18,29 @@ import {
 import { RemoteWorkspaceFields } from "./remote-workspace-fields";
 import type { CreateRemoteWorkspaceModalProps } from "./types";
 
+type RemoteWorkspaceFormState = {
+  openworkHostUrl: string;
+  openworkToken: string;
+  openworkTokenVisible: boolean;
+  directory: string;
+  displayName: string;
+};
+
+const emptyRemoteWorkspaceForm: RemoteWorkspaceFormState = {
+  openworkHostUrl: "",
+  openworkToken: "",
+  openworkTokenVisible: false,
+  directory: "",
+  displayName: "",
+};
+
 export function CreateRemoteWorkspaceModal(
   props: CreateRemoteWorkspaceModalProps,
 ) {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const [openworkHostUrl, setOpenworkHostUrl] = useState("");
-  const [openworkToken, setOpenworkToken] = useState("");
-  const [openworkTokenVisible, setOpenworkTokenVisible] = useState(false);
-  const [directory, setDirectory] = useState("");
-  const [displayName, setDisplayName] = useState("");
+  const [form, setForm] = useState<RemoteWorkspaceFormState>(emptyRemoteWorkspaceForm);
+  const { openworkHostUrl, openworkToken, openworkTokenVisible, directory, displayName } = form;
 
   const showClose = props.showClose ?? true;
   const title = props.title ?? t("dashboard.create_remote_workspace_title");
@@ -52,11 +65,13 @@ export function CreateRemoteWorkspaceModal(
   useEffect(() => {
     if (!props.open) return;
     const defaults = props.initialValues ?? {};
-    setOpenworkHostUrl(defaults.openworkHostUrl?.trim() ?? "");
-    setOpenworkToken(defaults.openworkToken?.trim() ?? "");
-    setOpenworkTokenVisible(false);
-    setDirectory(defaults.directory?.trim() ?? "");
-    setDisplayName(defaults.displayName?.trim() ?? "");
+    setForm({
+      openworkHostUrl: defaults.openworkHostUrl?.trim() ?? "",
+      openworkToken: defaults.openworkToken?.trim() ?? "",
+      openworkTokenVisible: false,
+      directory: defaults.directory?.trim() ?? "",
+      displayName: defaults.displayName?.trim() ?? "",
+    });
   }, [props.initialValues, props.open]);
 
   if (!props.open && !isInline) {
@@ -84,17 +99,17 @@ export function CreateRemoteWorkspaceModal(
       <div className={modalBodyClass}>
         <RemoteWorkspaceFields
           hostUrl={openworkHostUrl}
-          onHostUrlInput={setOpenworkHostUrl}
+          onHostUrlInput={(value) => setForm((current) => ({ ...current, openworkHostUrl: value }))}
           token={openworkToken}
           tokenVisible={openworkTokenVisible}
-          onTokenInput={setOpenworkToken}
+          onTokenInput={(value) => setForm((current) => ({ ...current, openworkToken: value }))}
           onToggleTokenVisible={() =>
-            setOpenworkTokenVisible((prev) => !prev)
+            setForm((current) => ({ ...current, openworkTokenVisible: !current.openworkTokenVisible }))
           }
           displayName={displayName}
-          onDisplayNameInput={setDisplayName}
+          onDisplayNameInput={(value) => setForm((current) => ({ ...current, displayName: value }))}
           directory={directory}
-          onDirectoryInput={setDirectory}
+          onDirectoryInput={(value) => setForm((current) => ({ ...current, directory: value }))}
           showDirectory
           submitting={submitting}
           hostInputRef={inputRef}


### PR DESCRIPTION
## Summary
- Collapses local state clusters in desktop config, config connection testing, remote workspace modal form state, and Electron updater environment state.
- Removes a safe subset of React Doctor state/effect warnings without touching session boot, command routing, or server lifecycle flows.

## React Doctor
- Before: score 88, 124 warnings; target counts: rerender-state-only-in-handlers 5, no-cascading-set-state 25, no-effect-chain 5, no-derived-state-effect 2.
- After: score 88, 117 warnings; target counts: rerender-state-only-in-handlers 4, no-cascading-set-state 22, no-effect-chain 4, no-derived-state-effect 1.

## Verification
- pnpm install: passed.
- pnpm dlx react-doctor apps/app --full --offline --no-dead-code --json --fail-on none: passed, score 88, 117 warnings.
- pnpm build: passed.
- pnpm typecheck: failed on existing broad React app type errors around unknown desktop/server bridge results and missing messaging exports; not introduced by this PR's touched files.

## Skipped
- Session boot/session surface/composer warnings: skipped to avoid task/session lifecycle risk.
- SettingsRoute active client and workspace connection warnings: skipped because they touch client routing and workspace connection status.
- Command palette reset warning: skipped as command routing is explicitly out of scope.
- Den/auth/MCP/authorized-folders/messaging settings effects: skipped as auth/config/form reset semantics are higher risk than this safe subset.
- Render watchdog/dev profiler visibility refs: skipped because state controls mounted UI, so ref conversion would break toggling.