### PR TITLE
fix(docker): copy and build @openwork/email package for den-api image

### DIFF
--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -8,6 +8,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
 COPY .npmrc /app/.npmrc
 COPY patches /app/patches
 COPY packages/types/package.json /app/packages/types/package.json
+COPY packages/email/package.json /app/packages/email/package.json
 COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
 COPY ee/packages/den-db/package.json /app/ee/packages/den-db/package.json
 COPY ee/apps/den-api/package.json /app/ee/apps/den-api/package.json
@@ -15,11 +16,13 @@ COPY ee/apps/den-api/package.json /app/ee/apps/den-api/package.json
 RUN pnpm install --frozen-lockfile
 
 COPY packages/types /app/packages/types
+COPY packages/email /app/packages/email
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/packages/den-db /app/ee/packages/den-db
 COPY ee/apps/den-api /app/ee/apps/den-api
 
 RUN pnpm --dir /app/ee/packages/utils run build
+RUN pnpm --dir /app/packages/email run build
 RUN pnpm --dir /app/ee/packages/den-db run build
 RUN pnpm --dir /app/ee/apps/den-api run build
 


### PR DESCRIPTION
Closes #1804

## Summary
- Copy `packages/email/package.json` into the den image before `pnpm install --frozen-lockfile` so the workspace package resolves.
- Copy the `packages/email` source after install and add a build step before `den-db` and `den-api` so the compiled `dist/` exists when den-api imports `@openwork/email` at runtime.
- Keep the existing build order otherwise unchanged; `@openwork/email` has no workspace deps so it can build right after `utils`.

## Verification
- `docker build -f packaging/docker/Dockerfile.den .` not run from this branch (no Docker on the dev box); the diff matches the exact patch the reporter posted in the issue.
- `grep '@openwork/email' ee/apps/den-api/package.json` confirms den-api lists the workspace dep, and `packages/email/package.json` exports `./dist/index.js` as the production entry, which makes the missing build step the failure path described in #1804.

## Notes
- `packages/email` has no workspace dependencies, so it can build independently of `den-db`.