### PR TITLE
fix(updater): scope electron checks to release channel

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -66,7 +66,7 @@ declare global {
           feedUrl: string;
           currentVersion: string;
         }>;
-        check?: () => Promise<{
+        check?: (channel?: "stable" | "alpha") => Promise<{
           available: boolean;
           currentVersion?: string;
           latestVersion?: string | null;

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -190,7 +190,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
 
     setUpdateStatus({ state: "checking" });
     try {
-      const result = await bridge.check();
+      const result = await bridge.check(activeReleaseChannel);
       dispatchEnvState({ type: "app-version", appVersion: result.currentVersion ?? null });
       if (result.channel && result.channel !== releaseChannel) {
         onReleaseChannelChange(result.channel);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2494,12 +2494,10 @@ if (!app.requestSingleInstanceLock()) {
       flushPendingDeepLinks();
     });
 
-    // Kick the packaged-only updater after the window is up so the user
-    // sees a working app first. This is a no-op in dev.
-    void ensureAutoUpdater().then((updater) => {
-      if (!updater) return;
-      void updater.checkForUpdates().catch(() => undefined);
-    });
+    // Initialize the packaged updater after the window is up so the user sees
+    // a working app first. Renderer-owned checks pass the selected release
+    // channel explicitly, avoiding stale stable-feed results for alpha users.
+    void ensureAutoUpdater();
   });
 
   app.on("activate", async () => {

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -62,8 +62,8 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     setChannel(channel) {
       return ipcRenderer.invoke("openwork:updater:setChannel", channel);
     },
-    check() {
-      return ipcRenderer.invoke("openwork:updater:check");
+    check(channel) {
+      return ipcRenderer.invoke("openwork:updater:check", channel);
     },
     download() {
       return ipcRenderer.invoke("openwork:updater:download");

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -228,7 +228,10 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     return updaterChannelState(app, channel);
   });
 
-  ipcMain.handle("openwork:updater:check", async () => {
+  ipcMain.handle("openwork:updater:check", async (_event, rawChannel) => {
+    if (rawChannel !== undefined) {
+      await writeElectronUpdaterChannel(app, rawChannel);
+    }
     const updater = await ensureAutoUpdater();
     const channelState = updater
       ? await applyElectronUpdaterFeed(app, updater)


### PR DESCRIPTION
## Summary

- Pass the selected release channel through Electron updater checks so Settings probes the active feed instead of relying on previously persisted state.
- Stop the packaged startup path from launching a silent `checkForUpdates()` that can race Alpha channel sync and cache a Stable-feed result.
- Keep Electron updater initialization in place while making renderer-owned checks the source of truth for channel-scoped update status.

## Evidence

### Screenshots
No screenshot captured. This change targets packaged Electron updater IPC/feed behavior, which is not fully exercisable in the dev renderer without a signed packaged app.

### Build verification
- `pnpm install --frozen-lockfile --prefer-offline` -- passed
- `pnpm --filter @openwork/app build` -- passed
- `node --check apps/desktop/electron/updater.mjs && node --check apps/desktop/electron/preload.mjs && node --check apps/desktop/electron/main.mjs` -- passed
- `git diff --check` -- passed
- `pnpm --filter @openwork/app typecheck` -- failed on existing unrelated React type mismatch in `src/react-app/domains/session/surface/markdown.tsx` between `react-markdown` and `streamdown` component types

### Updater verification
- Fetched live alpha feed: `https://github.com/different-ai/openwork/releases/download/alpha-macos-latest/latest-mac.yml`
- Confirmed it advertises `0.13.9-alpha.823`
- Confirmed comparator treats `0.13.9-alpha.823` as newer than installed `0.13.9-alpha.819+23a856e`

### API verification
No API changes.

### UI verification
Not run through Chrome MCP. The affected path depends on packaged Electron `electron-updater` behavior and signed release feeds, not browser/dev renderer behavior.

## Test instructions

1. Install an older packaged Electron alpha build, for example `0.13.9-alpha.819+23a856e`.
2. Open Settings -> Updates.
3. Select `Alpha` as the release channel.
4. Click `Check for updates`.
5. Verify the app reports `0.13.9-alpha.823` or newer as available from the alpha feed.