### PR TITLE
fix: reuse Stripe customers for checkout

### DIFF
--- a/ee/apps/den-api/src/routes/org/inference.ts
+++ b/ee/apps/den-api/src/routes/org/inference.ts
@@ -2,9 +2,7 @@ import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { getInferenceStatus, setInferenceEnabled } from "../../inference.js"
-import { createInferenceCheckoutSession, organizationHasActiveInferenceSubscription } from "../../stripe-billing.js"
-import { getRequiredUserEmail } from "../../user.js"
-import { env } from "../../env.js"
+import { organizationHasActiveInferenceSubscription } from "../../stripe-billing.js"
 import { jsonValidator, requireUserMiddleware, resolveOrganizationContextMiddleware } from "../../middleware/index.js"
 import { forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import type { OrgRouteVariables } from "./shared.js"
@@ -96,26 +94,11 @@ export function registerOrgInferenceRoutes<T extends { Variables: OrgRouteVariab
       if (input.enabled) {
         const subscribed = await organizationHasActiveInferenceSubscription(payload.organization.id)
         if (!subscribed) {
-          const user = c.get("user")
-          const email = getRequiredUserEmail(user)
-          if (!email) {
-            return c.json({ error: "user_email_required" }, 400)
-          }
-          const origin = new URL(c.req.raw.url).origin
-          const session = await createInferenceCheckoutSession({
-            organizationId: payload.organization.id,
-            orgMemberId: payload.currentMember.id,
-            email,
-            name: user.name ?? email,
-            successUrl: env.stripe.billingSuccessUrl ?? `${origin}/dashboard/billing/stripe/checking?session_id={CHECKOUT_SESSION_ID}`,
-            cancelUrl: env.stripe.billingCancelUrl ?? `${origin}/dashboard/billing`,
-          })
           return c.json({
             inference: {
               ...await getInferenceStatus(payload.organization.id),
               subscribed: false,
             },
-            checkoutUrl: session.url,
           })
         }
       }

--- a/ee/apps/den-api/src/stripe-billing.ts
+++ b/ee/apps/den-api/src/stripe-billing.ts
@@ -111,6 +111,32 @@ async function findInferenceSubscriptionByStripeId(stripeSubscriptionId: string)
     .then((rows) => rows[0] ?? null)
 }
 
+async function findStripeCustomerIdByOrg(organizationId: string) {
+  return db
+    .select({ stripeCustomerId: OrgSubscriptionTable.stripe_customer_id })
+    .from(OrgSubscriptionTable)
+    .where(eq(OrgSubscriptionTable.organization_id, organizationId as OrgId))
+    .limit(1)
+    .then((rows) => rows[0]?.stripeCustomerId ?? null)
+}
+
+function stripeSearchLiteral(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")
+}
+
+async function findStripeCustomerIdByOrgMetadata(organizationId: string) {
+  try {
+    const customers = await stripe().customers.search({
+      query: `metadata['org_id']:'${stripeSearchLiteral(organizationId)}'`,
+      limit: 1,
+    })
+    return customers.data[0]?.id ?? null
+  } catch (error) {
+    console.warn("[stripe-billing] failed to search customers by org metadata", error)
+    return null
+  }
+}
+
 export async function organizationHasActiveInferenceSubscription(organizationId: OrgId) {
   const row = await findInferenceSubscriptionByOrg(organizationId)
   return Boolean(row && ACTIVE_STATUSES.has(row.status))
@@ -173,20 +199,45 @@ export async function upsertInferenceSubscriptionFromStripe(subscription: Stripe
   return findInferenceSubscriptionByStripeId(subscription.id)
 }
 
-async function ensureStripeCustomer(input: { organizationId: OrgId; orgMemberId: MemberId; email: string; name: string }) {
-  const existing = await findInferenceSubscriptionByOrg(input.organizationId)
-  if (existing?.stripe_customer_id) {
-    return existing.stripe_customer_id
+export async function findOrCreateStripeCustomer(input: {
+  email: string
+  name: string
+  organizationId?: string | null
+  metadata?: Stripe.MetadataParam
+  existingCustomerId?: string | null
+}) {
+  const existingCustomerId = input.existingCustomerId?.trim()
+  if (existingCustomerId) {
+    return existingCustomerId
+  }
+
+  const organizationId = input.organizationId?.trim()
+  if (organizationId) {
+    const dbCustomerId = await findStripeCustomerIdByOrg(organizationId)
+    if (dbCustomerId) {
+      return dbCustomerId
+    }
+
+    const stripeCustomerId = await findStripeCustomerIdByOrgMetadata(organizationId)
+    if (stripeCustomerId) {
+      return stripeCustomerId
+    }
+  }
+
+  const email = input.email.trim()
+  if (!email) {
+    throw new Error("stripe_customer_email_missing")
+  }
+
+  const existing = await stripe().customers.list({ email, limit: 1 })
+  if (existing.data[0]) {
+    return existing.data[0].id
   }
 
   const customer = await stripe().customers.create({
-    email: input.email,
+    email,
     name: input.name,
-    metadata: {
-      org_id: input.organizationId,
-      created_by_org_member_id: input.orgMemberId,
-      openwork_product: "openwork_models",
-    },
+    metadata: input.metadata,
   })
   return customer.id
 }
@@ -201,7 +252,16 @@ export async function createInferenceCheckoutSession(input: {
 }) {
   const priceId = requireInferencePriceId()
   const quantity = Math.max(1, await activeMemberCount(input.organizationId))
-  const customer = await ensureStripeCustomer(input)
+  const customer = await findOrCreateStripeCustomer({
+    organizationId: input.organizationId,
+    email: input.email,
+    name: input.name,
+    metadata: {
+      org_id: input.organizationId,
+      created_by_org_member_id: input.orgMemberId,
+      openwork_product: "openwork_models",
+    },
+  })
   return stripe().checkout.sessions.create({
     mode: "subscription",
     customer,

--- a/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/o/[orgSlug]/dashboard/_components/inference-screen.tsx
@@ -185,7 +185,7 @@ export function InferenceScreen() {
 
   async function toggleEnabled() {
     if (!status) return;
-    if (status.enabled) {
+    if (status.enabled || !status.subscribed) {
       router.push(getBillingRoute(activeOrg?.slug));
       return;
     }
@@ -222,6 +222,7 @@ export function InferenceScreen() {
 
   const enabled = status?.enabled === true;
   const cardTitle = enabled ? "OpenWork Models enabled" : "Enable OpenWork Models";
+  const actionLabel = enabled ? "Manage subscription" : status?.subscribed === false ? "Subscribe" : "Enable";
 
   return (
     <DashboardPageTemplate
@@ -249,7 +250,7 @@ export function InferenceScreen() {
               </h2>
             </div>
             <DenButton type="button" onClick={toggleEnabled} loading={saving || loading} variant={enabled ? "secondary" : "primary"}>
-              {enabled ? "Manage subscription" : "Enable"}
+              {actionLabel}
             </DenButton>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Stop `PATCH /v1/inference` from creating Stripe checkout sessions or Stripe customers.
- Route unsubscribed OpenWork Models users to Billing for subscription checkout.
- Add reusable `findOrCreateStripeCustomer()` that checks explicit ids, org subscription rows, Stripe `org_id` metadata, and email before creating a customer.

## Verification
- `pnpm --filter @openwork-ee/den-api build` passed
- `pnpm --filter @openwork-ee/den-web build` passed

## E2E Evidence
- No video or screenshot captured because this change requires live Stripe billing state to verify end-to-end safely.
- Reviewer can reproduce by starting OpenWork Models checkout from Billing and confirming it reuses an existing org/email Stripe customer before creating a new one.