### PR TITLE
Fix cloud control plane URL save race

### DIFF
--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -145,7 +145,10 @@ export function useDenSession({
   }, []);
 
   const clearSignedInState = React.useCallback(
-    (message?: string | null) => {
+    (
+      message?: string | null,
+      eventDetail?: Pick<DenSessionUpdatedDetail, "baseUrl">,
+    ) => {
       clearDenSession({ includeBaseUrls: !developerMode });
       if (!developerMode) {
         setBaseUrl(DEFAULT_DEN_BASE_URL);
@@ -177,7 +180,7 @@ export function useDenSession({
         }
       } catch {}
       // Notify provider auth store so it can clean up cloud-imported providers
-      dispatchDenSessionUpdated({ status: "signed_out" });
+      dispatchDenSessionUpdated({ status: "signed_out", ...eventDetail });
     },
     [clearSessionState, developerMode, setAuthToken, setBaseUrl],
   );
@@ -219,7 +222,17 @@ export function useDenSession({
 
     setBaseUrl(resolved.baseUrl);
     setBaseUrlDraft(resolved.baseUrl);
-    clearSignedInState(t("den.status_base_url_updated"));
+    writeDenSettings({
+      baseUrl: resolved.baseUrl,
+      apiBaseUrl: resolved.apiBaseUrl,
+      authToken: null,
+      activeOrgId: null,
+      activeOrgSlug: null,
+      activeOrgName: null,
+    });
+    clearSignedInState(t("den.status_base_url_updated"), {
+      baseUrl: resolved.baseUrl,
+    });
   }, [baseUrl, baseUrlDraft, clearSignedInState]);
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- Persist the custom Cloud control plane URL before clearing signed-in state.
- Include the updated base URL in the signed-out session update event.
- Prevent stale session listeners from restoring the previous/default Cloud URL after save.

## Issue
Closes #1798

## Testing
- `pnpm typecheck`
- `git diff --check`

## Manual validation
- Saved a custom Cloud control plane URL in developer mode.
- Confirmed the URL stays saved and does not revert.
- Confirmed the saved URL is persisted in localStorage.
- Restarted the Electron app and confirmed the custom URL remains selected.

## Evidence
Attached screenshot showing the custom URL save flow working.
<img width="1244" height="1028" alt="Screenshot 2026-05-15 181916" src="https://github.com/user-attachments/assets/9540e4fe-6a5d-4f1b-8ded-368b4a3311af" />
