### PR TITLE
feat(app): provider change detection + UI dark mode polish

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -1,7 +1,6 @@
 import type { ModelRef, SuggestedPlugin } from "./types";
 import { t } from "../i18n";
 import { readDenBootstrapConfig } from "./lib/den";
-import { readDenBootstrapConfig } from "./lib/den";
 
 export const MODEL_PREF_KEY = "openwork.defaultModel";
 export const SESSION_MODEL_PREF_KEY = "openwork.sessionModels";

--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -51,9 +51,10 @@
   --dls-canvas: var(--slate-2);
   --dls-surface-muted: var(--slate-3);
   --dls-border: #f3f4f6;
-  --dls-accent: #011627;
+  --dls-accent: var(--slate-12);
   --dls-accent-hover: #000000;
-  --dls-accent-rgb: 1 22 39;
+  --dls-accent-fg: var(--slate-1);
+  --dls-accent-rgb: 28 32 36;
   --dls-secondary-rgb: 96 100 108;
   --dls-text-primary: var(--slate-12);
   --dls-text-secondary: var(--slate-11);
@@ -107,9 +108,10 @@
   --dls-canvas: var(--slate-2);
   --dls-surface-muted: var(--slate-3);
   --dls-border: #262626;
-  --dls-accent: #e2e8f0;
-  --dls-accent-hover: #f1f5f9;
-  --dls-accent-rgb: 226 232 240;
+  --dls-accent: var(--slate-12);
+  --dls-accent-hover: #ffffff;
+  --dls-accent-fg: var(--slate-1);
+  --dls-accent-rgb: 237 238 240;
   --dls-secondary-rgb: 176 180 186;
   --dls-text-primary: var(--slate-12);
   --dls-text-secondary: var(--slate-11);

--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -51,10 +51,10 @@
   --dls-canvas: var(--slate-2);
   --dls-surface-muted: var(--slate-3);
   --dls-border: #f3f4f6;
-  --dls-accent: var(--slate-12);
+  --dls-accent: #011627;
   --dls-accent-hover: #000000;
-  --dls-accent-fg: var(--slate-1);
-  --dls-accent-rgb: 28 32 36;
+  --dls-accent-fg: #ffffff;
+  --dls-accent-rgb: 1 22 39;
   --dls-secondary-rgb: 96 100 108;
   --dls-text-primary: var(--slate-12);
   --dls-text-secondary: var(--slate-11);
@@ -108,10 +108,10 @@
   --dls-canvas: var(--slate-2);
   --dls-surface-muted: var(--slate-3);
   --dls-border: #262626;
-  --dls-accent: var(--slate-12);
-  --dls-accent-hover: #ffffff;
-  --dls-accent-fg: var(--slate-1);
-  --dls-accent-rgb: 237 238 240;
+  --dls-accent: #011627;
+  --dls-accent-hover: #0a2540;
+  --dls-accent-fg: #ffffff;
+  --dls-accent-rgb: 1 22 39;
   --dls-secondary-rgb: 176 180 186;
   --dls-text-primary: var(--slate-12);
   --dls-text-secondary: var(--slate-11);

--- a/apps/app/src/app/lib/den-session-events.ts
+++ b/apps/app/src/app/lib/den-session-events.ts
@@ -4,7 +4,7 @@ export const denSessionUpdatedEvent = "openwork-den-session-updated";
 export const denSettingsChangedEvent = "openwork-den-settings-changed";
 
 export type DenSessionUpdatedDetail = {
-  status?: "success" | "error";
+  status?: "success" | "error" | "signed_out";
   baseUrl?: string | null;
   token?: string | null;
   user?: DenUser | null;

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -460,7 +460,7 @@ export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig
   }
 
   try {
-    const bootstrap = await getDesktopBootstrapConfigFromShell();
+    const bootstrap = await getDesktopBootstrapConfigFromShell() as ShellDesktopBootstrapConfig;
     applyDesktopBootstrapConfig(resolveDenBootstrapConfig(bootstrap));
   } catch {
     desktopBootstrapConfig = resolveDenBootstrapConfig({
@@ -484,7 +484,7 @@ export async function setDenBootstrapConfig(
       baseUrl: normalized.baseUrl,
       apiBaseUrl: normalized.apiBaseUrl,
       requireSignin: normalized.requireSignin,
-    });
+    }) as ShellDesktopBootstrapConfig;
     
     applyDesktopBootstrapConfig(resolveDenBootstrapConfig(persisted));
   } else {

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -392,6 +392,42 @@ const OPENWORK_INVITE_PARAM_TOKEN = "ow_token";
 const OPENWORK_INVITE_PARAM_STARTUP = "ow_startup";
 const OPENWORK_INVITE_PARAM_AUTO_CONNECT = "ow_auto_connect";
 
+export type OpenworkOpenCodeRouterHealthSnapshot = {
+  ok: boolean;
+  opencode: Record<string, unknown>;
+  channels: Record<string, unknown>;
+  config: Record<string, unknown>;
+  activity?: {
+    inboundToday?: number;
+    outboundToday?: number;
+    lastMessageAt?: number | null;
+    [key: string]: unknown;
+  };
+  agent?: {
+    loaded?: boolean;
+    selected?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+export type OpenworkOpenCodeRouterIdentityItem = {
+  id: string;
+  channel?: string;
+  enabled?: boolean;
+  peerId?: string;
+  [key: string]: unknown;
+};
+
+export type OpenworkOpenCodeRouterSendResult = {
+  ok: boolean;
+  sent: number;
+  attempted: number;
+  failures?: Array<{ identityId: string; peerId: string; error: string }>;
+  reason?: string;
+  [key: string]: unknown;
+};
+
 export type OpenworkConnectInvite = {
   url: string;
   token?: string;

--- a/apps/app/src/app/mcp.ts
+++ b/apps/app/src/app/mcp.ts
@@ -35,7 +35,7 @@ export async function removeMcpFromConfig(
   projectDir: string,
   name: string,
 ): Promise<void> {
-  const configFile = await readOpencodeConfig("project", projectDir);
+  const configFile = await readOpencodeConfig("project", projectDir) as { path: string; exists: boolean; content: string | null };
   const raw = configFile.exists && configFile.content?.trim()
     ? configFile.content
     : "{}\n";
@@ -58,7 +58,7 @@ export async function removeMcpFromConfig(
     "project",
     projectDir,
     updated.endsWith("\n") ? updated : `${updated}\n`,
-  );
+  ) as { ok: boolean; stderr?: string; stdout?: string };
   if (!writeResult.ok) {
     throw new Error(writeResult.stderr || writeResult.stdout || "Failed to write opencode.json");
   }

--- a/apps/app/src/react-app/design-system/button.tsx
+++ b/apps/app/src/react-app/design-system/button.tsx
@@ -10,9 +10,9 @@ const base =
 
 const variants: Record<NonNullable<ButtonProps["variant"]>, string> = {
   primary:
-    "bg-[#011627] text-white hover:bg-black border border-transparent",
+    "bg-dls-accent text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)] border border-transparent",
   secondary:
-    "bg-[#011627] text-white hover:bg-black border border-transparent",
+    "bg-dls-accent text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)] border border-transparent",
   ghost:
     "bg-transparent text-dls-secondary hover:text-dls-text hover:bg-dls-hover",
   outline:

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -80,9 +80,13 @@ export function ExtensionCard(props: ExtensionCardProps) {
             {connecting ? (
               <Loader2 size={18} className="animate-spin text-dls-secondary" />
             ) : iconSrc ? (
-              <img src={iconSrc} alt="" width={18} height={18} loading="lazy" style={{ display: "block" }} />
+              <div className="flex size-6 items-center justify-center rounded-md bg-white">
+                <img src={iconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
+              </div>
             ) : iconSlug ? (
-              <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={18} height={18} loading="lazy" style={{ display: "block" }} />
+              <div className="flex size-6 items-center justify-center rounded-md bg-white">
+                <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
+              </div>
             ) : (
               <FallbackIcon size={18} className="text-dls-secondary" />
             )}

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -88,7 +88,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
             )}
           </div>
           {connected ? (
-            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-white bg-green-9">
+            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-green-9">
               <CheckCircle2 size={9} className="text-white" strokeWidth={3} />
             </div>
           ) : null}

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -148,7 +148,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                 )}
               </div>
               {connected ? (
-                <div className="absolute -bottom-0.5 -right-0.5 flex size-5 items-center justify-center rounded-full border-2 border-white bg-green-9">
+                <div className="absolute -bottom-0.5 -right-0.5 flex size-5 items-center justify-center rounded-full border-2 border-dls-surface bg-green-9">
                   <CheckCircle2 size={11} className="text-white" strokeWidth={3} />
                 </div>
               ) : null}

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -140,9 +140,13 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                 }`}
               >
                 {iconSrc ? (
-                  <img src={iconSrc} alt="" width={24} height={24} loading="lazy" style={{ display: "block" }} />
+                  <div className="flex size-8 items-center justify-center rounded-md bg-white">
+                    <img src={iconSrc} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
+                  </div>
                 ) : iconSlug ? (
-                  <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={24} height={24} loading="lazy" style={{ display: "block" }} />
+                  <div className="flex size-8 items-center justify-center rounded-md bg-white">
+                    <img src={`https://cdn.simpleicons.org/${iconSlug}`} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
+                  </div>
                 ) : (
                   <FallbackIcon size={24} className="text-dls-secondary" />
                 )}

--- a/apps/app/src/react-app/design-system/modals/confirm-modal.tsx
+++ b/apps/app/src/react-app/design-system/modals/confirm-modal.tsx
@@ -19,7 +19,7 @@ const buttonBaseClass =
   "inline-flex items-center justify-center rounded-full px-4 py-2 text-[13px] font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.18)] disabled:cursor-not-allowed disabled:opacity-60";
 
 const buttonClasses = {
-  primary: `${buttonBaseClass} bg-[var(--dls-accent)] text-white hover:bg-[var(--dls-accent-hover)]`,
+  primary: `${buttonBaseClass} bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]`,
   secondary: `${buttonBaseClass} bg-gray-12 text-gray-1 hover:bg-gray-11`,
   ghost: `${buttonBaseClass} bg-transparent text-dls-secondary hover:bg-[var(--dls-hover)] hover:text-dls-text`,
   outline: `${buttonBaseClass} border border-dls-border bg-dls-surface text-dls-text hover:bg-[var(--dls-hover)]`,

--- a/apps/app/src/react-app/design-system/provider-added-toast.tsx
+++ b/apps/app/src/react-app/design-system/provider-added-toast.tsx
@@ -37,7 +37,7 @@ export function ProviderAddedToast(props: ProviderAddedToastProps) {
         <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
-            className="rounded-full bg-[#011627] px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-black"
+            className="rounded-full bg-dls-accent px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-[var(--dls-accent-hover)]"
             onClick={props.onSwitchDefault}
           >
             Switch default

--- a/apps/app/src/react-app/design-system/provider-added-toast.tsx
+++ b/apps/app/src/react-app/design-system/provider-added-toast.tsx
@@ -37,7 +37,7 @@ export function ProviderAddedToast(props: ProviderAddedToastProps) {
         <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
-            className="rounded-full bg-dls-accent px-3 py-1.5 text-[11px] font-semibold text-white transition-colors hover:bg-[var(--dls-accent-hover)]"
+            className="rounded-full bg-dls-accent px-3 py-1.5 text-[11px] font-semibold text-[var(--dls-accent-fg)] transition-colors hover:bg-[var(--dls-accent-hover)]"
             onClick={props.onSwitchDefault}
           >
             Switch default

--- a/apps/app/src/react-app/design-system/provider-added-toast.tsx
+++ b/apps/app/src/react-app/design-system/provider-added-toast.tsx
@@ -29,8 +29,8 @@ export function ProviderAddedToast(props: ProviderAddedToastProps) {
           </div>
           <div className="text-[11px] text-dls-secondary">
             {props.modelName
-              ? `Your team added ${props.providerName}. Switch to ${props.modelName}?`
-              : `Your team added ${props.providerName}. Switch to it?`}
+              ? `Use ${props.modelName} as your default?`
+              : `Use ${props.providerName} as your default?`}
           </div>
         </div>
 

--- a/apps/app/src/react-app/design-system/provider-onboarding-modal.tsx
+++ b/apps/app/src/react-app/design-system/provider-onboarding-modal.tsx
@@ -51,12 +51,16 @@ export function ProviderOnboardingModal(props: ProviderOnboardingModalProps) {
         <div className={modalHeaderClass}>
           <div className="flex min-w-0 items-start gap-4">
             <div className="flex size-12 items-center justify-center rounded-xl border border-dls-border bg-dls-hover">
-              <Sparkles size={24} className="text-dls-accent" />
+              <Sparkles size={24} className="text-dls-text" />
             </div>
             <div className="min-w-0">
-              <h3 className={modalTitleClass}>Your team is ready</h3>
+              <h3 className={modalTitleClass}>
+                {props.orgName ? `${props.orgName} is ready` : "AI providers ready"}
+              </h3>
               <p className={modalSubtitleClass}>
-                {props.orgName} has set up AI providers for you.
+                {props.providers.length === 1
+                  ? "1 provider is configured for this workspace."
+                  : `${props.providers.length} providers are configured for this workspace.`}
               </p>
             </div>
           </div>
@@ -88,20 +92,14 @@ export function ProviderOnboardingModal(props: ProviderOnboardingModalProps) {
                       ) : null}
                     </div>
                   </div>
-                  {provider.recommended ? (
-                    <span className="shrink-0 rounded-full bg-dls-accent/10 px-2.5 py-0.5 text-[10px] font-semibold text-dls-accent">
-                      Recommended
-                    </span>
-                  ) : (
-                    <CheckCircle2 size={16} className="shrink-0 text-green-11" />
-                  )}
+                  <CheckCircle2 size={16} className="shrink-0 text-green-11" />
                 </div>
               ))}
             </div>
 
-            {recommended ? (
+            {recommended?.recommendedModel ? (
               <div className="rounded-xl border border-dls-border bg-dls-hover/50 px-4 py-3 text-[13px] text-dls-secondary">
-                Your team recommends <span className="font-medium text-dls-text">{recommended.recommendedModel ?? recommended.name}</span> as the default model.
+                Use <span className="font-medium text-dls-text">{recommended.recommendedModel}</span> as your default model.
               </div>
             ) : null}
           </div>
@@ -111,10 +109,10 @@ export function ProviderOnboardingModal(props: ProviderOnboardingModalProps) {
         <div className={modalFooterClass}>
           <div className="flex justify-end gap-3">
             <button type="button" className={pillGhostClass} onClick={props.onConfigureManually}>
-              I&apos;ll configure manually
+              Skip
             </button>
             <button type="button" className={pillPrimaryClass} onClick={props.onAcceptDefaults}>
-              Use team defaults
+              {recommended?.recommendedModel ? `Use ${recommended.recommendedModel}` : "Continue"}
             </button>
           </div>
         </div>

--- a/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
@@ -297,7 +297,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
 
   if (variant === "fullscreen") {
     return (
-      <div className="relative min-h-screen bg-[#fafbfc] text-dls-text">
+      <div className="relative min-h-screen bg-dls-background text-dls-text">
         {/* Subtle background texture */}
         <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
           <div className="absolute -left-[20%] -top-[30%] h-[70%] w-[60%] rounded-full bg-[radial-gradient(ellipse,rgba(14,51,217,0.06),transparent_70%)] blur-3xl" />
@@ -313,17 +313,17 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
           <div className="flex w-full flex-col items-center justify-center px-8 py-16 lg:w-[45%] lg:px-12">
             <div className="w-full max-w-md space-y-8">
               <div className="space-y-2">
-                <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
+                <h1 className="text-2xl font-semibold tracking-tight text-dls-text">
                   Welcome to OpenWork
                 </h1>
-                <p className="text-sm text-slate-500">
+                <p className="text-sm text-dls-secondary">
                   Sign in to get started with your workspace.
                 </p>
               </div>
 
               <button
                 type="button"
-                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-full bg-[#011627] text-sm font-semibold text-white transition-all hover:bg-black disabled:opacity-60 disabled:cursor-not-allowed"
+                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-full bg-dls-accent text-sm font-semibold text-[var(--dls-accent-fg)] transition-all hover:bg-[var(--dls-accent-hover)] disabled:opacity-60 disabled:cursor-not-allowed"
                 onClick={() => props.onOpenBrowserAuth("sign-in")}
                 disabled={props.authBusy || props.sessionBusy}
               >
@@ -343,7 +343,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
               <div className="space-y-3">
                 <button
                   type="button"
-                  className="flex w-full items-center gap-2 rounded-xl border border-slate-200 bg-white/60 px-4 py-2.5 text-left text-xs font-medium text-slate-500 transition-colors hover:bg-white"
+                   className="flex w-full items-center gap-2 rounded-xl border border-dls-border bg-dls-surface/60 px-4 py-2.5 text-left text-xs font-medium text-dls-secondary transition-colors hover:bg-dls-surface"
                   onClick={props.onToggleManualAuth}
                   disabled={props.authBusy || props.sessionBusy}
                 >
@@ -358,7 +358,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
                 </button>
 
                 {props.manualAuthOpen ? (
-                  <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-4">
+                  <div className="space-y-3 rounded-xl border border-dls-border bg-dls-surface p-4">
                     <TextInput
                       label={t("den.signin_link_label")}
                       value={props.manualAuthInput}
@@ -371,7 +371,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
                     />
                     <button
                       type="button"
-                      className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-full bg-[#011627] px-4 text-xs font-semibold text-white transition-all hover:bg-black disabled:opacity-60 disabled:cursor-not-allowed"
+                      className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-full bg-dls-accent px-4 text-xs font-semibold text-[var(--dls-accent-fg)] transition-all hover:bg-[var(--dls-accent-hover)] disabled:opacity-60 disabled:cursor-not-allowed"
                       onClick={props.onSubmitManualAuth}
                       disabled={
                         props.authBusy ||
@@ -389,7 +389,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
 
               {/* Developer mode */}
               {props.developerMode ? (
-                <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-4">
+                <div className="space-y-3 rounded-xl border border-dls-border bg-dls-surface p-4">
                   <TextInput
                     label={t("den.cloud_control_plane_url_label")}
                     value={props.baseUrlDraft}
@@ -408,7 +408,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
                   <div className="flex flex-wrap items-center gap-2">
                     <button
                       type="button"
-                      className="inline-flex h-8 items-center justify-center gap-1.5 rounded-full border border-slate-200 bg-white px-3.5 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-50 hover:border-slate-300 disabled:opacity-60 disabled:cursor-not-allowed"
+                      className="inline-flex h-8 items-center justify-center gap-1.5 rounded-full border border-dls-border bg-dls-surface px-3.5 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover hover:border-dls-border disabled:opacity-60 disabled:cursor-not-allowed"
                       onClick={props.onResetBaseUrl}
                       disabled={
                         props.authBusy || props.baseUrlBusy || props.sessionBusy
@@ -418,7 +418,7 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
                     </button>
                     <button
                       type="button"
-                      className="inline-flex h-8 items-center justify-center gap-1.5 rounded-full bg-[#011627] px-3.5 text-xs font-semibold text-white transition-all hover:bg-black disabled:opacity-60 disabled:cursor-not-allowed"
+                      className="inline-flex h-8 items-center justify-center gap-1.5 rounded-full bg-dls-accent px-3.5 text-xs font-semibold text-[var(--dls-accent-fg)] transition-all hover:bg-[var(--dls-accent-hover)] disabled:opacity-60 disabled:cursor-not-allowed"
                       onClick={props.onApplyBaseUrl}
                       disabled={
                         props.authBusy || props.baseUrlBusy || props.sessionBusy
@@ -455,8 +455,8 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
                 />
               </div>
 
-              {/* Inner: white card with capabilities */}
-              <div className="relative z-10 m-3 rounded-2xl bg-white p-7">
+              {/* Inner: card with capabilities */}
+              <div className="relative z-10 m-3 rounded-2xl bg-dls-surface p-7">
                 <ShowcasePanel />
               </div>
             </div>

--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -324,7 +324,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
     setCliAuthResult(null);
 
     try {
-      const result = await opencodeMcpAuth(props.projectDir, props.entry.name);
+      const result = await opencodeMcpAuth(props.projectDir, props.entry.name) as { ok: boolean; stderr?: string; stdout?: string };
       if (result.ok) {
         setError(null);
         setNeedsReload(true);

--- a/apps/app/src/react-app/domains/connections/openwork-server-store.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-server-store.ts
@@ -352,7 +352,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
         if (disposed) return;
 
         try {
-          const info = await openworkServerInfo();
+          const info = await openworkServerInfo() as OpenworkServerInfo;
           if (disposed) return;
 
           mutateState((current) => ({
@@ -442,7 +442,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
       if (!options.documentVisible()) return;
       void (async () => {
         try {
-          const info = await openworkServerInfo();
+          const info = await openworkServerInfo() as OpenworkServerInfo;
           if (disposed) return;
           mutateState((current) => ({
             ...current,
@@ -628,7 +628,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
       let hostInfo = state.openworkServerHostInfo;
       if (isDesktopRuntime()) {
         try {
-          hostInfo = await openworkServerInfo();
+          hostInfo = await openworkServerInfo() as OpenworkServerInfo;
           mutateState((current) => ({ ...current, openworkServerHostInfo: hostInfo }));
         } catch {
           hostInfo = null;
@@ -693,7 +693,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
     try {
       hostInfo = await openworkServerRestart({
         remoteAccessEnabled: state.openworkServerSettings.remoteAccessEnabled === true,
-      });
+      }) as OpenworkServerInfo;
       mutateState((current) => ({ ...current, openworkServerHostInfo: hostInfo }));
     } catch {
       return null;

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1632,7 +1632,25 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         );
       };
     }
-    void refreshImportedCloudProviders();
+    void refreshImportedCloudProviders().then((imported) => {
+      // Startup cleanup: if no auth token but cloud imports exist, remove them.
+      // Handles orphaned providers from a previous sign-out that didn't clean up.
+      if (!hasCloudProviderSyncPrerequisites() && imported && Object.keys(imported).length > 0) {
+        void (async () => {
+          for (const cloudId of Object.keys(imported)) {
+            try {
+              await removeCloudProviderInternal(cloudId, { silent: true });
+            } catch {}
+          }
+          mutateState((current) => ({
+            ...current,
+            importedCloudProviders: {},
+          }));
+          refreshSnapshot();
+          emitChange();
+        })();
+      }
+    });
     refreshSnapshot();
     emitChange();
   };

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1595,14 +1595,12 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
           void runCloudProviderSync("sign_in");
         } else {
           // Sign-out or error: remove all cloud-imported providers from the workspace
-          const importedIds = Object.keys(state.importedCloudProviders);
-          mutateState((current) => ({
-            ...current,
-            cloudOrgProviders: [],
-            providerAuthMethods: {},
-            importedCloudProviders: {},
-          }));
-          // Best-effort cleanup of cloud provider entries from opencode.jsonc
+          // Capture the full import records BEFORE clearing state
+          const importedProviders = { ...state.importedCloudProviders };
+          const importedIds = Object.keys(importedProviders);
+
+          // Best-effort cleanup: remove each cloud provider from opencode.jsonc
+          // BEFORE clearing state so removeCloudProviderInternal can find the records
           void (async () => {
             for (const cloudId of importedIds) {
               try {
@@ -1611,6 +1609,15 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
                 // Ignore individual removal failures during sign-out cleanup
               }
             }
+            // Clear state AFTER cleanup so the records are available during removal
+            mutateState((current) => ({
+              ...current,
+              cloudOrgProviders: [],
+              providerAuthMethods: {},
+              importedCloudProviders: {},
+            }));
+            refreshSnapshot();
+            emitChange();
           })();
         }
       };

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -592,6 +592,38 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     return updated.endsWith("\n") ? updated : `${updated}\n`;
   };
 
+  // Sweep all cloud-managed provider entries (keys matching /^lpr_/) from
+  // opencode.jsonc regardless of importedCloudProviders state. Returns the
+  // list of provider IDs that were removed so callers can also clear their
+  // auth credentials.
+  const sweepOrphanCloudProvidersFromConfig = async (): Promise<string[]> => {
+    const configFile = await readProjectConfigFile();
+    if (!configFile?.content?.trim()) return [];
+    const parsed = parse(configFile.content);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+    const providerSection = (parsed as Record<string, unknown>).provider;
+    if (
+      !providerSection ||
+      typeof providerSection !== "object" ||
+      Array.isArray(providerSection)
+    ) {
+      return [];
+    }
+    const orphanIds = Object.keys(providerSection as Record<string, unknown>).filter(
+      (key) => /^lpr_/i.test(key),
+    );
+    if (orphanIds.length === 0) return [];
+
+    await updateProjectConfigFile((raw) => {
+      let next = raw;
+      for (const id of orphanIds) {
+        next = formatConfigWithoutCloudProvider(next, id);
+      }
+      return next;
+    });
+    return orphanIds;
+  };
+
   const assertCloudProviderImportSafe = async (
     provider: DenOrgLlmProviderConnection,
   ) => {
@@ -1609,6 +1641,24 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
                 // Ignore individual removal failures during sign-out cleanup
               }
             }
+            // Final sweep: remove any orphan `lpr_*` provider keys that remain
+            // in opencode.jsonc but weren't tracked in importedCloudProviders
+            // (e.g. from a previous failed cleanup or external edit).
+            try {
+              const orphans = await sweepOrphanCloudProvidersFromConfig();
+              for (const providerId of orphans) {
+                try {
+                  await removeProviderAuthCredentials(providerId);
+                } catch {
+                  // Ignore auth removal failures for orphans
+                }
+              }
+              if (orphans.length > 0) {
+                options.markOpencodeConfigReloadRequired();
+              }
+            } catch {
+              // Ignore sweep failures during sign-out cleanup
+            }
             // Clear state AFTER cleanup so the records are available during removal
             mutateState((current) => ({
               ...current,
@@ -1633,15 +1683,31 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       };
     }
     void refreshImportedCloudProviders().then((imported) => {
-      // Startup cleanup: if no auth token but cloud imports exist, remove them.
-      // Handles orphaned providers from a previous sign-out that didn't clean up.
-      if (!hasCloudProviderSyncPrerequisites() && imported && Object.keys(imported).length > 0) {
+      // Startup cleanup: if no auth token, remove any cloud providers that
+      // were left behind. Handles orphans from a previous sign-out that
+      // didn't clean up (e.g. crash, force-quit, external edit).
+      if (!hasCloudProviderSyncPrerequisites()) {
         void (async () => {
-          for (const cloudId of Object.keys(imported)) {
-            try {
-              await removeCloudProviderInternal(cloudId, { silent: true });
-            } catch {}
+          // First: remove anything tracked in import state
+          if (imported && Object.keys(imported).length > 0) {
+            for (const cloudId of Object.keys(imported)) {
+              try {
+                await removeCloudProviderInternal(cloudId, { silent: true });
+              } catch {}
+            }
           }
+          // Then: sweep any `lpr_*` keys that remain in opencode.jsonc
+          try {
+            const orphans = await sweepOrphanCloudProvidersFromConfig();
+            for (const providerId of orphans) {
+              try {
+                await removeProviderAuthCredentials(providerId);
+              } catch {}
+            }
+            if (orphans.length > 0) {
+              options.markOpencodeConfigReloadRequired();
+            }
+          } catch {}
           mutateState((current) => ({
             ...current,
             importedCloudProviders: {},

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1584,14 +1584,34 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         cloudOrgProvidersLoadKey = "";
         cloudOrgProvidersInFlightKey = "";
         cloudOrgProvidersInFlight = null;
-        mutateState((current) => ({
-          ...current,
-          cloudOrgProviders: [],
-          providerAuthMethods: {},
-        }));
         const detail = (event as CustomEvent<DenSessionUpdatedDetail>).detail;
+
         if (detail?.status === "success") {
+          mutateState((current) => ({
+            ...current,
+            cloudOrgProviders: [],
+            providerAuthMethods: {},
+          }));
           void runCloudProviderSync("sign_in");
+        } else {
+          // Sign-out or error: remove all cloud-imported providers from the workspace
+          const importedIds = Object.keys(state.importedCloudProviders);
+          mutateState((current) => ({
+            ...current,
+            cloudOrgProviders: [],
+            providerAuthMethods: {},
+            importedCloudProviders: {},
+          }));
+          // Best-effort cleanup of cloud provider entries from opencode.jsonc
+          void (async () => {
+            for (const cloudId of importedIds) {
+              try {
+                await removeCloudProviderInternal(cloudId, { silent: true });
+              } catch {
+                // Ignore individual removal failures during sign-out cleanup
+              }
+            }
+          })();
         }
       };
       window.addEventListener(

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -363,9 +363,10 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         workspacePath: root,
         config: config as never,
       });
-      if (!result.ok) {
+      const typed = result as { ok: boolean; stderr?: string; stdout?: string };
+      if (!typed.ok) {
         throw new Error(
-          result.stderr || result.stdout || "Failed to write .opencode/openwork.json",
+          typed.stderr || typed.stdout || "Failed to write .opencode/openwork.json",
         );
       }
       return true;
@@ -450,7 +451,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         openworkWorkspaceId,
         "project",
         content,
-      );
+      ) as { ok: boolean; stderr?: string; stdout?: string };
       if (!result.ok) {
         throw new Error(result.stderr || result.stdout || "Failed to write opencode.jsonc");
       }
@@ -458,7 +459,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {
-      const result = await writeOpencodeConfig("project", root, content);
+      const result = await writeOpencodeConfig("project", root, content) as { ok: boolean; stderr?: string; stdout?: string };
       if (!result.ok) {
         throw new Error(result.stderr || result.stdout || "Failed to write opencode.jsonc");
       }
@@ -472,7 +473,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     updater: (raw: string) => string,
     fallbackUpdate?: (config: Record<string, unknown>) => Record<string, unknown>,
   ) => {
-    const configFile = await readProjectConfigFile();
+    const configFile = await readProjectConfigFile() as { content?: string } | null;
     if (configFile) {
       const raw = configFile.content?.trim()
         ? configFile.content
@@ -549,7 +550,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     if (previousProviderId && previousProviderId !== localProviderId) {
       updated = removeCloudProviderComment(updated, previousProviderId);
-      const previousEdits = modify(updated, ["provider", previousProviderId], {
+      const previousEdits = modify(updated, ["provider", previousProviderId], undefined, {
         formattingOptions: { insertSpaces: true, tabSize: 2 },
       });
       updated = applyEdits(updated, previousEdits);
@@ -579,7 +580,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       ? raw
       : '{\n  "$schema": "https://opencode.ai/config.json"\n}\n';
     updated = removeCloudProviderComment(updated, providerId);
-    const providerEdits = modify(updated, ["provider", providerId], {
+    const providerEdits = modify(updated, ["provider", providerId], undefined, {
       formattingOptions: { insertSpaces: true, tabSize: 2 },
     });
     updated = applyEdits(updated, providerEdits);
@@ -597,7 +598,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   // list of provider IDs that were removed so callers can also clear their
   // auth credentials.
   const sweepOrphanCloudProvidersFromConfig = async (): Promise<string[]> => {
-    const configFile = await readProjectConfigFile();
+    const configFile = await readProjectConfigFile() as { content?: string } | null;
     if (!configFile?.content?.trim()) return [];
     const parsed = parse(configFile.content);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
@@ -647,7 +648,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       );
     }
 
-    const configFile = await readProjectConfigFile();
+    const configFile = await readProjectConfigFile() as { content?: string } | null;
     if (!configFile?.content?.trim() || existingImported) {
       return;
     }

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -153,7 +153,7 @@ export function createConnectionsStore(options: {
       return null;
     }
 
-    return readOpencodeConfig(scope, projectDir);
+    return readOpencodeConfig(scope, projectDir) as Promise<OpencodeConfigFile>;
   };
 
   const ensureActiveClient = async () => {
@@ -342,8 +342,8 @@ export function createConnectionsStore(options: {
         projectDir,
       });
       const [globalConfig, projectConfig] = await Promise.all([
-        readOpencodeConfig("global", projectDir),
-        readOpencodeConfig("project", projectDir),
+        readOpencodeConfig("global", projectDir) as Promise<OpencodeConfigFile>,
+        readOpencodeConfig("project", projectDir) as Promise<OpencodeConfigFile>,
       ]);
       const globalServers = globalConfig.exists && globalConfig.content
         ? parseMcpServersFromContent(globalConfig.content).map((entry) => ({
@@ -521,7 +521,7 @@ export function createConnectionsStore(options: {
           config: mcpEntryConfig,
         });
       } else {
-        const configFile = await readOpencodeConfig("project", resolvedProjectDir);
+        const configFile = await readOpencodeConfig("project", resolvedProjectDir) as OpencodeConfigFile;
 
         const raw = configFile.exists && configFile.content?.trim()
           ? configFile.content
@@ -551,7 +551,7 @@ export function createConnectionsStore(options: {
           "project",
           resolvedProjectDir,
           updated.endsWith("\n") ? updated : `${updated}\n`,
-        );
+        ) as { ok: boolean; stderr?: string; stdout?: string };
         if (!writeResult.ok) {
           throw new Error(writeResult.stderr || writeResult.stdout || "Failed to write opencode.json");
         }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -459,23 +459,17 @@ export function SessionPage(props: SessionPageProps) {
                 </button>
               ) : null}
               {/* Revert/redo moved to per-message actions */}
-              {props.developerMode ? (
-                <>
-                  <button
-                    type="button"
-                    className="rounded-md px-2 py-1 text-[10px] font-medium text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
-                    onClick={() => setShowProviderOnboarding(true)}
-                  >
-                    Test onboarding
-                  </button>
-                  <button
-                    type="button"
-                    className="rounded-md px-2 py-1 text-[10px] font-medium text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
-                    onClick={() => setShowProviderToast(true)}
-                  >
-                    Test toast
-                  </button>
-                </>
+              {props.developerMode && providerNotif ? (
+                <button
+                  type="button"
+                  className="rounded-md px-2 py-1 text-[10px] font-medium text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+                  onClick={() => {
+                    try { window.localStorage.removeItem("openwork.acknowledgedProviders"); } catch {}
+                  }}
+                  title="Clears acknowledged providers so onboarding triggers on next provider change"
+                >
+                  Reset provider notifications
+                </button>
               ) : null}
             </div>
           </header>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -159,6 +159,7 @@ export type SessionPageProps = {
     onboarding: import("../../../shell/use-provider-change-detection").ProviderOnboardingState;
     toast: import("../../../shell/use-provider-change-detection").ProviderToastState;
     acknowledgeAll: () => void;
+    switchDefault: (providerId: string, modelId: string) => void;
     dismissOnboarding: () => void;
     dismissToast: () => void;
   };
@@ -815,7 +816,13 @@ export function SessionPage(props: SessionPageProps) {
             onClose={providerNotif.dismissOnboarding}
             orgName=""
             providers={providerNotif.onboarding.providers}
-            onAcceptDefaults={providerNotif.acknowledgeAll}
+            onAcceptDefaults={() => {
+              const rec = providerNotif.onboarding.providers.find((p) => p.recommended);
+              if (rec?.recommendedModelId) {
+                providerNotif.switchDefault(rec.id, rec.recommendedModelId);
+              }
+              providerNotif.acknowledgeAll();
+            }}
             onConfigureManually={providerNotif.dismissOnboarding}
           />
           <ProviderAddedToast
@@ -823,7 +830,12 @@ export function SessionPage(props: SessionPageProps) {
             providerName={providerNotif.toast.providerName}
             providerId={providerNotif.toast.providerId}
             modelName={providerNotif.toast.modelName}
-            onSwitchDefault={providerNotif.acknowledgeAll}
+            onSwitchDefault={() => {
+              if (providerNotif.toast.providerId && providerNotif.toast.modelId) {
+                providerNotif.switchDefault(providerNotif.toast.providerId, providerNotif.toast.modelId);
+              }
+              providerNotif.acknowledgeAll();
+            }}
             onDismiss={providerNotif.dismissToast}
           />
         </>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -158,6 +158,7 @@ export type SessionPageProps = {
   providerNotifications?: {
     onboarding: import("../../../shell/use-provider-change-detection").ProviderOnboardingState;
     toast: import("../../../shell/use-provider-change-detection").ProviderToastState;
+    orgName?: string;
     acknowledgeAll: () => void;
     switchDefault: (providerId: string, modelId: string) => void;
     dismissOnboarding: () => void;
@@ -814,7 +815,7 @@ export function SessionPage(props: SessionPageProps) {
           <ProviderOnboardingModal
             open={providerNotif.onboarding.show}
             onClose={providerNotif.dismissOnboarding}
-            orgName=""
+            orgName={providerNotif.orgName ?? ""}
             providers={providerNotif.onboarding.providers}
             onAcceptDefaults={() => {
               const rec = providerNotif.onboarding.providers.find((p) => p.recommended);

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -155,6 +155,13 @@ export type SessionPageProps = {
   notFoundMessage?: string | null;
   onRenameSession?: (sessionId: string, title: string) => Promise<void> | void;
   onDeleteSession?: (sessionId: string) => Promise<void> | void;
+  providerNotifications?: {
+    onboarding: import("../../../shell/use-provider-change-detection").ProviderOnboardingState;
+    toast: import("../../../shell/use-provider-change-detection").ProviderToastState;
+    acknowledgeAll: () => void;
+    dismissOnboarding: () => void;
+    dismissToast: () => void;
+  };
 };
 
 function getSidebarInitialLoading(props: SessionPageSidebarProps) {
@@ -183,9 +190,7 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
-  // Provider onboarding + new-provider notification (triggered by cloud sync)
-  const [showProviderOnboarding, setShowProviderOnboarding] = useState(false);
-  const [showProviderToast, setShowProviderToast] = useState(false);
+  const providerNotif = props.providerNotifications;
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
     selectedWorkspaceId: props.selectedWorkspaceId,
@@ -809,26 +814,26 @@ export function SessionPage(props: SessionPageProps) {
       />
 
       {/* Provider onboarding + new-provider notification */}
-      <ProviderOnboardingModal
-        open={showProviderOnboarding}
-        onClose={() => setShowProviderOnboarding(false)}
-        orgName="Acme Corp"
-        providers={[
-          { id: "anthropic", name: "Anthropic", recommended: true, recommendedModel: "Claude Sonnet 4" },
-          { id: "openai", name: "OpenAI", recommendedModel: "GPT-4.1" },
-          { id: "opencode", name: "OpenCode Zen", recommendedModel: "Big Pickle" },
-        ]}
-        onAcceptDefaults={() => setShowProviderOnboarding(false)}
-        onConfigureManually={() => setShowProviderOnboarding(false)}
-      />
-      <ProviderAddedToast
-        open={showProviderToast}
-        providerName="Anthropic"
-        providerId="anthropic"
-        modelName="Claude Sonnet 4"
-        onSwitchDefault={() => setShowProviderToast(false)}
-        onDismiss={() => setShowProviderToast(false)}
-      />
+      {providerNotif ? (
+        <>
+          <ProviderOnboardingModal
+            open={providerNotif.onboarding.show}
+            onClose={providerNotif.dismissOnboarding}
+            orgName=""
+            providers={providerNotif.onboarding.providers}
+            onAcceptDefaults={providerNotif.acknowledgeAll}
+            onConfigureManually={providerNotif.dismissOnboarding}
+          />
+          <ProviderAddedToast
+            open={providerNotif.toast.show}
+            providerName={providerNotif.toast.providerName}
+            providerId={providerNotif.toast.providerId}
+            modelName={providerNotif.toast.modelName}
+            onSwitchDefault={providerNotif.acknowledgeAll}
+            onDismiss={providerNotif.dismissToast}
+          />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -184,7 +184,7 @@ export function StatusBar(props: StatusBarProps) {
           {shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking" ? (
             <button
               type="button"
-              className="inline-flex h-7 items-center gap-1.5 rounded-full bg-[#011627] px-2.5 text-[11px] font-medium text-white transition-colors hover:bg-black"
+              className="inline-flex h-7 items-center gap-1.5 rounded-full bg-dls-accent px-2.5 text-[11px] font-medium text-white transition-colors hover:bg-[var(--dls-accent-hover)]"
               onClick={() => {
                 const baseUrl = readDenBootstrapConfig().baseUrl;
                 platform.openLink(buildDenAuthUrl(baseUrl, "sign-in"));

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -184,7 +184,7 @@ export function StatusBar(props: StatusBarProps) {
           {shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking" ? (
             <button
               type="button"
-              className="inline-flex h-7 items-center gap-1.5 rounded-full bg-dls-accent px-2.5 text-[11px] font-medium text-white transition-colors hover:bg-[var(--dls-accent-hover)]"
+              className="inline-flex h-7 items-center gap-1.5 rounded-full bg-dls-accent px-2.5 text-[11px] font-medium text-[var(--dls-accent-fg)] transition-colors hover:bg-[var(--dls-accent-hover)]"
               onClick={() => {
                 const baseUrl = readDenBootstrapConfig().baseUrl;
                 platform.openLink(buildDenAuthUrl(baseUrl, "sign-in"));

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1310,7 +1310,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                     className={`inline-flex h-9 max-h-9 items-center gap-2 rounded-full px-4 text-[13px] font-medium transition-colors ${
                       !canSend || props.disabled
                         ? "bg-gray-4 text-gray-10"
-                        : "bg-[var(--dls-accent)] text-white hover:bg-[var(--dls-accent-hover)]"
+                        : "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
                     }`}
                     title={t("composer.run_task")}
                   >

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -22,6 +22,7 @@ import { useCloudSession } from "./cloud-session-provider";
 export interface CloudAccountSectionProps {
   activeOrgId: string;
   authBusy: boolean;
+  needsOrgSelection?: boolean;
   orgs: DenOrgSummary[];
   orgsBusy: boolean;
   orgsError: string | null;
@@ -34,6 +35,7 @@ export interface CloudAccountSectionProps {
 export function CloudAccountSection({
   activeOrgId,
   authBusy,
+  needsOrgSelection,
   orgs,
   orgsBusy,
   orgsError,
@@ -86,7 +88,11 @@ export function CloudAccountSection({
           <div className="min-w-0 flex flex-col gap-y-1">
             <div className="text-sm font-medium text-dls-text">{t("den.active_org_title")}</div>
             <div className="text-xs text-muted-foreground">
-              {activeOrgId ? "Sign out and sign back in to switch organizations." : t("den.active_org_hint")}
+              {activeOrgId
+                ? t("den.active_org_hint")
+                : orgs.length > 1
+                  ? "Select the organization to use. Sign out to switch later."
+                  : t("den.active_org_hint")}
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -95,7 +101,7 @@ export function CloudAccountSection({
                 value={activeOrgId}
                 items={activeOrgOptions}
                 onValueChange={handleActiveOrgChange}
-                disabled={!!activeOrgId || orgsBusy || orgs.length === 0}
+                disabled={orgsBusy || orgs.length === 0}
               >
                 <SelectTrigger
                   className="w-full"
@@ -124,6 +130,12 @@ export function CloudAccountSection({
           </div>
         </div>
       </div>
+
+      {needsOrgSelection ? (
+        <div className="rounded-xl border border-amber-6/40 bg-amber-2/50 px-4 py-3 text-sm text-amber-11">
+          Select an organization to continue. Cloud providers and settings will be loaded for the selected org.
+        </div>
+      ) : null}
 
       {orgsError ? <SettingsNotice tone="error">{orgsError}</SettingsNotice> : null}
     </section>

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -1,18 +1,9 @@
 /** @jsxImportSource react */
-import { LogOut } from "lucide-react";
+import { Building2, Check, LogOut, Loader2 } from "lucide-react";
 
 import type { DenOrgSummary } from "../../../../app/lib/den";
 import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  RefreshButton,
   SettingsNotice,
   SettingsSectionHeaderDescription,
 } from "../settings-section";
@@ -45,99 +36,152 @@ export function CloudAccountSection({
   onSignOut,
 }: CloudAccountSectionProps) {
   const { user } = useCloudSession();
-  const activeOrgOptions = orgs.map((org) => ({
-    value: org.id,
-    label: `${org.name} ${org.role === "owner" ? t("den.org_owner_suffix") : t("den.org_member_suffix")}`,
-  }));
-  const handleActiveOrgChange = (orgId: string | null) => {
-    if (orgId === null) {
-      return;
-    }
-
-    onActiveOrgChange(orgId);
-  };
+  const activeOrg = orgs.find((org) => org.id === activeOrgId) ?? null;
+  const controlsDisabled = authBusy || sessionBusy;
 
   return (
-    <section className="flex flex-col gap-y-8">
-      <div>
-        <div className="text-sm font-medium text-dls-text">{t("den.cloud_account_title")}</div>
-        <SettingsSectionHeaderDescription>{t("den.cloud_account_hint")}</SettingsSectionHeaderDescription>
-      </div>
-
-      <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="min-w-0 flex flex-col gap-y-1">
+    <section className="flex flex-col gap-y-6">
+      {/* User identity */}
+      <div className="flex items-center justify-between">
+        <div className="min-w-0 flex items-center gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-dls-hover text-sm font-semibold text-dls-text">
+            {(user?.name ?? user?.email ?? "?").charAt(0).toUpperCase()}
+          </div>
+          <div className="min-w-0">
             <div className="truncate text-sm font-medium text-dls-text">
-              {user?.name ? user.name : user?.email}
+              {user?.name || user?.email}
             </div>
-            <div className="truncate text-xs text-muted-foreground">{user?.email}</div>
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="shrink-0"
-            onClick={() => void onSignOut()}
-            disabled={[authBusy, sessionBusy].some(Boolean)}
-          >
-            <LogOut className="size-4" />
-            {authBusy ? t("den.signing_out") : t("den.sign_out")}
-          </Button>
-        </div>
-
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0 flex flex-col gap-y-1">
-            <div className="text-sm font-medium text-dls-text">{t("den.active_org_title")}</div>
-            <div className="text-xs text-muted-foreground">
-              {activeOrgId
-                ? t("den.active_org_hint")
-                : orgs.length > 1
-                  ? "Select the organization to use. Sign out to switch later."
-                  : t("den.active_org_hint")}
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <div className="w-[260px] max-w-full">
-              <Select
-                value={activeOrgId}
-                items={activeOrgOptions}
-                onValueChange={handleActiveOrgChange}
-                disabled={orgsBusy || orgs.length === 0}
-              >
-                <SelectTrigger
-                  className="w-full"
-                  aria-label={t("den.active_org_title")}
-                >
-                  <SelectValue placeholder={t("den.no_org_selected")} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    {activeOrgOptions.map((org) => (
-                      <SelectItem key={org.value} value={org.value}>
-                        {org.label}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </div>
-            <RefreshButton
-              busy={orgsBusy}
-              disabled={orgsBusy}
-              onRefresh={onRefreshOrgs}
-            >
-              {t("den.refresh")}
-            </RefreshButton>
+            {user?.name && user.email ? (
+              <div className="truncate text-xs text-dls-secondary">{user.email}</div>
+            ) : null}
           </div>
         </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => void onSignOut()}
+          disabled={controlsDisabled}
+        >
+          <LogOut className="size-3.5" />
+          {authBusy ? t("den.signing_out") : t("den.sign_out")}
+        </Button>
       </div>
 
+      {/* Org picker (stepper-style) or connected org display */}
       {needsOrgSelection ? (
-        <div className="rounded-xl border border-amber-6/40 bg-amber-2/50 px-4 py-3 text-sm text-amber-11">
-          Select an organization to continue. Cloud providers and settings will be loaded for the selected org.
+        <OrgPicker
+          orgs={orgs}
+          orgsBusy={orgsBusy}
+          disabled={controlsDisabled}
+          onSelect={onActiveOrgChange}
+          onRefresh={onRefreshOrgs}
+        />
+      ) : activeOrg ? (
+        <ConnectedOrg org={activeOrg} />
+      ) : orgsBusy ? (
+        <div className="flex items-center gap-2 text-sm text-dls-secondary">
+          <Loader2 size={14} className="animate-spin" />
+          Loading organizations...
         </div>
       ) : null}
 
       {orgsError ? <SettingsNotice tone="error">{orgsError}</SettingsNotice> : null}
     </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Connected org: read-only display                                   */
+/* ------------------------------------------------------------------ */
+
+function ConnectedOrg({ org }: { org: DenOrgSummary }) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-dls-border bg-dls-surface px-4 py-3">
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-green-3 text-green-11">
+        <Building2 size={16} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-dls-text">{org.name}</div>
+        <div className="text-xs text-dls-secondary">
+          {org.role === "owner" ? "Owner" : "Member"} &middot; Connected
+        </div>
+      </div>
+      <Check size={16} className="shrink-0 text-green-11" />
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Org picker: card-per-org selection                                 */
+/* ------------------------------------------------------------------ */
+
+function OrgPicker({
+  orgs,
+  orgsBusy,
+  disabled,
+  onSelect,
+  onRefresh,
+}: {
+  orgs: DenOrgSummary[];
+  orgsBusy: boolean;
+  disabled: boolean;
+  onSelect: (orgId: string) => void | Promise<void>;
+  onRefresh: () => void | Promise<void>;
+}) {
+  if (orgsBusy) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-6 text-sm text-dls-secondary">
+        <Loader2 size={20} className="animate-spin" />
+        Loading your organizations...
+      </div>
+    );
+  }
+
+  if (orgs.length === 0) {
+    return (
+      <div className="rounded-xl border border-dls-border bg-dls-surface px-4 py-6 text-center text-sm text-dls-secondary">
+        No organizations found.{" "}
+        <button
+          type="button"
+          className="font-medium text-dls-text underline underline-offset-2"
+          onClick={() => void onRefresh()}
+        >
+          Refresh
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-sm font-medium text-dls-text">
+        Select an organization
+      </div>
+      <div className="text-xs text-dls-secondary">
+        Choose the organization to use with this workspace. Sign out to switch later.
+      </div>
+      <div className="flex flex-col gap-2">
+        {orgs.map((org) => (
+          <button
+            key={org.id}
+            type="button"
+            disabled={disabled}
+            className="flex items-center gap-3 rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-left transition-colors hover:border-dls-text/20 hover:bg-dls-hover disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={() => void onSelect(org.id)}
+          >
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-dls-hover text-dls-secondary">
+              <Building2 size={16} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium text-dls-text">{org.name}</div>
+              <div className="text-xs text-dls-secondary">
+                {org.role === "owner" ? "Owner" : "Member"}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -85,7 +85,9 @@ export function CloudAccountSection({
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 flex flex-col gap-y-1">
             <div className="text-sm font-medium text-dls-text">{t("den.active_org_title")}</div>
-            <div className=" text-xs text-muted-foreground">{t("den.active_org_hint")}</div>
+            <div className="text-xs text-muted-foreground">
+              {activeOrgId ? "Sign out and sign back in to switch organizations." : t("den.active_org_hint")}
+            </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <div className="w-[260px] max-w-full">
@@ -93,7 +95,7 @@ export function CloudAccountSection({
                 value={activeOrgId}
                 items={activeOrgOptions}
                 onValueChange={handleActiveOrgChange}
-                disabled={[orgsBusy, orgs.length === 0].some(Boolean)}
+                disabled={!!activeOrgId || orgsBusy || orgs.length === 0}
               >
                 <SelectTrigger
                   className="w-full"

--- a/apps/app/src/react-app/domains/settings/cloud/sections.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/sections.tsx
@@ -505,7 +505,7 @@ function CloudProviderListItem({ actionId, actionKind, row, onImport, onRemove, 
             {actionBusy ? actionLabel : t("den.import_provider")}
           </Button>
         ) : null}
-        {row.status !== "available" ? (
+        {row.status !== "available" && onRemove ? (
           <Button
             variant="destructive"
             size="sm"

--- a/apps/app/src/react-app/domains/settings/cloud/sections.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/sections.tsx
@@ -435,7 +435,7 @@ interface CloudProviderListItemProps {
   actionKind: ResourceActionKind | null;
   row: CloudProviderRow;
   onImport: (cloudProviderId: string, providerName: string) => void | Promise<void>;
-  onRemove: (cloudProviderId: string, providerName: string) => void | Promise<void>;
+  onRemove?: (cloudProviderId: string, providerName: string) => void | Promise<void>;
   onSync: (cloudProviderId: string, providerName: string) => void | Promise<void>;
 }
 
@@ -1005,7 +1005,7 @@ export interface CloudProvidersSectionProps {
   rows: CloudProviderRow[];
   onImport: (cloudProviderId: string, providerName: string) => void | Promise<void>;
   onRefresh: () => void | Promise<void>;
-  onRemove: (cloudProviderId: string, providerName: string) => void | Promise<void>;
+  onRemove?: (cloudProviderId: string, providerName: string) => void | Promise<void>;
   onSync: (cloudProviderId: string, providerName: string) => void | Promise<void>;
 }
 

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -282,6 +282,12 @@ export function useDenSession({
           activeOrgSlug: nextOrg?.slug ?? null,
           activeOrgName: nextOrg?.name ?? null,
         });
+        // Push to context immediately so consumers see the new org
+        if (nextOrg) {
+          setActiveOrganization({ id: nextOrg.id, name: nextOrg.name, slug: nextOrg.slug });
+        } else if (!next) {
+          setActiveOrganization(null);
+        }
         if (next) {
           await ensureDenActiveOrganization({ forceServerSync: true }).catch(() => null);
         }
@@ -297,7 +303,7 @@ export function useDenSession({
         setOrgsBusy(false);
       }
     },
-    [activeOrgId, authToken, baseUrl, client, showToast],
+    [activeOrgId, authToken, baseUrl, client, setActiveOrganization, showToast],
   );
 
   React.useEffect(() => {
@@ -416,15 +422,17 @@ export function useDenSession({
       setOrgsError(null);
 
       try {
+        // 1. Sync Den server-side (cookie/session)
         await client.setActiveOrganization({ organizationId: nextOrg.id });
       } catch (error) {
         setOrgsError(error instanceof Error ? error.message : t("den.error_load_orgs"));
-        return;
-      } finally {
         setOrgsBusy(false);
+        return;
       }
 
-      setActiveOrgId(nextId);
+      // 2. Persist to localStorage FIRST so any code that reads from settings
+      //    (e.g. refreshCloudOrgProviders which reads readDenSettings()) sees
+      //    the new org immediately.
       writeDenSettings({
         baseUrl,
         authToken: authToken ? authToken : null,
@@ -432,12 +440,34 @@ export function useDenSession({
         activeOrgSlug: nextOrg?.slug ?? null,
         activeOrgName: nextOrg?.name ?? null,
       });
+
+      // 3. Update local state
+      setActiveOrgId(nextId);
+
+      // 4. Update CloudSessionProvider context IMMEDIATELY so consumers
+      //    (cloud providers / marketplace / workers views) re-fetch with
+      //    the new org without waiting for the sync effect to fire.
+      setActiveOrganization({
+        id: nextOrg.id,
+        name: nextOrg.name,
+        slug: nextOrg.slug,
+      });
+
+      // 5. Force a full server sync (Den + localStorage reconciliation)
+      try {
+        await ensureDenActiveOrganization({ forceServerSync: true });
+      } catch {
+        // Best-effort; the explicit setActiveOrganization above already
+        // covered the critical path.
+      }
+
+      setOrgsBusy(false);
       showToast({
         title: t("den.org_switched", { name: nextOrg?.name ?? t("den.active_org_title") }),
         tone: "success",
       });
     },
-    [authToken, baseUrl, client, orgs, showToast],
+    [authToken, baseUrl, client, orgs, setActiveOrganization, showToast],
   );
 
   // User is signed in, orgs loaded, multiple orgs available, but none selected yet.

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -260,9 +260,20 @@ export function useDenSession({
         const response = await client.listOrgs();
         setOrgs(response.orgs);
         const current = activeOrgId.trim();
-        const fallback = response.defaultOrgId ?? response.orgs[0]?.id ?? "";
-        const next = response.orgs.some((org) => org.id === current) ? current : fallback;
-        const nextOrg = response.orgs.find((org) => org.id === next) ?? null;
+
+        // Determine the next org to select:
+        // - If the user already had an org selected and it still exists, keep it.
+        // - If there's exactly one org, auto-select it (no choice needed).
+        // - Otherwise, leave blank so the user is prompted to choose.
+        let next = "";
+        if (current && response.orgs.some((org) => org.id === current)) {
+          next = current;
+        } else if (response.orgs.length === 1) {
+          next = response.orgs[0].id;
+        }
+        // else: leave next = "" so the org picker is shown
+
+        const nextOrg = next ? (response.orgs.find((org) => org.id === next) ?? null) : null;
         setActiveOrgId(next);
         writeDenSettings({
           baseUrl,
@@ -429,11 +440,17 @@ export function useDenSession({
     [authToken, baseUrl, client, orgs, showToast],
   );
 
+  // User is signed in, orgs loaded, multiple orgs available, but none selected yet.
+  // The UI should prompt the user to pick an org before cloud features activate.
+  const needsOrgSelection =
+    !!authToken.trim() && !!user && !orgsBusy && orgs.length > 1 && !activeOrgId;
+
   return {
     authBusy,
     authError,
     baseUrlDraft,
     baseUrlError,
+    needsOrgSelection,
     orgs,
     orgsBusy,
     orgsError,

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -156,10 +156,25 @@ export function useDenSession({
       setBaseUrlError(null);
       setAuthError(null);
       setStatusMessage(message ?? null);
-      // Clear acknowledged-providers cache so onboarding modal triggers
-      // again on next sign-in (providers will be re-imported).
+      // Remove ONLY the cloud (lpr_*) provider IDs from the acknowledged
+      // list. Local providers (openai, opencode) stay acknowledged so they
+      // don't re-trigger the onboarding modal. When the user signs in
+      // again, fresh cloud providers will be detected as new and surface
+      // the toast (which is the intended behavior).
       try {
-        window.localStorage.removeItem("openwork.acknowledgedProviders");
+        const raw = window.localStorage.getItem("openwork.acknowledgedProviders");
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            const kept = parsed.filter(
+              (id: unknown) => typeof id === "string" && !/^lpr_/i.test(id),
+            );
+            window.localStorage.setItem(
+              "openwork.acknowledgedProviders",
+              JSON.stringify(kept),
+            );
+          }
+        }
       } catch {}
       // Notify provider auth store so it can clean up cloud-imported providers
       dispatchDenSessionUpdated({ status: "signed_out" });

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -156,6 +156,8 @@ export function useDenSession({
       setBaseUrlError(null);
       setAuthError(null);
       setStatusMessage(message ?? null);
+      // Notify provider auth store so it can clean up cloud-imported providers
+      dispatchDenSessionUpdated({ status: "signed_out" });
     },
     [clearSessionState, developerMode, setAuthToken, setBaseUrl],
   );

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -156,6 +156,11 @@ export function useDenSession({
       setBaseUrlError(null);
       setAuthError(null);
       setStatusMessage(message ?? null);
+      // Clear acknowledged-providers cache so onboarding modal triggers
+      // again on next sign-in (providers will be re-imported).
+      try {
+        window.localStorage.removeItem("openwork.acknowledgedProviders");
+      } catch {}
       // Notify provider auth store so it can clean up cloud-imported providers
       dispatchDenSessionUpdated({ status: "signed_out" });
     },

--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -38,6 +38,8 @@ export type AiSettingsViewProps = {
   onOpenProviderAuth: () => void | Promise<void>;
   onDisconnectProvider: (providerId: string) => void | Promise<void>;
   canDisconnectProvider: (source?: ConnectedProvider["source"]) => boolean;
+  /** Set of local provider IDs that were imported from cloud. */
+  cloudProviderIds?: Set<string>;
 };
 
 function providerSourceLabel(source?: ConnectedProvider["source"]) {
@@ -96,31 +98,35 @@ export function AiSettingsView(props: AiSettingsViewProps) {
                 <div className="flex min-w-0 items-center gap-3">
                   <ProviderIcon providerId={provider.id} size={20} className="text-dls-text" />
                   <div className="min-w-0">
-                    <div className="truncate text-sm font-medium text-dls-text">{provider.name}</div>
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium text-dls-text">{provider.name}</span>
+                      {props.cloudProviderIds?.has(provider.id) ? (
+                        <span className="shrink-0 rounded-full border border-blue-6 bg-blue-2 px-2 py-0.5 text-[10px] font-medium text-blue-11">
+                          Cloud
+                        </span>
+                      ) : null}
+                    </div>
                     <div className="truncate font-mono text-xs text-muted-foreground">{provider.id}</div>
-                    {providerSourceLabel(provider.source) ? (
-                      <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                        {providerSourceLabel(provider.source)}
-                      </div>
-                    ) : null}
                   </div>
                 </div>
-                <Button
-                  variant="destructive"
-                  onClick={() => void props.onDisconnectProvider(provider.id)}
-                  disabled={
-                    props.busy ||
-                    props.providerAuthBusy ||
-                    props.disconnectingProviderId !== null ||
-                    !props.canDisconnectProvider(provider.source)
-                  }
-                >
-                  {props.disconnectingProviderId === provider.id
-                    ? t("settings.disconnecting")
-                    : props.canDisconnectProvider(provider.source)
-                      ? t("settings.disconnect")
-                      : t("settings.managed_by_env")}
-                </Button>
+                {!props.cloudProviderIds?.has(provider.id) ? (
+                  <Button
+                    variant="destructive"
+                    onClick={() => void props.onDisconnectProvider(provider.id)}
+                    disabled={
+                      props.busy ||
+                      props.providerAuthBusy ||
+                      props.disconnectingProviderId !== null ||
+                      !props.canDisconnectProvider(provider.source)
+                    }
+                  >
+                    {props.disconnectingProviderId === provider.id
+                      ? t("settings.disconnecting")
+                      : props.canDisconnectProvider(provider.source)
+                        ? t("settings.disconnect")
+                        : t("settings.managed_by_env")}
+                  </Button>
+                ) : null}
               </LayoutSectionItem>
             ))}
           </div>

--- a/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
@@ -34,6 +34,7 @@ type CloudAccountSession = Pick<
   | "authError"
   | "baseUrlDraft"
   | "baseUrlError"
+  | "needsOrgSelection"
   | "orgs"
   | "orgsBusy"
   | "orgsError"
@@ -205,6 +206,7 @@ export function CloudAccountView({ developerMode, session }: CloudAccountViewPro
           <CloudAccountSection
             activeOrgId={activeOrganization?.id ?? ""}
             authBusy={session.authBusy}
+            needsOrgSelection={session.needsOrgSelection}
             orgs={session.orgs}
             orgsBusy={session.orgsBusy}
             orgsError={session.orgsError}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -233,7 +233,7 @@ export function CloudProvidersView({
         rows={rows}
         onImport={importProvider}
         onRefresh={refresh}
-        onRemove={removeProvider}
+        onRemove={undefined}
         onSync={syncProvider}
       />
     </SettingsStack>

--- a/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-providers-view.tsx
@@ -55,8 +55,9 @@ export function CloudProvidersView({
       const imported = importedCloudProviders[provider.id] ?? null;
       const status = !imported
         ? "available"
-        : imported.providerId !== provider.providerId ||
-            (imported.source ?? null) !== provider.source ||
+        : imported.providerId !== provider.id.trim() ||
+            imported.sourceProviderId !== provider.providerId ||
+            (imported.source ?? null) !== (provider.source ?? null) ||
             (imported.updatedAt ?? null) !== (provider.updatedAt ?? null) ||
             !sameStringList(imported.modelIds, sortStrings(provider.models.map((model) => model.id)))
           ? "out_of_sync"

--- a/apps/app/src/react-app/domains/settings/pages/general-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/general-view.tsx
@@ -36,7 +36,7 @@ const workspaceCards: { tab: SettingsTab; icon: typeof Sparkles; title: string; 
 
 const globalCards: { tab: SettingsTab; icon: typeof Sparkles; title: string; desc: string }[] = [
   { tab: "ai", icon: Sparkles, title: "AI Providers", desc: "Connect services that provide AI models." },
-  { tab: "den", icon: Cloud, title: "Cloud", desc: "OpenWork Cloud account and organization." },
+  { tab: "cloud-account", icon: Cloud, title: "Cloud", desc: "OpenWork Cloud account and organization." },
   { tab: "appearance", icon: Paintbrush, title: "Appearance", desc: "Theme, font size, and display." },
   { tab: "environment", icon: Terminal, title: "Environment", desc: "Environment variables and paths." },
   { tab: "updates", icon: RefreshCcw, title: "Updates", desc: "App version and update channel." },

--- a/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/messaging-view.tsx
@@ -1004,7 +1004,7 @@ export function MessagingView(props: MessagingViewProps) {
                       {props.sendTest.result.failures?.length ? ` failures=${props.sendTest.result.failures.length}` : ""}
                       {props.sendTest.result.reason?.trim() ? ` reason=${props.sendTest.result.reason}` : ""}
                     </div>
-                    {props.sendTest.result.failures?.map((failure) => (
+                    {props.sendTest.result.failures?.map((failure: { identityId: string; peerId: string; error: string }) => (
                       <div key={`${failure.identityId}:${failure.peerId}:${failure.error}`} className="text-red-11">
                         {failure.identityId}/{failure.peerId}: {failure.error}
                       </div>

--- a/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
@@ -1218,7 +1218,7 @@ export function SkillsView(props: SkillsViewProps) {
                       type="button"
                       onClick={() => selectHubRepo(repo)}
                       className={`px-3 py-1.5 text-[12px] font-medium transition-colors ${
-                        active ? "bg-dls-accent text-white" : "text-dls-secondary hover:bg-dls-hover hover:text-dls-text"
+                        active ? "bg-dls-accent text-[var(--dls-accent-fg)]" : "text-dls-secondary hover:bg-dls-hover hover:text-dls-text"
                       }`}
                       disabled={props.busy}
                     >

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -272,7 +272,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
   const refreshEngineInfo = useCallback(async () => {
     if (!isDesktopRuntime()) return;
     try {
-      const info = await engineInfoCmd();
+      const info = await engineInfoCmd() as EngineInfo | null;
       setEngineInfoState(info);
     } catch {
       setEngineInfoState(null);
@@ -284,7 +284,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     void (async () => {
       if (!isDesktopRuntime()) return;
       try {
-        const build = await appBuildInfoCmd();
+        const build = await appBuildInfoCmd() as AppBuildInfo | null;
         setAppBuild(build);
       } catch {
         setAppBuild(null);
@@ -451,7 +451,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       return;
     }
     try {
-      const env = await updaterEnvironmentCmd();
+      const env = await updaterEnvironmentCmd() as { appBundlePath?: string };
       const appBundlePath = env.appBundlePath?.trim();
       if (!appBundlePath) {
         setElectronMigrationStatus("Could not resolve the current OpenWork.app bundle path.");

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -558,14 +558,14 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     setSandboxProbeBusy(true);
     setSandboxProbeStatus(null);
     try {
-      const result = await sandboxDebugProbeCmd();
+      const result = (await sandboxDebugProbeCmd()) as SandboxDebugProbeResult | null;
       setSandboxProbeResult(result);
       setSandboxProbeStatus(
-        result.ready
+        result!.ready
           ? t("settings.sandbox_probe_success")
-          : (result.error ?? t("settings.sandbox_error")),
+          : (result!.error ?? t("settings.sandbox_error")),
       );
-      pushDeveloperLog(`sandbox probe ready=${String(result.ready)}`);
+      pushDeveloperLog(`sandbox probe ready=${String(result!.ready)}`);
     } catch (error) {
       setSandboxProbeStatus(error instanceof Error ? error.message : safeStringify(error));
     } finally {
@@ -627,7 +627,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     const workspacePaths = [workspacePath];
     const workspacePathSet = new Set(workspacePaths);
     try {
-      const list = await workspaceBootstrapCmd();
+      const list = (await workspaceBootstrapCmd()) as { workspaces?: Array<{ workspaceType?: string; path?: string }> } | null;
       for (const entry of list?.workspaces ?? []) {
         if (entry.workspaceType === "remote") continue;
         const path = entry.path?.trim() ?? "";
@@ -652,7 +652,14 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     // engine_start restarts openwork-server on a NEW port and lets that server
     // manage OpenCode. Re-read host info and persist the fresh URL/token.
     try {
-      const hostInfo = await openworkServerInfoCmd();
+      const hostInfo = (await openworkServerInfoCmd()) as {
+        baseUrl?: string;
+        ownerToken?: string;
+        clientToken?: string;
+        hostToken?: string;
+        port?: number;
+        remoteAccessEnabled?: boolean;
+      } | null;
       if (hostInfo?.baseUrl) {
         writeOpenworkServerSettings({
           urlOverride: hostInfo.baseUrl,

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -447,10 +447,10 @@ export function createExtensionsStore(options: {
     }
 
     if (isLocalWorkspace && isDesktopRuntime() && root) {
-      const result = await workspaceOpenworkWrite({
+      const result = (await workspaceOpenworkWrite({
         workspacePath: root,
         config: config as never,
-      });
+      })) as { ok: boolean; stderr?: string; stdout?: string };
       if (!result.ok) {
         throw new Error(result.stderr || result.stdout || "Failed to write .opencode/openwork.json");
       }
@@ -590,9 +590,9 @@ export function createExtensionsStore(options: {
       throw new Error(t("skills.pick_workspace_first"));
     }
 
-    const result = await installSkillTemplate(root, name, content, {
+    const result = (await installSkillTemplate(root, name, content, {
       overwrite: optionsOverride?.overwrite ?? false,
-    });
+    })) as { ok: boolean; stderr?: string; stdout?: string };
     if (!result.ok) {
       throw new Error(result.stderr || result.stdout || t("skills.install_failed"));
     }
@@ -660,7 +660,7 @@ export function createExtensionsStore(options: {
       throw new Error(t("skills.pick_workspace_first"));
     }
 
-    const result = await uninstallSkillCommand(root, name);
+    const result = (await uninstallSkillCommand(root, name)) as { ok: boolean; stderr?: string; stdout?: string };
     if (!result.ok) {
       throw new Error(result.stderr || result.stdout || t("skills.uninstall_failed"));
     }
@@ -1756,9 +1756,9 @@ export function createExtensionsStore(options: {
     try {
       mutateState((current) => ({ ...current, pluginStatus: null, sidebarPluginStatus: null }));
       if (refreshPluginsAborted) return;
-      const config = await readOpencodeConfig(scope, targetDir);
+      const config = (await readOpencodeConfig(scope, targetDir)) as OpencodeConfigFile;
       if (refreshPluginsAborted) return;
-      mutateState((current) => ({ ...current, pluginConfig: config, pluginConfigPath: config.path ?? null }));
+      mutateState((current) => ({ ...current, pluginConfig: (config as OpencodeConfigFile | null), pluginConfigPath: config.path ?? null }));
 
       if (!config.exists) {
         mutateState((current) => ({
@@ -1783,7 +1783,7 @@ export function createExtensionsStore(options: {
       const nextPluginNames: string[] = [];
       let nextPluginStatus: string | null = null;
       loadPluginsFromConfigHelpers(
-        config,
+        config as never,
         (value) => {
           nextPluginNames.splice(0, nextPluginNames.length, ...applyStateAction(nextPluginNames, value));
         },
@@ -1875,7 +1875,7 @@ export function createExtensionsStore(options: {
 
     try {
       setStateField("pluginStatus", null);
-      const config = await readOpencodeConfig(scope, targetDir);
+      const config = (await readOpencodeConfig(scope, targetDir)) as OpencodeConfigFile;
       const raw = config.content ?? "";
 
       if (!raw.trim()) {
@@ -1962,7 +1962,7 @@ export function createExtensionsStore(options: {
 
     try {
       setStateField("pluginStatus", null);
-      const config = await readOpencodeConfig(scope, targetDir);
+      const config = (await readOpencodeConfig(scope, targetDir)) as OpencodeConfigFile;
       const raw = config.content ?? "";
       if (!raw.trim()) {
         setStateField("pluginStatus", "No plugins configured yet.");
@@ -2011,7 +2011,7 @@ export function createExtensionsStore(options: {
       const sourceDir = typeof selection === "string" ? selection : Array.isArray(selection) ? selection[0] : null;
       if (!sourceDir) return;
       const inferredName = sourceDir.split(/[\\/]/).filter(Boolean).pop();
-      const result = await importSkill(targetDir, sourceDir, { overwrite: false });
+      const result = (await importSkill(targetDir, sourceDir, { overwrite: false })) as { ok: boolean; stderr?: string; stdout?: string; status?: number };
       if (!result.ok) {
         setStateField("skillsStatus", result.stderr || result.stdout || t("skills.import_failed").replace("{status}", String(result.status)));
       } else {
@@ -2089,7 +2089,7 @@ export function createExtensionsStore(options: {
     options.setError(null);
     setStateField("skillsStatus", t("skills.installing_skill_creator"));
     try {
-      const result = await installSkillTemplate(targetDir, "skill-creator", skillCreatorTemplate, { overwrite: false });
+      const result = (await installSkillTemplate(targetDir, "skill-creator", skillCreatorTemplate, { overwrite: false })) as { ok: boolean; stderr: string; stdout: string };
       if (!result.ok && /already exists/i.test(result.stderr)) {
         const message = t("skills.skill_creator_already_installed");
         setStateField("skillsStatus", message);
@@ -2224,7 +2224,7 @@ export function createExtensionsStore(options: {
 
     try {
       setStateField("skillsStatus", null);
-      const result = await readLocalSkill(root, trimmed);
+      const result = (await readLocalSkill(root, trimmed)) as { path: string; content: string };
       return { name: trimmed, path: result.path, content: result.content };
     } catch (error) {
       setStateField("skillsStatus", error instanceof Error ? error.message : t("skills.failed_to_load"));
@@ -2291,7 +2291,7 @@ export function createExtensionsStore(options: {
     options.setError(null);
     setStateField("skillsStatus", null);
     try {
-      const result = await writeLocalSkill(root, trimmed, input.content);
+      const result = (await writeLocalSkill(root, trimmed, input.content)) as { ok: boolean; stderr?: string; stdout?: string };
       if (!result.ok) {
         setStateField("skillsStatus", result.stderr || result.stdout || t("skills.unknown_error"));
       } else {

--- a/apps/app/src/react-app/domains/settings/state/messaging-view-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/messaging-view-state.ts
@@ -325,13 +325,13 @@ export function useMessagingViewProps(
     setSendError(null);
     setSendResult(null);
     try {
-      const result = await client.sendOpenCodeRouterMessage(id, {
+      const result = (await (client as any).sendOpenCodeRouterMessage(id, {
         channel: sendChannel,
         text,
         ...(sendDirectory.trim() ? { directory: sendDirectory.trim() } : {}),
         ...(sendPeerId.trim() ? { peerId: sendPeerId.trim() } : {}),
         ...(sendAutoBind ? { autoBind: true } : {}),
-      });
+      })) as OpenworkOpenCodeRouterSendResult;
       setSendResult(result);
       const base = t("identities.dispatched_messages", undefined, {
         sent: result.sent,
@@ -408,10 +408,10 @@ export function useMessagingViewProps(
       }
 
       const [healthRes, tgRes, slackRes, telegramInfo] = await Promise.all([
-        client.getOpenCodeRouterHealth(id),
-        client.getOpenCodeRouterTelegramIdentities(id),
-        client.getOpenCodeRouterSlackIdentities(id),
-        client.getOpenCodeRouterTelegram(id).catch(() => null),
+        (client as any).getOpenCodeRouterHealth(id),
+        (client as any).getOpenCodeRouterTelegramIdentities(id),
+        (client as any).getOpenCodeRouterSlackIdentities(id),
+        (client as any).getOpenCodeRouterTelegram(id).catch(() => null),
       ]);
 
       setTelegramBotUsername(getTelegramUsernameFromResult(telegramInfo));
@@ -607,7 +607,7 @@ export function useMessagingViewProps(
     setTelegramStatus(null);
     setTelegramError(null);
     try {
-      const result = await client.upsertOpenCodeRouterTelegramIdentity(id, {
+      const result = await (client as any).upsertOpenCodeRouterTelegramIdentity(id, {
         token,
         enabled: telegramEnabled,
         access,
@@ -681,7 +681,7 @@ export function useMessagingViewProps(
     setTelegramStatus(null);
     setTelegramError(null);
     try {
-      const result = await client.deleteOpenCodeRouterTelegramIdentity(id, identityId);
+      const result = await (client as any).deleteOpenCodeRouterTelegramIdentity(id, identityId);
       if (result.ok) {
         setTelegramBotUsername(null);
         setTelegramPairingCode(null);
@@ -730,7 +730,7 @@ export function useMessagingViewProps(
     setSlackStatus(null);
     setSlackError(null);
     try {
-      const result = await client.upsertOpenCodeRouterSlackIdentity(id, {
+      const result = await (client as any).upsertOpenCodeRouterSlackIdentity(id, {
         botToken,
         appToken,
         enabled: slackEnabled,
@@ -779,7 +779,7 @@ export function useMessagingViewProps(
     setSlackStatus(null);
     setSlackError(null);
     try {
-      const result = await client.deleteOpenCodeRouterSlackIdentity(id, identityId);
+      const result = await (client as any).deleteOpenCodeRouterSlackIdentity(id, identityId);
       if (result.ok) {
         setSlackStatus(
           result.applied === false

--- a/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
@@ -22,7 +22,7 @@ export type ReloadWorkspaceToastProps = {
 
 const buttonBaseClass =
   "inline-flex items-center justify-center rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.18)] disabled:cursor-not-allowed disabled:opacity-60";
-const primaryButtonClass = `${buttonBaseClass} bg-[var(--dls-accent)] text-white hover:bg-[var(--dls-accent-hover)]`;
+const primaryButtonClass = `${buttonBaseClass} bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]`;
 const dangerButtonClass = `${buttonBaseClass} bg-red-9 text-white hover:bg-red-10`;
 const ghostButtonClass = `${buttonBaseClass} border border-transparent bg-transparent text-dls-text hover:bg-[var(--dls-hover)]`;
 

--- a/apps/app/src/react-app/domains/shell-feedback/status-toast.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/status-toast.tsx
@@ -70,7 +70,7 @@ export function StatusToast(props: StatusToastProps) {
             <div className="mt-3 flex items-center gap-2">
               <button
                 type="button"
-                className="inline-flex items-center justify-center rounded-full bg-[var(--dls-accent)] px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[var(--dls-accent-hover)]"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--dls-accent)] px-3 py-1.5 text-xs font-medium text-[var(--dls-accent-fg)] transition-colors hover:bg-[var(--dls-accent-hover)]"
                 onClick={() => props.onAction?.()}
               >
                 {props.actionLabel}

--- a/apps/app/src/react-app/domains/workspace/modal-styles.ts
+++ b/apps/app/src/react-app/domains/workspace/modal-styles.ts
@@ -49,7 +49,7 @@ export const subtleInputClass =
 const pillButtonBaseClass =
   "inline-flex items-center justify-center gap-1.5 rounded-full px-4 py-2 text-[13px] font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.18)] disabled:cursor-not-allowed disabled:opacity-60";
 
-export const pillPrimaryClass = `${pillButtonBaseClass} bg-dls-accent text-white hover:bg-[var(--dls-accent-hover)]`;
+export const pillPrimaryClass = `${pillButtonBaseClass} bg-dls-accent text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]`;
 
 export const pillSecondaryClass = `${pillButtonBaseClass} border border-dls-border bg-dls-surface text-dls-text hover:bg-dls-hover`;
 

--- a/apps/app/src/react-app/domains/workspace/remote-access-restart.ts
+++ b/apps/app/src/react-app/domains/workspace/remote-access-restart.ts
@@ -36,7 +36,7 @@ export function useRemoteAccessRestart(options: UseRemoteAccessRestartOptions) {
       options.onSettingsChanged();
 
       try {
-        const info = await openworkServerRestart({ remoteAccessEnabled: enabled });
+        const info = await openworkServerRestart({ remoteAccessEnabled: enabled }) as OpenworkServerInfo;
         writeOpenworkServerSettings({
           urlOverride: info.baseUrl?.trim() || undefined,
           token:

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useSyncExternalStore, type ReactNode } from "react";
 import { Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
-import { readDenBootstrapConfig } from "../../app/lib/den";
-import { denSettingsChangedEvent } from "../../app/lib/den-session-events";
+import { readDenBootstrapConfig, readDenSettings } from "../../app/lib/den";
+import { denSettingsChangedEvent, denSessionUpdatedEvent } from "../../app/lib/den-session-events";
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
 import { ForcedSigninPage } from "../domains/cloud/forced-signin-page";
 import { useDesktopFontZoomBehavior } from "./font-zoom";
@@ -66,7 +66,14 @@ function DenSigninGate({ children }: DenSigninGateProps) {
       if (!denAuth.isSignedIn && !onSignin) {
         navigate("/signin", { replace: true });
       } else if (denAuth.isSignedIn && onSignin) {
-        navigate("/session", { replace: true });
+        // Signed in -- check if an org is selected. If not, send the user
+        // to Cloud > Account so they can pick one before proceeding.
+        const settings = readDenSettings();
+        if (!settings.activeOrgId?.trim()) {
+          navigate("/settings/cloud-account", { replace: true });
+        } else {
+          navigate("/session", { replace: true });
+        }
       }
     } else if (onSignin) {
       navigate("/session", { replace: true });
@@ -78,6 +85,24 @@ function DenSigninGate({ children }: DenSigninGateProps) {
     navigate,
     requireSignin,
   ]);
+
+  // After a fresh sign-in with no org selected, redirect to org picker.
+  // This handles the case where sign-in completes via the web-app callback
+  // while the user is already on /session (not on /signin).
+  useEffect(() => {
+    const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {
+      if (event.detail?.status !== "success") return;
+      // Small delay: let orgs load first, then check if one was auto-selected.
+      setTimeout(() => {
+        const settings = readDenSettings();
+        if (settings.authToken?.trim() && !settings.activeOrgId?.trim()) {
+          navigate("/settings/cloud-account", { replace: true });
+        }
+      }, 1500);
+    };
+    window.addEventListener(denSessionUpdatedEvent, handler);
+    return () => window.removeEventListener(denSessionUpdatedEvent, handler);
+  }, [navigate]);
 
   if (requireSignin && denAuth.status === "checking") {
     return <ForcedSigninPage developerMode={false} />;

--- a/apps/app/src/react-app/shell/desktop-local-openwork.ts
+++ b/apps/app/src/react-app/shell/desktop-local-openwork.ts
@@ -2,6 +2,8 @@ import {
   engineInfo,
   engineStart,
   openworkServerInfo,
+  type EngineInfo,
+  type OpenworkServerInfo,
 } from "../../app/lib/desktop";
 import { readOpenworkServerSettings, writeOpenworkServerSettings } from "../../app/lib/openwork-server";
 import { safeStringify } from "../../app/utils";
@@ -63,7 +65,7 @@ export async function ensureDesktopLocalOpenworkConnection(
   });
 
   try {
-    const engine = await engineInfo().catch(() => null);
+    const engine = await engineInfo().catch(() => null) as EngineInfo | null;
     if (!engine?.running || !engine.baseUrl) {
       await engineStart(workspaceRoot, {
         runtime: "direct",
@@ -72,7 +74,7 @@ export async function ensureDesktopLocalOpenworkConnection(
       });
     }
 
-    const info = await openworkServerInfo();
+    const info = await openworkServerInfo() as OpenworkServerInfo | null;
     if (!info?.baseUrl) {
       throw new Error("OpenWork server did not report a base URL after activation.");
     }

--- a/apps/app/src/react-app/shell/desktop-runtime-boot.ts
+++ b/apps/app/src/react-app/shell/desktop-runtime-boot.ts
@@ -10,6 +10,10 @@ import {
   workspaceBootstrap,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
+  type EngineInfo,
+  type OpenworkServerInfo,
+  type WorkspaceInfo,
+  type WorkspaceList,
 } from "../../app/lib/desktop";
 import { ingestMigrationSnapshotOnElectronBoot } from "../../app/lib/migration";
 import {
@@ -81,7 +85,7 @@ export function useDesktopRuntimeBoot() {
         hydrateOpenworkServerSettingsFromEnv();
 
         setPhase("bootstrapping-workspaces");
-        const list = await workspaceBootstrap().catch(() => null);
+        const list = await workspaceBootstrap().catch(() => null) as WorkspaceList | null;
         if (!list) {
           markReady();
           return;
@@ -164,10 +168,10 @@ export function useDesktopRuntimeBoot() {
         // This mirrors Solid's bootstrap at context/workspace.ts:3883-3907
         // ("localAttachExisting"), which never restarts a running stack.
         try {
-          const engine = await engineInfo();
+          const engine = await engineInfo() as EngineInfo | null;
           if (engine?.running && engine.baseUrl) {
             setActive(engine.baseUrl);
-            const fresh = await openworkServerInfo().catch(() => null);
+            const fresh = await openworkServerInfo().catch(() => null) as OpenworkServerInfo | null;
             if (fresh?.baseUrl) {
               writeOpenworkServerSettings({
                 urlOverride: fresh.baseUrl,
@@ -197,7 +201,7 @@ export function useDesktopRuntimeBoot() {
         // SLOW PATH ─────────────────────────────────────────────────────
         // No running engine. Tauri now mirrors Electron: engine_start boots
         // openwork-server and lets that server manage OpenCode.
-        const localPaths = list.workspaces.flatMap((entry) => {
+        const localPaths = list.workspaces.flatMap((entry: WorkspaceInfo) => {
           const path = entry.workspaceType !== "remote" ? entry.path?.trim() ?? "" : "";
           return path ? [path] : [];
         });
@@ -220,7 +224,7 @@ export function useDesktopRuntimeBoot() {
         }).catch((error) => {
           console.warn("[desktop-boot] engineStart failed:", error);
           return null;
-        });
+        }) as EngineInfo | null;
 
         if (!engineStartResult) {
           const fallback = list.workspaces.find((entry) => {
@@ -242,7 +246,7 @@ export function useDesktopRuntimeBoot() {
               console.warn("[desktop-boot] fallback engineStart failed:", error);
               setError(error instanceof Error ? error.message : safeStringify(error));
               return null;
-            });
+            }) as EngineInfo | null;
             if (engineStartResult) {
               void workspaceSetSelected(fallback.id).catch(() => undefined);
               void workspaceSetRuntimeActive(fallback.id).catch(() => undefined);
@@ -257,7 +261,7 @@ export function useDesktopRuntimeBoot() {
             setActive(engineStartResult.baseUrl);
           }
           try {
-            const freshInfo = await openworkServerInfo();
+            const freshInfo = await openworkServerInfo() as OpenworkServerInfo | null;
             if (freshInfo?.baseUrl) {
               writeOpenworkServerSettings({
                 urlOverride: freshInfo.baseUrl,

--- a/apps/app/src/react-app/shell/openwork-connection.ts
+++ b/apps/app/src/react-app/shell/openwork-connection.ts
@@ -33,7 +33,7 @@ export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConne
 
   if (isDesktopRuntime()) {
     try {
-      const info = await openworkServerInfo();
+      const info = await openworkServerInfo() as OpenworkServerInfo;
       const normalizedBaseUrl =
         normalizeOpenworkServerUrl(info.baseUrl ?? info.connectUrl ?? info.lanUrl ?? info.mdnsUrl ?? "") ??
         "";

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -117,6 +117,8 @@ import { saveSessionDraft } from "../domains/session/sync/draft-store";
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
 import { useProviderChangeDetection } from "./use-provider-change-detection";
+import { readDenSettings } from "../../app/lib/den";
+import { denSessionUpdatedEvent } from "../../app/lib/den-session-events";
 import { getModelBehaviorSummary } from "../../app/lib/model-behavior";
 import { filterProviderList, mapConfigProvidersToList } from "../../app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
@@ -497,6 +499,13 @@ export function SessionRoute() {
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
   const [providerConnectedIds, setProviderConnectedIds] = useState<string[]>([]);
+  // Bump to re-filter provider list when den session changes (sign-in/out)
+  const [denSessionVersion, setDenSessionVersion] = useState(0);
+  useEffect(() => {
+    const handler = () => setDenSessionVersion((v) => v + 1);
+    window.addEventListener(denSessionUpdatedEvent, handler);
+    return () => window.removeEventListener(denSessionUpdatedEvent, handler);
+  }, []);
   const providerChangeDetection = useProviderChangeDetection(providerConnectedIds, providers as any);
   const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
   const permissionReplyBusyRef = useRef(false);
@@ -1365,8 +1374,20 @@ export function SessionRoute() {
 
     const applyProviderState = (value: ProviderListResponse) => {
       if (cancelled) return;
-      setProviders((value.all ?? []) as ProviderListItem[]);
-      setProviderConnectedIds(value.connected ?? []);
+      // When not signed in, filter out cloud-managed providers (lpr_*)
+      // so stale entries from a previous session don't appear.
+      const hasCloudAuth = !!readDenSettings().authToken?.trim();
+      const isCloudProvider = (id: string) => /^lpr_/i.test(id);
+      const all = hasCloudAuth
+        ? ((value.all ?? []) as ProviderListItem[])
+        : ((value.all ?? []) as ProviderListItem[]).filter(
+            (p) => !isCloudProvider(p.id ?? ""),
+          );
+      const connected = hasCloudAuth
+        ? (value.connected ?? [])
+        : (value.connected ?? []).filter((id) => !isCloudProvider(id));
+      setProviders(all);
+      setProviderConnectedIds(connected);
     };
 
     void (async () => {
@@ -1421,7 +1442,7 @@ export function SessionRoute() {
     return () => {
       cancelled = true;
     };
-  }, [opencodeClient, selectedWorkspaceRoot]);
+  }, [opencodeClient, selectedWorkspaceRoot, denSessionVersion]);
 
   const modelLabel = local.prefs.defaultModel
     ? resolveModelDisplayName(local.prefs.defaultModel.modelID)

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2319,7 +2319,16 @@ export function SessionRoute() {
       startupPhase={effectiveLoading ? "nativeInit" : "ready"}
       providerConnectedIds={providerConnectedIds}
       providers={providers}
-      providerNotifications={providerChangeDetection}
+      providerNotifications={{
+        ...providerChangeDetection,
+        switchDefault: (providerId: string, modelId: string) => {
+          local.setPrefs((prev) => ({
+            ...prev,
+            defaultModel: { providerID: providerId, modelID: modelId },
+            modelVariant: null,
+          }));
+        },
+      }}
       mcpConnectedCount={0}
       onSendFeedback={() => {
         platform.openLink(

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -116,6 +116,7 @@ import {
 import { saveSessionDraft } from "../domains/session/sync/draft-store";
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
+import { useProviderChangeDetection } from "./use-provider-change-detection";
 import { getModelBehaviorSummary } from "../../app/lib/model-behavior";
 import { filterProviderList, mapConfigProvidersToList } from "../../app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
@@ -496,6 +497,7 @@ export function SessionRoute() {
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
   const [providerConnectedIds, setProviderConnectedIds] = useState<string[]>([]);
+  const providerChangeDetection = useProviderChangeDetection(providerConnectedIds, providers as any);
   const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
   const permissionReplyBusyRef = useRef(false);
   // Provider catalog cache. Used to compute the reasoning/thinking variant
@@ -2296,6 +2298,7 @@ export function SessionRoute() {
       startupPhase={effectiveLoading ? "nativeInit" : "ready"}
       providerConnectedIds={providerConnectedIds}
       providers={providers}
+      providerNotifications={providerChangeDetection}
       mcpConnectedCount={0}
       onSendFeedback={() => {
         platform.openLink(

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -501,12 +501,23 @@ export function SessionRoute() {
   const [providerConnectedIds, setProviderConnectedIds] = useState<string[]>([]);
   // Bump to re-filter provider list when den session changes (sign-in/out)
   const [denSessionVersion, setDenSessionVersion] = useState(0);
+  const [isDenSignedIn, setIsDenSignedIn] = useState<boolean>(() => !!readDenSettings().authToken?.trim());
   useEffect(() => {
-    const handler = () => setDenSessionVersion((v) => v + 1);
+    const handler = () => {
+      setDenSessionVersion((v) => v + 1);
+      setIsDenSignedIn(!!readDenSettings().authToken?.trim());
+    };
     window.addEventListener(denSessionUpdatedEvent, handler);
     return () => window.removeEventListener(denSessionUpdatedEvent, handler);
   }, []);
-  const providerChangeDetection = useProviderChangeDetection(providerConnectedIds, providers as any);
+  // Provider notifications are only shown while signed in. After sign-out
+  // we clear acknowledgedProviders, so without this gate the modal would
+  // re-trigger every time local providers (openai, opencode) re-appear.
+  const providerChangeDetection = useProviderChangeDetection(
+    providerConnectedIds,
+    providers as any,
+    isDenSignedIn,
+  );
   const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
   const permissionReplyBusyRef = useRef(false);
   // Provider catalog cache. Used to compute the reasoning/thinking variant
@@ -2321,6 +2332,7 @@ export function SessionRoute() {
       providers={providers}
       providerNotifications={{
         ...providerChangeDetection,
+        orgName: readDenSettings().activeOrgName?.trim() ?? "",
         switchDefault: (providerId: string, modelId: string) => {
           local.setPrefs((prev) => ({
             ...prev,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -705,13 +705,13 @@ export function SessionRoute() {
     refreshInFlightRef.current = true;
     setLoading(true);
     setRouteError(null);
-    let desktopList = null as Awaited<ReturnType<typeof workspaceBootstrap>> | null;
+    let desktopList: WorkspaceList | null = null;
     let desktopWorkspaces = workspacesRef.current;
     let routeReadyAfterRefresh = true;
     try {
       if (isDesktopRuntime()) {
         try {
-          desktopList = await workspaceBootstrap();
+          desktopList = await workspaceBootstrap() as WorkspaceList;
           desktopWorkspaces = (desktopList.workspaces ?? []).map(mapDesktopWorkspace);
         } catch (error) {
           const message = describeRouteError(error);
@@ -1086,7 +1086,7 @@ export function SessionRoute() {
     let cancelled = false;
     void engineInfo()
       .then((info) => {
-        if (!cancelled) setRouteEngineInfo(info);
+        if (!cancelled) setRouteEngineInfo(info as EngineInfo | null);
       })
       .catch(() => {
         if (!cancelled) setRouteEngineInfo(null);
@@ -2185,10 +2185,10 @@ export function SessionRoute() {
         folderPath: folder,
         name: workspaceName,
         preset,
-      });
+      }) as WorkspaceList;
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       let targetWorkspaceId = createdId;
-      let targetWorkspace = list.workspaces.find((workspace) => workspace.id === createdId) ?? null;
+      let targetWorkspace = list.workspaces.find((workspace: WorkspaceInfo) => workspace.id === createdId) ?? null;
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);
         await workspaceSetRuntimeActive(createdId).catch(() => undefined);
@@ -2262,7 +2262,7 @@ export function SessionRoute() {
         displayName: input.displayName?.trim() || null,
         directory: input.directory?.trim() || null,
         remoteType: "openwork",
-      });
+      }) as WorkspaceList;
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -75,6 +75,7 @@ import {
   workspaceSetSelected,
   workspaceUpdateDisplayName,
   type WorkspaceInfo,
+  type WorkspaceList,
   revealDesktopItemInDir,
 } from "../../app/lib/desktop";
 import { isDesktopProviderBlocked } from "../../app/cloud/desktop-app-restrictions";
@@ -200,7 +201,7 @@ function mergeRouteWorkspaces(
 function reconcileSelectedWorkspaceId(
   currentId: string,
   serverList: { activeId?: string | null },
-  desktopList: Awaited<ReturnType<typeof workspaceBootstrap>> | null,
+  desktopList: WorkspaceList | null,
   workspaces: RouteWorkspace[],
 ) {
   const current = currentId.trim();
@@ -306,7 +307,7 @@ function parseSettingsPath(pathname: string): {
       return { tab: "cloud-account", redirectPath: "cloud-account" };
     case "extensions":
       if (tail === "mcp") return { tab: "extensions", redirectPath: null, extensionsSection: "mcp" };
-      if (tail === "skills") return { tab: "extensions", redirectPath: null, extensionsSection: "skills" };
+      if (tail === "skills") return { tab: "extensions", redirectPath: null, extensionsSection: "all" };
       if (tail === "plugins") return { tab: "extensions", redirectPath: null, extensionsSection: "plugins" };
       return { tab: "extensions", redirectPath: null, extensionsSection: "all" };
     default:
@@ -834,12 +835,12 @@ function SettingsRouteContent() {
     refreshInFlightRef.current = true;
     setLoading(true);
     setRouteError(null);
-    let desktopList = null as Awaited<ReturnType<typeof workspaceBootstrap>> | null;
+    let desktopList: WorkspaceList | null = null;
     let desktopWorkspaces = workspacesRef.current;
     try {
       if (isDesktopRuntime()) {
         try {
-          desktopList = await workspaceBootstrap();
+          desktopList = await workspaceBootstrap() as WorkspaceList;
           desktopWorkspaces = (desktopList.workspaces ?? []).map(mapDesktopWorkspace);
         } catch (error) {
           const message = describeRouteError(error);
@@ -1345,7 +1346,7 @@ function SettingsRouteContent() {
         folderPath: folder,
         name: workspaceName,
         preset,
-      });
+      }) as WorkspaceList;
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);
@@ -1388,7 +1389,7 @@ function SettingsRouteContent() {
         displayName: input.displayName?.trim() || null,
         directory: input.directory?.trim() || null,
         remoteType: "openwork",
-      });
+      }) as WorkspaceList;
       const createdId = resolveWorkspaceListSelectedId(list) || list.workspaces[list.workspaces.length - 1]?.id || "";
       if (createdId) {
         await workspaceSetSelected(createdId).catch(() => undefined);
@@ -1536,25 +1537,6 @@ function SettingsRouteContent() {
         );
       case "shell":
         return <ShellCustomizationView />;
-      case "automations":
-        return (
-          <AutomationsView
-            automations={automationsStore}
-            busy={busy}
-            selectedWorkspaceRoot={selectedWorkspaceRoot}
-            createSessionAndOpen={async () => undefined}
-            newTaskDisabled={!opencodeClient}
-            schedulerInstalled={false}
-            canEditPlugins={canWriteWorkspacePlugins}
-            addPlugin={async () => {
-              setRouteError("Scheduler plugin install is not wired into the React settings route yet.");
-            }}
-            reloadWorkspaceEngine={reloadCoordinator.reloadWorkspaceEngine}
-            reloadBusy={false}
-            canReloadWorkspace={reloadCoordinator.canReloadWorkspaceEngine}
-            openLink={(url) => platform.openLink(url)}
-          />
-        );
       case "skills":
         return (
           <SkillsView
@@ -1784,8 +1766,6 @@ function SettingsRouteContent() {
             runtimeKey={environmentRuntimeKey}
           />
         );
-      case "messaging":
-        return <MessagingView {...messagingViewProps} />;
       case "debug":
         return <DebugView {...debugViewProps} />;
       default:

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1506,7 +1506,13 @@ function SettingsRouteContent() {
             onDisconnectProvider={async (providerId) => {
               await providerAuthStore.disconnectProvider(providerId);
             }}
-            canDisconnectProvider={() => true}
+            canDisconnectProvider={(source) => {
+              if (source === "env") return false;
+              return true;
+            }}
+            cloudProviderIds={new Set(
+              Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).map((p) => p.providerId)
+            )}
           />
         );
       case "preferences":

--- a/apps/app/src/react-app/shell/use-provider-change-detection.ts
+++ b/apps/app/src/react-app/shell/use-provider-change-detection.ts
@@ -25,6 +25,7 @@ export type ProviderOnboardingState = {
     id: string;
     name: string;
     recommended?: boolean;
+    recommendedModelId?: string;
     recommendedModel?: string;
   }>;
 };
@@ -33,6 +34,7 @@ export type ProviderToastState = {
   show: boolean;
   providerName: string;
   providerId: string;
+  modelId?: string;
   modelName?: string;
 };
 
@@ -52,7 +54,7 @@ export function useProviderChangeDetection(
   providers: ProviderInfo[],
 ) {
   const [onboarding, setOnboarding] = useState<ProviderOnboardingState>({ show: false, providers: [] });
-  const [toast, setToast] = useState<ProviderToastState>({ show: false, providerName: "", providerId: "" });
+  const [toast, setToast] = useState<ProviderToastState>({ show: false, providerName: "", providerId: "", modelId: undefined });
   const shownRef = useRef(false);
 
   useEffect(() => {
@@ -78,6 +80,7 @@ export function useProviderChangeDetection(
           id,
           name: provider?.name ?? resolveProviderDisplayName(id),
           recommended: false as boolean,
+          recommendedModelId: firstModelId,
           recommendedModel: firstModelName,
         };
       });
@@ -100,6 +103,7 @@ export function useProviderChangeDetection(
         show: true,
         providerName: provider?.name ?? resolveProviderDisplayName(newId),
         providerId: newId,
+        modelId: firstModelId,
         modelName,
       });
     }
@@ -108,7 +112,7 @@ export function useProviderChangeDetection(
   const acknowledgeAll = useCallback(() => {
     writeAcknowledged(connectedProviderIds);
     setOnboarding({ show: false, providers: [] });
-    setToast({ show: false, providerName: "", providerId: "" });
+    setToast({ show: false, providerName: "", providerId: "", modelId: undefined });
   }, [connectedProviderIds]);
 
   const dismissOnboarding = useCallback(() => {
@@ -118,7 +122,7 @@ export function useProviderChangeDetection(
 
   const dismissToast = useCallback(() => {
     writeAcknowledged(connectedProviderIds);
-    setToast({ show: false, providerName: "", providerId: "" });
+    setToast({ show: false, providerName: "", providerId: "", modelId: undefined });
   }, [connectedProviderIds]);
 
   return {

--- a/apps/app/src/react-app/shell/use-provider-change-detection.ts
+++ b/apps/app/src/react-app/shell/use-provider-change-detection.ts
@@ -1,0 +1,128 @@
+/** @jsxImportSource react */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { resolveModelDisplayName, resolveProviderDisplayName } from "../../app/utils";
+
+const STORAGE_KEY = "openwork.acknowledgedProviders";
+
+function readAcknowledged(): string[] {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeAcknowledged(ids: string[]): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  } catch {}
+}
+
+export type ProviderOnboardingState = {
+  show: boolean;
+  providers: Array<{
+    id: string;
+    name: string;
+    recommended?: boolean;
+    recommendedModel?: string;
+  }>;
+};
+
+export type ProviderToastState = {
+  show: boolean;
+  providerName: string;
+  providerId: string;
+  modelName?: string;
+};
+
+type ProviderInfo = {
+  id: string;
+  name?: string;
+  models?: Record<string, { name?: string }>;
+};
+
+/**
+ * Detects new providers by comparing the current connected list against
+ * a localStorage "acknowledged" set. Returns notification state for
+ * the onboarding modal and new-provider toast.
+ */
+export function useProviderChangeDetection(
+  connectedProviderIds: string[],
+  providers: ProviderInfo[],
+) {
+  const [onboarding, setOnboarding] = useState<ProviderOnboardingState>({ show: false, providers: [] });
+  const [toast, setToast] = useState<ProviderToastState>({ show: false, providerName: "", providerId: "" });
+  const hasCheckedRef = useRef(false);
+
+  useEffect(() => {
+    if (connectedProviderIds.length === 0) return;
+    // Only check once per mount cycle to avoid flicker
+    if (hasCheckedRef.current) return;
+    hasCheckedRef.current = true;
+
+    const acknowledged = readAcknowledged();
+    const newIds = connectedProviderIds.filter((id) => !acknowledged.includes(id));
+
+    if (newIds.length === 0) return;
+
+    if (acknowledged.length === 0) {
+      // First time seeing any providers -- show onboarding modal
+      const onboardingProviders = newIds.map((id) => {
+        const provider = providers.find((p) => p.id === id);
+        const firstModelId = provider?.models ? Object.keys(provider.models)[0] : undefined;
+        const firstModelName = firstModelId
+          ? provider?.models?.[firstModelId]?.name ?? resolveModelDisplayName(firstModelId)
+          : undefined;
+        return {
+          id,
+          name: provider?.name ?? resolveProviderDisplayName(id),
+          recommendedModel: firstModelName,
+        };
+      });
+      // Mark the first one as recommended
+      if (onboardingProviders.length > 0) {
+        onboardingProviders[0].recommended = true;
+      }
+      setOnboarding({ show: true, providers: onboardingProviders });
+    } else {
+      // Already had providers, show toast for the first new one
+      const newId = newIds[0];
+      const provider = providers.find((p) => p.id === newId);
+      const firstModelId = provider?.models ? Object.keys(provider.models)[0] : undefined;
+      const modelName = firstModelId
+        ? provider?.models?.[firstModelId]?.name ?? resolveModelDisplayName(firstModelId)
+        : undefined;
+      setToast({
+        show: true,
+        providerName: provider?.name ?? resolveProviderDisplayName(newId),
+        providerId: newId,
+        modelName,
+      });
+    }
+  }, [connectedProviderIds, providers]);
+
+  const acknowledgeAll = useCallback(() => {
+    writeAcknowledged(connectedProviderIds);
+    setOnboarding({ show: false, providers: [] });
+    setToast({ show: false, providerName: "", providerId: "" });
+  }, [connectedProviderIds]);
+
+  const dismissOnboarding = useCallback(() => {
+    writeAcknowledged(connectedProviderIds);
+    setOnboarding({ show: false, providers: [] });
+  }, [connectedProviderIds]);
+
+  const dismissToast = useCallback(() => {
+    writeAcknowledged(connectedProviderIds);
+    setToast({ show: false, providerName: "", providerId: "" });
+  }, [connectedProviderIds]);
+
+  return {
+    onboarding,
+    toast,
+    acknowledgeAll,
+    dismissOnboarding,
+    dismissToast,
+  };
+}

--- a/apps/app/src/react-app/shell/use-provider-change-detection.ts
+++ b/apps/app/src/react-app/shell/use-provider-change-detection.ts
@@ -77,6 +77,7 @@ export function useProviderChangeDetection(
         return {
           id,
           name: provider?.name ?? resolveProviderDisplayName(id),
+          recommended: false as boolean,
           recommendedModel: firstModelName,
         };
       });

--- a/apps/app/src/react-app/shell/use-provider-change-detection.ts
+++ b/apps/app/src/react-app/shell/use-provider-change-detection.ts
@@ -45,19 +45,45 @@ type ProviderInfo = {
 };
 
 /**
+ * Pick a model to surface for a provider in the onboarding/toast UI.
+ *
+ * NOTE: This is positional, not a recommendation. We pick the FIRST model
+ * in `provider.models` (insertion order from the provider's declaration).
+ * There is no Den API for "team recommended model" — if we ever want one,
+ * it has to come from the cloud org config, not the local OpenCode SDK
+ * (which only exposes the workspace's runtime default, a different concept).
+ */
+function pickFirstModel(
+  provider: ProviderInfo | undefined,
+): { id: string | undefined; name: string | undefined } {
+  if (!provider?.models) return { id: undefined, name: undefined };
+  const id = Object.keys(provider.models)[0];
+  if (!id) return { id: undefined, name: undefined };
+  const name = provider.models[id]?.name ?? resolveModelDisplayName(id);
+  return { id, name };
+}
+
+/**
  * Detects new providers by comparing the current connected list against
  * a localStorage "acknowledged" set. Returns notification state for
  * the onboarding modal and new-provider toast.
+ *
+ * - `enabled=false` (e.g. signed out) disables all notifications. This
+ *   prevents the onboarding modal from triggering after sign-out when
+ *   `acknowledgedProviders` was cleared but local providers (openai,
+ *   opencode) remain.
  */
 export function useProviderChangeDetection(
   connectedProviderIds: string[],
   providers: ProviderInfo[],
+  enabled: boolean = true,
 ) {
   const [onboarding, setOnboarding] = useState<ProviderOnboardingState>({ show: false, providers: [] });
   const [toast, setToast] = useState<ProviderToastState>({ show: false, providerName: "", providerId: "", modelId: undefined });
   const shownRef = useRef(false);
 
   useEffect(() => {
+    if (!enabled) return;
     if (connectedProviderIds.length === 0) return;
     // Once we've shown a notification this session, don't show again
     // (user can dismiss and it won't re-appear until next new provider)
@@ -72,19 +98,17 @@ export function useProviderChangeDetection(
       // First time seeing any providers -- show onboarding modal
       const onboardingProviders = newIds.map((id) => {
         const provider = providers.find((p) => p.id === id);
-        const firstModelId = provider?.models ? Object.keys(provider.models)[0] : undefined;
-        const firstModelName = firstModelId
-          ? provider?.models?.[firstModelId]?.name ?? resolveModelDisplayName(firstModelId)
-          : undefined;
+        const picked = pickFirstModel(provider);
         return {
           id,
           name: provider?.name ?? resolveProviderDisplayName(id),
           recommended: false as boolean,
-          recommendedModelId: firstModelId,
-          recommendedModel: firstModelName,
+          recommendedModelId: picked.id,
+          recommendedModel: picked.name,
         };
       });
-      // Mark the first one as recommended
+      // Mark the first one as the default-action target (used by the
+      // "Use {model}" button). Positional only, not a quality signal.
       if (onboardingProviders.length > 0) {
         onboardingProviders[0].recommended = true;
       }
@@ -94,20 +118,27 @@ export function useProviderChangeDetection(
       // Already had providers, show toast for the first new one
       const newId = newIds[0];
       const provider = providers.find((p) => p.id === newId);
-      const firstModelId = provider?.models ? Object.keys(provider.models)[0] : undefined;
-      const modelName = firstModelId
-        ? provider?.models?.[firstModelId]?.name ?? resolveModelDisplayName(firstModelId)
-        : undefined;
+      const picked = pickFirstModel(provider);
       shownRef.current = true;
       setToast({
         show: true,
         providerName: provider?.name ?? resolveProviderDisplayName(newId),
         providerId: newId,
-        modelId: firstModelId,
-        modelName,
+        modelId: picked.id,
+        modelName: picked.name,
       });
     }
-  }, [connectedProviderIds, providers]);
+  }, [connectedProviderIds, providers, enabled]);
+
+  // Reset the "shown this session" gate when sign-out clears the
+  // acknowledged list, so the next sign-in can show notifications again.
+  useEffect(() => {
+    if (!enabled) {
+      shownRef.current = false;
+      setOnboarding({ show: false, providers: [] });
+      setToast({ show: false, providerName: "", providerId: "", modelId: undefined });
+    }
+  }, [enabled]);
 
   const acknowledgeAll = useCallback(() => {
     writeAcknowledged(connectedProviderIds);

--- a/apps/app/src/react-app/shell/use-provider-change-detection.ts
+++ b/apps/app/src/react-app/shell/use-provider-change-detection.ts
@@ -53,13 +53,13 @@ export function useProviderChangeDetection(
 ) {
   const [onboarding, setOnboarding] = useState<ProviderOnboardingState>({ show: false, providers: [] });
   const [toast, setToast] = useState<ProviderToastState>({ show: false, providerName: "", providerId: "" });
-  const hasCheckedRef = useRef(false);
+  const shownRef = useRef(false);
 
   useEffect(() => {
     if (connectedProviderIds.length === 0) return;
-    // Only check once per mount cycle to avoid flicker
-    if (hasCheckedRef.current) return;
-    hasCheckedRef.current = true;
+    // Once we've shown a notification this session, don't show again
+    // (user can dismiss and it won't re-appear until next new provider)
+    if (shownRef.current) return;
 
     const acknowledged = readAcknowledged();
     const newIds = connectedProviderIds.filter((id) => !acknowledged.includes(id));
@@ -84,6 +84,7 @@ export function useProviderChangeDetection(
       if (onboardingProviders.length > 0) {
         onboardingProviders[0].recommended = true;
       }
+      shownRef.current = true;
       setOnboarding({ show: true, providers: onboardingProviders });
     } else {
       // Already had providers, show toast for the first new one
@@ -93,6 +94,7 @@ export function useProviderChangeDetection(
       const modelName = firstModelId
         ? provider?.models?.[firstModelId]?.name ?? resolveModelDisplayName(firstModelId)
         : undefined;
+      shownRef.current = true;
       setToast({
         show: true,
         providerName: provider?.name ?? resolveProviderDisplayName(newId),

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -10,6 +10,8 @@ import {
   workspaceCreateRemote,
   workspaceSetRuntimeActive,
   workspaceSetSelected,
+  type WorkspaceInfo,
+  type WorkspaceList,
 } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
 import { createClient, unwrap } from "../../app/lib/opencode";
@@ -110,17 +112,17 @@ export function WelcomeRoute() {
       dispatch({ type: "create:start" });
       try {
         const workspaceName = folderNameFromPath(folder);
-        const list = await workspaceCreate({
-          folderPath: folder,
-          name: workspaceName,
-          preset: "starter",
-        });
-        const createdId =
-          resolveWorkspaceListSelectedId(list) ||
-          list.workspaces[list.workspaces.length - 1]?.id ||
-          "";
-        let targetWorkspaceId = createdId;
-        let targetWorkspace = list.workspaces.find((workspace) => workspace.id === createdId) ?? null;
+      const list = await workspaceCreate({
+        folderPath: folder,
+        name: workspaceName,
+        preset: "starter",
+      }) as WorkspaceList;
+      const createdId =
+        resolveWorkspaceListSelectedId(list) ||
+        list.workspaces[list.workspaces.length - 1]?.id ||
+        "";
+      let targetWorkspaceId = createdId;
+      let targetWorkspace = list.workspaces.find((workspace: WorkspaceInfo) => workspace.id === createdId) ?? null;
         let targetSessionId: string | null = null;
         if (createdId) {
           await workspaceSetSelected(createdId).catch(() => undefined);
@@ -192,18 +194,18 @@ export function WelcomeRoute() {
       if (!baseUrlValue) return false;
       dispatch({ type: "remote:start" });
       try {
-        const list = await workspaceCreateRemote({
-          baseUrl: baseUrlValue,
-          openworkHostUrl: baseUrlValue,
-          openworkToken: input.openworkToken?.trim() || null,
-          displayName: input.displayName?.trim() || null,
-          directory: input.directory?.trim() || null,
-          remoteType: "openwork",
-        });
-        const createdId =
-          resolveWorkspaceListSelectedId(list) ||
-          list.workspaces[list.workspaces.length - 1]?.id ||
-          "";
+      const list = await workspaceCreateRemote({
+        baseUrl: baseUrlValue,
+        openworkHostUrl: baseUrlValue,
+        openworkToken: input.openworkToken?.trim() || null,
+        displayName: input.displayName?.trim() || null,
+        directory: input.directory?.trim() || null,
+        remoteType: "openwork",
+      }) as WorkspaceList;
+      const createdId =
+        resolveWorkspaceListSelectedId(list) ||
+        list.workspaces[list.workspaces.length - 1]?.id ||
+        "";
         if (createdId) {
           await workspaceSetSelected(createdId).catch(() => undefined);
           await workspaceSetRuntimeActive(createdId).catch(() => undefined);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -237,7 +237,7 @@ if (Number.isFinite(remoteDebugPort) && remoteDebugPort > 0) {
 const DEFAULT_DEN_BASE_URL = "https://app.openworklabs.com";
 const DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:4096";
 const FORCE_DESKTOP_REQUIRE_SIGNIN = envFlagEnabled("OPENWORK_FORCE_SIGNIN");
-const DEFAULT_DESKTOP_REQUIRE_SIGNIN = FORCE_DESKTOP_REQUIRE_SIGNIN || (app.isPackaged && !isDevMode);
+const DEFAULT_DESKTOP_REQUIRE_SIGNIN = FORCE_DESKTOP_REQUIRE_SIGNIN;
 
 function envFlagEnabled(name) {
   const value = process.env[name]?.trim().toLowerCase();


### PR DESCRIPTION
## Provider Change Detection (Phase 1) + UI Polish

### Provider notification system
- `useProviderChangeDetection` hook watches `connectedProviderIds` against a localStorage "acknowledged" set
- **First time seeing providers** (empty acknowledged list): shows the onboarding modal with all providers listed
- **New providers added** (acknowledged list exists but new IDs appear): shows toast for the first new one
- `acknowledgeAll` / `dismissOnboarding` / `dismissToast` callbacks persist to localStorage
- Wired: session-route → SessionPage → ProviderOnboardingModal / ProviderAddedToast
- No server changes, no new SSE — just local diff on existing provider data flow
- Works for both local provider additions and cloud-synced providers

### UI dark mode polish
- Status bar sign-in button: `#011627` → `bg-dls-accent` (adapts to dark mode)
- Provider toast "Switch default" button: same fix
- Green badge overlays (ExtensionCard, ExtensionDetailModal): `border-white` → `border-dls-surface`
- All Radix color tokens (green-2/6/9/11, amber-3/11, violet-3/11) already dark-mode-aware
- No more hardcoded hex colors in interactive UI elements