### PR TITLE
fix(app): respect themed startup backgrounds

### DIFF
--- a/apps/app/src/app/theme.ts
+++ b/apps/app/src/app/theme.ts
@@ -1,18 +1,36 @@
 export type ThemeMode = "light" | "dark" | "system";
+export type ResolvedThemeMode = "light" | "dark";
 
-const THEME_PREF_KEY = "openwork.themePref";
+const THEME_PREF_KEY = "openwork.react.settings.theme-mode";
+const LEGACY_THEME_PREF_KEYS = ["openwork.themePref"];
 
 const mediaQuery = "(prefers-color-scheme: dark)";
+const listeners = new Set<() => void>();
+let currentMode: ThemeMode | null = null;
+let systemThemeCleanup: (() => void) | null = null;
 
 const getMediaQueryList = () =>
-  typeof window === "undefined" ? null : window.matchMedia(mediaQuery);
+  typeof window === "undefined" || typeof window.matchMedia !== "function"
+    ? null
+    : window.matchMedia(mediaQuery);
+
+const isThemeMode = (value: string | null): value is ThemeMode =>
+  value === "light" || value === "dark" || value === "system";
 
 const readStoredMode = (): ThemeMode => {
   if (typeof window === "undefined") return "system";
   try {
     const stored = window.localStorage.getItem(THEME_PREF_KEY);
-    if (stored === "light" || stored === "dark" || stored === "system") {
+    if (isThemeMode(stored)) {
       return stored;
+    }
+
+    for (const key of LEGACY_THEME_PREF_KEYS) {
+      const legacyStored = window.localStorage.getItem(key);
+      if (isThemeMode(legacyStored)) {
+        window.localStorage.setItem(THEME_PREF_KEY, legacyStored);
+        return legacyStored;
+      }
     }
   } catch {
     // ignore
@@ -20,7 +38,7 @@ const readStoredMode = (): ThemeMode => {
   return "system";
 };
 
-const resolveMode = (mode: ThemeMode) => {
+const resolveMode = (mode: ThemeMode): ResolvedThemeMode => {
   if (mode !== "system") return mode;
   return getMediaQueryList()?.matches ? "dark" : "light";
 };
@@ -32,14 +50,53 @@ const applyTheme = (mode: ThemeMode) => {
   document.documentElement.style.colorScheme = resolved;
 };
 
-export const bootstrapTheme = () => {
-  const mode = readStoredMode();
-  applyTheme(mode);
+const emitThemeChange = () => {
+  for (const listener of listeners) {
+    listener();
+  }
 };
 
-export const getInitialThemeMode = () => readStoredMode();
+const syncNativeTheme = (mode: ThemeMode) => {
+  if (typeof window === "undefined") return;
+  void window.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setNativeTheme", mode);
+};
 
-export const persistThemeMode = (mode: ThemeMode) => {
+const getCurrentMode = () => {
+  if (currentMode === null) {
+    currentMode = readStoredMode();
+  }
+  return currentMode;
+};
+
+const handleSystemThemeChange = () => {
+  if (getCurrentMode() !== "system") return;
+  applyTheme("system");
+  syncNativeTheme("system");
+  emitThemeChange();
+};
+
+const ensureSystemThemeSubscription = () => {
+  if (systemThemeCleanup || typeof window === "undefined") return;
+
+  const list = getMediaQueryList();
+  if (!list) return;
+
+  list.addEventListener("change", handleSystemThemeChange);
+  systemThemeCleanup = () => list.removeEventListener("change", handleSystemThemeChange);
+};
+
+export const bootstrapTheme = () => {
+  const mode = getCurrentMode();
+  applyTheme(mode);
+  syncNativeTheme(mode);
+  ensureSystemThemeSubscription();
+};
+
+export const getInitialThemeMode = () => getCurrentMode();
+
+export const getResolvedThemeMode = () => resolveMode(getCurrentMode());
+
+const persistThemeMode = (mode: ThemeMode) => {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(THEME_PREF_KEY, mode);
@@ -48,15 +105,19 @@ export const persistThemeMode = (mode: ThemeMode) => {
   }
 };
 
-export const subscribeToSystemTheme = (onChange: (isDark: boolean) => void) => {
-  const list = getMediaQueryList();
-  if (!list) return () => undefined;
-
-  const handler = (event: MediaQueryListEvent) => onChange(event.matches);
-  list.addEventListener("change", handler);
-  return () => list.removeEventListener("change", handler);
+export const subscribeToTheme = (onChange: () => void) => {
+  ensureSystemThemeSubscription();
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+  };
 };
 
-export const applyThemeMode = (mode: ThemeMode) => {
+export const setThemeMode = (mode: ThemeMode) => {
+  currentMode = mode;
+  persistThemeMode(mode);
   applyTheme(mode);
+  syncNativeTheme(mode);
+  ensureSystemThemeSubscription();
+  emitThemeChange();
 };

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -1,5 +1,11 @@
 /** @jsxImportSource react */
-import { FolderOpen, MessageSquare, MousePointerClick, Users, Share2 } from "lucide-react";
+import {
+  FolderOpen,
+  MessageSquare,
+  MousePointerClick,
+  Users,
+  Share2,
+} from "lucide-react";
 import { PaperGrainGradient } from "@openwork/ui/react";
 
 import { t } from "../../../i18n";
@@ -26,12 +32,36 @@ function BrandIcon({ slug, size = 18 }: { slug: string; size?: number }) {
 /* ------------------------------------------------------------------ */
 
 const capabilities = [
-  { slug: "googlesheets", title: "Edit spreadsheets", desc: "Create, clean, and transform CSV and Excel files." },
-  { slug: "googlechrome", title: "Control your browser", desc: "Automate Chrome for repetitive web tasks." },
-  { slug: "apple", title: "Organize files", desc: "Read, write, and manage files and folders." },
-  { slug: "zapier", title: "Automate tasks", desc: "Build reusable workflows with skills and commands." },
-  { slug: "medium", title: "Generate content", desc: "Draft documents, emails, and reports." },
-  { slug: "stripe", title: "Connect to APIs", desc: "Plug into external services and tools via MCP." },
+  {
+    slug: "googlesheets",
+    title: "Edit spreadsheets",
+    desc: "Create, clean, and transform CSV and Excel files.",
+  },
+  {
+    slug: "googlechrome",
+    title: "Control your browser",
+    desc: "Automate Chrome for repetitive web tasks.",
+  },
+  {
+    slug: "apple",
+    title: "Organize files",
+    desc: "Read, write, and manage files and folders.",
+  },
+  {
+    slug: "zapier",
+    title: "Automate tasks",
+    desc: "Build reusable workflows with skills and commands.",
+  },
+  {
+    slug: "medium",
+    title: "Generate content",
+    desc: "Draft documents, emails, and reports.",
+  },
+  {
+    slug: "stripe",
+    title: "Connect to APIs",
+    desc: "Plug into external services and tools via MCP.",
+  },
 ];
 
 function ShowcasePanel() {
@@ -64,7 +94,11 @@ function ShowcasePanel() {
 
       <div className="grid grid-cols-2 gap-2">
         <div className="flex items-start gap-2.5 rounded-xl border border-dls-border bg-dls-surface p-3">
-          <Share2 size={16} className="mt-0.5 shrink-0 text-dls-secondary" strokeWidth={1.5} />
+          <Share2
+            size={16}
+            className="mt-0.5 shrink-0 text-dls-secondary"
+            strokeWidth={1.5}
+          />
           <div>
             <div className="text-[12px] font-medium text-dls-text">
               Share in one link
@@ -75,7 +109,11 @@ function ShowcasePanel() {
           </div>
         </div>
         <div className="flex items-start gap-2.5 rounded-xl border border-dls-border bg-dls-surface p-3">
-          <Users size={16} className="mt-0.5 shrink-0 text-dls-secondary" strokeWidth={1.5} />
+          <Users
+            size={16}
+            className="mt-0.5 shrink-0 text-dls-secondary"
+            strokeWidth={1.5}
+          />
           <div>
             <div className="text-[12px] font-medium text-dls-text">
               Provision your team
@@ -125,7 +163,7 @@ type WelcomePageProps = {
 
 export function WelcomePage({ onGetStarted }: WelcomePageProps) {
   return (
-    <div className="relative min-h-screen bg-[#fafbfc] text-dls-text">
+    <div className="relative min-h-screen bg-gray-3 text-dls-text">
       {/* Subtle background texture */}
       <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
         <div className="absolute -left-[20%] -top-[30%] h-[70%] w-[60%] rounded-full bg-[radial-gradient(ellipse,rgba(14,51,217,0.06),transparent_70%)] blur-3xl" />
@@ -145,18 +183,13 @@ export function WelcomePage({ onGetStarted }: WelcomePageProps) {
               <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
                 {t("welcome.title")}
               </h1>
-              <p className="text-sm text-slate-500">
-                {t("welcome.subtitle")}
-              </p>
+              <p className="text-sm text-slate-500">{t("welcome.subtitle")}</p>
             </div>
 
             {/* Steps */}
             <div className="space-y-4">
               {steps.map((step) => (
-                <div
-                  key={step.number}
-                  className="flex items-start gap-4"
-                >
+                <div key={step.number} className="flex items-start gap-4">
                   <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#011627] text-[13px] font-semibold text-white">
                     {step.number}
                   </div>
@@ -201,12 +234,16 @@ export function WelcomePage({ onGetStarted }: WelcomePageProps) {
                 frame={37706.748}
                 colors={["#0E33D9", "#FF7E2E", "#FFE340", "#000000"]}
                 colorBack="#00000000"
-                style={{ backgroundColor: "#FFFFFF", width: "100%", height: "100%" }}
+                style={{
+                  backgroundColor: "#FFFFFF",
+                  width: "100%",
+                  height: "100%",
+                }}
               />
             </div>
 
             {/* Inner white card */}
-            <div className="relative z-10 m-3 rounded-2xl bg-white p-7">
+            <div className="relative z-10 m-3 rounded-2xl bg-gray-2 p-7">
               <ShowcasePanel />
             </div>
           </div>

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -14,6 +14,11 @@ import {
 } from "../../app/lib/openwork-server";
 import { resolveWorkspaceEndpoint } from "../../app/lib/workspace-endpoint";
 import { buildOpenworkEnvRuntimeKey } from "../../app/lib/openwork-env-runtime";
+import {
+  getInitialThemeMode,
+  setThemeMode as setAppThemeMode,
+  type ThemeMode,
+} from "../../app/theme";
 import type {
   Client,
   ProviderListItem,
@@ -255,9 +260,6 @@ function folderNameFromPath(path: string) {
   return parts[parts.length - 1] ?? "workspace";
 }
 
-type PersistedThemeMode = "light" | "dark" | "system";
-
-const SETTINGS_THEME_KEY = "openwork.react.settings.theme-mode";
 const SETTINGS_HIDE_TITLEBAR_KEY = "openwork.react.settings.hide-titlebar";
 const SETTINGS_UPDATE_AUTO_CHECK_KEY = "openwork.react.settings.update-auto-check";
 const SETTINGS_UPDATE_AUTO_DOWNLOAD_KEY = "openwork.react.settings.update-auto-download";
@@ -385,23 +387,6 @@ function settingsPathForRoute(route: ReturnType<typeof parseSettingsPath>) {
   return route.tab;
 }
 
-function readStoredThemeMode(): PersistedThemeMode {
-  if (typeof window === "undefined") return "system";
-  try {
-    const raw = window.localStorage.getItem(SETTINGS_THEME_KEY);
-    return raw === "light" || raw === "dark" || raw === "system" ? raw : "system";
-  } catch {
-    return "system";
-  }
-}
-
-function applyThemeMode(mode: PersistedThemeMode) {
-  if (typeof document === "undefined" || typeof window === "undefined") return;
-  const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
-  const resolved = mode === "system" ? (prefersDark ? "dark" : "light") : mode;
-  document.documentElement.dataset.theme = resolved;
-}
-
 function SettingsRouteContent() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -446,7 +431,7 @@ function SettingsRouteContent() {
     if (typeof window === "undefined") return false;
     return window.localStorage.getItem("openwork.developerMode") === "1";
   });
-  const [themeMode, setThemeMode] = useState<PersistedThemeMode>(readStoredThemeMode);
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(getInitialThemeMode);
   const [hideTitlebar, setHideTitlebar] = useState(() => readStoredBoolean(SETTINGS_HIDE_TITLEBAR_KEY, false));
   const [updateAutoCheck, setUpdateAutoCheck] = useState(() =>
     readStoredBoolean(SETTINGS_UPDATE_AUTO_CHECK_KEY, true),
@@ -899,11 +884,7 @@ function SettingsRouteContent() {
   }, [route.tab]);
 
   useEffect(() => {
-    applyThemeMode(themeMode);
-    void window.__OPENWORK_ELECTRON__?.invokeDesktop?.("__setNativeTheme", themeMode);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(SETTINGS_THEME_KEY, themeMode);
-    }
+    setAppThemeMode(themeMode);
   }, [themeMode]);
 
   useEffect(() => {
@@ -1846,7 +1827,7 @@ function SettingsRouteContent() {
           <AppearanceView
             busy={busy}
             themeMode={themeMode}
-            setThemeMode={setThemeMode}
+            setThemeMode={setThemeModeState}
             language={currentLocale() as Language}
             setLanguage={setLocale}
             hideTitlebar={hideTitlebar}


### PR DESCRIPTION
## Summary
- Use theme background tokens on the onboarding welcome page so startup respects themed surfaces.
- Centralize renderer theme reads/writes in app/theme.ts instead of settings keeping a separate localStorage + matchMedia path.
- Subscribe to system color-scheme changes once at startup so system light/dark changes update the whole app immediately.

## Tests
- pnpm --filter @openwork/app typecheck
- git diff --check

## Visual evidence
- Not captured in this session; verification was limited to typecheck/whitespace for this styling and theme-state change.