### PR TITLE
chore(inference): remove Claude Opus from OpenWork models

### DIFF
--- a/ee/apps/inference/src/models/openwork-dev.json
+++ b/ee/apps/inference/src/models/openwork-dev.json
@@ -26,43 +26,6 @@
           "cache_write": 0.029
         }
       },
-      "anthropic/claude-opus-4.7": {
-        "id": "anthropic/claude-opus-4.7",
-        "name": "Claude Opus 4.7",
-        "family": "claude-opus",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2026-01-31",
-        "release_date": "2026-04-16",
-        "last_updated": "2026-04-16",
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-        "open_weights": false,
-        "limit": { "context": 1000000, "output": 128000 },
-        "cost": {
-          "input": 5,
-          "output": 25,
-          "cache_read": 0.5,
-          "cache_write": 6.25,
-          "tiers": [
-            {
-              "input": 10,
-              "output": 37.5,
-              "cache_read": 1,
-              "cache_write": 12.5,
-              "tier": { "type": "context", "size": 200000 }
-            }
-          ],
-          "context_over_200k": {
-            "input": 10,
-            "output": 37.5,
-            "cache_read": 1,
-            "cache_write": 12.5
-          }
-        }
-      },
       "moonshotai/kimi-k2.6": {
         "id": "moonshotai/kimi-k2.6",
         "name": "Kimi K2.6",

--- a/ee/apps/inference/src/models/openwork-prod.json
+++ b/ee/apps/inference/src/models/openwork-prod.json
@@ -26,43 +26,6 @@
           "cache_write": 0.029
         }
       },
-      "anthropic/claude-opus-4.7": {
-        "id": "anthropic/claude-opus-4.7",
-        "name": "Claude Opus 4.7",
-        "family": "claude-opus",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2026-01-31",
-        "release_date": "2026-04-16",
-        "last_updated": "2026-04-16",
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
-        "open_weights": false,
-        "limit": { "context": 1000000, "output": 128000 },
-        "cost": {
-          "input": 5,
-          "output": 25,
-          "cache_read": 0.5,
-          "cache_write": 6.25,
-          "tiers": [
-            {
-              "input": 10,
-              "output": 37.5,
-              "cache_read": 1,
-              "cache_write": 12.5,
-              "tier": { "type": "context", "size": 200000 }
-            }
-          ],
-          "context_over_200k": {
-            "input": 10,
-            "output": 37.5,
-            "cache_read": 1,
-            "cache_write": 12.5
-          }
-        }
-      },
       "moonshotai/kimi-k2.6": {
         "id": "moonshotai/kimi-k2.6",
         "name": "Kimi K2.6",

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -60,12 +60,6 @@ export const INFERENCE_MODEL_ALIASES = {
     enabled: true,
     usageFactor: 1,
   },
-  "anthropic/claude-opus-4.7": {
-    upstreamModel: "anthropic/claude-opus-4.7",
-    displayName: "OpenWork: Claude Opus 4.7",
-    enabled: true,
-    usageFactor: 0.75,
-  },
   "moonshotai/kimi-k2.6": {
     upstreamModel: "moonshotai/kimi-k2.6",
     displayName: "OpenWork: Kimi K2.6",


### PR DESCRIPTION
## Summary

- Remove `anthropic/claude-opus-4.7` from OpenWork dev and production inference model manifests.
- Remove the matching `INFERENCE_MODEL_ALIASES` entry so it is no longer advertised as an OpenWork inference alias.

## Evidence

### Screenshots
- Not applicable; this change only updates inference model configuration and shared types.

### Build verification
- `pnpm install --frozen-lockfile` -- passed
- `pnpm --filter @openwork-ee/inference build` -- passed
- `pnpm --filter @openwork/types build` -- passed

### API verification
- No API endpoint changes. The inference model catalog generation ran as part of `@openwork-ee/inference` build and completed successfully.

### UI verification
- No UI changes.

## Test instructions

1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @openwork-ee/inference build`
3. `pnpm --filter @openwork/types build`
4. Confirm `anthropic/claude-opus-4.7` is absent from `ee/apps/inference/src/models/openwork-dev.json`, `ee/apps/inference/src/models/openwork-prod.json`, and `packages/types/src/den/inference.ts`.