### PR TITLE
fix(updater): avoid cloning click events

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
@@ -140,7 +140,7 @@ export function UpdatesView(props: UpdatesViewProps) {
                   <div className="flex flex-wrap items-center gap-2">
                     <Button
                       variant="outline"
-                      onClick={props.checkForUpdates}
+                      onClick={() => void props.checkForUpdates()}
                       disabled={props.busy || updateState === "checking" || updateState === "downloading"}
                     >
                       {updateState === "checking" ? <Spinner className="size-4" /> : null}
@@ -150,7 +150,7 @@ export function UpdatesView(props: UpdatesViewProps) {
                     {updateState === "available" ? (
                       <Button
                         variant="secondary"
-                        onClick={props.downloadUpdate}
+                        onClick={() => void props.downloadUpdate()}
                         disabled={props.busy}
                       >
                         {t("settings.update_download_button")}
@@ -160,7 +160,7 @@ export function UpdatesView(props: UpdatesViewProps) {
                     {updateState === "ready" ? (
                       <Button
                         variant="secondary"
-                        onClick={props.installUpdateAndRestart}
+                        onClick={() => void props.installUpdateAndRestart()}
                         disabled={props.busy || props.anyActiveRuns}
                         title={updateRestartBlockedMessage ?? ""}
                       >


### PR DESCRIPTION
## Summary

- Wrap the Updates page updater button handlers so React click events are not passed into updater actions.
- Prevent `checkForUpdates(channelOverride?)` from receiving a synthetic click event and forwarding it through Electron IPC.
- Fix the packaged app error: `An object could not be cloned.`

## Evidence

### Screenshots
No screenshot captured. This is a one-line UI event wiring fix; the packaged Electron error depends on clicking the Updates button in a signed app build.

### Build verification
- `pnpm install --frozen-lockfile --prefer-offline` -- passed
- `pnpm --filter @openwork/app build` -- passed
- `pnpm --filter @openwork/app typecheck` -- passed
- `git diff --check` -- passed

### API verification
No API changes.

### UI verification
Local packaged Electron UI was not exercised. Static verification confirms no direct `onClick={props.checkForUpdates}` / `downloadUpdate` / `installUpdateAndRestart` handlers remain in `updates-view.tsx`, so click events are no longer forwarded as function arguments.

## Test instructions

1. Install an alpha build containing PR #1792, for example `0.13.9-alpha.825+adf54d1`.
2. Open Settings -> Updates.
3. Click `Check for updates`.
4. Verify the page no longer shows `An object could not be cloned.`
5. If on Alpha, verify the check completes against the selected Alpha channel.