### PR TITLE
fix(den): update Daytona sandbox pagination

### DIFF
--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@better-auth/api-key": "^1.5.6",
     "@better-auth/oauth-provider": "^1.5.6",
-    "@daytonaio/sdk": "^0.150.0",
+    "@daytonaio/sdk": "^0.173.0",
     "@hono/mcp": "^0.2.5",
     "@hono/node-server": "^1.13.8",
     "@hono/standard-validator": "^0.2.2",

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -22,6 +22,11 @@ type ProvisionedInstance = {
   region?: string
 }
 
+type DaytonaSandboxListPage = {
+  items: Array<{ id?: unknown }>
+  nextCursor?: string | null
+}
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 const maxSignedPreviewExpirySeconds = 60 * 60 * 24
 const signedPreviewRefreshLeadMs = 5 * 60 * 1000
@@ -43,6 +48,72 @@ function createDaytonaClient() {
     apiUrl: env.daytona.apiUrl,
     ...(env.daytona.target ? { target: env.daytona.target } : {}),
   })
+}
+
+function daytonaApiUrl(path: string) {
+  return `${env.daytona.apiUrl.replace(/\/+$/, "")}${path}`
+}
+
+function readDaytonaSandboxListPage(value: unknown): DaytonaSandboxListPage {
+  if (Array.isArray(value)) {
+    return { items: value as Array<{ id?: unknown }> }
+  }
+
+  if (!value || typeof value !== "object") {
+    return { items: [] }
+  }
+
+  const page = value as Record<string, unknown>
+  const items = Array.isArray(page.items)
+    ? page.items
+    : Array.isArray(page.data)
+      ? page.data
+      : Array.isArray(page.sandboxes)
+        ? page.sandboxes
+        : []
+  const nextCursor = typeof page.nextCursor === "string"
+    ? page.nextCursor
+    : typeof page.next_cursor === "string"
+      ? page.next_cursor
+      : null
+
+  return { items: items as Array<{ id?: unknown }>, nextCursor }
+}
+
+async function listDaytonaSandboxIdsByLabels(labels: Record<string, string>) {
+  const ids: string[] = []
+  let cursor: string | undefined
+
+  do {
+    const url = new URL(daytonaApiUrl("/sandbox"))
+    url.searchParams.set("limit", "100")
+    url.searchParams.set("labels", JSON.stringify(labels))
+    if (cursor) {
+      url.searchParams.set("cursor", cursor)
+    }
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${env.daytona.apiKey}`,
+        "X-Daytona-Source": "openwork-den-api",
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(`Daytona sandbox list failed with ${response.status}`)
+    }
+
+    const page = readDaytonaSandboxListPage(await response.json())
+    for (const sandbox of page.items) {
+      if (typeof sandbox.id === "string") {
+        ids.push(sandbox.id)
+      }
+    }
+
+    cursor = page.nextCursor ?? undefined
+  } while (cursor)
+
+  return ids
 }
 
 function normalizedSignedPreviewExpirySeconds() {
@@ -546,13 +617,16 @@ export async function deprovisionWorkerOnDaytona(workerId: WorkerId) {
     return
   }
 
-  const sandboxes = await daytona.list(sandboxLabels(workerId), 1, 20)
+  const sandboxIds = await listDaytonaSandboxIdsByLabels(sandboxLabels(workerId))
 
-  for (const sandbox of sandboxes.items) {
-    await sandbox.delete(env.daytona.deleteTimeoutSeconds).catch((error) => {
-      const message = error instanceof Error ? error.message : "unknown_error"
-      console.warn(`[provisioner] failed to delete Daytona sandbox ${sandbox.id}: ${message}`)
-    })
+  for (const sandboxId of sandboxIds) {
+    await daytona
+      .get(sandboxId)
+      .then((sandbox) => sandbox.delete(env.daytona.deleteTimeoutSeconds))
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : "unknown_error"
+        console.warn(`[provisioner] failed to delete Daytona sandbox ${sandboxId}: ${message}`)
+      })
   }
 
   await cleanupWorkerDataOnDaytona(daytona, workerId)

--- a/ee/apps/den-worker-proxy/package.json
+++ b/ee/apps/den-worker-proxy/package.json
@@ -10,10 +10,10 @@
     "start": "node dist/server.js"
   },
   "dependencies": {
+    "@daytonaio/sdk": "^0.173.0",
+    "@hono/node-server": "^1.13.8",
     "@openwork-ee/den-db": "workspace:*",
     "@openwork-ee/utils": "workspace:*",
-    "@daytonaio/sdk": "^0.150.0",
-    "@hono/node-server": "^1.13.8",
     "dotenv": "^16.4.5",
     "hono": "^4.7.2",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: ^1.5.6
         version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(better-sqlite3@11.10.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.15)(mysql2@3.17.4))(mysql2@3.17.4)(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.10))(better-call@1.3.2(zod@4.3.6))
       '@daytonaio/sdk':
-        specifier: ^0.150.0
-        version: 0.150.0(ws@8.19.0)
+        specifier: ^0.173.0
+        version: 0.173.0(ws@8.19.0)
       '@hono/mcp':
         specifier: ^0.2.5
         version: 0.2.5(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(hono-rate-limiter@0.4.2(hono@4.12.8))(hono@4.12.8)(zod@4.3.6)
@@ -604,8 +604,8 @@ importers:
   ee/apps/den-worker-proxy:
     dependencies:
       '@daytonaio/sdk':
-        specifier: ^0.150.0
-        version: 0.150.0(ws@8.19.0)
+        specifier: ^0.173.0
+        version: 0.173.0(ws@8.19.0)
       '@hono/node-server':
         specifier: ^1.13.8
         version: 1.19.11(hono@4.12.8)
@@ -1426,14 +1426,14 @@ packages:
   '@codemirror/view@6.39.14':
     resolution: {integrity: sha512-WJcvgHm/6Q7dvGT0YFv/6PSkoc36QlR0VCESS6x9tGsnF1lWLmmYxOgX3HH6v8fo6AvSLgpcs+H0Olre6MKXlg==}
 
-  '@daytonaio/api-client@0.150.0':
-    resolution: {integrity: sha512-NXGE1sgd8+VBzu3B7P/pLrlpci9nMoZecvLmK3zFDh8hr5Ra5vuXJN9pEVJmev93zUItQxHbuvaxaWrYzHevVA==}
+  '@daytona/api-client@0.173.0':
+    resolution: {integrity: sha512-QY36eKumXGuPoI36jNidTarIyWfGX/WBGSZkyPtwrqUDmNHxQ9Re9KPBWMYo2NBZaO2tTPxM/bSCwnmJV/BjiQ==}
 
-  '@daytonaio/sdk@0.150.0':
-    resolution: {integrity: sha512-JmNulFaLhmpjVVFtaRDZa84fxPuy0axQYVLrj1lvRgcZzcrwJRdHv9FZPMLbKdrbicMh3D7GYA9XeBMYVZBTIg==}
+  '@daytona/toolbox-api-client@0.173.0':
+    resolution: {integrity: sha512-+JQZpJnZYYI0bjiX9KDJibepI73+Y4DNiowYsiBnGErA+hSdz44hDhoDrtZsdXSzyn/4yJpH+qH++uq1kKMN2g==}
 
-  '@daytonaio/toolbox-api-client@0.150.0':
-    resolution: {integrity: sha512-7MCbD1FrzYjOaOmqpMDQe7cyoQTSImEOjQ+6Js4NlBOwPlz2PMi352XuG9qrBp9ngNpo8fpduYr35iDOjrpIVg==}
+  '@daytonaio/sdk@0.173.0':
+    resolution: {integrity: sha512-/eaP3YMhyhkZrmjEYT1pgTWyN0soBqi98+xSEa7lFhI0jc8E83eGv8yOS7DrzDIkc7cZqTmWKHOqn4dZmcfw1A==}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -7175,10 +7175,6 @@ packages:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -10289,18 +10285,24 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
-  '@daytonaio/api-client@0.150.0':
+  '@daytona/api-client@0.173.0':
     dependencies:
       axios: 1.13.6
     transitivePeerDependencies:
       - debug
 
-  '@daytonaio/sdk@0.150.0(ws@8.19.0)':
+  '@daytona/toolbox-api-client@0.173.0':
+    dependencies:
+      axios: 1.13.6
+    transitivePeerDependencies:
+      - debug
+
+  '@daytonaio/sdk@0.173.0(ws@8.19.0)':
     dependencies:
       '@aws-sdk/client-s3': 3.1009.0
       '@aws-sdk/lib-storage': 3.1009.0(@aws-sdk/client-s3@3.1009.0)
-      '@daytonaio/api-client': 0.150.0
-      '@daytonaio/toolbox-api-client': 0.150.0
+      '@daytona/api-client': 0.173.0
+      '@daytona/toolbox-api-client': 0.173.0
       '@iarna/toml': 2.2.5
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-http': 0.207.0(@opentelemetry/api@1.9.0)
@@ -10325,12 +10327,6 @@ snapshots:
       - debug
       - supports-color
       - ws
-
-  '@daytonaio/toolbox-api-client@0.150.0':
-    dependencies:
-      axios: 1.13.6
-    transitivePeerDependencies:
-      - debug
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -10967,7 +10963,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@jimp/core@1.6.0':
     dependencies:
@@ -16259,8 +16255,6 @@ snapshots:
 
   minipass@5.0.0: {}
 
-  minipass@7.1.2: {}
-
   minipass@7.1.3: {}
 
   minizlib@2.1.2:
@@ -16270,7 +16264,7 @@ snapshots:
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mkdirp-classic@0.5.3: {}
 
@@ -17908,7 +17902,7 @@ snapshots:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 


### PR DESCRIPTION
## Summary

- Upgrade Daytona SDK consumers from `^0.150.0` to `^0.173.0`, the newest version allowed by the repo minimum-release-age policy.
- Replace the Den Daytona cleanup fallback's offset-based `daytona.list(labels, page, limit)` call with cursor-compatible `GET /sandbox` pagination.
- Keep response parsing compatible with Daytona's current flat list and upcoming paginated list response shapes.

## Evidence

### Screenshots
No UI changes.

### Build verification
- `pnpm --filter @openwork-ee/den-api build` -- passed
- `pnpm --filter @openwork-ee/den-worker-proxy build` -- passed
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit` -- passed
- `pnpm --filter @openwork-ee/den-worker-proxy exec tsc -p tsconfig.json --noEmit` -- passed

### API verification
- Static audit passed: no remaining deprecated Daytona `daytona.list(...)`, `listSandboxesPaginated`, `/sandbox/paginated`, `/api/workspace`, or `daytona sandbox list --page` usages in source/docs/scripts.
- Did not run live Daytona API calls because local Daytona credentials were not provided in this worktree.

### UI verification
No UI changes.

## Test instructions

1. Set `DAYTONA_API_KEY` and any required Daytona env vars for Den.
2. Run the Den stack with `DEN_PROVISIONER_MODE=daytona`.
3. Create and deprovision a Daytona-backed worker.
4. Verify orphan cleanup lists sandboxes through `GET /sandbox` without offset pagination.