### PR TITLE
fix(inference): revert free weekend usage factors

### DIFF
--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -58,31 +58,31 @@ export const INFERENCE_MODEL_ALIASES = {
     upstreamModel: "tencent/hy3-preview",
     displayName: "OpenWork: Hy3 Preview",
     enabled: true,
-    usageFactor: 0.05,
+    usageFactor: 1,
   },
   "moonshotai/kimi-k2.6": {
     upstreamModel: "moonshotai/kimi-k2.6",
     displayName: "OpenWork: Kimi K2.6",
     enabled: true,
-    usageFactor: 0.05,
+    usageFactor: 1,
   },
   "deepseek/deepseek-v4-flash": {
     upstreamModel: "deepseek/deepseek-v4-flash",
     displayName: "OpenWork: DeepSeek V4 Flash",
     enabled: true,
-    usageFactor: 0.05,
+    usageFactor: 1,
   },
   "minimax/minimax-m2.7": {
     upstreamModel: "minimax/minimax-m2.7",
     displayName: "OpenWork: MiniMax M2.7",
     enabled: true,
-    usageFactor: 0.05,
+    usageFactor: 1,
   },
   "z-ai/glm-5.1": {
     upstreamModel: "z-ai/glm-5.1",
     displayName: "OpenWork: GLM-5.1",
     enabled: true,
-    usageFactor: 0.05,
+    usageFactor: 1,
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Revert promoted inference model usage factors from `0.05` back to `1`
- Restores normal usage accounting for Hy3 Preview, Kimi K2.6, DeepSeek V4 Flash, MiniMax M2.7, and GLM-5.1

## Tests
- `pnpm --filter @openwork/types build` passed

## Evidence
- No video/screenshot captured because this is a constants-only backend/shared types change with no UI flow to demonstrate.