### PR TITLE
feat(app): add multi tab support

### DIFF
--- a/apps/app/overlay.html
+++ b/apps/app/overlay.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <title>OpenWork Overlay</title>
+    <script>
+      (function () {
+        try {
+          var mode = localStorage.getItem("openwork.themePref") || "system";
+          var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+          var resolved = mode === "dark" || (mode === "system" && prefersDark) ? "dark" : "light";
+          document.documentElement.dataset.theme = resolved;
+          document.documentElement.style.colorScheme = resolved;
+        } catch (e) {
+          document.documentElement.dataset.theme = "light";
+          document.documentElement.style.colorScheme = "light";
+        }
+      })();
+    </script>
+  </head>
+  <body class="overflow-hidden bg-transparent text-dls-text">
+    <div id="root"></div>
+    <script type="module" src="/src/overlay/index.tsx"></script>
+  </body>
+</html>

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -32,6 +32,7 @@ import type { WorkspaceList } from "./desktop-types";
 
 declare global {
   interface Window {
+    __OPENWORK_ZOOM_FACTOR__?: number;
     __OPENWORK_ELECTRON__?: {
       invokeDesktop?: (command: string, ...args: unknown[]) => Promise<unknown>;
       shell?: {
@@ -87,9 +88,68 @@ declare global {
         forward?: () => Promise<void>;
         reload?: () => Promise<void>;
         setBounds?: (bounds: { x: number; y: number; width: number; height: number }) => Promise<void>;
-        getState?: () => Promise<{ url: string; title: string; canGoBack: boolean; canGoForward: boolean; isLoading: boolean } | null>;
+        getState?: () => Promise<{
+          url: string;
+          title: string;
+          canGoBack: boolean;
+          canGoForward: boolean;
+          isLoading: boolean;
+          activeTabId?: string | null;
+          tabs?: Array<{
+            tabId: string;
+            url: string;
+            title: string;
+            favicon?: string | null;
+            canGoBack: boolean;
+            canGoForward: boolean;
+            isLoading: boolean;
+            isActive: boolean;
+          }>;
+        } | null>;
+        createTab?: (url?: string) => Promise<{ tabId: string }>;
+        closeTab?: (tabId: string) => Promise<string | null>;
+        closeAllTabs?: () => Promise<string[]>;
+        selectTab?: (tabId: string) => Promise<string>;
+        reorderTabs?: (tabIds: string[]) => Promise<Array<{
+          tabId: string;
+          url: string;
+          title: string;
+          favicon?: string | null;
+          canGoBack: boolean;
+          canGoForward: boolean;
+          isLoading: boolean;
+          isActive: boolean;
+        }>>;
+        listTabs?: () => Promise<Array<{
+          tabId: string;
+          url: string;
+          title: string;
+          favicon?: string | null;
+          canGoBack: boolean;
+          canGoForward: boolean;
+          isLoading: boolean;
+          isActive: boolean;
+        }>>;
+        showTabContextMenu?: (tabId: string, point?: { x: number; y: number }) => Promise<void>;
         destroy?: () => Promise<void>;
-        onStateChange?: (callback: (state: { url: string; title: string; canGoBack: boolean; canGoForward: boolean; isLoading: boolean }) => void) => () => void;
+        onStateChange?: (callback: (state: {
+          url: string;
+          title: string;
+          canGoBack: boolean;
+          canGoForward: boolean;
+          isLoading: boolean;
+          activeTabId?: string | null;
+          tabs?: Array<{
+            tabId: string;
+            url: string;
+            title: string;
+            favicon?: string | null;
+            canGoBack: boolean;
+            canGoForward: boolean;
+            isLoading: boolean;
+            isActive: boolean;
+          }>;
+        }) => void) => () => void;
         onPanelOpened?: (callback: () => void) => () => void;
         onPanelClosed?: (callback: () => void) => () => void;
       };

--- a/apps/app/src/overlay/context-menu.tsx
+++ b/apps/app/src/overlay/context-menu.tsx
@@ -1,0 +1,72 @@
+/** @jsxImportSource react */
+import * as React from "react";
+
+import { cn } from "../lib/utils";
+
+function ContextMenuContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="context-menu-content"
+      data-open=""
+      data-side="bottom"
+      className={cn(
+        "dark z-50 max-h-(--available-height) min-w-48 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-3xl p-1.5 text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-start-2 data-[side=inline-start]:slide-in-from-end-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuItem({
+  className,
+  disabled,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"button"> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <button
+      type="button"
+      data-slot="context-menu-item"
+      data-inset={inset ? "" : undefined}
+      data-variant={variant}
+      data-disabled={disabled ? "" : undefined}
+      disabled={disabled}
+      className={cn(
+        "group/context-menu-item relative flex w-full cursor-default items-center gap-2.5 rounded-2xl px-3 py-2 text-sm font-medium outline-hidden select-none hover:bg-foreground/10 focus:bg-accent focus:text-accent-foreground active:bg-foreground/10 data-inset:ps-9.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="context-menu-separator"
+      role="separator"
+      className={cn("-mx-1.5 my-1.5 h-px bg-border/50", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ms-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuShortcut };

--- a/apps/app/src/overlay/index.tsx
+++ b/apps/app/src/overlay/index.tsx
@@ -1,0 +1,128 @@
+/** @jsxImportSource react */
+import * as React from "react";
+import ReactDOM from "react-dom/client";
+
+import { bootstrapTheme } from "../app/theme";
+import { ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuShortcut } from "./context-menu";
+import "../app/index.css";
+
+type ContextMenuItem = {
+  id: string;
+  label: string;
+  iconName?: "copy" | "external" | "close";
+  disabled?: boolean;
+  shortcut?: string;
+  separatorBefore?: boolean;
+};
+
+type ContextMenuRequest = {
+  id: string;
+  source: "tab" | "page" | "sidebar";
+  items: ContextMenuItem[];
+};
+
+type MenuOverlayApi = {
+  ready: () => void;
+  onShow: (callback: (request: ContextMenuRequest) => void) => () => void;
+  choose: (requestId: string, itemId: string) => void;
+  close: (requestId?: string) => void;
+};
+
+const MENU_ITEM_SELECTOR = "button[data-slot='context-menu-item']:not(:disabled)";
+
+declare global {
+  interface Window {
+    __OPENWORK_MENU_OVERLAY__?: MenuOverlayApi;
+  }
+}
+
+function ContextMenuSurface({
+  request,
+  onChoose,
+  onClose,
+}: {
+  request: ContextMenuRequest;
+  onChoose: (itemId: string) => void;
+  onClose: () => void;
+}) {
+  React.useEffect(() => {
+    // document.querySelector<HTMLButtonElement>(MENU_ITEM_SELECTOR)?.focus();
+  }, [request.id]);
+
+  return (
+    <div
+      className="dark h-dvh overflow-hidden bg-transparent text-popover-foreground p-px"
+      onKeyDown={(event) => {
+        const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>(MENU_ITEM_SELECTOR));
+        const currentIndex = Math.max(buttons.indexOf(document.activeElement as HTMLButtonElement), 0);
+        if (event.key === "Escape") {
+          event.preventDefault();
+          onClose();
+        } else if (event.key === "ArrowDown") {
+          event.preventDefault();
+          buttons[(currentIndex + 1) % buttons.length]?.focus();
+        } else if (event.key === "ArrowUp") {
+          event.preventDefault();
+          buttons[(currentIndex - 1 + buttons.length) % buttons.length]?.focus();
+        }
+      }}
+    >
+      <ContextMenuContent
+        role="menu"
+        aria-label={`${request.source} context menu`}
+        className="w-full"
+      >
+        {request.items.map((item) => {
+          return (
+            <React.Fragment key={item.id}>
+              {item.separatorBefore ? <ContextMenuSeparator /> : null}
+              <ContextMenuItem
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={() => onChoose(item.id)}
+              >
+                <span className="min-w-0 flex-1 truncate text-left">{item.label}</span>
+                {item.shortcut ? <ContextMenuShortcut>{item.shortcut}</ContextMenuShortcut> : null}
+              </ContextMenuItem>
+            </React.Fragment>
+          );
+        })}
+      </ContextMenuContent>
+    </div>
+  );
+}
+
+function OverlayApp() {
+  const [request, setRequest] = React.useState<ContextMenuRequest | null>(null);
+  const api = window.__OPENWORK_MENU_OVERLAY__;
+
+  React.useEffect(() => {
+    if (!api) return;
+    const unsubscribe = api.onShow((nextRequest) => {
+      setRequest(nextRequest);
+    });
+    api.ready();
+    return unsubscribe;
+  }, [api]);
+
+  if (!api || !request) return null;
+
+  return (
+    <ContextMenuSurface
+      request={request}
+      onChoose={(itemId) => api.choose(request.id, itemId)}
+      onClose={() => api.close(request.id)}
+    />
+  );
+}
+
+bootstrapTheme();
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Overlay root element not found");
+
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <OverlayApp />
+  </React.StrictMode>,
+);

--- a/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
+++ b/apps/app/src/react-app/domains/session/browser/browser-panel.tsx
@@ -1,58 +1,81 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useReducer, useRef } from "react";
-import { ArrowLeft, ArrowRight, Globe, Loader2, RotateCw, X } from "lucide-react";
+import { useCallback, useEffect, useRef } from "react";
+import { ArrowLeft, ArrowRight, Globe, Loader2, Plus, RotateCw, X } from "lucide-react";
+import { Reorder, useDragControls } from "motion/react";
 import { isElectronRuntime } from "../../../../app/utils";
-
-type BrowserState = {
-  url: string;
-  title: string;
-  canGoBack: boolean;
-  canGoForward: boolean;
-  isLoading: boolean;
-};
-
-type BrowserPanelState = {
-  browserState: BrowserState;
-  urlInput: string;
-};
-
-type BrowserPanelAction =
-  | { type: "browserStateChanged"; browserState: BrowserState; syncUrlInput: boolean }
-  | { type: "urlInputChanged"; value: string };
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import {
+  getActiveTab,
+  type BrowserStatePayload,
+  type BrowserTabInfo,
+  useBrowserState,
+} from "./use-browser-state";
 
 type BrowserPanelProps = { onClose: () => void };
 
-const EMPTY_STATE: BrowserState = { url: "", title: "", canGoBack: false, canGoForward: false, isLoading: false };
-
-function browserPanelReducer(
-  state: BrowserPanelState,
-  action: BrowserPanelAction,
-): BrowserPanelState {
-  switch (action.type) {
-    case "browserStateChanged":
-      return {
-        browserState: action.browserState,
-        urlInput: action.syncUrlInput ? action.browserState.url : state.urlInput,
-      };
-    case "urlInputChanged":
-      return { ...state, urlInput: action.value };
+function getTabLabel(tab: BrowserTabInfo) {
+  if (tab.title) {
+    return tab.title;
   }
+
+  if (tab.url && tab.url !== "about:blank") {
+    return tab.url;
+  }
+
+  return "New tab";
+}
+
+function getNativeMenuPoint(
+  el: HTMLElement | null,
+  point?: { clientX: number; clientY: number },
+) {
+  const zoom = window.__OPENWORK_ZOOM_FACTOR__ ?? 1;
+
+  if (point) {
+    return {
+      x: Math.round(point.clientX / zoom),
+      y: Math.round(point.clientY / zoom),
+    };
+  }
+
+  if (!el) {
+    return undefined;
+  }
+
+  const rect = el.getBoundingClientRect();
+
+  return {
+    x: Math.round((rect.left + 8) / zoom),
+    y: Math.round((rect.bottom + 4) / zoom),
+  };
 }
 
 function getElectronBrowser() {
-  if (!isElectronRuntime()) return null;
-  return (window as Window).__OPENWORK_ELECTRON__?.browser ?? null;
+  if (!isElectronRuntime()) {
+    return null;
+  }
+
+  return window.__OPENWORK_ELECTRON__?.browser ?? null;
 }
 
 function computeBounds(el: HTMLElement, toolbar: HTMLElement) {
   const rect = el.getBoundingClientRect();
   const toolbarRect = toolbar.getBoundingClientRect();
+
   // Electron's WebContentsView.setBounds() uses the parent contentView's
   // coordinate space (CSS pixels at zoom=1). If the app has a font-zoom /
   // zoom factor, getBoundingClientRect() returns *zoomed* CSS pixels.
   // Dividing by the zoom factor gives the unzoomed coordinates that the
   // native view expects.
-  const zoom = (window as Window & { __OPENWORK_ZOOM_FACTOR__?: number }).__OPENWORK_ZOOM_FACTOR__ ?? 1;
+  const zoom = window.__OPENWORK_ZOOM_FACTOR__ ?? 1;
+
   return {
     x: Math.round(rect.x / zoom),
     y: Math.round((rect.y + toolbarRect.height) / zoom),
@@ -61,11 +84,110 @@ function computeBounds(el: HTMLElement, toolbar: HTMLElement) {
   };
 }
 
+type BrowserTabProps = {
+  tab: BrowserTabInfo;
+};
+
+function BrowserTab({ tab }: BrowserTabProps) {
+  const dragControls = useDragControls();
+  const tabRef = useRef<HTMLDivElement>(null);
+  const label = getTabLabel(tab);
+
+  const selectTab = () => {
+    getElectronBrowser()?.selectTab?.(tab.tabId);
+  };
+
+  const closeTab = () => {
+    getElectronBrowser()?.closeTab?.(tab.tabId);
+  };
+
+  const showTabContextMenu = (point?: { clientX: number; clientY: number }) => {
+    void getElectronBrowser()?.showTabContextMenu?.(
+      tab.tabId,
+      getNativeMenuPoint(tabRef.current, point),
+    );
+  };
+
+  return (
+    <Reorder.Item
+      as="div"
+      value={tab.tabId}
+      id={tab.tabId}
+      layout="position"
+      dragElastic={0}
+      dragListener={false}
+      dragControls={dragControls}
+      className="group relative w-44 min-w-0 shrink-0"
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        showTabContextMenu({ clientX: event.clientX, clientY: event.clientY });
+      }}
+    >
+      <div ref={tabRef} className="relative">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className={cn(
+            "w-full min-w-0 justify-start gap-2 px-2 pr-8 text-left text-sm font-normal text-muted-foreground hover:bg-muted hover:text-foreground",
+            tab.isActive && "bg-muted/80 text-foreground",
+          )}
+          onClick={selectTab}
+          onPointerDown={(event) => {
+            if (event.button !== 0) {
+              return;
+            }
+
+            dragControls.start(event);
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "ContextMenu" && !(event.shiftKey && event.key === "F10")) {
+              return;
+            }
+
+            event.preventDefault();
+            showTabContextMenu();
+          }}
+          title={label}
+          aria-label={`Select tab: ${label}`}
+        >
+          {tab.favicon ? (
+            <img src={tab.favicon} alt="" className="size-3.5 shrink-0 rounded-[2px]" />
+          ) : tab.isLoading ? (
+            <Loader2 className="animate-spin" />
+          ) : (
+            <Globe />
+          )}
+          <span className="min-w-0 flex-1 truncate text-left">{label}</span>
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className={cn(
+            "absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100",
+            tab.isActive && "text-foreground hover:bg-muted hover:text-foreground",
+          )}
+          title="Close tab"
+          aria-label={`Close tab: ${label}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            closeTab();
+          }}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+        >
+          <X />
+        </Button>
+      </div>
+    </Reorder.Item>
+  );
+}
+
 export function BrowserPanel({ onClose }: BrowserPanelProps) {
-  const [state, dispatch] = useReducer(browserPanelReducer, {
-    browserState: EMPTY_STATE,
-    urlInput: "",
-  });
+  const [state, dispatch] = useBrowserState();
   const urlFocusedRef = useRef(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
@@ -76,15 +198,20 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
   // Subscribe to state changes from the main process
   useEffect(() => {
     const browser = getElectronBrowser();
-    if (!browser) return;
-    const unsub = browser.onStateChange?.((s: BrowserState) => {
+
+    if (!browser) {
+      return;
+    }
+
+    const unsub = browser.onStateChange?.((s: BrowserStatePayload) => {
       dispatch({
         type: "browserStateChanged",
         browserState: s,
         syncUrlInput: !urlFocusedRef.current,
       });
     });
-    browser.getState?.().then((s: BrowserState | null) => {
+
+    browser.getState?.().then((s: BrowserStatePayload | null) => {
       if (s) {
         dispatch({
           type: "browserStateChanged",
@@ -93,20 +220,31 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
         });
       }
     });
+
     return unsub;
   }, []);
 
   // Show the browser view when the panel mounts, keep bounds in sync, hide on unmount.
   useEffect(() => {
     const browser = getElectronBrowser();
-    if (!browser || !panelRef.current || !toolbarRef.current) return;
+
+    if (!browser || !panelRef.current || !toolbarRef.current) {
+      return;
+    }
+
     const panel = panelRef.current;
     const toolbar = toolbarRef.current;
 
     const syncBounds = () => {
       boundsFrameRef.current = null;
+
       const bounds = computeBounds(panel, toolbar);
-      if (bounds.width < 1 || bounds.height < 1) return; // not laid out yet
+
+      if (bounds.width < 1 || bounds.height < 1) {
+        return;
+      }
+
+      // not laid out yet
       if (!shownRef.current) {
         browser.show?.(bounds);
         shownRef.current = true;
@@ -114,6 +252,7 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
         browser.setBounds?.(bounds);
       }
     };
+
     const scheduleSyncBounds = () => {
       if (boundsFrameRef.current != null) return;
       boundsFrameRef.current = window.requestAnimationFrame(syncBounds);
@@ -123,17 +262,22 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     syncBounds();
 
     const observer = new ResizeObserver(scheduleSyncBounds);
+
     observer.observe(panel);
     observer.observe(toolbar);
+
     window.addEventListener("resize", scheduleSyncBounds);
 
     return () => {
       observer.disconnect();
+
       window.removeEventListener("resize", scheduleSyncBounds);
+
       if (boundsFrameRef.current != null) {
         window.cancelAnimationFrame(boundsFrameRef.current);
         boundsFrameRef.current = null;
       }
+
       browser.hide?.();
       shownRef.current = false;
     };
@@ -143,6 +287,27 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     getElectronBrowser()?.navigate?.(url ?? state.urlInput);
   }, [state.urlInput]);
 
+  const createTab = useCallback(() => {
+    getElectronBrowser()?.createTab?.();
+  }, []);
+
+  const reorderTabs = useCallback((tabIds: string[]) => {
+    dispatch({ type: "tabsReordered", tabIds });
+    getElectronBrowser()?.reorderTabs?.(tabIds);
+  }, []);
+
+  const back = useCallback(() => {
+    getElectronBrowser()?.back?.();
+  }, []);
+
+  const forward = useCallback(() => {
+    getElectronBrowser()?.forward?.();
+  }, []);
+
+  const reload = useCallback(() => {
+    getElectronBrowser()?.reload?.();
+  }, []);
+
   const handleUrlKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
@@ -151,51 +316,108 @@ export function BrowserPanel({ onClose }: BrowserPanelProps) {
     }
   }, [navigate]);
 
+  const activeTab = getActiveTab(state);
   const browser = getElectronBrowser();
+
   if (!isElectronRuntime() || !browser) {
     return (
-      <div className="flex h-full items-center justify-center p-4 text-center text-dls-secondary">
+      <div className="flex h-full items-center justify-center p-4 text-center text-muted-foreground">
         <p className="text-sm">Browser panel is only available in the desktop app.</p>
       </div>
     );
   }
 
   return (
-    <div ref={panelRef} className="flex h-full flex-col">
-      <div ref={toolbarRef} className="flex h-10 shrink-0 items-center gap-1 border-b border-border px-2">
-        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.back?.()} disabled={!state.browserState.canGoBack} title="Back" aria-label="Go back">
-          <ArrowLeft className="size-4" />
-        </button>
-        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40" onClick={() => browser.forward?.()} disabled={!state.browserState.canGoForward} title="Forward" aria-label="Go forward">
-          <ArrowRight className="size-4" />
-        </button>
-        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text" onClick={() => browser.reload?.()} title="Reload" aria-label="Reload page">
-          {state.browserState.isLoading ? <Loader2 className="size-4 animate-spin" /> : <RotateCw className="size-4" />}
-        </button>
-        <div className="relative mx-1 flex min-w-0 flex-1 items-center">
-          <Globe className="absolute left-2 size-3.5 text-dls-secondary" />
-          <input
-            ref={urlInputRef}
-            type="text"
-            className="h-7 w-full rounded-md border border-dls-border bg-dls-background-secondary pl-7 pr-2 text-[12px] text-dls-text placeholder:text-dls-secondary focus:border-dls-accent focus:outline-none"
-            value={state.urlInput}
-            onChange={(e) =>
-              dispatch({ type: "urlInputChanged", value: e.target.value })
-            }
-            onKeyDown={handleUrlKeyDown}
-            onFocus={() => { urlFocusedRef.current = true; urlInputRef.current?.select(); }}
-            onBlur={() => { urlFocusedRef.current = false; }}
-            placeholder="Enter URL..."
-            spellCheck={false}
-            autoComplete="off"
-          />
+    <TooltipProvider delay={1000}>
+      <div ref={panelRef} className="flex h-full flex-col">
+        <div ref={toolbarRef} className="shrink-0 border-b border-border bg-background mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+          <div className="flex h-10 items-center gap-1 border-b border-border/60 px-2">
+            <div className="no-scrollbar min-w-0 flex-1 overflow-x-auto">
+              <Reorder.Group
+                as="div"
+                axis="x"
+                values={state.tabs.map((tab) => tab.tabId)}
+                onReorder={reorderTabs}
+                className="flex min-w-max items-center gap-1"
+              >
+                {state.tabs.map((tab) => (
+                  <BrowserTab
+                    key={tab.tabId}
+                    tab={tab}
+                  />
+                ))}
+              </Reorder.Group>
+            </div>
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="icon-sm" onClick={createTab} aria-label="New tab">
+                    <Plus />
+                  </Button>
+                )}
+              />
+              <TooltipContent>New tab</TooltipContent>
+            </Tooltip>
+          </div>
+          <div className="flex h-10 items-center gap-1 px-2">
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="icon-sm" onClick={back} disabled={!activeTab.canGoBack} aria-label="Go back">
+                    <ArrowLeft />
+                  </Button>
+                )}
+              />
+              <TooltipContent>Back</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="icon-sm" onClick={forward} disabled={!activeTab.canGoForward} aria-label="Go forward">
+                    <ArrowRight />
+                  </Button>
+                )}
+              />
+              <TooltipContent>Forward</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="icon-sm" onClick={reload} aria-label="Reload page">
+                    {activeTab.isLoading ? <Loader2 className="animate-spin" /> : <RotateCw />}
+                  </Button>
+                )}
+              />
+              <TooltipContent>Reload</TooltipContent>
+            </Tooltip>
+            <InputGroup className="mx-1 h-7 flex-1 rounded-md">
+              <InputGroupInput
+                ref={urlInputRef}
+                type="text"
+                className="h-7"
+                value={state.urlInput}
+                onChange={(e) =>
+                  dispatch({ type: "urlInputChanged", value: e.target.value })
+                }
+                onKeyDown={handleUrlKeyDown}
+                onFocus={() => { urlFocusedRef.current = true; urlInputRef.current?.select(); }}
+                onBlur={() => { urlFocusedRef.current = false; }}
+                placeholder="Enter URL..."
+                spellCheck={false}
+                autoComplete="off"
+              />
+              <InputGroupAddon align="inline-start" className="ps-2">
+                <Globe />
+              </InputGroupAddon>
+            </InputGroup>
+            <Button variant="ghost" size="icon-sm" onClick={onClose} title="Close browser" aria-label="Close browser panel">
+              <X />
+            </Button>
+          </div>
         </div>
-        <button type="button" className="inline-flex size-7 items-center justify-center rounded-md text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text" onClick={onClose} title="Close browser" aria-label="Close browser panel">
-          <X className="size-4" />
-        </button>
+        {/* WebContentsView renders in this area (managed by Electron main process) */}
+        <div className="min-h-0 flex-1" />
       </div>
-      {/* WebContentsView renders in this area (managed by Electron main process) */}
-      <div className="min-h-0 flex-1" />
-    </div>
+    </TooltipProvider>
   );
 }

--- a/apps/app/src/react-app/domains/session/browser/use-browser-state.ts
+++ b/apps/app/src/react-app/domains/session/browser/use-browser-state.ts
@@ -1,0 +1,124 @@
+import { useReducer } from "react";
+
+export type BrowserTabInfo = {
+  tabId: string;
+  url: string;
+  title: string;
+  favicon?: string | null;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
+  isActive: boolean;
+};
+
+export type BrowserStatePayload = {
+  url: string;
+  title: string;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
+  activeTabId?: string | null;
+  tabs?: BrowserTabInfo[];
+};
+
+export type BrowserPanelState = {
+  tabs: BrowserTabInfo[];
+  activeTabId: string | null;
+  urlInput: string;
+};
+
+export type BrowserPanelAction =
+  | { type: "browserStateChanged"; browserState: BrowserStatePayload; syncUrlInput: boolean }
+  | { type: "tabsReordered"; tabIds: string[] }
+  | { type: "urlInputChanged"; value: string };
+
+const EMPTY_TAB_STATE: BrowserTabInfo = {
+  tabId: "",
+  url: "",
+  title: "",
+  favicon: null,
+  canGoBack: false,
+  canGoForward: false,
+  isLoading: false,
+  isActive: false,
+};
+
+function normalizeTabs(browserState: BrowserStatePayload): {
+  tabs: BrowserTabInfo[];
+  activeTabId: string | null;
+} {
+  if (browserState.tabs?.length) {
+    const activeTabId =
+      browserState.activeTabId ??
+      browserState.tabs.find((tab) => tab.isActive)?.tabId ??
+      browserState.tabs[0]?.tabId ??
+      null;
+
+    return {
+      tabs: browserState.tabs.map((tab) => ({ ...tab, isActive: tab.tabId === activeTabId })),
+      activeTabId,
+    };
+  }
+
+  const tabId = browserState.activeTabId ?? "active";
+
+  return {
+    tabs: [{
+      tabId,
+      url: browserState.url,
+      title: browserState.title,
+      favicon: null,
+      canGoBack: browserState.canGoBack,
+      canGoForward: browserState.canGoForward,
+      isLoading: browserState.isLoading,
+      isActive: true,
+    }],
+    activeTabId: tabId,
+  };
+}
+
+export function getActiveTab(state: BrowserPanelState): BrowserTabInfo {
+  return state.tabs.find((tab) => tab.tabId === state.activeTabId) ?? state.tabs[0] ?? EMPTY_TAB_STATE;
+}
+
+function browserPanelReducer(
+  state: BrowserPanelState,
+  action: BrowserPanelAction,
+): BrowserPanelState {
+  switch (action.type) {
+    case "browserStateChanged": {
+      const { tabs, activeTabId } = normalizeTabs(action.browserState);
+
+      const activeTab = tabs.find((tab) => tab.tabId === activeTabId) ?? tabs[0] ?? EMPTY_TAB_STATE;
+
+      return {
+        tabs,
+        activeTabId,
+        urlInput: action.syncUrlInput ? activeTab.url : state.urlInput,
+      };
+    }
+    case "tabsReordered": {
+      const tabsById = new Map(state.tabs.map((tab) => [tab.tabId, tab]));
+
+      const reorderedTabs = action.tabIds
+        .map((tabId) => tabsById.get(tabId))
+        .filter((tab): tab is BrowserTabInfo => Boolean(tab));
+
+      if (reorderedTabs.length !== state.tabs.length) {
+        return state;
+      }
+
+      return { ...state, tabs: reorderedTabs };
+    }
+    case "urlInputChanged":
+      return { ...state, urlInput: action.value };
+  }
+}
+
+export function useBrowserState() {
+  return useReducer(browserPanelReducer, {
+    tabs: [],
+    activeTabId: null,
+    urlInput: "",
+  });
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -444,9 +444,13 @@ export function SessionPage(props: SessionPageProps) {
 
             <div className="flex items-center gap-1.5 text-gray-10 mac:titlebar-no-drag">
               {isElectronRuntime() ? (
-                <button
-                  type="button"
-                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors ${browserPanelOpen ? "bg-dls-accent/10 text-dls-accent" : "text-gray-10 hover:bg-gray-2/70 hover:text-dls-text"}`}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "transition-colors",
+                    browserPanelOpen && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
+                  )}
                   onClick={toggleBrowserPanel}
                   title="Toggle browser panel"
                   aria-label="Toggle browser panel"
@@ -454,13 +458,13 @@ export function SessionPage(props: SessionPageProps) {
                 >
                   <Globe size={16} />
                   <span className="hidden @lg/titlebar:inline">Browser</span>
-                </button>
+                </Button>
               ) : null}
               {/* Revert/redo moved to per-message actions */}
               {props.developerMode ? (
-                <button
-                  type="button"
-                  className="rounded-md px-2 py-1 text-[10px] font-medium text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() => {
                     try {
                       window.localStorage.removeItem("openwork.acknowledgedProviders");
@@ -470,7 +474,7 @@ export function SessionPage(props: SessionPageProps) {
                   title="Clears acknowledged providers + org onboarding so they trigger again"
                 >
                   Reset notifications
-                </button>
+                </Button>
               ) : null}
             </div>
           </header>

--- a/apps/app/src/react-app/shell/font-zoom.ts
+++ b/apps/app/src/react-app/shell/font-zoom.ts
@@ -24,7 +24,7 @@ export function useDesktopFontZoomBehavior() {
       // Expose the zoom factor so the browser panel's computeBounds can
       // convert zoomed CSS pixels back to the native coordinate space
       // that Electron's WebContentsView.setBounds() expects.
-      (window as Window & { __OPENWORK_ZOOM_FACTOR__?: number }).__OPENWORK_ZOOM_FACTOR__ = next;
+      window.__OPENWORK_ZOOM_FACTOR__ = next;
 
       void setDesktopZoomFactor(next)
         .then((applied) => {

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -23,6 +23,7 @@
     "src/components/**/*",
     "src/i18n/**/*",
     "src/lib/**/*",
+    "src/overlay/**/*",
     "src/react-app/**/*",
     "src/app/lib/**/*",
     "src/app/bundles/**/*",

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -101,6 +101,12 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
+    rollupOptions: {
+      input: {
+        app: resolve(appRoot, "index.html"),
+        overlay: resolve(appRoot, "overlay.html"),
+      },
+    },
   },
   resolve: {
     alias: {

--- a/apps/desktop/electron/browser-content-preload.cjs
+++ b/apps/desktop/electron/browser-content-preload.cjs
@@ -1,0 +1,17 @@
+const { ipcRenderer } = require("electron");
+
+function dismissMenuOverlay() {
+  ipcRenderer.send("openwork:menu-overlay:dismiss");
+}
+
+function installDismissListeners() {
+  window.addEventListener("pointerdown", dismissMenuOverlay, { capture: true });
+  window.addEventListener("wheel", dismissMenuOverlay, { capture: true, passive: true });
+  window.addEventListener("keydown", dismissMenuOverlay, { capture: true });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", installDismissListeners, { once: true });
+} else {
+  installDismissListeners();
+}

--- a/apps/desktop/electron/browser-mcp.mjs
+++ b/apps/desktop/electron/browser-mcp.mjs
@@ -248,12 +248,24 @@ async function startMcpHttpServer(mcpServerFactory, preferredPort = 0) {
  * Boot both MCP servers.
  *
  * @param {object}   opts
- * @param {Function} opts.getWebContents    — () => WebContents | null (built-in browser view)
+ * @param {Function} opts.getWebContents    — () => WebContents | null (active built-in browser tab)
+ * @param {Function} opts.listTabs          — () => BrowserTabInfo[]
+ * @param {Function} opts.createTab         — (url?: string) => tabId
+ * @param {Function} opts.closeTab          — (tabId: string) => tabId | null
+ * @param {Function} opts.selectTab         — (tabId: string) => tabId
  * @param {Function} opts.onBuiltinToolCall — called before each built-in browser tool (opens panel)
  * @param {Function} opts.onHideBrowser     — called to close the browser panel
  * @returns {{ builtinPort: number, externalPort: number, stop: () => Promise<void> }}
  */
-export async function startBrowserMcpServers({ getWebContents, onBuiltinToolCall, onHideBrowser }) {
+export async function startBrowserMcpServers({
+  getWebContents,
+  listTabs,
+  createTab,
+  closeTab,
+  selectTab,
+  onBuiltinToolCall,
+  onHideBrowser,
+}) {
   let externalBrowser = null;
 
   // ── Built-in browser: native Electron APIs ────────────────────────

--- a/apps/desktop/electron/browser-native-tools.mjs
+++ b/apps/desktop/electron/browser-native-tools.mjs
@@ -34,6 +34,7 @@ class NativeSnapshot {
   #snapshotCounter = 0;
   #stableIdMap = new Map(); // backendDOMNodeId → uid (stable across snapshots)
   #debuggerReady = false;
+  #attachedWebContents = null;
 
   constructor(getWebContents) {
     this.#getWebContents = getWebContents;
@@ -42,6 +43,11 @@ class NativeSnapshot {
   #ensureDebugger() {
     const wc = this.#getWebContents();
     if (!wc || wc.isDestroyed()) throw new Error("No browser page available.");
+    if (this.#attachedWebContents && this.#attachedWebContents !== wc) {
+      try { this.#attachedWebContents.debugger?.detach(); } catch { /* ok */ }
+      this.#debuggerReady = false;
+      this.#attachedWebContents = null;
+    }
     if (!this.#debuggerReady) {
       try {
         wc.debugger.attach("1.3");
@@ -49,7 +55,11 @@ class NativeSnapshot {
         // Already attached — fine
       }
       this.#debuggerReady = true;
-      wc.once("destroyed", () => { this.#debuggerReady = false; });
+      this.#attachedWebContents = wc;
+      wc.once("destroyed", () => {
+        if (this.#attachedWebContents === wc) this.#attachedWebContents = null;
+        this.#debuggerReady = false;
+      });
     }
     return wc;
   }
@@ -170,8 +180,9 @@ class NativeSnapshot {
 
   /** Reset snapshot state. Call when the WebContentsView is destroyed. */
   reset() {
-    try { this.#getWebContents()?.debugger?.detach(); } catch { /* ok */ }
+    try { this.#attachedWebContents?.debugger?.detach(); } catch { /* ok */ }
     this.#debuggerReady = false;
+    this.#attachedWebContents = null;
     this.#nodes.clear();
     this.#stableIdMap.clear();
   }
@@ -183,12 +194,24 @@ class NativeSnapshot {
  * Create an MCP server for the built-in browser using native Electron APIs.
  *
  * @param {object}   opts
- * @param {Function} opts.getWebContents — () => webContents | null
+ * @param {Function} opts.getWebContents — () => active webContents | null
+ * @param {Function} [opts.listTabs]     — () => browser tab info[]
+ * @param {Function} [opts.createTab]    — (url?: string) => tabId
+ * @param {Function} [opts.closeTab]     — (tabId: string) => tabId | null
+ * @param {Function} [opts.selectTab]    — (tabId: string) => tabId
  * @param {Function} [opts.onToolCall]   — called before each tool
  * @param {Function} [opts.onHideBrowser] — called to close the browser panel
  * @returns {McpServer}
  */
-export function createNativeBuiltinServer({ getWebContents, onToolCall, onHideBrowser }) {
+export function createNativeBuiltinServer({
+  getWebContents,
+  listTabs,
+  createTab,
+  closeTab,
+  selectTab,
+  onToolCall,
+  onHideBrowser,
+}) {
   const server = new McpServer(
     { name: "openwork-browser", version: "0.2.0" },
     { capabilities: { logging: {} } },
@@ -203,6 +226,19 @@ export function createNativeBuiltinServer({ getWebContents, onToolCall, onHideBr
     const c = getWebContents();
     if (!c || c.isDestroyed()) throw new Error("Built-in browser is not open.");
     return c;
+  }
+
+  function tabs() {
+    return typeof listTabs === "function" ? listTabs() : [];
+  }
+
+  function resolveTabId(pageId) {
+    const availableTabs = tabs();
+    if (typeof pageId === "number") {
+      return availableTabs[pageId - 1]?.tabId ?? null;
+    }
+    const id = String(pageId ?? "").trim();
+    return availableTabs.some((tab) => tab.tabId === id) ? id : null;
   }
 
   /** Navigate and wait for the page to load. Simple event-based wait —
@@ -730,27 +766,68 @@ export function createNativeBuiltinServer({ getWebContents, onToolCall, onHideBr
     },
   );
 
-  // ── Page management (single-page) ─────────────────────────────────
+  // ── Page management ───────────────────────────────────────────────
 
   defineTool(
     "list_pages",
-    "Get a list of pages open in the browser.",
+    "Get a list of tabs open in the built-in browser. Use select_page before interacting with a non-selected tab.",
     {},
     async () => {
-      const w = wc();
-      return { content: [{ type: "text", text: JSON.stringify([{
-        pageId: 1, url: w.getURL(), title: w.getTitle(), selected: true,
-      }]) }] };
+      const pages = tabs().map((tab, index) => ({
+        pageId: tab.tabId,
+        index: index + 1,
+        url: tab.url,
+        title: tab.title,
+        selected: tab.isActive,
+        isLoading: tab.isLoading,
+        canGoBack: tab.canGoBack,
+        canGoForward: tab.canGoForward,
+      }));
+      return { content: [{ type: "text", text: JSON.stringify(pages, null, 2) }] };
     },
   );
 
   defineTool(
     "select_page",
-    "Select a page as context for future tool calls.",
-    { pageId: z.number().describe("Page ID to select.") },
+    "Select a tab as context for future tool calls. After switching tabs, take a fresh snapshot before using element uids.",
+    { pageId: z.union([z.string(), z.number()]).describe("Page ID from list_pages. Numeric 1-based indexes are also accepted.") },
     async (params) => {
-      if (params.pageId !== 1) throw new Error("Only page 1 exists in the built-in browser.");
-      return { content: [{ type: "text", text: "Page 1 selected." }] };
+      if (typeof selectTab !== "function") throw new Error("Tab selection is not available.");
+      const tabId = resolveTabId(params.pageId);
+      if (!tabId) throw new Error(`No such page: ${params.pageId}`);
+      await selectTab(tabId);
+      snap.reset();
+      return { content: [{ type: "text", text: `Page ${tabId} selected. Take a fresh snapshot before interacting.` }] };
+    },
+  );
+
+  defineTool(
+    "create_page",
+    "Create a new browser tab, optionally navigate it to a URL, and select it for future tool calls.",
+    {
+      url: z.string().optional().describe("Optional URL to open in the new tab."),
+    },
+    async (params) => {
+      if (typeof createTab !== "function") throw new Error("Tab creation is not available.");
+      const tabId = await createTab(params.url);
+      snap.reset();
+      return { content: [{ type: "text", text: `Created and selected page ${tabId}.` }] };
+    },
+  );
+
+  defineTool(
+    "close_page",
+    "Close a browser tab by page ID. If the selected tab is closed, another tab may become selected; take a fresh snapshot before interacting.",
+    {
+      pageId: z.union([z.string(), z.number()]).describe("Page ID from list_pages. Numeric 1-based indexes are also accepted."),
+    },
+    async (params) => {
+      if (typeof closeTab !== "function") throw new Error("Tab closing is not available.");
+      const tabId = resolveTabId(params.pageId);
+      if (!tabId) throw new Error(`No such page: ${params.pageId}`);
+      await closeTab(tabId);
+      snap.reset();
+      return { content: [{ type: "text", text: `Closed page ${tabId}.` }] };
     },
   );
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -18,7 +18,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { app, BrowserWindow, Menu, WebContentsView, dialog, ipcMain, nativeImage, nativeTheme, shell } from "electron";
+import { app, BrowserWindow, Menu, WebContentsView, clipboard, dialog, ipcMain, nativeImage, nativeTheme, shell } from "electron";
 import { registerMigrationIpc } from "./migration.mjs";
 import { startBrowserMcpServers } from "./browser-mcp.mjs";
 import { createRuntimeManager } from "./runtime.mjs";
@@ -336,9 +336,52 @@ let uiControlDiscoveryPath = null;
 const uiControlToken = randomBytes(32).toString("hex");
 
 // ── Embedded browser panel ─────────────────────────────────────────────
-let browserView = null;
+const browserTabs = new Map();
+let browserTabOrder = [];
+let activeBrowserTabId = null;
 let browserViewVisible = false;
+let lastBrowserBounds = null;
+let browserTabCounter = 0;
 const BROWSER_DEFAULT_URL = "https://www.google.com";
+const MENU_OVERLAY_HTML = "overlay.html";
+const MENU_OVERLAY_WIDTH = 196;
+const MENU_OVERLAY_HEIGHT = 176;
+const MENU_OVERLAY_READY_TIMEOUT_MS = 2000;
+let menuOverlayView = null;
+let menuOverlayRequest = null;
+let menuOverlayReady = false;
+let menuOverlayReadyResolvers = [];
+let menuOverlayShowSerial = 0;
+
+function resetMenuOverlayReady({ resolvePending = false } = {}) {
+  menuOverlayReady = false;
+  if (resolvePending) {
+    const resolvers = menuOverlayReadyResolvers.splice(0);
+    for (const resolve of resolvers) resolve(false);
+  }
+}
+
+function markMenuOverlayReady(view) {
+  if (!view || view.webContents.isDestroyed()) return;
+  menuOverlayReady = true;
+  const resolvers = menuOverlayReadyResolvers.splice(0);
+  for (const resolve of resolvers) resolve(true);
+}
+
+function waitForMenuOverlayReady(view) {
+  if (menuOverlayReady) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    let timer = null;
+    const done = (ready) => {
+      if (timer) clearTimeout(timer);
+      menuOverlayReadyResolvers = menuOverlayReadyResolvers.filter((candidate) => candidate !== done);
+      resolve(ready);
+    };
+    timer = setTimeout(() => done(false), MENU_OVERLAY_READY_TIMEOUT_MS);
+    menuOverlayReadyResolvers.push(done);
+    if (!view || view.webContents.isDestroyed()) done(false);
+  });
+}
 
 /** Send an IPC message to the main renderer, guarding against disposed frames. */
 function sendToRenderer(channel, payload) {
@@ -494,40 +537,411 @@ function setApplicationMenuVisible(visible) {
   return applicationMenuVisible;
 }
 
-function createBrowserView() {
-  if (browserView) return browserView;
-  browserView = new WebContentsView({
+function createBrowserTabId() {
+  browserTabCounter += 1;
+  return `tab_${Date.now().toString(36)}_${browserTabCounter.toString(36)}`;
+}
+
+function normalizeBrowserUrl(url, fallback = BROWSER_DEFAULT_URL) {
+  const target = typeof url === "string" && url.trim() ? url.trim() : fallback;
+  if (!target || target === "about:blank") return "about:blank";
+  return /^https?:\/\//i.test(target) ? target : `https://${target}`;
+}
+
+function getBrowserTab(tabId = activeBrowserTabId) {
+  return tabId ? browserTabs.get(tabId) ?? null : null;
+}
+
+function getActiveBrowserView() {
+  return getBrowserTab()?.view ?? null;
+}
+
+function getActiveWebContents() {
+  return getActiveBrowserView()?.webContents ?? null;
+}
+
+function listBrowserTabs() {
+  return browserTabOrder
+    .map((tabId) => {
+      const tab = browserTabs.get(tabId);
+      if (!tab || tab.view.webContents.isDestroyed()) return null;
+      return {
+        tabId,
+        url: tab.view.webContents.getURL(),
+        title: tab.view.webContents.getTitle(),
+        favicon: tab.favicon,
+        canGoBack: tab.view.webContents.canGoBack(),
+        canGoForward: tab.view.webContents.canGoForward(),
+        isLoading: tab.view.webContents.isLoading(),
+        isActive: tabId === activeBrowserTabId,
+      };
+    })
+    .filter(Boolean);
+}
+
+function browserStatePayload() {
+  const activeTab = getBrowserTab();
+  const activeWebContents = activeTab?.view.webContents;
+  const activeState = activeWebContents && !activeWebContents.isDestroyed()
+    ? {
+        url: activeWebContents.getURL(),
+        title: activeWebContents.getTitle(),
+        canGoBack: activeWebContents.canGoBack(),
+        canGoForward: activeWebContents.canGoForward(),
+        isLoading: activeWebContents.isLoading(),
+      }
+    : {
+        url: "",
+        title: "",
+        canGoBack: false,
+        canGoForward: false,
+        isLoading: false,
+      };
+  return {
+    ...activeState,
+    activeTabId: activeBrowserTabId,
+    tabs: listBrowserTabs(),
+  };
+}
+
+function browserTabUrl(tab) {
+  const url = tab?.view?.webContents?.getURL?.();
+  return typeof url === "string" && url && url !== "about:blank" ? url : null;
+}
+
+function isHttpUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeMenuOverlayPoint(point) {
+  if (!point || typeof point !== "object") {
+    return { x: 0, y: 0 };
+  }
+  const x = Number(point.x);
+  const y = Number(point.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return { x: 0, y: 0 };
+  }
+  return { x: Math.round(x), y: Math.round(y) };
+}
+
+function menuOverlayBounds(point) {
+  const [contentWidth, contentHeight] = mainWindow?.getContentSize?.() ?? [MENU_OVERLAY_WIDTH, MENU_OVERLAY_HEIGHT];
+  return {
+    x: Math.min(Math.max(point.x, 0), Math.max(contentWidth - MENU_OVERLAY_WIDTH - 4, 0)),
+    y: Math.min(Math.max(point.y, 0), Math.max(contentHeight - MENU_OVERLAY_HEIGHT - 4, 0)),
+    width: MENU_OVERLAY_WIDTH,
+    height: MENU_OVERLAY_HEIGHT,
+  };
+}
+
+function menuOverlayUrl() {
+  const currentUrl = mainWindow?.webContents?.getURL?.();
+  if (currentUrl && /^https?:\/\//i.test(currentUrl)) {
+    return new URL(MENU_OVERLAY_HTML, currentUrl).toString();
+  }
+  return null;
+}
+
+async function loadMenuOverlayRenderer(view) {
+  const devUrl = menuOverlayUrl();
+  if (devUrl) {
+    await view.webContents.loadURL(devUrl);
+    return;
+  }
+
+  const packagedOverlayPath = path.join(process.resourcesPath, "app-dist", MENU_OVERLAY_HTML);
+  const devOverlayPath = path.resolve(__dirname, "../../app/dist", MENU_OVERLAY_HTML);
+  await view.webContents.loadFile(app.isPackaged ? packagedOverlayPath : devOverlayPath);
+}
+
+async function ensureMenuOverlayView() {
+  if (menuOverlayView && !menuOverlayView.webContents.isDestroyed()) {
+    return menuOverlayView;
+  }
+
+  const view = new WebContentsView({
+    webPreferences: {
+      // Electron only runs ESM preload scripts reliably with sandbox disabled.
+      // Keep the bridge isolated and node-free for the React overlay document.
+      sandbox: false,
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: path.join(__dirname, "menu-overlay-preload.mjs"),
+    },
+  });
+  view.setBackgroundColor?.("#00000000");
+  view.setVisible?.(false);
+  view.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  view.webContents.on("did-start-navigation", (_event, _url, isInPlace, isMainFrame) => {
+    if (isMainFrame && !isInPlace) resetMenuOverlayReady();
+  });
+  view.webContents.once("destroyed", () => {
+    if (menuOverlayView === view) {
+      menuOverlayView = null;
+      menuOverlayRequest = null;
+      resetMenuOverlayReady({ resolvePending: true });
+    }
+  });
+
+  menuOverlayView = view;
+  resetMenuOverlayReady({ resolvePending: true });
+  await loadMenuOverlayRenderer(view);
+  return view;
+}
+
+function hideMenuOverlay() {
+  const view = menuOverlayView;
+  menuOverlayShowSerial += 1;
+  menuOverlayRequest = null;
+  if (!view || !mainWindow) return;
+  view.setVisible?.(false);
+  try {
+    if (mainWindow.contentView.children.includes(view)) {
+      mainWindow.contentView.removeChildView(view);
+    }
+  } catch {
+    // already removed
+  }
+}
+
+function bringMenuOverlayToTop(view) {
+  if (!mainWindow) return;
+  try {
+    if (mainWindow.contentView.children.includes(view)) {
+      mainWindow.contentView.removeChildView(view);
+    }
+  } catch {
+    // already removed
+  }
+  mainWindow.contentView.addChildView(view);
+}
+
+function tabMenuRequest(tab, point) {
+  const url = browserTabUrl(tab);
+  return {
+    id: `tab-menu:${tab.tabId}:${Date.now()}`,
+    source: "tab",
+    tabId: tab.tabId,
+    url,
+    bounds: menuOverlayBounds(normalizeMenuOverlayPoint(point)),
+    items: [
+      { id: "copy-url", label: "Copy URL", iconName: "copy", disabled: !url },
+      { id: "open-external", label: "Open in Browser", iconName: "external", disabled: !(url && isHttpUrl(url)) },
+      { id: "close-tab", label: "Close Tab", iconName: "close", separatorBefore: true },
+      { id: "close-all-tabs", label: "Close All Tabs", iconName: "close" },
+    ],
+  };
+}
+
+async function showBrowserTabContextMenu(tabId, point) {
+  const tab = getBrowserTab(String(tabId ?? ""));
+  if (!mainWindow || !tab || tab.view.webContents.isDestroyed()) return;
+
+  const showSerial = menuOverlayShowSerial + 1;
+  menuOverlayShowSerial = showSerial;
+  const request = tabMenuRequest(tab, point);
+  const view = await ensureMenuOverlayView();
+  if (showSerial !== menuOverlayShowSerial || menuOverlayView !== view) return;
+  menuOverlayRequest = request;
+  view.setBounds(request.bounds);
+  view.setVisible?.(true);
+  bringMenuOverlayToTop(view);
+  const ready = await waitForMenuOverlayReady(view);
+  if (showSerial !== menuOverlayShowSerial || menuOverlayRequest !== request || menuOverlayView !== view) return;
+  if (!ready) {
+    console.warn("[menu-overlay] renderer did not signal readiness before show");
+  }
+  view.webContents.send("openwork:menu-overlay:show", {
+    id: request.id,
+    source: request.source,
+    items: request.items,
+  });
+  view.webContents.focus();
+}
+
+function handleMenuOverlayChoice(payload) {
+  if (!payload || payload.requestId !== menuOverlayRequest?.id) return;
+  const request = menuOverlayRequest;
+  const tab = getBrowserTab(request.tabId);
+  hideMenuOverlay();
+
+  switch (payload.itemId) {
+    case "copy-url":
+      if (request.url) clipboard.writeText(request.url);
+      break;
+    case "open-external":
+      if (request.url && isHttpUrl(request.url)) void shell.openExternal(request.url);
+      break;
+    case "close-tab":
+      if (tab) closeBrowserTab(tab.tabId);
+      break;
+    case "close-all-tabs":
+      closeAllBrowserTabs();
+      break;
+  }
+}
+
+function createBrowserTab(url = "about:blank", { select = true } = {}) {
+  const tabId = createBrowserTabId();
+  const view = new WebContentsView({
     webPreferences: {
       sandbox: true,
       contextIsolation: true,
       nodeIntegration: false,
+      preload: path.join(__dirname, "browser-content-preload.cjs"),
       partition: "persist:openwork-browser",
     },
   });
+  const tab = { tabId, view, favicon: null };
+  browserTabs.set(tabId, tab);
+  browserTabOrder.push(tabId);
   // Load about:blank immediately to preempt persistent-session restore.
   // Cookies live on the session object, not the document — they survive this.
-  browserView.webContents.loadURL("about:blank");
-  browserView.webContents.setWindowOpenHandler(({ url }) => {
-    void shell.openExternal(url);
+  view.webContents.loadURL("about:blank");
+  view.webContents.setWindowOpenHandler(({ url: targetUrl }) => {
+    void shell.openExternal(targetUrl);
     return { action: "deny" };
   });
-  browserView.webContents.on("did-navigate", () => sendBrowserState());
-  browserView.webContents.on("did-navigate-in-page", () => sendBrowserState());
-  browserView.webContents.on("page-title-updated", () => sendBrowserState());
-  browserView.webContents.on("did-start-loading", () => sendBrowserState());
-  browserView.webContents.on("did-stop-loading", () => sendBrowserState());
-  return browserView;
+  view.webContents.on("did-navigate", () => sendBrowserState());
+  view.webContents.on("did-navigate-in-page", () => sendBrowserState());
+  view.webContents.on("page-title-updated", () => sendBrowserState());
+  view.webContents.on("page-favicon-updated", (_event, favicons) => {
+    tab.favicon = Array.isArray(favicons) ? favicons[0] ?? null : null;
+    sendBrowserState();
+  });
+  view.webContents.on("did-start-loading", () => sendBrowserState());
+  view.webContents.on("did-stop-loading", () => sendBrowserState());
+  view.webContents.once("destroyed", () => {
+    browserTabs.delete(tabId);
+    browserTabOrder = browserTabOrder.filter((id) => id !== tabId);
+    if (activeBrowserTabId === tabId) activeBrowserTabId = browserTabOrder[0] ?? null;
+    sendBrowserState();
+  });
+  if (select || !activeBrowserTabId) {
+    selectBrowserTab(tabId);
+  } else {
+    sendBrowserState();
+  }
+  const finalUrl = normalizeBrowserUrl(url, "about:blank");
+  if (finalUrl !== "about:blank") {
+    view.webContents.loadURL(finalUrl);
+  }
+  return tab;
+}
+
+function detachBrowserView(view) {
+  if (!mainWindow || !view) return;
+  try {
+    if (mainWindow.contentView.children.includes(view)) {
+      mainWindow.contentView.removeChildView(view);
+    }
+  } catch {
+    // already removed
+  }
+}
+
+function attachActiveBrowserView() {
+  if (!mainWindow || !browserViewVisible) return;
+  const view = getActiveBrowserView();
+  if (!view) return;
+  for (const tab of browserTabs.values()) {
+    if (tab.view !== view) detachBrowserView(tab.view);
+  }
+  if (!mainWindow.contentView.children.includes(view)) {
+    mainWindow.contentView.addChildView(view);
+  }
+  if (lastBrowserBounds && lastBrowserBounds.width > 0 && lastBrowserBounds.height > 0) {
+    view.setBounds(lastBrowserBounds);
+  }
+}
+
+function selectBrowserTab(tabId) {
+  if (!browserTabs.has(tabId)) throw new Error(`Unknown browser tab: ${tabId}`);
+  hideMenuOverlay();
+  const previousView = getActiveBrowserView();
+  activeBrowserTabId = tabId;
+  if (previousView && previousView !== getActiveBrowserView()) {
+    detachBrowserView(previousView);
+  }
+  _snapshotReset?.();
+  attachActiveBrowserView();
+  sendBrowserState();
+  return getBrowserTab(tabId);
+}
+
+function closeBrowserTab(tabId = activeBrowserTabId) {
+  const tab = getBrowserTab(tabId);
+  if (!tab) return null;
+  if (menuOverlayRequest?.tabId === tabId) hideMenuOverlay();
+  const closingIndex = browserTabOrder.indexOf(tabId);
+  const wasActive = activeBrowserTabId === tabId;
+  detachBrowserView(tab.view);
+  browserTabs.delete(tabId);
+  browserTabOrder = browserTabOrder.filter((id) => id !== tabId);
+  if (wasActive) {
+    const nextTabId =
+      browserTabOrder[Math.min(closingIndex, browserTabOrder.length - 1)] ??
+      browserTabOrder[closingIndex - 1] ??
+      null;
+    activeBrowserTabId = nextTabId;
+    _snapshotReset?.();
+    if (nextTabId) {
+      attachActiveBrowserView();
+    } else {
+      hideBrowserView();
+      sendToRenderer("openwork:browser:panel-closed");
+    }
+  }
+  try { tab.view.webContents.close(); } catch { /* already destroyed */ }
+  sendBrowserState();
+  return tabId;
+}
+
+function closeAllBrowserTabs() {
+  const closedTabIds = [...browserTabOrder];
+  if (closedTabIds.length === 0) return [];
+  hideMenuOverlay();
+  const tabsToClose = closedTabIds
+    .map((tabId) => browserTabs.get(tabId))
+    .filter(Boolean);
+  hideBrowserView();
+  _snapshotReset?.();
+  browserTabs.clear();
+  browserTabOrder = [];
+  activeBrowserTabId = null;
+  for (const tab of tabsToClose) {
+    try { tab.view.webContents.close(); } catch { /* already destroyed */ }
+  }
+  sendToRenderer("openwork:browser:panel-closed");
+  sendBrowserState();
+  return closedTabIds;
+}
+
+function reorderBrowserTabs(tabIds) {
+  const nextOrder = Array.isArray(tabIds) ? tabIds.map(String) : [];
+  if (nextOrder.length !== browserTabOrder.length) {
+    throw new Error("Tab order must include every open tab.");
+  }
+  if (new Set(nextOrder).size !== nextOrder.length) {
+    throw new Error("Tab order must not contain duplicate tabs.");
+  }
+  const current = new Set(browserTabOrder);
+  if (nextOrder.some((tabId) => !current.has(tabId))) {
+    throw new Error("Tab order contains an unknown tab.");
+  }
+  browserTabOrder = nextOrder;
+  sendBrowserState();
+  return listBrowserTabs();
 }
 
 function sendBrowserState() {
-  if (!browserView) return;
-  sendToRenderer("openwork:browser:state", {
-    url: browserView.webContents.getURL(),
-    title: browserView.webContents.getTitle(),
-    canGoBack: browserView.webContents.canGoBack(),
-    canGoForward: browserView.webContents.canGoForward(),
-    isLoading: browserView.webContents.isLoading(),
-  });
+  sendToRenderer("openwork:browser:state", browserStatePayload());
 }
 
 /**
@@ -536,42 +950,49 @@ function sendBrowserState() {
  * @param {object} [opts]
  * @param {boolean} [opts.preloadDefault=true] — load default URL if the view has no URL
  */
-function attachBrowserView(bounds, { preloadDefault = true } = {}) {
+function attachBrowserView(bounds, { preloadDefault = true, ensureTab = true } = {}) {
   if (!mainWindow) return;
-  const view = createBrowserView();
-  if (!mainWindow.contentView.children.includes(view)) {
-    mainWindow.contentView.addChildView(view);
-  }
-  if (bounds.width > 0 && bounds.height > 0) {
-    view.setBounds(bounds);
-  }
+  lastBrowserBounds = bounds;
   browserViewVisible = true;
-  const url = view.webContents.getURL();
+  if (ensureTab && !activeBrowserTabId) createBrowserTab("about:blank");
+  const view = getActiveBrowserView();
+  attachActiveBrowserView();
+  if (bounds.width > 0 && bounds.height > 0) {
+    view?.setBounds(bounds);
+  }
+  const url = view?.webContents.getURL();
   if (preloadDefault && (!url || url === "about:blank")) {
-    view.webContents.loadURL(BROWSER_DEFAULT_URL);
+    view?.webContents.loadURL(BROWSER_DEFAULT_URL);
   }
   sendBrowserState();
 }
 
 function hideBrowserView() {
-  if (!mainWindow || !browserView) return;
-  try {
-    mainWindow.contentView.removeChildView(browserView);
-  } catch {
-    // already removed
-  }
+  hideMenuOverlay();
   browserViewVisible = false;
+  if (!mainWindow) return;
+  for (const tab of browserTabs.values()) {
+    detachBrowserView(tab.view);
+  }
 }
 
 let _snapshotReset = null; // set by ensureBrowserMcpServers
 
 function destroyBrowserView() {
   hideBrowserView();
-  if (browserView) {
-    _snapshotReset?.();
-    try { browserView.webContents.close(); } catch { /* already destroyed */ }
-    browserView = null;
+  const overlayView = menuOverlayView;
+  menuOverlayView = null;
+  menuOverlayRequest = null;
+  try { overlayView?.webContents.close(); } catch { /* already destroyed */ }
+  _snapshotReset?.();
+  for (const tab of browserTabs.values()) {
+    try { tab.view.webContents.close(); } catch { /* already destroyed */ }
   }
+  browserTabs.clear();
+  browserTabOrder = [];
+  activeBrowserTabId = null;
+  lastBrowserBounds = null;
+  sendBrowserState();
 }
 
 // ── In-process browser MCP servers ─────────────────────────────────────
@@ -586,13 +1007,20 @@ async function ensureBrowserMcpServers() {
 
   try {
     browserMcpPorts = await startBrowserMcpServers({
-      getWebContents: () => browserView?.webContents ?? null,
+      getWebContents: () => getActiveWebContents(),
+      listTabs: () => listBrowserTabs(),
+      createTab: async (url) => createBrowserTab(url ?? "about:blank", { select: true }).tabId,
+      closeTab: async (tabId) => closeBrowserTab(tabId),
+      selectTab: async (tabId) => selectBrowserTab(tabId).tabId,
       onBuiltinToolCall: async (toolName) => {
         // Ensure the browser panel is open so the agent can interact.
         // preloadDefault: false — the tool will navigate on its own.
         if (!mainWindow) return;
         if (!browserViewVisible) {
-          attachBrowserView({ x: 0, y: 0, width: 0, height: 0 }, { preloadDefault: false });
+          attachBrowserView(
+            { x: 0, y: 0, width: 0, height: 0 },
+            { preloadDefault: false, ensureTab: toolName !== "create_page" },
+          );
         }
         sendToRenderer("openwork:browser:panel-opened");
       },
@@ -2411,34 +2839,54 @@ ipcMain.handle("openwork:system:architecture", async () => resolveArchitectureIn
 ipcMain.handle("openwork:browser:show", (_event, bounds) => attachBrowserView(bounds));
 ipcMain.handle("openwork:browser:hide", () => hideBrowserView());
 ipcMain.handle("openwork:browser:navigate", (_event, url) => {
-  if (!browserView) return;
-  const target = typeof url === "string" && url.trim() ? url.trim() : BROWSER_DEFAULT_URL;
-  const finalUrl = /^https?:\/\//i.test(target) ? target : `https://${target}`;
-  browserView.webContents.loadURL(finalUrl);
+  const view = getActiveBrowserView() ?? createBrowserTab("about:blank", { select: true }).view;
+  view.webContents.loadURL(normalizeBrowserUrl(url));
 });
 ipcMain.handle("openwork:browser:back", () => {
-  if (browserView?.webContents.canGoBack()) browserView.webContents.goBack();
+  const webContents = getActiveWebContents();
+  if (webContents?.canGoBack()) webContents.goBack();
 });
 ipcMain.handle("openwork:browser:forward", () => {
-  if (browserView?.webContents.canGoForward()) browserView.webContents.goForward();
+  const webContents = getActiveWebContents();
+  if (webContents?.canGoForward()) webContents.goForward();
 });
-ipcMain.handle("openwork:browser:reload", () => browserView?.webContents.reload());
+ipcMain.handle("openwork:browser:reload", () => getActiveWebContents()?.reload());
 ipcMain.handle("openwork:browser:bounds", (_event, bounds) => {
-  if (browserView && browserViewVisible && bounds.width > 0 && bounds.height > 0) {
-    browserView.setBounds(bounds);
+  lastBrowserBounds = bounds;
+  const view = getActiveBrowserView();
+  if (view && browserViewVisible && bounds.width > 0 && bounds.height > 0) {
+    view.setBounds(bounds);
   }
 });
-ipcMain.handle("openwork:browser:state", () => {
-  if (!browserView) return null;
-  return {
-    url: browserView.webContents.getURL(),
-    title: browserView.webContents.getTitle(),
-    canGoBack: browserView.webContents.canGoBack(),
-    canGoForward: browserView.webContents.canGoForward(),
-    isLoading: browserView.webContents.isLoading(),
-  };
+ipcMain.handle("openwork:browser:state", () => browserStatePayload());
+ipcMain.handle("openwork:browser:createTab", (_event, url) => {
+  const tab = createBrowserTab(url ?? "about:blank", { select: true });
+  return { tabId: tab.tabId };
 });
+ipcMain.handle("openwork:browser:closeTab", (_event, tabId) => closeBrowserTab(tabId == null ? undefined : String(tabId)));
+ipcMain.handle("openwork:browser:closeAllTabs", () => closeAllBrowserTabs());
+ipcMain.handle("openwork:browser:selectTab", (_event, tabId) => selectBrowserTab(String(tabId ?? "")).tabId);
+ipcMain.handle("openwork:browser:reorderTabs", (_event, tabIds) => reorderBrowserTabs(tabIds));
+ipcMain.handle("openwork:browser:listTabs", () => listBrowserTabs());
+ipcMain.handle("openwork:browser:tabContextMenu", (_event, tabId, point) => showBrowserTabContextMenu(tabId, point));
 ipcMain.handle("openwork:browser:destroy", () => destroyBrowserView());
+ipcMain.on("openwork:menu-overlay:ready", (event) => {
+  if (event.sender !== menuOverlayView?.webContents) return;
+  markMenuOverlayReady(menuOverlayView);
+});
+ipcMain.on("openwork:menu-overlay:choose", (event, payload) => {
+  if (event.sender !== menuOverlayView?.webContents) return;
+  handleMenuOverlayChoice(payload);
+});
+ipcMain.on("openwork:menu-overlay:close", (event, payload) => {
+  if (event.sender !== menuOverlayView?.webContents) return;
+  if (payload?.requestId && payload.requestId !== menuOverlayRequest?.id) return;
+  hideMenuOverlay();
+});
+ipcMain.on("openwork:menu-overlay:dismiss", (event) => {
+  if (event.sender === menuOverlayView?.webContents) return;
+  hideMenuOverlay();
+});
 
 registerMigrationIpc({ app, ipcMain });
 const { ensureAutoUpdater } = registerUpdaterIpc({ app, ipcMain, getMainWindow: () => mainWindow });

--- a/apps/desktop/electron/menu-overlay-preload.mjs
+++ b/apps/desktop/electron/menu-overlay-preload.mjs
@@ -1,0 +1,32 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+let latestRequest = null;
+let showCallback = null;
+
+ipcRenderer.on("openwork:menu-overlay:show", (_event, request) => {
+  latestRequest = request;
+  showCallback?.(request);
+});
+
+contextBridge.exposeInMainWorld("__OPENWORK_MENU_OVERLAY__", {
+  ready() {
+    ipcRenderer.send("openwork:menu-overlay:ready");
+  },
+  onShow(callback) {
+    showCallback = callback;
+    if (latestRequest) {
+      callback(latestRequest);
+    }
+    return () => {
+      if (showCallback === callback) {
+        showCallback = null;
+      }
+    };
+  },
+  choose(requestId, itemId) {
+    ipcRenderer.send("openwork:menu-overlay:choose", { requestId, itemId });
+  },
+  close(requestId) {
+    ipcRenderer.send("openwork:menu-overlay:close", { requestId });
+  },
+});

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -30,6 +30,22 @@ function applyShellDocumentMarkers() {
   }
 }
 
+function notifyMenuOverlayDismiss() {
+  ipcRenderer.send("openwork:menu-overlay:dismiss");
+}
+
+function installMenuOverlayDismissListeners() {
+  try {
+    const target = window;
+    target.addEventListener("pointerdown", notifyMenuOverlayDismiss, { capture: true });
+    target.addEventListener("wheel", notifyMenuOverlayDismiss, { capture: true, passive: true });
+    target.addEventListener("keydown", notifyMenuOverlayDismiss, { capture: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
   invokeDesktop(command, ...args) {
     return ipcRenderer.invoke("openwork:desktop", command, ...args);
@@ -89,6 +105,13 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     reload() { return ipcRenderer.invoke("openwork:browser:reload"); },
     setBounds(bounds) { return ipcRenderer.invoke("openwork:browser:bounds", bounds); },
     getState() { return ipcRenderer.invoke("openwork:browser:state"); },
+    createTab(url) { return ipcRenderer.invoke("openwork:browser:createTab", url); },
+    closeTab(tabId) { return ipcRenderer.invoke("openwork:browser:closeTab", tabId); },
+    closeAllTabs() { return ipcRenderer.invoke("openwork:browser:closeAllTabs"); },
+    selectTab(tabId) { return ipcRenderer.invoke("openwork:browser:selectTab", tabId); },
+    reorderTabs(tabIds) { return ipcRenderer.invoke("openwork:browser:reorderTabs", tabIds); },
+    listTabs() { return ipcRenderer.invoke("openwork:browser:listTabs"); },
+    showTabContextMenu(tabId, point) { return ipcRenderer.invoke("openwork:browser:tabContextMenu", tabId, point); },
     destroy() { return ipcRenderer.invoke("openwork:browser:destroy"); },
     onStateChange(callback) {
       const handler = (_event, state) => callback(state);
@@ -130,4 +153,8 @@ ipcRenderer.on(NATIVE_MENU_TOGGLE_SIDEBAR_EVENT, () => {
 
 if (!applyShellDocumentMarkers() && typeof document !== "undefined") {
   document.addEventListener("DOMContentLoaded", applyShellDocumentMarkers, { once: true });
+}
+
+if (!installMenuOverlayDismissListeners() && typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", installMenuOverlayDismissListeners, { once: true });
 }


### PR DESCRIPTION
## Summary
- Adds multi-tab support to the embedded browser panel.
- Adds browser tab state/hooks, tab creation/switching/closing, and updated browser panel UI.
- Adds an Electron overlay entrypoint for browser context/menu UI.
- Extends Electron browser view management, preload messaging, and native browser tools for multiple tabs.
- Updates Vite/TS config to build the new overlay entry.