### PR TITLE
Fix session transcript reconciliation

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -6,7 +6,7 @@ import {
   deriveRenderedSessionMessages,
   resolveRenderedSessionSnapshot,
 } from "../src/react-app/domains/session/surface/session-render-state";
-import { mergeSnapshotIntoCachedMessages } from "../src/react-app/domains/session/sync/message-merge";
+import { reconcileTranscriptMessages } from "../src/react-app/domains/session/sync/transcript-reconcile";
 
 function snapshotWithMessages(
   messages: Array<{ id: string; role: "user" | "assistant"; text: string }>,
@@ -55,16 +55,40 @@ function snapshotWithText(text: string, sessionId = "ses_test"): OpenworkSession
   return snapshotWithMessages([{ id: "msg_user", role: "user", text }], sessionId);
 }
 
-describe("mergeSnapshotIntoCachedMessages", () => {
+describe("reconcileTranscriptMessages", () => {
+  it("hydrates an empty transcript cache from the snapshot", () => {
+    const snapshot = [uiMessage("msg_user", "user", "hello")];
+
+    expect(reconcileTranscriptMessages({
+      currentMessages: [],
+      snapshotMessages: snapshot,
+      reason: "snapshot",
+    })).toBe(snapshot);
+  });
+
+  it("does not clear live messages when a snapshot is temporarily empty", () => {
+    const current = [
+      uiMessage("msg_user", "user", "latest prompt"),
+      uiMessage("msg_assistant", "assistant", "latest answer"),
+    ];
+
+    expect(reconcileTranscriptMessages({
+      currentMessages: current,
+      snapshotMessages: [],
+      reason: "snapshot",
+    })).toBe(current);
+  });
+
   it("keeps older cached messages when a busy snapshot only contains the active tail", () => {
-    const merged = mergeSnapshotIntoCachedMessages(
-      [uiMessage("msg_current_user", "user", "latest prompt")],
-      [
+    const merged = reconcileTranscriptMessages({
+      snapshotMessages: [uiMessage("msg_current_user", "user", "latest prompt")],
+      currentMessages: [
         uiMessage("msg_old_user", "user", "old prompt"),
         uiMessage("msg_old_assistant", "assistant", "old answer"),
         uiMessage("msg_current_user", "user", "latest"),
       ],
-    );
+      reason: "snapshot",
+    });
 
     expect(merged.map((message) => message.id)).toEqual([
       "msg_old_user",
@@ -72,6 +96,43 @@ describe("mergeSnapshotIntoCachedMessages", () => {
       "msg_current_user",
     ]);
     expect(merged[2]?.parts[0]).toMatchObject({ text: "latest prompt" });
+  });
+
+  it("keeps snapshot history and live-only tail messages together", () => {
+    const merged = reconcileTranscriptMessages({
+      currentMessages: [
+        uiMessage("msg_current_user", "user", "latest prompt"),
+        uiMessage("msg_current_assistant", "assistant", "streaming answer"),
+      ],
+      snapshotMessages: [
+        uiMessage("msg_old_user", "user", "old prompt"),
+        uiMessage("msg_old_assistant", "assistant", "old answer"),
+      ],
+      reason: "snapshot",
+    });
+
+    expect(merged.map((message) => message.id)).toEqual([
+      "msg_old_user",
+      "msg_old_assistant",
+      "msg_current_user",
+      "msg_current_assistant",
+    ]);
+  });
+
+  it("keeps longer live text when the snapshot lags the event stream", () => {
+    const merged = reconcileTranscriptMessages({
+      currentMessages: [
+        uiMessage("msg_user", "user", "hello"),
+        uiMessage("msg_assistant", "assistant", "finished answer"),
+      ],
+      snapshotMessages: [
+        uiMessage("msg_user", "user", "hello"),
+        uiMessage("msg_assistant", "assistant", "finished"),
+      ],
+      reason: "snapshot",
+    });
+
+    expect(merged[1]?.parts[0]).toMatchObject({ text: "finished answer" });
   });
 });
 
@@ -104,7 +165,7 @@ describe("deriveRenderedSessionMessages", () => {
     })).toBe(cached);
   });
 
-  it("keeps snapshot history visible when the live cache only has the active turn", () => {
+  it("renders the canonical live cache without merging snapshot history", () => {
     const messages = deriveRenderedSessionMessages({
       transcriptState: [
         {
@@ -125,14 +186,12 @@ describe("deriveRenderedSessionMessages", () => {
     });
 
     expect(messages.map((message) => message.id)).toEqual([
-      "msg_old_user",
-      "msg_old_assistant",
       "msg_current_user",
       "msg_current_assistant",
     ]);
   });
 
-  it("keeps live-only tail messages after the stream flips idle before the snapshot catches up", () => {
+  it("keeps live-only tail messages instead of merging a stale snapshot during render", () => {
     const messages = deriveRenderedSessionMessages({
       transcriptState: [
         uiMessage("msg_current_user", "user", "latest prompt"),
@@ -145,8 +204,6 @@ describe("deriveRenderedSessionMessages", () => {
     });
 
     expect(messages.map((message) => message.id)).toEqual([
-      "msg_old_user",
-      "msg_old_assistant",
       "msg_current_user",
       "msg_current_assistant",
     ]);

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -1,7 +1,7 @@
 import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
-import { mergeSnapshotAndLiveMessages, messageListContainsAll } from "../sync/message-merge";
+import { applyRevertCursor } from "../sync/transcript-reconcile";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
 
 export function resolveRenderedSessionSnapshot(input: {
@@ -21,44 +21,20 @@ export function resolveRenderedSessionSnapshot(input: {
   return null;
 }
 
-/**
- * Truncate a message list at the revert cursor. OpenCode's session.revert
- * sets a messageID on the session but the snapshot still returns all messages.
- * The UI must hide messages after the revert point.
- */
-function applyRevertCursor(messages: UIMessage[], revertMessageId: string | null | undefined): UIMessage[] {
-  if (!revertMessageId || messages.length === 0) return messages;
-  const idx = messages.findIndex((m) => m.id === revertMessageId);
-  if (idx < 0) return messages;
-  // Keep messages up to and including the revert point
-  return messages.slice(0, idx + 1);
-}
-
 export function deriveRenderedSessionMessages(input: {
   transcriptState: UIMessage[] | null | undefined;
   snapshot: OpenworkSessionSnapshot | null | undefined;
 }) {
   const revertMessageId = (input.snapshot?.session as any)?.revert?.messageID ?? null;
-
   const liveMessages = input.transcriptState ?? [];
-  const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
+
+  // Render from the canonical transcript cache. The snapshot fallback only
+  // covers the first hydration frame before seedSessionState writes the cache.
+  const messages = liveMessages.length > 0
+    ? liveMessages
+    : input.snapshot && input.snapshot.messages.length > 0
     ? snapshotToUIMessages(input.snapshot)
     : [];
 
-  let result: UIMessage[];
-
-  if (liveMessages.length > 0 && snapshotMessages.length === 0) result = liveMessages;
-  else if (liveMessages.length === 0 && snapshotMessages.length > 0) result = snapshotMessages;
-  else if (liveMessages.length > 0 && snapshotMessages.length > 0) {
-    if (messageListContainsAll(liveMessages, snapshotMessages)) result = liveMessages;
-    else result = mergeSnapshotAndLiveMessages(snapshotMessages, liveMessages, {
-      appendLiveOnlyMessages: true,
-    });
-  } else if (input.snapshot && input.snapshot.messages.length > 0) {
-    result = snapshotMessages;
-  } else {
-    result = input.transcriptState ?? [];
-  }
-
-  return applyRevertCursor(result, revertMessageId);
+  return applyRevertCursor(messages, revertMessageId);
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -7,7 +7,7 @@ import { normalizeEvent } from "../../../../app/utils";
 import type { OpencodeEvent, PendingPermission } from "../../../../app/types";
 import { snapshotToUIMessages } from "./usechat-adapter";
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
-import { mergeSnapshotIntoCachedMessages } from "./message-merge";
+import { reconcileTranscriptMessages } from "./transcript-reconcile";
 
 type SyncOptions = {
   workspaceId: string;
@@ -644,15 +644,11 @@ export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionS
   const incoming = snapshotToUIMessages(snapshot);
   const existing = queryClient.getQueryData<UIMessage[]>(key);
 
-  if (existing && existing.length > 0 && incoming.length > 0) {
-    // Server snapshots can lag the event stream even after OpenCode reports
-    // idle. Merge rather than replace so a just-finished answer cannot vanish
-    // until the next reload reconstructs it from persisted state.
-    const merged = mergeSnapshotIntoCachedMessages(incoming, existing);
-    queryClient.setQueryData(key, merged);
-  } else {
-    queryClient.setQueryData(key, incoming);
-  }
+  queryClient.setQueryData(key, reconcileTranscriptMessages({
+    currentMessages: existing ?? [],
+    snapshotMessages: incoming,
+    reason: "snapshot",
+  }));
 
   queryClient.setQueryData(statusKey(workspaceId, snapshot.session.id), snapshot.status);
   queryClient.setQueryData(todoKey(workspaceId, snapshot.session.id), snapshot.todos);

--- a/apps/app/src/react-app/domains/session/sync/transcript-reconcile.ts
+++ b/apps/app/src/react-app/domains/session/sync/transcript-reconcile.ts
@@ -1,0 +1,45 @@
+import type { UIMessage } from "ai";
+
+import { mergeSnapshotIntoCachedMessages } from "./message-merge";
+
+export type TranscriptReconcileReason = "snapshot" | "revert";
+
+export type ReconcileTranscriptInput = {
+  /** Current canonical transcript cache rendered by the session UI. */
+  currentMessages: UIMessage[];
+  /** Messages reconstructed from the latest server snapshot. */
+  snapshotMessages: UIMessage[];
+  /** Why this reconciliation is happening. Reserved for explicit truncation rules. */
+  reason?: TranscriptReconcileReason;
+};
+
+/**
+ * Reconcile a server snapshot into the canonical transcript cache.
+ *
+ * Snapshot reads can lag behind the OpenCode event stream during prompt
+ * submission. This helper centralizes the invariant that ordinary snapshots
+ * may fill/update the cache, but must not make the visible transcript move
+ * backwards. Explicit history operations such as revert can opt into their own
+ * truncation path instead of relying on snapshot absence.
+ */
+export function reconcileTranscriptMessages(input: ReconcileTranscriptInput): UIMessage[] {
+  const current = input.currentMessages;
+  const snapshot = input.snapshotMessages;
+
+  if (current.length === 0) return snapshot;
+  if (snapshot.length === 0) return current;
+
+  return mergeSnapshotIntoCachedMessages(snapshot, current);
+}
+
+/**
+ * Hide messages after OpenCode's revert cursor. Revert is an explicit history
+ * mutation, so it is the one place the rendered transcript is allowed to move
+ * backwards.
+ */
+export function applyRevertCursor(messages: UIMessage[], revertMessageId: string | null | undefined): UIMessage[] {
+  if (!revertMessageId || messages.length === 0) return messages;
+  const idx = messages.findIndex((message) => message.id === revertMessageId);
+  if (idx < 0) return messages;
+  return messages.slice(0, idx + 1);
+}


### PR DESCRIPTION
## Summary
- Make the session surface render from the canonical transcript cache instead of merging snapshot and live data during render.
- Add a pure transcript reconciliation helper that preserves live-only messages and longer live text when snapshots lag.
- Cover lagging snapshot and live-message preservation behavior with focused Bun tests.

## Verification
- `bun test scripts/session-render-state.test.ts` - passed in the main workspace with dependencies installed.
- `bun test tests/session-sync-permissions.test.ts` - passed in the main workspace with dependencies installed.
- `pnpm --filter @openwork/app typecheck` - passed in the main workspace with dependencies installed.

No screenshot/video captured; this is a data-flow race fix covered by unit tests.