### PR TITLE
fix(server): guard response writes after end

### DIFF
--- a/apps/server/src/serve-node.test.ts
+++ b/apps/server/src/serve-node.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { setTimeout as delay } from "node:timers/promises";
+import { serve } from "./serve-node.js";
+
+describe("serve", () => {
+  test("does not write an error response after a streaming response has ended", async () => {
+    const uncaught: unknown[] = [];
+    const onUncaughtException = (error: unknown) => {
+      uncaught.push(error);
+    };
+    process.on("uncaughtException", onUncaughtException);
+
+    const encoder = new TextEncoder();
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        if (new URL(request.url).pathname === "/health") {
+          return Response.json({ ok: true });
+        }
+
+        let wroteChunk = false;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (!wroteChunk) {
+                wroteChunk = true;
+                controller.enqueue(encoder.encode("partial"));
+                return;
+              }
+              controller.error(new Error("stream failed after response started"));
+            },
+          }),
+        );
+      },
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/stream`);
+      await response.text().catch(() => undefined);
+      await delay(25);
+
+      expect(uncaught).toEqual([]);
+
+      const health = await fetch(`http://127.0.0.1:${server.port}/health`);
+      expect(health.status).toBe(200);
+      expect(await health.json()).toEqual({ ok: true });
+    } finally {
+      process.off("uncaughtException", onUncaughtException);
+      server.stop();
+    }
+  });
+});

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -20,6 +20,49 @@ export type ServeResult = {
   stop: () => void;
 };
 
+function isResponseWritable(nodeRes: ServerResponse): boolean {
+  return !nodeRes.destroyed && !nodeRes.closed && !nodeRes.writableEnded;
+}
+
+function isWriteAfterEndError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ERR_STREAM_WRITE_AFTER_END" || error.message.includes("write after end");
+}
+
+function endResponse(nodeRes: ServerResponse, chunk?: string): void {
+  if (!isResponseWritable(nodeRes)) return;
+  nodeRes.end(chunk);
+}
+
+async function waitForDrainOrClose(nodeRes: ServerResponse): Promise<void> {
+  if (!isResponseWritable(nodeRes)) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      nodeRes.off("drain", done);
+      nodeRes.off("close", done);
+      nodeRes.off("error", fail);
+    };
+    const done = () => {
+      cleanup();
+      resolve();
+    };
+    const fail = (error: Error) => {
+      cleanup();
+      if (isWriteAfterEndError(error)) {
+        resolve();
+        return;
+      }
+      reject(error);
+    };
+
+    nodeRes.once("drain", done);
+    nodeRes.once("close", done);
+    nodeRes.once("error", fail);
+  });
+}
+
 /**
  * Convert a Node.js IncomingMessage into a Web API Request.
  */
@@ -69,10 +112,12 @@ async function writeWebResponse(webRes: Response, nodeRes: ServerResponse): Prom
     }
   });
 
+  if (!isResponseWritable(nodeRes)) return;
+
   nodeRes.writeHead(webRes.status, headersObj);
 
   if (!webRes.body) {
-    nodeRes.end();
+    endResponse(nodeRes);
     return;
   }
 
@@ -81,13 +126,14 @@ async function writeWebResponse(webRes: Response, nodeRes: ServerResponse): Prom
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
+      if (!isResponseWritable(nodeRes)) break;
       if (!nodeRes.write(value)) {
-        await new Promise<void>((resolve) => nodeRes.once("drain", resolve));
+        await waitForDrainOrClose(nodeRes);
       }
     }
   } finally {
     reader.releaseLock();
-    nodeRes.end();
+    endResponse(nodeRes);
   }
 }
 
@@ -100,16 +146,25 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
   const { hostname, port, fetch: fetchHandler } = options;
 
   const server = createServer(async (nodeReq, nodeRes) => {
+    nodeRes.on("error", (error) => {
+      if (isWriteAfterEndError(error)) {
+        console.warn("[serve-node] Ignored response write after end");
+        return;
+      }
+      console.error("[serve-node] Response stream error:", error);
+    });
+
     try {
       const webReq = toWebRequest(nodeReq, hostname, boundPort);
       const webRes = await fetchHandler(webReq);
       await writeWebResponse(webRes, nodeRes);
     } catch (error) {
       console.error("[serve-node] Unhandled error:", error);
+      if (!isResponseWritable(nodeRes)) return;
       if (!nodeRes.headersSent) {
         nodeRes.writeHead(500, { "Content-Type": "application/json" });
       }
-      nodeRes.end(JSON.stringify({ error: "internal_error" }));
+      endResponse(nodeRes, JSON.stringify({ error: "internal_error" }));
     }
   });
 


### PR DESCRIPTION
## Summary

- Guard the Node HTTP adapter from writing or ending a `ServerResponse` after it has already closed.
- Handle `ERR_STREAM_WRITE_AFTER_END` as a response-stream lifecycle error instead of letting it crash Electron main process.
- Add regression coverage for a streaming response that fails after response output has started.

Fixes #1743.

## Evidence

### Screenshots
No UI changes.

### Build verification
- `bun test apps/server/src/serve-node.test.ts` -- passed
- `pnpm --filter openwork-server typecheck` -- passed
- `pnpm --filter openwork-server build` -- passed
- `pnpm --filter openwork-server build:bin` -- passed

### API verification
Server adapter lifecycle change only; no endpoint contract changes. Regression test verifies the server remains alive after the failing streaming response and can still serve `/health`.

### UI verification
No UI changes.

## Test instructions

1. `pnpm install --frozen-lockfile`
2. `bun test apps/server/src/serve-node.test.ts`
3. `pnpm --filter openwork-server typecheck`
4. `pnpm --filter openwork-server build:bin`