### PR TITLE
fix(app): prevent stale Den org refreshes

### DIFF
--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -248,6 +248,9 @@ export function createExtensionsStore(options: {
   let refreshCloudOrgSkillsInFlight = false;
   let refreshCloudOrgSkillHubsInFlight = false;
   let refreshCloudOrgMarketplacesInFlight = false;
+  let refreshCloudOrgSkillsInFlightKey = "";
+  let refreshCloudOrgSkillHubsInFlightKey = "";
+  let refreshCloudOrgMarketplacesInFlightKey = "";
   let refreshSkillsAborted = false;
   let refreshPluginsAborted = false;
   let refreshHubSkillsAborted = false;
@@ -884,6 +887,11 @@ export function createExtensionsStore(options: {
     cloudOrgMarketplacesLoadKey = "";
   };
 
+  const getCurrentCloudOrgLoadKey = () => {
+    const orgId = readDenSettings().activeOrgId?.trim() ?? "";
+    return `${getWorkspaceContextKey()}::${orgId}`;
+  };
+
   const touch = () => {
     refreshSnapshot();
     emitChange();
@@ -1023,9 +1031,10 @@ export function createExtensionsStore(options: {
       await refreshImportedCloudSkills();
       return;
     }
-    if (refreshCloudOrgSkillsInFlight) return;
+    if (refreshCloudOrgSkillsInFlight && refreshCloudOrgSkillsInFlightKey === loadKey) return;
 
     refreshCloudOrgSkillsInFlight = true;
+    refreshCloudOrgSkillsInFlightKey = loadKey;
     refreshCloudOrgSkillsAborted = false;
 
     try {
@@ -1046,7 +1055,7 @@ export function createExtensionsStore(options: {
 
       const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
       const catalog = await fetchDenOrgSkillsCatalog(client, orgId);
-      if (refreshCloudOrgSkillsAborted) return;
+      if (refreshCloudOrgSkillsAborted || getCurrentCloudOrgLoadKey() !== loadKey) return;
       mutateState((current) => ({
         ...current,
         cloudOrgSkills: catalog,
@@ -1057,7 +1066,7 @@ export function createExtensionsStore(options: {
       cloudOrgSkillsLoadKey = loadKey;
       await refreshImportedCloudSkills();
     } catch (error) {
-      if (refreshCloudOrgSkillsAborted) return;
+      if (refreshCloudOrgSkillsAborted || getCurrentCloudOrgLoadKey() !== loadKey) return;
       mutateState((current) => ({
         ...current,
         cloudOrgSkills: [],
@@ -1065,7 +1074,10 @@ export function createExtensionsStore(options: {
           error instanceof Error ? error.message : t("skills.cloud_org_load_failed"),
       }));
     } finally {
-      refreshCloudOrgSkillsInFlight = false;
+      if (refreshCloudOrgSkillsInFlightKey === loadKey) {
+        refreshCloudOrgSkillsInFlight = false;
+        refreshCloudOrgSkillsInFlightKey = "";
+      }
     }
   }
 
@@ -1084,9 +1096,10 @@ export function createExtensionsStore(options: {
       await refreshImportedCloudSkillHubs();
       return;
     }
-    if (refreshCloudOrgSkillHubsInFlight) return;
+    if (refreshCloudOrgSkillHubsInFlight && refreshCloudOrgSkillHubsInFlightKey === loadKey) return;
 
     refreshCloudOrgSkillHubsInFlight = true;
+    refreshCloudOrgSkillHubsInFlightKey = loadKey;
     refreshCloudOrgSkillHubsAborted = false;
 
     try {
@@ -1106,7 +1119,7 @@ export function createExtensionsStore(options: {
 
       const client = createDenClient({ baseUrl: settings.baseUrl, apiBaseUrl: settings.apiBaseUrl, token });
       const hubs = await client.listOrgSkillHubs(orgId);
-      if (refreshCloudOrgSkillHubsAborted) return;
+      if (refreshCloudOrgSkillHubsAborted || getCurrentCloudOrgLoadKey() !== loadKey) return;
       mutateState((current) => ({
         ...current,
         cloudOrgSkillHubs: hubs,
@@ -1116,7 +1129,7 @@ export function createExtensionsStore(options: {
       cloudOrgSkillHubsLoadKey = loadKey;
       await refreshImportedCloudSkillHubs();
     } catch (error) {
-      if (refreshCloudOrgSkillHubsAborted) return;
+      if (refreshCloudOrgSkillHubsAborted || getCurrentCloudOrgLoadKey() !== loadKey) return;
       mutateState((current) => ({
         ...current,
         cloudOrgSkillHubs: [],
@@ -1124,7 +1137,10 @@ export function createExtensionsStore(options: {
           error instanceof Error ? error.message : "Failed to load organization skill hubs.",
       }));
     } finally {
-      refreshCloudOrgSkillHubsInFlight = false;
+      if (refreshCloudOrgSkillHubsInFlightKey === loadKey) {
+        refreshCloudOrgSkillHubsInFlight = false;
+        refreshCloudOrgSkillHubsInFlightKey = "";
+      }
     }
   }
 
@@ -1143,9 +1159,10 @@ export function createExtensionsStore(options: {
       await refreshImportedCloudPlugins();
       return;
     }
-    if (refreshCloudOrgMarketplacesInFlight) return;
+    if (refreshCloudOrgMarketplacesInFlight && refreshCloudOrgMarketplacesInFlightKey === loadKey) return;
 
     refreshCloudOrgMarketplacesInFlight = true;
+    refreshCloudOrgMarketplacesInFlightKey = loadKey;
     refreshCloudOrgMarketplacesAborted = false;
 
     try {
@@ -1168,7 +1185,7 @@ export function createExtensionsStore(options: {
       const resolved = await Promise.all(
         marketplaces.map((marketplace) => client.getOrgMarketplaceResolved(orgId, marketplace.id)),
       );
-      if (refreshCloudOrgMarketplacesAborted) return;
+      if (refreshCloudOrgMarketplacesAborted || getCurrentCloudOrgLoadKey() !== loadKey) return;
       mutateState((current) => ({
         ...current,
         cloudOrgMarketplaces: resolved,
@@ -1178,7 +1195,7 @@ export function createExtensionsStore(options: {
       cloudOrgMarketplacesLoadKey = loadKey;
       await refreshImportedCloudPlugins();
     } catch (error) {
-      if (refreshCloudOrgMarketplacesAborted) return;
+      if (refreshCloudOrgMarketplacesAborted || getCurrentCloudOrgLoadKey() !== loadKey) return;
       mutateState((current) => ({
         ...current,
         cloudOrgMarketplaces: [],
@@ -1186,7 +1203,10 @@ export function createExtensionsStore(options: {
           error instanceof Error ? error.message : "Failed to load organization marketplaces.",
       }));
     } finally {
-      refreshCloudOrgMarketplacesInFlight = false;
+      if (refreshCloudOrgMarketplacesInFlightKey === loadKey) {
+        refreshCloudOrgMarketplacesInFlight = false;
+        refreshCloudOrgMarketplacesInFlightKey = "";
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Allow cloud extension refreshes for a newly selected org to start even when the previous org's refresh is still in flight.
- Guard cloud skill, skill hub, and marketplace responses so stale previous-org results cannot overwrite the selected org's UI.

## Evidence

### Build verification
- `pnpm install` -- passed in the fresh worktree.
- `pnpm --filter @openwork/app build` -- passed.

### API verification
- No API contract changes.

### UI verification
- Not run via Chrome MCP in this turn. The fix targets the Settings cloud refresh race where org switching could continue showing the initial org's cloud data.

## Test instructions

1. Sign in to OpenWork Cloud with at least two orgs.
2. Open Settings -> Cloud.
3. Switch rapidly between orgs while cloud sections are loading.
4. Verify Skills, Skill Hubs, and Marketplaces & Plugins show data for the selected org, not the initial org.