### PR TITLE
fix(inference): return OpenAI-compatible rate limit errors

### DIFF
--- a/ee/apps/inference/src/limits.ts
+++ b/ee/apps/inference/src/limits.ts
@@ -107,7 +107,18 @@ export async function ensureUsableBuckets(organizationId: string, now = new Date
     }
     const remaining = effectiveLimit - bucket.used_amount
     if (remaining <= 0) {
-      return { ok: false as const, bucketIds, bucketLimits, limitedBy: bucket.id, windowType: policy.window_type }
+      return {
+        ok: false as const,
+        bucketIds,
+        bucketLimits,
+        limitedBy: bucket.id,
+        windowType: policy.window_type,
+        limitedBucket: {
+          limitAmount: effectiveLimit,
+          usedAmount: bucket.used_amount,
+          windowEndAt: bucket.window_end_at,
+        },
+      }
     }
     bucketIds[policy.window_type] = bucket.id
     bucketLimits[policy.window_type] = effectiveLimit

--- a/ee/apps/inference/src/proxy.ts
+++ b/ee/apps/inference/src/proxy.ts
@@ -71,6 +71,10 @@ function buildRequestId() {
   return createHash("sha256").update(`${Date.now()}:${Math.random()}`).digest("hex").slice(0, 32)
 }
 
+function secondsUntil(date: Date) {
+  return Math.max(0, Math.ceil((date.getTime() - Date.now()) / 1000))
+}
+
 function trackStream(body: ReadableStream<Uint8Array> | null, done: () => Promise<void>, fail: () => Promise<void>) {
   if (!body) return body
   const reader = body.getReader()
@@ -167,7 +171,24 @@ export function registerProxyRoutes(app: Hono) {
         orgMembershipId: inferenceKey.org_membership_id,
         limitedBy: limits.limitedBy,
       })
-      return c.json({ error: { message: "Inference usage limit exceeded.", type: "rate_limit_error", code: "usage_limit_exceeded", bucket_id: limits.limitedBy } }, 429)
+      c.header("x-openwork-limit-bucket-id", limits.limitedBy)
+      c.header("x-openwork-limit-window-type", limits.windowType)
+      const limitedBucket = "limitedBucket" in limits ? limits.limitedBucket : null
+      if (limitedBucket) {
+        const retryAfter = secondsUntil(limitedBucket.windowEndAt)
+        c.header("retry-after", String(retryAfter))
+        c.header("x-ratelimit-limit-tokens", String(limitedBucket.limitAmount))
+        c.header("x-ratelimit-remaining-tokens", "0")
+        c.header("x-ratelimit-reset-tokens", `${retryAfter}s`)
+      }
+      return c.json({
+        error: {
+          message: `Rate limit reached for organization ${inferenceKey.organization_id}.`,
+          type: "tokens",
+          param: null,
+          code: "rate_limit_exceeded",
+        },
+      }, 429)
     }
 
     const providerKey = await getOpenRouterProviderKey(inferenceKey.organization_id)


### PR DESCRIPTION
## Summary

- Return an OpenAI-compatible 429 error envelope for exceeded inference usage limits.
- Add token rate-limit headers and retry timing for exhausted usage buckets.
- Preserve OpenWork bucket metadata in vendor-specific response headers.

## Evidence

### Screenshots
No UI changes.

### Build verification
- `pnpm i` -- passed
- `pnpm --filter @openwork-ee/inference build` -- passed

### API verification
Not run against a live inference database; behavior is covered by build/type verification for the changed proxy and limit metadata path.

### UI verification
No UI changes.

## Test instructions

1. Configure an org whose active inference usage bucket is exhausted.
2. Send an authenticated request through `ee/apps/inference` under `/api/v1/*`.
3. Verify the response is HTTP 429 with `error.code: rate_limit_exceeded`, `error.type: tokens`, `error.param: null`, and token rate-limit headers.