### PR TITLE
fix(app): reduce React Doctor architecture warnings

### DIFF
--- a/apps/app/src/react-app/domains/connections/modals/add-mcp-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/add-mcp-modal.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useId, useState } from "react";
+import { useId, useReducer } from "react";
 import { Loader2, Plus, X } from "lucide-react";
 
 import { Button } from "../../../design-system/button";
@@ -15,48 +15,61 @@ export type AddMcpModalProps = {
   isRemoteWorkspace: boolean;
 };
 
+type AddMcpState = {
+  name: string;
+  serverType: "remote" | "local";
+  url: string;
+  command: string;
+  oauthRequired: boolean;
+  error: string | null;
+  submitting: boolean;
+};
+
+const initialAddMcpState: AddMcpState = {
+  name: "",
+  serverType: "remote",
+  url: "",
+  command: "",
+  oauthRequired: false,
+  error: null,
+  submitting: false,
+};
+
+function addMcpReducer(state: AddMcpState, patch: Partial<AddMcpState> | "reset") {
+  if (patch === "reset") return initialAddMcpState;
+  return { ...state, ...patch };
+}
+
 export function AddMcpModal(props: AddMcpModalProps) {
-  const [name, setName] = useState("");
-  const [serverType, setServerType] = useState<"remote" | "local">("remote");
-  const [url, setUrl] = useState("");
-  const [command, setCommand] = useState("");
-  const [oauthRequired, setOauthRequired] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [state, dispatch] = useReducer(addMcpReducer, initialAddMcpState);
   const oauthRequiredId = useId();
 
   const reset = () => {
-    setName("");
-    setServerType("remote");
-    setUrl("");
-    setCommand("");
-    setOauthRequired(false);
-    setError(null);
+    dispatch("reset");
   };
 
   const handleClose = () => {
-    if (submitting) return;
+    if (state.submitting) return;
     reset();
     props.onClose();
   };
 
   const handleSubmit = async () => {
-    if (submitting) return;
-    setError(null);
+    if (state.submitting) return;
+    dispatch({ error: null });
 
-    const trimmedName = name.trim();
+    const trimmedName = state.name.trim();
     if (!trimmedName) {
-      setError(t("mcp.name_required"));
+      dispatch({ error: t("mcp.name_required") });
       return;
     }
 
-    setSubmitting(true);
+    dispatch({ submitting: true });
 
-    if (serverType === "remote") {
-      const trimmedUrl = url.trim();
+    if (state.serverType === "remote") {
+      const trimmedUrl = state.url.trim();
       if (!trimmedUrl) {
-        setError(t("mcp.url_or_command_required"));
-        setSubmitting(false);
+        dispatch({ error: t("mcp.url_or_command_required"), submitting: false });
         return;
       }
 
@@ -67,17 +80,16 @@ export function AddMcpModal(props: AddMcpModalProps) {
             description: "",
             type: "remote",
             url: trimmedUrl,
-            oauth: oauthRequired,
+            oauth: state.oauthRequired,
           }),
         );
       } finally {
-        setSubmitting(false);
+        dispatch({ submitting: false });
       }
     } else {
-      const trimmedCommand = command.trim();
+      const trimmedCommand = state.command.trim();
       if (!trimmedCommand) {
-        setError(t("mcp.url_or_command_required"));
-        setSubmitting(false);
+        dispatch({ error: t("mcp.url_or_command_required"), submitting: false });
         return;
       }
 
@@ -92,7 +104,7 @@ export function AddMcpModal(props: AddMcpModalProps) {
           }),
         );
       } finally {
-        setSubmitting(false);
+        dispatch({ submitting: false });
       }
     }
 
@@ -136,8 +148,8 @@ export function AddMcpModal(props: AddMcpModalProps) {
           <TextInput
             label={t("mcp.server_name")}
             placeholder={t("mcp.server_name_placeholder")}
-            value={name}
-            onChange={(event) => setName(event.currentTarget.value)}
+            value={state.name}
+            onChange={(event) => dispatch({ name: event.currentTarget.value })}
           />
 
           <div>
@@ -148,11 +160,11 @@ export function AddMcpModal(props: AddMcpModalProps) {
               <button
                 type="button"
                 className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                  serverType === "remote"
+                  state.serverType === "remote"
                     ? "bg-dls-active text-dls-text"
                     : "text-dls-secondary hover:text-dls-text hover:bg-dls-hover"
                 }`}
-                onClick={() => setServerType("remote")}
+                onClick={() => dispatch({ serverType: "remote" })}
               >
                 {t("mcp.type_remote")}
               </button>
@@ -160,13 +172,13 @@ export function AddMcpModal(props: AddMcpModalProps) {
                 type="button"
                 disabled={props.isRemoteWorkspace}
                 className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-                  serverType === "local"
+                  state.serverType === "local"
                     ? "bg-dls-active text-dls-text"
                     : "text-dls-secondary hover:text-dls-text hover:bg-dls-hover"
                 } ${props.isRemoteWorkspace ? "opacity-50 cursor-not-allowed" : ""}`}
                 onClick={() => {
                   if (props.isRemoteWorkspace) return;
-                  setServerType("local");
+                  dispatch({ serverType: "local" });
                 }}
               >
                 {t("mcp.type_local_cmd")}
@@ -179,13 +191,13 @@ export function AddMcpModal(props: AddMcpModalProps) {
             ) : null}
           </div>
 
-          {serverType === "remote" ? (
+          {state.serverType === "remote" ? (
             <div className="space-y-3">
               <TextInput
                 label={t("mcp.server_url")}
                 placeholder={t("mcp.server_url_placeholder")}
-                value={url}
-                onChange={(event) => setUrl(event.currentTarget.value)}
+                value={state.url}
+                onChange={(event) => dispatch({ url: event.currentTarget.value })}
               />
               <div className="rounded-xl border border-dls-border bg-dls-hover/40 p-3">
                 <div className="mb-2 text-xs font-medium text-dls-text">
@@ -196,9 +208,9 @@ export function AddMcpModal(props: AddMcpModalProps) {
                     id={oauthRequiredId}
                     type="checkbox"
                     className="mt-0.5 size-4 rounded border border-dls-border"
-                    checked={oauthRequired}
+                    checked={state.oauthRequired}
                     onChange={(event) =>
-                      setOauthRequired(event.currentTarget.checked)
+                      dispatch({ oauthRequired: event.currentTarget.checked })
                     }
                   />
                   <label htmlFor={oauthRequiredId}>
@@ -214,19 +226,19 @@ export function AddMcpModal(props: AddMcpModalProps) {
             </div>
           ) : null}
 
-          {serverType === "local" ? (
+          {state.serverType === "local" ? (
             <TextInput
               label={t("mcp.server_command")}
               placeholder={t("mcp.server_command_placeholder")}
               hint={t("mcp.server_command_hint")}
-              value={command}
-              onChange={(event) => setCommand(event.currentTarget.value)}
+              value={state.command}
+              onChange={(event) => dispatch({ command: event.currentTarget.value })}
             />
           ) : null}
 
-          {error ? (
+          {state.error ? (
             <div className="rounded-lg bg-red-2 border border-red-6 px-3 py-2 text-xs text-red-11">
-              {error}
+              {state.error}
             </div>
           ) : null}
         </div>
@@ -235,16 +247,16 @@ export function AddMcpModal(props: AddMcpModalProps) {
           <Button
             variant="ghost"
             onClick={handleClose}
-            disabled={submitting}
+            disabled={state.submitting}
           >
             {t("mcp.auth.cancel")}
           </Button>
           <Button
             variant="secondary"
             onClick={() => void handleSubmit()}
-            disabled={props.busy || submitting}
+            disabled={props.busy || state.submitting}
           >
-            {props.busy || submitting ? (
+            {props.busy || state.submitting ? (
               <Loader2 size={16} className="animate-spin" />
             ) : (
               <Plus size={16} />

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -45,6 +45,12 @@ import { BrowserPanel } from "../browser/browser-panel";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
 import { cn } from "@/lib/utils";
 
+const STARTUP_SKELETON_ROWS = [
+  { id: "intro", titleWidth: "42%", bodyWidth: "88%" },
+  { id: "middle", titleWidth: "56%", bodyWidth: "88%" },
+  { id: "final", titleWidth: "36%", bodyWidth: "74%" },
+];
+
 type StatusBarOverrides = Pick<
   StatusBarProps,
   | "statusLabel"
@@ -484,17 +490,17 @@ export function SessionPage(props: SessionPageProps) {
                       <div className="h-3 w-64 animate-pulse rounded-full bg-dls-hover/60" />
                     </div>
                     <div className="space-y-3">
-                      {[0, 1, 2].map((idx) => (
-                        <div key={idx} className="rounded-2xl border border-dls-border bg-dls-hover/40 p-4">
+                      {STARTUP_SKELETON_ROWS.map((row) => (
+                        <div key={row.id} className="rounded-2xl border border-dls-border bg-dls-hover/40 p-4">
                           <div
                             className="mb-3 h-3 animate-pulse rounded-full bg-dls-hover/80"
-                            style={{ width: idx === 0 ? "42%" : idx === 1 ? "56%" : "36%" }}
+                            style={{ width: row.titleWidth }}
                           />
                           <div className="space-y-2">
                             <div className="h-2.5 animate-pulse rounded-full bg-dls-hover/70" />
                             <div
                               className="h-2.5 animate-pulse rounded-full bg-dls-hover/60"
-                              style={{ width: idx === 2 ? "74%" : "88%" }}
+                              style={{ width: row.bodyWidth }}
                             />
                           </div>
                         </div>
@@ -626,7 +632,7 @@ export function SessionPage(props: SessionPageProps) {
                       const cancelled = todo.status === "cancelled";
                       const active = todo.status === "in_progress";
                       return (
-                        <div key={`${todo.content}-${index}`} className="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
+                        <div key={todo.id} className="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
                           <div className="flex items-center gap-1.5 pt-0.5">
                             <div
                               className={`flex size-4.5 items-center justify-center rounded-full border ${

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -79,6 +79,8 @@ import {
 import type { SessionListItem, SessionTreeState } from "./utils";
 import { cn } from "@/lib/utils";
 
+const WORKSPACE_MENU_SKELETON_ROWS = ["short", "medium", "compact"];
+
 type SessionActionsProps = {
   className: string;
   sessionId: string;
@@ -793,8 +795,8 @@ function WorkspaceSidebarGroup({
                   />
                 ) : showInitialLoading ? (
                   <>
-                    {[0, 1, 2].map((idx) => (
-                      <SidebarMenuSubItem key={`skeleton-${idx}`}>
+                    {WORKSPACE_MENU_SKELETON_ROWS.map((rowId) => (
+                      <SidebarMenuSubItem key={`skeleton-${rowId}`}>
                         <SidebarMenuSkeleton showIcon />
                       </SidebarMenuSubItem>
                     ))}

--- a/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/workspace-session-list.tsx
@@ -28,6 +28,12 @@ import {
 } from "../../../../app/utils";
 import { t } from "../../../../i18n";
 
+const WORKSPACE_SESSION_SKELETON_ROWS = [
+  { id: "short", width: "62%" },
+  { id: "medium", width: "78%" },
+  { id: "compact", width: "54%" },
+];
+
 type Props = {
   workspaceSessionGroups: WorkspaceSessionGroup[];
   showInitialLoading?: boolean;
@@ -802,14 +808,14 @@ export function WorkspaceSessionList(props: Props) {
                         />
                       ) : props.showInitialLoading ? (
                         <div className="space-y-2">
-                          {[0, 1, 2].map((idx) => (
+                          {WORKSPACE_SESSION_SKELETON_ROWS.map((row) => (
                             <div
-                              key={`${workspace.id}:skeleton:${idx}`}
+                              key={`${workspace.id}:skeleton:${row.id}`}
                               className="w-full rounded-[15px] border border-dls-border/70 bg-dls-hover/30 px-3 py-2.5"
                             >
                               <div
                                 className="h-2.5 rounded-full bg-dls-hover/80 animate-pulse"
-                                style={{ width: idx === 0 ? "62%" : idx === 1 ? "78%" : "54%" }}
+                                style={{ width: row.width }}
                               />
                             </div>
                           ))}

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -694,6 +694,210 @@ function StepsContainer(props: {
   );
 }
 
+function messageGroupKey(messageId: string, group: MessageGroup) {
+  if (group.kind === "steps") return `${messageId}:steps:${group.id}`;
+  const partId = "id" in group.part && typeof group.part.id === "string" ? group.part.id : partToText(group.part);
+  return `${messageId}:text:${group.segment}:${partId}`;
+}
+
+function MessageBlockRow(props: {
+  block: MessageBlockItem;
+  blockIndex: number;
+  totalBlocks: number;
+  isNestedVariant: boolean;
+  shouldUseContentVisibility: boolean;
+  expandedStepIds: Set<string>;
+  onExpandedStepIdsChange: (updater: (current: Set<string>) => Set<string>) => void;
+  searchMatchMessageIds?: ReadonlySet<string>;
+  activeSearchMessageId?: string | null;
+  searchHighlightQuery?: string;
+  isStreaming: boolean;
+  latestAssistantMessageId: string;
+}) {
+  const block = props.block;
+  const blockMessageIds = block.kind === "steps-cluster" ? block.messageIds : [block.messageId];
+  const hasSearchMatch = blockMessageIds.some((id) => props.searchMatchMessageIds?.has(id));
+  const hasActiveSearchMatch = blockMessageIds.some((id) => id === props.activeSearchMessageId);
+  const searchOutlineClass = hasActiveSearchMatch
+    ? "outline outline-2 outline-amber-8/70 outline-offset-2 rounded-2xl"
+    : hasSearchMatch
+      ? "outline outline-1 outline-amber-7/50 outline-offset-1 rounded-2xl"
+      : "";
+  const perfStyle = props.shouldUseContentVisibility && props.blockIndex < props.totalBlocks - 12
+    ? { contentVisibility: "auto", containIntrinsicSize: "180px" } satisfies CSSProperties
+    : undefined;
+
+  if (block.kind === "steps-cluster") {
+    return (
+      <div
+        className={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
+        data-message-role={block.isUser ? "user" : "assistant"}
+        data-message-id={block.messageIds[0] ?? ""}
+        style={{ contain: "layout style paint", ...perfStyle }}
+      >
+        <div
+          className={`${
+            block.isUser
+              ? props.isNestedVariant
+                ? "relative max-w-[92%] rounded-[20px] border border-dls-border bg-dls-sidebar px-4 py-3 text-[14px] leading-relaxed text-dls-text"
+                : "relative max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text"
+              : props.isNestedVariant
+                ? "w-full relative text-[14px] leading-[1.65] text-dls-text group"
+                : "w-full relative max-w-[760px] text-[15px] leading-[1.7] text-dls-text group"
+          } ${searchOutlineClass}`}
+        >
+          <StepsContainer
+            stepGroups={block.stepGroups}
+            isUser={block.isUser}
+            isNestedVariant={props.isNestedVariant}
+            expandedStepIds={props.expandedStepIds}
+            onExpandedStepIdsChange={props.onExpandedStepIdsChange}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const groupSpacing = block.isUser ? "mb-3" : "mb-4";
+  const isSyntheticSessionError =
+    !block.isUser && block.messageId.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX);
+
+  if (isSyntheticSessionError) {
+    const messageText = block.renderableParts
+      .map((part) => partToText(part))
+      .join(" ")
+      .replace(/\s*\n+\s*/g, " ")
+      .replace(/\s{2,}/g, " ")
+      .trim();
+
+    return (
+      <div
+        className="flex group justify-start"
+        data-message-role="assistant"
+        data-message-id={block.messageId}
+        style={{ contain: "layout style paint", ...perfStyle }}
+      >
+        <div className={`w-full relative ${props.isNestedVariant ? "" : "max-w-[650px]"} ${searchOutlineClass}`}>
+          <div
+            className="inline-flex max-w-full items-start gap-2 rounded-[18px] border border-red-7/20 bg-red-1/35 px-3 py-2 text-[13px] leading-5 text-red-12 shadow-sm"
+            role="alert"
+          >
+            <CircleAlert size={14} className="mt-0.5 shrink-0" />
+            <div className="min-w-0 break-words">{messageText}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
+      data-message-role={block.isUser ? "user" : "assistant"}
+      data-message-id={block.messageId}
+      style={{ contain: "layout style paint", ...perfStyle }}
+    >
+      <div
+        className={`${
+          block.isUser
+            ? props.isNestedVariant
+              ? "relative max-w-[92%] rounded-[20px] border border-dls-border bg-dls-sidebar px-4 py-3 text-[14px] leading-relaxed text-dls-text"
+              : "relative max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text"
+            : props.isNestedVariant
+              ? "w-full relative text-[14px] leading-[1.65] text-dls-text antialiased group"
+              : "w-full relative max-w-[760px] text-[15px] leading-[1.72] text-dls-text antialiased group"
+        } ${searchOutlineClass}`}
+      >
+        {block.attachments.length > 0 ? (
+          <div className={block.isUser ? "mb-3 flex flex-wrap gap-2" : "mb-4 flex flex-wrap gap-2"}>
+            {block.attachments.map((attachment) => (
+              <FileCard
+                key={`${block.messageId}:${attachment.url}`}
+                part={{
+                  filename: attachment.filename,
+                  url: attachment.url,
+                  mediaType: attachment.mime,
+                }}
+                tone={block.isUser ? "user" : "assistant"}
+              />
+            ))}
+          </div>
+        ) : null}
+
+        {block.groups.map((group) => {
+          const highlightQuery = hasSearchMatch ? props.searchHighlightQuery : undefined;
+          const isStreamingLatestAssistant =
+            !block.isUser && props.isStreaming && block.messageId === props.latestAssistantMessageId;
+
+          return (
+            <div key={messageGroupKey(block.messageId, group)} className={group === block.groups.at(-1) ? "" : groupSpacing}>
+              {group.kind === "text" ? (() => {
+                if (group.part.type === "file") {
+                  const filePart = group.part as {
+                    filename?: string;
+                    url?: string;
+                    mime?: string;
+                  };
+                  return (
+                    <FileCard
+                      part={{
+                        filename: filePart.filename,
+                        url: filePart.url ?? "",
+                        mediaType: filePart.mime ?? "application/octet-stream",
+                      }}
+                      tone={block.isUser ? "user" : "assistant"}
+                    />
+                  );
+                }
+
+                const text = partToText(group.part);
+                if (block.isUser) {
+                  return (
+                    <HighlightedPlainText
+                      text={text}
+                      className="whitespace-pre-wrap break-words text-gray-12"
+                      highlightQuery={highlightQuery}
+                    />
+                  );
+                }
+
+                return (
+                  <MarkdownBlock
+                    text={text}
+                    streaming={isStreamingLatestAssistant}
+                    highlightQuery={highlightQuery}
+                  />
+                );
+              })() : null}
+
+              {group.kind === "steps" ? (
+                <StepsContainer
+                  stepGroups={[{
+                    id: group.id,
+                    parts: group.parts,
+                    mode: group.mode,
+                  }]}
+                  isUser={block.isUser}
+                  isInline={true}
+                  isNestedVariant={props.isNestedVariant}
+                  expandedStepIds={props.expandedStepIds}
+                  onExpandedStepIdsChange={props.onExpandedStepIdsChange}
+                />
+              ) : null}
+            </div>
+          );
+        })}
+
+        {!props.isNestedVariant ? (
+          <div className="absolute bottom-2 right-2 flex justify-end opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto md:group-focus-within:opacity-100 md:group-focus-within:pointer-events-auto transition-opacity select-none">
+            <CopyButton getText={() => messageToText(block.message)} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 function SessionTranscriptInner(props: SessionTranscriptProps) {
   const showThinking = props.showThinking ?? props.developerMode;
   const isNestedVariant = props.variant === "nested";
@@ -912,200 +1116,6 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
   // work reduces the chance that one large session makes the UI feel frozen.
   const shouldUseContentVisibility = !shouldVirtualize && messageBlocks.length > 24;
 
-  const blockPerfStyle = (index: number): CSSProperties | undefined => {
-    if (!shouldUseContentVisibility) return undefined;
-    const total = messageBlocks.length;
-      if (index >= total - 12) return undefined;
-      return {
-        contentVisibility: "auto",
-        containIntrinsicSize: "180px",
-      };
-    };
-
-  const renderBlock = (block: MessageBlockItem, blockIndex: number) => {
-    const blockMessageIds = block.kind === "steps-cluster" ? block.messageIds : [block.messageId];
-    const hasSearchMatch = blockMessageIds.some((id) => props.searchMatchMessageIds?.has(id));
-    const hasActiveSearchMatch = blockMessageIds.some((id) => id === props.activeSearchMessageId);
-    const searchOutlineClass = hasActiveSearchMatch
-      ? "outline outline-2 outline-amber-8/70 outline-offset-2 rounded-2xl"
-      : hasSearchMatch
-        ? "outline outline-1 outline-amber-7/50 outline-offset-1 rounded-2xl"
-        : "";
-
-    if (block.kind === "steps-cluster") {
-      return (
-        <div
-          key={`steps-${block.id}`}
-          className={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
-          data-message-role={block.isUser ? "user" : "assistant"}
-          data-message-id={block.messageIds[0] ?? ""}
-          style={{ contain: "layout style paint", ...blockPerfStyle(blockIndex) }}
-        >
-          <div
-            className={`${
-              block.isUser
-                ? isNestedVariant
-                  ? "relative max-w-[92%] rounded-[20px] border border-dls-border bg-dls-sidebar px-4 py-3 text-[14px] leading-relaxed text-dls-text"
-                  : "relative max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text"
-                : isNestedVariant
-                  ? "w-full relative text-[14px] leading-[1.65] text-dls-text group"
-                  : "w-full relative max-w-[760px] text-[15px] leading-[1.7] text-dls-text group"
-            } ${searchOutlineClass}`}
-          >
-            <StepsContainer
-              stepGroups={block.stepGroups}
-              isUser={block.isUser}
-              isNestedVariant={isNestedVariant}
-              expandedStepIds={expandedStepIds}
-              onExpandedStepIdsChange={onExpandedStepIdsChange}
-            />
-          </div>
-        </div>
-      );
-    }
-
-    const groupSpacing = block.isUser ? "mb-3" : "mb-4";
-    const isSyntheticSessionError =
-      !block.isUser && block.messageId.startsWith(SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX);
-
-    if (isSyntheticSessionError) {
-      const messageText = block.renderableParts
-        .map((part) => partToText(part))
-        .join(" ")
-        .replace(/\s*\n+\s*/g, " ")
-        .replace(/\s{2,}/g, " ")
-        .trim();
-
-      return (
-        <div
-          key={`error-${block.messageId}`}
-          className="flex group justify-start"
-          data-message-role="assistant"
-          data-message-id={block.messageId}
-          style={{ contain: "layout style paint", ...blockPerfStyle(blockIndex) }}
-        >
-          <div className={`w-full relative ${isNestedVariant ? "" : "max-w-[650px]"} ${searchOutlineClass}`}>
-            <div
-              className="inline-flex max-w-full items-start gap-2 rounded-[18px] border border-red-7/20 bg-red-1/35 px-3 py-2 text-[13px] leading-5 text-red-12 shadow-sm"
-              role="alert"
-            >
-              <CircleAlert size={14} className="mt-0.5 shrink-0" />
-              <div className="min-w-0 break-words">{messageText}</div>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div
-        key={`message-${block.messageId}`}
-        className={`flex group ${block.isUser ? "justify-end" : "justify-start"}`.trim()}
-        data-message-role={block.isUser ? "user" : "assistant"}
-        data-message-id={block.messageId}
-        style={{ contain: "layout style paint", ...blockPerfStyle(blockIndex) }}
-      >
-        <div
-          className={`${
-            block.isUser
-              ? isNestedVariant
-                ? "relative max-w-[92%] rounded-[20px] border border-dls-border bg-dls-sidebar px-4 py-3 text-[14px] leading-relaxed text-dls-text"
-                : "relative max-w-[85%] rounded-[24px] border border-dls-border bg-dls-sidebar px-6 py-4 text-[15px] leading-relaxed text-dls-text"
-              : isNestedVariant
-                ? "w-full relative text-[14px] leading-[1.65] text-dls-text antialiased group"
-                : "w-full relative max-w-[760px] text-[15px] leading-[1.72] text-dls-text antialiased group"
-          } ${searchOutlineClass}`}
-        >
-          {block.attachments.length > 0 ? (
-            <div className={block.isUser ? "mb-3 flex flex-wrap gap-2" : "mb-4 flex flex-wrap gap-2"}>
-              {block.attachments.map((attachment) => (
-                <FileCard
-                  key={`${block.messageId}:${attachment.url}`}
-                  part={{
-                    filename: attachment.filename,
-                    url: attachment.url,
-                    mediaType: attachment.mime,
-                  }}
-                  tone={block.isUser ? "user" : "assistant"}
-                />
-              ))}
-            </div>
-          ) : null}
-
-          {block.groups.map((group, index) => {
-            const highlightQuery = hasSearchMatch ? props.searchHighlightQuery : undefined;
-            const isStreamingLatestAssistant =
-              !block.isUser && props.isStreaming && block.messageId === latestAssistantMessageId;
-
-            return (
-              <div key={`${block.messageId}:${group.kind}:${index}`} className={index === block.groups.length - 1 ? "" : groupSpacing}>
-                {group.kind === "text" ? (() => {
-                  if (group.part.type === "file") {
-                    const filePart = group.part as {
-                      filename?: string;
-                      url?: string;
-                      mime?: string;
-                    };
-                    return (
-                      <FileCard
-                        part={{
-                          filename: filePart.filename,
-                          url: filePart.url ?? "",
-                          mediaType: filePart.mime ?? "application/octet-stream",
-                        }}
-                        tone={block.isUser ? "user" : "assistant"}
-                      />
-                    );
-                  }
-
-                  const text = partToText(group.part);
-                  if (block.isUser) {
-                    return (
-                      <HighlightedPlainText
-                        text={text}
-                        className="whitespace-pre-wrap break-words text-gray-12"
-                        highlightQuery={highlightQuery}
-                      />
-                    );
-                  }
-
-                  return (
-                    <MarkdownBlock
-                      text={text}
-                      streaming={isStreamingLatestAssistant}
-                      highlightQuery={highlightQuery}
-                    />
-                  );
-                })() : null}
-
-                {group.kind === "steps" ? (
-                  <StepsContainer
-                    stepGroups={[{
-                      id: group.id,
-                      parts: group.parts,
-                      mode: group.mode,
-                    }]}
-                    isUser={block.isUser}
-                    isInline={true}
-                    isNestedVariant={isNestedVariant}
-                    expandedStepIds={expandedStepIds}
-                    onExpandedStepIdsChange={onExpandedStepIdsChange}
-                  />
-                ) : null}
-              </div>
-            );
-          })}
-
-          {!isNestedVariant ? (
-            <div className="absolute bottom-2 right-2 flex justify-end opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto md:group-focus-within:opacity-100 md:group-focus-within:pointer-events-auto transition-opacity select-none">
-              <CopyButton getText={() => messageToText(block.message)} />
-            </div>
-          ) : null}
-        </div>
-      </div>
-    );
-  };
-
   return (
     <div className={isNestedVariant ? "pb-0" : "pb-10"} style={{ contain: "layout paint style" }}>
       {shouldVirtualize ? (
@@ -1138,14 +1148,43 @@ function SessionTranscriptInner(props: SessionTranscriptProps) {
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
               >
-                {renderBlock(block, virtualRow.index)}
+                <MessageBlockRow
+                  block={block}
+                  blockIndex={virtualRow.index}
+                  totalBlocks={messageBlocks.length}
+                  isNestedVariant={isNestedVariant}
+                  shouldUseContentVisibility={shouldUseContentVisibility}
+                  expandedStepIds={expandedStepIds}
+                  onExpandedStepIdsChange={onExpandedStepIdsChange}
+                  searchMatchMessageIds={props.searchMatchMessageIds}
+                  activeSearchMessageId={props.activeSearchMessageId}
+                  searchHighlightQuery={props.searchHighlightQuery}
+                  isStreaming={props.isStreaming}
+                  latestAssistantMessageId={latestAssistantMessageId}
+                />
               </div>
             );
           })}
         </div>
       ) : (
         <div className={isNestedVariant ? "space-y-3" : "space-y-4"}>
-          {messageBlocks.map((block, index) => renderBlock(block, index))}
+          {messageBlocks.map((block, index) => (
+            <MessageBlockRow
+              key={blockIdentityKey(block)}
+              block={block}
+              blockIndex={index}
+              totalBlocks={messageBlocks.length}
+              isNestedVariant={isNestedVariant}
+              shouldUseContentVisibility={shouldUseContentVisibility}
+              expandedStepIds={expandedStepIds}
+              onExpandedStepIdsChange={onExpandedStepIdsChange}
+              searchMatchMessageIds={props.searchMatchMessageIds}
+              activeSearchMessageId={props.activeSearchMessageId}
+              searchHighlightQuery={props.searchHighlightQuery}
+              isStreaming={props.isStreaming}
+              latestAssistantMessageId={latestAssistantMessageId}
+            />
+          ))}
         </div>
       )}
 

--- a/apps/app/src/react-app/domains/settings/pages/config-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/config-view.tsx
@@ -43,6 +43,47 @@ export type ConfigViewProps = {
 
 type OpenworkTestState = "idle" | "testing" | "success" | "error";
 
+function TokenRow(props: {
+  label: string;
+  tokenValue: string | null | undefined;
+  hint: string;
+  visible: boolean;
+  toggle: () => void;
+  copyKey: string;
+  copyingField: string | null;
+  onCopy: (value: string, field: string) => void | Promise<void>;
+}) {
+  return (
+    <div className="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
+      <div className="min-w-0">
+        <div className="text-xs font-medium text-gray-11">{props.label}</div>
+        <div className="text-xs text-gray-7 font-mono truncate">
+          {props.visible ? props.tokenValue || "—" : props.tokenValue ? "••••••••••••" : "—"}
+        </div>
+        <div className="text-[11px] text-gray-8 mt-1">{props.hint}</div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Button
+          variant="outline"
+          className="text-xs h-8 py-0 px-3"
+          onClick={props.toggle}
+          disabled={!props.tokenValue}
+        >
+          {props.visible ? t("common.hide") : t("common.show")}
+        </Button>
+        <Button
+          variant="outline"
+          className="text-xs h-8 py-0 px-3"
+          onClick={() => props.onCopy(props.tokenValue ?? "", props.copyKey)}
+          disabled={!props.tokenValue}
+        >
+          {props.copyingField === props.copyKey ? t("config.copied") : t("config.copy")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function ConfigView(props: ConfigViewProps) {
   const [openworkUrl, setOpenworkUrl] = useState("");
   const [openworkToken, setOpenworkToken] = useState("");
@@ -262,43 +303,6 @@ export function ConfigView(props: ConfigViewProps) {
     }
   };
 
-  const renderTokenRow = (
-    label: string,
-    tokenValue: string | null | undefined,
-    hint: string,
-    visible: boolean,
-    toggle: () => void,
-    copyKey: string,
-  ) => (
-    <div className="flex items-center justify-between bg-gray-1 p-3 rounded-xl border border-gray-6 gap-3">
-      <div className="min-w-0">
-        <div className="text-xs font-medium text-gray-11">{label}</div>
-        <div className="text-xs text-gray-7 font-mono truncate">
-          {visible ? tokenValue || "—" : tokenValue ? "••••••••••••" : "—"}
-        </div>
-        <div className="text-[11px] text-gray-8 mt-1">{hint}</div>
-      </div>
-      <div className="flex items-center gap-2 shrink-0">
-        <Button
-          variant="outline"
-          className="text-xs h-8 py-0 px-3"
-          onClick={toggle}
-          disabled={!tokenValue}
-        >
-          {visible ? t("common.hide") : t("common.show")}
-        </Button>
-        <Button
-          variant="outline"
-          className="text-xs h-8 py-0 px-3"
-          onClick={() => handleCopy(tokenValue ?? "", copyKey)}
-          disabled={!tokenValue}
-        >
-          {copyingField === copyKey ? t("config.copied") : t("config.copy")}
-        </Button>
-      </div>
-    </div>
-  );
-
   return (
     <section className="space-y-6 max-w-3xl w-full">
       <div className="bg-gray-2/30 border border-gray-6/50 rounded-2xl p-5 space-y-2">
@@ -442,36 +446,46 @@ export function ConfigView(props: ConfigViewProps) {
               </Button>
             </div>
 
-            {renderTokenRow(
-              t("config.collaborator_token_label"),
-              hostInfo?.clientToken,
-              hostRemoteAccessEnabled
-                ? t("config.collaborator_token_remote_hint")
-                : t("config.collaborator_token_disabled_hint"),
-              clientTokenVisible,
-              () => setClientTokenVisible((prev) => !prev),
-              "client-token",
-            )}
+            <TokenRow
+              label={t("config.collaborator_token_label")}
+              tokenValue={hostInfo?.clientToken}
+              hint={
+                hostRemoteAccessEnabled
+                  ? t("config.collaborator_token_remote_hint")
+                  : t("config.collaborator_token_disabled_hint")
+              }
+              visible={clientTokenVisible}
+              toggle={() => setClientTokenVisible((prev) => !prev)}
+              copyKey="client-token"
+              copyingField={copyingField}
+              onCopy={handleCopy}
+            />
 
-            {renderTokenRow(
-              t("config.owner_token_label"),
-              hostInfo?.ownerToken,
-              hostRemoteAccessEnabled
-                ? t("config.owner_token_remote_hint")
-                : t("config.owner_token_disabled_hint"),
-              ownerTokenVisible,
-              () => setOwnerTokenVisible((prev) => !prev),
-              "owner-token",
-            )}
+            <TokenRow
+              label={t("config.owner_token_label")}
+              tokenValue={hostInfo?.ownerToken}
+              hint={
+                hostRemoteAccessEnabled
+                  ? t("config.owner_token_remote_hint")
+                  : t("config.owner_token_disabled_hint")
+              }
+              visible={ownerTokenVisible}
+              toggle={() => setOwnerTokenVisible((prev) => !prev)}
+              copyKey="owner-token"
+              copyingField={copyingField}
+              onCopy={handleCopy}
+            />
 
-            {renderTokenRow(
-              t("config.host_admin_token_label"),
-              hostInfo?.hostToken,
-              t("config.host_admin_token_hint"),
-              hostTokenVisible,
-              () => setHostTokenVisible((prev) => !prev),
-              "host-token",
-            )}
+            <TokenRow
+              label={t("config.host_admin_token_label")}
+              tokenValue={hostInfo?.hostToken}
+              hint={t("config.host_admin_token_hint")}
+              visible={hostTokenVisible}
+              toggle={() => setHostTokenVisible((prev) => !prev)}
+              copyKey="host-token"
+              copyingField={copyingField}
+              onCopy={handleCopy}
+            />
           </div>
 
           <div className="text-xs text-gray-9">

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -179,8 +179,8 @@ function formatUptime(ms: number) {
   return `${seconds}s`;
 }
 
-function renderLines(lines: string[]) {
-  return lines.map((line, index) => (
+function DebugLines(props: { lines: string[] }) {
+  return props.lines.map((line, index) => (
     <div key={`${line}-${index}`} className="truncate text-[11px] font-mono text-dls-secondary">
       {line}
     </div>
@@ -231,7 +231,7 @@ function ServiceCard(props: ServiceCardProps) {
         </div>
       </div>
 
-      <div className="space-y-1">{renderLines(props.lines)}</div>
+      <div className="space-y-1"><DebugLines lines={props.lines} /></div>
 
       <div className="flex flex-wrap items-center gap-2">
         <Button
@@ -416,10 +416,10 @@ export function DebugView(props: DebugViewProps) {
               {props.opencodeConnectCard.label}
             </div>
           </div>
-          <div className="space-y-1">{renderLines(props.opencodeConnectCard.lines)}</div>
+          <div className="space-y-1"><DebugLines lines={props.opencodeConnectCard.lines} /></div>
           {props.opencodeConnectCard.metricsLines.length > 0 ? (
             <div className="space-y-1 border-t border-dls-border/60 pt-1">
-              {renderLines(props.opencodeConnectCard.metricsLines)}
+              <DebugLines lines={props.opencodeConnectCard.metricsLines} />
             </div>
           ) : null}
           {props.opencodeConnectCard.error ? (

--- a/apps/app/src/react-app/domains/settings/pages/plugins-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/plugins-view.tsx
@@ -202,7 +202,10 @@ export function PluginsView(props: PluginsViewProps) {
                   {isGuided && isGuideOpen ? (
                     <div className="rounded-xl border border-gray-6/70 bg-gray-1/60 p-4 space-y-3">
                       {(plugin.steps ?? []).map((step, idx) => (
-                        <div key={`${plugin.packageName}-step-${idx}`} className="space-y-1">
+                        <div
+                          key={`${plugin.packageName}:step:${step.title}:${step.command ?? step.url ?? step.path ?? step.description}`}
+                          className="space-y-1"
+                        >
                           <div className="text-xs font-medium text-gray-11">
                             {idx + 1}. {step.title}
                           </div>


### PR DESCRIPTION
## Summary

- Replaced safe array index keys with stable skeleton, todo, plugin step, and message group keys where stable data was available.
- Extracted local render helpers into named components for transcript rows, debug lines, and config token rows.
- Converted the small Add MCP modal state cluster to `useReducer`; skipped larger form/shell state warnings as too risky for this pass.

## Evidence

### React Doctor
- Baseline focused scan: score 88, total 124 warnings.
- Final focused scan: score 89, total 109 warnings.
- Target counts: `no-array-index-as-key` 9 -> 3, `no-render-in-render` 7 -> 0, `no-giant-component` 21 -> 20, `prefer-useReducer` 20 -> 19, `rerender-memo-before-early-return` 0 -> 0.

### Build verification
- `pnpm install` passed.
- `pnpm build` passed.
- `pnpm --filter @openwork/app exec tsc -p tsconfig.json --noEmit --pretty false` failed on existing baseline TypeScript errors outside changed files; no reported errors were in the files changed by this PR.

### API/UI verification
- No API changes.
- No user-facing flow changes; build and static diagnostics were used as verification.

## Test instructions

1. `pnpm install`
2. `npx --yes react-doctor --json --json-compact --full --offline --no-dead-code --fail-on none apps/app`
3. `pnpm build`