### PR TITLE
fix(billing): allow promo codes for Stripe checkout

### DIFF
--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -41,6 +41,15 @@ function requireInferencePriceId() {
   return env.stripe.inferencePriceId
 }
 
+async function requireInferenceUsdPriceId() {
+  const priceId = requireInferencePriceId()
+  const price = await stripe().prices.retrieve(priceId)
+  if (price.currency.toLowerCase() !== "usd") {
+    throw new Error("stripe_inference_price_must_be_usd")
+  }
+  return price.id
+}
+
 function fromUnixSeconds(value: number | null | undefined) {
   return typeof value === "number" ? new Date(value * 1000) : null
 }
@@ -199,12 +208,13 @@ export async function createInferenceCheckoutSession(input: {
   successUrl: string
   cancelUrl: string
 }) {
-  const priceId = requireInferencePriceId()
+  const priceId = await requireInferenceUsdPriceId()
   const quantity = Math.max(1, await activeMemberCount(input.organizationId))
   const customer = await ensureStripeCustomer(input)
   return stripe().checkout.sessions.create({
     mode: "subscription",
     customer,
+    allow_promotion_codes: true,
     line_items: [{ price: priceId, quantity }],
     success_url: input.successUrl,
     cancel_url: input.cancelUrl,

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -41,15 +41,6 @@ function requireInferencePriceId() {
   return env.stripe.inferencePriceId
 }
 
-async function requireInferenceUsdPriceId() {
-  const priceId = requireInferencePriceId()
-  const price = await stripe().prices.retrieve(priceId)
-  if (price.currency.toLowerCase() !== "usd") {
-    throw new Error("stripe_inference_price_must_be_usd")
-  }
-  return price.id
-}
-
 function fromUnixSeconds(value: number | null | undefined) {
   return typeof value === "number" ? new Date(value * 1000) : null
 }
@@ -208,7 +199,7 @@ export async function createInferenceCheckoutSession(input: {
   successUrl: string
   cancelUrl: string
 }) {
-  const priceId = await requireInferenceUsdPriceId()
+  const priceId = requireInferencePriceId()
   const quantity = Math.max(1, await activeMemberCount(input.organizationId))
   const customer = await ensureStripeCustomer(input)
   return stripe().checkout.sessions.create({


### PR DESCRIPTION
## Summary

- Enable customer-entered Stripe promotion codes for OpenWork Models Checkout.
- Continue relying on the configured Stripe Price for currency, amount, and interval.

## Evidence

### Build verification
- `pnpm --filter @openwork-ee/den-api build` -- passed

### API verification
- No local Stripe Checkout API flow was run; change is limited to the Checkout session creation payload.

### UI verification
- No UI changes.

## Test instructions

1. Configure `STRIPE_SECRET_KEY` and `STRIPE_INFERENCE_PRICE_ID`.
2. Start the Den stack.
3. Begin OpenWork Models billing Checkout from an owner account.
4. Verify Checkout shows the promo code entry affordance.