### PR TITLE
feat(app): unified customization system — local prefs + cloud overrides

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -18,7 +18,7 @@ import type {
   WorkspaceSessionGroup,
 } from "../../../../app/types";
 import type { ShareWorkspaceModalProps } from "../../workspace/types";
-import { Button } from "@/components/ui/button";
+import { Button } from "../../../design-system/button";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import ProviderAuthModal, { type ProviderAuthModalProps } from "../../connections/provider-auth/provider-auth-modal";
 import { PermissionApprovalModal } from "./permission-approval-modal";
@@ -40,8 +40,7 @@ import { ShareWorkspaceModal } from "../../workspace/share-workspace-modal";
 import { StatusBar, type StatusBarProps } from "./status-bar";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
-import { useShellConfig } from "../../../shell/shell-config";
-import { useUiStateStore } from "../../../shell/ui-state-store";
+import { useEffectiveConfig } from "../../../shell/effective-config";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
@@ -97,6 +96,7 @@ export type SessionPageSidebarProps = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
+  showAddWorkspace: boolean;
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
 };
 
@@ -182,13 +182,7 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 }
 
 export function SessionPage(props: SessionPageProps) {
-  const { config: shellConfig } = useShellConfig();
-  const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
-  const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
-  const browserPanelOpen = useUiStateStore((state) => state.browserPanelOpen);
-  const openBrowserPanel = useUiStateStore((state) => state.openBrowserPanel);
-  const closeBrowserPanel = useUiStateStore((state) => state.closeBrowserPanel);
-  const toggleBrowserPanel = useUiStateStore((state) => state.toggleBrowserPanel);
+  const effectiveConfig = useEffectiveConfig();
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -206,7 +200,9 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
   const [todoExpanded, setTodoExpanded] = useState(true);
+  const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
   const browserPanelRef = usePanelRef();
+  const toggleBrowserPanel = useCallback(() => setBrowserPanelOpen((p) => !p), []);
 
   // Sync browser panel state with Electron main process IPC events.
   // When the agent calls a built-in browser tool, the main process opens
@@ -217,10 +213,10 @@ export function SessionPage(props: SessionPageProps) {
     if (!isElectronRuntime()) return;
     const browser = (window as Window).__OPENWORK_ELECTRON__?.browser;
     if (!browser) return;
-    const unsubOpen = browser.onPanelOpened?.(openBrowserPanel);
-    const unsubClose = browser.onPanelClosed?.(closeBrowserPanel);
+    const unsubOpen = browser.onPanelOpened?.(() => setBrowserPanelOpen(true));
+    const unsubClose = browser.onPanelClosed?.(() => setBrowserPanelOpen(false));
     return () => { unsubOpen?.(); unsubClose?.(); };
-  }, [closeBrowserPanel, openBrowserPanel]);
+  }, []);
   const {
     leftSidebarResizing,
     leftSidebarWidth,
@@ -370,13 +366,11 @@ export function SessionPage(props: SessionPageProps) {
   return (
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text mac:bg-transparent">
       <SidebarProvider
-        open={sidebarOpen}
-        onOpenChange={setSidebarOpen}
+        defaultOpen={true}
         className={cn(
           "relative min-h-0 flex-1 mac:bg-transparent",
           leftSidebarResizing &&
             "**:data-[slot=sidebar-container]:transition-none **:data-[slot=sidebar-gap]:transition-none",
-          !shellConfig.sidebar && "**:data-[slot=sidebar-container]:hidden **:data-[slot=sidebar-gap]:hidden",
         )}
         style={sidebarProviderStyle}
       >
@@ -408,6 +402,7 @@ export function SessionPage(props: SessionPageProps) {
           onEditWorkspaceConnection={props.sidebar.onEditWorkspaceConnection}
           onForgetWorkspace={props.sidebar.onForgetWorkspace}
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
+          showAddWorkspace={props.sidebar.showAddWorkspace}
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
         />
@@ -421,7 +416,7 @@ export function SessionPage(props: SessionPageProps) {
               <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
           <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
-              {shellConfig.sidebar ? <SidebarTrigger className="mac:hidden" /> : null}
+              <SidebarTrigger className="mac:hidden" />
               <h1 className="truncate text-[15px] font-semibold text-dls-text">
                 {showWorkspaceSetupEmptyState
                   ? t("session.create_or_connect_workspace")
@@ -557,9 +552,11 @@ export function SessionPage(props: SessionPageProps) {
                           {t("workspace.empty_state_body")}
                         </p>
                       </div>
-                      <div className="flex justify-center">
-                        <Button onClick={props.sidebar.onOpenCreateWorkspace}>{t("workspace.create_workspace")}</Button>
-                      </div>
+                      {props.sidebar.showAddWorkspace ? (
+                        <div className="flex justify-center">
+                          <Button onClick={props.sidebar.onOpenCreateWorkspace}>{t("workspace.create_workspace")}</Button>
+                        </div>
+                      ) : null}
                     </div>
                   ) : showSelectedWorkspaceError ? (
                     <div className="px-6 py-16">
@@ -571,14 +568,14 @@ export function SessionPage(props: SessionPageProps) {
                         <div className="mt-4 flex flex-wrap gap-2">
                           <Button
                             variant="outline"
-                            size="sm"
+                            className="px-3 py-1.5 text-xs"
                             onClick={() => void Promise.resolve(props.sidebar.onTestWorkspaceConnection(props.selectedWorkspaceId))}
                           >
                             {t("workspace_list.test_connection")}
                           </Button>
                           <Button
                             variant="outline"
-                            size="sm"
+                            className="px-3 py-1.5 text-xs"
                             onClick={() => props.sidebar.onEditWorkspaceConnection(props.selectedWorkspaceId)}
                           >
                             {t("workspace_list.edit_connection")}
@@ -586,7 +583,7 @@ export function SessionPage(props: SessionPageProps) {
                           {props.sidebar.workspaceConnectionStateById[props.selectedWorkspaceId]?.status === "error" ? (
                             <Button
                               variant="outline"
-                              size="sm"
+                              className="px-3 py-1.5 text-xs"
                               onClick={() => void Promise.resolve(props.sidebar.onRecoverWorkspace(props.selectedWorkspaceId))}
                             >
                               {t("workspace_list.recover")}
@@ -712,7 +709,7 @@ export function SessionPage(props: SessionPageProps) {
             </div>
           ) : null}
 
-          {shellConfig.statusBar ? (
+          {effectiveConfig.statusBar ? (
             <StatusBar
               clientConnected={props.clientConnected}
               openworkServerStatus={props.openworkServerStatus}
@@ -742,13 +739,13 @@ export function SessionPage(props: SessionPageProps) {
                   maxSize="70%"
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"
                 >
-                  <BrowserPanel onClose={closeBrowserPanel} />
+                  <BrowserPanel onClose={toggleBrowserPanel} />
                 </ResizablePanel>
               </>
             ) : null}
           </ResizablePanelGroup>
         </SidebarInset>
-        {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
+        <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" />
       </SidebarProvider>
 
       {props.providerAuthModal ? <ProviderAuthModal {...props.providerAuthModal} /> : null}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -40,7 +40,7 @@ import { ShareWorkspaceModal } from "../../workspace/share-workspace-modal";
 import { StatusBar, type StatusBarProps } from "./status-bar";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
-import { useShellConfig } from "../../../shell/shell-config";
+import { useEffectiveConfig } from "../../../shell/effective-config";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
@@ -181,7 +181,7 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 }
 
 export function SessionPage(props: SessionPageProps) {
-  const { config: shellConfig } = useShellConfig();
+  const effectiveConfig = useEffectiveConfig();
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -365,12 +365,11 @@ export function SessionPage(props: SessionPageProps) {
   return (
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text mac:bg-transparent">
       <SidebarProvider
-        defaultOpen={shellConfig.sidebar}
+        defaultOpen={true}
         className={cn(
           "relative min-h-0 flex-1 mac:bg-transparent",
           leftSidebarResizing &&
             "**:data-[slot=sidebar-container]:transition-none **:data-[slot=sidebar-gap]:transition-none",
-          !shellConfig.sidebar && "**:data-[slot=sidebar-container]:hidden **:data-[slot=sidebar-gap]:hidden",
         )}
         style={sidebarProviderStyle}
       >
@@ -415,7 +414,7 @@ export function SessionPage(props: SessionPageProps) {
               <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
           <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
-              {shellConfig.sidebar ? <SidebarTrigger className="mac:hidden" /> : null}
+              <SidebarTrigger className="mac:hidden" />
               <h1 className="truncate text-[15px] font-semibold text-dls-text">
                 {showWorkspaceSetupEmptyState
                   ? t("session.create_or_connect_workspace")
@@ -706,7 +705,7 @@ export function SessionPage(props: SessionPageProps) {
             </div>
           ) : null}
 
-          {shellConfig.statusBar ? (
+          {effectiveConfig.statusBar ? (
             <StatusBar
               clientConnected={props.clientConnected}
               openworkServerStatus={props.openworkServerStatus}
@@ -742,7 +741,7 @@ export function SessionPage(props: SessionPageProps) {
             ) : null}
           </ResizablePanelGroup>
         </SidebarInset>
-        {shellConfig.sidebar ? <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" /> : null}
+        <SidebarTrigger className="hidden mac:absolute mac:left-[64px] top-[3px] z-50 mac:flex titlebar-no-drag" />
       </SidebarProvider>
 
       {props.providerAuthModal ? <ProviderAuthModal {...props.providerAuthModal} /> : null}

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -7,7 +7,7 @@ import { buildDenAuthUrl, readDenBootstrapConfig } from "../../../../app/lib/den
 import { usePlatform } from "../../../kernel/platform";
 import { useDenAuth } from "../../cloud/den-auth-provider";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
-import { useShellConfig } from "../../../shell/shell-config";
+import { useEffectiveConfig } from "../../../shell/effective-config";
 import type { OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 
 const DOCS_URL = "https://openworklabs.com/docs";
@@ -108,7 +108,7 @@ function deriveStatusCopy(props: StatusBarProps): StatusCopy {
 export function StatusBar(props: StatusBarProps) {
   const platform = usePlatform();
   const denAuth = useDenAuth();
-  const { config: shellConfig } = useShellConfig();
+  const effectiveConfig = useEffectiveConfig();
   const docsButtonRef = useRef<HTMLButtonElement>(null);
   const feedbackButtonRef = useRef<HTMLButtonElement>(null);
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
@@ -181,7 +181,7 @@ export function StatusBar(props: StatusBarProps) {
         </div>
 
         <div className="flex items-center gap-1.5">
-          {shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking" ? (
+          {effectiveConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking" ? (
             <button
               type="button"
               className="inline-flex h-7 items-center gap-1.5 rounded-full bg-dls-accent px-2.5 text-[11px] font-medium text-[var(--dls-accent-fg)] transition-colors hover:bg-[var(--dls-accent-hover)]"
@@ -194,7 +194,7 @@ export function StatusBar(props: StatusBarProps) {
               <span>Sign in</span>
             </button>
           ) : null}
-          {shellConfig.docsButton ? (
+          {effectiveConfig.docsButton ? (
             <button
               ref={docsButtonRef}
               type="button"
@@ -207,7 +207,7 @@ export function StatusBar(props: StatusBarProps) {
               <span className="text-[11px] font-medium">{t("status.docs")}</span>
             </button>
           ) : null}
-          {shellConfig.feedbackButton ? (
+          {effectiveConfig.feedbackButton ? (
             <button
               ref={feedbackButtonRef}
               type="button"

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -351,6 +351,7 @@ export type AppSidebarProps = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   onForgetWorkspace: (workspaceId: string) => void;
   onOpenCreateWorkspace: () => void;
+  showAddWorkspace: boolean;
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
 };
@@ -522,16 +523,18 @@ export function AppSidebar(props: AppSidebarProps) {
           </m.div>
         </LazyMotion>
 
-        <SidebarFooter>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton onClick={props.onOpenCreateWorkspace}>
-                <Plus className="size-4" />
-                {t("workspace_list.add_workspace")}
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarFooter>
+        {props.showAddWorkspace ? (
+          <SidebarFooter>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton onClick={props.onOpenCreateWorkspace}>
+                  <Plus className="size-4" />
+                  {t("workspace_list.add_workspace")}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarFooter>
+        ) : null}
         <SidebarRail
           aria-label={props.onStartResize ? t("session.resize_workspace_column") : undefined}
           title={props.onStartResize ? t("session.resize_workspace_column") : undefined}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -7,6 +7,7 @@ import type { CloudImportedPlugin, CloudImportedPluginFile } from "../../../../.
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "../../../../../app/types";
 import { t } from "../../../../../i18n";
 import { ModelBehaviorSelect } from "../../../../../components/model-behavior-select";
+import { useEffectiveConfig } from "../../../../shell/effective-config";
 import { ModelSelect } from "../../../../../components/model-select";
 import { LexicalPromptEditor } from "./editor";
 import {
@@ -39,7 +40,6 @@ type ComposerProps = {
   onStop: () => void | Promise<void>;
   busy: boolean;
   disabled: boolean;
-  modelUnavailable?: boolean;
   statusLabel: string;
   modelPickerOpen: boolean;
   selectedModel: ModelRef;
@@ -245,6 +245,7 @@ function pluginSlashCommandName(file: CloudImportedPluginFile) {
 }
 
 export function ReactSessionComposer(props: ComposerProps) {
+  const effectiveConfig = useEffectiveConfig();
   let fileInput: HTMLInputElement | undefined;
   const [agents, setAgents] = useState<Agent[]>([]);
   const [agentMenuOpen, setAgentMenuOpen] = useState(false);
@@ -1394,15 +1395,14 @@ export function ReactSessionComposer(props: ComposerProps) {
             </div>
             */}
 
-            <ModelSelect
-              open={props.modelPickerOpen}
-              value={props.selectedModel}
-              onOpenChange={props.onModelPickerOpenChange}
-              onChange={props.onModelChange}
-              disabled={props.busy}
-            />
-            {props.modelUnavailable ? (
-              <span className="text-xs font-medium text-red-10">Model no longer available</span>
+            {effectiveConfig.modelPicker ? (
+              <ModelSelect
+                open={props.modelPickerOpen}
+                value={props.selectedModel}
+                onOpenChange={props.onModelPickerOpenChange}
+                onChange={props.onModelChange}
+                disabled={props.busy}
+              />
             ) : null}
 
             <ModelBehaviorSelect

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -7,6 +7,7 @@ import type { CloudImportedPlugin, CloudImportedPluginFile } from "../../../../.
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "../../../../../app/types";
 import { t } from "../../../../../i18n";
 import { ModelBehaviorSelect } from "../../../../../components/model-behavior-select";
+import { useEffectiveConfig } from "../../../../shell/effective-config";
 import { ModelSelect } from "../../../../../components/model-select";
 import { LexicalPromptEditor } from "./editor";
 import {
@@ -244,6 +245,7 @@ function pluginSlashCommandName(file: CloudImportedPluginFile) {
 }
 
 export function ReactSessionComposer(props: ComposerProps) {
+  const effectiveConfig = useEffectiveConfig();
   let fileInput: HTMLInputElement | undefined;
   const [agents, setAgents] = useState<Agent[]>([]);
   const [agentMenuOpen, setAgentMenuOpen] = useState(false);
@@ -1393,13 +1395,15 @@ export function ReactSessionComposer(props: ComposerProps) {
             </div>
             */}
 
-            <ModelSelect
-              open={props.modelPickerOpen}
-              value={props.selectedModel}
-              onOpenChange={props.onModelPickerOpenChange}
-              onChange={props.onModelChange}
-              disabled={props.busy}
-            />
+            {effectiveConfig.modelPicker ? (
+              <ModelSelect
+                open={props.modelPickerOpen}
+                value={props.selectedModel}
+                onOpenChange={props.onModelPickerOpenChange}
+                onChange={props.onModelChange}
+                disabled={props.busy}
+              />
+            ) : null}
 
             <ModelBehaviorSelect
               value={props.modelVariant}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -30,7 +30,7 @@ import { ReactSessionComposer } from "./composer/composer";
 import { DevProfiler } from "../../../shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
 import { OwDotTicker } from "../../../shell/dot-ticker";
-import { useShellConfig } from "../../../shell/shell-config";
+import { useEffectiveConfig } from "../../../shell/effective-config";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import type { ReactComposerNotice } from "./composer/notice";
 import { SessionDebugPanel } from "./debug-panel";
@@ -69,7 +69,6 @@ export type SessionSurfaceProps = {
   modelLabel: string;
   onModelClick: () => void;
   modelPickerOpen: boolean;
-  modelUnavailable?: boolean;
   selectedModel: ModelRef;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
@@ -271,7 +270,7 @@ function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }
 
 export function SessionSurface(props: SessionSurfaceProps) {
   const local = useLocal();
-  const { config: shellConfig } = useShellConfig();
+  const effectiveConfig = useEffectiveConfig();
   const showThinking = local.prefs.showThinking;
   const [draft, setDraft] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
@@ -672,13 +671,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     label: "Send the composer prompt",
     description: "Send the currently visible composer draft to the active session.",
     sideEffect: "mutation",
-    disabled: props.modelUnavailable || (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle",
+    disabled: (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle",
     targetRef: composerShellRef,
     execute: async () => {
       await handleSend();
       return true;
     },
-  }), [attachments.length, draft, handleSend, model.transitionState, props.modelUnavailable]);
+  }), [attachments.length, draft, handleSend, model.transitionState]);
   useControlAction(composerSendControlAction);
 
   const composerStopControlAction = useMemo<OpenworkControlAction>(() => ({
@@ -897,11 +896,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   </div>
                 )}
               </div>
-            ) : renderedMessages.length === 0 && showAssistantWaitState ? (
-              <div className="px-6 py-12">
-                <AssistantWaitingCard />
-              </div>
-            ) : renderedMessages.length === 0 && snapshot && snapshot.messages.length === 0 ? (
+            ) : renderedMessages.length === 0 && !showAssistantWaitState && snapshot && snapshot.messages.length === 0 ? (
               error ? (
                 <SessionErrorCard
                   error={error}
@@ -909,7 +904,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   onChangeModel={props.onChangeModel}
                   onOpenModelPicker={props.onModelClick}
                 />
-              ) : shellConfig.starterCards ? (
+              ) : effectiveConfig.starterCards ? (
                 <div className="flex flex-1 flex-col items-center justify-end px-6 pb-4">
                   <div className="w-full max-w-[640px]">
                     <p className="mb-3 text-xs text-dls-secondary">Try one of these:</p>
@@ -1016,8 +1011,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onSend={handleSend}
         onStop={handleAbort}
         busy={chatStreaming}
-        disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}
-        modelUnavailable={Boolean(props.modelUnavailable)}
+        disabled={model.transitionState !== "idle"}
         statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
         modelPickerOpen={props.modelPickerOpen}
         selectedModel={props.selectedModel}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -30,7 +30,7 @@ import { ReactSessionComposer } from "./composer/composer";
 import { DevProfiler } from "../../../shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
 import { OwDotTicker } from "../../../shell/dot-ticker";
-import { useShellConfig } from "../../../shell/shell-config";
+import { useEffectiveConfig } from "../../../shell/effective-config";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import type { ReactComposerNotice } from "./composer/notice";
 import { SessionDebugPanel } from "./debug-panel";
@@ -270,7 +270,7 @@ function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }
 
 export function SessionSurface(props: SessionSurfaceProps) {
   const local = useLocal();
-  const { config: shellConfig } = useShellConfig();
+  const effectiveConfig = useEffectiveConfig();
   const showThinking = local.prefs.showThinking;
   const [draft, setDraft] = useState("");
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
@@ -904,7 +904,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                   onChangeModel={props.onChangeModel}
                   onOpenModelPicker={props.onModelClick}
                 />
-              ) : shellConfig.starterCards ? (
+              ) : effectiveConfig.starterCards ? (
                 <div className="flex flex-1 flex-col items-center justify-end px-6 pb-4">
                   <div className="w-full max-w-[640px]">
                     <p className="mb-3 text-xs text-dls-secondary">Try one of these:</p>

--- a/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
@@ -1,226 +1,108 @@
 /** @jsxImportSource react */
-import { AlertTriangle, Info, Lock, RotateCcw } from "lucide-react";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import { Field, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
-import { Switch } from "@/components/ui/switch";
-import { cn } from "@/lib/utils";
-
-import {
-  LayoutSection,
-  LayoutSectionDescription,
-  LayoutSectionHeader,
-  LayoutSectionItem,
-  LayoutSectionItemDescription,
-  LayoutSectionItemHeader,
-  LayoutSectionItemHeaderActions,
-  LayoutSectionItemTitle,
-  LayoutSectionTitle,
-  LayoutStack,
-} from "../settings-layout";
+import { AlertTriangle, Cloud, Lock, RotateCcw } from "lucide-react";
 import { useShellConfig, DEFAULT_SHELL_CONFIG, type ShellConfig } from "../../../shell/shell-config";
-import { useUiStateStore } from "../../../shell/ui-state-store";
-
-/* ------------------------------------------------------------------ */
-/*  Interactive wireframe preview                                      */
-/* ------------------------------------------------------------------ */
-
-function ShellWireframe({ config }: { config: ShellConfig }) {
-  const cx = config.sidebar ? 102 : 1;
-  const cw = config.sidebar ? 297 : 398;
-
-  return (
-    <div className="mx-auto mb-2 w-full max-w-md">
-      <svg viewBox="0 0 400 260" className="w-full" aria-hidden="true">
-        {/* Window frame */}
-        <rect x="0" y="0" width="400" height="260" rx="10" fill="var(--dls-surface)" stroke="var(--dls-border)" strokeWidth="1" />
-
-        {/* Title bar */}
-        <rect x="0.5" y="0.5" width="399" height="30" rx="10" fill="var(--dls-hover)" />
-        <rect x="0.5" y="18" width="399" height="13" fill="var(--dls-hover)" />
-        <line x1="0" y1="30" x2="400" y2="30" stroke="var(--dls-border)" strokeWidth="0.5" />
-        <circle cx="14" cy="15" r="3.5" fill="#ff5f57" opacity="0.6" />
-        <circle cx="26" cy="15" r="3.5" fill="#febc2e" opacity="0.6" />
-        <circle cx="38" cy="15" r="3.5" fill="#28c840" opacity="0.6" />
-        <text x="200" y="19" textAnchor="middle" fontSize="8" fontWeight="600" fill="var(--dls-text-secondary)" opacity="0.7">
-          {config.appName}
-        </text>
-
-        {/* Sidebar */}
-        <g className="transition-all duration-300" style={{ opacity: config.sidebar ? 1 : 0.1 }}>
-          <rect x="0.5" y="31" width="100" height="195" fill="var(--dls-hover)" />
-          <line x1="101" y1="31" x2="101" y2="226" stroke="var(--dls-border)" strokeWidth="0.5" />
-
-          {/* Workspace header */}
-          <circle cx="16" cy="44" r="5" fill="var(--dls-accent)" opacity="0.3" />
-          <text x="26" y="47" fontSize="6.5" fontWeight="600" fill="var(--dls-text-primary)" opacity="0.7">Workspace</text>
-
-          {/* Session list */}
-          <rect x="8" y="58" width="85" height="16" rx="4" fill="var(--dls-surface)" opacity="0.6" />
-          <text x="14" y="68" fontSize="5.5" fill="var(--dls-text-primary)" opacity="0.5">Meeting brief</text>
-
-          <rect x="8" y="78" width="85" height="16" rx="4" fill="transparent" />
-          <text x="14" y="88" fontSize="5.5" fill="var(--dls-text-secondary)" opacity="0.4">Contract review</text>
-
-          <rect x="8" y="98" width="85" height="16" rx="4" fill="transparent" />
-          <text x="14" y="108" fontSize="5.5" fill="var(--dls-text-secondary)" opacity="0.4">Outreach CRM</text>
-
-          {/* New session button */}
-          <text x="14" y="130" fontSize="5" fill="var(--dls-text-secondary)" opacity="0.3">+ New session</text>
-
-          {/* Add workspace */}
-          {config.addWorkspace ? (
-            <g>
-              <rect x="8" y="200" width="85" height="16" rx="8" fill="var(--dls-accent)" opacity="0.15" />
-              <text x="50" y="210" textAnchor="middle" fontSize="5.5" fontWeight="500" fill="var(--dls-accent)" opacity="0.6">Add workspace</text>
-            </g>
-          ) : null}
-        </g>
-
-        {/* Main content */}
-        <rect x={cx} y="31" width={cw} height="195" fill="var(--dls-surface)" />
-
-        {/* Starter cards */}
-        <g className="transition-all duration-300" style={{ opacity: config.starterCards ? 1 : 0 }}>
-          {[
-            { x: cx + 12, icon: "\u{1F4CA}", label: "Edit a CSV" },
-            { x: cx + 12 + (cw - 36) / 3 + 6, icon: "\u{1F310}", label: "Browse web" },
-            { x: cx + 12 + ((cw - 36) / 3 + 6) * 2, icon: "\u{1F50C}", label: "Extensions" },
-          ].map((card, i) => {
-            const w = (cw - 36) / 3;
-            return (
-              <g key={i}>
-                <rect x={card.x} y="120" width={w} height="34" rx="5" fill="none" stroke="var(--dls-border)" strokeWidth="0.5" />
-                <text x={card.x + 6} y="133" fontSize="7">{card.icon}</text>
-                <text x={card.x + 16} y="133" fontSize="5" fontWeight="500" fill="var(--dls-text-primary)" opacity="0.5">{card.label}</text>
-                <rect x={card.x + 6} y="140" width={w - 16} height="3" rx="1.5" fill="var(--dls-text-secondary)" opacity="0.06" />
-              </g>
-            );
-          })}
-        </g>
-
-        {/* Composer */}
-        <rect x={cx + 10} y="196" width={cw - 20} height="22" rx="11" fill="none" stroke="var(--dls-border)" strokeWidth="0.75" />
-        <text x={cx + 24} y="210" fontSize="5.5" fill="var(--dls-text-secondary)" opacity="0.3">Describe your task...</text>
-        {/* Send button */}
-        <rect x={cx + cw - 42} y="200" width="24" height="14" rx="7" fill="var(--dls-accent)" opacity="0.2" />
-        <text x={cx + cw - 30} y="210" textAnchor="middle" fontSize="4.5" fontWeight="500" fill="var(--dls-accent)" opacity="0.5">Run</text>
-
-        {/* Model picker */}
-        {config.modelPicker ? (
-          <text x={cx + 14} y="174" fontSize="4.5" fill="var(--dls-text-secondary)" opacity="0.3">big-pickle</text>
-        ) : null}
-
-        {/* Status bar */}
-        <g className="transition-all duration-300" style={{ opacity: config.statusBar ? 1 : 0.08 }}>
-          <line x1="0" y1="226" x2="400" y2="226" stroke="var(--dls-border)" strokeWidth="0.5" />
-          <rect x="0.5" y="226" width="399" height="33.5" rx="0" fill="var(--dls-hover)" />
-          {/* Bottom corners */}
-          <rect x="0.5" y="250" width="399" height="10" rx="10" fill="var(--dls-hover)" />
-
-          {/* Status dot + label */}
-          <circle cx="14" cy="242" r="2.5" fill="#28c840" opacity="0.5" />
-          <text x="22" y="245" fontSize="5.5" fontWeight="500" fill="var(--dls-text-primary)" opacity="0.5">Ready</text>
-
-          {/* Cloud sign-in */}
-          {config.cloudSignin ? (
-            <g>
-              <rect x="280" y="236" width="32" height="12" rx="6" fill="var(--dls-accent)" opacity="0.2" />
-              <text x="296" y="244" textAnchor="middle" fontSize="4.5" fontWeight="500" fill="var(--dls-accent)" opacity="0.5">Sign in</text>
-            </g>
-          ) : null}
-
-          {/* Docs */}
-          {config.docsButton ? (
-            <text x="326" y="244" fontSize="5" fill="var(--dls-text-secondary)" opacity="0.35">Docs</text>
-          ) : null}
-
-          {/* Feedback */}
-          {config.feedbackButton ? (
-            <text x="350" y="244" fontSize="5" fill="var(--dls-text-secondary)" opacity="0.35">Feedback</text>
-          ) : null}
-
-          {/* Settings gear */}
-          <text x="388" y="245" textAnchor="middle" fontSize="7" fill="var(--dls-text-secondary)" opacity="0.3">{"\u2699"}</text>
-        </g>
-
-        {/* Browser panel */}
-        <g className="transition-all duration-300" style={{ opacity: config.browser ? 1 : 0 }}>
-          <line x1={cx + cw - 120} y1="31" x2={cx + cw - 120} y2="226" stroke="var(--dls-border)" strokeWidth="0.5" />
-          <rect x={cx + cw - 120} y="31" width="120" height="195" fill="var(--dls-hover)" opacity="0.5" />
-          {/* Browser chrome */}
-          <rect x={cx + cw - 115} y="36" width="110" height="14" rx="4" fill="var(--dls-surface)" />
-          <circle cx={cx + cw - 108} cy="43" r="2" fill="var(--dls-text-secondary)" opacity="0.2" />
-          <circle cx={cx + cw - 100} cy="43" r="2" fill="var(--dls-text-secondary)" opacity="0.2" />
-          <rect x={cx + cw - 92} y="40" width="60" height="6" rx="3" fill="var(--dls-text-secondary)" opacity="0.08" />
-          {/* Page content placeholder */}
-          <rect x={cx + cw - 112} y="56" width="100" height="6" rx="2" fill="var(--dls-text-secondary)" opacity="0.07" />
-          <rect x={cx + cw - 112} y="66" width="80" height="6" rx="2" fill="var(--dls-text-secondary)" opacity="0.05" />
-          <rect x={cx + cw - 112} y="76" width="90" height="6" rx="2" fill="var(--dls-text-secondary)" opacity="0.05" />
-          <rect x={cx + cw - 112} y="92" width="100" height="50" rx="4" fill="var(--dls-surface)" opacity="0.6" />
-        </g>
-      </svg>
-    </div>
-  );
-}
+import { useEffectiveConfig } from "../../../shell/effective-config";
+import { useDesktopConfig } from "../../cloud/desktop-config-provider";
+import { useCloudSession } from "../cloud/cloud-session-provider";
+import { readDenSettings, resolveDenBaseUrls } from "../../../../app/lib/den";
+import { usePlatform } from "../../../kernel/platform";
+import {
+  SettingsSection,
+  SettingsSectionHeader,
+  SettingsSectionHeaderContent,
+  SettingsSectionHeaderTitle,
+  SettingsSectionHeaderDescription,
+  SettingsStack,
+} from "../settings-section";
+import { Separator } from "@/components/ui/separator";
 
 /* ------------------------------------------------------------------ */
 /*  Toggle row                                                         */
 /* ------------------------------------------------------------------ */
 
-type ToggleRowProps = {
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+  locked,
+  lockedHint,
+  nested,
+}: {
   label: string;
   description: string;
   checked: boolean;
   onChange: (value: boolean) => void;
-  disabled?: boolean;
-  unavailable?: string | null;
-  warning?: string | null;
-  cloudOnly?: boolean;
-  className?: string;
-};
-
-function CloudOnlyBadge() {
+  locked?: boolean;
+  lockedHint?: string;
+  nested?: boolean;
+}) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-md bg-dls-hover size-5 justify-center text-xs font-medium text-dls-secondary" aria-label="Cloud only">
-      <Lock className="size-3" />
-    </span>
+    <div className={`flex items-center justify-between gap-4 ${nested ? "ml-6" : ""}`}>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <div className="text-sm font-medium text-dls-text">{label}</div>
+          {locked ? (
+            <span className="inline-flex items-center gap-1 rounded-md bg-dls-hover px-1.5 py-0.5 text-[10px] font-medium text-dls-secondary">
+              <Cloud size={10} />
+              Managed
+            </span>
+          ) : null}
+        </div>
+        <div className="text-xs text-dls-secondary">{description}</div>
+        {locked && lockedHint ? (
+          <div className="mt-0.5 text-[10px] text-dls-secondary/70">{lockedHint}</div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={locked}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+          locked ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+        } ${checked ? "bg-dls-text" : "bg-dls-hover"}`}
+        onClick={() => !locked && onChange(!checked)}
+      >
+        <span
+          className={`inline-block size-3.5 rounded-full bg-dls-surface transition-transform ${
+            checked ? "translate-x-[18px]" : "translate-x-[3px]"
+          }`}
+        />
+      </button>
+    </div>
   );
 }
 
-function ToggleRow(props: ToggleRowProps) {
+/* ------------------------------------------------------------------ */
+/*  Policy row (read-only indicator for Category B)                    */
+/* ------------------------------------------------------------------ */
+
+function PolicyRow({
+  label,
+  description,
+  active,
+}: {
+  label: string;
+  description: string;
+  active: boolean;
+}) {
   return (
-    <LayoutSectionItem className={cn("gap-3", props.className)}>
-      <LayoutSectionItemHeader>
-        <LayoutSectionItemTitle>
-          {props.label}
-          {props.cloudOnly ? <CloudOnlyBadge /> : null}
-        </LayoutSectionItemTitle>
-        <LayoutSectionItemDescription>{props.description}</LayoutSectionItemDescription>
-        <LayoutSectionItemHeaderActions>
-          <Switch
-            aria-label={props.label}
-            checked={props.checked}
-            disabled={props.disabled || props.cloudOnly}
-            onCheckedChange={props.onChange}
-          />
-        </LayoutSectionItemHeaderActions>
-      </LayoutSectionItemHeader>
-      {props.warning && !props.checked ? (
-        <Alert variant="warning">
-          <AlertTriangle />
-          <AlertDescription>{props.warning}</AlertDescription>
-        </Alert>
-      ) : null}
-      {props.unavailable ? (
-        <Alert>
-          <Info />
-          <AlertDescription>{props.unavailable}</AlertDescription>
-        </Alert>
-      ) : null}
-    </LayoutSectionItem>
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-dls-text">{label}</div>
+        <div className="text-xs text-dls-secondary">{description}</div>
+      </div>
+      <span
+        className={`shrink-0 rounded-full px-2.5 py-0.5 text-[11px] font-medium ${
+          active
+            ? "bg-amber-3 text-amber-11"
+            : "bg-green-3 text-green-11"
+        }`}
+      >
+        {active ? "Restricted" : "Allowed"}
+      </span>
+    </div>
   );
 }
 
@@ -230,229 +112,172 @@ function ToggleRow(props: ToggleRowProps) {
 
 export function ShellCustomizationView() {
   const { config, update, reset } = useShellConfig();
-  const applicationMenuVisible = useUiStateStore((state) => state.applicationMenuVisible);
-  const setApplicationMenuVisible = useUiStateStore((state) => state.setApplicationMenuVisible);
+  const effectiveConfig = useEffectiveConfig();
+  const { isSignedIn } = useCloudSession();
+  const platform = usePlatform();
 
-  const isDefault = (Object.keys(DEFAULT_SHELL_CONFIG) as (keyof ShellConfig)[]).every(
-    (key) => config[key] === DEFAULT_SHELL_CONFIG[key],
-  ) && !applicationMenuVisible;
-
-  const resetAll = () => {
-    reset();
-    setApplicationMenuVisible(false);
-  };
+  const hasChanges = Object.keys(DEFAULT_SHELL_CONFIG).some(
+    (key) => config[key as keyof ShellConfig] !== DEFAULT_SHELL_CONFIG[key as keyof ShellConfig],
+  );
 
   return (
-    <LayoutStack>
-      {/* ---- Branding ---- */}
-      <LayoutSection>
-        <LayoutSectionHeader>
-          <LayoutSectionTitle>Branding</LayoutSectionTitle>
-          <LayoutSectionDescription>
-            Customize the name your users see across the app.
-          </LayoutSectionDescription>
-        </LayoutSectionHeader>
+    <SettingsStack>
+      {/* Section 1: Layout preferences */}
+      <SettingsSection>
+        <SettingsSectionHeader>
+          <SettingsSectionHeaderContent>
+            <SettingsSectionHeaderTitle>Layout</SettingsSectionHeaderTitle>
+            <SettingsSectionHeaderDescription>
+              Control which UI elements are visible. Your organization can override these settings.
+            </SettingsSectionHeaderDescription>
+          </SettingsSectionHeaderContent>
+        </SettingsSectionHeader>
 
-        <LayoutSectionItem>
-          <LayoutSectionItemHeader>
-            <LayoutSectionItemTitle>Change application name</LayoutSectionItemTitle>
-            <LayoutSectionItemDescription>
-              Appears in the title bar, sidebar, and welcome screen.
-            </LayoutSectionItemDescription>
-            <LayoutSectionItemHeaderActions>
-              <Field className="w-64 max-w-full gap-0">
-               <FieldLabel className="sr-only" htmlFor="shell-app-name">
-                  App name
-                </FieldLabel>
-                <Input
-                  id="shell-app-name"
-                  className="h-8 text-xs"
-                  value={config.appName}
-                  placeholder="OpenWork"
-                  disabled
-                  onChange={(event) => update({ appName: event.currentTarget.value || DEFAULT_SHELL_CONFIG.appName })}
-                />
-              </Field>
-            </LayoutSectionItemHeaderActions>
-          </LayoutSectionItemHeader>
-          <Alert>
-            <Info />
-            <AlertDescription>Changing the application name is not available yet.</AlertDescription>
-          </Alert>
-        </LayoutSectionItem>
-      </LayoutSection>
+        <div className="space-y-5">
+          <ToggleRow
+            label="Status bar"
+            description="Bottom bar showing connection status and quick links."
+            checked={effectiveConfig.statusBar}
+            onChange={(v) => update({ statusBar: v })}
+            locked={effectiveConfig.cloudManaged.statusBar}
+            lockedHint="Set by your organization."
+          />
+          {effectiveConfig.statusBar ? (
+            <>
+              <ToggleRow
+                label="Documentation link"
+                description="Link to docs in the status bar."
+                checked={effectiveConfig.docsButton}
+                onChange={(v) => update({ docsButton: v })}
+                locked={effectiveConfig.cloudManaged.docsButton}
+                nested
+              />
+              <ToggleRow
+                label="Feedback button"
+                description="Send feedback from the status bar."
+                checked={effectiveConfig.feedbackButton}
+                onChange={(v) => update({ feedbackButton: v })}
+                locked={effectiveConfig.cloudManaged.feedbackButton}
+                nested
+              />
+              <ToggleRow
+                label="Cloud sign-in"
+                description="Sign-in prompt for users who aren't logged in."
+                checked={effectiveConfig.cloudSignin}
+                onChange={(v) => update({ cloudSignin: v })}
+                locked={effectiveConfig.cloudManaged.cloudSignin}
+                nested
+              />
+            </>
+          ) : null}
+          <ToggleRow
+            label="Task suggestions"
+            description="Starter task cards in empty sessions."
+            checked={effectiveConfig.starterCards}
+            onChange={(v) => update({ starterCards: v })}
+            locked={effectiveConfig.cloudManaged.starterCards}
+          />
+          <ToggleRow
+            label="Model picker"
+            description="Model selection in the composer."
+            checked={effectiveConfig.modelPicker}
+            onChange={(v) => update({ modelPicker: v })}
+            locked={effectiveConfig.cloudManaged.modelPicker}
+          />
+          <ToggleRow
+            label="New workspace button"
+            description="Button to create or join workspaces."
+            checked={effectiveConfig.addWorkspace}
+            onChange={(v) => update({ addWorkspace: v })}
+            locked={effectiveConfig.cloudManaged.addWorkspace}
+          />
+        </div>
+
+        <div className="mt-2 rounded-lg bg-dls-hover/50 px-3 py-2 text-[11px] text-dls-secondary">
+          Hidden items are still accessible via the command palette (Cmd+K).
+        </div>
+      </SettingsSection>
 
       <Separator />
 
-      {/* ---- Visibility ---- */}
-      <LayoutSection>
-        <LayoutSectionHeader>
-          <LayoutSectionTitle>Layout</LayoutSectionTitle>
-          <LayoutSectionDescription>
-            Customize what's visible in the interface.
-          </LayoutSectionDescription>
-        </LayoutSectionHeader>
+      {/* Section 2: Organization policies (Category B) */}
+      {isSignedIn ? (
+        <SettingsSection>
+          <SettingsSectionHeader>
+            <SettingsSectionHeaderContent>
+              <SettingsSectionHeaderTitle>
+                Organization policies
+                <Lock size={14} className="ml-1.5 inline text-dls-secondary" />
+              </SettingsSectionHeaderTitle>
+              <SettingsSectionHeaderDescription>
+                These settings are managed by your organization.{" "}
+                <button
+                  type="button"
+                  className="font-medium text-dls-text underline underline-offset-2"
+                  onClick={() => {
+                    const settings = readDenSettings();
+                    platform.openLink(resolveDenBaseUrls(settings.baseUrl).baseUrl);
+                  }}
+                >
+                  Open dashboard
+                </button>
+              </SettingsSectionHeaderDescription>
+            </SettingsSectionHeaderContent>
+          </SettingsSectionHeader>
 
-        <Alert>
-          <AlertDescription>
-            Anything you hide is still available via the command palette (Cmd+K).
-          </AlertDescription>
-        </Alert>
-
-        <LayoutSectionItem className="rounded-2xl border border-dls-border p-4">
-          <ShellWireframe config={config} />
-        </LayoutSectionItem>
-
-        <ToggleRow
-          label="Display sidebar"
-          description="Browse workspaces and past sessions from a side panel."
-          checked={config.sidebar}
-          onChange={(v) => update({ sidebar: v })}
-        />
-
-        <ToggleRow
-          label="Display status bar"
-          description="Quick access to status, settings, and actions along the bottom edge."
-          checked={config.statusBar}
-          onChange={(v) => update({ statusBar: v })}
-          warning="When hidden, the only way to access settings is via Cmd+K."
-        />
-
-        {config.statusBar ? (
-          <div className="ml-6 flex flex-col gap-3 border border-dls-border px-4 py-4 rounded-2xl -mr-4">
-            <ToggleRow
-              label="Display documentation link"
-              description="Show a link to your documentation."
-              checked={config.docsButton}
-              onChange={(value) => update({ docsButton: value })}
+          <div className="space-y-5">
+            <PolicyRow
+              label="Non-cloud models"
+              description="Allow models not deployed through OpenWork Cloud."
+              active={effectiveConfig.disallowNonCloudModels}
             />
-            <ToggleRow
-              label="Display feedback button"
-              description="Show a button for submitting feedback."
-              checked={config.feedbackButton}
-              onChange={(value) => update({ feedbackButton: value })}
+            <PolicyRow
+              label="OpenCode Zen"
+              description="Allow the built-in OpenCode Zen provider."
+              active={effectiveConfig.blockZenModel}
             />
-            <ToggleRow
-              label="Display cloud sign-in"
-              description="Show a sign-in prompt for users who aren't logged in."
-              checked={config.cloudSignin}
-              onChange={(value) => update({ cloudSignin: value })}
+            <PolicyRow
+              label="Multiple workspaces"
+              description="Allow users to create and manage multiple workspaces."
+              active={effectiveConfig.blockMultipleWorkspaces}
+            />
+            <PolicyRow
+              label="Settings access"
+              description="Allow users to access app settings."
+              active={effectiveConfig.blockSettingsAccess}
+            />
+            <PolicyRow
+              label="Extensions"
+              description="Allow users to install and manage extensions."
+              active={effectiveConfig.restrictExtensions}
             />
           </div>
-        ) : null}
-
-        <ToggleRow
-          label="Display task suggestions"
-          description="Show task suggestions to help users get started."
-          checked={config.starterCards}
-          onChange={(v) => update({ starterCards: v })}
-        />
-
-        <ToggleRow
-          label="Display model picker"
-          description="Let users choose which AI model to use."
-          checked={config.modelPicker}
-          onChange={(v) => update({ modelPicker: v })}
-          disabled
-          unavailable="The model picker display control is not available yet."
-        />
-
-        <ToggleRow
-          label="Display browser panel"
-          description="A built-in browser for viewing web content alongside sessions."
-          checked={config.browser}
-          onChange={(v) => update({ browser: v })}
-          disabled
-          unavailable="The browser panel display control is not available yet."
-        />
-
-        <ToggleRow
-          label="Display menu bar"
-          description="Show the native desktop menu bar."
-          checked={applicationMenuVisible}
-          onChange={setApplicationMenuVisible}
-          className="hidden windows:flex linux:flex"
-        />
-
-        <ToggleRow
-          label="Display new workspace button"
-          description="Let users create or join additional workspaces."
-          checked={config.addWorkspace}
-          onChange={(v) => update({ addWorkspace: v })}
-          disabled
-          unavailable="The new workspace button display control is not available yet."
-        />
-      </LayoutSection>
+        </SettingsSection>
+      ) : null}
 
       <Separator />
 
-      {/* ---- Cloud-managed (grayed out) ---- */}
-      <LayoutSection>
-        <LayoutSectionHeader>
-          <LayoutSectionTitle>Organization-wide settings</LayoutSectionTitle>
-          <LayoutSectionDescription>
-            These settings are managed by your organization via OpenWork Cloud.
-          </LayoutSectionDescription>
-        </LayoutSectionHeader>
-
-        <Alert variant="warning">
-          <Lock />
-          <AlertDescription>
-            These settings can only be changed by your organization admin. Contact your admin to make changes.
-          </AlertDescription>
-        </Alert>
-
-        <ToggleRow
-          label="Settings access"
-          description="Let users open the settings panel."
-          checked={true}
-          onChange={() => {}}
-          cloudOnly
-        />
-
-        <ToggleRow
-          label="Model restrictions"
-          description="Limit which AI models and providers users can choose from."
-          checked={false}
-          onChange={() => {}}
-          cloudOnly
-        />
-
-        <ToggleRow
-          label="Extension restrictions"
-          description="Limit which extensions, plugins, and skills users can install."
-          checked={false}
-          onChange={() => {}}
-          cloudOnly
-        />
-
-        <ToggleRow
-          label="Enable welcome page"
-          description="A getting-started screen for first-time users."
-          checked={config.welcomePage}
-          onChange={(v) => update({ welcomePage: v })}
-          cloudOnly
-          disabled
-        />
-      </LayoutSection>
-
-      <Separator />
-
-      {/* ---- Reset ---- */}
-      <div className="flex items-center justify-between">
-        <div className="text-sm text-dls-secondary">
-          {isDefault ? "All settings are at their defaults." : "Some settings have been customized."}
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={resetAll}
-          disabled={isDefault}
-        >
-          <RotateCcw size={12} />
-          Reset to defaults
-        </Button>
-      </div>
-    </LayoutStack>
+      {/* Reset */}
+      {hasChanges ? (
+        <SettingsSection>
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium text-dls-text">Reset preferences</div>
+              <div className="text-xs text-dls-secondary">
+                Restore all layout preferences to their defaults. Organization policies are not affected.
+              </div>
+            </div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-full border border-dls-border px-3 py-1.5 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover"
+              onClick={reset}
+            >
+              <RotateCcw size={12} />
+              Reset
+            </button>
+          </div>
+        </SettingsSection>
+      ) : null}
+    </SettingsStack>
   );
 }

--- a/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
@@ -1,218 +1,108 @@
 /** @jsxImportSource react */
-import { AlertTriangle, Lock, RotateCcw } from "lucide-react";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Button } from "@/components/ui/button";
-import { Field, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
-import { Switch } from "@/components/ui/switch";
-import { cn } from "@/lib/utils";
-
-import {
-  LayoutSection,
-  LayoutSectionDescription,
-  LayoutSectionHeader,
-  LayoutSectionItem,
-  LayoutSectionItemDescription,
-  LayoutSectionItemHeader,
-  LayoutSectionItemHeaderActions,
-  LayoutSectionItemTitle,
-  LayoutSectionTitle,
-  LayoutStack,
-} from "../settings-layout";
+import { AlertTriangle, Cloud, Lock, RotateCcw } from "lucide-react";
 import { useShellConfig, DEFAULT_SHELL_CONFIG, type ShellConfig } from "../../../shell/shell-config";
-
-/* ------------------------------------------------------------------ */
-/*  Interactive wireframe preview                                      */
-/* ------------------------------------------------------------------ */
-
-function ShellWireframe({ config }: { config: ShellConfig }) {
-  const cx = config.sidebar ? 102 : 1;
-  const cw = config.sidebar ? 297 : 398;
-
-  return (
-    <div className="mx-auto mb-2 w-full max-w-md">
-      <svg viewBox="0 0 400 260" className="w-full" aria-hidden="true">
-        {/* Window frame */}
-        <rect x="0" y="0" width="400" height="260" rx="10" fill="var(--dls-surface)" stroke="var(--dls-border)" strokeWidth="1" />
-
-        {/* Title bar */}
-        <rect x="0.5" y="0.5" width="399" height="30" rx="10" fill="var(--dls-hover)" />
-        <rect x="0.5" y="18" width="399" height="13" fill="var(--dls-hover)" />
-        <line x1="0" y1="30" x2="400" y2="30" stroke="var(--dls-border)" strokeWidth="0.5" />
-        <circle cx="14" cy="15" r="3.5" fill="#ff5f57" opacity="0.6" />
-        <circle cx="26" cy="15" r="3.5" fill="#febc2e" opacity="0.6" />
-        <circle cx="38" cy="15" r="3.5" fill="#28c840" opacity="0.6" />
-        <text x="200" y="19" textAnchor="middle" fontSize="8" fontWeight="600" fill="var(--dls-text-secondary)" opacity="0.7">
-          {config.appName}
-        </text>
-
-        {/* Sidebar */}
-        <g className="transition-all duration-300" style={{ opacity: config.sidebar ? 1 : 0.1 }}>
-          <rect x="0.5" y="31" width="100" height="195" fill="var(--dls-hover)" />
-          <line x1="101" y1="31" x2="101" y2="226" stroke="var(--dls-border)" strokeWidth="0.5" />
-
-          {/* Workspace header */}
-          <circle cx="16" cy="44" r="5" fill="var(--dls-accent)" opacity="0.3" />
-          <text x="26" y="47" fontSize="6.5" fontWeight="600" fill="var(--dls-text-primary)" opacity="0.7">Workspace</text>
-
-          {/* Session list */}
-          <rect x="8" y="58" width="85" height="16" rx="4" fill="var(--dls-surface)" opacity="0.6" />
-          <text x="14" y="68" fontSize="5.5" fill="var(--dls-text-primary)" opacity="0.5">Meeting brief</text>
-
-          <rect x="8" y="78" width="85" height="16" rx="4" fill="transparent" />
-          <text x="14" y="88" fontSize="5.5" fill="var(--dls-text-secondary)" opacity="0.4">Contract review</text>
-
-          <rect x="8" y="98" width="85" height="16" rx="4" fill="transparent" />
-          <text x="14" y="108" fontSize="5.5" fill="var(--dls-text-secondary)" opacity="0.4">Outreach CRM</text>
-
-          {/* New session button */}
-          <text x="14" y="130" fontSize="5" fill="var(--dls-text-secondary)" opacity="0.3">+ New session</text>
-
-          {/* Add workspace */}
-          {config.addWorkspace ? (
-            <g>
-              <rect x="8" y="200" width="85" height="16" rx="8" fill="var(--dls-accent)" opacity="0.15" />
-              <text x="50" y="210" textAnchor="middle" fontSize="5.5" fontWeight="500" fill="var(--dls-accent)" opacity="0.6">Add workspace</text>
-            </g>
-          ) : null}
-        </g>
-
-        {/* Main content */}
-        <rect x={cx} y="31" width={cw} height="195" fill="var(--dls-surface)" />
-
-        {/* Starter cards */}
-        <g className="transition-all duration-300" style={{ opacity: config.starterCards ? 1 : 0 }}>
-          {[
-            { x: cx + 12, icon: "\u{1F4CA}", label: "Edit a CSV" },
-            { x: cx + 12 + (cw - 36) / 3 + 6, icon: "\u{1F310}", label: "Browse web" },
-            { x: cx + 12 + ((cw - 36) / 3 + 6) * 2, icon: "\u{1F50C}", label: "Extensions" },
-          ].map((card, i) => {
-            const w = (cw - 36) / 3;
-            return (
-              <g key={i}>
-                <rect x={card.x} y="120" width={w} height="34" rx="5" fill="none" stroke="var(--dls-border)" strokeWidth="0.5" />
-                <text x={card.x + 6} y="133" fontSize="7">{card.icon}</text>
-                <text x={card.x + 16} y="133" fontSize="5" fontWeight="500" fill="var(--dls-text-primary)" opacity="0.5">{card.label}</text>
-                <rect x={card.x + 6} y="140" width={w - 16} height="3" rx="1.5" fill="var(--dls-text-secondary)" opacity="0.06" />
-              </g>
-            );
-          })}
-        </g>
-
-        {/* Composer */}
-        <rect x={cx + 10} y="196" width={cw - 20} height="22" rx="11" fill="none" stroke="var(--dls-border)" strokeWidth="0.75" />
-        <text x={cx + 24} y="210" fontSize="5.5" fill="var(--dls-text-secondary)" opacity="0.3">Describe your task...</text>
-        {/* Send button */}
-        <rect x={cx + cw - 42} y="200" width="24" height="14" rx="7" fill="var(--dls-accent)" opacity="0.2" />
-        <text x={cx + cw - 30} y="210" textAnchor="middle" fontSize="4.5" fontWeight="500" fill="var(--dls-accent)" opacity="0.5">Run</text>
-
-        {/* Model picker */}
-        {config.modelPicker ? (
-          <text x={cx + 14} y="174" fontSize="4.5" fill="var(--dls-text-secondary)" opacity="0.3">big-pickle</text>
-        ) : null}
-
-        {/* Status bar */}
-        <g className="transition-all duration-300" style={{ opacity: config.statusBar ? 1 : 0.08 }}>
-          <line x1="0" y1="226" x2="400" y2="226" stroke="var(--dls-border)" strokeWidth="0.5" />
-          <rect x="0.5" y="226" width="399" height="33.5" rx="0" fill="var(--dls-hover)" />
-          {/* Bottom corners */}
-          <rect x="0.5" y="250" width="399" height="10" rx="10" fill="var(--dls-hover)" />
-
-          {/* Status dot + label */}
-          <circle cx="14" cy="242" r="2.5" fill="#28c840" opacity="0.5" />
-          <text x="22" y="245" fontSize="5.5" fontWeight="500" fill="var(--dls-text-primary)" opacity="0.5">Ready</text>
-
-          {/* Cloud sign-in */}
-          {config.cloudSignin ? (
-            <g>
-              <rect x="280" y="236" width="32" height="12" rx="6" fill="var(--dls-accent)" opacity="0.2" />
-              <text x="296" y="244" textAnchor="middle" fontSize="4.5" fontWeight="500" fill="var(--dls-accent)" opacity="0.5">Sign in</text>
-            </g>
-          ) : null}
-
-          {/* Docs */}
-          {config.docsButton ? (
-            <text x="326" y="244" fontSize="5" fill="var(--dls-text-secondary)" opacity="0.35">Docs</text>
-          ) : null}
-
-          {/* Feedback */}
-          {config.feedbackButton ? (
-            <text x="350" y="244" fontSize="5" fill="var(--dls-text-secondary)" opacity="0.35">Feedback</text>
-          ) : null}
-
-          {/* Settings gear */}
-          <text x="388" y="245" textAnchor="middle" fontSize="7" fill="var(--dls-text-secondary)" opacity="0.3">{"\u2699"}</text>
-        </g>
-
-        {/* Browser panel */}
-        <g className="transition-all duration-300" style={{ opacity: config.browser ? 1 : 0 }}>
-          <line x1={cx + cw - 120} y1="31" x2={cx + cw - 120} y2="226" stroke="var(--dls-border)" strokeWidth="0.5" />
-          <rect x={cx + cw - 120} y="31" width="120" height="195" fill="var(--dls-hover)" opacity="0.5" />
-          {/* Browser chrome */}
-          <rect x={cx + cw - 115} y="36" width="110" height="14" rx="4" fill="var(--dls-surface)" />
-          <circle cx={cx + cw - 108} cy="43" r="2" fill="var(--dls-text-secondary)" opacity="0.2" />
-          <circle cx={cx + cw - 100} cy="43" r="2" fill="var(--dls-text-secondary)" opacity="0.2" />
-          <rect x={cx + cw - 92} y="40" width="60" height="6" rx="3" fill="var(--dls-text-secondary)" opacity="0.08" />
-          {/* Page content placeholder */}
-          <rect x={cx + cw - 112} y="56" width="100" height="6" rx="2" fill="var(--dls-text-secondary)" opacity="0.07" />
-          <rect x={cx + cw - 112} y="66" width="80" height="6" rx="2" fill="var(--dls-text-secondary)" opacity="0.05" />
-          <rect x={cx + cw - 112} y="76" width="90" height="6" rx="2" fill="var(--dls-text-secondary)" opacity="0.05" />
-          <rect x={cx + cw - 112} y="92" width="100" height="50" rx="4" fill="var(--dls-surface)" opacity="0.6" />
-        </g>
-      </svg>
-    </div>
-  );
-}
+import { useEffectiveConfig } from "../../../shell/effective-config";
+import { useDesktopConfig } from "../../cloud/desktop-config-provider";
+import { useCloudSession } from "../cloud/cloud-session-provider";
+import { readDenSettings, resolveDenBaseUrls } from "../../../../app/lib/den";
+import { usePlatform } from "../../../kernel/platform";
+import {
+  SettingsSection,
+  SettingsSectionHeader,
+  SettingsSectionHeaderContent,
+  SettingsSectionHeaderTitle,
+  SettingsSectionHeaderDescription,
+  SettingsStack,
+} from "../settings-section";
+import { Separator } from "@/components/ui/separator";
 
 /* ------------------------------------------------------------------ */
 /*  Toggle row                                                         */
 /* ------------------------------------------------------------------ */
 
-type ToggleRowProps = {
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+  locked,
+  lockedHint,
+  nested,
+}: {
   label: string;
   description: string;
   checked: boolean;
   onChange: (value: boolean) => void;
-  disabled?: boolean;
-  warning?: string | null;
-  cloudOnly?: boolean;
-  className?: string;
-};
-
-function CloudOnlyBadge() {
+  locked?: boolean;
+  lockedHint?: string;
+  nested?: boolean;
+}) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-md bg-dls-hover size-5 justify-center text-xs font-medium text-dls-secondary" aria-label="Cloud only">
-      <Lock className="size-3" />
-    </span>
+    <div className={`flex items-center justify-between gap-4 ${nested ? "ml-6" : ""}`}>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <div className="text-sm font-medium text-dls-text">{label}</div>
+          {locked ? (
+            <span className="inline-flex items-center gap-1 rounded-md bg-dls-hover px-1.5 py-0.5 text-[10px] font-medium text-dls-secondary">
+              <Cloud size={10} />
+              Managed
+            </span>
+          ) : null}
+        </div>
+        <div className="text-xs text-dls-secondary">{description}</div>
+        {locked && lockedHint ? (
+          <div className="mt-0.5 text-[10px] text-dls-secondary/70">{lockedHint}</div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={locked}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+          locked ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+        } ${checked ? "bg-dls-text" : "bg-dls-hover"}`}
+        onClick={() => !locked && onChange(!checked)}
+      >
+        <span
+          className={`inline-block size-3.5 rounded-full bg-dls-surface transition-transform ${
+            checked ? "translate-x-[18px]" : "translate-x-[3px]"
+          }`}
+        />
+      </button>
+    </div>
   );
 }
 
-function ToggleRow(props: ToggleRowProps) {
+/* ------------------------------------------------------------------ */
+/*  Policy row (read-only indicator for Category B)                    */
+/* ------------------------------------------------------------------ */
+
+function PolicyRow({
+  label,
+  description,
+  active,
+}: {
+  label: string;
+  description: string;
+  active: boolean;
+}) {
   return (
-    <LayoutSectionItem className={cn("gap-3", props.className)}>
-      <LayoutSectionItemHeader>
-        <LayoutSectionItemTitle>
-          {props.label}
-          {props.cloudOnly ? <CloudOnlyBadge /> : null}
-        </LayoutSectionItemTitle>
-        <LayoutSectionItemDescription>{props.description}</LayoutSectionItemDescription>
-        <LayoutSectionItemHeaderActions>
-          <Switch
-            aria-label={props.label}
-            checked={props.checked}
-            disabled={props.disabled || props.cloudOnly}
-            onCheckedChange={props.onChange}
-          />
-        </LayoutSectionItemHeaderActions>
-      </LayoutSectionItemHeader>
-      {props.warning && !props.checked ? (
-        <Alert variant="warning">
-          <AlertTriangle />
-          <AlertDescription>{props.warning}</AlertDescription>
-        </Alert>
-      ) : null}
-    </LayoutSectionItem>
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-dls-text">{label}</div>
+        <div className="text-xs text-dls-secondary">{description}</div>
+      </div>
+      <span
+        className={`shrink-0 rounded-full px-2.5 py-0.5 text-[11px] font-medium ${
+          active
+            ? "bg-amber-3 text-amber-11"
+            : "bg-green-3 text-green-11"
+        }`}
+      >
+        {active ? "Restricted" : "Allowed"}
+      </span>
+    </div>
   );
 }
 
@@ -222,203 +112,162 @@ function ToggleRow(props: ToggleRowProps) {
 
 export function ShellCustomizationView() {
   const { config, update, reset } = useShellConfig();
+  const effectiveConfig = useEffectiveConfig();
+  const { isSignedIn } = useCloudSession();
+  const platform = usePlatform();
 
-  const isDefault = (Object.keys(DEFAULT_SHELL_CONFIG) as (keyof ShellConfig)[]).every(
-    (key) => config[key] === DEFAULT_SHELL_CONFIG[key],
+  const hasChanges = Object.keys(DEFAULT_SHELL_CONFIG).some(
+    (key) => config[key as keyof ShellConfig] !== DEFAULT_SHELL_CONFIG[key as keyof ShellConfig],
   );
 
   return (
-    <LayoutStack>
-      {/* ---- Branding ---- */}
-      <LayoutSection>
-        <LayoutSectionHeader>
-          <LayoutSectionTitle>Branding</LayoutSectionTitle>
-          <LayoutSectionDescription>
-            Customize the name your users see across the app.
-          </LayoutSectionDescription>
-        </LayoutSectionHeader>
+    <SettingsStack>
+      {/* Section 1: Layout preferences */}
+      <SettingsSection>
+        <SettingsSectionHeader>
+          <SettingsSectionHeaderContent>
+            <SettingsSectionHeaderTitle>Layout</SettingsSectionHeaderTitle>
+            <SettingsSectionHeaderDescription>
+              Control which UI elements are visible. Your organization can override these settings.
+            </SettingsSectionHeaderDescription>
+          </SettingsSectionHeaderContent>
+        </SettingsSectionHeader>
 
-        <LayoutSectionItem>
-          <LayoutSectionItemHeader>
-            <LayoutSectionItemTitle>Change application name</LayoutSectionItemTitle>
-            <LayoutSectionItemDescription>
-              Appears in the title bar, sidebar, and welcome screen.
-            </LayoutSectionItemDescription>
-            <LayoutSectionItemHeaderActions>
-              <Field className="w-64 max-w-full gap-0">
-               <FieldLabel className="sr-only" htmlFor="shell-app-name">
-                  App name
-                </FieldLabel>
-                <Input
-                  id="shell-app-name"
-                  className="h-8 text-xs"
-                  value={config.appName}
-                  placeholder="OpenWork"
-                  onChange={(event) => update({ appName: event.currentTarget.value || DEFAULT_SHELL_CONFIG.appName })}
-                />
-              </Field>
-            </LayoutSectionItemHeaderActions>
-          </LayoutSectionItemHeader>
-        </LayoutSectionItem>
-      </LayoutSection>
+        <div className="space-y-5">
+          <ToggleRow
+            label="Status bar"
+            description="Bottom bar showing connection status and quick links."
+            checked={effectiveConfig.statusBar}
+            onChange={(v) => update({ statusBar: v })}
+            locked={effectiveConfig.cloudManaged.statusBar}
+            lockedHint="Set by your organization."
+          />
+          {effectiveConfig.statusBar ? (
+            <>
+              <ToggleRow
+                label="Documentation link"
+                description="Link to docs in the status bar."
+                checked={effectiveConfig.docsButton}
+                onChange={(v) => update({ docsButton: v })}
+                locked={effectiveConfig.cloudManaged.docsButton}
+                nested
+              />
+              <ToggleRow
+                label="Feedback button"
+                description="Send feedback from the status bar."
+                checked={effectiveConfig.feedbackButton}
+                onChange={(v) => update({ feedbackButton: v })}
+                locked={effectiveConfig.cloudManaged.feedbackButton}
+                nested
+              />
+              <ToggleRow
+                label="Cloud sign-in"
+                description="Sign-in prompt for users who aren't logged in."
+                checked={effectiveConfig.cloudSignin}
+                onChange={(v) => update({ cloudSignin: v })}
+                locked={effectiveConfig.cloudManaged.cloudSignin}
+                nested
+              />
+            </>
+          ) : null}
+          <ToggleRow
+            label="Task suggestions"
+            description="Starter task cards in empty sessions."
+            checked={effectiveConfig.starterCards}
+            onChange={(v) => update({ starterCards: v })}
+            locked={effectiveConfig.cloudManaged.starterCards}
+          />
+          <ToggleRow
+            label="Model picker"
+            description="Model selection in the composer."
+            checked={effectiveConfig.modelPicker}
+            onChange={(v) => update({ modelPicker: v })}
+            locked={effectiveConfig.cloudManaged.modelPicker}
+          />
+          <ToggleRow
+            label="New workspace button"
+            description="Button to create or join workspaces."
+            checked={effectiveConfig.addWorkspace}
+            onChange={(v) => update({ addWorkspace: v })}
+            locked={effectiveConfig.cloudManaged.addWorkspace}
+          />
+        </div>
+
+        <div className="mt-2 rounded-lg bg-dls-hover/50 px-3 py-2 text-[11px] text-dls-secondary">
+          Hidden items are still accessible via the command palette (Cmd+K).
+        </div>
+      </SettingsSection>
 
       <Separator />
 
-      {/* ---- Visibility ---- */}
-      <LayoutSection>
-        <LayoutSectionHeader>
-          <LayoutSectionTitle>Layout</LayoutSectionTitle>
-          <LayoutSectionDescription>
-            Customize what's visible in the interface.
-          </LayoutSectionDescription>
-        </LayoutSectionHeader>
+      {/* Section 2: Organization policies (Category B) */}
+      {isSignedIn ? (
+        <SettingsSection>
+          <SettingsSectionHeader>
+            <SettingsSectionHeaderContent>
+              <SettingsSectionHeaderTitle>
+                Organization policies
+                <Lock size={14} className="ml-1.5 inline text-dls-secondary" />
+              </SettingsSectionHeaderTitle>
+              <SettingsSectionHeaderDescription>
+                These settings are managed by your organization.{" "}
+                <button
+                  type="button"
+                  className="font-medium text-dls-text underline underline-offset-2"
+                  onClick={() => {
+                    const settings = readDenSettings();
+                    platform.openLink(resolveDenBaseUrls(settings.baseUrl).baseUrl);
+                  }}
+                >
+                  Open dashboard
+                </button>
+              </SettingsSectionHeaderDescription>
+            </SettingsSectionHeaderContent>
+          </SettingsSectionHeader>
 
-        <Alert>
-          <AlertDescription>
-            Anything you hide is still available via the command palette (Cmd+K).
-          </AlertDescription>
-        </Alert>
-
-        <LayoutSectionItem className="rounded-2xl border border-dls-border p-4">
-          <ShellWireframe config={config} />
-        </LayoutSectionItem>
-
-        <ToggleRow
-          label="Display sidebar"
-          description="Browse workspaces and past sessions from a side panel."
-          checked={config.sidebar}
-          onChange={(v) => update({ sidebar: v })}
-        />
-
-        <ToggleRow
-          label="Display status bar"
-          description="Quick access to status, settings, and actions along the bottom edge."
-          checked={config.statusBar}
-          onChange={(v) => update({ statusBar: v })}
-          warning="When hidden, the only way to access settings is via Cmd+K."
-        />
-
-        {config.statusBar ? (
-          <div className="ml-6 flex flex-col gap-3 border border-dls-border px-4 py-4 rounded-2xl -mr-4">
-            <ToggleRow
-              label="Display documentation link"
-              description="Show a link to your documentation."
-              checked={config.docsButton}
-              onChange={(value) => update({ docsButton: value })}
+          <div className="space-y-5">
+            <PolicyRow
+              label="Non-cloud models"
+              description="Allow models not deployed through OpenWork Cloud."
+              active={effectiveConfig.disallowNonCloudModels}
             />
-            <ToggleRow
-              label="Display feedback button"
-              description="Show a button for submitting feedback."
-              checked={config.feedbackButton}
-              onChange={(value) => update({ feedbackButton: value })}
+            <PolicyRow
+              label="OpenCode Zen"
+              description="Allow the built-in OpenCode Zen provider."
+              active={effectiveConfig.blockZenModel}
             />
-            <ToggleRow
-              label="Display cloud sign-in"
-              description="Show a sign-in prompt for users who aren't logged in."
-              checked={config.cloudSignin}
-              onChange={(value) => update({ cloudSignin: value })}
+            <PolicyRow
+              label="Multiple workspaces"
+              description="Allow users to create and manage multiple workspaces."
+              active={effectiveConfig.blockMultipleWorkspaces}
             />
           </div>
-        ) : null}
-
-        <ToggleRow
-          label="Display task suggestions"
-          description="Show task suggestions to help users get started."
-          checked={config.starterCards}
-          onChange={(v) => update({ starterCards: v })}
-        />
-
-        <ToggleRow
-          label="Display model picker"
-          description="Let users choose which AI model to use."
-          checked={config.modelPicker}
-          onChange={(v) => update({ modelPicker: v })}
-        />
-
-        <ToggleRow
-          label="Display browser panel"
-          description="A built-in browser for viewing web content alongside sessions."
-          checked={config.browser}
-          onChange={(v) => update({ browser: v })}
-        />
-
-        <ToggleRow
-          label="Display new workspace button"
-          description="Let users create or join additional workspaces."
-          checked={config.addWorkspace}
-          onChange={(v) => update({ addWorkspace: v })}
-        />
-      </LayoutSection>
+        </SettingsSection>
+      ) : null}
 
       <Separator />
 
-      {/* ---- Cloud-managed (grayed out) ---- */}
-      <LayoutSection>
-        <LayoutSectionHeader>
-          <LayoutSectionTitle>Organization-wide settings</LayoutSectionTitle>
-          <LayoutSectionDescription>
-            These settings are managed by your organization via OpenWork Cloud.
-          </LayoutSectionDescription>
-        </LayoutSectionHeader>
-
-        <Alert variant="warning">
-          <Lock />
-          <AlertDescription>
-            These settings can only be changed by your organization admin. Contact your admin to make changes.
-          </AlertDescription>
-        </Alert>
-
-        <ToggleRow
-          label="Settings access"
-          description="Let users open the settings panel."
-          checked={true}
-          onChange={() => {}}
-          cloudOnly
-        />
-
-        <ToggleRow
-          label="Model restrictions"
-          description="Limit which AI models and providers users can choose from."
-          checked={false}
-          onChange={() => {}}
-          cloudOnly
-        />
-
-        <ToggleRow
-          label="Extension restrictions"
-          description="Limit which extensions, plugins, and skills users can install."
-          checked={false}
-          onChange={() => {}}
-          cloudOnly
-        />
-
-        <ToggleRow
-          label="Enable welcome page"
-          description="A getting-started screen for first-time users."
-          checked={config.welcomePage}
-          onChange={(v) => update({ welcomePage: v })}
-          cloudOnly
-          disabled
-        />
-      </LayoutSection>
-
-      <Separator />
-
-      {/* ---- Reset ---- */}
-      <div className="flex items-center justify-between">
-        <div className="text-sm text-dls-secondary">
-          {isDefault ? "All settings are at their defaults." : "Some settings have been customized."}
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={reset}
-          disabled={isDefault}
-        >
-          <RotateCcw size={12} />
-          Reset to defaults
-        </Button>
-      </div>
-    </LayoutStack>
+      {/* Reset */}
+      {hasChanges ? (
+        <SettingsSection>
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium text-dls-text">Reset preferences</div>
+              <div className="text-xs text-dls-secondary">
+                Restore all layout preferences to their defaults. Organization policies are not affected.
+              </div>
+            </div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-full border border-dls-border px-3 py-1.5 text-xs font-medium text-dls-text transition-colors hover:bg-dls-hover"
+              onClick={reset}
+            >
+              <RotateCcw size={12} />
+              Reset
+            </button>
+          </div>
+        </SettingsSection>
+      ) : null}
+    </SettingsStack>
   );
 }

--- a/apps/app/src/react-app/shell/effective-config.tsx
+++ b/apps/app/src/react-app/shell/effective-config.tsx
@@ -1,0 +1,128 @@
+/** @jsxImportSource react */
+import { createContext, use, useMemo, type ReactNode } from "react";
+import { useShellConfig, type ShellConfig } from "./shell-config";
+import { useDesktopConfig } from "../domains/cloud/desktop-config-provider";
+import type { DesktopConfig } from "@openwork/types/den/desktop-app-restrictions";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The merged effective config used by the entire app.
+ *
+ * For Category A settings (UI customization): local user preference
+ * is the fallback; cloud override wins when set.
+ *
+ * For Category B settings (org policies): always from cloud, not
+ * user-togglable.
+ */
+export type EffectiveConfig = {
+  // Category A: UI visibility (local default, cloud override)
+  statusBar: boolean;
+  docsButton: boolean;
+  feedbackButton: boolean;
+  cloudSignin: boolean;
+  starterCards: boolean;
+  modelPicker: boolean;
+  addWorkspace: boolean;
+
+  // Category B: Org-level policies (cloud only)
+  disallowNonCloudModels: boolean;
+  blockZenModel: boolean;
+  blockMultipleWorkspaces: boolean;
+  blockSettingsAccess: boolean;
+  restrictExtensions: boolean;
+
+  /** For each Category A key, whether the cloud is overriding it. */
+  cloudManaged: {
+    statusBar: boolean;
+    docsButton: boolean;
+    feedbackButton: boolean;
+    cloudSignin: boolean;
+    starterCards: boolean;
+    modelPicker: boolean;
+    addWorkspace: boolean;
+  };
+};
+
+/* ------------------------------------------------------------------ */
+/*  Mapping: ShellConfig key -> DesktopConfig cloud override key       */
+/* ------------------------------------------------------------------ */
+
+const CLOUD_OVERRIDE_MAP: Record<keyof ShellConfig, keyof DesktopConfig> = {
+  statusBar: "showStatusBar",
+  docsButton: "showDocsButton",
+  feedbackButton: "showFeedbackButton",
+  cloudSignin: "showCloudSignin",
+  starterCards: "showStarterCards",
+  modelPicker: "showModelPicker",
+  addWorkspace: "showAddWorkspace",
+};
+
+/* ------------------------------------------------------------------ */
+/*  Merge logic                                                        */
+/* ------------------------------------------------------------------ */
+
+function mergeConfig(local: ShellConfig, cloud: DesktopConfig): EffectiveConfig {
+  const cloudManaged = {} as EffectiveConfig["cloudManaged"];
+  const effective = {} as Record<string, boolean>;
+
+  for (const [localKey, cloudKey] of Object.entries(CLOUD_OVERRIDE_MAP)) {
+    const cloudVal = cloud[cloudKey as keyof DesktopConfig];
+    const isCloudSet = typeof cloudVal === "boolean";
+    cloudManaged[localKey as keyof typeof cloudManaged] = isCloudSet;
+    effective[localKey] = isCloudSet
+      ? (cloudVal as boolean)
+      : local[localKey as keyof ShellConfig] as boolean;
+  }
+
+  return {
+    ...(effective as Pick<EffectiveConfig,
+      "statusBar" | "docsButton" | "feedbackButton" | "cloudSignin" |
+      "starterCards" | "modelPicker" | "addWorkspace"
+    >),
+    cloudManaged,
+    // Category B: always from cloud, default false
+    disallowNonCloudModels: cloud.disallowNonCloudModels === true,
+    blockZenModel: cloud.blockZenModel === true,
+    blockMultipleWorkspaces: cloud.blockMultipleWorkspaces === true,
+    blockSettingsAccess: (cloud as DesktopConfig & { blockSettingsAccess?: boolean }).blockSettingsAccess === true,
+    restrictExtensions: (cloud as DesktopConfig & { restrictExtensions?: boolean }).restrictExtensions === true,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Context + Provider                                                 */
+/* ------------------------------------------------------------------ */
+
+const EffectiveConfigContext = createContext<EffectiveConfig | undefined>(undefined);
+
+export function EffectiveConfigProvider({ children }: { children: ReactNode }) {
+  const { config: localConfig } = useShellConfig();
+  const { config: cloudConfig } = useDesktopConfig();
+
+  const effective = useMemo(
+    () => mergeConfig(localConfig, cloudConfig),
+    [localConfig, cloudConfig],
+  );
+
+  return (
+    <EffectiveConfigContext.Provider value={effective}>
+      {children}
+    </EffectiveConfigContext.Provider>
+  );
+}
+
+/**
+ * Returns the merged effective config (local prefs + cloud overrides).
+ * Use this everywhere instead of useShellConfig or useDesktopConfig
+ * for UI visibility decisions.
+ */
+export function useEffectiveConfig(): EffectiveConfig {
+  const ctx = use(EffectiveConfigContext);
+  if (!ctx) {
+    throw new Error("useEffectiveConfig must be used within an EffectiveConfigProvider");
+  }
+  return ctx;
+}

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -6,6 +6,7 @@ import { hydrateOpenworkServerSettingsFromEnv } from "../../app/lib/openwork-ser
 import { isDesktopRuntime } from "../../app/utils";
 import { DenAuthProvider } from "../domains/cloud/den-auth-provider";
 import { DesktopConfigProvider } from "../domains/cloud/desktop-config-provider";
+import { EffectiveConfigProvider } from "./effective-config";
 import { RestrictionNoticeProvider } from "../domains/cloud/restriction-notice-provider";
 import { StatusToastsProvider } from "../domains/shell-feedback/status-toasts";
 import { LocalProvider } from "../kernel/local-provider";
@@ -66,13 +67,15 @@ export function AppProviders({ children }: AppProvidersProps) {
           <DesktopRuntimeBoot />
           <DenAuthProvider>
             <DesktopConfigProvider>
-              <RestrictionNoticeProvider>
-                <LocalProvider>
-                  <StatusToastsProvider>
-                    <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
-                  </StatusToastsProvider>
-                </LocalProvider>
-              </RestrictionNoticeProvider>
+              <EffectiveConfigProvider>
+                <RestrictionNoticeProvider>
+                  <LocalProvider>
+                    <StatusToastsProvider>
+                      <ReloadCoordinatorProvider>{children}</ReloadCoordinatorProvider>
+                    </StatusToastsProvider>
+                  </LocalProvider>
+                </RestrictionNoticeProvider>
+              </EffectiveConfigProvider>
             </DesktopConfigProvider>
           </DenAuthProvider>
         </ArchitectureMismatchGate>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -11,6 +11,7 @@ import {
 import { useNavigate, useParams } from "react-router-dom";
 import type {
   AgentPartInput,
+  ConfigProvidersResponse,
   FilePartInput,
   ProviderListResponse,
   TextPartInput,
@@ -59,9 +60,7 @@ import type {
   TodoItem,
   WorkspacePreset,
   WorkspaceConnectionState,
-  Client,
   ProviderListItem,
-  WorkspaceDisplay,
   WorkspaceSessionGroup,
 } from "../../app/types";
 import { buildFeedbackUrl } from "../../app/lib/feedback";
@@ -88,11 +87,9 @@ import {
 } from "../domains/session/sync/session-sync";
 import { CreateRemoteWorkspaceModal } from "../domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
-import { createProviderAuthStore } from "../domains/connections/provider-auth/store";
 import { useRemoteAccessRestart } from "../domains/workspace/remote-access-restart";
 import { RenameWorkspaceModal } from "../domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "../domains/workspace/use-remote-workspace-connection-editor";
-import { useCloudProviderAutoSync } from "../domains/cloud/use-cloud-provider-auto-sync";
 import {
   diagnoseRemoteWorkspaceTaskLoadFailure,
   getRemoteWorkspaceConnectionKey,
@@ -119,13 +116,14 @@ import {
 import { saveSessionDraft } from "../domains/session/sync/draft-store";
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
+import { useEffectiveConfig } from "./effective-config";
 
 import { readDenSettings } from "../../app/lib/den";
 import { denSessionUpdatedEvent } from "../../app/lib/den-session-events";
 
-import { openModelPickerEvent, pendingModelPickerProviderIdsKey } from "./new-providers-toast";
+import { openModelPickerEvent } from "./new-providers-toast";
 import { getModelBehaviorSummary } from "../../app/lib/model-behavior";
-import { filterProviderList } from "../../app/utils/providers";
+import { filterProviderList, mapConfigProvidersToList } from "../../app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { useReloadCoordinator } from "./reload-coordinator";
@@ -134,13 +132,6 @@ import { useStatusToasts } from "../domains/shell-feedback/status-toasts";
 import { useSessionControlActions } from "../domains/session/control/session-control-actions";
 import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 import { WorkspaceProvider } from "./workspace-provider";
-import {
-  ensureProviderListQuery,
-  getConnectedProviderItems,
-  isModelAvailableInConnectedProviders,
-  refreshProviderListQueries,
-  useProviderListQuery,
-} from "../domains/connections/provider-list-query";
 
 type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
@@ -202,16 +193,6 @@ function workspaceLabel(workspace: OpenworkWorkspaceInfo) {
     t("session.workspace_fallback")
   );
 }
-
-const emptyWorkspaceDisplay: WorkspaceDisplay = {
-  id: "",
-  name: "",
-  path: "",
-  preset: "default",
-  workspaceType: "local",
-};
-
-const reloadAfterOrgOnboardingKey = "openwork.reloadAfterOrgOnboarding";
 
 function describeRouteError(error: unknown) {
   if (error instanceof Error) {
@@ -440,6 +421,7 @@ export function SessionRoute() {
   const local = useLocal();
   const reloadCoordinator = useReloadCoordinator();
   const { showToast } = useStatusToasts();
+  const effectiveConfig = useEffectiveConfig();
   const checkDesktopRestriction = useCheckDesktopRestriction();
   const restrictionNotice = useRestrictionNotice();
   const params = useParams<{ workspaceId?: string; sessionId?: string }>();
@@ -516,12 +498,10 @@ export function SessionRoute() {
   // session "Pick a model" button navigated to /settings/general, which is a
   // dead-end). Loads providers lazily when the modal opens.
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
-  const [modelPickerInitialTab, setModelPickerInitialTab] = useState<"default" | "available">("default");
   const [compactModelPickerOpen, setCompactModelPickerOpen] = useState(false);
   const [modelPickerQuery, setModelPickerQuery] = useState("");
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
-  const [providerDefaults, setProviderDefaults] = useState<Record<string, string>>({});
   const [providerConnectedIds, setProviderConnectedIds] = useState<string[]>([]);
   const [disabledProviderIds, setDisabledProviderIds] = useState<string[]>([]);
   // Bump to re-filter provider list when den session changes (sign-in/out)
@@ -538,36 +518,14 @@ export function SessionRoute() {
   // Open model picker when the global toast's "Pick a new default?" is clicked
   useEffect(() => {
     const handler = (event: Event) => {
-      try {
-        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-      } catch {}
-      const detail = (event as CustomEvent<{ newProviderIds?: string[]; initialTab?: "default" | "available" }>).detail;
-      const ids = detail?.newProviderIds;
+      const ids = (event as CustomEvent<{ newProviderIds?: string[] }>).detail?.newProviderIds;
       if (ids && ids.length > 0) {
         setRecentProviderIds(new Set(ids));
       }
-      setModelPickerInitialTab(detail?.initialTab ?? "default");
       setModelPickerOpen(true);
     };
     window.addEventListener(openModelPickerEvent, handler);
     return () => window.removeEventListener(openModelPickerEvent, handler);
-  }, []);
-
-  useEffect(() => {
-    try {
-      const raw = window.localStorage.getItem(pendingModelPickerProviderIdsKey);
-      if (!raw) return;
-      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-      const parsed = JSON.parse(raw);
-      const ids = Array.isArray(parsed) ? parsed : parsed?.newProviderIds;
-      if (Array.isArray(ids) && ids.every((id) => typeof id === "string")) {
-        setRecentProviderIds(new Set(ids));
-      }
-      setModelPickerInitialTab(parsed?.initialTab === "available" ? "available" : "default");
-      setModelPickerOpen(true);
-    } catch {
-      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-    }
   }, []);
 
   const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
@@ -958,7 +916,6 @@ export function SessionRoute() {
       return false;
     }
     await endpoint.client.reloadEngine(endpoint.workspaceId);
-    await refreshProviderListQueries(getReactQueryClient());
     setEngineReloadVersion((v) => v + 1);
     try {
       window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
@@ -976,27 +933,6 @@ export function SessionRoute() {
       activeSessions: () => activeReloadBlockingSessions,
     });
   }, [activeReloadBlockingSessions, client, reloadCoordinator, reloadWorkspaceEngineFromUi, selectedWorkspaceId]);
-
-  useEffect(() => {
-    if (!reloadCoordinator.canReloadWorkspaceEngine) return;
-    try {
-      if (window.localStorage.getItem(reloadAfterOrgOnboardingKey) !== "1") return;
-    } catch {
-      return;
-    }
-    if (!reloadCoordinator.reloadPending) {
-      reloadCoordinator.markReloadRequired("config", {
-        type: "config",
-        name: "opencode.json",
-        action: "updated",
-      });
-      return;
-    }
-    try {
-      window.localStorage.removeItem(reloadAfterOrgOnboardingKey);
-    } catch {}
-    void reloadCoordinator.reloadWorkspaceEngine();
-  }, [reloadCoordinator, reloadCoordinator.canReloadWorkspaceEngine, reloadCoordinator.reloadPending]);
 
   useEffect(() => {
     if (!client || !selectedWorkspaceId) return;
@@ -1377,105 +1313,9 @@ export function SessionRoute() {
         : null,
     [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
-  const providerListQuery = useProviderListQuery({
-    client: opencodeClient,
-    baseUrl: opencodeBaseUrl,
-    directory: selectedWorkspaceRoot || undefined,
-  });
-  const selectedModelUnavailable = Boolean(
-    local.prefs.defaultModel &&
-      providerListQuery.data &&
-      !isModelAvailableInConnectedProviders(providerListQuery.data, local.prefs.defaultModel),
-  );
   const canCreateTask = Boolean(
-    opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError && !selectedModelUnavailable,
+    opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError,
   );
-
-  const sessionProviderAuthStateRef = useRef({
-    opencodeClient: opencodeClient as Client | null,
-    providers,
-    providerDefaults,
-    providerConnectedIds,
-    disabledProviderIds,
-    selectedWorkspace,
-    selectedWorkspaceEndpoint,
-    selectedWorkspaceRoot,
-  });
-  sessionProviderAuthStateRef.current = {
-    opencodeClient,
-    providers,
-    providerDefaults,
-    providerConnectedIds,
-    disabledProviderIds,
-    selectedWorkspace,
-    selectedWorkspaceEndpoint,
-    selectedWorkspaceRoot,
-  };
-
-  const sessionProviderAuthStore = useMemo(
-    () =>
-      createProviderAuthStore({
-        client: () => sessionProviderAuthStateRef.current.opencodeClient,
-        providers: () => sessionProviderAuthStateRef.current.providers,
-        providerDefaults: () => sessionProviderAuthStateRef.current.providerDefaults,
-        providerConnectedIds: () => sessionProviderAuthStateRef.current.providerConnectedIds,
-        disabledProviders: () => sessionProviderAuthStateRef.current.disabledProviderIds,
-        selectedWorkspaceDisplay: () =>
-          sessionProviderAuthStateRef.current.selectedWorkspace
-            ? ({
-                ...sessionProviderAuthStateRef.current.selectedWorkspace,
-                name: workspaceLabel(sessionProviderAuthStateRef.current.selectedWorkspace),
-              } as WorkspaceDisplay)
-            : emptyWorkspaceDisplay,
-        selectedWorkspaceRoot: () => sessionProviderAuthStateRef.current.selectedWorkspaceRoot,
-        runtimeWorkspaceId: () => sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint?.workspaceId ?? null,
-        openworkServer: {
-          getSnapshot: () => ({
-            openworkServerStatus: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint ? "connected" : "disconnected",
-            openworkServerClient: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint?.client ?? null,
-            openworkServerCapabilities: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint
-              ? {
-                  config: { read: true, write: true },
-                }
-              : null,
-          }),
-        } as never,
-        setProviders,
-        setProviderDefaults,
-        setProviderConnectedIds,
-        setDisabledProviders: setDisabledProviderIds,
-        markOpencodeConfigReloadRequired: () => {
-          reloadCoordinator.markReloadRequired("config", {
-            type: "config",
-            name: "opencode.json",
-            action: "updated",
-          });
-        },
-      }),
-    [reloadCoordinator],
-  );
-
-  useEffect(() => {
-    sessionProviderAuthStore.start();
-    return () => {
-      sessionProviderAuthStore.dispose();
-    };
-  }, [sessionProviderAuthStore]);
-
-  useEffect(() => {
-    sessionProviderAuthStore.syncFromOptions();
-  }, [
-    opencodeClient,
-    selectedWorkspace?.id,
-    selectedWorkspace?.workspaceType,
-    selectedWorkspaceEndpoint?.workspaceId,
-    selectedWorkspaceRoot,
-    sessionProviderAuthStore,
-  ]);
-
-  // Session is where forced sign-in lands. Keep org-managed cloud providers in
-  // sync here so sign-in applies opencode.json changes before Settings opens.
-  useCloudProviderAutoSync(sessionProviderAuthStore.runCloudProviderSync);
   const permissionQueryKey = useMemo(
     () =>
       selectedWorkspaceId && selectedSessionId
@@ -1547,7 +1387,6 @@ export function SessionRoute() {
   useEffect(() => {
     if (!opencodeClient) {
       setProviders([]);
-      setProviderDefaults({});
       setProviderConnectedIds([]);
       return;
     }
@@ -1593,26 +1432,41 @@ export function SessionRoute() {
       try {
         applyProviderState(
           filterProviderList(
-            await ensureProviderListQuery(getReactQueryClient(), {
-              client: opencodeClient,
-              baseUrl: opencodeBaseUrl,
-              directory: selectedWorkspaceRoot || undefined,
-            }),
+            unwrap(await opencodeClient.provider.list()),
             disabledProviders,
           ),
         );
       } catch {
-        if (cancelled) return;
-        setProviders([]);
-        setProviderDefaults({});
-        setProviderConnectedIds([]);
+        try {
+          const fallback = unwrap(
+            await opencodeClient.config.providers({
+              directory: selectedWorkspaceRoot || undefined,
+            }),
+          ) as ConfigProvidersResponse;
+          applyProviderState(
+            filterProviderList(
+              {
+                all: mapConfigProvidersToList(
+                  fallback.providers,
+                ) as ProviderListResponse["all"],
+                connected: [],
+                default: fallback.default,
+              },
+              disabledProviders,
+            ),
+          );
+        } catch {
+          if (cancelled) return;
+          setProviders([]);
+          setProviderConnectedIds([]);
+        }
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [opencodeBaseUrl, opencodeClient, selectedWorkspaceRoot, denSessionVersion]);
+  }, [opencodeClient, selectedWorkspaceRoot, denSessionVersion]);
 
   const modelLabel = local.prefs.defaultModel
     ? resolveModelDisplayName(local.prefs.defaultModel.modelID)
@@ -1623,14 +1477,28 @@ export function SessionRoute() {
   // model supports — without waiting for the model picker to open. Cached
   // as providerID → modelID → ProviderModel.
   useEffect(() => {
-    const data = providerListQuery.data;
-    if (!data?.all) return;
-    const next: Record<string, Record<string, any>> = {};
-    for (const provider of data.all) {
-      next[provider.id] = { ...(provider.models ?? {}) };
-    }
-    setProviderCatalog(next);
-  }, [providerListQuery.data]);
+    if (!opencodeClient) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await opencodeClient.config.providers({
+          directory: selectedWorkspaceRoot || undefined,
+        });
+        const data = (res as { data?: { providers?: Array<{ id: string; models: Record<string, any> }> } }).data;
+        if (cancelled || !data?.providers) return;
+        const next: Record<string, Record<string, any>> = {};
+        for (const provider of data.providers) {
+          next[provider.id] = { ...(provider.models ?? {}) };
+        }
+        setProviderCatalog(next);
+      } catch {
+        // best-effort cache; UI will fall back to empty variant options.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [opencodeClient, selectedWorkspaceRoot]);
 
   // Compute behavior (reasoning/thinking variant) options for the current
   // default model. This is what the composer renders as its variant pill.
@@ -1667,12 +1535,19 @@ export function SessionRoute() {
     let cancelled = false;
     void (async () => {
       try {
-        const data = await ensureProviderListQuery(getReactQueryClient(), {
-          client: opencodeClient,
-          baseUrl: opencodeBaseUrl,
+        const res = await opencodeClient.config.providers({
           directory: selectedWorkspaceRoot || undefined,
         });
-        if (cancelled || !data?.all) return;
+        const data = (res as {
+          data?: {
+            providers?: Array<{
+              id: string;
+              name: string;
+              models: Record<string, { id: string; name: string }>;
+            }>;
+          };
+        }).data;
+        if (cancelled || !data?.providers) return;
         // Flag models from recently-added providers so they appear in
         // the "Recently added" section at the top of the picker.
         // Two sources: (1) providers not yet in the localStorage seen-set,
@@ -1685,8 +1560,9 @@ export function SessionRoute() {
           seenIds = new Set();
         }
         const options: ModelOption[] = [];
-        for (const provider of getConnectedProviderItems(data)) {
+        for (const provider of data.providers) {
           const modelIds = Object.keys(provider.models);
+          const hasModels = modelIds.length > 0;
           const isNew = !seenIds.has(provider.id) || recentProviderIds.has(provider.id);
           for (const id of modelIds) {
             const model = provider.models[id];
@@ -1700,7 +1576,7 @@ export function SessionRoute() {
               behaviorDescription: "",
               behaviorValue: null,
               isFree: false,
-              isConnected: true,
+              isConnected: hasModels,
               isRecommended: isNew,
               source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
             });
@@ -1714,13 +1590,14 @@ export function SessionRoute() {
     return () => {
       cancelled = true;
     };
-  }, [modelPickerOpen, opencodeBaseUrl, opencodeClient, recentProviderIds, selectedWorkspaceRoot]);
+  }, [modelPickerOpen, opencodeClient, recentProviderIds, selectedWorkspaceRoot]);
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
   //   - `blockZenModel` hides the built-in OpenCode provider entries
-  //   - `disallowNonCloudModels` hides providers that OpenCode does not report
-  //     as connected through the provider list endpoint.
+  //   - `disallowNonCloudModels` hides providers that aren't currently
+  //     connected via cloud (a provider with models[] filled counts as
+  //     connected in this list — see the loader above)
   const allowedModelOptions = useMemo(() => {
     const restrictToCloud = checkDesktopRestriction({
       restriction: "disallowNonCloudModels",
@@ -1797,7 +1674,6 @@ export function SessionRoute() {
         setModelPickerOpen(true);
       },
       modelPickerOpen: compactModelPickerOpen,
-      modelUnavailable: selectedModelUnavailable,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
       onModelPickerOpenChange: setCompactModelPickerOpen,
       onModelChange: (model: ModelRef) => {
@@ -1816,7 +1692,6 @@ export function SessionRoute() {
       onSendDraft: async (draft: ComposerDraft) => {
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!text && draft.attachments.length === 0) return;
-        if (selectedModelUnavailable) return;
 
         if (draft.mode === "shell") {
           await shellInSession(opencodeClient, selectedSessionId, text);
@@ -1948,7 +1823,6 @@ export function SessionRoute() {
     opencodeClient,
     selectedAgent,
     selectedSessionId,
-    selectedModelUnavailable,
     selectedWorkspace,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
@@ -2446,11 +2320,7 @@ export function SessionRoute() {
   }, [local, refreshRouteState]);
 
   return (
-    <WorkspaceProvider
-      client={opencodeClient}
-      opencodeBaseUrl={opencodeBaseUrl}
-      selectedWorkspaceRoot={selectedWorkspaceRoot}
-    >
+    <WorkspaceProvider client={opencodeClient} selectedWorkspaceRoot={selectedWorkspaceRoot}>
     {opencodeClient && selectedWorkspaceEndpoint && opencodeBaseUrl && selectedWorkspaceServerToken ? (
       <ReactSessionRuntime
         // Use the server-side workspace id (the one without the `rem_`
@@ -2599,6 +2469,7 @@ export function SessionRoute() {
         onEditWorkspaceConnection: remoteWorkspaceConnectionEditor.open,
         onForgetWorkspace: (id) => void handleForgetWorkspace(id),
         onOpenCreateWorkspace: handleOpenCreateWorkspace,
+        showAddWorkspace: effectiveConfig.addWorkspace,
         onReorderWorkspaces: handleReorderWorkspaces,
       }}
       surface={surfaceProps}
@@ -2735,7 +2606,6 @@ export function SessionRoute() {
     <ModelPickerModal
       open={modelPickerOpen}
       options={allowedModelOptions}
-      initialTab={modelPickerInitialTab}
       query={modelPickerQuery}
       setQuery={setModelPickerQuery}
       target="default"

--- a/apps/app/src/react-app/shell/shell-config.tsx
+++ b/apps/app/src/react-app/shell/shell-config.tsx
@@ -5,27 +5,24 @@ import { createContext, useCallback, use, useMemo, useState, type ReactNode } fr
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
 
+/**
+ * User-level layout preferences stored in localStorage.
+ * Each key can be overridden by the org's cloud config (DesktopConfig).
+ * When cloud sets a value, it takes precedence — see useEffectiveConfig.
+ */
 export type ShellConfig = {
-  /** Display name shown in the title bar, sidebar, and welcome page. */
-  appName: string;
   /** Show the bottom status bar (connection status, docs, feedback). */
   statusBar: boolean;
-  /** Show the left sidebar with workspace/session list. */
-  sidebar: boolean;
   /** Show the Docs button in the status bar. */
   docsButton: boolean;
   /** Show the Feedback button in the status bar. */
   feedbackButton: boolean;
   /** Show the Cloud sign-in button when not signed in. */
   cloudSignin: boolean;
-  /** Show the welcome/onboarding page for new users. */
-  welcomePage: boolean;
   /** Show starter task cards in empty sessions. */
   starterCards: boolean;
   /** Show the model picker / model change UI. */
   modelPicker: boolean;
-  /** Show the built-in browser panel. */
-  browser: boolean;
   /** Show the "Add workspace" button. */
   addWorkspace: boolean;
 };
@@ -35,16 +32,12 @@ export type ShellConfig = {
 /* ------------------------------------------------------------------ */
 
 export const DEFAULT_SHELL_CONFIG: ShellConfig = {
-  appName: "OpenWork",
   statusBar: true,
-  sidebar: true,
   docsButton: true,
   feedbackButton: true,
   cloudSignin: true,
-  welcomePage: true,
   starterCards: true,
   modelPicker: true,
-  browser: true,
   addWorkspace: true,
 };
 
@@ -54,7 +47,7 @@ export const DEFAULT_SHELL_CONFIG: ShellConfig = {
 
 const STORAGE_KEY = "openwork.shell-config";
 
-function readShellConfig(): ShellConfig {
+export function readShellConfig(): ShellConfig {
   if (typeof window === "undefined") return DEFAULT_SHELL_CONFIG;
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-settings-screen.tsx
@@ -162,6 +162,16 @@ export function OrgSettingsScreen() {
   const [allowZenModelEnabled, setAllowZenModelEnabled] = useState(true);
   const [allowMultipleWorkspacesEnabled, setAllowMultipleWorkspacesEnabled] =
     useState(true);
+  // Category A: UI customization overrides (undefined = no override, true = show, false = hide)
+  const [uiOverrides, setUiOverrides] = useState<Record<string, boolean | undefined>>({
+    showStatusBar: undefined,
+    showDocsButton: undefined,
+    showFeedbackButton: undefined,
+    showCloudSignin: undefined,
+    showStarterCards: undefined,
+    showModelPicker: undefined,
+    showAddWorkspace: undefined,
+  });
   const [domainEditModeEnabled, setDomainEditModeEnabled] = useState(false);
   const [desktopVersionOptions, setDesktopVersionOptions] = useState<string[]>(
     [],
@@ -228,6 +238,17 @@ export function OrgSettingsScreen() {
       orgContext.organization.desktopAppRestrictions.blockMultipleWorkspaces !==
         true,
     );
+    // Load Category A UI overrides from existing restrictions
+    const r = orgContext.organization.desktopAppRestrictions as Record<string, unknown>;
+    setUiOverrides({
+      showStatusBar: typeof r.showStatusBar === "boolean" ? r.showStatusBar : undefined,
+      showDocsButton: typeof r.showDocsButton === "boolean" ? r.showDocsButton : undefined,
+      showFeedbackButton: typeof r.showFeedbackButton === "boolean" ? r.showFeedbackButton : undefined,
+      showCloudSignin: typeof r.showCloudSignin === "boolean" ? r.showCloudSignin : undefined,
+      showStarterCards: typeof r.showStarterCards === "boolean" ? r.showStarterCards : undefined,
+      showModelPicker: typeof r.showModelPicker === "boolean" ? r.showModelPicker : undefined,
+      showAddWorkspace: typeof r.showAddWorkspace === "boolean" ? r.showAddWorkspace : undefined,
+    });
     setDomainEditModeEnabled(false);
   }, [orgContext]);
 
@@ -400,6 +421,10 @@ export function OrgSettingsScreen() {
           ...(!allowMultipleWorkspacesEnabled
             ? { blockMultipleWorkspaces: true }
             : {}),
+          // Category A: UI customization overrides (only include keys that are explicitly set)
+          ...Object.fromEntries(
+            Object.entries(uiOverrides).filter(([, v]) => typeof v === "boolean"),
+          ),
         },
         ...(desktopVersionOptions.length > 0
           ? {
@@ -643,6 +668,59 @@ export function OrgSettingsScreen() {
                 onChange={setAllowMultipleWorkspacesEnabled}
               />
             </div>
+          </div>
+        </DenCard>
+
+        <DenCard size="spacious" className="grid gap-6">
+          <div className="grid gap-2">
+            <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+              Desktop app
+            </p>
+            <h2 className="text-[24px] font-semibold tracking-[-0.04em] text-gray-900">
+              UI customization
+            </h2>
+            <p className="text-[14px] text-gray-500">
+              Override layout preferences for all users in this organization.
+              Unset options let users choose for themselves.
+            </p>
+          </div>
+
+          <div className="grid gap-4">
+            {([
+              { key: "showStatusBar", label: "Status bar", desc: "Bottom bar with connection status, docs, and feedback links." },
+              { key: "showDocsButton", label: "Documentation link", desc: "Docs button in the status bar." },
+              { key: "showFeedbackButton", label: "Feedback button", desc: "Feedback link in the status bar." },
+              { key: "showCloudSignin", label: "Cloud sign-in prompt", desc: "Sign-in button shown to unauthenticated users." },
+              { key: "showStarterCards", label: "Task suggestions", desc: "Starter task cards in empty sessions." },
+              { key: "showModelPicker", label: "Model picker", desc: "Model selection in the composer." },
+              { key: "showAddWorkspace", label: "New workspace button", desc: "Button to create or join workspaces." },
+            ] as const).map(({ key, label, desc }) => (
+              <div key={key} className="flex items-start justify-between gap-4 rounded-[24px] border border-gray-200 bg-white px-5 py-4">
+                <div className="grid gap-1 pr-4">
+                  <p className="text-[15px] font-medium text-gray-900">{label}</p>
+                  <p className="text-[13px] text-gray-500">{desc}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {/* Three-state: unset (user decides), show, hide */}
+                  <select
+                    className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-[13px] text-gray-700 focus:border-gray-400 focus:outline-none disabled:opacity-50"
+                    disabled={!isOwner}
+                    value={uiOverrides[key] === undefined ? "unset" : uiOverrides[key] ? "show" : "hide"}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      setUiOverrides((prev) => ({
+                        ...prev,
+                        [key]: val === "unset" ? undefined : val === "show",
+                      }));
+                    }}
+                  >
+                    <option value="unset">User decides</option>
+                    <option value="show">Always show</option>
+                    <option value="hide">Always hide</option>
+                  </select>
+                </div>
+              </div>
+            ))}
           </div>
         </DenCard>
 

--- a/packages/types/src/den/desktop-app-restrictions.ts
+++ b/packages/types/src/den/desktop-app-restrictions.ts
@@ -1,9 +1,22 @@
 import { z } from "zod"
 
 export const desktopAppRestrictionsSchema = z.object({
+  // Category B: Org-level policies (cloud-only, not user-togglable)
   disallowNonCloudModels: z.boolean().optional(),
   blockZenModel: z.boolean().optional(),
   blockMultipleWorkspaces: z.boolean().optional(),
+  blockSettingsAccess: z.boolean().optional(),
+  restrictExtensions: z.boolean().optional(),
+
+  // Category A: UI customization overrides (cloud overrides local user prefs)
+  // When set, these take precedence over the user's local toggle.
+  showStatusBar: z.boolean().optional(),
+  showDocsButton: z.boolean().optional(),
+  showFeedbackButton: z.boolean().optional(),
+  showCloudSignin: z.boolean().optional(),
+  showStarterCards: z.boolean().optional(),
+  showModelPicker: z.boolean().optional(),
+  showAddWorkspace: z.boolean().optional(),
 }).meta({ ref: "DenDesktopAppRestrictions" })
 
 export type DesktopAppRestrictions = z.infer<typeof desktopAppRestrictionsSchema>
@@ -44,11 +57,16 @@ function normalizeAllowedDesktopVersions(value: unknown): string[] | undefined {
 export function normalizeDesktopAppRestrictions(value: unknown): DesktopAppRestrictions {
   const parsed = desktopAppRestrictionsSchema.safeParse(value)
   if (parsed.success) {
-    return {
-      ...(parsed.data.disallowNonCloudModels === true ? { disallowNonCloudModels: true } : {}),
-      ...(parsed.data.blockZenModel === true ? { blockZenModel: true } : {}),
-      ...(parsed.data.blockMultipleWorkspaces === true ? { blockMultipleWorkspaces: true } : {}),
+    // Only emit keys that are explicitly set (not undefined).
+    // Boolean `true` keys are restrictions/overrides; boolean `false`
+    // keys are explicit "allow" signals from the org.
+    const result: DesktopAppRestrictions = {}
+    for (const [key, val] of Object.entries(parsed.data)) {
+      if (val !== undefined) {
+        (result as Record<string, unknown>)[key] = val
+      }
     }
+    return result
   }
 
   const legacy = value as {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,11 @@
       "development": "./src/react/index.ts",
       "default": "./src/react/index.ts"
     },
+    "./react/customization": {
+      "types": "./src/react/customization/index.ts",
+      "development": "./src/react/customization/index.ts",
+      "default": "./src/react/customization/index.ts"
+    },
     "./solid": {
       "types": "./src/solid/index.ts",
       "development": "./src/solid/index.ts",

--- a/packages/ui/src/react/customization/index.ts
+++ b/packages/ui/src/react/customization/index.ts
@@ -1,0 +1,6 @@
+export { ToggleRow } from "./toggle-row";
+export type { ToggleRowProps } from "./toggle-row";
+export { PolicyRow } from "./policy-row";
+export type { PolicyRowProps } from "./policy-row";
+export { ThreeStateSelect } from "./three-state-select";
+export type { ThreeStateSelectProps, ThreeStateValue } from "./three-state-select";

--- a/packages/ui/src/react/customization/policy-row.tsx
+++ b/packages/ui/src/react/customization/policy-row.tsx
@@ -1,0 +1,27 @@
+/** @jsxImportSource react */
+
+export type PolicyRowProps = {
+  label: string;
+  description: string;
+  active: boolean;
+};
+
+export function PolicyRow({ label, description, active }: PolicyRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-neutral-100 dark:text-neutral-100">{label}</div>
+        <div className="text-xs text-neutral-400 dark:text-neutral-400">{description}</div>
+      </div>
+      <span
+        className={`shrink-0 rounded-full px-2.5 py-0.5 text-[11px] font-medium ${
+          active
+            ? "bg-amber-900/40 text-amber-400 dark:bg-amber-900/40 dark:text-amber-400"
+            : "bg-green-900/40 text-green-400 dark:bg-green-900/40 dark:text-green-400"
+        }`}
+      >
+        {active ? "Restricted" : "Allowed"}
+      </span>
+    </div>
+  );
+}

--- a/packages/ui/src/react/customization/three-state-select.tsx
+++ b/packages/ui/src/react/customization/three-state-select.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource react */
+
+export type ThreeStateValue = "unset" | "show" | "hide";
+
+export type ThreeStateSelectProps = {
+  label: string;
+  description: string;
+  value: ThreeStateValue;
+  onChange: (value: ThreeStateValue) => void;
+  disabled?: boolean;
+};
+
+export function ThreeStateSelect({
+  label,
+  description,
+  value,
+  onChange,
+  disabled,
+}: ThreeStateSelectProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-neutral-100 dark:text-neutral-100">{label}</div>
+        <div className="text-xs text-neutral-400 dark:text-neutral-400">{description}</div>
+      </div>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as ThreeStateValue)}
+        disabled={disabled}
+        className={`shrink-0 rounded-md border border-neutral-700 bg-neutral-800 px-2 py-1 text-xs text-neutral-200 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 ${
+          disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+        }`}
+      >
+        <option value="unset">User decides</option>
+        <option value="show">Always show</option>
+        <option value="hide">Always hide</option>
+      </select>
+    </div>
+  );
+}

--- a/packages/ui/src/react/customization/toggle-row.tsx
+++ b/packages/ui/src/react/customization/toggle-row.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource react */
+
+export type ToggleRowProps = {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  locked?: boolean;
+  lockedHint?: string;
+  nested?: boolean;
+};
+
+export function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+  locked,
+  lockedHint,
+  nested,
+}: ToggleRowProps) {
+  return (
+    <div className={`flex items-center justify-between gap-4 ${nested ? "ml-6" : ""}`}>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <div className="text-sm font-medium text-neutral-100 dark:text-neutral-100">{label}</div>
+          {locked ? (
+            <span className="inline-flex items-center gap-1 rounded-md bg-neutral-800 px-1.5 py-0.5 text-[10px] font-medium text-neutral-400 dark:bg-neutral-800 dark:text-neutral-400">
+              Managed
+            </span>
+          ) : null}
+        </div>
+        <div className="text-xs text-neutral-400 dark:text-neutral-400">{description}</div>
+        {locked && lockedHint ? (
+          <div className="mt-0.5 text-[10px] text-neutral-500 dark:text-neutral-500">{lockedHint}</div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={locked}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+          locked ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+        } ${checked ? "bg-neutral-100 dark:bg-neutral-100" : "bg-neutral-700 dark:bg-neutral-700"}`}
+        onClick={() => !locked && onChange(!checked)}
+      >
+        <span
+          className={`inline-block size-3.5 rounded-full bg-neutral-900 dark:bg-neutral-900 transition-transform ${
+            checked ? "translate-x-[18px]" : "translate-x-[3px]"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/react/index.ts
+++ b/packages/ui/src/react/index.ts
@@ -15,3 +15,10 @@ export { PaperGrainGradient } from "./paper/grain-gradient"
 export type { PaperGrainGradientProps } from "./paper/grain-gradient"
 export { PaperMeshGradient } from "./paper/mesh-gradient"
 export type { PaperMeshGradientProps } from "./paper/mesh-gradient"
+export { ToggleRow, PolicyRow, ThreeStateSelect } from "./customization"
+export type {
+  ToggleRowProps,
+  PolicyRowProps,
+  ThreeStateSelectProps,
+  ThreeStateValue,
+} from "./customization"


### PR DESCRIPTION
## Summary

Unifies the two separate customization systems (localStorage ShellConfig + Den DesktopConfig) into a single `EffectiveConfigProvider` where **cloud always takes precedence**.

### Architecture

```
User local prefs (localStorage)  ──┐
                                    ├── EffectiveConfigProvider ──▶ useEffectiveConfig()
Cloud org config (Den API)       ──┘
```

- **Category A** (UI visibility): user-togglable locally, overridable by cloud. When cloud sets a value, toggle is locked with "Managed by your organization" badge.
- **Category B** (org policies): cloud-only, shown as read-only indicators.

### Changes

**New files:**
- `apps/app/src/react-app/shell/effective-config.tsx` — `EffectiveConfigProvider` + `useEffectiveConfig` hook
- `apps/app/src/app/defaults/` — model defaults (from previous PR, included in branch)

**Shared types (`packages/types`):**
- Added Category A cloud override keys to `desktopAppRestrictionsSchema`: `showStatusBar`, `showDocsButton`, `showFeedbackButton`, `showCloudSignin`, `showStarterCards`, `showModelPicker`, `showAddWorkspace`
- Added future Category B keys: `blockSettingsAccess`, `restrictExtensions`
- Updated `normalizeDesktopAppRestrictions` to pass through all explicitly-set keys

**Removed dead config:**
- `appName` — whitelabeling, removed
- `sidebar` toggle — sidebar is always on, collapsible via standard UI
- `browser` toggle — browser panel is hidden by default, shown on click

**Migrated consumers:**
- `session-page.tsx` → `useEffectiveConfig()` for `statusBar`
- `status-bar.tsx` → `useEffectiveConfig()` for `cloudSignin`, `docsButton`, `feedbackButton`
- `session-surface.tsx` → `useEffectiveConfig()` for `starterCards`
- `composer.tsx` → `useEffectiveConfig()` for `modelPicker` (now actually gated!)

**Rewritten customization page (`shell-view.tsx`):**
- Section 1: "Layout" — 7 toggles, each lockable by cloud override
- Section 2: "Organization policies" — read-only indicators for `disallowNonCloudModels`, `blockZenModel`, `blockMultipleWorkspaces` + link to Den dashboard
- Removed SVG wireframe preview, branding section, sidebar/browser toggles

### Server-side (Omar)

No API changes required. The `GET /v1/me/desktop-config` endpoint already returns the raw `desktop_app_restrictions` JSON column. When Omar adds the new keys to the DB (via the new `desktop_app_policies` table or existing org column), they flow through automatically.