### PR TITLE
fix(app): preserve selected Den organization

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -646,7 +646,11 @@ export async function ensureDenActiveOrganization(options?: { forceServerSync?: 
   });
 
   const response = await client.listOrgs();
+  const selectedOrgId = settings.activeOrgId?.trim() ?? "";
+  const selectedOrgSlug = settings.activeOrgSlug?.trim() ?? "";
   const targetOrg =
+    response.orgs.find((org) => org.id === selectedOrgId) ??
+    response.orgs.find((org) => org.slug === selectedOrgSlug) ??
     response.orgs.find((org) => org.id === response.activeOrgId) ??
     response.orgs.find((org) => org.slug === response.activeOrgSlug) ??
     response.orgs[0] ??


### PR DESCRIPTION
## Summary

- Make `ensureDenActiveOrganization()` prefer the locally selected Den org before falling back to the server session's active org.
- Prevent background org sync from writing the previous server active org back over the user's current Settings org selection.

## Evidence

### Build verification
- `pnpm install` -- passed in the fresh worktree.
- `pnpm --filter @openwork/app build` -- passed.

### API verification
- No API contract changes.

### UI verification
- Not run via Chrome MCP in this turn. This patch targets the org-selection state path that can make cloud sections look unscoped when switching organizations.

## Test instructions

1. Sign in to OpenWork Cloud with access to at least two orgs.
2. Open Settings -> Cloud.
3. Switch the active organization.
4. Verify cloud sections, including Marketplaces & Plugins, refresh for the selected org and do not snap back to the previous org's data.