### PR TITLE
feat(app): open artifacts in session pane

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -22,6 +22,7 @@
     "test:todos": "node scripts/todos.mjs",
     "test:permissions": "node scripts/permissions.mjs",
     "test:remote-diagnostics": "bun test scripts/remote-workspace-diagnostics.test.ts",
+    "test:open-target": "bun test scripts/open-target.test.ts",
     "test:dev-log": "bun scripts/dev-log.ts",
     "test:session-error-recovery": "bun scripts/session-error-recovery.ts",
     "test:session-scope": "bun scripts/session-scope.ts",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -23,6 +23,7 @@
     "test:permissions": "node scripts/permissions.mjs",
     "test:remote-diagnostics": "bun test scripts/remote-workspace-diagnostics.test.ts",
     "test:open-target": "bun test scripts/open-target.test.ts",
+    "test:artifact-spreadsheet": "bun test scripts/artifact-spreadsheet.test.ts",
     "test:dev-log": "bun scripts/dev-log.ts",
     "test:session-error-recovery": "bun scripts/session-error-recovery.ts",
     "test:session-scope": "bun scripts/session-scope.ts",
@@ -74,6 +75,7 @@
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "xlsx": "^0.18.5",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/apps/app/scripts/artifact-spreadsheet.test.ts
+++ b/apps/app/scripts/artifact-spreadsheet.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  parseSpreadsheet,
+  serializeSpreadsheet,
+} from "../src/react-app/domains/session/artifacts/artifact-spreadsheet-model";
+
+describe("artifact spreadsheet model", () => {
+  it("round-trips CSV edits", async () => {
+    const rows = await parseSpreadsheet({ name: "artifact-eval.csv", text: "name,revenue\nAda,10\n" });
+    rows[1]![1] = "11";
+    const output = await serializeSpreadsheet("artifact-eval.csv", rows);
+    expect(output).toEqual({ kind: "text", content: "name,revenue\nAda,11\n" });
+  });
+
+  it("round-trips XLSX edits", async () => {
+    const output = await serializeSpreadsheet("artifact-eval.xlsx", [["name", "revenue"], ["Ada", "10"]]);
+    expect(output.kind).toBe("binary");
+    if (output.kind !== "binary") throw new Error("expected binary");
+    const parsed = await parseSpreadsheet({ name: "artifact-eval.xlsx", data: output.data });
+    expect(parsed.slice(0, 2)).toEqual([["name", "revenue"], ["Ada", "10"]]);
+  });
+});

--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -17,6 +17,7 @@ describe("open target classification", () => {
     expect(classifyOpenTarget("customers.csv", "file")).toBe("sheet");
     expect(classifyOpenTarget("forecast.xlsx", "file")).toBe("sheet");
     expect(classifyOpenTarget("diagram.svg", "file")).toBe("image");
+    expect(classifyOpenTarget("dist/index.html", "file")).toBe("html");
     expect(classifyOpenTarget("http://localhost:5173", "url")).toBe("browser");
   });
 });
@@ -30,6 +31,24 @@ describe("deriveOpenTargets", () => {
     expect(targets.map((target) => target.value)).toContain("reports/revenue.xlsx");
     expect(targets.map((target) => target.value)).toContain("http://localhost:5173");
     expect(targets.find((target) => target.value === "reports/revenue.xlsx")?.preview).toBe("sheet");
+  });
+
+  it("extracts websocket URLs so local socket/dev-server hints stay visible", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Socket open at ws://localhost:5173/socket and preview at dist/index.html"),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("ws://localhost:5173/socket");
+    expect(targets.map((target) => target.value)).toContain("dist/index.html");
+  });
+
+  it("normalizes Workspace/<id>/ prefixes from artifact paths", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "See Workspace/32423/reports/artifact-eval.md and Workspace/32423/reports/artifact-eval.csv"),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("reports/artifact-eval.md");
+    expect(targets.map((target) => target.value)).toContain("reports/artifact-eval.csv");
   });
 
   it("prefers explicit dynamic tool metadata over prose guesses", () => {
@@ -58,7 +77,8 @@ describe("deriveOpenTargets", () => {
     const csv = targets.find((target) => target.value === "data/customers.csv");
     const externalUrl = targets.find((target) => target.value === "https://example.com");
 
-    expect(csv && shouldAutoOpenTarget(csv)).toBe(true);
+    expect(csv && shouldAutoOpenTarget({ ...csv, exists: true })).toBe(true);
+    expect(csv && shouldAutoOpenTarget({ ...csv, exists: false })).toBe(false);
     expect(externalUrl && shouldAutoOpenTarget(externalUrl)).toBe(false);
   });
 });

--- a/apps/app/scripts/open-target.test.ts
+++ b/apps/app/scripts/open-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import type { UIMessage } from "ai";
+
+import {
+  classifyOpenTarget,
+  deriveOpenTargets,
+  shouldAutoOpenTarget,
+} from "../src/react-app/domains/session/artifacts/open-target";
+
+function message(id: string, role: "user" | "assistant", text: string): UIMessage {
+  return { id, role, parts: [{ type: "text", text, state: "done" }] };
+}
+
+describe("open target classification", () => {
+  it("routes common artifact formats to deterministic previews", () => {
+    expect(classifyOpenTarget("report.md", "file")).toBe("markdown");
+    expect(classifyOpenTarget("customers.csv", "file")).toBe("sheet");
+    expect(classifyOpenTarget("forecast.xlsx", "file")).toBe("sheet");
+    expect(classifyOpenTarget("diagram.svg", "file")).toBe("image");
+    expect(classifyOpenTarget("http://localhost:5173", "url")).toBe("browser");
+  });
+});
+
+describe("deriveOpenTargets", () => {
+  it("extracts file and localhost URL targets from recent assistant output", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Created reports/revenue.xlsx and started http://localhost:5173 for preview."),
+    ]);
+
+    expect(targets.map((target) => target.value)).toContain("reports/revenue.xlsx");
+    expect(targets.map((target) => target.value)).toContain("http://localhost:5173");
+    expect(targets.find((target) => target.value === "reports/revenue.xlsx")?.preview).toBe("sheet");
+  });
+
+  it("prefers explicit dynamic tool metadata over prose guesses", () => {
+    const targets = deriveOpenTargets([
+      {
+        id: "msg_tool",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolName: "write",
+          toolCallId: "tool_1",
+          state: "output-available",
+          input: { path: "summary.md" },
+          output: { path: "summary.md" },
+        } as any],
+      },
+    ]);
+
+    expect(targets[0]).toMatchObject({ value: "summary.md", preview: "markdown", confidence: 95 });
+  });
+
+  it("auto-opens high-confidence deliverables and localhost previews only", () => {
+    const targets = deriveOpenTargets([
+      message("msg_1", "assistant", "Created data/customers.csv and see https://example.com for docs."),
+    ]);
+    const csv = targets.find((target) => target.value === "data/customers.csv");
+    const externalUrl = targets.find((target) => target.value === "https://example.com");
+
+    expect(csv && shouldAutoOpenTarget(csv)).toBe(true);
+    expect(externalUrl && shouldAutoOpenTarget(externalUrl)).toBe(false);
+  });
+});

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -175,6 +175,16 @@ export type OpenworkWorkspaceFileWriteResult = {
   revision?: string;
 };
 
+function arrayBufferToBase64(data: ArrayBuffer): string {
+  const bytes = new Uint8Array(data);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
 export type OpenworkCommandItem = {
   name: string;
   description?: string;
@@ -249,6 +259,20 @@ export type OpenworkArtifactItem = {
 
 export type OpenworkArtifactList = {
   items: OpenworkArtifactItem[];
+};
+
+export type OpenworkResolvedArtifactTarget = {
+  id: string;
+  kind: "file" | "url";
+  value: string;
+  name: string;
+  preview: "browser" | "markdown" | "sheet" | "image" | "pdf" | "html" | "text" | "external";
+  confidence: number;
+  reason: string;
+  exists?: boolean;
+  size?: number;
+  updatedAt?: number;
+  contentType?: string;
 };
 
 export type OpenworkWorkspaceFileStat = {
@@ -1275,6 +1299,26 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         },
       ),
 
+    writeWorkspaceBinaryFile: (
+      workspaceId: string,
+      payload: { path: string; data: ArrayBuffer; baseUpdatedAt?: number | null; force?: boolean },
+    ) =>
+      requestJson<OpenworkWorkspaceFileWriteResult>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/raw`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: {
+            path: payload.path,
+            dataBase64: arrayBufferToBase64(payload.data),
+            baseUpdatedAt: payload.baseUpdatedAt,
+            force: payload.force,
+          },
+        },
+      ),
+
     downloadWorkspaceFile: (workspaceId: string, path: string) =>
       requestBinary(
         baseUrl,
@@ -1287,6 +1331,23 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         token,
         hostToken,
       }),
+
+    resolveArtifacts: (
+      workspaceId: string,
+      targets: Array<{
+        kind: "file" | "url";
+        value: string;
+        name?: string;
+        preview?: string;
+        confidence?: number;
+        reason?: string;
+      }>,
+    ) =>
+      requestJson<{ items: OpenworkResolvedArtifactTarget[] }>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/artifacts/resolve`,
+        { token, hostToken, method: "POST", body: { targets } },
+      ),
 
     downloadArtifact: (workspaceId: string, artifactId: string) =>
       requestBinary(

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -251,6 +251,15 @@ export type OpenworkArtifactList = {
   items: OpenworkArtifactItem[];
 };
 
+export type OpenworkWorkspaceFileStat = {
+  ok: boolean;
+  path: string;
+  exists: boolean;
+  kind?: "file" | "dir" | "other";
+  size?: number;
+  updatedAt?: number;
+};
+
 export type OpenworkInboxItem = {
   id: string;
   name?: string;
@@ -1244,6 +1253,13 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         { token, hostToken },
       ),
 
+    statWorkspaceFile: (workspaceId: string, path: string) =>
+      requestJson<OpenworkWorkspaceFileStat>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/stat?path=${encodeURIComponent(path)}`,
+        { token, hostToken },
+      ),
+
     writeWorkspaceFile: (
       workspaceId: string,
       payload: { path: string; content: string; baseUpdatedAt?: number | null; force?: boolean },
@@ -1257,6 +1273,13 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
           method: "POST",
           body: payload,
         },
+      ),
+
+    downloadWorkspaceFile: (workspaceId: string, path: string) =>
+      requestBinary(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/files/raw?path=${encodeURIComponent(path)}`,
+        { token, hostToken, timeoutMs: timeouts.binary },
       ),
 
     listArtifacts: (workspaceId: string) =>

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,25 +1,33 @@
 /** @jsxImportSource react */
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { ExternalLink, FileText, Loader2, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
 import { openDesktopPath } from "../../../../app/lib/desktop";
 import { Button } from "@/components/ui/button";
 import { MarkdownBlock } from "../surface/markdown";
+import { cn } from "@/lib/utils";
 import type { OpenTarget } from "./open-target";
+
+const ArtifactTextEditor = lazy(() =>
+  import("./artifact-text-editor").then((module) => ({ default: module.ArtifactTextEditor })),
+);
 
 type ArtifactPanelProps = {
   client: OpenworkServerClient;
   workspaceId: string;
   workspaceRoot: string;
+  isRemoteWorkspace?: boolean;
   target: OpenTarget;
+  targets?: OpenTarget[];
+  onSelectTarget?: (target: OpenTarget) => void;
   onClose: () => void;
 };
 
 type LoadState =
   | { status: "loading" }
   | { status: "error"; message: string }
-  | { status: "text"; content: string }
+  | { status: "text"; content: string; updatedAt: number | null }
   | { status: "binary"; url: string; contentType: string | null };
 
 function absoluteWorkspacePath(root: string, path: string) {
@@ -34,13 +42,6 @@ function parseDelimited(content: string, delimiter: string) {
     .filter((line) => line.trim().length > 0)
     .slice(0, 200)
     .map((line) => line.split(delimiter).map((cell) => cell.replace(/^"|"$/g, "")));
-}
-
-function encodeArtifactId(path: string) {
-  const bytes = new TextEncoder().encode(path);
-  let binary = "";
-  bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 function SheetPreview(props: { target: OpenTarget; content?: string }) {
@@ -82,15 +83,23 @@ function SheetPreview(props: { target: OpenTarget; content?: string }) {
   );
 }
 
-export function ArtifactPanel({ client, workspaceId, workspaceRoot, target, onClose }: ArtifactPanelProps) {
+export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWorkspace = false, target, targets = [], onSelectTarget, onClose }: ArtifactPanelProps) {
   const [state, setState] = useState<LoadState>({ status: "loading" });
-  const canReadAsText = ["markdown", "text", "sheet"].includes(target.preview) && !/\.(xlsx|xls|ods)$/i.test(target.value);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const canReadAsText = ["markdown", "text", "sheet", "html"].includes(target.preview) && !/\.(xlsx|xls|ods)$/i.test(target.value);
+  const canEditText = target.kind === "file" && canReadAsText;
   const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
 
   useEffect(() => {
     let cancelled = false;
     let objectUrl: string | null = null;
     setState({ status: "loading" });
+    setEditing(false);
+    setDraft("");
+    setSaveMessage(null);
 
     async function load() {
       try {
@@ -98,12 +107,19 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, target, onCl
           setState({ status: "error", message: "URLs open in browser tabs." });
           return;
         }
-        if (canReadAsText) {
-          const result = await client.readWorkspaceFile(workspaceId, target.value);
-          if (!cancelled) setState({ status: "text", content: result.content });
+        if (target.exists === false) {
+          setState({ status: "error", message: "File not found in this workspace." });
           return;
         }
-        const result = await client.downloadArtifact(workspaceId, encodeArtifactId(target.value));
+        if (canReadAsText) {
+          const result = await client.readWorkspaceFile(workspaceId, target.value);
+          if (!cancelled) {
+            setState({ status: "text", content: result.content, updatedAt: result.updatedAt ?? null });
+            setDraft(result.content);
+          }
+          return;
+        }
+        const result = await client.downloadWorkspaceFile(workspaceId, target.value);
         objectUrl = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
         if (!cancelled) setState({ status: "binary", url: objectUrl, contentType: result.contentType });
       } catch (error) {
@@ -118,9 +134,39 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, target, onCl
     };
   }, [canReadAsText, client, target, workspaceId]);
 
-  const openExternal = () => {
+  const openExternal = async () => {
     if (target.kind === "url") window.open(target.value, "_blank", "noopener,noreferrer");
-    else void openDesktopPath(externalPath);
+    else if (isRemoteWorkspace) {
+      const result = await client.downloadWorkspaceFile(workspaceId, target.value);
+      const url = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = target.name;
+      anchor.click();
+      window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } else {
+      void openDesktopPath(externalPath);
+    }
+  };
+
+  const save = async () => {
+    if (!canEditText || state.status !== "text") return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      const result = await client.writeWorkspaceFile(workspaceId, {
+        path: target.value,
+        content: draft,
+        baseUpdatedAt: state.updatedAt,
+      });
+      setState({ status: "text", content: draft, updatedAt: result.updatedAt ?? null });
+      setEditing(false);
+      setSaveMessage("Saved");
+    } catch (error) {
+      setSaveMessage(error instanceof Error ? error.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -128,24 +174,64 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, target, onCl
       <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-2">
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-medium text-foreground">{target.name}</div>
-          <div className="truncate text-[11px] text-muted-foreground">{target.value}</div>
+          <div className="truncate text-[11px] text-muted-foreground">
+            {target.value}{target.exists === false ? " · missing" : target.size ? ` · ${target.size} bytes` : ""}
+          </div>
         </div>
-        <Button variant="ghost" size="icon-sm" onClick={openExternal} aria-label="Open externally" title="Open externally">
+        {canEditText && state.status === "text" ? (
+          editing ? (
+            <>
+              <Button variant="ghost" size="sm" onClick={() => { setDraft(state.content); setEditing(false); }} disabled={saving}>Discard</Button>
+              <Button variant="default" size="sm" onClick={() => void save()} disabled={saving || draft === state.content}>{saving ? "Saving" : "Save"}</Button>
+            </>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={() => setEditing(true)}>Edit</Button>
+          )
+        ) : null}
+        <Button variant="ghost" size="icon-sm" onClick={() => void openExternal()} aria-label={isRemoteWorkspace ? "Download artifact" : "Open externally"} title={isRemoteWorkspace ? "Download artifact" : "Open externally"}>
           <ExternalLink />
         </Button>
         <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close artifact" title="Close artifact">
           <X />
         </Button>
       </div>
+      {targets.length > 0 ? (
+        <div className="no-scrollbar flex shrink-0 gap-1 overflow-x-auto border-b border-border px-2 py-1.5">
+          {targets.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={cn(
+                "max-w-44 shrink-0 truncate rounded-md border px-2 py-1 text-left text-[11px] transition-colors",
+                item.id === target.id
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+                item.exists === false && "opacity-60",
+              )}
+              title={`${item.value}${item.exists === false ? " (missing)" : ""}`}
+              onClick={() => onSelectTarget?.(item)}
+            >
+              {item.name}{item.exists === false ? " · missing" : ""}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {saveMessage ? <div className="shrink-0 border-b border-border px-3 py-1 text-[11px] text-muted-foreground">{saveMessage}</div> : null}
       <div className="min-h-0 flex-1 overflow-hidden">
         {state.status === "loading" ? (
           <div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>
         ) : state.status === "error" ? (
           <div className="p-4 text-sm text-muted-foreground">{state.message}</div>
+        ) : editing && state.status === "text" ? (
+          <Suspense fallback={<div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>}>
+            <ArtifactTextEditor value={draft} language={target.preview === "markdown" ? "markdown" : "text"} onChange={setDraft} />
+          </Suspense>
         ) : target.preview === "markdown" && state.status === "text" ? (
           <div className="h-full overflow-auto p-4"><MarkdownBlock text={state.content} /></div>
         ) : target.preview === "sheet" ? (
           <SheetPreview target={target} content={state.status === "text" ? state.content : undefined} />
+        ) : target.preview === "html" && state.status === "text" ? (
+          <iframe srcDoc={state.content} title={target.name} className="h-full w-full border-0" sandbox="allow-scripts allow-same-origin" />
         ) : target.preview === "image" && state.status === "binary" ? (
           <div className="flex h-full items-center justify-center overflow-auto bg-muted/30 p-3"><img src={state.url} alt={target.name} className="max-h-full max-w-full object-contain" /></div>
         ) : state.status === "binary" && (target.preview === "pdf" || target.preview === "html") ? (

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,0 +1,161 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, FileText, Loader2, X } from "lucide-react";
+
+import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
+import { openDesktopPath } from "../../../../app/lib/desktop";
+import { Button } from "@/components/ui/button";
+import { MarkdownBlock } from "../surface/markdown";
+import type { OpenTarget } from "./open-target";
+
+type ArtifactPanelProps = {
+  client: OpenworkServerClient;
+  workspaceId: string;
+  workspaceRoot: string;
+  target: OpenTarget;
+  onClose: () => void;
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "text"; content: string }
+  | { status: "binary"; url: string; contentType: string | null };
+
+function absoluteWorkspacePath(root: string, path: string) {
+  const cleanRoot = root.trim().replace(/[/\\]+$/, "");
+  const cleanPath = path.trim().replace(/^\.\//, "");
+  return cleanRoot ? `${cleanRoot}/${cleanPath}` : cleanPath;
+}
+
+function parseDelimited(content: string, delimiter: string) {
+  return content
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .slice(0, 200)
+    .map((line) => line.split(delimiter).map((cell) => cell.replace(/^"|"$/g, "")));
+}
+
+function encodeArtifactId(path: string) {
+  const bytes = new TextEncoder().encode(path);
+  let binary = "";
+  bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function SheetPreview(props: { target: OpenTarget; content?: string }) {
+  const ext = props.target.name.toLowerCase().split(".").pop();
+  if (ext === "xlsx" || ext === "xls" || ext === "ods") {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-center">
+        <div className="max-w-sm rounded-2xl border border-border bg-card p-5 shadow-sm">
+          <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-xl bg-muted text-muted-foreground">
+            <FileText className="size-5" />
+          </div>
+          <div className="text-sm font-medium text-foreground">Spreadsheet preview needs a parser</div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            OpenWork detected this spreadsheet reliably. Full .xlsx rendering can be added with a lazy-loaded parser; for now open it externally.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const rows = parseDelimited(props.content ?? "", ext === "tsv" ? "\t" : ",");
+  if (!rows.length) return <div className="p-4 text-sm text-muted-foreground">No rows to preview.</div>;
+  return (
+    <div className="h-full overflow-auto p-3">
+      <table className="w-full border-collapse text-xs">
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {row.slice(0, 40).map((cell, cellIndex) => (
+                <td key={cellIndex} className="max-w-[220px] truncate border border-border px-2 py-1 align-top">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function ArtifactPanel({ client, workspaceId, workspaceRoot, target, onClose }: ArtifactPanelProps) {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const canReadAsText = ["markdown", "text", "sheet"].includes(target.preview) && !/\.(xlsx|xls|ods)$/i.test(target.value);
+  const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    setState({ status: "loading" });
+
+    async function load() {
+      try {
+        if (target.kind === "url") {
+          setState({ status: "error", message: "URLs open in browser tabs." });
+          return;
+        }
+        if (canReadAsText) {
+          const result = await client.readWorkspaceFile(workspaceId, target.value);
+          if (!cancelled) setState({ status: "text", content: result.content });
+          return;
+        }
+        const result = await client.downloadArtifact(workspaceId, encodeArtifactId(target.value));
+        objectUrl = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
+        if (!cancelled) setState({ status: "binary", url: objectUrl, contentType: result.contentType });
+      } catch (error) {
+        if (!cancelled) setState({ status: "error", message: error instanceof Error ? error.message : "Failed to load artifact" });
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [canReadAsText, client, target, workspaceId]);
+
+  const openExternal = () => {
+    if (target.kind === "url") window.open(target.value, "_blank", "noopener,noreferrer");
+    else void openDesktopPath(externalPath);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">{target.name}</div>
+          <div className="truncate text-[11px] text-muted-foreground">{target.value}</div>
+        </div>
+        <Button variant="ghost" size="icon-sm" onClick={openExternal} aria-label="Open externally" title="Open externally">
+          <ExternalLink />
+        </Button>
+        <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close artifact" title="Close artifact">
+          <X />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {state.status === "loading" ? (
+          <div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>
+        ) : state.status === "error" ? (
+          <div className="p-4 text-sm text-muted-foreground">{state.message}</div>
+        ) : target.preview === "markdown" && state.status === "text" ? (
+          <div className="h-full overflow-auto p-4"><MarkdownBlock text={state.content} /></div>
+        ) : target.preview === "sheet" ? (
+          <SheetPreview target={target} content={state.status === "text" ? state.content : undefined} />
+        ) : target.preview === "image" && state.status === "binary" ? (
+          <div className="flex h-full items-center justify-center overflow-auto bg-muted/30 p-3"><img src={state.url} alt={target.name} className="max-h-full max-w-full object-contain" /></div>
+        ) : state.status === "binary" && (target.preview === "pdf" || target.preview === "html") ? (
+          <iframe src={state.url} title={target.name} className="h-full w-full border-0" sandbox="allow-scripts allow-same-origin" />
+        ) : state.status === "text" ? (
+          <pre className="h-full overflow-auto p-4 text-xs leading-5 text-foreground whitespace-pre-wrap">{state.content}</pre>
+        ) : (
+          <div className="p-4 text-sm text-muted-foreground">Preview unavailable. Open externally to view this file.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { ExternalLink, FileText, Loader2, X } from "lucide-react";
+import { Download, ExternalLink, Loader2, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "../../../../app/lib/openwork-server";
 import { openDesktopPath } from "../../../../app/lib/desktop";
@@ -11,6 +11,9 @@ import type { OpenTarget } from "./open-target";
 
 const ArtifactTextEditor = lazy(() =>
   import("./artifact-text-editor").then((module) => ({ default: module.ArtifactTextEditor })),
+);
+const ArtifactSpreadsheetEditor = lazy(() =>
+  import("./artifact-spreadsheet-editor").then((module) => ({ default: module.ArtifactSpreadsheetEditor })),
 );
 
 type ArtifactPanelProps = {
@@ -28,59 +31,12 @@ type LoadState =
   | { status: "loading" }
   | { status: "error"; message: string }
   | { status: "text"; content: string; updatedAt: number | null }
-  | { status: "binary"; url: string; contentType: string | null };
+  | { status: "binary"; url: string; data: ArrayBuffer; contentType: string | null; updatedAt: number | null };
 
 function absoluteWorkspacePath(root: string, path: string) {
   const cleanRoot = root.trim().replace(/[/\\]+$/, "");
   const cleanPath = path.trim().replace(/^\.\//, "");
   return cleanRoot ? `${cleanRoot}/${cleanPath}` : cleanPath;
-}
-
-function parseDelimited(content: string, delimiter: string) {
-  return content
-    .split(/\r?\n/)
-    .filter((line) => line.trim().length > 0)
-    .slice(0, 200)
-    .map((line) => line.split(delimiter).map((cell) => cell.replace(/^"|"$/g, "")));
-}
-
-function SheetPreview(props: { target: OpenTarget; content?: string }) {
-  const ext = props.target.name.toLowerCase().split(".").pop();
-  if (ext === "xlsx" || ext === "xls" || ext === "ods") {
-    return (
-      <div className="flex h-full items-center justify-center p-6 text-center">
-        <div className="max-w-sm rounded-2xl border border-border bg-card p-5 shadow-sm">
-          <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-xl bg-muted text-muted-foreground">
-            <FileText className="size-5" />
-          </div>
-          <div className="text-sm font-medium text-foreground">Spreadsheet preview needs a parser</div>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            OpenWork detected this spreadsheet reliably. Full .xlsx rendering can be added with a lazy-loaded parser; for now open it externally.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  const rows = parseDelimited(props.content ?? "", ext === "tsv" ? "\t" : ",");
-  if (!rows.length) return <div className="p-4 text-sm text-muted-foreground">No rows to preview.</div>;
-  return (
-    <div className="h-full overflow-auto p-3">
-      <table className="w-full border-collapse text-xs">
-        <tbody>
-          {rows.map((row, rowIndex) => (
-            <tr key={rowIndex}>
-              {row.slice(0, 40).map((cell, cellIndex) => (
-                <td key={cellIndex} className="max-w-[220px] truncate border border-border px-2 py-1 align-top">
-                  {cell}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
 }
 
 export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWorkspace = false, target, targets = [], onSelectTarget, onClose }: ArtifactPanelProps) {
@@ -121,7 +77,7 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
         }
         const result = await client.downloadWorkspaceFile(workspaceId, target.value);
         objectUrl = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
-        if (!cancelled) setState({ status: "binary", url: objectUrl, contentType: result.contentType });
+        if (!cancelled) setState({ status: "binary", url: objectUrl, data: result.data, contentType: result.contentType, updatedAt: target.updatedAt ?? null });
       } catch (error) {
         if (!cancelled) setState({ status: "error", message: error instanceof Error ? error.message : "Failed to load artifact" });
       }
@@ -134,9 +90,8 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
     };
   }, [canReadAsText, client, target, workspaceId]);
 
-  const openExternal = async () => {
-    if (target.kind === "url") window.open(target.value, "_blank", "noopener,noreferrer");
-    else if (isRemoteWorkspace) {
+  const download = async () => {
+    if (target.kind === "url") return;
       const result = await client.downloadWorkspaceFile(workspaceId, target.value);
       const url = URL.createObjectURL(new Blob([result.data], { type: result.contentType ?? "application/octet-stream" }));
       const anchor = document.createElement("a");
@@ -144,8 +99,14 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
       anchor.download = target.name;
       anchor.click();
       window.setTimeout(() => URL.revokeObjectURL(url), 1000);
-    } else {
+  };
+
+  const openExternal = async () => {
+    if (target.kind === "url") window.open(target.value, "_blank", "noopener,noreferrer");
+    else if (!isRemoteWorkspace) {
       void openDesktopPath(externalPath);
+    } else {
+      await download();
     }
   };
 
@@ -169,6 +130,42 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
     }
   };
 
+  const saveTextContent = async (content: string) => {
+    if (target.kind !== "file") return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      const baseUpdatedAt = state.status === "text" ? state.updatedAt : target.updatedAt ?? null;
+      const result = await client.writeWorkspaceFile(workspaceId, { path: target.value, content, baseUpdatedAt });
+      setState({ status: "text", content, updatedAt: result.updatedAt ?? null });
+      setDraft(content);
+      setSaveMessage("Saved");
+    } catch (error) {
+      setSaveMessage(error instanceof Error ? error.message : "Save failed");
+      throw error;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveBinaryContent = async (data: ArrayBuffer) => {
+    if (target.kind !== "file") return;
+    setSaving(true);
+    setSaveMessage(null);
+    try {
+      const baseUpdatedAt = state.status === "binary" ? state.updatedAt : target.updatedAt ?? null;
+      const result = await client.writeWorkspaceBinaryFile(workspaceId, { path: target.value, data, baseUpdatedAt });
+      const url = URL.createObjectURL(new Blob([data], { type: state.status === "binary" ? state.contentType ?? "application/octet-stream" : "application/octet-stream" }));
+      setState({ status: "binary", url, data, contentType: state.status === "binary" ? state.contentType : null, updatedAt: result.updatedAt ?? null });
+      setSaveMessage("Saved");
+    } catch (error) {
+      setSaveMessage(error instanceof Error ? error.message : "Save failed");
+      throw error;
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-2">
@@ -187,6 +184,11 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
           ) : (
             <Button variant="ghost" size="sm" onClick={() => setEditing(true)}>Edit</Button>
           )
+        ) : null}
+        {target.kind === "file" ? (
+          <Button variant="ghost" size="icon-sm" onClick={() => void download()} aria-label="Download artifact" title="Download artifact">
+            <Download />
+          </Button>
         ) : null}
         <Button variant="ghost" size="icon-sm" onClick={() => void openExternal()} aria-label={isRemoteWorkspace ? "Download artifact" : "Open externally"} title={isRemoteWorkspace ? "Download artifact" : "Open externally"}>
           <ExternalLink />
@@ -229,7 +231,16 @@ export function ArtifactPanel({ client, workspaceId, workspaceRoot, isRemoteWork
         ) : target.preview === "markdown" && state.status === "text" ? (
           <div className="h-full overflow-auto p-4"><MarkdownBlock text={state.content} /></div>
         ) : target.preview === "sheet" ? (
-          <SheetPreview target={target} content={state.status === "text" ? state.content : undefined} />
+          <Suspense fallback={<div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>}>
+            <ArtifactSpreadsheetEditor
+              name={target.name}
+              text={state.status === "text" ? state.content : undefined}
+              data={state.status === "binary" ? state.data : undefined}
+              saving={saving}
+              onSaveText={saveTextContent}
+              onSaveBinary={saveBinaryContent}
+            />
+          </Suspense>
         ) : target.preview === "html" && state.status === "text" ? (
           <iframe srcDoc={state.content} title={target.name} className="h-full w-full border-0" sandbox="allow-scripts allow-same-origin" />
         ) : target.preview === "image" && state.status === "binary" ? (

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-editor.tsx
@@ -1,0 +1,109 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { parseSpreadsheet, serializeSpreadsheet, type SpreadsheetRows } from "./artifact-spreadsheet-model";
+
+type ArtifactSpreadsheetEditorProps = {
+  name: string;
+  text?: string;
+  data?: ArrayBuffer;
+  saving?: boolean;
+  onSaveText: (content: string) => void | Promise<void>;
+  onSaveBinary: (data: ArrayBuffer) => void | Promise<void>;
+};
+
+function cloneRows(rows: SpreadsheetRows): SpreadsheetRows {
+  return rows.map((row) => [...row]);
+}
+
+function normalizeShape(rows: SpreadsheetRows): SpreadsheetRows {
+  const width = Math.max(1, ...rows.map((row) => row.length));
+  return rows.map((row) => Array.from({ length: width }, (_, index) => row[index] ?? ""));
+}
+
+export function ArtifactSpreadsheetEditor(props: ArtifactSpreadsheetEditorProps) {
+  const [rows, setRows] = useState<SpreadsheetRows>([[""]]);
+  const [baseRows, setBaseRows] = useState<SpreadsheetRows>([[""]]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+  const dirty = useMemo(() => JSON.stringify(rows) !== JSON.stringify(baseRows), [baseRows, rows]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setMessage(null);
+    parseSpreadsheet({ name: props.name, text: props.text, data: props.data })
+      .then((parsed) => {
+        if (cancelled) return;
+        const shaped = normalizeShape(parsed);
+        setRows(shaped);
+        setBaseRows(cloneRows(shaped));
+      })
+      .catch((error) => {
+        if (!cancelled) setMessage(error instanceof Error ? error.message : "Failed to parse spreadsheet");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [props.data, props.name, props.text]);
+
+  const updateCell = (rowIndex: number, columnIndex: number, value: string) => {
+    setRows((current) => {
+      const next = cloneRows(current);
+      next[rowIndex] = [...(next[rowIndex] ?? [])];
+      next[rowIndex][columnIndex] = value;
+      return normalizeShape(next);
+    });
+  };
+
+  const addRow = () => setRows((current) => [...current, Array.from({ length: Math.max(1, current[0]?.length ?? 1) }, () => "")]);
+  const addColumn = () => setRows((current) => current.map((row) => [...row, ""]));
+  const discard = () => setRows(cloneRows(baseRows));
+
+  const save = async () => {
+    setMessage(null);
+    const serialized = await serializeSpreadsheet(props.name, rows);
+    if (serialized.kind === "text") await props.onSaveText(serialized.content);
+    else await props.onSaveBinary(serialized.data);
+    setBaseRows(cloneRows(rows));
+    setMessage("Saved");
+  };
+
+  if (loading) {
+    return <div className="flex h-full items-center justify-center text-muted-foreground"><Loader2 className="size-4 animate-spin" /></div>;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <Button variant="ghost" size="xs" onClick={addRow}><Plus className="size-3" /> Row</Button>
+        <Button variant="ghost" size="xs" onClick={addColumn}><Plus className="size-3" /> Column</Button>
+        <div className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">{message}</div>
+        <Button variant="ghost" size="xs" onClick={discard} disabled={!dirty || props.saving}>Discard</Button>
+        <Button variant="default" size="xs" onClick={() => void save()} disabled={!dirty || props.saving}>{props.saving ? "Saving" : "Save"}</Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        <table className="w-full border-collapse text-xs">
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {row.map((cell, columnIndex) => (
+                  <td key={columnIndex} className="border border-border p-0 align-top">
+                    <input
+                      className="h-8 w-full min-w-[120px] bg-transparent px-2 text-foreground outline-none focus:bg-muted/50"
+                      value={cell}
+                      onChange={(event) => updateCell(rowIndex, columnIndex, event.target.value)}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-spreadsheet-model.ts
@@ -1,0 +1,104 @@
+export type SpreadsheetRows = string[][];
+
+function extension(name: string) {
+  const clean = name.toLowerCase().split(/[?#]/)[0] ?? name.toLowerCase();
+  const index = clean.lastIndexOf(".");
+  return index >= 0 ? clean.slice(index + 1) : "";
+}
+
+function delimiterForName(name: string) {
+  return extension(name) === "tsv" ? "\t" : ",";
+}
+
+function parseDelimited(content: string, delimiter: string): SpreadsheetRows {
+  const rows: SpreadsheetRows = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+    if (quoted) {
+      if (char === '"' && next === '"') {
+        cell += '"';
+        index += 1;
+      } else if (char === '"') {
+        quoted = false;
+      } else {
+        cell += char;
+      }
+      continue;
+    }
+    if (char === '"') {
+      quoted = true;
+      continue;
+    }
+    if (char === delimiter) {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+    if (char === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+    if (char === "\r") continue;
+    cell += char;
+  }
+
+  if (cell || row.length) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows.length ? rows : [[""]];
+}
+
+function serializeDelimited(rows: SpreadsheetRows, delimiter: string) {
+  return rows
+    .map((row) => row.map((value) => {
+      const cell = String(value ?? "");
+      if (!cell.includes(delimiter) && !/["\r\n]/.test(cell)) return cell;
+      return `"${cell.replace(/"/g, '""')}"`;
+    }).join(delimiter))
+    .join("\n") + "\n";
+}
+
+function normalizeRows(rows: unknown[][]): SpreadsheetRows {
+  const next = rows.map((row) => row.map((cell) => cell == null ? "" : String(cell)));
+  return next.length ? next : [[""]];
+}
+
+export async function parseSpreadsheet(input: { name: string; text?: string; data?: ArrayBuffer }): Promise<SpreadsheetRows> {
+  const ext = extension(input.name);
+  if (ext === "csv" || ext === "tsv") return parseDelimited(input.text ?? "", delimiterForName(input.name));
+  const XLSX = await import("xlsx");
+  const workbook = XLSX.read(input.data ?? new ArrayBuffer(0), { type: "array" });
+  const firstSheetName = workbook.SheetNames[0];
+  if (!firstSheetName) return [[""]];
+  const sheet = workbook.Sheets[firstSheetName];
+  return normalizeRows(XLSX.utils.sheet_to_json(sheet, { header: 1, raw: false, blankrows: true }) as unknown[][]);
+}
+
+export async function serializeSpreadsheet(name: string, rows: SpreadsheetRows): Promise<
+  | { kind: "text"; content: string }
+  | { kind: "binary"; data: ArrayBuffer }
+> {
+  const ext = extension(name);
+  if (ext === "csv" || ext === "tsv") {
+    return { kind: "text", content: serializeDelimited(rows, delimiterForName(name)) };
+  }
+  const XLSX = await import("xlsx");
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet(rows), "Sheet1");
+  const bookType = ext === "xls" ? "xls" : ext === "ods" ? "ods" : "xlsx";
+  const output = XLSX.write(workbook, { type: "array", bookType: bookType as any });
+  if (output instanceof ArrayBuffer) return { kind: "binary", data: output };
+  const view = output as Uint8Array;
+  const copy = new Uint8Array(view.byteLength);
+  copy.set(view);
+  return { kind: "binary", data: copy.buffer };
+}

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
@@ -1,0 +1,65 @@
+/** @jsxImportSource react */
+import { useEffect, useRef } from "react";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { markdown } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+
+type ArtifactTextEditorProps = {
+  value: string;
+  language: "markdown" | "text";
+  onChange: (value: string) => void;
+};
+
+export function ArtifactTextEditor(props: ArtifactTextEditorProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onChangeRef = useRef(props.onChange);
+  onChangeRef.current = props.onChange;
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const view = new EditorView({
+      parent: root,
+      state: EditorState.create({
+        doc: props.value,
+        extensions: [
+          lineNumbers(),
+          history(),
+          keymap.of([...defaultKeymap, ...historyKeymap]),
+          props.language === "markdown" ? markdown() : [],
+          EditorView.lineWrapping,
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) onChangeRef.current(update.state.doc.toString());
+          }),
+          EditorView.theme({
+            "&": { height: "100%", background: "transparent" },
+            ".cm-scroller": { fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" },
+            ".cm-content": { minHeight: "100%", padding: "12px 0", fontSize: "12px", lineHeight: "20px" },
+            ".cm-gutters": { background: "transparent", borderRight: "1px solid hsl(var(--border))" },
+            ".cm-lineNumbers .cm-gutterElement": { padding: "0 8px", color: "hsl(var(--muted-foreground))" },
+            ".cm-activeLine": { backgroundColor: "hsl(var(--muted) / 0.35)" },
+            ".cm-activeLineGutter": { backgroundColor: "hsl(var(--muted) / 0.35)" },
+          }),
+        ],
+      }),
+    });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+  }, [props.language]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current === props.value) return;
+    view.dispatch({ changes: { from: 0, to: current.length, insert: props.value } });
+  }, [props.value]);
+
+  return <div ref={rootRef} className="h-full min-h-0 overflow-hidden" />;
+}

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -12,13 +12,25 @@ export type OpenTarget = {
   preview: OpenTargetPreview;
   confidence: number;
   reason: string;
+  exists?: boolean;
+  size?: number;
+  updatedAt?: number;
 };
+
+const WORKSPACES_PREFIX_PATTERN = /^workspaces\/[^/]+\//i;
+const WORKSPACE_ID_PREFIX_PATTERN = /^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i;
 
 const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:[/\\][\w.\-]+)+\.[a-z][a-z0-9]{0,9}|[\w.\-]+\.[a-z][a-z0-9]{0,9})/gi;
 const URL_PATTERN = /https?:\/\/[^\s)\]}>"']+/gi;
+const SOCKET_PATTERN = /(?:ws|wss):\/\/[^\s)\]}>"']+/gi;
 
 function normalizePath(path: string) {
-  return path.trim().replace(/[\\]+/g, "/").replace(/^\.\//, "");
+  return path
+    .trim()
+    .replace(/[\\]+/g, "/")
+    .replace(/^\.\//, "")
+    .replace(WORKSPACES_PREFIX_PATTERN, "")
+    .replace(WORKSPACE_ID_PREFIX_PATTERN, "");
 }
 
 function basename(value: string) {
@@ -84,6 +96,10 @@ function scanText(map: Map<string, OpenTarget>, text: string, confidence: number
   for (const match of text.matchAll(URL_PATTERN)) {
     if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
   }
+  SOCKET_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(SOCKET_PATTERN)) {
+    if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
+  }
   FILE_PATTERN.lastIndex = 0;
   for (const match of text.matchAll(FILE_PATTERN)) {
     if (match[1]) addTarget(map, targetFromFile(match[1], confidence, reason));
@@ -121,6 +137,6 @@ export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
 }
 
 export function shouldAutoOpenTarget(target: OpenTarget): boolean {
-  if (target.kind === "url") return /https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target.value);
-  return target.confidence >= 65 && ["markdown", "sheet", "image", "pdf", "html"].includes(target.preview);
+  if (target.kind === "url") return /(?:https?|wss?):\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target.value);
+  return target.exists === true && target.confidence >= 65 && ["markdown", "sheet", "image", "pdf", "html"].includes(target.preview);
 }

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -1,0 +1,126 @@
+/** @jsxImportSource react */
+import type { UIMessage } from "ai";
+
+export type OpenTargetKind = "url" | "file";
+export type OpenTargetPreview = "browser" | "markdown" | "sheet" | "image" | "pdf" | "html" | "text" | "external";
+
+export type OpenTarget = {
+  id: string;
+  kind: OpenTargetKind;
+  value: string;
+  name: string;
+  preview: OpenTargetPreview;
+  confidence: number;
+  reason: string;
+};
+
+const FILE_PATTERN = /(?:^|[\s"'`([{])((?:\.{1,2}[/\\]|~[/\\]|[/\\])?[\w.\-]+(?:[/\\][\w.\-]+)+\.[a-z][a-z0-9]{0,9}|[\w.\-]+\.[a-z][a-z0-9]{0,9})/gi;
+const URL_PATTERN = /https?:\/\/[^\s)\]}>"']+/gi;
+
+function normalizePath(path: string) {
+  return path.trim().replace(/[\\]+/g, "/").replace(/^\.\//, "");
+}
+
+function basename(value: string) {
+  const clean = value.split(/[?#]/)[0] ?? value;
+  return clean.split("/").filter(Boolean).pop() ?? value;
+}
+
+function extname(value: string) {
+  const name = basename(value).toLowerCase();
+  const index = name.lastIndexOf(".");
+  return index >= 0 ? name.slice(index) : "";
+}
+
+export function classifyOpenTarget(value: string, kind: OpenTargetKind): OpenTargetPreview {
+  if (kind === "url") return "browser";
+  const ext = extname(value);
+  if ([".md", ".markdown", ".mdx"].includes(ext)) return "markdown";
+  if ([".csv", ".tsv", ".xlsx", ".xls", ".ods"].includes(ext)) return "sheet";
+  if ([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"].includes(ext)) return "image";
+  if (ext === ".pdf") return "pdf";
+  if ([".html", ".htm"].includes(ext)) return "html";
+  if ([".txt", ".log", ".json", ".jsonc", ".yaml", ".yml", ".toml", ".xml", ".ts", ".tsx", ".js", ".jsx", ".css", ".scss"].includes(ext)) return "text";
+  return "external";
+}
+
+function targetFromFile(path: string, confidence: number, reason: string): OpenTarget | null {
+  const normalized = normalizePath(path).replace(/[.,;:]+$/, "");
+  if (!normalized || normalized.length > 500 || !normalized.includes(".")) return null;
+  return {
+    id: `file:${normalized.toLowerCase()}`,
+    kind: "file",
+    value: normalized,
+    name: basename(normalized),
+    preview: classifyOpenTarget(normalized, "file"),
+    confidence,
+    reason,
+  };
+}
+
+function targetFromUrl(url: string, confidence: number, reason: string): OpenTarget | null {
+  const clean = url.trim().replace(/[.,;:]+$/, "");
+  if (!clean) return null;
+  return {
+    id: `url:${clean}`,
+    kind: "url",
+    value: clean,
+    name: basename(clean) || clean,
+    preview: "browser",
+    confidence,
+    reason,
+  };
+}
+
+function addTarget(map: Map<string, OpenTarget>, target: OpenTarget | null) {
+  if (!target) return;
+  const existing = map.get(target.id);
+  if (!existing || target.confidence >= existing.confidence) map.set(target.id, target);
+}
+
+function scanText(map: Map<string, OpenTarget>, text: string, confidence: number, reason: string) {
+  if (!text) return;
+  URL_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(URL_PATTERN)) {
+    if (match[0]) addTarget(map, targetFromUrl(match[0], confidence, reason));
+  }
+  FILE_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(FILE_PATTERN)) {
+    if (match[1]) addTarget(map, targetFromFile(match[1], confidence, reason));
+  }
+}
+
+export function deriveOpenTargets(messages: UIMessage[]): OpenTarget[] {
+  const targets = new Map<string, OpenTarget>();
+  const recent = messages.slice(-8);
+
+  for (const message of recent) {
+    for (const part of message.parts) {
+      const record = part as any;
+      if (part.type === "text" && typeof record.text === "string") {
+        scanText(targets, record.text, message.role === "assistant" ? 65 : 40, "message");
+        continue;
+      }
+      if (part.type === "dynamic-tool") {
+        const values = [record.input, record.output].flatMap((value) => {
+          if (!value || typeof value !== "object") return [];
+          const entries = value as Record<string, unknown>;
+          return [entries.path, entries.file, ...(Array.isArray(entries.files) ? entries.files : [])];
+        });
+        for (const value of values) {
+          if (typeof value === "string") addTarget(targets, targetFromFile(value, 95, "tool metadata"));
+        }
+        scanText(targets, JSON.stringify(record.output ?? record.input ?? ""), 75, "tool output");
+      }
+    }
+  }
+
+  return Array.from(targets.values())
+    .filter((target) => target.preview !== "external" || target.confidence >= 95)
+    .sort((left, right) => right.confidence - left.confidence);
+}
+
+export function shouldAutoOpenTarget(target: OpenTarget): boolean {
+  if (target.kind === "url") return /https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/i.test(target.value);
+  return target.confidence >= 65 && ["markdown", "sheet", "image", "pdf", "html"].includes(target.preview);
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -192,6 +192,8 @@ export function SessionPage(props: SessionPageProps) {
   const toggleBrowserPanel = useUiStateStore((state) => state.toggleBrowserPanel);
   const [rightPaneMode, setRightPaneMode] = useState<"browser" | "artifact">("browser");
   const [artifactTarget, setArtifactTarget] = useState<OpenTarget | null>(null);
+  const [artifactTargets, setArtifactTargets] = useState<OpenTarget[]>([]);
+  const artifactFileTargets = useMemo(() => artifactTargets.filter((target) => target.kind === "file"), [artifactTargets]);
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -241,18 +243,28 @@ export function SessionPage(props: SessionPageProps) {
     if (browserPanelOpen) return;
     setBrowserPanelDefaultWidth(browserPanelWidth);
   }, [browserPanelOpen, browserPanelWidth]);
+  useEffect(() => {
+    setArtifactTarget(null);
+    setArtifactTargets([]);
+    setRightPaneMode("browser");
+  }, [props.selectedSessionId]);
   const commitBrowserPanelWidth = useCallback(() => {
     const size = browserPanelRef.current?.getSize();
     if (size?.inPixels) setBrowserPanelWidth(Math.round(size.inPixels));
   }, [browserPanelRef, setBrowserPanelWidth]);
+  const browserUrlForTarget = useCallback((target: OpenTarget) => {
+    if (/^wss?:\/\//i.test(target.value)) return target.value.replace(/^ws:/i, "http:").replace(/^wss:/i, "https:");
+    return target.value;
+  }, []);
   const openTarget = useCallback((target: OpenTarget, options?: { auto?: boolean }) => {
     if (target.kind === "url" || target.preview === "browser") {
+      const url = browserUrlForTarget(target);
       if (isElectronRuntime()) {
         setRightPaneMode("browser");
         openBrowserPanel();
-        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(target.value);
+        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(url);
       } else {
-        window.open(target.value, "_blank", "noopener,noreferrer");
+        window.open(url, "_blank", "noopener,noreferrer");
       }
       return;
     }
@@ -260,7 +272,14 @@ export function SessionPage(props: SessionPageProps) {
     setArtifactTarget(target);
     setRightPaneMode("artifact");
     openBrowserPanel();
-  }, [artifactTarget?.id, openBrowserPanel]);
+  }, [artifactTarget?.id, browserUrlForTarget, openBrowserPanel]);
+  const handleOpenTargetsChange = useCallback((targets: OpenTarget[]) => {
+    setArtifactTargets(targets);
+    setArtifactTarget((current) => {
+      if (!current) return current;
+      return targets.find((target) => target.id === current.id || target.value === current.value) ?? current;
+    });
+  }, []);
   const closeRightPane = useCallback(() => {
     closeBrowserPanel();
   }, [closeBrowserPanel]);
@@ -471,7 +490,7 @@ export function SessionPage(props: SessionPageProps) {
                   <span className="hidden @lg/titlebar:inline">Browser</span>
                 </Button>
               ) : null}
-              {artifactTarget ? (
+              {artifactTarget || artifactFileTargets.length > 0 ? (
                 <Button
                   variant="ghost"
                   size="sm"
@@ -488,7 +507,7 @@ export function SessionPage(props: SessionPageProps) {
                   aria-pressed={browserPanelOpen && rightPaneMode === "artifact"}
                 >
                   <FileText size={16} />
-                  <span className="hidden @lg/titlebar:inline">Artifact</span>
+                  <span className="hidden @lg/titlebar:inline">Artifact{artifactFileTargets.length > 1 ? `s ${artifactFileTargets.length}` : ""}</span>
                 </Button>
               ) : null}
               {/* Revert/redo moved to per-message actions */}
@@ -575,6 +594,7 @@ export function SessionPage(props: SessionPageProps) {
                   respondPermission={props.respondPermission}
                   safeStringify={props.safeStringify}
                   onOpenTarget={openTarget}
+                  onOpenTargetsChange={handleOpenTargetsChange}
                 />
               ) : null}
 
@@ -739,7 +759,10 @@ export function SessionPage(props: SessionPageProps) {
                       client={props.openworkServerClient}
                       workspaceId={props.runtimeWorkspaceId}
                       workspaceRoot={props.selectedWorkspaceRoot}
+                      isRemoteWorkspace={props.surface?.isRemoteWorkspace ?? false}
                       target={artifactTarget}
+                      targets={artifactFileTargets}
+                      onSelectTarget={openTarget}
                       onClose={closeRightPane}
                     />
                   ) : (

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Globe, Loader2, Redo2, Undo2, Zap } from "lucide-react";
+import { FileText, Globe, Loader2, Redo2, Undo2, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
@@ -44,6 +44,8 @@ import { useUiStateStore } from "../../../shell/ui-state-store";
 
 import { isElectronRuntime } from "../../../../app/utils";
 import { BrowserPanel } from "../browser/browser-panel";
+import { ArtifactPanel } from "../artifacts/artifact-panel";
+import type { OpenTarget } from "../artifacts/open-target";
 import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
 import { cn } from "@/lib/utils";
 
@@ -188,6 +190,8 @@ export function SessionPage(props: SessionPageProps) {
   const openBrowserPanel = useUiStateStore((state) => state.openBrowserPanel);
   const closeBrowserPanel = useUiStateStore((state) => state.closeBrowserPanel);
   const toggleBrowserPanel = useUiStateStore((state) => state.toggleBrowserPanel);
+  const [rightPaneMode, setRightPaneMode] = useState<"browser" | "artifact">("browser");
+  const [artifactTarget, setArtifactTarget] = useState<OpenTarget | null>(null);
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -241,6 +245,25 @@ export function SessionPage(props: SessionPageProps) {
     const size = browserPanelRef.current?.getSize();
     if (size?.inPixels) setBrowserPanelWidth(Math.round(size.inPixels));
   }, [browserPanelRef, setBrowserPanelWidth]);
+  const openTarget = useCallback((target: OpenTarget, options?: { auto?: boolean }) => {
+    if (target.kind === "url" || target.preview === "browser") {
+      if (isElectronRuntime()) {
+        setRightPaneMode("browser");
+        openBrowserPanel();
+        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(target.value);
+      } else {
+        window.open(target.value, "_blank", "noopener,noreferrer");
+      }
+      return;
+    }
+    if (options?.auto && artifactTarget?.id === target.id) return;
+    setArtifactTarget(target);
+    setRightPaneMode("artifact");
+    openBrowserPanel();
+  }, [artifactTarget?.id, openBrowserPanel]);
+  const closeRightPane = useCallback(() => {
+    closeBrowserPanel();
+  }, [closeBrowserPanel]);
   const [showDelayedSessionLoadingState, setShowDelayedSessionLoadingState] = useState(false);
 
   const selectedSessionTitle = useMemo(
@@ -448,6 +471,26 @@ export function SessionPage(props: SessionPageProps) {
                   <span className="hidden @lg/titlebar:inline">Browser</span>
                 </Button>
               ) : null}
+              {artifactTarget ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "transition-colors",
+                    browserPanelOpen && rightPaneMode === "artifact" && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary"
+                  )}
+                  onClick={() => {
+                    setRightPaneMode("artifact");
+                    openBrowserPanel();
+                  }}
+                  title="Open artifact panel"
+                  aria-label="Open artifact panel"
+                  aria-pressed={browserPanelOpen && rightPaneMode === "artifact"}
+                >
+                  <FileText size={16} />
+                  <span className="hidden @lg/titlebar:inline">Artifact</span>
+                </Button>
+              ) : null}
               {/* Revert/redo moved to per-message actions */}
               {props.developerMode ? (
                 <Button
@@ -531,6 +574,7 @@ export function SessionPage(props: SessionPageProps) {
                   permissionReplyBusy={props.permissionReplyBusy}
                   respondPermission={props.respondPermission}
                   safeStringify={props.safeStringify}
+                  onOpenTarget={openTarget}
                 />
               ) : null}
 
@@ -690,7 +734,17 @@ export function SessionPage(props: SessionPageProps) {
                   maxSize="70%"
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"
                 >
-                  <BrowserPanel onClose={closeBrowserPanel} />
+                  {rightPaneMode === "artifact" && artifactTarget && props.openworkServerClient && props.runtimeWorkspaceId ? (
+                    <ArtifactPanel
+                      client={props.openworkServerClient}
+                      workspaceId={props.runtimeWorkspaceId}
+                      workspaceRoot={props.selectedWorkspaceRoot}
+                      target={artifactTarget}
+                      onClose={closeRightPane}
+                    />
+                  ) : (
+                    <BrowserPanel onClose={closeRightPane} />
+                  )}
                 </ResizablePanel>
               </>
             ) : null}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -44,6 +44,7 @@ import { useLocal } from "../../../kernel/local-provider";
 import { deriveSessionRenderModel } from "../sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import { PermissionApprovalPanel } from "../chat/permission-approval-modal";
+import { deriveOpenTargets, shouldAutoOpenTarget, type OpenTarget } from "../artifacts/open-target";
 import {
   seedSessionState,
   statusKey as reactStatusKey,
@@ -105,6 +106,7 @@ export type SessionSurfaceProps = {
   onOpenSettingsSection?: ((section: "commands" | "skills" | "mcps" | "plugins") => void) | undefined;
   onRevertToMessage?: (messageId: string) => void;
   onForkAtMessage?: (messageId: string) => void;
+  onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }) => void;
 };
 
 function messageToReadableText(message: UIMessage) {
@@ -358,6 +360,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
   const composerShellRef = useRef<HTMLDivElement>(null);
   const hydratedKeyRef = useRef<string | null>(null);
+  const autoOpenedTargetRef = useRef<string | null>(null);
   const attachmentsRef = useRef<ComposerAttachment[]>([]);
   attachmentsRef.current = attachments;
   const opencodeClient = useMemo(
@@ -410,6 +413,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setMentions({});
     setPasteParts([]);
     setNotice(null);
+    autoOpenedTargetRef.current = null;
   }, [props.sessionId]);
 
   useEffect(() => {
@@ -493,6 +497,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     () => deriveRenderedSessionMessages({ transcriptState, snapshot }),
     [snapshot, transcriptState],
   );
+  const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
+  const autoOpenTarget = openTargets.find(shouldAutoOpenTarget) ?? null;
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;
@@ -511,6 +517,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     showAssistantWaitState,
     hasSnapshot: Boolean(snapshot),
   });
+
+  useEffect(() => {
+    if (!autoOpenTarget || chatStreaming) return;
+    if (autoOpenedTargetRef.current === autoOpenTarget.id) return;
+    autoOpenedTargetRef.current = autoOpenTarget.id;
+    props.onOpenTarget?.(autoOpenTarget, { auto: true });
+  }, [autoOpenTarget, chatStreaming, props.onOpenTarget]);
 
   useEffect(() => {
     if (!pendingSessionLoad) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -501,6 +501,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
     [snapshot, transcriptState],
   );
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
+  const openTargetsFingerprint = useMemo(
+    () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),
+    [openTargets],
+  );
   const autoOpenTarget = verifiedOpenTargets.find(shouldAutoOpenTarget) ?? null;
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {
@@ -531,29 +535,20 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useEffect(() => {
     let cancelled = false;
     async function verifyTargets() {
-      const verified = await Promise.all(openTargets.map(async (target) => {
-        if (target.kind !== "file") return { ...target, exists: true };
-        try {
-          const stat = await props.client.statWorkspaceFile(props.workspaceId, target.value);
-          const normalizedName = stat.path.split("/").filter(Boolean).pop() ?? target.name;
-          return {
-            ...target,
-            id: `file:${stat.path.toLowerCase()}`,
-            value: stat.path,
-            name: normalizedName,
-            exists: stat.exists && stat.kind === "file",
-            size: stat.size,
-            updatedAt: stat.updatedAt,
-          } satisfies OpenTarget;
-        } catch {
-          return { ...target, exists: false } satisfies OpenTarget;
-        }
-      }));
-      if (!cancelled) setVerifiedOpenTargets(verified);
+      if (!openTargets.length) {
+        setVerifiedOpenTargets([]);
+        return;
+      }
+      try {
+        const response = await props.client.resolveArtifacts(props.workspaceId, openTargets);
+        if (!cancelled) setVerifiedOpenTargets(response.items as OpenTarget[]);
+      } catch {
+        if (!cancelled) setVerifiedOpenTargets(openTargets.map((target) => ({ ...target, exists: target.kind === "url" })));
+      }
     }
     void verifyTargets();
     return () => { cancelled = true; };
-  }, [openTargets, props.client, props.workspaceId]);
+  }, [openTargetsFingerprint, props.client, props.workspaceId]);
 
   useEffect(() => {
     props.onOpenTargetsChange?.(verifiedOpenTargets);

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -107,6 +107,7 @@ export type SessionSurfaceProps = {
   onRevertToMessage?: (messageId: string) => void;
   onForkAtMessage?: (messageId: string) => void;
   onOpenTarget?: (target: OpenTarget, options?: { auto?: boolean }) => void;
+  onOpenTargetsChange?: (targets: OpenTarget[]) => void;
 };
 
 function messageToReadableText(message: UIMessage) {
@@ -358,6 +359,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolMcpStatus, setToolMcpStatus] = useState<string | null>(null);
   const [toolMcpStatuses, setToolMcpStatuses] = useState<McpStatusMap>({});
   const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
+  const [verifiedOpenTargets, setVerifiedOpenTargets] = useState<OpenTarget[]>([]);
   const composerShellRef = useRef<HTMLDivElement>(null);
   const hydratedKeyRef = useRef<string | null>(null);
   const autoOpenedTargetRef = useRef<string | null>(null);
@@ -414,6 +416,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     setPasteParts([]);
     setNotice(null);
     autoOpenedTargetRef.current = null;
+    setVerifiedOpenTargets([]);
   }, [props.sessionId]);
 
   useEffect(() => {
@@ -498,7 +501,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     [snapshot, transcriptState],
   );
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
-  const autoOpenTarget = openTargets.find(shouldAutoOpenTarget) ?? null;
+  const autoOpenTarget = verifiedOpenTargets.find(shouldAutoOpenTarget) ?? null;
   const pendingSessionLoad = !snapshot && snapshotQuery.isLoading && renderedMessages.length === 0;
   const assistantOutputAfterAwaitStart = useMemo(() => {
     if (awaitingAssistantBaseline === null) return false;
@@ -524,6 +527,37 @@ export function SessionSurface(props: SessionSurfaceProps) {
     autoOpenedTargetRef.current = autoOpenTarget.id;
     props.onOpenTarget?.(autoOpenTarget, { auto: true });
   }, [autoOpenTarget, chatStreaming, props.onOpenTarget]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function verifyTargets() {
+      const verified = await Promise.all(openTargets.map(async (target) => {
+        if (target.kind !== "file") return { ...target, exists: true };
+        try {
+          const stat = await props.client.statWorkspaceFile(props.workspaceId, target.value);
+          const normalizedName = stat.path.split("/").filter(Boolean).pop() ?? target.name;
+          return {
+            ...target,
+            id: `file:${stat.path.toLowerCase()}`,
+            value: stat.path,
+            name: normalizedName,
+            exists: stat.exists && stat.kind === "file",
+            size: stat.size,
+            updatedAt: stat.updatedAt,
+          } satisfies OpenTarget;
+        } catch {
+          return { ...target, exists: false } satisfies OpenTarget;
+        }
+      }));
+      if (!cancelled) setVerifiedOpenTargets(verified);
+    }
+    void verifyTargets();
+    return () => { cancelled = true; };
+  }, [openTargets, props.client, props.workspaceId]);
+
+  useEffect(() => {
+    props.onOpenTargetsChange?.(verifiedOpenTargets);
+  }, [props.onOpenTargetsChange, verifiedOpenTargets]);
 
   useEffect(() => {
     if (!pendingSessionLoad) {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 bun src/cli.ts",
     "test": "bun test",
+    "test:artifacts": "bun test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
     "build": "tsc -p tsconfig.json",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64",

--- a/apps/server/src/artifact-files.e2e.test.ts
+++ b/apps/server/src/artifact-files.e2e.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+type Served = { port: number; stop: (closeActiveConnections?: boolean) => void | Promise<void> };
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-artifacts-"));
+  roots.push(root);
+  await mkdir(join(root, "reports"), { recursive: true });
+  await writeFile(join(root, "reports", "artifact-eval.md"), "# Artifact Eval\n\nHello markdown.\n", "utf8");
+  await writeFile(join(root, "reports", "artifact-eval.csv"), "name,revenue\nAda,10\nGrace,20\n", "utf8");
+  await writeFile(join(root, "reports", "index.html"), "<!doctype html><h1>Artifact site</h1>", "utf8");
+  await writeFile(join(root, "reports", "artifact-eval.xlsx"), new Uint8Array([80, 75, 3, 4, 1, 2, 3, 4]));
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config) as Served;
+  stops.push(() => server.stop(true));
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+describe("artifact file routes", () => {
+  test("resolve, read, write, and download markdown/csv/xlsx/html artifacts", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+
+    const resolveResponse = await fetch(`${base}/workspace/ws_1/artifacts/resolve`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({
+        targets: [
+          { kind: "file", value: "Workspace/32423/reports/artifact-eval.md", confidence: 80 },
+          { kind: "file", value: "reports/artifact-eval.csv", confidence: 80 },
+          { kind: "file", value: "reports/artifact-eval.xlsx", confidence: 80 },
+          { kind: "file", value: "reports/index.html", confidence: 80 },
+          { kind: "file", value: "reports/missing.md", confidence: 80 },
+          { kind: "url", value: "http://localhost:4321", confidence: 80 },
+          { kind: "url", value: "ws://localhost:4321/socket", confidence: 80 },
+        ],
+      }),
+    });
+    expect(resolveResponse.status).toBe(200);
+    const resolved = await resolveResponse.json() as { items: Array<any> };
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.md")).toMatchObject({ exists: true, preview: "markdown" });
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.csv")).toMatchObject({ exists: true, preview: "sheet" });
+    expect(resolved.items.find((item) => item.value === "reports/artifact-eval.xlsx")).toMatchObject({ exists: true, preview: "sheet" });
+    expect(resolved.items.find((item) => item.value === "reports/index.html")).toMatchObject({ exists: true, preview: "html" });
+    expect(resolved.items.find((item) => item.value === "reports/missing.md")).toMatchObject({ exists: false });
+    expect(resolved.items.find((item) => item.value === "http://localhost:4321/")).toMatchObject({ kind: "url", preview: "browser" });
+    expect(resolved.items.find((item) => item.value === "ws://localhost:4321/socket")).toMatchObject({ kind: "url", preview: "browser" });
+
+    const csvRead = await fetch(`${base}/workspace/ws_1/files/content?path=${encodeURIComponent("reports/artifact-eval.csv")}`, { headers: auth(token) });
+    expect(await csvRead.json()).toMatchObject({ content: "name,revenue\nAda,10\nGrace,20\n" });
+
+    const mdWrite = await fetch(`${base}/workspace/ws_1/files/content`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({ path: "reports/artifact-eval.md", content: "# Updated\n" }),
+    });
+    expect(mdWrite.status).toBe(200);
+    expect(await readFile(join(root, "reports", "artifact-eval.md"), "utf8")).toBe("# Updated\n");
+
+    const xlsxWrite = await fetch(`${base}/workspace/ws_1/files/raw`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({ path: "reports/artifact-eval.xlsx", dataBase64: Buffer.from([80, 75, 9, 9]).toString("base64") }),
+    });
+    expect(xlsxWrite.status).toBe(200);
+
+    const xlsxDownload = await fetch(`${base}/workspace/ws_1/files/raw?path=${encodeURIComponent("reports/artifact-eval.xlsx")}`, { headers: auth(token) });
+    expect(xlsxDownload.status).toBe(200);
+    expect(Array.from(new Uint8Array(await xlsxDownload.arrayBuffer()))).toEqual([80, 75, 9, 9]);
+  });
+});

--- a/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
+++ b/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
@@ -11,6 +11,11 @@ describe("normalizeWorkspaceRelativePath", () => {
     expect(normalizeWorkspaceRelativePath("workspace/dir/notes.md", { allowSubdirs: true })).toBe("dir/notes.md");
   });
 
+  test("strips Workspace/<id>/ prefix from rendered artifact paths", () => {
+    expect(normalizeWorkspaceRelativePath("Workspace/32423/reports/artifact-eval.md", { allowSubdirs: true })).toBe("reports/artifact-eval.md");
+    expect(normalizeWorkspaceRelativePath("workspaces/demo/reports/artifact-eval.csv", { allowSubdirs: true })).toBe("reports/artifact-eval.csv");
+  });
+
   test("strips /workspace/ prefix", () => {
     expect(normalizeWorkspaceRelativePath("/workspace/notes.md", { allowSubdirs: true })).toBe("notes.md");
     expect(normalizeWorkspaceRelativePath("//workspace/dir/notes.md", { allowSubdirs: true })).toBe("dir/notes.md");
@@ -42,6 +47,7 @@ describe("isSupportedWorkspaceTextFilePath", () => {
     expect(isSupportedWorkspaceTextFilePath("logs/run.log")).toBe(true);
     expect(isSupportedWorkspaceTextFilePath("config/app.yaml")).toBe(true);
     expect(isSupportedWorkspaceTextFilePath("styles/app.css")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("dist/index.html")).toBe(true);
   });
 
   test("keeps accepting OpenCode config/plugin text file extensions", () => {

--- a/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
+++ b/apps/server/src/server.normalizeWorkspaceRelativePath.test.ts
@@ -36,7 +36,15 @@ describe("normalizeWorkspaceRelativePath", () => {
 });
 
 describe("isSupportedWorkspaceTextFilePath", () => {
-  test("accepts plugin import text file extensions", () => {
+  test("accepts workspace text artifact extensions", () => {
+    expect(isSupportedWorkspaceTextFilePath("reports/revenue.csv")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("reports/revenue.tsv")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("logs/run.log")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("config/app.yaml")).toBe(true);
+    expect(isSupportedWorkspaceTextFilePath("styles/app.css")).toBe(true);
+  });
+
+  test("keeps accepting OpenCode config/plugin text file extensions", () => {
     expect(isSupportedWorkspaceTextFilePath(".opencode/tools/cloud.ts")).toBe(true);
     expect(isSupportedWorkspaceTextFilePath(".opencode/mcps/cloud.json")).toBe(true);
     expect(isSupportedWorkspaceTextFilePath(".opencode/plugins/cloud.txt")).toBe(true);

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -868,8 +868,115 @@ function contentTypeForPath(path: string): string {
   if (lowered.endsWith(".gif")) return "image/gif";
   if (lowered.endsWith(".webp")) return "image/webp";
   if (lowered.endsWith(".pdf")) return "application/pdf";
+  if (lowered.endsWith(".csv")) return "text/csv; charset=utf-8";
+  if (lowered.endsWith(".tsv")) return "text/tab-separated-values; charset=utf-8";
+  if (lowered.endsWith(".xlsx")) return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  if (lowered.endsWith(".xls")) return "application/vnd.ms-excel";
+  if (lowered.endsWith(".ods")) return "application/vnd.oasis.opendocument.spreadsheet";
   if (isSupportedWorkspaceTextFilePath(path)) return "text/plain; charset=utf-8";
   return "application/octet-stream";
+}
+
+type ArtifactTargetInput = {
+  kind?: unknown;
+  value?: unknown;
+  name?: unknown;
+  preview?: unknown;
+  confidence?: unknown;
+  reason?: unknown;
+};
+
+function artifactPreviewForPath(path: string): string {
+  const lowered = path.toLowerCase();
+  if (/\.(md|markdown|mdx)$/.test(lowered)) return "markdown";
+  if (/\.(csv|tsv|xlsx|xls|ods)$/.test(lowered)) return "sheet";
+  if (/\.(png|jpe?g|gif|webp|svg)$/.test(lowered)) return "image";
+  if (lowered.endsWith(".pdf")) return "pdf";
+  if (/\.(html|htm)$/.test(lowered)) return "html";
+  if (isSupportedWorkspaceTextFilePath(path)) return "text";
+  return "external";
+}
+
+function normalizeUrlTarget(value: string): string | null {
+  try {
+    const url = new URL(value.trim());
+    if (!["http:", "https:", "ws:", "wss:"].includes(url.protocol)) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveWorkspaceArtifactTargets(workspaceRoot: string, input: unknown): Promise<Array<Record<string, unknown>>> {
+  const targets = Array.isArray(input) ? input.slice(0, 80) : [];
+  const results = new Map<string, Record<string, unknown>>();
+
+  for (const item of targets) {
+    if (!item || typeof item !== "object") continue;
+    const target = item as ArtifactTargetInput;
+    const kind = target.kind === "url" ? "url" : "file";
+    const rawValue = typeof target.value === "string" ? target.value.trim() : "";
+    if (!rawValue) continue;
+    const confidence = typeof target.confidence === "number" && Number.isFinite(target.confidence) ? target.confidence : 0;
+    const reason = typeof target.reason === "string" ? target.reason : "server";
+
+    if (kind === "url") {
+      const url = normalizeUrlTarget(rawValue);
+      if (!url) continue;
+      const key = `url:${url}`;
+      const next = {
+        id: key,
+        kind: "url",
+        value: url,
+        name: typeof target.name === "string" && target.name.trim() ? target.name.trim() : url,
+        preview: "browser",
+        confidence,
+        reason,
+        exists: true,
+      };
+      const previous = results.get(key);
+      if (!previous || confidence >= Number(previous.confidence ?? 0)) results.set(key, next);
+      continue;
+    }
+
+    let relativePath: string;
+    try {
+      relativePath = normalizeWorkspaceRelativePath(rawValue, { allowSubdirs: true });
+    } catch {
+      continue;
+    }
+    const key = `file:${relativePath.toLowerCase()}`;
+    const absPath = resolveSafeChildPath(workspaceRoot, relativePath);
+    let existsFile = false;
+    let size: number | undefined;
+    let updatedAt: number | undefined;
+    let kindValue: "file" | "dir" | "other" | undefined;
+    if (await exists(absPath)) {
+      const info = await stat(absPath);
+      kindValue = info.isFile() ? "file" : info.isDirectory() ? "dir" : "other";
+      existsFile = info.isFile();
+      size = info.size;
+      updatedAt = info.mtimeMs;
+    }
+    const next = {
+      id: key,
+      kind: "file",
+      value: relativePath,
+      name: basename(relativePath),
+      preview: artifactPreviewForPath(relativePath),
+      confidence,
+      reason,
+      exists: existsFile,
+      fileKind: kindValue,
+      size,
+      updatedAt,
+      contentType: contentTypeForPath(relativePath),
+    };
+    const previous = results.get(key);
+    if (!previous || confidence >= Number(previous.confidence ?? 0)) results.set(key, next);
+  }
+
+  return Array.from(results.values());
 }
 
 function encodeInboxId(path: string): string {
@@ -1955,6 +2062,13 @@ function createRoutes(
     return new Response(stream, { status: 200, headers });
   });
 
+  addRoute(routes, "POST", "/workspace/:id/artifacts/resolve", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const items = await resolveWorkspaceArtifactTargets(workspace.path, (body as Record<string, unknown>).targets);
+    return jsonResponse({ items });
+  });
+
   addRoute(routes, "POST", "/workspace/:id/files/sessions", "client", async (ctx) => {
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
@@ -2373,6 +2487,67 @@ function createRoutes(
     headers.set("Content-Disposition", `inline; filename="${basename(relativePath)}"`);
     const stream = Readable.toWeb(createReadStream(absPath)) as unknown as ReadableStream;
     return new Response(stream, { status: 200, headers });
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/files/raw", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const body = await readJsonBody(ctx.request);
+    const requestedPath = String(body.path ?? "");
+    const relativePath = normalizeWorkspaceRelativePath(requestedPath, { allowSubdirs: true });
+    if (typeof body.dataBase64 !== "string") {
+      throw new ApiError(400, "invalid_payload", "dataBase64 must be a string");
+    }
+    let bytes: Buffer;
+    try {
+      bytes = Buffer.from(body.dataBase64, "base64");
+    } catch {
+      throw new ApiError(400, "invalid_payload", "dataBase64 is invalid");
+    }
+    const maxBytes = FILE_SESSION_MAX_FILE_BYTES;
+    if (bytes.byteLength > maxBytes) {
+      throw new ApiError(413, "file_too_large", "File exceeds size limit", { maxBytes, size: bytes.byteLength });
+    }
+
+    const baseUpdatedAtRaw = body.baseUpdatedAt;
+    const baseUpdatedAt =
+      typeof baseUpdatedAtRaw === "number" && Number.isFinite(baseUpdatedAtRaw) ? baseUpdatedAtRaw : null;
+    const force = body.force === true;
+    const absPath = resolveSafeChildPath(workspace.path, relativePath);
+    const before = (await exists(absPath)) ? await stat(absPath) : null;
+    if (before && !before.isFile()) {
+      throw new ApiError(400, "invalid_path", "Path must point to a file");
+    }
+    const beforeUpdatedAt = before ? before.mtimeMs : null;
+    if (!force && beforeUpdatedAt !== null && baseUpdatedAt !== null && beforeUpdatedAt !== baseUpdatedAt) {
+      throw new ApiError(409, "conflict", "File changed since it was loaded", { baseUpdatedAt, currentUpdatedAt: beforeUpdatedAt });
+    }
+
+    await requireApproval(ctx, {
+      workspaceId: workspace.id,
+      action: "workspace.file.write",
+      summary: `Write ${relativePath}`,
+      paths: [absPath],
+    });
+
+    await ensureDir(dirname(absPath));
+    const tmp = `${absPath}.tmp-${shortId()}`;
+    await writeFile(tmp, bytes);
+    await rename(tmp, absPath);
+    const after = await stat(absPath);
+    const revision = fileRevision(after);
+    recordWorkspaceFileEvent(workspace.id, { type: "write", path: relativePath, revision });
+    await recordAudit(workspace.path, {
+      id: shortId(),
+      workspaceId: workspace.id,
+      actor: ctx.actor ?? { type: "remote" },
+      action: "workspace.file.write",
+      target: absPath,
+      summary: `Wrote ${relativePath}`,
+      timestamp: Date.now(),
+    });
+    return jsonResponse({ ok: true, path: relativePath, bytes: bytes.byteLength, updatedAt: after.mtimeMs, revision });
   });
 
   addRoute(routes, "POST", "/workspace/:id/files/content", "client", async (ctx) => {
@@ -3195,6 +3370,7 @@ async function resolveWorkspace(config: ServerConfig, id: string): Promise<Works
     throw new ApiError(403, "workspace_unauthorized", "Workspace is not authorized");
   }
   if (!config.readOnly) {
+    await ensureWorkspaceFiles(resolvedWorkspace, workspace.preset ?? "starter");
     await repairCommands(resolvedWorkspace);
   }
   return { ...workspace, path: resolvedWorkspace };

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -799,7 +799,29 @@ export function normalizeWorkspaceRelativePath(input: string, options: { allowSu
 
 export function isSupportedWorkspaceTextFilePath(relativePath: string): boolean {
   const lowered = relativePath.toLowerCase();
-  return [".md", ".mdx", ".markdown", ".json", ".jsonc", ".ts", ".js", ".mjs", ".cjs", ".txt"].some((ext) =>
+  return [
+    ".md",
+    ".mdx",
+    ".markdown",
+    ".csv",
+    ".tsv",
+    ".json",
+    ".jsonc",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".xml",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".css",
+    ".scss",
+    ".txt",
+    ".log",
+  ].some((ext) =>
     lowered.endsWith(ext),
   );
 }
@@ -2275,7 +2297,7 @@ function createRoutes(
     const requested = (ctx.url.searchParams.get("path") ?? "").trim();
     const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
     if (!isSupportedWorkspaceTextFilePath(relativePath)) {
-      throw new ApiError(400, "invalid_path", "Only Markdown and OpenCode plugin text files are supported");
+      throw new ApiError(400, "invalid_path", "Only supported text artifact files can be read inline");
     }
 
     const absPath = resolveSafeChildPath(workspace.path, relativePath);
@@ -2305,7 +2327,7 @@ function createRoutes(
     const requestedPath = String(body.path ?? "");
     const relativePath = normalizeWorkspaceRelativePath(requestedPath, { allowSubdirs: true });
     if (!isSupportedWorkspaceTextFilePath(relativePath)) {
-      throw new ApiError(400, "invalid_path", "Only Markdown and OpenCode plugin text files are supported");
+      throw new ApiError(400, "invalid_path", "Only supported text artifact files can be edited inline");
     }
 
     if (typeof body.content !== "string") {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -779,6 +779,8 @@ export function normalizeWorkspaceRelativePath(input: string, options: { allowSu
   let normalized = raw.replace(/\\/g, "/");
   normalized = normalized.replace(/^\/+/, "");
   normalized = normalized.replace(/^\.\//, "");
+  normalized = normalized.replace(/^workspaces\/[^/]+\//i, "");
+  normalized = normalized.replace(/^workspace\/(?:ws_[^/]+|\d+|[0-9a-f-]{6,})\//i, "");
   normalized = normalized.replace(/^workspace\//, "");
   normalized = normalized.replace(/^\/+/, "");
 
@@ -811,6 +813,8 @@ export function isSupportedWorkspaceTextFilePath(relativePath: string): boolean 
     ".yml",
     ".toml",
     ".xml",
+    ".html",
+    ".htm",
     ".ts",
     ".tsx",
     ".js",
@@ -853,6 +857,19 @@ function decodeArtifactId(id: string): string {
   } catch {
     throw new ApiError(400, "invalid_artifact", "Artifact id is invalid");
   }
+}
+
+function contentTypeForPath(path: string): string {
+  const lowered = path.toLowerCase();
+  if (lowered.endsWith(".html") || lowered.endsWith(".htm")) return "text/html; charset=utf-8";
+  if (lowered.endsWith(".svg")) return "image/svg+xml";
+  if (lowered.endsWith(".png")) return "image/png";
+  if (lowered.endsWith(".jpg") || lowered.endsWith(".jpeg")) return "image/jpeg";
+  if (lowered.endsWith(".gif")) return "image/gif";
+  if (lowered.endsWith(".webp")) return "image/webp";
+  if (lowered.endsWith(".pdf")) return "application/pdf";
+  if (isSupportedWorkspaceTextFilePath(path)) return "text/plain; charset=utf-8";
+  return "application/octet-stream";
 }
 
 function encodeInboxId(path: string): string {
@@ -2316,6 +2333,46 @@ function createRoutes(
 
     const content = await readFile(absPath, "utf8");
     return jsonResponse({ path: relativePath, content, bytes: info.size, updatedAt: info.mtimeMs });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/files/stat", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
+    const absPath = resolveSafeChildPath(workspace.path, relativePath);
+    if (!(await exists(absPath))) {
+      return jsonResponse({ ok: true, path: relativePath, exists: false });
+    }
+    const info = await stat(absPath);
+    return jsonResponse({
+      ok: true,
+      path: relativePath,
+      exists: true,
+      kind: info.isFile() ? "file" : info.isDirectory() ? "dir" : "other",
+      size: info.size,
+      updatedAt: info.mtimeMs,
+    });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/files/raw", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    const requested = (ctx.url.searchParams.get("path") ?? "").trim();
+    const relativePath = normalizeWorkspaceRelativePath(requested, { allowSubdirs: true });
+    const absPath = resolveSafeChildPath(workspace.path, relativePath);
+    if (!(await exists(absPath))) {
+      throw new ApiError(404, "file_not_found", "File not found");
+    }
+    const info = await stat(absPath);
+    if (!info.isFile()) {
+      throw new ApiError(404, "file_not_found", "File not found");
+    }
+
+    const headers = new Headers();
+    headers.set("Content-Type", contentTypeForPath(relativePath));
+    headers.set("Content-Length", String(info.size));
+    headers.set("Content-Disposition", `inline; filename="${basename(relativePath)}"`);
+    const stream = Readable.toWeb(createReadStream(absPath)) as unknown as ReadableStream;
+    return new Response(stream, { status: 200, headers });
   });
 
   addRoute(routes, "POST", "/workspace/:id/files/content", "client", async (ctx) => {

--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ensureWorkspaceFiles } from "./workspace-init.js";
+
+async function withWorkspace(fn: (root: string) => Promise<void>) {
+  const root = await mkdtemp(join(tmpdir(), "openwork-workspace-init-"));
+  try {
+    await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("ensureWorkspaceFiles", () => {
+  test("creates default agent with artifact guidance for new workspaces", async () => {
+    await withWorkspace(async (root) => {
+      await ensureWorkspaceFiles(root, "starter");
+      const agent = await readFile(join(root, ".opencode", "agents", "openwork.md"), "utf8");
+      expect(agent).toContain("OpenWork Artifacts");
+      expect(agent).toContain("reports/artifact-eval.xlsx");
+    });
+  });
+
+  test("adds artifact guidance to existing OpenWork agents", async () => {
+    await withWorkspace(async (root) => {
+      await mkdir(join(root, ".opencode", "agents"), { recursive: true });
+      await writeFile(join(root, ".opencode", "agents", "openwork.md"), "---\ndescription: Old\n---\n\nOld instructions\n", "utf8");
+      await ensureWorkspaceFiles(root, "starter");
+      const agent = await readFile(join(root, ".opencode", "agents", "openwork.md"), "utf8");
+      expect(agent).toContain("Old instructions");
+      expect(agent).toContain("OpenWork Artifacts");
+    });
+  });
+});

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -6,6 +6,18 @@ import { ApiError } from "./errors.js";
 import { openworkConfigPath, opencodeConfigPath } from "./workspace-files.js";
 import { readJsoncFile, writeJsoncFile } from "./jsonc.js";
 
+const OPENWORK_ARTIFACT_GUIDANCE = `<!-- OPENWORK_ARTIFACTS_START -->
+## OpenWork Artifacts
+
+OpenWork can preview, edit, and download standard artifacts when you create or update them in the workspace.
+
+- Prefer standard output files for user-visible deliverables: Markdown (\`.md\`), CSV (\`.csv\`), Excel workbooks (\`.xlsx\`), and browser previews (\`index.html\` or a local \`http://localhost:<port>\` URL).
+- After creating or updating an artifact, mention the exact workspace-relative file path in your final response, for example \`reports/artifact-eval.md\` or \`reports/artifact-eval.xlsx\`.
+- Do not invent \`Workspace/<id>/...\` paths unless a tool returns them; prefer clean workspace-relative paths.
+- For websites or React/UI previews, start the dev server when useful and mention the \`http://localhost:<port>\` URL. Socket URLs such as \`ws://localhost:<port>/...\` are diagnostic hints, not primary preview links.
+- For spreadsheets, use \`.csv\` for simple tabular data and \`.xlsx\` when the user asks for Excel/XLS specifically.
+<!-- OPENWORK_ARTIFACTS_END -->`;
+
 const OPENWORK_AGENT = `---
 description: OpenWork default agent
 mode: primary
@@ -62,6 +74,8 @@ Hard rule: never copy private memory into repo files. Store only redacted summar
 - If you change code, run the smallest meaningful test.
 - If steps repeat, factor them into a skill.
 - Prefer clear, practical steps over abstract explanations.
+
+${OPENWORK_ARTIFACT_GUIDANCE}
 `;
 
 type WorkspaceOpenworkConfig = {
@@ -121,9 +135,20 @@ async function ensureOpencodeConfig(workspaceRoot: string): Promise<void> {
 async function ensureOpenworkAgent(workspaceRoot: string): Promise<void> {
   const agentsDir = join(workspaceRoot, ".opencode", "agents");
   const agentPath = join(agentsDir, "openwork.md");
-  if (await exists(agentPath)) return;
   await ensureDir(agentsDir);
-  await writeFile(agentPath, OPENWORK_AGENT.endsWith("\n") ? OPENWORK_AGENT : `${OPENWORK_AGENT}\n`, "utf8");
+  if (!(await exists(agentPath))) {
+    await writeFile(agentPath, OPENWORK_AGENT.endsWith("\n") ? OPENWORK_AGENT : `${OPENWORK_AGENT}\n`, "utf8");
+    return;
+  }
+  const current = await readFile(agentPath, "utf8");
+  const start = "<!-- OPENWORK_ARTIFACTS_START -->";
+  const end = "<!-- OPENWORK_ARTIFACTS_END -->";
+  const startIndex = current.indexOf(start);
+  const endIndex = current.indexOf(end);
+  const next = startIndex >= 0 && endIndex > startIndex
+    ? `${current.slice(0, startIndex)}${OPENWORK_ARTIFACT_GUIDANCE}${current.slice(endIndex + end.length)}`
+    : `${current.trimEnd()}\n\n${OPENWORK_ARTIFACT_GUIDANCE}\n`;
+  if (next !== current) await writeFile(agentPath, next, "utf8");
 }
 
 export async function ensureWorkspaceFiles(workspaceRoot: string, presetInput: string): Promise<void> {

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -106,15 +106,22 @@ classification, right-pane mode switching, and artifact preview fallbacks.
 Steps:
 1. Hover the workspace header in the sidebar → click **New task**.
 2. Fill the composer:
-   `Create reports/artifact-eval.csv with three rows of sample revenue data and reports/artifact-eval.md summarizing it. Mention both file paths when done.`
+   `Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all three file paths when done.`
 3. Click **Run task** and wait until the status bar returns to **Ready**.
 4. Observe the right pane.
 
 Pass criteria:
 - The right pane opens automatically after the run completes.
 - The pane has an **Artifact** tab/button state in the titlebar.
-- The artifact pane shows either `artifact-eval.csv` as a table preview or
-  `artifact-eval.md` as rendered markdown.
+- The artifact pane only auto-opens a file after the OpenWork server confirms
+  it exists on the workspace filesystem.
+- The artifact pane shows either `artifact-eval.csv` as a table preview,
+  `artifact-eval.md` as rendered markdown, or `index.html` as a sandboxed HTML
+  preview.
+- The artifact pane includes a per-session artifact strip when multiple files
+  are detected.
+- Markdown/text-backed artifacts expose an **Edit** action and can save through
+  the OpenWork server write API.
 - Clicking **Browser** still restores the browser panel without losing the
   selected artifact button.
 - There are no console errors from `ArtifactPanel`, `deriveOpenTargets`, or
@@ -124,7 +131,7 @@ Tool recipe:
 ```
 chrome-devtools_click { uid: <New task button> }
 chrome-devtools_click { uid: <composer textbox> }
-chrome-devtools_type_text { text: "Create reports/artifact-eval.csv with three rows of sample revenue data and reports/artifact-eval.md summarizing it. Mention both file paths when done." }
+chrome-devtools_type_text { text: "Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all three file paths when done." }
 chrome-devtools_click { uid: <Run task> }
 chrome-devtools_wait_for { text: ["Ready"], timeout: 60000 }
 chrome-devtools_take_snapshot
@@ -135,8 +142,30 @@ chrome-devtools_take_screenshot
 Known regressions this catches:
 - Tool output paths are not extracted from live transcript messages.
 - `.csv`/`.md` targets are classified as unsupported external files.
+- Rendered paths like `Workspace/32423/reports/artifact-eval.md` are not
+  normalized before reading.
+- Missing files auto-open before the server confirms they exist.
 - The right pane remains browser-only and cannot display artifacts.
 - Browser automation tabs are overwritten by file previews.
+
+---
+
+## Flow 1B — Local preview URLs and socket hints open through browser mode
+
+**Why**: React/UI previews and running local services should use the browser
+pane, not the artifact renderer. WebSocket hints should not break URL parsing.
+
+Steps:
+1. In a new task, ask the agent to create a minimal HTML or React preview and
+   start a local server, then mention both `http://localhost:<port>` and any
+   `ws://localhost:<port>/...` socket endpoint it uses.
+2. Wait until the run completes.
+
+Pass criteria:
+- The `http://localhost:<port>` target opens in a browser tab.
+- Any `ws://localhost:<port>/...` target is extracted without corrupting the
+  artifact list; selecting it opens the sibling HTTP URL in browser mode.
+- No socket URL is routed through markdown/CSV artifact preview.
 
 ---
 

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -97,6 +97,49 @@ Known regressions this catches:
 
 ---
 
+## Flow 1A — Artifact pane opens generated spreadsheet/markdown targets
+
+**Why**: Artifact opening must be deterministic from tool/file outputs, not a
+one-off LLM convention. This catches regressions in target extraction,
+classification, right-pane mode switching, and artifact preview fallbacks.
+
+Steps:
+1. Hover the workspace header in the sidebar → click **New task**.
+2. Fill the composer:
+   `Create reports/artifact-eval.csv with three rows of sample revenue data and reports/artifact-eval.md summarizing it. Mention both file paths when done.`
+3. Click **Run task** and wait until the status bar returns to **Ready**.
+4. Observe the right pane.
+
+Pass criteria:
+- The right pane opens automatically after the run completes.
+- The pane has an **Artifact** tab/button state in the titlebar.
+- The artifact pane shows either `artifact-eval.csv` as a table preview or
+  `artifact-eval.md` as rendered markdown.
+- Clicking **Browser** still restores the browser panel without losing the
+  selected artifact button.
+- There are no console errors from `ArtifactPanel`, `deriveOpenTargets`, or
+  the right pane resize layout.
+
+Tool recipe:
+```
+chrome-devtools_click { uid: <New task button> }
+chrome-devtools_click { uid: <composer textbox> }
+chrome-devtools_type_text { text: "Create reports/artifact-eval.csv with three rows of sample revenue data and reports/artifact-eval.md summarizing it. Mention both file paths when done." }
+chrome-devtools_click { uid: <Run task> }
+chrome-devtools_wait_for { text: ["Ready"], timeout: 60000 }
+chrome-devtools_take_snapshot
+chrome-devtools_list_console_messages { types: ["error"] }
+chrome-devtools_take_screenshot
+```
+
+Known regressions this catches:
+- Tool output paths are not extracted from live transcript messages.
+- `.csv`/`.md` targets are classified as unsupported external files.
+- The right pane remains browser-only and cannot display artifacts.
+- Browser automation tabs are overwritten by file previews.
+
+---
+
 ## Flow 2 — Add a new session
 
 Steps:

--- a/evals/react-session-flows.md
+++ b/evals/react-session-flows.md
@@ -104,24 +104,31 @@ one-off LLM convention. This catches regressions in target extraction,
 classification, right-pane mode switching, and artifact preview fallbacks.
 
 Steps:
-1. Hover the workspace header in the sidebar → click **New task**.
-2. Fill the composer:
-   `Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all three file paths when done.`
-3. Click **Run task** and wait until the status bar returns to **Ready**.
-4. Observe the right pane.
+1. Run this once in an existing workspace, then create a new workspace and run
+   it again there. The default OpenWork agent should include artifact guidance
+   in both cases.
+2. Hover the workspace header in the sidebar → click **New task**.
+3. Fill the composer:
+   `Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.xlsx with the same data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all four file paths when done.`
+4. Click **Run task** and wait until the status bar returns to **Ready**.
+5. Observe the right pane.
 
 Pass criteria:
 - The right pane opens automatically after the run completes.
 - The pane has an **Artifact** tab/button state in the titlebar.
 - The artifact pane only auto-opens a file after the OpenWork server confirms
   it exists on the workspace filesystem.
-- The artifact pane shows either `artifact-eval.csv` as a table preview,
-  `artifact-eval.md` as rendered markdown, or `index.html` as a sandboxed HTML
-  preview.
+- The artifact pane shows `artifact-eval.csv` and `artifact-eval.xlsx` in the
+  same spreadsheet grid renderer, `artifact-eval.md` as rendered markdown, and
+  `index.html` as a sandboxed HTML preview.
 - The artifact pane includes a per-session artifact strip when multiple files
   are detected.
+- CSV/XLSX spreadsheet artifacts allow editing cells and saving through the
+  OpenWork server.
 - Markdown/text-backed artifacts expose an **Edit** action and can save through
   the OpenWork server write API.
+- CSV/XLSX/Markdown artifacts expose a **Download artifact** action backed by
+  the OpenWork server, so it works for local and remote workspaces.
 - Clicking **Browser** still restores the browser panel without losing the
   selected artifact button.
 - There are no console errors from `ArtifactPanel`, `deriveOpenTargets`, or
@@ -131,7 +138,7 @@ Tool recipe:
 ```
 chrome-devtools_click { uid: <New task button> }
 chrome-devtools_click { uid: <composer textbox> }
-chrome-devtools_type_text { text: "Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all three file paths when done." }
+chrome-devtools_type_text { text: "Create reports/artifact-eval.csv with three rows of sample revenue data, reports/artifact-eval.xlsx with the same data, reports/artifact-eval.md summarizing it, and reports/index.html with a tiny HTML preview. Mention all four file paths when done." }
 chrome-devtools_click { uid: <Run task> }
 chrome-devtools_wait_for { text: ["Ready"], timeout: 60000 }
 chrome-devtools_take_snapshot
@@ -142,6 +149,9 @@ chrome-devtools_take_screenshot
 Known regressions this catches:
 - Tool output paths are not extracted from live transcript messages.
 - `.csv`/`.md` targets are classified as unsupported external files.
+- `.xlsx` targets are detected but cannot be read, edited, saved, or downloaded.
+- The client performs one stat call per mentioned file instead of a single
+  server-side artifact resolve call.
 - Rendered paths like `Workspace/32423/reports/artifact-eval.md` are not
   normalized before reading.
 - Missing files auto-open before the server confirms they exist.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -4520,6 +4523,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -4967,6 +4974,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -5085,6 +5096,10 @@ packages:
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -6005,6 +6020,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -8401,6 +8420,10 @@ packages:
     resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
     engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   ssri@9.0.1:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -9083,6 +9106,14 @@ packages:
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -9121,6 +9152,11 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-parse-from-string@1.0.1:
     resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
@@ -13225,6 +13261,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -13758,6 +13796,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -13872,6 +13915,8 @@ snapshots:
       - '@types/react-dom'
 
   code-block-writer@13.0.3: {}
+
+  codepage@1.15.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -14886,6 +14931,8 @@ snapshots:
   forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
+
+  frac@1.1.2: {}
 
   fraction.js@4.3.7: {}
 
@@ -17675,6 +17722,10 @@ snapshots:
 
   sql-escaper@1.3.3: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   ssri@9.0.1:
     dependencies:
       minipass: 3.3.6
@@ -18323,6 +18374,10 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -18345,6 +18400,16 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-parse-from-string@1.0.1: {}
 


### PR DESCRIPTION
## Summary
- add deterministic open-target extraction/classification for files and URLs in session messages/tool output
- add an artifact mode in the existing right pane with markdown, CSV/text, image/PDF/HTML, and spreadsheet fallback previews
- add focused Bun coverage and a human eval flow for artifact auto-open behavior

## Tests
- pnpm --filter @openwork/app test:open-target ✅
- pnpm --filter @openwork/app typecheck ✅
- pnpm --filter @openwork/app test:refactor ✅
- pnpm --filter @openwork/app test:e2e ✅
- pnpm --filter @openwork/app build ✅

## Evidence
- CDP screenshot captured locally: /var/folders/d9/xqhkvsp94rg0n0n523snqztm0000gn/T/browser-screenshot-1779130207668.png
- Added eval: evals/react-session-flows.md Flow 1A — Artifact pane opens generated spreadsheet/markdown targets

## Notes
- .xlsx/.xls/.ods are detected and routed to the sheet preview surface, with an explicit external-open fallback until we add a lazy spreadsheet parser.
- Browser/localhost targets reuse the existing browser tab infrastructure instead of replacing the browser automation target with file previews.