### PR TITLE
chore(den): soft-disable skill hubs and shared workspaces

### DIFF
--- a/ee/apps/den-api/src/routes/workers/core.ts
+++ b/ee/apps/den-api/src/routes/workers/core.ts
@@ -181,13 +181,13 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
     describeRoute({
       tags: ["Workers"],
       summary: "Create worker",
-      description: "Creates a local worker or shared cloud workspace for the active organization and returns the initial tokens needed to connect to it.",
+      description: "Creates a local worker or cloud worker for the active organization and returns the initial tokens needed to connect to it.",
       responses: {
         201: jsonResponse("Local worker created successfully.", workerCreateResponseSchema),
         202: jsonResponse("Cloud worker creation started successfully.", workerCreateResponseSchema),
         400: jsonResponse("The worker creation payload was invalid.", z.union([invalidRequestSchema, organizationUnavailableSchema, workspacePathRequiredSchema, userEmailRequiredSchema])),
         401: jsonResponse("The caller must be signed in to create workers.", unauthorizedSchema),
-        402: jsonResponse("The caller needs an active cloud plan before launching a shared workspace.", paymentRequiredSchema),
+        402: jsonResponse("The caller needs an active cloud plan before launching a cloud worker.", paymentRequiredSchema),
         409: jsonResponse("The organization has reached its worker limit.", orgLimitReachedSchema),
       },
     }),
@@ -222,7 +222,7 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
       if (!access.allowed) {
         return c.json({
           error: "payment_required",
-          message: "Launching a shared workspace requires an active OpenWork Cloud plan.",
+          message: "Launching a cloud worker requires an active OpenWork Cloud plan.",
           polar: {
             checkoutUrl: access.checkoutUrl,
             productId: env.polar.productId,

--- a/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/checkout-screen.tsx
@@ -27,9 +27,9 @@ function CheckoutStatusPanel({ body }: { body: string }) {
         <div className="flex flex-col gap-4 lg:max-w-3xl">
           <div className="grid gap-3">
             <p className="den-eyebrow">OpenWork Cloud</p>
-            <h1 className="den-title-xl max-w-[14ch]">Shared workspace billing.</h1>
+            <h1 className="den-title-xl max-w-[14ch]">Workspace billing.</h1>
             <p className="den-copy max-w-2xl">
-              Den is free for solo setup. Billing appears only when launching a shared cloud workspace.
+              Den is free for solo setup. Billing appears when you need team features or cloud hosting.
             </p>
           </div>
 
@@ -214,9 +214,9 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
         <div className="flex flex-col gap-4 lg:max-w-3xl">
           <div className="grid gap-3">
             <p className="den-eyebrow">OpenWork Cloud</p>
-            <h1 className="den-title-xl max-w-[14ch]">Purchase a plan before launching a shared workspace.</h1>
+            <h1 className="den-title-xl max-w-[14ch]">Purchase a plan to unlock team features.</h1>
             <p className="den-copy max-w-2xl">
-              Den is free for solo setup. Shared cloud workspaces require a workspace plan with up to 5 members and 1 hosted worker.
+              Den is free for solo setup. A workspace plan gives you up to 5 members, custom LLM providers, and team management.
             </p>
           </div>
 
@@ -271,21 +271,21 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
 
               <div className="grid gap-3 text-sm text-[var(--dls-text-secondary)]">
                 <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Share setup across your team and org</div>
-                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Background agents in alpha for selected workflows</div>
                 <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Custom LLM providers with team access controls</div>
+                <div className="flex gap-3"><span className="mt-2 h-1.5 w-1.5 rounded-full bg-slate-300" />Background tasks — coming soon</div>
               </div>
 
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="den-frame-inset rounded-[1.5rem] p-4">
-                  <p className="den-stat-label">Background agents</p>
-                  <p className="mt-3 text-sm text-[var(--dls-text-secondary)]">
-                    Keep selected workflows running in the background. Alpha.
-                  </p>
-                </div>
-                <div className="den-frame-inset rounded-[1.5rem] p-4">
                   <p className="den-stat-label">LLM providers</p>
                   <p className="mt-3 text-sm text-[var(--dls-text-secondary)]">
                     Standardize provider access, model selection, and team rollout.
+                  </p>
+                </div>
+                <div className="den-frame-inset rounded-[1.5rem] p-4">
+                  <p className="den-stat-label">Background tasks</p>
+                  <p className="mt-3 text-sm text-[var(--dls-text-secondary)]">
+                    Run selected workflows in the background. Coming soon.
                   </p>
                 </div>
               </div>
@@ -319,7 +319,7 @@ export function CheckoutScreen({ customerSessionToken }: { customerSessionToken:
               <p className="den-eyebrow">Billing status</p>
               <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">{subscriptionStatus}</h2>
               <p className="den-copy text-sm">
-                {billingSummary.hasActivePlan ? "Your workspace plan is active." : "Purchase a plan to launch shared workspaces."}
+                {billingSummary.hasActivePlan ? "Your workspace plan is active." : "Purchase a plan to unlock team features."}
               </p>
             </div>
 

--- a/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/dashboard-screen.tsx
@@ -558,7 +558,7 @@ export function DashboardScreen({ showSidebar = true }: { showSidebar?: boolean 
                     {billingSummary?.featureGateEnabled
                       ? billingSummary.hasActivePlan
                         ? "Your account has active worker billing."
-                        : "Shared workspace launches require a workspace plan."
+                        : "Team features require a workspace plan."
                       : "Billing gates are disabled in this environment."}
                   </p>
                   <Link
@@ -575,12 +575,12 @@ export function DashboardScreen({ showSidebar = true }: { showSidebar?: boolean 
           <div className="rounded-[24px] border border-[var(--dls-border)] bg-[var(--dls-surface)] p-8">
             <div className="mx-auto max-w-[30rem] text-center">
               <h2 className="text-2xl font-semibold tracking-tight text-[var(--dls-text-primary)]">No workers yet</h2>
-              <p className="mt-3 text-sm leading-6 text-[var(--dls-text-secondary)]">Launch a shared workspace to unlock connection details and runtime controls.</p>
+              <p className="mt-3 text-sm leading-6 text-[var(--dls-text-secondary)]">Launch a worker to unlock connection details and runtime controls.</p>
               <Link
                 href="/checkout"
                 className="mt-5 inline-flex rounded-[12px] border border-[var(--dls-border)] bg-[var(--dls-surface)] px-3 py-2 text-xs font-semibold text-[var(--dls-text-secondary)] transition hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)]"
               >
-                Open shared workspace billing
+                Open billing
               </Link>
             </div>
           </div>
@@ -659,7 +659,7 @@ export function DashboardScreen({ showSidebar = true }: { showSidebar?: boolean 
 
             {workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">Loading workers...</p> : null}
             {workersError ? <p className="text-xs font-medium text-rose-600">{workersError}</p> : null}
-            {workers.length === 0 && !workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">No shared workspaces yet.</p> : null}
+            {workers.length === 0 && !workersBusy ? <p className="text-xs text-[var(--dls-text-secondary)]">No workers yet.</p> : null}
           </div>
 
             <div className="text-xs text-[var(--dls-text-secondary)] md:text-sm">

--- a/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/organization-screen.tsx
@@ -152,7 +152,7 @@ export function OrganizationScreen() {
                     Create your first organization.
                   </h1>
                   <p className="mt-3 max-w-xl text-sm leading-6 text-gray-500">
-                    Name the workspace you want to set up. Billing only appears when you launch a shared cloud workspace.
+                    Name the workspace you want to set up. Billing only appears when you need team features or cloud hosting.
                   </p>
                 </div>
               </div>

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/background-agents-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/background-agents-screen.tsx
@@ -407,8 +407,8 @@ export function BackgroundAgentsScreen() {
     <DashboardPageTemplate
       icon={Bot}
       badgeLabel="Alpha"
-      title="Shared Workspaces"
-      description="Keep selected workflows running in the background without asking each teammate to run them locally."
+      title="Background Tasks"
+      description="Run selected workflows in the background without asking each teammate to run them locally. Coming soon."
       colors={["#E9FFE0", "#3E9A1D", "#B3F750", "#51F0A3"]}
     >
       <OrgLimitDialog

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/org-dashboard-shell.tsx
@@ -107,7 +107,7 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
     return "API Keys";
   }
   if (pathname.startsWith(getBackgroundAgentsRoute(orgSlug))) {
-    return "Shared Workspaces";
+    return "Background Tasks";
   }
   if (pathname.startsWith(getCustomLlmProvidersRoute(orgSlug))) {
     return "LLM Providers";
@@ -164,22 +164,24 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
       label: "Dashboard",
       icon: Home,
     },
-    {
-      href: activeOrg ? getBackgroundAgentsRoute(activeOrg.slug) : "#",
-      label: "Shared Workspace",
-      icon: Bot,
-      badge: "Alpha",
-    },
+    // NOTE: Shared Workspace soft-disabled — uncomment to re-enable
+    // {
+    //   href: activeOrg ? getBackgroundAgentsRoute(activeOrg.slug) : "#",
+    //   label: "Shared Workspace",
+    //   icon: Bot,
+    //   badge: "Alpha",
+    // },
     {
       href: activeOrg ? getCustomLlmProvidersRoute(activeOrg.slug) : "#",
       label: "LLM Providers",
       icon: Cpu,
     },
-    {
-      href: activeOrg ? getSkillHubsRoute(activeOrg.slug) : "#",
-      label: "Skill Hubs",
-      icon: BookOpen,
-    },
+    // NOTE: Skill Hubs soft-disabled — uncomment to re-enable
+    // {
+    //   href: activeOrg ? getSkillHubsRoute(activeOrg.slug) : "#",
+    //   label: "Skill Hubs",
+    //   icon: BookOpen,
+    // },
     {
       href: activeOrg ? getIntegrationsRoute(activeOrg.slug) : "#",
       label: "Integrations",


### PR DESCRIPTION
## Summary

- **Sidebar nav**: Commented out "Skill Hubs" and "Shared Workspace" nav items in the org dashboard shell (easy to re-enable)
- **Marketing copy**: Renamed "Shared Workspaces" → "Background Tasks (coming soon)" across checkout, dashboard, background-agents, and organization screens
- **API messages**: Replaced "shared workspace" with "cloud worker" in den-api 402 payment-required responses
- **Billing framing**: Reframed checkout and billing copy around "team features" instead of "shared workspaces"

## Files changed

| File | Change |
|---|---|
| `org-dashboard-shell.tsx` | Commented out Skill Hubs + Shared Workspace nav items; page title → "Background Tasks" |
| `checkout-screen.tsx` | Hero, subtitle, feature list, and billing sidebar copy updated |
| `dashboard-screen.tsx` | Billing text, empty state, CTA, sidebar copy updated |
| `background-agents-screen.tsx` | Title → "Background Tasks", description → "Coming soon" |
| `organization-screen.tsx` | Onboarding copy updated |
| `den-api/.../workers/core.ts` | 402 error messages updated |

## Evidence

### Build verification
- `pnpm --filter @openwork-ee/den-web build` — **passed**

### UI verification
- No UI stack booted (copy-only changes); all changes are string literals
- Console errors: n/a
- Failed network requests: n/a

## Test instructions

1. `pnpm dev:den`
2. Sign in and navigate to the org dashboard
3. Verify "Skill Hubs" and "Shared Workspace" are gone from the sidebar
4. Navigate to `/checkout` — verify no "shared workspace" language remains
5. Navigate to `/organization` — verify onboarding copy says "team features or cloud hosting"