### PR TITLE
docs(inference): add Atomic Chat as OpenAI-compatible LLM provider

### DIFF
--- a/ee/apps/inference/scripts/build-models.mjs
+++ b/ee/apps/inference/scripts/build-models.mjs
@@ -14,7 +14,8 @@ async function readJson(filePath) {
 const isDevMode = process.env.OPENWORK_DEV_MODE === "1"
 const base = await readJson(path.join(sourceDir, "base.json"))
 const openwork = await readJson(path.join(sourceDir, isDevMode ? "openwork-dev.json" : "openwork-prod.json"))
-const models = { ...base, ...openwork }
+const localProviders = await readJson(path.join(sourceDir, "local-providers.json"))
+const models = { ...base, ...openwork, ...localProviders }
 
 await mkdir(path.dirname(outputPath), { recursive: true })
 await writeFile(outputPath, `${JSON.stringify(models)}\n`)

--- a/ee/apps/inference/src/models/local-providers.json
+++ b/ee/apps/inference/src/models/local-providers.json
@@ -1,0 +1,27 @@
+{
+  "atomic-chat": {
+    "id": "atomic-chat",
+    "env": ["ATOMIC_CHAT_API_KEY"],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "http://127.0.0.1:1337/v1",
+    "name": "Atomic Chat",
+    "doc": "https://github.com/AtomicBot-ai/Atomic-Chat",
+    "models": {
+      "atomic-chat/default": {
+        "id": "atomic-chat/default",
+        "name": "Default (replace id from GET /v1/models)",
+        "family": "atomic-chat",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-01-01",
+        "last_updated": "2026-01-01",
+        "modalities": { "input": ["text"], "output": ["text"] },
+        "open_weights": true,
+        "limit": { "context": 131072, "output": 32768 },
+        "cost": { "input": 0, "output": 0 }
+      }
+    }
+  }
+}

--- a/packages/docs/cloud/share-with-your-team/custom-llm-provider.mdx
+++ b/packages/docs/cloud/share-with-your-team/custom-llm-provider.mdx
@@ -126,6 +126,43 @@ Pick the model and it's live in the session footer:
 
 Add more entries under `models` to expose other routes the gateway supports (e.g. `openai/gpt-5.4`, `google/gemini-2.5-flash`).
 
+### Functional example: Atomic Chat (local OpenAI-compatible API)
+
+Use this when [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) (or another compatible server) is running locally. Replace the model `id` with one returned by `GET http://127.0.0.1:1337/v1/models`. Use a placeholder API key if the server does not require auth.
+
+```json
+{
+  "id": "atomic-chat",
+  "name": "Atomic Chat",
+  "npm": "@ai-sdk/openai-compatible",
+  "env": ["ATOMIC_CHAT_API_KEY"],
+  "doc": "https://github.com/AtomicBot-ai/Atomic-Chat",
+  "api": "http://127.0.0.1:1337/v1",
+  "models": [
+    {
+      "id": "your-model-id",
+      "name": "Your model",
+      "attachment": false,
+      "reasoning": false,
+      "tool_call": true,
+      "temperature": true,
+      "release_date": "2026-01-01",
+      "last_updated": "2026-01-01",
+      "open_weights": true,
+      "limit": {
+        "context": 131072,
+        "input": 131072,
+        "output": 32768
+      },
+      "modalities": {
+        "input": ["text"],
+        "output": ["text"]
+      }
+    }
+  ]
+}
+```
+
 ## When to use a cloud provider
 
 Use a Cloud provider when the setup is meant to be shared across an org or team. For solo use, configuring it directly in the desktop app is simpler.

--- a/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-a-custom-llm.mdx
@@ -56,4 +56,28 @@ Pull the model first with `ollama pull qwen3:8b`, then make sure the Ollama serv
 
 Open your desktop, change the provider name and voila! You have an fully local LLM running in your machine.
 
+### Functional example: Atomic Chat (local OpenAI-compatible API)
+
+[Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) exposes a local OpenAI-compatible API (default `http://127.0.0.1:1337`). List models with `GET /v1/models` and use `POST /v1/chat/completions` for chat.
+
+Replace `your-model-id` with an `id` from `/v1/models`. Set `ATOMIC_CHAT_API_KEY` only if your server requires a Bearer token (many local setups accept any value).
+
+```
+{
+  "provider": {
+    "atomic-chat": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Atomic Chat",
+      "api": "http://127.0.0.1:1337/v1",
+      "env": ["ATOMIC_CHAT_API_KEY"],
+      "models": {
+        "your-model-id": {
+          "name": "Your model"
+        }
+      }
+    }
+  }
+}
+```
+
 For teams, you can manage the provider in OpenWork Cloud under [LLM Providers](/cloud/share-with-your-team/managed-llm-provider), then import it into each workspace from `Settings -> Cloud`.


### PR DESCRIPTION
## Summary

Documents **Atomic Chat** as a local **OpenAI-compatible LLM provider** for OpenWork (workspace `opencode.json` and Cloud custom provider JSON). Adds an inference catalog overlay entry for self-hosted `GET /models/api.json`.

This PR does **not** add MCP servers, MCP clients, or desktop/den-app integration code.

Reference: [AtomicBot-ai/Atomic-Chat](https://github.com/AtomicBot-ai/Atomic-Chat)

## What changed

- **Docs**: workspace example in `add-a-custom-llm.mdx`; Cloud custom-provider example in `custom-llm-provider.mdx`
- **Inference catalog**: `local-providers.json` with `atomic-chat` (default `http://127.0.0.1:1337/v1`), merged in `build-models.mjs`

## How to test

**Desktop (workspace)**

1. Run Atomic Chat (or compatible server) at `http://127.0.0.1:1337`.
2. `curl http://127.0.0.1:1337/v1/models` and note a model `id`.
3. Add the workspace `provider.atomic-chat` block from the docs; set `your-model-id` and `ATOMIC_CHAT_API_KEY` if needed.
4. Select the model in Chat.

**Cloud**

1. LLM Providers → Custom provider → paste JSON from docs.
2. Settings → Cloud → Import.

**Inference catalog (optional)**

```bash
pnpm --dir ee/apps/inference models:build
node -e "console.log(require('./models-site/models/api.json')['atomic-chat']?.api)"

```

## Notes
-Model id must match GET /v1/models on your server (placeholder in examples).
-Cloud Catalog tab still uses live models.dev; use Custom provider or workspace config for Atomic Chat until upstream models.dev lists it.