### PR TITLE
feat(desktop): add native main menu

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -41,6 +41,7 @@ import { StatusBar, type StatusBarProps } from "./status-bar";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { useReactRenderWatchdog } from "../../../shell/react-render-watchdog";
 import { useShellConfig } from "../../../shell/shell-config";
+import { useUiStateStore } from "../../../shell/ui-state-store";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
@@ -182,6 +183,12 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
 
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
+  const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
+  const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
+  const browserPanelOpen = useUiStateStore((state) => state.browserPanelOpen);
+  const openBrowserPanel = useUiStateStore((state) => state.openBrowserPanel);
+  const closeBrowserPanel = useUiStateStore((state) => state.closeBrowserPanel);
+  const toggleBrowserPanel = useUiStateStore((state) => state.toggleBrowserPanel);
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -199,9 +206,7 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
   const [todoExpanded, setTodoExpanded] = useState(true);
-  const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
   const browserPanelRef = usePanelRef();
-  const toggleBrowserPanel = useCallback(() => setBrowserPanelOpen((p) => !p), []);
 
   // Sync browser panel state with Electron main process IPC events.
   // When the agent calls a built-in browser tool, the main process opens
@@ -212,10 +217,10 @@ export function SessionPage(props: SessionPageProps) {
     if (!isElectronRuntime()) return;
     const browser = (window as Window).__OPENWORK_ELECTRON__?.browser;
     if (!browser) return;
-    const unsubOpen = browser.onPanelOpened?.(() => setBrowserPanelOpen(true));
-    const unsubClose = browser.onPanelClosed?.(() => setBrowserPanelOpen(false));
+    const unsubOpen = browser.onPanelOpened?.(openBrowserPanel);
+    const unsubClose = browser.onPanelClosed?.(closeBrowserPanel);
     return () => { unsubOpen?.(); unsubClose?.(); };
-  }, []);
+  }, [closeBrowserPanel, openBrowserPanel]);
   const {
     leftSidebarResizing,
     leftSidebarWidth,
@@ -365,7 +370,8 @@ export function SessionPage(props: SessionPageProps) {
   return (
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text mac:bg-transparent">
       <SidebarProvider
-        defaultOpen={shellConfig.sidebar}
+        open={sidebarOpen}
+        onOpenChange={setSidebarOpen}
         className={cn(
           "relative min-h-0 flex-1 mac:bg-transparent",
           leftSidebarResizing &&
@@ -736,7 +742,7 @@ export function SessionPage(props: SessionPageProps) {
                   maxSize="70%"
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"
                 >
-                  <BrowserPanel onClose={toggleBrowserPanel} />
+                  <BrowserPanel onClose={closeBrowserPanel} />
                 </ResizablePanel>
               </>
             ) : null}

--- a/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/shell-view.tsx
@@ -21,6 +21,7 @@ import {
   LayoutStack,
 } from "../settings-layout";
 import { useShellConfig, DEFAULT_SHELL_CONFIG, type ShellConfig } from "../../../shell/shell-config";
+import { useUiStateStore } from "../../../shell/ui-state-store";
 
 /* ------------------------------------------------------------------ */
 /*  Interactive wireframe preview                                      */
@@ -222,10 +223,17 @@ function ToggleRow(props: ToggleRowProps) {
 
 export function ShellCustomizationView() {
   const { config, update, reset } = useShellConfig();
+  const applicationMenuVisible = useUiStateStore((state) => state.applicationMenuVisible);
+  const setApplicationMenuVisible = useUiStateStore((state) => state.setApplicationMenuVisible);
 
   const isDefault = (Object.keys(DEFAULT_SHELL_CONFIG) as (keyof ShellConfig)[]).every(
     (key) => config[key] === DEFAULT_SHELL_CONFIG[key],
-  );
+  ) && !applicationMenuVisible;
+
+  const resetAll = () => {
+    reset();
+    setApplicationMenuVisible(false);
+  };
 
   return (
     <LayoutStack>
@@ -343,6 +351,14 @@ export function ShellCustomizationView() {
         />
 
         <ToggleRow
+          label="Display menu bar"
+          description="Show the native desktop menu bar."
+          checked={applicationMenuVisible}
+          onChange={setApplicationMenuVisible}
+          className="hidden windows:flex linux:flex"
+        />
+
+        <ToggleRow
           label="Display new workspace button"
           description="Let users create or join additional workspaces."
           checked={config.addWorkspace}
@@ -412,7 +428,7 @@ export function ShellCustomizationView() {
         <Button
           variant="outline"
           size="sm"
-          onClick={reset}
+          onClick={resetAll}
           disabled={isDefault}
         >
           <RotateCcw size={12} />

--- a/apps/app/src/react-app/shell/app-menu.tsx
+++ b/apps/app/src/react-app/shell/app-menu.tsx
@@ -1,0 +1,26 @@
+/** @jsxImportSource react */
+import { useEffect, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useUiStateStore } from "./ui-state-store";
+
+const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
+const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
+
+export function AppMenuProvider({ children }: { children: ReactNode }) {
+  const navigate = useNavigate();
+  const toggleSidebar = useUiStateStore((state) => state.toggleSidebar);
+
+  useEffect(() => {
+    const openSettings = () => navigate("/settings/general");
+
+    window.addEventListener(NATIVE_MENU_OPEN_SETTINGS_EVENT, openSettings);
+    window.addEventListener(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, toggleSidebar);
+    return () => {
+      window.removeEventListener(NATIVE_MENU_OPEN_SETTINGS_EVENT, openSettings);
+      window.removeEventListener(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, toggleSidebar);
+    };
+  }, [navigate, toggleSidebar]);
+
+  return <>{children}</>;
+}

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -13,6 +13,7 @@ import { useDesktopFontZoomBehavior } from "./font-zoom";
 import { LoadingOverlay } from "./loading-overlay";
 import { DevProfiler, DevProfilerOverlay } from "./dev-profiler";
 import { ReactRenderWatchdogOverlay } from "./react-render-watchdog-overlay";
+import { AppMenuProvider } from "./app-menu";
 import { OpenworkControlProvider, OpenworkRouteControlActions } from "./control/control-provider";
 import { SessionRoute } from "./session-route";
 import { SettingsRoute } from "./settings-route";
@@ -128,6 +129,7 @@ export function AppRoot() {
     <>
       <DevProfiler id="AppRoot">
         <ShellConfigProvider>
+        <AppMenuProvider>
         <OpenworkControlProvider>
           <OpenworkRouteControlActions />
           <DenSigninGate>
@@ -211,6 +213,7 @@ export function AppRoot() {
             </Routes>
           </DenSigninGate>
         </OpenworkControlProvider>
+        </AppMenuProvider>
         </ShellConfigProvider>
         <LoadingOverlay />
       </DevProfiler>

--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -1,0 +1,162 @@
+import { create } from "zustand";
+
+export const PERSISTED_UI_STATE_KEY = "openwork:ui-state:v1";
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+
+export type PersistedUiState = {
+  sidebarOpen: boolean;
+  browserPanelOpen?: boolean;
+  applicationMenuVisible?: boolean;
+};
+
+export type UiState = {
+  sidebarOpen: boolean;
+  browserPanelOpen: boolean;
+  applicationMenuVisible: boolean;
+};
+
+const initialState: UiState = {
+  sidebarOpen: true,
+  browserPanelOpen: false,
+  applicationMenuVisible: false,
+};
+
+function readSidebarCookieOpen(): boolean | null {
+  if (globalThis.window === undefined) {
+    return null;
+  }
+
+  const prefix = `${SIDEBAR_COOKIE_NAME}=`;
+  const cookie = window.document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(prefix));
+
+  if (!cookie) {
+    return null;
+  }
+
+  return cookie.slice(prefix.length) === "true";
+}
+
+function readPersistedUiState(): UiState {
+  if (globalThis.window === undefined) {
+    return initialState;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(PERSISTED_UI_STATE_KEY);
+    
+    if (!raw) {
+      const sidebarOpen = readSidebarCookieOpen();
+
+      if (sidebarOpen === null) {
+        return initialState;
+      }
+
+      return { ...initialState, sidebarOpen };
+    }
+
+    const parsed: PersistedUiState = JSON.parse(raw);
+    const browserPanelOpen = parsed.browserPanelOpen ?? initialState.browserPanelOpen;
+    const applicationMenuVisible = parsed.applicationMenuVisible ?? initialState.applicationMenuVisible;
+
+    return {
+      ...initialState,
+      sidebarOpen: parsed.sidebarOpen,
+      browserPanelOpen,
+      applicationMenuVisible,
+    };
+  } catch {
+    return initialState;
+  }
+}
+
+export function persistUiState(state: UiState): void {
+  if (globalThis.window === undefined) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      PERSISTED_UI_STATE_KEY,
+      JSON.stringify({
+        sidebarOpen: state.sidebarOpen,
+        browserPanelOpen: state.browserPanelOpen,
+        applicationMenuVisible: state.applicationMenuVisible,
+      } satisfies PersistedUiState),
+    );
+  } catch {
+    return;
+  }
+}
+
+export function setSidebarOpen(state: UiState, open: boolean): UiState {
+  if (state.sidebarOpen === open) {
+    return state;
+  }
+
+  return {
+    ...state,
+    sidebarOpen: open,
+  };
+}
+
+export function toggleSidebar(state: UiState): UiState {
+  return setSidebarOpen(state, !state.sidebarOpen);
+}
+
+export function setBrowserPanelOpen(state: UiState, open: boolean): UiState {
+  if (state.browserPanelOpen === open) {
+    return state;
+  }
+
+  return {
+    ...state,
+    browserPanelOpen: open,
+  };
+}
+
+export function toggleBrowserPanel(state: UiState): UiState {
+  return setBrowserPanelOpen(state, !state.browserPanelOpen);
+}
+
+export function setApplicationMenuVisible(state: UiState, visible: boolean): UiState {
+  if (state.applicationMenuVisible === visible) {
+    return state;
+  }
+
+  return {
+    ...state,
+    applicationMenuVisible: visible,
+  };
+}
+
+function syncApplicationMenuVisible(visible: boolean): void {
+  void globalThis.window?.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setApplicationMenuVisible", visible);
+}
+
+type UiStateStore = UiState & {
+  setSidebarOpen: (open: boolean) => void;
+  toggleSidebar: () => void;
+  openBrowserPanel: () => void;
+  closeBrowserPanel: () => void;
+  toggleBrowserPanel: () => void;
+  setApplicationMenuVisible: (visible: boolean) => void;
+};
+
+export const useUiStateStore = create<UiStateStore>((set) => ({
+  ...readPersistedUiState(),
+  setSidebarOpen: (open) => set((state) => setSidebarOpen(state, open)),
+  toggleSidebar: () => set((state) => toggleSidebar(state)),
+  openBrowserPanel: () => set((state) => setBrowserPanelOpen(state, true)),
+  closeBrowserPanel: () => set((state) => setBrowserPanelOpen(state, false)),
+  toggleBrowserPanel: () => set((state) => toggleBrowserPanel(state)),
+  setApplicationMenuVisible: (visible) => {
+    set((state) => setApplicationMenuVisible(state, visible));
+    syncApplicationMenuVisible(visible);
+  },
+}));
+
+syncApplicationMenuVisible(useUiStateStore.getState().applicationMenuVisible);
+
+useUiStateStore.subscribe((state) => persistUiState(state));

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -18,7 +18,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, WebContentsView, dialog, ipcMain, nativeImage, nativeTheme, shell } from "electron";
+import { app, BrowserWindow, Menu, WebContentsView, dialog, ipcMain, nativeImage, nativeTheme, shell } from "electron";
 import { registerMigrationIpc } from "./migration.mjs";
 import { startBrowserMcpServers } from "./browser-mcp.mjs";
 import { createRuntimeManager } from "./runtime.mjs";
@@ -31,6 +31,8 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
+const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
+const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 const TAURI_APP_IDENTIFIER = "com.differentai.openwork";
 const DEV_APP_IDENTIFIER = "com.differentai.openwork.dev";
 const DESKTOP_PROTOCOL_SCHEME = "openwork";
@@ -39,6 +41,7 @@ const APP_NAME = isDevMode ? "OpenWork - Dev" : "OpenWork";
 const APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
 const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
 const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
+const DOCS_PAGE_URL = "https://openworklabs.com/docs";
 
 // Production Electron shares the same on-disk state folder as the Tauri shell
 // so in-place migration is a no-op for almost every file. Dev mode uses the
@@ -238,6 +241,7 @@ const DEFAULT_DEN_BASE_URL = "https://app.openworklabs.com";
 const DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:4096";
 const FORCE_DESKTOP_REQUIRE_SIGNIN = envFlagEnabled("OPENWORK_FORCE_SIGNIN");
 const DEFAULT_DESKTOP_REQUIRE_SIGNIN = FORCE_DESKTOP_REQUIRE_SIGNIN;
+let applicationMenuVisible = process.platform === "darwin";
 
 function envFlagEnabled(name) {
   const value = process.env[name]?.trim().toLowerCase();
@@ -340,6 +344,154 @@ const BROWSER_DEFAULT_URL = "https://www.google.com";
 function sendToRenderer(channel, payload) {
   if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return;
   try { mainWindow.webContents.send(channel, payload); } catch { /* window closing */ }
+}
+
+async function openSettingsFromNativeMenu() {
+  const win = await createMainWindow();
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  win.webContents.send(NATIVE_MENU_OPEN_SETTINGS_EVENT);
+}
+
+async function toggleSidebarFromNativeMenu() {
+  const win = await createMainWindow();
+  win.webContents.send(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT);
+}
+
+function installApplicationMenu() {
+  const isMac = process.platform === "darwin";
+  /** @type {import("electron").MenuItemConstructorOptions[]} */
+  const template = [
+    ...(isMac
+      ? [
+          {
+            label: APP_NAME,
+            submenu: [
+              { role: "about" },
+              { type: "separator" },
+              {
+                label: "Settings...",
+                accelerator: "Command+,",
+                click: () => {
+                  void openSettingsFromNativeMenu();
+                },
+              },
+              { type: "separator" },
+              { role: "services" },
+              { type: "separator" },
+              { role: "hide" },
+              { role: "hideOthers" },
+              { role: "unhide" },
+              { type: "separator" },
+              { role: "quit" },
+            ],
+          },
+        ]
+      : []),
+    {
+      label: "File",
+      submenu: [
+        { role: "close" },
+      ],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        ...(isMac
+          ? [
+              { role: "pasteAndMatchStyle" },
+              { role: "delete" },
+              { role: "selectAll" },
+              { type: "separator" },
+              {
+                label: "Speech",
+                submenu: [
+                  { role: "startSpeaking" },
+                  { role: "stopSpeaking" },
+                ],
+              },
+            ]
+          : [
+              { role: "delete" },
+              { type: "separator" },
+              { role: "selectAll" },
+            ]),
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        {
+          label: "Toggle Sidebar",
+          accelerator: "CommandOrControl+B",
+          click: () => {
+            void toggleSidebarFromNativeMenu();
+          },
+        },
+        { type: "separator" },
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "resetZoom" },
+        { role: "zoomIn" },
+        { role: "zoomOut" },
+        { type: "separator" },
+        { role: "togglefullscreen" },
+      ],
+    },
+    {
+      label: "Window",
+      submenu: [
+        { role: "minimize" },
+        { role: "zoom" },
+        ...(isMac
+          ? [
+              { type: "separator" },
+              { role: "front" },
+              { type: "separator" },
+              { role: "window" },
+            ]
+          : [
+              { role: "close" },
+            ]),
+      ],
+    },
+    {
+      role: "help",
+      submenu: [
+        {
+          label: "Docs",
+          click: async () => {
+            await shell.openExternal(DOCS_PAGE_URL);
+          },
+        },
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+function applyApplicationMenuVisibility(window) {
+  if (process.platform === "darwin") return;
+  window.setAutoHideMenuBar(false);
+  window.setMenuBarVisibility(applicationMenuVisible);
+}
+
+function setApplicationMenuVisible(visible) {
+  applicationMenuVisible = visible === true;
+  for (const window of BrowserWindow.getAllWindows()) {
+    applyApplicationMenuVisibility(window);
+  }
+  return applicationMenuVisible;
 }
 
 function createBrowserView() {
@@ -1973,6 +2125,8 @@ async function handleDesktopInvoke(event, command, ...args) {
     }
     case "__setNativeTheme":
       return applyNativeTheme(String(args[0]));
+    case "__setApplicationMenuVisible":
+      return setApplicationMenuVisible(args[0]);
     case "getBrowserMcpPorts":
       return browserMcpPorts
         ? { builtinPort: browserMcpPorts.builtinPort, externalPort: browserMcpPorts.externalPort }
@@ -2151,6 +2305,7 @@ async function createMainWindow() {
       sandbox: false,
     },
   });
+  applyApplicationMenuVisibility(mainWindow);
 
   if (isDevMode) {
     mainWindow.on("page-title-updated", (event) => {
@@ -2271,6 +2426,7 @@ if (!app.requestSingleInstanceLock()) {
   });
 
   app.whenReady().then(async () => {
+    installApplicationMenu();
     await installReactDevToolsForDev();
     await runtimeManager.prepareFreshRuntime().catch(() => undefined);
 

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -1,6 +1,8 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
+const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
+const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 
 function normalizePlatform(value) {
   if (value === "darwin" || value === "linux") return value;
@@ -114,6 +116,16 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
 ipcRenderer.on(NATIVE_DEEP_LINK_EVENT, (_event, urls) => {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent(NATIVE_DEEP_LINK_EVENT, { detail: urls }));
+});
+
+ipcRenderer.on(NATIVE_MENU_OPEN_SETTINGS_EVENT, () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(NATIVE_MENU_OPEN_SETTINGS_EVENT));
+});
+
+ipcRenderer.on(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT));
 });
 
 if (!applyShellDocumentMarkers() && typeof document !== "undefined") {


### PR DESCRIPTION
## Summary
- Adds a native Electron application menu with standard File/Edit/View/Window/Help actions.
- Adds menu actions for opening Settings, toggling the sidebar, and opening Docs.
- Bridges native menu events through preload into React via window events.
- Adds `AppMenuProvider` to handle those events in React and navigate to settings or toggle the sidebar.
- Adds a persisted Zustand UI state store for sidebar, browser panel, and application menu visibility.
- Updates `SessionPage` to use persisted UI state for sidebar/browser panel visibility instead of local state.
- Adds a Shell settings toggle for showing the native menu bar on Windows/Linux.
- Adds Electron support for applying menu bar visibility through `__setApplicationMenuVisible`; macOS keeps the native app menu visible by default.

## Manual verification
1. Requires restart for menu to changes