### PR TITLE
fix(app): reduce React Doctor async warnings

### DIFF
--- a/apps/app/scripts/dev-log.ts
+++ b/apps/app/scripts/dev-log.ts
@@ -9,12 +9,12 @@ const results = {
   steps: [] as Array<Record<string, unknown>>,
 };
 
-async function step(name: string, fn: () => void | Promise<void>) {
+function step(name: string, fn: () => void) {
   results.steps.push({ name, status: "running" });
   const index = results.steps.length - 1;
 
   try {
-    await fn();
+    fn();
     results.steps[index] = { name, status: "ok" };
   } catch (error) {
     results.ok = false;
@@ -30,12 +30,12 @@ async function step(name: string, fn: () => void | Promise<void>) {
 try {
   clearDevLogs();
 
-  await step("disabled logging does not retain entries", () => {
+  step("disabled logging does not retain entries", () => {
     recordDevLog(false, { level: "debug", source: "workspace", label: "connect:start" });
     assert.equal(readDevLogs(0).length, 0);
   });
 
-  await step("enabled logging retains ordered entries", () => {
+  step("enabled logging retains ordered entries", () => {
     recordDevLog(true, { level: "debug", source: "workspace", label: "connect:start", payload: { root: "/tmp/demo" } });
     recordDevLog(true, { level: "warn", source: "session", label: "stream:error", payload: { code: 500 } });
     const logs = readDevLogs(0);
@@ -44,7 +44,7 @@ try {
     assert.equal(logs[1]?.level, "warn");
   });
 
-  await step("formatted output stays readable and exportable", () => {
+  step("formatted output stays readable and exportable", () => {
     const line = formatDevLogLine(readDevLogs(1)[0]!);
     assert.match(line, /WARN session:stream:error/);
     const text = formatDevLogText(0);

--- a/apps/app/scripts/session-scope.ts
+++ b/apps/app/scripts/session-scope.ts
@@ -25,12 +25,12 @@ const results = {
   steps: [] as Array<Record<string, unknown>>,
 };
 
-async function step(name: string, fn: () => void | Promise<void>) {
+function step(name: string, fn: () => void) {
   results.steps.push({ name, status: "running" });
   const index = results.steps.length - 1;
 
   try {
-    await fn();
+    fn();
     results.steps[index] = { name, status: "ok" };
   } catch (error) {
     results.ok = false;
@@ -44,7 +44,7 @@ async function step(name: string, fn: () => void | Promise<void>) {
 }
 
 try {
-  await step("local connect prefers explicit target root", () => {
+  step("local connect prefers explicit target root", () => {
     assert.equal(
       resolveScopedClientDirectory({ workspaceType: "local", targetRoot: starterRoot }),
       starterRoot,
@@ -59,16 +59,16 @@ try {
     );
   });
 
-  await step("remote connect still waits for remote discovery", () => {
+  step("remote connect still waits for remote discovery", () => {
     assert.equal(resolveScopedClientDirectory({ workspaceType: "remote", targetRoot: starterRoot }), "");
   });
 
-  await step("scope matching is stable on desktop-style paths", () => {
+  step("scope matching is stable on desktop-style paths", () => {
     assert.equal(scopedRootsMatch(`${starterRoot}/`, starterRoot.toUpperCase()), true);
     assert.equal(scopedRootsMatch(starterRoot, otherRoot), false);
   });
 
-  await step("stale session loads cannot overwrite another workspace sidebar", () => {
+  step("stale session loads cannot overwrite another workspace sidebar", () => {
     for (let index = 0; index < 50; index += 1) {
       assert.equal(
         shouldApplyScopedSessionLoad({
@@ -80,7 +80,7 @@ try {
     }
   });
 
-  await step("same-scope session loads still update the active workspace", () => {
+  step("same-scope session loads still update the active workspace", () => {
     assert.equal(
       shouldApplyScopedSessionLoad({
         loadedScopeRoot: `${starterRoot}/`,
@@ -90,7 +90,7 @@ try {
     );
   });
 
-  await step("windows create and list use the same transport directory", () => {
+  step("windows create and list use the same transport directory", () => {
     Object.defineProperty(globalThis, "navigator", {
       configurable: true,
       value: {
@@ -115,7 +115,7 @@ try {
     assert.equal(describeDirectoryScope(verbatimDriveRoot).normalized, "c:/users/test/openwork/starter");
   });
 
-  await step("round-trip invariant: every query path equals the create path (unix)", () => {
+  step("round-trip invariant: every query path equals the create path (unix)", () => {
     // Restore macOS navigator for this step.
     Object.defineProperty(globalThis, "navigator", {
       configurable: true,
@@ -142,7 +142,7 @@ try {
     }
   });
 
-  await step("round-trip invariant: every query path equals the create path (windows)", () => {
+  step("round-trip invariant: every query path equals the create path (windows)", () => {
     Object.defineProperty(globalThis, "navigator", {
       configurable: true,
       value: {
@@ -170,7 +170,7 @@ try {
     }
   });
 
-  await step("idempotency: double-converting a transport directory is stable", () => {
+  step("idempotency: double-converting a transport directory is stable", () => {
     // Restore macOS for Unix paths.
     Object.defineProperty(globalThis, "navigator", {
       configurable: true,
@@ -210,7 +210,7 @@ try {
     }
   });
 
-  await step("route guard only redirects when the loaded scope matches", () => {
+  step("route guard only redirects when the loaded scope matches", () => {
     assert.equal(
       shouldRedirectMissingSessionAfterScopedLoad({
         loadedScopeRoot: otherRoot,

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1385,7 +1385,7 @@ export function SettingsRoute() {
     return ok;
   }, [openworkServerStore, refreshRouteState]);
 
-  const handleRestartLocalServer = useCallback(async () => {
+  const restartOpenworkServerAndRefresh = useCallback(async () => {
     if (!isDesktopRuntime()) return false;
     try {
       await openworkServerRestart({
@@ -1400,21 +1400,8 @@ export function SettingsRoute() {
     }
   }, [openworkServerStore, refreshRouteState]);
 
-  const handleRestartMessagingWorker = useCallback(async () => {
-    if (!isDesktopRuntime()) return false;
-
-    try {
-      await openworkServerRestart({
-        remoteAccessEnabled:
-          readOpenworkServerSettings().remoteAccessEnabled === true,
-      });
-      await openworkServerStore.reconnectOpenworkServer();
-      await refreshRouteState();
-      return true;
-    } catch {
-      return false;
-    }
-  }, [openworkServerStore, refreshRouteState]);
+  const handleRestartLocalServer = restartOpenworkServerAndRefresh;
+  const handleRestartMessagingWorker = restartOpenworkServerAndRefresh;
 
   const messagingViewProps = useMessagingViewProps({
     busy,


### PR DESCRIPTION
## Summary
- Removes unnecessary async wrappers from synchronous diagnostic scripts so ordered assertions stay sequential without triggering async-parallel warnings.
- Deduplicates the settings server restart/reconnect/refresh sequence while preserving its dependent ordering.

## Evidence

### Build verification
- `pnpm install --frozen-lockfile` - passed
- `pnpm build` - passed
- `pnpm typecheck` - failed on existing broad type errors unrelated to this change (unknown IPC/client typings and missing messaging/automations symbols)
- `pnpm --filter @openwork/app test:dev-log` - passed
- `pnpm --filter @openwork/app test:session-scope` - passed

### React Doctor
- Before: score 93, warnings 84, async-await-in-loop 7, async-parallel 4
- After: score 93, warnings 81, async-await-in-loop 7, async-parallel 1
- Command: `pnpm dlx react-doctor --json --full --offline --no-dead-code --fail-on none .`

### API verification
- No API changes.

### UI verification
- No UI behavior changes; no screenshots captured.

## Skipped target warnings
- `mcp-auth-modal.tsx`, `provider-auth/store.ts`, `opencode.ts`, `connections/store.ts`: polling/retry loops must remain sequential.
- `provider-auth/store.ts` cloud sync loops and `extensions-store.ts` plugin import writes: ordered mutation/config writes were not parallelized.
- Remaining settings restart warning: restart, reconnect, and refresh have dependency ordering and were intentionally not parallelized.