### PR TITLE
feat(app): UI improvements 2

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -115,4 +115,13 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     kind: "mcp",
     iconSrc: "/openwork-mark.svg",
   },
+  {
+    get name() { return t("mcp.quick_connect_openwork_ui_title"); },
+    serverName: "openwork-ui",
+    get description() { return t("mcp.quick_connect_openwork_ui_desc"); },
+    type: "remote",
+    oauth: false,
+    kind: "mcp",
+    iconSrc: "/openwork-mark.svg",
+  },
 ];

--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -21,7 +21,10 @@ export type ExtensionKind = "mcp" | "plugin" | "skill";
 
 export type McpDirectoryInfo = {
   id?: string;
+  /** Display name shown in the UI. */
   name: string;
+  /** Safe server name for opencode.jsonc (alphanumeric, - and _ only). Auto-derived from name if omitted. */
+  serverName?: string;
   description: string;
   url?: string;
   type?: "remote" | "local";
@@ -35,9 +38,20 @@ export type McpDirectoryInfo = {
   iconSrc?: string;
 };
 
+/** Derive a safe MCP server name from a display name or explicit serverName. */
+export function getMcpServerName(entry: McpDirectoryInfo): string {
+  if (entry.serverName) return entry.serverName;
+  return entry.name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "") || "mcp";
+}
+
 export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
   {
     get name() { return t("mcp.quick_connect_notion_title"); },
+    serverName: "notion",
     get description() { return t("mcp.quick_connect_notion_desc"); },
     url: "https://mcp.notion.com/mcp",
     type: "remote",
@@ -47,6 +61,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
   },
   {
     get name() { return t("mcp.quick_connect_linear_title"); },
+    serverName: "linear",
     get description() { return t("mcp.quick_connect_linear_desc"); },
     url: "https://mcp.linear.app/mcp",
     type: "remote",
@@ -56,6 +71,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
   },
   {
     get name() { return t("mcp.quick_connect_sentry_title"); },
+    serverName: "sentry",
     get description() { return t("mcp.quick_connect_sentry_desc"); },
     url: "https://mcp.sentry.dev/mcp",
     type: "remote",
@@ -65,6 +81,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
   },
   {
     get name() { return t("mcp.quick_connect_stripe_title"); },
+    serverName: "stripe",
     get description() { return t("mcp.quick_connect_stripe_desc"); },
     url: "https://mcp.stripe.com",
     type: "remote",
@@ -74,6 +91,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
   },
   {
     get name() { return t("mcp.quick_connect_context7_title"); },
+    serverName: "context7",
     get description() { return t("mcp.quick_connect_context7_desc"); },
     url: "https://mcp.context7.com/mcp",
     type: "remote",
@@ -83,6 +101,7 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
   },
   {
     get name() { return t("mcp.quick_connect_openwork_cloud_title"); },
+    serverName: "openwork-cloud",
     get description() { return t("mcp.quick_connect_openwork_cloud_desc"); },
     get url() {
       try {

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -61,7 +61,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
   return (
     <button
       type="button"
-      disabled={disabled || connected || connecting}
+      disabled={disabled || connecting}
       onClick={onClick}
       className={`group w-full rounded-xl border p-4 text-left transition-all ${
         connected

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -71,22 +71,27 @@ export function ExtensionCard(props: ExtensionCardProps) {
     >
       <div className="flex items-start gap-3">
         {/* Icon */}
-        <div
-          className={`flex size-10 shrink-0 items-center justify-center rounded-lg border ${
-            connected ? "border-green-6 bg-green-3" : "border-dls-border bg-dls-hover"
-          }`}
-        >
-          {connecting ? (
-            <Loader2 size={18} className="animate-spin text-dls-secondary" />
-          ) : connected ? (
-            <CheckCircle2 size={18} className="text-green-11" />
-          ) : iconSrc ? (
-            <img src={iconSrc} alt="" width={18} height={18} loading="lazy" style={{ display: "block" }} />
-          ) : iconSlug ? (
-            <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={18} height={18} loading="lazy" style={{ display: "block" }} />
-          ) : (
-            <FallbackIcon size={18} className="text-dls-secondary" />
-          )}
+        <div className="relative shrink-0">
+          <div
+            className={`flex size-10 items-center justify-center rounded-lg border ${
+              connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover"
+            }`}
+          >
+            {connecting ? (
+              <Loader2 size={18} className="animate-spin text-dls-secondary" />
+            ) : iconSrc ? (
+              <img src={iconSrc} alt="" width={18} height={18} loading="lazy" style={{ display: "block" }} />
+            ) : iconSlug ? (
+              <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={18} height={18} loading="lazy" style={{ display: "block" }} />
+            ) : (
+              <FallbackIcon size={18} className="text-dls-secondary" />
+            )}
+          </div>
+          {connected ? (
+            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-white bg-green-9">
+              <CheckCircle2 size={9} className="text-white" strokeWidth={3} />
+            </div>
+          ) : null}
         </div>
 
         {/* Content */}

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -32,10 +32,12 @@ export type ExtensionDetailModalProps = {
   url?: string;
   /** Whether OAuth is required. */
   oauth?: boolean;
-  /** Filesystem path (for skills). */
+  /** Filesystem path (for skills). Not shown directly, used for reveal. */
   path?: string;
   /** Skill trigger phrase (e.g. "when user asks to create an agent"). */
   trigger?: string;
+  /** Reveal the file in Finder/Explorer. */
+  onReveal?: () => void;
   /** Skill content preview (first ~500 chars of the SKILL.md). */
   contentPreview?: string;
   /** Connect handler. */
@@ -113,6 +115,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     path,
     trigger,
     contentPreview,
+    onReveal,
     onConnect,
     onUninstall,
   } = props;
@@ -192,10 +195,17 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                   </div>
                 ) : null}
 
-                {path ? (
+                {path && onReveal ? (
                   <div className="flex items-center justify-between text-[13px]">
-                    <span className="text-dls-secondary">Path</span>
-                    <span className="truncate font-mono text-[11px] text-dls-text max-w-[240px]">{path}</span>
+                    <span className="text-dls-secondary">Location</span>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 font-medium text-dls-text transition-colors hover:text-dls-accent"
+                      onClick={onReveal}
+                    >
+                      Reveal in Finder
+                      <ExternalLink size={10} />
+                    </button>
                   </div>
                 ) : null}
 
@@ -209,7 +219,9 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                 <div className="flex items-center justify-between text-[13px]">
                   <span className="text-dls-secondary">Status</span>
                   <span className={`font-medium ${connected ? "text-green-11" : "text-dls-secondary"}`}>
-                    {connected ? "Connected" : connecting ? "Connecting..." : "Not connected"}
+                    {kind === "skill"
+                      ? (connected ? "Installed" : "Not installed")
+                      : (connected ? "Connected" : connecting ? "Connecting..." : "Not connected")}
                   </span>
                 </div>
               </div>

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -33,6 +33,10 @@ export type ExtensionDetailModalProps = {
   oauth?: boolean;
   /** Filesystem path (for skills). */
   path?: string;
+  /** Skill trigger phrase (e.g. "when user asks to create an agent"). */
+  trigger?: string;
+  /** Skill content preview (first ~500 chars of the SKILL.md). */
+  contentPreview?: string;
   /** Connect handler. */
   onConnect?: () => void;
   /** Uninstall/disconnect handler. Shown when connected. */
@@ -66,6 +70,8 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     url,
     oauth,
     path,
+    trigger,
+    contentPreview,
     onConnect,
     onUninstall,
   } = props;
@@ -168,15 +174,40 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
               </div>
             </div>
 
-            {/* What this enables */}
-            <div className={`${surfaceCardClass} space-y-2 p-4`}>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
-                What this enables
+            {/* Skill-specific: trigger + content preview */}
+            {kind === "skill" && trigger ? (
+              <div className={`${surfaceCardClass} space-y-2 p-4`}>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+                  Trigger
+                </div>
+                <div className="text-[13px] leading-relaxed text-dls-text">
+                  {trigger}
+                </div>
               </div>
-              <div className="text-[13px] leading-relaxed text-dls-secondary">
-                {kindDesc[kind]}
+            ) : null}
+
+            {kind === "skill" && contentPreview ? (
+              <div className={`${surfaceCardClass} space-y-2 p-4`}>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+                  Skill preview
+                </div>
+                <div className="max-h-[200px] overflow-y-auto rounded-lg bg-dls-hover p-3 font-mono text-[11px] leading-relaxed text-dls-secondary whitespace-pre-wrap">
+                  {contentPreview}
+                </div>
               </div>
-            </div>
+            ) : null}
+
+            {/* What this enables (generic, for non-skills or skills without preview) */}
+            {kind !== "skill" || (!trigger && !contentPreview) ? (
+              <div className={`${surfaceCardClass} space-y-2 p-4`}>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+                  What this enables
+                </div>
+                <div className="text-[13px] leading-relaxed text-dls-secondary">
+                  {kindDesc[kind]}
+                </div>
+              </div>
+            ) : null}
           </div>
         </div>
 

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -56,6 +56,37 @@ const kindDesc: Record<ExtensionKind, string> = {
   skill: "A reusable workflow that your agent can execute on demand.",
 };
 
+/**
+ * Strip YAML-like frontmatter lines (name:, description:, trigger:) from
+ * the beginning of a skill content string, returning only the body.
+ */
+function stripSkillFrontmatter(content: string): string {
+  const lines = content.split("\n");
+  let startIndex = 0;
+
+  // Skip leading blank lines
+  while (startIndex < lines.length && !lines[startIndex].trim()) {
+    startIndex++;
+  }
+
+  // Skip frontmatter lines (key: value pattern at the top)
+  while (startIndex < lines.length) {
+    const line = lines[startIndex].trim();
+    if (/^(name|description|trigger)\s*:/i.test(line)) {
+      startIndex++;
+    } else {
+      break;
+    }
+  }
+
+  // Skip blank lines after frontmatter
+  while (startIndex < lines.length && !lines[startIndex].trim()) {
+    startIndex++;
+  }
+
+  return lines.slice(startIndex).join("\n");
+}
+
 export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
   const {
     open,
@@ -187,16 +218,20 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
               </div>
             ) : null}
 
-            {kind === "skill" && contentPreview ? (
-              <div className={`${surfaceCardClass} space-y-2 p-4`}>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
-                  Skill preview
+            {kind === "skill" && contentPreview ? (() => {
+              const body = stripSkillFrontmatter(contentPreview);
+              if (!body.trim()) return null;
+              return (
+                <div className="space-y-2">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+                    Skill content
+                  </div>
+                  <div className="max-h-[300px] overflow-y-auto rounded-xl border border-dls-border bg-dls-surface p-4 text-[13px] leading-relaxed text-dls-text">
+                    <MarkdownBlock text={body} />
+                  </div>
                 </div>
-                <div className="max-h-[240px] overflow-y-auto rounded-lg bg-dls-hover p-3 text-[12px] leading-relaxed text-dls-text">
-                  <MarkdownBlock text={contentPreview} />
-                </div>
-              </div>
-            ) : null}
+              );
+            })() : null}
 
             {/* What this enables (generic, for non-skills or skills without preview) */}
             {kind !== "skill" || (!trigger && !contentPreview) ? (

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -57,34 +57,43 @@ const kindDesc: Record<ExtensionKind, string> = {
 };
 
 /**
- * Strip YAML-like frontmatter lines (name:, description:, trigger:) from
- * the beginning of a skill content string, returning only the body.
+ * Strip YAML-like frontmatter from the beginning of a skill content string.
+ * Handles both `---` delimited blocks and bare `key: value` lines at the top.
  */
 function stripSkillFrontmatter(content: string): string {
-  const lines = content.split("\n");
-  let startIndex = 0;
+  let text = content;
 
-  // Skip leading blank lines
-  while (startIndex < lines.length && !lines[startIndex].trim()) {
-    startIndex++;
-  }
+  // Handle --- delimited frontmatter block
+  const fencedMatch = text.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/);
+  if (fencedMatch) {
+    text = text.slice(fencedMatch[0].length);
+  } else {
+    // Handle bare key: value lines at the top
+    const lines = text.split("\n");
+    let startIndex = 0;
 
-  // Skip frontmatter lines (key: value pattern at the top)
-  while (startIndex < lines.length) {
-    const line = lines[startIndex].trim();
-    if (/^(name|description|trigger)\s*:/i.test(line)) {
+    // Skip leading blank lines
+    while (startIndex < lines.length && !lines[startIndex].trim()) {
       startIndex++;
-    } else {
-      break;
+    }
+
+    // Skip any key: value lines (common frontmatter keys)
+    while (startIndex < lines.length) {
+      const line = lines[startIndex].trim();
+      if (/^[a-zA-Z_-]+\s*:/.test(line) && !line.startsWith("#")) {
+        startIndex++;
+      } else {
+        break;
+      }
+    }
+
+    if (startIndex > 0) {
+      text = lines.slice(startIndex).join("\n");
     }
   }
 
-  // Skip blank lines after frontmatter
-  while (startIndex < lines.length && !lines[startIndex].trim()) {
-    startIndex++;
-  }
-
-  return lines.slice(startIndex).join("\n");
+  // Trim leading blank lines
+  return text.replace(/^\s*\n/, "");
 }
 
 export function ExtensionDetailModal(props: ExtensionDetailModalProps) {

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -31,8 +31,12 @@ export type ExtensionDetailModalProps = {
   url?: string;
   /** Whether OAuth is required. */
   oauth?: boolean;
+  /** Filesystem path (for skills). */
+  path?: string;
   /** Connect handler. */
   onConnect?: () => void;
+  /** Uninstall/disconnect handler. Shown when connected. */
+  onUninstall?: () => void;
 };
 
 const kindLabel: Record<ExtensionKind, string> = {
@@ -61,7 +65,9 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     connecting = false,
     url,
     oauth,
+    path,
     onConnect,
+    onUninstall,
   } = props;
 
   if (!open) return null;
@@ -139,6 +145,13 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                   </div>
                 ) : null}
 
+                {path ? (
+                  <div className="flex items-center justify-between text-[13px]">
+                    <span className="text-dls-secondary">Path</span>
+                    <span className="truncate font-mono text-[11px] text-dls-text max-w-[240px]">{path}</span>
+                  </div>
+                ) : null}
+
                 {oauth ? (
                   <div className="flex items-center justify-between text-[13px]">
                     <span className="text-dls-secondary">Authentication</span>
@@ -169,27 +182,40 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
 
         {/* Footer */}
         <div className={modalFooterClass}>
-          <div className="flex justify-end gap-3">
-            <button type="button" className={pillGhostClass} onClick={onClose}>
-              Close
-            </button>
-            {!connected && onConnect ? (
-              <button
-                type="button"
-                className={pillPrimaryClass}
-                onClick={onConnect}
-                disabled={connecting}
-              >
-                {connecting ? (
-                  <>
-                    <Loader2 size={14} className="animate-spin" />
-                    Connecting...
-                  </>
-                ) : (
-                  "Connect"
-                )}
+          <div className="flex justify-between">
+            <div>
+              {connected && onUninstall ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center gap-1.5 rounded-full border border-red-6 px-4 py-2 text-[13px] font-medium text-red-11 transition-colors hover:bg-red-3"
+                  onClick={() => { onUninstall(); onClose(); }}
+                >
+                  {kind === "skill" ? "Uninstall" : "Disconnect"}
+                </button>
+              ) : null}
+            </div>
+            <div className="flex gap-3">
+              <button type="button" className={pillGhostClass} onClick={onClose}>
+                Close
               </button>
+              {!connected && onConnect ? (
+                <button
+                  type="button"
+                  className={pillPrimaryClass}
+                  onClick={onConnect}
+                  disabled={connecting}
+                >
+                  {connecting ? (
+                    <>
+                      <Loader2 size={14} className="animate-spin" />
+                      Connecting...
+                    </>
+                  ) : (
+                    "Connect"
+                  )}
+                </button>
             ) : null}
+            </div>
           </div>
         </div>
       </div>

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -1,0 +1,198 @@
+/** @jsxImportSource react */
+import { CheckCircle2, ExternalLink, Loader2, Plug2, X } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ExtensionKind } from "../../app/constants";
+import {
+  modalOverlayClass,
+  modalShellClass,
+  modalHeaderClass,
+  modalHeaderButtonClass,
+  modalTitleClass,
+  modalSubtitleClass,
+  modalBodyClass,
+  modalFooterClass,
+  pillPrimaryClass,
+  pillGhostClass,
+  surfaceCardClass,
+} from "../domains/workspace/modal-styles";
+
+export type ExtensionDetailModalProps = {
+  open: boolean;
+  onClose: () => void;
+  name: string;
+  description: string;
+  iconSlug?: string;
+  iconSrc?: string;
+  fallbackIcon?: LucideIcon;
+  kind?: ExtensionKind;
+  connected?: boolean;
+  connecting?: boolean;
+  /** Remote URL if applicable. */
+  url?: string;
+  /** Whether OAuth is required. */
+  oauth?: boolean;
+  /** Connect handler. */
+  onConnect?: () => void;
+};
+
+const kindLabel: Record<ExtensionKind, string> = {
+  mcp: "MCP Server",
+  plugin: "Plugin",
+  skill: "Skill",
+};
+
+const kindDesc: Record<ExtensionKind, string> = {
+  mcp: "Connects as a Model Context Protocol server, giving your agent access to external tools and data.",
+  plugin: "Extends OpenWork with additional capabilities managed by your organization.",
+  skill: "A reusable workflow that your agent can execute on demand.",
+};
+
+export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
+  const {
+    open,
+    onClose,
+    name,
+    description,
+    iconSlug,
+    iconSrc,
+    fallbackIcon: FallbackIcon = Plug2,
+    kind = "mcp",
+    connected = false,
+    connecting = false,
+    url,
+    oauth,
+    onConnect,
+  } = props;
+
+  if (!open) return null;
+
+  return (
+    <div className={modalOverlayClass} onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div
+        className={`${modalShellClass} max-w-[520px]`}
+        role="dialog"
+        aria-modal="true"
+      >
+        {/* Header */}
+        <div className={modalHeaderClass}>
+          <div className="flex min-w-0 items-start gap-4">
+            {/* Icon */}
+            <div className="relative shrink-0">
+              <div
+                className={`flex size-12 items-center justify-center rounded-xl border ${
+                  connected ? "border-green-6 bg-green-2" : "border-dls-border bg-dls-hover"
+                }`}
+              >
+                {iconSrc ? (
+                  <img src={iconSrc} alt="" width={24} height={24} loading="lazy" style={{ display: "block" }} />
+                ) : iconSlug ? (
+                  <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={24} height={24} loading="lazy" style={{ display: "block" }} />
+                ) : (
+                  <FallbackIcon size={24} className="text-dls-secondary" />
+                )}
+              </div>
+              {connected ? (
+                <div className="absolute -bottom-0.5 -right-0.5 flex size-5 items-center justify-center rounded-full border-2 border-white bg-green-9">
+                  <CheckCircle2 size={11} className="text-white" strokeWidth={3} />
+                </div>
+              ) : null}
+            </div>
+
+            <div className="min-w-0">
+              <h3 className={modalTitleClass}>{name}</h3>
+              <p className={modalSubtitleClass}>{kindLabel[kind]}</p>
+            </div>
+          </div>
+
+          <button type="button" onClick={onClose} className={modalHeaderButtonClass} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className={modalBodyClass}>
+          <div className="space-y-5">
+            {/* Description */}
+            <div className="text-[14px] leading-relaxed text-dls-text">
+              {description}
+            </div>
+
+            {/* Details */}
+            <div className={`${surfaceCardClass} space-y-3 p-4`}>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+                Details
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-[13px]">
+                  <span className="text-dls-secondary">Type</span>
+                  <span className="font-medium text-dls-text">{kindLabel[kind]}</span>
+                </div>
+
+                {url ? (
+                  <div className="flex items-center justify-between text-[13px]">
+                    <span className="text-dls-secondary">Endpoint</span>
+                    <span className="flex items-center gap-1.5 truncate font-mono text-[11px] text-dls-text">
+                      {url.replace(/^https?:\/\//, "").slice(0, 40)}
+                      <ExternalLink size={10} className="shrink-0 text-dls-secondary" />
+                    </span>
+                  </div>
+                ) : null}
+
+                {oauth ? (
+                  <div className="flex items-center justify-between text-[13px]">
+                    <span className="text-dls-secondary">Authentication</span>
+                    <span className="font-medium text-dls-text">OAuth required</span>
+                  </div>
+                ) : null}
+
+                <div className="flex items-center justify-between text-[13px]">
+                  <span className="text-dls-secondary">Status</span>
+                  <span className={`font-medium ${connected ? "text-green-11" : "text-dls-secondary"}`}>
+                    {connected ? "Connected" : connecting ? "Connecting..." : "Not connected"}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* What this enables */}
+            <div className={`${surfaceCardClass} space-y-2 p-4`}>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+                What this enables
+              </div>
+              <div className="text-[13px] leading-relaxed text-dls-secondary">
+                {kindDesc[kind]}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className={modalFooterClass}>
+          <div className="flex justify-end gap-3">
+            <button type="button" className={pillGhostClass} onClick={onClose}>
+              Close
+            </button>
+            {!connected && onConnect ? (
+              <button
+                type="button"
+                className={pillPrimaryClass}
+                onClick={onConnect}
+                disabled={connecting}
+              >
+                {connecting ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" />
+                    Connecting...
+                  </>
+                ) : (
+                  "Connect"
+                )}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -2,6 +2,7 @@
 import { CheckCircle2, ExternalLink, Loader2, Plug2, X } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ExtensionKind } from "../../app/constants";
+import { MarkdownBlock } from "../domains/session/surface/markdown";
 import {
   modalOverlayClass,
   modalShellClass,
@@ -191,8 +192,8 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                 <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
                   Skill preview
                 </div>
-                <div className="max-h-[200px] overflow-y-auto rounded-lg bg-dls-hover p-3 font-mono text-[11px] leading-relaxed text-dls-secondary whitespace-pre-wrap">
-                  {contentPreview}
+                <div className="max-h-[240px] overflow-y-auto rounded-lg bg-dls-hover p-3 text-[12px] leading-relaxed text-dls-text">
+                  <MarkdownBlock text={contentPreview} />
                 </div>
               </div>
             ) : null}

--- a/apps/app/src/react-app/design-system/provider-added-toast.tsx
+++ b/apps/app/src/react-app/design-system/provider-added-toast.tsx
@@ -1,0 +1,57 @@
+/** @jsxImportSource react */
+import { X } from "lucide-react";
+import { ProviderIcon } from "./provider-icon";
+
+export type ProviderAddedToastProps = {
+  open: boolean;
+  providerName: string;
+  providerId: string;
+  modelName?: string;
+  onSwitchDefault: () => void;
+  onDismiss: () => void;
+};
+
+/**
+ * Toast shown when a new provider is added (e.g. from cloud sync).
+ * Appears at the bottom of the screen, offers to switch default model.
+ */
+export function ProviderAddedToast(props: ProviderAddedToastProps) {
+  if (!props.open) return null;
+
+  return (
+    <div className="fixed bottom-20 left-1/2 z-50 -translate-x-1/2 animate-in slide-in-from-bottom-4 fade-in duration-300">
+      <div className="flex items-center gap-3 rounded-2xl border border-dls-border bg-dls-surface px-4 py-3 shadow-lg">
+        <ProviderIcon providerId={props.providerId} size={20} className="shrink-0 text-dls-text" />
+
+        <div className="min-w-0">
+          <div className="text-[13px] font-medium text-dls-text">
+            {props.providerName} added
+          </div>
+          <div className="text-[11px] text-dls-secondary">
+            {props.modelName
+              ? `Your team added ${props.providerName}. Switch to ${props.modelName}?`
+              : `Your team added ${props.providerName}. Switch to it?`}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            className="rounded-full bg-[#011627] px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-black"
+            onClick={props.onSwitchDefault}
+          >
+            Switch default
+          </button>
+          <button
+            type="button"
+            className="flex size-7 items-center justify-center rounded-full text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+            onClick={props.onDismiss}
+            aria-label="Dismiss"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/design-system/provider-onboarding-modal.tsx
+++ b/apps/app/src/react-app/design-system/provider-onboarding-modal.tsx
@@ -1,0 +1,124 @@
+/** @jsxImportSource react */
+import { CheckCircle2, Sparkles, X } from "lucide-react";
+import { ProviderIcon } from "./provider-icon";
+import {
+  modalOverlayClass,
+  modalShellClass,
+  modalHeaderClass,
+  modalHeaderButtonClass,
+  modalTitleClass,
+  modalSubtitleClass,
+  modalBodyClass,
+  modalFooterClass,
+  pillPrimaryClass,
+  pillGhostClass,
+  surfaceCardClass,
+} from "../domains/workspace/modal-styles";
+
+export type ProviderOnboardingItem = {
+  id: string;
+  name: string;
+  recommended?: boolean;
+  recommendedModel?: string;
+};
+
+export type ProviderOnboardingModalProps = {
+  open: boolean;
+  onClose: () => void;
+  orgName: string;
+  providers: ProviderOnboardingItem[];
+  onAcceptDefaults: () => void;
+  onConfigureManually: () => void;
+};
+
+/**
+ * Shown after first sign-in when the user's org has pre-configured providers.
+ * Presents what's available and offers to set team defaults.
+ */
+export function ProviderOnboardingModal(props: ProviderOnboardingModalProps) {
+  if (!props.open || props.providers.length === 0) return null;
+
+  const recommended = props.providers.find((p) => p.recommended);
+
+  return (
+    <div className={modalOverlayClass} onClick={(e) => { if (e.target === e.currentTarget) props.onClose(); }}>
+      <div
+        className={`${modalShellClass} max-w-[480px]`}
+        role="dialog"
+        aria-modal="true"
+      >
+        {/* Header */}
+        <div className={modalHeaderClass}>
+          <div className="flex min-w-0 items-start gap-4">
+            <div className="flex size-12 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
+              <Sparkles size={24} className="text-dls-accent" />
+            </div>
+            <div className="min-w-0">
+              <h3 className={modalTitleClass}>Your team is ready</h3>
+              <p className={modalSubtitleClass}>
+                {props.orgName} has set up AI providers for you.
+              </p>
+            </div>
+          </div>
+          <button type="button" onClick={props.onClose} className={modalHeaderButtonClass} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className={modalBodyClass}>
+          <div className="space-y-4">
+            {/* Provider list */}
+            <div className="space-y-2">
+              {props.providers.map((provider) => (
+                <div
+                  key={provider.id}
+                  className={`${surfaceCardClass} flex items-center justify-between gap-3 px-4 py-3 ${
+                    provider.recommended ? "ring-1 ring-dls-accent/20" : ""
+                  }`}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <ProviderIcon providerId={provider.id} size={20} className="text-dls-text" />
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-dls-text">{provider.name}</div>
+                      {provider.recommendedModel ? (
+                        <div className="truncate font-mono text-[11px] text-dls-secondary">
+                          {provider.recommendedModel}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                  {provider.recommended ? (
+                    <span className="shrink-0 rounded-full bg-dls-accent/10 px-2.5 py-0.5 text-[10px] font-semibold text-dls-accent">
+                      Recommended
+                    </span>
+                  ) : (
+                    <CheckCircle2 size={16} className="shrink-0 text-green-11" />
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {recommended ? (
+              <div className="rounded-xl border border-dls-border bg-dls-hover/50 px-4 py-3 text-[13px] text-dls-secondary">
+                Your team recommends <span className="font-medium text-dls-text">{recommended.recommendedModel ?? recommended.name}</span> as the default model.
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className={modalFooterClass}>
+          <div className="flex justify-end gap-3">
+            <button type="button" className={pillGhostClass} onClick={props.onConfigureManually}>
+              I&apos;ll configure manually
+            </button>
+            <button type="button" className={pillPrimaryClass} onClick={props.onAcceptDefaults}>
+              Use team defaults
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -475,11 +475,15 @@ export function createConnectionsStore(options: {
 
       // Resolve dynamic URLs for built-in MCPs
       let resolvedUrl = entry.url;
+      let resolvedHeaders: Record<string, string> | undefined;
       if (!resolvedUrl && entry.serverName === "openwork-ui") {
         try {
           const bridgeInfo = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getUiControlBridgeInfo");
           if (bridgeInfo?.baseUrl) {
             resolvedUrl = `${bridgeInfo.baseUrl}/mcp`;
+            if (bridgeInfo.token) {
+              resolvedHeaders = { Authorization: `Bearer ${bridgeInfo.token}` };
+            }
           }
         } catch {
           // Bridge not available
@@ -496,7 +500,10 @@ export function createConnectionsStore(options: {
           throw new Error("Missing MCP URL. Is the OpenWork desktop app running?");
         }
         mcpEntryConfig["url"] = resolvedUrl;
-        if (entry.oauth) {
+        if (resolvedHeaders) {
+          mcpEntryConfig["headers"] = resolvedHeaders;
+        }
+        if (entry.oauth && !resolvedHeaders) {
           mcpEntryConfig["oauth"] = {};
         }
       }

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -473,16 +473,29 @@ export function createConnectionsStore(options: {
     try {
       mutateState((current) => ({ ...current, mcpStatus: null, mcpConnectingName: entry.name }));
 
+      // Resolve dynamic URLs for built-in MCPs
+      let resolvedUrl = entry.url;
+      if (!resolvedUrl && entry.serverName === "openwork-ui") {
+        try {
+          const bridgeInfo = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getUiControlBridgeInfo");
+          if (bridgeInfo?.baseUrl) {
+            resolvedUrl = `${bridgeInfo.baseUrl}/mcp`;
+          }
+        } catch {
+          // Bridge not available
+        }
+      }
+
       const mcpEntryConfig: Record<string, unknown> = {
         type: entryType,
         enabled: true,
       };
 
       if (entryType === "remote") {
-        if (!entry.url) {
-          throw new Error("Missing MCP URL.");
+        if (!resolvedUrl) {
+          throw new Error("Missing MCP URL. Is the OpenWork desktop app running?");
         }
-        mcpEntryConfig["url"] = entry.url;
+        mcpEntryConfig["url"] = resolvedUrl;
         if (entry.oauth) {
           mcpEntryConfig["oauth"] = {};
         }

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -4,6 +4,7 @@ import { applyEdits, modify, parse, printParseErrorCode } from "jsonc-parser";
 
 import { t } from "../../../i18n";
 import {
+  getMcpServerName,
   MCP_QUICK_CONNECT,
   type McpDirectoryInfo,
 } from "../../../app/constants";
@@ -466,7 +467,7 @@ export function createConnectionsStore(options: {
       return;
     }
 
-    const slug = entry.id ?? entry.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    const slug = entry.id ?? getMcpServerName(entry);
     const action = snapshot.mcpServers.some((server) => server.name === slug) ? "updated" : "added";
 
     try {

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -808,8 +808,8 @@ export function SessionPage(props: SessionPageProps) {
         }}
       />
 
-      {/* Provider provisioning UI prototypes (dev mode only) */}
-      {props.developerMode ? (
+      {/* Provider provisioning UI prototypes */}
+      {(
         <>
           <ProviderOnboardingModal
             open={showProviderOnboarding}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -41,6 +41,8 @@ import { StatusBar, type StatusBarProps } from "./status-bar";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { useShellConfig } from "../../../shell/shell-config";
+import { ProviderOnboardingModal } from "../../../design-system/provider-onboarding-modal";
+import { ProviderAddedToast } from "../../../design-system/provider-added-toast";
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
@@ -181,6 +183,9 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
+  // Provider provisioning prototypes (dev mode only)
+  const [showProviderOnboarding, setShowProviderOnboarding] = useState(true);
+  const [showProviderToast, setShowProviderToast] = useState(true);
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
     selectedWorkspaceId: props.selectedWorkspaceId,
@@ -784,6 +789,32 @@ export function SessionPage(props: SessionPageProps) {
           }
         }}
       />
+
+      {/* Provider provisioning UI prototypes (dev mode only) */}
+      {props.developerMode ? (
+        <>
+          <ProviderOnboardingModal
+            open={showProviderOnboarding}
+            onClose={() => setShowProviderOnboarding(false)}
+            orgName="Acme Corp"
+            providers={[
+              { id: "anthropic", name: "Anthropic", recommended: true, recommendedModel: "claude-sonnet-4-20250514" },
+              { id: "openai", name: "OpenAI", recommendedModel: "gpt-4.1" },
+              { id: "opencode", name: "OpenCode Zen", recommendedModel: "big-pickle" },
+            ]}
+            onAcceptDefaults={() => setShowProviderOnboarding(false)}
+            onConfigureManually={() => setShowProviderOnboarding(false)}
+          />
+          <ProviderAddedToast
+            open={showProviderToast}
+            providerName="Anthropic"
+            providerId="anthropic"
+            modelName="claude-sonnet-4-20250514"
+            onSwitchDefault={() => setShowProviderToast(false)}
+            onDismiss={() => setShowProviderToast(false)}
+          />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -183,9 +183,9 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
-  // Provider provisioning prototypes (dev mode only)
-  const [showProviderOnboarding, setShowProviderOnboarding] = useState(true);
-  const [showProviderToast, setShowProviderToast] = useState(true);
+  // Provider provisioning prototypes
+  const [showProviderOnboarding, setShowProviderOnboarding] = useState(false);
+  const [showProviderToast, setShowProviderToast] = useState(false);
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
     selectedWorkspaceId: props.selectedWorkspaceId,
@@ -454,6 +454,24 @@ export function SessionPage(props: SessionPageProps) {
                 </button>
               ) : null}
               {/* Revert/redo moved to per-message actions */}
+              {props.developerMode ? (
+                <>
+                  <button
+                    type="button"
+                    className="rounded-md px-2 py-1 text-[10px] font-medium text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+                    onClick={() => setShowProviderOnboarding(true)}
+                  >
+                    Test onboarding
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md px-2 py-1 text-[10px] font-medium text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+                    onClick={() => setShowProviderToast(true)}
+                  >
+                    Test toast
+                  </button>
+                </>
+              ) : null}
             </div>
           </header>
 

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -808,8 +808,8 @@ export function SessionPage(props: SessionPageProps) {
         }}
       />
 
-      {/* Provider provisioning UI prototypes */}
-      {(
+      {/* Provider provisioning UI prototypes (dev mode) */}
+      {props.developerMode ? (
         <>
           <ProviderOnboardingModal
             open={showProviderOnboarding}

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { Box, Cpu, Sparkles } from "lucide-react";
+import { Cpu } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { Button } from "../../../design-system/button";
@@ -26,10 +26,6 @@ type SuggestedPlugin = {
   }>;
 };
 
-// The Solid ExtensionsView pulled the MCP-connected count from
-// useConnections(). In React we let the parent pass that plus an
-// already-rendered MCP view so we can ship this page before the full
-// connections provider is ported.
 export type ExtensionsViewProps = {
   busy: boolean;
   selectedWorkspaceRoot: string;
@@ -56,7 +52,6 @@ export function ExtensionsView(props: ExtensionsViewProps) {
   useEffect(() => {
     if (!props.initialSection || props.initialSection === section) return;
     setSection(props.initialSection);
-    // Intentional: only react to incoming prop changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.initialSection]);
 
@@ -72,12 +67,7 @@ export function ExtensionsView(props: ExtensionsViewProps) {
     }
   };
 
-  const pillClass = (active: boolean) =>
-    `px-3 py-1 rounded-full text-xs font-medium border transition-colors flex items-center gap-2 ${
-      active
-        ? "bg-gray-12/10 text-gray-12 border-gray-6/20"
-        : "text-gray-10 border-gray-6 hover:text-gray-12"
-    }`;
+  const showAdvanced = section === "all" || section === "plugins";
 
   return (
     <section className="space-y-6 max-w-3xl w-full animate-in fade-in duration-300">
@@ -104,97 +94,40 @@ export function ExtensionsView(props: ExtensionsViewProps) {
                 </span>
               </div>
             ) : null}
-            {pluginCount > 0 ? (
-              <div className="inline-flex items-center gap-2 rounded-full bg-gray-3 px-3 py-1">
-                <Cpu size={14} className="text-gray-11" />
-                <span className="text-xs font-medium text-gray-11">
-                  {t("extensions.plugin_count", { count: pluginCount })}
-                </span>
-              </div>
-            ) : null}
           </div>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className={pillClass(section === "all")}
-              aria-pressed={section === "all"}
-              onClick={() => selectSection("all")}
-            >
-              {t("extensions.filter_all")}
-            </button>
-            <button
-              type="button"
-              className={pillClass(section === "mcp")}
-              aria-pressed={section === "mcp"}
-              onClick={() => selectSection("mcp")}
-            >
-              <Box size={14} />
-              {t("extensions.filter_apps")}
-            </button>
-            <button
-              type="button"
-              className={pillClass(section === "skills")}
-              aria-pressed={section === "skills"}
-              onClick={() => selectSection("skills")}
-            >
-              <Sparkles size={14} />
-              Skills
-            </button>
-            <button
-              type="button"
-              className={pillClass(section === "plugins")}
-              aria-pressed={section === "plugins"}
-              onClick={() => selectSection("plugins")}
-            >
-              <Cpu size={14} />
-              {t("extensions.filter_plugins")}
-            </button>
-          </div>
           <Button variant="ghost" onClick={props.onRefresh}>
             {t("common.refresh")}
           </Button>
         </div>
       </div>
 
-      {section === "all" || section === "mcp" ? (
-        <div className="space-y-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-gray-12">
-            <Box size={16} className="text-gray-11" />
-            <span>{t("extensions.apps_mcp_header")}</span>
-          </div>
-          {props.mcpView}
-        </div>
-      ) : null}
+      {/* MCPs and Skills together -- they're the same level of abstraction */}
+      {props.mcpView}
+      {props.skillsView ?? null}
 
-      {(section === "all" || section === "skills") && props.skillsView ? (
-        <div className="space-y-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-gray-12">
-            <Sparkles size={16} className="text-gray-11" />
-            <span>Skills</span>
+      {/* OpenCode plugins -- advanced, collapsed */}
+      {pluginCount > 0 || showAdvanced ? (
+        <details className="group">
+          <summary className="flex cursor-pointer items-center gap-2 rounded-lg px-1 py-2 text-sm font-medium text-dls-secondary transition-colors hover:text-dls-text">
+            <Cpu size={14} />
+            <span>OpenCode Plugins</span>
+            <span className="text-[11px] text-dls-secondary">({pluginCount})</span>
+          </summary>
+          <div className="mt-3">
+            <PluginsView
+              extensions={props.extensions}
+              busy={props.busy}
+              selectedWorkspaceRoot={props.selectedWorkspaceRoot}
+              canEditPlugins={props.canEditPlugins}
+              canUseGlobalScope={props.canUseGlobalScope}
+              accessHint={props.accessHint}
+              suggestedPlugins={props.suggestedPlugins}
+            />
           </div>
-          {props.skillsView}
-        </div>
-      ) : null}
-
-      {section === "all" || section === "plugins" ? (
-        <div className="space-y-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-gray-12">
-            <Cpu size={16} className="text-gray-11" />
-            <span>{t("extensions.plugins_opencode_header")}</span>
-          </div>
-          <PluginsView
-            extensions={props.extensions}
-            busy={props.busy}
-            selectedWorkspaceRoot={props.selectedWorkspaceRoot}
-            canEditPlugins={props.canEditPlugins}
-            canUseGlobalScope={props.canUseGlobalScope}
-            accessHint={props.accessHint}
-            suggestedPlugins={props.suggestedPlugins}
-          />
-        </div>
+        </details>
       ) : null}
     </section>
   );

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -1,13 +1,13 @@
 /** @jsxImportSource react */
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { Box, Cpu } from "lucide-react";
+import { Box, Cpu, Sparkles } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { Button } from "../../../design-system/button";
 
 import { PluginsView, type PluginsExtensionsStore } from "./plugins-view";
 
-export type ExtensionsSection = "all" | "mcp" | "plugins";
+export type ExtensionsSection = "all" | "mcp" | "skills" | "plugins";
 
 type SuggestedPlugin = {
   name: string;
@@ -41,9 +41,10 @@ export type ExtensionsViewProps = {
   extensions: PluginsExtensionsStore;
   mcpConnectedAppsCount: number;
   mcpView: ReactNode;
+  skillsView?: ReactNode;
   onRefresh: () => void;
   initialSection?: ExtensionsSection;
-  setSectionRoute?: (tab: "mcp" | "plugins") => void;
+  setSectionRoute?: (tab: "mcp" | "skills" | "plugins") => void;
   showHeader?: boolean;
 };
 
@@ -66,7 +67,7 @@ export function ExtensionsView(props: ExtensionsViewProps) {
 
   const selectSection = (nextSection: ExtensionsSection) => {
     setSection(nextSection);
-    if (nextSection === "mcp" || nextSection === "plugins") {
+    if (nextSection === "mcp" || nextSection === "skills" || nextSection === "plugins") {
       props.setSectionRoute?.(nextSection);
     }
   };
@@ -135,6 +136,15 @@ export function ExtensionsView(props: ExtensionsViewProps) {
             </button>
             <button
               type="button"
+              className={pillClass(section === "skills")}
+              aria-pressed={section === "skills"}
+              onClick={() => selectSection("skills")}
+            >
+              <Sparkles size={14} />
+              Skills
+            </button>
+            <button
+              type="button"
               className={pillClass(section === "plugins")}
               aria-pressed={section === "plugins"}
               onClick={() => selectSection("plugins")}
@@ -156,6 +166,16 @@ export function ExtensionsView(props: ExtensionsViewProps) {
             <span>{t("extensions.apps_mcp_header")}</span>
           </div>
           {props.mcpView}
+        </div>
+      ) : null}
+
+      {(section === "all" || section === "skills") && props.skillsView ? (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-gray-12">
+            <Sparkles size={16} className="text-gray-11" />
+            <span>Skills</span>
+          </div>
+          {props.skillsView}
         </div>
       ) : null}
 

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -52,37 +52,20 @@ export function ExtensionsView(props: ExtensionsViewProps) {
 
   return (
     <section className="space-y-6 max-w-3xl w-full animate-in fade-in duration-300">
-      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-        <div className="space-y-1">
-          {props.showHeader !== false ? (
-            <>
-              <h2 className="text-3xl font-semibold text-dls-text">
-                {t("extensions.title")}
-              </h2>
-              <p className="text-sm text-dls-secondary mt-1.5">
-                {t("extensions.subtitle")}
-              </p>
-            </>
-          ) : null}
-          <div
-            className={`${props.showHeader === false ? "" : "mt-3"} flex flex-wrap items-center gap-2`}
-          >
-            {props.mcpConnectedAppsCount > 0 ? (
-              <div className="inline-flex items-center gap-2 rounded-full bg-green-3 px-3 py-1">
-                <div className="size-2 rounded-full bg-green-9" />
-                <span className="text-xs font-medium text-green-11">
-                  {t("extensions.app_count", { count: props.mcpConnectedAppsCount })}
-                </span>
-              </div>
-            ) : null}
-          </div>
-        </div>
-
+      <div className="flex items-center justify-between">
         <div className="flex flex-wrap items-center gap-2">
-          <Button variant="ghost" onClick={props.onRefresh}>
-            {t("common.refresh")}
-          </Button>
+          {props.mcpConnectedAppsCount > 0 ? (
+            <div className="inline-flex items-center gap-2 rounded-full bg-green-3 px-3 py-1">
+              <div className="size-2 rounded-full bg-green-9" />
+              <span className="text-xs font-medium text-green-11">
+                {t("extensions.app_count", { count: props.mcpConnectedAppsCount })}
+              </span>
+            </div>
+          ) : null}
         </div>
+        <Button variant="ghost" onClick={props.onRefresh}>
+          {t("common.refresh")}
+        </Button>
       </div>
 
       {/* All extensions: MCPs + skills in one view */}

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -36,8 +36,8 @@ export type ExtensionsViewProps = {
   suggestedPlugins: SuggestedPlugin[];
   extensions: PluginsExtensionsStore;
   mcpConnectedAppsCount: number;
+  /** The MCP view (quick-connect grid + configured servers). Skills are injected into it. */
   mcpView: ReactNode;
-  skillsView?: ReactNode;
   onRefresh: () => void;
   initialSection?: ExtensionsSection;
   setSectionRoute?: (tab: "mcp" | "skills" | "plugins") => void;
@@ -45,29 +45,10 @@ export type ExtensionsViewProps = {
 };
 
 export function ExtensionsView(props: ExtensionsViewProps) {
-  const [section, setSection] = useState<ExtensionsSection>(
-    props.initialSection ?? "all",
-  );
-
-  useEffect(() => {
-    if (!props.initialSection || props.initialSection === section) return;
-    setSection(props.initialSection);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.initialSection]);
-
   const pluginCount = useMemo(
     () => props.extensions.pluginList().length,
     [props.extensions],
   );
-
-  const selectSection = (nextSection: ExtensionsSection) => {
-    setSection(nextSection);
-    if (nextSection === "mcp" || nextSection === "skills" || nextSection === "plugins") {
-      props.setSectionRoute?.(nextSection);
-    }
-  };
-
-  const showAdvanced = section === "all" || section === "plugins";
 
   return (
     <section className="space-y-6 max-w-3xl w-full animate-in fade-in duration-300">
@@ -104,12 +85,11 @@ export function ExtensionsView(props: ExtensionsViewProps) {
         </div>
       </div>
 
-      {/* MCPs and Skills together -- they're the same level of abstraction */}
+      {/* All extensions: MCPs + skills in one view */}
       {props.mcpView}
-      {props.skillsView ?? null}
 
       {/* OpenCode plugins -- advanced, collapsed */}
-      {pluginCount > 0 || showAdvanced ? (
+      {pluginCount > 0 ? (
         <details className="group">
           <summary className="flex cursor-pointer items-center gap-2 rounded-lg px-1 py-2 text-sm font-medium text-dls-secondary transition-colors hover:text-dls-text">
             <Cpu size={14} />

--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -28,8 +28,7 @@ export type GeneralSettingsViewProps = {
 
 const workspaceCards: { tab: SettingsTab; icon: typeof Sparkles; title: string; desc: string }[] = [
   { tab: "permissions", icon: FolderLock, title: "Permissions", desc: "Authorized folders and file access." },
-  { tab: "skills", icon: Sparkles, title: "Skills", desc: "Install, create, and manage workspace skills." },
-  { tab: "extensions", icon: Puzzle, title: "Extensions", desc: "MCP servers, plugins, and integrations." },
+  { tab: "extensions", icon: Puzzle, title: "Extensions", desc: "MCPs, skills, plugins, and integrations." },
   { tab: "advanced", icon: Wrench, title: "Advanced", desc: "Runtime, engine, and developer options." },
 ];
 

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -17,6 +17,7 @@ import {
   Plug2,
   Plus,
   Power,
+  Search,
   Settings2,
   Unplug,
   Zap,
@@ -178,10 +179,14 @@ const serviceIconBg = (name: string) => {
   return "bg-dls-hover border-dls-border";
 };
 
+type ExtensionFilter = "all" | "mcp" | "skill" | "plugin";
+
 export function McpView(props: McpViewProps) {
   const showHeader = props.showHeader !== false;
   const [detailEntry, setDetailEntry] = useState<McpDirectoryInfo | null>(null);
   const [detailSkill, setDetailSkill] = useState<SkillItem | null>(null);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<ExtensionFilter>("all");
 
   const [localState, dispatchLocal] = useReducer(
     mcpViewLocalReducer,
@@ -372,9 +377,53 @@ export function McpView(props: McpViewProps) {
 
       <McpCustomAppCard onOpen={() => setAddMcpModalOpen(true)} />
 
+      {/* Search + filter */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-dls-secondary" />
+          <input
+            className="w-full rounded-lg border border-dls-border bg-dls-surface py-2 pl-9 pr-3 text-xs text-dls-text placeholder:text-dls-secondary focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)]"
+            placeholder="Search extensions..."
+            value={search}
+            onChange={(e) => setSearch(e.currentTarget.value)}
+          />
+        </div>
+        <div className="flex items-center gap-1.5">
+          {(["all", "mcp", "skill"] as const).map((f) => (
+            <button
+              key={f}
+              type="button"
+              className={`rounded-full border px-3 py-1 text-[11px] font-medium transition-colors ${
+                filter === f
+                  ? "border-dls-text/20 bg-dls-text/10 text-dls-text"
+                  : "border-dls-border text-dls-secondary hover:text-dls-text"
+              }`}
+              onClick={() => setFilter(f)}
+            >
+              {f === "all" ? "All" : f === "mcp" ? "MCPs" : "Skills"}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <McpQuickConnectSection
-        entries={quickConnectList}
-        installedSkills={props.installedSkills}
+        entries={
+          quickConnectList.filter((entry) => {
+            if (filter === "skill") return false;
+            if (filter === "mcp" && (entry.kind ?? "mcp") !== "mcp") return false;
+            if (!search.trim()) return true;
+            const q = search.toLowerCase();
+            return entry.name.toLowerCase().includes(q) || entry.description.toLowerCase().includes(q);
+          })
+        }
+        installedSkills={
+          (props.installedSkills ?? []).filter((skill) => {
+            if (filter === "mcp") return false;
+            if (!search.trim()) return true;
+            const q = search.toLowerCase();
+            return skill.name.toLowerCase().includes(q) || (skill.description ?? "").toLowerCase().includes(q);
+          })
+        }
         busy={props.busy}
         connectingName={props.mcpConnectingName}
         isConfigured={isQuickConnectConfigured}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -440,7 +440,7 @@ export function McpView(props: McpViewProps) {
           if (props.readSkill) {
             void props.readSkill(skill.name).then((result) => {
               if (result?.content) {
-                setDetailSkillContent(result.content.slice(0, 800));
+                setDetailSkillContent(result.content.slice(0, 2000));
               }
             });
           }

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useEffect, useReducer, useRef, type SetStateAction } from "react";
+import { useEffect, useReducer, useRef, useState, type SetStateAction } from "react";
 import {
   BookOpen,
   CheckCircle2,
@@ -24,6 +24,7 @@ import {
 
 import { type McpDirectoryInfo } from "../../../../app/constants";
 import { ExtensionCard } from "../../../design-system/extension-card";
+import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
 import {
   openDesktopPath,
   readOpencodeConfig,
@@ -169,6 +170,7 @@ const serviceIconBg = (name: string) => {
 
 export function McpView(props: McpViewProps) {
   const showHeader = props.showHeader !== false;
+  const [detailEntry, setDetailEntry] = useState<McpDirectoryInfo | null>(null);
 
   const [localState, dispatchLocal] = useReducer(
     mcpViewLocalReducer,
@@ -366,6 +368,7 @@ export function McpView(props: McpViewProps) {
         isConfigured={isQuickConnectConfigured}
         statusForEntry={quickConnectStatus}
         onConnect={props.connectMcp}
+        onDetail={setDetailEntry}
       />
 
       <McpConfiguredServersSection
@@ -451,6 +454,27 @@ export function McpView(props: McpViewProps) {
         open={chromeSetupOpen}
         onClose={() => setChromeSetupOpen(false)}
       />
+
+      {detailEntry ? (
+        <ExtensionDetailModal
+          open={!!detailEntry}
+          onClose={() => setDetailEntry(null)}
+          name={detailEntry.name}
+          description={detailEntry.description}
+          iconSlug={detailEntry.iconSlug}
+          iconSrc={detailEntry.iconSrc}
+          fallbackIcon={serviceIcon(detailEntry.name)}
+          kind={detailEntry.kind ?? "mcp"}
+          connected={isQuickConnectConfigured(detailEntry)}
+          connecting={props.mcpConnectingName === detailEntry.name}
+          url={typeof detailEntry.url === "string" ? detailEntry.url : undefined}
+          oauth={detailEntry.oauth}
+          onConnect={() => {
+            props.connectMcp(detailEntry);
+            setDetailEntry(null);
+          }}
+        />
+      ) : null}
     </section>
   );
 }
@@ -513,6 +537,7 @@ function McpQuickConnectSection(props: {
   isConfigured: (entry: McpDirectoryInfo) => boolean;
   statusForEntry: (entry: McpDirectoryInfo) => { status: ReactMcpStatus } | undefined;
   onConnect: (entry: McpDirectoryInfo) => void;
+  onDetail: (entry: McpDirectoryInfo) => void;
 }) {
   return (
     <div className="space-y-4">
@@ -541,10 +566,8 @@ function McpQuickConnectSection(props: {
               connected={configured}
               connecting={connecting}
               disabled={props.busy}
-              actionLabel={t("mcp.tap_to_connect")}
-              onClick={() => {
-                if (!configured) props.onConnect(entry);
-              }}
+              actionLabel={configured ? "View details" : t("mcp.tap_to_connect")}
+              onClick={() => props.onDetail(entry)}
             />
           );
         })}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 
 import { type McpDirectoryInfo } from "../../../../app/constants";
+import { revealDesktopItemInDir } from "../../../../app/lib/desktop";
 import { ExtensionCard } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
 import {
@@ -568,6 +569,9 @@ export function McpView(props: McpViewProps) {
           path={detailSkill.path}
           trigger={detailSkill.trigger}
           contentPreview={detailSkillContent ?? undefined}
+          onReveal={detailSkill.path ? () => {
+            void revealDesktopItemInDir(detailSkill.path);
+          } : undefined}
           onUninstall={props.uninstallSkill ? () => {
             props.uninstallSkill?.(detailSkill.name);
             setDetailSkill(null);

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -61,6 +61,7 @@ export type ReactMcpStatus =
 export type SkillItem = {
   name: string;
   description?: string;
+  trigger?: string;
   path: string;
 };
 
@@ -72,6 +73,8 @@ export type McpViewProps = {
   installedSkills?: SkillItem[];
   /** Uninstall a skill by name. */
   uninstallSkill?: (name: string) => void;
+  /** Read skill content by name. */
+  readSkill?: (name: string) => Promise<{ content: string } | null>;
   readConfigFile?: (scope: "project" | "global") => Promise<OpencodeConfigFile | null>;
   showHeader?: boolean;
   mcpServers: McpServerEntry[];
@@ -185,6 +188,7 @@ export function McpView(props: McpViewProps) {
   const showHeader = props.showHeader !== false;
   const [detailEntry, setDetailEntry] = useState<McpDirectoryInfo | null>(null);
   const [detailSkill, setDetailSkill] = useState<SkillItem | null>(null);
+  const [detailSkillContent, setDetailSkillContent] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<ExtensionFilter>("all");
 
@@ -430,7 +434,17 @@ export function McpView(props: McpViewProps) {
         statusForEntry={quickConnectStatus}
         onConnect={props.connectMcp}
         onDetail={setDetailEntry}
-        onSkillDetail={setDetailSkill}
+        onSkillDetail={(skill) => {
+          setDetailSkill(skill);
+          setDetailSkillContent(null);
+          if (props.readSkill) {
+            void props.readSkill(skill.name).then((result) => {
+              if (result?.content) {
+                setDetailSkillContent(result.content.slice(0, 800));
+              }
+            });
+          }
+        }}
       />
 
       <McpConfiguredServersSection
@@ -546,12 +560,14 @@ export function McpView(props: McpViewProps) {
       {detailSkill ? (
         <ExtensionDetailModal
           open={!!detailSkill}
-          onClose={() => setDetailSkill(null)}
+          onClose={() => { setDetailSkill(null); setDetailSkillContent(null); }}
           name={detailSkill.name}
           description={detailSkill.description ?? "Installed skill"}
           kind="skill"
           connected={true}
           path={detailSkill.path}
+          trigger={detailSkill.trigger}
+          contentPreview={detailSkillContent ?? undefined}
           onUninstall={props.uninstallSkill ? () => {
             props.uninstallSkill?.(detailSkill.name);
             setDetailSkill(null);

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -69,6 +69,8 @@ export type McpViewProps = {
   isRemoteWorkspace: boolean;
   /** Installed skills to render alongside MCPs in the grid. */
   installedSkills?: SkillItem[];
+  /** Uninstall a skill by name. */
+  uninstallSkill?: (name: string) => void;
   readConfigFile?: (scope: "project" | "global") => Promise<OpencodeConfigFile | null>;
   showHeader?: boolean;
   mcpServers: McpServerEntry[];
@@ -179,6 +181,7 @@ const serviceIconBg = (name: string) => {
 export function McpView(props: McpViewProps) {
   const showHeader = props.showHeader !== false;
   const [detailEntry, setDetailEntry] = useState<McpDirectoryInfo | null>(null);
+  const [detailSkill, setDetailSkill] = useState<SkillItem | null>(null);
 
   const [localState, dispatchLocal] = useReducer(
     mcpViewLocalReducer,
@@ -378,6 +381,7 @@ export function McpView(props: McpViewProps) {
         statusForEntry={quickConnectStatus}
         onConnect={props.connectMcp}
         onDetail={setDetailEntry}
+        onSkillDetail={setDetailSkill}
       />
 
       <McpConfiguredServersSection
@@ -482,6 +486,27 @@ export function McpView(props: McpViewProps) {
             props.connectMcp(detailEntry);
             setDetailEntry(null);
           }}
+          onUninstall={isQuickConnectConfigured(detailEntry) ? () => {
+            const slug = getMcpIdentityKey(detailEntry);
+            props.removeMcp(slug);
+            setDetailEntry(null);
+          } : undefined}
+        />
+      ) : null}
+
+      {detailSkill ? (
+        <ExtensionDetailModal
+          open={!!detailSkill}
+          onClose={() => setDetailSkill(null)}
+          name={detailSkill.name}
+          description={detailSkill.description ?? "Installed skill"}
+          kind="skill"
+          connected={true}
+          path={detailSkill.path}
+          onUninstall={props.uninstallSkill ? () => {
+            props.uninstallSkill?.(detailSkill.name);
+            setDetailSkill(null);
+          } : undefined}
         />
       ) : null}
     </section>
@@ -548,6 +573,7 @@ function McpQuickConnectSection(props: {
   statusForEntry: (entry: McpDirectoryInfo) => { status: ReactMcpStatus } | undefined;
   onConnect: (entry: McpDirectoryInfo) => void;
   onDetail: (entry: McpDirectoryInfo) => void;
+  onSkillDetail?: (skill: SkillItem) => void;
 }) {
   return (
     <div className="space-y-4">
@@ -591,7 +617,8 @@ function McpQuickConnectSection(props: {
             description={skill.description ?? "Installed skill"}
             kind="skill"
             connected={true}
-            actionLabel="Installed"
+            actionLabel="View details"
+            onClick={() => props.onSkillDetail?.(skill)}
           />
         ))}
       </div>

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -24,7 +24,6 @@ import {
 } from "lucide-react";
 
 import { type McpDirectoryInfo } from "../../../../app/constants";
-import { revealDesktopItemInDir } from "../../../../app/lib/desktop";
 import { ExtensionCard } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
 import {

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -57,10 +57,18 @@ export type ReactMcpStatus =
   | "disabled"
   | "disconnected";
 
+export type SkillItem = {
+  name: string;
+  description?: string;
+  path: string;
+};
+
 export type McpViewProps = {
   busy: boolean;
   selectedWorkspaceRoot: string;
   isRemoteWorkspace: boolean;
+  /** Installed skills to render alongside MCPs in the grid. */
+  installedSkills?: SkillItem[];
   readConfigFile?: (scope: "project" | "global") => Promise<OpencodeConfigFile | null>;
   showHeader?: boolean;
   mcpServers: McpServerEntry[];
@@ -363,6 +371,7 @@ export function McpView(props: McpViewProps) {
 
       <McpQuickConnectSection
         entries={quickConnectList}
+        installedSkills={props.installedSkills}
         busy={props.busy}
         connectingName={props.mcpConnectingName}
         isConfigured={isQuickConnectConfigured}
@@ -532,6 +541,7 @@ function McpCustomAppCard(props: { onOpen: () => void }) {
 
 function McpQuickConnectSection(props: {
   entries: McpDirectoryInfo[];
+  installedSkills?: SkillItem[];
   busy: boolean;
   connectingName: string | null;
   isConfigured: (entry: McpDirectoryInfo) => boolean;
@@ -549,6 +559,7 @@ function McpQuickConnectSection(props: {
       </div>
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {/* MCP entries */}
         {props.entries.map((entry) => {
           const configured = props.isConfigured(entry);
           const connecting = props.connectingName === entry.name;
@@ -571,6 +582,18 @@ function McpQuickConnectSection(props: {
             />
           );
         })}
+
+        {/* Installed skills */}
+        {(props.installedSkills ?? []).map((skill) => (
+          <ExtensionCard
+            key={`skill:${skill.name}`}
+            name={skill.name}
+            description={skill.description ?? "Installed skill"}
+            kind="skill"
+            connected={true}
+            actionLabel="Installed"
+          />
+        ))}
       </div>
     </div>
   );

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -147,7 +147,7 @@ export function getSettingsTabDescription(tab: SettingsTab) {
 }
 
 export function getWorkspaceSettingsTabs(): SettingsTab[] {
-  return ["permissions", "skills", "extensions", "advanced"];
+  return ["permissions", "extensions", "advanced"];
 }
 
 export function getGlobalSettingsTabs(developerMode: boolean): SettingsTab[] {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1593,24 +1593,11 @@ export function SettingsRoute() {
                     : undefined
                 }
                 readConfigFile={(scope) => connectionsStore.readMcpConfigFile(scope)}
+                installedSkills={extensionsStore.skills()}
                 showHeader={false}
               />
             }
-            skillsView={
-              <SkillsView
-                workspaceName={selectedWorkspaceName}
-                busy={busy}
-                canInstallSkillCreator={canWriteWorkspaceSkills}
-                canUseDesktopTools={!isRemoteWorkspace}
-                accessHint={skillsAccessHint}
-                extensions={extensionsStore}
-                onOpenLink={(url) => platform.openLink(url)}
-                createSessionAndOpen={async () => {
-                  navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session");
-                  return undefined;
-                }}
-              />
-            }
+
           />
         );
       case "den":

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -294,8 +294,11 @@ function parseSettingsPath(pathname: string): {
       return { tab: head, redirectPath: null };
     case "extensions":
       if (tail === "mcp") return { tab: "extensions", redirectPath: null, extensionsSection: "mcp" };
+      if (tail === "skills") return { tab: "extensions", redirectPath: null, extensionsSection: "skills" };
       if (tail === "plugins") return { tab: "extensions", redirectPath: null, extensionsSection: "plugins" };
       return { tab: "extensions", redirectPath: null, extensionsSection: "all" };
+    case "skills":
+      return { tab: "extensions", redirectPath: "extensions/skills", extensionsSection: "skills" };
     default:
       return { tab: "general", redirectPath: "general" };
   }
@@ -1591,6 +1594,21 @@ export function SettingsRoute() {
                 }
                 readConfigFile={(scope) => connectionsStore.readMcpConfigFile(scope)}
                 showHeader={false}
+              />
+            }
+            skillsView={
+              <SkillsView
+                workspaceName={selectedWorkspaceName}
+                busy={busy}
+                canInstallSkillCreator={canWriteWorkspaceSkills}
+                canUseDesktopTools={!isRemoteWorkspace}
+                accessHint={skillsAccessHint}
+                extensions={extensionsStore}
+                onOpenLink={(url) => platform.openLink(url)}
+                createSessionAndOpen={async () => {
+                  navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session");
+                  return undefined;
+                }}
               />
             }
           />

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1595,6 +1595,7 @@ export function SettingsRoute() {
                 readConfigFile={(scope) => connectionsStore.readMcpConfigFile(scope)}
                 installedSkills={extensionsStore.skills()}
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
+                readSkill={(name) => extensionsStore.readSkill(name)}
                 showHeader={false}
               />
             }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1594,6 +1594,7 @@ export function SettingsRoute() {
                 }
                 readConfigFile={(scope) => connectionsStore.readMcpConfigFile(scope)}
                 installedSkills={extensionsStore.skills()}
+                uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
                 showHeader={false}
               />
             }

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -501,6 +501,20 @@ async function seedBrowserMcpConfig(workspaceDir) {
     changed = true;
   }
 
+  // UI control bridge
+  try {
+    const uiDiscovery = JSON.parse(await readFile(path.join(app.getPath("userData"), "openwork-ui-control.json"), "utf8"));
+    if (uiDiscovery?.baseUrl) {
+      const uiUrl = `${uiDiscovery.baseUrl}/mcp`;
+      if (config.mcp["openwork-ui"]?.url !== uiUrl) {
+        config.mcp["openwork-ui"] = { type: "remote", url: uiUrl };
+        changed = true;
+      }
+    }
+  } catch {
+    // UI control bridge not started yet — skip.
+  }
+
   // Remove legacy entries
   for (const key of ["chrome-devtools", "control-chrome"]) {
     if (config.mcp[key]) {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1767,6 +1767,13 @@ async function handleDesktopInvoke(event, command, ...args) {
         buildEpoch: process.env.OPENWORK_BUILD_EPOCH ?? null,
         openworkDevMode: process.env.OPENWORK_DEV_MODE === "1",
       };
+    case "getUiControlBridgeInfo":
+      try {
+        const raw = await readFile(path.join(app.getPath("userData"), "openwork-ui-control.json"), "utf8");
+        return JSON.parse(raw);
+      } catch {
+        return null;
+      }
     case "getDesktopBootstrapConfig":
       return getDesktopBootstrapConfig();
     case "setDesktopBootstrapConfig":


### PR DESCRIPTION
## Improvements PR 2

Living PR -- will be updated with additional changes.

### MCP server name fix
- `serverName` field on `McpDirectoryInfo` for safe `opencode.jsonc` keys
- `getMcpServerName()` auto-slugifies display names (spaces, special chars → dashes)
- All quick-connect entries have explicit `serverName` slugs (notion, linear, sentry, stripe, context7, openwork-cloud)
- Users can type any name in the Add MCP form -- it auto-transforms to a valid server name
- No more `server_name must be alphanumeric` errors

### Extension card always shows brand icon
- Connected state no longer replaces the icon with a checkmark
- Brand icon (Simple Icons CDN or local SVG) always visible
- Small green dot badge overlays the icon corner when connected
- Better visual identity even after connecting