### PR TITLE
fix(session): preserve live tail messages

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -122,7 +122,26 @@ describe("deriveRenderedSessionMessages", () => {
         { id: "msg_old_user", role: "user", text: "old prompt" },
         { id: "msg_old_assistant", role: "assistant", text: "old answer" },
       ]),
-      includeLiveOnlyMessages: true,
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "msg_old_user",
+      "msg_old_assistant",
+      "msg_current_user",
+      "msg_current_assistant",
+    ]);
+  });
+
+  it("keeps live-only tail messages after the stream flips idle before the snapshot catches up", () => {
+    const messages = deriveRenderedSessionMessages({
+      transcriptState: [
+        uiMessage("msg_current_user", "user", "latest prompt"),
+        uiMessage("msg_current_assistant", "assistant", "latest answer"),
+      ],
+      snapshot: snapshotWithMessages([
+        { id: "msg_old_user", role: "user", text: "old prompt" },
+        { id: "msg_old_assistant", role: "assistant", text: "old answer" },
+      ]),
     });
 
     expect(messages.map((message) => message.id)).toEqual([

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -24,7 +24,6 @@ export function resolveRenderedSessionSnapshot(input: {
 export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
   snapshot: OpenworkSessionSnapshot | null | undefined;
-  includeLiveOnlyMessages?: boolean;
 }) {
   const liveMessages = input.transcriptState ?? [];
   const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
@@ -36,7 +35,7 @@ export function deriveRenderedSessionMessages(input: {
   if (liveMessages.length > 0 && snapshotMessages.length > 0) {
     if (messageListContainsAll(liveMessages, snapshotMessages)) return liveMessages;
     return mergeSnapshotAndLiveMessages(snapshotMessages, liveMessages, {
-      appendLiveOnlyMessages: input.includeLiveOnlyMessages,
+      appendLiveOnlyMessages: true,
     });
   }
   if (input.snapshot && input.snapshot.messages.length > 0) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -400,7 +400,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const liveStatus = statusState ?? snapshot?.status ?? IDLE_STATUS;
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
   const renderedMessages = useMemo(
-    () => deriveRenderedSessionMessages({ transcriptState, snapshot, includeLiveOnlyMessages: true }),
+    () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
     [snapshot, transcriptState],
   );
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;


### PR DESCRIPTION
## Summary

- Always merge live-only transcript tail messages with the latest snapshot so newly sent turns stay visible even if the snapshot endpoint lags after `session.idle`.
- Removes the streaming-only gate from rendered session message derivation.
- Adds regression coverage for the stale-snapshot/live-tail race.

Closes #1747

## Evidence

### Build verification
- `bun test apps/app/scripts/session-render-state.test.ts` -- passed: 8 tests, 12 assertions.
- `pnpm --filter @openwork/app build` -- passed.
- `pnpm --filter @openwork/app typecheck` -- failed on existing unrelated TypeScript errors in connection/settings/desktop files; no errors were reported in the changed session files.

### API verification
- No API changes.

### UI verification
- No screenshot captured; this is a session render-state race covered by the focused regression test.

## Test instructions

1. Open an existing chat thread.
2. Send several messages until the backend has a stale snapshot while live SSE has the newest tail.
3. Verify the last user/assistant turn remains visible after the run becomes idle, without switching threads.