### PR TITLE
fix(cloud): apply org provider config after sign-in

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -31,6 +31,7 @@ import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
 import { readHiddenModels } from "@/react-app/domains/session/modals/model-picker-modal";
 import { Settings2 } from "lucide-react";
 import { openModelPickerEvent } from "@/react-app/shell/new-providers-toast";
+import { newProvidersEvent } from "@/app/lib/provider-events";
 
 function getProviderDisplayName(providerId: string) {
   return providerId
@@ -40,11 +41,11 @@ function getProviderDisplayName(providerId: string) {
     .join(" ");
 }
 
-function useModelOptions() {
+function useModelOptions(open: boolean) {
   const { client, selectedWorkspaceRoot } = useWorkspace();
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
-  const { data } = useQuery({
+  const { data, refetch } = useQuery({
     queryKey: ["model-options", selectedWorkspaceRoot],
     enabled: Boolean(client),
     queryFn: async () => {
@@ -78,6 +79,20 @@ function useModelOptions() {
       );
     },
   });
+
+  React.useEffect(() => {
+    if (!open || !client) return;
+    void refetch();
+  }, [client, open, refetch]);
+
+  React.useEffect(() => {
+    if (!client) return;
+    const handler = () => {
+      void refetch();
+    };
+    window.addEventListener(newProvidersEvent, handler);
+    return () => window.removeEventListener(newProvidersEvent, handler);
+  }, [client, refetch]);
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
@@ -151,7 +166,7 @@ export function ModelSelect({
 }: ModelSelectProps) {
   const [search, setSearch] = React.useState("");
   const searchInputRef = React.useRef<HTMLInputElement>(null);
-  const modelOptions = useModelOptions();
+  const modelOptions = useModelOptions(open);
 
   const focusSearchInput = React.useCallback(() => {
     window.requestAnimationFrame(() => {

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -15,14 +15,20 @@ import {
   createDenClient,
   readDenSettings,
   resolveDenBaseUrls,
+  writeDenSettings,
   type DenOrgLlmProvider,
   type DenOrgMarketplace,
+  type DenOrgSummary,
   type DenWorkerSummary,
 } from "../../../app/lib/den";
 import { usePlatform } from "../../kernel/platform";
 import { resolveModelDisplayName, resolveProviderDisplayName } from "../../../app/utils";
 import { ProviderIcon } from "../../design-system/provider-icon";
 import { writeStoredDefaultModel } from "../../kernel/model-config";
+import { orgOnboardingVisibilityEvent, useReloadCoordinator } from "../../shell/reload-coordinator";
+import { dispatchNewProviders } from "../../../app/lib/provider-events";
+
+const RELOAD_AFTER_ONBOARDING_KEY = "openwork.reloadAfterOrgOnboarding";
 
 
 
@@ -42,11 +48,17 @@ type OrgResources = {
 export function OrgOnboardingPage() {
   const navigate = useNavigate();
   const platform = usePlatform();
-  const settings = useMemo(() => readDenSettings(), []);
+  const reloadCoordinator = useReloadCoordinator();
+  const [settings, setSettings] = useState(() => readDenSettings());
   const orgId = settings.activeOrgId?.trim() ?? "";
   const orgName = settings.activeOrgName?.trim() ?? "";
   const authToken = settings.authToken?.trim() ?? "";
 
+  const [orgs, setOrgs] = useState<DenOrgSummary[]>([]);
+  const [selectedOrgId, setSelectedOrgId] = useState(orgId);
+  const [orgsLoading, setOrgsLoading] = useState(true);
+  const [orgSwitchBusy, setOrgSwitchBusy] = useState(false);
+  const [orgSelectionConfirmed, setOrgSelectionConfirmed] = useState(false);
   const [resources, setResources] = useState<OrgResources>({
     providers: [],
     marketplaces: [],
@@ -60,16 +72,24 @@ export function OrgOnboardingPage() {
     label: string;
   } | null>(null);
 
-  // Redirect if no auth or no org — can't show onboarding without them
   useEffect(() => {
-    if (!authToken || !orgId) {
+    window.dispatchEvent(new CustomEvent(orgOnboardingVisibilityEvent, { detail: { visible: true } }));
+    return () => {
+      window.dispatchEvent(new CustomEvent(orgOnboardingVisibilityEvent, { detail: { visible: false } }));
+    };
+  }, []);
+
+  // Redirect if no auth — can't show onboarding without a signed-in session.
+  useEffect(() => {
+    if (!authToken) {
       navigate("/session", { replace: true });
     }
-  }, [authToken, navigate, orgId]);
+  }, [authToken, navigate]);
 
-  // Fetch all org resources in parallel
+  // Load organizations before fetching org resources. If the user belongs to
+  // multiple orgs, require an explicit choice so we don't import the wrong org.
   useEffect(() => {
-    if (!authToken || !orgId) return;
+    if (!authToken) return;
     let cancelled = false;
 
     const client = createDenClient({
@@ -78,10 +98,98 @@ export function OrgOnboardingPage() {
       token: authToken,
     });
 
+    setOrgsLoading(true);
+    void client.listOrgs()
+      .then((response) => {
+        if (cancelled) return;
+        setOrgs(response.orgs);
+        const preferred =
+          response.orgs.find((org) => org.id === orgId) ??
+          response.orgs.find((org) => org.id === response.activeOrgId) ??
+          response.orgs[0] ??
+          null;
+        setSelectedOrgId(preferred?.id ?? "");
+        if (response.orgs.length <= 1) {
+          if (preferred) {
+            const nextSettings = {
+              ...settings,
+              authToken,
+              activeOrgId: preferred.id,
+              activeOrgSlug: preferred.slug,
+              activeOrgName: preferred.name,
+            };
+            writeDenSettings(nextSettings, { persistBootstrap: false });
+            setSettings(nextSettings);
+            void client.setActiveOrganization({ organizationId: preferred.id }).catch(() => undefined);
+          } else {
+            setLoading(false);
+          }
+          setOrgSelectionConfirmed(true);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load organizations");
+      })
+      .finally(() => {
+        if (!cancelled) setOrgsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authToken, orgId, settings.apiBaseUrl, settings.baseUrl]);
+
+  const confirmOrgSelection = useCallback(async () => {
+    if (!authToken || !selectedOrgId || orgSwitchBusy) return;
+    const nextOrg = orgs.find((org) => org.id === selectedOrgId) ?? null;
+    if (!nextOrg) return;
+
+    setOrgSwitchBusy(true);
+    setError(null);
+    try {
+      const client = createDenClient({
+        baseUrl: settings.baseUrl,
+        apiBaseUrl: settings.apiBaseUrl,
+        token: authToken,
+      });
+      await client.setActiveOrganization({ organizationId: nextOrg.id });
+      const nextSettings = {
+        ...settings,
+        authToken,
+        activeOrgId: nextOrg.id,
+        activeOrgSlug: nextOrg.slug,
+        activeOrgName: nextOrg.name,
+      };
+      writeDenSettings(nextSettings, { persistBootstrap: false });
+      setSettings(nextSettings);
+      setResources({ providers: [], marketplaces: [], workers: [] });
+      setSelectedDefault(null);
+      setOrgSelectionConfirmed(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to select organization");
+    } finally {
+      setOrgSwitchBusy(false);
+    }
+  }, [authToken, orgSwitchBusy, orgs, selectedOrgId, settings]);
+
+  // Fetch all org resources in parallel
+  useEffect(() => {
+    const resourceOrgId = orgId || selectedOrgId;
+    if (!authToken || !resourceOrgId || !orgSelectionConfirmed) return;
+    let cancelled = false;
+
+    const client = createDenClient({
+      baseUrl: settings.baseUrl,
+      apiBaseUrl: settings.apiBaseUrl,
+      token: authToken,
+    });
+
+    setLoading(true);
+    setError(null);
     void Promise.all([
-      client.listOrgLlmProviders(orgId).catch(() => [] as DenOrgLlmProvider[]),
-      client.listOrgMarketplaces(orgId).catch(() => [] as DenOrgMarketplace[]),
-      client.listWorkers(orgId).catch(() => [] as DenWorkerSummary[]),
+      client.listOrgLlmProviders(resourceOrgId).catch(() => [] as DenOrgLlmProvider[]),
+      client.listOrgMarketplaces(resourceOrgId).catch(() => [] as DenOrgMarketplace[]),
+      client.listWorkers(resourceOrgId).catch(() => [] as DenWorkerSummary[]),
     ])
       .then(([providers, marketplaces, workers]) => {
         if (cancelled) return;
@@ -97,7 +205,7 @@ export function OrgOnboardingPage() {
     return () => {
       cancelled = true;
     };
-  }, [authToken, orgId, settings.apiBaseUrl, settings.baseUrl]);
+  }, [authToken, orgId, orgSelectionConfirmed, selectedOrgId, settings.apiBaseUrl, settings.baseUrl]);
 
   const handleContinue = useCallback(() => {
     // If user picked a default model, write it
@@ -107,23 +215,34 @@ export function OrgOnboardingPage() {
         modelID: selectedDefault.modelId,
       });
     }
-    // Mark all providers shown on this page as "seen" so the global
-    // toast doesn't re-fire for them on the next sync interval.
-    if (resources.providers.length > 0) {
+    if (reloadCoordinator.reloadPending || resources.providers.length > 0) {
       try {
-        const raw = window.localStorage.getItem("openwork.seenProviderIds");
-        const existing: string[] = raw ? JSON.parse(raw) : [];
-        const ids = new Set(existing);
-        for (const p of resources.providers) ids.add(p.id);
-        window.localStorage.setItem("openwork.seenProviderIds", JSON.stringify([...ids]));
+        window.localStorage.setItem(RELOAD_AFTER_ONBOARDING_KEY, "1");
       } catch {}
     }
+    if (resources.providers.length > 0) {
+      dispatchNewProviders({
+        source: "sign_in",
+        providers: resources.providers.map((provider) => {
+          const firstModel = provider.models[0] ?? null;
+          return {
+            id: provider.id,
+            name: provider.name,
+            providerId: provider.providerId,
+            firstModelId: firstModel?.id,
+            firstModelName: firstModel?.name ?? firstModel?.id,
+          };
+        }),
+      });
+    }
     navigate("/session", { replace: true });
-  }, [navigate, resources.providers, selectedDefault]);
+  }, [navigate, reloadCoordinator.reloadPending, resources.providers, selectedDefault]);
 
   const { providers, marketplaces, workers } = resources;
   const totalModels = providers.reduce((sum, p) => sum + p.models.length, 0);
   const hasResources = providers.length > 0 || marketplaces.length > 0 || workers.length > 0;
+  const needsOrgSelection = orgs.length > 1 && !orgSelectionConfirmed;
+  const selectedOrg = orgs.find((org) => org.id === selectedOrgId) ?? null;
 
   return (
     <div className="relative h-screen overflow-y-auto bg-dls-background text-dls-text">
@@ -145,9 +264,13 @@ export function OrgOnboardingPage() {
               <Building2 size={28} className="text-dls-text" />
             </div>
             <h1 className="text-2xl font-semibold tracking-tight text-dls-text">
-              {orgName || "Your organization"}
+              {needsOrgSelection ? "Choose your organization" : orgName || selectedOrg?.name || "Your organization"}
             </h1>
-            {loading ? (
+            {orgsLoading ? (
+              <p className="text-sm text-dls-secondary">Loading organizations...</p>
+            ) : needsOrgSelection ? (
+              <p className="text-sm text-dls-secondary">Select the org whose resources should be added to this workspace.</p>
+            ) : loading ? (
               <p className="text-sm text-dls-secondary">Loading available resources...</p>
             ) : error ? (
               <p className="text-sm text-red-11">{error}</p>
@@ -158,7 +281,47 @@ export function OrgOnboardingPage() {
             ) : null}
           </div>
 
-          {loading ? (
+          {orgsLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 size={24} className="animate-spin text-dls-secondary" />
+            </div>
+          ) : needsOrgSelection ? (
+            <div className="space-y-3">
+              {orgs.map((org) => {
+                const selected = org.id === selectedOrgId;
+                return (
+                  <button
+                    key={org.id}
+                    type="button"
+                    className={`flex w-full items-center gap-3 rounded-xl border bg-dls-surface px-4 py-3 text-left transition-colors ${
+                      selected ? "border-green-6" : "border-dls-border hover:bg-dls-hover"
+                    }`}
+                    onClick={() => setSelectedOrgId(org.id)}
+                  >
+                    <Building2 size={18} className="shrink-0 text-dls-secondary" />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-dls-text">{org.name}</div>
+                      <div className="mt-0.5 text-xs text-dls-secondary">{org.slug}</div>
+                    </div>
+                    {selected ? <Check size={16} className="shrink-0 text-green-11" /> : null}
+                  </button>
+                );
+              })}
+              {error ? <p className="text-center text-sm text-red-11">{error}</p> : null}
+              <div className="flex justify-center pt-2">
+                <button
+                  type="button"
+                  className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-dls-accent px-8 text-sm font-semibold text-[var(--dls-accent-fg)] transition-all hover:bg-[var(--dls-accent-hover)] disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={() => void confirmOrgSelection()}
+                  disabled={!selectedOrgId || orgSwitchBusy}
+                >
+                  {orgSwitchBusy ? <Loader2 size={16} className="animate-spin" /> : null}
+                  Continue with {selectedOrg?.name ?? "organization"}
+                  <ArrowRight size={16} />
+                </button>
+              </div>
+            </div>
+          ) : loading ? (
             <div className="flex justify-center py-8">
               <Loader2 size={24} className="animate-spin text-dls-secondary" />
             </div>
@@ -256,14 +419,14 @@ export function OrgOnboardingPage() {
           ) : null}
 
           {/* Footer hint */}
-          {!loading && hasResources ? (
+          {!needsOrgSelection && !loading && hasResources ? (
             <p className="text-center text-xs text-dls-secondary">
               Providers are added to your workspace automatically. Marketplaces and workers are available from Cloud settings.
             </p>
           ) : null}
 
           {/* Continue button */}
-          <div className="flex justify-center pt-2">
+          {!needsOrgSelection ? <div className="flex justify-center pt-2">
             <button
               type="button"
               className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-dls-accent px-8 text-sm font-semibold text-[var(--dls-accent-fg)] transition-all hover:bg-[var(--dls-accent-hover)] disabled:cursor-not-allowed disabled:opacity-60"
@@ -273,7 +436,7 @@ export function OrgOnboardingPage() {
               {hasResources ? "Continue to workspace" : "Continue"}
               <ArrowRight size={16} />
             </button>
-          </div>
+          </div> : null}
         </div>
       </div>
     </div>

--- a/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
+++ b/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
@@ -2,16 +2,18 @@
 import { useEffect, useRef } from "react";
 
 import { CLOUD_SYNC_INTERVAL_MS } from "../../../app/cloud/sync/constants";
+import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
 import { useDenAuth } from "./den-auth-provider";
 
 type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
 type SyncFn = (reason: CloudProviderSyncReason) => Promise<unknown>;
 
 /**
- * Periodic cloud-provider reconciliation, ported from dev #1509 "auto-sync
- * cloud providers". Runs the provided sync function every
- * `CLOUD_SYNC_INTERVAL_MS` while the Den session is signed-in; suspends while
- * signed-out and lets the provider-auth store own user-visible errors.
+  * Periodic cloud-provider reconciliation, ported from dev #1509 "auto-sync
+  * cloud providers". Runs the provided sync function immediately, whenever Den
+  * settings change (for example active-org selection), and every
+  * `CLOUD_SYNC_INTERVAL_MS` while the Den session is signed-in; suspends while
+  * signed-out and lets the provider-auth store own user-visible errors.
  *
  * Mount once (e.g. from the settings route) — the hook is idempotent
  * within a single mount, and avoids overlapping ticks using an in-flight
@@ -34,11 +36,11 @@ export function useCloudProviderAutoSync(sync: SyncFn) {
 
     let cancelled = false;
 
-    const tick = async () => {
+    const tick = async (reason: CloudProviderSyncReason = "interval") => {
       if (inFlightRef.current || cancelled) return;
       inFlightRef.current = true;
       try {
-        await syncRef.current("interval");
+        await syncRef.current(reason);
       } catch {
         // Network errors, org misconfig, etc. are non-fatal — we'll try
         // again on the next interval. The refresh function owns surfacing
@@ -49,7 +51,12 @@ export function useCloudProviderAutoSync(sync: SyncFn) {
     };
 
     // Immediate pass so users see server state quickly after sign-in.
-    void tick();
+    void tick("sign_in");
+
+    const handleDenSettingsChanged = () => {
+      void tick("sign_in");
+    };
+    window.addEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
 
     const interval = window.setInterval(() => {
       void tick();
@@ -57,6 +64,7 @@ export function useCloudProviderAutoSync(sync: SyncFn) {
 
     return () => {
       cancelled = true;
+      window.removeEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
       window.clearInterval(interval);
     };
   }, [denAuth.isSignedIn]);

--- a/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import * as React from "react";
 import { ArrowUpRight } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -161,6 +162,12 @@ function DenSignedOutPanel({
 
 export function CloudAccountView({ developerMode, session }: CloudAccountViewProps) {
   const { activeOrganization, isSignedIn, statusMessage } = useCloudSession();
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (!isSignedIn || !session.needsOrgSelection) return;
+    navigate("/onboarding", { replace: true });
+  }, [isSignedIn, navigate, session.needsOrgSelection]);
 
   return (
     <SettingsStack>

--- a/apps/app/src/react-app/shell/new-providers-toast.tsx
+++ b/apps/app/src/react-app/shell/new-providers-toast.tsx
@@ -8,11 +8,14 @@ import {
   type NewProvidersEventDetail,
 } from "../../app/lib/provider-events";
 import { ProviderIcon } from "../design-system/provider-icon";
+import { orgOnboardingVisibilityEvent } from "./reload-coordinator";
 
 const SEEN_KEY = "openwork.seenProviderIds";
+const PENDING_MODEL_PICKER_KEY = "openwork.pendingModelPickerProviderIds";
 
 /** Custom event to request the model picker to open. */
 export const openModelPickerEvent = "openwork-open-model-picker";
+export const pendingModelPickerProviderIdsKey = PENDING_MODEL_PICKER_KEY;
 
 function readSeenProviderIds(): Set<string> {
   try {
@@ -42,27 +45,52 @@ type ToastState = {
  */
 export function NewProvidersToast() {
   const [state, setState] = useState<ToastState>({ show: false, providers: [] });
+  const [orgOnboardingVisible, setOrgOnboardingVisible] = useState(false);
+  const [pendingProviders, setPendingProviders] = useState<NewProviderInfo[]>([]);
+
+  const showProviders = useCallback((providers: NewProviderInfo[]) => {
+    const seen = readSeenProviderIds();
+    const genuinelyNew = providers.filter((p) => !seen.has(p.id));
+    if (genuinelyNew.length === 0) return;
+
+    setState((prev) => ({
+      show: true,
+      providers: prev.show
+        ? [...prev.providers, ...genuinelyNew.filter((p) => !prev.providers.some((e) => e.id === p.id))]
+        : genuinelyNew,
+    }));
+  }, []);
 
   useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<NewProvidersEventDetail>).detail;
-      if (detail.source === "sign_in") return;
       if (detail.providers.length === 0) return;
-
-      const seen = readSeenProviderIds();
-      const genuinelyNew = detail.providers.filter((p) => !seen.has(p.id));
-      if (genuinelyNew.length === 0) return;
-
-      setState((prev) => ({
-        show: true,
-        providers: prev.show
-          ? [...prev.providers, ...genuinelyNew.filter((p) => !prev.providers.some((e) => e.id === p.id))]
-          : genuinelyNew,
-      }));
+      if (orgOnboardingVisible) {
+        setPendingProviders((current) => [
+          ...current,
+          ...detail.providers.filter((p) => !current.some((existing) => existing.id === p.id)),
+        ]);
+        return;
+      }
+      showProviders(detail.providers);
     };
     window.addEventListener(newProvidersEvent, handler);
     return () => window.removeEventListener(newProvidersEvent, handler);
+  }, [orgOnboardingVisible, showProviders]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      setOrgOnboardingVisible(Boolean((event as CustomEvent<{ visible?: boolean }>).detail?.visible));
+    };
+    window.addEventListener(orgOnboardingVisibilityEvent, handler);
+    return () => window.removeEventListener(orgOnboardingVisibilityEvent, handler);
   }, []);
+
+  useEffect(() => {
+    if (orgOnboardingVisible || pendingProviders.length === 0) return;
+    showProviders(pendingProviders);
+    setPendingProviders([]);
+  }, [orgOnboardingVisible, pendingProviders, showProviders]);
 
   const dismiss = useCallback(() => {
     markProvidersSeen(state.providers.map((p) => p.id));
@@ -73,9 +101,19 @@ export function NewProvidersToast() {
     const ids = state.providers.map((p) => p.id);
     markProvidersSeen(ids);
     setState({ show: false, providers: [] });
+    try {
+      window.localStorage.setItem(PENDING_MODEL_PICKER_KEY, JSON.stringify(ids));
+    } catch {}
     // Pass the new provider IDs so the picker can highlight them as
     // "Recently added" even though they were just marked as seen.
     window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { newProviderIds: ids } }));
+    window.setTimeout(() => {
+      try {
+        if (window.localStorage.getItem(PENDING_MODEL_PICKER_KEY)) {
+          window.location.hash = "/session";
+        }
+      } catch {}
+    }, 0);
   }, [state.providers]);
 
   if (!state.show || state.providers.length === 0) return null;

--- a/apps/app/src/react-app/shell/reload-coordinator.tsx
+++ b/apps/app/src/react-app/shell/reload-coordinator.tsx
@@ -30,14 +30,18 @@ type ReloadCoordinatorContextValue = {
   clearReloadRequired: () => void;
   reloadWorkspaceEngine: () => Promise<void>;
   canReloadWorkspaceEngine: boolean;
+  reloadPending: boolean;
   registerWorkspaceReloadControls: (controls: WorkspaceReloadControls | null) => () => void;
 };
+
+export const orgOnboardingVisibilityEvent = "openwork-org-onboarding-visibility";
 
 const ReloadCoordinatorContext = createContext<ReloadCoordinatorContextValue | null>(null);
 
 export function ReloadCoordinatorProvider({ children }: { children: ReactNode }) {
   const controlsRef = useRef<WorkspaceReloadControls | null>(null);
   const [activeSessions, setActiveSessions] = useState<ReloadSession[]>([]);
+  const [orgOnboardingVisible, setOrgOnboardingVisible] = useState(false);
 
   const registerWorkspaceReloadControls = useCallback((controls: WorkspaceReloadControls | null) => {
     controlsRef.current = controls;
@@ -75,6 +79,16 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
   const systemState = useSystemState(systemStateOptions);
 
   useEffect(() => {
+    const update = (event: Event) => {
+      setOrgOnboardingVisible(Boolean((event as CustomEvent<{ visible?: boolean }>).detail?.visible));
+    };
+    window.addEventListener(orgOnboardingVisibilityEvent, update);
+    return () => {
+      window.removeEventListener(orgOnboardingVisibilityEvent, update);
+    };
+  }, []);
+
+  useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<{ reason?: ReloadReason; trigger?: ReloadTrigger }>).detail;
       systemState.markReloadRequired(detail?.reason ?? "config", detail?.trigger);
@@ -98,6 +112,7 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
       clearReloadRequired: systemState.clearReloadRequired,
       reloadWorkspaceEngine: systemState.reloadWorkspaceEngine,
       canReloadWorkspaceEngine: systemState.canReloadWorkspaceEngine,
+      reloadPending: systemState.reload.reloadPending,
       registerWorkspaceReloadControls,
     }),
     [
@@ -105,6 +120,7 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
       systemState.canReloadWorkspaceEngine,
       systemState.clearReloadRequired,
       systemState.markReloadRequired,
+      systemState.reload.reloadPending,
       systemState.reloadWorkspaceEngine,
     ],
   );
@@ -115,7 +131,7 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
       <div className="pointer-events-none fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-1.5rem))] max-w-full flex-col gap-3 sm:right-6 sm:top-6">
         <div className="pointer-events-auto">
           <ReloadWorkspaceToast
-            open={systemState.reload.reloadPending && activeSessions.length === 0}
+            open={systemState.reload.reloadPending && activeSessions.length === 0 && !orgOnboardingVisible}
             title={systemState.reloadCopy.title}
             description={systemState.reloadCopy.body}
             trigger={systemState.reload.reloadTrigger}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -60,7 +60,9 @@ import type {
   TodoItem,
   WorkspacePreset,
   WorkspaceConnectionState,
+  Client,
   ProviderListItem,
+  WorkspaceDisplay,
   WorkspaceSessionGroup,
 } from "../../app/types";
 import { buildFeedbackUrl } from "../../app/lib/feedback";
@@ -87,9 +89,11 @@ import {
 } from "../domains/session/sync/session-sync";
 import { CreateRemoteWorkspaceModal } from "../domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
+import { createProviderAuthStore } from "../domains/connections/provider-auth/store";
 import { useRemoteAccessRestart } from "../domains/workspace/remote-access-restart";
 import { RenameWorkspaceModal } from "../domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "../domains/workspace/use-remote-workspace-connection-editor";
+import { useCloudProviderAutoSync } from "../domains/cloud/use-cloud-provider-auto-sync";
 import {
   diagnoseRemoteWorkspaceTaskLoadFailure,
   getRemoteWorkspaceConnectionKey,
@@ -120,7 +124,7 @@ import { useReactRenderWatchdog } from "./react-render-watchdog";
 import { readDenSettings } from "../../app/lib/den";
 import { denSessionUpdatedEvent } from "../../app/lib/den-session-events";
 
-import { openModelPickerEvent } from "./new-providers-toast";
+import { openModelPickerEvent, pendingModelPickerProviderIdsKey } from "./new-providers-toast";
 import { getModelBehaviorSummary } from "../../app/lib/model-behavior";
 import { filterProviderList, mapConfigProvidersToList } from "../../app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
@@ -192,6 +196,16 @@ function workspaceLabel(workspace: OpenworkWorkspaceInfo) {
     t("session.workspace_fallback")
   );
 }
+
+const emptyWorkspaceDisplay: WorkspaceDisplay = {
+  id: "",
+  name: "",
+  path: "",
+  preset: "default",
+  workspaceType: "local",
+};
+
+const reloadAfterOrgOnboardingKey = "openwork.reloadAfterOrgOnboarding";
 
 function describeRouteError(error: unknown) {
   if (error instanceof Error) {
@@ -500,6 +514,7 @@ export function SessionRoute() {
   const [modelPickerQuery, setModelPickerQuery] = useState("");
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
+  const [providerDefaults, setProviderDefaults] = useState<Record<string, string>>({});
   const [providerConnectedIds, setProviderConnectedIds] = useState<string[]>([]);
   const [disabledProviderIds, setDisabledProviderIds] = useState<string[]>([]);
   // Bump to re-filter provider list when den session changes (sign-in/out)
@@ -516,6 +531,9 @@ export function SessionRoute() {
   // Open model picker when the global toast's "Pick a new default?" is clicked
   useEffect(() => {
     const handler = (event: Event) => {
+      try {
+        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+      } catch {}
       const ids = (event as CustomEvent<{ newProviderIds?: string[] }>).detail?.newProviderIds;
       if (ids && ids.length > 0) {
         setRecentProviderIds(new Set(ids));
@@ -524,6 +542,21 @@ export function SessionRoute() {
     };
     window.addEventListener(openModelPickerEvent, handler);
     return () => window.removeEventListener(openModelPickerEvent, handler);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(pendingModelPickerProviderIdsKey);
+      if (!raw) return;
+      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+      const ids = JSON.parse(raw);
+      if (Array.isArray(ids) && ids.every((id) => typeof id === "string")) {
+        setRecentProviderIds(new Set(ids));
+      }
+      setModelPickerOpen(true);
+    } catch {
+      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+    }
   }, []);
 
   const [permissionReplyBusy, setPermissionReplyBusy] = useState(false);
@@ -933,6 +966,27 @@ export function SessionRoute() {
   }, [activeReloadBlockingSessions, client, reloadCoordinator, reloadWorkspaceEngineFromUi, selectedWorkspaceId]);
 
   useEffect(() => {
+    if (!reloadCoordinator.canReloadWorkspaceEngine) return;
+    try {
+      if (window.localStorage.getItem(reloadAfterOrgOnboardingKey) !== "1") return;
+    } catch {
+      return;
+    }
+    if (!reloadCoordinator.reloadPending) {
+      reloadCoordinator.markReloadRequired("config", {
+        type: "config",
+        name: "opencode.json",
+        action: "updated",
+      });
+      return;
+    }
+    try {
+      window.localStorage.removeItem(reloadAfterOrgOnboardingKey);
+    } catch {}
+    void reloadCoordinator.reloadWorkspaceEngine();
+  }, [reloadCoordinator, reloadCoordinator.canReloadWorkspaceEngine, reloadCoordinator.reloadPending]);
+
+  useEffect(() => {
     if (!client || !selectedWorkspaceId) return;
     const endpoint = endpointForWorkspace(selectedWorkspace);
     if (!endpoint) return;
@@ -1314,6 +1368,92 @@ export function SessionRoute() {
   const canCreateTask = Boolean(
     opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError,
   );
+
+  const sessionProviderAuthStateRef = useRef({
+    opencodeClient: opencodeClient as Client | null,
+    providers,
+    providerDefaults,
+    providerConnectedIds,
+    disabledProviderIds,
+    selectedWorkspace,
+    selectedWorkspaceEndpoint,
+    selectedWorkspaceRoot,
+  });
+  sessionProviderAuthStateRef.current = {
+    opencodeClient,
+    providers,
+    providerDefaults,
+    providerConnectedIds,
+    disabledProviderIds,
+    selectedWorkspace,
+    selectedWorkspaceEndpoint,
+    selectedWorkspaceRoot,
+  };
+
+  const sessionProviderAuthStore = useMemo(
+    () =>
+      createProviderAuthStore({
+        client: () => sessionProviderAuthStateRef.current.opencodeClient,
+        providers: () => sessionProviderAuthStateRef.current.providers,
+        providerDefaults: () => sessionProviderAuthStateRef.current.providerDefaults,
+        providerConnectedIds: () => sessionProviderAuthStateRef.current.providerConnectedIds,
+        disabledProviders: () => sessionProviderAuthStateRef.current.disabledProviderIds,
+        selectedWorkspaceDisplay: () =>
+          sessionProviderAuthStateRef.current.selectedWorkspace
+            ? ({
+                ...sessionProviderAuthStateRef.current.selectedWorkspace,
+                name: workspaceLabel(sessionProviderAuthStateRef.current.selectedWorkspace),
+              } as WorkspaceDisplay)
+            : emptyWorkspaceDisplay,
+        selectedWorkspaceRoot: () => sessionProviderAuthStateRef.current.selectedWorkspaceRoot,
+        runtimeWorkspaceId: () => sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint?.workspaceId ?? null,
+        openworkServer: {
+          getSnapshot: () => ({
+            openworkServerStatus: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint ? "connected" : "disconnected",
+            openworkServerClient: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint?.client ?? null,
+            openworkServerCapabilities: sessionProviderAuthStateRef.current.selectedWorkspaceEndpoint
+              ? {
+                  config: { read: true, write: true },
+                }
+              : null,
+          }),
+        } as never,
+        setProviders,
+        setProviderDefaults,
+        setProviderConnectedIds,
+        setDisabledProviders: setDisabledProviderIds,
+        markOpencodeConfigReloadRequired: () => {
+          reloadCoordinator.markReloadRequired("config", {
+            type: "config",
+            name: "opencode.json",
+            action: "updated",
+          });
+        },
+      }),
+    [reloadCoordinator],
+  );
+
+  useEffect(() => {
+    sessionProviderAuthStore.start();
+    return () => {
+      sessionProviderAuthStore.dispose();
+    };
+  }, [sessionProviderAuthStore]);
+
+  useEffect(() => {
+    sessionProviderAuthStore.syncFromOptions();
+  }, [
+    opencodeClient,
+    selectedWorkspace?.id,
+    selectedWorkspace?.workspaceType,
+    selectedWorkspaceEndpoint?.workspaceId,
+    selectedWorkspaceRoot,
+    sessionProviderAuthStore,
+  ]);
+
+  // Session is where forced sign-in lands. Keep org-managed cloud providers in
+  // sync here so sign-in applies opencode.json changes before Settings opens.
+  useCloudProviderAutoSync(sessionProviderAuthStore.runCloudProviderSync);
   const permissionQueryKey = useMemo(
     () =>
       selectedWorkspaceId && selectedSessionId
@@ -1385,6 +1525,7 @@ export function SessionRoute() {
   useEffect(() => {
     if (!opencodeClient) {
       setProviders([]);
+      setProviderDefaults({});
       setProviderConnectedIds([]);
       return;
     }


### PR DESCRIPTION
## Summary

- Move multi-org selection into the post-sign-in onboarding flow so users choose the org before org resources are imported.
- Run org-managed provider sync from the Session route and on Den settings changes so `opencode.json` updates trigger reload without visiting Settings.
- Queue the existing new-provider/default-model prompt until onboarding closes and refresh the composer model picker when providers change.

## Evidence

### Build verification
- `pnpm --filter @openwork/app typecheck` -- passed
- `pnpm --filter @openwork/app build` -- passed

### API verification
- No API changes.

### UI verification
- Not run via Chrome MCP in this session; changes were verified by typecheck/build and manual reasoning against the reported desktop sign-in flow.
- Expected flow: sign in, choose org in onboarding if multiple orgs exist, continue through org summary, OpenCode reload applies config, then the new-provider prompt can open the Models picker.

## Test instructions

1. Start the desktop app against Den.
2. Sign in with a user that belongs to two orgs.
3. Confirm onboarding shows the org picker before the org summary.
4. Select an org with managed providers and continue.
5. Confirm OpenCode reloads/applies the imported provider config.
6. Confirm the bottom new-provider prompt appears after onboarding and opens the Models picker.
7. Confirm the composer model dropdown includes the newly imported provider after reload.