### PR TITLE
chore(ci): enforce pnpm minimum release age

### DIFF
--- a/.github/workflows/ci-openwork-ui-mcp.yml
+++ b/.github/workflows/ci-openwork-ui-mcp.yml
@@ -36,8 +36,13 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Syntax check
         run: node --check index.mjs
@@ -65,8 +70,13 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Syntax check
         run: node --check index.mjs

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 1440
+
 packages:
   - "apps/*"
   - "packages/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-minimumReleaseAge: 1440
+minimumReleaseAge: 4320
 
 packages:
   - "apps/*"


### PR DESCRIPTION
## Summary

- Add `minimumReleaseAge: 4320` to the pnpm workspace config so pnpm resolves newly published packages only after a 72-hour delay.
- Switch the `openwork-ui-mcp` CI installs from npm to pnpm so CI inherits the same minimum-release-age policy.

## Evidence

### Build verification
- No package build required; this change only updates dependency resolution policy and CI install commands.
- `pnpm --filter openwork-ui-mcp test` -- passed (`node --check index.mjs`).

### Config verification
- `pnpm config get minimumReleaseAge` from repo root -- `4320`.
- `pnpm config get minimumReleaseAge` from `packages/openwork-ui-mcp` -- `4320`.

### API verification
- No API changes.

### UI verification
- No UI changes.

## Test instructions

1. Run `pnpm config get minimumReleaseAge` from the repo root and verify it prints `4320`.
2. Run `pnpm config get minimumReleaseAge` from `packages/openwork-ui-mcp` and verify it prints `4320`.
3. Run `pnpm --filter openwork-ui-mcp test`.