### PR TITLE
fix(app): preserve live session state

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -400,8 +400,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const liveStatus = statusState ?? snapshot?.status ?? IDLE_STATUS;
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
   const renderedMessages = useMemo(
-    () => deriveRenderedSessionMessages({ transcriptState, snapshot, includeLiveOnlyMessages: chatStreaming }),
-    [chatStreaming, snapshot, transcriptState],
+    () => deriveRenderedSessionMessages({ transcriptState, snapshot, includeLiveOnlyMessages: true }),
+    [snapshot, transcriptState],
   );
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -7,7 +7,7 @@ import { normalizeEvent } from "../../../../app/utils";
 import type { OpencodeEvent, PendingPermission } from "../../../../app/types";
 import { snapshotToUIMessages } from "./usechat-adapter";
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
-import { mergeSnapshotIntoCachedMessages, messageListContainsAll } from "./message-merge";
+import { mergeSnapshotIntoCachedMessages } from "./message-merge";
 
 type SyncOptions = {
   workspaceId: string;
@@ -623,20 +623,10 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   const incoming = snapshotToUIMessages(snapshot);
   const existing = queryClient.getQueryData<UIMessage[]>(key);
 
-  if (
-    existing &&
-    existing.length > 0 &&
-    (
-      snapshot.status.type === "busy" ||
-      snapshot.status.type === "retry" ||
-      (existing.length > incoming.length && messageListContainsAll(existing, incoming))
-    )
-  ) {
-    // During active streaming the server snapshot may have empty/stale text
-    // for in-progress parts while the cache already accumulated text via
-    // deltas.  Merge so we never overwrite longer cached text with shorter
-    // server text. Also preserve a longer cache when a remount first sees an
-    // older snapshot before the fresh snapshot request returns.
+  if (existing && existing.length > 0 && incoming.length > 0) {
+    // Server snapshots can lag the event stream even after OpenCode reports
+    // idle. Merge rather than replace so a just-finished answer cannot vanish
+    // until the next reload reconstructs it from persisted state.
     const merged = mergeSnapshotIntoCachedMessages(incoming, existing);
     queryClient.setQueryData(key, merged);
   } else {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -461,6 +461,7 @@ export function SessionRoute() {
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
   const remoteWorkspaceCheckRunCounterRef = useRef(0);
   const sessionsByWorkspaceIdRef = useRef<Record<string, any[]>>({});
+  const pendingCreatedSessionIdsRef = useRef<Record<string, Record<string, number>>>({});
   const startupRetryTimerRef = useRef<number | null>(null);
   const [retryingWorkspaceIds, setRetryingWorkspaceIds] = useState<string[]>([]);
   const launchActivatedWorkspaceIdsRef = useRef(new Set<string>());
@@ -536,6 +537,46 @@ export function SessionRoute() {
   );
 
   const backgroundSessionLoadInFlight = useRef<Map<string, number>>(new Map());
+  const rememberPendingCreatedSession = useCallback((workspaceId: string, sessionId: string) => {
+    const id = sessionId.trim();
+    if (!workspaceId || !id) return;
+    pendingCreatedSessionIdsRef.current[workspaceId] = {
+      ...(pendingCreatedSessionIdsRef.current[workspaceId] ?? {}),
+      [id]: Date.now(),
+    };
+  }, []);
+  const mergeFetchedSessionsWithPending = useCallback((workspaceId: string, fetched: any[], current: any[]) => {
+    const pending = pendingCreatedSessionIdsRef.current[workspaceId];
+    if (!pending) return fetched;
+
+    const now = Date.now();
+    const fetchedIds = new Set(fetched.flatMap((session: any) => session?.id ? [String(session.id)] : []));
+    const pendingIds = Object.keys(pending);
+
+    for (const id of pendingIds) {
+      if (fetchedIds.has(id)) {
+        delete pending[id];
+      }
+    }
+
+    const preserved = current.filter((session: any) => {
+      const id = String(session?.id ?? "");
+      if (!id || fetchedIds.has(id)) return false;
+      const createdAt = pending[id];
+      if (typeof createdAt !== "number") return false;
+      if (now - createdAt > 30_000) {
+        delete pending[id];
+        return false;
+      }
+      return true;
+    });
+
+    if (Object.keys(pending).length === 0) {
+      delete pendingCreatedSessionIdsRef.current[workspaceId];
+    }
+
+    return preserved.length > 0 ? [...preserved, ...fetched] : fetched;
+  }, []);
   const loadWorkspaceSessionsInBackground = useCallback(
     async (workspaces: RouteWorkspace[]) => {
       const MAX_ATTEMPTS = 6;
@@ -556,7 +597,12 @@ export function SessionRoute() {
                 normalizeDirectoryPath(session?.directory ?? "") === workspaceRoot,
               )
             : (response.items ?? []);
-          setSessionsByWorkspaceId((current) => ({ ...current, [workspace.id]: items }));
+          setSessionsByWorkspaceId((current) => {
+            const nextItems = mergeFetchedSessionsWithPending(workspace.id, items, current[workspace.id] ?? []);
+            const next = { ...current, [workspace.id]: nextItems };
+            sessionsByWorkspaceIdRef.current = next;
+            return next;
+          });
           setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: null }));
           setWorkspaceConnectionOverrides((current) => {
             if (current[workspace.id]?.status !== "error") return current;
@@ -622,7 +668,7 @@ export function SessionRoute() {
 
       await Promise.all(workspaces.map((workspace) => fetchOnce(workspace, 0)));
     },
-    [endpointForWorkspace],
+    [endpointForWorkspace, mergeFetchedSessionsWithPending],
   );
 
   const refreshRouteState = useCallback(async () => {
@@ -666,6 +712,7 @@ export function SessionRoute() {
         setToken("");
         const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
         setWorkspaces(orderedDesktopWorkspaces);
+        sessionsByWorkspaceIdRef.current = {};
         setSessionsByWorkspaceId({});
         setErrorsByWorkspaceId({});
         setLegacySelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "");
@@ -726,7 +773,9 @@ export function SessionRoute() {
       setBaseUrl(normalizedBaseUrl);
       setToken(resolvedToken);
       setWorkspaces(nextWorkspaces);
-      setSessionsByWorkspaceId(Object.fromEntries(cachedEntries.map((entry) => [entry.workspaceId, entry.sessions])));
+      const nextSessionsByWorkspaceId = Object.fromEntries(cachedEntries.map((entry) => [entry.workspaceId, entry.sessions]));
+      sessionsByWorkspaceIdRef.current = nextSessionsByWorkspaceId;
+      setSessionsByWorkspaceId(nextSessionsByWorkspaceId);
       setErrorsByWorkspaceId((previous) => {
         const next: Record<string, string | null> = {};
         for (const workspace of nextWorkspaces) {
@@ -1857,10 +1906,15 @@ export function SessionRoute() {
       setLegacySelectedWorkspaceId(workspaceId);
       writeActiveWorkspaceId(workspaceId || null);
       writeLastSessionFor(workspaceId, session.id);
-      setSessionsByWorkspaceId((current) => ({
-        ...current,
-        [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
-      }));
+      rememberPendingCreatedSession(workspaceId, session.id);
+      setSessionsByWorkspaceId((current) => {
+        const next = {
+          ...current,
+          [workspaceId]: [session as any, ...(current[workspaceId] ?? [])],
+        };
+        sessionsByWorkspaceIdRef.current = next;
+        return next;
+      });
       navigateToWorkspaceSession(workspaceId, session.id);
       focusPromptSoon();
       void refreshRouteState();
@@ -1878,7 +1932,7 @@ export function SessionRoute() {
         }
       }
     }
-  }, [baseUrl, errorsByWorkspaceId, loading, navigateToWorkspaceSession, refreshRouteState, retryingWorkspaceIds, token, workspaces]);
+  }, [baseUrl, errorsByWorkspaceId, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
 
   // Global shortcuts:
   //   Cmd/Ctrl+N  -> new task in selected workspace
@@ -2067,10 +2121,15 @@ export function SessionRoute() {
         writeActiveWorkspaceId(targetWorkspaceId);
         if (session?.id) {
           writeLastSessionFor(targetWorkspaceId, session.id);
-          setSessionsByWorkspaceId((current) => ({
-            ...current,
-            [targetWorkspaceId]: [session as any, ...(current[targetWorkspaceId] ?? [])],
-          }));
+          rememberPendingCreatedSession(targetWorkspaceId, session.id);
+          setSessionsByWorkspaceId((current) => {
+            const next = {
+              ...current,
+              [targetWorkspaceId]: [session as any, ...(current[targetWorkspaceId] ?? [])],
+            };
+            sessionsByWorkspaceIdRef.current = next;
+            return next;
+          });
         }
         navigateToWorkspaceSession(targetWorkspaceId, session?.id ?? null, { replace: true });
         if (session?.id) focusPromptSoon();
@@ -2080,7 +2139,7 @@ export function SessionRoute() {
     } finally {
       setCreateWorkspaceBusy(false);
     }
-  }, [client, local, navigateToWorkspaceSession, refreshRouteState]);
+  }, [client, local, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession]);
 
   const handleCreateRemoteWorkspace = useCallback(async (input: {
     openworkHostUrl?: string | null;

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
 import type { PermissionRequest } from "@opencode-ai/sdk/v2/client";
 
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import {
   permissionKey,
   seedPermissionState,
+  seedSessionState,
+  transcriptKey,
 } from "../src/react-app/domains/session/sync/session-sync";
 
 function permission(id: string, sessionID: string): PermissionRequest {
@@ -19,6 +23,49 @@ function permission(id: string, sessionID: string): PermissionRequest {
       project: false,
     },
   };
+}
+
+function uiMessage(id: string, role: "user" | "assistant", text: string): UIMessage {
+  return {
+    id,
+    role,
+    parts: [{ type: "text", text, state: "done" }],
+  };
+}
+
+function snapshotWithMessages(
+  messages: Array<{ id: string; role: "user" | "assistant"; text: string }>,
+  sessionId = "session-a",
+): OpenworkSessionSnapshot {
+  return {
+    session: {
+      id: sessionId,
+      parentID: undefined,
+      title: "Test session",
+      time: { created: 1, updated: 2 },
+      share: undefined,
+      version: "0",
+    },
+    messages: messages.map((message, index) => ({
+      info: {
+        id: message.id,
+        role: message.role,
+        sessionID: sessionId,
+        time: { created: index + 1 },
+      },
+      parts: [
+        {
+          id: `part_${message.id}`,
+          type: "text",
+          text: message.text,
+          sessionID: sessionId,
+          messageID: message.id,
+        },
+      ],
+    })),
+    todos: [],
+    status: { type: "idle" },
+  } as unknown as OpenworkSessionSnapshot;
 }
 
 afterEach(() => {
@@ -77,5 +124,36 @@ describe("session permission sync", () => {
     seedPermissionState("workspace-a", "session-a", [], { snapshotStartedAt: 200 });
 
     expect(getReactQueryClient().getQueryData(permissionKey("workspace-a", "session-a"))).toEqual([]);
+  });
+});
+
+describe("session transcript sync", () => {
+  test("keeps live-only messages when an idle snapshot is stale", () => {
+    getReactQueryClient().setQueryData(transcriptKey("workspace-a", "session-a"), [
+      uiMessage("msg-user", "user", "hello"),
+      uiMessage("msg-assistant", "assistant", "finished answer"),
+    ]);
+
+    seedSessionState("workspace-a", snapshotWithMessages([
+      { id: "msg-user", role: "user", text: "hello" },
+    ]));
+
+    const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"));
+    expect(transcript?.map((message) => message.id)).toEqual(["msg-user", "msg-assistant"]);
+  });
+
+  test("keeps longer live text when an idle snapshot lags the event stream", () => {
+    getReactQueryClient().setQueryData(transcriptKey("workspace-a", "session-a"), [
+      uiMessage("msg-user", "user", "hello"),
+      uiMessage("msg-assistant", "assistant", "finished answer"),
+    ]);
+
+    seedSessionState("workspace-a", snapshotWithMessages([
+      { id: "msg-user", role: "user", text: "hello" },
+      { id: "msg-assistant", role: "assistant", text: "finished" },
+    ]));
+
+    const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"));
+    expect(transcript?.[1]?.parts[0]).toMatchObject({ text: "finished answer" });
   });
 });


### PR DESCRIPTION
## Summary

- Preserve newly created sessions during immediate route refresh/list races so the sidebar does not drop them before the server list catches up.
- Merge stale server snapshots with live transcript cache even after idle so completed answers do not disappear until reload.
- Add regression coverage for stale idle snapshots preserving live-only messages and longer live text.

Fixes #1695
Fixes #1745

## Evidence

### Build verification
- `pnpm --filter @openwork/app typecheck` -- failed on existing unrelated type errors across desktop bridge/messaging/settings files; no new errors were isolated from this change.

### Test verification
- `bun test tests/session-sync-permissions.test.ts scripts/session-render-state.test.ts` -- passed: 13 pass, 0 fail, 17 assertions.
- `git diff --check` -- passed.

### API verification
- No API changes.

### UI verification
- Not run via Chrome MCP; this is a state reconciliation fix covered by targeted unit tests. Manual verification should create a session, send a prompt, and confirm the session remains in the sidebar and the completed answer stays visible after the model goes idle.

## Test instructions

1. Run `pnpm install --frozen-lockfile` if dependencies are not linked.
2. Run `bun test tests/session-sync-permissions.test.ts scripts/session-render-state.test.ts` from `apps/app`.
3. Launch the desktop app, create a new session, send a prompt, and verify the session remains in the sidebar and the final answer does not disappear after completion.