### PR TITLE
fix(app): harden session streaming and server health

### DIFF
--- a/.opencode/skills/run-evals/SKILL.md
+++ b/.opencode/skills/run-evals/SKILL.md
@@ -25,6 +25,12 @@ Run the OpenWork UI evaluation flows against a real Electron app. Prefer a fresh
 
 Create a new Daytona sandbox for each eval run. Avoid reusing old sandboxes unless the user explicitly asks to debug existing state.
 
+Before creating the sandbox, explicitly point Daytona at the Different AI org:
+
+```bash
+daytona organization use "Different AI"
+```
+
 Pick a unique name:
 
 ```bash

--- a/apps/app/src/react-app/domains/connections/openwork-server-store.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-server-store.ts
@@ -103,6 +103,8 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
   let healthTimeoutId: number | null = null;
   let healthBusy = false;
   let healthDelayMs = 10_000;
+  let consecutiveHealthFailures = 0;
+  let visibilityChangeHandler: (() => void) | null = null;
   let snapshot: OpenworkServerStoreSnapshot;
 
   let state: MutableState = {
@@ -327,13 +329,20 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
 
   const runHealthCheck = async () => {
     if (disposed || typeof window === "undefined") return;
-    if (!options.documentVisible()) return;
-    if (shouldWaitForLocalHostInfo()) return;
+    if (!options.documentVisible()) {
+      queueHealthCheck(healthDelayMs);
+      return;
+    }
+    if (shouldWaitForLocalHostInfo()) {
+      queueHealthCheck(250);
+      return;
+    }
     if (healthBusy) return;
 
     const url = getBaseUrl().trim();
     const auth = getAuth();
     if (!url) {
+      consecutiveHealthFailures = 0;
       mutateState((current) => ({
         ...current,
         openworkServerStatus: "disconnected",
@@ -373,15 +382,26 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
       }
 
       if (disposed) return;
-      healthDelayMs =
-        result.status === "connected" || result.status === "limited"
-          ? 10_000
-          : Math.min(healthDelayMs * 2, 60_000);
+      const previousStatus = state.openworkServerStatus;
+      const previousCapabilities = state.openworkServerCapabilities;
+      const healthy = result.status === "connected" || result.status === "limited";
+      if (healthy) {
+        consecutiveHealthFailures = 0;
+        healthDelayMs = 10_000;
+      } else {
+        consecutiveHealthFailures += 1;
+        healthDelayMs = Math.min(healthDelayMs * 2, 60_000);
+      }
+
+      const preservePrevious =
+        !healthy &&
+        consecutiveHealthFailures < 3 &&
+        (previousStatus === "connected" || previousStatus === "limited");
 
       mutateState((current) => ({
         ...current,
-        openworkServerStatus: result.status,
-        openworkServerCapabilities: result.capabilities,
+        openworkServerStatus: preservePrevious ? previousStatus : result.status,
+        openworkServerCapabilities: preservePrevious ? previousCapabilities : result.capabilities,
         openworkServerCheckedAt: Date.now(),
       }));
     } catch {
@@ -436,6 +456,12 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
 
     syncFromOptions();
     queueHealthCheck(0);
+    visibilityChangeHandler = () => {
+      if (!options.documentVisible()) return;
+      consecutiveHealthFailures = 0;
+      queueHealthCheck(0);
+    };
+    window.addEventListener("visibilitychange", visibilityChangeHandler);
 
     const refreshHostInfo = () => {
       if (!isDesktopRuntime()) return;
@@ -578,6 +604,10 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
     disposed = true;
     started = false;
     clearHealthTimeout();
+    if (visibilityChangeHandler && typeof window !== "undefined") {
+      window.removeEventListener("visibilitychange", visibilityChangeHandler);
+      visibilityChangeHandler = null;
+    }
     for (const key of [...intervals.keys()]) stopInterval(key);
   };
 
@@ -594,6 +624,7 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
     }
 
     const result = await checkOpenworkServer(derived, next.token);
+    consecutiveHealthFailures = result.status === "disconnected" ? consecutiveHealthFailures + 1 : 0;
     mutateState((current) => ({
       ...current,
       openworkServerStatus: result.status,

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -376,29 +376,9 @@ function hasStructuredValue(value: unknown) {
   return true;
 }
 
-function formatElapsed(ms: number) {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  if (minutes <= 0) return `${seconds}s`;
-  return `${minutes}m ${seconds}s`;
-}
-
-function ActivityHeader(props: { active: boolean }) {
-  const startedAtRef = useRef(Date.now());
-  const [now, setNow] = useState(() => Date.now());
-
-  useEffect(() => {
-    if (!props.active) return;
-    const interval = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(interval);
-  }, [props.active]);
-
+function ActivityHeader() {
   return (
     <div className="mb-7 font-sans">
-      <div className="mb-4 text-[17px] leading-none text-[#7b7f83] antialiased">
-        Working for {formatElapsed(now - startedAtRef.current)}
-      </div>
       <div className="h-px w-full bg-[#dddddd]" />
     </div>
   );
@@ -764,7 +744,7 @@ function StepsContainer(props: {
 
   return (
     <div className={props.isInline ? (props.isUser ? "mt-3" : "mt-7") : ""}>
-      {!props.isUser && !props.isNestedVariant && props.isActive ? <ActivityHeader active={props.isActive} /> : null}
+      {!props.isUser && !props.isNestedVariant && props.isActive ? <ActivityHeader /> : null}
       <div
         data-scrollable={!props.isNestedVariant ? "true" : undefined}
         className={

--- a/apps/app/src/react-app/domains/session/surface/message-list.tsx
+++ b/apps/app/src/react-app/domains/session/surface/message-list.tsx
@@ -376,14 +376,6 @@ function hasStructuredValue(value: unknown) {
   return true;
 }
 
-function ActivityHeader() {
-  return (
-    <div className="mb-7 font-sans">
-      <div className="h-px w-full bg-[#dddddd]" />
-    </div>
-  );
-}
-
 function ToolActivityIcon(props: { category?: string }) {
   const className = "mt-[6px] size-[17px] shrink-0 text-[#9a9da0]";
   switch (props.category) {
@@ -744,7 +736,6 @@ function StepsContainer(props: {
 
   return (
     <div className={props.isInline ? (props.isUser ? "mt-3" : "mt-7") : ""}>
-      {!props.isUser && !props.isNestedVariant && props.isActive ? <ActivityHeader /> : null}
       <div
         data-scrollable={!props.isNestedVariant ? "true" : undefined}
         className={

--- a/apps/app/src/react-app/domains/session/surface/session-render-state.ts
+++ b/apps/app/src/react-app/domains/session/surface/session-render-state.ts
@@ -1,6 +1,7 @@
 import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../../../../app/lib/openwork-server";
+import { mergeSnapshotAndLiveMessages } from "../sync/message-merge";
 import { applyRevertCursor } from "../sync/transcript-reconcile";
 import { snapshotToUIMessages } from "../sync/usechat-adapter";
 
@@ -28,13 +29,16 @@ export function deriveRenderedSessionMessages(input: {
   const revertMessageId = (input.snapshot?.session as any)?.revert?.messageID ?? null;
   const liveMessages = input.transcriptState ?? [];
 
-  // Render from the canonical transcript cache. The snapshot fallback only
-  // covers the first hydration frame before seedSessionState writes the cache.
-  const messages = liveMessages.length > 0
-    ? liveMessages
-    : input.snapshot && input.snapshot.messages.length > 0
+  const snapshotMessages = input.snapshot && input.snapshot.messages.length > 0
     ? snapshotToUIMessages(input.snapshot)
     : [];
+
+  // Render the server snapshot as the history floor and layer live stream
+  // updates on top. During prompt submission the live cache can briefly contain
+  // only the new turn; it must not replace the older persisted transcript.
+  const messages = snapshotMessages.length > 0
+    ? mergeSnapshotAndLiveMessages(snapshotMessages, liveMessages, { appendLiveOnlyMessages: true })
+    : liveMessages;
 
   return applyRevertCursor(messages, revertMessageId);
 }

--- a/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
+++ b/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
@@ -1,11 +1,12 @@
 /** @jsxImportSource react */
 import { useEffect } from "react";
 
-import { ensureWorkspaceSessionSync, trackWorkspaceSessionSync } from "./session-sync";
+import { ensureWorkspaceSessionSync, trackWorkspaceSessionsSync } from "./session-sync";
 
 type ReactSessionRuntimeProps = {
   workspaceId: string;
   sessionId: string | null;
+  activeSessionIds?: string[];
   opencodeBaseUrl: string;
   openworkToken: string;
 };
@@ -20,15 +21,15 @@ export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
   }, [props.workspaceId, props.opencodeBaseUrl, props.openworkToken]);
 
   useEffect(() => {
-    return trackWorkspaceSessionSync(
+    return trackWorkspaceSessionsSync(
       {
         workspaceId: props.workspaceId,
         baseUrl: props.opencodeBaseUrl,
         openworkToken: props.openworkToken,
       },
-      props.sessionId,
+      [props.sessionId, ...(props.activeSessionIds ?? [])],
     );
-  }, [props.workspaceId, props.sessionId, props.opencodeBaseUrl, props.openworkToken]);
+  }, [props.workspaceId, props.sessionId, props.activeSessionIds, props.opencodeBaseUrl, props.openworkToken]);
 
   return null;
 }

--- a/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
+++ b/apps/app/src/react-app/domains/session/sync/runtime-sync.tsx
@@ -13,22 +13,17 @@ type ReactSessionRuntimeProps = {
 
 export function ReactSessionRuntime(props: ReactSessionRuntimeProps) {
   useEffect(() => {
-    return ensureWorkspaceSessionSync({
+    const input = {
       workspaceId: props.workspaceId,
       baseUrl: props.opencodeBaseUrl,
       openworkToken: props.openworkToken,
-    });
-  }, [props.workspaceId, props.opencodeBaseUrl, props.openworkToken]);
-
-  useEffect(() => {
-    return trackWorkspaceSessionsSync(
-      {
-        workspaceId: props.workspaceId,
-        baseUrl: props.opencodeBaseUrl,
-        openworkToken: props.openworkToken,
-      },
-      [props.sessionId, ...(props.activeSessionIds ?? [])],
-    );
+    };
+    const releaseWorkspace = ensureWorkspaceSessionSync(input);
+    const releaseSessions = trackWorkspaceSessionsSync(input, [props.sessionId, ...(props.activeSessionIds ?? [])]);
+    return () => {
+      releaseSessions();
+      releaseWorkspace();
+    };
   }, [props.workspaceId, props.sessionId, props.activeSessionIds, props.opencodeBaseUrl, props.openworkToken]);
 
   return null;

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -476,8 +476,14 @@ function scheduleDeltaFlush(entry: SyncEntry, workspaceId: string) {
     if (entry.deltaFlushBuffer.length === 0) return;
     flushDeltas(entry, workspaceId);
   };
-  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function" &&
+    (typeof document === "undefined" || document.visibilityState === "visible")
+  ) {
     window.requestAnimationFrame(run);
+  } else if (typeof window !== "undefined") {
+    window.setTimeout(run, 50);
   } else {
     queueMicrotask(run);
   }
@@ -563,10 +569,15 @@ function startSync(input: SyncOptions) {
   const entry = syncs.get(syncKey(input));
   let disposed = false;
   let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let watchdogTimer: ReturnType<typeof setInterval> | null = null;
+  let activeConnectionController: AbortController | null = null;
+  let lastEventAt = Date.now();
   let retryDelayMs = 1_000;
+  const staleStreamMs = 30_000;
 
   const scheduleRetry = () => {
     if (disposed || controller.signal.aborted || retryTimer) return;
+    activeConnectionController = null;
     retryTimer = setTimeout(() => {
       retryTimer = null;
       void connect();
@@ -575,27 +586,48 @@ function startSync(input: SyncOptions) {
   };
 
   const connect = async () => {
+    const connectionController = new AbortController();
+    activeConnectionController = connectionController;
     try {
-      const sub = await client.event.subscribe(undefined, { signal: controller.signal });
+      const sub = await client.event.subscribe(undefined, { signal: connectionController.signal });
       retryDelayMs = 1_000;
+      lastEventAt = Date.now();
       for await (const raw of sub.stream) {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted || connectionController.signal.aborted) return;
+        lastEventAt = Date.now();
         const event = normalizeEvent(raw);
         if (!event) continue;
         if (!entry) continue;
         applyEvent(entry, input.workspaceId, event);
       }
-      if (!controller.signal.aborted) scheduleRetry();
+      if (!controller.signal.aborted && activeConnectionController === connectionController) scheduleRetry();
     } catch (error) {
-      if (!controller.signal.aborted && shouldRetrySyncSubscribe(error)) scheduleRetry();
+      if (
+        !controller.signal.aborted &&
+        (connectionController.signal.aborted || shouldRetrySyncSubscribe(error))
+      ) {
+        scheduleRetry();
+      }
+    } finally {
+      if (activeConnectionController === connectionController) activeConnectionController = null;
     }
   };
 
   void connect();
+  watchdogTimer = setInterval(() => {
+    if (disposed || controller.signal.aborted || retryTimer) return;
+    const active = activeConnectionController;
+    if (!active || active.signal.aborted) return;
+    if (Date.now() - lastEventAt < staleStreamMs) return;
+    active.abort();
+    scheduleRetry();
+  }, 10_000);
 
   return () => {
     disposed = true;
     if (retryTimer) clearTimeout(retryTimer);
+    if (watchdogTimer) clearInterval(watchdogTimer);
+    activeConnectionController?.abort();
     controller.abort();
   };
 }

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -27,6 +27,7 @@ type SyncEntry = {
   input: SyncOptions;
   refs: number;
   dispose: () => void;
+  disposeTimer: ReturnType<typeof setTimeout> | null;
   trackedSessionRefs: Map<string, number>;
   retainedSessionTimers: Map<string, ReturnType<typeof setTimeout>>;
   pendingDeltas: Map<string, { messageId: string; reasoning: boolean; text: string }>;
@@ -99,6 +100,18 @@ function retainSession(input: SyncOptions, entry: SyncEntry, sessionId: string, 
   entry.retainedSessionTimers.set(sessionId, setTimeout(() => {
     clearTrackedSession(input, entry, sessionId);
   }, ttlMs));
+}
+
+function disposeWorkspaceSync(key: string, entry: SyncEntry) {
+  if (entry.refs > 0) return;
+  if (entry.disposeTimer) {
+    clearTimeout(entry.disposeTimer);
+    entry.disposeTimer = null;
+  }
+  for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
+  entry.retainedSessionTimers.clear();
+  entry.dispose();
+  if (syncs.get(key) === entry) syncs.delete(key);
 }
 
 function releaseRetainedSessionSoon(input: SyncOptions, entry: SyncEntry, sessionId: string) {
@@ -672,6 +685,10 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   const key = syncKey(input);
   const existing = syncs.get(key);
   if (existing) {
+    if (existing.disposeTimer) {
+      clearTimeout(existing.disposeTimer);
+      existing.disposeTimer = null;
+    }
     existing.refs += 1;
     return () => releaseWorkspaceSessionSync(input);
   }
@@ -680,6 +697,7 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
     input,
     refs: 1,
     dispose: () => {},
+    disposeTimer: null,
     trackedSessionRefs: new Map(),
     retainedSessionTimers: new Map(),
     pendingDeltas: new Map(),
@@ -699,14 +717,14 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   if (!existing) return;
   existing.refs -= 1;
   if (existing.refs > 0) return;
-  // Immediate disposal is important here: a single OpenCode runtime is shared
-  // across local workspaces, and keeping old workspace subscriptions alive for
-  // 10s means rapid workspace switches accumulate multiple parallel event
-  // streams. Under larger transcripts that duplicates cache writes and can make
-  // the UI feel frozen after a handful of switches.
-  for (const timer of existing.retainedSessionTimers.values()) clearTimeout(timer);
-  existing.dispose();
-  syncs.delete(key);
+  if (existing.retainedSessionTimers.size === 0) {
+    disposeWorkspaceSync(key, existing);
+    return;
+  }
+  if (existing.disposeTimer) return;
+  existing.disposeTimer = setTimeout(() => {
+    disposeWorkspaceSync(key, existing);
+  }, retainedSessionTtlMs);
 }
 
 export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionSnapshot) {
@@ -773,6 +791,7 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     input,
     refs: 1,
     dispose: () => {},
+    disposeTimer: null,
     trackedSessionRefs: new Map(),
     retainedSessionTimers: new Map(),
     pendingDeltas: new Map(),
@@ -786,6 +805,18 @@ export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
     }
     syncs.delete(key);
   };
+}
+
+export function __hasWorkspaceSessionSyncForTest(input: SyncOptions) {
+  return syncs.has(syncKey(input));
+}
+
+export function __disposeWorkspaceSessionSyncForTest(input: SyncOptions) {
+  const key = syncKey(input);
+  const entry = syncs.get(key);
+  if (!entry) return;
+  entry.refs = 0;
+  disposeWorkspaceSync(key, entry);
 }
 
 export function __applySessionSyncEventForTest(input: SyncOptions, event: OpencodeEvent) {

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -42,7 +42,7 @@ type SyncEntry = {
 
 const idleStatus: SessionStatus = { type: "idle" };
 const syncs = new Map<string, SyncEntry>();
-const retainedSessionTtlMs = 120_000;
+const retainedSessionTtlMs = 10 * 60_000;
 const idleRetainedSessionTtlMs = 10_000;
 
 export const transcriptKey = (workspaceId: string, sessionId: string) =>
@@ -92,6 +92,9 @@ function clearTrackedSession(input: SyncOptions, entry: SyncEntry, sessionId: st
   );
   const queryClient = getReactQueryClient();
   queryClient.removeQueries({ queryKey: permissionKey(input.workspaceId, sessionId), exact: true });
+  if (entry.refs <= 0 && entry.retainedSessionTimers.size === 0) {
+    disposeWorkspaceSync(syncKey(input), entry);
+  }
 }
 
 function retainSession(input: SyncOptions, entry: SyncEntry, sessionId: string, ttlMs = retainedSessionTtlMs) {
@@ -719,12 +722,7 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   if (existing.refs > 0) return;
   if (existing.retainedSessionTimers.size === 0) {
     disposeWorkspaceSync(key, existing);
-    return;
   }
-  if (existing.disposeTimer) return;
-  existing.disposeTimer = setTimeout(() => {
-    disposeWorkspaceSync(key, existing);
-  }, retainedSessionTtlMs);
 }
 
 export function seedSessionState(workspaceId: string, snapshot: OpenworkSessionSnapshot) {

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -24,9 +24,11 @@ export type PendingDelta = {
 };
 
 type SyncEntry = {
+  input: SyncOptions;
   refs: number;
   dispose: () => void;
   trackedSessionRefs: Map<string, number>;
+  retainedSessionTimers: Map<string, ReturnType<typeof setTimeout>>;
   pendingDeltas: Map<string, { messageId: string; reasoning: boolean; text: string }>;
   // Coalesce rapid-fire delta events from the SSE stream into one cache
   // commit per animation frame. Without this, a long response produces a
@@ -39,6 +41,8 @@ type SyncEntry = {
 
 const idleStatus: SessionStatus = { type: "idle" };
 const syncs = new Map<string, SyncEntry>();
+const retainedSessionTtlMs = 120_000;
+const idleRetainedSessionTtlMs = 10_000;
 
 export const transcriptKey = (workspaceId: string, sessionId: string) =>
   ["react-session-transcript", workspaceId, sessionId] as const;
@@ -70,7 +74,36 @@ function shouldRetrySyncSubscribe(error: unknown) {
 }
 
 function isTrackedSession(entry: SyncEntry, sessionId: string) {
-  return (entry.trackedSessionRefs.get(sessionId) ?? 0) > 0;
+  return (entry.trackedSessionRefs.get(sessionId) ?? 0) > 0 || entry.retainedSessionTimers.has(sessionId);
+}
+
+function isLiveStatus(status: SessionStatus | null | undefined) {
+  return status?.type === "busy" || status?.type === "retry";
+}
+
+function clearTrackedSession(input: SyncOptions, entry: SyncEntry, sessionId: string) {
+  entry.trackedSessionRefs.delete(sessionId);
+  const retainedTimer = entry.retainedSessionTimers.get(sessionId);
+  if (retainedTimer) clearTimeout(retainedTimer);
+  entry.retainedSessionTimers.delete(sessionId);
+  entry.deltaFlushBuffer = entry.deltaFlushBuffer.filter(
+    (item) => item.sessionId !== sessionId,
+  );
+  const queryClient = getReactQueryClient();
+  queryClient.removeQueries({ queryKey: permissionKey(input.workspaceId, sessionId), exact: true });
+}
+
+function retainSession(input: SyncOptions, entry: SyncEntry, sessionId: string, ttlMs = retainedSessionTtlMs) {
+  const existing = entry.retainedSessionTimers.get(sessionId);
+  if (existing) clearTimeout(existing);
+  entry.retainedSessionTimers.set(sessionId, setTimeout(() => {
+    clearTrackedSession(input, entry, sessionId);
+  }, ttlMs));
+}
+
+function releaseRetainedSessionSoon(input: SyncOptions, entry: SyncEntry, sessionId: string) {
+  if (!entry.retainedSessionTimers.has(sessionId)) return;
+  retainSession(input, entry, sessionId, idleRetainedSessionTtlMs);
 }
 
 function withReceivedAt(permission: PermissionRequest, receivedAt: number): PendingPermission {
@@ -325,12 +358,14 @@ export function coalescePendingDeltas(items: PendingDelta[]) {
 
 function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent) {
   const queryClient = getReactQueryClient();
+  const input = entry.input;
 
   if (event.type === "session.status") {
     const props = (event.properties ?? {}) as { sessionID?: string; status?: SessionStatus };
     if (!props.sessionID || !props.status) return;
     if (!isTrackedSession(entry, props.sessionID)) return;
     queryClient.setQueryData(statusKey(workspaceId, props.sessionID), props.status);
+    if (input && !isLiveStatus(props.status)) releaseRetainedSessionSoon(input, entry, props.sessionID);
     return;
   }
 
@@ -465,6 +500,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     if (!props.sessionID) return;
     if (!isTrackedSession(entry, props.sessionID)) return;
     queryClient.setQueryData(statusKey(workspaceId, props.sessionID), idleStatus);
+    if (input) releaseRetainedSessionSoon(input, entry, props.sessionID);
   }
 }
 
@@ -641,9 +677,11 @@ export function ensureWorkspaceSessionSync(input: SyncOptions) {
   }
 
   syncs.set(key, {
+    input,
     refs: 1,
     dispose: () => {},
     trackedSessionRefs: new Map(),
+    retainedSessionTimers: new Map(),
     pendingDeltas: new Map(),
     deltaFlushBuffer: [],
     deltaFlushScheduled: false,
@@ -666,6 +704,7 @@ function releaseWorkspaceSessionSync(input: SyncOptions) {
   // 10s means rapid workspace switches accumulate multiple parallel event
   // streams. Under larger transcripts that duplicates cache writes and can make
   // the UI feel frozen after a handful of switches.
+  for (const timer of existing.retainedSessionTimers.values()) clearTimeout(timer);
   existing.dispose();
   syncs.delete(key);
 }
@@ -693,6 +732,12 @@ export function trackWorkspaceSessionSync(input: SyncOptions, sessionId: string 
   const entry = syncs.get(syncKey(input));
   if (!entry) return () => {};
 
+  const retainedTimer = entry.retainedSessionTimers.get(normalizedSessionId);
+  if (retainedTimer) {
+    clearTimeout(retainedTimer);
+    entry.retainedSessionTimers.delete(normalizedSessionId);
+  }
+
   entry.trackedSessionRefs.set(
     normalizedSessionId,
     (entry.trackedSessionRefs.get(normalizedSessionId) ?? 0) + 1,
@@ -702,13 +747,49 @@ export function trackWorkspaceSessionSync(input: SyncOptions, sessionId: string 
     const current = entry.trackedSessionRefs.get(normalizedSessionId) ?? 0;
     if (current <= 1) {
       entry.trackedSessionRefs.delete(normalizedSessionId);
-      entry.deltaFlushBuffer = entry.deltaFlushBuffer.filter(
-        (item) => item.sessionId !== normalizedSessionId,
-      );
-      const queryClient = getReactQueryClient();
-      queryClient.removeQueries({ queryKey: permissionKey(input.workspaceId, normalizedSessionId), exact: true });
+      retainSession(input, entry, normalizedSessionId);
       return;
     }
     entry.trackedSessionRefs.set(normalizedSessionId, current - 1);
   };
+}
+
+export function trackWorkspaceSessionsSync(input: SyncOptions, sessionIds: Array<string | null | undefined>) {
+  const seen = new Set<string>();
+  const releases = sessionIds.flatMap((sessionId) => {
+    const id = sessionId?.trim() ?? "";
+    if (!id || seen.has(id)) return [];
+    seen.add(id);
+    return [trackWorkspaceSessionSync(input, id)];
+  });
+  return () => {
+    for (const release of releases) release();
+  };
+}
+
+export function __createWorkspaceSessionSyncForTest(input: SyncOptions) {
+  const key = syncKey(input);
+  syncs.set(key, {
+    input,
+    refs: 1,
+    dispose: () => {},
+    trackedSessionRefs: new Map(),
+    retainedSessionTimers: new Map(),
+    pendingDeltas: new Map(),
+    deltaFlushBuffer: [],
+    deltaFlushScheduled: false,
+  });
+  return () => {
+    const entry = syncs.get(key);
+    if (entry) {
+      for (const timer of entry.retainedSessionTimers.values()) clearTimeout(timer);
+    }
+    syncs.delete(key);
+  };
+}
+
+export function __applySessionSyncEventForTest(input: SyncOptions, event: OpencodeEvent) {
+  const entry = syncs.get(syncKey(input));
+  if (!entry) return;
+  applyEvent(entry, input.workspaceId, event);
 }

--- a/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
+++ b/apps/app/src/react-app/domains/shell-feedback/reload-workspace-toast.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { AlertTriangle, RefreshCcw, X } from "lucide-react";
+import { RefreshCcw, X } from "lucide-react";
 
 import type { ReloadTrigger } from "../../../app/types";
 
@@ -19,12 +19,6 @@ export type ReloadWorkspaceToastProps = {
   onReload: () => void;
   onDismiss: () => void;
 };
-
-const buttonBaseClass =
-  "inline-flex items-center justify-center rounded-full px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.18)] disabled:cursor-not-allowed disabled:opacity-60";
-const primaryButtonClass = `${buttonBaseClass} bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]`;
-const dangerButtonClass = `${buttonBaseClass} bg-red-9 text-white hover:bg-red-10`;
-const ghostButtonClass = `${buttonBaseClass} border border-transparent bg-transparent text-dls-text hover:bg-[var(--dls-hover)]`;
 
 function describeTrigger(
   description: string,
@@ -78,100 +72,45 @@ function describeTrigger(
 export function ReloadWorkspaceToast(props: ReloadWorkspaceToastProps) {
   if (!props.open) return null;
 
-  const bodyHasContent =
-    Boolean(props.description) ||
-    Boolean(props.error) ||
-    Boolean(props.warning) ||
-    Boolean(props.blockedReason);
+  const message = props.hasActiveRuns
+    ? "Reloading will stop active tasks."
+    : props.error
+      ? props.error
+      : describeTrigger(props.description, props.trigger);
 
   return (
-    <div className="w-full max-w-[24rem] overflow-hidden rounded-[1.4rem] border border-dls-border bg-dls-surface shadow-[var(--dls-shell-shadow)] backdrop-blur-xl animate-in fade-in slide-in-from-top-4 duration-300">
-      <div className="flex items-start gap-3 p-4">
-        <div
-          className={`flex size-10 shrink-0 items-center justify-center rounded-2xl border ${
-            props.hasActiveRuns
-              ? "border-amber-6/40 bg-amber-4/80 text-amber-11"
-              : "border-sky-6/40 bg-sky-4/80 text-sky-11"
-          }`.trim()}
-        >
+    <div className="fixed bottom-6 left-1/2 z-[9999] -translate-x-1/2 animate-in slide-in-from-bottom-4 fade-in duration-300">
+      <div className="flex max-w-[calc(100vw-1.5rem)] items-center gap-4 rounded-2xl border border-dls-border bg-dls-surface px-5 py-3.5 shadow-lg">
+        <div className={props.hasActiveRuns ? "text-amber-11" : "text-dls-text"}>
           <RefreshCcw
-            size={18}
+            size={16}
             className={props.busy ? "animate-spin" : undefined}
           />
         </div>
 
-        <div className="min-w-0 flex-1">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-semibold text-gray-12 truncate">
-                  {props.title}
-                </span>
-                {props.hasActiveRuns ? (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-amber-4 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-11">
-                    Active tasks
-                  </span>
-                ) : null}
-              </div>
-
-              {bodyHasContent ? (
-                <div className="mt-1 space-y-1 text-sm leading-relaxed text-gray-10">
-                  <div>
-                    {props.hasActiveRuns ? (
-                      <span className="font-medium text-amber-11">
-                        Reloading will stop active tasks.
-                      </span>
-                    ) : props.error ? (
-                      <span className="font-medium text-red-11">
-                        {props.error}
-                      </span>
-                    ) : (
-                      describeTrigger(props.description, props.trigger)
-                    )}
-                  </div>
-                  {props.warning ? (
-                    <div className="flex items-start gap-2 rounded-2xl border border-amber-6/40 bg-amber-3/70 px-3 py-2 text-xs text-amber-11">
-                      <AlertTriangle size={14} className="mt-0.5 shrink-0" />
-                      <span>{props.warning}</span>
-                    </div>
-                  ) : null}
-                  {props.blockedReason ? (
-                    <div className="text-xs text-gray-9">
-                      Blocked: {props.blockedReason}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-
-            <button
-              type="button"
-              onClick={() => props.onDismiss()}
-              className="rounded-full p-1 text-gray-9 transition hover:bg-gray-3 hover:text-gray-12"
-              aria-label={props.dismissLabel}
-            >
-              <X size={16} />
-            </button>
-          </div>
-
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              className={props.hasActiveRuns ? dangerButtonClass : primaryButtonClass}
-              onClick={() => props.onReload()}
-              disabled={props.busy || !props.canReload}
-            >
-              {props.reloadLabel}
-            </button>
-            <button
-              type="button"
-              className={ghostButtonClass}
-              onClick={() => props.onDismiss()}
-            >
-              {props.dismissLabel}
-            </button>
-          </div>
+        <div className="min-w-0 text-[13px] text-dls-text">
+          <span className="font-medium">{props.title}</span>{" "}
+          <span className={props.error ? "text-red-11" : props.hasActiveRuns ? "text-amber-11" : undefined}>
+            {message}
+          </span>{" "}
+          <button
+            type="button"
+            className="font-medium underline underline-offset-2 transition-colors hover:text-dls-text/80 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={() => props.onReload()}
+            disabled={props.busy || !props.canReload}
+          >
+            {props.reloadLabel}
+          </button>
         </div>
+
+        <button
+          type="button"
+          className="flex size-6 shrink-0 items-center justify-center rounded-full text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text"
+          onClick={() => props.onDismiss()}
+          aria-label={props.dismissLabel}
+        >
+          <X size={14} />
+        </button>
       </div>
     </div>
   );

--- a/apps/app/src/react-app/shell/reload-coordinator.tsx
+++ b/apps/app/src/react-app/shell/reload-coordinator.tsx
@@ -128,29 +128,27 @@ export function ReloadCoordinatorProvider({ children }: { children: ReactNode })
   return (
     <ReloadCoordinatorContext.Provider value={value}>
       {children}
+      <ReloadWorkspaceToast
+        open={systemState.reload.reloadPending && activeSessions.length === 0 && !orgOnboardingVisible}
+        title={systemState.reloadCopy.title}
+        description={systemState.reloadCopy.body}
+        trigger={systemState.reload.reloadTrigger}
+        error={systemState.reload.reloadError}
+        reloadLabel={
+          activeSessions.length > 0 ? t("app.reload_stop_tasks") : t("app.reload_now")
+        }
+        dismissLabel={t("app.reload_later")}
+        busy={systemState.reload.reloadBusy}
+        canReload={systemState.canReloadWorkspaceEngine}
+        hasActiveRuns={activeSessions.length > 0}
+        onReload={() => {
+          void (activeSessions.length > 0
+            ? forceStopActiveSessionsAndReload()
+            : systemState.reloadWorkspaceEngine());
+        }}
+        onDismiss={systemState.clearReloadRequired}
+      />
       <div className="pointer-events-none fixed right-4 top-4 z-50 flex w-[min(24rem,calc(100vw-1.5rem))] max-w-full flex-col gap-3 sm:right-6 sm:top-6">
-        <div className="pointer-events-auto">
-          <ReloadWorkspaceToast
-            open={systemState.reload.reloadPending && activeSessions.length === 0 && !orgOnboardingVisible}
-            title={systemState.reloadCopy.title}
-            description={systemState.reloadCopy.body}
-            trigger={systemState.reload.reloadTrigger}
-            error={systemState.reload.reloadError}
-            reloadLabel={
-              activeSessions.length > 0 ? t("app.reload_stop_tasks") : t("app.reload_now")
-            }
-            dismissLabel={t("app.reload_later")}
-            busy={systemState.reload.reloadBusy}
-            canReload={systemState.canReloadWorkspaceEngine}
-            hasActiveRuns={activeSessions.length > 0}
-            onReload={() => {
-              void (activeSessions.length > 0
-                ? forceStopActiveSessionsAndReload()
-                : systemState.reloadWorkspaceEngine());
-            }}
-            onDismiss={systemState.clearReloadRequired}
-          />
-        </div>
         <StatusToastsViewport />
       </div>
     </ReloadCoordinatorContext.Provider>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -896,7 +896,7 @@ export function SessionRoute() {
       // OpenCode engine bound to it re-reads opencode.jsonc and applies
       // permissions. Fire-and-forget; the route is idempotent and any
       // transport failure is non-fatal. See issue #870.
-      if (nextWorkspaceId && !launchActivatedWorkspaceIdsRef.current.has(nextWorkspaceId)) {
+      if (nextWorkspaceId && list.activeId !== nextWorkspaceId && !launchActivatedWorkspaceIdsRef.current.has(nextWorkspaceId)) {
         launchActivatedWorkspaceIdsRef.current.add(nextWorkspaceId);
         const nextWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId) ?? null;
         const nextEndpoint = endpointForWorkspace(nextWorkspace);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -625,6 +625,15 @@ export function SessionRoute() {
         }),
     [sessionsByWorkspaceId],
   );
+  const activeSelectedWorkspaceSessionIds = useMemo(
+    () =>
+      (sessionsByWorkspaceId[selectedWorkspaceId] ?? []).flatMap((session: any) => {
+        if (!isActiveSessionStatus(getSessionStatus(session))) return [];
+        const id = String(session?.id ?? "").trim();
+        return id ? [id] : [];
+      }),
+    [selectedWorkspaceId, sessionsByWorkspaceId],
+  );
 
   const backgroundSessionLoadInFlight = useRef<Map<string, number>>(new Map());
   const rememberPendingCreatedSession = useCallback((workspaceId: string, sessionId: string) => {
@@ -2469,6 +2478,7 @@ export function SessionRoute() {
         // the UI never sees them and gets stuck on "thinking".
         workspaceId={selectedWorkspaceEndpoint.workspaceId}
         sessionId={selectedSessionId}
+        activeSessionIds={activeSelectedWorkspaceSessionIds}
         opencodeBaseUrl={opencodeBaseUrl}
         openworkToken={selectedWorkspaceServerToken}
       />

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1826,7 +1826,7 @@ export function SessionRoute() {
       onSendDraft: async (draft: ComposerDraft) => {
         const text = (draft.resolvedText ?? draft.text).trim();
         if (!text && draft.attachments.length === 0) return;
-        if (selectedModelUnavailable) return;
+        if (selectedModelUnavailable) throw new Error("Selected model is unavailable. Choose another model before sending.");
 
         if (draft.mode === "shell") {
           await shellInSession(opencodeClient, selectedSessionId, text);

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -7,7 +7,10 @@ import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import {
   __applySessionSyncEventForTest,
   __createWorkspaceSessionSyncForTest,
+  __disposeWorkspaceSessionSyncForTest,
+  __hasWorkspaceSessionSyncForTest,
   coalescePendingDeltas,
+  ensureWorkspaceSessionSync,
   permissionKey,
   seedPermissionState,
   seedSessionState,
@@ -219,6 +222,52 @@ describe("session transcript sync", () => {
       releaseSessionB();
     } finally {
       cleanup();
+    }
+  });
+
+  test("keeps workspace stream alive briefly when the session route unmounts", async () => {
+    const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+    const releaseWorkspace = ensureWorkspaceSessionSync(syncInput);
+    const releaseSessionA = trackWorkspaceSessionSync(syncInput, "session-a");
+
+    releaseSessionA();
+    releaseWorkspace();
+
+    try {
+      expect(__hasWorkspaceSessionSyncForTest(syncInput)).toBe(true);
+
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.updated",
+        properties: { info: { id: "msg-route-leave", role: "assistant", sessionID: "session-a" } },
+      } as any);
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "part-route-leave",
+            type: "text",
+            text: "",
+            sessionID: "session-a",
+            messageID: "msg-route-leave",
+          },
+        },
+      } as any);
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session-a",
+          messageID: "msg-route-leave",
+          partID: "part-route-leave",
+          delta: "stream survived settings route",
+        },
+      } as any);
+
+      await Promise.resolve();
+
+      const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"));
+      expect(transcript?.[0]?.parts[0]).toMatchObject({ text: "stream survived settings route" });
+    } finally {
+      __disposeWorkspaceSessionSyncForTest(syncInput);
     }
   });
 });

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -225,7 +225,7 @@ describe("session transcript sync", () => {
     }
   });
 
-  test("keeps workspace stream alive briefly when the session route unmounts", async () => {
+  test("keeps workspace stream alive while retained sessions remain after route unmount", async () => {
     const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
     const releaseWorkspace = ensureWorkspaceSessionSync(syncInput);
     const releaseSessionA = trackWorkspaceSessionSync(syncInput, "session-a");

--- a/apps/app/tests/session-sync-permissions.test.ts
+++ b/apps/app/tests/session-sync-permissions.test.ts
@@ -5,10 +5,13 @@ import type { PermissionRequest } from "@opencode-ai/sdk/v2/client";
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import { getReactQueryClient } from "../src/react-app/infra/query-client";
 import {
+  __applySessionSyncEventForTest,
+  __createWorkspaceSessionSyncForTest,
   coalescePendingDeltas,
   permissionKey,
   seedPermissionState,
   seedSessionState,
+  trackWorkspaceSessionSync,
   transcriptKey,
 } from "../src/react-app/domains/session/sync/session-sync";
 
@@ -171,5 +174,51 @@ describe("session transcript sync", () => {
 
     const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"));
     expect(transcript?.[1]?.parts[0]).toMatchObject({ text: "finished answer" });
+  });
+
+  test("continues accepting stream deltas for a recently unselected session", async () => {
+    const syncInput = { workspaceId: "workspace-a", baseUrl: "http://127.0.0.1:1234", openworkToken: "token" };
+    const cleanup = __createWorkspaceSessionSyncForTest(syncInput);
+
+    try {
+      const releaseSessionA = trackWorkspaceSessionSync(syncInput, "session-a");
+      releaseSessionA();
+      const releaseSessionB = trackWorkspaceSessionSync(syncInput, "session-b");
+
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.updated",
+        properties: { info: { id: "msg-assistant", role: "assistant", sessionID: "session-a" } },
+      } as any);
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "part-assistant",
+            type: "text",
+            text: "",
+            sessionID: "session-a",
+            messageID: "msg-assistant",
+          },
+        },
+      } as any);
+      __applySessionSyncEventForTest(syncInput, {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session-a",
+          messageID: "msg-assistant",
+          partID: "part-assistant",
+          delta: "still streaming after switch",
+        },
+      } as any);
+
+      await Promise.resolve();
+
+      const transcript = getReactQueryClient().getQueryData<UIMessage[]>(transcriptKey("workspace-a", "session-a"));
+      expect(transcript?.[0]?.parts[0]).toMatchObject({ text: "still streaming after switch" });
+
+      releaseSessionB();
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/apps/server/src/reload-watcher.ts
+++ b/apps/server/src/reload-watcher.ts
@@ -262,7 +262,17 @@ function createDirectoryTreeWatcher(input: {
     const base = basename(absPath);
     if (!base) return true;
     if (base === ".DS_Store" || base === "Thumbs.db") return true;
+    if (base.startsWith(".") || base.endsWith("~") || base.endsWith(".tmp") || base.endsWith(".swp")) return true;
     return false;
+  };
+
+  const shouldRecordEntry = (absPath: string) => {
+    if (shouldIgnoreEntry(absPath)) return false;
+    const base = basename(absPath);
+    if (triggerType === "skill") return /^SKILL\.md$/i.test(base);
+    if (triggerType === "command") return /\.md$/i.test(base);
+    if (triggerType === "agent") return /\.(md|json|jsonc)$/i.test(base);
+    return true;
   };
 
   const shouldSkipDir = (name: string) => {
@@ -283,7 +293,7 @@ function createDirectoryTreeWatcher(input: {
           const raw = filename ? filename.toString() : "";
           const name = raw.trim();
           const absPath = name ? join(dir, name) : dir;
-          if (!shouldIgnoreEntry(absPath)) {
+          if (shouldRecordEntry(absPath)) {
             record(absPath);
           }
           scheduleRescan();

--- a/evals/README.md
+++ b/evals/README.md
@@ -82,8 +82,9 @@ Chrome DevTools MCP. Every tool takes `browser_url` as the first argument.
 
 - [`daytona-flows.md`](./daytona-flows.md) — Daytona sandbox flows (workspace
   creation, session messaging, screenshot verification).
-- [`react-session-flows.md`](./react-session-flows.md) — the 9 core
-  session/settings flows verified during the React port cutover.
+- [`react-session-flows.md`](./react-session-flows.md) — core
+  session/settings flows verified during the React port cutover, including
+  long streaming interruption coverage.
 - [`onboarding-welcome-flows.md`](./onboarding-welcome-flows.md) — the 7
   onboarding/welcome flows covering first-run experience and folder
   explanation.

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -575,6 +575,148 @@ Known regressions this catches:
 
 ---
 
+## Flow 21 — Streaming survives session and route interruptions
+
+**Why**: Long-running assistant streams must continue when users click away.
+The session runtime filters OpenCode events by tracked session id, and route
+changes can unmount the session surface. This flow catches regressions where
+streaming stops, aborts, or only resumes after a full reload.
+
+Run both subflows against a model/provider that can complete long text output.
+If the model returns an error (for example missing API key), the eval is blocked
+and should be rerun with an authenticated provider.
+
+### Subflow A — Switch to a different session while streaming
+
+Steps:
+1. Create Session A with **New task**.
+2. Send this prompt:
+   ```text
+   Write exactly 500 short numbered lines about a lighthouse keeper. Each line should be 3 to 7 words. End the final line with the exact marker SESSION_SWITCH_500_DONE. Do not use tools.
+   ```
+3. As soon as **Run task** is clicked, create or open Session B within 1 second.
+4. Wait 2–5 seconds on Session B.
+5. Return to Session A.
+6. Poll the transcript until status is ready/idle or 90 seconds elapse.
+
+Pass criteria:
+- Session A does not show `MessageAbortedError` or an aborted assistant turn.
+- Session A eventually contains `SESSION_SWITCH_500_DONE` in assistant text.
+- The highest numbered line in Session A is `500.`.
+- Returning to Session A does not require a full app reload to show the final
+  text.
+
+Known regressions this catches:
+- Releasing `trackWorkspaceSessionSync()` immediately when a session is no
+  longer selected, causing off-screen deltas to be ignored.
+- Dropping the workspace event subscription during fast session switches.
+
+### Subflow B — Navigate to Settings while streaming
+
+Steps:
+1. Create Session C with **New task**.
+2. Send this prompt:
+   ```text
+   Write exactly 500 short numbered lines about a lighthouse keeper. Each line should be 3 to 7 words. End the final line with the exact marker SETTINGS_ROUTE_500_DONE. Do not use tools.
+   ```
+3. Within 1 second of clicking **Run task**, click the footer **Settings** gear.
+4. Wait 2–5 seconds on Settings.
+5. Click **Back to app**.
+6. Poll the transcript until status is ready/idle or 90 seconds elapse.
+
+Pass criteria:
+- Session C does not show `MessageAbortedError` or an aborted assistant turn.
+- Session C eventually contains `SETTINGS_ROUTE_500_DONE` in assistant text.
+- The highest numbered line in Session C is `500.`.
+- Returning from Settings must not reload the OpenCode engine for the same
+  already-active workspace.
+
+Known regressions this catches:
+- Disposing the workspace SSE subscription when `SessionRoute` unmounts.
+- Re-activating the already-active workspace when returning from Settings,
+  which reloads the OpenCode engine and aborts the run.
+
+### Browser tool recipe
+
+Use `browser_evaluate` against the Electron CDP target. The snippets below use
+the OpenWork inspector and React Query cache so the eval can assert transcript
+state directly instead of relying on a visual snapshot cadence.
+
+Create a new session:
+```js
+(function() {
+  var btn = [...document.querySelectorAll('button')]
+    .find((b) => b.getAttribute('aria-label') === 'New task');
+  if (!btn) return JSON.stringify({ ok: false, error: 'no new task' });
+  btn.click();
+  return JSON.stringify({ ok: true, hash: window.location.hash });
+})()
+```
+
+Fill and run a prompt:
+```js
+(function() {
+  var editor = document.querySelector('[contenteditable=true]');
+  var text = 'Write exactly 500 short numbered lines about a lighthouse keeper. Each line should be 3 to 7 words. End the final line with the exact marker SETTINGS_ROUTE_500_DONE. Do not use tools.';
+  if (!editor) return JSON.stringify({ ok: false, error: 'no editor' });
+  editor.focus();
+  var p = editor.querySelector('p') || editor;
+  p.textContent = text;
+  p.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+  editor.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+  var btn = [...document.querySelectorAll('button')]
+    .find((b) => b.textContent.trim() === 'Run task' && !b.disabled);
+  if (!btn) return JSON.stringify({ ok: false, error: 'run disabled', editorText: editor.textContent });
+  btn.click();
+  return JSON.stringify({ ok: true, sessionId: window.__openwork.snapshot().route.selectedSessionId });
+})()
+```
+
+Open Settings quickly:
+```js
+(function() {
+  var btn = [...document.querySelectorAll('button')]
+    .find((b) => b.getAttribute('aria-label') === 'Settings');
+  if (!btn) return JSON.stringify({ ok: false, error: 'no settings button' });
+  btn.click();
+  return JSON.stringify({ ok: true, hash: window.location.hash });
+})()
+```
+
+Return from Settings:
+```js
+(function() {
+  var btn = [...document.querySelectorAll('button')]
+    .find((b) => b.textContent.trim() === 'Back to app');
+  if (!btn) return JSON.stringify({ ok: false, error: 'no back button' });
+  btn.click();
+  return JSON.stringify({ ok: true, hash: window.location.hash });
+})()
+```
+
+Assert transcript completion for a marker:
+```js
+(async function() {
+  const { getReactQueryClient } = await import('/src/react-app/infra/query-client.ts');
+  const { transcriptKey, statusKey } = await import('/src/react-app/domains/session/sync/session-sync.ts');
+  const route = window.__openwork.snapshot().route;
+  const messages = getReactQueryClient().getQueryData(transcriptKey(route.selectedWorkspaceId, route.selectedSessionId)) || [];
+  const status = getReactQueryClient().getQueryData(statusKey(route.selectedWorkspaceId, route.selectedSessionId));
+  const assistant = [...messages].reverse().find((message) => message.role === 'assistant');
+  const text = (assistant?.parts || []).map((part) => part.text || '').join('\n');
+  const numbers = [...text.matchAll(/(?:^|\n)(\d+)\./g)].map((match) => Number(match[1]));
+  return JSON.stringify({
+    status,
+    hasMarker: text.includes('SETTINGS_ROUTE_500_DONE'),
+    lastNumber: numbers.length ? Math.max(...numbers) : null,
+    hasAbort: /MessageAbortedError|Aborted/.test(document.body.innerText),
+    tail: text.slice(-1000),
+  });
+})()
+```
+
+---
+
 ## Change log
 
 - 2026-04-16 — initial doc after the React port cutover fixed streaming,
@@ -588,3 +730,5 @@ Known regressions this catches:
   button, skill lifecycle, and workspace button placement.
 - 2026-05-06 — added Flow 20 to ensure local workspace creation opens the
   new workspace session surface instead of settings.
+- 2026-05-18 — added Flow 21 to verify long streams survive switching to
+  another session and navigating to Settings/back.


### PR DESCRIPTION
## Summary
- Flush streaming transcript deltas outside requestAnimationFrame when the webview is hidden/minimized.
- Add a stale SSE watchdog that reconnects stuck event subscriptions.
- Keep recently unselected sessions retained in the workspace event filter so stream deltas keep applying after switching away.
- Keep the workspace session stream alive when leaving the session route, including trips to Settings, until retained sessions settle or expire.
- Avoid redundant workspace activation when returning from Settings; server activation reloads the OpenCode engine and can abort an in-flight generation.
- Preserve composer drafts when the selected model is unavailable by surfacing an error.
- Filter noisy reload watcher events and reduce transient server disconnect status flips.
- Update the run-evals skill to select the Different AI Daytona org before sandbox creation.
- Add React session Flow 21 eval for 500-line streaming interruption across session switches and Settings route changes.

## Why
- Users reported responses appearing stuck until minimizing/reopening, lost prompts after stop/retry, repeated skills reload notifications, frequent OpenWork server disconnects, stream interruption after clicking away from a running session, and stream loss/abort after navigating to Settings.

## Issue
- Closes #

## Scope
- React session stream sync and composer send handling.
- Session route workspace activation behavior.
- OpenWork server reload filesystem watcher filtering.
- App OpenWork server health polling hysteresis and visibility recovery.
- Daytona eval skill instruction.
- Human/browser-tool eval documentation.

## Out of scope
- Provider/model backend reliability changes.
- Full redesign of reload notification UX.

## Testing
### Ran locally
- pnpm --filter @openwork/app typecheck
- pnpm --filter openwork-server typecheck
- bun test tests/session-sync-permissions.test.ts from apps/app
- pnpm --filter openwork-server test
- git diff --check

### Ran on Daytona
- daytona organization use Different AI
- Created fresh sandbox openwork-pr1831-20260518-091511 and checked out fix/session-stream-reload-health.
- pnpm install
- bun test tests/session-sync-permissions.test.ts from /workspace/apps/app
- Started services and connected browser tools to https://9825-6rkwpszoftylxghh.daytonaproxy01.net.
- Created /workspace/hello workspace through the UI.
- Verified route connected in window.__openwork snapshot.
- Backend model calls could not produce a real assistant stream because the sandbox returned Missing API key from opencode.ai/zen.
- Used browser tools to switch from Session A to Session B, inject synthetic OpenCode stream events for retained Session A through the app module, switch back to Session A, and verify STREAM_SWITCH_RETENTION_OK rendered in the transcript.
- Deleted the Daytona sandbox after verification.

### Local CDP settings-route verification
- Used local Electron CDP at http://127.0.0.1:9823.
- Verified hidden-window streaming flush with a short OK response.
- Verified immediate Settings navigation and return during a GPT-5.5 run with final marker SETTINGS_STREAM_DONE.
- A stricter 500-line Settings test exposed persisted MessageAbortedError; root cause was redundant workspace activation on SessionRoute remount reloading the OpenCode engine.
- Added activation guard so returning from Settings does not reactivate/reload when the server already has the same active workspace.
- Added eval coverage in evals/react-session-flows.md Flow 21 for 500-line final-marker checks while switching sessions and while navigating to Settings/back.

### Result
- pass: app typecheck, server typecheck, app session sync unit test locally.
- pass: app session sync unit test in Daytona.
- pass: Daytona browser verification of retained off-screen session stream event application.
- pass: eval docs whitespace validation with git diff --check.
- fail: pnpm --filter openwork-server test has pre-existing/environment failures unrelated to this PR: better-sqlite3 is not supported in Bun in opencode-db.test, and serve-node.test intentionally surfaces a stream error after response start.

## CI status
- pass: not yet available locally.
- code-related failures: none found in targeted checks.
- external/env/auth blockers: Bun/better-sqlite3 full server test limitation above; Daytona model backend auth missing for real LLM stream.

## Manual verification
1. Local Electron/CDP fallback at http://127.0.0.1:9823 verified hidden-window streaming flush.
2. Daytona browser/CDP verified workspace creation, connected route state, session switching, and retained off-screen session stream event rendering.
3. Local testing identified and fixed Settings return abort caused by redundant workspace activation.
4. Unit coverage verifies retained session deltas after session switch and retained workspace sync after session route unmount.
5. Eval coverage now documents repeatable browser-tool checks for both interruption cases with explicit 500-line final markers.

## Evidence
- Local browser-tools screenshot: /var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779116257911.png
- Daytona browser-tools screenshot: /var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779121647528.png
- Local Settings-route marker screenshot: /var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779123199366.png

## Risk
- Low-to-medium: stream reconnect timing and retained-session cleanup affect live update behavior. Retained sessions/workspace streams are bounded by TTL and released shortly after idle.

## Rollback
- Revert b625f91a9, 3afcadbbd, 4d626ae5, 566070da, fb597beb, and ee47b000 to restore previous stream sync, watcher, activation, health-check, and eval documentation behavior.