### PR TITLE
feat(desktop): isolate dev URL scheme

### DIFF
--- a/apps/desktop/electron-builder.dev.yml
+++ b/apps/desktop/electron-builder.dev.yml
@@ -1,0 +1,34 @@
+# Development shell bundle. This intentionally uses a different app identity and
+# URL scheme so local development never takes over production openwork:// links.
+appId: com.differentai.openwork.dev
+productName: OpenWork-Dev
+protocols:
+  - name: OpenWork Dev
+    schemes:
+      - openwork-dev
+directories:
+  output: dist-electron-dev
+files:
+  - electron/**/*
+  - server/**/*
+  - package.json
+extraResources:
+  - from: resources/sidecars
+    to: sidecars
+asar: true
+npmRebuild: false
+afterPack: scripts/electron-after-pack.cjs
+mac:
+  icon: resources/icons/dev/icon-dev.icns
+  category: public.app-category.developer-tools
+  target:
+    - dir
+linux:
+  icon: resources/icons/dev/icon.png
+  target:
+    - dir
+win:
+  icon: resources/icons/icon.ico
+  target:
+    - dir
+artifactName: openwork-dev-${os}-${arch}-${version}.${ext}

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -29,15 +29,16 @@ import {
   selectOpenworkWorkspaceForConnection,
 } from "./remote-workspace.mjs";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const NATIVE_DEEP_LINK_EVENT = "openwork:deep-link-native";
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 const TAURI_APP_IDENTIFIER = "com.differentai.openwork";
 const DEV_APP_IDENTIFIER = "com.differentai.openwork.dev";
-const DESKTOP_PROTOCOL_SCHEME = "openwork";
 const isDevMode = process.env.OPENWORK_DEV_MODE === "1";
-const APP_NAME = isDevMode ? "OpenWork - Dev" : "OpenWork";
+const DESKTOP_PROTOCOL_SCHEME = isDevMode ? "openwork-dev" : "openwork";
+const APP_NAME = isDevMode ? "OpenWork-Dev" : "OpenWork";
 const APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
 const RELEASE_DOWNLOAD_BASE_URL = "https://github.com/different-ai/openwork/releases/latest/download";
 const RELEASE_PAGE_URL = "https://github.com/different-ai/openwork/releases/latest";
@@ -50,9 +51,12 @@ const DOCS_PAGE_URL = "https://openworklabs.com/docs";
 // Override via OPENWORK_ELECTRON_USERDATA so dogfooders can isolate their
 // Electron install from the real Tauri app.
 app.setName(APP_NAME);
+process.title = APP_NAME;
 app.setAppUserModelId(APP_IDENTIFIER);
 if (app.isPackaged) {
   app.setAsDefaultProtocolClient(DESKTOP_PROTOCOL_SCHEME);
+} else if (isDevMode) {
+  app.setAsDefaultProtocolClient(DESKTOP_PROTOCOL_SCHEME, process.execPath, [__filename]);
 }
 const userDataOverride = process.env.OPENWORK_ELECTRON_USERDATA?.trim();
 if (userDataOverride) {

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -1,12 +1,25 @@
 import { spawn, spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import net from "node:net";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "../..");
 const electronSidecarDir = resolve(desktopRoot, "resources", "sidecars");
+const devBundleOutputDir = resolve(desktopRoot, "dist-electron-dev");
+const packagedServerRoot = resolve(desktopRoot, "server");
 const defaultDevDataDir = resolve(
   process.env.HOME ?? process.env.USERPROFILE ?? repoRoot,
   ".openwork",
@@ -19,6 +32,7 @@ const portValue = Number.parseInt(process.env.PORT ?? "", 10);
 const devPort = Number.isFinite(portValue) && portValue > 0 ? portValue : 5173;
 const explicitStartUrl = process.env.OPENWORK_ELECTRON_START_URL?.trim() || "";
 const startUrl = explicitStartUrl || `http://localhost:${devPort}`;
+const useDevBundle = process.env.OPENWORK_ELECTRON_DEV_BUNDLE !== "0";
 const viteProbeUrls = explicitStartUrl
   ? [explicitStartUrl]
   : [
@@ -48,6 +62,72 @@ function runSync(command, args, options = {}) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+}
+
+function findPath(root, predicate, maxDepth = 5) {
+  if (!existsSync(root) || maxDepth < 0) return null;
+  for (const entry of readdirSync(root)) {
+    const fullPath = join(root, entry);
+    const stats = statSync(fullPath);
+    if (predicate(fullPath, entry, stats)) return fullPath;
+    if (stats.isDirectory()) {
+      const found = findPath(fullPath, predicate, maxDepth - 1);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function resolveDevBundleExecutable() {
+  if (process.platform === "darwin") {
+    const appBundle = findPath(devBundleOutputDir, (_fullPath, entry, stats) => stats.isDirectory() && entry === "OpenWork-Dev.app");
+    if (!appBundle) return null;
+    const macosDir = join(appBundle, "Contents", "MacOS");
+    const preferred = join(macosDir, "OpenWork-Dev");
+    if (existsSync(preferred)) return preferred;
+    return findPath(macosDir, (_fullPath, _entry, stats) => stats.isFile(), 1);
+  }
+
+  if (process.platform === "win32") {
+    return findPath(devBundleOutputDir, (_fullPath, entry, stats) => stats.isFile() && entry === "OpenWork-Dev.exe");
+  }
+
+  return findPath(devBundleOutputDir, (_fullPath, entry, stats) => stats.isFile() && entry === "OpenWork-Dev");
+}
+
+function buildDevBundle() {
+  console.log("[electron-dev] Packaging OpenWork-Dev Electron shell...");
+  runSync(pnpmCmd, ["exec", "electron-builder", "--config", "electron-builder.dev.yml", "--dir", "--publish", "never"], {
+    cwd: desktopRoot,
+    env: {
+      ...process.env,
+      OPENWORK_DEV_MODE: process.env.OPENWORK_DEV_MODE ?? "1",
+    },
+  });
+  const executable = resolveDevBundleExecutable();
+  if (!executable) {
+    throw new Error(`Unable to find packaged OpenWork-Dev executable in ${devBundleOutputDir}`);
+  }
+  return executable;
+}
+
+function stageServerForBundle() {
+  const serverDistDir = resolve(repoRoot, "apps", "server", "dist");
+  const constantsSrc = resolve(repoRoot, "constants.json");
+  copyFileSync(constantsSrc, resolve(serverDistDir, "constants.json"));
+  const serverJsPath = resolve(serverDistDir, "server.js");
+  const serverJsSrc = readFileSync(serverJsPath, "utf8");
+  const patched = serverJsSrc.replace(
+    /from\s+["']\.\.\/\.\.\/\.\.\/constants\.json["']/,
+    'from "./constants.json"',
+  );
+  if (patched !== serverJsSrc) {
+    writeFileSync(serverJsPath, patched, "utf8");
+  }
+  rmSync(packagedServerRoot, { recursive: true, force: true });
+  mkdirSync(packagedServerRoot, { recursive: true });
+  cpSync(serverDistDir, resolve(packagedServerRoot, "dist"), { recursive: true });
+  copyFileSync(resolve(repoRoot, "apps", "server", "package.json"), resolve(packagedServerRoot, "package.json"));
 }
 
 async function fetchWithTimeout(url, timeoutMs = 4000) {
@@ -200,6 +280,7 @@ runSync(nodeCmd, [resolve(__dirname, "prepare-sidecar.mjs"), "--force", "--outdi
 // Build the server TS → JS so Electron can import it in-process
 console.log("[electron-dev] Building openwork-server (tsc)...");
 runSync(pnpmCmd, ["--filter", "openwork-server", "build"], { cwd: repoRoot });
+stageServerForBundle();
 
 const initialProbeUrls = [startUrl, ...viteProbeUrls].filter(Boolean);
 let viteReady = false;
@@ -239,7 +320,10 @@ const resolvedStartUrl = await waitForVite(startUrl);
 const cdpPortRaw = process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT?.trim() ?? "";
 const cdpPort = cdpPortRaw === "" || cdpPortRaw === "0" ? "" : cdpPortRaw;
 
-electronChild = run(pnpmCmd, ["exec", "electron", "./electron/main.mjs"], {
+const electronCommand = useDevBundle ? buildDevBundle() : pnpmCmd;
+const electronArgs = useDevBundle ? [] : ["exec", "electron", "./electron/main.mjs"];
+
+electronChild = run(electronCommand, electronArgs, {
   cwd: desktopRoot,
   env: {
     ...process.env,


### PR DESCRIPTION
## Summary
- add an Electron Builder dev config for an OpenWork-Dev app variant
- register openwork-dev:// for dev builds while keeping openwork:// on packaged production builds
- make pnpm dev package and launch the dev Electron bundle by default, with OPENWORK_ELECTRON_DEV_BUNDLE=0 as the raw Electron opt-out

## Verification
- node --check apps/desktop/scripts/electron-dev.mjs
- node --check apps/desktop/electron/main.mjs
- pnpm -C apps/desktop exec node -e "const fs=require('node:fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('electron-builder.dev.yml','utf8'));"
- git diff --check

## Known issue
- pnpm -C apps/desktop typecheck:electron still fails on existing Electron typing issues in browser-mcp.mjs, browser-native-tools.mjs, and menu typing in main.mjs. These are unrelated to this change.

## Demo
- No video/screenshot captured; change was verified with syntax/config checks only.