### PR TITLE
feat(app): redesign command palette

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -20,8 +20,11 @@ import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-co
 import { getConnectedProviderItems, useProviderListQuery } from "@/react-app/domains/connections/provider-list-query";
 import {
   Command,
+  CommandCollection,
   CommandEmpty,
   CommandGroup,
+  CommandGroupLabel,
+  CommandHeader,
   CommandInput,
   CommandItem,
   CommandList,
@@ -126,8 +129,8 @@ function groupByProvider(modelOptions: ModelOption[]) {
   }
 
   return [...groups.entries()].map(([providerLabel, options]) => ({
-    providerLabel,
-    options,
+    value: providerLabel,
+    items: options,
   }));
 }
 
@@ -237,58 +240,54 @@ export function ModelSelect({
         </TooltipContent>
       </Tooltip>
       <PopoverContent
-        className="w-72 gap-0 p-0"
+        className="h-80 max-h-(--available-height) w-72 gap-0 overflow-hidden p-px **:data-[slot=scroll-area-viewport]:data-has-overflow-y:pe-0.5"
         align="start"
         initialFocus={false}
       >
-        <Command
-          value={`${value.providerID}:${value.modelID}`}
-          filter={(value, search, keywords) => {
-            const haystack = (keywords ?? []).join(" ").toLowerCase();
-
-            return haystack.includes(search.toLowerCase()) ? 1 : 0;
-          }}
-        >
-          <CommandInput
-            ref={searchInputRef}
-            value={search}
-            onValueChange={setSearch}
-            placeholder="Search models..."
-          />
+        <Command items={groups} value={search} onValueChange={setSearch}>
+          <CommandHeader>
+            <CommandInput
+              ref={searchInputRef}
+              placeholder="Search models..."
+            />
+          </CommandHeader>
+          <CommandEmpty>No models found.</CommandEmpty>
           <CommandList>
-            <CommandEmpty>No models found.</CommandEmpty>
-            {groups.map((group) => (
+            {(group) => (
               <CommandGroup
-                key={group.providerLabel}
-                heading={group.providerLabel}
+                key={group.value}
+                items={group.items}
               >
-                {group.options.map((option) => (
-                  <CommandItem
-                    key={`${option.providerID}:${option.modelID}`}
-                    value={`${option.providerID}:${option.modelID}`}
-                    keywords={[option.title, group.providerLabel]}
-                    onSelect={() => handleSelect(option)}
-                    data-checked={isSameModel(value, option)}
-                  >
-                    <ProviderIcon
-                      providerId={option.providerID}
-                      providerName={option.description}
-                      className="size-3.5 opacity-70"
-                      size={14}
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-foreground">
-                        {option.title}
+                <CommandGroupLabel>{group.value}</CommandGroupLabel>
+                <CommandCollection>
+                  {(option: ModelOption) => (
+                    <CommandItem
+                      className="gap-2"
+                      key={`${option.providerID}:${option.modelID}`}
+                      value={`${option.providerID}:${option.modelID}`}
+                      onClick={() => handleSelect(option)}
+                      data-checked={isSameModel(value, option)}
+                    >
+                      <ProviderIcon
+                        providerId={option.providerID}
+                        providerName={option.description}
+                        className="size-3.5 opacity-70"
+                        size={14}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-foreground">
+                          {option.title}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {option.description ??
+                            getProviderDisplayName(option.providerID)}
+                        </span>
                       </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {option.description ??
-                          getProviderDisplayName(option.providerID)}
-                      </span>
-                    </span>
-                  </CommandItem>
-                ))}
+                    </CommandItem>
+                  )}
+                </CommandCollection>
               </CommandGroup>
-            ))}
+            )}
           </CommandList>
           {/* Link to full model picker */}
           <div className="border-t border-border px-2 py-1.5">

--- a/apps/app/src/components/ui/autocomplete.tsx
+++ b/apps/app/src/components/ui/autocomplete.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { Autocomplete as AutocompletePrimitive } from "@base-ui/react/autocomplete";
+import { ChevronsUpDownIcon, XIcon } from "lucide-react";
+import type React from "react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export const Autocomplete: typeof AutocompletePrimitive.Root =
+  AutocompletePrimitive.Root;
+
+export function AutocompleteInput({
+  className,
+  showTrigger = false,
+  showClear = false,
+  startAddon,
+  triggerProps,
+  clearProps,
+  ...props
+}: Omit<AutocompletePrimitive.Input.Props, "size"> & {
+  showTrigger?: boolean;
+  showClear?: boolean;
+  startAddon?: React.ReactNode;
+  ref?: React.Ref<HTMLInputElement>;
+  triggerProps?: AutocompletePrimitive.Trigger.Props;
+  clearProps?: AutocompletePrimitive.Clear.Props;
+}): React.ReactElement {
+  return (
+    <AutocompletePrimitive.InputGroup
+      className="relative not-has-[>*.w-full]:w-fit w-full text-foreground has-disabled:opacity-64"
+      data-slot="autocomplete-input-group"
+    >
+      {startAddon && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 start-px z-10 flex items-center ps-[calc(--spacing(3)-1px)] opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:-mx-0.5"
+          data-slot="autocomplete-start-addon"
+        >
+          {startAddon}
+        </div>
+      )}
+      <AutocompletePrimitive.Input
+        className={cn(
+          startAddon &&
+            "ps-[calc(--spacing(8.5)-1px)] sm:ps-[calc(--spacing(8)-1px)]",
+          "has-[+[data-slot=autocomplete-trigger],+[data-slot=autocomplete-clear]]:pe-7",
+          className,
+        )}
+        data-slot="autocomplete-input"
+        render={<Input />}
+        {...props}
+      />
+      {showTrigger && (
+        <AutocompleteTrigger
+          className="absolute end-0.5 top-1/2 inline-flex size-8 shrink-0 -translate-y-1/2 cursor-pointer items-center justify-center rounded-md border border-transparent opacity-80 outline-none transition-colors pointer-coarse:after:absolute pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:opacity-100 has-[+[data-slot=autocomplete-clear]]:hidden sm:size-7 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+          {...triggerProps}
+        >
+          <AutocompletePrimitive.Icon data-slot="autocomplete-icon">
+            <ChevronsUpDownIcon />
+          </AutocompletePrimitive.Icon>
+        </AutocompleteTrigger>
+      )}
+      {showClear && (
+        <AutocompleteClear
+          className="absolute end-0.5 top-1/2 inline-flex size-8 shrink-0 -translate-y-1/2 cursor-pointer items-center justify-center rounded-md border border-transparent opacity-80 outline-none transition-colors pointer-coarse:after:absolute pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:opacity-100 has-[+[data-slot=autocomplete-clear]]:hidden sm:size-7 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+          {...clearProps}
+        >
+          <XIcon />
+        </AutocompleteClear>
+      )}
+    </AutocompletePrimitive.InputGroup>
+  );
+}
+
+export function AutocompletePopup({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  alignOffset,
+  align = "start",
+  anchor,
+  portalProps,
+  ...props
+}: AutocompletePrimitive.Popup.Props & {
+  align?: AutocompletePrimitive.Positioner.Props["align"];
+  sideOffset?: AutocompletePrimitive.Positioner.Props["sideOffset"];
+  alignOffset?: AutocompletePrimitive.Positioner.Props["alignOffset"];
+  side?: AutocompletePrimitive.Positioner.Props["side"];
+  anchor?: AutocompletePrimitive.Positioner.Props["anchor"];
+  portalProps?: AutocompletePrimitive.Portal.Props;
+}): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Portal {...portalProps}>
+      <AutocompletePrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        className="z-50 select-none"
+        data-slot="autocomplete-positioner"
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <span
+          className={cn(
+            "relative flex max-h-full min-w-(--anchor-width) max-w-(--available-width) origin-(--transform-origin) rounded-lg border bg-popover not-dark:bg-clip-padding shadow-lg/5 transition-[scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+            className,
+          )}
+        >
+          <AutocompletePrimitive.Popup
+            className="flex max-h-[min(var(--available-height),23rem)] flex-1 flex-col text-foreground"
+            data-slot="autocomplete-popup"
+            {...props}
+          >
+            {children}
+          </AutocompletePrimitive.Popup>
+        </span>
+      </AutocompletePrimitive.Positioner>
+    </AutocompletePrimitive.Portal>
+  );
+}
+
+export function AutocompleteItem({
+  className,
+  children,
+  ...props
+}: AutocompletePrimitive.Item.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Item
+      className={cn(
+        "flex min-h-8 cursor-default select-none items-center rounded-sm px-2 py-1 text-base outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm",
+        className,
+      )}
+      data-slot="autocomplete-item"
+      {...props}
+    >
+      {children}
+    </AutocompletePrimitive.Item>
+  );
+}
+
+export function AutocompleteSeparator({
+  className,
+  ...props
+}: AutocompletePrimitive.Separator.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Separator
+      className={cn("mx-2 my-1 h-px bg-border last:hidden", className)}
+      data-slot="autocomplete-separator"
+      {...props}
+    />
+  );
+}
+
+export function AutocompleteGroup({
+  className,
+  ...props
+}: AutocompletePrimitive.Group.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Group
+      className={cn("[[role=group]+&]:mt-1.5", className)}
+      data-slot="autocomplete-group"
+      {...props}
+    />
+  );
+}
+
+export function AutocompleteGroupLabel({
+  className,
+  ...props
+}: AutocompletePrimitive.GroupLabel.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.GroupLabel
+      className={cn(
+        "px-2 py-1.5 font-medium text-muted-foreground text-xs",
+        className,
+      )}
+      data-slot="autocomplete-group-label"
+      {...props}
+    />
+  );
+}
+
+export function AutocompleteEmpty({
+  className,
+  ...props
+}: AutocompletePrimitive.Empty.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Empty
+      className={cn(
+        "not-empty:p-2 text-center text-base text-muted-foreground sm:text-sm",
+        className,
+      )}
+      data-slot="autocomplete-empty"
+      {...props}
+    />
+  );
+}
+
+export function AutocompleteRow({
+  className,
+  ...props
+}: AutocompletePrimitive.Row.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Row
+      className={className}
+      data-slot="autocomplete-row"
+      {...props}
+    />
+  );
+}
+
+export function AutocompleteValue({
+  ...props
+}: AutocompletePrimitive.Value.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Value data-slot="autocomplete-value" {...props} />
+  );
+}
+
+export function AutocompleteList({
+  className,
+  ...props
+}: AutocompletePrimitive.List.Props): React.ReactElement {
+  return (
+    <ScrollArea>
+      <AutocompletePrimitive.List
+        className={cn(
+          "not-empty:scroll-py-1 not-empty:p-1 in-data-has-overflow-y:pe-3",
+          className,
+        )}
+        data-slot="autocomplete-list"
+        {...props}
+      />
+    </ScrollArea>
+  );
+}
+
+export function AutocompleteClear({
+  className,
+  ...props
+}: AutocompletePrimitive.Clear.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Clear
+      className={cn(
+        "absolute end-0.5 top-1/2 inline-flex size-8 shrink-0 -translate-y-1/2 cursor-pointer items-center justify-center rounded-md border border-transparent opacity-80 outline-none transition-[color,background-color,box-shadow,opacity] pointer-coarse:after:absolute pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 hover:opacity-100 sm:size-7 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      data-slot="autocomplete-clear"
+      {...props}
+    >
+      <XIcon />
+    </AutocompletePrimitive.Clear>
+  );
+}
+
+export function AutocompleteStatus({
+  className,
+  ...props
+}: AutocompletePrimitive.Status.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Status
+      className={cn(
+        "px-3 py-2 font-medium text-muted-foreground text-xs empty:m-0 empty:p-0",
+        className,
+      )}
+      data-slot="autocomplete-status"
+      {...props}
+    />
+  );
+}
+
+export function AutocompleteCollection({
+  ...props
+}: AutocompletePrimitive.Collection.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Collection
+      data-slot="autocomplete-collection"
+      {...props}
+    />
+  );
+}
+
+export function AutocompleteTrigger({
+  className,
+  children,
+  ...props
+}: AutocompletePrimitive.Trigger.Props): React.ReactElement {
+  return (
+    <AutocompletePrimitive.Trigger
+      className={className}
+      data-slot="autocomplete-trigger"
+      {...props}
+    >
+      {children}
+    </AutocompletePrimitive.Trigger>
+  );
+}
+
+export const useAutocompleteFilter: typeof AutocompletePrimitive.useFilter =
+  AutocompletePrimitive.useFilter;
+
+export { AutocompletePrimitive };

--- a/apps/app/src/components/ui/command.tsx
+++ b/apps/app/src/components/ui/command.tsx
@@ -1,194 +1,289 @@
-import * as React from "react"
-import { Command as CommandPrimitive } from "cmdk"
+"use client";
 
-import { cn } from "@/lib/utils"
+import { Dialog as CommandDialogPrimitive } from "@base-ui/react/dialog";
+import { SearchIcon } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import {
-  InputGroup,
-  InputGroupAddon,
-} from "@/components/ui/input-group"
-import { SearchIcon, CheckIcon } from "lucide-react"
+  Autocomplete,
+  AutocompleteCollection,
+  AutocompleteEmpty,
+  AutocompleteGroup,
+  AutocompleteGroupLabel,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteList,
+  AutocompleteSeparator,
+} from "@/components/ui/autocomplete";
 
-function Command({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive>) {
+export const CommandDialog: typeof CommandDialogPrimitive.Root =
+  CommandDialogPrimitive.Root;
+
+export const CommandDialogPortal: typeof CommandDialogPrimitive.Portal =
+  CommandDialogPrimitive.Portal;
+
+export const CommandCreateHandle: typeof CommandDialogPrimitive.createHandle =
+  CommandDialogPrimitive.createHandle;
+
+export function CommandDialogTrigger(
+  props: CommandDialogPrimitive.Trigger.Props,
+): React.ReactElement {
   return (
-    <CommandPrimitive
-      data-slot="command"
-      className={cn(
-        "flex size-full flex-col overflow-hidden rounded-4xl bg-popover p-1 text-popover-foreground",
-        className
-      )}
+    <CommandDialogPrimitive.Trigger
+      data-slot="command-dialog-trigger"
       {...props}
     />
-  )
+  );
 }
 
-function CommandDialog({
-  title = "Command Palette",
-  description = "Search for a command to run...",
+export function CommandDialogBackdrop({
+  className,
+  ...props
+}: CommandDialogPrimitive.Backdrop.Props): React.ReactElement {
+  return (
+    <CommandDialogPrimitive.Backdrop
+      className={cn(
+        "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm transition-all duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0",
+        className,
+      )}
+      data-slot="command-dialog-backdrop"
+      {...props}
+    />
+  );
+}
+
+export function CommandDialogViewport({
+  className,
+  ...props
+}: CommandDialogPrimitive.Viewport.Props): React.ReactElement {
+  return (
+    <CommandDialogPrimitive.Viewport
+      className={cn(
+        "fixed inset-0 z-50 flex flex-col items-center px-4 py-[max(--spacing(4),4vh)] sm:py-[10vh]",
+        className,
+      )}
+      data-slot="command-dialog-viewport"
+      {...props}
+    />
+  );
+}
+
+export function CommandDialogPopup({
+  className,
   children,
-  className,
-  showCloseButton = false,
+  portalProps,
   ...props
-}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
-  title?: string
-  description?: string
-  className?: string
-  showCloseButton?: boolean
-  children: React.ReactNode
-}) {
+}: CommandDialogPrimitive.Popup.Props & {
+  portalProps?: CommandDialogPrimitive.Portal.Props;
+}): React.ReactElement {
   return (
-    <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
-      <DialogContent
-        className={cn(
-          "top-1/3 translate-y-0 overflow-hidden rounded-4xl! p-0",
-          className
-        )}
-        showCloseButton={showCloseButton}
-      >
-        {children}
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-function CommandInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
-  return (
-    <div data-slot="command-input-wrapper" className="p-1 pb-0">
-      <InputGroup className="h-9 bg-input/50">
-        <CommandPrimitive.Input
-          data-slot="command-input"
+    <CommandDialogPortal {...portalProps}>
+      <CommandDialogBackdrop />
+      <CommandDialogViewport>
+        <CommandDialogPrimitive.Popup
           className={cn(
-            "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-            className
+            "relative row-start-2 flex max-h-105 min-h-0 w-full min-w-0 max-w-xl -translate-y-[calc(1.25rem*var(--nested-dialogs))] scale-[calc(1-0.1*var(--nested-dialogs))] flex-col rounded-2xl border bg-popover not-dark:bg-clip-padding text-popover-foreground opacity-[calc(1-0.1*var(--nested-dialogs))] shadow-lg/5 outline-none transition-[scale,opacity,translate] duration-200 ease-in-out will-change-transform before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-2xl)-1px)] before:bg-muted/20 before:shadow-[0_1px_--theme(--color-black/4%)] data-nested:data-ending-style:translate-y-8 data-nested:data-starting-style:translate-y-8 data-nested-dialog-open:origin-top data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 **:data-[slot=scroll-area-viewport]:data-has-overflow-y:pe-0.5 dark:before:shadow-[0_-1px_--theme(--color-white/6%)] backdrop-blur-xl",
+            className,
           )}
+          data-slot="command-dialog-popup"
           {...props}
-        />
-        <InputGroupAddon>
-          <SearchIcon className="size-4 shrink-0 opacity-50" />
-        </InputGroupAddon>
-      </InputGroup>
-    </div>
-  )
+        >
+          {children}
+        </CommandDialogPrimitive.Popup>
+      </CommandDialogViewport>
+    </CommandDialogPortal>
+  );
 }
 
-function CommandList({
+export function Command({
+  autoHighlight = "always",
+  keepHighlight = true,
+  ...props
+}: React.ComponentProps<typeof Autocomplete>): React.ReactElement {
+  return (
+    <Autocomplete
+      autoHighlight={autoHighlight}
+      inline
+      keepHighlight={keepHighlight}
+      open
+      {...props}
+    />
+  );
+}
+
+export function CommandInput({
+  className,
+  placeholder = undefined,
+  ...props
+}: React.ComponentProps<typeof AutocompleteInput>): React.ReactElement {
+  return (
+    <AutocompleteInput
+      autoFocus
+      className={cn(
+        "border-transparent! bg-transparent! shadow-none before:hidden focus-visible:ring-0! has-focus-visible:ring-0!",
+        className,
+      )}
+      placeholder={placeholder}
+      startAddon={<SearchIcon />}
+      {...props}
+    />
+  );
+}
+
+export function CommandList({
   className,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.List>) {
+}: React.ComponentProps<typeof AutocompleteList>): React.ReactElement {
   return (
-    <CommandPrimitive.List
+    <AutocompleteList
+      className={cn("not-empty:scroll-py-2 not-empty:p-2", className)}
       data-slot="command-list"
-      className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
-        className
-      )}
       {...props}
     />
-  )
+  );
 }
 
-function CommandEmpty({
+export function CommandEmpty({
   className,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+}: React.ComponentProps<typeof AutocompleteEmpty>): React.ReactElement {
   return (
-    <CommandPrimitive.Empty
+    <AutocompleteEmpty
+      className={cn("not-empty:py-6", className)}
       data-slot="command-empty"
-      className={cn("py-6 text-center text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
-function CommandGroup({
+export function CommandPanel({
   className,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+}: React.ComponentProps<"div">): React.ReactElement {
   return (
-    <CommandPrimitive.Group
+    <div
+      className={cn(
+        "relative min-h-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof AutocompleteGroup>): React.ReactElement {
+  return (
+    <AutocompleteGroup
+      className={className}
       data-slot="command-group"
+      {...props}
+    />
+  );
+}
+
+export function CommandGroupLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AutocompleteGroupLabel>): React.ReactElement {
+  return (
+    <AutocompleteGroupLabel
+      className={className}
+      data-slot="command-group-label"
+      {...props}
+    />
+  );
+}
+
+export function CommandCollection({
+  ...props
+}: React.ComponentProps<typeof AutocompleteCollection>): React.ReactElement {
+  return <AutocompleteCollection data-slot="command-collection" {...props} />;
+}
+
+export function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AutocompleteItem>): React.ReactElement {
+  return (
+    <AutocompleteItem
       className={cn(
-        "overflow-hidden p-1.5 text-foreground **:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:py-2 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
-        className
+        "py-1.5 data-highlighted:bg-foreground/5",
+        className,
       )}
-      {...props}
-    />
-  )
-}
-
-function CommandSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
-  return (
-    <CommandPrimitive.Separator
-      data-slot="command-separator"
-      className={cn("my-1.5 h-px bg-border/50", className)}
-      {...props}
-    />
-  )
-}
-
-function CommandItem({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
-  return (
-    <CommandPrimitive.Item
       data-slot="command-item"
-      className={cn(
-        "group/command-item relative flex cursor-default items-center gap-2 rounded-2xl px-3 py-2 text-sm font-medium outline-hidden select-none in-data-[slot=dialog-content]:rounded-3xl data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-selected:bg-muted data-selected:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-selected:*:[svg]:text-foreground",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <CheckIcon className="ms-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
-    </CommandPrimitive.Item>
-  )
-}
-
-function CommandShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
-  return (
-    <span
-      data-slot="command-shortcut"
-      className={cn(
-        "ms-auto text-xs tracking-widest text-muted-foreground group-data-selected/command-item:text-foreground",
-        className
-      )}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Command,
-  CommandDialog,
-  CommandInput,
-  CommandList,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandShortcut,
-  CommandSeparator,
+export function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof AutocompleteSeparator>): React.ReactElement {
+  return (
+    <AutocompleteSeparator
+      className={cn("my-2", className)}
+      data-slot="command-separator"
+      {...props}
+    />
+  );
 }
+
+export function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"kbd">): React.ReactElement {
+  return (
+    <kbd
+      className={cn(
+        "ms-auto font-medium font-sans text-muted-foreground/72 text-xs tracking-widest",
+        className,
+      )}
+      data-slot="command-shortcut"
+      {...props}
+    />
+  );
+}
+
+export function CommandFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">): React.ReactElement {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 rounded-b-[calc(var(--radius-2xl)-1px)] border-t border-foreground/10 dark:border-border px-5 py-3 text-muted-foreground text-xs",
+        className,
+      )}
+      data-slot="command-footer"
+      {...props}
+    />
+  );
+}
+
+export function CommandDialogTitle({ className, ...props }: React.ComponentProps<typeof CommandDialogPrimitive.Title>) {
+  return (
+    <CommandDialogPrimitive.Title
+      className={cn("sr-only", className)}
+      {...props}
+    />
+  );
+}
+
+export function CommandHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">): React.ReactElement {
+  return (
+    <div
+      className={cn("p-2", className)}
+      data-slot="command-header"
+      {...props}
+    />
+  );
+}
+
+export { CommandDialogPrimitive };

--- a/apps/app/src/components/ui/scroll-area.tsx
+++ b/apps/app/src/components/ui/scroll-area.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: ScrollAreaPrimitive.Root.Props) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative size-full min-h-0", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-s data-vertical:border-s-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -2,79 +2,39 @@
 import {
   useEffect,
   useMemo,
-  useReducer,
-  useRef,
+  useState,
   type KeyboardEvent as ReactKeyboardEvent,
-  type RefObject,
 } from "react";
-import { Search, X } from "lucide-react";
 
 import { t } from "@/i18n";
+import {
+  Command,
+  CommandDialog,
+  CommandDialogPopup,
+  CommandDialogTitle,
+  CommandEmpty,
+  CommandFooter,
+  CommandHeader,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandPanel,
+  CommandShortcut,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { ChevronLeftIcon } from "lucide-react";
 
 export type PaletteItem = {
   id: string;
   title: string;
   detail?: string;
   meta?: string;
+  searchText?: string;
   action: () => void;
 };
 
 type PaletteMode = "root" | "sessions";
 
-type PaletteDialogProps = {
-  mode: PaletteMode;
-  query: string;
-  items: PaletteItem[];
-  activeIndex: number;
-  visibleActiveIndex: number;
-  inputRef: RefObject<HTMLInputElement | null>;
-  optionRefs: MutableRefObject<Array<HTMLButtonElement | null>>;
-  placeholder: string;
-  title: string;
-  onBack: () => void;
-  onClose: () => void;
-  onQueryChange: (value: string) => void;
-  onActiveIndexChange: (value: number) => void;
-  onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => void;
-};
-
-type PaletteState = {
-  mode: PaletteMode;
-  query: string;
-  activeIndex: number;
-};
-
-type PaletteAction =
-  | { type: "reset" }
-  | { type: "sessions" }
-  | { type: "query"; query: string }
-  | { type: "activeIndex"; activeIndex: number }
-  | { type: "move"; delta: 1 | -1; itemCount: number };
-
-const initialPaletteState: PaletteState = {
-  mode: "root",
-  query: "",
-  activeIndex: 0,
-};
-
-function paletteReducer(state: PaletteState, action: PaletteAction): PaletteState {
-  switch (action.type) {
-    case "reset":
-      return initialPaletteState;
-    case "sessions":
-      return { mode: "sessions", query: "", activeIndex: 0 };
-    case "query":
-      return { ...state, query: action.query, activeIndex: 0 };
-    case "activeIndex":
-      return { ...state, activeIndex: action.activeIndex };
-    case "move":
-      if (action.itemCount === 0) return state;
-      return {
-        ...state,
-        activeIndex: (state.activeIndex + action.delta + action.itemCount) % action.itemCount,
-      };
-  }
-}
 export type SessionOption = {
   workspaceId: string;
   sessionId: string;
@@ -100,95 +60,6 @@ export type CommandPaletteProps = {
   sessions: SessionOption[];
 };
 
-function PaletteDialog(props: PaletteDialogProps) {
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4"
-      role="dialog"
-      aria-modal="true"
-      onKeyDown={props.onKeyDown}
-    >
-      <button type="button" className="absolute inset-0 cursor-default border-0 bg-gray-1/60 p-0 backdrop-blur-sm" aria-label={t("common.close")} onClick={props.onClose} />
-      <div className="relative z-10 w-full max-w-2xl mt-12 rounded-2xl border border-dls-border bg-dls-surface shadow-2xl overflow-hidden">
-        <div className="border-b border-dls-border px-4 py-3 space-y-2">
-          <div className="flex items-center gap-2">
-            {props.mode !== "root" ? (
-              <button
-                type="button"
-                className="h-8 px-2 rounded-md text-xs text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors"
-                onClick={props.onBack}
-              >
-                {t("common.back")}
-              </button>
-            ) : null}
-            <Search size={14} className="text-dls-secondary shrink-0" />
-            <input
-              ref={props.inputRef}
-              type="text"
-              value={props.query}
-              onChange={(event) => props.onQueryChange(event.currentTarget.value)}
-              placeholder={props.placeholder}
-              className="min-w-0 flex-1 bg-transparent text-sm text-dls-text placeholder:text-dls-secondary focus:outline-none"
-              aria-label={props.title}
-            />
-            <button
-              type="button"
-              className="size-8 rounded-md text-dls-secondary hover:text-dls-text hover:bg-dls-hover transition-colors flex items-center justify-center"
-              onClick={props.onClose}
-              aria-label={t("common.close")}
-            >
-              <X size={14} />
-            </button>
-          </div>
-        </div>
-        <div className="max-h-[60vh] overflow-y-auto py-2">
-          {props.items.length === 0 ? (
-            <div className="px-4 py-6 text-sm text-dls-secondary text-center">
-              {t("session.palette_no_matches")}
-            </div>
-          ) : (
-            <ul>
-              {props.items.map((item, index) => (
-                <li key={item.id}>
-                  <button
-                    ref={(element) => {
-                      props.optionRefs.current[index] = element;
-                    }}
-                    type="button"
-                    className={`w-full px-4 py-2.5 flex items-start gap-3 text-left transition-colors ${
-                      index === props.visibleActiveIndex
-                        ? "bg-dls-hover"
-                        : "hover:bg-dls-hover/60"
-                    }`}
-                    onMouseEnter={() => props.onActiveIndexChange(index)}
-                    onClick={() => item.action()}
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium text-dls-text truncate">{item.title}</div>
-                      {item.detail ? (
-                        <div className="text-xs text-dls-secondary truncate">{item.detail}</div>
-                      ) : null}
-                    </div>
-                    {item.meta ? (
-                      <div className="text-[10px] uppercase tracking-wide text-dls-secondary shrink-0">
-                        {item.meta}
-                      </div>
-                    ) : null}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-        <div className="border-t border-dls-border px-4 py-2 text-[11px] text-dls-secondary flex items-center gap-3">
-          <span>{t("session.palette_hint_navigate")}</span>
-          <span>{t("session.palette_hint_run")}</span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 /**
  * React command palette (Cmd/Ctrl+K).
  *
@@ -196,244 +67,235 @@ function PaletteDialog(props: PaletteDialogProps) {
  * - Sessions submode: fuzzy list of every session across workspaces.
  */
 export function CommandPalette(props: CommandPaletteProps) {
-  const [state, dispatch] = useReducer(paletteReducer, initialPaletteState);
-  const { mode, query, activeIndex } = state;
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [mode, setMode] = useState<PaletteMode>("root");
 
   useEffect(() => {
     if (!props.open) {
-      dispatch({ type: "reset" });
-      return;
+      setMode("root");
     }
-    const id = window.setTimeout(() => {
-      inputRef.current?.focus();
-    }, 10);
-    return () => window.clearTimeout(id);
   }, [props.open]);
 
   const openUrl = (url: string) => {
     if (props.onOpenUrl) {
       props.onOpenUrl(url);
-    } else if (typeof window !== "undefined") {
+    } else {
       window.open(url, "_blank", "noopener");
     }
   };
 
-  const rootItems = useMemo<PaletteItem[]>(() => {
-    const items: PaletteItem[] = [
-      {
-        id: "new-session",
-        title: t("session.cmd_new_session_title"),
-        detail: t("session.cmd_new_session_detail"),
-        meta: t("session.cmd_new_session_meta"),
-        action: () => {
-          props.onClose();
-          props.onCreateNewSession();
-        },
-      },
-      {
-        id: "sessions",
-        title: t("session.cmd_sessions_title"),
-        detail: t("session.cmd_sessions_detail", undefined, {
-          count: props.sessions.length.toLocaleString(),
-        }),
-        meta: t("session.cmd_sessions_meta"),
-        action: () => {
-          dispatch({ type: "sessions" });
-          window.setTimeout(() => inputRef.current?.focus(), 0);
-        },
-      },
-      {
-        id: "open-settings",
-        title: t("settings.tab_general"),
-        detail: t("settings.tab_description_general"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          props.onOpenSettings();
-        },
-      },
-      // Top-bar shortcuts — these used to be selectable via Cmd+K and were
-      // missing after the React port. Each one mirrors one of the icons at
-      // the bottom-right of the session surface (documentation / feedback)
-      // plus every settings tab the user is likely to reach for.
-      {
-        id: "open-docs",
-        title: t("session.support_docs"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          openUrl("https://openwork.dev/docs");
-        },
-      },
-      {
-        id: "open-feedback",
-        title: t("session.support_feedback"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          openUrl("https://openwork.dev/feedback");
-        },
-      },
-      {
-        id: "settings-skills",
-        title: t("settings.tab_skills"),
-        detail: t("settings.tab_description_skills"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          props.onOpenSettings("/settings/skills");
-        },
-      },
-      {
-        id: "settings-extensions",
-        title: t("settings.tab_extensions"),
-        detail: t("settings.tab_description_extensions"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          props.onOpenSettings("/settings/extensions");
-        },
-      },
-      {
-        id: "settings-appearance",
-        title: t("settings.tab_appearance"),
-        detail: t("settings.tab_description_appearance"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          props.onOpenSettings("/settings/appearance");
-        },
-      },
-      {
-        id: "settings-recovery",
-        title: t("settings.tab_recovery"),
-        detail: t("settings.tab_description_recovery"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          props.onOpenSettings("/settings/recovery");
-        },
-      },
-      {
-        id: "settings-updates",
-        title: t("settings.tab_updates"),
-        detail: t("settings.tab_description_updates"),
-        meta: t("session.cmd_settings_meta"),
-        action: () => {
-          props.onClose();
-          props.onOpenSettings("/settings/updates");
-        },
-      },
-    ];
-    const q = query.trim().toLowerCase();
-    if (!q) return items;
-    return items.filter((item) =>
-      `${item.title} ${item.detail ?? ""}`.toLowerCase().includes(q),
-    );
-  }, [props, query]);
-
-  const sessionItems = useMemo<PaletteItem[]>(() => {
-    const q = query.trim().toLowerCase();
-    const candidates = q
-      ? props.sessions.filter((item) => item.searchText.includes(q))
-      : props.sessions;
-    return candidates.slice(0, 80).map((item) => ({
-      id: `session:${item.workspaceId}:${item.sessionId}`,
-      title: item.title,
-      detail: item.workspaceTitle,
-      meta: item.isActive
-        ? t("session.cmd_current_workspace")
-        : t("session.cmd_switch"),
+  const rootItems = useMemo<PaletteItem[]>(() => [
+    {
+      id: "new-session",
+      title: t("session.cmd_new_session_title"),
+      detail: t("session.cmd_new_session_detail"),
+      meta: t("session.cmd_new_session_meta"),
       action: () => {
         props.onClose();
-        props.onOpenSession(item.workspaceId, item.sessionId);
+        props.onCreateNewSession();
       },
-    }));
-  }, [props, query]);
+    },
+    {
+      id: "sessions",
+      title: t("session.cmd_sessions_title"),
+      detail: t("session.cmd_sessions_detail", undefined, {
+        count: props.sessions.length.toLocaleString(),
+      }),
+      meta: t("session.cmd_sessions_meta"),
+      action: () => {
+        setMode("sessions");
+      },
+    },
+    {
+      id: "open-settings",
+      title: t("settings.tab_general"),
+      detail: t("settings.tab_description_general"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        props.onOpenSettings();
+      },
+    },
+    // Top-bar shortcuts — these used to be selectable via Cmd+K and were
+    // missing after the React port. Each one mirrors one of the icons at
+    // the bottom-right of the session surface (documentation / feedback)
+    // plus every settings tab the user is likely to reach for.
+    {
+      id: "open-docs",
+      title: t("session.support_docs"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        openUrl("https://openwork.dev/docs");
+      },
+    },
+    {
+      id: "open-feedback",
+      title: t("session.support_feedback"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        openUrl("https://openwork.dev/feedback");
+      },
+    },
+    {
+      id: "settings-skills",
+      title: t("settings.tab_skills"),
+      detail: t("settings.tab_description_skills"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        props.onOpenSettings("/settings/skills");
+      },
+    },
+    {
+      id: "settings-extensions",
+      title: t("settings.tab_extensions"),
+      detail: t("settings.tab_description_extensions"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        props.onOpenSettings("/settings/extensions");
+      },
+    },
+    {
+      id: "settings-appearance",
+      title: t("settings.tab_appearance"),
+      detail: t("settings.tab_description_appearance"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        props.onOpenSettings("/settings/appearance");
+      },
+    },
+    {
+      id: "settings-recovery",
+      title: t("settings.tab_recovery"),
+      detail: t("settings.tab_description_recovery"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        props.onOpenSettings("/settings/recovery");
+      },
+    },
+    {
+      id: "settings-updates",
+      title: t("settings.tab_updates"),
+      detail: t("settings.tab_description_updates"),
+      meta: t("session.cmd_settings_meta"),
+      action: () => {
+        props.onClose();
+        props.onOpenSettings("/settings/updates");
+      },
+    },
+  ], [props]);
 
-  const items = mode === "sessions" ? sessionItems : rootItems;
-  const visibleActiveIndex = items.length > 0 ? Math.min(activeIndex, items.length - 1) : 0;
+  const sessionItems = useMemo<PaletteItem[]>(
+    () =>
+      props.sessions.map((item) => ({
+        id: `session:${item.workspaceId}:${item.sessionId}`,
+        title: item.title,
+        detail: item.workspaceTitle,
+        meta: item.isActive
+          ? t("session.cmd_current_workspace")
+          : t("session.cmd_switch"),
+        searchText: item.searchText,
+        action: () => {
+          props.onClose();
+          props.onOpenSession(item.workspaceId, item.sessionId);
+        },
+      })),
+    [props],
+  );
 
-  useEffect(() => {
-    if (!props.open) return;
-    const target = optionRefs.current[visibleActiveIndex];
-    target?.scrollIntoView({ block: "nearest" });
-  }, [props.open, visibleActiveIndex]);
-
-  const handleKey = (event: ReactKeyboardEvent<HTMLElement>) => {
+  const handleEscape = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key === "Escape") {
       event.preventDefault();
+      event.stopPropagation();
       if (mode !== "root") {
-        dispatch({ type: "reset" });
-        window.setTimeout(() => inputRef.current?.focus(), 0);
+        setMode("root");
         return;
       }
       props.onClose();
-      return;
-    }
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      if (items.length === 0) return;
-      dispatch({ type: "move", delta: 1, itemCount: items.length });
-      return;
-    }
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      if (items.length === 0) return;
-      dispatch({ type: "move", delta: -1, itemCount: items.length });
-      return;
-    }
-    if (event.key === "Enter") {
-      event.preventDefault();
-      const item = items[visibleActiveIndex];
-      if (item) item.action();
-      return;
-    }
-    if (event.key === "Backspace" && !query && mode !== "root") {
-      event.preventDefault();
-      dispatch({ type: "reset" });
     }
   };
 
-  if (!props.open) return null;
-
-  const placeholder =
-    mode === "sessions"
-      ? t("session.palette_placeholder_sessions")
-      : t("session.palette_placeholder_actions");
-
-  const title =
-    mode === "sessions"
-      ? t("session.palette_title_sessions")
-      : t("session.palette_title_actions");
-
-  const handleBack = () => {
-    dispatch({ type: "reset" });
-    window.setTimeout(() => inputRef.current?.focus(), 0);
+  const handleBackspace = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (
+      event.key === "Backspace" &&
+      event.currentTarget.value === "" &&
+      mode !== "root"
+    ) {
+      event.preventDefault();
+      setMode("root");
+    }
   };
 
-  const handleQueryChange = (value: string) => {
-    dispatch({ type: "query", query: value });
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      props.onClose();
+    }
   };
+
+  const items = mode === "sessions" ? sessionItems : rootItems;
 
   return (
-    <PaletteDialog
-      mode={mode}
-      query={query}
-      items={items}
-      activeIndex={activeIndex}
-      visibleActiveIndex={visibleActiveIndex}
-      inputRef={inputRef}
-      optionRefs={optionRefs}
-      placeholder={placeholder}
-      title={title}
-      onBack={handleBack}
-      onClose={props.onClose}
-      onQueryChange={handleQueryChange}
-      onActiveIndexChange={(value) => dispatch({ type: "activeIndex", activeIndex: value })}
-      onKeyDown={handleKey}
-    />
+    <CommandDialog open={props.open} onOpenChange={handleOpenChange}>
+      <CommandDialogPopup onKeyDownCapture={handleEscape}>
+        <CommandDialogTitle>
+          {mode === "sessions"
+            ? t("session.palette_title_sessions")
+            : t("session.palette_title_actions")
+          }
+        </CommandDialogTitle>
+        <Command key={mode} items={items}>
+          <CommandHeader className="flex items-center gap-0">
+            {mode === "sessions" && (
+              <Button variant="outline" size="icon-sm" className="rounded-xl" onClick={() => setMode("root")}>
+                <ChevronLeftIcon className="size-4" />
+                <span className="sr-only">{t("common.back")}</span>
+              </Button>
+            )}
+            <CommandInput
+              className="w-full"
+              placeholder={
+                mode === "sessions"
+                  ? t("session.palette_placeholder_sessions")
+                  : t("session.palette_placeholder_actions")
+              }
+              onKeyDown={handleBackspace}
+            />
+          </CommandHeader>
+          <CommandPanel>
+            <CommandEmpty>{t("session.palette_no_matches")}</CommandEmpty>
+            <CommandList>
+              {(item: PaletteItem) => (
+                <CommandItem
+                  key={item.id}
+                  value={item.id}
+                  onClick={item.action}
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate font-medium">{item.title}</div>
+                    {item.detail ? (
+                      <div className="truncate text-muted-foreground text-xs">
+                        {item.detail}
+                      </div>
+                    ) : null}
+                    {item.searchText ? (
+                      <span className="sr-only">{item.searchText}</span>
+                    ) : null}
+                  </div>
+                  {item.meta ? <CommandShortcut>{item.meta}</CommandShortcut> : null}
+                </CommandItem>
+              )}
+            </CommandList>
+          </CommandPanel>
+          <CommandFooter>
+            <span>{t("session.palette_hint_navigate")}</span>
+            <span>{t("session.palette_hint_run")}</span>
+          </CommandFooter>
+        </Command>
+      </CommandDialogPopup>
+    </CommandDialog>
   );
 }


### PR DESCRIPTION
## Summary
- Redesigns the command palette around shared `Command`, `Autocomplete`, and `ScrollArea` UI primitives.
- Adds reusable autocomplete and scroll-area components.
- Updates the model selector to use the refreshed command/autocomplete behavior.
- Simplifies command palette implementation while preserving grouped commands and search.

## Evidence
<img width="2564" height="1974" alt="CleanShot 2026-05-15 at 16 46 55@2x" src="https://github.com/user-attachments/assets/d6a6e8e0-2df3-4fcc-af9c-066519299ec4" />
<img width="2564" height="1974" alt="CleanShot 2026-05-15 at 16 47 12@2x" src="https://github.com/user-attachments/assets/78daec82-7f79-4f5a-a3d3-6c6eedfc2946" />
