### PR TITLE
fix: connect OpenWork UI MCP in dev

### DIFF
--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -16,7 +16,7 @@ export const DEFAULT_MODEL: ModelRef = {
 
 export const SUGGESTED_PLUGINS: SuggestedPlugin[] = [];
 
-export type ExtensionKind = "mcp" | "plugin" | "skill";
+export type ExtensionKind = "mcp" | "plugin" | "skill" | "ui-control";
 
 export type McpDirectoryInfo = {
   id?: string;
@@ -118,9 +118,11 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
     get name() { return t("mcp.quick_connect_openwork_ui_title"); },
     serverName: "openwork-ui",
     get description() { return t("mcp.quick_connect_openwork_ui_desc"); },
-    type: "remote",
+    type: "local",
+    // Dev builds replace this with the local checkout path before writing config.
+    command: ["npx", "-y", "openwork-ui-mcp"],
     oauth: false,
-    kind: "mcp",
+    kind: "ui-control",
     iconSrc: "/openwork-mark.svg",
   },
 ];

--- a/apps/app/src/app/mcp.ts
+++ b/apps/app/src/app/mcp.ts
@@ -6,6 +6,7 @@ type McpConfigValue = Record<string, unknown> | null | undefined;
 
 type McpIdentity = {
   id?: string;
+  serverName?: string;
   name: string;
 };
 
@@ -14,7 +15,7 @@ export function normalizeMcpSlug(name: string): string {
 }
 
 export function getMcpIdentityKey(entry: McpIdentity): string {
-  return entry.id ?? normalizeMcpSlug(entry.name);
+  return entry.id ?? entry.serverName ?? normalizeMcpSlug(entry.name);
 }
 
 export function validateMcpServerName(name: string): string {

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -30,12 +30,14 @@ const kindLabel: Record<ExtensionKind, string> = {
   mcp: "MCP",
   plugin: "Plugin",
   skill: "Skill",
+  "ui-control": "UI Control",
 };
 
 const kindStyle: Record<ExtensionKind, string> = {
   mcp: "bg-dls-hover text-dls-secondary",
   plugin: "bg-violet-3 text-violet-11",
   skill: "bg-amber-3 text-amber-11",
+  "ui-control": "bg-blue-3 text-blue-11",
 };
 
 /**

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -32,6 +32,10 @@ export type ExtensionDetailModalProps = {
   url?: string;
   /** Whether OAuth is required. */
   oauth?: boolean;
+  /** Exact local command this extension will launch, when known. */
+  launchCommand?: string[];
+  /** Environment passed to the local MCP process, when known. */
+  environment?: Record<string, string>;
   /** Filesystem path (for skills). Not shown directly, used for reveal. */
   path?: string;
   /** Skill trigger phrase (e.g. "when user asks to create an agent"). */
@@ -50,13 +54,49 @@ const kindLabel: Record<ExtensionKind, string> = {
   mcp: "MCP Server",
   plugin: "Plugin",
   skill: "Skill",
+  "ui-control": "UI Control",
 };
 
 const kindDesc: Record<ExtensionKind, string> = {
   mcp: "Connects as a Model Context Protocol server, giving your agent access to external tools and data.",
   plugin: "Extends OpenWork with additional capabilities managed by your organization.",
   skill: "A reusable workflow that your agent can execute on demand.",
+  "ui-control": "Lets another MCP client inspect and drive this OpenWork desktop UI through a local stdio wrapper.",
 };
+
+const uiControlClientConfig = `{
+  "mcpServers": {
+    "openwork-ui": {
+      "command": "npx",
+      "args": ["-y", "openwork-ui-mcp"]
+    }
+  }
+}`;
+
+function uiControlOpencodeConfig(command: string[], environment?: Record<string, string>) {
+  return JSON.stringify({
+    mcp: {
+      "openwork-ui": {
+        type: "local",
+        command,
+        ...(environment ? { environment } : {}),
+        enabled: true,
+      },
+    },
+  }, null, 2);
+}
+
+const fallbackUiControlCommand = ["npx", "-y", "openwork-ui-mcp"];
+
+const fallbackUiControlOpencodeConfig = `{
+  "mcp": {
+    "openwork-ui": {
+      "type": "local",
+      "command": ["npx", "-y", "openwork-ui-mcp"],
+      "enabled": true
+    }
+  }
+}`;
 
 /**
  * Strip YAML-like frontmatter from the beginning of a skill content string.
@@ -112,6 +152,8 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
     connecting = false,
     url,
     oauth,
+    launchCommand,
+    environment,
     path,
     trigger,
     contentPreview,
@@ -199,6 +241,13 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
                   </div>
                 ) : null}
 
+                {kind === "ui-control" ? (
+                  <div className="flex items-center justify-between text-[13px]">
+                    <span className="text-dls-secondary">Launch</span>
+                    <span className="max-w-[300px] truncate font-mono text-[11px] text-dls-text">{(launchCommand ?? fallbackUiControlCommand).join(" ")}</span>
+                  </div>
+                ) : null}
+
                 {path && onReveal ? (
                   <div className="flex items-center justify-between text-[13px]">
                     <span className="text-dls-secondary">Location</span>
@@ -232,6 +281,8 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
             </div>
 
             {/* Skill-specific: trigger + content preview */}
+            {kind === "ui-control" ? <UiControlConnectionDetails launchCommand={launchCommand} environment={environment} /> : null}
+
             {kind === "skill" && trigger ? (
               <div className={`${surfaceCardClass} space-y-2 p-4`}>
                 <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
@@ -259,7 +310,7 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
             })() : null}
 
             {/* What this enables (generic, for non-skills or skills without preview) */}
-            {kind !== "skill" || (!trigger && !contentPreview) ? (
+            {(kind !== "skill" && kind !== "ui-control") || (!trigger && !contentPreview && kind !== "ui-control") ? (
               <div className={`${surfaceCardClass} space-y-2 p-4`}>
                 <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
                   What this enables
@@ -310,6 +361,52 @@ export function ExtensionDetailModal(props: ExtensionDetailModalProps) {
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function UiControlConnectionDetails(props: { launchCommand?: string[]; environment?: Record<string, string> }) {
+  const opencodeConfig = props.launchCommand ? uiControlOpencodeConfig(props.launchCommand, props.environment) : fallbackUiControlOpencodeConfig;
+
+  return (
+    <div className="space-y-4">
+      <div className={`${surfaceCardClass} space-y-3 p-4`}>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+          How to connect another client
+        </div>
+        <div className="space-y-2 text-[13px] leading-relaxed text-dls-secondary">
+          <div>OpenWork desktop starts a private localhost bridge automatically.</div>
+          <div>Your MCP client starts <span className="font-mono text-dls-text">openwork-ui-mcp</span> over stdio; the wrapper discovers the bridge and proxies UI tools to it.</div>
+          <div>Do not point clients at the random localhost bridge URL directly.</div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+          Claude Desktop, Codex, Cursor
+        </div>
+        <pre className="max-h-[180px] overflow-x-auto rounded-xl border border-dls-border bg-dls-surface p-3 text-[11px] leading-relaxed text-dls-text">
+          <code>{uiControlClientConfig}</code>
+        </pre>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-dls-secondary">
+          OpenCode
+        </div>
+        <pre className="max-h-[180px] overflow-x-auto rounded-xl border border-dls-border bg-dls-surface p-3 text-[11px] leading-relaxed text-dls-text">
+          <code>{opencodeConfig}</code>
+        </pre>
+      </div>
+
+      <div className={`${surfaceCardClass} space-y-2 p-4 text-[12px] leading-relaxed text-dls-secondary`}>
+        <div>Production discovery file: <span className="font-mono text-dls-text">~/Library/Application Support/com.differentai.openwork/openwork-ui-control.json</span></div>
+        <div>Dev discovery file: <span className="font-mono text-dls-text">~/Library/Application Support/com.differentai.openwork.dev/openwork-ui-control.json</span></div>
+        <div>Override: <span className="font-mono text-dls-text">OPENWORK_UI_CONTROL_DISCOVERY=/path/to/openwork-ui-control.json</span></div>
+        {props.environment?.OPENWORK_UI_CONTROL_DISCOVERY ? (
+          <div>Current override: <span className="font-mono text-dls-text">{props.environment.OPENWORK_UI_CONTROL_DISCOVERY}</span></div>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -272,6 +272,38 @@ export function createConnectionsStore(options: {
     return { next, nextStatuses };
   };
 
+  const resolveLocalMcpCommand = async (entry: McpDirectoryInfo) => {
+    if (entry.serverName !== "openwork-ui") {
+      return entry.command;
+    }
+    try {
+      const command = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpCommand");
+      if (Array.isArray(command) && command.every((part) => typeof part === "string") && command.length > 0) {
+        return command;
+      }
+    } catch {
+      // Fall through to the published package command.
+    }
+    return entry.command;
+  };
+
+  const resolveLocalMcpEnvironment = async (entry: McpDirectoryInfo) => {
+    if (entry.serverName !== "openwork-ui") return undefined;
+    try {
+      const environment = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpEnvironment");
+      if (environment && typeof environment === "object" && !Array.isArray(environment)) {
+        return Object.fromEntries(
+          Object.entries(environment).filter((entry): entry is [string, string] =>
+            typeof entry[0] === "string" && typeof entry[1] === "string"
+          ),
+        );
+      }
+    } catch {
+      // Discovery fallback in openwork-ui-mcp still handles normal launches.
+    }
+    return undefined;
+  };
+
   async function refreshMcpServers() {
     if (disposed) return;
 
@@ -512,7 +544,11 @@ export function createConnectionsStore(options: {
         if (!entry.command?.length) {
           throw new Error("Missing MCP command.");
         }
-        mcpEntryConfig["command"] = entry.command;
+        mcpEntryConfig["command"] = await resolveLocalMcpCommand(entry);
+        const environment = await resolveLocalMcpEnvironment(entry);
+        if (environment) {
+          mcpEntryConfig["environment"] = environment;
+        }
       }
 
       if (canUseOpenworkServer && openworkClient && openworkWorkspaceId) {

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -189,6 +189,8 @@ export function McpView(props: McpViewProps) {
   const [detailEntry, setDetailEntry] = useState<McpDirectoryInfo | null>(null);
   const [detailSkill, setDetailSkill] = useState<SkillItem | null>(null);
   const [detailSkillContent, setDetailSkillContent] = useState<string | null>(null);
+  const [openworkUiMcpCommand, setOpenworkUiMcpCommand] = useState<string[] | null>(null);
+  const [openworkUiMcpEnvironment, setOpenworkUiMcpEnvironment] = useState<Record<string, string> | null>(null);
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<ExtensionFilter>("all");
 
@@ -231,6 +233,29 @@ export function McpView(props: McpViewProps) {
   const configRequestId = useRef(0);
 
   const quickConnectList = props.quickConnect;
+
+  useEffect(() => {
+    if (!isDesktopRuntime()) return;
+    void (async () => {
+      try {
+        const command = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpCommand");
+        if (Array.isArray(command) && command.every((part) => typeof part === "string")) {
+          setOpenworkUiMcpCommand(command);
+        }
+        const environment = await (window as any).__OPENWORK_ELECTRON__?.invokeDesktop?.("getOpenworkUiMcpEnvironment");
+        if (environment && typeof environment === "object" && !Array.isArray(environment)) {
+          setOpenworkUiMcpEnvironment(Object.fromEntries(
+            Object.entries(environment).filter((entry): entry is [string, string] =>
+              typeof entry[0] === "string" && typeof entry[1] === "string"
+            ),
+          ));
+        }
+      } catch {
+        setOpenworkUiMcpCommand(null);
+        setOpenworkUiMcpEnvironment(null);
+      }
+    })();
+  }, []);
 
   useEffect(() => {
     const root = props.selectedWorkspaceRoot.trim();
@@ -414,7 +439,7 @@ export function McpView(props: McpViewProps) {
         entries={
           quickConnectList.filter((entry) => {
             if (filter === "skill") return false;
-            if (filter === "mcp" && (entry.kind ?? "mcp") !== "mcp") return false;
+            if (filter === "mcp" && (entry.kind ?? "mcp") !== "mcp" && entry.kind !== "ui-control") return false;
             if (!search.trim()) return true;
             const q = search.toLowerCase();
             return entry.name.toLowerCase().includes(q) || entry.description.toLowerCase().includes(q);
@@ -543,6 +568,8 @@ export function McpView(props: McpViewProps) {
           kind={detailEntry.kind ?? "mcp"}
           connected={isQuickConnectConfigured(detailEntry)}
           connecting={props.mcpConnectingName === detailEntry.name}
+          launchCommand={detailEntry.serverName === "openwork-ui" ? openworkUiMcpCommand ?? undefined : undefined}
+          environment={detailEntry.serverName === "openwork-ui" ? openworkUiMcpEnvironment ?? undefined : undefined}
           url={typeof detailEntry.url === "string" ? detailEntry.url : undefined}
           oauth={detailEntry.oauth}
           onConnect={() => {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1956,6 +1956,17 @@ async function handleDesktopInvoke(event, command, ...args) {
       } catch {
         return null;
       }
+    case "getOpenworkUiMcpCommand": {
+      if (process.env.OPENWORK_DEV_MODE === "1") {
+        return ["node", path.resolve(__dirname, "../../..", "packages/openwork-ui-mcp/index.mjs")];
+      }
+      return ["npx", "-y", "openwork-ui-mcp"];
+    }
+    case "getOpenworkUiMcpEnvironment": {
+      return {
+        OPENWORK_UI_CONTROL_DISCOVERY: path.join(app.getPath("userData"), "openwork-ui-control.json"),
+      };
+    }
     case "getDesktopBootstrapConfig":
       return getDesktopBootstrapConfig();
     case "debugDesktopBootstrapConfig":


### PR DESCRIPTION
## Summary
- Model OpenWork UI Control as a dedicated UI Control extension type with a custom modal instead of a generic MCP details view.
- Configure the built-in OpenWork UI MCP as a local stdio server and expose the exact launch command/discovery environment for dev and prod.
- Pass `OPENWORK_UI_CONTROL_DISCOVERY` explicitly so OpenCode-launched MCP processes can reach the dev desktop bridge.

## Verification
- `pnpm --filter @openwork/app typecheck` passed.
- Launched dev app with `pnpm dev` and verified the Extensions UI via Electron CDP.
- Reconnected OpenWork UI Control, reloaded MCPs, and confirmed `OpenWork UI Control Ready`.
- Smoke-tested the configured MCP command/env: `ui_status` connected to `OpenWork - Dev`, `route.session` executed, and `session.create_task` created a new session.

## Evidence
- Live MCP create-session result: `Executed session.create_task.`
- Follow-up snapshot route: `/workspace/ws_bb4cf6b4fcf0/session/ses_1d7322e7affe9YFy7nHXFNjt0p`