### PR TITLE
fix(app): coalesce streaming transcript deltas

### DIFF
--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -15,7 +15,7 @@ type SyncOptions = {
   openworkToken: string;
 };
 
-type PendingDelta = {
+export type PendingDelta = {
   sessionId: string;
   messageId: string;
   partId: string;
@@ -302,6 +302,27 @@ function appendDelta(messages: UIMessage[], messageId: string, partId: string, d
   return nextMessages;
 }
 
+export function coalescePendingDeltas(items: PendingDelta[]) {
+  if (items.length < 2) return items;
+
+  const ordered: PendingDelta[] = [];
+  const byKey = new Map<string, PendingDelta>();
+  for (const item of items) {
+    const key = `${item.sessionId}\u0000${item.messageId}\u0000${item.partId}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.delta += item.delta;
+      existing.reasoning = existing.reasoning || item.reasoning;
+      continue;
+    }
+
+    const next = { ...item };
+    byKey.set(key, next);
+    ordered.push(next);
+  }
+  return ordered;
+}
+
 function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent) {
   const queryClient = getReactQueryClient();
 
@@ -464,7 +485,7 @@ function scheduleDeltaFlush(entry: SyncEntry, workspaceId: string) {
 
 function flushDeltas(entry: SyncEntry, workspaceId: string) {
   const queryClient = getReactQueryClient();
-  const pending = entry.deltaFlushBuffer;
+  const pending = coalescePendingDeltas(entry.deltaFlushBuffer);
   entry.deltaFlushBuffer = [];
 
   // Group by session id so each transcript cache is touched at most once

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -5,6 +5,7 @@ import type { PermissionRequest } from "@opencode-ai/sdk/v2/client";
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import {
+  coalescePendingDeltas,
   permissionKey,
   seedPermissionState,
   seedSessionState,
@@ -128,6 +129,21 @@ describe("session permission sync", () => {
 });
 
 describe("session transcript sync", () => {
+  test("coalesces token-sized deltas by transcript part", () => {
+    const deltas = coalescePendingDeltas([
+      { sessionId: "session-a", messageId: "msg-a", partId: "part-a", reasoning: false, delta: "hel" },
+      { sessionId: "session-a", messageId: "msg-a", partId: "part-a", reasoning: false, delta: "lo" },
+      { sessionId: "session-a", messageId: "msg-a", partId: "part-b", reasoning: true, delta: "think" },
+      { sessionId: "session-b", messageId: "msg-b", partId: "part-a", reasoning: false, delta: "other" },
+    ]);
+
+    expect(deltas).toEqual([
+      { sessionId: "session-a", messageId: "msg-a", partId: "part-a", reasoning: false, delta: "hello" },
+      { sessionId: "session-a", messageId: "msg-a", partId: "part-b", reasoning: true, delta: "think" },
+      { sessionId: "session-b", messageId: "msg-b", partId: "part-a", reasoning: false, delta: "other" },
+    ]);
+  });
+
   test("keeps live-only messages when an idle snapshot is stale", () => {
     getReactQueryClient().setQueryData(transcriptKey("workspace-a", "session-a"), [
       uiMessage("msg-user", "user", "hello"),


### PR DESCRIPTION
## Summary
- Coalesce same-frame transcript token deltas by session/message/part before touching React Query state.
- Match the OpenCode-style streaming strategy more closely by reducing per-token transcript cloning during thinking/tool progress bursts.
- Add coverage that verifies token-sized deltas preserve order while collapsing repeated updates for the same part.

## Why
OpenWork already scheduled streaming deltas once per animation frame, but each frame still replayed every token-sized `message.part.delta` through the transcript update path. Large thinking streams could clone the active transcript thousands of times before paint, starving the main thread and making thoughts/tool progress feel delayed. OpenCode keeps streaming state finer-grained and coalesces repeated stream updates before UI state is updated; this PR applies the same principle to OpenWork's React Query transcript cache.

## Local Validation
- `bun test tests/session-sync-permissions.test.ts` in `apps/app` -> 7 pass
- `pnpm typecheck` in `apps/app` -> pass
- `pnpm --filter @openwork/app build` -> pass
- `git diff --check` -> pass
- Local synthetic frame benchmark in this worktree: 5,000 same-part delta events collapsed to 1 frame item; median apply time changed from `4.69ms` to `0.03ms` (`164.4x` faster)

## Daytona Validation
Sandbox: `openwork-thinking-speed`
Branch: `fix/thinking-stream-speed`

- `bun test tests/session-sync-permissions.test.ts` in `/workspace/apps/app` -> 7 pass
- `pnpm typecheck` in `/workspace/apps/app` -> pass
- `pnpm --filter @openwork/app build` in `/workspace` -> pass
- Daytona coalescing benchmark: 5,000 same-part deltas collapsed to 1 item in `1.155ms`
- Electron stack started via `.devcontainer/start-services.sh`; CDP preview listed OpenWork target at `http://localhost:5173/#/welcome`
- Browser automation verified the rendered Welcome page text over CDP (`Welcome to OpenWork`, `Get started`, feature cards visible)

## Notes
The existing `openwork-test` Daytona sandbox had a 3GB disk and hit `ENOSPC` while installing a separate PR worktree, so I created a fresh 10GB validation sandbox instead of mutating the dirty existing checkout.