### PR TITLE
Move session activity panels into composer surface

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/permission-approval-modal.tsx
+++ b/apps/app/src/react-app/domains/session/chat/permission-approval-modal.tsx
@@ -379,7 +379,7 @@ export function PermissionApprovalPanel(props: PermissionApprovalModalProps) {
   const Icon = presentation.isDoomLoop ? RefreshCcw : ShieldCheck;
 
   return (
-    <div className="overflow-hidden rounded-t-[24px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
+    <div className="overflow-hidden border-b border-dls-border bg-transparent">
         <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 items-start gap-3">
             <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover text-dls-secondary">

--- a/apps/app/src/react-app/domains/session/chat/permission-approval-modal.tsx
+++ b/apps/app/src/react-app/domains/session/chat/permission-approval-modal.tsx
@@ -11,6 +11,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { t } from "@/i18n";
 import type { PendingPermission } from "@/app/types";
 
@@ -365,5 +366,102 @@ export function PermissionApprovalModal(props: PermissionApprovalModalProps) {
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  );
+}
+
+export function PermissionApprovalPanel(props: PermissionApprovalModalProps) {
+  const presentation = useMemo(() => describePermissionRequest(props.permission), [props.permission]);
+  const metadata =
+    props.permission.metadata && typeof props.permission.metadata === "object"
+      ? props.permission.metadata
+      : {};
+  const hasMetadata = Object.keys(metadata).length > 0;
+  const Icon = presentation.isDoomLoop ? RefreshCcw : ShieldCheck;
+
+  return (
+    <div className="mx-auto w-full max-w-[800px] px-4">
+      <div className="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
+        <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover text-dls-secondary">
+              <Icon size={16} strokeWidth={1.9} />
+            </div>
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium leading-5 text-dls-text">{presentation.title}</div>
+              <div className="mt-0.5 text-[12px] leading-5 text-dls-secondary">{presentation.message}</div>
+              {presentation.note ? (
+                <div className="mt-1 text-[12px] leading-5 text-dls-secondary">{presentation.note}</div>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="border-red-7/25 text-red-11 hover:bg-red-1/40"
+              onClick={() => props.respondPermission?.(props.permission.id, "reject")}
+              disabled={props.busy || !props.respondPermission}
+            >
+              <XCircle data-icon="inline-start" />
+              {t("session.deny")}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => props.respondPermission?.(props.permission.id, "once")}
+              disabled={props.busy || !props.respondPermission}
+            >
+              <Clock3 data-icon="inline-start" />
+              {t("session.allow_once")}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => props.respondPermission?.(props.permission.id, "always")}
+              disabled={props.busy || !props.respondPermission}
+            >
+              <Check data-icon="inline-start" />
+              {t("session.allow_for_session")}
+            </Button>
+          </div>
+        </div>
+
+        <div className="border-t border-dls-border px-4 py-3">
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+            <div>
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-dls-secondary">
+                {t("session.permission_label")}
+              </div>
+              <div className="mt-1 font-mono text-[12px] leading-5 text-dls-text">
+                {presentation.permissionLabel}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-dls-secondary">
+                {presentation.scopeLabel}
+              </div>
+              <div className="mt-1 truncate rounded-lg border border-dls-border bg-dls-hover/55 px-2.5 py-1.5 font-mono text-[12px] leading-5 text-dls-text">
+                {presentation.scopeValue}
+              </div>
+            </div>
+          </div>
+
+          {hasMetadata ? (
+            <details className="group mt-3 rounded-xl border border-dls-border bg-dls-surface px-3 py-2">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-[12px] font-medium text-dls-text">
+                <span>{t("session.details_label")}</span>
+                <ChevronRight size={14} className="text-dls-secondary transition-transform group-open:rotate-90" />
+              </summary>
+              <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-dls-hover/45 px-3 py-2 text-[11px] leading-5 text-dls-secondary">
+                {stringifyMetadata(metadata, props.safeStringify)}
+              </pre>
+            </details>
+          ) : null}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/chat/permission-approval-modal.tsx
+++ b/apps/app/src/react-app/domains/session/chat/permission-approval-modal.tsx
@@ -379,8 +379,7 @@ export function PermissionApprovalPanel(props: PermissionApprovalModalProps) {
   const Icon = presentation.isDoomLoop ? RefreshCcw : ShieldCheck;
 
   return (
-    <div className="mx-auto w-full max-w-[800px] px-4">
-      <div className="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
+    <div className="overflow-hidden rounded-t-[24px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
         <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 items-start gap-3">
             <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-xl border border-dls-border bg-dls-hover text-dls-secondary">
@@ -461,7 +460,6 @@ export function PermissionApprovalPanel(props: PermissionApprovalModalProps) {
             </details>
           ) : null}
         </div>
-      </div>
     </div>
   );
 }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Check, Globe, Loader2, Minimize2, Redo2, Undo2, Zap } from "lucide-react";
+import { Globe, Loader2, Redo2, Undo2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -21,7 +21,6 @@ import type { ShareWorkspaceModalProps } from "../../workspace/types";
 import { Button } from "@/components/ui/button";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import ProviderAuthModal, { type ProviderAuthModalProps } from "../../connections/provider-auth/provider-auth-modal";
-import { PermissionApprovalModal } from "./permission-approval-modal";
 import { QuestionModal } from "../modals/question-modal";
 import { RenameSessionModal } from "../modals/rename-session-modal";
 import { AppSidebar } from "../sidebar/app-sidebar";
@@ -205,7 +204,6 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
-  const [todoExpanded, setTodoExpanded] = useState(true);
   const browserPanelRef = usePanelRef();
 
   // Sync browser panel state with Electron main process IPC events.
@@ -268,11 +266,6 @@ export function SessionPage(props: SessionPageProps) {
     props.startupPhase !== "ready";
   const showSessionLoadingState =
     Boolean(props.selectedSessionId) && props.sessionLoadingById(props.selectedSessionId) && !showWorkspaceSetupEmptyState;
-  const todos = useMemo(() => props.todos.filter((todo) => todo.content.trim()), [props.todos]);
-  const completedTodos = useMemo(
-    () => todos.filter((todo) => todo.status === "completed").length,
-    [todos],
-  );
   const sidebarInitialLoading = useMemo(() => getSidebarInitialLoading(props.sidebar), [props.sidebar]);
   // Derive the main-pane error from the same data the sidebar uses so the two
   // panes can never disagree. We check (in priority order):
@@ -361,11 +354,6 @@ export function SessionPage(props: SessionPageProps) {
       setDeleteBusy(false);
     }
   };
-
-  const todoLabel =
-    completedTodos > 0
-      ? t("session.todo_progress_label", { completed: completedTodos, total: todos.length })
-      : t("session.todo_label", { count: todos.length });
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[radial-gradient(circle_at_top,rgba(74,111,255,0.12),transparent_42%),var(--app-bg,#0b1020)] text-dls-text mac:bg-transparent">
@@ -534,6 +522,11 @@ export function SessionPage(props: SessionPageProps) {
                   sessionId={props.selectedSessionId!}
                   opencodeBaseUrl={reactSessionBaseUrl}
                   openworkToken={reactSessionToken}
+                  todos={props.todos}
+                  activePermission={props.activePermission}
+                  permissionReplyBusy={props.permissionReplyBusy}
+                  respondPermission={props.respondPermission}
+                  safeStringify={props.safeStringify}
                 />
               ) : null}
 
@@ -663,55 +656,6 @@ export function SessionPage(props: SessionPageProps) {
             </div>
           </div>
 
-          {todos.length > 0 ? (
-            <div className="mx-auto w-full max-w-[800px] px-4">
-              <div className="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
-                <button
-                  type="button"
-                  className="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
-                  onClick={() => setTodoExpanded((current) => !current)}
-                >
-                  <div className="flex items-center gap-2">
-                    <span className="text-gray-11 font-medium">{todoLabel}</span>
-                  </div>
-                  <Minimize2 size={12} className={`text-gray-8 transition-transform ${todoExpanded ? "" : "rotate-180"}`} />
-                </button>
-                {todoExpanded ? (
-                  <div className="max-h-60 space-y-2.5 overflow-auto border-t border-dls-border px-4 pb-3">
-                    {todos.map((todo, index) => {
-                      const done = todo.status === "completed";
-                      const cancelled = todo.status === "cancelled";
-                      const active = todo.status === "in_progress";
-                      return (
-                        <div key={todo.id} className="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
-                          <div className="flex items-center gap-1.5 pt-0.5">
-                            <div
-                              className={`flex size-4.5 items-center justify-center rounded-full border ${
-                                done
-                                  ? "border-green-6 bg-green-2 text-green-11"
-                                  : active
-                                    ? "border-amber-6 bg-amber-2 text-amber-11"
-                                    : cancelled
-                                      ? "border-gray-6 bg-gray-2 text-gray-8"
-                                      : "border-gray-6 bg-gray-1 text-gray-8"
-                              }`}
-                            >
-                              {done ? <Check size={10} /> : active ? <span className="size-1.5 rounded-full bg-amber-9" /> : null}
-                            </div>
-                          </div>
-                          <div className={`flex-1 text-sm leading-relaxed ${cancelled ? "text-gray-9 line-through" : "text-gray-12"}`}>
-                            <span className="mr-1.5 text-gray-9">{index + 1}.</span>
-                            {todo.content}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
-
           {shellConfig.statusBar ? (
             <StatusBar
               clientConnected={props.clientConnected}
@@ -787,15 +731,6 @@ export function SessionPage(props: SessionPageProps) {
       ) : null}
 
       {props.shareWorkspaceModal ? <ShareWorkspaceModal {...props.shareWorkspaceModal} /> : null}
-
-      {props.activePermission ? (
-        <PermissionApprovalModal
-          permission={props.activePermission}
-          busy={props.permissionReplyBusy}
-          respondPermission={props.respondPermission}
-          safeStringify={props.safeStringify}
-        />
-      ) : null}
 
       <QuestionModal
         open={Boolean(props.activeQuestion)}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
 import { ArrowUp, ChevronRight, FileText, Paperclip, Plug, Settings, Square, Terminal, X, Zap } from "lucide-react";
 import fuzzysort from "fuzzysort";
@@ -83,6 +83,7 @@ type ComposerProps = {
   onUploadInboxFiles?: ((files: File[]) => void | Promise<unknown>) | null;
   draftScopeKey?: string;
   compactTopSpacing?: boolean;
+  topAccessory?: ReactNode;
 };
 
 const FLUSH_PROMPT_EVENT = "openwork:flushPromptDraft";
@@ -817,6 +818,8 @@ export function ReactSessionComposer(props: ComposerProps) {
   const panelRoundedClass =
     mentionOpen || slashOpen
       ? "rounded-t-[18px] border-t-transparent"
+      : props.topAccessory
+        ? "rounded-t-none"
       : "";
 
   const renderSlashMenu = () => {
@@ -936,6 +939,7 @@ export function ReactSessionComposer(props: ComposerProps) {
       }}
     >
       <div className="max-w-[800px] mx-auto">
+        {props.topAccessory ? <div className="relative z-10">{props.topAccessory}</div> : null}
         {/* Main composer panel */}
         <div
           className={`relative overflow-visible rounded-[24px] border border-dls-border bg-dls-surface transition-all ${panelRoundedClass}`}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -818,8 +818,6 @@ export function ReactSessionComposer(props: ComposerProps) {
   const panelRoundedClass =
     mentionOpen || slashOpen
       ? "rounded-t-[18px] border-t-transparent"
-      : props.topAccessory
-        ? "rounded-t-none"
       : "";
 
   const renderSlashMenu = () => {
@@ -939,11 +937,11 @@ export function ReactSessionComposer(props: ComposerProps) {
       }}
     >
       <div className="max-w-[800px] mx-auto">
-        {props.topAccessory ? <div className="relative z-10">{props.topAccessory}</div> : null}
         {/* Main composer panel */}
         <div
           className={`relative overflow-visible rounded-[24px] border border-dls-border bg-dls-surface transition-all ${panelRoundedClass}`}
         >
+          {props.topAccessory ? <div className="relative z-10">{props.topAccessory}</div> : null}
           <ReactComposerNotice notice={props.notice} />
 
           {renderMentionMenu()}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -3,9 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import type { UIMessage } from "ai";
 import { useQuery } from "@tanstack/react-query";
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client";
+import { Check, Minimize2 } from "lucide-react";
 
 import { createClient, unwrap } from "../../../../app/lib/opencode";
 import { abortSessionSafe } from "../../../../app/lib/opencode-session";
+import { t } from "../../../../i18n";
 import { readWorkspaceCloudImports, type CloudImportedPlugin } from "../../../../app/cloud/import-state";
 import type {
   OpenworkServerClient,
@@ -18,7 +20,9 @@ import type {
   McpServerEntry,
   McpStatusMap,
   ModelRef,
+  PendingPermission,
   SkillCard,
+  TodoItem,
 } from "../../../../app/types";
 import {
   publishInspectorSlice,
@@ -39,6 +43,7 @@ import { SessionTranscript } from "./message-list";
 import { useLocal } from "../../../kernel/local-provider";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
+import { PermissionApprovalPanel } from "../chat/permission-approval-modal";
 import {
   seedSessionState,
   statusKey as reactStatusKey,
@@ -90,6 +95,11 @@ export type SessionSurfaceProps = {
   searchFiles: (query: string) => Promise<string[]>;
   isRemoteWorkspace: boolean;
   isSandboxWorkspace: boolean;
+  todos?: TodoItem[];
+  activePermission?: PendingPermission | null;
+  permissionReplyBusy?: boolean;
+  respondPermission?: (requestID: string, reply: "once" | "always" | "reject") => void;
+  safeStringify?: (value: unknown) => string;
   onChangeModel?: (model: { providerID: string; modelID: string }) => void;
   onUploadInboxFiles?: ((files: File[], options?: { notify?: boolean }) => void | Promise<unknown>) | null;
   onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins") => void) | undefined;
@@ -178,6 +188,66 @@ function AssistantWaitingCard() {
           />
         </div>
         <span>Thinking</span>
+      </div>
+    </div>
+  );
+}
+
+function TodoPanel(props: { todos: TodoItem[] }) {
+  const [expanded, setExpanded] = useState(true);
+  const todos = props.todos.filter((todo) => todo.content.trim());
+  const completedTodos = todos.filter((todo) => todo.status === "completed").length;
+  const label = completedTodos > 0
+    ? t("session.todo_progress_label", { completed: completedTodos, total: todos.length })
+    : t("session.todo_label", { count: todos.length });
+
+  if (todos.length === 0) return null;
+
+  return (
+    <div className="mx-auto w-full max-w-[800px] px-4">
+      <div className="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-gray-11">{label}</span>
+          </div>
+          <Minimize2 size={12} className={`text-gray-8 transition-transform ${expanded ? "" : "rotate-180"}`} />
+        </button>
+        {expanded ? (
+          <div className="max-h-60 space-y-2.5 overflow-auto border-t border-dls-border px-4 pb-3">
+            {todos.map((todo, index) => {
+              const done = todo.status === "completed";
+              const cancelled = todo.status === "cancelled";
+              const active = todo.status === "in_progress";
+              return (
+                <div key={todo.id} className="flex items-start gap-2.5 pt-2.5 first:pt-2.5">
+                  <div className="flex items-center gap-1.5 pt-0.5">
+                    <div
+                      className={`flex size-4.5 items-center justify-center rounded-full border ${
+                        done
+                          ? "border-green-6 bg-green-2 text-green-11"
+                          : active
+                            ? "border-amber-6 bg-amber-2 text-amber-11"
+                            : cancelled
+                              ? "border-gray-6 bg-gray-2 text-gray-8"
+                              : "border-gray-6 bg-gray-1 text-gray-8"
+                      }`}
+                    >
+                      {done ? <Check size={10} /> : active ? <span className="size-1.5 rounded-full bg-amber-9" /> : null}
+                    </div>
+                  </div>
+                  <div className={`flex-1 text-sm leading-relaxed ${cancelled ? "text-gray-9 line-through" : "text-gray-12"}`}>
+                    <span className="mr-1.5 text-gray-9">{index + 1}.</span>
+                    {todo.content}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -1006,6 +1076,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
           </div>
         ) : null}
       </div>
+
+      <TodoPanel todos={props.todos ?? []} />
+
+      {props.activePermission ? (
+        <PermissionApprovalPanel
+          permission={props.activePermission}
+          busy={props.permissionReplyBusy}
+          respondPermission={props.respondPermission}
+          safeStringify={props.safeStringify}
+        />
+      ) : null}
 
       <div ref={composerShellRef} className="shrink-0 border-t border-dls-border/70 px-0 pb-3 pt-3">
         <DevProfiler id="SessionComposer">

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -204,7 +204,7 @@ function TodoPanel(props: { todos: TodoItem[] }) {
   if (todos.length === 0) return null;
 
   return (
-    <div className="overflow-hidden rounded-t-[24px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
+    <div className="overflow-hidden border-b border-dls-border bg-transparent">
         <button
           type="button"
           className="flex w-full items-center justify-between px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
@@ -1130,7 +1130,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
           compactTopSpacing={Boolean((props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission)}
           topAccessory={
             (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission ? (
-              <div className="-mb-px">
+              <div>
                 <TodoPanel todos={props.todos ?? []} />
                 {props.activePermission ? (
                   <PermissionApprovalPanel

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -204,11 +204,10 @@ function TodoPanel(props: { todos: TodoItem[] }) {
   if (todos.length === 0) return null;
 
   return (
-    <div className="mx-auto w-full max-w-[800px] px-4">
-      <div className="rounded-t-[20px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
+    <div className="overflow-hidden rounded-t-[24px] border border-b-0 border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]">
         <button
           type="button"
-          className="flex w-full items-center justify-between rounded-t-[20px] px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
+          className="flex w-full items-center justify-between px-4 py-3 text-xs text-gray-9 transition-colors hover:bg-gray-2/50"
           onClick={() => setExpanded((current) => !current)}
         >
           <div className="flex items-center gap-2">
@@ -248,7 +247,6 @@ function TodoPanel(props: { todos: TodoItem[] }) {
             })}
           </div>
         ) : null}
-      </div>
     </div>
   );
 }
@@ -1077,17 +1075,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
         ) : null}
       </div>
 
-      <TodoPanel todos={props.todos ?? []} />
-
-      {props.activePermission ? (
-        <PermissionApprovalPanel
-          permission={props.activePermission}
-          busy={props.permissionReplyBusy}
-          respondPermission={props.respondPermission}
-          safeStringify={props.safeStringify}
-        />
-      ) : null}
-
       <div ref={composerShellRef} className="shrink-0 border-t border-dls-border/70 px-0 pb-3 pt-3">
         <DevProfiler id="SessionComposer">
         <ReactSessionComposer
@@ -1140,6 +1127,22 @@ export function SessionSurface(props: SessionSurfaceProps) {
         isRemoteWorkspace={props.isRemoteWorkspace}
           isSandboxWorkspace={props.isSandboxWorkspace}
           onUploadInboxFiles={props.onUploadInboxFiles ?? handleUploadInboxFiles}
+          compactTopSpacing={Boolean((props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission)}
+          topAccessory={
+            (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission ? (
+              <div className="-mb-px">
+                <TodoPanel todos={props.todos ?? []} />
+                {props.activePermission ? (
+                  <PermissionApprovalPanel
+                    permission={props.activePermission}
+                    busy={props.permissionReplyBusy}
+                    respondPermission={props.respondPermission}
+                    safeStringify={props.safeStringify}
+                  />
+                ) : null}
+              </div>
+            ) : null
+          }
         />
         </DevProfiler>
       </div>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -85,6 +85,7 @@ import { buildOpenworkEnvSystemContext } from "../domains/session/sync/env-conte
 import {
   permissionKey as reactPermissionKey,
   seedPermissionState,
+  todoKey as reactTodoKey,
 } from "../domains/session/sync/session-sync";
 import { CreateRemoteWorkspaceModal } from "../domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "../domains/workspace/create-workspace-modal";
@@ -241,6 +242,7 @@ function focusPromptSoon() {
 }
 
 const emptyPendingPermissions: PendingPermission[] = [];
+const emptyTodos: TodoItem[] = [];
 const emptyModelBehaviorOptions: { value: string | null; label: string }[] = [];
 
 function useQueryCacheState<T>(queryKey: readonly unknown[] | null, fallback: T): T {
@@ -1487,6 +1489,14 @@ export function SessionRoute() {
     permissionQueryKey,
     emptyPendingPermissions,
   );
+  const todoQueryKey = useMemo(
+    () =>
+      selectedWorkspaceId && selectedSessionId
+        ? reactTodoKey(selectedWorkspaceId, selectedSessionId)
+        : null,
+    [selectedSessionId, selectedWorkspaceId],
+  );
+  const todos = useQueryCacheState<TodoItem[]>(todoQueryKey, emptyTodos);
   useEffect(() => {
     if (!opencodeClient || !selectedWorkspaceId || !selectedSessionId) return;
     let cancelled = false;
@@ -2609,7 +2619,7 @@ export function SessionRoute() {
         onUndo: () => {},
         onRedo: () => {},
       }}
-      todos={[] satisfies TodoItem[]}
+      todos={todos}
       sessionLoadingById={(sessionId) => effectiveLoading && Boolean(sessionId && sessionId === selectedSessionId)}
       shareWorkspaceModal={
         shareWorkspaceState.shareWorkspaceOpen

--- a/apps/app/tests/permission-approval-modal.test.ts
+++ b/apps/app/tests/permission-approval-modal.test.ts
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { PendingPermission } from "../src/app/types";
 
 import {
-  PermissionApprovalModal,
+  PermissionApprovalPanel,
   permissionDetailRows,
 } from "../src/react-app/domains/session/chat/permission-approval-modal";
 
@@ -69,7 +69,7 @@ describe("permission approval modal helpers", () => {
 
   test("keeps keyboard order on the safer one-shot approval before session approval", () => {
     const html = renderToStaticMarkup(
-      React.createElement(PermissionApprovalModal, {
+      React.createElement(PermissionApprovalPanel, {
         permission: pendingPermission(),
         respondPermission: () => {},
       }),
@@ -84,7 +84,7 @@ describe("permission approval modal helpers", () => {
 
   test("uses readable labels for generic permission titles", () => {
     const html = renderToStaticMarkup(
-      React.createElement(PermissionApprovalModal, {
+      React.createElement(PermissionApprovalPanel, {
         permission: pendingPermission({ permission: "todowrite" }),
         respondPermission: () => {},
       }),


### PR DESCRIPTION
## Summary
- Move permission approvals from the full-screen modal path into a compact composer-attached panel.
- Restore todo/task visibility by wiring the session todo cache into the React session surface.
- Add composer top-accessory support so permissions and todos visually attach to the composer instead of floating above it.

## Tests
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app exec bun test tests/permission-approval-modal.test.ts

## Notes
- Manual prompts to verify: `Create a 5 step plan, track it as todos, and then complete the first two steps only.` and `List files in /Applications and tell me whether Ableton is installed.`