### PR TITLE
docs: Atomic Chat integration and openwork-atomic-chat-mcp

### DIFF
--- a/packages/atomic-chat-mcp/index.mjs
+++ b/packages/atomic-chat-mcp/index.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+/**
+ * openwork-atomic-chat-mcp
+ *
+ * Stdio MCP server that exposes tools calling [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat)'s
+ * OpenAI-compatible HTTP API. Atomic Chat itself is an MCP *client* in its UI; this package is a small *server*
+ * so OpenCode / OpenWork agents can invoke Atomic-backed completions alongside the session model.
+ *
+ * Prerequisites: Atomic Chat running with the local API (default `http://localhost:1337/v1`).
+ *
+ * Environment:
+ *   ATOMIC_CHAT_BASE_URL — default `http://localhost:1337/v1`
+ *   ATOMIC_CHAT_API_KEY  — optional `Authorization: Bearer …` if your Atomic build requires a key
+ *
+ * OpenCode / OpenWork (workspace `.config/opencode/opencode.json` or root `opencode.jsonc`):
+ *   "mcp": {
+ *     "atomic-chat": {
+ *       "type": "local",
+ *       "command": ["npx", "-y", "openwork-atomic-chat-mcp"],
+ *       "environment": {
+ *         "ATOMIC_CHAT_BASE_URL": "http://localhost:1337/v1"
+ *       }
+ *     }
+ *   }
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const DEFAULT_BASE = "http://localhost:1337/v1";
+const REQUEST_TIMEOUT_MS = 180_000;
+
+function baseUrl() {
+  return (process.env.ATOMIC_CHAT_BASE_URL || DEFAULT_BASE).trim().replace(/\/+$/, "");
+}
+
+function authHeaders() {
+  const key = process.env.ATOMIC_CHAT_API_KEY?.trim();
+  if (!key) return {};
+  return { Authorization: `Bearer ${key}` };
+}
+
+async function atomicFetch(path, { method = "GET", body } = {}) {
+  const url = `${baseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+  try {
+    const response = await fetch(url, {
+      method,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      headers: {
+        ...authHeaders(),
+        ...(body ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    const text = await response.text();
+    let parsed;
+    try {
+      parsed = text ? JSON.parse(text) : {};
+    } catch {
+      return {
+        ok: false,
+        error: `Non-JSON response (${response.status}): ${text.slice(0, 500)}`,
+      };
+    }
+    if (!response.ok) {
+      const msg = parsed?.error?.message || parsed?.message || JSON.stringify(parsed);
+      return { ok: false, error: `HTTP ${response.status}: ${msg}` };
+    }
+    return { ok: true, data: parsed };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Request to ${url} failed: ${err.message}. Is Atomic Chat running? See https://github.com/AtomicBot-ai/Atomic-Chat`,
+    };
+  }
+}
+
+const server = new McpServer({
+  name: "openwork-atomic-chat",
+  version: "0.1.0",
+});
+
+server.tool(
+  "atomic_list_models",
+  "List models available from Atomic Chat's OpenAI-compatible API. Use the returned `id` as `model` in atomic_chat_completion.",
+  {},
+  async () => {
+    const result = await atomicFetch("/models");
+    if (!result.ok) {
+      return { content: [{ type: "text", text: result.error }], isError: true };
+    }
+    const models = result.data?.data;
+    if (!Array.isArray(models)) {
+      return {
+        content: [{ type: "text", text: `Unexpected payload: ${JSON.stringify(result.data).slice(0, 800)}` }],
+        isError: true,
+      };
+    }
+    const lines = models.map((m) => `${m.id}${m.id !== m.name && m.name ? ` (${m.name})` : ""}`);
+    return {
+      content: [
+        {
+          type: "text",
+          text: lines.length ? lines.join("\n") : "No models returned. Open Atomic Chat and load a model.",
+        },
+      ],
+    };
+  }
+);
+
+server.tool(
+  "atomic_chat_completion",
+  "Run a non-streaming chat completion via Atomic Chat (isolated from the main OpenWork session LLM). Use for a second local opinion, summarization, or long-running local generation.",
+  {
+    model: z.string().describe("Model id from atomic_list_models"),
+    messages: z
+      .array(
+        z.object({
+          role: z.enum(["system", "user", "assistant"]),
+          content: z.string(),
+        })
+      )
+      .min(1)
+      .describe("Chat messages; typically end with a user message"),
+    temperature: z.number().optional().describe("Sampling temperature"),
+    max_tokens: z.number().optional().describe("Max tokens to generate"),
+  },
+  async ({ model, messages, temperature, max_tokens }) => {
+    const body = {
+      model,
+      messages,
+      stream: false,
+      ...(temperature !== undefined ? { temperature } : {}),
+      ...(max_tokens !== undefined ? { max_tokens } : {}),
+    };
+    const result = await atomicFetch("/chat/completions", { method: "POST", body });
+    if (!result.ok) {
+      return { content: [{ type: "text", text: result.error }], isError: true };
+    }
+    const choice = result.data?.choices?.[0];
+    const content = choice?.message?.content;
+    if (typeof content === "string" && content.length > 0) {
+      return { content: [{ type: "text", text: content }] };
+    }
+    return {
+      content: [{ type: "text", text: JSON.stringify(result.data, null, 2).slice(0, 12_000) }],
+    };
+  }
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/atomic-chat-mcp/package.json
+++ b/packages/atomic-chat-mcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "openwork-atomic-chat-mcp",
+  "version": "0.1.0",
+  "description": "MCP bridge to Atomic Chat OpenAI-compatible local API (localhost:1337) for OpenCode / OpenWork",
+  "author": "OpenWork <support@openworklabs.com>",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "openwork-atomic-chat-mcp": "index.mjs"
+  },
+  "files": [
+    "index.mjs"
+  ],
+  "scripts": {
+    "check": "node --check index.mjs",
+    "test": "node --check index.mjs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/different-ai/openwork.git",
+    "directory": "packages/atomic-chat-mcp"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.76"
+  }
+}

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -27,6 +27,7 @@
               "start-here/connect-your-stack/sign-in-with-chatgpt",
               "start-here/connect-your-stack/add-anthropic-api-key",
               "start-here/connect-your-stack/add-a-custom-llm",
+              "start-here/connect-your-stack/atomic-chat",
               "start-here/connect-your-stack/add-an-mcp-server",
               "start-here/connect-your-stack/enable-exa-search"
             ]

--- a/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
@@ -56,4 +56,10 @@ Pull the model first with `ollama pull qwen3:8b`, then make sure the Ollama serv
 
 Open your desktop, change the provider name and voila! You have an fully local LLM running in your machine.
 
+### Functional example: Atomic Chat
+
+[Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) exposes an OpenAI-compatible API at `http://localhost:1337/v1` by default. Use the same `@ai-sdk/openai-compatible` pattern with that `baseURL`, then set `"model": "atomic-chat/<model-id>"` for ids returned by Atomic (see `GET /v1/models` or the in-app model list).
+
+The OpenWork desktop reads workspace **`opencode.jsonc` / `opencode.json` in the project root** when listing models; if you only see OpenCode Zen, add the provider there (you can mirror the same JSON under `.config/opencode/opencode.json` for OpenCode CLI). See [Atomic Chat (local LLM)](/start-here/connect-your-stack/atomic-chat) for the full flow, including optional MCP tools via `openwork-atomic-chat-mcp`.
+
 For teams, you can manage the provider in OpenWork Cloud under [LLM Providers](/cloud/share-with-your-team/managed-llm-provider), then import it into each workspace from `Settings -> Cloud`.

--- a/packages/docs/start-here/connect-your-stack/atomic-chat.mdx
+++ b/packages/docs/start-here/connect-your-stack/atomic-chat.mdx
@@ -1,0 +1,95 @@
+---
+title: "Atomic Chat (local LLM)"
+description: "Use Atomic Chat as your OpenWork session model and as MCP tools for side completions"
+---
+
+[Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) runs local (or hybrid) models and exposes an **OpenAI-compatible** HTTP API at `http://localhost:1337/v1` by default. OpenWork is built on OpenCode, so you can combine:
+
+1. **Session provider** — the same API powers your main agent model.
+2. **MCP tools** — optional one-off completions via the `openwork-atomic-chat-mcp` bridge (Atomic Chat is an MCP *client* in its own UI; it does not expose an MCP server for OpenWork, so this small package calls its HTTP API instead).
+
+## Prerequisites
+
+- [Atomic Chat](https://atomic.chat/) installed and running.
+- Local server reachable (see their README): `http://localhost:1337/v1`.
+
+## Where to put config (important)
+
+- **OpenCode upstream** recommends workspace **`.config/opencode/opencode.json`** for provider entries.
+- **OpenWork** also resolves project config from **`opencode.jsonc`** or **`opencode.json` in the workspace root** (and `.opencode/` variants) when syncing providers with the app. If you only see **OpenCode Zen** in the model picker, add the provider block to **root `opencode.jsonc`** (or `opencode.json`) in the folder you opened as the workspace, then reload the engine or restart OpenWork.
+
+You can keep the same JSON in **both** places if you use OpenCode CLI and OpenWork together.
+
+## 1. Provider for OpenWork sessions
+
+Add a provider block and pick a model id that Atomic lists (often the same string you see in the Atomic UI).
+
+Use `@ai-sdk/openai-compatible` and point `baseURL` at Atomic’s `/v1` root:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "atomic-chat": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Atomic Chat",
+      "options": {
+        "baseURL": "http://localhost:1337/v1"
+      },
+      "models": {
+        "your-model-id": {
+          "name": "Your model (Atomic Chat)"
+        }
+      }
+    }
+  },
+  "model": "atomic-chat/your-model-id"
+}
+```
+
+Replace `your-model-id` with a real id from Atomic Chat (for example after loading a model in the app, or from `GET http://localhost:1337/v1/models`).
+
+If your Atomic build requires an API key for the local server, add the same fields you use for other OpenAI-compatible providers (see [Add a custom LLM](/start-here/connect-your-stack/add-a-custom-llm)).
+
+## 2. MCP: extra Atomic-backed completions
+
+npm package **`openwork-atomic-chat-mcp`** (source: [`packages/atomic-chat-mcp`](https://github.com/different-ai/openwork/tree/dev/packages/atomic-chat-mcp) in this repo). It registers:
+
+- `atomic_list_models` — lists models from Atomic’s `/v1/models`.
+- `atomic_chat_completion` — non-streaming `POST /v1/chat/completions` for a one-off reply (useful when the primary session model is cloud but you want a local pass, or a second opinion).
+
+Add to the same OpenCode config (merge with your existing `mcp` block):
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "atomic-chat": {
+      "type": "local",
+      "command": ["npx", "-y", "openwork-atomic-chat-mcp"],
+      "enabled": true,
+      "environment": {
+        "ATOMIC_CHAT_BASE_URL": "http://localhost:1337/v1"
+      }
+    }
+  }
+}
+```
+
+Optional: set `ATOMIC_CHAT_API_KEY` in `environment` if your Atomic instance expects `Authorization: Bearer …`.
+
+If `npx -y openwork-atomic-chat-mcp` is not available yet (before the package is published to npm), point `command` at the script in your clone, for example `"command": ["node", "/path/to/openwork/packages/atomic-chat-mcp/index.mjs"]` after `pnpm install` in the OpenWork repo.
+
+From a prompt you can steer the agent explicitly, for example: *“List models with atomic_list_models, then answer X using atomic_chat_completion with model …”.* See [OpenCode MCP docs](https://opencode.ai/docs/mcp-servers/) for `enabled`, timeouts, and per-agent tool toggles.
+
+## Troubleshooting
+
+- **`atomic_list_models` errors** — Atomic Chat is not running, the API port differs from `1337`, or a firewall blocks localhost.
+- **Only OpenCode Zen in the model list** — put the provider JSON in **workspace root** `opencode.jsonc` / `opencode.json`, then restart OpenWork or reload the OpenCode engine.
+- **Session model fails but MCP works (or the reverse)** — confirm `baseURL` matches exactly (including `/v1`) and model ids match `/v1/models`.
+- **Large context from MCP** — each enabled MCP adds tool definitions to context; keep `atomic-chat` disabled globally and enable only for specific [agents](https://opencode.ai/docs/agents#tools) if you hit limits.
+
+## Related
+
+- [Add a custom LLM](/start-here/connect-your-stack/add-a-custom-llm) — same `provider` pattern as Ollama, different `baseURL`.
+- [Add an MCP server](/start-here/connect-your-stack/add-an-mcp-server) — UI flow for remote MCP; local Atomic bridge uses the JSON above.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -743,6 +743,15 @@ importers:
         specifier: ^5.5.4
         version: 5.9.3
 
+  packages/atomic-chat-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+
   packages/email:
     dependencies:
       '@react-email/components':


### PR DESCRIPTION
Add npm package `openwork-atomic-chat-mcp` (stdio MCP) that calls Atomic Chat OpenAI-compatible API for `atomic_list_models` and `atomic_chat_completion`.

Document session provider setup, MCP wiring, and that OpenWork reads root `opencode.jsonc` / `opencode.json` for the model picker so custom providers appear alongside OpenCode Zen.

Link new doc from `add-a-custom-llm` and docs navigation.

## Summary
- Adds `packages/atomic-chat-mcp` published as **`openwork-atomic-chat-mcp`**: stdio MCP server that proxies to Atomic Chat’s OpenAI-compatible HTTP API (`GET /v1/models`, non-streaming `POST /v1/chat/completions`).
- Adds docs page **`start-here/connect-your-stack/atomic-chat.mdx`**: session LLM via `@ai-sdk/openai-compatible`, optional MCP block, env vars (`ATOMIC_CHAT_BASE_URL`, `ATOMIC_CHAT_API_KEY`), troubleshooting.
- Documents that the **OpenWork desktop** resolves workspace config from **root `opencode.jsonc` / `opencode.json`** (in addition to upstream `.config/opencode/opencode.json` guidance), so custom providers show in the model picker instead of only OpenCode Zen.
- Links the new page from **`add-a-custom-llm.mdx`** and **`packages/docs/docs.json`** navigation.
- Updates **`pnpm-lock.yaml`** for the new workspace package.

## Why
- Atomic Chat is a local-first OpenAI-compatible desktop stack used for local LLM workflows.
- OpenWork users expect a supported path for local OpenAI-compatible providers.
- Atomic Chat itself acts as an MCP client in-app, not a stdio MCP server for OpenWork.
- A lightweight MCP bridge provides a clean integration path without runtime changes.

## Scope
- New package: `openwork-atomic-chat-mcp` (`atomic_list_models`, `atomic_chat_completion`).
- Docs + navigation + cross-link from custom LLM guide.
- Lockfile update for the new workspace dependency.

## Out of scope
- npm publishing/release
- OpenWork runtime resolution changes
- Atomic Chat application/runtime changes
- CORS or context auto-growth behavior

## Testing
### Ran
- `node --check packages/atomic-chat-mcp/index.mjs`
- `npx pnpm@10.27.0 install --filter openwork-atomic-chat-mcp --no-frozen-lockfile`

### Result

```
Lockfile is up to date, resolution step is skipped
Done in 232ms using pnpm v10.27.0
```

## CI status

## Manual verification
1. Start Atomic Chat with local API at `http://127.0.0.1:1337/v1` and note a model id from `GET /v1/models`.
2. Open a workspace in OpenWork; add provider JSON to **root** `opencode.jsonc` (and/or `.config/opencode/opencode.json`); restart/reload engine.
3. Confirm the model appears in the picker and a short chat completes.
4. (Optional) Add MCP stanza pointing `command` at `node …/packages/atomic-chat-mcp/index.mjs` until npm publish; verify tools list includes `atomic_list_models` / `atomic_chat_completion`.

## Evidence
`node packages/atomic-chat-mcp/index.mjs`

## Risk
-Low risk.
-Runtime behavior is unchanged unless users opt into the MCP integration.
-Changes are isolated to docs and a new optional package.
Potential follow-up:
-npm package name availability verification during publish step.

## Rollback
- Revert the single commit / remove `packages/atomic-chat-mcp` and revert docs + lockfile + navigation edits.