### PR TITLE
fix(desktop): persist remote OpenWork workspace ids

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -24,6 +24,10 @@ import { startBrowserMcpServers } from "./browser-mcp.mjs";
 import { createRuntimeManager } from "./runtime.mjs";
 import { registerUpdaterIpc } from "./updater.mjs";
 import { exportWorkspaceConfig, importWorkspaceConfig } from "./workspace-archive.mjs";
+import {
+  openworkWorkspaceDisplayName,
+  selectOpenworkWorkspaceForConnection,
+} from "./remote-workspace.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
@@ -860,6 +864,32 @@ function openworkRemoteWorkspaceId(hostUrl, workspaceId) {
   return `rem_${createHash("sha256").update(`openwork::${hostUrl}`).digest("hex").slice(0, 12)}`;
 }
 
+async function fetchOpenworkWorkspaceList(hostUrl, token, hostToken) {
+  const url = `${String(hostUrl ?? "").replace(/\/+$/, "")}/workspaces`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8_000);
+  const headers = new Headers();
+  const bearerToken = String(token ?? "").trim();
+  const hostAuthToken = String(hostToken ?? "").trim();
+  if (bearerToken) headers.set("Authorization", `Bearer ${bearerToken}`);
+  if (hostAuthToken) headers.set("X-OpenWork-Host-Token", hostAuthToken);
+
+  try {
+    const response = await fetch(url, { headers, signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`OpenWork workspace discovery failed (${response.status} ${response.statusText || "HTTP error"})`);
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function discoverOpenworkWorkspace({ hostUrl, token, hostToken, directory }) {
+  const list = await fetchOpenworkWorkspaceList(hostUrl, token, hostToken);
+  return selectOpenworkWorkspaceForConnection(list, directory);
+}
+
 async function readWorkspaceOpenworkConfig(workspacePath) {
   const openworkPath = path.join(workspacePath, ".opencode", "openwork.json");
   if (!(await pathExists(openworkPath))) {
@@ -1463,25 +1493,44 @@ async function handleDesktopInvoke(event, command, ...args) {
         : remoteType === "openwork"
           ? parseOpenworkWorkspaceIdFromUrl(rawOpenworkHostUrl) || parseOpenworkWorkspaceIdFromUrl(baseUrl)
           : null;
+      let resolvedOpenworkWorkspaceId = openworkWorkspaceId;
+      let resolvedOpenworkWorkspaceName = input.openworkWorkspaceName ?? null;
+      if (remoteType === "openwork" && !resolvedOpenworkWorkspaceId) {
+        const discovered = await discoverOpenworkWorkspace({
+          hostUrl: openworkHostUrl ?? baseUrl,
+          token: input.openworkToken,
+          hostToken: input.openworkHostToken,
+          directory,
+        });
+        if (!discovered?.id) {
+          throw new Error(
+            directory
+              ? `OpenWork server has no workspace matching ${directory}.`
+              : "OpenWork server returned no workspaces.",
+          );
+        }
+        resolvedOpenworkWorkspaceId = String(discovered.id).trim();
+        resolvedOpenworkWorkspaceName = openworkWorkspaceDisplayName(discovered);
+      }
       const id = remoteType === "openwork"
-        ? openworkRemoteWorkspaceId(openworkHostUrl ?? baseUrl, openworkWorkspaceId)
+        ? openworkRemoteWorkspaceId(openworkHostUrl ?? baseUrl, resolvedOpenworkWorkspaceId)
         : remoteWorkspaceId(baseUrl, directory);
       const workspace = normalizeWorkspaceEntry({
         id,
-        name: String(input.displayName ?? input.openworkWorkspaceName ?? "Remote workspace"),
+        name: String(input.displayName ?? resolvedOpenworkWorkspaceName ?? "Remote workspace"),
         displayName: input.displayName ?? null,
         path: directory ?? "",
         preset: "remote",
         workspaceType: "remote",
         remoteType,
-        baseUrl,
+        baseUrl: remoteType === "openwork" ? (openworkHostUrl ?? baseUrl) : baseUrl,
         directory,
         openworkHostUrl,
         openworkToken: input.openworkToken ?? null,
         openworkClientToken: input.openworkClientToken ?? null,
         openworkHostToken: input.openworkHostToken ?? null,
-        openworkWorkspaceId,
-        openworkWorkspaceName: input.openworkWorkspaceName ?? null,
+        openworkWorkspaceId: resolvedOpenworkWorkspaceId,
+        openworkWorkspaceName: resolvedOpenworkWorkspaceName,
         sandboxBackend: input.sandboxBackend ?? null,
         sandboxRunId: input.sandboxRunId ?? null,
         sandboxContainerName: input.sandboxContainerName ?? null,
@@ -1499,9 +1548,62 @@ async function handleDesktopInvoke(event, command, ...args) {
       const workspaceId = String(input.workspaceId ?? "").trim();
       if (!workspaceId) throw new Error("workspaceId is required");
       const { workspaceId: _workspaceId, ...patch } = input;
-      return mutateWorkspaceState((state) => {
+      return mutateWorkspaceState(async (state) => {
+        const existing = state.workspaces.find((entry) => entry.id === workspaceId);
+        if (!existing) return state;
+
+        let nextWorkspace = { ...existing, ...patch };
+        const nextRemoteType = nextWorkspace.remoteType === "opencode" ? "opencode" : "openwork";
+        if (nextRemoteType === "openwork") {
+          const rawHostUrl = typeof nextWorkspace.openworkHostUrl === "string" && nextWorkspace.openworkHostUrl.trim()
+            ? nextWorkspace.openworkHostUrl.trim()
+            : null;
+          const nextBaseUrl = String(nextWorkspace.baseUrl ?? "").trim();
+          const hostUrl = stripOpenworkWorkspaceMount(rawHostUrl ?? nextBaseUrl);
+          const directory = typeof nextWorkspace.directory === "string" && nextWorkspace.directory.trim()
+            ? nextWorkspace.directory.trim()
+            : null;
+          let remoteWorkspaceId = typeof nextWorkspace.openworkWorkspaceId === "string" && nextWorkspace.openworkWorkspaceId.trim()
+            ? nextWorkspace.openworkWorkspaceId.trim()
+            : parseOpenworkWorkspaceIdFromUrl(rawHostUrl) || parseOpenworkWorkspaceIdFromUrl(nextBaseUrl);
+          let remoteWorkspaceName = nextWorkspace.openworkWorkspaceName ?? null;
+          if (!remoteWorkspaceId) {
+            const discovered = await discoverOpenworkWorkspace({
+              hostUrl: hostUrl ?? nextBaseUrl,
+              token: nextWorkspace.openworkToken,
+              hostToken: nextWorkspace.openworkHostToken,
+              directory,
+            });
+            if (!discovered?.id) {
+              throw new Error(
+                directory
+                  ? `OpenWork server has no workspace matching ${directory}.`
+                  : "OpenWork server returned no workspaces.",
+              );
+            }
+            remoteWorkspaceId = String(discovered.id).trim();
+            remoteWorkspaceName = openworkWorkspaceDisplayName(discovered);
+          }
+          const nextId = openworkRemoteWorkspaceId(hostUrl ?? nextBaseUrl, remoteWorkspaceId);
+          nextWorkspace = normalizeWorkspaceEntry({
+            ...nextWorkspace,
+            id: nextId,
+            baseUrl: hostUrl ?? nextBaseUrl,
+            openworkHostUrl: hostUrl,
+            directory,
+            remoteType: "openwork",
+            openworkWorkspaceId: remoteWorkspaceId,
+            openworkWorkspaceName: remoteWorkspaceName,
+          });
+          if (nextId !== workspaceId) {
+            if (state.selectedId === workspaceId) state.selectedId = nextId;
+            if (state.activeId === workspaceId) state.activeId = nextId;
+            if (state.watchedId === workspaceId) state.watchedId = nextId;
+          }
+        }
+
         state.workspaces = state.workspaces.map((entry) =>
-          entry.id === workspaceId ? { ...entry, ...patch } : entry,
+          entry.id === workspaceId ? nextWorkspace : entry,
         );
         return state;
       });

--- a/apps/desktop/electron/remote-workspace.mjs
+++ b/apps/desktop/electron/remote-workspace.mjs
@@ -1,0 +1,46 @@
+function trim(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeRemoteDirectory(value) {
+  const normalized = trim(value).replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || "";
+}
+
+function workspaceDirectoryCandidates(workspace) {
+  if (!workspace || typeof workspace !== "object") return [];
+  return [
+    workspace.directory,
+    workspace.path,
+    workspace.opencode?.directory,
+  ]
+    .map(normalizeRemoteDirectory)
+    .filter(Boolean);
+}
+
+export function selectOpenworkWorkspaceForConnection(list, directory) {
+  const items = Array.isArray(list?.items)
+    ? list.items
+    : Array.isArray(list?.workspaces)
+      ? list.workspaces
+      : [];
+  if (!items.length) return null;
+
+  const expectedDirectory = normalizeRemoteDirectory(directory);
+  if (expectedDirectory) {
+    return items.find((item) => workspaceDirectoryCandidates(item).includes(expectedDirectory)) ?? null;
+  }
+
+  const activeId = trim(list?.activeId);
+  return (activeId ? items.find((item) => trim(item?.id) === activeId) : null) ?? items[0] ?? null;
+}
+
+export function openworkWorkspaceDisplayName(workspace) {
+  return (
+    trim(workspace?.displayName) ||
+    trim(workspace?.openworkWorkspaceName) ||
+    trim(workspace?.name) ||
+    trim(workspace?.id) ||
+    null
+  );
+}

--- a/apps/desktop/electron/remote-workspace.test.mjs
+++ b/apps/desktop/electron/remote-workspace.test.mjs
@@ -1,0 +1,101 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  openworkWorkspaceDisplayName,
+  selectOpenworkWorkspaceForConnection,
+} from "./remote-workspace.mjs";
+
+describe("selectOpenworkWorkspaceForConnection", () => {
+  it("selects the active worker workspace when no directory is provided", () => {
+    const selected = selectOpenworkWorkspaceForConnection(
+      {
+        activeId: "ws_active",
+        items: [
+          { id: "ws_first", path: "/workspace/first" },
+          { id: "ws_active", path: "/workspace/active" },
+        ],
+      },
+      null,
+    );
+
+    assert.equal(selected?.id, "ws_active");
+  });
+
+  it("falls back to the first workspace when activeId is missing", () => {
+    const selected = selectOpenworkWorkspaceForConnection(
+      {
+        items: [
+          { id: "ws_first", path: "/workspace/first" },
+          { id: "ws_second", path: "/workspace/second" },
+        ],
+      },
+      "",
+    );
+
+    assert.equal(selected?.id, "ws_first");
+  });
+
+  it("selects a workspace whose path matches the requested remote directory", () => {
+    const selected = selectOpenworkWorkspaceForConnection(
+      {
+        activeId: "ws_other",
+        items: [
+          { id: "ws_other", path: "/workspace/other" },
+          { id: "ws_demo", path: "/home/user/workspaces/demo" },
+        ],
+      },
+      "/home/user/workspaces/demo/",
+    );
+
+    assert.equal(selected?.id, "ws_demo");
+  });
+
+  it("selects by opencode directory when workers expose it there", () => {
+    const selected = selectOpenworkWorkspaceForConnection(
+      {
+        items: [
+          {
+            id: "ws_demo",
+            path: "/workspace",
+            opencode: { directory: "/home/user/workspaces/demo" },
+          },
+        ],
+      },
+      "/home/user/workspaces/demo",
+    );
+
+    assert.equal(selected?.id, "ws_demo");
+  });
+
+  it("returns null when a requested directory is not present", () => {
+    const selected = selectOpenworkWorkspaceForConnection(
+      { items: [{ id: "ws_demo", path: "/workspace/demo" }] },
+      "/workspace/missing",
+    );
+
+    assert.equal(selected, null);
+  });
+
+  it("reads legacy workspaces arrays", () => {
+    const selected = selectOpenworkWorkspaceForConnection(
+      { activeId: "ws_legacy", workspaces: [{ id: "ws_legacy", path: "/workspace" }] },
+      null,
+    );
+
+    assert.equal(selected?.id, "ws_legacy");
+  });
+});
+
+describe("openworkWorkspaceDisplayName", () => {
+  it("prefers display fields before id", () => {
+    assert.equal(
+      openworkWorkspaceDisplayName({
+        id: "ws_demo",
+        name: "Worker project",
+        displayName: "Demo",
+      }),
+      "Demo",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Discover the worker's real `ws_*` workspace id from `GET /workspaces` before persisting Add Remote entries.
- Persist OpenWork remote entries as `rem_<worker-workspace-id>` with `openworkWorkspaceId`/`openworkWorkspaceName`, including repair through Edit Connection.
- Add focused selector coverage for active workspace fallback, directory matching, and legacy response shapes.

Fixes #1744

## Evidence

### Build verification
- `pnpm install --frozen-lockfile` -- passed
- `node --test apps/desktop/electron/remote-workspace.test.mjs` -- passed, 7 tests
- `pnpm --filter @openwork/desktop check:electron` -- passed
- `pnpm --filter @openwork/app build` -- passed
- `pnpm --filter @openwork/desktop build` -- passed
- `pnpm --filter @openwork/desktop typecheck:electron` -- failed on existing browser MCP/Electron JSDoc typing issues outside this fix path; the new fetch header typing issue was fixed and no errors remain from the changed discovery helper.

### API verification
- No server API changed. The desktop bridge now calls existing worker `GET /workspaces` and stores the returned workspace id.

### UI verification
- No UI layout changed. Flow impact is Add workspace -> Connect remote and Edit Connection save behavior.

## Test instructions

1. Start an OpenWork worker with one workspace and a client token.
2. In the desktop app, use Add workspace -> Connect remote with the worker host URL and token.
3. Confirm `openwork-workspaces.json` stores `openworkWorkspaceId` as the worker `ws_*` id and local `id` as `rem_ws_*`.
4. Confirm subsequent `/workspace/<ws_*>/opencode/...` requests succeed instead of using the synthetic local hash.