### PR TITLE
feat: CDP browser tools — direct OpenCode tools, no MCP, multi-target

### DIFF
--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: run-evals
+description: Run OpenWork UI evals on a Daytona sandbox or local Electron instance. Handles sandbox creation, service startup, and eval execution via CDP browser tools.
+---
+
+# Skill: Run Evals
+
+Run the OpenWork UI evaluation flows against a real Electron app — either on a Daytona cloud sandbox or a local instance.
+
+## When to use
+
+- User says "run evals on Daytona" or "run this flow on Daytona"
+- User wants to verify a UI change end-to-end
+- User wants to test the onboarding, session, or settings flows
+
+## Prerequisites
+
+- `daytona` CLI installed and logged in (`daytona login`)
+- Using the "Different AI" org (`daytona organization use "Different AI"`)
+- The `.devcontainer/` files exist in the repo
+
+## Workflow
+
+### Step 1: Create sandbox (if not running)
+
+Check for existing sandbox first:
+
+```bash
+daytona list
+```
+
+If no `openwork-test` sandbox, create one:
+
+```bash
+daytona create \
+  --name openwork-test \
+  --dockerfile .devcontainer/Dockerfile \
+  --context .devcontainer/Dockerfile \
+  --context .devcontainer/start-display.sh \
+  --context .devcontainer/start-services.sh \
+  --class large \
+  --memory 8 \
+  --auto-stop 60 \
+  --public \
+  --target us
+```
+
+### Step 2: Start services
+
+```bash
+daytona exec openwork-test 'bash /workspace/.devcontainer/start-services.sh'
+```
+
+Wait for it to start (this runs in background, may timeout — that's OK).
+
+### Step 3: Verify
+
+```bash
+# Get CDP URL
+daytona preview-url openwork-test -p 9825
+```
+
+Then use the browser tools to verify:
+
+```
+browser_list({ browser_url: "<CDP_URL>" })
+→ should show "OpenWork" page target
+```
+
+### Step 4: Create a workspace (if on welcome page)
+
+If the app shows the Welcome page, create a workspace:
+
+1. Create directory on sandbox:
+   ```bash
+   daytona exec openwork-test 'mkdir -p /workspace/hello'
+   ```
+
+2. Follow the workspace creation flow from `evals/daytona-flows.md` Flow 1:
+   - Click "Get started" → "Local workspace"
+   - Inject path via React fiber dispatch: `{ key: "selectedFolder", value: "/workspace/hello" }`
+   - Click "Create Workspace"
+   - Wait 10s for opencode sidecar to boot
+
+### Step 5: Run the requested eval
+
+Read the eval file from `evals/` and execute each step using the browser tools.
+
+For each step:
+1. Execute the `browser_evaluate` / `browser_click` / `browser_screenshot` call
+2. Verify the expected outcome
+3. Report pass/fail
+
+### Key techniques
+
+**Clicking buttons:**
+```
+browser_evaluate({ browser_url: URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.indexOf('BUTTON_TEXT') !== -1) { btns[i].click(); return 'clicked'; } } return 'not found'; })()" })
+```
+
+**Typing in Lexical editors:**
+```
+browser_evaluate({ browser_url: URL, expression: "(function() { var e = document.querySelector('[contenteditable=true]'); e.focus(); document.execCommand('insertText', false, 'YOUR TEXT'); return 'typed'; })()" })
+```
+
+**Injecting folder path (bypass native picker):**
+Use the `__reactFiber$` → `CreateWorkspaceModal` reducer dispatch with `{ key: "selectedFolder", value: "/path" }`. Full code in `evals/daytona-flows.md` Flow 1 Step 5.
+
+**Checking page state:**
+```
+browser_evaluate({ browser_url: URL, expression: "document.body.innerText.substring(0, 500)" })
+```
+
+**Screenshots:**
+```
+browser_screenshot({ browser_url: URL })
+```
+
+### Teardown
+
+```bash
+daytona stop openwork-test    # preserves state for re-runs
+daytona delete openwork-test  # full cleanup
+```

--- a/.opencode/tools/browser.ts
+++ b/.opencode/tools/browser.ts
@@ -1,0 +1,280 @@
+/**
+ * Browser control tools — direct CDP, no MCP, multi-target.
+ *
+ * Every tool takes a `browser_url` (e.g. "http://127.0.0.1:9825")
+ * and optionally a `target_id`. No hidden state, no singleton browser.
+ *
+ * Usage in opencode:
+ *   browser_list     — list all page targets on a browser
+ *   browser_navigate — navigate a target to a URL
+ *   browser_snapshot — get accessibility tree with UIDs
+ *   browser_click    — click an element by snapshot UID
+ *   browser_fill     — fill an input by snapshot UID
+ *   browser_eval     — evaluate JS in the page
+ *   browser_screenshot — take a PNG screenshot
+ */
+
+import { tool } from "@opencode-ai/plugin";
+import { listTargets, connectTarget, connectFirstPage } from "./lib/cdp";
+import { takeSnapshot, resolveUid, type Snapshot } from "./lib/snapshot";
+
+// Cache the last snapshot per target so click/fill can resolve UIDs
+const snapshotCache = new Map<string, Snapshot>();
+
+function cacheKey(browserUrl: string, targetId?: string): string {
+  return `${browserUrl}::${targetId ?? "default"}`;
+}
+
+async function getClient(browserUrl: string, targetId?: string) {
+  if (targetId) {
+    const targets = await listTargets(browserUrl);
+    const target = targets.find((t) => t.id === targetId);
+    if (!target) throw new Error(`Target ${targetId} not found`);
+    return { client: await connectTarget(target.webSocketDebuggerUrl), target };
+  }
+  return connectFirstPage(browserUrl);
+}
+
+// ── browser_list ──
+
+export const list = tool({
+  description:
+    "List all page targets (tabs/windows) on a Chrome/Electron instance. " +
+    "Returns target IDs, titles, and URLs. Use browser_url to specify which browser.",
+  args: {
+    browser_url: tool.schema
+      .string()
+      .describe('CDP HTTP endpoint, e.g. "http://127.0.0.1:9825"'),
+  },
+  async execute(args) {
+    const targets = await listTargets(args.browser_url);
+    const pages = targets.filter((t) => t.type === "page");
+    if (pages.length === 0) return "No page targets found.";
+    return pages
+      .map((t) => `[${t.id}] ${t.title}\n  ${t.url}`)
+      .join("\n\n");
+  },
+});
+
+// ── browser_navigate ──
+
+export const navigate = tool({
+  description:
+    "Navigate a browser target to a URL. Returns the new page title after navigation.",
+  args: {
+    browser_url: tool.schema.string().describe("CDP HTTP endpoint"),
+    target_id: tool.schema.string().optional().describe("Target ID (omit for first page)"),
+    url: tool.schema.string().describe("URL to navigate to"),
+  },
+  async execute(args) {
+    const { client, target } = await getClient(args.browser_url, args.target_id);
+    try {
+      await client.send("Page.enable");
+      await client.send("Page.navigate", { url: args.url });
+      // Wait for load
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, 10000);
+        client.on("Page.loadEventFired", () => { clearTimeout(timeout); resolve(); });
+      });
+      const result = await client.send("Runtime.evaluate", {
+        expression: "document.title",
+        returnByValue: true,
+      });
+      const title = (result.result as Record<string, unknown>)?.value as string ?? "";
+      return `Navigated to: ${args.url}\nTitle: ${title}`;
+    } finally {
+      client.close();
+    }
+  },
+});
+
+// ── browser_snapshot ──
+
+export const snapshot = tool({
+  description:
+    "Get an accessibility tree snapshot of the page. Returns a text tree with [uid] markers. " +
+    "Use these UIDs with browser_click and browser_fill.",
+  args: {
+    browser_url: tool.schema.string().describe("CDP HTTP endpoint"),
+    target_id: tool.schema.string().optional().describe("Target ID (omit for first page)"),
+  },
+  async execute(args) {
+    const { client, target } = await getClient(args.browser_url, args.target_id);
+    try {
+      await client.send("Accessibility.enable");
+      const snap = await takeSnapshot(client);
+      snapshotCache.set(cacheKey(args.browser_url, args.target_id), snap);
+      if (!snap.text || snap.text === "(empty page)") {
+        // Fallback: return page text content
+        const result = await client.send("Runtime.evaluate", {
+          expression: "document.body?.innerText?.substring(0, 3000) ?? '(empty)'",
+          returnByValue: true,
+        });
+        return `Page text:\n${(result.result as Record<string, unknown>)?.value ?? "(empty)"}`;
+      }
+      return snap.text;
+    } finally {
+      client.close();
+    }
+  },
+});
+
+// ── browser_click ──
+
+export const click = tool({
+  description:
+    "Click an element on the page identified by its snapshot UID. " +
+    "Take a browser_snapshot first to get UIDs.",
+  args: {
+    browser_url: tool.schema.string().describe("CDP HTTP endpoint"),
+    target_id: tool.schema.string().optional().describe("Target ID"),
+    uid: tool.schema.number().describe("Element UID from the snapshot"),
+  },
+  async execute(args) {
+    const snap = snapshotCache.get(cacheKey(args.browser_url, args.target_id));
+    if (!snap) return "No snapshot cached. Call browser_snapshot first.";
+    const node = resolveUid(snap, args.uid);
+    if (!node) return `UID ${args.uid} not found in snapshot.`;
+
+    const { client } = await getClient(args.browser_url, args.target_id);
+    try {
+      // Resolve the backend node to a remote object
+      const resolved = await client.send("DOM.resolveNode", {
+        backendNodeId: node.backendNodeId,
+      });
+      const objectId = (resolved.object as Record<string, unknown>)?.objectId as string;
+      if (!objectId) return `Could not resolve UID ${args.uid} to a DOM node.`;
+
+      // Get the bounding box
+      const box = await client.send("DOM.getBoxModel", {
+        backendNodeId: node.backendNodeId,
+      });
+      const model = box.model as Record<string, unknown> | undefined;
+      const content = model?.content as number[] | undefined;
+
+      if (content && content.length >= 4) {
+        // Click the center of the element
+        const x = (content[0] + content[2] + content[4] + content[6]) / 4;
+        const y = (content[1] + content[3] + content[5] + content[7]) / 4;
+        await client.send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: "left", clickCount: 1 });
+        await client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+        return `Clicked [${args.uid}] "${node.name}" at (${Math.round(x)}, ${Math.round(y)})`;
+      }
+
+      // Fallback: focus + click via JS
+      await client.send("Runtime.callFunctionOn", {
+        objectId,
+        functionDeclaration: "function() { this.scrollIntoView({block:'center'}); this.click(); }",
+      });
+      return `Clicked [${args.uid}] "${node.name}" via JS fallback`;
+    } finally {
+      client.close();
+    }
+  },
+});
+
+// ── browser_fill ──
+
+export const fill = tool({
+  description:
+    "Fill an input element identified by its snapshot UID with text. " +
+    "Clears existing value first.",
+  args: {
+    browser_url: tool.schema.string().describe("CDP HTTP endpoint"),
+    target_id: tool.schema.string().optional().describe("Target ID"),
+    uid: tool.schema.number().describe("Element UID from the snapshot"),
+    value: tool.schema.string().describe("Text to fill"),
+  },
+  async execute(args) {
+    const snap = snapshotCache.get(cacheKey(args.browser_url, args.target_id));
+    if (!snap) return "No snapshot cached. Call browser_snapshot first.";
+    const node = resolveUid(snap, args.uid);
+    if (!node) return `UID ${args.uid} not found in snapshot.`;
+
+    const { client } = await getClient(args.browser_url, args.target_id);
+    try {
+      const resolved = await client.send("DOM.resolveNode", {
+        backendNodeId: node.backendNodeId,
+      });
+      const objectId = (resolved.object as Record<string, unknown>)?.objectId as string;
+      if (!objectId) return `Could not resolve UID ${args.uid}.`;
+
+      // Focus, clear, then type
+      await client.send("Runtime.callFunctionOn", {
+        objectId,
+        functionDeclaration: `function() {
+          this.focus();
+          this.value = '';
+          this.dispatchEvent(new Event('input', { bubbles: true }));
+        }`,
+      });
+
+      // Type character by character for React compatibility
+      for (const char of args.value) {
+        await client.send("Input.dispatchKeyEvent", { type: "keyDown", text: char });
+        await client.send("Input.dispatchKeyEvent", { type: "keyUp", text: char });
+      }
+
+      return `Filled [${args.uid}] "${node.name}" with "${args.value}"`;
+    } finally {
+      client.close();
+    }
+  },
+});
+
+// ── browser_eval ──
+
+export const evaluate = tool({
+  description:
+    "Evaluate a JavaScript expression in the page and return the result.",
+  args: {
+    browser_url: tool.schema.string().describe("CDP HTTP endpoint"),
+    target_id: tool.schema.string().optional().describe("Target ID"),
+    expression: tool.schema.string().describe("JavaScript expression to evaluate"),
+  },
+  async execute(args) {
+    const { client } = await getClient(args.browser_url, args.target_id);
+    try {
+      const result = await client.send("Runtime.evaluate", {
+        expression: args.expression,
+        returnByValue: true,
+        awaitPromise: true,
+      });
+      if (result.exceptionDetails) {
+        const err = result.exceptionDetails as Record<string, unknown>;
+        return `Error: ${err.text ?? JSON.stringify(err)}`;
+      }
+      const val = (result.result as Record<string, unknown>)?.value;
+      if (val === undefined) return "(undefined)";
+      return typeof val === "string" ? val : JSON.stringify(val, null, 2);
+    } finally {
+      client.close();
+    }
+  },
+});
+
+// ── browser_screenshot ──
+
+export const screenshot = tool({
+  description:
+    "Take a PNG screenshot of the page. Returns the base64-encoded image data.",
+  args: {
+    browser_url: tool.schema.string().describe("CDP HTTP endpoint"),
+    target_id: tool.schema.string().optional().describe("Target ID"),
+  },
+  async execute(args) {
+    const { client } = await getClient(args.browser_url, args.target_id);
+    try {
+      const result = await client.send("Page.captureScreenshot", { format: "png" });
+      const data = result.data as string;
+      if (!data) return "Failed to capture screenshot.";
+      // Write to temp file and return path
+      const path = `/tmp/browser-screenshot-${Date.now()}.png`;
+      const fs = await import("fs");
+      fs.writeFileSync(path, Buffer.from(data, "base64"));
+      return `Screenshot saved: ${path}\n(${Math.round(data.length * 0.75 / 1024)} KB)`;
+    } finally {
+      client.close();
+    }
+  },
+});

--- a/.opencode/tools/lib/cdp.ts
+++ b/.opencode/tools/lib/cdp.ts
@@ -90,7 +90,22 @@ export async function listTargets(browserUrl: string): Promise<Array<{
   const url = browserUrl.replace(/\/$/, "");
   const res = await fetch(`${url}/json/list`);
   if (!res.ok) throw new Error(`Failed to list targets: ${res.status}`);
-  return res.json();
+  const targets = await res.json();
+
+  // CDP returns ws://localhost:PORT/... URLs. When accessing via a proxy
+  // (e.g. Daytona), we need to rewrite them to use the proxy host.
+  const parsed = new URL(url);
+  const isProxy = !["localhost", "127.0.0.1", "0.0.0.0"].includes(parsed.hostname);
+  if (isProxy) {
+    const wsScheme = parsed.protocol === "https:" ? "wss:" : "ws:";
+    for (const target of targets) {
+      if (target.webSocketDebuggerUrl) {
+        const wsPath = new URL(target.webSocketDebuggerUrl).pathname;
+        target.webSocketDebuggerUrl = `${wsScheme}//${parsed.host}${wsPath}`;
+      }
+    }
+  }
+  return targets;
 }
 
 /**

--- a/.opencode/tools/lib/cdp.ts
+++ b/.opencode/tools/lib/cdp.ts
@@ -1,0 +1,114 @@
+/**
+ * Minimal CDP (Chrome DevTools Protocol) client.
+ * Raw WebSocket, no Puppeteer, no dependencies.
+ *
+ * Supports connecting to any Chrome/Electron instance that exposes CDP.
+ */
+
+import WebSocket from "ws";
+
+type CDPResponse = {
+  id: number;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+};
+
+export class CDPClient {
+  private ws: WebSocket | null = null;
+  private id = 0;
+  private pending = new Map<number, { resolve: (v: CDPResponse) => void; reject: (e: Error) => void }>();
+  private eventHandlers = new Map<string, Array<(params: Record<string, unknown>) => void>>();
+
+  constructor(public readonly endpoint: string) {}
+
+  async connect(): Promise<void> {
+    if (this.ws?.readyState === WebSocket.OPEN) return;
+    return new Promise((resolve, reject) => {
+      this.ws = new WebSocket(this.endpoint);
+      this.ws.once("open", () => resolve());
+      this.ws.once("error", (err) => reject(err));
+      this.ws.on("message", (data: Buffer) => {
+        const msg = JSON.parse(data.toString());
+        if (msg.id !== undefined && this.pending.has(msg.id)) {
+          const p = this.pending.get(msg.id)!;
+          this.pending.delete(msg.id);
+          p.resolve(msg);
+        }
+        if (msg.method && this.eventHandlers.has(msg.method)) {
+          for (const handler of this.eventHandlers.get(msg.method)!) {
+            handler(msg.params ?? {});
+          }
+        }
+      });
+      this.ws.on("close", () => { this.ws = null; });
+    });
+  }
+
+  async send(method: string, params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("CDP not connected");
+    }
+    const id = ++this.id;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP timeout: ${method}`));
+      }, 30000);
+      this.pending.set(id, {
+        resolve: (msg) => {
+          clearTimeout(timeout);
+          if (msg.error) reject(new Error(`CDP error: ${msg.error.message}`));
+          else resolve(msg.result ?? {});
+        },
+        reject: (err) => { clearTimeout(timeout); reject(err); },
+      });
+      this.ws!.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  on(event: string, handler: (params: Record<string, unknown>) => void) {
+    if (!this.eventHandlers.has(event)) this.eventHandlers.set(event, []);
+    this.eventHandlers.get(event)!.push(handler);
+  }
+
+  close() {
+    this.ws?.close();
+    this.ws = null;
+  }
+}
+
+/**
+ * Discover targets (pages, iframes, workers) from a CDP HTTP endpoint.
+ */
+export async function listTargets(browserUrl: string): Promise<Array<{
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+}>> {
+  const url = browserUrl.replace(/\/$/, "");
+  const res = await fetch(`${url}/json/list`);
+  if (!res.ok) throw new Error(`Failed to list targets: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Connect to a specific target by its webSocketDebuggerUrl.
+ */
+export async function connectTarget(wsUrl: string): Promise<CDPClient> {
+  const client = new CDPClient(wsUrl);
+  await client.connect();
+  return client;
+}
+
+/**
+ * Connect to the first page target on a browser endpoint.
+ */
+export async function connectFirstPage(browserUrl: string): Promise<{ client: CDPClient; target: { id: string; title: string; url: string } }> {
+  const targets = await listTargets(browserUrl);
+  const page = targets.find((t) => t.type === "page");
+  if (!page) throw new Error("No page target found");
+  const client = await connectTarget(page.webSocketDebuggerUrl);
+  return { client, target: { id: page.id, title: page.title, url: page.url } };
+}

--- a/.opencode/tools/lib/snapshot.ts
+++ b/.opencode/tools/lib/snapshot.ts
@@ -1,0 +1,119 @@
+/**
+ * Accessibility-tree-based page snapshot.
+ * Produces a text representation with UIDs that can be used for click/fill.
+ */
+
+import type { CDPClient } from "./cdp";
+
+export type SnapshotNode = {
+  uid: number;
+  role: string;
+  name: string;
+  value?: string;
+  backendNodeId: number;
+  bounds?: { x: number; y: number; width: number; height: number };
+  children?: SnapshotNode[];
+};
+
+export type Snapshot = {
+  nodes: SnapshotNode[];
+  byUid: Map<number, SnapshotNode>;
+  text: string;
+};
+
+let nextUid = 1;
+
+function walkAXTree(
+  axNode: Record<string, unknown>,
+  allNodes: Record<string, Record<string, unknown>>,
+  byUid: Map<number, SnapshotNode>,
+): SnapshotNode | null {
+  const role = (axNode.role as Record<string, unknown>)?.value as string ?? "";
+  const name = (axNode.name as Record<string, unknown>)?.value as string ?? "";
+  const value = (axNode.value as Record<string, unknown>)?.value as string | undefined;
+  const backendNodeId = axNode.backendDOMNodeId as number ?? 0;
+  const ignored = axNode.ignored as boolean;
+
+  // Skip invisible / ignored nodes with no useful content
+  if (ignored && !name) return null;
+
+  const uid = nextUid++;
+  const children: SnapshotNode[] = [];
+
+  const childIds = axNode.childIds as string[] ?? [];
+  for (const childId of childIds) {
+    const childAx = allNodes[childId];
+    if (!childAx) continue;
+    const childNode = walkAXTree(childAx, allNodes, byUid);
+    if (childNode) children.push(childNode);
+  }
+
+  // Skip generic containers that have no name and only pass-through children
+  if (!name && !value && (role === "generic" || role === "none") && children.length <= 1) {
+    return children[0] ?? null;
+  }
+
+  const node: SnapshotNode = {
+    uid,
+    role,
+    name,
+    ...(value !== undefined ? { value } : {}),
+    backendNodeId,
+    ...(children.length > 0 ? { children } : {}),
+  };
+  byUid.set(uid, node);
+  return node;
+}
+
+function renderTree(nodes: SnapshotNode[], indent = 0): string {
+  const lines: string[] = [];
+  for (const node of nodes) {
+    const pad = "  ".repeat(indent);
+    const parts = [`[${node.uid}]`, node.role];
+    if (node.name) parts.push(`"${node.name}"`);
+    if (node.value) parts.push(`value="${node.value}"`);
+    lines.push(`${pad}${parts.join(" ")}`);
+    if (node.children) {
+      lines.push(renderTree(node.children, indent + 1));
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Take an accessibility tree snapshot of the page.
+ */
+export async function takeSnapshot(client: CDPClient): Promise<Snapshot> {
+  nextUid = 1;
+
+  // Get the full accessibility tree
+  const result = await client.send("Accessibility.getFullAXTree");
+  const axNodes = result.nodes as Array<Record<string, unknown>>;
+
+  if (!axNodes || axNodes.length === 0) {
+    return { nodes: [], byUid: new Map(), text: "(empty page)" };
+  }
+
+  // Index by nodeId
+  const indexed: Record<string, Record<string, unknown>> = {};
+  for (const node of axNodes) {
+    indexed[node.nodeId as string] = node;
+  }
+
+  const byUid = new Map<number, SnapshotNode>();
+  const roots: SnapshotNode[] = [];
+
+  // The first node is typically the root
+  const rootNode = walkAXTree(axNodes[0], indexed, byUid);
+  if (rootNode) roots.push(rootNode);
+
+  const text = renderTree(roots);
+  return { nodes: roots, byUid, text };
+}
+
+/**
+ * Resolve a snapshot UID to a CDP backendNodeId for interaction.
+ */
+export function resolveUid(snapshot: Snapshot, uid: number): SnapshotNode | undefined {
+  return snapshot.byUid.get(uid);
+}

--- a/evals/README.md
+++ b/evals/README.md
@@ -6,7 +6,7 @@ OpenWork instance to verify end-to-end behavior of the UI.
 Each eval is:
 - A short list of steps written in plain English.
 - An **expected outcome** with observable signals.
-- The most useful Chrome DevTools MCP calls to drive it.
+- The CDP browser tool calls to drive it.
 
 They are not unit tests. They intentionally exercise the running stack
 (OpenCode + OpenWork server + React UI) so regressions in wiring — not just
@@ -14,33 +14,74 @@ types — get caught.
 
 ## How to run
 
-1. Start the narrowest supported local app/server stack for the flow under test.
-   Use its web URL and avoid hard-coding default ports unless that stack documents them.
+### Option A: On Daytona (recommended)
 
-2. Pick a runner:
-   - **Chrome DevTools MCP** (recommended). The tool names referenced in each
-     flow are the `chrome-devtools_*` tools from the Chrome DevTools MCP
-     server. Open the printed web URL in a fresh page via
-     `chrome-devtools_new_page` and drive from there.
-   - **Manual browser** — open the URL and follow the step lists by hand.
+Run against a real Electron app in a Daytona cloud sandbox. No local Docker or
+display needed. See [`daytona-flows.md`](./daytona-flows.md) for full details.
 
-3. Walk each eval top-to-bottom. Only mark ✅ when every expected signal is
-   visible. Capture a screenshot with `chrome-devtools_take_screenshot` if you
-   want evidence.
+Quick start:
 
-4. Stop the stack using the teardown command for the stack you started.
+```bash
+# 1. Create sandbox
+daytona create --name openwork-test --dockerfile .devcontainer/Dockerfile \
+  --context .devcontainer/Dockerfile --context .devcontainer/start-display.sh \
+  --context .devcontainer/start-services.sh \
+  --class large --memory 8 --auto-stop 60 --public --target us
+
+# 2. Start services
+daytona exec openwork-test 'bash /workspace/.devcontainer/start-services.sh'
+
+# 3. Get CDP URL
+daytona preview-url openwork-test -p 9825
+# → https://9825-xxx.daytonaproxy01.net
+
+# 4. Run evals using browser_* tools with that URL
+browser_list({ browser_url: "https://9825-xxx.daytonaproxy01.net" })
+```
+
+### Option B: Local Electron
+
+Start the Electron dev app locally:
+
+```bash
+pnpm dev
+```
+
+Wait ~15s, then use the browser tools against `http://127.0.0.1:9825`.
+
+### Option C: Manual browser
+
+Open the app and follow the step lists by hand.
+
+## Tool reference
+
+Evals use the OpenCode browser tools (`.opencode/tools/browser.ts`), not
+Chrome DevTools MCP. Every tool takes `browser_url` as the first argument.
+
+| Tool | Description |
+|------|-------------|
+| `browser_list` | List page targets on the CDP endpoint |
+| `browser_navigate` | Navigate a target to a URL |
+| `browser_snapshot` | Accessibility tree with UIDs |
+| `browser_click` | Click by snapshot UID |
+| `browser_fill` | Fill input by snapshot UID |
+| `browser_evaluate` | Run JS in the page |
+| `browser_screenshot` | Capture PNG |
 
 ## Conventions
 
-- Selectors in the steps are descriptive, not CSS. Resolve them via
-  `chrome-devtools_take_snapshot` and click by `uid`.
-- When asked to "wait for X", use `chrome-devtools_wait_for` with the exact
-  visible text. Keep the text short and unique.
-- If a step expects a connected provider and the stack shows none, note it
-  as an environment limitation, not an eval failure.
+- Use `browser_evaluate` for button clicks and text input — it's more reliable
+  than snapshot UIDs for dynamic React UIs.
+- For Lexical editors, use `document.execCommand('insertText', false, text)`
+  after focusing. Direct DOM manipulation doesn't trigger Lexical state updates.
+- For React state injection (e.g., folder picker bypass), use the
+  `__reactFiber$` → reducer dispatch pattern documented in `daytona-flows.md`.
+- When asked to "wait for X", use `sleep` then `browser_evaluate` to check.
 
 ## Files
 
+- [`daytona-flows.md`](./daytona-flows.md) — Daytona sandbox flows (workspace
+  creation, session messaging, screenshot verification).
 - [`react-session-flows.md`](./react-session-flows.md) — the 9 core
   session/settings flows verified during the React port cutover.
 - [`onboarding-welcome-flows.md`](./onboarding-welcome-flows.md) — the 7

--- a/evals/daytona-flows.md
+++ b/evals/daytona-flows.md
@@ -1,0 +1,209 @@
+# Daytona sandbox flows
+
+End-to-end scenarios that run against a real Electron OpenWork instance in a
+Daytona cloud sandbox. The agent drives the app through CDP browser tools
+(`browser_list`, `browser_evaluate`, `browser_screenshot`, etc.) over the
+Daytona proxy.
+
+## Preflight
+
+### 1. Create the sandbox
+
+```bash
+daytona create \
+  --name openwork-test \
+  --dockerfile .devcontainer/Dockerfile \
+  --context .devcontainer/Dockerfile \
+  --context .devcontainer/start-display.sh \
+  --context .devcontainer/start-services.sh \
+  --class large \
+  --memory 8 \
+  --auto-stop 60 \
+  --public \
+  --target us
+```
+
+### 2. Start services
+
+```bash
+daytona exec openwork-test 'bash /workspace/.devcontainer/start-services.sh'
+```
+
+Wait ~30s for Xvfb + Vite + Electron + opencode sidecar to boot.
+
+### 3. Get the CDP proxy URL
+
+```bash
+daytona preview-url openwork-test -p 9825
+```
+
+This returns something like `https://9825-xxx.daytonaproxy01.net`.
+
+### 4. Verify connectivity
+
+Use the `browser_list` tool:
+
+```
+browser_list({ browser_url: "https://9825-xxx.daytonaproxy01.net" })
+```
+
+Should return the OpenWork page target.
+
+### 5. Verify opencode sidecar
+
+```bash
+daytona exec openwork-test 'ps aux | grep opencode | grep -v grep'
+```
+
+If no opencode process, the workspace hasn't been created yet (expected on fresh sandbox).
+
+---
+
+## Flow 1: Create a local workspace
+
+**Goal:** Create a workspace named "hello" from the Welcome page.
+
+### Steps
+
+1. Create the workspace directory on the sandbox:
+   ```bash
+   daytona exec openwork-test 'mkdir -p /workspace/hello'
+   ```
+
+2. Verify we're on the Welcome page:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "window.location.hash" })
+   → "#/welcome"
+   ```
+
+3. Click "Get started" to expand options:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.indexOf('Get started') !== -1) { btns[i].click(); return 'clicked'; } } return 'not found'; })()" })
+   ```
+
+4. Click "Local workspace":
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.indexOf('Local workspace') !== -1) { btns[i].click(); return 'clicked'; } } return 'not found'; })()" })
+   ```
+
+5. Wait 2s, then inject the folder path into the CreateWorkspaceModal React reducer:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "JSON.stringify((function() { function findFiber(el) { var key = Object.keys(el).find(function(k) { return k.startsWith('__reactFiber$'); }); return key ? el[key] : null; } var spans = document.querySelectorAll('span'); var p = null; for (var i = 0; i < spans.length; i++) { if (spans[i].textContent.indexOf('No folder') !== -1) { p = spans[i]; break; } } if (!p) return {err: 'no placeholder'}; var fiber = findFiber(p); while (fiber) { var name = (fiber.elementType && fiber.elementType.name) || (fiber.type && fiber.type.name) || ''; if (name === 'CreateWorkspaceModal') break; fiber = fiber.return; } if (!fiber) return {err: 'no fiber'}; var hook = fiber.memoizedState; while (hook) { if (hook.queue && hook.queue.dispatch) { hook.queue.dispatch({ key: 'selectedFolder', value: '/workspace/hello' }); hook.queue.dispatch({ key: 'pickingFolder', value: false }); return {ok: true}; } hook = hook.next; } return {err: 'no dispatch'}; })())" })
+   ```
+
+   **Key:** The reducer uses `{ key, value }` action format, NOT direct state replacement.
+
+6. Verify "Create Workspace" is enabled (not disabled):
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.trim() === 'Create Workspace') return btns[i].disabled ? 'DISABLED' : 'ENABLED'; } return 'not found'; })()" })
+   → "ENABLED"
+   ```
+
+7. Click "Create Workspace":
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.trim() === 'Create Workspace' && !btns[i].disabled) { btns[i].click(); return 'clicked'; } } return 'not found'; })()" })
+   ```
+
+8. Wait 10s for workspace creation + opencode sidecar boot.
+
+9. Verify navigation to session page:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "window.location.hash" })
+   → should contain "/session"
+   ```
+
+10. Verify opencode sidecar started:
+    ```bash
+    daytona exec openwork-test 'ps aux | grep opencode | grep -v grep'
+    → should show opencode serve process
+    ```
+
+### Expected outcome
+- URL contains `#/workspace/ws_.../session`
+- Sidebar shows "hello" workspace
+- Status bar shows "OpenWork Ready"
+- opencode process running on a random port
+
+---
+
+## Flow 2: Send a message in a session
+
+**Prerequisite:** Flow 1 completed (workspace exists, opencode running).
+
+### Steps
+
+1. Click a starter card to create a session:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.indexOf('Edit a CSV') !== -1) { btns[i].click(); return 'clicked'; } } return 'not found'; })()" })
+   ```
+
+2. Wait 5s for session creation.
+
+3. Verify session URL:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "window.location.hash" })
+   → should contain "/session/ses_"
+   ```
+
+4. Focus the composer and type a message:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "(function() { var editor = document.querySelector('[contenteditable=true]'); if (!editor) return 'no editor'; editor.focus(); document.execCommand('selectAll', false, null); document.execCommand('insertText', false, 'Hello from Daytona! List the files in the current directory.'); return 'typed'; })()" })
+   ```
+
+   **Key:** Use `document.execCommand('insertText', ...)` for Lexical editors, NOT `textContent =` or `innerHTML =`.
+
+5. Click "Run task":
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "(function() { var btns = document.querySelectorAll('button'); for (var i = 0; i < btns.length; i++) { if (btns[i].textContent.indexOf('Run task') !== -1 && !btns[i].disabled) { btns[i].click(); return 'clicked'; } } return 'not found'; })()" })
+   ```
+
+6. Wait 15s for LLM response.
+
+7. Verify agent response appeared:
+   ```
+   browser_evaluate({ browser_url: CDP_URL, expression: "document.body.innerText.substring(0, 500)" })
+   → should contain the agent's response about directory contents
+   ```
+
+### Expected outcome
+- Session title auto-generated in sidebar
+- Agent response visible in the chat
+- No errors in console
+
+---
+
+## Flow 3: Take a screenshot
+
+```
+browser_screenshot({ browser_url: CDP_URL })
+```
+
+Returns path to a PNG file. Verify it's not empty.
+
+---
+
+## Teardown
+
+```bash
+daytona stop openwork-test    # preserves state
+daytona delete openwork-test  # destroys everything
+```
+
+---
+
+## Troubleshooting
+
+**"Create Workspace" stays disabled after path injection:**
+The reducer uses `{ key, value }` actions. If you dispatched a full state object, it won't work.
+
+**Lexical editor doesn't accept text:**
+Use `document.execCommand('insertText', false, text)` after focusing. Direct `textContent` assignment doesn't trigger Lexical's internal state update.
+
+**opencode sidecar not starting:**
+Check memory. Electron + opencode + Vite needs ~6GB. Use `--memory 8`.
+
+**CDP timeouts:**
+The renderer might be frozen (e.g., a blocking IPC call). Restart Electron:
+```bash
+daytona exec openwork-test 'pkill -f electron; sleep 3; DISPLAY=:99 ELECTRON_DISABLE_SANDBOX=1 OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9825 OPENWORK_DEV_MODE=1 ELECTRON_EXTRA_LAUNCH_ARGS="--disable-gpu" nohup pnpm --filter @openwork/desktop dev:electron > /tmp/electron.log 2>&1 &'
+```


### PR DESCRIPTION
Direct CDP browser control tools for OpenCode. No MCP, no Puppeteer, no npx. Multi-target support. Tested against Daytona sandbox.