### PR TITLE
fix(app): refresh connected provider models

### DIFF
--- a/apps/app/src/app/lib/provider-events.ts
+++ b/apps/app/src/app/lib/provider-events.ts
@@ -18,9 +18,11 @@ export type NewProviderInfo = {
 
 export type NewProvidersEventDetail = {
   providers: NewProviderInfo[];
+  newProviderCount?: number;
+  newModelCount?: number;
   /** Where the change originated. "sign_in" is suppressed by the toast
    *  because the onboarding page handles first-time notification. */
-  source: "cloud_sync" | "local_config" | "sign_in";
+  source: "cloud_sync" | "local_config" | "models_refresh" | "sign_in";
 };
 
 export function dispatchNewProviders(detail: NewProvidersEventDetail): void {

--- a/apps/app/src/app/utils/providers.ts
+++ b/apps/app/src/app/utils/providers.ts
@@ -1,4 +1,4 @@
-import type { Provider as ConfigProvider, ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
 
 const PINNED_PROVIDER_ORDER = ["opencode", "openai", "anthropic"] as const;
 
@@ -21,19 +21,6 @@ export const compareProviders = (
   const bName = (b.name ?? b.id).trim();
   return aName.localeCompare(bName);
 };
-
-// Starting with @opencode-ai/sdk@1.4.x, `ConfigProvider` (from `config.providers()`)
-// and the provider items in `ProviderListResponse.all` share the same shape, so
-// this mapper is effectively an identity function. It is kept for call-site
-// stability and to normalize optional fields (`name`, `env`).
-export const mapConfigProvidersToList = (
-  providers: ConfigProvider[],
-): ProviderListResponse["all"] =>
-  providers.map((provider) => ({
-    ...provider,
-    name: provider.name ?? provider.id,
-    env: provider.env ?? [],
-  }));
 
 export const filterProviderList = (
   value: ProviderListResponse,

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -15,10 +15,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { unwrap } from "@/app/lib/opencode";
 import { useWorkspace } from "@/react-app/shell/workspace-provider";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
-import { useQuery } from "@tanstack/react-query";
+import { getConnectedProviderItems, useProviderListQuery } from "@/react-app/domains/connections/provider-list-query";
 import {
   Command,
   CommandEmpty,
@@ -42,42 +41,14 @@ function getProviderDisplayName(providerId: string) {
 }
 
 function useModelOptions(open: boolean) {
-  const { client, selectedWorkspaceRoot } = useWorkspace();
+  const { client, opencodeBaseUrl, selectedWorkspaceRoot } = useWorkspace();
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
-  const { data, refetch } = useQuery({
-    queryKey: ["model-options", selectedWorkspaceRoot],
+  const { data, refetch } = useProviderListQuery({
+    client,
+    baseUrl: opencodeBaseUrl,
+    directory: selectedWorkspaceRoot,
     enabled: Boolean(client),
-    queryFn: async () => {
-      if (!client) {
-        return [];
-      }
-
-      const data = unwrap(
-        await client.config.providers({
-          directory: selectedWorkspaceRoot,
-        }),
-      );
-
-      if (!data.providers) {
-        return [];
-      }
-
-      return data.providers.flatMap((provider) =>
-        Object.entries(provider.models).map(([id, model]) => ({
-          providerID: provider.id,
-          modelID: id,
-          title: model.name,
-          description: provider.name,
-          behaviorTitle: "Reasoning",
-          behaviorLabel: "Default",
-          behaviorDescription: "",
-          behaviorValue: null,
-          isFree: false,
-          isConnected: true,
-        })),
-      );
-    },
   });
 
   React.useEffect(() => {
@@ -97,15 +68,30 @@ function useModelOptions(open: boolean) {
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
   //   - `blockZenModel` hides the built-in OpenCode provider entries
-  //   - `disallowNonCloudModels` hides providers that aren't currently
-  //     connected via cloud (a provider with models[] filled counts as
-  //     connected in this list — see the loader above)
+  //   - `disallowNonCloudModels` hides providers that OpenCode does not report
+  //     as connected through the provider list endpoint.
   return React.useMemo(() => {
     const restrictToCloud = checkDesktopRestriction({
       restriction: "disallowNonCloudModels",
     });
 
-    return (data ?? []).filter((option) => {
+    const options = getConnectedProviderItems(data)
+      .flatMap((provider) =>
+        Object.entries(provider.models).map(([id, model]) => ({
+          providerID: provider.id,
+          modelID: id,
+          title: model.name,
+          description: provider.name,
+          behaviorTitle: "Reasoning",
+          behaviorLabel: "Default",
+          behaviorDescription: "",
+          behaviorValue: null,
+          isFree: false,
+          isConnected: true,
+        })),
+      );
+
+    return options.filter((option) => {
       if (
         isDesktopProviderBlocked({
           providerId: option.providerID,

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -30,8 +30,9 @@ import { isDesktopRuntime, safeStringify } from "../../../../app/utils";
 import {
   compareProviders,
   filterProviderList,
-  mapConfigProvidersToList,
 } from "../../../../app/utils/providers";
+import { getReactQueryClient } from "../../../infra/query-client";
+import { ensureProviderListQuery } from "../provider-list-query";
 import type { OpenworkServerStore } from "../openwork-server-store";
 import {
   denSessionUpdatedEvent,
@@ -1072,30 +1073,17 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
 
     try {
       const updated = filterProviderList(
-        unwrap(await activeClient.provider.list()),
+        await ensureProviderListQuery(getReactQueryClient(), {
+          client: activeClient,
+          directory: options.selectedWorkspaceRoot(),
+          force: Boolean(optionsArg?.dispose),
+        }),
         disabledProviders,
       );
       applyProviderListState(updated);
       return updated;
     } catch {
-      try {
-        const fallback = unwrap(await activeClient.config.providers());
-        const mapped = mapConfigProvidersToList(fallback.providers);
-        const next = filterProviderList(
-          {
-            all: mapped,
-            connected: options
-              .providerConnectedIds()
-              .filter((id) => mapped.some((provider) => provider.id === id)),
-            default: fallback.default,
-          },
-          disabledProviders,
-        );
-        applyProviderListState(next);
-        return next;
-      } catch {
-        return null;
-      }
+      return null;
     }
   }
 

--- a/apps/app/src/react-app/domains/connections/provider-list-query.ts
+++ b/apps/app/src/react-app/domains/connections/provider-list-query.ts
@@ -1,0 +1,217 @@
+import { useQuery, type QueryClient } from "@tanstack/react-query";
+
+import type { Client, ModelRef, ProviderListItem } from "../../../app/types";
+import { unwrap } from "../../../app/lib/opencode";
+import { dispatchNewProviders } from "../../../app/lib/provider-events";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
+
+export const PROVIDER_LIST_CACHE_MS = 5 * 60 * 1000;
+const PROVIDER_LIST_QUERY_ROOT = ["opencode-provider-list"] as const;
+
+export type ConnectedProviderSnapshot = Array<{
+  id: string;
+  name: string;
+  source: ProviderListItem["source"];
+  models: Record<string, ProviderListItem["models"][string]>;
+}>;
+
+export type ConnectedProviderSnapshotChange = {
+  changed: boolean;
+  previous: ConnectedProviderSnapshot | null;
+  next: ConnectedProviderSnapshot;
+};
+
+const connectedProviderSnapshots = new Map<string, ConnectedProviderSnapshot>();
+const connectedProviderSnapshotChanges = new Map<string, ConnectedProviderSnapshotChange>();
+
+export function providerListQueryKey(input: {
+  baseUrl?: string | null;
+  directory?: string | null;
+}) {
+  return [
+    ...PROVIDER_LIST_QUERY_ROOT,
+    input.baseUrl?.trim() ?? "",
+    input.directory?.trim() ?? "",
+  ] as const;
+}
+
+export async function refreshProviderListQueries(queryClient: QueryClient) {
+  await queryClient.invalidateQueries({ queryKey: PROVIDER_LIST_QUERY_ROOT });
+  await queryClient.refetchQueries({ queryKey: PROVIDER_LIST_QUERY_ROOT, type: "active" });
+}
+
+export async function fetchProviderList(input: {
+  client: Client;
+  baseUrl?: string | null;
+  directory?: string | null;
+}): Promise<ProviderListResponse> {
+  const value = unwrap(
+    await input.client.provider.list({
+      directory: input.directory?.trim() || undefined,
+    }),
+  );
+  recordConnectedProviderSnapshot(input, value);
+  return value;
+}
+
+export function getConnectedProviderItems(value: ProviderListResponse | null | undefined) {
+  const connected = new Set(value?.connected ?? []);
+  return (value?.all ?? []).filter(
+    (provider) =>
+      connected.has(provider.id) &&
+      (provider.source !== "custom" || provider.id === "opencode"),
+  );
+}
+
+export function getConnectedProviderSnapshot(value: ProviderListResponse | null | undefined): ConnectedProviderSnapshot {
+  return getConnectedProviderItems(value)
+    .map((provider) => ({
+      id: provider.id,
+      name: provider.name,
+      source: provider.source,
+      models: Object.fromEntries(
+        Object.entries(provider.models ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+      ),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function isModelAvailableInConnectedProviders(
+  value: ProviderListResponse | null | undefined,
+  model: ModelRef | null | undefined,
+) {
+  if (!model?.providerID || !model.modelID) return true;
+  return getConnectedProviderItems(value).some(
+    (provider) => provider.id === model.providerID && Boolean(provider.models?.[model.modelID]),
+  );
+}
+
+export function getConnectedProviderSnapshotChange(input: {
+  baseUrl?: string | null;
+  directory?: string | null;
+}) {
+  return connectedProviderSnapshotChanges.get(connectedProviderSnapshotKey(input)) ?? null;
+}
+
+function recordConnectedProviderSnapshot(
+  input: {
+    baseUrl?: string | null;
+    directory?: string | null;
+  },
+  value: ProviderListResponse,
+) {
+  const key = connectedProviderSnapshotKey(input);
+  const previous = connectedProviderSnapshots.get(key) ?? null;
+  const next = getConnectedProviderSnapshot(value);
+  const changed = previous !== null && JSON.stringify(previous) !== JSON.stringify(next);
+  connectedProviderSnapshots.set(key, next);
+  connectedProviderSnapshotChanges.set(key, { changed, previous, next });
+  if (changed) {
+    dispatchConnectedProviderChanges(previous, next);
+  }
+}
+
+function connectedProviderSnapshotKey(input: {
+  baseUrl?: string | null;
+  directory?: string | null;
+}) {
+  return JSON.stringify(providerListQueryKey(input));
+}
+
+function dispatchConnectedProviderChanges(
+  previous: ConnectedProviderSnapshot | null,
+  next: ConnectedProviderSnapshot,
+) {
+  if (!previous) return;
+  const previousById = new Map(previous.map((provider) => [provider.id, provider]));
+  const newProviders = next.filter((provider) => !previousById.has(provider.id));
+  const changedProviders = new Map<string, ConnectedProviderSnapshot[number]>();
+  let newModelCount = 0;
+
+  for (const provider of next) {
+    const before = previousById.get(provider.id);
+    if (!before) {
+      newModelCount += Object.keys(provider.models).length;
+      changedProviders.set(provider.id, provider);
+      continue;
+    }
+    for (const [id, model] of Object.entries(provider.models)) {
+      if (JSON.stringify(before.models[id]) !== JSON.stringify(model)) {
+        newModelCount += 1;
+        changedProviders.set(provider.id, provider);
+      }
+    }
+  }
+
+  if (newProviders.length === 0 && newModelCount === 0) return;
+
+  dispatchNewProviders({
+    providers: [...changedProviders.values()].map((provider) => {
+      const firstModelId = Object.keys(provider.models)[0];
+      return {
+        id: provider.id,
+        name: provider.name,
+        providerId: provider.id,
+        firstModelId,
+        firstModelName: firstModelId ? provider.models[firstModelId]?.name ?? firstModelId : undefined,
+      };
+    }),
+    newProviderCount: newProviders.length,
+    newModelCount,
+    source: "models_refresh",
+  });
+}
+
+export function ensureProviderListQuery(
+  queryClient: QueryClient,
+  input: {
+    client: Client;
+    baseUrl?: string | null;
+    directory?: string | null;
+    force?: boolean;
+  },
+) {
+  const options = {
+    queryKey: providerListQueryKey(input),
+    queryFn: () => fetchProviderList(input),
+    gcTime: PROVIDER_LIST_CACHE_MS,
+  };
+  if (input.force) {
+    return queryClient.fetchQuery({
+      ...options,
+      staleTime: 0,
+    });
+  }
+  return queryClient.ensureQueryData({
+    ...options,
+    staleTime: PROVIDER_LIST_CACHE_MS,
+  });
+}
+
+export function useProviderListQuery(input: {
+  client: Client | null;
+  baseUrl?: string | null;
+  directory?: string | null;
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: providerListQueryKey(input),
+    enabled: Boolean(input.client) && (input.enabled ?? true),
+    staleTime: PROVIDER_LIST_CACHE_MS,
+    gcTime: PROVIDER_LIST_CACHE_MS,
+    queryFn: () => {
+      if (!input.client) {
+        return {
+          all: [] as ProviderListItem[],
+          connected: [],
+          default: {},
+        } satisfies ProviderListResponse;
+      }
+      return fetchProviderList({
+        client: input.client,
+        baseUrl: input.baseUrl,
+        directory: input.directory,
+      });
+    },
+  });
+}

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -65,6 +65,7 @@ export type ModelPickerModalProps = {
   open: boolean;
   options: ModelOption[];
   disabledProviders?: string[];
+  initialTab?: Tab;
   query: string;
   setQuery: (value: string) => void;
   target: "default" | "session";
@@ -103,7 +104,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
   // Reset on open + seed defaults on first run
   useEffect(() => {
     if (props.open) {
-      setTab("default");
+      setTab(props.initialTab ?? "default");
       props.setQuery("");
       if (!hasSeededHiddenModels() && props.options.length > 0) {
         const seeded = seedHiddenModels(props.options);
@@ -114,7 +115,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         setHiddenModels(readHiddenModels());
       }
     }
-  }, [props.open, props.options]);
+  }, [props.initialTab, props.open, props.options]);
 
   // Focus search
   useEffect(() => {

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -39,6 +39,7 @@ type ComposerProps = {
   onStop: () => void | Promise<void>;
   busy: boolean;
   disabled: boolean;
+  modelUnavailable?: boolean;
   statusLabel: string;
   modelPickerOpen: boolean;
   selectedModel: ModelRef;
@@ -1400,6 +1401,9 @@ export function ReactSessionComposer(props: ComposerProps) {
               onChange={props.onModelChange}
               disabled={props.busy}
             />
+            {props.modelUnavailable ? (
+              <span className="text-xs font-medium text-red-10">Model no longer available</span>
+            ) : null}
 
             <ModelBehaviorSelect
               value={props.modelVariant}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -69,6 +69,7 @@ export type SessionSurfaceProps = {
   modelLabel: string;
   onModelClick: () => void;
   modelPickerOpen: boolean;
+  modelUnavailable?: boolean;
   selectedModel: ModelRef;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
@@ -671,13 +672,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     label: "Send the composer prompt",
     description: "Send the currently visible composer draft to the active session.",
     sideEffect: "mutation",
-    disabled: (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle",
+    disabled: props.modelUnavailable || (!draft.trim() && attachments.length === 0) || model.transitionState !== "idle",
     targetRef: composerShellRef,
     execute: async () => {
       await handleSend();
       return true;
     },
-  }), [attachments.length, draft, handleSend, model.transitionState]);
+  }), [attachments.length, draft, handleSend, model.transitionState, props.modelUnavailable]);
   useControlAction(composerSendControlAction);
 
   const composerStopControlAction = useMemo<OpenworkControlAction>(() => ({
@@ -1015,7 +1016,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onSend={handleSend}
         onStop={handleAbort}
         busy={chatStreaming}
-        disabled={model.transitionState !== "idle"}
+        disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}
+        modelUnavailable={Boolean(props.modelUnavailable)}
         statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
         modelPickerOpen={props.modelPickerOpen}
         selectedModel={props.selectedModel}

--- a/apps/app/src/react-app/kernel/global-sync-provider.tsx
+++ b/apps/app/src/react-app/kernel/global-sync-provider.tsx
@@ -11,7 +11,6 @@ import {
 } from "react";
 import type {
   Config,
-  ConfigProvidersResponse,
   Event,
   GlobalHealthResponse,
   LspStatus,
@@ -28,10 +27,9 @@ import { t } from "../../i18n";
 import { unwrap } from "../../app/lib/opencode";
 import type { McpStatusMap, TodoItem } from "../../app/types";
 import { safeStringify } from "../../app/utils";
-import {
-  filterProviderList,
-  mapConfigProvidersToList,
-} from "../../app/utils/providers";
+import { filterProviderList } from "../../app/utils/providers";
+import { getReactQueryClient } from "../infra/query-client";
+import { ensureProviderListQuery } from "../domains/connections/provider-list-query";
 
 import { useGlobalSDK } from "./global-sdk-provider";
 
@@ -168,25 +166,14 @@ export function GlobalSyncProvider({ children }: GlobalSyncProviderProps) {
     }
     try {
       const result = filterProviderList(
-        unwrap(await globalSDK.client.provider.list()),
+        await ensureProviderListQuery(getReactQueryClient(), {
+          client: globalSDK.client,
+        }),
         disabledProviders,
       );
       setField("provider", result);
     } catch {
-      const fallback = unwrap(
-        await globalSDK.client.config.providers(),
-      ) as ConfigProvidersResponse;
-      setField(
-        "provider",
-        filterProviderList(
-          {
-            all: mapConfigProvidersToList(fallback.providers),
-            connected: [],
-            default: fallback.default,
-          },
-          disabledProviders,
-        ),
-      );
+      setField("provider", { all: [], connected: [], default: {} });
     }
   }, [globalSDK.client, setField]);
 

--- a/apps/app/src/react-app/shell/new-providers-toast.tsx
+++ b/apps/app/src/react-app/shell/new-providers-toast.tsx
@@ -37,6 +37,8 @@ function markProvidersSeen(ids: string[]): void {
 type ToastState = {
   show: boolean;
   providers: NewProviderInfo[];
+  newProviderCount: number;
+  newModelCount: number;
 };
 
 /**
@@ -44,27 +46,40 @@ type ToastState = {
  * picker so the user can change their default if they want.
  */
 export function NewProvidersToast() {
-  const [state, setState] = useState<ToastState>({ show: false, providers: [] });
+  const [state, setState] = useState<ToastState>({
+    show: false,
+    providers: [],
+    newProviderCount: 0,
+    newModelCount: 0,
+  });
   const [orgOnboardingVisible, setOrgOnboardingVisible] = useState(false);
   const [pendingProviders, setPendingProviders] = useState<NewProviderInfo[]>([]);
 
-  const showProviders = useCallback((providers: NewProviderInfo[]) => {
+  const showProviders = useCallback((detail: NewProvidersEventDetail) => {
     const seen = readSeenProviderIds();
-    const genuinelyNew = providers.filter((p) => !seen.has(p.id));
-    if (genuinelyNew.length === 0) return;
+    const genuinelyNew = detail.providers.filter((p) => !seen.has(p.id));
+    const newProviderCount = detail.newProviderCount ?? genuinelyNew.length;
+    const newModelCount = detail.newModelCount ?? 0;
+    if (genuinelyNew.length === 0 && newModelCount === 0) return;
 
     setState((prev) => ({
       show: true,
       providers: prev.show
-        ? [...prev.providers, ...genuinelyNew.filter((p) => !prev.providers.some((e) => e.id === p.id))]
-        : genuinelyNew,
+        ? [...prev.providers, ...detail.providers.filter((p) => !prev.providers.some((e) => e.id === p.id))]
+        : detail.providers,
+      newProviderCount: prev.show
+        ? prev.newProviderCount + newProviderCount
+        : newProviderCount,
+      newModelCount: prev.show
+        ? prev.newModelCount + newModelCount
+        : newModelCount,
     }));
   }, []);
 
   useEffect(() => {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent<NewProvidersEventDetail>).detail;
-      if (detail.providers.length === 0) return;
+      if (detail.providers.length === 0 && !detail.newModelCount) return;
       if (orgOnboardingVisible) {
         setPendingProviders((current) => [
           ...current,
@@ -72,7 +87,7 @@ export function NewProvidersToast() {
         ]);
         return;
       }
-      showProviders(detail.providers);
+      showProviders(detail);
     };
     window.addEventListener(newProvidersEvent, handler);
     return () => window.removeEventListener(newProvidersEvent, handler);
@@ -88,52 +103,64 @@ export function NewProvidersToast() {
 
   useEffect(() => {
     if (orgOnboardingVisible || pendingProviders.length === 0) return;
-    showProviders(pendingProviders);
+    showProviders({ providers: pendingProviders, source: "cloud_sync" });
     setPendingProviders([]);
   }, [orgOnboardingVisible, pendingProviders, showProviders]);
 
   const dismiss = useCallback(() => {
     markProvidersSeen(state.providers.map((p) => p.id));
-    setState({ show: false, providers: [] });
+    setState({ show: false, providers: [], newProviderCount: 0, newModelCount: 0 });
   }, [state.providers]);
 
   const pickDefault = useCallback(() => {
     const ids = state.providers.map((p) => p.id);
     markProvidersSeen(ids);
-    setState({ show: false, providers: [] });
+    setState({ show: false, providers: [], newProviderCount: 0, newModelCount: 0 });
     try {
-      window.localStorage.setItem(PENDING_MODEL_PICKER_KEY, JSON.stringify(ids));
+      window.localStorage.setItem(
+        PENDING_MODEL_PICKER_KEY,
+        JSON.stringify({ newProviderIds: ids, initialTab: "available" }),
+      );
     } catch {}
-    // Pass the new provider IDs so the picker can highlight them as
-    // "Recently added" even though they were just marked as seen.
-    window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { newProviderIds: ids } }));
+    window.dispatchEvent(new CustomEvent(openModelPickerEvent, { detail: { newProviderIds: ids, initialTab: "available" } }));
     window.setTimeout(() => {
       try {
         if (window.localStorage.getItem(PENDING_MODEL_PICKER_KEY)) {
-          window.location.hash = "/session";
+          const path = window.location.hash.replace(/^#/, "") || "/settings/preferences";
+          const match = path.match(/^\/workspace\/([^/]+)/);
+          window.location.hash = match?.[1]
+            ? `/workspace/${match[1]}/settings/preferences`
+            : "/settings/preferences";
         }
       } catch {}
     }, 0);
   }, [state.providers]);
 
-  if (!state.show || state.providers.length === 0) return null;
+  if (!state.show || (state.providers.length === 0 && state.newModelCount === 0)) return null;
+
+  const message = (() => {
+    const parts: string[] = [];
+    if (state.newProviderCount > 0) {
+      parts.push(`${state.newProviderCount} new ${state.newProviderCount === 1 ? "provider" : "providers"}`);
+    }
+    if (state.newModelCount > 0) {
+      parts.push(`${state.newModelCount} new ${state.newModelCount === 1 ? "model" : "models"}`);
+    }
+    return parts.join(" & ");
+  })();
 
   return (
     <div className="fixed bottom-6 left-1/2 z-[9999] -translate-x-1/2 animate-in slide-in-from-bottom-4 fade-in duration-300">
       <div className="flex items-center gap-4 rounded-2xl border border-dls-border bg-dls-surface px-5 py-3.5 shadow-lg">
         <div className="flex items-center gap-2">
-          {state.providers.map((p) => (
+          {state.providers.slice(0, 6).map((p) => (
             <ProviderIcon key={p.id} providerId={p.providerId} providerName={p.name} size={16} className="text-dls-text" />
           ))}
         </div>
 
         <div className="min-w-0 text-[13px] text-dls-text">
-          <span className="font-medium">
-            {state.providers.length === 1
-              ? resolveProviderDisplayName(state.providers[0].name || state.providers[0].providerId)
-              : `${state.providers.length} new providers`}
-          </span>
-          {" "}added.{" "}
+          <span className="font-medium">{message || resolveProviderDisplayName(state.providers[0]?.name || state.providers[0]?.providerId || "Models")}</span>
+          {" "}available.{" "}
           <button
             type="button"
             className="font-medium underline underline-offset-2 transition-colors hover:text-dls-text/80"

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -11,7 +11,6 @@ import {
 import { useNavigate, useParams } from "react-router-dom";
 import type {
   AgentPartInput,
-  ConfigProvidersResponse,
   FilePartInput,
   ProviderListResponse,
   TextPartInput,
@@ -126,7 +125,7 @@ import { denSessionUpdatedEvent } from "../../app/lib/den-session-events";
 
 import { openModelPickerEvent, pendingModelPickerProviderIdsKey } from "./new-providers-toast";
 import { getModelBehaviorSummary } from "../../app/lib/model-behavior";
-import { filterProviderList, mapConfigProvidersToList } from "../../app/utils/providers";
+import { filterProviderList } from "../../app/utils/providers";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { useReloadCoordinator } from "./reload-coordinator";
@@ -135,6 +134,13 @@ import { useStatusToasts } from "../domains/shell-feedback/status-toasts";
 import { useSessionControlActions } from "../domains/session/control/session-control-actions";
 import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 import { WorkspaceProvider } from "./workspace-provider";
+import {
+  ensureProviderListQuery,
+  getConnectedProviderItems,
+  isModelAvailableInConnectedProviders,
+  refreshProviderListQueries,
+  useProviderListQuery,
+} from "../domains/connections/provider-list-query";
 
 type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
@@ -510,6 +516,7 @@ export function SessionRoute() {
   // session "Pick a model" button navigated to /settings/general, which is a
   // dead-end). Loads providers lazily when the modal opens.
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const [modelPickerInitialTab, setModelPickerInitialTab] = useState<"default" | "available">("default");
   const [compactModelPickerOpen, setCompactModelPickerOpen] = useState(false);
   const [modelPickerQuery, setModelPickerQuery] = useState("");
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
@@ -534,10 +541,12 @@ export function SessionRoute() {
       try {
         window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
       } catch {}
-      const ids = (event as CustomEvent<{ newProviderIds?: string[] }>).detail?.newProviderIds;
+      const detail = (event as CustomEvent<{ newProviderIds?: string[]; initialTab?: "default" | "available" }>).detail;
+      const ids = detail?.newProviderIds;
       if (ids && ids.length > 0) {
         setRecentProviderIds(new Set(ids));
       }
+      setModelPickerInitialTab(detail?.initialTab ?? "default");
       setModelPickerOpen(true);
     };
     window.addEventListener(openModelPickerEvent, handler);
@@ -549,10 +558,12 @@ export function SessionRoute() {
       const raw = window.localStorage.getItem(pendingModelPickerProviderIdsKey);
       if (!raw) return;
       window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
-      const ids = JSON.parse(raw);
+      const parsed = JSON.parse(raw);
+      const ids = Array.isArray(parsed) ? parsed : parsed?.newProviderIds;
       if (Array.isArray(ids) && ids.every((id) => typeof id === "string")) {
         setRecentProviderIds(new Set(ids));
       }
+      setModelPickerInitialTab(parsed?.initialTab === "available" ? "available" : "default");
       setModelPickerOpen(true);
     } catch {
       window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
@@ -947,6 +958,7 @@ export function SessionRoute() {
       return false;
     }
     await endpoint.client.reloadEngine(endpoint.workspaceId);
+    await refreshProviderListQueries(getReactQueryClient());
     setEngineReloadVersion((v) => v + 1);
     try {
       window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
@@ -1365,8 +1377,18 @@ export function SessionRoute() {
         : null,
     [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
+  const providerListQuery = useProviderListQuery({
+    client: opencodeClient,
+    baseUrl: opencodeBaseUrl,
+    directory: selectedWorkspaceRoot || undefined,
+  });
+  const selectedModelUnavailable = Boolean(
+    local.prefs.defaultModel &&
+      providerListQuery.data &&
+      !isModelAvailableInConnectedProviders(providerListQuery.data, local.prefs.defaultModel),
+  );
   const canCreateTask = Boolean(
-    opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError,
+    opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError && !selectedModelUnavailable,
   );
 
   const sessionProviderAuthStateRef = useRef({
@@ -1571,41 +1593,26 @@ export function SessionRoute() {
       try {
         applyProviderState(
           filterProviderList(
-            unwrap(await opencodeClient.provider.list()),
+            await ensureProviderListQuery(getReactQueryClient(), {
+              client: opencodeClient,
+              baseUrl: opencodeBaseUrl,
+              directory: selectedWorkspaceRoot || undefined,
+            }),
             disabledProviders,
           ),
         );
       } catch {
-        try {
-          const fallback = unwrap(
-            await opencodeClient.config.providers({
-              directory: selectedWorkspaceRoot || undefined,
-            }),
-          ) as ConfigProvidersResponse;
-          applyProviderState(
-            filterProviderList(
-              {
-                all: mapConfigProvidersToList(
-                  fallback.providers,
-                ) as ProviderListResponse["all"],
-                connected: [],
-                default: fallback.default,
-              },
-              disabledProviders,
-            ),
-          );
-        } catch {
-          if (cancelled) return;
-          setProviders([]);
-          setProviderConnectedIds([]);
-        }
+        if (cancelled) return;
+        setProviders([]);
+        setProviderDefaults({});
+        setProviderConnectedIds([]);
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [opencodeClient, selectedWorkspaceRoot, denSessionVersion]);
+  }, [opencodeBaseUrl, opencodeClient, selectedWorkspaceRoot, denSessionVersion]);
 
   const modelLabel = local.prefs.defaultModel
     ? resolveModelDisplayName(local.prefs.defaultModel.modelID)
@@ -1616,28 +1623,14 @@ export function SessionRoute() {
   // model supports — without waiting for the model picker to open. Cached
   // as providerID → modelID → ProviderModel.
   useEffect(() => {
-    if (!opencodeClient) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const res = await opencodeClient.config.providers({
-          directory: selectedWorkspaceRoot || undefined,
-        });
-        const data = (res as { data?: { providers?: Array<{ id: string; models: Record<string, any> }> } }).data;
-        if (cancelled || !data?.providers) return;
-        const next: Record<string, Record<string, any>> = {};
-        for (const provider of data.providers) {
-          next[provider.id] = { ...(provider.models ?? {}) };
-        }
-        setProviderCatalog(next);
-      } catch {
-        // best-effort cache; UI will fall back to empty variant options.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [opencodeClient, selectedWorkspaceRoot]);
+    const data = providerListQuery.data;
+    if (!data?.all) return;
+    const next: Record<string, Record<string, any>> = {};
+    for (const provider of data.all) {
+      next[provider.id] = { ...(provider.models ?? {}) };
+    }
+    setProviderCatalog(next);
+  }, [providerListQuery.data]);
 
   // Compute behavior (reasoning/thinking variant) options for the current
   // default model. This is what the composer renders as its variant pill.
@@ -1674,19 +1667,12 @@ export function SessionRoute() {
     let cancelled = false;
     void (async () => {
       try {
-        const res = await opencodeClient.config.providers({
+        const data = await ensureProviderListQuery(getReactQueryClient(), {
+          client: opencodeClient,
+          baseUrl: opencodeBaseUrl,
           directory: selectedWorkspaceRoot || undefined,
         });
-        const data = (res as {
-          data?: {
-            providers?: Array<{
-              id: string;
-              name: string;
-              models: Record<string, { id: string; name: string }>;
-            }>;
-          };
-        }).data;
-        if (cancelled || !data?.providers) return;
+        if (cancelled || !data?.all) return;
         // Flag models from recently-added providers so they appear in
         // the "Recently added" section at the top of the picker.
         // Two sources: (1) providers not yet in the localStorage seen-set,
@@ -1699,9 +1685,8 @@ export function SessionRoute() {
           seenIds = new Set();
         }
         const options: ModelOption[] = [];
-        for (const provider of data.providers) {
+        for (const provider of getConnectedProviderItems(data)) {
           const modelIds = Object.keys(provider.models);
-          const hasModels = modelIds.length > 0;
           const isNew = !seenIds.has(provider.id) || recentProviderIds.has(provider.id);
           for (const id of modelIds) {
             const model = provider.models[id];
@@ -1715,7 +1700,7 @@ export function SessionRoute() {
               behaviorDescription: "",
               behaviorValue: null,
               isFree: false,
-              isConnected: hasModels,
+              isConnected: true,
               isRecommended: isNew,
               source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
             });
@@ -1729,14 +1714,13 @@ export function SessionRoute() {
     return () => {
       cancelled = true;
     };
-  }, [modelPickerOpen, opencodeClient, recentProviderIds, selectedWorkspaceRoot]);
+  }, [modelPickerOpen, opencodeBaseUrl, opencodeClient, recentProviderIds, selectedWorkspaceRoot]);
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:
   //   - `blockZenModel` hides the built-in OpenCode provider entries
-  //   - `disallowNonCloudModels` hides providers that aren't currently
-  //     connected via cloud (a provider with models[] filled counts as
-  //     connected in this list — see the loader above)
+  //   - `disallowNonCloudModels` hides providers that OpenCode does not report
+  //     as connected through the provider list endpoint.
   const allowedModelOptions = useMemo(() => {
     const restrictToCloud = checkDesktopRestriction({
       restriction: "disallowNonCloudModels",
@@ -1813,6 +1797,7 @@ export function SessionRoute() {
         setModelPickerOpen(true);
       },
       modelPickerOpen: compactModelPickerOpen,
+      modelUnavailable: selectedModelUnavailable,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
       onModelPickerOpenChange: setCompactModelPickerOpen,
       onModelChange: (model: ModelRef) => {
@@ -1831,6 +1816,7 @@ export function SessionRoute() {
       onSendDraft: async (draft: ComposerDraft) => {
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!text && draft.attachments.length === 0) return;
+        if (selectedModelUnavailable) return;
 
         if (draft.mode === "shell") {
           await shellInSession(opencodeClient, selectedSessionId, text);
@@ -1962,6 +1948,7 @@ export function SessionRoute() {
     opencodeClient,
     selectedAgent,
     selectedSessionId,
+    selectedModelUnavailable,
     selectedWorkspace,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
@@ -2459,7 +2446,11 @@ export function SessionRoute() {
   }, [local, refreshRouteState]);
 
   return (
-    <WorkspaceProvider client={opencodeClient} selectedWorkspaceRoot={selectedWorkspaceRoot}>
+    <WorkspaceProvider
+      client={opencodeClient}
+      opencodeBaseUrl={opencodeBaseUrl}
+      selectedWorkspaceRoot={selectedWorkspaceRoot}
+    >
     {opencodeClient && selectedWorkspaceEndpoint && opencodeBaseUrl && selectedWorkspaceServerToken ? (
       <ReactSessionRuntime
         // Use the server-side workspace id (the one without the `rem_`
@@ -2744,6 +2735,7 @@ export function SessionRoute() {
     <ModelPickerModal
       open={modelPickerOpen}
       options={allowedModelOptions}
+      initialTab={modelPickerInitialTab}
       query={modelPickerQuery}
       setQuery={setModelPickerQuery}
       target="default"

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -81,7 +81,15 @@ import {
 import { isDesktopProviderBlocked } from "../../app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction, useDesktopConfig } from "../domains/cloud/desktop-config-provider";
 import { useCloudProviderAutoSync } from "../domains/cloud/use-cloud-provider-auto-sync";
-import { isDesktopRuntime, isElectronRuntime, isMacPlatform, normalizeDirectoryPath, safeStringify } from "../../app/utils";
+import {
+  isDesktopRuntime,
+  isElectronRuntime,
+  isMacPlatform,
+  normalizeDirectoryPath,
+  resolveModelDisplayName,
+  resolveProviderDisplayName,
+  safeStringify,
+} from "../../app/utils";
 import { CreateRemoteWorkspaceModal } from "../domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
 import { RenameWorkspaceModal } from "../domains/workspace/rename-workspace-modal";
@@ -104,6 +112,9 @@ import { useReloadCoordinator } from "./reload-coordinator";
 import { buildFeedbackUrl } from "../../app/lib/feedback";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
 import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
+import { getReactQueryClient } from "../infra/query-client";
+import { ensureProviderListQuery, getConnectedProviderItems, refreshProviderListQueries } from "../domains/connections/provider-list-query";
+import { openModelPickerEvent, pendingModelPickerProviderIdsKey } from "./new-providers-toast";
 
 type RouteWorkspace = OpenworkWorkspaceInfo & {
   displayNameResolved: string;
@@ -448,6 +459,7 @@ function SettingsRouteContent() {
   const [autoCompactContextBusy, setAutoCompactContextBusy] = useState(false);
   const [autoCompactContextLoaded, setAutoCompactContextLoaded] = useState(false);
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const [modelPickerInitialTab, setModelPickerInitialTab] = useState<"default" | "available">("default");
   const [modelPickerQuery, setModelPickerQuery] = useState("");
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const emptyWorkspaceDisplay = useMemo<WorkspaceDisplay>(
@@ -556,6 +568,7 @@ function SettingsRouteContent() {
     }
 
     await openworkClient.reloadEngine(workspaceId);
+    await refreshProviderListQueries(getReactQueryClient());
 
     try {
       window.dispatchEvent(new CustomEvent("openwork-server-settings-changed"));
@@ -763,16 +776,49 @@ function SettingsRouteContent() {
   }, [opencodeClient]);
 
   useEffect(() => {
+    const openFromPending = (raw: string | null) => {
+      if (!raw) return false;
+      const parsed = JSON.parse(raw);
+      setModelPickerInitialTab(parsed?.initialTab === "available" ? "available" : "default");
+      setModelPickerQuery("");
+      setModelPickerOpen(true);
+      return true;
+    };
+
+    try {
+      const raw = window.localStorage.getItem(pendingModelPickerProviderIdsKey);
+      if (openFromPending(raw)) {
+        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+      }
+    } catch {
+      window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+    }
+
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ initialTab?: "default" | "available" }>).detail;
+      setModelPickerInitialTab(detail?.initialTab ?? "default");
+      setModelPickerQuery("");
+      setModelPickerOpen(true);
+      try {
+        window.localStorage.removeItem(pendingModelPickerProviderIdsKey);
+      } catch {}
+    };
+    window.addEventListener(openModelPickerEvent, handler);
+    return () => window.removeEventListener(openModelPickerEvent, handler);
+  }, []);
+
+  useEffect(() => {
     if (!modelPickerOpen || !opencodeClient) return;
     let cancelled = false;
     void providerAuthStore.refreshProviders();
     void (async () => {
       try {
-        const res = await opencodeClient.config.providers({
+        const data = await ensureProviderListQuery(getReactQueryClient(), {
+          client: opencodeClient,
+          baseUrl: opencodeBaseUrl,
           directory: selectedWorkspaceRoot || undefined,
         });
-        const data = (res as { data?: { providers?: Array<{ id: string; name: string; source?: string; models: Record<string, { id: string; name: string }> }> } }).data;
-        if (cancelled || !data?.providers) return;
+        if (cancelled || !data?.all) return;
         let seenIds: Set<string>;
         try {
           const raw = window.localStorage.getItem("openwork.seenProviderIds");
@@ -781,9 +827,8 @@ function SettingsRouteContent() {
           seenIds = new Set();
         }
         const options: ModelOption[] = [];
-        for (const provider of data.providers) {
+        for (const provider of getConnectedProviderItems(data)) {
           const modelIds = Object.keys(provider.models);
-          const hasModels = modelIds.length > 0;
           const isNew = !seenIds.has(provider.id);
           for (const id of modelIds) {
             const model = provider.models[id];
@@ -797,7 +842,7 @@ function SettingsRouteContent() {
               behaviorDescription: "",
               behaviorValue: null,
               isFree: false,
-              isConnected: hasModels,
+              isConnected: true,
               isRecommended: isNew,
               source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
             });
@@ -815,7 +860,7 @@ function SettingsRouteContent() {
     return () => {
       cancelled = true;
     };
-  }, [modelPickerOpen, opencodeClient, selectedWorkspaceRoot]);
+  }, [modelPickerOpen, opencodeBaseUrl, opencodeClient, selectedWorkspaceRoot]);
 
   useEffect(() => {
     local.setUi((previous) => ({ ...previous, view: "settings", tab: route.tab }));
@@ -1227,7 +1272,13 @@ function SettingsRouteContent() {
   const pluginsAccessHint =
     isRemoteWorkspace && !canWriteWorkspacePlugins ? t("app.plugins_hint_readonly") : null;
   const defaultModelLabel = local.prefs.defaultModel
-    ? `${local.prefs.defaultModel.providerID}/${local.prefs.defaultModel.modelID}`
+    ? (() => {
+        const provider = providers.find((item) => item.id === local.prefs.defaultModel?.providerID);
+        const model = provider?.models?.[local.prefs.defaultModel.modelID];
+        const providerLabel = provider?.name ?? resolveProviderDisplayName(local.prefs.defaultModel.providerID);
+        const modelLabel = model?.name ?? resolveModelDisplayName(local.prefs.defaultModel.modelID);
+        return `${providerLabel} - ${modelLabel}`;
+      })()
     : t("session.default_model");
   const defaultModelRef = local.prefs.defaultModel
     ? `${local.prefs.defaultModel.providerID}/${local.prefs.defaultModel.modelID}`
@@ -1578,6 +1629,7 @@ function SettingsRouteContent() {
             defaultModelLabel={defaultModelLabel}
             defaultModelRef={defaultModelRef}
             onChangeDefaultModel={() => {
+              setModelPickerInitialTab("default");
               setModelPickerQuery("");
               setModelPickerOpen(true);
             }}
@@ -1964,6 +2016,7 @@ function SettingsRouteContent() {
       <ModelPickerModal
         open={modelPickerOpen}
         options={modelOptions}
+        initialTab={modelPickerInitialTab}
         query={modelPickerQuery}
         setQuery={setModelPickerQuery}
         target="default"

--- a/apps/app/src/react-app/shell/workspace-provider.ts
+++ b/apps/app/src/react-app/shell/workspace-provider.ts
@@ -4,6 +4,7 @@ import type { Client } from "@/app/types";
 
 type WorkspaceContextValue = {
   client: Client | null;
+  opencodeBaseUrl: string;
   selectedWorkspaceRoot: string;
 };
 
@@ -11,14 +12,20 @@ const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null)
 
 type WorkspaceProviderProps = {
   client: Client | null;
+  opencodeBaseUrl?: string;
   selectedWorkspaceRoot: string;
   children: React.ReactNode;
 };
 
-export function WorkspaceProvider({ client, selectedWorkspaceRoot, children }: WorkspaceProviderProps) {
+export function WorkspaceProvider({
+  client,
+  opencodeBaseUrl = "",
+  selectedWorkspaceRoot,
+  children,
+}: WorkspaceProviderProps) {
   const value = React.useMemo(
-    () => ({ client, selectedWorkspaceRoot }),
-    [client, selectedWorkspaceRoot],
+    () => ({ client, opencodeBaseUrl, selectedWorkspaceRoot }),
+    [client, opencodeBaseUrl, selectedWorkspaceRoot],
   );
 
   return React.createElement(WorkspaceContext.Provider, { value }, children);


### PR DESCRIPTION
## Summary

- Route model/provider lists through the connected-aware OpenCode provider endpoint with a shared 5-minute React Query cache.
- Detect connected provider/model changes after refresh or reload and surface the existing bottom toast with new provider/model counts.
- Limit model pickers to connected providers, preserve OpenCode provider visibility, and block task submission when the selected model is no longer available.

## Evidence

### Screenshots
Not captured. This PR changes provider/model picker state and requires a live OpenWork runtime with model/provider changes to demonstrate visually.

### Build verification
- `pnpm typecheck` from `apps/app` -- passed
- `pnpm --filter @openwork/app build` -- passed

### API verification
No API changes.

### UI verification
Manual code-path verification: unified model picker reads now use `provider.list()` via the shared provider-list query; OpenCode reload paths invalidate/refetch provider-list queries; unavailable models disable composer submission and show inline warning.

## Test instructions

1. Start the OpenWork app against a workspace with at least one connected provider.
2. Open the session model picker and Settings > Preferences > Model; verify only connected provider models are shown, including OpenCode when connected.
3. Simulate a provider/model refresh or reload and verify the bottom toast shows new provider/model counts.
4. Select or retain a model that disappears from connected providers; verify Run task is disabled and `Model no longer available` appears by the model picker.