### PR TITLE
fix(repo): disable design md files for app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Design principles for hot reload:
 
 * Use `VISION.md`, `PRINCIPLES.md`, `PRODUCT.md`, `ARCHITECTURE.md`, and `INFRASTRUCTURE.md` to understand the "why" and requirements so you can guide your decisions.
 * Treat `ARCHITECTURE.md` as the authoritative system design source for runtime flow, server ownership, filesystem mutation policy, and agent/runtime boundaries. If those behaviors change, update `ARCHITECTURE.md` in the same task.
-* Use `DESIGN-LANGUAGE.md` as the default visual reference for OpenWork app and landing work.
+* Use `DESIGN-LANGUAGE.md` as the default visual reference for OpenWork app and landing work (NOTE: do not use for `apps/app`).
 * For OpenWork session-surface details, also reference `packages/docs/orbita-layout-style.mdx`.
 
 ## App Architecture (CUPID)

--- a/DESIGN-LANGUAGE.md
+++ b/DESIGN-LANGUAGE.md
@@ -1,5 +1,7 @@
 # OpenWork Design Language
 
+# NOTE: do not use for `apps/app`
+
 This is the definitive visual system for OpenWork product and landing work.
 
 OpenWork should feel like a premium work tool: calm, useful, technical, and trustworthy. The design should read as software first, not a flashy marketing site. The goal is clarity with taste, not visual noise.

--- a/DESIGN-SYSTEM.md
+++ b/DESIGN-SYSTEM.md
@@ -1,8 +1,9 @@
 # OpenWork Design System
 
+# NOTE: do not use for `apps/app`
+
 This document turns the visual direction in `DESIGN-LANGUAGE.md` into an implementation system that can unify:
 
-- `apps/app` (OpenWork app)
 - `ee/apps/den-web` (OpenWork Cloud / Den web surfaces)
 - `ee/apps/landing` (marketing + product storytelling)
 


### PR DESCRIPTION
## Summary
- Prevent applying design markdown files to `apps/app`.