### PR TITLE
fix(app): reduce React Doctor architecture warnings

### DIFF
--- a/apps/app/src/react-app/domains/bundles/skill-destination-modal.tsx
+++ b/apps/app/src/react-app/domains/bundles/skill-destination-modal.tsx
@@ -42,6 +42,93 @@ const displayName = (workspace: WorkspaceInfo, fallback: string): string =>
   workspace.baseUrl?.trim() ||
   fallback;
 
+const subtitle = (workspace: WorkspaceInfo): string => {
+  if (workspace.workspaceType === "local") {
+    return (
+      workspace.path?.trim() ||
+      t("share_skill_destination.local_badge")
+    );
+  }
+  return (
+    workspace.directory?.trim() ||
+    workspace.openworkHostUrl?.trim() ||
+    workspace.baseUrl?.trim() ||
+    workspace.path?.trim() ||
+    t("share_skill_destination.remote_badge")
+  );
+};
+
+const workspaceBadge = (workspace: WorkspaceInfo): string => {
+  if (isSandboxWorkspace(workspace)) {
+    return t("share_skill_destination.sandbox_badge");
+  }
+  if (workspace.workspaceType === "remote") {
+    return t("share_skill_destination.remote_badge");
+  }
+  return t("share_skill_destination.local_badge");
+};
+
+const workspaceCircleClass = (
+  workspace: WorkspaceInfo,
+  selected: boolean,
+): string => {
+  if (selected) {
+    return "bg-indigo-7/15 text-indigo-11 border border-indigo-7/30";
+  }
+  if (isSandboxWorkspace(workspace)) {
+    return "bg-indigo-7/10 text-indigo-11 border border-indigo-7/20";
+  }
+  if (workspace.workspaceType === "remote") {
+    return "bg-sky-7/10 text-sky-11 border border-sky-7/20";
+  }
+  return "bg-amber-7/10 text-amber-11 border border-amber-7/20";
+};
+
+function SkillDestinationFooter(props: {
+  selectedWorkspace: WorkspaceInfo | null;
+  footerBusy: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="border-t border-gray-6 bg-gray-1 px-6 py-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {props.selectedWorkspace ? (
+          <div className="min-w-0 text-sm text-gray-10">
+            <span className="font-medium text-gray-12">
+              {displayName(props.selectedWorkspace, "Worker")}
+            </span>
+            <span className="mx-2 text-gray-8">·</span>
+            <span className="truncate align-middle">
+              {subtitle(props.selectedWorkspace)}
+            </span>
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-3">
+          <Button variant="ghost" onClick={props.onClose} disabled={props.footerBusy}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="primary"
+            onClick={props.onSubmit}
+            disabled={!props.selectedWorkspace || props.footerBusy}
+          >
+            {props.footerBusy ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 size={16} className="animate-spin" />
+                {t("share_skill_destination.adding")}
+              </span>
+            ) : (
+              t("share_skill_destination.add_to_workspace")
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function SkillDestinationModal(props: SkillDestinationModalProps) {
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<
     string | null
@@ -66,48 +153,6 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
       null;
     setSelectedWorkspaceId(activeMatch?.id ?? null);
   }, [props.open, props.selectedWorkspaceId, props.workspaces]);
-
-  const subtitle = (workspace: WorkspaceInfo): string => {
-    if (workspace.workspaceType === "local") {
-      return (
-        workspace.path?.trim() ||
-        t("share_skill_destination.local_badge")
-      );
-    }
-    return (
-      workspace.directory?.trim() ||
-      workspace.openworkHostUrl?.trim() ||
-      workspace.baseUrl?.trim() ||
-      workspace.path?.trim() ||
-      t("share_skill_destination.remote_badge")
-    );
-  };
-
-  const workspaceBadge = (workspace: WorkspaceInfo): string => {
-    if (isSandboxWorkspace(workspace)) {
-      return t("share_skill_destination.sandbox_badge");
-    }
-    if (workspace.workspaceType === "remote") {
-      return t("share_skill_destination.remote_badge");
-    }
-    return t("share_skill_destination.local_badge");
-  };
-
-  const workspaceCircleClass = (
-    workspace: WorkspaceInfo,
-    selected: boolean,
-  ): string => {
-    if (selected) {
-      return "bg-indigo-7/15 text-indigo-11 border border-indigo-7/30";
-    }
-    if (isSandboxWorkspace(workspace)) {
-      return "bg-indigo-7/10 text-indigo-11 border border-indigo-7/20";
-    }
-    if (workspace.workspaceType === "remote") {
-      return "bg-sky-7/10 text-sky-11 border border-sky-7/20";
-    }
-    return "bg-amber-7/10 text-amber-11 border border-amber-7/20";
-  };
 
   const submitSelectedWorkspace = () => {
     const workspaceId = selectedWorkspaceId?.trim();
@@ -342,45 +387,12 @@ export function SkillDestinationModal(props: SkillDestinationModalProps) {
           ) : null}
         </div>
 
-        <div className="border-t border-gray-6 bg-gray-1 px-6 py-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            {selectedWorkspace ? (
-              <div className="min-w-0 text-sm text-gray-10">
-                <span className="font-medium text-gray-12">
-                  {displayName(selectedWorkspace, "Worker")}
-                </span>
-                <span className="mx-2 text-gray-8">·</span>
-                <span className="truncate align-middle">
-                  {subtitle(selectedWorkspace)}
-                </span>
-              </div>
-            ) : null}
-
-            <div className="flex items-center justify-end gap-3">
-              <Button
-                variant="ghost"
-                onClick={props.onClose}
-                disabled={footerBusy}
-              >
-                {t("common.cancel")}
-              </Button>
-              <Button
-                variant="primary"
-                onClick={submitSelectedWorkspace}
-                disabled={!selectedWorkspace || footerBusy}
-              >
-                {footerBusy ? (
-                  <span className="inline-flex items-center gap-2">
-                    <Loader2 size={16} className="animate-spin" />
-                    {t("share_skill_destination.adding")}
-                  </span>
-                ) : (
-                  t("share_skill_destination.add_to_workspace")
-                )}
-              </Button>
-            </div>
-          </div>
-        </div>
+        <SkillDestinationFooter
+          selectedWorkspace={selectedWorkspace}
+          footerBusy={footerBusy}
+          onClose={props.onClose}
+          onSubmit={submitSelectedWorkspace}
+        />
       </div>
     </div>
   );

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -438,17 +438,20 @@ function HighlightedPlainText(props: {
 
   // Split on paste tokens and render chips inline.
   const segments = props.text.split(PASTE_TOKEN_RE);
+  let segmentOffset = 0;
   return (
     <div ref={rootRef} className={props.className}>
-      {segments.map((segment, index) => {
+      {segments.map((segment) => {
+        const key = `${segmentOffset}:${segment}`;
+        segmentOffset += segment.length;
         const match = segment.match(/^\[pasted text (.+)\]$/);
         if (match?.[1]) {
           const pastedBody = props.pastedTextMap?.get(match[1]);
           if (pastedBody) {
-            return <PastedTextChip key={index} label={match[1]} text={pastedBody} />;
+            return <PastedTextChip key={key} label={match[1]} text={pastedBody} />;
           }
         }
-        return <span key={index}>{segment}</span>;
+        return <span key={key}>{segment}</span>;
       })}
     </div>
   );

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -180,10 +180,17 @@ function formatUptime(ms: number) {
 }
 
 function DebugLines(props: { lines: string[] }) {
-  return props.lines.map((line, index) => (
-    <div key={`${line}-${index}`} className="truncate text-[11px] font-mono text-dls-secondary">
-      {line}
-    </div>
+  let offset = 0;
+  return props.lines.map((line) => (
+    (() => {
+      const key = `${offset}:${line}`;
+      offset += line.length + 1;
+      return (
+        <div key={key} className="truncate text-[11px] font-mono text-dls-secondary">
+          {line}
+        </div>
+      );
+    })()
   ));
 }
 

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -5,6 +5,8 @@ import {
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
+  type MutableRefObject,
+  type RefObject,
 } from "react";
 import { Search, X } from "lucide-react";
 
@@ -19,6 +21,23 @@ export type PaletteItem = {
 };
 
 type PaletteMode = "root" | "sessions";
+
+type PaletteDialogProps = {
+  mode: PaletteMode;
+  query: string;
+  items: PaletteItem[];
+  activeIndex: number;
+  visibleActiveIndex: number;
+  inputRef: RefObject<HTMLInputElement | null>;
+  optionRefs: MutableRefObject<Array<HTMLButtonElement | null>>;
+  placeholder: string;
+  title: string;
+  onBack: () => void;
+  onClose: () => void;
+  onQueryChange: (value: string) => void;
+  onActiveIndexChange: (value: number) => void;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
+};
 
 export type SessionOption = {
   workspaceId: string;
@@ -44,6 +63,95 @@ export type CommandPaletteProps = {
   /** Optional: sessions for the second mode. */
   sessions: SessionOption[];
 };
+
+function PaletteDialog(props: PaletteDialogProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4"
+      role="dialog"
+      aria-modal="true"
+      onKeyDown={props.onKeyDown}
+    >
+      <button type="button" className="absolute inset-0 cursor-default border-0 bg-gray-1/60 p-0 backdrop-blur-sm" aria-label={t("common.close")} onClick={props.onClose} />
+      <div className="relative z-10 w-full max-w-2xl mt-12 rounded-2xl border border-dls-border bg-dls-surface shadow-2xl overflow-hidden">
+        <div className="border-b border-dls-border px-4 py-3 space-y-2">
+          <div className="flex items-center gap-2">
+            {props.mode !== "root" ? (
+              <button
+                type="button"
+                className="h-8 px-2 rounded-md text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors"
+                onClick={props.onBack}
+              >
+                {t("common.back")}
+              </button>
+            ) : null}
+            <Search size={14} className="text-dls-secondary shrink-0" />
+            <input
+              ref={props.inputRef}
+              type="text"
+              value={props.query}
+              onChange={(event) => props.onQueryChange(event.currentTarget.value)}
+              placeholder={props.placeholder}
+              className="min-w-0 flex-1 bg-transparent text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none"
+              aria-label={props.title}
+            />
+            <button
+              type="button"
+              className="size-8 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors flex items-center justify-center"
+              onClick={props.onClose}
+              aria-label={t("common.close")}
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+        <div className="max-h-[60vh] overflow-y-auto py-2">
+          {props.items.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-dls-secondary text-center">
+              {t("session.palette_no_matches")}
+            </div>
+          ) : (
+            <ul>
+              {props.items.map((item, index) => (
+                <li key={item.id}>
+                  <button
+                    ref={(element) => {
+                      props.optionRefs.current[index] = element;
+                    }}
+                    type="button"
+                    className={`w-full px-4 py-2.5 flex items-start gap-3 text-left transition-colors ${
+                      index === props.visibleActiveIndex
+                        ? "bg-dls-hover"
+                        : "hover:bg-dls-hover/60"
+                    }`}
+                    onMouseEnter={() => props.onActiveIndexChange(index)}
+                    onClick={() => item.action()}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-dls-text truncate">{item.title}</div>
+                      {item.detail ? (
+                        <div className="text-xs text-dls-secondary truncate">{item.detail}</div>
+                      ) : null}
+                    </div>
+                    {item.meta ? (
+                      <div className="text-[10px] uppercase tracking-wide text-dls-secondary shrink-0">
+                        {item.meta}
+                      </div>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="border-t border-dls-border px-4 py-2 text-[11px] text-dls-secondary flex items-center gap-3">
+          <span>{t("session.palette_hint_navigate")}</span>
+          <span>{t("session.palette_hint_run")}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 /**
  * React command palette (Cmd/Ctrl+K).
@@ -273,104 +381,34 @@ export function CommandPalette(props: CommandPaletteProps) {
       ? t("session.palette_title_sessions")
       : t("session.palette_title_actions");
 
+  const handleBack = () => {
+    setMode("root");
+    setQuery("");
+    setActiveIndex(0);
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    setActiveIndex(0);
+  };
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4"
-      role="dialog"
-      aria-modal="true"
+    <PaletteDialog
+      mode={mode}
+      query={query}
+      items={items}
+      activeIndex={activeIndex}
+      visibleActiveIndex={visibleActiveIndex}
+      inputRef={inputRef}
+      optionRefs={optionRefs}
+      placeholder={placeholder}
+      title={title}
+      onBack={handleBack}
+      onClose={props.onClose}
+      onQueryChange={handleQueryChange}
+      onActiveIndexChange={setActiveIndex}
       onKeyDown={handleKey}
-    >
-      <button type="button" className="absolute inset-0 cursor-default border-0 bg-gray-1/60 p-0 backdrop-blur-sm" aria-label={t("common.close")} onClick={props.onClose} />
-      <div
-        className="relative z-10 w-full max-w-2xl mt-12 rounded-2xl border border-dls-border bg-dls-surface shadow-2xl overflow-hidden"
-      >
-        <div className="border-b border-dls-border px-4 py-3 space-y-2">
-          <div className="flex items-center gap-2">
-            {mode !== "root" ? (
-              <button
-                type="button"
-                className="h-8 px-2 rounded-md text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors"
-                onClick={() => {
-                  setMode("root");
-                  setQuery("");
-                  setActiveIndex(0);
-                  window.setTimeout(() => inputRef.current?.focus(), 0);
-                }}
-              >
-                {t("common.back")}
-              </button>
-            ) : null}
-            <Search size={14} className="text-dls-secondary shrink-0" />
-            <input
-              ref={inputRef}
-              type="text"
-              value={query}
-              onChange={(event) => {
-                setQuery(event.currentTarget.value);
-                setActiveIndex(0);
-              }}
-              placeholder={placeholder}
-              className="min-w-0 flex-1 bg-transparent text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none"
-              aria-label={title}
-            />
-            <button
-              type="button"
-              className="size-8 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors flex items-center justify-center"
-              onClick={props.onClose}
-              aria-label={t("common.close")}
-            >
-              <X size={14} />
-            </button>
-          </div>
-        </div>
-        <div className="max-h-[60vh] overflow-y-auto py-2">
-          {items.length === 0 ? (
-            <div className="px-4 py-6 text-sm text-dls-secondary text-center">
-              {t("session.palette_no_matches")}
-            </div>
-          ) : (
-            <ul>
-              {items.map((item, index) => (
-                <li key={item.id}>
-                  <button
-                    ref={(element) => {
-                      optionRefs.current[index] = element;
-                    }}
-                    type="button"
-                    className={`w-full px-4 py-2.5 flex items-start gap-3 text-left transition-colors ${
-                      index === visibleActiveIndex
-                        ? "bg-dls-hover"
-                        : "hover:bg-dls-hover/60"
-                    }`}
-                    onMouseEnter={() => setActiveIndex(index)}
-                    onClick={() => item.action()}
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium text-dls-text truncate">
-                        {item.title}
-                      </div>
-                      {item.detail ? (
-                        <div className="text-xs text-dls-secondary truncate">
-                          {item.detail}
-                        </div>
-                      ) : null}
-                    </div>
-                    {item.meta ? (
-                      <div className="text-[10px] uppercase tracking-wide text-dls-secondary shrink-0">
-                        {item.meta}
-                      </div>
-                    ) : null}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-        <div className="border-t border-dls-border px-4 py-2 text-[11px] text-dls-secondary flex items-center gap-3">
-          <span>{t("session.palette_hint_navigate")}</span>
-          <span>{t("session.palette_hint_run")}</span>
-        </div>
-      </div>
-    </div>
+    />
   );
 }

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { t } from "../../i18n";
@@ -33,6 +33,53 @@ function focusPromptSoon() {
   [0, 80, 240, 600].forEach((delay) => window.setTimeout(focus, delay));
 }
 
+type WelcomeState = {
+  modalOpen: boolean;
+  createBusy: boolean;
+  createError: string | null;
+  remoteBusy: boolean;
+  remoteError: string | null;
+};
+
+type WelcomeAction =
+  | { type: "open" }
+  | { type: "close" }
+  | { type: "create:start" }
+  | { type: "create:error"; error: string }
+  | { type: "create:finish" }
+  | { type: "remote:start" }
+  | { type: "remote:error"; error: string }
+  | { type: "remote:finish" };
+
+const initialWelcomeState: WelcomeState = {
+  modalOpen: false,
+  createBusy: false,
+  createError: null,
+  remoteBusy: false,
+  remoteError: null,
+};
+
+function welcomeReducer(state: WelcomeState, action: WelcomeAction): WelcomeState {
+  switch (action.type) {
+    case "open":
+      return { ...state, modalOpen: true };
+    case "close":
+      return { ...state, modalOpen: false, createError: null, remoteError: null };
+    case "create:start":
+      return { ...state, createBusy: true, createError: null };
+    case "create:error":
+      return { ...state, createError: action.error };
+    case "create:finish":
+      return { ...state, createBusy: false };
+    case "remote:start":
+      return { ...state, remoteBusy: true, remoteError: null };
+    case "remote:error":
+      return { ...state, remoteError: action.error };
+    case "remote:finish":
+      return { ...state, remoteBusy: false };
+  }
+}
+
 /**
  * WelcomeRoute: full-screen welcome page shown on first launch when
  * the user has no workspaces and has not completed onboarding.
@@ -44,11 +91,7 @@ function focusPromptSoon() {
 export function WelcomeRoute() {
   const navigate = useNavigate();
   const local = useLocal();
-  const [modalOpen, setModalOpen] = useState(false);
-  const [createBusy, setCreateBusy] = useState(false);
-  const [createError, setCreateError] = useState<string | null>(null);
-  const [remoteBusy, setRemoteBusy] = useState(false);
-  const [remoteError, setRemoteError] = useState<string | null>(null);
+  const [state, dispatch] = useReducer(welcomeReducer, initialWelcomeState);
 
   // If user already completed onboarding, redirect away immediately.
   useEffect(() => {
@@ -64,8 +107,7 @@ export function WelcomeRoute() {
   const handleCreateWorkspace = useCallback(
     async (_preset: string, folder: string | null) => {
       if (!folder) return;
-      setCreateBusy(true);
-      setCreateError(null);
+      dispatch({ type: "create:start" });
       try {
         const workspaceName = folderNameFromPath(folder);
         const list = await workspaceCreate({
@@ -124,15 +166,16 @@ export function WelcomeRoute() {
           if (targetSessionId) writeLastSessionFor(targetWorkspaceId, targetSessionId);
         }
         markOnboardingComplete();
-        setModalOpen(false);
+        dispatch({ type: "close" });
         navigate(targetWorkspaceId ? workspaceSessionRoute(targetWorkspaceId, targetSessionId) : "/session", { replace: true });
         if (targetSessionId) focusPromptSoon();
       } catch (error) {
-        setCreateError(
-          error instanceof Error ? error.message : "Failed to create workspace.",
-        );
+        dispatch({
+          type: "create:error",
+          error: error instanceof Error ? error.message : "Failed to create workspace.",
+        });
       } finally {
-        setCreateBusy(false);
+        dispatch({ type: "create:finish" });
       }
     },
     [markOnboardingComplete, navigate],
@@ -147,8 +190,7 @@ export function WelcomeRoute() {
     }) => {
       const baseUrlValue = input.openworkHostUrl?.trim() ?? "";
       if (!baseUrlValue) return false;
-      setRemoteBusy(true);
-      setRemoteError(null);
+      dispatch({ type: "remote:start" });
       try {
         const list = await workspaceCreateRemote({
           baseUrl: baseUrlValue,
@@ -168,16 +210,17 @@ export function WelcomeRoute() {
           writeActiveWorkspaceId(createdId);
         }
         markOnboardingComplete();
-        setModalOpen(false);
+        dispatch({ type: "close" });
         navigate(createdId ? workspaceSessionRoute(createdId) : "/session", { replace: true });
         return true;
       } catch (error) {
-        setRemoteError(
-          error instanceof Error ? error.message : "Connection failed.",
-        );
+        dispatch({
+          type: "remote:error",
+          error: error instanceof Error ? error.message : "Connection failed.",
+        });
         return false;
       } finally {
-        setRemoteBusy(false);
+        dispatch({ type: "remote:finish" });
       }
     },
     [markOnboardingComplete, navigate],
@@ -185,14 +228,10 @@ export function WelcomeRoute() {
 
   return (
     <>
-      <WelcomePage onGetStarted={() => setModalOpen(true)} />
+      <WelcomePage onGetStarted={() => dispatch({ type: "open" })} />
       <CreateWorkspaceModal
-        open={modalOpen}
-        onClose={() => {
-          setModalOpen(false);
-          setCreateError(null);
-          setRemoteError(null);
-        }}
+        open={state.modalOpen}
+        onClose={() => dispatch({ type: "close" })}
         onConfirm={handleCreateWorkspace}
         onConfirmRemote={handleCreateRemote}
         onPickFolder={() =>
@@ -200,10 +239,10 @@ export function WelcomeRoute() {
             string | null
           >
         }
-        submitting={createBusy}
-        localError={createError}
-        remoteSubmitting={remoteBusy}
-        remoteError={remoteError}
+        submitting={state.createBusy}
+        localError={state.createError}
+        remoteSubmitting={state.remoteBusy}
+        remoteError={state.remoteError}
         localDisabled={!isDesktopRuntime()}
         localDisabledReason={
           isDesktopRuntime()


### PR DESCRIPTION
## Summary

- Extract command palette dialog and skill destination footer rendering into focused child components.
- Convert welcome route modal submit state to a local reducer.
- Replace React array-index keys in debug lines and pasted-text segment rendering with stable content-offset keys.

## Evidence

### React Doctor
- Before: score 93, warnings 84; target counts: no-giant-component 20, prefer-useReducer 18, no-array-index-as-key 3.
- After: score 93, warnings 78; target counts: no-giant-component 18, prefer-useReducer 17, no-array-index-as-key 0.
- Command: `pnpm dlx react-doctor@latest --json --full --project @openwork/app --fail-on none`.

### Build verification
- `pnpm install` passed.
- `pnpm build:ui` passed.
- `pnpm typecheck` failed on existing `origin/dev` type errors unrelated to this change, primarily unknown desktop bridge return types and missing OpenCode Router messaging exports.

### UI verification
- No behavior-flow UI test run; this is presentational extraction/state-localization only.

### API verification
- No API changes.

## Test instructions

1. `pnpm install`
2. `pnpm dlx react-doctor@latest --json --full --project @openwork/app --fail-on none`
3. `pnpm build:ui`