### PR TITLE
Fix GitHub Copilot OAuth callback completion

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -105,6 +105,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const providerPollRef = useRef<number | null>(null);
   const oauthAutoPollRef = useRef<number | null>(null);
+  const oauthAutoBusyRef = useRef(false);
   const oauthCodeCopiedResetRef = useRef<number | null>(null);
   const autoOpenedPreferredProviderIdRef = useRef<string | null>(null);
 
@@ -354,6 +355,12 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const isActiveProviderConnected =
     !!activeProviderId && (props.connectedProviderIds ?? []).includes(activeProviderId);
 
+  const closeConnectedOauthView = () => {
+    stopOauthAutoPolling();
+    stopProviderPolling();
+    handleClose();
+  };
+
   const pollProviders = async () => {
     const id = activeProviderId;
     if (!id || pollingBusy) return;
@@ -364,7 +371,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       setPollingBusy(false);
     }
     if ((props.connectedProviderIds ?? []).includes(id)) {
-      handleClose();
+      closeConnectedOauthView();
     }
   };
 
@@ -383,7 +390,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       return;
     }
     if (isActiveProviderConnected) {
-      handleClose();
+      closeConnectedOauthView();
       return;
     }
     startProviderPolling();
@@ -433,14 +440,20 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
   const attemptOauthAutoCompletion = async () => {
     const session = oauthSession;
-    if (!session || oauthAutoBusy) return;
+    if (!session || oauthAutoBusyRef.current) return;
+    oauthAutoBusyRef.current = true;
     setOauthAutoBusy(true);
     try {
-      const result = await submitOauth(session.providerId, session.methodIndex);
+      const result = await submitOauth(
+        session.providerId,
+        session.methodIndex,
+        oauthDisplayCode || undefined,
+      );
       if (result?.connected) {
-        stopOauthAutoPolling();
+        closeConnectedOauthView();
       }
     } finally {
+      oauthAutoBusyRef.current = false;
       setOauthAutoBusy(false);
     }
   };


### PR DESCRIPTION
## Summary
- Fix GitHub Copilot OAuth device login completion in the provider connection modal.
- The automatic callback now includes the displayed OAuth device code.
- OAuth/provider polling is stopped once the provider connects, and overlapping automatic callback attempts are prevented.

## Why
- GitHub device authorization could succeed in the browser, but OpenWork stayed on the confirmation screen because the callback request did not include the device code.

## Issue
- Closes #1754

## Scope
- Updated GitHub Copilot/OAuth auto-completion behavior in the provider auth modal.
- Added an in-flight guard for automatic OAuth callback polling.

## Out of scope
- No provider UI redesign.
- No changes to OpenCode provider APIs.
- No changes to non-OAuth provider setup.

## Testing
### Ran
- `pnpm typecheck`

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: not run locally
- code-related failures: N/A
- external/env/auth blockers: N/A

## Manual verification
1. Opened Settings -> AI Providers.
2. Selected GitHub Copilot from Connect provider.
3. Completed GitHub device auth in the browser.
4. Confirmed the provider modal closed automatically.
5. Confirmed GitHub Copilot appeared in connected providers.
6. Confirmed there was no repeated callback loop.

## Evidence
- Attached screen recording showing the successful GitHub Copilot connection flow.

## Risk
- Low. The change is limited to the provider auth modal OAuth polling flow.

## Rollback
- Revert this PR.

https://github.com/user-attachments/assets/1f923770-fbd5-4532-af02-9ec81d3e9903

