### PR TITLE
feat(settings): add OpenWork models subscribe CTA

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -47,6 +47,7 @@ const BUILD_DEN_REQUIRE_SIGNIN =
     : false);
 
 export const DEFAULT_DEN_BASE_URL = BUILD_DEN_BASE_URL;
+export const DEN_INFERENCE_PATH = "/dashboard/inference";
 
 export type DenSettings = {
   baseUrl: string;
@@ -304,6 +305,11 @@ export function normalizeDenBaseUrl(input: string | null | undefined): string | 
   } catch {
     return null;
   }
+}
+
+export function getDenInferenceUrl(baseUrl?: string | null): string {
+  const normalized = normalizeDenBaseUrl(baseUrl ?? readDenSettings().baseUrl) ?? DEFAULT_DEN_BASE_URL;
+  return `${normalized}${DEN_INFERENCE_PATH}`;
 }
 
 function isWebAppHost(hostname: string): boolean {

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -40,12 +40,15 @@ type ProviderOAuthSession = ProviderOAuthStartResult & {
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
+  openwork: "OpenWork",
   opencode: "OpenCode Zen",
   openai: "OpenAI",
   anthropic: "Anthropic",
   google: "Google",
   openrouter: "OpenRouter",
 };
+
+const OPENWORK_MODELS_PROVIDER_ID = "openwork";
 
 export type ProviderAuthModalProps = {
   open: boolean;
@@ -66,6 +69,8 @@ export type ProviderAuthModalProps = {
     code?: string,
   ) => Promise<{ connected: boolean; pending?: boolean; message?: string }>;
   onRefreshProviders?: () => Promise<unknown>;
+  showOpenWorkModelsSubscribe?: boolean;
+  onSubscribeOpenWorkModels?: () => void | Promise<void>;
   onClose: () => void;
 };
 
@@ -74,7 +79,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const isRemoteWorker = workerType === "remote";
 
   const [view, setView] = useState<
-    "list" | "method" | "api" | "cloud" | "oauth-code" | "oauth-auto"
+    "list" | "method" | "api" | "cloud" | "oauth-code" | "oauth-auto" | "openwork-subscribe"
   >("list");
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
   const [selectedCloudMethod, setSelectedCloudMethod] = useState<ProviderAuthMethod | null>(null);
@@ -160,7 +165,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     const providers = props.providers ?? [];
 
     const providersById = new Map(providers.map((provider) => [provider.id, provider]));
-    return Object.keys(methods)
+    const nextEntries = Object.keys(methods)
       .flatMap((id) => {
         const provider = providersById.get(id);
         const entryMethods = (methods[id] ?? []).filter((method) => {
@@ -182,7 +187,23 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
         } satisfies ProviderAuthEntry];
       })
       .sort(compareProviders);
-  }, [isRemoteWorker, props.authMethods, props.connectedProviderIds, props.providers]);
+
+    if (props.showOpenWorkModelsSubscribe) {
+      const connectedToOpenWork = connected.has(OPENWORK_MODELS_PROVIDER_ID);
+      return [
+        {
+          id: OPENWORK_MODELS_PROVIDER_ID,
+          name: "OpenWork",
+          methods: [{ type: "cloud", label: "Subscribe" }],
+          connected: connectedToOpenWork,
+          env: [],
+        },
+        ...nextEntries.filter((entry) => entry.id.trim().toLowerCase() !== OPENWORK_MODELS_PROVIDER_ID),
+      ];
+    }
+
+    return nextEntries;
+  }, [isRemoteWorker, props.authMethods, props.connectedProviderIds, props.providers, props.showOpenWorkModelsSubscribe]);
 
   const selectedEntry = useMemo(
     () => entries.find((entry) => entry.id === selectedProviderId) ?? null,
@@ -499,6 +520,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     setLocalError(null);
     setSelectedProviderId(entry.id);
 
+    if (props.showOpenWorkModelsSubscribe && entry.id.trim().toLowerCase() === OPENWORK_MODELS_PROVIDER_ID) {
+      setView("openwork-subscribe");
+      return;
+    }
+
     if (entry.methods.length === 1) {
       void handleMethodSelect(entry.methods[0]);
       return;
@@ -558,6 +584,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   };
 
   const handleBack = () => {
+    if (resolvedView === "openwork-subscribe") {
+      resetState();
+      return;
+    }
+
     if (resolvedView === "oauth-code" || resolvedView === "oauth-auto") {
       if ((selectedEntry?.methods.length ?? 0) > 1) {
         setView("method");
@@ -903,6 +934,27 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     </div>
                     <Button variant="secondary" onClick={handleCloudSubmit} disabled={actionDisabled}>
                       {props.submitting ? "Connecting..." : "Connect provider"}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+
+              {resolvedView === "openwork-subscribe" && selectedEntry ? (
+                <div className="rounded-xl border border-blue-6/50 bg-blue-2/25 shadow-sm p-5 space-y-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-sm font-medium text-gray-12">OpenWork Models</div>
+                      <div className="text-xs text-gray-10 mt-1">
+                        Frontier intelligence, hand picked for your team&apos;s most ambitious work.
+                      </div>
+                    </div>
+                    <Button variant="ghost" onClick={handleBack} disabled={actionDisabled}>
+                      Back
+                    </Button>
+                  </div>
+                  <div className="flex items-center justify-end">
+                    <Button onClick={() => void props.onSubscribeOpenWorkModels?.()} disabled={actionDisabled}>
+                      Subscribe
                     </Button>
                   </div>
                 </div>

--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -40,6 +40,8 @@ export type AiSettingsViewProps = {
   canDisconnectProvider: (source?: ConnectedProvider["source"]) => boolean;
   /** Set of local provider IDs that were imported from cloud. */
   cloudProviderIds?: Set<string>;
+  showOpenWorkModelsSubscribe?: boolean;
+  onSubscribeOpenWorkModels?: () => void | Promise<void>;
 };
 
 function providerSourceLabel(source?: ConnectedProvider["source"]) {
@@ -87,6 +89,26 @@ export function AiSettingsView(props: AiSettingsViewProps) {
             </LayoutSectionItemHeaderActions>
           </LayoutSectionItemHeader>
         </LayoutSectionItem>
+
+        {props.showOpenWorkModelsSubscribe ? (
+          <LayoutSectionItem className="flex-row flex-wrap items-center justify-between gap-3 rounded-2xl border border-blue-6 bg-blue-2/30 px-4 py-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <ProviderIcon providerId="openwork" size={20} className="text-blue-11" />
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-dls-text">OpenWork Models</div>
+                <div className="text-xs text-muted-foreground">
+                  Frontier intelligence, hand picked for your team&apos;s most ambitious work.
+                </div>
+              </div>
+            </div>
+            <Button
+              onClick={() => void props.onSubscribeOpenWorkModels?.()}
+              disabled={props.busy || props.providerAuthBusy}
+            >
+              Subscribe
+            </Button>
+          </LayoutSectionItem>
+        ) : null}
 
         {props.connectedProviders.length > 0 ? (
           <div className="space-y-2">

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -53,7 +53,7 @@ import { UpdatesView } from "../domains/settings/pages/updates-view";
 import { useDebugViewModel } from "../domains/settings/state/debug-view-model";
 import { useMessagingViewProps } from "../domains/settings/state/messaging-view-state";
 import { useElectronUpdaterState } from "../domains/settings/state/electron-updater-state";
-import { CloudSessionProvider } from "../domains/settings/cloud/cloud-session-provider";
+import { CloudSessionProvider, useCloudSession } from "../domains/settings/cloud/cloud-session-provider";
 import { useDenSession } from "../domains/settings/cloud/use-den-session";
 import { useBootState } from "./boot-state";
 import { SettingsShell } from "../domains/settings/shell/settings-shell";
@@ -102,6 +102,7 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import { abortSessionSafe } from "../../app/lib/opencode-session";
 import { useReloadCoordinator } from "./reload-coordinator";
 import { buildFeedbackUrl } from "../../app/lib/feedback";
+import { getDenInferenceUrl } from "../../app/lib/den";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
 import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 
@@ -126,6 +127,16 @@ function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
       workspace.path?.trim() ||
       t("session.workspace_fallback"),
   };
+}
+
+function isOpenWorkCloudProvider(provider: {
+  providerId?: string | null;
+  source?: string | null;
+  sourceProviderId?: string | null;
+}) {
+  return [provider.providerId, provider.source, provider.sourceProviderId].some(
+    (value) => value?.trim().toLowerCase() === "openwork",
+  );
 }
 
 function describeRouteError(error: unknown) {
@@ -701,6 +712,26 @@ function SettingsRouteContent() {
     developerMode,
     openLink: (url) => platform.openLink(url),
   });
+  const cloudSession = useCloudSession();
+
+  const hasOpenWorkCloudProvider = useMemo(
+    () =>
+      providerAuthSnapshot.cloudOrgProviders.some(isOpenWorkCloudProvider) ||
+      Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).some(isOpenWorkCloudProvider),
+    [providerAuthSnapshot.cloudOrgProviders, providerAuthSnapshot.importedCloudProviders],
+  );
+  const showOpenWorkModelsSubscribe = !cloudSession.isSignedIn || !hasOpenWorkCloudProvider;
+
+  const subscribeToOpenWorkModels = useCallback(() => {
+    providerAuthStore.closeProviderAuthModal();
+    const accountPath = selectedWorkspaceId
+      ? workspaceSettingsRoute(selectedWorkspaceId, "cloud-account")
+      : "/settings/cloud-account";
+    navigate(accountPath);
+    window.setTimeout(() => {
+      platform.openLink(getDenInferenceUrl(cloudSession.baseUrl));
+    }, 0);
+  }, [cloudSession.baseUrl, navigate, platform, providerAuthStore, selectedWorkspaceId]);
 
   const shareWorkspaceState = useShareWorkspaceState({
     workspaces,
@@ -1569,6 +1600,8 @@ function SettingsRouteContent() {
             cloudProviderIds={new Set(
               Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).map((p) => p.providerId)
             )}
+            showOpenWorkModelsSubscribe={showOpenWorkModelsSubscribe}
+            onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
           />
         );
       case "preferences":
@@ -1882,6 +1915,8 @@ function SettingsRouteContent() {
         onConnectCloudProvider={providerAuthStore.connectCloudProvider}
         onSubmitOAuth={providerAuthStore.completeProviderAuthOAuth}
         onRefreshProviders={providerAuthStore.refreshProviders}
+        showOpenWorkModelsSubscribe={showOpenWorkModelsSubscribe}
+        onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
         onClose={() => providerAuthStore.closeProviderAuthModal()}
       />
       <CreateWorkspaceModal


### PR DESCRIPTION
## Summary

- Adds an OpenWork Models subscribe CTA to Settings > AI Providers when the user is signed out or lacks an OpenWork cloud LLM provider.
- Pins OpenWork at the top of the Connect Provider modal and routes it to a subscription prompt instead of the API key flow.
- Resolves the subscribe destination from the configured Den base URL and returns users to Settings > Account before opening the browser.

## Evidence

### Screenshots
![OpenWork Models CTA](https://litter.catbox.moe/jumvxc.png)

### Build verification
- `pnpm --filter @openwork/app typecheck` -- passed
- `pnpm --filter @openwork/app build` -- passed

### API verification
- No API changes.

### UI verification
- Verified Settings > AI Providers renders the OpenWork Models CTA via Chrome MCP against the Vite renderer.
- Full Connect Provider modal verification was blocked in the web smoke run because the renderer was not connected to an OpenWork server and provider loading returned `Not connected to a server`.
- Console/network audit not completed because the smoke session was limited to the disconnected web renderer.

## Test instructions

1. Start the desktop app/dev renderer with an OpenWork server connection.
2. Sign out of Den, then open Settings > AI Providers.
3. Verify OpenWork Models appears at the top with the Subscribe button and opens the configured Den inference URL.
4. Click Connect Provider, verify OpenWork appears at the top, and selecting it shows the subscription prompt rather than the API key screen.
5. Sign in with an org that has no OpenWork cloud provider and repeat the same checks.
6. Sign in with an org that has an OpenWork cloud provider and verify the subscribe CTA is hidden.