### PR TITLE
fix(app): reduce React Doctor state warnings

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useState, type ReactNode } from "react";
+import { useReducer, type ReactNode } from "react";
 import { CircleAlert, Cpu, RefreshCcw, Server, Zap } from "lucide-react";
 
 import type { OpencodeConnectStatus } from "../../../../app/types";
@@ -23,6 +23,79 @@ type RuntimeStatusCardProps = {
   statusDot: string;
   detailLines?: string[];
 };
+
+type AdvancedLocalState = {
+  reconnectStatus: string | null;
+  reconnectError: string | null;
+  restartBusy: boolean;
+  restartStatus: string | null;
+  restartError: string | null;
+  deepLinkOpen: boolean;
+  deepLinkInput: string;
+  deepLinkBusy: boolean;
+  deepLinkStatus: string | null;
+};
+
+type AdvancedLocalAction =
+  | { type: "reconnectStart" }
+  | { type: "reconnectStatus"; status: string | null }
+  | { type: "reconnectError"; error: string | null }
+  | { type: "restartStart" }
+  | { type: "restartStatus"; status: string | null }
+  | { type: "restartError"; error: string | null }
+  | { type: "restartDone" }
+  | { type: "toggleDeepLink" }
+  | { type: "deepLinkInput"; input: string }
+  | { type: "deepLinkStart" }
+  | { type: "deepLinkStatus"; status: string | null }
+  | { type: "deepLinkDone" }
+  | { type: "deepLinkSuccess"; status: string | null };
+
+const initialAdvancedLocalState: AdvancedLocalState = {
+  reconnectStatus: null,
+  reconnectError: null,
+  restartBusy: false,
+  restartStatus: null,
+  restartError: null,
+  deepLinkOpen: false,
+  deepLinkInput: "",
+  deepLinkBusy: false,
+  deepLinkStatus: null,
+};
+
+function advancedLocalReducer(
+  state: AdvancedLocalState,
+  action: AdvancedLocalAction,
+): AdvancedLocalState {
+  switch (action.type) {
+    case "reconnectStart":
+      return { ...state, reconnectStatus: null, reconnectError: null };
+    case "reconnectStatus":
+      return { ...state, reconnectStatus: action.status };
+    case "reconnectError":
+      return { ...state, reconnectError: action.error };
+    case "restartStart":
+      return { ...state, restartStatus: null, restartError: null, restartBusy: true };
+    case "restartStatus":
+      return { ...state, restartStatus: action.status };
+    case "restartError":
+      return { ...state, restartError: action.error };
+    case "restartDone":
+      return { ...state, restartBusy: false };
+    case "toggleDeepLink":
+      return { ...state, deepLinkOpen: !state.deepLinkOpen, deepLinkStatus: null };
+    case "deepLinkInput":
+      return { ...state, deepLinkInput: action.input };
+    case "deepLinkStart":
+      return { ...state, deepLinkBusy: true, deepLinkStatus: null };
+    case "deepLinkStatus":
+      return { ...state, deepLinkStatus: action.status };
+    case "deepLinkDone":
+      return { ...state, deepLinkBusy: false };
+    case "deepLinkSuccess":
+      return { ...state, deepLinkInput: "", deepLinkStatus: action.status };
+  }
+}
 
 export type AdvancedViewProps = {
   busy: boolean;
@@ -87,15 +160,21 @@ function formatOpencodeBinary(info: EngineInfo | null) {
 }
 
 export function AdvancedView(props: AdvancedViewProps) {
-  const [openworkReconnectStatus, setOpenworkReconnectStatus] = useState<string | null>(null);
-  const [openworkReconnectError, setOpenworkReconnectError] = useState<string | null>(null);
-  const [openworkRestartBusy, setOpenworkRestartBusy] = useState(false);
-  const [openworkRestartStatus, setOpenworkRestartStatus] = useState<string | null>(null);
-  const [openworkRestartError, setOpenworkRestartError] = useState<string | null>(null);
-  const [debugDeepLinkOpen, setDebugDeepLinkOpen] = useState(false);
-  const [debugDeepLinkInput, setDebugDeepLinkInput] = useState("");
-  const [debugDeepLinkBusy, setDebugDeepLinkBusy] = useState(false);
-  const [debugDeepLinkStatus, setDebugDeepLinkStatus] = useState<string | null>(null);
+  const [localState, dispatchLocal] = useReducer(
+    advancedLocalReducer,
+    initialAdvancedLocalState,
+  );
+  const {
+    reconnectStatus: openworkReconnectStatus,
+    reconnectError: openworkReconnectError,
+    restartBusy: openworkRestartBusy,
+    restartStatus: openworkRestartStatus,
+    restartError: openworkRestartError,
+    deepLinkOpen: debugDeepLinkOpen,
+    deepLinkInput: debugDeepLinkInput,
+    deepLinkBusy: debugDeepLinkBusy,
+    deepLinkStatus: debugDeepLinkStatus,
+  } = localState;
 
   const clientStatusLabel = (() => {
     const status = props.opencodeConnectStatus?.status;
@@ -157,58 +236,56 @@ export function AdvancedView(props: AdvancedViewProps) {
 
   const handleReconnectOpenworkServer = async () => {
     if (props.busy || props.openworkReconnectBusy || !props.openworkServerUrl.trim()) return;
-    setOpenworkReconnectStatus(null);
-    setOpenworkReconnectError(null);
+    dispatchLocal({ type: "reconnectStart" });
     try {
       const ok = await props.reconnectOpenworkServer();
       if (!ok) {
-        setOpenworkReconnectError(t("settings.reconnect_failed"));
+        dispatchLocal({ type: "reconnectError", error: t("settings.reconnect_failed") });
         return;
       }
-      setOpenworkReconnectStatus(t("settings.reconnected"));
+      dispatchLocal({ type: "reconnectStatus", status: t("settings.reconnected") });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      setOpenworkReconnectError(message || t("settings.reconnect_server_failed"));
+      dispatchLocal({ type: "reconnectError", error: message || t("settings.reconnect_server_failed") });
     }
   };
 
   const handleRestartLocalServer = async () => {
     if (props.busy || openworkRestartBusy) return;
-    setOpenworkRestartStatus(null);
-    setOpenworkRestartError(null);
-    setOpenworkRestartBusy(true);
+    dispatchLocal({ type: "restartStart" });
     try {
       const ok = await props.restartLocalServer();
       if (!ok) {
-        setOpenworkRestartError(t("settings.restart_failed"));
+        dispatchLocal({ type: "restartError", error: t("settings.restart_failed") });
         return;
       }
-      setOpenworkRestartStatus(t("settings.restarted"));
+      dispatchLocal({ type: "restartStatus", status: t("settings.restarted") });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      setOpenworkRestartError(message || t("settings.restart_server_failed"));
+      dispatchLocal({ type: "restartError", error: message || t("settings.restart_server_failed") });
     } finally {
-      setOpenworkRestartBusy(false);
+      dispatchLocal({ type: "restartDone" });
     }
   };
 
   const submitDebugDeepLink = async () => {
     const rawUrl = debugDeepLinkInput.trim();
     if (!rawUrl || props.busy || debugDeepLinkBusy) return;
-    setDebugDeepLinkBusy(true);
-    setDebugDeepLinkStatus(null);
+    dispatchLocal({ type: "deepLinkStart" });
     try {
       const result = await props.openDebugDeepLink(rawUrl);
-      setDebugDeepLinkStatus(result.message);
       if (result.ok) {
-        setDebugDeepLinkInput("");
+        dispatchLocal({ type: "deepLinkSuccess", status: result.message });
+      } else {
+        dispatchLocal({ type: "deepLinkStatus", status: result.message });
       }
     } catch (error) {
-      setDebugDeepLinkStatus(
-        error instanceof Error ? error.message : t("settings.open_deeplink_failed"),
-      );
+      dispatchLocal({
+        type: "deepLinkStatus",
+        status: error instanceof Error ? error.message : t("settings.open_deeplink_failed"),
+      });
     } finally {
-      setDebugDeepLinkBusy(false);
+      dispatchLocal({ type: "deepLinkDone" });
     }
   };
 
@@ -331,10 +408,7 @@ export function AdvancedView(props: AdvancedViewProps) {
               <button
                 type="button"
                 className="inline-flex items-center gap-1.5 rounded-md border border-dls-border bg-dls-surface px-3 py-1.5 text-xs font-medium text-dls-secondary shadow-sm transition-colors duration-150 hover:bg-dls-hover hover:text-dls-text focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--dls-accent-rgb),0.25)] disabled:cursor-not-allowed disabled:opacity-60"
-                onClick={() => {
-                  setDebugDeepLinkOpen((value) => !value);
-                  setDebugDeepLinkStatus(null);
-                }}
+                onClick={() => dispatchLocal({ type: "toggleDeepLink" })}
                 disabled={props.busy || debugDeepLinkBusy}
               >
                 {debugDeepLinkOpen ? t("common.hide") : t("settings.open_deeplink_button")}
@@ -345,7 +419,7 @@ export function AdvancedView(props: AdvancedViewProps) {
               <div className="space-y-3">
                 <textarea
                   value={debugDeepLinkInput}
-                  onChange={(event) => setDebugDeepLinkInput(event.currentTarget.value)}
+                  onChange={(event) => dispatchLocal({ type: "deepLinkInput", input: event.currentTarget.value })}
                   rows={3}
                   placeholder="openwork://..."
                   className="w-full rounded-xl border border-gray-6 bg-gray-1 px-3 py-2 text-xs font-mono text-gray-12 outline-none transition focus:border-blue-8"

--- a/apps/app/src/react-app/domains/settings/pages/config-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/config-view.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef } from "react";
 import { RefreshCcw } from "lucide-react";
 
 import { readDevLogs } from "../../../../app/lib/dev-log";
@@ -50,6 +50,87 @@ type OpenworkConnectionState = {
   testMessage: string | null;
 };
 
+type TokenVisibilityKey = "openwork" | "client" | "owner" | "host";
+
+type ConfigLocalState = {
+  openworkConnection: OpenworkConnectionState;
+  tokenVisible: Record<TokenVisibilityKey, boolean>;
+  copyingField: string | null;
+};
+
+type ConfigLocalAction =
+  | { type: "serverSettings"; connection: OpenworkConnectionState }
+  | { type: "url"; url: string }
+  | { type: "token"; token: string }
+  | { type: "testState"; testState: OpenworkTestState; testMessage: string | null }
+  | { type: "toggleToken"; key: TokenVisibilityKey }
+  | { type: "copyingField"; field: string | null };
+
+const initialConfigLocalState: ConfigLocalState = {
+  openworkConnection: {
+    url: "",
+    token: "",
+    testState: "idle",
+    testMessage: null,
+  },
+  tokenVisible: {
+    openwork: false,
+    client: false,
+    owner: false,
+    host: false,
+  },
+  copyingField: null,
+};
+
+function configLocalReducer(
+  state: ConfigLocalState,
+  action: ConfigLocalAction,
+): ConfigLocalState {
+  switch (action.type) {
+    case "serverSettings":
+      return { ...state, openworkConnection: action.connection };
+    case "url":
+      return {
+        ...state,
+        openworkConnection: {
+          ...state.openworkConnection,
+          url: action.url,
+          testState: "idle",
+          testMessage: null,
+        },
+      };
+    case "token":
+      return {
+        ...state,
+        openworkConnection: {
+          ...state.openworkConnection,
+          token: action.token,
+          testState: "idle",
+          testMessage: null,
+        },
+      };
+    case "testState":
+      return {
+        ...state,
+        openworkConnection: {
+          ...state.openworkConnection,
+          testState: action.testState,
+          testMessage: action.testMessage,
+        },
+      };
+    case "toggleToken":
+      return {
+        ...state,
+        tokenVisible: {
+          ...state.tokenVisible,
+          [action.key]: !state.tokenVisible[action.key],
+        },
+      };
+    case "copyingField":
+      return { ...state, copyingField: action.field };
+  }
+}
+
 function TokenRow(props: {
   label: string;
   tokenValue: string | null | undefined;
@@ -92,30 +173,26 @@ function TokenRow(props: {
 }
 
 export function ConfigView(props: ConfigViewProps) {
-  const [openworkConnection, setOpenworkConnection] =
-    useState<OpenworkConnectionState>({
-      url: "",
-      token: "",
-      testState: "idle",
-      testMessage: null,
-    });
+  const [localState, dispatchLocal] = useReducer(
+    configLocalReducer,
+    initialConfigLocalState,
+  );
+  const { openworkConnection, tokenVisible, copyingField } = localState;
   const openworkUrl = openworkConnection.url;
   const openworkToken = openworkConnection.token;
   const openworkTestState = openworkConnection.testState;
   const openworkTestMessage = openworkConnection.testMessage;
-  const [openworkTokenVisible, setOpenworkTokenVisible] = useState(false);
-  const [clientTokenVisible, setClientTokenVisible] = useState(false);
-  const [ownerTokenVisible, setOwnerTokenVisible] = useState(false);
-  const [hostTokenVisible, setHostTokenVisible] = useState(false);
-  const [copyingField, setCopyingField] = useState<string | null>(null);
   const copyTimeoutRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
-    setOpenworkConnection({
-      url: props.openworkServerSettings.urlOverride ?? "",
-      token: props.openworkServerSettings.token ?? "",
-      testState: "idle",
-      testMessage: null,
+    dispatchLocal({
+      type: "serverSettings",
+      connection: {
+        url: props.openworkServerSettings.urlOverride ?? "",
+        token: props.openworkServerSettings.token ?? "",
+        testState: "idle",
+        testMessage: null,
+      },
     });
   }, [props.openworkServerSettings]);
 
@@ -278,12 +355,12 @@ export function ConfigView(props: ConfigViewProps) {
     if (!value) return;
     try {
       await navigator.clipboard.writeText(value);
-      setCopyingField(field);
+      dispatchLocal({ type: "copyingField", field });
       if (copyTimeoutRef.current !== undefined) {
         window.clearTimeout(copyTimeoutRef.current);
       }
       copyTimeoutRef.current = window.setTimeout(() => {
-        setCopyingField(null);
+        dispatchLocal({ type: "copyingField", field: null });
         copyTimeoutRef.current = undefined;
       }, 2000);
     } catch {
@@ -295,30 +372,30 @@ export function ConfigView(props: ConfigViewProps) {
     if (openworkTestState === "testing") return;
     const next = buildOpenworkSettings();
     props.updateOpenworkServerSettings(next);
-    setOpenworkConnection((current) => ({
-      ...current,
+    dispatchLocal({
+      type: "testState",
       testState: "testing",
       testMessage: null,
-    }));
+    });
     try {
       const ok = await props.testOpenworkServerConnection(next);
-      setOpenworkConnection((current) => ({
-        ...current,
+      dispatchLocal({
+        type: "testState",
         testState: ok ? "success" : "error",
         testMessage: ok
           ? t("config.connection_successful")
           : t("config.connection_failed"),
-      }));
+      });
     } catch (error) {
       const message =
         error instanceof Error
           ? error.message
           : t("config.connection_failed_check");
-      setOpenworkConnection((current) => ({
-        ...current,
+      dispatchLocal({
+        type: "testState",
         testState: "error",
         testMessage: message,
-      }));
+      });
     }
   };
 
@@ -473,8 +550,8 @@ export function ConfigView(props: ConfigViewProps) {
                   ? t("config.collaborator_token_remote_hint")
                   : t("config.collaborator_token_disabled_hint")
               }
-              visible={clientTokenVisible}
-              toggle={() => setClientTokenVisible((prev) => !prev)}
+              visible={tokenVisible.client}
+              toggle={() => dispatchLocal({ type: "toggleToken", key: "client" })}
               copyKey="client-token"
               copyingField={copyingField}
               onCopy={handleCopy}
@@ -488,8 +565,8 @@ export function ConfigView(props: ConfigViewProps) {
                   ? t("config.owner_token_remote_hint")
                   : t("config.owner_token_disabled_hint")
               }
-              visible={ownerTokenVisible}
-              toggle={() => setOwnerTokenVisible((prev) => !prev)}
+              visible={tokenVisible.owner}
+              toggle={() => dispatchLocal({ type: "toggleToken", key: "owner" })}
               copyKey="owner-token"
               copyingField={copyingField}
               onCopy={handleCopy}
@@ -499,8 +576,8 @@ export function ConfigView(props: ConfigViewProps) {
               label={t("config.host_admin_token_label")}
               tokenValue={hostInfo?.hostToken}
               hint={t("config.host_admin_token_hint")}
-              visible={hostTokenVisible}
-              toggle={() => setHostTokenVisible((prev) => !prev)}
+              visible={tokenVisible.host}
+              toggle={() => dispatchLocal({ type: "toggleToken", key: "host" })}
               copyKey="host-token"
               copyingField={copyingField}
               onCopy={handleCopy}
@@ -535,12 +612,7 @@ export function ConfigView(props: ConfigViewProps) {
             label={t("config.server_url_input_label")}
             value={openworkUrl}
             onChange={(event) =>
-              setOpenworkConnection((current) => ({
-                ...current,
-                url: event.currentTarget.value,
-                testState: "idle",
-                testMessage: null,
-              }))
+              dispatchLocal({ type: "url", url: event.currentTarget.value })
             }
             placeholder="http://127.0.0.1:<port>"
             hint={t("config.server_url_hint")}
@@ -553,15 +625,10 @@ export function ConfigView(props: ConfigViewProps) {
             </div>
             <div className="flex items-center gap-2">
               <input
-                type={openworkTokenVisible ? "text" : "password"}
+                type={tokenVisible.openwork ? "text" : "password"}
                 value={openworkToken}
                 onChange={(event) =>
-                  setOpenworkConnection((current) => ({
-                    ...current,
-                    token: event.currentTarget.value,
-                    testState: "idle",
-                    testMessage: null,
-                  }))
+                  dispatchLocal({ type: "token", token: event.currentTarget.value })
                 }
                 placeholder={t("config.token_placeholder")}
                 disabled={props.busy}
@@ -570,10 +637,10 @@ export function ConfigView(props: ConfigViewProps) {
               <Button
                 variant="outline"
                 className="text-xs h-9 px-3 shrink-0"
-                onClick={() => setOpenworkTokenVisible((prev) => !prev)}
+                onClick={() => dispatchLocal({ type: "toggleToken", key: "openwork" })}
                 disabled={props.busy}
               >
-                {openworkTokenVisible ? t("common.hide") : t("common.show")}
+                {tokenVisible.openwork ? t("common.hide") : t("common.show")}
               </Button>
             </div>
             <div className="mt-1 text-xs text-gray-10">

--- a/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
@@ -1,5 +1,13 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useReducer,
+  useRef,
+  type SetStateAction,
+} from "react";
 import { Eye, EyeOff, Plus, RefreshCw, Trash2, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
@@ -24,6 +32,55 @@ const RESERVED_PREFIXES = ["OPENWORK_", "OPENCODE_"] as const;
 
 type EnvItem = { key: string; value: string; updatedAt: number };
 type ApplyEnvironmentChangesResult = { statusMessage?: string } | void;
+type EnvironmentEditorState = { mode: "add" | "edit"; key: string; value: string } | null;
+
+type EnvironmentLocalState = {
+  items: EnvItem[];
+  loading: boolean;
+  error: string | null;
+  revealed: Record<string, boolean>;
+  editor: EnvironmentEditorState;
+  editorError: string | null;
+  saving: boolean;
+  deleteCandidate: EnvItem | null;
+  deletingKey: string | null;
+  pendingChanges: boolean;
+  applyConfirmOpen: boolean;
+  applyBusy: boolean;
+  applyError: string | null;
+};
+
+type EnvironmentLocalAction<K extends keyof EnvironmentLocalState = keyof EnvironmentLocalState> =
+  | {
+      type: "set";
+      key: K;
+      value: SetStateAction<any>;
+    }
+  | { type: "editingDisabled" };
+
+function environmentLocalReducer(
+  state: EnvironmentLocalState,
+  action: EnvironmentLocalAction,
+): EnvironmentLocalState {
+  if (action.type === "editingDisabled") {
+    return {
+      ...state,
+      editor: null,
+      editorError: null,
+      deleteCandidate: null,
+      deletingKey: null,
+      applyConfirmOpen: false,
+      applyError: null,
+    };
+  }
+  const current = state[action.key];
+  const next =
+    typeof action.value === "function"
+      ? (action.value as (value: typeof current) => typeof current)(current)
+      : action.value;
+  if (Object.is(current, next)) return state;
+  return { ...state, [action.key]: next };
+}
 
 export type EnvironmentViewProps = {
   client: OpenworkServerClient | null;
@@ -64,21 +121,57 @@ export function EnvironmentView(props: EnvironmentViewProps) {
   const canEdit = !isRemoteWorkspace && client !== null;
   const editorTitleId = useId();
 
-  const [items, setItems] = useState<EnvItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [revealed, setRevealed] = useState<Record<string, boolean>>({});
-  const [editor, setEditor] = useState<{ mode: "add" | "edit"; key: string; value: string } | null>(null);
-  const [editorError, setEditorError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [deleteCandidate, setDeleteCandidate] = useState<EnvItem | null>(null);
-  const [deletingKey, setDeletingKey] = useState<string | null>(null);
-  const [pendingChanges, setPendingChanges] = useState(() =>
-    readOpenworkEnvPendingChanges(props.runtimeKey),
+  const [localState, setLocalState] = useReducer(
+    environmentLocalReducer,
+    props.runtimeKey,
+    (runtimeKey): EnvironmentLocalState => ({
+      items: [],
+      loading: false,
+      error: null,
+      revealed: {},
+      editor: null,
+      editorError: null,
+      saving: false,
+      deleteCandidate: null,
+      deletingKey: null,
+      pendingChanges: readOpenworkEnvPendingChanges(runtimeKey),
+      applyConfirmOpen: false,
+      applyBusy: false,
+      applyError: null,
+    }),
   );
-  const [applyConfirmOpen, setApplyConfirmOpen] = useState(false);
-  const [applyBusy, setApplyBusy] = useState(false);
-  const [applyError, setApplyError] = useState<string | null>(null);
+  const {
+    items,
+    loading,
+    error,
+    revealed,
+    editor,
+    editorError,
+    saving,
+    deleteCandidate,
+    deletingKey,
+    pendingChanges,
+    applyConfirmOpen,
+    applyBusy,
+    applyError,
+  } = localState;
+  const updateLocalState = <K extends keyof EnvironmentLocalState>(
+    key: K,
+    value: SetStateAction<EnvironmentLocalState[K]>,
+  ) => setLocalState({ type: "set", key, value });
+  const setItems = (value: SetStateAction<EnvItem[]>) => updateLocalState("items", value);
+  const setLoading = (value: SetStateAction<boolean>) => updateLocalState("loading", value);
+  const setError = (value: SetStateAction<string | null>) => updateLocalState("error", value);
+  const setRevealed = (value: SetStateAction<Record<string, boolean>>) => updateLocalState("revealed", value);
+  const setEditor = (value: SetStateAction<EnvironmentEditorState>) => updateLocalState("editor", value);
+  const setEditorError = (value: SetStateAction<string | null>) => updateLocalState("editorError", value);
+  const setSaving = (value: SetStateAction<boolean>) => updateLocalState("saving", value);
+  const setDeleteCandidate = (value: SetStateAction<EnvItem | null>) => updateLocalState("deleteCandidate", value);
+  const setDeletingKey = (value: SetStateAction<string | null>) => updateLocalState("deletingKey", value);
+  const setPendingChanges = (value: SetStateAction<boolean>) => updateLocalState("pendingChanges", value);
+  const setApplyConfirmOpen = (value: SetStateAction<boolean>) => updateLocalState("applyConfirmOpen", value);
+  const setApplyBusy = (value: SetStateAction<boolean>) => updateLocalState("applyBusy", value);
+  const setApplyError = (value: SetStateAction<string | null>) => updateLocalState("applyError", value);
   const refreshRequestId = useRef(0);
   const applyBlockedReason = props.applyBlocked
     ? props.applyBlockedReason ?? t("settings.environment.apply_blocked_active_tasks")
@@ -117,12 +210,7 @@ export function EnvironmentView(props: EnvironmentViewProps) {
 
   useEffect(() => {
     if (canEdit) return;
-    setEditor(null);
-    setEditorError(null);
-    setDeleteCandidate(null);
-    setDeletingKey(null);
-    setApplyConfirmOpen(false);
-    setApplyError(null);
+    setLocalState({ type: "editingDisabled" });
   }, [canEdit]);
 
   const existingKeys = useMemo(() => new Set(items.map((item) => item.key)), [items]);

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef, type SetStateAction } from "react";
 import {
   BookOpen,
   CheckCircle2,
@@ -155,23 +155,110 @@ const serviceIconBg = (name: string) => {
   return "bg-dls-hover border-dls-border";
 };
 
+type ConfigScope = "project" | "global";
+
+type McpViewLocalState = {
+  logoutOpen: boolean;
+  logoutTarget: string | null;
+  logoutBusy: boolean;
+  removeOpen: boolean;
+  removeTarget: string | null;
+  configScope: ConfigScope;
+  projectConfig: OpencodeConfigFile | null;
+  globalConfig: OpencodeConfigFile | null;
+  configError: string | null;
+  revealBusy: boolean;
+  showAdvanced: boolean;
+  addMcpModalOpen: boolean;
+  togglingMcp: string | null;
+  chromeSetupOpen: boolean;
+};
+
+type McpViewLocalAction<K extends keyof McpViewLocalState = keyof McpViewLocalState> =
+  | { type: "set"; key: K; value: SetStateAction<any> }
+  | { type: "configUnavailable" }
+  | { type: "configLoaded"; project: OpencodeConfigFile | null; global: OpencodeConfigFile | null }
+  | { type: "configLoadError"; error: string };
+
+const initialMcpViewLocalState: McpViewLocalState = {
+  logoutOpen: false,
+  logoutTarget: null,
+  logoutBusy: false,
+  removeOpen: false,
+  removeTarget: null,
+  configScope: "project",
+  projectConfig: null,
+  globalConfig: null,
+  configError: null,
+  revealBusy: false,
+  showAdvanced: false,
+  addMcpModalOpen: false,
+  togglingMcp: null,
+  chromeSetupOpen: false,
+};
+
+function mcpViewLocalReducer(
+  state: McpViewLocalState,
+  action: McpViewLocalAction,
+): McpViewLocalState {
+  switch (action.type) {
+    case "set": {
+      const current = state[action.key];
+      const next =
+        typeof action.value === "function"
+          ? (action.value as (value: typeof current) => typeof current)(current)
+          : action.value;
+      if (Object.is(current, next)) return state;
+      return { ...state, [action.key]: next };
+    }
+    case "configUnavailable":
+      return { ...state, projectConfig: null, globalConfig: null, configError: null };
+    case "configLoaded":
+      return { ...state, projectConfig: action.project, globalConfig: action.global };
+    case "configLoadError":
+      return { ...state, projectConfig: null, globalConfig: null, configError: action.error };
+  }
+}
+
 export function McpView(props: McpViewProps) {
   const showHeader = props.showHeader !== false;
 
-  const [logoutOpen, setLogoutOpen] = useState(false);
-  const [logoutTarget, setLogoutTarget] = useState<string | null>(null);
-  const [logoutBusy, setLogoutBusy] = useState(false);
-  const [removeOpen, setRemoveOpen] = useState(false);
-  const [removeTarget, setRemoveTarget] = useState<string | null>(null);
-  const [configScope, setConfigScope] = useState<"project" | "global">("project");
-  const [projectConfig, setProjectConfig] = useState<OpencodeConfigFile | null>(null);
-  const [globalConfig, setGlobalConfig] = useState<OpencodeConfigFile | null>(null);
-  const [configError, setConfigError] = useState<string | null>(null);
-  const [revealBusy, setRevealBusy] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [addMcpModalOpen, setAddMcpModalOpen] = useState(false);
-  const [togglingMcp, setTogglingMcp] = useState<string | null>(null);
-  const [chromeSetupOpen, setChromeSetupOpen] = useState(false);
+  const [localState, dispatchLocal] = useReducer(
+    mcpViewLocalReducer,
+    initialMcpViewLocalState,
+  );
+  const {
+    logoutOpen,
+    logoutTarget,
+    logoutBusy,
+    removeOpen,
+    removeTarget,
+    configScope,
+    projectConfig,
+    globalConfig,
+    configError,
+    revealBusy,
+    showAdvanced,
+    addMcpModalOpen,
+    togglingMcp,
+    chromeSetupOpen,
+  } = localState;
+  const setLocal = <K extends keyof McpViewLocalState>(
+    key: K,
+    value: SetStateAction<McpViewLocalState[K]>,
+  ) => dispatchLocal({ type: "set", key, value });
+  const setLogoutOpen = (value: SetStateAction<boolean>) => setLocal("logoutOpen", value);
+  const setLogoutTarget = (value: SetStateAction<string | null>) => setLocal("logoutTarget", value);
+  const setLogoutBusy = (value: SetStateAction<boolean>) => setLocal("logoutBusy", value);
+  const setRemoveOpen = (value: SetStateAction<boolean>) => setLocal("removeOpen", value);
+  const setRemoveTarget = (value: SetStateAction<string | null>) => setLocal("removeTarget", value);
+  const setConfigScope = (value: SetStateAction<ConfigScope>) => setLocal("configScope", value);
+  const setConfigError = (value: SetStateAction<string | null>) => setLocal("configError", value);
+  const setRevealBusy = (value: SetStateAction<boolean>) => setLocal("revealBusy", value);
+  const setShowAdvanced = (value: SetStateAction<boolean>) => setLocal("showAdvanced", value);
+  const setAddMcpModalOpen = (value: SetStateAction<boolean>) => setLocal("addMcpModalOpen", value);
+  const setTogglingMcp = (value: SetStateAction<string | null>) => setLocal("togglingMcp", value);
+  const setChromeSetupOpen = (value: SetStateAction<boolean>) => setLocal("chromeSetupOpen", value);
   const configRequestId = useRef(0);
 
   const quickConnectList = props.quickConnect;
@@ -183,9 +270,7 @@ export function McpView(props: McpViewProps) {
     const readConfig = props.readConfigFile;
 
     if (!readConfig && !isDesktopRuntime()) {
-      setProjectConfig(null);
-      setGlobalConfig(null);
-      setConfigError(null);
+      dispatchLocal({ type: "configUnavailable" });
       return;
     }
 
@@ -201,15 +286,17 @@ export function McpView(props: McpViewProps) {
           readConfig ? readConfig("global") : readOpencodeConfig("global", root),
         ]);
         if (nextId !== configRequestId.current) return;
-        setProjectConfig(project);
-        setGlobalConfig(global);
+        dispatchLocal({
+          type: "configLoaded",
+          project: project as OpencodeConfigFile | null,
+          global: global as OpencodeConfigFile | null,
+        });
       } catch (error) {
         if (nextId !== configRequestId.current) return;
-        setProjectConfig(null);
-        setGlobalConfig(null);
-        setConfigError(
-          error instanceof Error ? error.message : t("mcp.config_load_failed"),
-        );
+        dispatchLocal({
+          type: "configLoadError",
+          error: error instanceof Error ? error.message : t("mcp.config_load_failed"),
+        });
       }
     })();
   }, [props.readConfigFile, props.selectedWorkspaceRoot]);
@@ -291,13 +378,14 @@ export function McpView(props: McpViewProps) {
       const resolved = props.readConfigFile
         ? await props.readConfigFile(configScope)
         : await readOpencodeConfig(configScope, root);
-      if (!resolved) {
+      const configFile = resolved as OpencodeConfigFile | null;
+      if (!configFile) {
         throw new Error(t("mcp.config_load_failed"));
       }
       if (isWindowsPlatform()) {
-        await openDesktopPath(resolved.path);
+        await openDesktopPath(configFile.path);
       } else {
-        await revealDesktopItemInDir(resolved.path);
+        await revealDesktopItemInDir(configFile.path);
       }
     } catch (error) {
       setConfigError(

--- a/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
@@ -3,8 +3,9 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useState,
+  useReducer,
   type KeyboardEvent as ReactKeyboardEvent,
+  type SetStateAction,
 } from "react";
 import {
   ArrowLeft,
@@ -140,41 +141,222 @@ export type SkillsViewProps = {
   createSessionAndOpen: (initialPrompt?: string) => Promise<string | undefined> | string | void;
 };
 
+type SkillsViewLocalState = {
+  uninstallTarget: SkillCard | null;
+  searchQuery: string;
+  activeFilter: SkillsFilter;
+  customRepoOpen: boolean;
+  customRepoOwner: string;
+  customRepoName: string;
+  customRepoRef: string;
+  customRepoError: string | null;
+  shareTarget: SkillCard | null;
+  shareSubView: ShareSkillSubView;
+  shareBusy: boolean;
+  shareUrl: string | null;
+  shareError: string | null;
+  cloudSessionNonce: number;
+  shareTeamBusy: boolean;
+  shareTeamError: string | null;
+  shareTeamSuccess: string | null;
+  sharePermissionChoice: string;
+  shareHubsLoading: boolean;
+  shareHubsError: string | null;
+  shareManageableHubs: DenOrgSkillHubSummary[];
+  selectedSkill: SkillCard | null;
+  selectedContent: string;
+  selectedLoading: boolean;
+  selectedDirty: boolean;
+  selectedError: string | null;
+  installingSkillCreator: boolean;
+  installingHubSkill: string | null;
+  installingCloudSkillId: string | null;
+  denUiTick: number;
+};
+
+type SkillsViewLocalAction<K extends keyof SkillsViewLocalState = keyof SkillsViewLocalState> =
+  | { type: "set"; key: K; value: SetStateAction<any> }
+  | { type: "denSessionUpdated" }
+  | { type: "resetShareChooser" }
+  | { type: "shareHubsStart" }
+  | { type: "shareHubsLoaded"; hubs: DenOrgSkillHubSummary[] }
+  | { type: "shareHubsFailed"; error: string }
+  | { type: "shareHubsDone" }
+  | { type: "closeShare" }
+  | { type: "openShare"; skill: SkillCard };
+
+const initialSkillsViewLocalState: SkillsViewLocalState = {
+  uninstallTarget: null,
+  searchQuery: "",
+  activeFilter: "all",
+  customRepoOpen: false,
+  customRepoOwner: "",
+  customRepoName: "",
+  customRepoRef: "main",
+  customRepoError: null,
+  shareTarget: null,
+  shareSubView: "chooser",
+  shareBusy: false,
+  shareUrl: null,
+  shareError: null,
+  cloudSessionNonce: 0,
+  shareTeamBusy: false,
+  shareTeamError: null,
+  shareTeamSuccess: null,
+  sharePermissionChoice: "org",
+  shareHubsLoading: false,
+  shareHubsError: null,
+  shareManageableHubs: [],
+  selectedSkill: null,
+  selectedContent: "",
+  selectedLoading: false,
+  selectedDirty: false,
+  selectedError: null,
+  installingSkillCreator: false,
+  installingHubSkill: null,
+  installingCloudSkillId: null,
+  denUiTick: 0,
+};
+
+function skillsViewLocalReducer(
+  state: SkillsViewLocalState,
+  action: SkillsViewLocalAction,
+): SkillsViewLocalState {
+  switch (action.type) {
+    case "set": {
+      const current = state[action.key];
+      const next =
+        typeof action.value === "function"
+          ? (action.value as (value: typeof current) => typeof current)(current)
+          : action.value;
+      if (Object.is(current, next)) return state;
+      return { ...state, [action.key]: next };
+    }
+    case "denSessionUpdated":
+      return {
+        ...state,
+        denUiTick: state.denUiTick + 1,
+        cloudSessionNonce: state.cloudSessionNonce + 1,
+      };
+    case "resetShareChooser":
+      return {
+        ...state,
+        shareSubView: "chooser",
+        shareError: null,
+        shareTeamError: null,
+        shareTeamSuccess: null,
+        sharePermissionChoice: "org",
+        shareHubsError: null,
+      };
+    case "shareHubsStart":
+      return { ...state, shareHubsLoading: true, shareHubsError: null };
+    case "shareHubsLoaded":
+      return { ...state, shareManageableHubs: action.hubs };
+    case "shareHubsFailed":
+      return { ...state, shareHubsError: action.error, shareManageableHubs: [] };
+    case "shareHubsDone":
+      return { ...state, shareHubsLoading: false };
+    case "closeShare":
+      return {
+        ...state,
+        shareTarget: null,
+        shareSubView: "chooser",
+        shareBusy: false,
+        shareUrl: null,
+        shareError: null,
+        shareTeamBusy: false,
+        shareTeamError: null,
+        shareTeamSuccess: null,
+        sharePermissionChoice: "org",
+        shareHubsError: null,
+        shareManageableHubs: [],
+      };
+    case "openShare":
+      return {
+        ...state,
+        shareTarget: action.skill,
+        shareSubView: "chooser",
+        shareBusy: false,
+        shareUrl: null,
+        shareError: null,
+        shareTeamBusy: false,
+        shareTeamError: null,
+        shareTeamSuccess: null,
+        sharePermissionChoice: "org",
+        shareHubsError: null,
+        shareManageableHubs: [],
+        cloudSessionNonce: state.cloudSessionNonce + 1,
+      };
+  }
+}
+
 export function SkillsView(props: SkillsViewProps) {
   const { extensions } = props;
-  const [uninstallTarget, setUninstallTarget] = useState<SkillCard | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [activeFilter, setActiveFilter] = useState<SkillsFilter>("all");
-  const [customRepoOpen, setCustomRepoOpen] = useState(false);
-  const [customRepoOwner, setCustomRepoOwner] = useState("");
-  const [customRepoName, setCustomRepoName] = useState("");
-  const [customRepoRef, setCustomRepoRef] = useState("main");
-  const [customRepoError, setCustomRepoError] = useState<string | null>(null);
-
-  const [shareTarget, setShareTarget] = useState<SkillCard | null>(null);
-  const [shareSubView, setShareSubView] = useState<ShareSkillSubView>("chooser");
-  const [shareBusy, setShareBusy] = useState(false);
-  const [shareUrl, setShareUrl] = useState<string | null>(null);
-  const [shareError, setShareError] = useState<string | null>(null);
-  const [cloudSessionNonce, setCloudSessionNonce] = useState(0);
-  const [shareTeamBusy, setShareTeamBusy] = useState(false);
-  const [shareTeamError, setShareTeamError] = useState<string | null>(null);
-  const [shareTeamSuccess, setShareTeamSuccess] = useState<string | null>(null);
-  const [sharePermissionChoice, setSharePermissionChoice] = useState("org");
-  const [shareHubsLoading, setShareHubsLoading] = useState(false);
-  const [shareHubsError, setShareHubsError] = useState<string | null>(null);
-  const [shareManageableHubs, setShareManageableHubs] = useState<DenOrgSkillHubSummary[]>([]);
-
-  const [selectedSkill, setSelectedSkill] = useState<SkillCard | null>(null);
-  const [selectedContent, setSelectedContent] = useState("");
-  const [selectedLoading, setSelectedLoading] = useState(false);
-  const [selectedDirty, setSelectedDirty] = useState(false);
-  const [selectedError, setSelectedError] = useState<string | null>(null);
-
-  const [installingSkillCreator, setInstallingSkillCreator] = useState(false);
-  const [installingHubSkill, setInstallingHubSkill] = useState<string | null>(null);
-  const [installingCloudSkillId, setInstallingCloudSkillId] = useState<string | null>(null);
-  const [denUiTick, setDenUiTick] = useState(0);
+  const [localState, dispatchLocal] = useReducer(
+    skillsViewLocalReducer,
+    initialSkillsViewLocalState,
+  );
+  const {
+    uninstallTarget,
+    searchQuery,
+    activeFilter,
+    customRepoOpen,
+    customRepoOwner,
+    customRepoName,
+    customRepoRef,
+    customRepoError,
+    shareTarget,
+    shareSubView,
+    shareBusy,
+    shareUrl,
+    shareError,
+    cloudSessionNonce,
+    shareTeamBusy,
+    shareTeamError,
+    shareTeamSuccess,
+    sharePermissionChoice,
+    shareHubsLoading,
+    shareHubsError,
+    shareManageableHubs,
+    selectedSkill,
+    selectedContent,
+    selectedLoading,
+    selectedDirty,
+    selectedError,
+    installingSkillCreator,
+    installingHubSkill,
+    installingCloudSkillId,
+    denUiTick,
+  } = localState;
+  const setLocal = <K extends keyof SkillsViewLocalState>(
+    key: K,
+    value: SetStateAction<SkillsViewLocalState[K]>,
+  ) => dispatchLocal({ type: "set", key, value });
+  const setUninstallTarget = (value: SetStateAction<SkillCard | null>) => setLocal("uninstallTarget", value);
+  const setSearchQuery = (value: SetStateAction<string>) => setLocal("searchQuery", value);
+  const setActiveFilter = (value: SetStateAction<SkillsFilter>) => setLocal("activeFilter", value);
+  const setCustomRepoOpen = (value: SetStateAction<boolean>) => setLocal("customRepoOpen", value);
+  const setCustomRepoOwner = (value: SetStateAction<string>) => setLocal("customRepoOwner", value);
+  const setCustomRepoName = (value: SetStateAction<string>) => setLocal("customRepoName", value);
+  const setCustomRepoRef = (value: SetStateAction<string>) => setLocal("customRepoRef", value);
+  const setCustomRepoError = (value: SetStateAction<string | null>) => setLocal("customRepoError", value);
+  const setShareTarget = (value: SetStateAction<SkillCard | null>) => setLocal("shareTarget", value);
+  const setShareSubView = (value: SetStateAction<ShareSkillSubView>) => setLocal("shareSubView", value);
+  const setShareBusy = (value: SetStateAction<boolean>) => setLocal("shareBusy", value);
+  const setShareUrl = (value: SetStateAction<string | null>) => setLocal("shareUrl", value);
+  const setShareError = (value: SetStateAction<string | null>) => setLocal("shareError", value);
+  const setShareTeamBusy = (value: SetStateAction<boolean>) => setLocal("shareTeamBusy", value);
+  const setShareTeamError = (value: SetStateAction<string | null>) => setLocal("shareTeamError", value);
+  const setShareTeamSuccess = (value: SetStateAction<string | null>) => setLocal("shareTeamSuccess", value);
+  const setSharePermissionChoice = (value: SetStateAction<string>) => setLocal("sharePermissionChoice", value);
+  const setSelectedSkill = (value: SetStateAction<SkillCard | null>) => setLocal("selectedSkill", value);
+  const setSelectedContent = (value: SetStateAction<string>) => setLocal("selectedContent", value);
+  const setSelectedLoading = (value: SetStateAction<boolean>) => setLocal("selectedLoading", value);
+  const setSelectedDirty = (value: SetStateAction<boolean>) => setLocal("selectedDirty", value);
+  const setSelectedError = (value: SetStateAction<string | null>) => setLocal("selectedError", value);
+  const setInstallingSkillCreator = (value: SetStateAction<boolean>) => setLocal("installingSkillCreator", value);
+  const setInstallingHubSkill = (value: SetStateAction<string | null>) => setLocal("installingHubSkill", value);
+  const setInstallingCloudSkillId = (value: SetStateAction<string | null>) => setLocal("installingCloudSkillId", value);
 
   const showToast = useCallback(
     (title: string, tone: ToastTone = "info") => {
@@ -193,8 +375,7 @@ export function SkillsView(props: SkillsViewProps) {
     void extensions.ensureHubSkillsFresh();
     void extensions.ensureCloudOrgSkillsFresh();
     const onDenSession = () => {
-      setDenUiTick((value) => value + 1);
-      setCloudSessionNonce((value) => value + 1);
+      dispatchLocal({ type: "denSessionUpdated" });
       void extensions.refreshCloudOrgSkills({ force: true });
     };
     window.addEventListener("openwork-den-session-updated", onDenSession);
@@ -207,12 +388,7 @@ export function SkillsView(props: SkillsViewProps) {
       if (event.key !== "Escape") return;
       event.preventDefault();
       if (shareSubView !== "chooser") {
-        setShareSubView("chooser");
-        setShareError(null);
-        setShareTeamError(null);
-        setShareTeamSuccess(null);
-        setSharePermissionChoice("org");
-        setShareHubsError(null);
+        dispatchLocal({ type: "resetShareChooser" });
         return;
       }
       setShareTarget(null);
@@ -246,8 +422,7 @@ export function SkillsView(props: SkillsViewProps) {
 
     let cancelled = false;
     void (async () => {
-      setShareHubsLoading(true);
-      setShareHubsError(null);
+      dispatchLocal({ type: "shareHubsStart" });
       try {
         const settings = readDenSettings();
         const token = settings.authToken?.trim() ?? "";
@@ -264,13 +439,12 @@ export function SkillsView(props: SkillsViewProps) {
         }
         const hubs = await client.listOrgSkillHubSummaries(orgId);
         if (cancelled) return;
-        setShareManageableHubs(hubs.filter((hub) => hub.canManage));
+        dispatchLocal({ type: "shareHubsLoaded", hubs: hubs.filter((hub) => hub.canManage) });
       } catch (error) {
         if (cancelled) return;
-        setShareHubsError(maskError(error));
-        setShareManageableHubs([]);
+        dispatchLocal({ type: "shareHubsFailed", error: maskError(error) });
       } finally {
-        if (!cancelled) setShareHubsLoading(false);
+        if (!cancelled) dispatchLocal({ type: "shareHubsDone" });
       }
     })();
 
@@ -413,26 +587,11 @@ export function SkillsView(props: SkillsViewProps) {
   };
 
   const closeShareLink = useCallback(() => {
-    setShareTarget(null);
-    setShareSubView("chooser");
-    setShareBusy(false);
-    setShareUrl(null);
-    setShareError(null);
-    setShareTeamBusy(false);
-    setShareTeamError(null);
-    setShareTeamSuccess(null);
-    setSharePermissionChoice("org");
-    setShareHubsError(null);
-    setShareManageableHubs([]);
+    dispatchLocal({ type: "closeShare" });
   }, []);
 
   const goBackShareSubView = useCallback(() => {
-    setShareSubView("chooser");
-    setShareError(null);
-    setShareTeamError(null);
-    setShareTeamSuccess(null);
-    setSharePermissionChoice("org");
-    setShareHubsError(null);
+    dispatchLocal({ type: "resetShareChooser" });
   }, []);
 
   const runDesktopAction = useCallback(
@@ -526,18 +685,7 @@ export function SkillsView(props: SkillsViewProps) {
   const openShareLink = useCallback(
     (skill: SkillCard) => {
       if (props.busy) return;
-      setShareTarget(skill);
-      setShareSubView("chooser");
-      setShareBusy(false);
-      setShareUrl(null);
-      setShareError(null);
-      setShareTeamBusy(false);
-      setShareTeamError(null);
-      setShareTeamSuccess(null);
-      setSharePermissionChoice("org");
-      setShareHubsError(null);
-      setShareManageableHubs([]);
-      setCloudSessionNonce((value) => value + 1);
+      dispatchLocal({ type: "openShare", skill });
     },
     [props.busy],
   );

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, type SetStateAction } from "react";
 import { Folder, FolderLock, FolderSearch, X } from "lucide-react";
 
 import { t } from "../../../../i18n";
@@ -28,6 +28,59 @@ export type AuthorizedFoldersPanelProps = {
 
 const panelClass = "rounded-[28px] border border-dls-border bg-dls-surface p-5 md:p-6";
 const softPanelClass = "rounded-2xl border border-gray-6/60 bg-gray-1/40 p-4";
+
+type AuthorizedFoldersState = {
+  folders: string[];
+  draft: string;
+  loading: boolean;
+  saving: boolean;
+  status: string | null;
+  error: string | null;
+};
+
+type AuthorizedFoldersAction =
+  | { type: "set"; key: keyof AuthorizedFoldersState; value: SetStateAction<any> }
+  | { type: "reset" }
+  | { type: "loadStart" }
+  | { type: "loadSuccess"; folders: string[]; status: string | null }
+  | { type: "loadError"; message: string }
+  | { type: "loadDone" };
+
+const initialAuthorizedFoldersState: AuthorizedFoldersState = {
+  folders: [],
+  draft: "",
+  loading: false,
+  saving: false,
+  status: null,
+  error: null,
+};
+
+function authorizedFoldersReducer(
+  state: AuthorizedFoldersState,
+  action: AuthorizedFoldersAction,
+): AuthorizedFoldersState {
+  switch (action.type) {
+    case "set": {
+      const current = state[action.key];
+      const next =
+        typeof action.value === "function"
+          ? (action.value as (value: typeof current) => typeof current)(current)
+          : action.value;
+      if (Object.is(current, next)) return state;
+      return { ...state, [action.key]: next };
+    }
+    case "reset":
+      return initialAuthorizedFoldersState;
+    case "loadStart":
+      return { ...state, draft: "", loading: true, error: null, status: null };
+    case "loadSuccess":
+      return { ...state, folders: action.folders, status: action.status };
+    case "loadError":
+      return { ...state, folders: [], error: action.message };
+    case "loadDone":
+      return { ...state, loading: false };
+  }
+}
 
 const ensureRecord = (value: unknown): Record<string, unknown> => {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
@@ -102,12 +155,27 @@ const mergeAuthorizedFoldersIntoExternalDirectory = (
 };
 
 export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
-  const [authorizedFolders, setAuthorizedFolders] = useState<string[]>([]);
-  const [authorizedFolderDraft, setAuthorizedFolderDraft] = useState("");
-  const [authorizedFoldersLoading, setAuthorizedFoldersLoading] = useState(false);
-  const [authorizedFoldersSaving, setAuthorizedFoldersSaving] = useState(false);
-  const [authorizedFoldersStatus, setAuthorizedFoldersStatus] = useState<string | null>(null);
-  const [authorizedFoldersError, setAuthorizedFoldersError] = useState<string | null>(null);
+  const [folderState, dispatchFolderState] = useReducer(
+    authorizedFoldersReducer,
+    initialAuthorizedFoldersState,
+  );
+  const {
+    folders: authorizedFolders,
+    draft: authorizedFolderDraft,
+    loading: authorizedFoldersLoading,
+    saving: authorizedFoldersSaving,
+    status: authorizedFoldersStatus,
+    error: authorizedFoldersError,
+  } = folderState;
+  const setFolderState = <K extends keyof AuthorizedFoldersState>(
+    key: K,
+    value: SetStateAction<AuthorizedFoldersState[K]>,
+  ) => dispatchFolderState({ type: "set", key, value });
+  const setAuthorizedFolders = (value: SetStateAction<string[]>) => setFolderState("folders", value);
+  const setAuthorizedFolderDraft = (value: SetStateAction<string>) => setFolderState("draft", value);
+  const setAuthorizedFoldersSaving = (value: SetStateAction<boolean>) => setFolderState("saving", value);
+  const setAuthorizedFoldersStatus = (value: SetStateAction<string | null>) => setFolderState("status", value);
+  const setAuthorizedFoldersError = (value: SetStateAction<string | null>) => setFolderState("error", value);
 
   const openworkServerReady = props.openworkServerStatus === "connected";
   const openworkServerWorkspaceReady = Boolean(props.runtimeWorkspaceId);
@@ -141,37 +209,29 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
     const openworkWorkspaceId = props.runtimeWorkspaceId;
 
     if (!openworkClient || !openworkWorkspaceId || !canReadConfig) {
-      setAuthorizedFolders([]);
-      setAuthorizedFolderDraft("");
-      setAuthorizedFoldersLoading(false);
-      setAuthorizedFoldersSaving(false);
-      setAuthorizedFoldersStatus(null);
-      setAuthorizedFoldersError(null);
+      dispatchFolderState({ type: "reset" });
       return;
     }
 
     let cancelled = false;
-    setAuthorizedFolderDraft("");
-    setAuthorizedFoldersLoading(true);
-    setAuthorizedFoldersError(null);
-    setAuthorizedFoldersStatus(null);
+    dispatchFolderState({ type: "loadStart" });
 
     void (async () => {
       try {
         const config = await openworkClient.getConfig(openworkWorkspaceId);
         if (cancelled) return;
         const next = readAuthorizedFoldersFromConfig(ensureRecord(config.opencode));
-        setAuthorizedFolders(next.folders);
-        setAuthorizedFoldersStatus(
-          buildAuthorizedFoldersStatus(Object.keys(next.hiddenEntries).length),
-        );
+        dispatchFolderState({
+          type: "loadSuccess",
+          folders: next.folders,
+          status: buildAuthorizedFoldersStatus(Object.keys(next.hiddenEntries).length),
+        });
       } catch (error) {
         if (cancelled) return;
         const message = error instanceof Error ? error.message : safeStringify(error);
-        setAuthorizedFolders([]);
-        setAuthorizedFoldersError(message);
+        dispatchFolderState({ type: "loadError", message });
       } finally {
-        if (!cancelled) setAuthorizedFoldersLoading(false);
+        if (!cancelled) dispatchFolderState({ type: "loadDone" });
       }
     })();
 

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -2,8 +2,8 @@
 import {
   useEffect,
   useMemo,
+  useReducer,
   useRef,
-  useState,
   type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
   type RefObject,
@@ -39,6 +39,43 @@ type PaletteDialogProps = {
   onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
 };
 
+type PaletteState = {
+  mode: PaletteMode;
+  query: string;
+  activeIndex: number;
+};
+
+type PaletteAction =
+  | { type: "reset" }
+  | { type: "sessions" }
+  | { type: "query"; query: string }
+  | { type: "activeIndex"; activeIndex: number }
+  | { type: "move"; delta: 1 | -1; itemCount: number };
+
+const initialPaletteState: PaletteState = {
+  mode: "root",
+  query: "",
+  activeIndex: 0,
+};
+
+function paletteReducer(state: PaletteState, action: PaletteAction): PaletteState {
+  switch (action.type) {
+    case "reset":
+      return initialPaletteState;
+    case "sessions":
+      return { mode: "sessions", query: "", activeIndex: 0 };
+    case "query":
+      return { ...state, query: action.query, activeIndex: 0 };
+    case "activeIndex":
+      return { ...state, activeIndex: action.activeIndex };
+    case "move":
+      if (action.itemCount === 0) return state;
+      return {
+        ...state,
+        activeIndex: (state.activeIndex + action.delta + action.itemCount) % action.itemCount,
+      };
+  }
+}
 export type SessionOption = {
   workspaceId: string;
   sessionId: string;
@@ -160,17 +197,14 @@ function PaletteDialog(props: PaletteDialogProps) {
  * - Sessions submode: fuzzy list of every session across workspaces.
  */
 export function CommandPalette(props: CommandPaletteProps) {
-  const [mode, setMode] = useState<PaletteMode>("root");
-  const [query, setQuery] = useState("");
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [state, dispatch] = useReducer(paletteReducer, initialPaletteState);
+  const { mode, query, activeIndex } = state;
   const inputRef = useRef<HTMLInputElement | null>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   useEffect(() => {
     if (!props.open) {
-      setMode("root");
-      setQuery("");
-      setActiveIndex(0);
+      dispatch({ type: "reset" });
       return;
     }
     const id = window.setTimeout(() => {
@@ -207,9 +241,7 @@ export function CommandPalette(props: CommandPaletteProps) {
         }),
         meta: t("session.cmd_sessions_meta"),
         action: () => {
-          setMode("sessions");
-          setQuery("");
-          setActiveIndex(0);
+          dispatch({ type: "sessions" });
           window.setTimeout(() => inputRef.current?.focus(), 0);
         },
       },
@@ -335,9 +367,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     if (event.key === "Escape") {
       event.preventDefault();
       if (mode !== "root") {
-        setMode("root");
-        setQuery("");
-        setActiveIndex(0);
+        dispatch({ type: "reset" });
         window.setTimeout(() => inputRef.current?.focus(), 0);
         return;
       }
@@ -347,13 +377,13 @@ export function CommandPalette(props: CommandPaletteProps) {
     if (event.key === "ArrowDown") {
       event.preventDefault();
       if (items.length === 0) return;
-      setActiveIndex((current) => (current + 1) % items.length);
+      dispatch({ type: "move", delta: 1, itemCount: items.length });
       return;
     }
     if (event.key === "ArrowUp") {
       event.preventDefault();
       if (items.length === 0) return;
-      setActiveIndex((current) => (current - 1 + items.length) % items.length);
+      dispatch({ type: "move", delta: -1, itemCount: items.length });
       return;
     }
     if (event.key === "Enter") {
@@ -364,8 +394,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     }
     if (event.key === "Backspace" && !query && mode !== "root") {
       event.preventDefault();
-      setMode("root");
-      setActiveIndex(0);
+      dispatch({ type: "reset" });
     }
   };
 
@@ -382,15 +411,12 @@ export function CommandPalette(props: CommandPaletteProps) {
       : t("session.palette_title_actions");
 
   const handleBack = () => {
-    setMode("root");
-    setQuery("");
-    setActiveIndex(0);
+    dispatch({ type: "reset" });
     window.setTimeout(() => inputRef.current?.focus(), 0);
   };
 
   const handleQueryChange = (value: string) => {
-    setQuery(value);
-    setActiveIndex(0);
+    dispatch({ type: "query", query: value });
   };
 
   return (
@@ -407,7 +433,7 @@ export function CommandPalette(props: CommandPaletteProps) {
       onBack={handleBack}
       onClose={props.onClose}
       onQueryChange={handleQueryChange}
-      onActiveIndexChange={setActiveIndex}
+      onActiveIndexChange={(value) => dispatch({ type: "activeIndex", activeIndex: value })}
       onKeyDown={handleKey}
     />
   );

--- a/apps/app/src/react-app/shell/dev-profiler.tsx
+++ b/apps/app/src/react-app/shell/dev-profiler.tsx
@@ -21,6 +21,7 @@
 import {
   Profiler,
   useEffect,
+  useReducer,
   useRef,
   useState,
   type PropsWithChildren,
@@ -259,8 +260,14 @@ export function DevProfilerOverlay() {
  * `recordCommit` short-circuits — the profiler becomes free.
  */
 function DevProfilerOverlayToggle() {
-  const stored = readOverlayStoredPreference();
-  const [visible, setVisible] = useState(stored === null ? false : stored);
+  const [visible, toggleVisible] = useReducer((current: boolean, next?: boolean) => {
+    const visible = next ?? !current;
+    writeOverlayStoredPreference(visible);
+    return visible;
+  }, false, () => {
+    const stored = readOverlayStoredPreference();
+    return stored === null ? false : stored;
+  });
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -268,10 +275,7 @@ function DevProfilerOverlayToggle() {
       if (!metaOrCtrl || !event.shiftKey) return;
       if (event.key.toLowerCase() !== "p") return;
       event.preventDefault();
-      setVisible((prev) => {
-        writeOverlayStoredPreference(!prev);
-        return !prev;
-      });
+      toggleVisible();
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
@@ -279,8 +283,7 @@ function DevProfilerOverlayToggle() {
 
   if (!visible) return null;
   return <DevProfilerOverlayVisible onHide={() => {
-    writeOverlayStoredPreference(false);
-    setVisible(false);
+    toggleVisible(false);
   }} />;
 }
 

--- a/apps/app/src/react-app/shell/react-render-watchdog-overlay.tsx
+++ b/apps/app/src/react-app/shell/react-render-watchdog-overlay.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 
 import {
   readReactRenderWatchdogSnapshot,
@@ -24,10 +24,42 @@ function writeStoredPreference(value: boolean) {
   }
 }
 
+type OverlayState = {
+  visible: boolean;
+  collapsed: boolean;
+  snapshot: ReturnType<typeof readReactRenderWatchdogSnapshot>;
+};
+
+type OverlayAction =
+  | { type: "toggleVisible" }
+  | { type: "hide" }
+  | { type: "toggleCollapsed" }
+  | { type: "snapshot"; snapshot: ReturnType<typeof readReactRenderWatchdogSnapshot> };
+
+function overlayReducer(state: OverlayState, action: OverlayAction): OverlayState {
+  switch (action.type) {
+    case "toggleVisible": {
+      const visible = !state.visible;
+      writeStoredPreference(visible);
+      return { ...state, visible };
+    }
+    case "hide":
+      writeStoredPreference(false);
+      return { ...state, visible: false };
+    case "toggleCollapsed":
+      return { ...state, collapsed: !state.collapsed };
+    case "snapshot":
+      return { ...state, snapshot: action.snapshot };
+  }
+}
+
 export function ReactRenderWatchdogOverlay() {
-  const [visible, setVisible] = useState(readStoredPreference);
-  const [collapsed, setCollapsed] = useState(false);
-  const [snapshot, setSnapshot] = useState(readReactRenderWatchdogSnapshot);
+  const [state, dispatch] = useReducer(overlayReducer, undefined, () => ({
+    visible: readStoredPreference(),
+    collapsed: false,
+    snapshot: readReactRenderWatchdogSnapshot(),
+  }));
+  const { visible, collapsed, snapshot } = state;
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -35,10 +67,7 @@ export function ReactRenderWatchdogOverlay() {
       if (!metaOrCtrl || !event.shiftKey) return;
       if (event.key.toLowerCase() !== "l") return;
       event.preventDefault();
-      setVisible((current) => {
-        writeStoredPreference(!current);
-        return !current;
-      });
+      dispatch({ type: "toggleVisible" });
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
@@ -46,7 +75,7 @@ export function ReactRenderWatchdogOverlay() {
 
   useEffect(() => {
     if (!visible) return;
-    const tick = () => setSnapshot(readReactRenderWatchdogSnapshot());
+    const tick = () => dispatch({ type: "snapshot", snapshot: readReactRenderWatchdogSnapshot() });
     tick();
     const interval = window.setInterval(tick, 500);
     return () => window.clearInterval(interval);
@@ -73,7 +102,7 @@ export function ReactRenderWatchdogOverlay() {
             className="rounded px-1.5 py-0.5 text-[10px] text-dls-secondary hover:bg-dls-hover"
             onClick={() => {
               resetReactRenderWatchdogStats();
-              setSnapshot([]);
+              dispatch({ type: "snapshot", snapshot: [] });
             }}
           >
             reset
@@ -81,17 +110,14 @@ export function ReactRenderWatchdogOverlay() {
           <button
             type="button"
             className="rounded px-1.5 py-0.5 text-[10px] text-dls-secondary hover:bg-dls-hover"
-            onClick={() => setCollapsed((value) => !value)}
+            onClick={() => dispatch({ type: "toggleCollapsed" })}
           >
             {collapsed ? "+" : "–"}
           </button>
           <button
             type="button"
             className="rounded px-1.5 py-0.5 text-[10px] text-dls-secondary hover:bg-dls-hover"
-            onClick={() => {
-              writeStoredPreference(false);
-              setVisible(false);
-            }}
+            onClick={() => dispatch({ type: "hide" })}
             title="Hide (Cmd+Shift+L to toggle)"
           >
             ×


### PR DESCRIPTION
## Summary

- Rebases the state round two cleanup after async/security/architecture PRs landed.
- Keeps the same scoped state reducer/ref cleanup from #1737 while resolving the command palette conflict against current `dev`.

## Evidence

### React Doctor
- Comparable clean baseline before this round: score 93 / 100, 84 warnings.
- Rebased installed-worktree scan: score 91 / 100 with `knip/*` dead-code diagnostics present after dependency installation.
- Target state warnings are reduced versus current `dev`, especially `no-cascading-set-state`, `prefer-useReducer`, and `rerender-state-only-in-handlers`.

### Build Verification
- `pnpm --filter @openwork/app build` passed.

### Typecheck
- Not rerun after conflict resolution; prior #1737 typecheck failed only on existing app-wide TypeScript errors unrelated to changed files.

### UI Verification
- No screenshots captured; this is state organization cleanup with no intended visual change.

### API Verification
- No API changes.